### PR TITLE
fix(discord): retain progress drafts after error finals

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -610,8 +610,9 @@ Discord YAML module scenarios (`qa/scenarios/channels/discord-*.yaml`):
 - `discord-mention-gating`
 - `discord-native-help-command-registration`
 - `discord-progress-draft-lifecycle` - runs a deterministic tool turn, verifies
-  the final answer has no synthesized activity receipt, and confirms the
-  working draft is deleted after the final lands.
+  the final answer has no synthesized activity receipt, confirms the working
+  draft is deleted after a successful final, and confirms an error final keeps
+  its draft visible as diagnostic context.
 - `discord-voice-autojoin` - opt-in voice scenario. Runs by itself, enables
   `channels.discord.voice.autoJoin`, and verifies the SUT bot's current
   Discord voice state is the target voice/stage channel. Convex Discord

--- a/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { RequestClient } from "../internal/discord.js";
+import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
+
+describe("Discord draft preview REST lifecycle", () => {
+  it("retains the progress draft after an error final is delivered", async () => {
+    const requests: string[] = [];
+    const rest = new RequestClient("test-token", {
+      queueRequests: false,
+      fetch: async (input, init) => {
+        const url = new URL(String(input));
+        requests.push(`${init?.method ?? "GET"} ${url.pathname.replace("/api/v10", "")}`);
+        if (init?.method === "POST") {
+          return Response.json({ id: "preview-error" });
+        }
+        return new Response(null, { status: 204 });
+      },
+    });
+    const controller = createDiscordDraftPreviewController({
+      cfg: {},
+      discordConfig: { streaming: { mode: "progress" } },
+      accountId: "default",
+      sourceRepliesAreToolOnly: false,
+      textLimit: 2_000,
+      deliveryRest: rest,
+      deliverChannelId: "c1",
+      replyReference: { peek: () => undefined },
+      tableMode: "off",
+      maxLinesPerMessage: undefined,
+      chunkMode: "length",
+      log: () => {},
+    });
+
+    controller.draftStream?.update("🛠️ Exec: failed");
+    await controller.flush();
+    controller.markFinalReplyStarted();
+    controller.markFinalReplyDelivered(true);
+    controller.draftStream?.update("stale pending update");
+    await controller.cleanup();
+    await controller.flush();
+
+    expect(requests).toEqual(["POST /channels/c1/messages"]);
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
@@ -8,7 +8,7 @@ describe("Discord draft preview REST lifecycle", () => {
     const rest = new RequestClient("test-token", {
       queueRequests: false,
       fetch: async (input, init) => {
-        const url = new URL(String(input));
+        const url = new URL(input instanceof Request ? input.url : input);
         requests.push(`${init?.method ?? "GET"} ${url.pathname.replace("/api/v10", "")}`);
         if (init?.method === "POST") {
           return Response.json({ id: "preview-error" });

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -89,7 +89,7 @@ export function createDiscordDraftPreviewController(params: {
   let draftText = "";
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
-  let finalReplyDelivered = false;
+  let finalReplyError: boolean | undefined;
   // Final delivery can cancel the gate before Discord consumes collapse
   // eligibility, so keep the pre-final state until that transition occurs.
   let progressDraftStartedBeforeFinal = false;
@@ -182,7 +182,7 @@ export function createDiscordDraftPreviewController(params: {
     if (beganNewTurn) {
       progressDraftCollapsed = false;
       progressDraftStartedBeforeFinal = false;
-      finalReplyDelivered = false;
+      finalReplyError = undefined;
       finalizedViaPreviewMessage = false;
       progressNarratorLifecycle?.beginTurn();
     }
@@ -232,8 +232,8 @@ export function createDiscordDraftPreviewController(params: {
       progressDraft.markFinalReplyStarted();
       progressNarratorLifecycle?.stopTurn();
     },
-    markFinalReplyDelivered() {
-      finalReplyDelivered = true;
+    markFinalReplyDelivered(isError = false) {
+      finalReplyError = isError;
       progressDraft.markFinalReplyDelivered();
     },
     markPreviewFinalized() {
@@ -414,10 +414,10 @@ export function createDiscordDraftPreviewController(params: {
     async cleanup() {
       try {
         progressDraft.cancel();
-        if (!finalReplyDelivered) {
+        if (finalReplyError !== false) {
           await draftStream?.discardPending();
         }
-        if (!finalizedViaPreviewMessage && draftStream?.messageId()) {
+        if (finalReplyError !== true && !finalizedViaPreviewMessage && draftStream?.messageId()) {
           await draftStream.clear();
         }
         await draftStream?.cleanupRetargeted();

--- a/extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts
@@ -256,7 +256,7 @@ describe("processDiscordMessage draft streaming recovery", () => {
     });
   });
 
-  it("does not flush draft previews for error finals before normal delivery", async () => {
+  it("retains draft previews after error finals are delivered", async () => {
     const draftStream = await runFinalReplyScenario({
       text: "Something failed",
       isError: true,
@@ -264,7 +264,7 @@ describe("processDiscordMessage draft streaming recovery", () => {
 
     expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -219,12 +219,14 @@ async function processDiscordMessageInner(
   let pendingToolWarningFinal:
     | { payload: ReplyPayload; info: { kind: ReplyDispatchKind } }
     | undefined;
-  const markUserFacingFinalDelivered = () => {
-    userFacingFinalDelivered = true;
-    userFacingFinalDeliveryFailed = false;
-    pendingToolWarningFinal = undefined;
-    draftPreview.markFinalReplyDelivered();
-    observer?.onFinalReplyDelivered?.();
+  const markFinalReplyDelivered = (isError = false) => {
+    draftPreview.markFinalReplyDelivered(isError);
+    if (!isError) {
+      userFacingFinalDelivered = true;
+      userFacingFinalDeliveryFailed = false;
+      pendingToolWarningFinal = undefined;
+      observer?.onFinalReplyDelivered?.();
+    }
   };
   // Set when a progress draft collapses: the draft message deletes once the
   // final answer has actually delivered.
@@ -432,7 +434,7 @@ async function processDiscordMessageInner(
             });
           },
           onPreviewFinalized: () => {
-            markUserFacingFinalDelivered();
+            markFinalReplyDelivered();
             draftPreview.markPreviewFinalized();
             replyReference.markSent();
           },
@@ -483,7 +485,7 @@ async function processDiscordMessageInner(
           return deliveryResult.visibleReplySent;
         },
         onNormalDelivered: () => {
-          markUserFacingFinalDelivered();
+          markFinalReplyDelivered();
           replyReference.markSent();
         },
       });
@@ -533,9 +535,9 @@ async function processDiscordMessageInner(
       return result;
     }
     replyReference.markSent();
-    if (isFinal && deliverablePayload.isError !== true) {
-      markUserFacingFinalDelivered();
-      if (clearProgressDraftAfterFinalDelivery) {
+    if (isFinal) {
+      markFinalReplyDelivered(deliverablePayload.isError === true);
+      if (deliverablePayload.isError !== true && clearProgressDraftAfterFinalDelivery) {
         clearProgressDraftAfterFinalDelivery = false;
         // Commit only after Discord accepted the final. A failed send leaves
         // the draft intact as the visible record for the queued retry.
@@ -673,7 +675,7 @@ async function processDiscordMessageInner(
           logVerbose(`discord: failed to finalize adopted thread progress (${String(error)})`);
         }
       }
-      markUserFacingFinalDelivered();
+      markFinalReplyDelivered();
     }
   } catch (err) {
     if (isProcessAborted(abortSignal)) {

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
@@ -53,6 +53,8 @@ export type DiscordQaScenarioRun =
     }
   | {
       kind: "progress-draft-lifecycle";
+      errorFinalText: string;
+      errorInput: string;
       finalMarker: string;
       input: string;
       progressLabel: string;
@@ -295,6 +297,12 @@ export const discordQaProgressDraftLifecycleScenario: DiscordQaScenarioImplement
     const finalMarker = `DISCORD_QA_PROGRESS_FINAL_${suffix}`;
     return {
       kind: "progress-draft-lifecycle",
+      errorFinalText:
+        "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.",
+      errorInput: [
+        `<@${sutApplicationId}> Tool progress QA check: Provider HTTP 503 after tool QA check:`,
+        "call the exec tool exactly once with this exact command before answering: `sleep 5`.",
+      ].join(" "),
       finalMarker,
       progressLabel: `Discord progress QA ${suffix}`,
       input: [

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
@@ -297,8 +297,7 @@ export const discordQaProgressDraftLifecycleScenario: DiscordQaScenarioImplement
     const finalMarker = `DISCORD_QA_PROGRESS_FINAL_${suffix}`;
     return {
       kind: "progress-draft-lifecycle",
-      errorFinalText:
-        "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.",
+      errorFinalText: "The AI service is temporarily overloaded. Please try again in a moment.",
       errorInput: [
         `<@${sutApplicationId}> Tool progress QA check: Provider HTTP 503 after tool QA check:`,
         "call the exec tool exactly once with this exact command before answering: `sleep 5`.",

--- a/extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
@@ -75,52 +75,57 @@ export async function runDiscordScenario(
   if (run.kind === "progress-draft-lifecycle") {
     const deadline = Date.now() + scenario.timeoutMs;
     const remainingMs = () => Math.max(1, deadline - Date.now());
-    const sent = await discordQaScenarioSupport.testing.sendChannelMessage(
-      environment.runtimeEnv.driverBotToken,
-      environment.runtimeEnv.channelId,
-      run.input,
-    );
-    const draft = await discordQaScenarioSupport.testing.pollChannelMessages({
-      token: environment.runtimeEnv.driverBotToken,
-      channelId: environment.runtimeEnv.channelId,
-      afterSnowflake: sent.id,
-      timeoutMs: remainingMs(),
-      observedMessages: environment.observedMessages,
-      observationScenarioId: scenario.id,
-      observationScenarioTitle: scenario.title,
-      triggerMessageId: sent.id,
-      triggerTimestamp: sent.timestamp,
-      predicate: (message) => message.senderId === environment.sutIdentity.id,
-    });
-    await discordQaScenarioSupport.testing.waitForDiscordMessageText({
-      token: environment.runtimeEnv.driverBotToken,
-      channelId: environment.runtimeEnv.channelId,
-      messageId: draft.message.messageId,
-      textIncludes: [run.progressLabel, "🛠️ Exec"],
-      timeoutMs: remainingMs(),
-    });
-    const final = await discordQaScenarioSupport.testing.pollChannelMessages({
-      token: environment.runtimeEnv.driverBotToken,
-      channelId: environment.runtimeEnv.channelId,
-      afterSnowflake: draft.message.messageId,
-      timeoutMs: remainingMs(),
-      observedMessages: environment.observedMessages,
-      observationScenarioId: scenario.id,
-      observationScenarioTitle: scenario.title,
-      triggerMessageId: sent.id,
-      triggerTimestamp: sent.timestamp,
-      predicate: (message) =>
-        message.senderId === environment.sutIdentity.id && message.text.includes(run.finalMarker),
-    });
-    discordQaScenarioSupport.testing.assertDiscordScenarioReply({
-      expectedTextIncludes: [run.finalMarker],
-      message: final.message,
-    });
+    const observeProgressTurn = async (input: string, finalText: string) => {
+      const sent = await discordQaScenarioSupport.testing.sendChannelMessage(
+        environment.runtimeEnv.driverBotToken,
+        environment.runtimeEnv.channelId,
+        input,
+      );
+      const draft = await discordQaScenarioSupport.testing.pollChannelMessages({
+        token: environment.runtimeEnv.driverBotToken,
+        channelId: environment.runtimeEnv.channelId,
+        afterSnowflake: sent.id,
+        timeoutMs: remainingMs(),
+        observedMessages: environment.observedMessages,
+        observationScenarioId: scenario.id,
+        observationScenarioTitle: scenario.title,
+        triggerMessageId: sent.id,
+        triggerTimestamp: sent.timestamp,
+        predicate: (message) => message.senderId === environment.sutIdentity.id,
+      });
+      await discordQaScenarioSupport.testing.waitForDiscordMessageText({
+        token: environment.runtimeEnv.driverBotToken,
+        channelId: environment.runtimeEnv.channelId,
+        messageId: draft.message.messageId,
+        textIncludes: [run.progressLabel, "🛠️ Exec"],
+        timeoutMs: remainingMs(),
+      });
+      const final = await discordQaScenarioSupport.testing.pollChannelMessages({
+        token: environment.runtimeEnv.driverBotToken,
+        channelId: environment.runtimeEnv.channelId,
+        afterSnowflake: draft.message.messageId,
+        timeoutMs: remainingMs(),
+        observedMessages: environment.observedMessages,
+        observationScenarioId: scenario.id,
+        observationScenarioTitle: scenario.title,
+        triggerMessageId: sent.id,
+        triggerTimestamp: sent.timestamp,
+        predicate: (message) =>
+          message.senderId === environment.sutIdentity.id && message.text.includes(finalText),
+      });
+      discordQaScenarioSupport.testing.assertDiscordScenarioReply({
+        expectedTextIncludes: [finalText],
+        message: final.message,
+      });
+      return { draft, final };
+    };
+
+    const success = await observeProgressTurn(run.input, run.finalMarker);
     const forbiddenReceipt = [
       /(?:^|\n)-#(?:\s|$)/u,
       /🛠️\s*\d+\s+tool calls?/iu,
       /⏱️\s*\d+(?:\.\d+)?s\b/u,
-    ].find((pattern) => pattern.test(final.message.text));
+    ].find((pattern) => pattern.test(success.final.message.text));
     if (forbiddenReceipt) {
       throw new Error(
         `Discord final reply retained synthesized activity receipt ${forbiddenReceipt}`,
@@ -129,10 +134,25 @@ export async function runDiscordScenario(
     await discordQaScenarioSupport.testing.waitForDiscordMessageDeleted({
       token: environment.runtimeEnv.driverBotToken,
       channelId: environment.runtimeEnv.channelId,
-      messageId: draft.message.messageId,
+      messageId: success.draft.message.messageId,
       timeoutMs: remainingMs(),
     });
-    return { details: "progress draft observed; receipt-free final landed; draft deleted" };
+
+    const failed = await observeProgressTurn(run.errorInput, run.errorFinalText);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1_500);
+    });
+    await discordQaScenarioSupport.testing.waitForDiscordMessageText({
+      token: environment.runtimeEnv.driverBotToken,
+      channelId: environment.runtimeEnv.channelId,
+      messageId: failed.draft.message.messageId,
+      textIncludes: [run.progressLabel, "🛠️ Exec"],
+      timeoutMs: remainingMs(),
+    });
+    return {
+      details:
+        "success draft deleted after receipt-free final; error final landed with draft retained",
+    };
   }
   const sent = await discordQaScenarioSupport.testing.sendChannelMessage(
     environment.runtimeEnv.driverBotToken,

--- a/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
+++ b/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
@@ -5,6 +5,15 @@ scenario:
   coverage:
     primary:
       - agent-runtime.streaming-replies-delivery
+  gatewayConfigPatch:
+    agents:
+      defaults:
+        model:
+          fallbacks: []
+      entries:
+        qa:
+          model:
+            fallbacks: []
   regressionRefs:
     - openclaw/openclaw#124972
   objective: Verify Discord retires successful progress drafts without altering the final and retains failed-turn drafts as diagnostic context.

--- a/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
+++ b/qa/scenarios/channels/discord-progress-draft-lifecycle.yaml
@@ -1,4 +1,4 @@
-title: Discord progress draft retires after a receipt-free final
+title: Discord progress draft finalization
 scenario:
   id: discord-progress-draft-lifecycle
   surface: channels
@@ -7,11 +7,12 @@ scenario:
       - agent-runtime.streaming-replies-delivery
   regressionRefs:
     - openclaw/openclaw#124972
-  objective: Verify a real Discord tool-progress draft stays transient and does not synthesize activity into the final answer.
+  objective: Verify Discord retires successful progress drafts without altering the final and retains failed-turn drafts as diagnostic context.
   successCriteria:
     - A tool-using turn creates a visible Discord progress draft while the tool is running.
     - The final answer contains no tool-count, elapsed-time, or Discord subtext receipt.
     - The working draft is deleted only after the final answer lands.
+    - A delivered error final leaves its working draft visible.
   codeRefs:
     - extensions/discord/src/monitor/message-handler.process.ts
     - extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -24,7 +25,7 @@ scenario:
     timeoutMs: 90000
     retryCount: 0
     suiteIsolation: isolated
-    isolationReason: Enables Discord progress streaming and observes one real draft create/final/delete lifecycle.
+    isolationReason: Enables Discord progress streaming and observes successful and failed draft finalization.
 flow:
   module: ./live-transports/discord/scenario-runtime.js
   call: runDiscordScenario


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord users lost the visible progress draft after a turn ended with a delivered error final. The final error message still appeared, but the tool/progress context that explained the failed turn was deleted, contradicting the shipped streaming contract.

Related: #124972

## Why This Change Was Made

The cleanup owner only tracked whether a normal final had been delivered. Error finals correctly skipped the intentional success collapse, but the unconditional cleanup path still treated their draft as unfinished and cleared it through the Discord REST delete boundary.

The Discord draft-preview controller now records one terminal cleanup outcome from the existing `deliverablePayload.isError` decision: pending, successful final, or error final. Cleanup still discards pending updates for error finals, but skips only the remote clear. `finalizedViaPreviewMessage` remains reserved for the distinct invariant that the preview itself became the delivered final; no parallel retain flag was added.

The existing recovery test that required `clear()` once for an error final encoded the defect. It now requires pending updates to be discarded and the draft not to be cleared. A permanent real-REST regression covers the full draft stream boundary.

Sibling audit:

- Telegram does not use the shared finalizable lifecycle and intentionally retires progress drafts at completion before normal error delivery.
- Slack progress mode already terminalizes and retains its error card; its non-progress preview cleanup is a separate intentional path.
- WhatsApp has no editable preview draft and suppresses error payload delivery.
- Mattermost uses the shared lifecycle but intentionally clears the preview before normal error delivery, as documented and tested. This PR leaves that channel-specific contract unchanged.

Production LOC: +20/-18 (net +2). Tests/test support: +131/-49. Docs: +3/-2. The two net production lines are the owner-boundary outcome propagation needed to replace the insufficient delivered boolean without duplicating retention state.

Provenance: the invariant mismatch dates to #22111 (`09e69703860367cf9ef29c37d8adce71ed1f7f15`, 2026-02-20), authored and merged by @thewilloftheshadow. #124972 carried it forward; its parent already reproduced the delete. #125089 explicitly documented error-final retention as the missing QA case.

## User Impact

When a Discord turn fails after showing progress, users now keep both the delivered error final and the existing progress draft. The draft remains useful diagnostic context, while successful turns continue deleting their transient draft after the final lands.

## Evidence

Pre-fix REST-boundary regression on `ac5c8be00196bad2fca0f87b756c859efa8aae89`:

```text
Expected:
  POST /channels/c1/messages
Received:
  POST /channels/c1/messages
  DELETE /channels/c1/messages/preview-error
```

Post-fix proof:

- `node scripts/run-vitest.mjs extensions/discord`: 222 files, 2,766 tests passed.
- `node scripts/run-vitest.mjs extensions/qa-lab`: 197 files, 2,721 passed and 2 skipped.
- Focused Telegram, Slack, WhatsApp, and Mattermost policy tests: 4 files, 254 tests passed.
- Real REST regression now observes only `POST /channels/c1/messages`; a queued stale update is also discarded without a PATCH.
- Discord QA scenario now defines a second deterministic post-tool HTTP 503 turn, disables fallback replay for that fixture, verifies the sanitized error final lands, then verifies the original draft remains GET-visible. The full local qa-lab suite passed this scenario contract.
- `node scripts/check-changed.mjs`: 24 lanes passed through Daytona; its resource-limited `2x4x10` sandbox terminated `tsgo:core` after 1,166.97 seconds without compiler diagnostics. Local fallback via the same repo wrappers passed core, extension production, and extension test typechecks, plus changed-file oxlint and `git diff --check`. Remote run: https://crabbox.openclaw.ai/portal/runs/run_1f1cb2b63153
- Autoreview: clean, no accepted/actionable findings.

Live/CI gap: the first live Discord run exposed that the QA base config recovered through its alternate mock model, so this scenario now disables fallbacks just like the canonical post-tool 503 scenario. The corrected live run could not reach the scenario because its required private-QA build failed on the same pre-existing Linux Control UI gzip budget that fails current `main`: PR 338,728/338,752 B and current-main 338,737 B versus a 338,567 B limit. The single permitted unrelated `build-artifacts` rerun failed identically. No UI code or baseline was changed in this PR.

- Current-main proof: https://github.com/openclaw/openclaw/actions/runs/32007030955
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32007833233
- Corrected live QA attempt (blocked in build before scenario): https://github.com/openclaw/openclaw/actions/runs/32007839206
