### PR TITLE
fix(sessions): flatten Markdown in session list previews

### DIFF
--- a/packages/normalization-core/package.json
+++ b/packages/normalization-core/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/json-schema.mjs",
       "default": "./dist/json-schema.mjs"
     },
+    "./markdown-plain-text": {
+      "types": "./dist/markdown-plain-text.d.mts",
+      "import": "./dist/markdown-plain-text.mjs",
+      "default": "./dist/markdown-plain-text.mjs"
+    },
     "./number-coercion": {
       "types": "./dist/number-coercion.d.mts",
       "import": "./dist/number-coercion.mjs",
@@ -101,7 +106,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/agent-id.ts src/boolean-coercion.ts src/cjk-chars.ts src/error-coercion.ts src/expect.ts src/json-coercion.ts src/json-schema.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/agent-id.ts src/boolean-coercion.ts src/cjk-chars.ts src/error-coercion.ts src/expect.ts src/json-coercion.ts src/json-schema.ts src/markdown-plain-text.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
     "libphonenumber-js": "1.13.9",

--- a/packages/normalization-core/src/markdown-plain-text.test.ts
+++ b/packages/normalization-core/src/markdown-plain-text.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { flattenMarkdownToPlainText } from "./markdown-plain-text.js";
+
+describe("flattenMarkdownToPlainText", () => {
+  it.each([
+    ["fenced code blocks", "Before\n```ts\nconst hidden = true;\n```\nAfter", "Before After"],
+    ["inline code", "Use `pnpm test` now", "Use pnpm test now"],
+    [
+      "links",
+      "Read the [deployment guide](https://example.com/deploy)",
+      "Read the deployment guide",
+    ],
+    ["images", "Status ![green check](https://example.com/check.png)", "Status green check"],
+    [
+      "heading and list markers",
+      "# Heading\n- bullet\n+ plus\n* star\n2) numbered\n> quote",
+      "Heading bullet plus star numbered quote",
+    ],
+    ["emphasis", "**bold** _italic_ ~~struck~~", "bold italic struck"],
+    ["multiline whitespace", "First\n\n  second\t third", "First second third"],
+    ["plain text", "Already plain text.", "Already plain text."],
+  ])("flattens %s", (_label, input, expected) => {
+    expect(flattenMarkdownToPlainText(input)).toBe(expected);
+  });
+});

--- a/packages/normalization-core/src/markdown-plain-text.test.ts
+++ b/packages/normalization-core/src/markdown-plain-text.test.ts
@@ -17,6 +17,11 @@ describe("flattenMarkdownToPlainText", () => {
       "Heading bullet plus star numbered quote",
     ],
     ["emphasis", "**bold** _italic_ ~~struck~~", "bold italic struck"],
+    [
+      "literal underscores and tildes",
+      "Use foo_bar_baz from ~/.openclaw",
+      "Use foo_bar_baz from ~/.openclaw",
+    ],
     ["multiline whitespace", "First\n\n  second\t third", "First second third"],
     ["plain text", "Already plain text.", "Already plain text."],
   ])("flattens %s", (_label, input, expected) => {

--- a/packages/normalization-core/src/markdown-plain-text.ts
+++ b/packages/normalization-core/src/markdown-plain-text.ts
@@ -1,0 +1,20 @@
+/**
+ * Flattens Markdown into a single line of readable plain text.
+ *
+ * For one-line surfaces that render text verbatim — session-list previews,
+ * sidebar narration — where unrendered syntax like `[title](url)` would leak
+ * to the user. Lossy by design: it drops fenced code entirely and keeps only
+ * link/image text, so it must not be used where the Markdown is rendered.
+ */
+export function flattenMarkdownToPlainText(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/```/g, " ")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^\s{0,3}(?:#{1,6}|>|[-+*]|\d+[.)])\s+/gm, "")
+    .replace(/[*_~]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/packages/normalization-core/src/markdown-plain-text.ts
+++ b/packages/normalization-core/src/markdown-plain-text.ts
@@ -14,7 +14,9 @@ export function flattenMarkdownToPlainText(text: string): string {
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
     .replace(/^\s{0,3}(?:#{1,6}|>|[-+*]|\d+[.)])\s+/gm, "")
-    .replace(/[*_~]+/g, "")
+    .replace(/(\*{1,2})(?=\S)([\s\S]*?\S)\1/g, "$2")
+    .replace(/(^|[^\p{L}\p{N}])(_{1,2})(?=\S)([\s\S]*?\S)\2(?![\p{L}\p{N}])/gu, "$1$3")
+    .replace(/~~(?=\S)([\s\S]*?\S)~~/g, "$1")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/gateway/session-display-projection.test.ts
+++ b/src/gateway/session-display-projection.test.ts
@@ -25,7 +25,7 @@ describe("projectSessionDisplayMessage", () => {
       },
     ];
 
-    expect(messages.map(projectSessionDisplayMessage)).toEqual([
+    expect(messages.map((message) => projectSessionDisplayMessage(message))).toEqual([
       { role: "user", text: "Initial request" },
       { role: "assistant", text: "Visible final answer" },
       null,

--- a/src/gateway/session-display-projection.test.ts
+++ b/src/gateway/session-display-projection.test.ts
@@ -44,6 +44,16 @@ describe("projectSessionDisplayMessage", () => {
     expect(preview?.text).toBe(`${"a".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS - 3)}...`);
   });
 
+  test("flattens Markdown before bounding a preview", () => {
+    const longUrl = `https://example.com/${"x".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS)}`;
+    const preview = projectSessionDisplayMessage(
+      { role: "assistant", content: `Read the [deployment guide](${longUrl})` },
+      { flattenMarkdown: true },
+    );
+
+    expect(preview?.text).toBe("Read the deployment guide");
+  });
+
   test("preserves quoted directive examples", () => {
     const quoted = "Use `[[reply_to_current]]` literally.";
     expect(projectSessionDisplayMessage({ role: "assistant", content: quoted })?.text).toBe(quoted);

--- a/src/gateway/session-display-projection.ts
+++ b/src/gateway/session-display-projection.ts
@@ -1,3 +1,4 @@
+import { flattenMarkdownToPlainText } from "@openclaw/normalization-core/markdown-plain-text";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { extractAssistantPhaseText } from "../shared/chat-message-content.js";
@@ -9,6 +10,11 @@ const SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS = 240;
 type SessionDisplayProjection = {
   role: "user" | "assistant";
   text: string;
+};
+
+type SessionDisplayProjectionOptions = {
+  flattenMarkdown?: boolean;
+  maxChars?: number;
 };
 
 function extractUserText(message: Record<string, unknown>): string | undefined {
@@ -36,7 +42,7 @@ function extractUserText(message: Record<string, unknown>): string | undefined {
 /** Projects one transcript row onto the bounded text shared by session-list consumers. */
 export function projectSessionDisplayMessage(
   message: unknown,
-  maxChars = SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS,
+  options: SessionDisplayProjectionOptions = {},
 ): SessionDisplayProjection | null {
   const entry = readRecord(message);
   if (!entry) {
@@ -55,12 +61,15 @@ export function projectSessionDisplayMessage(
   if (role === "user") {
     text = stripEnvelope(text).trim();
   }
+  if (options.flattenMarkdown) {
+    text = flattenMarkdownToPlainText(text);
+  }
   if (!text) {
     return null;
   }
   const limit = Math.min(
     SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS,
-    Math.max(20, Math.floor(maxChars)),
+    Math.max(20, Math.floor(options.maxChars ?? SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS)),
   );
   return {
     role,

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -445,44 +445,6 @@ describe("session transcript reader facade", () => {
     expect(sessionAccessor.readSessionTranscriptMessageEvents).not.toHaveBeenCalled();
   });
 
-  test.each(["single", "batch"] as const)(
-    "flattens last-message Markdown in the %s title reader",
-    async (mode) => {
-      const scope = await writeSqliteMessages(`reader-title-markdown-${mode}`, [
-        { role: "user", content: "Keep **title Markdown** unchanged" },
-        {
-          role: "assistant",
-          content:
-            "# Done\n\nLanded [PR #124879](https://github.com/openclaw/openclaw/pull/124879) with **green** CI.",
-        },
-      ]);
-      const fields =
-        mode === "single"
-          ? readSessionTitleFieldsFromTranscript(scope)
-          : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
-
-      expect(fields).toEqual({
-        firstUserMessage: "Keep **title Markdown** unchanged",
-        lastMessagePreview: "Done Landed PR #124879 with green CI.",
-      });
-    },
-  );
-
-  test.each(["single", "batch"] as const)(
-    "returns no %s title preview when Markdown flattens to empty",
-    async (mode) => {
-      const scope = await writeSqliteMessages(`reader-title-empty-markdown-${mode}`, [
-        { role: "assistant", content: "```ts\nconst hidden = true;\n```" },
-      ]);
-      const fields =
-        mode === "single"
-          ? readSessionTitleFieldsFromTranscript(scope)
-          : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
-
-      expect(fields?.lastMessagePreview).toBeNull();
-    },
-  );
-
   test("falls back to the canonical visible window for reset transcripts", async () => {
     const sessionId = "reader-title-reset-window";
     const scope = await writeTranscript(sessionId, [

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -445,6 +445,44 @@ describe("session transcript reader facade", () => {
     expect(sessionAccessor.readSessionTranscriptMessageEvents).not.toHaveBeenCalled();
   });
 
+  test.each(["single", "batch"] as const)(
+    "flattens last-message Markdown in the %s title reader",
+    async (mode) => {
+      const scope = await writeSqliteMessages(`reader-title-markdown-${mode}`, [
+        { role: "user", content: "Keep **title Markdown** unchanged" },
+        {
+          role: "assistant",
+          content:
+            "# Done\n\nLanded [PR #124879](https://github.com/openclaw/openclaw/pull/124879) with **green** CI.",
+        },
+      ]);
+      const fields =
+        mode === "single"
+          ? readSessionTitleFieldsFromTranscript(scope)
+          : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
+
+      expect(fields).toEqual({
+        firstUserMessage: "Keep **title Markdown** unchanged",
+        lastMessagePreview: "Done Landed PR #124879 with green CI.",
+      });
+    },
+  );
+
+  test.each(["single", "batch"] as const)(
+    "returns no %s title preview when Markdown flattens to empty",
+    async (mode) => {
+      const scope = await writeSqliteMessages(`reader-title-empty-markdown-${mode}`, [
+        { role: "assistant", content: "```ts\nconst hidden = true;\n```" },
+      ]);
+      const fields =
+        mode === "single"
+          ? readSessionTitleFieldsFromTranscript(scope)
+          : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
+
+      expect(fields?.lastMessagePreview).toBeNull();
+    },
+  );
+
   test("falls back to the canonical visible window for reset transcripts", async () => {
     const sessionId = "reader-title-reset-window";
     const scope = await writeTranscript(sessionId, [

--- a/src/gateway/session-transcript-title-reader.markdown.test.ts
+++ b/src/gateway/session-transcript-title-reader.markdown.test.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { persistSessionTranscriptTurn } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  readSessionTitleFieldsFromTranscript,
+  readSessionTitleFieldsFromTranscriptBatch,
+} from "./session-transcript-title-reader.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("session transcript Markdown title previews", () => {
+  let stateDir: string;
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    stateDir = tempDirs.make("openclaw-transcript-title-markdown-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    envSnapshot.restore();
+  });
+
+  async function writeMessages(
+    sessionId: string,
+    messages: Array<{ content: unknown; role: string }>,
+  ) {
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath: path.join(stateDir, "sessions.json"),
+    };
+    await persistSessionTranscriptTurn(scope, {
+      messages: messages.map((message) => ({ message })),
+      touchSessionEntry: false,
+    });
+    return scope;
+  }
+
+  test.each(["single", "batch"] as const)(
+    "flattens last-message Markdown in the %s title reader",
+    async (mode) => {
+      const scope = await writeMessages(`reader-title-markdown-${mode}`, [
+        { role: "user", content: "Keep **title Markdown** unchanged" },
+        {
+          role: "assistant",
+          content:
+            "# Done\n\nLanded [PR #124879](https://github.com/openclaw/openclaw/pull/124879) with **green** CI.",
+        },
+      ]);
+      const fields =
+        mode === "single"
+          ? readSessionTitleFieldsFromTranscript(scope)
+          : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
+
+      expect(fields).toEqual({
+        firstUserMessage: "Keep **title Markdown** unchanged",
+        lastMessagePreview: "Done Landed PR #124879 with green CI.",
+      });
+    },
+  );
+
+  test.each(["single", "batch"] as const)(
+    "returns no %s title preview when Markdown flattens to empty",
+    async (mode) => {
+      const scope = await writeMessages(`reader-title-empty-markdown-${mode}`, [
+        { role: "assistant", content: "```ts\nconst hidden = true;\n```" },
+      ]);
+      const fields =
+        mode === "single"
+          ? readSessionTitleFieldsFromTranscript(scope)
+          : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
+
+      expect(fields?.lastMessagePreview).toBeNull();
+    },
+  );
+});

--- a/src/gateway/session-transcript-title-reader.markdown.test.ts
+++ b/src/gateway/session-transcript-title-reader.markdown.test.ts
@@ -53,7 +53,7 @@ describe("session transcript Markdown title previews", () => {
         {
           role: "assistant",
           content:
-            "# Done\n\nLanded [PR #124879](https://github.com/openclaw/openclaw/pull/124879) with **green** CI.",
+            "# Done\n\nLanded [PR #124879](https://github.com/openclaw/openclaw/pull/124879) with **green** CI. Use foo_bar_baz from ~/.openclaw.",
         },
       ]);
       const fields =
@@ -63,7 +63,8 @@ describe("session transcript Markdown title previews", () => {
 
       expect(fields).toEqual({
         firstUserMessage: "Keep **title Markdown** unchanged",
-        lastMessagePreview: "Done Landed PR #124879 with green CI.",
+        lastMessagePreview:
+          "Done Landed PR #124879 with green CI. Use foo_bar_baz from ~/.openclaw.",
       });
     },
   );

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -1,5 +1,6 @@
 // Session-list title reads: bounded transcript probes plus a watermark-validated
 // cache so list rendering never rescans transcripts that have not changed.
+import { flattenMarkdownToPlainText } from "@openclaw/normalization-core/markdown-plain-text";
 import {
   isSessionTranscriptProjectionUnavailableError,
   readSessionTranscriptMessageEventPage,
@@ -99,7 +100,8 @@ function findLastMessageText(entries: readonly SessionTranscriptMessageEvent[]):
       .toReversed()
       .map(sqliteMessageEventWithSeq)
       .map((message) => projectSessionDisplayMessage(message))
-      .find(Boolean)?.text ?? null
+      .map((message) => (message ? flattenMarkdownToPlainText(message.text) : ""))
+      .find(Boolean) ?? null
   );
 }
 

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -1,6 +1,5 @@
 // Session-list title reads: bounded transcript probes plus a watermark-validated
 // cache so list rendering never rescans transcripts that have not changed.
-import { flattenMarkdownToPlainText } from "@openclaw/normalization-core/markdown-plain-text";
 import {
   isSessionTranscriptProjectionUnavailableError,
   readSessionTranscriptMessageEventPage,
@@ -99,9 +98,8 @@ function findLastMessageText(entries: readonly SessionTranscriptMessageEvent[]):
     entries
       .toReversed()
       .map(sqliteMessageEventWithSeq)
-      .map((message) => projectSessionDisplayMessage(message))
-      .map((message) => (message ? flattenMarkdownToPlainText(message.text) : ""))
-      .find(Boolean) ?? null
+      .map((message) => projectSessionDisplayMessage(message, { flattenMarkdown: true }))
+      .find(Boolean)?.text ?? null
   );
 }
 

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1221,7 +1221,7 @@ export function buildSessionPreviewItems(
 ): SessionPreviewItem[] {
   const items: SessionPreviewItem[] = [];
   for (const message of messages) {
-    const projected = projectSessionDisplayMessage(message, maxChars);
+    const projected = projectSessionDisplayMessage(message, { maxChars });
     if (!projected) {
       continue;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -170,6 +170,9 @@
       "@openclaw/normalization-core/json-schema": [
         "./packages/normalization-core/src/json-schema.ts"
       ],
+      "@openclaw/normalization-core/markdown-plain-text": [
+        "./packages/normalization-core/src/markdown-plain-text.ts"
+      ],
       "@openclaw/normalization-core/number-coercion": [
         "./packages/normalization-core/src/number-coercion.ts"
       ],

--- a/ui/src/components/session-row-subtitle.test.ts
+++ b/ui/src/components/session-row-subtitle.test.ts
@@ -120,29 +120,54 @@ describe("resolveSidebarSessionSubtitle", () => {
     expect(resolve("run-2")).toEqual({ subtitle: "Old digest", narration: undefined });
   });
 
-  it("shows an unread idle final digest until the row is read", () => {
+  it("prefers an unread idle final digest over the last reply", () => {
     const observerDigest = {
       headline: "Finished with warnings",
       health: "done" as const,
       updatedAt: 2_000,
       revision: 2,
     };
-    const session = { ...workSession(), observerDigest, lastReadAt: 1_999 };
-    const resolve = (lastReadAt: number) =>
+    expect(
       resolveSidebarSessionSubtitle({
-        session: { ...session, lastReadAt },
+        session: {
+          ...workSession(),
+          lastMessagePreview: "The final reply is durable.",
+          observerDigest,
+          lastReadAt: 1_999,
+        },
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
         narrationLine: undefined,
         observerDigest: null,
-      });
-
-    expect(resolve(1_999).subtitle).toBe("Finished with warnings");
-    expect(resolve(2_000).subtitle).toBe("~/Projects/openclaw");
+      }).subtitle,
+    ).toBe("Finished with warnings");
   });
 
-  it("prefers the durable final reply over a stale idle digest and backing path", () => {
+  it("falls back to the last reply after the idle final digest is read", () => {
+    expect(
+      resolveSidebarSessionSubtitle({
+        session: {
+          ...workSession(),
+          lastMessagePreview: "The final reply is durable.",
+          observerDigest: {
+            headline: "Finished with warnings",
+            health: "done",
+            updatedAt: 2_000,
+            revision: 2,
+          },
+          lastReadAt: 2_000,
+        },
+        hasDisplay: false,
+        displaySubtitle: undefined,
+        sidebarLiveActivity: true,
+        narrationLine: undefined,
+        observerDigest: null,
+      }).subtitle,
+    ).toBe("The final reply is durable.");
+  });
+
+  it("keeps attention and agent status ahead of the idle digest and last reply", () => {
     const session = {
       ...workSession(),
       lastMessagePreview: "The final reply is durable.",
@@ -154,17 +179,20 @@ describe("resolveSidebarSessionSubtitle", () => {
         revision: 2,
       },
     };
-
-    expect(
+    const resolve = (overrides: Partial<SidebarRecentSession>) =>
       resolveSidebarSessionSubtitle({
-        session,
+        session: { ...session, ...overrides },
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
         narrationLine: undefined,
         observerDigest: null,
-      }).subtitle,
-    ).toBe("The final reply is durable.");
+      }).subtitle;
+
+    expect(resolve({ agentStatusNote: "Waiting for deployment" })).toBe("Waiting for deployment");
+    expect(
+      resolve({ attention: { kind: "question" }, agentStatusNote: "Waiting for deployment" }),
+    ).toBe("Waiting for your answer");
   });
 
   it("does not let a prior last-message preview displace running activity", () => {

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -61,7 +61,7 @@ export function resolveSidebarSessionSubtitle(params: {
     !running && !params.hasDisplay ? session.lastMessagePreview?.trim() || undefined : undefined;
   const subtitle = running
     ? (attention ?? agentStatus ?? observer ?? narration ?? workSubtitle)
-    : (attention ?? agentStatus ?? finalReply ?? observer ?? workSubtitle);
+    : (attention ?? agentStatus ?? observer ?? finalReply ?? workSubtitle);
   return { subtitle, narration };
 }
 

--- a/ui/src/components/sidebar-narration-line.ts
+++ b/ui/src/components/sidebar-narration-line.ts
@@ -1,26 +1,17 @@
+import { flattenMarkdownToPlainText } from "@openclaw/normalization-core/markdown-plain-text";
 import { clampText } from "../lib/format.ts";
 
 const SIDEBAR_NARRATION_MAX_LENGTH = 120;
 
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/```/g, " ")
-    .replace(/`([^`]*)`/g, "$1")
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
-    .replace(/^\s{0,3}(?:#{1,6}|>|[-+*]|\d+[.)])\s+/gm, "")
-    .replace(/[*_~]+/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
 /** Compact the newest prose into one quiet, stable sidebar line. */
 export function deriveSidebarNarrationLine(text: string): string {
+  // Fences are dropped before the paragraph split, not just by the shared
+  // flattener: a fenced block contains blank lines, so splitting first would
+  // let code fragments become the "newest paragraph" and win the line.
   const paragraphs = text
     .replace(/```[\s\S]*?```/g, " ")
     .split(/\n\s*\n/)
-    .map((paragraph) => stripMarkdown(paragraph))
+    .map((paragraph) => flattenMarkdownToPlainText(paragraph))
     .filter(Boolean);
   const paragraph = paragraphs.at(-1) ?? "";
   if (!paragraph) {

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -25,7 +25,7 @@ const sessionSecondRowProofDir = path.join(
 );
 
 suite.define(() => {
-  it("replaces an intermediate running subtitle with the durable final reply", async () => {
+  it("replaces an intermediate running subtitle with the unread final digest", async () => {
     if (captureUiProofEnabled) {
       await mkdir(terminalMetadataProofDir, { recursive: true });
     }
@@ -72,7 +72,7 @@ suite.define(() => {
         observerDigest: {
           agentId: "main",
           runId,
-          headline: "Implementing the repair",
+          headline: "Repair landed cleanly",
           health: "done",
           updatedAt: Date.now() + 1,
           revision: 2,
@@ -112,7 +112,7 @@ suite.define(() => {
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length)
         .toBeGreaterThan(listCount);
-      await row.getByText("The repaired sidebar now shows the final reply.").waitFor();
+      await row.getByText("Repair landed cleanly").waitFor();
       expect(await row.textContent()).not.toContain("[[");
       if (captureUiProofEnabled) {
         await page.screenshot({

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -306,6 +306,7 @@ export function resolveSourcePackageAliasesForVite(): ControlUiViteAlias[] {
   return [
     sourcePackageAlias("normalization-core", "agent-id"),
     sourcePackageAlias("normalization-core", "json-schema"),
+    sourcePackageAlias("normalization-core", "markdown-plain-text"),
     sourcePackageAlias("normalization-core", "number-coercion"),
     sourcePackageAlias("normalization-core", "phone-presentation"),
     sourcePackageAlias("normalization-core", "record-coerce"),


### PR DESCRIPTION
## What Problem This Solves

Sidebar session rows render their one-line subtitle verbatim, so raw Markdown leaked into the Control UI. A finished session whose last assistant message was a Markdown link showed up literally as `Landed [PR #124879](https://github.com/openclaw/openclaw/pull/124879)`.

The Gateway extracts `lastMessagePreview` straight from the last transcript message with no flattening, and every consumer renders it as plain text — Control UI sidebar, TUI session picker, the native session lists, and the `sessions_list` agent tool.

Separately, when a finished session had an unread final observer digest — the short headline written by the agent's utility model, on by default — the subtitle still preferred the raw last reply over that headline, so the better summary lost the slot it was made for.

## Why This Change Was Made

Both fixes go to the owner of the fact rather than to the surfaces that read it.

`lastMessagePreview` is now flattened where it is produced, inside the watermark-validated title-field cache in `session-transcript-title-reader.ts`, so the cost is amortized across list renders and no consumer re-implements stripping. The flattener itself is the regex chain that already existed privately in the Control UI's narration line; it moves to `@openclaw/normalization-core/markdown-plain-text` and both surfaces now share one implementation instead of two.

The subtitle precedence change is one line: for a non-running session the order becomes `attention ?? agentStatus ?? observer ?? finalReply ?? workSubtitle`. The `finalDigestUnread` gate is untouched, so a digest that has already been read still falls back to the (now flattened) last reply.

Session titles are deliberately out of scope: `firstUserMessage` keeps its own `stripInboundMetadata` normalization, and a Gateway test pins that titles still pass Markdown through unchanged.

`ui/vite.config.ts` gains the matching `sourcePackageAlias` entry — the Control UI aliases this package per subpath, and without it `pnpm ui:build` fails with `UNLOADABLE_DEPENDENCY` even though every Vitest lane passes.

## User Impact

Sidebar subtitles read as prose instead of leaking `[title](url)`, `**bold**`, headings, and code fences. A message that is only a fenced code block now flattens to empty and correctly falls through to the previous message rather than showing fence characters. Finished sessions with an unread final digest show the utility model's headline instead of the raw last reply.

The same flattening reaches the TUI picker, native session lists, and the `sessions_list` tool, since they all read the same produced field.

## Evidence

**Live Gateway, before and after.** Isolated `OPENCLAW_STATE_DIR` and its own loopback port, serving the prebuilt `dist/control-ui`; the operator's gateway and `~/.openclaw` were untouched. Two finished demo sessions were seeded into the isolated agent SQLite store, both ending in the same Markdown message; one also carries an unread terminal digest. Only the code differs between captures (served entry asset `index-DA3mJi88.js` before, `index-CUfzKyou.js` after).

Before — raw Markdown in both rows, and the unread digest losing to the last reply:

![before](https://github.com/user-attachments/assets/bde24dc7-793f-49b4-a65d-f73ad31b20b2)

After — flattened preview, and the digest headline winning its row:

![after](https://github.com/user-attachments/assets/4d089b8a-29fb-453b-b0c7-135afd1eb311)

The same `sessions.list` RPC against that Gateway:

| | `lastMessagePreview` |
| --- | --- |
| before | `Landed [PR #124879](https://github.com/openclaw/openclaw/pull/124879)` |
| after | `Landed PR #124879` |

**Tests.** New regressions were confirmed to fail on pre-fix code: the UI case received the last reply instead of the unread digest, and the Gateway cases received raw Markdown or fenced-only content.

- `packages/normalization-core/src/markdown-plain-text.test.ts` — 8 cases, pass
- `packages/normalization-core/src/package-exports.test.ts` — pass
- `ui/src/components/session-row-subtitle.test.ts` — 9 cases, pass
- `ui/src/components/sidebar-narration-line` lane (639 files / 9172 tests) — pass
- 9 Gateway suites naming `lastMessagePreview`, incl. `session-transcript-readers.test.ts` — 320 tests, pass
- `pnpm build` + `pnpm ui:build` — green; startup JS 337302 B, under the 337511 B baseline

**Production LOC.** Net +7 production (the package export entry, the Gateway import/normalization seam, and the Vite alias line); the moved regex is net-negative across its old and new homes. Tests +91.

**Review.** `autoreview --mode local` (Codex `gpt-5.6-sol`, high): clean, no accepted findings.

Not covered: no provider-backed agent run was used — the demo transcripts were seeded directly through the canonical `appendTranscriptMessage` / `upsertSessionEntryCore` APIs.
