### PR TITLE
test(plugins): drop duplicate SDK-alias loader case that timed out under load

### DIFF
--- a/src/plugins/loader.native-module-loader.test.ts
+++ b/src/plugins/loader.native-module-loader.test.ts
@@ -74,55 +74,6 @@ function writePackagedPluginFixture(id: string) {
   return pluginRoot;
 }
 
-function writePreManagedLlamaCppProviderFixture() {
-  const pluginRoot = tempDirs.make("openclaw-plugin-loader-");
-  fs.mkdirSync(path.join(pluginRoot, "dist"));
-  fs.writeFileSync(
-    path.join(pluginRoot, "package.json"),
-    JSON.stringify(
-      {
-        name: "@openclaw/llama-cpp-provider",
-        version: "2026.7.2-beta.7",
-        type: "module",
-        openclaw: {
-          extensions: ["./dist/index.js"],
-          runtimeExtensions: ["./dist/index.js"],
-        },
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
-  fs.writeFileSync(
-    path.join(pluginRoot, "openclaw.plugin.json"),
-    JSON.stringify(
-      {
-        id: "llama-cpp",
-        configSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: {},
-        },
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
-  fs.writeFileSync(
-    path.join(pluginRoot, "dist", "index.js"),
-    [
-      'import { createLocalEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";',
-      'export default { id: "llama-cpp", register() {',
-      '  if (typeof createLocalEmbeddingProvider !== "function") throw new Error("missing bridge");',
-      "} };",
-    ].join("\n"),
-    "utf-8",
-  );
-  return pluginRoot;
-}
-
 function writePreSplitSdkBridgeConsumerFixture() {
   const pluginRoot = tempDirs.make("openclaw-plugin-loader-");
   fs.mkdirSync(path.join(pluginRoot, "dist"));
@@ -162,6 +113,9 @@ function writePreSplitSdkBridgeConsumerFixture() {
   // Import shapes copied from published 2026.7.2-beta.7 artifacts:
   // voice-call/matrix doctor contracts (runtime-doctor), whatsapp ack policy
   // (channel-feedback), slack progress-draft render (channel-outbound).
+  // Covers both alias classes on purpose: runtime-doctor is private-local-only,
+  // the channel subpaths are public. A source checkout has no dist/, so every
+  // subpath listed here is evaluated through jiti — keep them light.
   fs.writeFileSync(
     path.join(pluginRoot, "dist", "index.js"),
     [
@@ -282,30 +236,6 @@ describe("createPluginModuleLoader", () => {
 
     expect(registry.plugins.find((plugin) => plugin.id === "npm-demo")?.status).toBe("loaded");
     expect(sourceLoaderCalls).toStrictEqual([]);
-  });
-
-  it("loads the released pre-managed llama.cpp provider import through the SDK alias", async () => {
-    const { loadOpenClawPlugins } = await importFreshModule<typeof import("./loader.js")>(
-      import.meta.url,
-      "./loader.js?scope=llama-cpp-upgrade-compat",
-    );
-    const pluginRoot = writePreManagedLlamaCppProviderFixture();
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = tempDirs.make("openclaw-plugin-loader-");
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      onlyPluginIds: ["llama-cpp"],
-      config: {
-        plugins: {
-          enabled: true,
-          load: { paths: [pluginRoot] },
-          allow: ["llama-cpp"],
-          entries: { "llama-cpp": { enabled: true } },
-        },
-      },
-    });
-
-    expect(registry.plugins.find((plugin) => plugin.id === "llama-cpp")?.status).toBe("loaded");
   });
 
   it("loads published pre-split SDK bridge imports (doctor repair, WhatsApp ack, Slack render)", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running the plugin test suite hit spurious
failures from `src/plugins/loader.native-module-loader.test.ts`. Its
`loads the released pre-managed llama.cpp provider import through the SDK alias`
case took ~54s on its own and blew through the 120s per-test timeout whenever the
machine was under CPU contention, then passed on an immediate standalone rerun.
It was observed as the sole failure of a 1171-file / 18320-test run while landing
#125037.

The cost was structural, not incidental. In a source checkout there is no
`dist/`, so the fixture's `openclaw/plugin-sdk/memory-core-host-engine-embeddings`
import resolves to TypeScript source. The loader's fallback path deliberately
drops `openclaw` from jiti's `nativeModules`
(`src/plugins/plugin-module-loader-cache.ts:200`), so jiti transformed and
evaluated the full core graph reachable from that subpath — roughly 3,000 modules
per run — just to prove an alias resolves.

## Why This Change Was Made

The expensive case proved nothing that was not already proven elsewhere, so it is
deleted rather than given a bigger timeout (raising timeouts to hide a slow test
is explicitly a masking pattern under the Repair Doctrine).

Its two invariants are each already owned somewhere cheaper:

- **Released-shape ESM plugin resolves `openclaw/plugin-sdk/*` through the loader
  alias** — covered by the sibling
  `loads published pre-split SDK bridge imports` case in the same file. That
  fixture spans both alias visibility classes on purpose: `runtime-doctor` is
  private-local-only (same class as the deleted subpath) and `channel-feedback` /
  `channel-outbound` are public, so removing the llama.cpp case loses no alias
  class.
- **`memory-core-host-engine-embeddings` still exports
  `createLocalEmbeddingProvider`, and it rejects with upgrade guidance instead of
  reviving the retired runtime** — covered by
  `extensions/llama-cpp/index.test.ts`, added in the same PR (#124041) that
  introduced the deleted case.

An inline comment now records why the surviving fixture's subpath list is what it
is, so the trap does not come back the next time someone extends it.

## User Impact

Developer-facing only; no runtime or product behavior changes. The test file
drops from ~67s to ~30s, and the flakiest test in the plugins lane is gone. No
coverage is lost.

## Evidence

Per-test timings before, on this machine (`--reporter=verbose`):

```
✓ loads bundled JavaScript without creating a module loader                1381ms
✓ loads packaged JavaScript without creating a module loader                131ms
✓ loads the released pre-managed llama.cpp provider import ...            54214ms
✓ loads published pre-split SDK bridge imports ...                        10904ms
  Duration 66.96s
```

After:

```
✓ loads bundled JavaScript without creating a module loader                1432ms
✓ loads packaged JavaScript without creating a module loader                129ms
✓ loads published pre-split SDK bridge imports ...                        28571ms
  Duration 30.47s
```

The surviving bridge case absorbs the cold jiti/core-graph warm-up the deleted
case used to pay first, which is why it rises from 10.9s to 28.6s while the file
total still drops by more than half.

Commands run:

- `node scripts/run-vitest.mjs src/plugins/loader.native-module-loader.test.ts` — 3 passed
- `node scripts/run-vitest.mjs src/plugins` — 1171 files / 18320 tests, same result before and after
- `autoreview --mode uncommitted` (codex, gpt-5.6-sol) — clean, no accepted findings

Production LOC delta: 0. Test LOC delta: +3 / -73.

Known follow-up, not introduced here: the broad `run-vitest src/plugins` run
produces a small, non-deterministic set of failures under CPU contention that all
pass in isolation — `provider-auth-choices.test.ts` in one run;
`contracts/tts.contract.test.ts`, `web-search-providers.runtime.test.ts`, and
`status-effective-plugin-discovery.test.ts` in another. Verified pre-existing
(present on the unmodified tree, absent when the files are run on their own) and
unrelated to this diff; `main` CI is green.
