### PR TITLE
fix(ui): lead the Files panel with the project browser instead of a placeholder

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -21,7 +21,8 @@ const expectedColdOpenOutcomes: Record<string, ColdOpenOutcome> = {
   Review: { outcome: "generic-empty", emptyStateOffersAction: false },
   Terminal: { outcome: "content", emptyStateOffersAction: false },
   Browser: { outcome: "generic-empty", emptyStateOffersAction: true },
-  Files: { outcome: "generic-empty", emptyStateOffersAction: false },
+  // Files deliberately defaults to the project browser when the session has no items.
+  Files: { outcome: "content", emptyStateOffersAction: false },
   "Side chat": { outcome: "generic-empty", emptyStateOffersAction: false },
   Tasks: { outcome: "generic-empty", emptyStateOffersAction: false },
   Desktop: { outcome: "content", emptyStateOffersAction: false },

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -19,7 +19,6 @@ import {
   type UiSettings,
 } from "../../../app/settings.ts";
 import { icons } from "../../../components/icons.ts";
-import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
 import { t } from "../../../i18n/index.ts";
 import "../../../components/tooltip.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
@@ -1254,13 +1253,8 @@ export function renderSessionWorkspaceRail(
           ? html`<div class="chat-workspace-rail__state">${t("chat.workspaceFiles.loading")}</div>`
           : html`
               <div class="chat-workspace-rail__scroll">
-                ${!hasSessionItems
-                  ? renderPanelEmptyState({
-                      icon: icons.fileText,
-                      heading: t("chat.sidePanel.files"),
-                      description: t("chat.sidePanel.filesEmpty"),
-                    })
-                  : html`
+                ${hasSessionItems
+                  ? html`
                       ${renderWorkspaceRailSection(
                         t("chat.workspaceFiles.changed"),
                         renderFileRows(modifiedFiles),
@@ -1273,7 +1267,8 @@ export function renderSessionWorkspaceRail(
                         t("chat.workspaceFiles.artifacts"),
                         renderArtifactRows(),
                       )}
-                    `}
+                    `
+                  : nothing}
                 ${renderWorkspaceRailSection(
                   t("chat.workspaceFiles.browser"),
                   browser ? renderBrowserRows() : nothing,


### PR DESCRIPTION
## What Problem This Solves

Opening the **Files** tab on a session that had touched no files produced three separate "nothing here"
messages stacked in one panel: the summary chips reading `0 changed · 0 read · 0 artifacts · 0 shown`, a
generic centered empty state rendered *inside* the scroll area ("Files — Browse files, artifacts, and
changes from this session."), and below it the project browser with its own, more specific "No files in
this folder."

Unlike the Review dead end this panel was never silent — the rail loads eagerly — but it led with a
placeholder while the genuinely useful surface, the project file browser, was pushed below the fold.

## Why This Change Was Made

Same move the Review panel got in #124824 and the contract formalized in #125105: a panel's default state
should be a real document, not a placeholder describing what the panel would show if it had one. The
project browser is what an operator can actually use when the session has touched nothing, so it owns the
panel; the session sections (Changed / Read / Artifacts) render only when they have entries.

Judgment calls, stated for the record:

- **Zero-count chips stay.** They are a loaded-state summary, not an empty state — "0 changed" is a fact
  about the session, and keeping them avoids the panel silently changing shape as counts cross zero.
- **"No files in this folder." stays.** That message is truthful and specific about a directory, unlike the
  generic placeholder it replaces.
- **"PROJECT FILES" keeps its label**, because it still distinguishes project browsing from the session's
  Changed/Read/Artifacts sections when those appear.

## User Impact

The Files panel opens onto a usable file browser instead of a placeholder. No change to what the rail loads
or when, to the diff action, or to the workspace rail's collapsed default.

## Evidence

| Before | After |
| --- | --- |
| <img width="420" alt="Files panel with three stacked empty messages" src="https://github.com/user-attachments/assets/4f6b4578-d9df-4c3f-9080-37c4ff9389e2" /> | <img width="420" alt="Files panel led by the project browser" src="https://github.com/user-attachments/assets/782e26b6-c954-4a4d-964d-7ca7be0ab255" /> |

Captured from the mocked Control UI dev server at this commit's exact parent and at its head.

The characterization test from #124950 recorded Files as `{ outcome: "generic-empty" }`. That expectation
was one of the wrong answers it deliberately captured, and this PR flips it to `{ outcome: "content" }` with
an inline comment marking the change as intentional — so a future reader can tell a purposeful flip from
drift. Every other slot's expectation is untouched, as are `chat-session-diff.e2e.test.ts`,
`chat-sidebar-region.test.ts`, `terminal-open.e2e.test.ts`, and `chat-session-workspace.test.ts`.

```
 Test Files  3 passed (3)      Tests  13 passed (13)
 Test Files  2 passed (2)      Tests  33 passed (33)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `+4 / −9` (net **−5**), tests `+2 / −1`. The fix is a
deletion: the generic empty-state branch goes away and the session sections become conditional. Series
running total: −17 (#124950) +11 (#125019) +7 (#125105) −5 here = **net −4** in production.

No `CHANGELOG.md` edit — release-only per repo policy; user-facing context lives in this body.
