### PR TITLE
fix(plugins): report malformed manifests during metadata discovery

### DIFF
--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -2,11 +2,29 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { loadPluginManifest } from "./manifest.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+
+const { manifestScanWarn } = vi.hoisted(() => ({
+  manifestScanWarn: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../logging/subsystem.js")>("../logging/subsystem.js");
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "plugins/manifest-metadata-scan"
+        ? { ...logger, warn: manifestScanWarn }
+        : logger;
+    },
+  };
+});
 
 const tempRoots: string[] = [];
 
@@ -21,7 +39,42 @@ function writeJson(filePath: string, value: unknown): void {
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
 }
 
+function createGlobalPluginFixture(pluginName: string) {
+  const root = createTempRoot();
+  const home = path.join(root, "home");
+  const pluginDir = path.join(home, ".openclaw", "extensions", pluginName);
+  const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  return {
+    pluginDir,
+    manifestPath,
+    env: {
+      OPENCLAW_HOME: home,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "empty-bundled"),
+    },
+  };
+}
+
+function warningMessagesForPath(manifestPath: string): string[] {
+  return manifestScanWarn.mock.calls
+    .map(([message]) => String(message))
+    .filter((message) => message.includes(manifestPath));
+}
+
+function expectPluginAbsentAcrossTwoScans(pluginDir: string, env: NodeJS.ProcessEnv): void {
+  for (const records of [
+    listOpenClawPluginManifestMetadata(env),
+    listOpenClawPluginManifestMetadata(env),
+  ]) {
+    expect(records.find((record) => record.pluginDir === pluginDir)).toBeUndefined();
+  }
+}
+
 describe("listOpenClawPluginManifestMetadata", () => {
+  beforeEach(() => {
+    manifestScanWarn.mockClear();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     clearPluginMetadataLifecycleCaches();
@@ -248,14 +301,75 @@ describe("listOpenClawPluginManifestMetadata", () => {
     );
     expect(fs.statSync(oversizedPath).size).toBeGreaterThan(256 * 1024);
 
-    const records = listOpenClawPluginManifestMetadata({
+    const env = {
       OPENCLAW_HOME: home,
       OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "empty-bundled"),
-    });
+    };
+    const records = listOpenClawPluginManifestMetadata(env);
+    const cachedRecords = listOpenClawPluginManifestMetadata(env);
 
     // "good-plugin" is present; "big-plugin" is skipped due to oversized manifest.
     expect(records.find((record) => record.manifest.id === "good-plugin")).toBeTruthy();
     expect(records.find((record) => record.manifest.id === "big-plugin")).toBeUndefined();
+    expect(cachedRecords).toEqual(records);
+    expect(warningMessagesForPath(oversizedPath)).toEqual([
+      `Ignoring oversized plugin manifest at ${oversizedPath}: file exceeds the 262144-byte limit`,
+    ]);
+  });
+
+  it.each([
+    {
+      name: "malformed JSON and JSON5",
+      contents: "{invalid",
+    },
+    {
+      name: "valid non-object JSON",
+      contents: "[]",
+    },
+  ])("skips $name and warns once across cache hits", ({ contents }) => {
+    const { pluginDir, manifestPath, env } = createGlobalPluginFixture("invalid-plugin");
+    fs.writeFileSync(manifestPath, contents, "utf8");
+
+    const canonicalResult = loadPluginManifest(pluginDir, false);
+    assert(!canonicalResult.ok);
+
+    expectPluginAbsentAcrossTwoScans(pluginDir, env);
+    expect(warningMessagesForPath(manifestPath)).toEqual([
+      `Ignoring invalid plugin manifest at ${manifestPath}: ${canonicalResult.error}`,
+    ]);
+  });
+
+  it("warns once for a present non-regular manifest across cache hits", () => {
+    const { pluginDir, manifestPath, env } = createGlobalPluginFixture("non-regular-plugin");
+    fs.mkdirSync(manifestPath);
+
+    expectPluginAbsentAcrossTwoScans(pluginDir, env);
+    expect(warningMessagesForPath(manifestPath)).toEqual([
+      `Ignoring unreadable plugin manifest at ${manifestPath}: Error: path must be a regular file`,
+    ]);
+  });
+
+  it("silently skips a child plugin directory with no manifest across cache hits", () => {
+    const { pluginDir, manifestPath, env } = createGlobalPluginFixture("missing-manifest-plugin");
+
+    expectPluginAbsentAcrossTwoScans(pluginDir, env);
+    expect(warningMessagesForPath(manifestPath)).toEqual([]);
+  });
+
+  it("accepts JSON5 manifests without warning when strict JSON parsing fails", () => {
+    const { pluginDir, manifestPath, env } = createGlobalPluginFixture("json5-plugin");
+    const contents = "{ id: 'json5-plugin', }";
+    fs.writeFileSync(manifestPath, contents, "utf8");
+    expect(() => JSON.parse(contents)).toThrow();
+
+    const records = listOpenClawPluginManifestMetadata(env);
+
+    expect(records).toContainEqual({
+      pluginDir,
+      manifest: { id: "json5-plugin" },
+      origin: "global",
+    });
+    expect(warningMessagesForPath(manifestPath)).toEqual([]);
   });
 
   it("accepts plugin manifests at the exact byte limit", () => {

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -6,6 +6,7 @@ import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/nor
 import { resolveRealpathOrAbsolute } from "../infra/boundary-path.js";
 import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { hasNodeErrorCode, isNotFoundPathError } from "../infra/path-guards.js";
 import { readRegularFileSync } from "../infra/regular-file.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
@@ -71,21 +72,42 @@ function listChildPluginDirs(
 }
 
 function readJsonObject(filePath: string): Record<string, unknown> | undefined {
+  let raw: string;
   try {
     const { buffer } = readRegularFileSync({
       filePath,
       maxBytes: PLUGIN_MANIFEST_METADATA_MAX_BYTES,
     });
-    const parsed = parseJsonWithJson5Fallback(buffer.toString("utf-8"));
-    return isRecord(parsed) ? parsed : undefined;
-  } catch (err) {
-    if (err instanceof Error && err.message.includes("exceeds")) {
+    raw = buffer.toString("utf-8");
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return undefined;
+    }
+    if (hasNodeErrorCode(error, "too-large")) {
       log.warn(
         `Ignoring oversized plugin manifest at ${filePath}: file exceeds the ${PLUGIN_MANIFEST_METADATA_MAX_BYTES}-byte limit`,
       );
+    } else {
+      log.warn(`Ignoring unreadable plugin manifest at ${filePath}: ${String(error)}`);
     }
     return undefined;
   }
+
+  let parsed: unknown;
+  try {
+    parsed = parseJsonWithJson5Fallback(raw);
+  } catch (error) {
+    log.warn(
+      `Ignoring invalid plugin manifest at ${filePath}: failed to parse plugin manifest: ${String(error)}`,
+    );
+    return undefined;
+  }
+
+  if (!isRecord(parsed)) {
+    log.warn(`Ignoring invalid plugin manifest at ${filePath}: plugin manifest must be an object`);
+    return undefined;
+  }
+  return parsed;
 }
 
 function readManifestObject(pluginDir: string): Record<string, unknown> | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the lightweight plugin metadata scan silently dropped present manifests that were unreadable, malformed, or valid JSON with a non-object top level. Providers, auth markers, static model catalogs, and doctor migrations could then lose plugin metadata without leaving an operator-visible explanation.

Missing optional manifests remain silent because candidate directories are not guaranteed to be plugins.

## Why This Change Was Made

The metadata scanner now owns explicit read, parse, and shape outcomes:

- missing paths are skipped silently;
- unreadable and oversized manifests produce path-specific warnings;
- failures of both JSON and JSON5 parsing produce the same canonical parse reason as the full manifest loader;
- valid non-object JSON produces the canonical `plugin manifest must be an object` reason;
- valid JSON5 remains accepted;
- lifecycle-cache hits do not repeat warnings until explicit plugin metadata invalidation.

This remains a lightweight raw-metadata scan: it does not add `id`, `configSchema`, or full manifest-schema validation, and it introduces no logger or cache test seam.

This is distinct from #125414: that PR owns managed plugin install transactions and persistence rollback, while this PR only reports metadata discovery failures without mutating installed payloads or durable state.

Provenance: the scanner originated in direct commit `e508d81f7947` (2026-04-28). PR #110036 added bounded reads and an oversized-only warning on 2026-07-18, leaving the other failure branches silent.

## User Impact

Operators now receive one actionable warning with the manifest path and failure reason when installed plugin metadata cannot be consumed, instead of capabilities disappearing silently. Valid and absent manifests behave as before.

## Evidence

- Regression-first proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/plugins/manifest-metadata-scan.test.ts` failed before the production repair with exactly 3 failures / 10 passes: malformed, non-object, and present non-regular manifests emitted no warning.
- Current-main focused proof: the same owner-boundary suite passes 14/14 tests at `0e00c4c89a2905afa658bec0da88f7856e7f2bc2`, including lifecycle cache invalidation from current `main`.
- Dependency contract checked directly: `readRegularFileSync` preserves `ENOENT`, reports `too-large` structurally, and rejects non-regular paths; the scanner uses canonical path-error helpers rather than message matching.
- Exact-head PR CI: [run 32072603232](https://github.com/openclaw/openclaw/actions/runs/32072603232) passed with 147 jobs successful, 15 skipped, and no failures.
- Fresh exact-head Codex-backed autoreview: clean, no accepted/actionable findings.
- Production LOC: +26/-4 (net +22), replacing one catch-all silent path with explicit missing/read/size/parse/shape outcomes. Tests: +117/-3 (net +114), covering every requested category and lifecycle-cache behavior at the public scan boundary.
- No external API, protocol, config, persistence, install transaction, or plugin schema contract changed.

AI-assisted: yes.
