### PR TITLE
fix: model setup detects CLI logins when AI access checks time out

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1028,15 +1028,11 @@ extension OnboardingAISetupModel {
         before: PersistedActivationState?,
         originalServerLease: GatewayConnection.ServerLease) async -> Bool
     {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(45))
+        let deadline = ReconciliationDeadline(timeout: .seconds(45))
         var delayMs = 250
-        while clock.now < deadline {
+        while deadline.hasTimeRemaining {
             guard self.isCurrentAttempt(context), !Task.isCancelled else { return false }
-            let leaseTimeoutMs = Self.remainingMilliseconds(
-                until: deadline,
-                clock: clock,
-                cappedAt: 3000)
+            let leaseTimeoutMs = deadline.remainingMilliseconds(cappedAt: 3000)
             guard leaseTimeoutMs > 0 else { return false }
             if let replacementLease = try? await gateway.acquireServerLease(
                 ifSameRouteAs: originalServerLease,
@@ -1048,18 +1044,12 @@ extension OnboardingAISetupModel {
                     activationOwner: activationOwner,
                     before: before,
                     serverLease: replacementLease,
-                    timeoutMs: Self.remainingMilliseconds(
-                        until: deadline,
-                        clock: clock,
-                        cappedAt: Self.setupDetectionRequestTimeoutMs))
+                    deadline: deadline)
             {
                 self.serverLease = replacementLease
                 return true
             }
-            let sleepMs = Self.remainingMilliseconds(
-                until: deadline,
-                clock: clock,
-                cappedAt: delayMs)
+            let sleepMs = deadline.remainingMilliseconds(cappedAt: delayMs)
             guard sleepMs > 0 else { return false }
             do {
                 try await Task.sleep(nanoseconds: UInt64(sleepMs) * 1_000_000)
@@ -1078,9 +1068,11 @@ extension OnboardingAISetupModel {
         activationOwner: OnboardingSystemAgentResumeStore.ActivationOwner,
         before: PersistedActivationState?,
         serverLease: GatewayConnection.ServerLease,
-        timeoutMs: Int) async -> Bool
+        deadline: ReconciliationDeadline) async -> Bool
     {
-        guard timeoutMs > 0,
+        let detectTimeoutMs = deadline.remainingMilliseconds(
+            cappedAt: Self.setupDetectionRequestTimeoutMs)
+        guard detectTimeoutMs > 0,
               self.isCurrentAttempt(context),
               !Task.isCancelled,
               OnboardingSystemAgentResumeStore.isOwned(
@@ -1093,7 +1085,7 @@ extension OnboardingAISetupModel {
         guard let detectData = try? await gateway.request(
             method: "openclaw.setup.detect",
             params: [:],
-            timeoutMs: Double(timeoutMs),
+            timeoutMs: Double(detectTimeoutMs),
             ifCurrentServerLease: serverLease),
             await gateway.isCurrentServerLease(serverLease),
             isCurrentAttempt(context),
@@ -1104,10 +1096,13 @@ extension OnboardingAISetupModel {
                 before: before,
                 after: detection.persistedActivationState)
         else { return false }
+        let verifyTimeoutMs = deadline.remainingMilliseconds(
+            cappedAt: Self.setupDetectionRequestTimeoutMs)
+        guard verifyTimeoutMs > 0 else { return false }
         guard let verifyData = try? await gateway.request(
             method: "openclaw.setup.verify",
             params: [:],
-            timeoutMs: Double(timeoutMs),
+            timeoutMs: Double(verifyTimeoutMs),
             ifCurrentServerLease: serverLease),
             await gateway.isCurrentServerLease(serverLease),
             isCurrentAttempt(context),

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -15,6 +15,8 @@ import OpenClawProtocol
 @MainActor
 @Observable
 final class OnboardingAISetupModel {
+    static let setupDetectionRequestTimeoutMs = 40_000
+
     /// Device-code providers advertise windows up to 15 minutes. Keep transport
     /// alive long enough for approval plus the post-login inference probe.
     static let providerAuthRequestTimeoutMs: Double = 1_200_000
@@ -613,7 +615,7 @@ extension OnboardingAISetupModel {
             let data = try await gateway.request(
                 method: "openclaw.setup.detect",
                 params: [:],
-                timeoutMs: 20000,
+                timeoutMs: Double(Self.setupDetectionRequestTimeoutMs),
                 ifCurrentServerLease: lease)
             guard await self.gateway.isCurrentServerLease(lease),
                   self.isCurrentAttempt(context),
@@ -1027,7 +1029,7 @@ extension OnboardingAISetupModel {
         originalServerLease: GatewayConnection.ServerLease) async -> Bool
     {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(30))
+        let deadline = clock.now.advanced(by: .seconds(45))
         var delayMs = 250
         while clock.now < deadline {
             guard self.isCurrentAttempt(context), !Task.isCancelled else { return false }
@@ -1049,7 +1051,7 @@ extension OnboardingAISetupModel {
                     timeoutMs: Self.remainingMilliseconds(
                         until: deadline,
                         clock: clock,
-                        cappedAt: 10000))
+                        cappedAt: Self.setupDetectionRequestTimeoutMs))
             {
                 self.serverLease = replacementLease
                 return true
@@ -1421,7 +1423,7 @@ extension OnboardingAISetupModel {
         guard let data = try? await gateway.request(
             method: "openclaw.setup.detect",
             params: [:],
-            timeoutMs: 10000,
+            timeoutMs: Double(Self.setupDetectionRequestTimeoutMs),
             ifCurrentServerLease: lease),
             token == attemptToken,
             let result = try? JSONDecoder().decode(DetectResult.self, from: data),

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -15,7 +15,7 @@ import OpenClawProtocol
 @MainActor
 @Observable
 final class OnboardingAISetupModel {
-    static let setupDetectionRequestTimeoutMs = 40_000
+    static let setupDetectionRequestTimeoutMs = 40000
 
     /// Device-code providers advertise windows up to 15 minutes. Keep transport
     /// alive long enough for approval plus the post-login inference probe.

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -24,6 +24,28 @@ extension OnboardingAISetupModel {
         let activationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?
     }
 
+    @MainActor
+    struct ReconciliationDeadline {
+        private let clock: ContinuousClock
+        private let deadline: ContinuousClock.Instant
+
+        init(timeout: ContinuousClock.Duration, clock: ContinuousClock = .init()) {
+            self.clock = clock
+            self.deadline = clock.now.advanced(by: timeout)
+        }
+
+        var hasTimeRemaining: Bool {
+            self.clock.now < self.deadline
+        }
+
+        func remainingMilliseconds(cappedAt capMs: Int) -> Int {
+            OnboardingAISetupModel.remainingMilliseconds(
+                until: self.deadline,
+                clock: self.clock,
+                cappedAt: capMs)
+        }
+    }
+
     struct DetectResult: Decodable {
         struct DetectedCandidate: Decodable {
             let brandId: String?

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -814,6 +814,16 @@ struct OnboardingAISetupTests {
         #expect(OnboardingAISetupModel.providerAuthRequestTimeoutMs > 15 * 60 * 1000)
     }
 
+    @Test func `reconciliation deadline recomputes each RPC budget`() async throws {
+        let deadline = OnboardingAISetupModel.ReconciliationDeadline(timeout: .seconds(2))
+        let detectionBudget = deadline.remainingMilliseconds(cappedAt: 10000)
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let verificationBudget = deadline.remainingMilliseconds(cappedAt: 10000)
+        #expect(verificationBudget < detectionBudget)
+    }
+
     @Test func `prepare choices use wire presentation and hide usable local models`() {
         let candidates = [
             OnboardingAISetupModel.Candidate(

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -512,6 +512,9 @@ openclaw gateway call logs.tail --params '{"limit": 200}'
   Machine-readable JSON output.
 </ParamField>
 
+`openclaw.setup.detect` uses a 40-second default so the Gateway can finish its
+bounded AI-access scan. An explicit `--timeout` still takes precedence.
+
 <Note>
 `--params` must be valid JSON, and each method validates its own param shape (extra/misnamed fields are rejected). Use `--port` for a custom-port local Gateway; explicit `--url` targets still require explicit credentials.
 </Note>

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -176,11 +176,11 @@ function parseClaudeCliOauthCredential(claudeOauth: unknown): ClaudeCliCredentia
   };
 }
 
-function resolveCodexHomePath(codexHome?: string) {
-  const configured = codexHome ?? process.env.CODEX_HOME;
+export function resolveCodexCliHomePath(codexHome?: string, env: NodeJS.ProcessEnv = process.env) {
+  const configured = codexHome ?? env.CODEX_HOME;
   // External CLI state belongs to the OS user, not OpenClaw's relocatable
   // home. Otherwise an isolated OPENCLAW_HOME hides an already logged-in CLI.
-  const home = resolveOsHomeRelativePath(configured || "~/.codex");
+  const home = resolveOsHomeRelativePath(configured || "~/.codex", { env });
   try {
     return fs.realpathSync.native(home);
   } catch {
@@ -274,7 +274,7 @@ function resolveCodexKeychainParams(options?: {
   return {
     platform: options?.platform ?? process.platform,
     execSyncImpl: options?.execSync ?? execSync,
-    codexHome: resolveCodexHomePath(options?.codexHome),
+    codexHome: resolveCodexCliHomePath(options?.codexHome),
   };
 }
 
@@ -703,7 +703,7 @@ function readCodexCliCredentials(options?: {
     }
   }
 
-  const authPath = path.join(resolveCodexHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
+  const authPath = path.join(resolveCodexCliHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
   const raw = loadJsonFileThroughSymlink(authPath);
   if (!raw || typeof raw !== "object") {
     return null;
@@ -727,7 +727,7 @@ export function readCodexCliCredentialsCached(options?: {
 }): CodexCliCredential | null {
   const platform = options?.platform ?? process.platform;
   const ttlMs = options?.ttlMs ?? 0;
-  const authPath = path.join(resolveCodexHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
+  const authPath = path.join(resolveCodexCliHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
   const keychainIntent =
     platform === "darwin" && options?.allowKeychainPrompt !== false ? "keychain" : "file";
   return readCachedCliCredential({

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -216,6 +216,15 @@ describe("gateway register option collisions", () => {
       },
     },
     {
+      name: "gives setup detection enough transport grace",
+      argv: ["gateway", "call", "openclaw.setup.detect", "--json"],
+      assert: () => {
+        const [method, opts] = firstGatewayCall();
+        expect(method).toBe("openclaw.setup.detect");
+        expect((opts as { timeout?: string } | undefined)?.timeout).toBe("40000");
+      },
+    },
+    {
       name: "projects gateway call --port into local config",
       argv: ["gateway", "call", "health", "--port", "19084", "--json"],
       assert: () => {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -58,6 +58,7 @@ const daemonStatusGatherModuleLoader = createLazyImportLoader(
 );
 
 const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
+const SETUP_INFERENCE_DETECT_RPC_TIMEOUT_MS = 40_000;
 type GatewayCliDependencies = {
   loadGatewayHealthModule?: typeof loadGatewayHealthModule;
   loadHealthStyleModule?: typeof loadHealthStyleModule;
@@ -579,7 +580,14 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .action(async (method, opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
+            // Setup detection owns a 30s worker deadline; its transport must
+            // leave enough grace for the Gateway to return the typed outcome.
+            const callOpts =
+              method === "openclaw.setup.detect" &&
+              command.getOptionValueSource("timeout") === "default"
+                ? { ...opts, timeout: String(SETUP_INFERENCE_DETECT_RPC_TIMEOUT_MS) }
+                : opts;
+            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(callOpts, command);
             const params = parseGatewayCallParams(String(opts.params ?? "{}"));
             const result = await callGatewayCli(method, rpcOpts, params);
             if (rpcOpts.json) {

--- a/src/commands/onboard-inference-ambient.test.ts
+++ b/src/commands/onboard-inference-ambient.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectAmbientInferenceBackends } from "./onboard-inference-ambient.js";
+
+const tempHomes = new Set<string>();
+
+async function createTempHome(): Promise<string> {
+  const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ambient-")));
+  tempHomes.add(home);
+  return home;
+}
+
+async function writeCredential(home: string, relativePath: string, value: unknown): Promise<void> {
+  const filePath = path.join(home, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(value), "utf8");
+}
+
+afterEach(async () => {
+  await Promise.all([...tempHomes].map((home) => fs.rm(home, { recursive: true, force: true })));
+  tempHomes.clear();
+});
+
+describe("detectAmbientInferenceBackends", () => {
+  it.each([
+    {
+      kind: "claude-cli" as const,
+      relativePath: ".claude/.credentials.json",
+      credential: {
+        claudeAiOauth: {
+          accessToken: "claude-access",
+          refreshToken: "claude-refresh",
+          expiresAt: Date.now() + 60_000,
+        },
+      },
+    },
+    {
+      kind: "codex-cli" as const,
+      relativePath: ".codex/auth.json",
+      credential: {
+        auth_mode: "chatgpt",
+        tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
+      },
+    },
+  ])("returns a verified $kind candidate only for readable file credentials", async (fixture) => {
+    const home = await createTempHome();
+    expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);
+
+    await writeCredential(home, fixture.relativePath, fixture.credential);
+
+    expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([
+      expect.objectContaining({ kind: fixture.kind, credentials: true }),
+    ]);
+  });
+});

--- a/src/commands/onboard-inference-ambient.ts
+++ b/src/commands/onboard-inference-ambient.ts
@@ -1,3 +1,11 @@
+import os from "node:os";
+import {
+  readClaudeCliCredentialsCached,
+  readCodexCliCredentialsCached,
+  resolveCodexCliHomePath,
+} from "../agents/cli-credentials.js";
+import { resolveOsHomeDir } from "../infra/home-dir.js";
+
 export const OPENAI_API_DEFAULT_MODEL_REF = "openai/gpt-5.6-sol";
 export const ANTHROPIC_API_DEFAULT_MODEL_REF = "anthropic/claude-opus-5";
 export const CLAUDE_CLI_DEFAULT_MODEL_REF = "claude-cli/claude-opus-5";
@@ -47,6 +55,40 @@ export function detectAmbientInferenceBackends(
       detail: "ANTHROPIC_API_KEY set",
       credentials: true,
     });
+  }
+  // An injected environment is authoritative; isolated detection must not
+  // fall through to another process user's home or prompt a keychain.
+  const homedir = env === process.env ? os.homedir : () => "";
+  const homeDir = resolveOsHomeDir(env, homedir);
+  const claudeCredential = homeDir
+    ? readClaudeCliCredentialsCached({ homeDir, allowKeychainPrompt: false, ttlMs: 0 })
+    : null;
+  if (claudeCredential && claudeCredential.type !== "api_key_helper") {
+    candidates.push({
+      kind: "claude-cli",
+      modelRef: CLAUDE_CLI_DEFAULT_MODEL_REF,
+      label: "Claude Code",
+      detail: "credential file found",
+      credentials: true,
+    });
+  }
+  try {
+    const codexHome =
+      homeDir || env.CODEX_HOME?.trim() ? resolveCodexCliHomePath(undefined, env) : undefined;
+    if (
+      codexHome &&
+      readCodexCliCredentialsCached({ codexHome, allowKeychainPrompt: false, ttlMs: 0 })
+    ) {
+      candidates.push({
+        kind: "codex-cli",
+        modelRef: CODEX_APP_SERVER_DEFAULT_MODEL_REF,
+        label: "Codex",
+        detail: "credential file found",
+        credentials: true,
+      });
+    }
+  } catch {
+    // No usable OS home means there is no prompt-free file credential to report.
   }
   return candidates;
 }

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -262,7 +262,9 @@ export async function detectInferenceBackends(
       credentials: true,
     });
   }
-  const envCandidates = detectAmbientInferenceBackends(env);
+  const envCandidates = detectAmbientInferenceBackends(env).filter(
+    (candidate) => candidate.kind === "openai-api-key" || candidate.kind === "anthropic-api-key",
+  );
 
   const [claudeProbe, codexProbe, geminiProbe] = await Promise.all([
     probe("claude"),

--- a/src/commands/onboard-remote-gateway.test.ts
+++ b/src/commands/onboard-remote-gateway.test.ts
@@ -153,7 +153,7 @@ describe("runRemoteGatewayInferenceOnboarding", () => {
         order.push(options.method);
 
         if (options.method === "openclaw.setup.detect") {
-          expect(options.timeoutMs).toBe(20_000);
+          expect(options.timeoutMs).toBe(40_000);
           return detectResult();
         }
         if (options.method === "openclaw.setup.activate") {

--- a/src/commands/onboard-remote-gateway.ts
+++ b/src/commands/onboard-remote-gateway.ts
@@ -19,7 +19,7 @@ import { t } from "../wizard/i18n/index.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
 import type { GuidedOnboardingDeps } from "./onboard-guided.js";
 
-const GATEWAY_SETUP_DETECT_TIMEOUT_MS = 20_000;
+const GATEWAY_SETUP_DETECT_TIMEOUT_MS = 40_000;
 const GATEWAY_SETUP_ACTIVATE_TIMEOUT_MS = 150_000;
 const GATEWAY_CODEX_SETUP_ACTIVATE_TIMEOUT_MS = 480_000;
 const GATEWAY_SETUP_VERIFY_TIMEOUT_MS = 30_000;

--- a/src/system-agent/inference-fallback.test.ts
+++ b/src/system-agent/inference-fallback.test.ts
@@ -34,6 +34,22 @@ const config: OpenClawConfig = {
 };
 
 describe("system-agent inference fallback", () => {
+  it("does not claim providers are unconfigured when no route can be verified", async () => {
+    const result = await verifySystemAgentInferenceWithFallback({
+      runtime,
+      deps: {
+        readConfig: async () => ({}),
+        resolveRoute: async () => null,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "unknown",
+      error: "OpenClaw could not verify a usable inference route. Check model setup and try again.",
+    });
+  });
+
   it("tries the system-agent route first, then authenticated providers by provider id", async () => {
     const attempts: string[] = [];
     const verify = vi.fn(async ({ agentId }: { agentId: string }) => {

--- a/src/system-agent/inference-fallback.ts
+++ b/src/system-agent/inference-fallback.ts
@@ -142,8 +142,8 @@ export async function verifySystemAgentInferenceWithFallback(params: {
   return (
     lastFailure ?? {
       ok: false,
-      status: "unavailable",
-      error: "No configured authenticated inference provider is available.",
+      status: "unknown",
+      error: "OpenClaw could not verify a usable inference route. Check model setup and try again.",
     }
   );
 }

--- a/src/system-agent/setup-inference-detection.test.ts
+++ b/src/system-agent/setup-inference-detection.test.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs/promises";
 import { createServer, get } from "node:http";
 import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "../agents/workspace-default.js";
@@ -57,6 +60,7 @@ function detectedCodex(): SetupInferenceDetection {
 }
 
 const servers = new Set<ReturnType<typeof createServer>>();
+const tempHomes = new Set<string>();
 
 beforeEach(() => {
   vi.resetModules();
@@ -82,15 +86,17 @@ async function requestHealth(url: string): Promise<{ body: string; statusCode: n
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(
-    [...servers].map(
+  await Promise.all([
+    ...[...servers].map(
       (server) =>
         new Promise<void>((resolve, reject) => {
           server.close((error) => (error ? reject(error) : resolve()));
         }),
     ),
-  );
+    ...[...tempHomes].map((home) => fs.rm(home, { recursive: true, force: true })),
+  ]);
   servers.clear();
+  tempHomes.clear();
 });
 
 describe("isolated setup inference detection", () => {
@@ -155,8 +161,8 @@ describe("isolated setup inference detection", () => {
     ).rejects.toMatchObject({
       name: "SetupInferenceDetectionTimeoutError",
       message:
-        "Checking this Gateway for AI access timed out after 0.05s. " +
-        "The Gateway may be busy — try again.",
+        "AI access detection did not finish after 0.05s. " +
+        "This Gateway may still be checking — try again.",
     });
   });
 
@@ -219,6 +225,45 @@ describe("isolated setup inference detection", () => {
     ]);
   });
 
+  it("returns stored CLI credentials when detection times out", async () => {
+    const { detectSetupInferenceIsolated } = await loadDetectionModule();
+    const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-detect-")));
+    tempHomes.add(home);
+    const authPath = path.join(home, ".codex", "auth.json");
+    await fs.mkdir(path.dirname(authPath), { recursive: true });
+    await fs.writeFile(
+      authPath,
+      JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
+      }),
+      "utf8",
+    );
+
+    const detection = await detectSetupInferenceIsolated({
+      workerUrl: blockingWorkerUrl,
+      workerData: {
+        blockMs: 10_000,
+        detection: emptyDetection(),
+        partialDetection: emptyDetection(),
+      },
+      timeoutMs: 50,
+      fallbackEnv: { HOME: home },
+    });
+
+    expect(detection.candidates).toEqual([
+      {
+        kind: "codex-cli",
+        brandId: "openai",
+        modelRef: "openai/gpt-5.6-sol",
+        label: "Codex",
+        detail: "credential file found",
+        credentials: true,
+        recommended: false,
+      },
+    ]);
+  });
+
   it("waits for timed-out worker shutdown before running a fresh detection", async () => {
     const { detectSetupInferenceIsolated } = await loadDetectionModule();
     let releaseShutdown: (() => void) | undefined;
@@ -240,7 +285,7 @@ describe("isolated setup inference detection", () => {
         timeoutMs: 50,
         fallbackEnv: {},
       }),
-    ).rejects.toThrow("Checking this Gateway for AI access timed out");
+    ).rejects.toThrow("AI access detection did not finish");
 
     let retrySettled = false;
     const fresh = detectedCodex();

--- a/src/system-agent/setup-inference-detection.ts
+++ b/src/system-agent/setup-inference-detection.ts
@@ -8,7 +8,7 @@ import { listRecommendedToolInstalls } from "../plugins/recommended-tool-install
 import { resolveSetupInferenceCandidateBrandId } from "./setup-inference-brand.js";
 import type { SetupInferenceDetection } from "./setup-inference.js";
 
-const SETUP_INFERENCE_DETECTION_TIMEOUT_MS = 10_000;
+const SETUP_INFERENCE_DETECTION_TIMEOUT_MS = 30_000;
 
 const log = createSubsystemLogger("system-agent/setup-inference-detection");
 
@@ -17,8 +17,8 @@ class SetupInferenceDetectionTimeoutError extends Error {
 
   constructor(timeoutMs: number) {
     super(
-      `Checking this Gateway for AI access timed out after ${timeoutMs / 1_000}s. ` +
-        "The Gateway may be busy — try again.",
+      `AI access detection did not finish after ${timeoutMs / 1_000}s. ` +
+        "This Gateway may still be checking — try again.",
     );
   }
 }

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -156,7 +156,7 @@ describe("model setup first-run redirect", () => {
     expect(request).toHaveBeenCalledWith(
       "openclaw.setup.detect",
       { agentId: "main" },
-      expect.objectContaining({ timeoutMs: 20_000 }),
+      expect.objectContaining({ timeoutMs: 40_000 }),
     );
     expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
     expect(

--- a/ui/src/pages/model-setup/state.ts
+++ b/ui/src/pages/model-setup/state.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../api/types.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
 
-export const MODEL_SETUP_DETECT_TIMEOUT_MS = 20_000;
+export const MODEL_SETUP_DETECT_TIMEOUT_MS = 40_000;
 export const MODEL_SETUP_VERIFY_TIMEOUT_MS = 30_000;
 const MODEL_SETUP_ACTIVATE_TIMEOUT_MS = 150_000;
 const MODEL_SETUP_CODEX_ACTIVATE_TIMEOUT_MS = 480_000;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI → Models → “Connect a verified AI model” hard-failed with `SetupInferenceDetectionTimeoutError: Checking this Gateway for AI access timed out after 10s. The Gateway may be busy — try again.` even though an ordinary agent turn on `openai/gpt-5.6-sol` had succeeded on the same Gateway minutes earlier. Because the Control UI “New agent” button routes through the custodian and the custodian gates on this detection, agent creation was unusable in that state.

## Why This Change Was Made

The live worker measurement showed the detection path was simply close to the old deadline:

```text
partial at 4846ms  candidates=0
RESULT at 7897ms   candidates=codex-cli:true, claude-cli:true
```

The 10-second budget was only the trigger. On timeout, `setup-inference-detection.ts` fell back to `detectAmbientInferenceBackends`, which read only `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` while declaring CLI backend kinds it never detected. The slow worker was therefore the only path that could see CLI-subscription logins—the same setup that made the probe slow—and the 4.8-second partial carried zero candidates.

This change makes prompt-free ambient detection recognize readable Claude Code and Codex CLI credential files through the canonical readers with keychain prompting disabled. It preserves the tri-state `credentials` contract; Gemini remains deliberately omitted because its auth is secure-store-backed and cannot be read prompt-free. A still-running probe now reports that detection did not finish instead of asserting that no provider is configured, and the downstream no-attempt fallback returns `unknown` with neutral wording.

The detection budget is raised from 10 to 30 seconds, with stacked caller budgets raised to 40 seconds for Control UI, remote onboarding, direct `gateway call openclaw.setup.detect`, and macOS. macOS restart reconciliation carries one monotonic 45-second deadline through lease acquisition, detection, and verification, recomputing the remaining timeout before each RPC. The direct CLI timeout is documented in `docs/cli/gateway.md`.

## User Impact

Operators using Claude Code or Codex subscription logins can complete model setup and create agents even when the full provider scan is slow. A genuinely unfinished scan no longer produces the false conclusion that the Gateway has no configured provider.

## Evidence

Before the fix, the isolated `OPENCLAW_STATE_DIR` Gateway reproduced two consecutive `SetupInferenceDetectionTimeoutError` failures at the 10-second budget. The operator’s Gateway was never used for this proof.

The fixed ambient fallback, called directly, returned the following instantly and without prompting:

```text
[{claude-cli, credential file found, credentials:true},{codex-cli, credential file found, credentials:true}]
```

After the fix, the same isolated rig and flow completed detection and rendered “Found on this Gateway — Claude Code · Credentials ready · logged in · Claude subscription” plus actionable local/sign-in options instead of dead-ending. That host’s Claude OAuth token is expired; the subsequent verify step reported that real credential state correctly rather than misreporting a detection failure.

![Model Setup detection succeeds](https://github.com/user-attachments/assets/f9abcd0d-012b-4a04-b7c9-6a711a9af051)

The implementing run captured 10 expected regressions when replaying the pre-fix production code, then passed:

- 58 focused tests across 6 files
- 88 adjacent credential/backend/gateway tests
- `pnpm tsgo`
- `pnpm check:test-types`
- targeted oxlint
- `pnpm format:check`
- `pnpm build`
- `pnpm check:docs`
- autoreview with no actionable findings

Landing follow-up proof:

- `pnpm build` passed after the initial rebase.
- The macOS deadline repair passed source formatting and compiled the full filtered Swift test bundle. Local XCTest launch remains blocked because `Sparkle.framework` is absent from the test runtime search paths; hosted `macos-swift` passed on the exact head.
- Remote `check:changed` passed with 336 tests across 7 Vitest shards (39 skipped) plus the native-state schema guard.
- Exact-head CI run [32008870671](https://github.com/openclaw/openclaw/actions/runs/32008870671) passed after rebasing onto the current main baseline.
- Final autoreview reported no accepted/actionable findings.

The matching Codex contract was checked directly in sibling Codex source: `codex-rs/utils/home-dir/src/lib.rs:5-17,52-60` defines `CODEX_HOME` and the `~/.codex` default; `codex-rs/config/defaults.toml:6` defaults CLI auth storage to `file`; `codex-rs/config/src/types.rs:104-116` defines file storage as `CODEX_HOME/auth.json`; and `codex-rs/login/src/auth/storage.rs:38-61,150-152,179-200,498-524` defines, locates, reads, and selects that auth file.

Numstat: production/docs +110/-36 (net +74, for the missing detection capability and bounded caller/reconciliation ownership); tests +145/-8.
