### PR TITLE
fix(msteams): avoid ambiguous delivery replay

### DIFF
--- a/extensions/msteams/src/errors.test.ts
+++ b/extensions/msteams/src/errors.test.ts
@@ -2,11 +2,17 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   classifyMSTeamsSendError,
+  formatMSTeamsDeliveryFailureGuidance,
   formatMSTeamsSendErrorHint,
   formatUnknownError,
   isRevokedProxyError,
 } from "./errors.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
+
+function replaySafeRetryAfterMs(error: unknown): number | undefined {
+  const classification = classifyMSTeamsSendError(error);
+  return classification.kind === "replay-safe" ? classification.retryAfterMs : undefined;
+}
 
 describe("msteams errors", () => {
   it("formats unknown errors", () => {
@@ -35,61 +41,59 @@ describe("msteams errors", () => {
     expect(result.errorCode).toBe("ContentStreamNotAllowed");
   });
 
-  it("classifies throttling errors and parses retry-after", () => {
+  it("classifies Teams rate limiting as replay-safe and parses retry-after", () => {
     const result = classifyMSTeamsSendError({ statusCode: 429, retryAfter: "1.5" });
-    expect(result.kind).toBe("throttled");
+    expect(result.kind).toBe("replay-safe");
     expect(result.statusCode).toBe(429);
-    expect(result.retryAfterMs).toBe(1500);
+    expect(replaySafeRetryAfterMs({ statusCode: 429, retryAfter: "1.5" })).toBe(1500);
   });
 
   it("does not parse partial retry-after values", () => {
+    expect(replaySafeRetryAfterMs({ statusCode: 429, retryAfter: "1.5s" })).toBeUndefined();
     expect(
-      classifyMSTeamsSendError({ statusCode: 429, retryAfter: "1.5s" }).retryAfterMs,
-    ).toBeUndefined();
-    expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         response: { headers: { "retry-after": "2 seconds" } },
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
     expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         response: { headers: new Headers({ "retry-after": "3 seconds" }) },
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
   });
 
   it("ignores unsafe retry-after magnitudes", () => {
     expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         retryAfterMs: Number.MAX_SAFE_INTEGER + 1,
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
     expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         retryAfter: Number.MAX_SAFE_INTEGER,
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
     expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         retryAfter: "9007199254741",
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
     expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         response: { headers: { "retry-after": "9007199254741" } },
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
     expect(
-      classifyMSTeamsSendError({
+      replaySafeRetryAfterMs({
         statusCode: 429,
         response: { headers: new Headers({ "retry-after": "9007199254741" }) },
-      }).retryAfterMs,
+      }),
     ).toBeUndefined();
   });
 
@@ -101,10 +105,30 @@ describe("msteams errors", () => {
     ).toBe("unknown");
   });
 
-  it("classifies transient errors", () => {
-    const result = classifyMSTeamsSendError({ statusCode: 503 });
-    expect(result.kind).toBe("transient");
-    expect(result.statusCode).toBe(503);
+  it.each([408, 500, 502, 503, 504])("classifies HTTP %i as delivery-ambiguous", (statusCode) => {
+    const classification = classifyMSTeamsSendError({ statusCode });
+    expect(classification).toMatchObject({
+      kind: "ambiguous",
+      source: "http",
+      statusCode,
+    });
+    expect(formatMSTeamsSendErrorHint(classification)).toContain("outcome is unknown");
+    expect(formatMSTeamsSendErrorHint(classification)).not.toMatch(/retry|resend/iu);
+    expect(formatMSTeamsDeliveryFailureGuidance(classification)).toContain(
+      "may already have succeeded",
+    );
+    expect(formatMSTeamsDeliveryFailureGuidance(classification)).not.toContain(
+      "Retrying later may succeed",
+    );
+  });
+
+  it("keeps model guidance aligned with replay safety", () => {
+    expect(
+      formatMSTeamsDeliveryFailureGuidance(classifyMSTeamsSendError({ statusCode: 429 })),
+    ).toBe("The request was rate-limited before delivery; retrying later may succeed.");
+    expect(
+      formatMSTeamsDeliveryFailureGuidance(classifyMSTeamsSendError({ statusCode: 401 })),
+    ).toBeUndefined();
   });
 
   it("classifies permanent 4xx errors", () => {
@@ -114,13 +138,19 @@ describe("msteams errors", () => {
   });
 
   it("provides actionable hints for common cases", () => {
-    expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("msteams");
-    expect(formatMSTeamsSendErrorHint({ kind: "throttled" })).toContain("throttled");
+    expect(formatMSTeamsSendErrorHint(classifyMSTeamsSendError({ statusCode: 401 }))).toContain(
+      "msteams",
+    );
+    expect(formatMSTeamsSendErrorHint(classifyMSTeamsSendError({ statusCode: 429 }))).toContain(
+      "throttled",
+    );
     expect(
-      formatMSTeamsSendErrorHint({
-        kind: "permanent",
-        errorCode: "ContentStreamNotAllowed",
-      }),
+      formatMSTeamsSendErrorHint(
+        classifyMSTeamsSendError({
+          statusCode: 403,
+          response: { body: { error: { code: "ContentStreamNotAllowed" } } },
+        }),
+      ),
     ).toContain("expired the content stream");
   });
 
@@ -132,19 +162,34 @@ describe("msteams errors", () => {
     const etimedout = Object.assign(new Error("ETIMEDOUT"), { code: "ETIMEDOUT" });
 
     const econnrefusedResult = classifyMSTeamsSendError(econnrefused);
-    expect(econnrefusedResult.kind).toBe("network");
+    expect(econnrefusedResult).toMatchObject({ kind: "ambiguous", source: "transport" });
     expect(econnrefusedResult.errorCode).toBe("ECONNREFUSED");
     const enotfoundResult = classifyMSTeamsSendError(enotfound);
-    expect(enotfoundResult.kind).toBe("network");
+    expect(enotfoundResult).toMatchObject({ kind: "ambiguous", source: "transport" });
     expect(enotfoundResult.errorCode).toBe("ENOTFOUND");
     const etimedoutResult = classifyMSTeamsSendError(etimedout);
-    expect(etimedoutResult.kind).toBe("network");
+    expect(etimedoutResult).toMatchObject({ kind: "ambiguous", source: "transport" });
     expect(etimedoutResult.errorCode).toBe("ETIMEDOUT");
 
-    // Hints for network errors must mention smba (Connector endpoint) and egress
-    expect(formatMSTeamsSendErrorHint({ kind: "network" })).toContain("smba");
-    expect(formatMSTeamsSendErrorHint({ kind: "network" })).toContain("egress");
+    const hint = formatMSTeamsSendErrorHint(econnrefusedResult);
+    expect(hint).toContain("smba");
+    expect(hint).toContain("egress");
+    expect(hint).toContain("outcome is unknown");
+    expect(hint).not.toMatch(/retry|resend/iu);
   });
+
+  it.each(["ECONNABORTED", "ETIMEDOUT", "ECONNRESET"])(
+    "keeps transport %s delivery ambiguous without retry guidance",
+    (code) => {
+      const classification = classifyMSTeamsSendError(Object.assign(new Error(code), { code }));
+      expect(classification).toMatchObject({
+        kind: "ambiguous",
+        source: "transport",
+        errorCode: code,
+      });
+      expect(formatMSTeamsSendErrorHint(classification)).not.toMatch(/retry|resend/iu);
+    },
+  );
 
   it("still classifies HTTP errors as unknown when no status code and no network code", () => {
     expect(classifyMSTeamsSendError(new Error("unexpected error")).kind).toBe("unknown");

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -1,6 +1,9 @@
 // Msteams plugin module implements errors behavior.
 import { asFiniteNumberInRange, parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
-import { parseRetryAfterHeaderSeconds } from "openclaw/plugin-sdk/retry-runtime";
+import {
+  isTransientNetworkError,
+  parseRetryAfterHeaderSeconds,
+} from "openclaw/plugin-sdk/retry-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const MAX_SAFE_RETRY_AFTER_SECONDS = Number.MAX_SAFE_INTEGER / 1000;
@@ -174,28 +177,28 @@ function parseNonNegativeRetryAfterSeconds(raw: string): number | undefined {
   });
 }
 
-type MSTeamsSendErrorKind =
-  | "auth"
-  | "throttled"
-  | "transient"
-  | "permanent"
-  | "network"
-  | "unknown";
-
-type MSTeamsSendErrorClassification = {
-  kind: MSTeamsSendErrorKind;
+type MSTeamsSendErrorMetadata = {
   statusCode?: number;
-  retryAfterMs?: number;
   errorCode?: string;
 };
 
+type MSTeamsSendErrorClassification =
+  | (MSTeamsSendErrorMetadata & { kind: "auth" })
+  | (MSTeamsSendErrorMetadata & {
+      kind: "replay-safe";
+      statusCode: 429;
+      retryAfterMs?: number;
+    })
+  | (MSTeamsSendErrorMetadata & {
+      kind: "ambiguous";
+      source: "http" | "transport";
+    })
+  | (MSTeamsSendErrorMetadata & { kind: "permanent" })
+  | (MSTeamsSendErrorMetadata & { kind: "unknown" });
+
 /**
- * Classify outbound send errors for safe retries and actionable logs.
- *
- * Important: We only mark errors as retryable when we have an explicit HTTP
- * status code that indicates the message was not accepted (e.g. 429, 5xx).
- * For transport-level errors where delivery is ambiguous, we prefer to avoid
- * retries to reduce the chance of duplicate posts.
+ * Owns retry safety and delivery ambiguity for Teams send failures.
+ * Only Teams rate-limit rejection proves this unkeyed POST safe to replay.
  */
 export function classifyMSTeamsSendError(err: unknown): MSTeamsSendErrorClassification {
   const statusCode = extractStatusCode(err);
@@ -215,7 +218,7 @@ export function classifyMSTeamsSendError(err: unknown): MSTeamsSendErrorClassifi
 
   if (statusCode === 429) {
     return {
-      kind: "throttled",
+      kind: "replay-safe",
       statusCode,
       retryAfterMs: retryAfterMs ?? undefined,
       errorCode,
@@ -224,9 +227,9 @@ export function classifyMSTeamsSendError(err: unknown): MSTeamsSendErrorClassifi
 
   if (statusCode === 408 || (statusCode != null && statusCode >= 500)) {
     return {
-      kind: "transient",
+      kind: "ambiguous",
+      source: "http",
       statusCode,
-      retryAfterMs: retryAfterMs ?? undefined,
       errorCode,
     };
   }
@@ -235,25 +238,15 @@ export function classifyMSTeamsSendError(err: unknown): MSTeamsSendErrorClassifi
     return { kind: "permanent", statusCode, errorCode };
   }
 
-  // Transport-level errors (no HTTP status code) — check for well-known
-  // network error codes that indicate egress is blocked (#77674).
-  if (statusCode == null) {
-    const networkCode = isRecord(err) && typeof err.code === "string" ? err.code : null;
-    if (
-      networkCode === "ECONNREFUSED" ||
-      networkCode === "ENOTFOUND" ||
-      networkCode === "EHOSTUNREACH" ||
-      networkCode === "ETIMEDOUT" ||
-      networkCode === "ECONNRESET"
-    ) {
-      return { kind: "network", errorCode: networkCode };
-    }
+  // A transport failure can happen after the Connector accepted the POST.
+  // Preserve its code for diagnostics without implying replay is safe.
+  if (statusCode == null && isTransientNetworkError(err)) {
+    return { kind: "ambiguous", source: "transport", errorCode };
   }
 
   return {
     kind: "unknown",
     statusCode: statusCode ?? undefined,
-    retryAfterMs: retryAfterMs ?? undefined,
     errorCode,
   };
 }
@@ -282,14 +275,26 @@ export function formatMSTeamsSendErrorHint(
   if (classification.errorCode === "ContentStreamNotAllowed") {
     return "Teams expired the content stream; stop streaming earlier and fall back to normal message delivery";
   }
-  if (classification.kind === "throttled") {
+  if (classification.kind === "replay-safe") {
     return "Teams throttled the bot; backing off may help";
   }
-  if (classification.kind === "transient") {
-    return "transient Teams/Bot Framework error; retry may succeed";
+  if (classification.kind === "ambiguous") {
+    if (classification.source === "transport") {
+      return "transport-level failure sending to Teams Bot Connector (smba.trafficmanager.net); the outcome is unknown, so check egress and conversation history before taking further action";
+    }
+    return "Teams/Bot Framework delivery outcome is unknown; inspect the conversation history before taking further action";
   }
-  if (classification.kind === "network") {
-    return "transport-level failure sending reply to Teams Bot Connector (smba.trafficmanager.net) — check egress firewall rules allow outbound HTTPS to smba.trafficmanager.net";
+  return undefined;
+}
+
+export function formatMSTeamsDeliveryFailureGuidance(
+  classification: MSTeamsSendErrorClassification,
+): string | undefined {
+  if (classification.kind === "replay-safe") {
+    return "The request was rate-limited before delivery; retrying later may succeed.";
+  }
+  if (classification.kind === "ambiguous") {
+    return "Delivery may already have succeeded; do not send the same content again without checking the conversation.";
   }
   return undefined;
 }

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -485,7 +485,7 @@ describe("msteams messenger", () => {
       ).rejects.toBeInstanceOf(PlatformMessageNotDispatchedError);
     });
 
-    it("retries thread sends on throttling (429)", async () => {
+    it("retries thread sends after a replay-safe HTTP 429", async () => {
       const attempts: string[] = [];
       const retryEvents: Array<{ nextAttempt: number; delayMs: number }> = [];
 
@@ -785,22 +785,73 @@ describe("msteams messenger", () => {
       expect(capturedConversationId).toBe("19:abc@thread.tacv2");
     });
 
-    it("retries top-level sends on transient (5xx)", async () => {
-      const attempts: string[] = [];
+    it.each([408, 500, 502, 503, 504])(
+      "does not retry top-level sends after ambiguous HTTP %i",
+      async (statusCode) => {
+        const attempts: string[] = [];
 
-      const ids = await sendMSTeamsMessages({
+        const error = await sendMSTeamsMessages({
+          replyStyle: "top-level",
+          app: createMockApp({
+            createFn: createRecordedSendActivity(attempts, statusCode),
+          }),
+          appId: "app123",
+          conversationRef: baseRef,
+          messages: [{ text: "hello" }],
+          retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+        }).catch((cause: unknown) => cause);
+
+        expect(attempts).toEqual(["hello"]);
+        expect(error).toMatchObject({ statusCode });
+      },
+    );
+
+    it.each(["ECONNABORTED", "ETIMEDOUT", "ECONNRESET"])(
+      "does not retry top-level sends after ambiguous transport %s",
+      async (code) => {
+        const attempts: string[] = [];
+        const error = await sendMSTeamsMessages({
+          replyStyle: "top-level",
+          app: createMockApp({
+            createFn: async (activity) => {
+              attempts.push((activity as { text?: string }).text ?? "");
+              throw Object.assign(new Error(code), { code });
+            },
+          }),
+          appId: "app123",
+          conversationRef: baseRef,
+          messages: [{ text: "hello" }],
+          retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
+        }).catch((cause: unknown) => cause);
+
+        expect(attempts).toEqual(["hello"]);
+        expect(error).toMatchObject({ code });
+      },
+    );
+
+    it("does not replay accepted blocks when a later block has an ambiguous failure", async () => {
+      const attempts: string[] = [];
+      const error = await sendMSTeamsMessages({
         replyStyle: "top-level",
         app: createMockApp({
-          createFn: createRecordedSendActivity(attempts, 503),
+          createFn: async (activity) => {
+            const text = (activity as { text?: string }).text ?? "";
+            attempts.push(text);
+            if (text === "second") {
+              throw Object.assign(new Error("gateway timeout"), { statusCode: 504 });
+            }
+            return { id: `id:${text}` };
+          },
         }),
         appId: "app123",
         conversationRef: baseRef,
-        messages: [{ text: "hello" }],
-        retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
-      });
+        messages: [{ text: "first" }, { text: "second" }],
+        retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
+      }).catch((cause: unknown) => cause);
 
-      expect(attempts).toEqual(["hello", "hello"]);
-      expect(ids).toEqual(["id:hello"]);
+      expect(attempts).toEqual(["first", "second"]);
+      expect(error).toMatchObject({ statusCode: 504 });
+      expect(error).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
     });
 
     it("delivers all blocks in a multi-block reply via a single proactive send context (#29379)", async () => {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -204,7 +204,7 @@ function computeRetryDelayMs(
   classification: ReturnType<typeof classifyMSTeamsSendError>,
   opts: Required<MSTeamsSendRetryOptions>,
 ): number {
-  if (classification.retryAfterMs != null) {
+  if (classification.kind === "replay-safe" && classification.retryAfterMs != null) {
     return clampMs(classification.retryAfterMs, opts.maxDelayMs);
   }
   const exponential = opts.baseDelayMs * 2 ** Math.max(0, attempt - 1);
@@ -212,7 +212,7 @@ function computeRetryDelayMs(
 }
 
 function shouldRetry(classification: ReturnType<typeof classifyMSTeamsSendError>): boolean {
-  return classification.kind === "throttled" || classification.kind === "transient";
+  return classification.kind === "replay-safe";
 }
 
 export function renderReplyPayloadsToMessages(

--- a/extensions/msteams/src/qa/bot-framework-server.test.ts
+++ b/extensions/msteams/src/qa/bot-framework-server.test.ts
@@ -53,6 +53,31 @@ describe("Microsoft Teams QA Bot Framework server", () => {
     }
   });
 
+  it("models an ambiguous gateway timeout after accepting the marked activity", async () => {
+    const onOutbound = vi.fn(async () => {});
+    const server = await startMSTeamsQaBotFrameworkServer({
+      botToken: "bot-token",
+      nonce: "qa-nonce",
+      onOutbound,
+    });
+    try {
+      const response = await fetch(`${server.baseUrl}qa/v3/conversations/channel/activities`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer bot-token",
+          "content-type": "application/json",
+          "x-openclaw-msteams-qa-nonce": "qa-nonce",
+        },
+        body: JSON.stringify({ type: "message", text: "QA-MSTEAMS-AMBIGUOUS-504" }),
+      });
+
+      expect(response.status).toBe(504);
+      expect(onOutbound).toHaveBeenCalledOnce();
+    } finally {
+      await server.close();
+    }
+  });
+
   it("stops accepting requests after cleanup", async () => {
     const server = await startMSTeamsQaBotFrameworkServer({
       botToken: "bot-token",

--- a/extensions/msteams/src/qa/bot-framework-server.ts
+++ b/extensions/msteams/src/qa/bot-framework-server.ts
@@ -17,6 +17,8 @@ type ServerOptions = {
   onOutbound: (activity: MSTeamsQaOutboundActivity) => Promise<void>;
 };
 
+const AMBIGUOUS_GATEWAY_TIMEOUT_MARKER = "QA-MSTEAMS-AMBIGUOUS-504";
+
 async function readJson(request: IncomingMessage): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
   for await (const chunk of request) {
@@ -72,7 +74,16 @@ export async function startMSTeamsQaBotFrameworkServer(options: ServerOptions) {
         conversationId: route.conversationId,
         ...(route.threadId ? { threadId: route.threadId } : {}),
       });
-      sendJson(response, 200, { id: activityId });
+      // This fixture records the accepted activity before returning 504, modeling a gateway
+      // timeout whose upstream side effect cannot safely be replayed by the Teams adapter.
+      const acceptedButTimedOut =
+        typeof activity.text === "string" &&
+        activity.text.includes(AMBIGUOUS_GATEWAY_TIMEOUT_MARKER);
+      sendJson(
+        response,
+        acceptedButTimedOut ? 504 : 200,
+        acceptedButTimedOut ? { error: "gateway timeout after acceptance" } : { id: activityId },
+      );
     })().catch((error: unknown) => {
       sendJson(response, 500, {
         error: coerceErrorMessage(error),

--- a/extensions/msteams/src/qa/private-runtime.test.ts
+++ b/extensions/msteams/src/qa/private-runtime.test.ts
@@ -82,4 +82,19 @@ describe("Microsoft Teams private QA runtime", () => {
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves Connector HTTP status for transport retry classification", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({ error: "gateway timeout" }, { status: 504 })),
+    );
+    const runtime = resolveMSTeamsPrivateQaRuntime(completeEnv, completeBootstrap);
+    if (!runtime) {
+      throw new Error("expected Microsoft Teams private QA runtime");
+    }
+
+    await expect(
+      runtime.client.post("/v3/conversations/test/activities", {}),
+    ).rejects.toMatchObject({ statusCode: 504 });
+  });
 });

--- a/extensions/msteams/src/qa/private-runtime.ts
+++ b/extensions/msteams/src/qa/private-runtime.ts
@@ -81,7 +81,10 @@ class PrivateQaHttpClient {
       const text = await response.text();
       const data = text ? (JSON.parse(text) as T) : (undefined as T);
       if (!response.ok) {
-        throw new Error(`Microsoft Teams private QA connector returned HTTP ${response.status}`);
+        throw Object.assign(
+          new Error(`Microsoft Teams private QA connector returned HTTP ${response.status}`),
+          { statusCode: response.status },
+        );
       }
       return {
         data,

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -8,7 +8,9 @@ const getMSTeamsRuntimeMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const renderReplyPayloadsToMessagesMock = vi.hoisted(() => vi.fn(() => []));
-const sendMSTeamsMessagesMock = vi.hoisted(() => vi.fn(async () => []));
+const sendMSTeamsMessagesMock = vi.hoisted(() =>
+  vi.fn<(typeof import("./messenger.js"))["sendMSTeamsMessages"]>(async () => []),
+);
 
 vi.mock("../runtime-api.js", () => ({
   createChannelMessageReplyPipeline: createChannelMessageReplyPipelineMock,
@@ -29,12 +31,6 @@ vi.mock("./messenger.js", () => ({
   buildConversationReference: vi.fn((ref) => ref),
   renderReplyPayloadsToMessages: renderReplyPayloadsToMessagesMock,
   sendMSTeamsMessages: sendMSTeamsMessagesMock,
-}));
-
-vi.mock("./errors.js", () => ({
-  classifyMSTeamsSendError: vi.fn(() => ({})),
-  formatMSTeamsSendErrorHint: vi.fn(() => undefined),
-  formatUnknownError: vi.fn((err) => String(err)),
 }));
 
 vi.mock("./revoked-context.js", () => ({
@@ -830,9 +826,17 @@ describe("createMSTeamsReplyDispatcher", () => {
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
     const [message, context] = firstSystemEventCall();
     expect(message).toContain("Microsoft Teams delivery failed");
-    expect(message).toContain("1 of 2 message blocks were not delivered");
-    expect(message).toContain("The user may not have received the full reply");
-    expect(message).toContain("Error: Error: gateway timeout.");
+    expect(message).toContain("the delivery outcome is unknown for 1 of 2 message blocks");
+    expect(message).not.toContain("not delivered");
+    expect(message).not.toContain("The user may not have received");
+    expect(message).toContain("Error: gateway timeout.");
+    expect(message).toContain("Delivery may already have succeeded");
+    expect(message).not.toContain("Retrying later may succeed");
+    expect(sendMSTeamsMessagesMock).toHaveBeenCalledTimes(2);
+    expect(sendMSTeamsMessagesMock.mock.calls.map(([send]) => send.messages)).toEqual([
+      [{ text: "one" }],
+      [{ text: "two" }],
+    ]);
     expect(context).toEqual({
       sessionKey: "agent:main:main",
       contextKey: "msteams:delivery-failure:conv",

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -31,6 +31,7 @@ import { resolveMSTeamsSdkCloudOptions } from "./cloud.js";
 import type { StoredConversationReference } from "./conversation-store.js";
 import {
   classifyMSTeamsSendError,
+  formatMSTeamsDeliveryFailureGuidance,
   formatMSTeamsSendErrorHint,
   formatUnknownError,
 } from "./errors.js";
@@ -265,17 +266,22 @@ export function createMSTeamsReplyDispatcher(params: {
     const classification = classifyMSTeamsSendError(failure.error);
     const errorText = formatUnknownError(failure.error);
     const failedAll = failure.failed >= failure.total;
-    const summary = failedAll
-      ? "the previous reply was not delivered"
-      : `${failure.failed} of ${failure.total} message blocks were not delivered`;
+    const ambiguous = classification.kind === "ambiguous";
+    const summary = ambiguous
+      ? failedAll
+        ? "the delivery outcome is unknown for the previous reply"
+        : `the delivery outcome is unknown for ${failure.failed} of ${failure.total} message blocks`
+      : failedAll
+        ? "the previous reply was not delivered"
+        : `${failure.failed} of ${failure.total} message blocks were not delivered`;
     const sentences = [
       `Microsoft Teams delivery failed: ${summary}.`,
-      `The user may not have received ${failedAll ? "that reply" : "the full reply"}.`,
+      ambiguous
+        ? undefined
+        : `The user may not have received ${failedAll ? "that reply" : "the full reply"}.`,
       `Error: ${errorText}.`,
       classification.statusCode != null ? `Status: ${classification.statusCode}.` : undefined,
-      classification.kind === "transient" || classification.kind === "throttled"
-        ? "Retrying later may succeed."
-        : undefined,
+      formatMSTeamsDeliveryFailureGuidance(classification),
     ].filter(Boolean);
     core.system.enqueueSystemEvent(sentences.join(" "), {
       sessionKey: params.sessionKey,

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -243,6 +243,7 @@ export const QA_TOOL_PROGRESS_PROMPT_RE = /tool progress qa check/i;
 export const QA_TOOL_LOOP_GLOBAL_BREAKER_PROMPT_RE = /global tool loop breaker qa check/i;
 export const QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE = /provider http 503 after tool qa check/i;
 export const QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE = /qa group visible reply tool check/i;
+export const QA_MSTEAMS_AMBIGUOUS_TIMEOUT_PROMPT_RE = /qa msteams ambiguous gateway timeout/i;
 export const QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE = /qa msteams thread message-tool final dedupe/i;
 export const QA_A2A_MESSAGE_TOOL_MIRROR_PROMPT_RE = /qa a2a message-tool mirror check/i;
 export const QA_GROUP_MESSAGE_UNAVAILABLE_FALLBACK_PROMPT_RE =

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -731,6 +731,30 @@ describe("qa mock openai server", () => {
     expect(outputItems(finalBody).some((item) => item.type === "function_call")).toBe(false);
   });
 
+  it("returns a distinct final after the ambiguous Teams message-tool send", async () => {
+    const server = await startMockServer();
+    const prompt = "qa msteams ambiguous gateway timeout. exact marker: `QA-MSTEAMS-AMBIGUOUS-504`";
+
+    const initialBody = await expectOpenAiNonStreamingResponsesJson(server, {
+      tools: [MESSAGE_TOOL],
+      input: [makeUserInput(prompt)],
+    });
+    const toolCall = outputToolCall(initialBody, "message");
+    expect(outputToolArgsFromItem(toolCall)).toEqual({
+      action: "send",
+      message: "QA-MSTEAMS-AMBIGUOUS-504",
+    });
+
+    const finalBody = await expectOpenAiNonStreamingResponsesJson(server, {
+      tools: [MESSAGE_TOOL],
+      input: [
+        makeUserInput(prompt),
+        makeToolOutputWithCallId(outputToolCallId(toolCall, "call_msteams_timeout"), "failed"),
+      ],
+    });
+    expect(outputText(finalBody)).toBe("QA-MSTEAMS-AMBIGUOUS-FINAL");
+  });
+
   it("keeps the retry-failure stranded-final fixture as text without a message tool call", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -50,6 +50,7 @@ import {
   QA_TOOL_LOOP_GLOBAL_BREAKER_PROMPT_RE,
   QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE,
   QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE,
+  QA_MSTEAMS_AMBIGUOUS_TIMEOUT_PROMPT_RE,
   QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE,
   QA_A2A_MESSAGE_TOOL_MIRROR_PROMPT_RE,
   QA_GROUP_MESSAGE_UNAVAILABLE_FALLBACK_PROMPT_RE,
@@ -1739,6 +1740,15 @@ async function buildResponsesPayload(
       });
     }
     return buildAssistantEvents("");
+  }
+  if (QA_MSTEAMS_AMBIGUOUS_TIMEOUT_PROMPT_RE.test(allInputText)) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
+      return buildToolCallEventsWithArgs("message", {
+        action: "send",
+        message: exactMarkerDirective ?? "QA-MSTEAMS-AMBIGUOUS-504",
+      });
+    }
+    return buildAssistantEvents("QA-MSTEAMS-AMBIGUOUS-FINAL");
   }
   if (QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE.test(allInputText)) {
     const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-MSTEAMS-THREAD-DEDUPE-OK";

--- a/qa/scenarios/channels/msteams-ambiguous-gateway-timeout.yaml
+++ b/qa/scenarios/channels/msteams-ambiguous-gateway-timeout.yaml
@@ -1,0 +1,73 @@
+title: Microsoft Teams ambiguous Gateway timeout
+
+scenario:
+  id: msteams-ambiguous-gateway-timeout
+  surface: channels
+  coverage:
+    primary:
+      - channels.outbound-message
+    secondary:
+      - channels.automatic-final-reply
+  objective: Verify an accepted Microsoft Teams activity is not replayed when its non-idempotent Connector POST returns an ambiguous 504 response.
+  gatewayConfigPatch:
+    tools:
+      alsoAllow:
+        - message
+    agents:
+      entries:
+        qa:
+          tools:
+            alsoAllow:
+              - message
+  successCriteria:
+    - The real Microsoft Teams plugin sends through the loopback Bot Framework Connector.
+    - The Connector records the accepted activity before returning HTTP 504.
+    - The plugin performs exactly one POST for the marker instead of replaying the ambiguous send.
+  docsRefs:
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - extensions/msteams/src/messenger.ts
+    - extensions/msteams/src/qa/bot-framework-server.ts
+  execution:
+    kind: flow
+    channel: msteams
+    suiteIsolation: isolated
+    isolationReason: Injects an accepted-then-504 Connector response for one outbound marker.
+    summary: Run a real Gateway and Microsoft Teams plugin against the loopback Bot Framework Connector while the mock provider produces one exact final reply.
+    config:
+      expectedMarker: QA-MSTEAMS-AMBIGUOUS-504
+      finalMarker: QA-MSTEAMS-AMBIGUOUS-FINAL
+
+flow:
+  steps:
+    - name: does not replay an ambiguous Connector response
+      actions:
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - sendInbound:
+            conversation: { id: ambiguous-timeout, kind: direct }
+            senderId: driver
+            senderName: Teams QA Driver
+            text:
+              expr: '`qa msteams ambiguous gateway timeout. exact marker: \`${config.expectedMarker}\``'
+        - waitForOutbound:
+            conversation: { id: ambiguous-timeout, kind: direct }
+            textIncludes: { ref: config.expectedMarker }
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+        - waitForOutbound:
+            conversation: { id: ambiguous-timeout, kind: direct }
+            textIncludes: { ref: config.finalMarker }
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+        - set: matchingOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === 'ambiguous-timeout' && String(message.text ?? '').includes(config.expectedMarker))"
+        - assert:
+            expr: matchingOutbound.length === 1
+            message:
+              expr: "`expected one ambiguous Teams POST, saw ${matchingOutbound.length}; transcript=${formatTransportTranscript(state, { conversationId: 'ambiguous-timeout' })}`"
+      detailsExpr: "`accepted ambiguous Teams POST count=${matchingOutbound.length}`"


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams activity creation is a non-idempotent Connector `POST`, but the reply path treated HTTP 408 and 5xx responses as transient and automatically replayed them. When the Connector accepted the first request and only the response timed out, that replay could duplicate a user-visible message. The same old classification also let operator/model guidance imply non-delivery when the actual outcome was unknown.

## Why This Change Was Made

`classifyMSTeamsSendError` now owns one closed send policy: authentication, replay-safe, ambiguous, permanent, or unknown. Only Teams HTTP 429 is replay-safe, retaining bounded `Retry-After` backoff. HTTP 408, 5xx, timeout/reset, and recognized transport failures are explicit ambiguity and are attempted once.

The retry loop, operator diagnostics, and model-visible system event all consume that classification. Multi-block delivery keeps custody of earlier accepted blocks if a later block fails ambiguously; the event says the result may already have succeeded and does not instruct blind resend. The loopback failure injector is available only in the private-QA build/runtime.

The provider contract supports this boundary:

- Exact published `@microsoft/teams.api@2.0.14`, `dist/clients/conversation/activity.js:29-35`: `create` transforms the activity, directly performs `POST ${serviceUrl}/v3/conversations/${conversationId}/activities`, and returns response data.
- `@microsoft/teams.api@2.0.14`, `dist/activity-CGPsOzKr.d.ts:39-51`: `create` returns `Promise<Resource>`.
- `@microsoft/teams.api@2.0.14`, `dist/models/resource.d.ts:1-9`: `Resource` exposes only `id`; there is no idempotency or reconciliation token.
- Exact published `@microsoft/teams.common@2.0.14`, `dist/http/client.js:24-38`: the client creates Axios and forwards `post` directly, with no retry, idempotency, or reconciliation in this path.
- [RFC 9110 §9.2.2](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.2) defines the general non-idempotent retry boundary. [Teams rate-limit guidance](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/rate-limit) explicitly requires 429 backoff, which is the retained endpoint-specific replay-safe case.

Codex does not own Teams Connector delivery policy. Direct inspection of current sibling Codex source at `57f42a81131c` confirmed that MCP results become model-visible function-call output in [`codex-rs/core/src/tools/context.rs:96-140`](https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/core/src/tools/context.rs#L96-L140), while the authoritative output body/serialization contract remains text or structured content in [`codex-rs/protocol/src/models.rs:1830-1993`](https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/protocol/src/models.rs#L1830-L1993). The safety guidance therefore remains owned by the Teams/OpenClaw delivery boundary rather than inferred by Codex.

## User Impact

Teams bots no longer automatically duplicate a message after an uncertain timeout or server/transport failure. Operators and the model see explicit “outcome unknown / may already have succeeded” guidance. Proven 429 rate limits still retry with bounded backoff.

No public API, config, Gateway protocol, Plugin SDK, or storage contract changes. No release is published and `CHANGELOG.md` is unchanged.

## Evidence

- Exact candidate head: `9b62b96a36411b36a7a06120c50ed4dd9f715061`; exact candidate tree: `464865cab9039c6e7e9c605408c4cd6f83980fee`.
- Blacksmith Testbox `tbx_01m0756nqymbz0xfn9vk8kdx2k`, [run 32000246329](https://github.com/openclaw/openclaw/actions/runs/32000246329): private-QA build passed.
- The source-blind `msteams-ambiguous-gateway-timeout` scenario passed through a real ephemeral Gateway, the real Teams plugin, the loopback Bot Framework Connector, and the mock provider. The Connector recorded the activity before returning 504; verdict: `accepted ambiguous Teams POST count=1`.
- The same Testbox passed 73 focused owner tests (`errors.test.ts` + `messenger.test.ts`), including the 429 replay control and bounded `Retry-After` parsing/clamping.
- Final local focused proof passed 537 tests: 150 Teams owner/sibling tests, 340 QA Lab/provider/catalog tests, and 47 Discord retry-sibling tests.
- Routed `check:changed` passed on the exact tree in 22m56s: full tsgo, full lint, formatting, import cycles, bundled-channel config metadata, plugin boundaries, dead exports, and repository guards.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.98 confidence.
- Judged production runtime LOC: +55/-38 (net +17; the closed policy owner plus two safe guidance projections after removing stale transient/network policy). Raw runtime diff is +60/-49. Runtime tests: +156/-56 (net +100). Private QA/test support: +164/-2 (net +162).
- No real external Microsoft Teams message was sent. The real ephemeral Gateway plus loopback Bot Framework Connector supplies the external-boundary proof without contacting a live Teams conversation.
