### PR TITLE
feat(ui): load session transcripts instantly from snapshots

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2465,6 +2465,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      fake-indexeddb:
+        specifier: 6.2.5
+        version: 6.2.5
       jsdom:
         specifier: 29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,6 +49,7 @@
     "@types/markdown-it": "14.1.2",
     "@vitest/browser": "4.1.10",
     "@vitest/browser-playwright": "4.1.10",
+    "fake-indexeddb": "6.2.5",
     "jsdom": "29.1.1",
     "openclaw": "workspace:*",
     "playwright": "1.62.1",

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -40,6 +40,7 @@ import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import type { ChatPage } from "../pages/chat/chat-page.ts";
+import { deleteStoredChatSessionSnapshots } from "../pages/chat/session-snapshot-invalidation.runtime.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { selectShellRouteState, type ShellRouteState } from "./app-host-route-state.ts";
 import { OpenClawApp } from "./app-root.ts";
@@ -318,7 +319,10 @@ class OpenClawShell
       .watch(
         () => this.context?.sessions,
         (sessions, notify) => sessions.subscribe(notify),
-        (sessions) => this.recoverDeletedActiveSession(sessions.state),
+        (sessions) => {
+          this.invalidateDeletedSessionSnapshots(sessions.state);
+          this.recoverDeletedActiveSession(sessions.state);
+        },
       )
       .watch(
         () => this.context?.runtimeConfig,
@@ -470,6 +474,23 @@ class OpenClawShell
 
   recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]) {
     this.shellNavigation.recoverDeletedActiveSession(sessionState);
+  }
+
+  private invalidateDeletedSessionSnapshots(
+    sessionState: ApplicationContext["sessions"]["state"],
+  ): void {
+    const context = this.context;
+    if (!context || sessionState.deletedSessions.length === 0) {
+      return;
+    }
+    void deleteStoredChatSessionSnapshots(
+      {
+        assistantAgentId: context.gateway.snapshot.assistantAgentId,
+        agentsList: context.agents.state.agentsList,
+        hello: context.gateway.snapshot.hello,
+      },
+      sessionState.deletedSessions,
+    );
   }
 
   exitSettings() {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -40,6 +40,10 @@ import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import type { ChatPage } from "../pages/chat/chat-page.ts";
+import {
+  deleteStoredChatSnapshot,
+  resolveChatSnapshotKey,
+} from "../pages/chat/session-snapshot-invalidation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { selectShellRouteState, type ShellRouteState } from "./app-host-route-state.ts";
 import { OpenClawApp } from "./app-root.ts";
@@ -318,7 +322,10 @@ class OpenClawShell
       .watch(
         () => this.context?.sessions,
         (sessions, notify) => sessions.subscribe(notify),
-        (sessions) => this.recoverDeletedActiveSession(sessions.state),
+        (sessions) => {
+          this.invalidateDeletedSessionSnapshots(sessions.state);
+          this.recoverDeletedActiveSession(sessions.state);
+        },
       )
       .watch(
         () => this.context?.runtimeConfig,
@@ -470,6 +477,26 @@ class OpenClawShell
 
   recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]) {
     this.shellNavigation.recoverDeletedActiveSession(sessionState);
+  }
+
+  private invalidateDeletedSessionSnapshots(
+    sessionState: ApplicationContext["sessions"]["state"],
+  ): void {
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+    for (const { key, agentId } of sessionState.deletedSessions) {
+      const sessionKey = resolveChatSnapshotKey(
+        {
+          assistantAgentId: agentId ?? context.gateway.snapshot.assistantAgentId,
+          agentsList: context.agents.state.agentsList,
+          hello: context.gateway.snapshot.hello,
+        },
+        { sessionKey: key, agentId },
+      );
+      void deleteStoredChatSnapshot(sessionKey);
+    }
   }
 
   exitSettings() {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -40,10 +40,6 @@ import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import type { ChatPage } from "../pages/chat/chat-page.ts";
-import {
-  deleteStoredChatSnapshot,
-  resolveChatSnapshotKey,
-} from "../pages/chat/session-snapshot-invalidation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { selectShellRouteState, type ShellRouteState } from "./app-host-route-state.ts";
 import { OpenClawApp } from "./app-root.ts";
@@ -483,20 +479,19 @@ class OpenClawShell
     sessionState: ApplicationContext["sessions"]["state"],
   ): void {
     const context = this.context;
-    if (!context) {
+    const deletedSessions = sessionState.deletedSessions;
+    if (!context || deletedSessions.length === 0) {
       return;
     }
-    for (const { key, agentId } of sessionState.deletedSessions) {
-      const sessionKey = resolveChatSnapshotKey(
-        {
-          assistantAgentId: agentId ?? context.gateway.snapshot.assistantAgentId,
-          agentsList: context.agents.state.agentsList,
-          hello: context.gateway.snapshot.hello,
-        },
-        { sessionKey: key, agentId },
-      );
-      void deleteStoredChatSnapshot(sessionKey);
-    }
+    const snapshotHost = {
+      assistantAgentId: context.gateway.snapshot.assistantAgentId,
+      agentsList: context.agents.state.agentsList,
+      hello: context.gateway.snapshot.hello,
+    };
+    void import("../pages/chat/session-snapshot-invalidation.ts").then(
+      ({ deleteStoredChatSessionSnapshots }) =>
+        deleteStoredChatSessionSnapshots(snapshotHost, deletedSessions),
+    );
   }
 
   exitSettings() {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -318,10 +318,7 @@ class OpenClawShell
       .watch(
         () => this.context?.sessions,
         (sessions, notify) => sessions.subscribe(notify),
-        (sessions) => {
-          this.invalidateDeletedSessionSnapshots(sessions.state);
-          this.recoverDeletedActiveSession(sessions.state);
-        },
+        (sessions) => this.recoverDeletedActiveSession(sessions.state),
       )
       .watch(
         () => this.context?.runtimeConfig,
@@ -473,25 +470,6 @@ class OpenClawShell
 
   recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]) {
     this.shellNavigation.recoverDeletedActiveSession(sessionState);
-  }
-
-  private invalidateDeletedSessionSnapshots(
-    sessionState: ApplicationContext["sessions"]["state"],
-  ): void {
-    const context = this.context;
-    const deletedSessions = sessionState.deletedSessions;
-    if (!context || deletedSessions.length === 0) {
-      return;
-    }
-    const snapshotHost = {
-      assistantAgentId: context.gateway.snapshot.assistantAgentId,
-      agentsList: context.agents.state.agentsList,
-      hello: context.gateway.snapshot.hello,
-    };
-    void import("../pages/chat/session-snapshot-invalidation.ts").then(
-      ({ deleteStoredChatSessionSnapshots }) =>
-        deleteStoredChatSessionSnapshots(snapshotHost, deletedSessions),
-    );
   }
 
   exitSettings() {

--- a/ui/src/app/app-shell-navigation.ts
+++ b/ui/src/app/app-shell-navigation.ts
@@ -15,10 +15,6 @@ import {
   resolveUiConfiguredMainKey,
   uiSessionEventMatches,
 } from "../lib/sessions/session-key.ts";
-import {
-  deleteStoredChatSnapshot,
-  resolveChatSnapshotKey,
-} from "../pages/chat/session-snapshot-invalidation.ts";
 import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
 import { selectApplicationSession } from "./agent-selection.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
@@ -163,34 +159,22 @@ export class ShellNavigationOwner {
 
   recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]): void {
     const context = this.host.context;
-    if (!context) {
+    const routeId = this.host.routeState.routeId;
+    const sessionKey = this.host.activeSessionKey.trim();
+    if (!context || !routeId || !isSessionRouteId(routeId) || !sessionKey) {
       return;
     }
-    const agentsList = context.agents.state.agentsList;
-    const { assistantAgentId, hello } = context.gateway.snapshot;
-    const sessionKey = this.host.activeSessionKey.trim();
-    let selectedSessionDeleted = false;
-    for (const { key, agentId } of sessionState.deletedSessions) {
-      void deleteStoredChatSnapshot(
-        resolveChatSnapshotKey(
-          {
-            assistantAgentId: agentId ?? assistantAgentId,
-            agentsList,
-            hello,
-          },
-          { sessionKey: key, agentId },
-        ),
-      );
-      selectedSessionDeleted ||= uiSessionEventMatches(
-        { agentsList, hello, sessionKey },
+    const selectedSessionDeleted = sessionState.deletedSessions.some(({ key, agentId }) =>
+      uiSessionEventMatches(
+        {
+          agentsList: context.agents.state.agentsList,
+          hello: context.gateway.snapshot.hello,
+          sessionKey,
+        },
         key,
         agentId,
-      );
-    }
-    const routeId = this.host.routeState.routeId;
-    if (!routeId || !isSessionRouteId(routeId) || !sessionKey) {
-      return;
-    }
+      ),
+    );
     if (selectedSessionDeleted) {
       this.replaceChatWithCurrentSession();
     }

--- a/ui/src/app/app-shell-navigation.ts
+++ b/ui/src/app/app-shell-navigation.ts
@@ -15,6 +15,10 @@ import {
   resolveUiConfiguredMainKey,
   uiSessionEventMatches,
 } from "../lib/sessions/session-key.ts";
+import {
+  deleteStoredChatSnapshot,
+  resolveChatSnapshotKey,
+} from "../pages/chat/session-snapshot-invalidation.ts";
 import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
 import { selectApplicationSession } from "./agent-selection.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
@@ -159,22 +163,34 @@ export class ShellNavigationOwner {
 
   recoverDeletedActiveSession(sessionState: ApplicationContext["sessions"]["state"]): void {
     const context = this.host.context;
-    const routeId = this.host.routeState.routeId;
-    const sessionKey = this.host.activeSessionKey.trim();
-    if (!context || !routeId || !isSessionRouteId(routeId) || !sessionKey) {
+    if (!context) {
       return;
     }
-    const selectedSessionDeleted = sessionState.deletedSessions.some(({ key, agentId }) =>
-      uiSessionEventMatches(
-        {
-          agentsList: context.agents.state.agentsList,
-          hello: context.gateway.snapshot.hello,
-          sessionKey,
-        },
+    const agentsList = context.agents.state.agentsList;
+    const { assistantAgentId, hello } = context.gateway.snapshot;
+    const sessionKey = this.host.activeSessionKey.trim();
+    let selectedSessionDeleted = false;
+    for (const { key, agentId } of sessionState.deletedSessions) {
+      void deleteStoredChatSnapshot(
+        resolveChatSnapshotKey(
+          {
+            assistantAgentId: agentId ?? assistantAgentId,
+            agentsList,
+            hello,
+          },
+          { sessionKey: key, agentId },
+        ),
+      );
+      selectedSessionDeleted ||= uiSessionEventMatches(
+        { agentsList, hello, sessionKey },
         key,
         agentId,
-      ),
-    );
+      );
+    }
+    const routeId = this.host.routeState.routeId;
+    if (!routeId || !isSessionRouteId(routeId) || !sessionKey) {
+      return;
+    }
     if (selectedSessionDeleted) {
       this.replaceChatWithCurrentSession();
     }

--- a/ui/src/app/gateway-store.session-snapshot.test.ts
+++ b/ui/src/app/gateway-store.session-snapshot.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayBrowserClientOptions } from "../api/gateway.ts";
+import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.ts";
+import { SessionSnapshotStore } from "../pages/chat/session-snapshot-store.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { createApplicationGateway } from "./gateway-store.ts";
+import { loadSettings } from "./settings.ts";
+
+class SnapshotTestGatewayClient {
+  constructor(readonly opts: GatewayBrowserClientOptions) {}
+  start() {}
+  stop() {}
+}
+
+describe("gateway credential snapshot invalidation", () => {
+  beforeEach(() => {
+    vi.stubGlobal("indexedDB", new IDBFactory());
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal("location", new URL("http://control.test/"));
+  });
+
+  afterEach(async () => {
+    await clearStoredChatSnapshots();
+    vi.unstubAllGlobals();
+  });
+
+  it("clears persisted transcripts on credential change but not an unchanged reconnect", async () => {
+    const sessionKey = "agent:main:credential-scope";
+    const snapshots = new SessionSnapshotStore();
+    snapshots.write(sessionKey, {
+      messages: ["private transcript"],
+      pagination: { hasMore: false, completeSnapshot: true },
+      sessionId: "credential-session",
+    });
+    await snapshots.flush();
+    const settings = { ...loadSettings(), gatewayUrl: "ws://control.test", token: "old-token" };
+    const gateway = createApplicationGateway(settings, "", "", (options) => {
+      return new SnapshotTestGatewayClient(options) as unknown as GatewayBrowserClient;
+    });
+
+    gateway.connect();
+    expect(await new SessionSnapshotStore().read(sessionKey)).not.toBeNull();
+
+    gateway.connect({ token: "" });
+    await vi.waitFor(async () => {
+      expect(await new SessionSnapshotStore().read(sessionKey)).toBeNull();
+    });
+  });
+});

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -20,7 +20,7 @@ import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
-import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.ts";
+import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.runtime.ts";
 import type {
   ApplicationGateway,
   ApplicationGatewayConnectOptions,
@@ -286,11 +286,13 @@ export function createApplicationGateway(
         ? { bootstrapProfile: undefined }
         : {}),
     };
-    if (
-      (Object.keys(nextConnection) as Array<keyof ApplicationGatewayConnection>).some(
-        (key) => nextConnection[key] !== connection[key],
-      )
-    ) {
+    const credentialsChanged =
+      nextConnection.gatewayUrl !== connection.gatewayUrl ||
+      nextConnection.token !== connection.token ||
+      nextConnection.password !== connection.password ||
+      nextConnection.bootstrapToken !== connection.bootstrapToken ||
+      nextConnection.bootstrapProfile !== connection.bootstrapProfile;
+    if (credentialsChanged) {
       void clearStoredChatSnapshots();
     }
     const hasRequestedSessionKey = requestedSessionKey !== undefined;

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -20,6 +20,7 @@ import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
+import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.ts";
 import type {
   ApplicationGateway,
   ApplicationGatewayConnectOptions,
@@ -285,16 +286,12 @@ export function createApplicationGateway(
         ? { bootstrapProfile: undefined }
         : {}),
     };
-    const credentialsChanged =
-      nextConnection.gatewayUrl !== connection.gatewayUrl ||
-      nextConnection.token !== connection.token ||
-      nextConnection.password !== connection.password ||
-      nextConnection.bootstrapToken !== connection.bootstrapToken ||
-      nextConnection.bootstrapProfile !== connection.bootstrapProfile;
-    if (credentialsChanged) {
-      void import("../pages/chat/session-snapshot-invalidation.ts").then(
-        ({ clearStoredChatSnapshots }) => clearStoredChatSnapshots(),
-      );
+    if (
+      (Object.keys(nextConnection) as Array<keyof ApplicationGatewayConnection>).some(
+        (key) => nextConnection[key] !== connection[key],
+      )
+    ) {
+      void clearStoredChatSnapshots();
     }
     const hasRequestedSessionKey = requestedSessionKey !== undefined;
     const nextSessionKey = hasRequestedSessionKey

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -20,6 +20,7 @@ import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
+import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.ts";
 import type {
   ApplicationGateway,
   ApplicationGatewayConnectOptions,
@@ -285,6 +286,15 @@ export function createApplicationGateway(
         ? { bootstrapProfile: undefined }
         : {}),
     };
+    const credentialsChanged =
+      nextConnection.gatewayUrl !== connection.gatewayUrl ||
+      nextConnection.token !== connection.token ||
+      nextConnection.password !== connection.password ||
+      nextConnection.bootstrapToken !== connection.bootstrapToken ||
+      nextConnection.bootstrapProfile !== connection.bootstrapProfile;
+    if (credentialsChanged) {
+      void clearStoredChatSnapshots();
+    }
     const hasRequestedSessionKey = requestedSessionKey !== undefined;
     const nextSessionKey = hasRequestedSessionKey
       ? requestedSessionKey.trim()

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -20,7 +20,6 @@ import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
-import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.ts";
 import type {
   ApplicationGateway,
   ApplicationGatewayConnectOptions,
@@ -293,7 +292,9 @@ export function createApplicationGateway(
       nextConnection.bootstrapToken !== connection.bootstrapToken ||
       nextConnection.bootstrapProfile !== connection.bootstrapProfile;
     if (credentialsChanged) {
-      void clearStoredChatSnapshots();
+      void import("../pages/chat/session-snapshot-invalidation.ts").then(
+        ({ clearStoredChatSnapshots }) => clearStoredChatSnapshots(),
+      );
     }
     const hasRequestedSessionKey = requestedSessionKey !== undefined;
     const nextSessionKey = hasRequestedSessionKey

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -63,7 +63,11 @@ import {
 } from "./performance.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
-import { cacheChatSessionSnapshot, clearChatMessagesFromCache } from "./session-message-cache.ts";
+import {
+  cacheChatSessionSnapshot,
+  clearChatMessagesFromCache,
+  type ChatSessionSnapshot,
+} from "./session-message-cache.ts";
 import { retirePersistedSteeredChips } from "./steer-lifecycle.ts";
 import {
   clearToolStreamSegments,
@@ -992,6 +996,34 @@ function requestSharedChatHistory(
     shared?.consumers.delete(consumer);
     updateChatHistoryOwnerRequestCount(registry, consumerOwner, requestKey, -1);
   });
+}
+
+export async function requestChatSessionSnapshot(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  consumerOwner: object,
+  isCurrentConsumer: () => boolean,
+): Promise<ChatSessionSnapshot> {
+  const method = "chat.history";
+  const requestKey = `prefetch\u0000${method}\u0000${sessionKey}\u0000${CHAT_HISTORY_REQUEST_LIMIT}`;
+  const result = await requestSharedChatHistory(
+    client,
+    requestKey,
+    method,
+    sessionKey,
+    undefined,
+    consumerOwner,
+    isCurrentConsumer,
+  );
+  const sessionInfo = result.sessionInfo;
+  return {
+    ...(Object.hasOwn(sessionInfo ?? {}, "activeLeafEntryId")
+      ? { displayedLeafEntryId: sessionInfo?.activeLeafEntryId?.trim() || null }
+      : {}),
+    messages: visibleChatHistoryMessages(result.messages),
+    pagination: resolveChatHistoryPagination(result),
+    sessionId: resolveChatHistorySessionId(result),
+  };
 }
 
 function recordChatHistoryTiming(

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -160,7 +160,7 @@ function shouldApplyChatHistoryResult(
   );
 }
 
-function resetChatHistoryProjection(state: ChatState, agentId?: string): void {
+export function resetChatHistoryProjection(state: ChatState, agentId?: string): void {
   const requests = getChatHistoryPaneRequests(state);
   // A destructive reset keeps the session key, so invalidate both the old
   // snapshot owner and its coalesced request before creating the next epoch.

--- a/ui/src/pages/chat/chat-page-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-page-attachment-handoff.test.ts
@@ -42,7 +42,7 @@ function configure(page: ChatPage) {
   const context = {
     sessions: { state: { result: null }, subscribe: () => () => undefined, patch: vi.fn() },
     agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
-    gateway: { snapshot: { hello: null } },
+    gateway: { snapshot: { hello: null }, subscribe: () => () => undefined },
     navigate: vi.fn(),
     replace: vi.fn(),
     agentSelection: { state: { selectedId: "main" }, set: vi.fn() },

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -11,11 +11,13 @@ import type { RouteDraftComposerFocus } from "./route-draft-focus-handoff.ts";
 import { routeDraft } from "./route-draft.ts";
 import type { SessionChatRouteData } from "./route-loader.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
+import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import type { ChatSplitPane } from "./split-layout.ts";
 
 type ChatPagePaneRenderOptions = {
   active: boolean;
   chatMessagesBySession: ChatMessageCache;
+  sessionSnapshotStore: SessionSnapshotStore;
   consumedDraftData: SessionChatRouteData | null;
   context?: ApplicationContext;
   data?: SessionChatRouteData;
@@ -89,6 +91,7 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
               .paneId=${options.pane.id}
               .presentationId=${JSON.stringify([options.pane.id, sessionKey])}
               .chatMessagesBySession=${options.chatMessagesBySession}
+              .sessionSnapshotStore=${options.sessionSnapshotStore}
               .sessionKey=${sessionKey}
               .presented=${presented}
               .active=${active}

--- a/ui/src/pages/chat/chat-page-retained-sessions.test.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.test.ts
@@ -45,7 +45,7 @@ function setNavigationContext(page: ChatPage) {
     basePath: "",
     sessions: { state: { result: null }, subscribe: () => () => undefined, patch },
     agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
-    gateway: { snapshot: { hello: null } },
+    gateway: { snapshot: { hello: null }, subscribe: () => () => undefined },
     navigate,
     replace,
     agentSelection: {

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -151,7 +151,7 @@ function setNavigationContext(page: ChatPage) {
     basePath: "",
     sessions: { state: { result: null }, subscribe: () => () => undefined, patch },
     agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
-    gateway: { snapshot: { hello: null } },
+    gateway: { snapshot: { hello: null }, subscribe: () => () => undefined },
     navigate,
     replace,
     agentSelection: { state: agentSelectionState, set: setAgent },
@@ -784,7 +784,13 @@ describe("chat page split layout host", () => {
     };
     let notify = () => {};
     (page as unknown as { context: unknown }).context = {
+      agents: { state: { agentsList: null } },
+      gateway: {
+        snapshot: { assistantAgentId: "main", client: null, hello: null, phase: "stopped" },
+        subscribe: () => () => undefined,
+      },
       sessions: {
+        canonicalListRevision: 0,
         state: sessionsState,
         subscribe: (listener: () => void) => {
           notify = listener;
@@ -806,6 +812,8 @@ describe("chat page split layout host", () => {
     // the label anyway — including non-default agent ids.
     (page as unknown as { context: { gateway?: unknown; sessions: unknown } }).context.gateway = {
       snapshot: {
+        assistantAgentId: "dev",
+        client: null,
         hello: {
           snapshot: {
             sessionDefaults: {
@@ -815,7 +823,9 @@ describe("chat page split layout host", () => {
             },
           },
         },
+        phase: "stopped",
       },
+      subscribe: () => () => undefined,
     };
     sessionsState.result = {
       sessions: [{ key: "agent:dev:main", displayName: "Main desk" }],
@@ -849,12 +859,25 @@ describe("chat page split layout host", () => {
       }),
     };
     const page = new ChatPage();
-    (page as unknown as { context: unknown }).context = { sessions: firstSessions };
+    const sharedContext = {
+      agents: { state: { agentsList: null } },
+      gateway: {
+        snapshot: { assistantAgentId: "main", client: null, hello: null, phase: "stopped" },
+        subscribe: () => () => undefined,
+      },
+    };
+    (page as unknown as { context: unknown }).context = {
+      ...sharedContext,
+      sessions: firstSessions,
+    };
     document.body.append(page);
     await page.updateComplete;
 
     expect(firstSessions.subscribe).toHaveBeenCalledOnce();
-    (page as unknown as { context: unknown }).context = { sessions: secondSessions };
+    (page as unknown as { context: unknown }).context = {
+      ...sharedContext,
+      sessions: secondSessions,
+    };
     page.requestUpdate();
     await page.updateComplete;
 

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -28,6 +28,7 @@ import { RouteDraftComposerFocus, type ChatPaneElement } from "./route-draft-foc
 import { locationWithoutDraft } from "./route-draft.ts";
 import type { SessionChatRouteData } from "./route-loader.ts";
 import { observeChatCache, type ChatMessageCache } from "./session-message-cache.ts";
+import { installSessionPrefetch } from "./session-prefetch.ts";
 import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import {
   resolveSplitDropZone,
@@ -78,8 +79,8 @@ export class ChatPage extends OpenClawLightDomElement {
   private pendingDragOver: { pane: ChatPaneElement; x: number; y: number } | null = null;
   private consumedDraftData: SessionChatRouteData | null = null;
   private readonly draftFocus = new RouteDraftComposerFocus(this);
-  private readonly chatMessagesBySession: ChatMessageCache = new Map();
-  private readonly sessionSnapshotStore = new SessionSnapshotStore(this.chatMessagesBySession);
+  private readonly messageCache: ChatMessageCache = new Map();
+  private readonly snapshotStore = new SessionSnapshotStore(this.messageCache);
   private classicColumnId = "c1";
   private classicPaneId = "p1";
   private routeHref = "";
@@ -94,10 +95,15 @@ export class ChatPage extends OpenClawLightDomElement {
     },
   });
 
+  constructor() {
+    super();
+    installSessionPrefetch(this, this.messageCache, this.snapshotStore, () => this.context);
+  }
+
   override connectedCallback() {
     super.connectedCallback();
-    this.sessionSnapshotStore.connect();
-    observeChatCache(this.chatMessagesBySession, this.sessionSnapshotStore);
+    this.snapshotStore.connect();
+    observeChatCache(this.messageCache, this.snapshotStore);
     this.routeHref = window.location.href;
     this.layout = loadSettings().chatSplitLayout;
     this.mediaQuery = window.matchMedia("(max-width: 1099px)");
@@ -120,7 +126,7 @@ export class ChatPage extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
-    this.sessionSnapshotStore.disconnect();
+    this.snapshotStore.disconnect();
     this.retainedSessions.disconnect();
     this.viewerPresence.dispose();
     this.subscriptions.clear();
@@ -599,8 +605,8 @@ export class ChatPage extends OpenClawLightDomElement {
                 (pane, paneIndex) => html`
                   ${renderChatPagePaneCell({
                     active: pane.id === layout.activePaneId,
-                    chatMessagesBySession: this.chatMessagesBySession,
-                    sessionSnapshotStore: this.sessionSnapshotStore,
+                    chatMessagesBySession: this.messageCache,
+                    sessionSnapshotStore: this.snapshotStore,
                     consumedDraftData: this.consumedDraftData,
                     context: this.context,
                     data: this.data,

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -27,7 +27,8 @@ import "./chat-pane.ts";
 import { RouteDraftComposerFocus, type ChatPaneElement } from "./route-draft-focus-handoff.ts";
 import { locationWithoutDraft } from "./route-draft.ts";
 import type { SessionChatRouteData } from "./route-loader.ts";
-import type { ChatMessageCache } from "./session-message-cache.ts";
+import { observeChatCache, type ChatMessageCache } from "./session-message-cache.ts";
+import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import {
   resolveSplitDropZone,
   splitDropIndicatorRect,
@@ -78,6 +79,7 @@ export class ChatPage extends OpenClawLightDomElement {
   private consumedDraftData: SessionChatRouteData | null = null;
   private readonly draftFocus = new RouteDraftComposerFocus(this);
   private readonly chatMessagesBySession: ChatMessageCache = new Map();
+  private readonly sessionSnapshotStore = new SessionSnapshotStore(this.chatMessagesBySession);
   private classicColumnId = "c1";
   private classicPaneId = "p1";
   private routeHref = "";
@@ -94,6 +96,8 @@ export class ChatPage extends OpenClawLightDomElement {
 
   override connectedCallback() {
     super.connectedCallback();
+    this.sessionSnapshotStore.connect();
+    observeChatCache(this.chatMessagesBySession, this.sessionSnapshotStore);
     this.routeHref = window.location.href;
     this.layout = loadSettings().chatSplitLayout;
     this.mediaQuery = window.matchMedia("(max-width: 1099px)");
@@ -116,6 +120,7 @@ export class ChatPage extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
+    this.sessionSnapshotStore.disconnect();
     this.retainedSessions.disconnect();
     this.viewerPresence.dispose();
     this.subscriptions.clear();
@@ -595,6 +600,7 @@ export class ChatPage extends OpenClawLightDomElement {
                   ${renderChatPagePaneCell({
                     active: pane.id === layout.activePaneId,
                     chatMessagesBySession: this.chatMessagesBySession,
+                    sessionSnapshotStore: this.sessionSnapshotStore,
                     consumedDraftData: this.consumedDraftData,
                     context: this.context,
                     data: this.data,

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -58,7 +58,8 @@ import type { ChatPaneHeaderAction } from "./components/chat-pane-header.ts";
 import type { ChatSessionSharingState } from "./components/chat-session-sharing.ts";
 import { ChatTranscriptController } from "./components/chat-transcript-controller.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
-import type { ChatMessageCache } from "./session-message-cache.ts";
+import { resolveChatSnapshotKey, type ChatMessageCache } from "./session-message-cache.ts";
+import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import { closeSlot, openSlot, setSidebarOpen } from "./sidebar-layout.ts";
 
 export abstract class ChatPaneBase extends OpenClawLightDomElement {
@@ -71,6 +72,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @property({ attribute: false }) paneId = "single";
   @property({ attribute: false }) presentationId = "single";
   @property({ attribute: false }) chatMessagesBySession?: ChatMessageCache;
+  @property({ attribute: false }) sessionSnapshotStore?: SessionSnapshotStore;
   // Empty means "no route/layout opinion yet": the pane boots on the page
   // state's default session and must not canonicalize or write global session
   // bindings until the container supplies a real key (classic mode renders
@@ -155,8 +157,16 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected readonly composerCapabilities = new ChatComposerCapabilityHost(() =>
     this.requestUpdate(),
   );
-  protected readonly transcript = new ChatTranscriptController(this);
-  protected readonly taskSidebarTranscript = new ChatTranscriptController(this);
+  protected readonly transcript = new ChatTranscriptController(this, {
+    read: (sessionKey, rowKey) => this.readTranscriptRowHeight(sessionKey, rowKey),
+    write: (sessionKey, rowKey, height) =>
+      this.writeTranscriptRowHeight(sessionKey, rowKey, height),
+  });
+  protected readonly taskSidebarTranscript = new ChatTranscriptController(this, {
+    read: (sessionKey, rowKey) => this.readTranscriptRowHeight(sessionKey, rowKey),
+    write: (sessionKey, rowKey, height) =>
+      this.writeTranscriptRowHeight(sessionKey, rowKey, height),
+  });
   protected readonly questionPromptState = createQuestionPromptState(() => {
     this.questionPrompts = listQuestionPrompts(this.questionPromptState);
     this.requestUpdate();
@@ -176,6 +186,22 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   // across a reconnect or pane teardown dismiss itself, matching
   // SessionDataController's own epoch-scoped controller for the sidebar.
   protected headerSessionMutationAbortController = new AbortController();
+
+  private transcriptSnapshotKey(sessionKey: string): string | null {
+    return this.state ? resolveChatSnapshotKey(this.state, { sessionKey }) : null;
+  }
+
+  private readTranscriptRowHeight(sessionKey: string, rowKey: string): number | undefined {
+    const snapshotKey = this.transcriptSnapshotKey(sessionKey);
+    return snapshotKey ? this.sessionSnapshotStore?.readRowHeight(snapshotKey, rowKey) : undefined;
+  }
+
+  private writeTranscriptRowHeight(sessionKey: string, rowKey: string, height: number): void {
+    const snapshotKey = this.transcriptSnapshotKey(sessionKey);
+    if (snapshotKey) {
+      this.sessionSnapshotStore?.recordRowHeight(snapshotKey, rowKey, height);
+    }
+  }
   @litState() protected headerEditing = false;
   @litState() protected headerRenameValue = "";
   @litState() protected headerPlatform: string | null = null;

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -101,8 +101,8 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         agentId,
       ),
     );
-    for (const { key } of stateValue.deletedSessions) {
-      clearChatMessagesFromCache(state.chatMessagesBySession, state, { sessionKey: key });
+    for (const { key, agentId } of stateValue.deletedSessions) {
+      clearChatMessagesFromCache(state.chatMessagesBySession, state, { sessionKey: key, agentId });
     }
     state.sessionsResult = stateValue.result;
     state.sessionsResultAgentId = stateValue.agentId;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -65,7 +65,12 @@ import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 import { exportChatMarkdown } from "./export.ts";
 import { admitInitialUserMessageHandoff } from "./history-merge.ts";
 import { admitInitialTurnHandoff } from "./initial-turn-handoff.ts";
-import { readChatSessionSnapshot } from "./session-message-cache.ts";
+import {
+  applyChatCacheSnapshot,
+  cacheChatSessionSnapshot,
+  readChatSessionSnapshot,
+  resolveChatSnapshotKey,
+} from "./session-message-cache.ts";
 import { closeSlot, openSlot, type SidebarSlotId } from "./sidebar-layout.ts";
 
 const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 1_200;
@@ -86,6 +91,32 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
   private chatRouteReadyReported = false;
   private stagedAttachmentGatewayOwner: ChatAttachmentGatewayOwner = null;
   private suppressStagedAttachmentHandoffOnDisconnect = false;
+
+  private hydrateStoredChatSnapshot(
+    state: NonNullable<ChatPaneLifecycle["state"]>,
+    sessionKey: string,
+  ): void {
+    const store = this.sessionSnapshotStore;
+    if (!store) {
+      return;
+    }
+    const cacheKey = resolveChatSnapshotKey(state, { sessionKey });
+    void store.read(cacheKey).then((snapshot) => {
+      if (
+        !snapshot ||
+        this.state !== state ||
+        !areUiSessionKeysEquivalent(state.sessionKey, sessionKey) ||
+        readChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey })
+      ) {
+        return;
+      }
+      // The memory miss is the ordering fence: any network replacement or live
+      // append that landed while IndexedDB was pending remains authoritative.
+      cacheChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey }, snapshot);
+      applyChatCacheSnapshot(state, snapshot);
+      state.requestUpdate?.();
+    });
+  }
 
   public discardStagedAttachments(): void {
     // Explicit pane disposal is terminal. The DOM disconnect that follows must
@@ -448,10 +479,9 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
           sessionKey: initialSessionKey,
         });
         if (snapshot) {
-          pageState.chatMessages = snapshot.messages;
-          pageState.chatHistoryPagination = snapshot.pagination;
-          pageState.currentSessionId = snapshot.sessionId;
-          pageState.chatDisplayedLeafEntryId = snapshot.displayedLeafEntryId;
+          applyChatCacheSnapshot(pageState, snapshot);
+        } else {
+          this.hydrateStoredChatSnapshot(pageState, initialSessionKey);
         }
         if (admitInitialTurnHandoff(pageState, initialSessionKey)) {
           pageState.lastError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -49,7 +49,10 @@ import {
   CHAT_SPACE_ACTIVATION_SELECTOR,
   keyboardEventPathMatches,
 } from "./chat-pane-shared.ts";
-import { subscribeChatPaneStartup } from "./chat-pane-startup-subscriptions.ts";
+import {
+  subscribeChatPaneSnapshotInvalidation,
+  subscribeChatPaneStartup,
+} from "./chat-pane-startup-subscriptions.ts";
 import { setChatError } from "./chat-send-queue-state.ts";
 import { applySelectedChatAgent } from "./chat-session.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
@@ -602,6 +605,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     this.applySessionsState(this.context.sessions.state);
     chatState.addCleanup(this.context.sessions.subscribe(this.applySessionsState.bind(this)));
     chatState.addCleanup(subscribeChatPaneStartup(this.context, () => this.state));
+    chatState.addCleanup(subscribeChatPaneSnapshotInvalidation(() => this.state));
     this.applyGatewaySnapshot(this.context.gateway.snapshot);
   }
 

--- a/ui/src/pages/chat/chat-pane-startup-subscriptions.ts
+++ b/ui/src/pages/chat/chat-pane-startup-subscriptions.ts
@@ -1,6 +1,9 @@
 import type { ApplicationContext } from "../../app/context.ts";
+import { resetChatHistoryProjection } from "./chat-history.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { admitInitialUserMessageHandoff } from "./history-merge.ts";
+import { resolveChatSnapshotKey } from "./session-message-cache.ts";
+import { subscribeSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
 
 type ChatPaneStartupContext = Pick<ApplicationContext, "cloudStartup">;
 
@@ -14,5 +17,21 @@ export function subscribeChatPaneStartup(
       admitInitialUserMessageHandoff(state, state.sessionKey);
       state.requestUpdate?.();
     }
+  });
+}
+
+export function subscribeChatPaneSnapshotInvalidation(
+  getState: () => ChatPageHost | undefined,
+): () => void {
+  return subscribeSnapshotInvalidation(({ sessionKey }) => {
+    const state = getState();
+    if (
+      !state ||
+      (sessionKey && resolveChatSnapshotKey(state, { sessionKey: state.sessionKey }) !== sessionKey)
+    ) {
+      return;
+    }
+    resetChatHistoryProjection(state);
+    state.requestUpdate?.();
   });
 }

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -29,6 +29,7 @@ import { createBackgroundTasksProps } from "./components/chat-background-tasks.t
 import type { HeaderMenuAction } from "./components/chat-header-session-menu.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
+import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
 
 export type TestChatPane = HTMLElement & {
   catalogMessages: unknown[];
@@ -36,6 +37,7 @@ export type TestChatPane = HTMLElement & {
   presented: boolean;
   presentationId: string;
   chatMessagesBySession?: ChatMessageCache;
+  sessionSnapshotStore?: SessionSnapshotStore;
   chatState: { attach: (state: ChatPageHost) => void };
   context: ApplicationContext;
   state: ChatPageHost;
@@ -96,6 +98,8 @@ export type TestChatPane = HTMLElement & {
   paneId: string;
   sessionKey: string;
   updateComplete: Promise<boolean>;
+  requestUpdate: () => void;
+  performUpdate: () => void;
   deferSessionHydrationUntilTranscript: (
     sessionKey: string,
     transcriptLoad: Promise<unknown>,

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { IDBFactory } from "fake-indexeddb";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
@@ -12,6 +13,7 @@ import {
   installDialogPolyfill,
   waitForConfirmDialogActions,
 } from "../../test-helpers/modal-dialog.ts";
+import { loadChatHistory } from "./chat-history.ts";
 import {
   createGatewayBrowserClientFixture,
   createSessionCapabilityFixture,
@@ -21,7 +23,13 @@ import {
 } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
-import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
+import {
+  cacheChatSessionSnapshot,
+  observeChatCache,
+  type ChatMessageCache,
+} from "./session-message-cache.ts";
+import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
+import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import { openSlot } from "./sidebar-layout.ts";
 
 vi.mock("../../lib/toast.ts", () => ({ showToast: vi.fn() }));
@@ -79,9 +87,19 @@ function createInitializationContext(): ApplicationContext {
     },
     agentSelection: { state: { selectedId: "main" } },
     agents: { state: { agentsList: null } },
+    runtimeConfig: {
+      state: { configNeedsApply: false, configSnapshot: null },
+      subscribe: () => () => {},
+    },
+    cloudStartup: {
+      get: () => null,
+      retry: () => undefined,
+      subscribe: () => () => {},
+    },
+    navigate: () => undefined,
     initialUserMessage: createInitialUserMessageHandoff(),
     chatAttachmentHandoff: createChatAttachmentHandoff(),
-    sessions: {},
+    sessions: { state: { modelOverrides: {} } },
   } as unknown as ApplicationContext;
 }
 
@@ -546,6 +564,114 @@ describe("chat pane initialization", () => {
       expect(attachedState?.currentSessionId).toBe("split-session");
     } finally {
       pane.disconnectedCallback();
+    }
+  });
+
+  it("paints a persistent snapshot while the network refresh is already in flight", async () => {
+    vi.stubGlobal("indexedDB", new IDBFactory());
+    const targetSessionKey = "agent:main:persistent";
+    const cachedMessages = [nativeHistoryMessage(1, "persistent history")];
+    const networkMessages = [nativeHistoryMessage(1, "network history")];
+    const writer = new SessionSnapshotStore();
+    writer.write(targetSessionKey, {
+      messages: cachedMessages,
+      pagination: { hasMore: false, completeSnapshot: true },
+      sessionId: "persistent-session",
+    });
+    await writer.flush();
+    const response = createDeferred<Record<string, unknown>>();
+    const request = vi.fn(() => response.promise);
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
+    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
+    const sharedMessages: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(sharedMessages);
+    store.connect();
+    observeChatCache(sharedMessages, store);
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = sharedMessages;
+    pane.sessionSnapshotStore = store;
+    pane.context = createInitializationContext();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      state.client = client;
+      state.connected = true;
+      state.connectionEpoch = 1;
+      void loadChatHistory(state);
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      expect(request).toHaveBeenCalledWith(
+        "chat.history",
+        expect.objectContaining({ sessionKey: targetSessionKey }),
+      );
+      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(cachedMessages));
+
+      response.resolve({ messages: networkMessages, sessionId: "network-session" });
+      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(networkMessages));
+    } finally {
+      pane.disconnectedCallback();
+      store.disconnect();
+      await store.whenIdle();
+      await clearStoredChatSnapshots();
+    }
+  });
+
+  it("discards persistent hydration when the network snapshot lands first", async () => {
+    vi.stubGlobal("indexedDB", new IDBFactory());
+    const targetSessionKey = "agent:main:network-first";
+    const writer = new SessionSnapshotStore();
+    writer.write(targetSessionKey, {
+      messages: [nativeHistoryMessage(1, "stale persistent history")],
+      pagination: { hasMore: false, completeSnapshot: true },
+      sessionId: "persistent-session",
+    });
+    await writer.flush();
+    const networkMessages = [nativeHistoryMessage(1, "authoritative network history")];
+    const request = vi.fn(async () => ({
+      messages: networkMessages,
+      sessionId: "network-session",
+    }));
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
+    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
+    const sharedMessages: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(sharedMessages);
+    store.connect();
+    observeChatCache(sharedMessages, store);
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = sharedMessages;
+    pane.sessionSnapshotStore = store;
+    pane.context = createInitializationContext();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      state.client = client;
+      state.connected = true;
+      state.connectionEpoch = 1;
+      void loadChatHistory(state);
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(networkMessages));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(attachedState?.chatMessages).toEqual(networkMessages);
+    } finally {
+      pane.disconnectedCallback();
+      store.disconnect();
+      await store.whenIdle();
+      await clearStoredChatSnapshots();
     }
   });
 

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -3,6 +3,7 @@
 import { IDBFactory } from "fake-indexeddb";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -15,6 +15,7 @@ import {
   waitForConfirmDialogActions,
 } from "../../test-helpers/modal-dialog.ts";
 import { loadChatHistory } from "./chat-history.ts";
+import { subscribeChatPaneSnapshotInvalidation } from "./chat-pane-startup-subscriptions.ts";
 import {
   createGatewayBrowserClientFixture,
   createSessionCapabilityFixture,
@@ -673,6 +674,38 @@ describe("chat pane initialization", () => {
       store.disconnect();
       await store.whenIdle();
       await clearStoredChatSnapshots();
+    }
+  });
+
+  it("clears a mounted transcript and fences delayed history after cross-tab invalidation", async () => {
+    const response = createDeferred<Record<string, unknown>>();
+    const request = vi.fn(() => response.promise);
+    const client = createGatewayBrowserClientFixture({ request });
+    const sessions = createSessionCapabilityFixture();
+    const { state } = createTestChatPane({ client, sessions });
+    state.chatMessagesBySession = new Map();
+    state.chatMessages = [nativeHistoryMessage(1, "prior account transcript")];
+    const stop = subscribeChatPaneSnapshotInvalidation(() => state);
+    const loading = loadChatHistory(state);
+
+    try {
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "openclaw.control.chatSnapshots.invalidate.v1",
+          newValue: "other-tab",
+        }),
+      );
+      expect(state.chatMessages).toEqual([]);
+
+      response.resolve({
+        messages: [nativeHistoryMessage(2, "stale delayed transcript")],
+        sessionId: "stale-session",
+      });
+      await loading;
+      expect(state.chatMessages).toEqual([]);
+    } finally {
+      stop();
     }
   });
 

--- a/ui/src/pages/chat/chat-view.test-helpers.ts
+++ b/ui/src/pages/chat/chat-view.test-helpers.ts
@@ -2,13 +2,18 @@ import type { ReactiveControllerHost } from "lit";
 import { vi } from "vitest";
 import { ChatTranscriptController } from "./components/chat-transcript-controller.ts";
 
-export function createTestTranscript(): ChatTranscriptController {
-  return new ChatTranscriptController({
-    addController: () => undefined,
-    removeController: () => undefined,
-    requestUpdate: () => undefined,
-    updateComplete: Promise.resolve(true),
-  } satisfies ReactiveControllerHost);
+export function createTestTranscript(
+  rowHeightCache?: ConstructorParameters<typeof ChatTranscriptController>[1],
+): ChatTranscriptController {
+  return new ChatTranscriptController(
+    {
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate: () => undefined,
+      updateComplete: Promise.resolve(true),
+    } satisfies ReactiveControllerHost,
+    rowHeightCache,
+  );
 }
 
 export function createPasteEvent(

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -72,6 +72,31 @@ describe("chat transcript controller", () => {
     expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(100px)");
   });
 
+  it("uses persisted row measurements before remounted rows can be measured", async () => {
+    const measured = new Map<string, number>();
+    const first = createTestTranscript({
+      read: () => undefined,
+      write: (_sessionKey, rowKey, height) => measured.set(rowKey, height),
+    });
+    const props = threadProps("pane-persisted-heights", "agent:main:persisted-heights");
+    const firstContainer = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, first), firstContainer);
+    first.hostConnected();
+    first.hostUpdated();
+    await flushDeferredRowPrune();
+    expect(measured.size).toBeGreaterThan(0);
+
+    transcriptDomState.detachedRowHeight = 0;
+    const remounted = createTestTranscript({
+      read: (_sessionKey, rowKey) => measured.get(rowKey),
+      write: () => undefined,
+    });
+    const remountContainer = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, remounted), remountContainer);
+
+    expect(transcriptRows(remountContainer)[1]?.style.transform).toBe("translateY(100px)");
+  });
+
   it("pauses an unmeasurable restore until loading commits an empty transcript", () => {
     const transcript = createTestTranscript();
     const container = document.body.appendChild(document.createElement("div"));

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -1,6 +1,10 @@
 // Session-owned virtualizer lifecycle for chat transcripts.
 import { VirtualizerController } from "@tanstack/lit-virtual";
-import { defaultRangeExtractor, observeElementRect } from "@tanstack/virtual-core";
+import {
+  defaultRangeExtractor,
+  measureElement as measureVirtualElement,
+  observeElementRect,
+} from "@tanstack/virtual-core";
 import {
   html,
   nothing,
@@ -43,6 +47,11 @@ export type ChatTranscriptSession = {
   setContentReady(ready: boolean): void;
   handleFocusIn(event: FocusEvent): void;
   handleFocusOut(event: FocusEvent): void;
+};
+
+type TranscriptRowHeightCache = {
+  read: (sessionKey: string, rowKey: string) => number | undefined;
+  write: (sessionKey: string, rowKey: string, height: number) => void;
 };
 
 const CHAT_TRANSCRIPT_ESTIMATED_ROW_PX = 120;
@@ -140,10 +149,10 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
     const instance = this.virtualizerController.getVirtualizer();
     for (const row of this.threadInnerElement?.querySelectorAll<HTMLElement>(".chat-virtual-row") ??
       []) {
-      instance.resizeItem(
-        instance.indexFromElement(row),
-        row[instance.options.horizontal ? "offsetWidth" : "offsetHeight"],
-      );
+      const index = instance.indexFromElement(row);
+      const size = row[instance.options.horizontal ? "offsetWidth" : "offsetHeight"];
+      this.recordRowHeight(index, size);
+      instance.resizeItem(index, size);
     }
   }
   private queueConnectedRowMeasure(): void {
@@ -208,13 +217,20 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
 
   constructor(
     private readonly host: ReactiveControllerHost,
+    private readonly sessionKey: string,
+    private readonly rowHeightCache?: TranscriptRowHeightCache,
     initialOffset: number | null = null,
     onInitialOffsetSettled?: (position: ChatSessionScrollPosition) => void,
   ) {
     this.virtualizerController = new VirtualizerController(this, {
       count: 0,
       getScrollElement: () => this.scrollElement,
-      estimateSize: () => CHAT_TRANSCRIPT_ESTIMATED_ROW_PX,
+      estimateSize: (index) => {
+        const rowKey = this.rowKeys[index];
+        return rowKey
+          ? (this.rowHeightCache?.read(this.sessionKey, rowKey) ?? CHAT_TRANSCRIPT_ESTIMATED_ROW_PX)
+          : CHAT_TRANSCRIPT_ESTIMATED_ROW_PX;
+      },
       getItemKey: () => "",
       initialRect: initialTranscriptRect(host),
       initialOffset: initialOffset ?? Number.MAX_SAFE_INTEGER,
@@ -257,6 +273,11 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
             this.queueConnectedRowMeasure();
           }
         }),
+      measureElement: (element, entry, instance) => {
+        const size = measureVirtualElement(element, entry, instance);
+        this.recordRowHeight(instance.indexFromElement(element), size);
+        return size;
+      },
       rangeExtractor: (range) => {
         const indexes = defaultRangeExtractor(range);
         const focused =
@@ -514,6 +535,13 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
     return row.dataset.virtualRowKey || null;
   }
 
+  private recordRowHeight(index: number, height: number): void {
+    const rowKey = this.rowKeys[index];
+    if (rowKey && Number.isFinite(height) && height > 0) {
+      this.rowHeightCache?.write(this.sessionKey, rowKey, height);
+    }
+  }
+
   private syncAnnouncement(announcement: TranscriptAnnouncement | null, announce: boolean): void {
     if (!this.announcementInitialized || !announce) {
       this.announcementInitialized = true;
@@ -640,7 +668,10 @@ export class ChatTranscriptController implements ReactiveController {
   private sessionVirtualizer: ChatSessionVirtualizerHost | null = null;
   private connected = false;
 
-  constructor(private readonly host: ReactiveControllerHost) {
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    private readonly rowHeightCache?: TranscriptRowHeightCache,
+  ) {
     host.addController(this);
   }
 
@@ -664,6 +695,8 @@ export class ChatTranscriptController implements ReactiveController {
       this.activeSessionKey = sessionKey;
       this.sessionVirtualizer = new ChatSessionVirtualizerHost(
         this.host,
+        sessionKey,
+        this.rowHeightCache,
         initialOffset,
         initialOffset === null
           ? undefined

--- a/ui/src/pages/chat/session-cache.ts
+++ b/ui/src/pages/chat/session-cache.ts
@@ -1,5 +1,5 @@
 // Control UI chat module implements session cache behavior.
-const MAX_CACHED_CHAT_SESSIONS = 20;
+export const MAX_CACHED_CHAT_SESSIONS = 20;
 
 export function getSessionCacheValue<T>(map: Map<string, T>, sessionKey: string): T | undefined {
   if (!map.has(sessionKey)) {

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -1,29 +1,22 @@
 // Control UI chat module implements bounded visible-message caching.
 import { readSessionMessageSequence } from "@openclaw/gateway-client/browser";
-import {
-  DEFAULT_MAIN_KEY,
-  isUiGlobalSessionKey,
-  normalizeAgentId,
-  normalizeSessionKeyForUiComparison,
-  parseAgentSessionKey,
-  resolveUiConfiguredMainKey,
-  resolveUiDefaultAgentId,
-  resolveUiSelectedGlobalAgentId,
-  type UiSessionDefaultsHost,
-} from "../../lib/sessions/session-key.ts";
+import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import { getSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
+import { resolveChatSnapshotKey } from "./session-snapshot-invalidation.ts";
+
+export { resolveChatSnapshotKey } from "./session-snapshot-invalidation.ts";
 
 // JSON code-unit weight bounds retained payloads without allocating another
 // UTF-8 buffer on the route-switch path.
 const MAX_CACHED_CHAT_SNAPSHOT_WEIGHT = 12 * 1024 * 1024;
-const MAX_CACHED_CHAT_WEIGHT = 24 * 1024 * 1024;
+export const MAX_CACHED_CHAT_WEIGHT = 24 * 1024 * 1024;
 // History reconciliation replaces changed messages and retains unchanged
 // objects, so serialization weight can follow the same immutable identity.
 const cachedMessageWeights = new WeakMap<object, number>();
 const appendedEventClaims = new WeakMap<ChatMessageCache, WeakSet<object>>();
 
-type ChatSessionSnapshot = {
+export type ChatSessionSnapshot = {
   displayedLeafEntryId?: string | null;
   messages: unknown[];
   pagination: ChatHistoryPagination;
@@ -37,6 +30,13 @@ type CachedChatSessionSnapshot = {
 
 export type ChatMessageCache = Map<string, CachedChatSessionSnapshot>;
 
+export type ChatCacheObserver = {
+  delete: (sessionKey: string) => void | Promise<void>;
+  write: (sessionKey: string, snapshot: ChatSessionSnapshot) => void;
+};
+
+const chatCacheObservers = new WeakMap<ChatMessageCache, ChatCacheObserver>();
+
 type ChatMessageCacheTarget = {
   sessionKey: string;
   agentId?: string | null;
@@ -47,41 +47,36 @@ type ChatMessageCacheHost = Pick<
   "assistantAgentId" | "agentsList" | "hello"
 >;
 
-function resolveCacheAgentId(host: ChatMessageCacheHost, target: ChatMessageCacheTarget): string {
-  const explicitAgentId = target.agentId?.trim();
-  if (explicitAgentId) {
-    return normalizeAgentId(explicitAgentId);
-  }
-  const parsed = parseAgentSessionKey(target.sessionKey);
-  if (parsed) {
-    return normalizeAgentId(parsed.agentId);
-  }
-  return isUiGlobalSessionKey(target.sessionKey)
-    ? resolveUiSelectedGlobalAgentId(host)
-    : resolveUiDefaultAgentId(host);
+export function observeChatCache(cache: ChatMessageCache, observer: ChatCacheObserver): void {
+  chatCacheObservers.set(cache, observer);
 }
 
-function resolveCanonicalSessionKey(host: ChatMessageCacheHost, sessionKey: string): string {
-  const normalizedSessionKey = normalizeSessionKeyForUiComparison(sessionKey);
-  const parsed = parseAgentSessionKey(normalizedSessionKey);
-  const normalized = parsed
-    ? normalizedSessionKey.split(":").slice(2).join(":")
-    : normalizedSessionKey;
-  const configuredMainKey = resolveUiConfiguredMainKey(host);
-  return isUiGlobalSessionKey(sessionKey) ||
-    normalized === DEFAULT_MAIN_KEY ||
-    normalized === configuredMainKey
-    ? DEFAULT_MAIN_KEY
-    : normalized;
+function deleteChatSnapshot(cache: ChatMessageCache, cacheKey: string): void {
+  cache.delete(cacheKey);
+  void chatCacheObservers.get(cache)?.delete(cacheKey);
 }
 
-function resolveChatMessageCacheKey(
-  host: ChatMessageCacheHost,
-  target: ChatMessageCacheTarget,
-): string {
-  const agentId = resolveCacheAgentId(host, target);
-  const sessionKey = resolveCanonicalSessionKey(host, target.sessionKey);
-  return `agent:${agentId}:${sessionKey}`;
+export function applyChatCacheSnapshot(
+  state: {
+    chatDisplayedLeafEntryId?: string | null;
+    chatHistoryPagination: ChatHistoryPagination;
+    chatMessages: unknown[];
+    currentSessionId?: string | null;
+  },
+  snapshot: ChatSessionSnapshot,
+): void {
+  state.chatMessages = snapshot.messages;
+  state.chatHistoryPagination = snapshot.pagination;
+  state.currentSessionId = snapshot.sessionId;
+  state.chatDisplayedLeafEntryId = snapshot.displayedLeafEntryId;
+}
+
+function publishChatSnapshot(
+  cache: ChatMessageCache,
+  cacheKey: string,
+  snapshot: ChatSessionSnapshot,
+): void {
+  chatCacheObservers.get(cache)?.write(cacheKey, snapshot);
 }
 
 export function appendChatMessageToCache(
@@ -102,7 +97,7 @@ export function appendChatMessageToCache(
     }
     claims.add(eventClaim);
   }
-  const cacheKey = resolveChatMessageCacheKey(host, target);
+  const cacheKey = resolveChatSnapshotKey(host, target);
   const existing = getSessionCacheValue(cache, cacheKey);
   if (!existing) {
     cacheChatSessionSnapshot(cache, host, target, {
@@ -114,7 +109,7 @@ export function appendChatMessageToCache(
   }
   const messageWeight = serializedArrayItemWeight(message);
   if (messageWeight === null) {
-    cache.delete(cacheKey);
+    deleteChatSnapshot(cache, cacheKey);
     return;
   }
   const snapshot = {
@@ -135,6 +130,7 @@ export function appendChatMessageToCache(
     weight,
   });
   trimChatSessionSnapshotCache(cache);
+  publishChatSnapshot(cache, cacheKey, snapshot);
 }
 
 export function readChatMessagesFromCache(
@@ -150,7 +146,7 @@ export function clearChatMessagesFromCache(
   host: ChatMessageCacheHost,
   target: ChatMessageCacheTarget,
 ): void {
-  cache.delete(resolveChatMessageCacheKey(host, target));
+  deleteChatSnapshot(cache, resolveChatSnapshotKey(host, target));
 }
 
 export function cacheChatSessionSnapshot(
@@ -159,7 +155,7 @@ export function cacheChatSessionSnapshot(
   target: ChatMessageCacheTarget,
   snapshot: ChatSessionSnapshot,
 ): void {
-  const cacheKey = resolveChatMessageCacheKey(host, target);
+  const cacheKey = resolveChatSnapshotKey(host, target);
   const existing = getSessionCacheValue(cache, cacheKey);
   if (
     existing?.snapshot.messages === snapshot.messages &&
@@ -176,16 +172,17 @@ export function cacheChatSessionSnapshot(
     (snapshot.pagination.totalMessages ?? 0) === 0 &&
     snapshot.pagination.completeSnapshot !== true
   ) {
-    cache.delete(cacheKey);
+    deleteChatSnapshot(cache, cacheKey);
     return;
   }
   const bounded = boundChatSessionSnapshot(snapshot);
   if (!bounded) {
-    cache.delete(cacheKey);
+    deleteChatSnapshot(cache, cacheKey);
     return;
   }
   setSessionCacheValue(cache, cacheKey, bounded);
   trimChatSessionSnapshotCache(cache);
+  publishChatSnapshot(cache, cacheKey, bounded.snapshot);
 }
 
 export function readChatSessionSnapshot(
@@ -193,7 +190,21 @@ export function readChatSessionSnapshot(
   host: ChatMessageCacheHost,
   target: ChatMessageCacheTarget,
 ): ChatSessionSnapshot | null {
-  return getSessionCacheValue(cache, resolveChatMessageCacheKey(host, target))?.snapshot ?? null;
+  return getSessionCacheValue(cache, resolveChatSnapshotKey(host, target))?.snapshot ?? null;
+}
+
+export function measureChatSnapshotWeight(snapshot: ChatSessionSnapshot): number | null {
+  const messageWeights = measureMessageWeights(snapshot.messages);
+  if (!messageWeights) {
+    return null;
+  }
+  return measuredSnapshotWeight(
+    snapshot.pagination,
+    snapshot.sessionId,
+    snapshot.displayedLeafEntryId,
+    messageWeights.reduce((sum, weight) => sum + weight, 0),
+    messageWeights.length,
+  );
 }
 
 function boundChatSessionSnapshot(snapshot: ChatSessionSnapshot): CachedChatSessionSnapshot | null {

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -230,14 +230,16 @@ function boundChatSessionSnapshot(snapshot: ChatSessionSnapshot): CachedChatSess
       messageWeights.length - start,
     );
     if (weight !== null && weight <= MAX_CACHED_CHAT_SNAPSHOT_WEIGHT) {
-      const messages = start === 0 ? snapshot.messages : snapshot.messages.slice(start);
+      if (start === 0) {
+        return { snapshot, weight };
+      }
       return {
         snapshot: {
           ...(Object.hasOwn(snapshot, "displayedLeafEntryId")
             ? { displayedLeafEntryId: snapshot.displayedLeafEntryId }
             : {}),
-          messages,
-          pagination: start === 0 ? pagination : { ...pagination },
+          messages: snapshot.messages.slice(start),
+          pagination: { ...pagination },
           sessionId: snapshot.sessionId,
         },
         weight,

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -188,6 +188,8 @@ describe("recent session prefetch", () => {
 
   it("idles, excludes open and fresh sessions, and fills five cache entries sequentially", async () => {
     store.write("agent:main:fresh", historySnapshot("fresh"));
+    await store.flush();
+    const open = vi.spyOn(indexedDB, "open");
     const pending: Array<{
       resolve: (value: ReturnType<typeof historyResult>) => void;
       sessionKey: string;
@@ -267,6 +269,14 @@ describe("recent session prefetch", () => {
     expect(
       request.mock.calls.some((call) => sessionKeyFromCall(call) === "agent:main:eligible-6"),
     ).toBe(false);
+    expect(open).toHaveBeenCalledOnce();
+
+    await store.flush();
+    open.mockClear();
+    updatePrefetch({ ...state, listRevision: 2 });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    expect(open).not.toHaveBeenCalled();
   });
 
   it("coalesces a newer list revision until the per-session cooldown expires", async () => {

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -1,0 +1,402 @@
+/* @vitest-environment jsdom */
+
+import { IDBFactory } from "fake-indexeddb";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import {
+  observeChatCache,
+  readChatSessionSnapshot,
+  type ChatMessageCache,
+  type ChatSessionSnapshot,
+} from "./session-message-cache.ts";
+import { installSessionPrefetch } from "./session-prefetch.ts";
+import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
+import { SessionSnapshotStore } from "./session-snapshot-store.ts";
+
+const NOW = 1_000_000;
+const snapshotHost = { assistantAgentId: "main", agentsList: null, hello: null };
+
+type SessionPrefetchUpdate = {
+  client: GatewayBrowserClient | null;
+  listRevision: number;
+  openSessionKeys: readonly string[];
+  rows: readonly GatewaySessionRow[] | null;
+};
+
+function row(
+  key: string,
+  activityAt: number | undefined,
+  updatedAt = activityAt ?? 0,
+): GatewaySessionRow {
+  return {
+    key,
+    kind: "direct",
+    updatedAt,
+    ...(activityAt === undefined ? {} : { lastActivityAt: activityAt }),
+  };
+}
+
+function historySnapshot(message: string, sessionId = `session-${message}`): ChatSessionSnapshot {
+  return {
+    messages: [{ role: "assistant", content: message }],
+    pagination: { hasMore: false, completeSnapshot: true },
+    sessionId,
+  };
+}
+
+function historyResult(sessionKey: string) {
+  return {
+    completeSnapshot: true,
+    messages: [{ role: "assistant", content: sessionKey }],
+    sessionId: `id:${sessionKey}`,
+  };
+}
+
+function sessionKeyFromCall(call: unknown[]): string {
+  return (call[1] as { sessionKey: string }).sessionKey;
+}
+
+async function settlePromises(): Promise<void> {
+  for (let index = 0; index < 60; index += 1) {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    await Promise.resolve();
+  }
+}
+
+describe("recent session prefetch", () => {
+  let visibility: DocumentVisibilityState;
+  let cache: ChatMessageCache;
+  let store: SessionSnapshotStore;
+  let controller: ReactiveController;
+  let host: HTMLElement & ReactiveControllerHost;
+  let current: SessionPrefetchUpdate;
+  let context: ApplicationContext;
+  let originalVisibility: PropertyDescriptor | undefined;
+  let originalLocks: PropertyDescriptor | undefined;
+  let originalRequestIdleCallback: PropertyDescriptor | undefined;
+  let originalCancelIdleCallback: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(NOW);
+    vi.stubGlobal("indexedDB", new IDBFactory());
+    visibility = "visible";
+    originalVisibility = Object.getOwnPropertyDescriptor(document, "visibilityState");
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibility,
+    });
+    originalLocks = Object.getOwnPropertyDescriptor(navigator, "locks");
+    originalRequestIdleCallback = Object.getOwnPropertyDescriptor(window, "requestIdleCallback");
+    originalCancelIdleCallback = Object.getOwnPropertyDescriptor(window, "cancelIdleCallback");
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      value: (callback: IdleRequestCallback) =>
+        window.setTimeout(() => callback({ didTimeout: false, timeRemaining: () => 50 }), 0),
+    });
+    Object.defineProperty(window, "cancelIdleCallback", {
+      configurable: true,
+      value: (handle: number) => window.clearTimeout(handle),
+    });
+    Object.defineProperty(navigator, "locks", { configurable: true, value: undefined });
+    cache = new Map();
+    store = new SessionSnapshotStore(cache);
+    store.connect();
+    observeChatCache(cache, store);
+    current = { client: null, listRevision: 0, openSessionKeys: [], rows: null };
+    const gatewayListeners = new Set<() => void>();
+    context = {
+      agents: { state: { agentsList: null } },
+      gateway: {
+        get snapshot() {
+          return {
+            assistantAgentId: "main",
+            client: current.client,
+            hello: null,
+            phase: current.client ? ("connected" as const) : ("stopped" as const),
+          };
+        },
+        subscribe: (listener: () => void) => {
+          gatewayListeners.add(listener);
+          return () => gatewayListeners.delete(listener);
+        },
+      },
+      sessions: {
+        get canonicalListRevision() {
+          return current.listRevision;
+        },
+        get state() {
+          return { result: current.rows ? { sessions: current.rows } : null };
+        },
+      },
+    } as unknown as ApplicationContext;
+    host = Object.assign(document.createElement("div"), {
+      addController: (_controller: ReactiveController) => undefined,
+      removeController: (_controller: ReactiveController) => undefined,
+      requestUpdate: () => undefined,
+      updateComplete: Promise.resolve(true),
+    });
+    controller = installSessionPrefetch(host, cache, store, () => context);
+    controller.hostConnected?.();
+  });
+
+  afterEach(async () => {
+    controller.hostDisconnected?.();
+    await store.flush();
+    store.disconnect();
+    await store.whenIdle();
+    await clearStoredChatSnapshots();
+    if (originalVisibility) {
+      Object.defineProperty(document, "visibilityState", originalVisibility);
+    } else {
+      Reflect.deleteProperty(document, "visibilityState");
+    }
+    if (originalLocks) {
+      Object.defineProperty(navigator, "locks", originalLocks);
+    } else {
+      Reflect.deleteProperty(navigator, "locks");
+    }
+    if (originalRequestIdleCallback) {
+      Object.defineProperty(window, "requestIdleCallback", originalRequestIdleCallback);
+    } else {
+      Reflect.deleteProperty(window, "requestIdleCallback");
+    }
+    if (originalCancelIdleCallback) {
+      Object.defineProperty(window, "cancelIdleCallback", originalCancelIdleCallback);
+    } else {
+      Reflect.deleteProperty(window, "cancelIdleCallback");
+    }
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function updatePrefetch(update: SessionPrefetchUpdate): void {
+    current = update;
+    host.replaceChildren(
+      ...update.openSessionKeys.map((sessionKey) =>
+        Object.assign(document.createElement("openclaw-chat-pane"), { sessionKey }),
+      ),
+    );
+    controller.hostUpdated?.();
+  }
+
+  it("idles, excludes open and fresh sessions, and fills five cache entries sequentially", async () => {
+    store.write("agent:main:fresh", historySnapshot("fresh"));
+    const pending: Array<{
+      resolve: (value: ReturnType<typeof historyResult>) => void;
+      sessionKey: string;
+    }> = [];
+    const request = vi.fn((_method: string, params: unknown) => {
+      const sessionKey = (params as { sessionKey: string }).sessionKey;
+      return new Promise<ReturnType<typeof historyResult>>((resolve) => {
+        pending.push({ resolve, sessionKey });
+      });
+    });
+    const locksRequest = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock | null) => Promise<void>,
+      ) => await callback({ name: "openclaw-chat-prefetch", mode: "exclusive" } as Lock),
+    );
+    Object.defineProperty(navigator, "locks", {
+      configurable: true,
+      value: { request: locksRequest },
+    });
+    const rows = [
+      row("agent:main:eligible-6", NOW - 8),
+      row("agent:main:eligible-3", NOW - 5, NOW + 500),
+      row("agent:main:main", NOW - 1),
+      row("agent:main:eligible-1", NOW - 3),
+      row("agent:main:fresh", NOW - 2),
+      row("agent:main:eligible-5", NOW - 7),
+      row("agent:main:eligible-2", undefined, NOW - 4),
+      row("agent:main:eligible-4", NOW - 6),
+    ];
+    const state: SessionPrefetchUpdate = {
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: ["main"],
+      rows,
+    };
+
+    updatePrefetch(state);
+    expect(request).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(request).toHaveBeenCalledTimes(index + 1);
+      const pendingRequest = pending[index];
+      if (!pendingRequest) {
+        throw new Error(`missing pending history request ${index}`);
+      }
+      pendingRequest.resolve(historyResult(pendingRequest.sessionKey));
+      await settlePromises();
+    }
+
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual([
+      "agent:main:eligible-1",
+      "agent:main:eligible-2",
+      "agent:main:eligible-3",
+      "agent:main:eligible-4",
+      "agent:main:eligible-5",
+    ]);
+    expect(request.mock.calls.every((call) => (call[1] as { limit: number }).limit === 100)).toBe(
+      true,
+    );
+    expect(locksRequest).toHaveBeenCalledWith(
+      "openclaw-chat-prefetch",
+      { ifAvailable: true },
+      expect.any(Function),
+    );
+    expect(
+      readChatSessionSnapshot(cache, snapshotHost, { sessionKey: "agent:main:eligible-5" }),
+    ).toEqual({
+      messages: [{ role: "assistant", content: "agent:main:eligible-5" }],
+      pagination: { hasMore: false, completeSnapshot: true },
+      sessionId: "id:agent:main:eligible-5",
+    });
+    expect(
+      request.mock.calls.some((call) => sessionKeyFromCall(call) === "agent:main:eligible-6"),
+    ).toBe(false);
+  });
+
+  it("coalesces a newer list revision until the per-session cooldown expires", async () => {
+    const request = vi.fn(async (_method: string, params: unknown) =>
+      historyResult((params as { sessionKey: string }).sessionKey),
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const base = {
+      client,
+      openSessionKeys: [],
+    };
+    updatePrefetch({ ...base, listRevision: 1, rows: [row("agent:main:warm", NOW - 1)] });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const newerActivityAt = Date.now() + 1;
+    updatePrefetch({
+      ...base,
+      listRevision: 2,
+      rows: [row("agent:main:warm", newerActivityAt)],
+    });
+    updatePrefetch({
+      ...base,
+      listRevision: 3,
+      rows: [row("agent:main:warm", newerActivityAt + 1)],
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(27_000);
+    await settlePromises();
+    expect(request).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the cycle when another tab holds the Web Lock", async () => {
+    const request = vi.fn();
+    const locksRequest = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock | null) => Promise<void>,
+      ) => await callback(null),
+    );
+    Object.defineProperty(navigator, "locks", {
+      configurable: true,
+      value: { request: locksRequest },
+    });
+    updatePrefetch({
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: [],
+      rows: [row("agent:main:locked", NOW - 1)],
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+
+    expect(locksRequest).toHaveBeenCalledOnce();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does no lock or network work when the tab becomes hidden before idle", async () => {
+    const idle = { callback: null as IdleRequestCallback | null };
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      value: (callback: IdleRequestCallback) => {
+        idle.callback = callback;
+        return 1;
+      },
+    });
+    const request = vi.fn();
+    const locksRequest = vi.fn();
+    Object.defineProperty(navigator, "locks", {
+      configurable: true,
+      value: { request: locksRequest },
+    });
+    updatePrefetch({
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: [],
+      rows: [row("agent:main:hidden", NOW - 1)],
+    });
+    await vi.advanceTimersByTimeAsync(1_500);
+    visibility = "hidden";
+    idle.callback?.({ didTimeout: false, timeRemaining: () => 50 });
+    await settlePromises();
+
+    expect(locksRequest).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("logs fetch errors without retrying or stopping later candidates", async () => {
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const sessionKey = (params as { sessionKey: string }).sessionKey;
+      if (sessionKey.endsWith("failed")) {
+        throw new Error("prefetch failed");
+      }
+      return historyResult(sessionKey);
+    });
+    updatePrefetch({
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: [],
+      rows: [row("agent:main:failed", NOW - 1), row("agent:main:succeeded", NOW - 2)],
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual([
+      "agent:main:failed",
+      "agent:main:succeeded",
+    ]);
+    expect(debug).toHaveBeenCalledWith(
+      "[chat-session-prefetch] history fetch failed for agent:main:failed",
+      expect.any(Error),
+    );
+    expect(
+      readChatSessionSnapshot(cache, snapshotHost, { sessionKey: "agent:main:succeeded" }),
+    ).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(60_000);
+    await settlePromises();
+    expect(
+      request.mock.calls.filter((call) => sessionKeyFromCall(call).endsWith("failed")),
+    ).toHaveLength(1);
+  });
+});

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -1,0 +1,387 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { requestChatSessionSnapshot } from "./chat-history.ts";
+import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
+import { resolveChatSnapshotKey } from "./session-snapshot-invalidation.ts";
+import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
+
+const SESSION_PREFETCH_COUNT = 5;
+const SESSION_PREFETCH_INITIAL_DELAY_MS = 1_500;
+const SESSION_PREFETCH_COOLDOWN_MS = 30_000;
+const SESSION_PREFETCH_LOCK_NAME = "openclaw-chat-prefetch";
+
+type ChatSnapshotKeyHost = Parameters<typeof resolveChatSnapshotKey>[0];
+
+type SessionPrefetchSnapshot = {
+  client: GatewayBrowserClient | null;
+  listRevision: number;
+  openSessionKeys: readonly string[];
+  rows: readonly GatewaySessionRow[] | null;
+  snapshotHost: ChatSnapshotKeyHost;
+};
+
+type SessionPrefetchCandidate = {
+  activityAt: number;
+  snapshotKey: string;
+};
+
+function sessionActivityAt(row: GatewaySessionRow): number {
+  return row.lastActivityAt ?? row.updatedAt ?? 0;
+}
+
+function debugSessionPrefetch(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.debug(`[chat-session-prefetch] ${message}`);
+  } else {
+    console.debug(`[chat-session-prefetch] ${message}`, error);
+  }
+}
+
+function sameKeys(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((key, index) => key === right[index]);
+}
+
+class SessionPrefetcher {
+  private connected = false;
+  private snapshot: SessionPrefetchSnapshot | null = null;
+  private readonly lastAttemptAt = new Map<string, number>();
+  private delayTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private idleTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private idleCallback: number | null = null;
+  private running = false;
+  private rescheduleDelayMs: number | null = null;
+
+  constructor(
+    private readonly cache: ChatMessageCache,
+    private readonly snapshotStore: SessionSnapshotStore,
+  ) {}
+
+  connect(): void {
+    if (this.connected) {
+      return;
+    }
+    this.connected = true;
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    this.schedule();
+  }
+
+  disconnect(): void {
+    this.connected = false;
+    this.rescheduleDelayMs = null;
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    this.cancelScheduledWork();
+  }
+
+  update(snapshot: SessionPrefetchSnapshot): void {
+    const previous = this.snapshot;
+    this.snapshot = snapshot;
+    if (
+      !previous ||
+      previous.client !== snapshot.client ||
+      previous.listRevision !== snapshot.listRevision ||
+      !sameKeys(previous.openSessionKeys, snapshot.openSessionKeys)
+    ) {
+      this.schedule();
+    }
+  }
+
+  private readonly handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      this.schedule();
+    }
+  };
+
+  private schedule(delayMs = SESSION_PREFETCH_INITIAL_DELAY_MS): void {
+    if (!this.connected) {
+      return;
+    }
+    if (this.running) {
+      this.rescheduleDelayMs =
+        this.rescheduleDelayMs === null ? delayMs : Math.min(this.rescheduleDelayMs, delayMs);
+      return;
+    }
+    if (this.delayTimer !== null || this.idleTimer !== null || this.idleCallback !== null) {
+      return;
+    }
+    this.delayTimer = globalThis.setTimeout(() => {
+      this.delayTimer = null;
+      this.scheduleIdleCycle();
+    }, delayMs);
+  }
+
+  private scheduleIdleCycle(): void {
+    if (!this.connected) {
+      return;
+    }
+    if (typeof window.requestIdleCallback === "function") {
+      this.idleCallback = window.requestIdleCallback(() => {
+        this.idleCallback = null;
+        void this.runCycle();
+      });
+      return;
+    }
+    this.idleTimer = globalThis.setTimeout(() => {
+      this.idleTimer = null;
+      void this.runCycle();
+    }, 0);
+  }
+
+  private async runCycle(): Promise<void> {
+    if (!this.connected || this.running || document.visibilityState === "hidden") {
+      return;
+    }
+    this.running = true;
+    try {
+      const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
+      if (locks) {
+        await locks.request(SESSION_PREFETCH_LOCK_NAME, { ifAvailable: true }, async (lock) => {
+          // ifAvailable must skip instead of queueing so one visible tab owns the cycle.
+          if (lock) {
+            await this.prefetchEligibleSessions();
+          }
+        });
+      } else {
+        await this.prefetchEligibleSessions();
+      }
+    } catch (error) {
+      debugSessionPrefetch("cycle failed", error);
+    } finally {
+      this.running = false;
+      if (this.rescheduleDelayMs !== null) {
+        const delayMs = this.rescheduleDelayMs;
+        this.rescheduleDelayMs = null;
+        this.schedule(delayMs);
+      }
+    }
+  }
+
+  private async prefetchEligibleSessions(): Promise<void> {
+    const snapshot = this.snapshot;
+    if (
+      !snapshot?.client ||
+      !snapshot.rows ||
+      document.visibilityState === "hidden" ||
+      !this.connected
+    ) {
+      return;
+    }
+    const selection = await this.selectCandidates(snapshot);
+    if (selection.deferMs !== null) {
+      this.schedule(selection.deferMs);
+    }
+    for (const candidate of selection.candidates) {
+      if (!this.isCurrent(snapshot)) {
+        return;
+      }
+      if (this.isOpen(candidate.snapshotKey, this.snapshot)) {
+        continue;
+      }
+      this.lastAttemptAt.set(candidate.snapshotKey, Date.now());
+      try {
+        const cached = await requestChatSessionSnapshot(
+          snapshot.client,
+          candidate.snapshotKey,
+          this,
+          () => this.isCurrent(snapshot),
+        );
+        if (!this.isCurrent(snapshot)) {
+          return;
+        }
+        if (
+          this.isOpen(candidate.snapshotKey, this.snapshot) ||
+          this.currentActivityAt(candidate.snapshotKey) > candidate.activityAt
+        ) {
+          continue;
+        }
+        cacheChatSessionSnapshot(
+          this.cache,
+          snapshot.snapshotHost,
+          { sessionKey: candidate.snapshotKey },
+          cached,
+        );
+      } catch (error) {
+        debugSessionPrefetch(`history fetch failed for ${candidate.snapshotKey}`, error);
+      }
+    }
+  }
+
+  private async selectCandidates(snapshot: SessionPrefetchSnapshot): Promise<{
+    candidates: SessionPrefetchCandidate[];
+    deferMs: number | null;
+  }> {
+    const openKeys = new Set(
+      snapshot.openSessionKeys.map((sessionKey) =>
+        resolveChatSnapshotKey(snapshot.snapshotHost, { sessionKey }),
+      ),
+    );
+    const rows = [...(snapshot.rows ?? [])].toSorted(
+      (left, right) => sessionActivityAt(right) - sessionActivityAt(left),
+    );
+    const candidates: SessionPrefetchCandidate[] = [];
+    const seen = new Set<string>();
+    let deferMs: number | null = null;
+    for (const row of rows) {
+      const snapshotKey = resolveChatSnapshotKey(snapshot.snapshotHost, {
+        sessionKey: row.key,
+        agentId: row.agentId,
+      });
+      if (openKeys.has(snapshotKey) || seen.has(snapshotKey)) {
+        continue;
+      }
+      seen.add(snapshotKey);
+      const activityAt = sessionActivityAt(row);
+      const savedAt = await this.snapshotStore.readSavedAt(snapshotKey);
+      if (!this.isCurrent(snapshot)) {
+        return { candidates: [], deferMs: null };
+      }
+      if (savedAt !== null && savedAt >= activityAt) {
+        continue;
+      }
+      const elapsed = Date.now() - (this.lastAttemptAt.get(snapshotKey) ?? 0);
+      if (elapsed < SESSION_PREFETCH_COOLDOWN_MS) {
+        const remaining = SESSION_PREFETCH_COOLDOWN_MS - elapsed;
+        deferMs = deferMs === null ? remaining : Math.min(deferMs, remaining);
+        continue;
+      }
+      candidates.push({ activityAt, snapshotKey });
+      if (candidates.length === SESSION_PREFETCH_COUNT) {
+        break;
+      }
+    }
+    return { candidates, deferMs };
+  }
+
+  private isCurrent(snapshot: SessionPrefetchSnapshot): boolean {
+    return (
+      this.connected &&
+      document.visibilityState !== "hidden" &&
+      this.snapshot?.client === snapshot.client &&
+      this.snapshot.listRevision === snapshot.listRevision
+    );
+  }
+
+  private isOpen(snapshotKey: string, snapshot: SessionPrefetchSnapshot | null): boolean {
+    return Boolean(
+      snapshot?.openSessionKeys.some(
+        (sessionKey) =>
+          resolveChatSnapshotKey(snapshot.snapshotHost, { sessionKey }) === snapshotKey,
+      ),
+    );
+  }
+
+  private currentActivityAt(snapshotKey: string): number {
+    const snapshot = this.snapshot;
+    if (!snapshot?.rows) {
+      return 0;
+    }
+    let activityAt = 0;
+    for (const row of snapshot.rows) {
+      const rowSnapshotKey = resolveChatSnapshotKey(snapshot.snapshotHost, {
+        sessionKey: row.key,
+        agentId: row.agentId,
+      });
+      if (rowSnapshotKey === snapshotKey) {
+        activityAt = Math.max(activityAt, sessionActivityAt(row));
+      }
+    }
+    return activityAt;
+  }
+
+  private cancelScheduledWork(): void {
+    if (this.delayTimer !== null) {
+      globalThis.clearTimeout(this.delayTimer);
+      this.delayTimer = null;
+    }
+    if (this.idleTimer !== null) {
+      globalThis.clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    if (this.idleCallback !== null) {
+      window.cancelIdleCallback(this.idleCallback);
+      this.idleCallback = null;
+    }
+  }
+}
+
+type SessionPrefetchHost = ReactiveControllerHost & ParentNode;
+
+class SessionPrefetchController implements ReactiveController {
+  private readonly prefetcher: SessionPrefetcher;
+  private context: ApplicationContext | undefined;
+  private subscriptions: Array<() => void> = [];
+
+  constructor(
+    private readonly host: SessionPrefetchHost,
+    cache: ChatMessageCache,
+    snapshotStore: SessionSnapshotStore,
+    private readonly readContext: () => ApplicationContext | undefined,
+  ) {
+    this.prefetcher = new SessionPrefetcher(cache, snapshotStore);
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    this.prefetcher.connect();
+    this.sync();
+  }
+
+  hostUpdated(): void {
+    this.sync();
+  }
+
+  hostDisconnected(): void {
+    this.clearSubscriptions();
+    this.prefetcher.disconnect();
+  }
+
+  private readonly sync = () => {
+    const context = this.readContext();
+    if (context !== this.context) {
+      this.clearSubscriptions();
+      this.context = context;
+      if (context) {
+        this.subscriptions = [context.gateway.subscribe(this.sync)];
+      }
+    }
+    if (!context) {
+      return;
+    }
+    const panes = this.host.querySelectorAll<Element & { sessionKey?: string }>(
+      "openclaw-chat-pane",
+    );
+    const openSessionKeys = [...panes].flatMap((pane) =>
+      pane.sessionKey ? [pane.sessionKey] : [],
+    );
+    this.prefetcher.update({
+      client:
+        context.gateway.snapshot.phase === "connected" ? context.gateway.snapshot.client : null,
+      listRevision: context.sessions.canonicalListRevision,
+      openSessionKeys,
+      rows: context.sessions.state.result?.sessions ?? null,
+      snapshotHost: {
+        assistantAgentId: context.gateway.snapshot.assistantAgentId,
+        agentsList: context.agents.state.agentsList,
+        hello: context.gateway.snapshot.hello,
+      },
+    });
+  };
+
+  private clearSubscriptions(): void {
+    for (const unsubscribe of this.subscriptions) {
+      unsubscribe();
+    }
+    this.subscriptions = [];
+    this.context = undefined;
+  }
+}
+
+export function installSessionPrefetch(
+  host: SessionPrefetchHost,
+  cache: ChatMessageCache,
+  snapshotStore: SessionSnapshotStore,
+  readContext: () => ApplicationContext | undefined,
+): ReactiveController {
+  return new SessionPrefetchController(host, cache, snapshotStore, readContext);
+}

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -167,7 +167,11 @@ class SessionPrefetcher {
     ) {
       return;
     }
-    const selection = await this.selectCandidates(snapshot);
+    await this.snapshotStore.loadSavedAtIndex();
+    if (!this.isCurrent(snapshot)) {
+      return;
+    }
+    const selection = this.selectCandidates(snapshot);
     if (selection.deferMs !== null) {
       this.schedule(selection.deferMs);
     }
@@ -207,10 +211,10 @@ class SessionPrefetcher {
     }
   }
 
-  private async selectCandidates(snapshot: SessionPrefetchSnapshot): Promise<{
+  private selectCandidates(snapshot: SessionPrefetchSnapshot): {
     candidates: SessionPrefetchCandidate[];
     deferMs: number | null;
-  }> {
+  } {
     const openKeys = new Set(
       snapshot.openSessionKeys.map((sessionKey) =>
         resolveChatSnapshotKey(snapshot.snapshotHost, { sessionKey }),
@@ -232,10 +236,7 @@ class SessionPrefetcher {
       }
       seen.add(snapshotKey);
       const activityAt = sessionActivityAt(row);
-      const savedAt = await this.snapshotStore.readSavedAt(snapshotKey);
-      if (!this.isCurrent(snapshot)) {
-        return { candidates: [], deferMs: null };
-      }
+      const savedAt = this.snapshotStore.readSavedAt(snapshotKey);
       if (savedAt !== null && savedAt >= activityAt) {
         continue;
       }

--- a/ui/src/pages/chat/session-snapshot-database.ts
+++ b/ui/src/pages/chat/session-snapshot-database.ts
@@ -1,0 +1,104 @@
+import {
+  CHAT_SNAPSHOT_DB_NAME,
+  CHAT_SNAPSHOT_STORE_NAME,
+} from "./session-snapshot-invalidation.ts";
+
+const CHAT_SNAPSHOT_DB_VERSION = 1;
+
+function debugSnapshotDatabase(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.debug(`[chat-snapshot-cache] ${message}`);
+  } else {
+    console.debug(`[chat-snapshot-cache] ${message}`, error);
+  }
+}
+
+function indexedDbFactory(): IDBFactory | null {
+  try {
+    return globalThis.indexedDB ?? null;
+  } catch (error) {
+    debugSnapshotDatabase("IndexedDB is unavailable", error);
+    return null;
+  }
+}
+
+function openIndexedDb(factory: IDBFactory): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(CHAT_SNAPSHOT_DB_NAME, CHAT_SNAPSHOT_DB_VERSION);
+    request.addEventListener("upgradeneeded", () => {
+      const database = request.result;
+      for (const name of Array.from(database.objectStoreNames)) {
+        database.deleteObjectStore(name);
+      }
+      database.createObjectStore(CHAT_SNAPSHOT_STORE_NAME, { keyPath: "sessionKey" });
+    });
+    request.addEventListener("success", () => resolve(request.result));
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("IndexedDB open failed")),
+    );
+    request.addEventListener("blocked", () => reject(new Error("IndexedDB open was blocked")));
+  });
+}
+
+function deleteIndexedDb(factory: IDBFactory): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const request = factory.deleteDatabase(CHAT_SNAPSHOT_DB_NAME);
+      request.addEventListener("success", () => resolve(true));
+      request.addEventListener("error", () => resolve(false));
+      request.addEventListener("blocked", () => resolve(false));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+export async function openSessionSnapshotDatabase(): Promise<IDBDatabase | null> {
+  const factory = indexedDbFactory();
+  if (!factory) {
+    return null;
+  }
+  let database: IDBDatabase;
+  try {
+    database = await openIndexedDb(factory);
+  } catch (error) {
+    debugSnapshotDatabase("resetting cache after IndexedDB open failure", error);
+    if (!(await deleteIndexedDb(factory))) {
+      return null;
+    }
+    try {
+      database = await openIndexedDb(factory);
+    } catch (retryError) {
+      debugSnapshotDatabase("IndexedDB cache remains unavailable", retryError);
+      return null;
+    }
+  }
+  database.addEventListener("versionchange", () => database.close());
+  if (
+    database.objectStoreNames.length === 1 &&
+    database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME)
+  ) {
+    return database;
+  }
+  database.close();
+  debugSnapshotDatabase("resetting cache after IndexedDB schema mismatch");
+  if (!(await deleteIndexedDb(factory))) {
+    return null;
+  }
+  try {
+    const fresh = await openIndexedDb(factory);
+    fresh.addEventListener("versionchange", () => fresh.close());
+    return fresh;
+  } catch (error) {
+    debugSnapshotDatabase("IndexedDB cache reset failed", error);
+    return null;
+  }
+}
+
+export async function resetSessionSnapshotDatabase(database?: IDBDatabase | null): Promise<void> {
+  database?.close();
+  const factory = indexedDbFactory();
+  if (factory && !(await deleteIndexedDb(factory))) {
+    debugSnapshotDatabase("IndexedDB cache reset was blocked");
+  }
+}

--- a/ui/src/pages/chat/session-snapshot-invalidation-events.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation-events.ts
@@ -1,4 +1,4 @@
-export type SnapshotInvalidation = { sessionKey: string } | { sessionKey?: undefined };
+type SnapshotInvalidation = { sessionKey: string } | { sessionKey?: undefined };
 
 type SnapshotInvalidationListener = (invalidation: SnapshotInvalidation) => void | Promise<void>;
 

--- a/ui/src/pages/chat/session-snapshot-invalidation-events.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation-events.ts
@@ -1,0 +1,42 @@
+export type SnapshotInvalidation = { sessionKey: string } | { sessionKey?: undefined };
+
+type SnapshotInvalidationListener = (invalidation: SnapshotInvalidation) => void | Promise<void>;
+
+const SNAPSHOT_INVALIDATION_STORAGE_KEY = "openclaw.control.chatSnapshots.invalidate.v1";
+const invalidationListeners = new Set<SnapshotInvalidationListener>();
+let broadcastVersion = 0;
+
+function notifySnapshotInvalidation(invalidation: SnapshotInvalidation): Promise<void> {
+  return Promise.all(
+    [...invalidationListeners].map((listener) => Promise.resolve(listener(invalidation))),
+  ).then(() => undefined);
+}
+
+function broadcastSnapshotInvalidation(): void {
+  try {
+    localStorage.setItem(SNAPSHOT_INVALIDATION_STORAGE_KEY, String(++broadcastVersion));
+    localStorage.removeItem(SNAPSHOT_INVALIDATION_STORAGE_KEY);
+  } catch {}
+}
+
+export function publishSnapshotInvalidation(invalidation: SnapshotInvalidation): Promise<void> {
+  const notified = notifySnapshotInvalidation(invalidation);
+  broadcastSnapshotInvalidation();
+  return notified;
+}
+
+export function subscribeSnapshotInvalidation(listener: SnapshotInvalidationListener): () => void {
+  invalidationListeners.add(listener);
+  return () => invalidationListeners.delete(listener);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === SNAPSHOT_INVALIDATION_STORAGE_KEY && event.newValue !== null) {
+      // The cross-tab signal carries no session identifiers; peers safely drop all memory state.
+      void notifySnapshotInvalidation({}).catch((error) => {
+        console.error("[chat-snapshot-cache] cross-tab invalidation failed", error);
+      });
+    }
+  });
+}

--- a/ui/src/pages/chat/session-snapshot-invalidation-events.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation-events.ts
@@ -34,7 +34,7 @@ if (typeof window !== "undefined") {
   window.addEventListener("storage", (event) => {
     if (event.key === SNAPSHOT_INVALIDATION_STORAGE_KEY && event.newValue !== null) {
       // The cross-tab signal carries no session identifiers; peers safely drop all memory state.
-      void notifySnapshotInvalidation({}).catch((error) => {
+      void notifySnapshotInvalidation({}).catch((error: unknown) => {
         console.error("[chat-snapshot-cache] cross-tab invalidation failed", error);
       });
     }

--- a/ui/src/pages/chat/session-snapshot-invalidation.runtime.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.runtime.ts
@@ -10,8 +10,8 @@ type SnapshotKeyHost = {
 const loadSnapshotInvalidation = () => import("./session-snapshot-invalidation.ts");
 
 export function clearStoredChatSnapshots(): Promise<void> {
-  return loadSnapshotInvalidation().then(({ clearStoredChatSnapshots }) =>
-    clearStoredChatSnapshots(),
+  return loadSnapshotInvalidation().then(({ clearStoredChatSnapshots: clearSnapshots }) =>
+    clearSnapshots(),
   );
 }
 

--- a/ui/src/pages/chat/session-snapshot-invalidation.runtime.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.runtime.ts
@@ -1,5 +1,6 @@
 import type { ApplicationContext } from "../../app/context.ts";
 import type { SessionDeleteTarget } from "../../lib/sessions/session-capability.ts";
+import { publishSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
 
 type SnapshotKeyHost = {
   assistantAgentId: ApplicationContext["gateway"]["snapshot"]["assistantAgentId"];
@@ -10,9 +11,11 @@ type SnapshotKeyHost = {
 const loadSnapshotInvalidation = () => import("./session-snapshot-invalidation.ts");
 
 export function clearStoredChatSnapshots(): Promise<void> {
-  return loadSnapshotInvalidation().then(({ clearStoredChatSnapshots: clearSnapshots }) =>
-    clearSnapshots(),
-  );
+  const invalidated = publishSnapshotInvalidation({});
+  return loadSnapshotInvalidation().then(async ({ clearStoredChatSnapshotStorage }) => {
+    await invalidated;
+    await clearStoredChatSnapshotStorage();
+  });
 }
 
 export function deleteStoredChatSessionSnapshots(

--- a/ui/src/pages/chat/session-snapshot-invalidation.runtime.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.runtime.ts
@@ -1,0 +1,34 @@
+import type { ApplicationContext } from "../../app/context.ts";
+import type { SessionDeleteTarget } from "../../lib/sessions/session-capability.ts";
+
+type SnapshotKeyHost = {
+  assistantAgentId: ApplicationContext["gateway"]["snapshot"]["assistantAgentId"];
+  agentsList: ApplicationContext["agents"]["state"]["agentsList"];
+  hello: ApplicationContext["gateway"]["snapshot"]["hello"];
+};
+
+const loadSnapshotInvalidation = () => import("./session-snapshot-invalidation.ts");
+
+export function clearStoredChatSnapshots(): Promise<void> {
+  return loadSnapshotInvalidation().then(({ clearStoredChatSnapshots }) =>
+    clearStoredChatSnapshots(),
+  );
+}
+
+export function deleteStoredChatSessionSnapshots(
+  host: SnapshotKeyHost,
+  sessions: readonly Pick<SessionDeleteTarget, "agentId" | "key">[],
+): Promise<void> {
+  return loadSnapshotInvalidation().then(({ deleteStoredChatSnapshot, resolveChatSnapshotKey }) =>
+    Promise.all(
+      sessions.map(({ key, agentId }) =>
+        deleteStoredChatSnapshot(
+          resolveChatSnapshotKey(
+            { ...host, assistantAgentId: agentId ?? host.assistantAgentId },
+            { sessionKey: key, agentId },
+          ),
+        ),
+      ),
+    ).then(() => undefined),
+  );
+}

--- a/ui/src/pages/chat/session-snapshot-invalidation.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.ts
@@ -25,11 +25,6 @@ type ChatSnapshotKeyTarget = {
   agentId?: string | null;
 };
 
-type StoredChatSessionIdentity = {
-  key: string;
-  agentId?: string | null;
-};
-
 export function resolveChatSnapshotKey(
   host: ChatSnapshotKeyHost,
   target: ChatSnapshotKeyTarget,
@@ -109,22 +104,6 @@ export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void
       });
     });
   } catch {}
-}
-
-export async function deleteStoredChatSessionSnapshots(
-  host: ChatSnapshotKeyHost,
-  sessions: readonly StoredChatSessionIdentity[],
-): Promise<void> {
-  await Promise.all(
-    sessions.map(({ key, agentId }) =>
-      deleteStoredChatSnapshot(
-        resolveChatSnapshotKey(
-          { ...host, assistantAgentId: agentId ?? host.assistantAgentId },
-          { sessionKey: key, agentId },
-        ),
-      ),
-    ),
-  );
 }
 
 export async function clearStoredChatSnapshots(): Promise<void> {

--- a/ui/src/pages/chat/session-snapshot-invalidation.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.ts
@@ -9,14 +9,10 @@ import {
   resolveUiSelectedGlobalAgentId,
   type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
+import { publishSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
 
 export const CHAT_SNAPSHOT_DB_NAME = "openclaw-chat-snapshots";
 export const CHAT_SNAPSHOT_STORE_NAME = "snapshots";
-
-type SnapshotInvalidation = { sessionKey: string } | { sessionKey?: undefined };
-type SnapshotInvalidationListener = (invalidation: SnapshotInvalidation) => void | Promise<void>;
-
-const invalidationListeners = new Set<SnapshotInvalidationListener>();
 
 type ChatSnapshotKeyHost = Pick<UiSessionDefaultsHost, "assistantAgentId" | "agentsList" | "hello">;
 
@@ -52,17 +48,6 @@ export function resolveChatSnapshotKey(
   return `agent:${agentId}:${sessionKey}`;
 }
 
-export function subscribeSnapshotInvalidation(listener: SnapshotInvalidationListener): () => void {
-  invalidationListeners.add(listener);
-  return () => invalidationListeners.delete(listener);
-}
-
-async function notifySnapshotInvalidation(invalidation: SnapshotInvalidation): Promise<void> {
-  await Promise.all(
-    [...invalidationListeners].map((listener) => Promise.resolve(listener(invalidation))),
-  );
-}
-
 function indexedDbFactory(): IDBFactory | null {
   try {
     return globalThis.indexedDB ?? null;
@@ -72,7 +57,7 @@ function indexedDbFactory(): IDBFactory | null {
 }
 
 export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void> {
-  await notifySnapshotInvalidation({ sessionKey });
+  await publishSnapshotInvalidation({ sessionKey });
   const factory = indexedDbFactory();
   if (!factory) {
     return;
@@ -106,8 +91,7 @@ export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void
   } catch {}
 }
 
-export async function clearStoredChatSnapshots(): Promise<void> {
-  await notifySnapshotInvalidation({});
+export async function clearStoredChatSnapshotStorage(): Promise<void> {
   const factory = indexedDbFactory();
   if (!factory) {
     return;
@@ -120,4 +104,9 @@ export async function clearStoredChatSnapshots(): Promise<void> {
       request.addEventListener("blocked", () => resolve());
     });
   } catch {}
+}
+
+export async function clearStoredChatSnapshots(): Promise<void> {
+  await publishSnapshotInvalidation({});
+  await clearStoredChatSnapshotStorage();
 }

--- a/ui/src/pages/chat/session-snapshot-invalidation.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.ts
@@ -25,6 +25,11 @@ type ChatSnapshotKeyTarget = {
   agentId?: string | null;
 };
 
+type StoredChatSessionIdentity = {
+  key: string;
+  agentId?: string | null;
+};
+
 export function resolveChatSnapshotKey(
   host: ChatSnapshotKeyHost,
   target: ChatSnapshotKeyTarget,
@@ -104,6 +109,22 @@ export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void
       });
     });
   } catch {}
+}
+
+export async function deleteStoredChatSessionSnapshots(
+  host: ChatSnapshotKeyHost,
+  sessions: readonly StoredChatSessionIdentity[],
+): Promise<void> {
+  await Promise.all(
+    sessions.map(({ key, agentId }) =>
+      deleteStoredChatSnapshot(
+        resolveChatSnapshotKey(
+          { ...host, assistantAgentId: agentId ?? host.assistantAgentId },
+          { sessionKey: key, agentId },
+        ),
+      ),
+    ),
+  );
 }
 
 export async function clearStoredChatSnapshots(): Promise<void> {

--- a/ui/src/pages/chat/session-snapshot-invalidation.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.ts
@@ -1,0 +1,123 @@
+import {
+  DEFAULT_MAIN_KEY,
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+  normalizeSessionKeyForUiComparison,
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+  resolveUiDefaultAgentId,
+  resolveUiSelectedGlobalAgentId,
+  type UiSessionDefaultsHost,
+} from "../../lib/sessions/session-key.ts";
+
+export const CHAT_SNAPSHOT_DB_NAME = "openclaw-chat-snapshots";
+export const CHAT_SNAPSHOT_STORE_NAME = "snapshots";
+
+type SnapshotInvalidation = { sessionKey: string } | { sessionKey?: undefined };
+type SnapshotInvalidationListener = (invalidation: SnapshotInvalidation) => void | Promise<void>;
+
+const invalidationListeners = new Set<SnapshotInvalidationListener>();
+
+type ChatSnapshotKeyHost = Pick<UiSessionDefaultsHost, "assistantAgentId" | "agentsList" | "hello">;
+
+type ChatSnapshotKeyTarget = {
+  sessionKey: string;
+  agentId?: string | null;
+};
+
+export function resolveChatSnapshotKey(
+  host: ChatSnapshotKeyHost,
+  target: ChatSnapshotKeyTarget,
+): string {
+  const parsed = parseAgentSessionKey(target.sessionKey);
+  const explicitAgentId = target.agentId?.trim();
+  const agentId = explicitAgentId
+    ? normalizeAgentId(explicitAgentId)
+    : parsed
+      ? normalizeAgentId(parsed.agentId)
+      : isUiGlobalSessionKey(target.sessionKey)
+        ? resolveUiSelectedGlobalAgentId(host)
+        : resolveUiDefaultAgentId(host);
+  const normalizedSessionKey = normalizeSessionKeyForUiComparison(target.sessionKey);
+  const normalized = parsed
+    ? normalizedSessionKey.split(":").slice(2).join(":")
+    : normalizedSessionKey;
+  const configuredMainKey = resolveUiConfiguredMainKey(host);
+  const sessionKey =
+    isUiGlobalSessionKey(target.sessionKey) ||
+    normalized === DEFAULT_MAIN_KEY ||
+    normalized === configuredMainKey
+      ? DEFAULT_MAIN_KEY
+      : normalized;
+  return `agent:${agentId}:${sessionKey}`;
+}
+
+export function subscribeSnapshotInvalidation(listener: SnapshotInvalidationListener): () => void {
+  invalidationListeners.add(listener);
+  return () => invalidationListeners.delete(listener);
+}
+
+async function notifySnapshotInvalidation(invalidation: SnapshotInvalidation): Promise<void> {
+  await Promise.all(
+    [...invalidationListeners].map((listener) => Promise.resolve(listener(invalidation))),
+  );
+}
+
+function indexedDbFactory(): IDBFactory | null {
+  try {
+    return globalThis.indexedDB ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void> {
+  await notifySnapshotInvalidation({ sessionKey });
+  const factory = indexedDbFactory();
+  if (!factory) {
+    return;
+  }
+  try {
+    await new Promise<void>((resolve) => {
+      const request = factory.open(CHAT_SNAPSHOT_DB_NAME);
+      request.addEventListener("error", () => resolve());
+      request.addEventListener("blocked", () => resolve());
+      request.addEventListener("success", () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME)) {
+          database.close();
+          resolve();
+          return;
+        }
+        const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
+        transaction.addEventListener("complete", () => {
+          database.close();
+          resolve();
+        });
+        const settleFailure = () => {
+          database.close();
+          resolve();
+        };
+        transaction.addEventListener("error", settleFailure);
+        transaction.addEventListener("abort", settleFailure);
+        transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).delete(sessionKey);
+      });
+    });
+  } catch {}
+}
+
+export async function clearStoredChatSnapshots(): Promise<void> {
+  await notifySnapshotInvalidation({});
+  const factory = indexedDbFactory();
+  if (!factory) {
+    return;
+  }
+  try {
+    await new Promise<void>((resolve) => {
+      const request = factory.deleteDatabase(CHAT_SNAPSHOT_DB_NAME);
+      request.addEventListener("success", () => resolve());
+      request.addEventListener("error", () => resolve());
+      request.addEventListener("blocked", () => resolve());
+    });
+  } catch {}
+}

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -12,7 +12,6 @@ import {
   CHAT_SNAPSHOT_DB_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
   clearStoredChatSnapshots,
-  deleteStoredChatSnapshot,
 } from "./session-snapshot-invalidation.ts";
 import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 
@@ -83,14 +82,33 @@ describe("persistent chat session snapshots", () => {
     const writer = new SessionSnapshotStore();
     writer.write("agent:main:shared", snapshot({ text: "cached", callback: () => true }));
     writer.recordRowHeight("agent:main:shared", "message:1", 184);
-    const savedAt = await writer.readSavedAt("agent:main:shared");
+    const savedAt = writer.readSavedAt("agent:main:shared");
     expect(savedAt).not.toBeNull();
     await writer.flush();
+    expect(writer.readSavedAt("agent:main:shared")).toBe(savedAt);
 
     const reader = new SessionSnapshotStore();
+    await reader.loadSavedAtIndex();
     expect(await reader.read("agent:main:shared")).toEqual(snapshot({ text: "cached" }));
-    expect(await reader.readSavedAt("agent:main:shared")).toBe(savedAt);
+    expect(reader.readSavedAt("agent:main:shared")).toBe(savedAt);
     expect(reader.readRowHeight("agent:main:shared", "message:1")).toBe(184);
+  });
+
+  it("seeds the savedAt index once for every synchronous lookup", async () => {
+    const writer = new SessionSnapshotStore();
+    writer.write("agent:main:first", snapshot("first"));
+    writer.write("agent:main:second", snapshot("second"));
+    await writer.flush();
+    const open = vi.spyOn(indexedDB, "open");
+    const reader = new SessionSnapshotStore();
+
+    await reader.loadSavedAtIndex();
+    expect(reader.readSavedAt("agent:main:first")).not.toBeNull();
+    expect(reader.readSavedAt("agent:main:second")).not.toBeNull();
+    expect(reader.readSavedAt("agent:main:missing")).toBeNull();
+    await reader.loadSavedAtIndex();
+
+    expect(open).toHaveBeenCalledOnce();
   });
 
   it("defers snapshot sanitization until flush", async () => {
@@ -144,6 +162,7 @@ describe("persistent chat session snapshots", () => {
       await writer.flush();
     }
     const reader = new SessionSnapshotStore();
+    expect(writer.readSavedAt("agent:main:count-0")).toBeNull();
     expect(await reader.read("agent:main:count-0")).toBeNull();
     expect(await reader.read("agent:main:count-20")).not.toBeNull();
 
@@ -158,7 +177,7 @@ describe("persistent chat session snapshots", () => {
     expect(await weightReader.read("agent:main:weight-2")).not.toBeNull();
   });
 
-  it("resets the whole database when any record has the wrong shape", async () => {
+  it("resets the whole database when the savedAt seed finds a malformed record", async () => {
     const writer = new SessionSnapshotStore();
     writer.write("agent:main:valid", snapshot("valid"));
     await writer.flush();
@@ -171,7 +190,8 @@ describe("persistent chat session snapshots", () => {
     });
 
     const reader = new SessionSnapshotStore();
-    expect(await reader.read("agent:main:corrupt")).toBeNull();
+    await reader.loadSavedAtIndex();
+    expect(reader.readSavedAt("agent:main:corrupt")).toBeNull();
     expect(await reader.read("agent:main:valid")).toBeNull();
   });
 
@@ -181,7 +201,9 @@ describe("persistent chat session snapshots", () => {
     writer.write("agent:main:retained", snapshot("retained"));
     await writer.flush();
 
-    await deleteStoredChatSnapshot("agent:main:deleted");
+    await writer.delete("agent:main:deleted");
+    expect(writer.readSavedAt("agent:main:deleted")).toBeNull();
+    expect(writer.readSavedAt("agent:main:retained")).not.toBeNull();
 
     const reader = new SessionSnapshotStore();
     expect(await reader.read("agent:main:deleted")).toBeNull();

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -2,7 +2,12 @@
 
 import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatSessionSnapshot } from "./session-message-cache.ts";
+import {
+  cacheChatSessionSnapshot,
+  observeChatCache,
+  type ChatMessageCache,
+  type ChatSessionSnapshot,
+} from "./session-message-cache.ts";
 import {
   CHAT_SNAPSHOT_DB_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
@@ -44,6 +49,25 @@ async function putRawRecord(record: unknown): Promise<void> {
   database.close();
 }
 
+async function readRawRecord(sessionKey: string): Promise<{ savedAt: number } | undefined> {
+  const request = indexedDB.open(CHAT_SNAPSHOT_DB_NAME);
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result));
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("database open failed")),
+    );
+  });
+  const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readonly");
+  const result = await new Promise<{ savedAt: number } | undefined>((resolve, reject) => {
+    const get = transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).get(sessionKey);
+    get.addEventListener("success", () => resolve(get.result));
+    get.addEventListener("error", () => reject(get.error ?? new Error("record read failed")));
+  });
+  await transactionDone(transaction);
+  database.close();
+  return result;
+}
+
 describe("persistent chat session snapshots", () => {
   beforeEach(() => {
     vi.stubGlobal("indexedDB", new IDBFactory());
@@ -64,6 +88,48 @@ describe("persistent chat session snapshots", () => {
     const reader = new SessionSnapshotStore();
     expect(await reader.read("agent:main:shared")).toEqual(snapshot({ text: "cached" }));
     expect(reader.readRowHeight("agent:main:shared", "message:1")).toBe(184);
+  });
+
+  it("defers snapshot sanitization until flush", async () => {
+    const sessionKey = "agent:main:deferred-sanitize";
+    const writer = new SessionSnapshotStore();
+    writer.write(sessionKey, snapshot("persisted"));
+    await writer.flush();
+
+    writer.write(sessionKey, snapshot(1n));
+    writer.recordRowHeight(sessionKey, "message:1", 184);
+    expect(writer.readRowHeight(sessionKey, "message:1")).toBe(184);
+
+    await writer.flush();
+    expect(await new SessionSnapshotStore().read(sessionKey)).toBeNull();
+  });
+
+  it("does not write a snapshot back after pure hydration", async () => {
+    let now = 1;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const sessionKey = "agent:main:hydrate-only";
+    const writer = new SessionSnapshotStore();
+    writer.write(sessionKey, snapshot("persisted"));
+    await writer.flush();
+    expect((await readRawRecord(sessionKey))?.savedAt).toBe(1);
+
+    now = 2;
+    const memoryCache: ChatMessageCache = new Map();
+    const reader = new SessionSnapshotStore(memoryCache);
+    observeChatCache(memoryCache, reader);
+    const hydrated = await reader.read(sessionKey);
+    if (!hydrated) {
+      throw new Error("expected hydrated snapshot");
+    }
+    cacheChatSessionSnapshot(
+      memoryCache,
+      { assistantAgentId: "main", agentsList: null, hello: null },
+      { sessionKey },
+      hydrated,
+    );
+    await reader.flush();
+
+    expect((await readRawRecord(sessionKey))?.savedAt).toBe(1);
   });
 
   it("evicts the oldest sessions by count and total serialized weight", async () => {

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -1,0 +1,144 @@
+/* @vitest-environment jsdom */
+
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatSessionSnapshot } from "./session-message-cache.ts";
+import {
+  CHAT_SNAPSHOT_DB_NAME,
+  CHAT_SNAPSHOT_STORE_NAME,
+  clearStoredChatSnapshots,
+  deleteStoredChatSnapshot,
+} from "./session-snapshot-invalidation.ts";
+import { SessionSnapshotStore } from "./session-snapshot-store.ts";
+
+function snapshot(message: unknown, sessionId = "session-1"): ChatSessionSnapshot {
+  return {
+    displayedLeafEntryId: "leaf-1",
+    messages: [message],
+    pagination: { hasMore: true, nextOffset: 1, totalMessages: 2 },
+    sessionId,
+  };
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener("complete", () => resolve());
+    const rejectTransaction = () => reject(transaction.error ?? new Error("transaction failed"));
+    transaction.addEventListener("error", rejectTransaction);
+    transaction.addEventListener("abort", rejectTransaction);
+  });
+}
+
+async function putRawRecord(record: unknown): Promise<void> {
+  const request = indexedDB.open(CHAT_SNAPSHOT_DB_NAME);
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result));
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("database open failed")),
+    );
+  });
+  const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
+  const completed = transactionDone(transaction);
+  transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).put(record);
+  await completed;
+  database.close();
+}
+
+describe("persistent chat session snapshots", () => {
+  beforeEach(() => {
+    vi.stubGlobal("indexedDB", new IDBFactory());
+  });
+
+  afterEach(async () => {
+    await clearStoredChatSnapshots();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shares sanitized snapshots and measured row heights across store owners", async () => {
+    const writer = new SessionSnapshotStore();
+    writer.write("agent:main:shared", snapshot({ text: "cached", callback: () => true }));
+    writer.recordRowHeight("agent:main:shared", "message:1", 184);
+    await writer.flush();
+
+    const reader = new SessionSnapshotStore();
+    expect(await reader.read("agent:main:shared")).toEqual(snapshot({ text: "cached" }));
+    expect(reader.readRowHeight("agent:main:shared", "message:1")).toBe(184);
+  });
+
+  it("evicts the oldest sessions by count and total serialized weight", async () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => ++now);
+    const writer = new SessionSnapshotStore();
+    for (let index = 0; index <= 20; index += 1) {
+      writer.write(`agent:main:count-${index}`, snapshot(index, `count-${index}`));
+      await writer.flush();
+    }
+    const reader = new SessionSnapshotStore();
+    expect(await reader.read("agent:main:count-0")).toBeNull();
+    expect(await reader.read("agent:main:count-20")).not.toBeNull();
+
+    await clearStoredChatSnapshots();
+    const large = "x".repeat(9 * 1024 * 1024);
+    for (let index = 0; index < 3; index += 1) {
+      writer.write(`agent:main:weight-${index}`, snapshot(large, `weight-${index}`));
+      await writer.flush();
+    }
+    const weightReader = new SessionSnapshotStore();
+    expect(await weightReader.read("agent:main:weight-0")).toBeNull();
+    expect(await weightReader.read("agent:main:weight-2")).not.toBeNull();
+  });
+
+  it("resets the whole database when any record has the wrong shape", async () => {
+    const writer = new SessionSnapshotStore();
+    writer.write("agent:main:valid", snapshot("valid"));
+    await writer.flush();
+    await putRawRecord({
+      sessionKey: "agent:main:corrupt",
+      sessionId: "session-1",
+      savedAt: Date.now(),
+      snapshot: { messages: "not-an-array" },
+      rowHeights: new Map(),
+    });
+
+    const reader = new SessionSnapshotStore();
+    expect(await reader.read("agent:main:corrupt")).toBeNull();
+    expect(await reader.read("agent:main:valid")).toBeNull();
+  });
+
+  it("deletes only the invalidated session record", async () => {
+    const writer = new SessionSnapshotStore();
+    writer.write("agent:main:deleted", snapshot("deleted"));
+    writer.write("agent:main:retained", snapshot("retained"));
+    await writer.flush();
+
+    await deleteStoredChatSnapshot("agent:main:deleted");
+
+    const reader = new SessionSnapshotStore();
+    expect(await reader.read("agent:main:deleted")).toBeNull();
+    expect(await reader.read("agent:main:retained")).not.toBeNull();
+  });
+
+  it("keeps every operation non-fatal when IndexedDB is unavailable or throws", async () => {
+    vi.stubGlobal("indexedDB", undefined);
+    const unavailable = new SessionSnapshotStore();
+    unavailable.write("agent:main:none", snapshot("none"));
+    await expect(unavailable.flush()).resolves.toBeUndefined();
+    await expect(unavailable.read("agent:main:none")).resolves.toBeNull();
+    await expect(unavailable.delete("agent:main:none")).resolves.toBeUndefined();
+
+    vi.stubGlobal("indexedDB", {
+      open: () => {
+        throw new DOMException("denied", "SecurityError");
+      },
+      deleteDatabase: () => {
+        throw new DOMException("denied", "SecurityError");
+      },
+    });
+    const denied = new SessionSnapshotStore();
+    denied.write("agent:main:denied", snapshot("denied"));
+    await expect(denied.flush()).resolves.toBeUndefined();
+    await expect(denied.read("agent:main:denied")).resolves.toBeNull();
+    await expect(clearStoredChatSnapshots()).resolves.toBeUndefined();
+  });
+});

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -83,10 +83,13 @@ describe("persistent chat session snapshots", () => {
     const writer = new SessionSnapshotStore();
     writer.write("agent:main:shared", snapshot({ text: "cached", callback: () => true }));
     writer.recordRowHeight("agent:main:shared", "message:1", 184);
+    const savedAt = await writer.readSavedAt("agent:main:shared");
+    expect(savedAt).not.toBeNull();
     await writer.flush();
 
     const reader = new SessionSnapshotStore();
     expect(await reader.read("agent:main:shared")).toEqual(snapshot({ text: "cached" }));
+    expect(await reader.readSavedAt("agent:main:shared")).toBe(savedAt);
     expect(reader.readRowHeight("agent:main:shared", "message:1")).toBe(184);
   });
 

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -2,6 +2,7 @@
 
 import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
   cacheChatSessionSnapshot,
   observeChatCache,
@@ -70,6 +71,7 @@ async function readRawRecord(sessionKey: string): Promise<{ savedAt: number } | 
 describe("persistent chat session snapshots", () => {
   beforeEach(() => {
     vi.stubGlobal("indexedDB", new IDBFactory());
+    vi.stubGlobal("localStorage", createStorageMock());
   });
 
   afterEach(async () => {
@@ -208,6 +210,50 @@ describe("persistent chat session snapshots", () => {
     const reader = new SessionSnapshotStore();
     expect(await reader.read("agent:main:deleted")).toBeNull();
     expect(await reader.read("agent:main:retained")).not.toBeNull();
+  });
+
+  it("broadcasts invalidation and clears active memory for a peer-tab signal", async () => {
+    const sessionKey = "agent:main:cross-tab";
+    const memoryCache: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(memoryCache);
+    store.connect();
+    observeChatCache(memoryCache, store);
+    cacheChatSessionSnapshot(
+      memoryCache,
+      { assistantAgentId: "main", agentsList: null, hello: null },
+      { sessionKey },
+      snapshot("local"),
+    );
+    await store.flush();
+    const setItem = vi.spyOn(localStorage, "setItem");
+
+    try {
+      await clearStoredChatSnapshots();
+      expect(setItem).toHaveBeenCalledWith(
+        "openclaw.control.chatSnapshots.invalidate.v1",
+        expect.any(String),
+      );
+
+      cacheChatSessionSnapshot(
+        memoryCache,
+        { assistantAgentId: "main", agentsList: null, hello: null },
+        { sessionKey },
+        snapshot("refilled"),
+      );
+      await store.flush();
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "openclaw.control.chatSnapshots.invalidate.v1",
+          newValue: "other-tab",
+        }),
+      );
+
+      expect(memoryCache.size).toBe(0);
+      expect(store.readSavedAt(sessionKey)).toBeNull();
+    } finally {
+      store.disconnect();
+      await store.whenIdle();
+    }
   });
 
   it("keeps every operation non-fatal when IndexedDB is unavailable or throws", async () => {

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -15,10 +15,10 @@ import {
   openSessionSnapshotDatabase,
   resetSessionSnapshotDatabase,
 } from "./session-snapshot-database.ts";
+import { subscribeSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
 import {
   CHAT_SNAPSHOT_STORE_NAME,
   deleteStoredChatSnapshot,
-  subscribeSnapshotInvalidation,
 } from "./session-snapshot-invalidation.ts";
 const MAX_STORED_ROW_HEIGHTS = 500;
 const CHAT_SNAPSHOT_WRITE_DELAY_MS = 500;

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -65,7 +65,11 @@ const recordSchema = z
   .refine((record) => record.sessionId === record.snapshot.sessionId);
 
 type SessionSnapshotRecord = z.infer<typeof recordSchema>;
-type StoredSessionState = Pick<SessionSnapshotRecord, "rowHeights" | "snapshot">;
+type StoredSessionState = {
+  rowHeights: Map<string, number>;
+  snapshot: ChatSessionSnapshot;
+};
+type PendingSessionState = StoredSessionState & { savedAt: number };
 
 const activeStores = new Set<SessionSnapshotStore>();
 let snapshotStoreGeneration = 0;
@@ -99,14 +103,10 @@ function requestResult<T>(request: IDBRequest<T>): Promise<T> {
   });
 }
 
-function sanitizeSnapshot(snapshot: ChatSessionSnapshot): ChatSessionSnapshot | null {
+function sanitizeSnapshot(snapshot: ChatSessionSnapshot): unknown {
   try {
     const json = JSON.stringify(snapshot);
-    if (!json) {
-      return null;
-    }
-    const parsed = snapshotSchema.safeParse(JSON.parse(json));
-    return parsed.success ? parsed.data : null;
+    return json ? JSON.parse(json) : null;
   } catch {
     return null;
   }
@@ -117,6 +117,24 @@ function parseSnapshotRecord(value: unknown, sessionKey?: string): SessionSnapsh
   return parsed.success && (!sessionKey || parsed.data.sessionKey === sessionKey)
     ? parsed.data
     : null;
+}
+
+function createSnapshotRecord(
+  sessionKey: string,
+  pending: PendingSessionState,
+): SessionSnapshotRecord | null {
+  const sanitizedSnapshot = sanitizeSnapshot(pending.snapshot);
+  if (!sanitizedSnapshot) {
+    return null;
+  }
+  const parsed = recordSchema.safeParse({
+    rowHeights: pending.rowHeights,
+    savedAt: pending.savedAt,
+    sessionId: pending.snapshot.sessionId,
+    sessionKey,
+    snapshot: sanitizedSnapshot,
+  });
+  return parsed.success ? parsed.data : null;
 }
 
 async function readSnapshotRecord(sessionKey: string): Promise<SessionSnapshotRecord | null> {
@@ -219,7 +237,8 @@ async function writeSnapshotRecords(
 export class SessionSnapshotStore implements ChatCacheObserver {
   private connected = false;
   private readonly sessions = new Map<string, StoredSessionState>();
-  private readonly pending = new Map<string, SessionSnapshotRecord>();
+  private readonly pending = new Map<string, PendingSessionState>();
+  private readonly hydratedSnapshots = new Map<string, ChatSessionSnapshot>();
   private readonly revisions = new Map<string, number>();
   private writeTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private writeChain = Promise.resolve();
@@ -259,20 +278,22 @@ export class SessionSnapshotStore implements ChatCacheObserver {
         snapshot: record.snapshot,
       });
     }
+    setSessionCacheValue(this.hydratedSnapshots, sessionKey, record.snapshot);
     return record.snapshot;
   }
 
   write(sessionKey: string, snapshot: ChatSessionSnapshot): void {
     this.revisions.set(sessionKey, (this.revisions.get(sessionKey) ?? 0) + 1);
-    const sanitized = sanitizeSnapshot(snapshot);
-    if (!sanitized) {
-      void this.delete(sessionKey);
+    if (getSessionCacheValue(this.hydratedSnapshots, sessionKey) === snapshot) {
       return;
     }
+    this.hydratedSnapshots.delete(sessionKey);
     const existing = getSessionCacheValue(this.sessions, sessionKey);
+    // Cache reconciliation replaces snapshots immutably, so retaining this raw
+    // reference until the debounced flush cannot observe in-place mutation.
     const state = {
       rowHeights: existing?.rowHeights ?? new Map<string, number>(),
-      snapshot: sanitized,
+      snapshot,
     };
     setSessionCacheValue(this.sessions, sessionKey, state);
     this.schedule(sessionKey, state);
@@ -285,6 +306,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
   forget(sessionKey: string): void {
     this.revisions.set(sessionKey, (this.revisions.get(sessionKey) ?? 0) + 1);
     this.pending.delete(sessionKey);
+    this.hydratedSnapshots.delete(sessionKey);
     this.sessions.delete(sessionKey);
   }
 
@@ -317,8 +339,17 @@ export class SessionSnapshotStore implements ChatCacheObserver {
       globalThis.clearTimeout(this.writeTimer);
       this.writeTimer = null;
     }
-    const records = [...this.pending.values()];
+    const pending = [...this.pending.entries()];
     this.pending.clear();
+    const records: SessionSnapshotRecord[] = [];
+    for (const [sessionKey, state] of pending) {
+      const record = createSnapshotRecord(sessionKey, state);
+      if (record) {
+        records.push(record);
+      } else {
+        await this.delete(sessionKey);
+      }
+    }
     const generation = snapshotStoreGeneration;
     this.writeChain = this.writeChain.then(() => writeSnapshotRecords(records, generation));
     await this.writeChain;
@@ -330,6 +361,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
       this.writeTimer = null;
     }
     this.pending.clear();
+    this.hydratedSnapshots.clear();
     this.sessions.clear();
     this.revisions.clear();
     this.memoryCache?.clear();
@@ -343,8 +375,6 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     this.pending.set(sessionKey, {
       rowHeights: new Map(state.rowHeights),
       savedAt: Date.now(),
-      sessionId: state.snapshot.sessionId,
-      sessionKey,
       snapshot: state.snapshot,
     });
     if (this.writeTimer !== null) {

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -1,0 +1,385 @@
+import { z } from "zod";
+import {
+  getSessionCacheValue,
+  MAX_CACHED_CHAT_SESSIONS,
+  setSessionCacheValue,
+} from "./session-cache.ts";
+import {
+  MAX_CACHED_CHAT_WEIGHT,
+  measureChatSnapshotWeight,
+  type ChatCacheObserver,
+  type ChatMessageCache,
+  type ChatSessionSnapshot,
+} from "./session-message-cache.ts";
+import {
+  openSessionSnapshotDatabase,
+  resetSessionSnapshotDatabase,
+} from "./session-snapshot-database.ts";
+import {
+  CHAT_SNAPSHOT_STORE_NAME,
+  deleteStoredChatSnapshot,
+  subscribeSnapshotInvalidation,
+} from "./session-snapshot-invalidation.ts";
+const MAX_STORED_ROW_HEIGHTS = 500;
+const CHAT_SNAPSHOT_WRITE_DELAY_MS = 500;
+
+const paginationSchema = z.discriminatedUnion("hasMore", [
+  z
+    .object({
+      completeSnapshot: z.literal(true).optional(),
+      hasMore: z.literal(false),
+      totalMessages: z.number().finite().nonnegative().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      hasMore: z.literal(true),
+      nextOffset: z.number().finite().nonnegative(),
+      totalMessages: z.number().finite().nonnegative().optional(),
+    })
+    .strict(),
+]);
+
+const snapshotSchema = z
+  .object({
+    displayedLeafEntryId: z.string().nullable().optional(),
+    messages: z.array(z.unknown()),
+    pagination: paginationSchema,
+    sessionId: z.string().nullable(),
+  })
+  .strict();
+
+const rowHeightsSchema = z
+  .map(z.string(), z.number().finite().positive())
+  .refine((rowHeights) => rowHeights.size <= MAX_STORED_ROW_HEIGHTS);
+
+const recordSchema = z
+  .object({
+    rowHeights: rowHeightsSchema,
+    savedAt: z.number().finite().nonnegative(),
+    sessionId: z.string().nullable(),
+    sessionKey: z.string().min(1),
+    snapshot: snapshotSchema,
+  })
+  .strict()
+  .refine((record) => record.sessionId === record.snapshot.sessionId);
+
+type SessionSnapshotRecord = z.infer<typeof recordSchema>;
+type StoredSessionState = Pick<SessionSnapshotRecord, "rowHeights" | "snapshot">;
+
+const activeStores = new Set<SessionSnapshotStore>();
+let snapshotStoreGeneration = 0;
+
+function debugSnapshotStore(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.debug(`[chat-snapshot-cache] ${message}`);
+  } else {
+    console.debug(`[chat-snapshot-cache] ${message}`, error);
+  }
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener("complete", () => resolve());
+    transaction.addEventListener("error", () =>
+      reject(transaction.error ?? new Error("IndexedDB failed")),
+    );
+    transaction.addEventListener("abort", () =>
+      reject(transaction.error ?? new Error("IndexedDB aborted")),
+    );
+  });
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result));
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("IndexedDB request failed")),
+    );
+  });
+}
+
+function sanitizeSnapshot(snapshot: ChatSessionSnapshot): ChatSessionSnapshot | null {
+  try {
+    const json = JSON.stringify(snapshot);
+    if (!json) {
+      return null;
+    }
+    const parsed = snapshotSchema.safeParse(JSON.parse(json));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseSnapshotRecord(value: unknown, sessionKey?: string): SessionSnapshotRecord | null {
+  const parsed = recordSchema.safeParse(value);
+  return parsed.success && (!sessionKey || parsed.data.sessionKey === sessionKey)
+    ? parsed.data
+    : null;
+}
+
+async function readSnapshotRecord(sessionKey: string): Promise<SessionSnapshotRecord | null> {
+  const database = await openSessionSnapshotDatabase();
+  if (!database) {
+    return null;
+  }
+  try {
+    const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readonly");
+    const value = await requestResult(
+      transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).get(sessionKey),
+    );
+    await transactionDone(transaction);
+    if (value === undefined) {
+      return null;
+    }
+    const record = parseSnapshotRecord(value, sessionKey);
+    if (record) {
+      return record;
+    }
+    debugSnapshotStore("resetting cache after record shape mismatch");
+    await resetSessionSnapshotDatabase(database);
+    return null;
+  } catch (error) {
+    debugSnapshotStore("IndexedDB read failed", error);
+    await resetSessionSnapshotDatabase(database);
+    return null;
+  } finally {
+    database.close();
+  }
+}
+
+function measureStoredRecordWeight(record: SessionSnapshotRecord): number {
+  const snapshotWeight = measureChatSnapshotWeight(record.snapshot) ?? 0;
+  try {
+    return (
+      snapshotWeight +
+      JSON.stringify({
+        rowHeights: [...record.rowHeights],
+        savedAt: record.savedAt,
+        sessionId: record.sessionId,
+        sessionKey: record.sessionKey,
+      }).length
+    );
+  } catch {
+    return snapshotWeight;
+  }
+}
+
+async function writeSnapshotRecords(
+  records: SessionSnapshotRecord[],
+  generation: number,
+): Promise<void> {
+  if (records.length === 0 || generation !== snapshotStoreGeneration) {
+    return;
+  }
+  const database = await openSessionSnapshotDatabase();
+  if (!database) {
+    return;
+  }
+  try {
+    const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
+    const store = transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME);
+    const currentValues = await requestResult(store.getAll());
+    const next = new Map<string, SessionSnapshotRecord>();
+    for (const value of currentValues) {
+      const record = parseSnapshotRecord(value);
+      if (!record) {
+        transaction.abort();
+        throw new Error("IndexedDB record shape mismatch");
+      }
+      next.set(record.sessionKey, record);
+    }
+    for (const record of records) {
+      next.set(record.sessionKey, record);
+      store.put(record);
+    }
+    const oldestFirst = [...next.values()].toSorted((left, right) => left.savedAt - right.savedAt);
+    let totalWeight = oldestFirst.reduce(
+      (sum, record) => sum + measureStoredRecordWeight(record),
+      0,
+    );
+    while (oldestFirst.length > MAX_CACHED_CHAT_SESSIONS || totalWeight > MAX_CACHED_CHAT_WEIGHT) {
+      const oldest = oldestFirst.shift();
+      if (!oldest) {
+        break;
+      }
+      totalWeight -= measureStoredRecordWeight(oldest);
+      store.delete(oldest.sessionKey);
+    }
+    await transactionDone(transaction);
+  } catch (error) {
+    debugSnapshotStore("resetting cache after IndexedDB write failure", error);
+    await resetSessionSnapshotDatabase(database);
+  } finally {
+    database.close();
+  }
+}
+
+export class SessionSnapshotStore implements ChatCacheObserver {
+  private connected = false;
+  private readonly sessions = new Map<string, StoredSessionState>();
+  private readonly pending = new Map<string, SessionSnapshotRecord>();
+  private readonly revisions = new Map<string, number>();
+  private writeTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private writeChain = Promise.resolve();
+
+  constructor(private readonly memoryCache?: ChatMessageCache) {}
+
+  connect(): void {
+    this.connected = true;
+    activeStores.add(this);
+  }
+
+  disconnect(): void {
+    this.connected = false;
+    void this.flush().finally(() => {
+      if (!this.connected) {
+        activeStores.delete(this);
+      }
+    });
+  }
+
+  async read(sessionKey: string): Promise<ChatSessionSnapshot | null> {
+    const generation = snapshotStoreGeneration;
+    const revision = this.revisions.get(sessionKey) ?? 0;
+    const record = await readSnapshotRecord(sessionKey);
+    if (
+      !record ||
+      generation !== snapshotStoreGeneration ||
+      revision !== (this.revisions.get(sessionKey) ?? 0)
+    ) {
+      return null;
+    }
+    // A network write can win while IndexedDB is pending. Keep its snapshot and
+    // measurements authoritative even though the caller will discard this read.
+    if (!this.sessions.has(sessionKey)) {
+      setSessionCacheValue(this.sessions, sessionKey, {
+        rowHeights: new Map(record.rowHeights),
+        snapshot: record.snapshot,
+      });
+    }
+    return record.snapshot;
+  }
+
+  write(sessionKey: string, snapshot: ChatSessionSnapshot): void {
+    this.revisions.set(sessionKey, (this.revisions.get(sessionKey) ?? 0) + 1);
+    const sanitized = sanitizeSnapshot(snapshot);
+    if (!sanitized) {
+      void this.delete(sessionKey);
+      return;
+    }
+    const existing = getSessionCacheValue(this.sessions, sessionKey);
+    const state = {
+      rowHeights: existing?.rowHeights ?? new Map<string, number>(),
+      snapshot: sanitized,
+    };
+    setSessionCacheValue(this.sessions, sessionKey, state);
+    this.schedule(sessionKey, state);
+  }
+
+  async delete(sessionKey: string): Promise<void> {
+    await deleteStoredChatSnapshot(sessionKey);
+  }
+
+  forget(sessionKey: string): void {
+    this.revisions.set(sessionKey, (this.revisions.get(sessionKey) ?? 0) + 1);
+    this.pending.delete(sessionKey);
+    this.sessions.delete(sessionKey);
+  }
+
+  readRowHeight(sessionKey: string, rowKey: string): number | undefined {
+    return getSessionCacheValue(this.sessions, sessionKey)?.rowHeights.get(rowKey);
+  }
+
+  recordRowHeight(sessionKey: string, rowKey: string, height: number): void {
+    if (!Number.isFinite(height) || height <= 0) {
+      return;
+    }
+    const state = getSessionCacheValue(this.sessions, sessionKey);
+    if (!state || state.rowHeights.get(rowKey) === height) {
+      return;
+    }
+    state.rowHeights.delete(rowKey);
+    state.rowHeights.set(rowKey, height);
+    while (state.rowHeights.size > MAX_STORED_ROW_HEIGHTS) {
+      const oldest = state.rowHeights.keys().next().value;
+      if (typeof oldest !== "string") {
+        break;
+      }
+      state.rowHeights.delete(oldest);
+    }
+    this.schedule(sessionKey, state);
+  }
+
+  async flush(): Promise<void> {
+    if (this.writeTimer !== null) {
+      globalThis.clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+    const records = [...this.pending.values()];
+    this.pending.clear();
+    const generation = snapshotStoreGeneration;
+    this.writeChain = this.writeChain.then(() => writeSnapshotRecords(records, generation));
+    await this.writeChain;
+  }
+
+  clearMemory(): void {
+    if (this.writeTimer !== null) {
+      globalThis.clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+    this.pending.clear();
+    this.sessions.clear();
+    this.revisions.clear();
+    this.memoryCache?.clear();
+  }
+
+  async whenIdle(): Promise<void> {
+    await this.writeChain;
+  }
+
+  private schedule(sessionKey: string, state: StoredSessionState): void {
+    this.pending.set(sessionKey, {
+      rowHeights: new Map(state.rowHeights),
+      savedAt: Date.now(),
+      sessionId: state.snapshot.sessionId,
+      sessionKey,
+      snapshot: state.snapshot,
+    });
+    if (this.writeTimer !== null) {
+      globalThis.clearTimeout(this.writeTimer);
+    }
+    this.writeTimer = globalThis.setTimeout(() => {
+      this.writeTimer = null;
+      void this.flush();
+    }, CHAT_SNAPSHOT_WRITE_DELAY_MS);
+  }
+}
+
+subscribeSnapshotInvalidation(async ({ sessionKey }) => {
+  snapshotStoreGeneration += 1;
+  for (const store of activeStores) {
+    if (sessionKey) {
+      store.forget(sessionKey);
+    } else {
+      store.clearMemory();
+    }
+  }
+  await Promise.all([...activeStores].map((store) => store.whenIdle()));
+});
+
+function flushActiveStores(): void {
+  for (const store of activeStores) {
+    void store.flush();
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", flushActiveStores);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      flushActiveStores();
+    }
+  });
+}

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -282,6 +282,21 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     return record.snapshot;
   }
 
+  async readSavedAt(sessionKey: string): Promise<number | null> {
+    const pending = this.pending.get(sessionKey);
+    if (pending) {
+      return pending.savedAt;
+    }
+    const generation = snapshotStoreGeneration;
+    const revision = this.revisions.get(sessionKey) ?? 0;
+    const record = await readSnapshotRecord(sessionKey);
+    return record &&
+      generation === snapshotStoreGeneration &&
+      revision === (this.revisions.get(sessionKey) ?? 0)
+      ? record.savedAt
+      : null;
+  }
+
   write(sessionKey: string, snapshot: ChatSessionSnapshot): void {
     this.revisions.set(sessionKey, (this.revisions.get(sessionKey) ?? 0) + 1);
     if (getSessionCacheValue(this.hydratedSnapshots, sessionKey) === snapshot) {

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -167,6 +167,35 @@ async function readSnapshotRecord(sessionKey: string): Promise<SessionSnapshotRe
   }
 }
 
+async function readSnapshotRecords(): Promise<SessionSnapshotRecord[] | null> {
+  const database = await openSessionSnapshotDatabase();
+  if (!database) {
+    return [];
+  }
+  try {
+    const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readonly");
+    const values = await requestResult(transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).getAll());
+    await transactionDone(transaction);
+    const records: SessionSnapshotRecord[] = [];
+    for (const value of values) {
+      const record = parseSnapshotRecord(value);
+      if (!record) {
+        debugSnapshotStore("resetting cache after record shape mismatch");
+        await resetSessionSnapshotDatabase(database);
+        return null;
+      }
+      records.push(record);
+    }
+    return records;
+  } catch (error) {
+    debugSnapshotStore("IndexedDB read failed", error);
+    await resetSessionSnapshotDatabase(database);
+    return null;
+  } finally {
+    database.close();
+  }
+}
+
 function measureStoredRecordWeight(record: SessionSnapshotRecord): number {
   const snapshotWeight = measureChatSnapshotWeight(record.snapshot) ?? 0;
   try {
@@ -187,13 +216,13 @@ function measureStoredRecordWeight(record: SessionSnapshotRecord): number {
 async function writeSnapshotRecords(
   records: SessionSnapshotRecord[],
   generation: number,
-): Promise<void> {
+): Promise<string[] | null> {
   if (records.length === 0 || generation !== snapshotStoreGeneration) {
-    return;
+    return [];
   }
   const database = await openSessionSnapshotDatabase();
   if (!database) {
-    return;
+    return [];
   }
   try {
     const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
@@ -217,6 +246,7 @@ async function writeSnapshotRecords(
       (sum, record) => sum + measureStoredRecordWeight(record),
       0,
     );
+    const evicted: string[] = [];
     while (oldestFirst.length > MAX_CACHED_CHAT_SESSIONS || totalWeight > MAX_CACHED_CHAT_WEIGHT) {
       const oldest = oldestFirst.shift();
       if (!oldest) {
@@ -224,11 +254,14 @@ async function writeSnapshotRecords(
       }
       totalWeight -= measureStoredRecordWeight(oldest);
       store.delete(oldest.sessionKey);
+      evicted.push(oldest.sessionKey);
     }
     await transactionDone(transaction);
+    return evicted;
   } catch (error) {
     debugSnapshotStore("resetting cache after IndexedDB write failure", error);
     await resetSessionSnapshotDatabase(database);
+    return null;
   } finally {
     database.close();
   }
@@ -240,6 +273,10 @@ export class SessionSnapshotStore implements ChatCacheObserver {
   private readonly pending = new Map<string, PendingSessionState>();
   private readonly hydratedSnapshots = new Map<string, ChatSessionSnapshot>();
   private readonly revisions = new Map<string, number>();
+  // Cross-tab writes may leave this index stale until reload; the 30s prefetch
+  // cooldown bounds the resulting redundant fetches without per-row IDB reads.
+  private readonly savedAtBySession = new Map<string, number>();
+  private savedAtSeed: Promise<void> | null = null;
   private writeTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private writeChain = Promise.resolve();
 
@@ -282,19 +319,13 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     return record.snapshot;
   }
 
-  async readSavedAt(sessionKey: string): Promise<number | null> {
-    const pending = this.pending.get(sessionKey);
-    if (pending) {
-      return pending.savedAt;
-    }
-    const generation = snapshotStoreGeneration;
-    const revision = this.revisions.get(sessionKey) ?? 0;
-    const record = await readSnapshotRecord(sessionKey);
-    return record &&
-      generation === snapshotStoreGeneration &&
-      revision === (this.revisions.get(sessionKey) ?? 0)
-      ? record.savedAt
-      : null;
+  async loadSavedAtIndex(): Promise<void> {
+    this.savedAtSeed ??= this.seedSavedAtIndex();
+    await this.savedAtSeed;
+  }
+
+  readSavedAt(sessionKey: string): number | null {
+    return this.pending.get(sessionKey)?.savedAt ?? this.savedAtBySession.get(sessionKey) ?? null;
   }
 
   write(sessionKey: string, snapshot: ChatSessionSnapshot): void {
@@ -315,6 +346,8 @@ export class SessionSnapshotStore implements ChatCacheObserver {
   }
 
   async delete(sessionKey: string): Promise<void> {
+    this.pending.delete(sessionKey);
+    this.savedAtBySession.delete(sessionKey);
     await deleteStoredChatSnapshot(sessionKey);
   }
 
@@ -323,6 +356,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     this.pending.delete(sessionKey);
     this.hydratedSnapshots.delete(sessionKey);
     this.sessions.delete(sessionKey);
+    this.savedAtBySession.delete(sessionKey);
   }
 
   readRowHeight(sessionKey: string, rowKey: string): number | undefined {
@@ -366,7 +400,18 @@ export class SessionSnapshotStore implements ChatCacheObserver {
       }
     }
     const generation = snapshotStoreGeneration;
-    this.writeChain = this.writeChain.then(() => writeSnapshotRecords(records, generation));
+    this.writeChain = this.writeChain.then(async () => {
+      const evicted = await writeSnapshotRecords(records, generation);
+      if (evicted === null) {
+        this.resetSavedAtIndex();
+        return;
+      }
+      for (const sessionKey of evicted) {
+        if (!this.pending.has(sessionKey)) {
+          this.savedAtBySession.delete(sessionKey);
+        }
+      }
+    });
     await this.writeChain;
   }
 
@@ -379,6 +424,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     this.hydratedSnapshots.clear();
     this.sessions.clear();
     this.revisions.clear();
+    this.savedAtBySession.clear();
     this.memoryCache?.clear();
   }
 
@@ -387,11 +433,13 @@ export class SessionSnapshotStore implements ChatCacheObserver {
   }
 
   private schedule(sessionKey: string, state: StoredSessionState): void {
-    this.pending.set(sessionKey, {
+    const pending = {
       rowHeights: new Map(state.rowHeights),
       savedAt: Date.now(),
       snapshot: state.snapshot,
-    });
+    };
+    this.pending.set(sessionKey, pending);
+    this.savedAtBySession.set(sessionKey, pending.savedAt);
     if (this.writeTimer !== null) {
       globalThis.clearTimeout(this.writeTimer);
     }
@@ -399,6 +447,29 @@ export class SessionSnapshotStore implements ChatCacheObserver {
       this.writeTimer = null;
       void this.flush();
     }, CHAT_SNAPSHOT_WRITE_DELAY_MS);
+  }
+
+  private async seedSavedAtIndex(): Promise<void> {
+    const generation = snapshotStoreGeneration;
+    const records = await readSnapshotRecords();
+    if (generation !== snapshotStoreGeneration) {
+      return;
+    }
+    if (!records) {
+      this.resetSavedAtIndex();
+      return;
+    }
+    for (const record of records) {
+      const current = this.savedAtBySession.get(record.sessionKey) ?? 0;
+      this.savedAtBySession.set(record.sessionKey, Math.max(current, record.savedAt));
+    }
+  }
+
+  private resetSavedAtIndex(): void {
+    this.savedAtBySession.clear();
+    for (const [sessionKey, pending] of this.pending) {
+      this.savedAtBySession.set(sessionKey, pending.savedAt);
+    }
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Opening a session outside the roughly three retained chat panes—or reloading the page—shows a loading skeleton for the full network round trip. The existing transcript cache was in-memory and tab-local, so it disappeared on reload; no recent-session prefetch existed, and remounted transcripts visibly re-settled from 120 px row estimates.

## Why This Change Was Made

Sessions now paint immediately from a persistent per-origin IndexedDB cache shared by same-origin tabs, then refresh in the background. The cache is cleared on logout or credential change and invalidated when a session is deleted. On idle, one Web Locks-elected tab prefetches the five most recent sessions with a 30-second cooldown, and measured row heights are persisted so remounts do not visibly settle.

IndexedDB remains feature-detected and non-fatal: when it is unavailable, the existing network-backed behavior continues unchanged. Deleted-session invalidation shares the shell's existing authoritative deletion pass, avoiding a second startup-path scan.

## User Impact

Recently used sessions now show their transcript immediately, including after a reload, while the network refresh continues in the background. Staleness is bounded by refresh-on-open plus the idle re-warm cycle.

Accepted tradeoffs:

- Transcripts persist unencrypted in the browser profile, in the same exposure class as existing browser storage. They are cleared on logout or credential change.
- The cross-tab `savedAt` index can be briefly stale, bounded by the 30-second prefetch cooldown.

## Evidence

Before: at roughly 500 ms into a reload with `chat.startup` delayed by 2 seconds, the session still shows loading skeletons.

![Before: loading skeleton during delayed session refresh](https://github.com/user-attachments/assets/463c9189-8a7e-4f6c-8cf0-096e88313f7f)

Before reload video:

https://github.com/user-attachments/assets/fe74fba7-c13b-4799-9ad4-877af12f3cfd

After: under the same mocked scenario, the complete 30-message transcript is already painted from the IndexedDB snapshot while the network refresh remains pending.

![After: cached transcript painted during delayed session refresh](https://github.com/user-attachments/assets/b5679424-8a8d-4424-9966-578ac0b70ec8)

After reload video:

https://github.com/user-attachments/assets/97175cb8-3a1d-4dff-bb54-5476ae7772fc

Current-head validation:

- Focused UI suite: 104 tests passed across 9 files and 2 Vitest shards, including deleted-session recovery and both ChatPage files that failed in the first CI pass.
- Exact Node 24.19.0 `pnpm ui:build`: passed; local startup JavaScript is 337,817 bytes gzip against the 338,567-byte effective limit, with no baseline or budget change.
- `pnpm check:changed`: passed on owned AWS Node 24 on the preceding repair head after the hosted-provider fallback hit a capacity limit; run `run_4c264528b9fa`, lease `cbx_484f38c1eb49` (cleaned up). The current follow-up changes only the already-covered deletion owner and credential comparison.
- Autoreview: the exact preceding whole branch was clean at 0.91; the current deletion-owner repair diff is clean at 0.97 with no accepted/actionable findings.
- Source-blind evidence check: passed; the captures show the same session with the refresh still pending, changing from skeleton-only to a populated transcript.
- `fake-indexeddb` is added as a UI dev dependency for IndexedDB tests; it is already used elsewhere in this repository and is a healthy maintained package.

Initial CI run `32003000942` found partial ChatPage gateway fixtures and a missing test-only type import; those are fixed without weakening tests. Linux build runs `32003000942` and `32005326176` also exposed a startup gzip overage. The final follow-up folds persisted-snapshot invalidation into the existing deleted-session owner and removes its duplicate scan; no baseline, budget, guard, or generated file was changed.

AI-assisted implementation and review; the behavior, ownership boundaries, and validation were checked by the author.
