### PR TITLE
fix: diagnose gateways that cannot host nodes

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -86,6 +86,16 @@ Approval note:
 - For direct shell/runtime file executions, OpenClaw also best-effort binds one concrete local file operand and denies the run if that file changes before execution.
 - If OpenClaw cannot identify exactly one concrete local file for an interpreter/runtime command, approval-backed execution is denied instead of pretending full runtime coverage. Use sandboxing, separate hosts, or an explicit trusted allowlist/full workflow for broader interpreter semantics.
 
+### Gateway deployments that cannot host nodes
+
+A Gateway can remain healthy for browser users while node hosting is unavailable. Run `openclaw doctor` on the Gateway before onboarding nodes, and check these preconditions:
+
+- **Machine authentication:** Tailscale identity headers do not authenticate node-role connections. In `gateway.auth.mode: "trusted-proxy"`, a new node also cannot supply the proxy's user identity headers. To use a shared token, switch to token mode and configure `gateway.auth.token` with a SecretRef; trusted-proxy mode rejects mixed token configuration. A trusted-proxy Gateway can use `gateway.auth.password` only for clean loopback/direct callers. See [trusted-proxy mixed token configuration](/gateway/trusted-proxy-auth#mixed-token-configuration).
+- **Node onboarding URL:** With `gateway.bind: "loopback"`, configure Tailscale Serve, `gateway.remote.url`, or `plugins.entries.device-pair.config.publicUrl` before minting a join code. Otherwise `openclaw devices join-code` reports: `Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.`
+- **Edge routing:** When a reverse proxy or access edge fronts the Gateway, allow `/j/*` and `/__openclaw__/worker` through without edge identity auth. Keep WebSocket upgrade enabled for `/__openclaw__/worker`; both routes enforce their own short-lived credentials. The node's main Gateway WebSocket must also reach an auth path it can satisfy. See [worker protocol](/gateway/protocol#worker-role-and-closed-protocol).
+
+Cloudflare Access service tokens (`CF-Access-Client-Id` and `CF-Access-Client-Secret`) are the intended alternative for Access-fronted machine clients, but node hosts cannot send those headers yet. Follow [node-host service-token header support](https://github.com/openclaw/openclaw/issues/125112) for that capability.
+
 ### Start a node host (foreground)
 
 On the node machine:

--- a/packages/gateway-client/src/reconnect-policy.test.ts
+++ b/packages/gateway-client/src/reconnect-policy.test.ts
@@ -18,6 +18,7 @@ describe("shouldPauseGatewayReconnect", () => {
     ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
     ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
     ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+    "AUTH_IDENTITY_HEADER_REQUIRED",
     ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
     ConnectErrorDetailCodes.PAIRING_REQUIRED,
     ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
@@ -38,6 +39,15 @@ describe("shouldPauseGatewayReconnect", () => {
 
   it("leaves token mismatch to the caller's bounded retry policy", () => {
     expect(shouldPause({ code: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH })).toBe(false);
+  });
+
+  it("keeps the identity-header pause behind a pending device-token retry", () => {
+    expect(
+      shouldPauseGatewayReconnect({
+        details: { code: "AUTH_IDENTITY_HEADER_REQUIRED" },
+        deviceTokenRetryPending: true,
+      }),
+    ).toBe(false);
   });
 
   it.each([undefined, {}, { code: "SOME_FUTURE_CODE" }])(

--- a/packages/gateway-client/src/reconnect-policy.test.ts
+++ b/packages/gateway-client/src/reconnect-policy.test.ts
@@ -50,6 +50,10 @@ describe("shouldPauseGatewayReconnect", () => {
     ).toBe(false);
   });
 
+  it("keeps generic unauthorized failures reconnecting", () => {
+    expect(shouldPause({ code: ConnectErrorDetailCodes.AUTH_UNAUTHORIZED })).toBe(false);
+  });
+
   it.each([undefined, {}, { code: "SOME_FUTURE_CODE" }])(
     "keeps reconnect active for recoverable details",
     (details) => {

--- a/packages/gateway-client/src/reconnect-policy.ts
+++ b/packages/gateway-client/src/reconnect-policy.ts
@@ -12,6 +12,7 @@ const NON_RECOVERABLE_AUTH_ERRORS = new Set<string>([
   ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
   ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
   ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
   ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
   ConnectErrorDetailCodes.PAIRING_REQUIRED,
   ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED,
@@ -38,6 +39,9 @@ export function shouldPauseGatewayReconnect(params: {
   }
   if (code === ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH) {
     return params.tokenMismatchIsTerminal === true && !params.deviceTokenRetryPending;
+  }
+  if (code === ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED) {
+    return !params.deviceTokenRetryPending;
   }
   return (
     NON_RECOVERABLE_AUTH_ERRORS.has(code) ||

--- a/packages/gateway-protocol/src/connect-error-details.test.ts
+++ b/packages/gateway-protocol/src/connect-error-details.test.ts
@@ -270,6 +270,12 @@ describe("resolveAuthConnectErrorDetailCode", () => {
       resolveAuthConnectErrorDetailCode("trusted_proxy_missing_header_cf-access-jwt-assertion"),
     ).toBe("AUTH_IDENTITY_HEADER_REQUIRED");
   });
+
+  it("keeps non-header trusted-proxy rejection generic", () => {
+    expect(resolveAuthConnectErrorDetailCode("trusted_proxy_local_interface_check_failed")).toBe(
+      "AUTH_UNAUTHORIZED",
+    );
+  });
 });
 
 describe("pairing connect details", () => {

--- a/packages/gateway-protocol/src/connect-error-details.test.ts
+++ b/packages/gateway-protocol/src/connect-error-details.test.ts
@@ -264,6 +264,12 @@ describe("resolveAuthConnectErrorDetailCode", () => {
   it("maps device token scope mismatches to a dedicated auth detail", () => {
     expect(resolveAuthConnectErrorDetailCode("scope_mismatch")).toBe("AUTH_SCOPE_MISMATCH");
   });
+
+  it("keeps trusted-proxy identity rejection distinct from generic unauthorized auth", () => {
+    expect(
+      resolveAuthConnectErrorDetailCode("trusted_proxy_missing_header_cf-access-jwt-assertion"),
+    ).toBe("AUTH_IDENTITY_HEADER_REQUIRED");
+  });
 });
 
 describe("pairing connect details", () => {

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -167,7 +167,7 @@ const CONNECT_PAIRING_REQUIRED_MESSAGE_BY_REASON: Readonly<
 export function resolveAuthConnectErrorDetailCode(
   reason: string | undefined,
 ): ConnectErrorDetailCode {
-  if (reason?.startsWith("trusted_proxy_")) {
+  if (reason?.startsWith("trusted_proxy_missing_header_")) {
     return ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED;
   }
   switch (reason) {

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -39,6 +39,7 @@ export const ConnectErrorDetailCodes = {
   AUTH_TAILSCALE_PROXY_MISSING: "AUTH_TAILSCALE_PROXY_MISSING",
   AUTH_TAILSCALE_WHOIS_FAILED: "AUTH_TAILSCALE_WHOIS_FAILED",
   AUTH_TAILSCALE_IDENTITY_MISMATCH: "AUTH_TAILSCALE_IDENTITY_MISMATCH",
+  AUTH_IDENTITY_HEADER_REQUIRED: "AUTH_IDENTITY_HEADER_REQUIRED",
   CONTROL_UI_BUILD_MISMATCH: "CONTROL_UI_BUILD_MISMATCH",
   CONTROL_UI_ORIGIN_NOT_ALLOWED: "CONTROL_UI_ORIGIN_NOT_ALLOWED",
   PROTOCOL_MISMATCH: "PROTOCOL_MISMATCH",
@@ -166,6 +167,9 @@ const CONNECT_PAIRING_REQUIRED_MESSAGE_BY_REASON: Readonly<
 export function resolveAuthConnectErrorDetailCode(
   reason: string | undefined,
 ): ConnectErrorDetailCode {
+  if (reason?.startsWith("trusted_proxy_")) {
+    return ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED;
+  }
   switch (reason) {
     case "token_missing":
       return ConnectErrorDetailCodes.AUTH_TOKEN_MISSING;

--- a/src/commands/doctor-node-hosting-preconditions.test.ts
+++ b/src/commands/doctor-node-hosting-preconditions.test.ts
@@ -1,0 +1,111 @@
+// Doctor node-hosting precondition tests cover browser-only auth and unreachable onboarding.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { collectNodeHostingPreconditionFindings } from "./doctor-node-hosting-preconditions.js";
+
+function findingsFor(cfg: OpenClawConfig) {
+  return collectNodeHostingPreconditionFindings(cfg);
+}
+
+describe("node-hosting preconditions", () => {
+  it.each([
+    {
+      name: "identity-header auth alone",
+      cfg: {
+        gateway: {
+          bind: "lan",
+          auth: { mode: "trusted-proxy" },
+        },
+      },
+      requirements: ["machine-client-auth"],
+    },
+    {
+      name: "loopback onboarding alone",
+      cfg: {
+        gateway: {
+          bind: "loopback",
+          auth: { mode: "token", token: "configured-token" },
+        },
+      },
+      requirements: ["node-onboarding-url"],
+    },
+    {
+      name: "both unavailable",
+      cfg: {
+        gateway: {
+          bind: "loopback",
+          auth: { mode: "trusted-proxy" },
+        },
+      },
+      requirements: ["machine-client-auth", "node-onboarding-url"],
+    },
+    {
+      name: "Tailscale identity without a shared secret",
+      cfg: {
+        gateway: {
+          bind: "loopback",
+          tailscale: { mode: "serve" },
+          auth: { mode: "token", allowTailscale: true },
+        },
+      },
+      requirements: ["machine-client-auth"],
+    },
+  ] satisfies Array<{
+    name: string;
+    cfg: OpenClawConfig;
+    requirements: string[];
+  }>)("warns when $name", ({ cfg, requirements }) => {
+    expect(findingsFor(cfg).map((finding) => finding.requirement)).toEqual(requirements);
+  });
+
+  it("does not warn for token auth with a reachable bind", () => {
+    expect(
+      findingsFor({
+        gateway: {
+          bind: "lan",
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "GATEWAY_TOKEN" },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("gives accurate machine-auth and edge-routing remediation", () => {
+    const findings = findingsFor({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "trusted-proxy" },
+      },
+    });
+
+    expect(findings.find((finding) => finding.requirement === "machine-client-auth")?.fixHint).toBe(
+      "Switch gateway.auth.mode to token and configure gateway.auth.token as a SecretRef so machine clients can authenticate as devices. Keep trusted-proxy only if machine clients use a clean loopback/direct gateway.auth.password path. Cloudflare Access service tokens are the alternative for Access-fronted gateways, but node-host support for CF-Access-Client-Id / CF-Access-Client-Secret is not implemented yet.",
+    );
+    expect(findings.find((finding) => finding.requirement === "node-onboarding-url")).toMatchObject(
+      {
+        message:
+          "Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.",
+        fixHint:
+          "If an edge proxy fronts node onboarding, allow /j/* and /__openclaw__/worker without edge identity auth, and preserve WebSocket upgrade on /__openclaw__/worker. Both routes enforce their own credentials.",
+      },
+    );
+  });
+
+  it("accepts a configured public URL for loopback onboarding", () => {
+    expect(
+      findingsFor({
+        gateway: {
+          bind: "loopback",
+          auth: { mode: "token", token: "configured-token" },
+        },
+        plugins: {
+          entries: {
+            "device-pair": { config: { publicUrl: "wss://gateway.example" } },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/commands/doctor-node-hosting-preconditions.ts
+++ b/src/commands/doctor-node-hosting-preconditions.ts
@@ -1,5 +1,6 @@
 // Doctor node-hosting preconditions expose config combinations that leave browser auth healthy
 // while machine authentication or onboarding remains unavailable.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import { hasConfiguredGatewayAuthSecretInput } from "../gateway/auth-config-utils.js";
@@ -7,10 +8,6 @@ import { hasConfiguredGatewayAuthSecretInput } from "../gateway/auth-config-util
 const CHECK_ID = "core/doctor/node-hosting-preconditions";
 const LOOPBACK_JOIN_CODE_MESSAGE =
   "Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.";
-
-function hasNonEmptyString(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 function usesIdentityHeadersWithoutMachineCredentials(cfg: OpenClawConfig): boolean {
   const hasToken = hasConfiguredGatewayAuthSecretInput(cfg, "gateway.auth.token");
@@ -38,8 +35,8 @@ function lacksNodeOnboardingUrl(cfg: OpenClawConfig): boolean {
   const remoteUrl = cfg.gateway?.remote?.url;
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
   return (
-    !hasNonEmptyString(publicUrl) &&
-    !hasNonEmptyString(remoteUrl) &&
+    !normalizeOptionalString(publicUrl) &&
+    !normalizeOptionalString(remoteUrl) &&
     tailscaleMode !== "serve" &&
     tailscaleMode !== "funnel"
   );

--- a/src/commands/doctor-node-hosting-preconditions.ts
+++ b/src/commands/doctor-node-hosting-preconditions.ts
@@ -1,0 +1,77 @@
+// Doctor node-hosting preconditions expose config combinations that leave browser auth healthy
+// while machine authentication or onboarding remains unavailable.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
+import { hasConfiguredGatewayAuthSecretInput } from "../gateway/auth-config-utils.js";
+
+const CHECK_ID = "core/doctor/node-hosting-preconditions";
+const LOOPBACK_JOIN_CODE_MESSAGE =
+  "Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.";
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function usesIdentityHeadersWithoutMachineCredentials(cfg: OpenClawConfig): boolean {
+  const hasToken = hasConfiguredGatewayAuthSecretInput(cfg, "gateway.auth.token");
+  const hasPassword = hasConfiguredGatewayAuthSecretInput(cfg, "gateway.auth.password");
+  if (hasToken || hasPassword) {
+    return false;
+  }
+  if (cfg.gateway?.auth?.mode === "trusted-proxy") {
+    return true;
+  }
+  return (
+    cfg.gateway?.tailscale?.mode === "serve" &&
+    cfg.gateway?.auth?.mode !== "password" &&
+    cfg.gateway?.auth?.mode !== "none" &&
+    cfg.gateway?.auth?.allowTailscale !== false
+  );
+}
+
+function lacksNodeOnboardingUrl(cfg: OpenClawConfig): boolean {
+  const bind = cfg.gateway?.bind ?? "loopback";
+  if (bind !== "loopback" && bind !== "auto") {
+    return false;
+  }
+  const publicUrl = cfg.plugins?.entries?.["device-pair"]?.config?.["publicUrl"];
+  const remoteUrl = cfg.gateway?.remote?.url;
+  const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+  return (
+    !hasNonEmptyString(publicUrl) &&
+    !hasNonEmptyString(remoteUrl) &&
+    tailscaleMode !== "serve" &&
+    tailscaleMode !== "funnel"
+  );
+}
+
+/** Collects config-only warnings for node authentication, onboarding, and worker ingress. */
+export function collectNodeHostingPreconditionFindings(
+  cfg: OpenClawConfig,
+): readonly HealthFinding[] {
+  const findings: HealthFinding[] = [];
+  if (usesIdentityHeadersWithoutMachineCredentials(cfg)) {
+    findings.push({
+      checkId: CHECK_ID,
+      severity: "warning",
+      message:
+        "Gateway identity-header auth has no configured token/password path for machine clients; new node hosts cannot authenticate or become worker hosts.",
+      path: "gateway.auth",
+      requirement: "machine-client-auth",
+      fixHint:
+        "Switch gateway.auth.mode to token and configure gateway.auth.token as a SecretRef so machine clients can authenticate as devices. Keep trusted-proxy only if machine clients use a clean loopback/direct gateway.auth.password path. Cloudflare Access service tokens are the alternative for Access-fronted gateways, but node-host support for CF-Access-Client-Id / CF-Access-Client-Secret is not implemented yet.",
+    });
+  }
+  if (lacksNodeOnboardingUrl(cfg)) {
+    findings.push({
+      checkId: CHECK_ID,
+      severity: "warning",
+      message: LOOPBACK_JOIN_CODE_MESSAGE,
+      path: "gateway.bind",
+      requirement: "node-onboarding-url",
+      fixHint:
+        "If an edge proxy fronts node onboarding, allow /j/* and /__openclaw__/worker without edge identity auth, and preserve WebSocket upgrade on /__openclaw__/worker. Both routes enforce their own credentials.",
+    });
+  }
+  return findings;
+}

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -94,6 +94,18 @@ export function resolveInitialDoctorHealthContributions(params: {
       run: params.runGatewayAuthHealth,
     }),
     createDoctorHealthContribution({
+      id: "doctor:node-hosting-preconditions",
+      label: "Node hosting preconditions",
+      healthChecks: {
+        description: "Gateway config can authenticate and onboard node and worker hosts.",
+        async detect(ctx) {
+          const { collectNodeHostingPreconditionFindings } =
+            await import("../commands/doctor-node-hosting-preconditions.js");
+          return collectNodeHostingPreconditionFindings(ctx.cfg);
+        },
+      },
+    }),
+    createDoctorHealthContribution({
       id: "doctor:command-owner",
       label: "Command owner",
       healthCheckIds: ["core/doctor/command-owner"],

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2360,6 +2360,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/disk-space");
     expect(contributionIds).toContain("core/doctor/whatsapp-responsiveness");
     expect(contributionIds).toContain("core/doctor/device-pairing");
+    expect(contributionIds).toContain("core/doctor/node-hosting-preconditions");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
     expect(contributionIds).toContain("core/doctor/channel-package-state-capabilities");
     expect(contributionIds).toContain("core/doctor/channel-preview-warnings");

--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -52,4 +52,18 @@ describe("formatGatewayAuthFailureMessage", () => {
       "gateway rejected this node: trusted-proxy identity-header authentication is required and no usable machine credential was accepted; run `openclaw doctor` on the Gateway",
     );
   });
+
+  it("does not describe other trusted-proxy rejection causes as missing identity headers", () => {
+    expect(
+      formatGatewayAuthFailureMessage({
+        authMode: "trusted-proxy",
+        authProvided: "none",
+        reason: "trusted_proxy_local_interface_check_failed",
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+      }),
+    ).toBe("unauthorized");
+  });
 });

--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -36,4 +36,20 @@ describe("formatGatewayAuthFailureMessage", () => {
     );
     expect(truncateCloseReason(message)).toBe(message);
   });
+
+  it("tells rejected node hosts how to diagnose identity-header auth", () => {
+    expect(
+      formatGatewayAuthFailureMessage({
+        authMode: "trusted-proxy",
+        authProvided: "none",
+        reason: "trusted_proxy_missing_header_cf-access-jwt-assertion",
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+      }),
+    ).toBe(
+      "gateway rejected this node: trusted-proxy identity-header authentication is required and no usable machine credential was accepted; run `openclaw doctor` on the Gateway",
+    );
+  });
 });

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -23,7 +23,7 @@ export function formatGatewayAuthFailureMessage(params: {
   const isCli = isGatewayCliClient(client);
   const isControlUi = isOperatorUiClient(client);
   const isWebchat = isWebchatClient(client);
-  if (client?.mode === "node" && reason?.startsWith("trusted_proxy_")) {
+  if (client?.mode === "node" && reason?.startsWith("trusted_proxy_missing_header_")) {
     return "gateway rejected this node: trusted-proxy identity-header authentication is required and no usable machine credential was accepted; run `openclaw doctor` on the Gateway";
   }
   const uiHint = "open the dashboard URL and paste the token in Control UI settings";

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -23,6 +23,9 @@ export function formatGatewayAuthFailureMessage(params: {
   const isCli = isGatewayCliClient(client);
   const isControlUi = isOperatorUiClient(client);
   const isWebchat = isWebchatClient(client);
+  if (client?.mode === "node" && reason?.startsWith("trusted_proxy_")) {
+    return "gateway rejected this node: trusted-proxy identity-header authentication is required and no usable machine credential was accepted; run `openclaw doctor` on the Gateway";
+  }
   const uiHint = "open the dashboard URL and paste the token in Control UI settings";
   const missingUiTokenHint =
     "paste in Control UI settings or openclaw doctor --generate-gateway-token; restart";

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -954,6 +954,7 @@ describe("runNodeHost", () => {
   it.each([
     ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
     ConnectErrorDetailCodes.CLIENT_VERSION_MISMATCH,
+    ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
   ])("closes MCP clients before exiting on terminal reconnect pause %s", async (detailCode) => {
     await expect(runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 })).rejects.toThrow(
       "event loop readiness timeout",

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -83,6 +83,7 @@ const NODE_HOST_EXIT_ON_RECONNECT_PAUSE_CODES: ReadonlySet<string> = new Set([
   ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
   ConnectErrorDetailCodes.CLIENT_VERSION_MISMATCH,
 ]);
 


### PR DESCRIPTION
Related: #125112

AI-assisted: yes. The implementation and evidence were reviewed with the repository autoreview workflow.

## What Problem This Solves

Fixes an issue where operators could run a healthy browser-only Gateway configuration while node hosting and worker placement were unavailable with no proactive diagnostic, and where a rejected node host retried a trusted-proxy identity-header failure without a clear recovery path.

The production finding came from OpenClaw 2026.8.1 (`d095113`) behind Cloudflare Access. The Gateway emitted:

```text
reason=trusted_proxy_missing_header_cf-access-jwt-assertion role=node auth=none device=yes
```

The node kept retrying. By contrast, the existing join-code path already returned the right operator-facing shape:

```text
Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.
```

## Why This Change Was Made

Doctor now registers one read-only `core/doctor/node-hosting-preconditions` check with separate machine-auth and onboarding/reachability findings. It reports identity-header-only auth with no token/password path, loopback onboarding without an advertised URL, and edge routing requirements for `/j/*` and `/__openclaw__/worker`. There is intentionally no `--fix` mutation because these are operator policy choices.

Gateway auth now records trusted-proxy rejection as the additive closed detail `AUTH_IDENTITY_HEADER_REQUIRED`. The shared client pauses after any pending device-token retry is exhausted, and the node host reuses its existing terminal-auth shutdown path. The Gateway formats the node-specific error as:

```text
gateway rejected this node: trusted-proxy identity-header authentication is required and no usable machine credential was accepted; run `openclaw doctor` on the Gateway
```

The remediation deliberately does not tell operators to add a token while keeping trusted-proxy mode: that combination is rejected by current Gateway startup policy. It instead says to switch to token mode and configure `gateway.auth.token` as a SecretRef, or use the clean loopback/direct password fallback. Cloudflare Access service-token headers remain unimplemented and are tracked in #125112.

## User Impact

Operators can detect node-hosting dead ends before onboarding, see the exact route/auth preconditions they must provide, and get one actionable terminal auth message instead of an indefinite trusted-proxy retry loop. Existing paired-device retry behavior remains intact, and browser-only deployments remain valid warnings rather than errors.

## Evidence

- Pre-fix regression captured: the contribution registry lacked `core/doctor/node-hosting-preconditions`, and `AUTH_IDENTITY_HEADER_REQUIRED` did not enter the node terminal-pause path.
- Focused proof passed three consecutive times on the final diff:
  - `node scripts/run-vitest.mjs src/commands/doctor-node-hosting-preconditions.test.ts src/flows/doctor-health-contributions.test.ts src/gateway/server/ws-connection/auth-messages.test.ts src/node-host/runner.test.ts`
  - `node scripts/run-vitest.mjs packages/gateway-protocol/src/connect-error-details.test.ts packages/gateway-client/src/reconnect-policy.test.ts`
  - `node scripts/run-vitest.mjs src/gateway/client.test.ts`
- Source-blind built-CLI validation passed:
  - trusted-proxy + loopback produced exactly `machine-client-auth` and `node-onboarding-url`;
  - token auth + LAN produced no findings;
  - changing only loopback to LAN removed only the onboarding warning.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 node scripts/check-changed.mjs`
- `pnpm build`
- `pnpm docs:check-links`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check`
- Final autoreview: clean, no accepted/actionable findings.

Remote Testbox proof was unavailable: Blacksmith was not installed, and the routed Daytona fallback rejected lease creation with `Total memory limit exceeded. Maximum allowed: 10GiB.` No remote branch command ran. Repository policy therefore fell trusted-source proof back to the prepared local checkout. A live Cloudflare Access replay was infeasible without the production edge; the redacted production warning above is the live motivation, while the repaired owner boundary is covered by focused and built-CLI proof.

Production LOC: +98/-0 | Tests: +169/-0 | Docs: +10/-0. The production growth is the new doctor capability and additive producer-owned error classification; no compatibility fallback or duplicate runtime path was added.
