### PR TITLE
improve(ui): prewarm GitHub link previews

### DIFF
--- a/ui/src/components/github-prewarm.runtime.ts
+++ b/ui/src/components/github-prewarm.runtime.ts
@@ -1,0 +1,55 @@
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { parseGitHubLinkTarget } from "./github-link-target.ts";
+
+const GITHUB_PREVIEW_METHOD = "controlUi.githubPreview";
+const GITHUB_PREVIEW_PREWARM_LIMIT = 3;
+
+export async function prewarm(
+  root: ParentNode,
+  client: GatewayBrowserClient,
+  signal: AbortSignal,
+  isCurrent: () => boolean,
+): Promise<void> {
+  if (signal.aborted || !isCurrent()) {
+    return;
+  }
+  const anchors = root.querySelectorAll<HTMLAnchorElement>(
+    ".chat-thread a.markdown-github-link[href]",
+  );
+  const seen = new Set<string>();
+  const targets = [];
+  for (let index = anchors.length - 1; index >= 0; index -= 1) {
+    const target = parseGitHubLinkTarget(anchors[index]?.href ?? "");
+    if (!target) {
+      continue;
+    }
+    const key = `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    targets.push(target);
+    if (targets.length === GITHUB_PREVIEW_PREWARM_LIMIT) {
+      break;
+    }
+  }
+  // Responses are discarded intentionally: these calls fill the Gateway-process
+  // LRU without loading the browser hovercard runtime during session startup.
+  for (const target of targets) {
+    if (signal.aborted || !isCurrent()) {
+      return;
+    }
+    await client
+      .request(
+        GITHUB_PREVIEW_METHOD,
+        {
+          kind: target.kind,
+          number: target.number,
+          owner: target.owner,
+          repo: target.repo,
+        },
+        { signal },
+      )
+      .catch(() => undefined);
+  }
+}

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -214,6 +214,20 @@ describeControlUiE2e("GitHub link hover cards", () => {
       ],
     });
     await page.goto(`${server.baseUrl}chat`);
+    await expect
+      .poll(async () =>
+        (await gateway.getRequests("controlUi.githubPreview")).map((request) => request.params),
+      )
+      .toEqual([
+        {
+          kind: "issue",
+          number: 99817,
+          owner: "a-very-long-organization-name",
+          repo: "a-very-long-repository-name",
+        },
+        { kind: "issue", number: 999999, owner: "openclaw", repo: "openclaw" },
+        { kind: "issue", number: 99815, owner: "openclaw", repo: "openclaw" },
+      ]);
 
     const message = page.locator(".chat-text").filter({ hasText: "Review" });
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
@@ -264,7 +278,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expectText(card, "−12");
     await expectText(card, "3 files");
     await expect.poll(() => card.locator("img").count()).toBe(1);
-    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(1);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(4);
     const pullBox = await card.boundingBox();
     expect(pullBox).not.toBeNull();
     expect(pullBox!.x).toBeGreaterThanOrEqual(0);
@@ -278,13 +292,13 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expectText(card, "octocat");
     await expectText(card, "4 comments");
     await expect.poll(() => card.locator("img").count()).toBe(1);
-    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(5);
 
     await page.mouse.move(1, 1);
     await expect.poll(() => card.count()).toBe(0);
     await issueLink.hover();
     await expectText(card, "4 comments");
-    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(5);
 
     await page.mouse.move(1, 1);
     await page.getByRole("link", { exact: true, name: "repository" }).hover();
@@ -294,7 +308,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     const missingLink = page.getByRole("link", { name: "missing item" });
     await missingLink.hover();
     await expectText(card, "GitHub preview unavailable");
-    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(3);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(6);
     expect(await missingLink.getAttribute("href")).toBe(
       "https://github.com/openclaw/openclaw/issues/999999",
     );
@@ -304,7 +318,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
     await pullLink.hover();
     await expectText(card, "Merged");
-    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(3);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(6);
     await page.mouse.move(1, 1);
 
     await pullLink.focus();

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -672,6 +672,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     this.paneResizeObserver = null;
     this.connectionGeneration += 1;
     this.retireHeaderSessionMutations();
+    this.githubPreviewPrewarmAbortController.abort();
     this.deferredSessionHydrationRequestVersion += 1;
     this.sessionDiscussionPanels.clear();
     this.taskSuggestionsRequestVersion += 1;

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -7,6 +7,8 @@ import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
 import type { AfterCommitEffect, RenderLifecycle } from "./render-lifecycle.ts";
 
+const GITHUB_PREVIEW_METHOD = "controlUi.githubPreview";
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((next) => {
@@ -34,6 +36,13 @@ describe("chat pane session hydration", () => {
         methods: [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, "session.discussion.info"],
       },
     } as never;
+    const thread = document.createElement("div");
+    thread.className = "chat-thread";
+    const anchor = document.createElement("a");
+    anchor.className = "markdown-github-link";
+    anchor.href = "https://github.com/openclaw/openclaw/issues/1";
+    thread.append(anchor);
+    pane.append(thread);
     const commitEffects: AfterCommitEffect[] = [];
     const afterCommit = vi.fn((effect: AfterCommitEffect) => {
       commitEffects.push(effect);
@@ -71,6 +80,131 @@ describe("chat pane session hydration", () => {
       request.mock.calls.find(([method]) => method === "sessions.companion.state")?.[1],
     ).toEqual({ sessionKey: state.sessionKey, agentId: "work" });
     expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it("prewarms the newest three unique rendered GitHub cards after commit", async () => {
+    const request = vi.fn((_method: string, params?: unknown) =>
+      (params as { number?: number } | undefined)?.number === 4
+        ? Promise.reject(new Error("missing preview"))
+        : Promise.resolve({}),
+    );
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: [GITHUB_PREVIEW_METHOD] },
+    } as never;
+    const thread = document.createElement("div");
+    thread.className = "chat-thread";
+    for (const href of [
+      "https://github.com/openclaw/openclaw/issues/1",
+      "https://github.com/openclaw/openclaw/pull/2",
+      "https://github.com/openclaw/openclaw/pull/2#discussion_r1",
+      "https://example.com/openclaw/openclaw/issues/3",
+      "https://github.com/openclaw/openclaw/issues/3",
+      "https://github.com/openclaw/openclaw/pull/4/files",
+    ]) {
+      const anchor = document.createElement("a");
+      anchor.className = "markdown-github-link";
+      anchor.href = href;
+      thread.append(anchor);
+    }
+    pane.append(thread);
+    const commitEffects: AfterCommitEffect[] = [];
+    state.renderLifecycle = {
+      invalidate: vi.fn(),
+      afterCommit: (effect) => {
+        commitEffects.push(effect);
+        return () => undefined;
+      },
+    };
+    const transcript = deferred<void>();
+
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
+    expect(request).not.toHaveBeenCalled();
+    transcript.resolve();
+    await transcript.promise;
+    await Promise.resolve();
+    expect(request).not.toHaveBeenCalled();
+    const complete = vi.fn();
+    commitEffects[0]?.(complete);
+    expect(complete).toHaveBeenCalledOnce();
+
+    await vi.waitFor(() => {
+      expect(
+        request.mock.calls.filter(([method]) => method === GITHUB_PREVIEW_METHOD),
+      ).toHaveLength(3);
+    });
+    expect(
+      request.mock.calls
+        .filter(([method]) => method === GITHUB_PREVIEW_METHOD)
+        .map(([, params]) => params),
+    ).toEqual([
+      { kind: "pull", number: 4, owner: "openclaw", repo: "openclaw" },
+      { kind: "issue", number: 3, owner: "openclaw", repo: "openclaw" },
+      { kind: "pull", number: 2, owner: "openclaw", repo: "openclaw" },
+    ]);
+  });
+
+  it("aborts an in-flight preview prewarm when the session changes", async () => {
+    const preview = deferred<unknown>();
+    const request = vi.fn(
+      (method: string, _params?: unknown, _options?: { signal?: AbortSignal }) =>
+        method === GITHUB_PREVIEW_METHOD ? preview.promise : Promise.resolve({}),
+    );
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: [GITHUB_PREVIEW_METHOD] },
+    } as never;
+    const thread = document.createElement("div");
+    thread.className = "chat-thread";
+    for (const number of [5, 6]) {
+      const anchor = document.createElement("a");
+      anchor.className = "markdown-github-link";
+      anchor.href = `https://github.com/openclaw/openclaw/issues/${number}`;
+      thread.append(anchor);
+    }
+    pane.append(thread);
+    const commitEffects: AfterCommitEffect[] = [];
+    state.renderLifecycle = {
+      invalidate: vi.fn(),
+      afterCommit: (effect) => {
+        commitEffects.push(effect);
+        return () => undefined;
+      },
+    };
+    const firstTranscript = deferred<void>();
+
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, firstTranscript.promise);
+    firstTranscript.resolve();
+    await firstTranscript.promise;
+    await Promise.resolve();
+    commitEffects[0]?.(vi.fn());
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        GITHUB_PREVIEW_METHOD,
+        expect.anything(),
+        expect.anything(),
+      ),
+    );
+    const signal = request.mock.calls.find(([method]) => method === GITHUB_PREVIEW_METHOD)?.[2]
+      ?.signal;
+    expect(signal).toBeDefined();
+
+    state.sessionKey = "agent:main:next";
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, Promise.resolve());
+
+    preview.resolve({});
+    await preview.promise;
+    await Promise.resolve();
+    expect(request.mock.calls.filter(([method]) => method === GITHUB_PREVIEW_METHOD)).toHaveLength(
+      1,
+    );
+    expect(signal?.aborted).toBe(true);
   });
 
   it("drops a previous session's deferred hydration before it reaches commit", async () => {

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -36,13 +36,6 @@ describe("chat pane session hydration", () => {
         methods: [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, "session.discussion.info"],
       },
     } as never;
-    const thread = document.createElement("div");
-    thread.className = "chat-thread";
-    const anchor = document.createElement("a");
-    anchor.className = "markdown-github-link";
-    anchor.href = "https://github.com/openclaw/openclaw/issues/1";
-    thread.append(anchor);
-    pane.append(thread);
     const commitEffects: AfterCommitEffect[] = [];
     const afterCommit = vi.fn((effect: AfterCommitEffect) => {
       commitEffects.push(effect);
@@ -82,6 +75,61 @@ describe("chat pane session hydration", () => {
     expect(complete).toHaveBeenCalledOnce();
   });
 
+  it("keeps hidden retained-pane hydration independent of preview prewarming", async () => {
+    const request = vi.fn((_method: string, _params?: unknown) => Promise.resolve({}));
+    const listBranches = vi.fn(() => Promise.resolve([]));
+    const sessions = {
+      capturePullRequestEpoch: vi.fn(() => Symbol("pull-requests")),
+      listBranches,
+      setPullRequestSummary: vi.fn(),
+    } as unknown as SessionCapability;
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions,
+    });
+    state.assistantAgentId = "main";
+    state.sessionKey = "agent:work:current";
+    pane.context.gateway.snapshot.hello = {
+      features: {
+        methods: [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, "session.discussion.info"],
+      },
+    } as never;
+    const thread = document.createElement("div");
+    thread.className = "chat-thread";
+    const anchor = document.createElement("a");
+    anchor.className = "markdown-github-link";
+    anchor.href = "https://github.com/openclaw/openclaw/issues/1";
+    thread.append(anchor);
+    pane.append(thread);
+    const commitEffects: AfterCommitEffect[] = [];
+    state.renderLifecycle = {
+      invalidate: vi.fn(),
+      afterCommit: (effect) => {
+        commitEffects.push(effect);
+        return () => undefined;
+      },
+    };
+    const transcript = deferred<void>();
+
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
+    pane.presented = false;
+    transcript.resolve();
+    await transcript.promise;
+    await Promise.resolve();
+
+    expect(commitEffects).toHaveLength(1);
+    const complete = vi.fn();
+    commitEffects[0]?.(complete);
+    await Promise.resolve();
+
+    expect(listBranches).toHaveBeenCalledOnce();
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "session.discussion.info",
+      "sessions.companion.state",
+    ]);
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
   it("prewarms the newest three unique rendered GitHub cards after commit", async () => {
     const request = vi.fn((_method: string, params?: unknown) =>
       (params as { number?: number } | undefined)?.number === 4
@@ -92,9 +140,6 @@ describe("chat pane session hydration", () => {
       client: { request } as unknown as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: [GITHUB_PREVIEW_METHOD] },
-    } as never;
     const thread = document.createElement("div");
     thread.className = "chat-thread";
     for (const href of [

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -152,10 +152,10 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       this.deferredSessionHydrationRequestVersion === requestVersion &&
       this.connectionGeneration === connectionGeneration &&
       this.state === state &&
-      this.presented &&
       state.connected &&
       state.client === client &&
       state.sessionKey === sessionKey;
+    const isPrewarmCurrent = () => isCurrent() && this.presented;
     const scheduleAfterTranscript = () => {
       if (!isCurrent()) {
         return;
@@ -168,7 +168,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
           void this.probeSessionDiscussion(sessionKey);
           this.hydrateSessionCompanion(sessionKey);
           void this.refreshSessionPullRequests();
-          this.prewarmSessionGitHubPreviews(state, prewarmController.signal, isCurrent);
+          this.prewarmSessionGitHubPreviews(state, prewarmController.signal, isPrewarmCurrent);
         }
         complete();
       });
@@ -182,10 +182,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     isCurrent: () => boolean,
   ): void {
     const client = state.client;
-    if (
-      !client ||
-      isGatewayMethodAdvertised(this.context.gateway.snapshot, GITHUB_PREVIEW_METHOD) !== true
-    ) {
+    if (!client || signal.aborted || !isCurrent()) {
       return;
     }
     const anchors = this.querySelectorAll<HTMLAnchorElement>(

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -6,7 +6,6 @@ import type {
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
-import { parseGitHubLinkTarget } from "../../components/github-link-target.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -42,9 +41,6 @@ import {
   listDismissedChatPullRequests,
 } from "./components/chat-pull-requests.ts";
 import { scheduleChatScroll } from "./scroll.ts";
-
-const GITHUB_PREVIEW_METHOD = "controlUi.githubPreview";
-const GITHUB_PREVIEW_PREWARM_LIMIT = 3;
 
 export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
   protected githubPreviewPrewarmAbortController = new AbortController();
@@ -155,7 +151,6 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       state.connected &&
       state.client === client &&
       state.sessionKey === sessionKey;
-    const isPrewarmCurrent = () => isCurrent() && this.presented;
     const scheduleAfterTranscript = () => {
       if (!isCurrent()) {
         return;
@@ -168,64 +163,23 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
           void this.probeSessionDiscussion(sessionKey);
           this.hydrateSessionCompanion(sessionKey);
           void this.refreshSessionPullRequests();
-          this.prewarmSessionGitHubPreviews(state, prewarmController.signal, isPrewarmCurrent);
+          if (client && this.presented) {
+            void import("../../components/github-prewarm.runtime.ts").then(
+              ({ prewarm }) =>
+                prewarm(
+                  this,
+                  client,
+                  prewarmController.signal,
+                  () => isCurrent() && this.presented,
+                ),
+              () => undefined,
+            );
+          }
         }
         complete();
       });
     };
     void transcriptLoad.then(scheduleAfterTranscript, scheduleAfterTranscript);
-  }
-
-  private prewarmSessionGitHubPreviews(
-    state: ChatPageHost,
-    signal: AbortSignal,
-    isCurrent: () => boolean,
-  ): void {
-    const client = state.client;
-    if (!client || signal.aborted || !isCurrent()) {
-      return;
-    }
-    const anchors = this.querySelectorAll<HTMLAnchorElement>(
-      ".chat-thread a.markdown-github-link[href]",
-    );
-    const seen = new Set<string>();
-    const targets = [];
-    for (let index = anchors.length - 1; index >= 0; index -= 1) {
-      const target = parseGitHubLinkTarget(anchors[index]?.href ?? "");
-      if (!target) {
-        continue;
-      }
-      const key = `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;
-      if (seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-      targets.push(target);
-      if (targets.length === GITHUB_PREVIEW_PREWARM_LIMIT) {
-        break;
-      }
-    }
-    // Responses are discarded intentionally: these calls fill the Gateway-process
-    // LRU without loading the browser hovercard runtime during session startup.
-    void (async () => {
-      for (const target of targets) {
-        if (signal.aborted || !isCurrent()) {
-          return;
-        }
-        await client
-          .request(
-            GITHUB_PREVIEW_METHOD,
-            {
-              kind: target.kind,
-              number: target.number,
-              owner: target.owner,
-              repo: target.repo,
-            },
-            { signal },
-          )
-          .catch(() => undefined);
-      }
-    })();
   }
 
   protected markSessionRead(row: GatewaySessionRow | undefined) {

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -6,6 +6,7 @@ import type {
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
+import { parseGitHubLinkTarget } from "../../components/github-link-target.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -42,7 +43,12 @@ import {
 } from "./components/chat-pull-requests.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 
+const GITHUB_PREVIEW_METHOD = "controlUi.githubPreview";
+const GITHUB_PREVIEW_PREWARM_LIMIT = 3;
+
 export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
+  protected githubPreviewPrewarmAbortController = new AbortController();
+
   protected async refreshSessionPullRequests(options: { refresh?: boolean } = {}): Promise<void> {
     if (!this.presented) {
       sessionPullRequestsForGateway(this.context.gateway).unwatch(this);
@@ -136,6 +142,9 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     if (!state) {
       return;
     }
+    this.githubPreviewPrewarmAbortController.abort();
+    const prewarmController = new AbortController();
+    this.githubPreviewPrewarmAbortController = prewarmController;
     const requestVersion = ++this.deferredSessionHydrationRequestVersion;
     const connectionGeneration = this.connectionGeneration;
     const client = state.client;
@@ -143,6 +152,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       this.deferredSessionHydrationRequestVersion === requestVersion &&
       this.connectionGeneration === connectionGeneration &&
       this.state === state &&
+      this.presented &&
       state.connected &&
       state.client === client &&
       state.sessionKey === sessionKey;
@@ -158,11 +168,67 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
           void this.probeSessionDiscussion(sessionKey);
           this.hydrateSessionCompanion(sessionKey);
           void this.refreshSessionPullRequests();
+          this.prewarmSessionGitHubPreviews(state, prewarmController.signal, isCurrent);
         }
         complete();
       });
     };
     void transcriptLoad.then(scheduleAfterTranscript, scheduleAfterTranscript);
+  }
+
+  private prewarmSessionGitHubPreviews(
+    state: ChatPageHost,
+    signal: AbortSignal,
+    isCurrent: () => boolean,
+  ): void {
+    const client = state.client;
+    if (
+      !client ||
+      isGatewayMethodAdvertised(this.context.gateway.snapshot, GITHUB_PREVIEW_METHOD) !== true
+    ) {
+      return;
+    }
+    const anchors = this.querySelectorAll<HTMLAnchorElement>(
+      ".chat-thread a.markdown-github-link[href]",
+    );
+    const seen = new Set<string>();
+    const targets = [];
+    for (let index = anchors.length - 1; index >= 0; index -= 1) {
+      const target = parseGitHubLinkTarget(anchors[index]?.href ?? "");
+      if (!target) {
+        continue;
+      }
+      const key = `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      targets.push(target);
+      if (targets.length === GITHUB_PREVIEW_PREWARM_LIMIT) {
+        break;
+      }
+    }
+    // Responses are discarded intentionally: these calls fill the Gateway-process
+    // LRU without loading the browser hovercard runtime during session startup.
+    void (async () => {
+      for (const target of targets) {
+        if (signal.aborted || !isCurrent()) {
+          return;
+        }
+        await client
+          .request(
+            GITHUB_PREVIEW_METHOD,
+            {
+              kind: target.kind,
+              number: target.number,
+              owner: target.owner,
+              repo: target.repo,
+            },
+            { signal },
+          )
+          .catch(() => undefined);
+      }
+    })();
   }
 
   protected markSessionRead(row: GatewaySessionRow | undefined) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where GitHub issue and pull request hovercards could remain loading for a second or longer after opening a session, even though the relevant links were already visible in the transcript.

## Why This Change Was Made

After the authoritative transcript commits, the Control UI now prewarms the newest three unique rendered GitHub cards sequentially through the existing `controlUi.githubPreview` RPC. This reuses the Gateway's process-wide 200-entry memory LRU, preserves lazy browser hovercard loading, avoids hidden raw-transcript fetches, and cancels queued work when the pane changes session or disconnects.

## User Impact

Hovering recently visible GitHub issue and pull request links after opening a session should normally use the warmed Gateway cache instead of waiting on GitHub network requests. Prewarming is bounded, memory-only, and unavailable on older Gateways without producing errors.

## Evidence

- Focused prewarm regression covers post-commit timing, newest-first deduplication, a three-card bound, continuation after one failed preview, method gating, and stale-session cancellation.
- Existing Gateway preview tests cover shared promise caching and bounded success/failure TTL behavior.
- `git diff --check` clean.
- Oxfmt clean on all changed files.
- Autoreview: clean, 0 actionable findings, 0.98 confidence.
- Exact-head hosted CI/Testbox required before merge.

Production LOC: +67. Test LOC: +132. The production growth adds the session-open prewarm capability and lifecycle cancellation; no protocol, config, persistence, dependency, or browser hovercard-runtime surface changed.
