### PR TITLE
fix(cli): gateway restart reaches schema-ahead process

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -243,12 +243,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     },
     route: { id: "gateway-status" },
   },
-  { commandPath: ["gateway", "call"], exact: true, policy: { networkProxy: "bypass" } },
-  ...["suspend", "resume"].map(
+  ...["call", "restart", "suspend", "resume"].map(
     (subcommand): CliCommandCatalogEntry => ({
       commandPath: ["gateway", subcommand],
       exact: true,
-      policy: { configGuard: "validate", networkProxy: "bypass" },
+      policy: { configGuard: "validate", loadPlugins: "never", networkProxy: "bypass" },
     }),
   ),
   { commandPath: ["gateway", "diagnostics"], exact: true, policy: { networkProxy: "bypass" } },
@@ -263,7 +262,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   },
   { commandPath: ["gateway", "install"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "probe"], exact: true, policy: { networkProxy: "bypass" } },
-  { commandPath: ["gateway", "restart"], exact: true, policy: { networkProxy: "bypass" } },
   {
     commandPath: ["gateway", "stability"],
     exact: true,

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -125,10 +125,11 @@ describe("command-path-policy", () => {
     }
   });
 
-  it("keeps gateway suspension RPCs on non-observing config validation", () => {
-    for (const subcommand of ["suspend", "resume"]) {
+  it("keeps gateway control RPCs on core-only config validation", () => {
+    for (const subcommand of ["call", "restart", "suspend", "resume"]) {
       expectResolvedPolicy(["gateway", subcommand], {
         configGuard: "validate",
+        loadPlugins: "never",
         networkProxy: "bypass",
       });
     }

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -81,6 +81,8 @@ describe("command-startup-policy", () => {
       ["nodes", "remove"],
       ["devices", "approve"],
       ["devices", "remove"],
+      ["gateway", "call"],
+      ["gateway", "restart"],
       ["gateway", "suspend"],
       ["gateway", "resume"],
     ]) {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -969,6 +969,7 @@ describe("registerPreActionHooks", () => {
       measure: expect.any(Function),
       commandPath: ["gateway", "call"],
       suppressDoctorStdout: true,
+      validateConfigOnly: true,
     });
   });
 

--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -114,6 +114,9 @@ describe("resolveBrowserOpenCommand", () => {
     vi.stubEnv("WSL_INTEROP", "");
     vi.stubEnv("WSL_DISTRO_NAME", "");
     vi.stubEnv("WSLENV", "");
+    vi.stubEnv("SSH_CLIENT", "");
+    vi.stubEnv("SSH_CONNECTION", "");
+    vi.stubEnv("SSH_TTY", "");
 
     await expect(resolveBrowserOpenCommand()).resolves.toEqual({
       argv: null,


### PR DESCRIPTION
Closes #125115

AI-assisted: yes. I reviewed the implementation and proof.

## What Problem This Solves

Fixes an issue where operators restarting a Gateway during schema-forward recovery would have the control command exit before sending its restart RPC when the running binary encountered newer persisted plugin metadata. Generic Gateway calls could continue, but only after the same irrelevant invalid-config diagnostic and unnecessary plugin-state open.

## Why This Change Was Made

Exact Gateway control RPCs now share the existing core-only config-validation policy used by suspension control and never load plugins. This preserves core connection/config validation while keeping lifecycle control independent from plugin-owned state that may belong to a newer release.

The four commands use one canonical catalog policy rather than adding a recovery-only bypass or weakening database schema checks.

## User Impact

Operators can call and restart a running Gateway during a schema-forward deployment without the older controller opening newer persisted plugin metadata first. Normal invalid core configuration still fails validation; plugin state remains owned by the running or successor Gateway.

## Evidence

Observed before the fix during a production-shape, canaried schema-forward deployment:

```text
gateway restart exit=78
stdout=<empty>
stderr=Persisted plugin install records are invalid
restart RPC sent=false
```

The same predecessor process remained reachable through direct suspension RPCs.

Focused regression proof:

```text
node scripts/run-vitest.mjs src/cli/command-path-policy.test.ts src/cli/command-startup-policy.test.ts src/cli/program/config-guard.test.ts
3 files passed, 118 tests passed
```

Full changed-surface proof:

```text
node scripts/check-changed.mjs -- src/cli/command-catalog.ts src/cli/command-path-policy.test.ts src/cli/command-startup-policy.test.ts
```

Blacksmith Testbox `tbx_01m0776h08dwnq1r7wax8dq6cc` passed all selected core/core-test gates, including formatting, typechecks, lint, dead exports, import cycles, and database guards: https://github.com/openclaw/openclaw/actions/runs/32002602370

Exact-head CI exposed two coverage gaps in `checks-node-compact-small-2`:

- `src/infra/browser-open.test.ts` inherited SSH variables from the hydrated runner, changing its unrelated WSL-cache assertion from `no-display` to `ssh-no-display`. The fixture now clears the three SSH variables for that case. The five-group Blacksmith compact plan passed on Testbox `tbx_01m07emh645pe4vh03wc7gx18m`: https://github.com/openclaw/openclaw/actions/runs/32012269091
- `src/cli/program/preaction.test.ts` still expected the old Gateway call bootstrap shape. It now asserts `validateConfigOnly: true`. The exact hybrid-backend `checks-node-compact-small-2` plan used by PR CI passed both `agentic-cli` and `core-runtime-hooks` on Testbox `tbx_01m07fm5q3hehvt6rhwdvm8s1e`: https://github.com/openclaw/openclaw/actions/runs/32013655693

Autoreview completed clean after the production repair and both CI fixes, with no accepted/actionable findings.

Production LOC: `-2` (2 additions, 4 deletions). Tests: `+7` net.
