### PR TITLE
fix(update): defer source-runtime startup migrations

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -1,5 +1,5 @@
 // Declarative CLI command catalog for startup policy and fast-path routing.
-import { getCommandPositionalsWithRootOptions, hasFlag } from "./argv.js";
+import { hasFlag } from "./argv.js";
 
 export type CliCommandPluginLoadPolicy =
   | "never"
@@ -65,29 +65,6 @@ function hasCliOption(argv: readonly string[], name: string): boolean {
     }
   }
   return false;
-}
-
-const UPDATE_BOOLEAN_FLAGS = [
-  "--acknowledge-clawhub-risk",
-  "--dry-run",
-  "--json",
-  "--no-restart",
-  "--update",
-  "--yes",
-] as const;
-const UPDATE_VALUE_FLAGS = ["--channel", "--tag", "--timeout"] as const;
-
-function isRootUpdateDryRun(argv: string[], commandPath: string[]): boolean {
-  if (commandPath.length !== 1 || !hasFlag(argv, "--dry-run")) {
-    return false;
-  }
-  const usesRootShorthand = hasFlag(argv, "--update");
-  const positionals = getCommandPositionalsWithRootOptions(argv, {
-    commandPath: usesRootShorthand ? [] : ["update"],
-    booleanFlags: UPDATE_BOOLEAN_FLAGS,
-    valueFlags: UPDATE_VALUE_FLAGS,
-  });
-  return positionals?.length === 0;
 }
 
 /** Command path registry used before Commander registration has loaded all plugins. */
@@ -561,8 +538,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["update"],
     policy: {
-      configGuard: ({ argv, commandPath }) =>
-        isRootUpdateDryRun(argv, commandPath) ? "skip" : "run",
+      configGuard: "skip",
       hideBanner: true,
     },
   },

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -102,66 +102,32 @@ describe("command-startup-policy", () => {
     }
   });
 
-  it("skips the config guard for exact root update dry-runs", () => {
-    for (const argv of [
-      ["node", "openclaw", "update", "--dry-run"],
-      ["node", "openclaw", "--profile", "work", "update", "--dry-run"],
-      ["node", "openclaw", "--update", "--dry-run"],
-    ]) {
-      expect(
-        resolvePolicy({
-          argv,
-          commandPath: ["update"],
-        }).skipConfigGuard,
-        argv.join(" "),
-      ).toBe(true);
-    }
-  });
-
-  it("keeps the config guard for non-dry-run and descendant update invocations", () => {
+  it("defers startup migrations for every update invocation", () => {
     for (const testCase of [
+      { argv: ["node", "openclaw", "update"], commandPath: ["update"] },
+      { argv: ["node", "openclaw", "--update"], commandPath: ["update"] },
       {
-        argv: ["node", "openclaw", "update"],
+        argv: ["node", "openclaw", "update", "--dry-run"],
         commandPath: ["update"],
       },
       {
-        argv: ["node", "openclaw", "update", "--tag", "--dry-run"],
-        commandPath: ["update"],
-      },
-      {
-        argv: ["node", "openclaw", "update", "--channel", "--dry-run"],
-        commandPath: ["update"],
-      },
-      {
-        argv: ["node", "openclaw", "update", "--timeout", "--dry-run"],
-        commandPath: ["update"],
-      },
-      {
-        argv: ["node", "openclaw", "update", "--tag=--dry-run"],
-        commandPath: ["update"],
-      },
-      {
-        argv: ["node", "openclaw", "update", "--", "--dry-run"],
-        commandPath: ["update"],
-      },
-      {
-        argv: ["node", "openclaw", "update", "status", "--dry-run"],
+        argv: ["node", "openclaw", "update", "status"],
         commandPath: ["update", "status"],
       },
       {
-        argv: ["node", "openclaw", "update", "repair", "--dry-run"],
+        argv: ["node", "openclaw", "update", "repair"],
         commandPath: ["update", "repair"],
       },
       {
-        argv: ["node", "openclaw", "update", "finalize", "--dry-run"],
+        argv: ["node", "openclaw", "update", "finalize"],
         commandPath: ["update", "finalize"],
       },
       {
-        argv: ["node", "openclaw", "update", "wizard", "--dry-run"],
+        argv: ["node", "openclaw", "update", "wizard"],
         commandPath: ["update", "wizard"],
       },
     ]) {
-      expect(resolvePolicy(testCase).skipConfigGuard, testCase.argv.join(" ")).toBe(false);
+      expect(resolvePolicy(testCase).skipConfigGuard, testCase.argv.join(" ")).toBe(true);
     }
   });
 

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -107,6 +107,10 @@ describe("command-startup-policy", () => {
       { argv: ["node", "openclaw", "update"], commandPath: ["update"] },
       { argv: ["node", "openclaw", "--update"], commandPath: ["update"] },
       {
+        argv: ["node", "openclaw", "--profile", "work", "update"],
+        commandPath: ["update"],
+      },
+      {
         argv: ["node", "openclaw", "update", "--dry-run"],
         commandPath: ["update"],
       },

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -452,18 +452,13 @@ describe("registerPreActionHooks", () => {
     );
   });
 
-  it("allows invalid config for update migration commands", async () => {
+  it("defers config bootstrap for update commands", async () => {
     await runPreAction({
       parseArgv: ["update"],
       processArgv: ["node", "openclaw", "update", "--json"],
     });
 
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      measure: expect.any(Function),
-      commandPath: ["update"],
-      allowInvalid: true,
-    });
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
     await runPreAction({
@@ -471,13 +466,7 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "update", "status", "--json"],
     });
 
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      measure: expect.any(Function),
-      commandPath: ["update", "status"],
-      allowInvalid: true,
-      suppressDoctorStdout: true,
-    });
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
   });
 
   it("loads plugins for text local agent runs", async () => {
@@ -804,13 +793,8 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "update", "status", "--json"],
     });
 
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      measure: expect.any(Function),
-      commandPath: ["update", "status"],
-      allowInvalid: true,
-      suppressDoctorStdout: true,
-    });
+    expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -130,6 +130,11 @@ vi.mock("../state/openclaw-database-preflight.js", () => ({
   preflightOpenClawDatabaseSchemas: databasePreflightMocks.preflightOpenClawDatabaseSchemas,
 }));
 
+vi.mock("../state/openclaw-state-ownership.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../state/openclaw-state-ownership.js")>()),
+  assertOpenClawStateWriteAllowedAtPath: vi.fn(async () => undefined),
+}));
+
 vi.mock("../infra/openclaw-root.js", () => ({
   resolveOpenClawPackageRoot: vi.fn(),
   resolveOpenClawPackageRootSync: vi.fn(() => process.cwd()),

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1508,11 +1508,12 @@ describe("update-cli", () => {
     tempDirsToCleanup.clear();
   });
 
-  it("reads the initial update config without plugin schema validation", async () => {
+  it("reads the initial update config without schema validation or observation", async () => {
     await updateCommand({ yes: true, restart: false });
 
     expect(vi.mocked(readConfigFileSnapshot).mock.calls[0]?.[0]).toEqual({
       skipPluginValidation: true,
+      observe: false,
     });
   });
 
@@ -7879,6 +7880,7 @@ describe("update-cli", () => {
 
       await updateWizardCommand({});
 
+      expect(readConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
       const call = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
       expect(call?.channel).toBe("dev");
     });

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -55,6 +55,8 @@ import { restorePersistedInstalledPluginIndexIfCurrent } from "../../plugins/ins
 import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
 import { runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { assertOpenClawStateWriteAllowedAtPath } from "../../state/openclaw-state-ownership.js";
 import { VERSION } from "../../version.js";
 import { printResult } from "./progress.js";
 import {
@@ -161,6 +163,9 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
   }
 
   assertConfigWriteAllowedInCurrentMode();
+  await assertOpenClawStateWriteAllowedAtPath({
+    databasePath: resolveOpenClawStateSqlitePath(process.env),
+  });
 
   const root = await resolveUpdateRoot();
   let configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -169,10 +169,9 @@ async function updateCommandInternal(
     return;
   }
   if (opts.dryRun !== true) {
-    // Startup migrations belong to the freshly installed Doctor, but mutable updates
-    // must retain their read-only ownership fence before inspecting package state.
     await assertOpenClawStateWriteAllowedAtPath({
       databasePath: resolveOpenClawStateSqlitePath(process.env),
+      recoverOrphanedSidecars: false,
     });
   }
   const controlPlaneUpdateSentinelMeta = await readControlPlaneUpdateSentinelMeta();
@@ -229,7 +228,7 @@ async function updateCommandInternal(
 
   let configSnapshot = await readConfigFileSnapshot({
     skipPluginValidation: true,
-    ...(opts.dryRun === true ? { observe: false } : {}),
+    observe: false,
   });
   if (opts.channel && !opts.dryRun && !configSnapshot.valid) {
     configSnapshot = await maybeRepairLegacyConfigForUpdateChannel({
@@ -604,6 +603,11 @@ async function updateCommandInternal(
     }
   }
 
+  // Startup migrations belong to the freshly installed Doctor. Admit shared-state
+  // mutation only after every pre-install refusal has passed.
+  await assertOpenClawStateWriteAllowedAtPath({
+    databasePath: resolveOpenClawStateSqlitePath(process.env),
+  });
   await disableCurrentOpenClawUpdateLaunchdJob().catch(() => undefined);
 
   const showProgress = !opts.json && process.stdout.isTTY;

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -45,6 +45,8 @@ import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-man
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { assertOpenClawStateWriteAllowedAtPath } from "../../state/openclaw-state-ownership.js";
 import { VERSION } from "../../version.js";
 import { resolveCliName } from "../cli-name.js";
 import { createUpdateProgress } from "./progress.js";
@@ -165,6 +167,13 @@ async function updateCommandInternal(
     defaultRuntime.error(formatExternalSupervisorUpdateRequired());
     defaultRuntime.exit(1);
     return;
+  }
+  if (opts.dryRun !== true) {
+    // Startup migrations belong to the freshly installed Doctor, but mutable updates
+    // must retain their read-only ownership fence before inspecting package state.
+    await assertOpenClawStateWriteAllowedAtPath({
+      databasePath: resolveOpenClawStateSqlitePath(process.env),
+    });
   }
   const controlPlaneUpdateSentinelMeta = await readControlPlaneUpdateSentinelMeta();
   const discoveredRoot = await resolveUpdateRoot();

--- a/src/cli/update-cli/wizard.ts
+++ b/src/cli/update-cli/wizard.ts
@@ -48,7 +48,7 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
       fetchGit: false,
       includeRegistry: false,
     }),
-    readConfigFileSnapshot(),
+    readConfigFileSnapshot({ observe: false }),
   ]);
 
   const configChannel = configSnapshot.valid

--- a/src/cli/update-dry-run-state.process.test.ts
+++ b/src/cli/update-dry-run-state.process.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { CONTROL_PLANE_UPDATE_SENTINEL_META_ENV } from "../infra/update-control-plane-sentinel.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -47,7 +48,7 @@ function snapshotDatabaseArtifacts(snapshot: string[]): string[] {
   return snapshot.filter((entry) => /^f .*\.sqlite(?:-(?:wal|shm))? /.test(entry));
 }
 
-function runUpdateProcess(root: string, args: string[]) {
+function runUpdateProcess(root: string, args: string[], env: NodeJS.ProcessEnv = {}) {
   const configPath = path.join(root, "config", "openclaw.json");
   const stateDir = path.join(root, "state");
   const entryPath = fileURLToPath(new URL("../entry.ts", import.meta.url));
@@ -79,6 +80,7 @@ function runUpdateProcess(root: string, args: string[]) {
       all_proxy: undefined,
       http_proxy: undefined,
       https_proxy: undefined,
+      ...env,
     },
     maxBuffer: 4 * 1024 * 1024,
     timeout: 60_000,
@@ -178,6 +180,31 @@ describe("update process state", () => {
     expect(result.error).toBeUndefined();
     expect(result.status).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/--timeout must be a positive integer/iu);
+    expect(await snapshotTree(root)).toEqual(before);
+  });
+
+  it("keeps an orphaned SQLite journal immutable when a managed handoff is refused", async () => {
+    const root = tempDirs.make("openclaw-update-refused-handoff-");
+    const configPath = path.join(root, "config", "openclaw.json");
+    const stateDir = path.join(root, "state");
+    const metaPath = path.join(root, "handoff.json");
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.mkdir(path.join(stateDir, "state"), { recursive: true });
+    await fs.writeFile(configPath, '{ "gateway": { "mode": "local" } }\n');
+    await fs.writeFile(path.join(stateDir, "state", "openclaw.sqlite-journal"), "orphan journal\n");
+    await fs.writeFile(
+      metaPath,
+      `${JSON.stringify({ version: 1, meta: { root: path.join(root, "wrong-install") } })}\n`,
+    );
+    const before = await snapshotTree(root);
+
+    const result = runUpdateProcess(root, ["update", "--no-restart", "--json"], {
+      [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(/Managed update handoff root mismatch/iu);
     expect(await snapshotTree(root)).toEqual(before);
   });
 

--- a/src/cli/update-dry-run-state.process.test.ts
+++ b/src/cli/update-dry-run-state.process.test.ts
@@ -47,7 +47,7 @@ function snapshotDatabaseArtifacts(snapshot: string[]): string[] {
   return snapshot.filter((entry) => /^f .*\.sqlite(?:-(?:wal|shm))? /.test(entry));
 }
 
-function runUpdateDryRun(root: string, args: string[]) {
+function runUpdateProcess(root: string, args: string[]) {
   const configPath = path.join(root, "config", "openclaw.json");
   const stateDir = path.join(root, "state");
   const entryPath = fileURLToPath(new URL("../entry.ts", import.meta.url));
@@ -85,7 +85,7 @@ function runUpdateDryRun(root: string, args: string[]) {
   });
 }
 
-describe("update dry-run process state", () => {
+describe("update process state", () => {
   it("keeps malformed config immutable while producing a best-effort preview", async () => {
     const root = tempDirs.make("openclaw-update-dry-run-malformed-");
     const configPath = path.join(root, "config", "openclaw.json");
@@ -95,7 +95,7 @@ describe("update dry-run process state", () => {
     const configBefore = await fs.readFile(configPath);
     const treeBefore = await snapshotTree(root);
 
-    const result = runUpdateDryRun(root, ["update", "--dry-run", "--no-restart", "--json"]);
+    const result = runUpdateProcess(root, ["update", "--dry-run", "--no-restart", "--json"]);
 
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
@@ -129,7 +129,7 @@ describe("update dry-run process state", () => {
     const treeBefore = await snapshotTree(root);
     const databaseArtifactsBefore = snapshotDatabaseArtifacts(treeBefore);
 
-    const result = runUpdateDryRun(root, ["--update", "--dry-run", "--no-restart", "--json"]);
+    const result = runUpdateProcess(root, ["--update", "--dry-run", "--no-restart", "--json"]);
 
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
@@ -141,6 +141,44 @@ describe("update dry-run process state", () => {
       wal: await sha256File(walPath),
     }).toEqual(markerHashesBefore);
     expect(snapshotDatabaseArtifacts(await snapshotTree(root))).toEqual(databaseArtifactsBefore);
+  });
+
+  it("defers legacy-state migration until the updated runtime", async () => {
+    const root = tempDirs.make("openclaw-update-legacy-state-");
+    const configPath = path.join(root, "config", "openclaw.json");
+    const sessionsDir = path.join(root, "state", "sessions");
+    const sessionId = "legacy-会議-session";
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(configPath, '{ "gateway": { "mode": "local" } }\n');
+    await fs.writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      `${JSON.stringify({
+        "agent:main:discord:direct:user": {
+          sessionId,
+          sessionFile: path.join(sessionsDir, `${sessionId}.jsonl`),
+          updatedAt: 1,
+        },
+      })}\n`,
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, `${sessionId}.jsonl`),
+      `${JSON.stringify({ type: "session", id: sessionId })}\n`,
+    );
+    const before = await snapshotTree(root);
+
+    const result = runUpdateProcess(root, [
+      "update",
+      "--timeout",
+      "invalid",
+      "--no-restart",
+      "--json",
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(/--timeout must be a positive integer/iu);
+    expect(await snapshotTree(root)).toEqual(before);
   });
 
   it("fences the full mutable update path before observation or action", async () => {
@@ -163,19 +201,12 @@ describe("update dry-run process state", () => {
     const before = await snapshotTree(root);
     const beforeDatabaseHash = await sha256File(databasePath);
 
-    const refused = runUpdateDryRun(root, [
-      "update",
-      "--timeout",
-      "invalid",
-      "--no-restart",
-      "--json",
-    ]);
+    const refused = runUpdateProcess(root, ["update", "--timeout", "1", "--no-restart", "--json"]);
 
     expect(refused.error).toBeUndefined();
     expect(refused.status).not.toBe(0);
     expect(`${refused.stdout}\n${refused.stderr}`).toMatch(/gateway-supervisor/u);
     expect(`${refused.stdout}\n${refused.stderr}`).toMatch(/OPENCLAW_SUPERVISOR_MODE=external/u);
-    expect(`${refused.stdout}\n${refused.stderr}`).not.toMatch(/invalid timeout/iu);
     expect(await snapshotTree(root)).toEqual(before);
     expect(await sha256File(databasePath)).toBe(beforeDatabaseHash);
   });

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -284,18 +284,22 @@ export function runWithOpenClawStateWriteAccess<T>(
   );
 }
 
-/** Check path-based write admission without retaining the coordinator past this call. */
+/** Check write admission; callers may defer orphan-sidecar recovery until mutation is certain. */
 export async function assertOpenClawStateWriteAllowedAtPath(options: {
   databasePath: string;
   env?: NodeJS.ProcessEnv;
+  recoverOrphanedSidecars?: boolean;
 }): Promise<void> {
   const databasePath = path.resolve(options.databasePath);
-  quarantineOrphanedSqliteSidecars(databasePath);
+  const recoverOrphanedSidecars = options.recoverOrphanedSidecars !== false;
+  if (recoverOrphanedSidecars) {
+    quarantineOrphanedSqliteSidecars(databasePath);
+  }
   if (!existsSync(databasePath)) {
     return;
   }
   const env = options.env ?? process.env;
-  if (isGatewayExternallySupervised(env)) {
+  if (recoverOrphanedSidecars && isGatewayExternallySupervised(env)) {
     runWithOpenClawStateWriteAccess(
       { ...options, databasePath },
       "shared state write admission",
@@ -303,8 +307,6 @@ export async function assertOpenClawStateWriteAllowedAtPath(options: {
     );
     return;
   }
-  // Unmarked startup must discover ownership without opening the source writable.
-  // The async private snapshot keeps Windows PowerShell work off the sync startup path.
   const prepared = await prepareSqliteReadOnlyLocation(databasePath);
   try {
     assertOwnershipAllowsWrite(


### PR DESCRIPTION
Related: #118856

## What Problem This Solves

An updater should not run the source runtime's general config/state startup migrations before it has parsed the update request and decided whether package replacement will proceed. Doing so makes refused updates mutate state and couples every update hop to the older runtime's migration implementation.

## Why This Change Was Made

Every `update` invocation now bypasses global config/state bootstrap. Update handlers use non-observing initial config reads, perform a read-only shared-state ownership check before package inspection, and admit mutable state (including orphan-sidecar recovery) only immediately before actual mutation. Repair/finalize retain explicit admission at their mutation boundary.

This also deletes the dry-run-only update argument classifier and its duplicate flag inventory.

## Compatibility Boundary

This is forward hardening: a release containing this patch preserves source state for subsequent update hops. It cannot retroactively change startup in an already-published older binary, because that process runs its pre-action before the candidate package is installed.

Published `2026.7.1-2` diagnostics confirmed that distinction. Manually seeded session IDs outside that release's supported persisted-ID contract can be filtered by its own startup migration before candidate code exists; the remaining transcripts do not contain the deleted session key, label, provider, or model metadata needed for exact reconstruction. The published-baseline stress fixture therefore uses IDs accepted by that baseline while retaining Unicode/decomposed session keys, Unicode labels and transcript content, and an exactly 128-character session ID.

## User Impact

Once this reaches a release, update previews, refusals, subcommands, and package replacement all avoid source-runtime startup migration. The freshly installed Doctor remains the canonical owner of post-install migration.

## Evidence

- Rebased focused suites: 323/323 passed across startup policy, pre-action, update CLI, and update process tests.
- Process coverage proves byte-identical legacy state after a refused update, byte-identical orphan journals after a refused managed handoff, and shared-state ownership refusal before observation/action.
- Published `2026.7.1-2` compatibility diagnostic with six baseline-supported edge sessions: old startup retained 6/6 rows; candidate Doctor produced 3 main + 3 ops SQLite sessions and all 12 expected transcript events.
- Fresh complete-diff Codex autoreview: clean; no accepted/actionable findings; patch correct at 0.98 confidence.
- Production LOC: +29/-33 (net -4). Tests: +93/-74.
- No provider or channel requests were made; no schema version, config surface, protocol, dependency, release, or publishing changes.