### PR TITLE
improve(gateway): reduce chat history read-path latency

### DIFF
--- a/src/agents/tools/embedded-gateway-stub.runtime.ts
+++ b/src/agents/tools/embedded-gateway-stub.runtime.ts
@@ -22,7 +22,6 @@ export { getMaxChatHistoryMessagesBytes } from "../../gateway/server-constants.j
 export {
   augmentChatHistoryWithCanvasBlocks,
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-  enforceChatHistoryFinalBudget,
   replaceOversizedChatHistoryMessages,
 } from "../../gateway/server-methods/chat.js";
 export {

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -49,7 +49,6 @@ const runtime = vi.hoisted(() => ({
     messages,
   })),
   capArrayByJsonBytes: vi.fn((items: unknown[]) => ({ items })),
-  enforceChatHistoryFinalBudget: vi.fn(({ messages }: { messages: unknown[] }) => ({ messages })),
   loadCombinedSessionStoreForGatewayCore: vi.fn(() => ({
     storePath: "/tmp/openclaw-sessions.json",
     store: {},
@@ -525,7 +524,7 @@ describe("embedded gateway stub", () => {
       messages: rawMessages,
       totalMessages: 10,
     }));
-    runtime.enforceChatHistoryFinalBudget.mockReturnValueOnce({ messages: returnedMessages });
+    runtime.capArrayByJsonBytes.mockReturnValueOnce({ items: returnedMessages });
 
     const callGateway = createEmbeddedCallGateway();
     const result = await callGateway<{

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -56,9 +56,6 @@ interface EmbeddedGatewayRuntime {
   getMaxChatHistoryMessagesBytes: () => number;
   augmentChatHistoryWithCanvasBlocks: (msgs: unknown[]) => unknown[];
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES: number;
-  enforceChatHistoryFinalBudget: (opts: { messages: unknown[]; maxBytes: number }) => {
-    messages: unknown[];
-  };
   replaceOversizedChatHistoryMessages: (opts: {
     messages: unknown[];
     maxSingleMessageBytes: number;
@@ -452,11 +449,10 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
     maxSingleMessageBytes: perMessageHardCap,
   });
   const capped = rt.capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
-  const bounded = rt.enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
   const nextOffset =
     offsetPage !== undefined
       ? resolveChatHistoryNextOffset({
-          messages: bounded.messages,
+          messages: capped,
           totalMessages: offsetPage.totalMessages,
           offset,
           rawPageMessages:
@@ -470,7 +466,7 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   return {
     sessionKey,
     sessionId,
-    messages: bounded.messages,
+    messages: capped,
     ...(params.offset !== undefined
       ? { offset, hasMore, totalMessages: offsetPage?.totalMessages ?? projected.length }
       : {}),

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -56,10 +56,12 @@ function resolveVisibleHistoryProjection(
       .select((eb) =>
         eb
           .selectFrom("session_transcript_active_events as next")
-          .select((nextEb) => nextEb.fn.min<number>("next.message_position").as("position"))
+          .select("next.message_position")
           .whereRef("next.session_id", "=", "active.session_id")
           .whereRef("next.active_position", ">", "active.active_position")
           .where("next.message_position", "is not", null)
+          .orderBy("next.active_position", "asc")
+          .limit(1)
           .as("next_message_position"),
       )
       .where("active.session_id", "=", projection.resolved.sessionId)

--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -1,7 +1,7 @@
-// Covers the chat.history final byte-budget fallback, including the sentinel
-// that prevents an empty (blank) transcript from being returned to the dashboard.
+// Covers per-message history replacement, including the sentinel that prevents
+// oversized metadata from escaping through the ordinary placeholder.
 import { describe, expect, it } from "vitest";
-import { enforceChatHistoryFinalBudget } from "./chat-history-budget.js";
+import { replaceOversizedChatHistoryMessages } from "./chat-history-budget.js";
 
 type DisplayMessage = {
   role?: string;
@@ -13,39 +13,38 @@ function firstText(messages: unknown[]): string {
   return msg?.content?.[0]?.text ?? "";
 }
 
-describe("enforceChatHistoryFinalBudget", () => {
-  it("passes through history that already fits the budget", () => {
+describe("replaceOversizedChatHistoryMessages", () => {
+  it("passes through history that already fits the per-message budget", () => {
     const messages = [
       { role: "user", content: [{ type: "text", text: "hello" }] },
       { role: "assistant", content: [{ type: "text", text: "hi" }] },
     ];
-    const result = enforceChatHistoryFinalBudget({ messages, maxBytes: 1_000_000 });
+    const result = replaceOversizedChatHistoryMessages({
+      messages,
+      maxSingleMessageBytes: 1_000_000,
+    });
     expect(result.messages).toEqual(messages);
   });
 
   it("returns the empty array unchanged for empty input", () => {
-    const result = enforceChatHistoryFinalBudget({ messages: [], maxBytes: 10 });
+    const result = replaceOversizedChatHistoryMessages({
+      messages: [],
+      maxSingleMessageBytes: 10,
+    });
     expect(result.messages).toEqual([]);
   });
 
-  it("keeps just the last message when the full set is over budget but the last fits", () => {
-    const big = { role: "user", content: [{ type: "text", text: "x".repeat(4000) }] };
-    const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
-    const result = enforceChatHistoryFinalBudget({ messages: [big, last], maxBytes: 2_000 });
-    // The same last-message reference survives so callers can detect which
-    // originals were omitted by identity.
-    expect(result.messages).toEqual([last]);
-    expect(result.messages[0]).toBe(last);
-  });
-
-  it("falls back to a small placeholder when even the last message is too large", () => {
+  it("replaces an oversized message and preserves its cursor metadata", () => {
     const last = {
       role: "assistant",
       timestamp: 1,
       content: [{ type: "text", text: "y".repeat(4000) }],
       __openclaw: { id: "abc", seq: 7, turnBoundary: true },
     };
-    const result = enforceChatHistoryFinalBudget({ messages: [last], maxBytes: 2_000 });
+    const result = replaceOversizedChatHistoryMessages({
+      messages: [last],
+      maxSingleMessageBytes: 2_000,
+    });
     expect(result.messages).toHaveLength(1);
     expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
     expect(
@@ -56,7 +55,7 @@ describe("enforceChatHistoryFinalBudget", () => {
     expect(result.messages[0]).not.toBe(last);
   });
 
-  it("returns a metadata-free sentinel (never an empty transcript) when even the placeholder is over budget", () => {
+  it("returns a metadata-free sentinel when even the placeholder is over budget", () => {
     // A pathological message whose oversized-placeholder copy is itself too
     // large because it carries very large transcript metadata.
     const hugeId = "z".repeat(4000);
@@ -66,7 +65,10 @@ describe("enforceChatHistoryFinalBudget", () => {
       content: [{ type: "text", text: "hi" }],
       __openclaw: { id: hugeId, seq: 1 },
     };
-    const result = enforceChatHistoryFinalBudget({ messages: [message], maxBytes: 1_000 });
+    const result = replaceOversizedChatHistoryMessages({
+      messages: [message],
+      maxSingleMessageBytes: 1_000,
+    });
 
     // The critical guarantee: the dashboard never receives an empty history.
     expect(result.messages).toHaveLength(1);

--- a/src/gateway/server-methods/chat-history-budget.ts
+++ b/src/gateway/server-methods/chat-history-budget.ts
@@ -7,6 +7,26 @@ const CHAT_HISTORY_UNAVAILABLE_SENTINEL =
   "[chat.history unavailable: transcript too large to display; the full history is preserved on disk]";
 let chatHistoryOmittedEmitCount = 0;
 
+export function createChatHistoryByteCounter() {
+  const sizes = new Map<unknown, number>();
+  const messageBytes = (message: unknown): number => {
+    const cached = sizes.get(message);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const bytes = jsonUtf8Bytes(message);
+    sizes.set(message, bytes);
+    return bytes;
+  };
+  return {
+    messageBytes,
+    messagesBytes: (messages: unknown[]) =>
+      2 +
+      messages.reduce<number>((bytes, message) => bytes + messageBytes(message), 0) +
+      Math.max(0, messages.length - 1),
+  };
+}
+
 function buildChatHistoryUnavailableSentinel(): Record<string, unknown> {
   return {
     role: "assistant",
@@ -57,44 +77,27 @@ function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unk
 }
 
 export function replaceOversizedChatHistoryMessages(params: {
+  byteCounter?: ReturnType<typeof createChatHistoryByteCounter>;
   messages: unknown[];
   maxSingleMessageBytes: number;
 }): { messages: unknown[]; replacedCount: number } {
   const { messages, maxSingleMessageBytes } = params;
+  const byteCounter = params.byteCounter ?? createChatHistoryByteCounter();
   if (messages.length === 0) {
     return { messages, replacedCount: 0 };
   }
   let replacedCount = 0;
   const next = messages.map((message) => {
-    if (jsonUtf8Bytes(message) <= maxSingleMessageBytes) {
+    if (byteCounter.messageBytes(message) <= maxSingleMessageBytes) {
       return message;
     }
     replacedCount += 1;
-    return buildOversizedHistoryPlaceholder(message);
+    const placeholder = buildOversizedHistoryPlaceholder(message);
+    return byteCounter.messageBytes(placeholder) <= maxSingleMessageBytes
+      ? placeholder
+      : buildChatHistoryUnavailableSentinel();
   });
   return { messages: replacedCount > 0 ? next : messages, replacedCount };
-}
-
-// Preserve a visible terminal record when the complete projected history cannot fit.
-export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; maxBytes: number }): {
-  messages: unknown[];
-} {
-  const { messages, maxBytes } = params;
-  if (messages.length === 0) {
-    return { messages };
-  }
-  if (jsonUtf8Bytes(messages) <= maxBytes) {
-    return { messages };
-  }
-  const last = messages.at(-1);
-  if (last && jsonUtf8Bytes([last]) <= maxBytes) {
-    return { messages: [last] };
-  }
-  const placeholder = buildOversizedHistoryPlaceholder(last);
-  if (jsonUtf8Bytes([placeholder]) <= maxBytes) {
-    return { messages: [placeholder] };
-  }
-  return { messages: [buildChatHistoryUnavailableSentinel()] };
 }
 
 export function reportOmittedChatHistory(params: {

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -21,7 +21,6 @@ import {
   measureDiagnosticsTimelineSpanSync,
 } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import {
   boundInFlightRunSnapshotForChatHistory,
@@ -43,7 +42,7 @@ import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import { scheduleChatHistoryManagedMediaCleanup } from "./chat-assistant-content.js";
 import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-  enforceChatHistoryFinalBudget,
+  createChatHistoryByteCounter,
   replaceOversizedChatHistoryMessages,
   reportOmittedChatHistory,
 } from "./chat-history-budget.js";
@@ -250,16 +249,15 @@ async function handleChatHistoryRequest({
       return;
     }
   }
-  const workspaceIconPreparation =
-    method === "chat.startup"
-      ? prepareSessionWorkspaceIcon({ sessionKey, agentId: sessionAgentId }).catch(
-          (error: unknown) => {
-            context.logGateway.debug(
-              `chat.startup continuing without a workspace icon: ${formatErrorMessage(error)}`,
-            );
-          },
-        )
-      : Promise.resolve();
+  if (method === "chat.startup") {
+    void prepareSessionWorkspaceIcon({ sessionKey, agentId: sessionAgentId }).catch(
+      (error: unknown) => {
+        context.logGateway.debug(
+          `chat.startup continuing without a workspace icon: ${formatErrorMessage(error)}`,
+        );
+      },
+    );
+  }
   const modelCatalogPromise =
     method === "chat.history"
       ? (() => {
@@ -284,6 +282,58 @@ async function handleChatHistoryRequest({
           );
           void load.catch(() => undefined);
           return load;
+        })()
+      : Promise.resolve(undefined);
+  const startupProjectionsPromise =
+    method === "chat.startup"
+      ? (() => {
+          const includeSystem = hasGatewayClientCap(
+            client?.connect.caps,
+            GATEWAY_CLIENT_CAPS.AGENT_KIND,
+          );
+          return measureDiagnosticsTimelineSpan(
+            `gateway.${method}.startup_projections`,
+            async () => {
+              const projection = context.readChatStartupProjection
+                ? await context
+                    .readChatStartupProjection({
+                      agentId: sessionAgentId,
+                      sessionEntry: entry,
+                      includeSystem,
+                    })
+                    .catch((error: unknown) => {
+                      context.logGateway.debug(
+                        `chat.startup continuing without prepared startup projection: ${formatErrorMessage(error)}`,
+                      );
+                      return undefined;
+                    })
+                : undefined;
+              const metadata = includeMetadata
+                ? (projection?.metadata ??
+                  (await context
+                    .readChatMetadata({
+                      agentId: sessionAgentId,
+                      sessionEntry: entry,
+                    })
+                    .catch((error: unknown) => {
+                      context.logGateway.debug(
+                        `chat.startup continuing without metadata: ${formatErrorMessage(error)}`,
+                      );
+                      return undefined;
+                    })))
+                : undefined;
+              const agentsList = includeAgentsList
+                ? (projection?.agentsList ??
+                  listAgentsForGateway(cfg, undefined, { includeSystem }))
+                : undefined;
+              return { agentsList, projection, metadata };
+            },
+            {
+              config: cfg,
+              phase: method,
+              attributes: { agentId: sessionAgentId, includeSystem },
+            },
+          );
         })()
       : Promise.resolve(undefined);
   const sessionId = requestedSessionId ?? entry?.sessionId;
@@ -339,7 +389,9 @@ async function handleChatHistoryRequest({
   }
   const normalized = enrichChatHistoryCompactionMarkers(historyPage.messages, historyEntry);
   const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
+  const byteCounter = createChatHistoryByteCounter();
   const replaced = replaceOversizedChatHistoryMessages({
+    byteCounter,
     messages: normalized,
     maxSingleMessageBytes: perMessageHardCap,
   });
@@ -353,27 +405,25 @@ async function handleChatHistoryRequest({
     ? (capChatHistoryAroundMessage({
         messages: replaced.messages,
         messageId,
-        fits: (messages) => jsonUtf8Bytes(messages) <= maxHistoryBytes,
-      }) ?? capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items)
-    : capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
-  const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+        fits: (messages) => byteCounter.messagesBytes(messages) <= maxHistoryBytes,
+      }) ?? capArrayByJsonBytes(replaced.messages, maxHistoryBytes, byteCounter.messageBytes).items)
+    : capArrayByJsonBytes(replaced.messages, maxHistoryBytes, byteCounter.messageBytes).items;
   const historyBudgetPreserved =
     replaced.replacedCount === 0 &&
     capped.length === normalized.length &&
-    bounded.messages.length === capped.length &&
-    bounded.messages.every((message, index) => message === capped[index]);
+    capped.every((message, index) => message === normalized[index]);
   const pagination = historyPage.pagination;
   const candidateNextOffset =
     pagination === undefined
       ? undefined
       : resolveChatHistoryNextOffset({
-          messages: bounded.messages,
+          messages: capped,
           totalMessages: pagination.totalMessages,
           offset: pagination.offset,
           rawPageMessages: pagination.rawPageMessages,
           replayOldestRecord: shouldReplayOldestChatHistoryRecord({
             projected: normalized,
-            bounded: bounded.messages,
+            bounded: capped,
           }),
         });
   const hasMore =
@@ -383,8 +433,8 @@ async function handleChatHistoryRequest({
   const nextOffset = hasMore ? candidateNextOffset : undefined;
   reportOmittedChatHistory({
     originalMessages: normalized,
-    finalMessages: bounded.messages,
-    getNormalizedBytes: () => jsonUtf8Bytes(normalized),
+    finalMessages: capped,
+    getNormalizedBytes: () => byteCounter.messagesBytes(normalized),
     maxHistoryBytes,
     logDebug: (message) => context.logGateway.debug(message),
   });
@@ -392,60 +442,10 @@ async function handleChatHistoryRequest({
   const catalogOwnedBySessionAgent = modelCatalogSnapshot?.agentId === sessionAgentId;
   const modelCatalog = catalogOwnedBySessionAgent ? modelCatalogSnapshot.entries : undefined;
   const compatibilityOwnerAgentId = tryResolveSessionCompatibilityOwnerAgentId(cfg, sessionKey);
-  let startupProjection: ChatStartupProjectionResult | undefined;
-  let startupMetadata: ChatMetadataResult | undefined;
-  let startupAgentsList: AgentsListResult | undefined;
-  if (method === "chat.startup") {
-    const includeSystem = hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND);
-    const startupProjections = await measureDiagnosticsTimelineSpan(
-      `gateway.${method}.startup_projections`,
-      async () => {
-        const projection = context.readChatStartupProjection
-          ? await context
-              .readChatStartupProjection({
-                agentId: sessionAgentId,
-                sessionEntry: entry,
-                includeSystem,
-              })
-              .catch((error: unknown) => {
-                context.logGateway.debug(
-                  `chat.startup continuing without prepared startup projection: ${formatErrorMessage(error)}`,
-                );
-                return undefined;
-              })
-          : undefined;
-        const metadata = includeMetadata
-          ? (projection?.metadata ??
-            (await context
-              .readChatMetadata({
-                agentId: sessionAgentId,
-                sessionEntry: entry,
-              })
-              .catch((error: unknown) => {
-                context.logGateway.debug(
-                  `chat.startup continuing without metadata: ${formatErrorMessage(error)}`,
-                );
-                return undefined;
-              })))
-          : undefined;
-        const agentsList = includeAgentsList
-          ? (projection?.agentsList ?? listAgentsForGateway(cfg, modelCatalog, { includeSystem }))
-          : undefined;
-        return { agentsList, projection, metadata };
-      },
-      {
-        config: cfg,
-        phase: method,
-        attributes: {
-          agentId: sessionAgentId,
-          includeSystem,
-        },
-      },
-    );
-    startupProjection = startupProjections.projection;
-    startupMetadata = startupProjections.metadata;
-    startupAgentsList = startupProjections.agentsList;
-  }
+  const startupProjections = await startupProjectionsPromise;
+  const startupProjection: ChatStartupProjectionResult | undefined = startupProjections?.projection;
+  const startupMetadata: ChatMetadataResult | undefined = startupProjections?.metadata;
+  const startupAgentsList: AgentsListResult | undefined = startupProjections?.agentsList;
   const sessionModelCatalog = startupProjection?.sessionModelCatalog ?? modelCatalog;
   const defaultModelCatalog = startupProjection?.defaultModelCatalog ?? modelCatalog;
   const sessionInfo = measureDiagnosticsTimelineSpanSync(
@@ -504,13 +504,13 @@ async function handleChatHistoryRequest({
   });
   const boundedInFlightRun = boundInFlightRunSnapshotForChatHistory({
     snapshot: inFlightRun,
-    messages: bounded.messages,
+    messages: capped,
     maxBytes: maxHistoryBytes,
   });
   const payload = {
     sessionKey,
     sessionId,
-    messages: bounded.messages,
+    messages: capped,
     ...(historyPage.responseOffset !== undefined ? { offset: historyPage.responseOffset } : {}),
     ...(hasMore ? { nextOffset } : {}),
     ...(hasMore !== undefined ? { hasMore } : {}),
@@ -528,7 +528,6 @@ async function handleChatHistoryRequest({
     ...(includeAgentsList && startupAgentsList ? { agentsList: startupAgentsList } : {}),
     ...(startupMetadata ? { metadata: startupMetadata } : {}),
   };
-  await workspaceIconPreparation;
   respond(true, payload);
 }
 

--- a/src/gateway/server-methods/chat-history-omission-logging.test.ts
+++ b/src/gateway/server-methods/chat-history-omission-logging.test.ts
@@ -10,7 +10,6 @@ import { onDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import type { DiagnosticPayloadLargeEvent } from "../../infra/diagnostic-events.js";
 import { capArrayByJsonBytes } from "../session-transcript-readers.js";
 import {
-  enforceChatHistoryFinalBudget,
   replaceOversizedChatHistoryMessages,
   reportOmittedChatHistory,
 } from "./chat-history-budget.js";
@@ -18,8 +17,8 @@ import {
 type Captured = DiagnosticPayloadLargeEvent[];
 
 // Mirrors the production sequence in handleChatHistoryRequest: replace oversized
-// messages, cap the array by byte budget, enforce the final budget, then report
-// omissions. Captures any emitted `payload.large` diagnostic event.
+// messages, cap the array by byte budget, then report omissions. Captures any
+// emitted `payload.large` diagnostic event.
 function runHistoryBudgetPipeline(params: {
   messages: unknown[];
   maxHistoryBytes: number;
@@ -38,10 +37,9 @@ function runHistoryBudgetPipeline(params: {
       maxSingleMessageBytes: perMessageHardCap,
     });
     const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
-    const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
     const emittedCount = reportOmittedChatHistory({
       originalMessages: messages,
-      finalMessages: bounded.messages,
+      finalMessages: capped,
       getNormalizedBytes: () => Buffer.byteLength(JSON.stringify(messages), "utf8"),
       maxHistoryBytes,
       logDebug: () => {},

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -228,75 +228,120 @@ const SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES = 8_000;
 // contiguous reader that does not exist yet.
 const SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES = 100;
 
-/** Keeps a first history page displayable by scanning past an all-silent raw tail. */
-async function resolveDisplayableChatHistoryTail(params: {
+type IncrementalChatHistoryTail = {
+  overreadContextMessage: unknown;
+  projected: unknown[];
+  rawMessages: unknown[];
+  rawPageMessages: number;
+  readPage: ReadRecentSessionMessagesResult;
+};
+
+/** Reads only enough raw tail records to fill one projected history page. */
+async function readIncrementalChatHistoryTail(params: {
   entry: ReturnType<typeof loadSessionEntry>["entry"];
   readScope: SessionTranscriptReadScope;
   effectiveMaxChars: number;
   max: number;
   maxBytes: number;
-  projected: unknown[];
-  rawMessages: unknown[];
-  rawPageMessages: number;
-  totalMessages: number;
-}): Promise<{ messages: unknown[]; rawPageMessages: number }> {
-  const unchanged = { messages: params.projected, rawPageMessages: params.rawPageMessages };
-  if (params.projected.length > 0 || params.totalMessages <= params.rawPageMessages) {
-    return unchanged;
-  }
+}): Promise<IncrementalChatHistoryTail> {
+  const rawHistoryWindow = resolveSessionHistoryTailReadOptions(params.max);
+  // Three raw rows per requested display row covers common tool/silent pairs
+  // while keeping the first read far below the legacy 20x safety ceiling.
+  const initialMessages = Math.min(rawHistoryWindow.maxMessages, Math.max(1, params.max * 3));
+  const readPage = await readRecentSessionMessagesWithStatsAsync(params.readScope, {
+    maxMessages: initialMessages + 1,
+    maxLines: initialMessages + 1,
+    maxBytes: Math.max(params.maxBytes * 2, 1024 * 1024),
+    allowResetArchiveFallback: true,
+  });
   const sessionStartedAt =
     typeof params.entry?.sessionStartedAt === "number" ? params.entry.sessionStartedAt : undefined;
-  const scanLimit = params.rawPageMessages + SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES;
-  let scanned = params.rawPageMessages;
+  let rawPageMessages = Math.min(
+    initialMessages,
+    Math.max(readPage.messages.length, readPage.totalMessages > 0 ? 1 : 0),
+  );
+  let overreadContextMessage =
+    readPage.messages.length > initialMessages ? readPage.messages[0] : undefined;
+  let rawMessages = dropLocalHistoryOverreadContextMessage(
+    readPage.messages,
+    overreadContextMessage,
+  );
+  const filteredRawMessages = () =>
+    dropLocalHistoryOverreadContextMessage(
+      dropPreSessionStartAnnouncePairs(
+        overreadContextMessage === undefined
+          ? rawMessages
+          : [overreadContextMessage, ...rawMessages],
+        sessionStartedAt,
+      ),
+      overreadContextMessage,
+    );
+  const project = () =>
+    projectRecentChatDisplayMessages(filteredRawMessages(), {
+      maxChars: params.effectiveMaxChars,
+      maxMessages: params.max,
+      resolveCurrentUserProfileDisplay,
+      turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
+    });
+  let projected = project();
+  let scanLimit = rawHistoryWindow.maxMessages;
   // Record count alone does not bound a walk over large tool results, and the
   // reader cannot bound it either: a byte-budgeted page skips an oversized
   // record mid-window, which would strand it and its placeholder. Budget the
   // whole walk instead, at the payload one history response may already return.
   let scannedBytes = 0;
-  // Projection pairs records across turns (message-tool sends and their
-  // results, turn boundaries), so each chunk is projected together with the
-  // already-read newer records it borders. Only the neighbour is carried, which
-  // keeps the working set at two chunks plus the tail window.
-  let newerRawMessages = params.rawMessages;
-  while (scanned < params.totalMessages && scanned < scanLimit) {
+  // Projection pairs records across turns, so keep the accumulated window in
+  // chronological order and retain exactly one older context record.
+  while (rawPageMessages < readPage.totalMessages) {
+    if (projected.length >= params.max) {
+      break;
+    }
+    if (rawPageMessages >= rawHistoryWindow.maxMessages) {
+      if (projected.length > 0) {
+        break;
+      }
+      scanLimit = rawHistoryWindow.maxMessages + SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES;
+    }
+    if (rawPageMessages >= scanLimit) {
+      break;
+    }
+    const chunkMessages = Math.min(
+      SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES,
+      scanLimit - rawPageMessages,
+    );
     const page = await readSessionMessagesPageWithStatsAsync(params.readScope, {
-      offset: scanned,
-      maxMessages: SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES + 1,
+      offset: rawPageMessages,
+      maxMessages: chunkMessages + 1,
       allowResetArchiveFallback: true,
     });
     if (page.messages.length === 0) {
-      return unchanged;
+      break;
     }
     // The extra oldest record only supplies pair-filter and turn-boundary
     // context. Without it a chunk boundary between a stale announce and its
     // reply would leak the reply that the tail read hides. Each chunk's context
     // record is the newest record of the next chunk, so this one overread also
     // covers every junction the walk creates, including tail-to-first-chunk.
-    const contextMessage =
-      page.messages.length > SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES
-        ? page.messages[0]
-        : undefined;
-    scanned += page.messages.length - (contextMessage === undefined ? 0 : 1);
-    const chunkMessages = dropLocalHistoryOverreadContextMessage(
-      dropPreSessionStartAnnouncePairs(page.messages, sessionStartedAt),
+    const contextMessage = page.messages.length > chunkMessages ? page.messages[0] : undefined;
+    rawPageMessages += page.messages.length - (contextMessage === undefined ? 0 : 1);
+    rawMessages = dropLocalHistoryOverreadContextMessage(
+      [...page.messages, ...rawMessages],
       contextMessage,
     );
-    const projected = projectRecentChatDisplayMessages([...chunkMessages, ...newerRawMessages], {
-      maxChars: params.effectiveMaxChars,
-      maxMessages: params.max,
-      resolveCurrentUserProfileDisplay,
-      turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(contextMessage),
-    });
-    if (projected.length > 0) {
-      return { messages: projected, rawPageMessages: scanned };
-    }
+    overreadContextMessage = contextMessage;
+    projected = project();
     scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
-    if (scannedBytes >= params.maxBytes) {
-      return unchanged;
+    if (rawPageMessages > rawHistoryWindow.maxMessages && scannedBytes >= params.maxBytes) {
+      break;
     }
-    newerRawMessages = chunkMessages;
   }
-  return unchanged;
+  return {
+    overreadContextMessage,
+    projected,
+    rawMessages: filteredRawMessages(),
+    rawPageMessages,
+    readPage,
+  };
 }
 
 export async function readChatHistoryPage(params: {
@@ -353,10 +398,10 @@ export async function readChatHistoryPage(params: {
   // is deferred to a follow-up issue. Anchored reads fall through with them: the
   // full-snapshot merge below still centers on messageId at the handler cap.
   if ((offset !== undefined || messageId) && !cliSessionId) {
-    const rawHistoryWindow = resolveSessionHistoryTailReadOptions(max);
     let pageOffset = offset ?? 0;
     let hasOverreadContext = false;
     let readPage: ReadRecentSessionMessagesResult;
+    let incrementalTail: IncrementalChatHistoryTail | undefined;
     if (messageId) {
       const anchoredPage = await readSessionMessagesAroundIdWithStatsAsync(readScope, {
         messageId,
@@ -370,12 +415,14 @@ export async function readChatHistoryPage(params: {
       hasOverreadContext = anchoredPage.hasOverreadContext;
       readPage = anchoredPage;
     } else if (pageOffset === 0) {
-      readPage = await readRecentSessionMessagesWithStatsAsync(readScope, {
-        maxMessages: rawHistoryWindow.maxMessages + 1,
-        maxLines: rawHistoryWindow.maxLines + 1,
-        maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
-        allowResetArchiveFallback: true,
+      incrementalTail = await readIncrementalChatHistoryTail({
+        entry,
+        readScope,
+        effectiveMaxChars,
+        max,
+        maxBytes: maxHistoryBytes,
       });
+      readPage = incrementalTail.readPage;
     } else {
       readPage = await readSessionMessagesPageWithStatsAsync(readScope, {
         offset: pageOffset,
@@ -385,24 +432,21 @@ export async function readChatHistoryPage(params: {
     }
     const isTailPage = !messageId && pageOffset === 0;
     const overreadContextMessage = isTailPage
-      ? readPage.messages.length > rawHistoryWindow.maxMessages
-        ? readPage.messages[0]
-        : undefined
+      ? incrementalTail?.overreadContextMessage
       : hasOverreadContext || readPage.messages.length > max
         ? readPage.messages[0]
         : undefined;
-    const localMessages = dropLocalHistoryOverreadContextMessage(
-      dropPreSessionStartAnnouncePairs(
-        readPage.messages,
-        typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
-      ),
-      overreadContextMessage,
-    );
+    const localMessages = incrementalTail
+      ? incrementalTail.rawMessages
+      : dropLocalHistoryOverreadContextMessage(
+          dropPreSessionStartAnnouncePairs(
+            readPage.messages,
+            typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
+          ),
+          overreadContextMessage,
+        );
     const rawPageMessages = isTailPage
-      ? Math.min(
-          rawHistoryWindow.maxMessages,
-          Math.max(readPage.messages.length, readPage.totalMessages > 0 ? 1 : 0),
-        )
+      ? (incrementalTail?.rawPageMessages ?? 0)
       : Math.min(
           max,
           Math.max(readPage.messages.length, readPage.totalMessages > pageOffset ? 1 : 0),
@@ -411,12 +455,7 @@ export async function readChatHistoryPage(params: {
     // single-pass complete, so no second pass is needed.
     const recencyFilteredMessages = localMessages;
     const projected = isTailPage
-      ? projectRecentChatDisplayMessages(recencyFilteredMessages, {
-          maxChars: effectiveMaxChars,
-          maxMessages: max,
-          resolveCurrentUserProfileDisplay,
-          turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
-        })
+      ? (incrementalTail?.projected ?? [])
       : projectChatDisplayMessages(recencyFilteredMessages, {
           maxChars: effectiveMaxChars,
           resolveCurrentUserProfileDisplay,
@@ -435,56 +474,33 @@ export async function readChatHistoryPage(params: {
       // Numeric offsets do not encode the selected historical transcript source.
       return { messages: augmentChatHistoryWithCanvasBlocks(windowed) };
     }
-    const tail = isTailPage
-      ? await resolveDisplayableChatHistoryTail({
-          entry,
-          readScope,
-          effectiveMaxChars,
-          max,
-          maxBytes: maxHistoryBytes,
-          projected: windowed,
-          rawMessages: recencyFilteredMessages,
-          rawPageMessages,
-          totalMessages: readPage.totalMessages,
-        })
-      : { messages: windowed, rawPageMessages };
     return {
       ...(isTailPage
         ? {
             activeLeafEntryId: resolveChatHistoryActiveLeafEntryId(readPage),
           }
         : {}),
-      messages: augmentChatHistoryWithCanvasBlocks(tail.messages),
+      messages: augmentChatHistoryWithCanvasBlocks(windowed),
       responseOffset: pageOffset,
       pagination: {
         offset: pageOffset,
         totalMessages: readPage.totalMessages,
-        rawPageMessages: tail.rawPageMessages,
+        rawPageMessages,
       },
     };
   }
 
-  const rawHistoryWindow = resolveSessionHistoryTailReadOptions(max);
-  const localHistoryReadOptions = {
-    maxMessages: rawHistoryWindow.maxMessages + 1,
-    maxLines: rawHistoryWindow.maxLines + 1,
-  };
-  const readPage = await readRecentSessionMessagesWithStatsAsync(readScope, {
-    ...localHistoryReadOptions,
-    maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
-    allowResetArchiveFallback: true,
+  const incrementalTail = await readIncrementalChatHistoryTail({
+    entry,
+    readScope,
+    effectiveMaxChars,
+    max,
+    maxBytes: maxHistoryBytes,
   });
-  const overreadContextMessage =
-    readPage.messages.length > rawHistoryWindow.maxMessages ? readPage.messages[0] : undefined;
+  const { overreadContextMessage, readPage } = incrementalTail;
   const turnBoundaryPending = isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage);
   const activeLeafEntryId = resolveChatHistoryActiveLeafEntryId(readPage);
-  const localMessagesWithBoundaryFilter = dropLocalHistoryOverreadContextMessage(
-    dropPreSessionStartAnnouncePairs(
-      readPage.messages,
-      typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
-    ),
-    overreadContextMessage,
-  );
+  const localMessagesWithBoundaryFilter = incrementalTail.rawMessages;
   // The ignore flag must gate this resolver too: the tail-window merge can report
   // imported=true while the full merge below dedupes everything to imported=false,
   // and an ungated re-resolve here would recurse through this branch forever.
@@ -546,29 +562,13 @@ export async function readChatHistoryPage(params: {
     resolveCurrentUserProfileDisplay,
     turnBoundaryPending,
   });
-  const tail = await resolveDisplayableChatHistoryTail({
-    entry,
-    readScope,
-    effectiveMaxChars,
-    max,
-    maxBytes: maxHistoryBytes,
-    projected: displayMessages,
-    rawMessages: recencyFilteredMessages,
-    // The extra record supplies pair-filter context; it was not returned and
-    // must remain reachable by the next strictly-older page.
-    rawPageMessages: Math.min(
-      rawHistoryWindow.maxMessages,
-      Math.max(readPage.messages.length, readPage.totalMessages > 0 ? 1 : 0),
-    ),
-    totalMessages: readPage.totalMessages,
-  });
   return {
     activeLeafEntryId,
-    messages: augmentChatHistoryWithCanvasBlocks(tail.messages),
+    messages: augmentChatHistoryWithCanvasBlocks(displayMessages),
     pagination: {
       offset: 0,
       totalMessages: readPage.totalMessages,
-      rawPageMessages: tail.rawPageMessages,
+      rawPageMessages: incrementalTail.rawPageMessages,
     },
   };
 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -43,7 +43,6 @@ export {
 export { sanitizeChatSendMessageInput } from "../chat-input-sanitize.js";
 export {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-  enforceChatHistoryFinalBudget,
   replaceOversizedChatHistoryMessages,
   reportOmittedChatHistory,
 } from "./chat-history-budget.js";

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -6421,6 +6421,135 @@ describe("gateway server chat", () => {
     });
   });
 
+  test.each([
+    {
+      boundary: {
+        type: "reset",
+        id: "reset-boundary",
+        reason: "reset",
+        firstKeptEntryId: "kept-one",
+      },
+      expectedFirstSeqs: [3, 4, 12, 20],
+      expectedOlderSeqs: [1, 2],
+      marker: "Reset",
+      totalMessages: 27,
+    },
+    {
+      boundary: {
+        type: "compaction",
+        id: "compaction-boundary",
+        summary: "summary",
+        firstKeptEntryId: "old",
+      },
+      expectedFirstSeqs: [4, 5, 13, 21],
+      expectedOlderSeqs: [1, 2, 3],
+      marker: "Compaction",
+      totalMessages: 28,
+    },
+  ])(
+    "chat.history incrementally fills pages across $boundary.type boundaries",
+    async ({ boundary, expectedFirstSeqs, expectedOlderSeqs, marker, totalMessages }) => {
+      await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+        await prepareMainHistoryHarness({ ws, createSessionDir });
+        const timestamp = Date.now();
+        const events: Array<Record<string, unknown>> = [
+          {
+            type: "message",
+            ...createTextTranscriptEvent("user", "discarded old", {
+              id: "old",
+              parentId: null,
+              timestamp,
+            }),
+          },
+          {
+            type: "message",
+            ...createTextTranscriptEvent("user", "kept one", {
+              id: "kept-one",
+              parentId: "old",
+              timestamp: timestamp + 1,
+            }),
+          },
+          {
+            type: "message",
+            ...createTextTranscriptEvent("assistant", "kept two", {
+              id: "kept-two",
+              parentId: "kept-one",
+              timestamp: timestamp + 2,
+            }),
+          },
+          {
+            ...boundary,
+            parentId: "kept-two",
+            timestamp: new Date(timestamp + 3).toISOString(),
+          },
+        ];
+        let parentId = boundary.id;
+        let eventIndex = 4;
+        for (const label of ["visible one", "visible two", "visible three"]) {
+          const visibleId = `visible-${eventIndex}`;
+          events.push({
+            type: "message",
+            ...createTextTranscriptEvent("user", label, {
+              id: visibleId,
+              parentId,
+              timestamp: timestamp + eventIndex,
+            }),
+          });
+          parentId = visibleId;
+          eventIndex += 1;
+          for (let hidden = 0; hidden < 7; hidden += 1) {
+            const hiddenId = `hidden-${eventIndex}`;
+            events.push({
+              type: "message",
+              ...createTextTranscriptEvent("assistant", "NO_REPLY", {
+                id: hiddenId,
+                parentId,
+                timestamp: timestamp + eventIndex,
+              }),
+            });
+            parentId = hiddenId;
+            eventIndex += 1;
+          }
+        }
+        await writeMainSessionTranscript(events);
+
+        type HistoryPage = {
+          messages?: Array<{ __openclaw?: { seq?: number } }>;
+          nextOffset?: number;
+          hasMore?: boolean;
+          totalMessages?: number;
+        };
+        const first = await rpcReq<HistoryPage>(
+          ws,
+          "chat.history",
+          makeMainSessionParams({ limit: 4, offset: 0 }),
+        );
+        expect(first.ok).toBe(true);
+        expect(
+          first.payload?.messages?.map(readOpenClawSeq),
+          JSON.stringify(first.payload),
+        ).toEqual(expectedFirstSeqs);
+        expect(JSON.stringify(first.payload?.messages)).toContain(marker);
+        expect(JSON.stringify(first.payload?.messages)).toContain("visible three");
+        expect(first.payload).toMatchObject({
+          hasMore: true,
+          nextOffset: 25,
+          totalMessages,
+        });
+
+        const older = await rpcReq<HistoryPage>(
+          ws,
+          "chat.history",
+          makeMainSessionParams({ limit: 4, offset: first.payload?.nextOffset }),
+        );
+        expect(older.ok).toBe(true);
+        expect(older.payload?.messages?.map(readOpenClawSeq)).toEqual(expectedOlderSeqs);
+        expect(older.payload?.hasMore).toBe(false);
+        expect(older.payload?.nextOffset).toBeUndefined();
+      });
+    },
+  );
+
   test("chat.history first-page metadata pages backward without overlaps or gaps", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await prepareMainHistoryHarness({ ws, createSessionDir });

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -853,11 +853,12 @@ export { resolveSessionTranscriptCandidates } from "./session-transcript-files.f
 export function capArrayByJsonBytes<T>(
   items: T[],
   maxBytes: number,
+  byteLength: (item: T) => number = jsonUtf8Bytes,
 ): { items: T[]; bytes: number } {
   if (items.length === 0) {
     return { items, bytes: 2 };
   }
-  const parts = items.map((item) => jsonUtf8Bytes(item));
+  const parts = items.map(byteLength);
   let bytes = 2 + parts.reduce((a, b) => a + b, 0) + (items.length - 1);
   let start = 0;
   while (bytes > maxBytes && start < items.length - 1) {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -213,7 +213,6 @@ vi.mock("../gateway/server-constants.js", () => ({
 vi.mock("../gateway/server-methods/chat.js", () => ({
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES: 100_000,
   augmentChatHistoryWithCanvasBlocks: (messages: unknown[]) => messages,
-  enforceChatHistoryFinalBudget: ({ messages }: { messages: unknown[] }) => ({ messages }),
   replaceOversizedChatHistoryMessages: ({ messages }: { messages: unknown[] }) => ({ messages }),
 }));
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -61,7 +61,6 @@ import {
 } from "../gateway/server-methods/chat-history-pages.js";
 import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-  enforceChatHistoryFinalBudget,
   replaceOversizedChatHistoryMessages,
 } from "../gateway/server-methods/chat.js";
 import { loadGatewayModelCatalog } from "../gateway/server-model-catalog.js";
@@ -670,8 +669,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       maxSingleMessageBytes: perMessageHardCap,
     });
     const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
-    const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
-    const messages = bounded.messages;
+    const messages = capped;
     const newestInFlightRun = [...this.runs.entries()].findLast(
       ([, run]) =>
         !run.isBtw &&


### PR DESCRIPTION
## What Problem This Solves

`chat.history` and `chat.startup` for a 100-message page materialized about 2,021 raw transcript events (`limit * 20 + 20` speculative window), re-JSON-stringified messages across multiple budget passes, and bundled metadata, agents-list, and workspace-icon preparation on the blocking path. All of that work was synchronous on the gateway event loop, stalling concurrent RPCs.

## Why This Change Was Made

History reads now use an incremental tail: start at 3× the requested limit and extend only while the projected page is short, absorbing the old silent-tail walk into the same reader. Byte accounting is single-pass through a per-request counter, removing the provably redundant final-budget pass. The session query uses an indexed first-successor lookup instead of a correlated `MIN` subquery. Startup projections run concurrently with the history read, and icon preparation is detached because the response never carried icon bytes; at worst the icon paints a beat later on first open.

The accepted tradeoff is that pathological all-silent tails still scan up to the existing bounded fuse. A page cache was intentionally skipped because the uncached path is already about 3.15 ms.

## User Impact

Opening chat history and startup views does substantially less synchronous gateway work, reducing latency and event-loop stalls for concurrent RPCs without changing page semantics or response shape.

## Evidence

Synthetic 5,000-event session, 60% silent, hot p50:

| Measure | Before | After |
| --- | ---: | ---: |
| Raw candidates | 2,021 | 301 |
| Raw read | 5.34 ms | 1.54 ms |
| Projection | 7.13 ms | 1.61 ms |
| `chat.history` RPC | 26.61 ms | 17.09 ms |
| `chat.startup` RPC | 25.46 ms | 14.09 ms |

Net production LOC: −3.

Focused suites green:

- `src/gateway/server-methods/chat-history-budget.test.ts`
- `src/gateway/server-methods/chat-history-omission-logging.test.ts`
- `src/gateway/server.chat.gateway-server-chat-b.test.ts`
- `src/gateway/server-methods/chat-history-handler.test.ts`
- `src/gateway/server-methods/chat-history-pages.test.ts`

`check:changed` is green. Fresh exact-head autoreview is clean with no accepted/actionable findings.

AI-assisted: yes. The change and evidence were reviewed by the maintainer.
