### PR TITLE
fix(qa): reject suite summaries with missing outcomes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1113,7 +1113,7 @@ extensions/qa-lab/src/suite-runtime-agent-process.ts	7
 extensions/qa-lab/src/suite-runtime-agent-session.ts	5
 extensions/qa-lab/src/suite-runtime-agent-tools.ts	1
 extensions/qa-lab/src/suite-runtime-gateway.ts	2
-extensions/qa-lab/src/suite-summary.ts	6
+extensions/qa-lab/src/suite-summary.ts	5
 extensions/qa-lab/src/suite-support.ts	1
 extensions/qa-lab/src/test-file-scenario-script-evidence.ts	2
 extensions/qa-lab/src/test-file-scenario-vitest-report.ts	1

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -507,6 +507,84 @@ describe("qa cli runtime", () => {
     );
   });
 
+  it("rejects a direct suite summary with unaccounted outcomes", async () => {
+    await fs.writeFile(
+      suiteSummaryPath,
+      JSON.stringify({
+        counts: { total: 2, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+      }),
+      "utf8",
+    );
+    runQaSuite.mockResolvedValueOnce(
+      unifiedSuiteRuntimeResult({
+        outputDir: suiteArtifactsDir,
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+        evidencePath: suiteEvidencePath,
+      }),
+    );
+
+    await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toMatchObject({
+      code: "summary_counts_invalid",
+    });
+  });
+
+  it("rejects a direct suite summary whose canonical evidence contradicts its counts", async () => {
+    await fs.writeFile(
+      suiteSummaryPath,
+      JSON.stringify({
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+        evidence: { entries: [{ result: { status: "fail" } }] },
+      }),
+      "utf8",
+    );
+    runQaSuite.mockResolvedValueOnce(
+      unifiedSuiteRuntimeResult({
+        outputDir: suiteArtifactsDir,
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+        evidencePath: suiteEvidencePath,
+      }),
+    );
+
+    await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toMatchObject({
+      code: "summary_counts_invalid",
+    });
+  });
+
+  it("accepts a passing scenario with lower-level blocked and passing producer checks", async () => {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    await fs.writeFile(
+      suiteSummaryPath,
+      JSON.stringify({
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+        evidence: {
+          entries: [{ result: { status: "blocked" } }, { result: { status: "pass" } }],
+        },
+      }),
+      "utf8",
+    );
+    runQaSuite.mockResolvedValueOnce(
+      unifiedSuiteRuntimeResult({
+        outputDir: suiteArtifactsDir,
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+        evidencePath: suiteEvidencePath,
+      }),
+    );
+
+    try {
+      await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
   it("keeps a direct suite green for a real pass and a report-only optional tool skip", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
@@ -624,12 +702,10 @@ describe("qa cli runtime", () => {
         await fs.writeFile(
           suiteSummaryPath,
           JSON.stringify({
-            counts: {
-              total: 1,
-              passed: 0,
-              failed: 0,
-              skipped: summary === "required-skip" ? 1 : 0,
-            },
+            counts:
+              summary === "required-skip"
+                ? { total: 1, passed: 0, failed: 0, skipped: 1 }
+                : { total: 1 },
             scenarios: [
               {
                 name: "Required channel scenario",

--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -750,7 +750,7 @@ describe("qa confidence report", () => {
     for (const [artifact, expectedDetail] of [
       [
         { counts: { total: 1, passed: -1, skipped: 0, failed: 0 } },
-        "counts.passed must be a non-negative integer",
+        "counts.passed must be a non-negative safe integer",
       ],
       [
         { counts: { total: 1, passed: 2, failed: 0 } },

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -26,6 +26,7 @@ import {
   type RuntimeParityResult,
   type RuntimeParityToolCall,
 } from "./runtime-parity.js";
+import { findQaSuiteSummaryAccountingError } from "./suite-summary.js";
 import { buildTokenEfficiencyReport } from "./token-efficiency-report.js";
 
 const QA_CONFIDENCE_VERDICTS = [
@@ -364,44 +365,19 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
       details: "qa-suite-summary payload was not an object",
     };
   }
-  const counts = isRecord(payload.counts) ? payload.counts : undefined;
-  for (const key of ["total", "passed", "failed", "skipped"] as const) {
-    if (counts && Object.hasOwn(counts, key) && readCount(counts[key]) === undefined) {
-      return {
-        passed: false,
-        status: "unknown",
-        details: `qa-suite-summary counts.${key} must be a non-negative integer`,
-      };
-    }
+  const accountingError = findQaSuiteSummaryAccountingError(payload);
+  if (accountingError) {
+    return {
+      passed: false,
+      status: "unknown",
+      details: `qa-suite-summary ${accountingError}`,
+    };
   }
+  const counts = isRecord(payload.counts) ? payload.counts : undefined;
   const totalCount = readCount(counts?.total);
   const passedCount = readCount(counts?.passed);
   const failedCount = readCount(counts?.failed);
   const explicitSkippedCount = readCount(counts?.skipped);
-  if (totalCount !== undefined) {
-    const providedCountSum = (passedCount ?? 0) + (failedCount ?? 0) + (explicitSkippedCount ?? 0);
-    if (totalCount < providedCountSum) {
-      return {
-        passed: false,
-        status: "unknown",
-        details: `qa-suite-summary counts.total=${totalCount} is less than provided count sum=${providedCountSum}`,
-      };
-    }
-    if (
-      passedCount !== undefined &&
-      failedCount !== undefined &&
-      explicitSkippedCount !== undefined &&
-      totalCount !== providedCountSum
-    ) {
-      return {
-        passed: false,
-        status: "unknown",
-        details: `qa-suite-summary counts.total=${totalCount} does not match counts.passed+counts.failed+counts.skipped=${
-          providedCountSum
-        }`,
-      };
-    }
-  }
   const scenarios = Array.isArray(payload.scenarios) ? payload.scenarios : undefined;
   const failedScenarios = scenarios?.filter(
     (scenario) => isRecord(scenario) && scenario.status === "fail",

--- a/extensions/qa-lab/src/errors.ts
+++ b/extensions/qa-lab/src/errors.ts
@@ -11,6 +11,7 @@ type QaSuiteArtifactErrorCode =
   | "summary_missing"
   | "summary_read_failed"
   | "summary_parse_failed"
+  | "summary_counts_invalid"
   | "summary_failure_count_missing"
   | "summary_blocking_count_missing";
 

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -57,15 +57,20 @@ describe("Telegram live QA scenario gate", () => {
   let summaryPath: string;
 
   function writeSummary(status: string) {
+    const skipped = status === "skip" || status === "skipped";
+    const counts =
+      status === "pass" || status === "fail" || skipped
+        ? {
+            total: 1,
+            passed: status === "pass" ? 1 : 0,
+            failed: status === "fail" ? 1 : 0,
+            skipped: skipped ? 1 : 0,
+          }
+        : { total: 1 };
     writeFileSync(
       summaryPath,
       JSON.stringify({
-        counts: {
-          total: 1,
-          passed: status === "pass" ? 1 : 0,
-          failed: status === "fail" ? 1 : 0,
-          skipped: status === "skip" || status === "skipped" ? 1 : 0,
-        },
+        counts,
         scenarios: [{ name: "channel-canary", status }],
       }),
       "utf8",

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -52,27 +52,59 @@ describe("qa suite summary helpers", () => {
   it.each([
     ["failure", readQaSuiteFailedScenarioCountFromFile],
     ["failure and skip", readQaSuiteFailedOrSkippedScenarioCountFromFile],
-  ] as const)(
-    "does not authenticate a positive total without completed %s evidence",
-    async (_name, reader) => {
-      await expect(
-        readSummary({ counts: { total: 1, passed: 0, failed: 0, skipped: 0 } }, reader),
-      ).rejects.toThrow("did not include any executed scenarios");
-    },
-  );
+  ] as const)("rejects a positive total without accounted %s outcomes", async (_name, reader) => {
+    await expect(
+      readSummary({ counts: { total: 1, passed: 0, failed: 0, skipped: 0 } }, reader),
+    ).rejects.toMatchObject({ code: "summary_counts_invalid" });
+  });
 
-  it("does not let a claimed passed count override observed skipped-only scenarios", async () => {
+  it.each([
+    {
+      name: "unaccounted total",
+      summary: {
+        counts: { total: 2, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+      },
+    },
+    {
+      name: "contradictory pass count",
+      summary: {
+        counts: { total: 1, passed: 0, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+      },
+    },
+    {
+      name: "contradictory scenario statuses",
+      summary: {
+        counts: { total: 2, passed: 1, failed: 1, skipped: 0 },
+        scenarios: [{ status: "pass" }, { status: "pass" }],
+      },
+    },
+  ])("rejects complete suite accounting with $name", async ({ summary }) => {
+    for (const reader of [
+      readQaSuiteFailedScenarioCountFromFile,
+      readQaSuiteFailedOrSkippedScenarioCountFromFile,
+    ]) {
+      await expect(readSummary(summary, reader)).rejects.toMatchObject({
+        code: "summary_counts_invalid",
+      });
+    }
+  });
+
+  it("rejects a claimed pass that contradicts observed skipped-only scenarios", async () => {
     const summary = {
       counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
       scenarios: [{ name: "never executed", status: "skip" }],
     };
 
-    await expect(readSummary(summary, readQaSuiteFailedScenarioCountFromFile)).rejects.toThrow(
-      "did not include any executed scenarios",
-    );
-    await expect(
-      readSummary(summary, readQaSuiteFailedOrSkippedScenarioCountFromFile),
-    ).resolves.toBe(1);
+    for (const reader of [
+      readQaSuiteFailedScenarioCountFromFile,
+      readQaSuiteFailedOrSkippedScenarioCountFromFile,
+    ]) {
+      await expect(readSummary(summary, reader)).rejects.toMatchObject({
+        code: "summary_counts_invalid",
+      });
+    }
   });
 
   it.each([
@@ -175,14 +207,14 @@ describe("qa suite summary helpers", () => {
     {
       name: "blocked scenario",
       summary: {
-        counts: { total: 1, passed: 0, failed: 0, skipped: 0 },
+        counts: { total: 1 },
         scenarios: [{ name: "required scenario", status: "blocked" }],
       },
     },
     {
       name: "blocked evidence",
       summary: {
-        counts: { total: 1, passed: 0, failed: 0, skipped: 0 },
+        counts: { total: 1 },
         entries: [{ result: { status: "blocked" } }],
       },
     },
@@ -283,23 +315,46 @@ describe("qa suite summary helpers", () => {
     },
   );
 
-  it.each([
-    ["blocked", { status: "blocked" }],
-    ["timeout", { status: "timeout" }],
-    ["error", { status: "error" }],
-    ["missing", {}],
-  ] as const)("keeps standalone %s evidence fail-closed in both gates", async (_name, result) => {
+  it("uses scenario outcomes instead of counting lower-level producer checks", async () => {
     const summary = {
       counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
       scenarios: [{ status: "pass" }],
-      entries: [{ result }],
+      evidence: {
+        entries: [{ result: { status: "blocked" } }, { result: { status: "pass" } }],
+      },
     };
 
-    await expect(readSummary(summary, readQaSuiteFailedScenarioCountFromFile)).resolves.toBe(1);
-    await expect(
-      readSummary(summary, readQaSuiteFailedOrSkippedScenarioCountFromFile),
-    ).resolves.toBe(1);
+    for (const reader of [
+      readQaSuiteFailedScenarioCountFromFile,
+      readQaSuiteFailedOrSkippedScenarioCountFromFile,
+    ]) {
+      await expect(readSummary(summary, reader)).resolves.toBe(0);
+    }
   });
+
+  it.each([
+    ["timeout", { status: "timeout" }],
+    ["error", { status: "error" }],
+    ["missing", {}],
+  ] as const)(
+    "rejects unsupported %s evidence alongside complete counts",
+    async (_name, result) => {
+      const summary = {
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+        entries: [{ result }],
+      };
+
+      for (const reader of [
+        readQaSuiteFailedScenarioCountFromFile,
+        readQaSuiteFailedOrSkippedScenarioCountFromFile,
+      ]) {
+        await expect(readSummary(summary, reader)).rejects.toMatchObject({
+          code: "summary_counts_invalid",
+        });
+      }
+    },
+  );
 
   it("rejects evidence-only results without an observed status", async () => {
     await expect(
@@ -401,7 +456,7 @@ describe("qa suite summary helpers", () => {
     ).resolves.toBe(1);
   });
 
-  it("never lets an optional skip cancel a declared failure or unknown evidence", async () => {
+  it("rejects optional skip summaries that contradict counts", async () => {
     const optionalScenario = {
       name: "optional tool fixture",
       status: "skip",
@@ -420,17 +475,7 @@ describe("qa suite summary helpers", () => {
         },
         readWithOptionalPolicy,
       ),
-    ).resolves.toBe(1);
-    await expect(
-      readSummary(
-        {
-          counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
-          scenarios: [optionalScenario],
-          entries: [{ result: { status: "timeout" } }],
-        },
-        readWithOptionalPolicy,
-      ),
-    ).resolves.toBe(1);
+    ).rejects.toMatchObject({ code: "summary_counts_invalid" });
   });
 
   it("uses the larger failure signal when counts and scenarios disagree", async () => {
@@ -457,13 +502,15 @@ describe("qa suite summary helpers", () => {
     ).resolves.toBe(1);
   });
 
-  it("counts evidence entry results", async () => {
+  it("counts canonical evidence entry results", async () => {
     const summary = {
-      entries: [
-        { result: { status: "pass" } },
-        { result: { status: "fail" } },
-        { result: { status: "skipped" } },
-      ],
+      evidence: {
+        entries: [
+          { result: { status: "pass" } },
+          { result: { status: "fail" } },
+          { result: { status: "skipped" } },
+        ],
+      },
     };
 
     await expect(readSummary(summary, readQaSuiteFailedScenarioCountFromFile)).resolves.toBe(1);

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -77,11 +77,16 @@ type QaSuiteReportOnlyScenario = {
   status?: unknown;
   details?: unknown;
 };
-type QaEvidenceEntryStatus = {
-  result?: {
-    status?: unknown;
-  };
-};
+function readQaSuiteEvidenceEntries(summary: Record<string, unknown>): unknown[] | undefined {
+  if (isRecord(summary.evidence) && Array.isArray(summary.evidence.entries)) {
+    return summary.evidence.entries;
+  }
+  return Array.isArray(summary.entries) ? summary.entries : undefined;
+}
+
+function readQaSuiteEvidenceEntryStatus(entry: unknown): unknown {
+  return isRecord(entry) && isRecord(entry.result) ? entry.result.status : undefined;
+}
 
 function isQaSuiteFailureStatus(status: unknown): boolean {
   return status !== "pass" && status !== "skip" && status !== "skipped";
@@ -113,6 +118,119 @@ function readNonNegativeCount(value: unknown): number | null {
   return asSafeIntegerInRange(value, { min: 0 }) ?? null;
 }
 
+type QaSuiteOutcomeCounts = {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+};
+
+function countQaSuiteScenarioStatuses(statuses: readonly unknown[]): QaSuiteOutcomeCounts {
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  for (const status of statuses) {
+    if (status === "pass") {
+      passed += 1;
+    } else if (status === "skip" || status === "skipped") {
+      skipped += 1;
+    } else {
+      failed += 1;
+    }
+  }
+  return { total: statuses.length, passed, failed, skipped };
+}
+
+function isQaSuiteScenarioOutcomeStatus(status: unknown): boolean {
+  return status === "pass" || status === "fail" || status === "skip" || status === "skipped";
+}
+
+function isQaSuiteEvidenceOutcomeStatus(status: unknown): boolean {
+  return (
+    status === "pass" ||
+    status === "fail" ||
+    status === "blocked" ||
+    status === "skip" ||
+    status === "skipped"
+  );
+}
+
+function findQaSuiteScenarioCountMismatch(
+  counts: QaSuiteOutcomeCounts,
+  observed: QaSuiteOutcomeCounts,
+): string | undefined {
+  for (const key of ["total", "passed", "failed", "skipped"] as const) {
+    if (counts[key] !== observed[key]) {
+      return `count/scenario mismatch: counts.${key}=${counts[key]}, scenario.${key}=${observed[key]}`;
+    }
+  }
+  return undefined;
+}
+
+export function findQaSuiteSummaryAccountingError(summary: unknown): string | undefined {
+  if (!isRecord(summary) || summary.counts === undefined) {
+    return undefined;
+  }
+  if (!isRecord(summary.counts)) {
+    return "counts must be a non-array object";
+  }
+  for (const countName of ["total", "passed", "failed", "skipped"] as const) {
+    if (
+      Object.hasOwn(summary.counts, countName) &&
+      readNonNegativeCount(summary.counts[countName]) === null
+    ) {
+      return `counts.${countName} must be a non-negative safe integer`;
+    }
+  }
+
+  const total = readNonNegativeCount(summary.counts.total);
+  const passed = readNonNegativeCount(summary.counts.passed);
+  const failed = readNonNegativeCount(summary.counts.failed);
+  const skipped = readNonNegativeCount(summary.counts.skipped);
+  const providedCountSum = (passed ?? 0) + (failed ?? 0) + (skipped ?? 0);
+  if (total !== null && total < providedCountSum) {
+    return `counts.total=${total} is less than provided count sum=${providedCountSum}`;
+  }
+  if (total === null || passed === null || failed === null || skipped === null) {
+    return undefined;
+  }
+  if (total !== providedCountSum) {
+    return `counts.total=${total} does not match counts.passed+counts.failed+counts.skipped=${providedCountSum}`;
+  }
+
+  const counts = { total, passed, failed, skipped };
+  if (Array.isArray(summary.scenarios) && summary.scenarios.length > 0) {
+    const statuses = summary.scenarios.map((scenario) =>
+      isRecord(scenario) ? scenario.status : undefined,
+    );
+    if (statuses.every(isQaSuiteScenarioOutcomeStatus)) {
+      const mismatch = findQaSuiteScenarioCountMismatch(
+        counts,
+        countQaSuiteScenarioStatuses(statuses),
+      );
+      if (mismatch) {
+        return mismatch;
+      }
+    }
+  }
+  const evidenceEntries = readQaSuiteEvidenceEntries(summary);
+  if (evidenceEntries && evidenceEntries.length > 0) {
+    // Evidence rows are producer checks, not scenarios: one passing scenario may
+    // legitimately contain blocked and passing checks. Validate only facts that
+    // can contradict the aggregate without assuming one row per scenario.
+    for (const [index, entry] of evidenceEntries.entries()) {
+      const status = readQaSuiteEvidenceEntryStatus(entry);
+      if (!isQaSuiteEvidenceOutcomeStatus(status)) {
+        return `evidence.entries[${index}].result.status is not a supported outcome`;
+      }
+      if (status === "fail" && failed === 0) {
+        return `counts.failed=0 contradicts failed evidence entry ${index}`;
+      }
+    }
+  }
+  return undefined;
+}
+
 function assertQaSuiteSummaryHasExecutedScenarios(
   summary: unknown,
   summaryPath: string,
@@ -123,45 +241,32 @@ function assertQaSuiteSummaryHasExecutedScenarios(
   if (!summary || typeof summary !== "object") {
     return;
   }
+  const accountingError = findQaSuiteSummaryAccountingError(summary);
+  if (accountingError) {
+    throw new QaSuiteArtifactError(
+      "summary_counts_invalid",
+      `QA summary at ${summaryPath} ${accountingError}.`,
+    );
+  }
   const payload = summary as {
     counts?: { total?: unknown; passed?: unknown; failed?: unknown; skipped?: unknown };
     scenarios?: unknown;
-    entries?: unknown;
   };
-  if (payload.counts !== undefined) {
-    if (!isRecord(payload.counts)) {
-      throw new QaSuiteArtifactError(
-        errorCode,
-        `QA summary at ${summaryPath} counts must be a non-array object.`,
-      );
-    }
-    for (const countName of ["total", "passed", "failed", "skipped"] as const) {
-      if (
-        Object.hasOwn(payload.counts, countName) &&
-        readNonNegativeCount(payload.counts[countName]) === null
-      ) {
-        throw new QaSuiteArtifactError(
-          errorCode,
-          `QA summary at ${summaryPath} counts.${countName} must be a non-negative safe integer.`,
-        );
-      }
-    }
-  }
   const total = readNonNegativeCount(payload.counts?.total);
   const passed = readNonNegativeCount(payload.counts?.passed);
   const failed = readNonNegativeCount(payload.counts?.failed);
   const scenarios = Array.isArray(payload.scenarios)
     ? (payload.scenarios as QaSuiteReportOnlyScenario[])
     : undefined;
-  const entries = Array.isArray(payload.entries)
-    ? (payload.entries as QaEvidenceEntryStatus[])
-    : undefined;
+  const entries = isRecord(summary) ? readQaSuiteEvidenceEntries(summary) : undefined;
   const hasObservedOutcomeRows = (scenarios?.length ?? 0) > 0 || (entries?.length ?? 0) > 0;
   const hasCompletedScenario =
     scenarios?.some((scenario) => scenario.status === "pass" || scenario.status === "fail") ===
       true ||
-    entries?.some((entry) => entry.result?.status === "pass" || entry.result?.status === "fail") ===
-      true ||
+    entries?.some((entry) => {
+      const status = readQaSuiteEvidenceEntryStatus(entry);
+      return status === "pass" || status === "fail";
+    }) === true ||
     (failed ?? 0) > 0 ||
     (!hasObservedOutcomeRows && (passed ?? 0) > 0);
   const hasBlockingNonOptionalSkip =
@@ -174,13 +279,15 @@ function assertQaSuiteSummaryHasExecutedScenarios(
   const hasBlockingUnknownOrFailedScenario =
     scenarios?.some((scenario) => isQaSuiteFailureStatus(scenario.status)) === true;
   const hasBlockingNonPassEvidence =
-    entries?.some(
-      (entry) =>
-        typeof entry.result?.status === "string" &&
+    entries?.some((entry) => {
+      const status = readQaSuiteEvidenceEntryStatus(entry);
+      return (
+        typeof status === "string" &&
         (errorCode === "summary_blocking_count_missing"
-          ? isQaSuiteBlockingStatus(entry.result.status)
-          : isQaSuiteFailureStatus(entry.result.status)),
-    ) === true;
+          ? isQaSuiteBlockingStatus(status)
+          : isQaSuiteFailureStatus(status))
+      );
+    }) === true;
 
   // Optional skips are not execution: only a real scenario, evidence result,
   // or positive legacy count may clear a zero-work suite. Unverified skips
@@ -261,40 +368,34 @@ function countQaSuiteFailedOrSkippedScenarios(
 }
 
 function readQaSuiteFailedScenarioCountFromSummary(summary: unknown): number | null {
-  if (!summary || typeof summary !== "object") {
+  if (!isRecord(summary)) {
     return null;
   }
   const payload = summary as {
     counts?: {
       failed?: unknown;
     };
-    entries?: QaEvidenceEntryStatus[];
     scenarios?: Array<QaSuiteScenarioStatus>;
   };
+  const entries = readQaSuiteEvidenceEntries(summary);
   const countedFailures = readNonNegativeCount(payload.counts?.failed);
   const scenarioFailures = Array.isArray(payload.scenarios)
     ? countQaSuiteFailedScenarios(payload.scenarios)
     : null;
-  const evidenceFailures = Array.isArray(payload.entries)
-    ? payload.entries.filter((entry) => isQaSuiteFailureStatus(entry.result?.status)).length
+  const evidenceFailures = entries
+    ? entries.filter((entry) => isQaSuiteFailureStatus(readQaSuiteEvidenceEntryStatus(entry)))
+        .length
     : null;
-  if (countedFailures !== null && scenarioFailures !== null) {
-    return Math.max(countedFailures, scenarioFailures, evidenceFailures ?? 0);
+  // Counts and scenario rows own scenario cardinality. Raw evidence is a
+  // lower-level fallback only when neither aggregate is available.
+  if (countedFailures !== null || scenarioFailures !== null) {
+    return Math.max(countedFailures ?? 0, scenarioFailures ?? 0);
   }
-  if (countedFailures !== null && evidenceFailures !== null) {
-    return Math.max(countedFailures, evidenceFailures);
-  }
-  if (scenarioFailures !== null) {
-    return Math.max(scenarioFailures, evidenceFailures ?? 0);
-  }
-  if (evidenceFailures !== null) {
-    return evidenceFailures;
-  }
-  return countedFailures;
+  return evidenceFailures;
 }
 
 function readQaSuiteFailedOrSkippedScenarioCountFromSummary(summary: unknown): number | null {
-  if (!summary || typeof summary !== "object") {
+  if (!isRecord(summary)) {
     return null;
   }
   const payload = summary as {
@@ -302,9 +403,9 @@ function readQaSuiteFailedOrSkippedScenarioCountFromSummary(summary: unknown): n
       failed?: unknown;
       skipped?: unknown;
     };
-    entries?: QaEvidenceEntryStatus[];
     scenarios?: Array<QaSuiteScenarioStatus>;
   };
+  const entries = readQaSuiteEvidenceEntries(summary);
   const countedFailures = readNonNegativeCount(payload.counts?.failed);
   const countedSkipped = readNonNegativeCount(payload.counts?.skipped);
   const countedBlocking =
@@ -314,22 +415,14 @@ function readQaSuiteFailedOrSkippedScenarioCountFromSummary(summary: unknown): n
   const scenarioBlocking = Array.isArray(payload.scenarios)
     ? countQaSuiteFailedOrSkippedScenarios(payload.scenarios)
     : null;
-  const evidenceBlocking = Array.isArray(payload.entries)
-    ? payload.entries.filter((entry) => isQaSuiteBlockingStatus(entry.result?.status)).length
+  const evidenceBlocking = entries
+    ? entries.filter((entry) => isQaSuiteBlockingStatus(readQaSuiteEvidenceEntryStatus(entry)))
+        .length
     : null;
-  if (countedBlocking !== null && scenarioBlocking !== null) {
-    return Math.max(countedBlocking, scenarioBlocking, evidenceBlocking ?? 0);
+  if (countedBlocking !== null || scenarioBlocking !== null) {
+    return Math.max(countedBlocking ?? 0, scenarioBlocking ?? 0);
   }
-  if (countedBlocking !== null && evidenceBlocking !== null) {
-    return Math.max(countedBlocking, evidenceBlocking);
-  }
-  if (scenarioBlocking !== null) {
-    return Math.max(scenarioBlocking, evidenceBlocking ?? 0);
-  }
-  if (evidenceBlocking !== null) {
-    return evidenceBlocking;
-  }
-  return countedBlocking;
+  return evidenceBlocking;
 }
 
 export async function readQaSuiteFailedScenarioCountFromFile(summaryPath: string): Promise<number> {
@@ -360,27 +453,22 @@ export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
   const blockingScenarioCount = readQaSuiteFailedOrSkippedScenarioCountFromSummary(payload);
   if (blockingScenarioCount !== null) {
     const optionalScenarioNames = options?.optionalScenarioNames;
-    if (!optionalScenarioNames?.size || !payload || typeof payload !== "object") {
+    if (!optionalScenarioNames?.size || !isRecord(payload)) {
       return blockingScenarioCount;
     }
-    const { scenarios, entries } = payload as {
+    const { scenarios } = payload as {
       scenarios?: QaSuiteReportOnlyScenario[];
-      entries?: QaEvidenceEntryStatus[];
     };
     const reportOnlyOptionalSkips = Array.isArray(scenarios)
       ? scenarios.filter((scenario) =>
           isQaSuiteReportOnlyOptionalScenario(scenario, optionalScenarioNames),
         ).length
       : 0;
-    const evidenceBlocking = Array.isArray(entries)
-      ? entries.filter((entry) => isQaSuiteBlockingStatus(entry.result?.status)).length
-      : 0;
     // Optional skips may offset only their independently verified scenario results.
-    // Declared failures, unknown evidence, and count disagreements stay fail-closed.
+    // Declared failures and count disagreements stay fail-closed.
     return Math.max(
       readQaSuiteFailedScenarioCountFromSummary(payload) ?? 0,
       blockingScenarioCount - reportOnlyOptionalSkips,
-      evidenceBlocking,
     );
   }
   throw new QaSuiteArtifactError(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where direct QA suite commands could report success when a summary omitted required outcomes or contradicted its own scenario/evidence rows.

## Why This Change Was Made

Complete `total`/`passed`/`failed`/`skipped` counts now share one accounting invariant across direct suite gates and confidence reports. Invalid accounting is surfaced as a typed artifact error, while legacy partial-count fallback, all-skipped handling, and report-only optional scenarios retain their existing behavior.

## User Impact

QA operators no longer get a false-green exit from internally inconsistent complete suite summaries. Corrupt or incomplete accounting fails closed instead.

## Evidence

- Pre-fix regression run: 8 focused failures, including both deterministic false-green fixtures.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-summary.test.ts extensions/qa-lab/src/confidence-report.test.ts extensions/qa-lab/src/cli.runtime.test.ts` — 223/223 tests passed.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/errors.ts extensions/qa-lab/src/suite-summary.ts extensions/qa-lab/src/suite-summary.test.ts extensions/qa-lab/src/confidence-report.ts extensions/qa-lab/src/confidence-report.test.ts extensions/qa-lab/src/cli.runtime.test.ts` — all changed-file gates passed, including extension typechecks, type-aware lint, dead-export scan, formatting, and import-cycle checks.
- Structured autoreview was attempted; the Codex reviewer was unavailable because its authentication request failed, so no clean autoreview claim is made.
