### PR TITLE
fix(ui): widen the review sidebar by default

### DIFF
--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -515,6 +515,10 @@ describeControlUiE2e("session diff panel", () => {
 
     const panel = page.locator(".session-diff");
     await expect.poll(() => panel.count()).toBe(1);
+    const panelSurface = page.locator(".side-panel").filter({ has: panel });
+    await expect
+      .poll(() => panelSurface.evaluate((element) => element.getBoundingClientRect().width))
+      .toBe(480);
     await expect
       .poll(() => panel.locator(".session-diff__branch-label").textContent())
       .toBe("main → feature/panel");

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
@@ -140,6 +140,6 @@ describe("chat pane sidebar layout", () => {
       paneWidth: 1_000,
     });
     expect(layout.columns).toHaveLength(1);
-    expect(layout.columns[0]?.width).toBe(360);
+    expect(layout.columns[0]?.width).toBe(480);
   });
 });

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -345,7 +345,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
     }
     const column = this.layout.columns[0];
     const dock = sidebarDock(this.layout);
-    const width = this.layout.expanded || dock === "bottom" ? "100%" : `${column?.width ?? 360}px`;
+    const width = this.layout.expanded || dock === "bottom" ? "100%" : `${column?.width ?? 480}px`;
     const height = this.layout.expanded || dock === "right" ? "100%" : `${column?.height ?? 360}px`;
     return html`${!this.narrow && !this.layout.expanded && column
         ? this.renderDivider(column)

--- a/ui/src/pages/chat/components/chat-sidebar-region.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.test.ts
@@ -322,6 +322,7 @@ describe("chat sidebar region", () => {
 
   it("offers expand and minimize controls in the no-tabs selector", async () => {
     const region = await createRegion({ columns: [], open: true });
+    expect(root(region).querySelector<HTMLElement>(".side-panel")?.style.width).toBe("480px");
     root(region).querySelector<HTMLButtonElement>(".side-panel__expand")?.click();
     root(region).querySelector<HTMLButtonElement>(".side-panel__minimize")?.click();
     expect(region.callbacks?.setExpanded).toHaveBeenCalledWith(true);

--- a/ui/src/pages/chat/sidebar-layout-normalize.ts
+++ b/ui/src/pages/chat/sidebar-layout-normalize.ts
@@ -1,7 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core";
 import type { SidebarLayout, SidebarPanel, SidebarSlotId } from "./sidebar-layout-types.ts";
 
-const DEFAULT_WIDTH = 360;
+const DEFAULT_WIDTH = 480;
 const DEFAULT_HEIGHT = 360;
 const MIN_WIDTH = 260;
 const MIN_HEIGHT = 220;

--- a/ui/src/pages/chat/sidebar-layout.test.ts
+++ b/ui/src/pages/chat/sidebar-layout.test.ts
@@ -29,7 +29,7 @@ describe("sidebar layout", () => {
     ]);
     expect(layout.columns[0]?.activePanelId).toBe("detail");
     expect(layout.columns[0]?.height).toBe(360);
-    expect(layout.columns[0]?.width).toBe(360);
+    expect(layout.columns[0]?.width).toBe(480);
     expect(layout.open).toBe(true);
   });
 
@@ -103,7 +103,7 @@ describe("sidebar layout", () => {
 
     expect(resized.dock).toBe("bottom");
     expect(resized.columns[0]?.height).toBe(480);
-    expect(resized.columns[0]?.width).toBe(360);
+    expect(resized.columns[0]?.width).toBe(480);
     expect(fitSidebarLayout(resized, 560)).toEqual(resized);
   });
 
@@ -153,6 +153,17 @@ describe("sidebar layout", () => {
 
   it("deduplicates slots and repairs untrusted persisted values", () => {
     expect(normalizeSidebarLayout(null)).toEqual({ columns: [], open: false, expanded: false });
+    expect(
+      normalizeSidebarLayout({
+        columns: [
+          {
+            id: "review",
+            side: "right",
+            panels: [{ id: "detail", slot: "detail" }],
+          },
+        ],
+      }).columns[0]?.width,
+    ).toBe(480);
     expect(normalizeSidebarLayout({ columns: "nope" })).toEqual({
       columns: [],
       open: false,

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -13,7 +13,7 @@ export type {
   SidebarSlotId,
 } from "./sidebar-layout-types.ts";
 
-const SIDEBAR_DEFAULT_WIDTH_PX = 360;
+const SIDEBAR_DEFAULT_WIDTH_PX = 480;
 const SIDEBAR_DEFAULT_HEIGHT_PX = 360;
 export const SIDEBAR_MIN_WIDTH_PX = 260;
 export const SIDEBAR_MIN_HEIGHT_PX = 220;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the code review panel would get a cramped 360 px sidebar by default.

## Why This Change Was Made

The shared chat sidebar now defaults to 480 px across new layouts, missing-width normalization, and the empty/type-picker state. Explicit persisted user widths remain unchanged.

## User Impact

Code review opens with 120 px more horizontal space, while manual resizing and persisted layouts keep working as before.

## Evidence

- Pre-fix owner tests failed with `received 360`, expected `480` for new layouts, normalization, and the empty state.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-sidebar-layout.test.ts ui/src/pages/chat/sidebar-layout.test.ts ui/src/pages/chat/components/chat-sidebar-region.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-session-diff.e2e.test.ts` — 8/8 passed; browser assertion verifies the rendered Review sidebar is 480 px.
- Fresh full-branch Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +3/-3 (net 0). Tests: +19/-3.
