### PR TITLE
feat(cli): let agent exec select a configured agent

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2498,7 +2498,7 @@ src/cli/update-cli/update-command-config.ts	6
 src/cli/update-cli/update-command-plugins.ts	1
 src/cli/update-cli/update-command-post-update.ts	2
 src/cli/users-cli.ts	1
-src/commands/agent-exec.ts	6
+src/commands/agent-exec.ts	5
 src/commands/agent-via-gateway.ts	11
 src/commands/agents.commands.bind.ts	5
 src/commands/agents.commands.identity.ts	1

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -22,11 +22,12 @@ Related: [Agent send tool](/tools/agent-send)
 
 ```bash
 openclaw agent exec "Run the focused tests and fix failures"
+openclaw agent exec --agent ops "Run the focused tests and fix failures"
 openclaw agent exec --message-file task.md --cwd ./repo
 cat task.md | openclaw agent exec --message-file - --json
 ```
 
-By default, the command creates and later removes a temporary state directory, and it runs against your ordinary OpenClaw config, so configured providers, credentials, and `agentRuntime` harness selection apply exactly as they do elsewhere. `--cwd` defaults to the process working directory and is passed as both the agent workspace and tool working directory.
+By default, the command creates and later removes a temporary state directory, and it runs against your ordinary OpenClaw config, so configured providers, credentials, and `agentRuntime` harness selection apply exactly as they do elsewhere. Without `--agent`, `--cwd` defaults to the process working directory. With `--agent <id>`, the selected agent supplies the runtime, stored credentials, and default workspace; an explicit `--cwd` still overrides that workspace. The resolved directory is passed as both the agent workspace and tool working directory.
 
 Config is layered in three parts, entirely in memory: exec composes the run config and publishes it as this process's runtime config rather than writing a copy to disk. Exec defaults apply only where your config leaves a setting unset: workspace bootstrap files are skipped, the agent sandbox is off, the `coding` tool profile is selected, filesystem tools are restricted to `--cwd`, and exec runs under the full execution policy a headless turn needs. Anything your config sets wins over those defaults, so a configured sandbox, shell env, or tool profile is never downgraded, and exec host routing stays with the sandbox when your config enables one. The invocation itself always wins last: the run is scoped to `--cwd` and never bootstraps.
 
@@ -113,6 +114,7 @@ This is evaluation-only evidence, not a CI or release gate. Results do not chang
 
 - `[message]`: positional prompt text
 - `--message-file <path>`: read a UTF-8 prompt from a file; `-` reads stdin
+- `--agent <id>`: use a configured agent's runtime, credentials, and workspace
 - `--cwd <dir>`: set both the agent workspace and tool working directory
 - `--state-dir <dir>`: use an existing state directory without deleting it
 - `--config <path>`: run against this config file instead of the ambient config (JSON5 and `$include` supported)

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
+import { inheritOptionFromParent } from "../command-options.js";
 import { measureCliCommandStartup } from "../command-startup-timing.js";
 import { formatHelpExamples } from "../help-format.js";
 import { requestExitAfterOneShotOutput } from "../one-shot-exit.js";
@@ -132,6 +133,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .command("exec [message]")
     .description("Run one isolated headless embedded agent turn")
     .option("--message-file <path>", "Read the UTF-8 prompt from a file; use - for stdin")
+    .option("--agent <id>", "Use a configured agent's runtime, workspace, and credentials")
     .option("--cwd <dir>", "Set both the agent workspace and tool working directory")
     .option("--state-dir <dir>", "Use an existing state directory without deleting it")
     .option(
@@ -162,6 +164,10 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ['openclaw agent exec "Fix the failing test"', "Run in the current directory."],
           [
+            'openclaw agent exec --agent ops "Fix the failing test"',
+            "Run with a configured agent.",
+          ],
+          [
             "openclaw agent exec --message-file task.md --cwd ./repo",
             "Read a prompt file and set the workspace.",
           ],
@@ -187,6 +193,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
         | undefined;
       const execOpts = {
         ...opts,
+        agent: opts.agent ?? inheritOptionFromParent<string>(command, "agent"),
         messageFile: opts.messageFile ?? parentOpts?.messageFile,
         model: opts.model ?? parentOpts?.model,
         thinking: opts.thinking ?? parentOpts?.thinking,

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -262,6 +262,19 @@ describe("agent command registration", () => {
     );
   });
 
+  it.each([
+    ["before", ["agent", "--agent", "ops", "exec", "fix it"]],
+    ["after", ["agent", "exec", "--agent", "ops", "fix it"]],
+  ])("accepts an explicit agent %s the nested exec command", async (_position, args) => {
+    await runCli(args);
+
+    expect(agentExecCommandMock).toHaveBeenCalledWith(
+      "fix it",
+      expect.objectContaining({ agent: "ops" }),
+      runtime,
+    );
+  });
+
   it("runs agents add and detects explicit automation options", async () => {
     await runCli(["agents", "add", "alpha"]);
     const [alphaOptions, alphaRuntime, alphaFlags] = commandCall(agentsAddCommandMock, 0);

--- a/src/commands/agent-exec-config-isolation.ts
+++ b/src/commands/agent-exec-config-isolation.ts
@@ -1,15 +1,17 @@
-import type { AgentConfig } from "../config/types.agents.js";
+import type { AgentConfig, AgentEntryConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-function stripInheritedAgentLocation<T extends Pick<AgentConfig, "agentDir" | "runtime">>(
-  entry: T,
-): T {
+function stripInheritedAgentLocation(entry: AgentConfig): AgentConfig;
+function stripInheritedAgentLocation(entry: AgentEntryConfig): AgentEntryConfig;
+function stripInheritedAgentLocation(
+  entry: AgentConfig | AgentEntryConfig,
+): AgentConfig | AgentEntryConfig {
   const { agentDir: _agentDir, runtime, ...rest } = entry;
   if (runtime?.type !== "acp" || runtime.acp?.cwd === undefined) {
-    return { ...rest, ...(runtime ? { runtime } : {}) } as T;
+    return { ...rest, ...(runtime ? { runtime } : {}) };
   }
   const { cwd: _cwd, ...acp } = runtime.acp;
-  return { ...rest, runtime: { ...runtime, acp } } as T;
+  return { ...rest, runtime: { ...runtime, acp } };
 }
 
 /** Drops persistent locations that an isolated one-shot run cannot own. */
@@ -39,5 +41,5 @@ export function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConf
   return {
     ...withoutSessionStore,
     agents: { ...agents, ...roster },
-  } as OpenClawConfig;
+  };
 }

--- a/src/commands/agent-exec-config-isolation.ts
+++ b/src/commands/agent-exec-config-isolation.ts
@@ -1,0 +1,43 @@
+import type { AgentConfig } from "../config/types.agents.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+function stripInheritedAgentLocation<T extends Pick<AgentConfig, "agentDir" | "runtime">>(
+  entry: T,
+): T {
+  const { agentDir: _agentDir, runtime, ...rest } = entry;
+  if (runtime?.type !== "acp" || runtime.acp?.cwd === undefined) {
+    return { ...rest, ...(runtime ? { runtime } : {}) } as T;
+  }
+  const { cwd: _cwd, ...acp } = runtime.acp;
+  return { ...rest, runtime: { ...runtime, acp } } as T;
+}
+
+/** Drops persistent locations that an isolated one-shot run cannot own. */
+export function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
+  const { session, ...root } = base;
+  const { store: _store, ...sessionWithoutStore } = session ?? {};
+  const withoutSessionStore = session ? { ...root, session: sessionWithoutStore } : base;
+  const agents = withoutSessionStore.agents;
+  if (!agents) {
+    return withoutSessionStore;
+  }
+  const entries = agents.entries;
+  const list = agents.list;
+  const roster =
+    entries !== undefined
+      ? {
+          entries: Object.fromEntries(
+            Object.entries(entries).map(([id, entry]) => [id, stripInheritedAgentLocation(entry)]),
+          ),
+        }
+      : list !== undefined
+        ? { list: list.map((entry) => stripInheritedAgentLocation(entry)) }
+        : undefined;
+  if (!roster) {
+    return withoutSessionStore;
+  }
+  return {
+    ...withoutSessionStore,
+    agents: { ...agents, ...roster },
+  } as OpenClawConfig;
+}

--- a/src/commands/agent-exec-plugin.e2e.test.ts
+++ b/src/commands/agent-exec-plugin.e2e.test.ts
@@ -50,7 +50,7 @@ async function writeHarnessPlugin(
             : { supported: false },
           async runAttempt(params) {
             const text = params.agentId === "beta"
-              ? "SELECTED_AGENT_OK agent=" + params.agentId + " workspace=" + params.workspaceDir
+              ? "SELECTED_AGENT_OK agent=" + params.agentId + " workspace=" + params.workspaceDir + " agentDir=" + params.agentDir
               : "PLUGIN_HARNESS_OK";
             const assistant = {
               role: "assistant",
@@ -146,18 +146,21 @@ function buildExecProofConfig(): OpenClawConfig {
 function buildSelectedAgentExecProofConfig(params: {
   alphaWorkspace: string;
   betaWorkspace: string;
+  betaAgentDir: string;
 }): OpenClawConfig {
   return {
     ...buildExecProofConfig(),
     agents: {
       ownership: "explicit",
-      entries: {
-        alpha: { workspace: params.alphaWorkspace },
-        beta: {
+      list: [
+        { id: "alpha", workspace: params.alphaWorkspace },
+        {
+          id: "beta",
           workspace: params.betaWorkspace,
+          agentDir: params.betaAgentDir,
           model: "exec-proof/proof-model",
         },
-      },
+      ],
     },
   };
 }
@@ -169,9 +172,15 @@ async function writeConfig(
   await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify(config), "utf8");
 }
 
-function buildCliSource(args: string[]): string {
+function buildCliSource(args: string[], runtimeConfig?: OpenClawConfig): string {
   return `
     import { runMainOrRootHelp } from "./src/entry.ts";
+    ${
+      runtimeConfig
+        ? `const { setRuntimeConfigSnapshot } = await import("./src/config/io.ts");
+    setRuntimeConfigSnapshot(${JSON.stringify(runtimeConfig)});`
+        : ""
+    }
     await runMainOrRootHelp(${JSON.stringify(["node", "openclaw", ...args])});
   `;
 }
@@ -195,25 +204,33 @@ describe("agent exec installed plugin isolation", () => {
     const stateDir = tempDirs.make("openclaw-agent-exec-selected-plugin-e2e-");
     const alphaWorkspace = path.join(stateDir, "workspaces", "alpha");
     const betaWorkspace = path.join(stateDir, "workspaces", "beta");
+    const betaAgentDir = path.join(stateDir, "persistent-agents", "beta");
     const overrideWorkspace = path.join(stateDir, "workspaces", "override");
     await Promise.all(
-      [alphaWorkspace, betaWorkspace, overrideWorkspace].map((dir) =>
+      [alphaWorkspace, betaWorkspace, betaAgentDir, overrideWorkspace].map((dir) =>
         fs.mkdir(dir, { recursive: true }),
       ),
     );
-    const config = buildSelectedAgentExecProofConfig({ alphaWorkspace, betaWorkspace });
+    const config = buildSelectedAgentExecProofConfig({
+      alphaWorkspace,
+      betaWorkspace,
+      betaAgentDir,
+    });
     await writeHarnessPlugin(stateDir, config);
     await writeConfig(stateDir, config);
-    const source = buildCliSource([
-      "agent",
-      "exec",
-      "prove selected agent",
-      "--agent",
-      "beta",
-      "--cwd",
-      overrideWorkspace,
-      "--json",
-    ]);
+    const source = buildCliSource(
+      [
+        "agent",
+        "exec",
+        "prove selected agent",
+        "--agent",
+        "beta",
+        "--cwd",
+        overrideWorkspace,
+        "--json",
+      ],
+      config,
+    );
 
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
@@ -226,13 +243,23 @@ describe("agent exec installed plugin isolation", () => {
       },
     );
     expect(stdout, stderr).not.toBe("");
-    expect(JSON.parse(stdout)).toMatchObject({
+    const output = JSON.parse(stdout) as { final: string } & Record<string, unknown>;
+    expect(output).toMatchObject({
       ok: true,
       status: "ok",
-      final: `SELECTED_AGENT_OK agent=beta workspace=${overrideWorkspace}`,
       model: "proof-model",
       provider: "exec-proof",
     });
+    const finalPrefix = `SELECTED_AGENT_OK agent=beta workspace=${overrideWorkspace} agentDir=`;
+    expect(output.final.startsWith(finalPrefix)).toBe(true);
+    const isolatedAgentDir = output.final.slice(finalPrefix.length);
+    expect(path.resolve(isolatedAgentDir)).not.toBe(path.resolve(betaAgentDir));
+    expect(path.basename(isolatedAgentDir)).toBe("agent");
+    expect(path.basename(path.dirname(isolatedAgentDir))).toBe("beta");
+    expect(path.basename(path.dirname(path.dirname(isolatedAgentDir)))).toBe("agents");
+    expect(path.basename(path.dirname(path.dirname(path.dirname(isolatedAgentDir))))).toMatch(
+      /^openclaw-agent-exec-/u,
+    );
   });
 
   it("runs an operator-installed harness without retaining run state", async () => {

--- a/src/commands/agent-exec-plugin.e2e.test.ts
+++ b/src/commands/agent-exec-plugin.e2e.test.ts
@@ -10,7 +10,10 @@ import { writePersistedInstalledPluginIndexInstallRecords } from "../plugins/ins
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-async function writeHarnessPlugin(stateDir: string): Promise<void> {
+async function writeHarnessPlugin(
+  stateDir: string,
+  config: OpenClawConfig = buildExecProofConfig(),
+): Promise<void> {
   const pluginDir = path.join(stateDir, "extensions", "exec-proof");
   await fs.mkdir(pluginDir, { recursive: true });
   await fs.writeFile(
@@ -45,8 +48,10 @@ async function writeHarnessPlugin(stateDir: string): Promise<void> {
           supports: ({ provider }) => provider === "exec-proof"
             ? { supported: true, priority: 100 }
             : { supported: false },
-          async runAttempt() {
-            const text = "PLUGIN_HARNESS_OK";
+          async runAttempt(params) {
+            const text = params.agentId === "beta"
+              ? "SELECTED_AGENT_OK agent=" + params.agentId + " workspace=" + params.workspaceDir
+              : "PLUGIN_HARNESS_OK";
             const assistant = {
               role: "assistant",
               content: [{ type: "text", text }],
@@ -95,7 +100,7 @@ async function writeHarnessPlugin(stateDir: string): Promise<void> {
     },
     {
       stateDir,
-      config: buildExecProofConfig(),
+      config,
       candidates: [
         {
           idHint: "exec-proof",
@@ -138,12 +143,30 @@ function buildExecProofConfig(): OpenClawConfig {
   };
 }
 
-async function writeConfig(stateDir: string): Promise<void> {
-  await fs.writeFile(
-    path.join(stateDir, "openclaw.json"),
-    JSON.stringify(buildExecProofConfig()),
-    "utf8",
-  );
+function buildSelectedAgentExecProofConfig(params: {
+  alphaWorkspace: string;
+  betaWorkspace: string;
+}): OpenClawConfig {
+  return {
+    ...buildExecProofConfig(),
+    agents: {
+      ownership: "explicit",
+      entries: {
+        alpha: { workspace: params.alphaWorkspace },
+        beta: {
+          workspace: params.betaWorkspace,
+          model: "exec-proof/proof-model",
+        },
+      },
+    },
+  };
+}
+
+async function writeConfig(
+  stateDir: string,
+  config: OpenClawConfig = buildExecProofConfig(),
+): Promise<void> {
+  await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify(config), "utf8");
 }
 
 function buildCliSource(args: string[]): string {
@@ -153,22 +176,71 @@ function buildCliSource(args: string[]): string {
   `;
 }
 
+function buildChildEnv(stateDir: string): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    OPENCLAW_STATE_DIR: stateDir,
+  };
+  delete childEnv.NODE_ENV;
+  delete childEnv.OPENCLAW_RUN_NODE_OUTPUT_LOG;
+  delete childEnv.VITEST;
+  delete childEnv.VITEST_POOL_ID;
+  delete childEnv.VITEST_WORKER_ID;
+  return childEnv;
+}
+
 describe("agent exec installed plugin isolation", () => {
+  it("completes a selected-agent run and preserves explicit cwd precedence", async () => {
+    const stateDir = tempDirs.make("openclaw-agent-exec-selected-plugin-e2e-");
+    const alphaWorkspace = path.join(stateDir, "workspaces", "alpha");
+    const betaWorkspace = path.join(stateDir, "workspaces", "beta");
+    const overrideWorkspace = path.join(stateDir, "workspaces", "override");
+    await Promise.all(
+      [alphaWorkspace, betaWorkspace, overrideWorkspace].map((dir) =>
+        fs.mkdir(dir, { recursive: true }),
+      ),
+    );
+    const config = buildSelectedAgentExecProofConfig({ alphaWorkspace, betaWorkspace });
+    await writeHarnessPlugin(stateDir, config);
+    await writeConfig(stateDir, config);
+    const source = buildCliSource([
+      "agent",
+      "exec",
+      "prove selected agent",
+      "--agent",
+      "beta",
+      "--cwd",
+      overrideWorkspace,
+      "--json",
+    ]);
+
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", source],
+      {
+        cwd: path.resolve(import.meta.dirname, "../.."),
+        encoding: "utf8",
+        env: buildChildEnv(stateDir),
+        timeout: 30_000,
+      },
+    );
+    expect(stdout, stderr).not.toBe("");
+    expect(JSON.parse(stdout)).toMatchObject({
+      ok: true,
+      status: "ok",
+      final: `SELECTED_AGENT_OK agent=beta workspace=${overrideWorkspace}`,
+      model: "proof-model",
+      provider: "exec-proof",
+    });
+  });
+
   it("runs an operator-installed harness without retaining run state", async () => {
     const stateDir = tempDirs.make("openclaw-agent-exec-plugin-e2e-");
     await writeHarnessPlugin(stateDir);
     await writeConfig(stateDir);
     const source = buildCliSource(["agent", "exec", "prove plugin discovery", "--json"]);
-    const childEnv: NodeJS.ProcessEnv = {
-      ...process.env,
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      OPENCLAW_STATE_DIR: stateDir,
-    };
-    delete childEnv.NODE_ENV;
-    delete childEnv.OPENCLAW_RUN_NODE_OUTPUT_LOG;
-    delete childEnv.VITEST;
-    delete childEnv.VITEST_POOL_ID;
-    delete childEnv.VITEST_WORKER_ID;
+    const childEnv = buildChildEnv(stateDir);
 
     const { stdout, stderr } = await execFileAsync(
       process.execPath,

--- a/src/commands/agent-exec.agent-owner.test.ts
+++ b/src/commands/agent-exec.agent-owner.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { loadAuthProfileStoreForRuntime, saveAuthProfileStore } from "../agents/auth-profiles.js";
+import { getRuntimeConfigSnapshot } from "../config/io.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { resolveSqliteScope } from "../config/sessions/session-accessor.sqlite-scope.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -20,6 +22,177 @@ afterEach(() => {
 });
 
 describe("agent exec owner selection", () => {
+  it("uses an explicitly selected agent's workspace, runtime, and credentials", async () => {
+    const configRoot = tempDirs.make("openclaw-agent-exec-selected-agent-");
+    const configPath = path.join(configRoot, "openclaw.json");
+    const alphaWorkspace = path.join(configRoot, "workspaces", "alpha");
+    const betaWorkspace = path.join(configRoot, "workspaces", "beta");
+    const alphaAgentDir = path.join(configRoot, "agents", "alpha");
+    const betaAgentDir = path.join(configRoot, "agents", "beta");
+    await Promise.all(
+      [alphaWorkspace, betaWorkspace, alphaAgentDir, betaAgentDir].map((dir) =>
+        fs.mkdir(dir, { recursive: true }),
+      ),
+    );
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: {
+            alpha: {
+              workspace: alphaWorkspace,
+              agentDir: alphaAgentDir,
+              runtime: { type: "embedded" },
+            },
+            beta: {
+              workspace: betaWorkspace,
+              agentDir: betaAgentDir,
+              runtime: { type: "acp", acp: { agent: "codex" } },
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:alpha": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "alpha-access",
+            refresh: "alpha-refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      alphaAgentDir,
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:beta": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "beta-access",
+            refresh: "beta-refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      betaAgentDir,
+    );
+    let selectedOptions: Record<string, unknown> | undefined;
+    let selectedProfileIds: string[] = [];
+    let selectedRuntime: unknown;
+    const runAgent = vi.fn(async (options: Record<string, unknown>) => {
+      selectedOptions = options;
+      selectedProfileIds = Object.keys(
+        loadAuthProfileStoreForRuntime(undefined, {
+          allowKeychainPrompt: false,
+          syncExternalCli: false,
+        }).profiles,
+      );
+      selectedRuntime = getRuntimeConfigSnapshot()?.agents?.entries?.beta?.runtime;
+      return {
+        payloads: [{ text: "done" }],
+        meta: { durationMs: 1 },
+      };
+    });
+
+    const result = await agentExecCommand(
+      "inspect",
+      { config: configPath, agent: "beta" },
+      runtime,
+      { runAgent },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(selectedOptions).toMatchObject({
+      agentId: "beta",
+      workspaceDir: betaWorkspace,
+      cwd: betaWorkspace,
+    });
+    expect(selectedRuntime).toMatchObject({ type: "acp", acp: { agent: "codex" } });
+    expect(selectedProfileIds).toContain("openai-codex:beta");
+    expect(selectedProfileIds).not.toContain("openai-codex:alpha");
+  });
+
+  it("lets an explicit cwd override the selected agent workspace", async () => {
+    const configRoot = tempDirs.make("openclaw-agent-exec-selected-cwd-");
+    const configPath = path.join(configRoot, "openclaw.json");
+    const configuredWorkspace = path.join(configRoot, "configured-workspace");
+    const overrideWorkspace = path.join(configRoot, "override-workspace");
+    await Promise.all(
+      [configuredWorkspace, overrideWorkspace].map((dir) => fs.mkdir(dir, { recursive: true })),
+    );
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: { beta: { workspace: configuredWorkspace } },
+        },
+      }),
+      "utf8",
+    );
+    const runAgent = vi.fn(async () => ({
+      payloads: [{ text: "done" }],
+      meta: { durationMs: 1 },
+    }));
+
+    const result = await agentExecCommand(
+      "inspect",
+      { config: configPath, agent: "beta", cwd: overrideWorkspace },
+      runtime,
+      { runAgent },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "beta",
+        workspaceDir: overrideWorkspace,
+        cwd: overrideWorkspace,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects an unknown explicit agent before starting a run", async () => {
+    const configRoot = tempDirs.make("openclaw-agent-exec-unknown-agent-");
+    const configPath = path.join(configRoot, "openclaw.json");
+    const workspace = path.join(configRoot, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: { alpha: { workspace } },
+        },
+      }),
+      "utf8",
+    );
+    const runAgent = vi.fn();
+
+    const result = await agentExecCommand(
+      "inspect",
+      { config: configPath, agent: "missing" },
+      runtime,
+      { runAgent },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.envelope.error?.message).toBe(
+      'Unknown agent id "missing". Run openclaw agents list to see configured agents.',
+    );
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "a migrated legacy default",

--- a/src/commands/agent-exec.list-roster.test.ts
+++ b/src/commands/agent-exec.list-roster.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildExecRunConfig } from "./agent-exec.js";
+
+describe("agent exec list-roster isolation", () => {
+  it("pins the workspace and drops persistent state locations", () => {
+    const config = buildExecRunConfig({
+      base: {
+        agents: {
+          list: [
+            {
+              id: "ops",
+              workspace: "/persistent/workspace",
+              agentDir: "/persistent/agents/ops",
+              runtime: { type: "acp", acp: { agent: "codex", cwd: "/persistent/repo" } },
+            },
+          ],
+        },
+      },
+      cwd: "/run/here",
+    });
+
+    const [ops] = config.agents?.list ?? [];
+    expect(ops).toMatchObject({ id: "ops", workspace: "/run/here" });
+    expect(ops?.agentDir).toBeUndefined();
+    expect(ops?.runtime?.type === "acp" ? ops.runtime.acp?.cwd : "unset").toBeUndefined();
+    expect(ops?.runtime?.type === "acp" ? ops.runtime.acp?.agent : undefined).toBe("codex");
+  });
+});

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -19,6 +19,7 @@ import type {
 import { formatErrorMessage } from "../infra/errors.js";
 import type { GatewayLockIdentity, GatewayLockOptions } from "../infra/gateway-lock.js";
 import { writeRuntimeJson, writeRuntimeStdout, type RuntimeEnv } from "../runtime.js";
+import { stripInheritedAgentLocations } from "./agent-exec-config-isolation.js";
 
 const AGENT_EXEC_MESSAGE_MAX_BYTES = 4 * 1024 * 1024;
 const AGENT_EXEC_DEFAULT_TIMEOUT_SECONDS = 600;
@@ -292,40 +293,6 @@ function normalizeCodeMode(
  * it was pointed at, a one-shot turn never bootstraps, and explicit flags
  * outrank whatever the resolved config says.
  */
-/**
- * Drops inherited state and workspace location overrides, which outrank the
- * facts this invocation owns. `session.store` and `agentDir` can redirect state
- * outside the invocation root, where its lock or temporary cleanup cannot own
- * it; a native harness `runtime.acp.cwd` can make the turn edit the wrong repo.
- * `agents.bindings[].acp.cwd` needs no equivalent because exec runs no channel,
- * so no binding matches.
- */
-function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
-  const { session, ...root } = base;
-  const { store: _store, ...sessionWithoutStore } = session ?? {};
-  const withoutSessionStore = session ? { ...root, session: sessionWithoutStore } : base;
-  const entries = withoutSessionStore.agents?.entries;
-  if (!entries) {
-    return withoutSessionStore;
-  }
-  return {
-    ...withoutSessionStore,
-    agents: {
-      ...withoutSessionStore.agents,
-      entries: Object.fromEntries(
-        Object.entries(entries).map(([id, entry]) => {
-          const { agentDir: _agentDir, runtime, ...rest } = entry;
-          if (runtime?.type !== "acp" || runtime.acp?.cwd === undefined) {
-            return [id, { ...rest, ...(runtime ? { runtime } : {}) }];
-          }
-          const { cwd: _cwd, ...acp } = runtime.acp;
-          return [id, { ...rest, runtime: { ...runtime, acp } }];
-        }),
-      ),
-    },
-  } as OpenClawConfig;
-}
-
 function buildExecRunOverlay(params: {
   base: OpenClawConfig;
   cwd: string;
@@ -335,7 +302,8 @@ function buildExecRunOverlay(params: {
   // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
   // defaults would let an inherited entry silently run the turn against a
   // different repository. Override every configured entry as well.
-  const entries = Object.keys(params.base.agents?.entries ?? {});
+  const entries = params.base.agents?.entries;
+  const list = entries === undefined ? params.base.agents?.list : undefined;
   return {
     agents: {
       defaults: {
@@ -343,9 +311,15 @@ function buildExecRunOverlay(params: {
         skipBootstrap: true,
         ...(params.opts.localModelLean ? { experimental: { localModelLean: true } } : {}),
       },
-      ...(entries.length > 0
-        ? { entries: Object.fromEntries(entries.map((id) => [id, { workspace: params.cwd }])) }
-        : {}),
+      ...(entries !== undefined
+        ? {
+            entries: Object.fromEntries(
+              Object.keys(entries).map((id) => [id, { workspace: params.cwd }]),
+            ),
+          }
+        : list !== undefined
+          ? { list: list.map((entry) => Object.assign({}, entry, { workspace: params.cwd })) }
+          : {}),
     },
     // This process exits after one turn, so live skill invalidation cannot be
     // observed and would leave Chokidar retaining the otherwise-finished CLI.

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -26,6 +26,7 @@ const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 export type AgentExecCliOptions = {
   messageFile?: string;
+  agent?: string;
   cwd?: string;
   stateDir?: string;
   config?: string;
@@ -587,7 +588,6 @@ export async function agentExecCommand(
       opts.messageFile,
       deps.stdin ?? process.stdin,
     );
-    const cwd = await requireDirectory(opts.cwd ?? process.cwd(), "Working directory");
     const stateDir = opts.stateDir
       ? await requireDirectory(opts.stateDir, "State directory")
       : await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-exec-"));
@@ -624,6 +624,38 @@ export async function agentExecCommand(
         before: envBeforeConfigLoad,
         after: envAfterConfigLoad,
       });
+    const timeout = normalizeTimeoutSeconds(opts.timeout);
+    const fallbacks = normalizeFallbacks(opts.model, opts.fallback);
+    const {
+      resolveAgentDir,
+      resolveAgentWorkspaceDir,
+      resolveAmbientOwnerAgentId,
+      resolveConfiguredAgentId,
+    } = await import("../agents/agent-scope-config.js");
+    const { normalizeAgentId } = await import("../routing/session-key.js");
+    const requestedAgentIdRaw = opts.agent?.trim();
+    if (opts.agent !== undefined && !requestedAgentIdRaw) {
+      throw new Error("--agent must not be empty.");
+    }
+    const requestedAgentId = requestedAgentIdRaw
+      ? resolveConfiguredAgentId(baseConfig, normalizeAgentId(requestedAgentIdRaw))
+      : undefined;
+    // Resolve from the inherited config, not `{}`: the default agent may declare
+    // its own `agentDir`, and that is where its stored auth profiles live. This
+    // reads `baseConfig` rather than `runConfig` because the run config
+    // deliberately strips agent directories to keep run state ephemeral, while
+    // credential ownership must still follow the operator's configuration.
+    // Computed before the environment repoints the state dir so the unconfigured
+    // case still resolves against the real one.
+    const execAgentId = resolveAmbientOwnerAgentId(baseConfig, requestedAgentId, {
+      surface: "agent exec",
+      hint: "Set agents.defaults.systemAgent.agentId.",
+    });
+    const cwd = await requireDirectory(
+      opts.cwd ??
+        (requestedAgentId ? resolveAgentWorkspaceDir(baseConfig, execAgentId) : process.cwd()),
+      requestedAgentId && !opts.cwd ? "Agent workspace" : "Working directory",
+    );
     const runConfig = buildExecRunConfig({ base: baseConfig, cwd, opts });
     // Installed plugins belong to the operator config resolved above, not to
     // the disposable state root used for this run. Capture all roots before
@@ -633,21 +665,6 @@ export async function agentExecCommand(
       ? await import("../plugins/install-root-context.js")
       : undefined;
     const pluginInstallRoots = pluginInstallContext?.resolvePluginInstallRoots();
-    const timeout = normalizeTimeoutSeconds(opts.timeout);
-    const fallbacks = normalizeFallbacks(opts.model, opts.fallback);
-    const { resolveAgentDir, resolveAmbientOwnerAgentId } =
-      await import("../agents/agent-scope-config.js");
-    // Resolve from the inherited config, not `{}`: the default agent may declare
-    // its own `agentDir`, and that is where its stored auth profiles live. This
-    // reads `baseConfig` rather than `runConfig` because the run config
-    // deliberately strips agent directories to keep run state ephemeral, while
-    // credential ownership must still follow the operator's configuration.
-    // Computed before the environment repoints the state dir so the unconfigured
-    // case still resolves against the real one.
-    const execAgentId = resolveAmbientOwnerAgentId(baseConfig, undefined, {
-      surface: "agent exec",
-      hint: "Set agents.defaults.systemAgent.agentId.",
-    });
     // Auth, session keys, and SQLite ownership must share one resolved owner.
     // Splitting these paths can select an agent's store but emit a `main` key.
     const storedAuthAgentDir = resolveAgentDir(baseConfig, execAgentId);


### PR DESCRIPTION
Closes #124768

## What Problem This Solves

`openclaw agent exec` could not target an agent in an explicit multi-agent fleet. The parent `agent` command accepted `--agent`, but the nested `exec` command neither declared the option nor inherited it. Without a generic owner, the run failed before it could reach that agent's configured workspace, runtime, or stored OAuth profiles.

## Why This Change Was Made

This adds `--agent <id>` to the nested command and uses the existing roster normalization and validation path. An explicit selection now wins over legacy and system-owner compatibility defaults, scopes stored auth to the selected agent directory, and uses that agent's configured workspace unless `--cwd` explicitly overrides it. Temporary session and database state remain isolated exactly as before.

Current main already includes #124697, which aligned the implicit exec owner with `agents.defaults.systemAgent`. This PR builds on that owner seam and adds the missing explicit selection contract for fleets that intentionally have no generic default.

I also checked Codex's source contract directly: [`CODEX_HOME` owns the Codex config directory](https://github.com/openai/codex/blob/23094236acac6fdc22f67a408ea8ccb8fac8e6e1/codex-rs/utils/home-dir/src/lib.rs#L5-L17), and its credential file is [`$CODEX_HOME/auth.json`](https://github.com/openai/codex/blob/23094236acac6fdc22f67a408ea8ccb8fac8e6e1/codex-rs/login/src/auth/storage.rs#L38-L60). Selecting the OpenClaw agent before entering the harness/auth boundary is therefore required for deterministic credential ownership.

## User Impact

Operators can now run either form:

```bash
openclaw agent exec --agent ops "Run the focused tests"
openclaw agent --agent ops exec "Run the focused tests"
```

The selected agent contributes its runtime, stored credentials, and default workspace. Existing invocations without `--agent` retain their current process-working-directory and owner-resolution behavior, and `--cwd` remains the final workspace override.

## Evidence

- Regression reproduced before the implementation: the parent-position `--agent ops` parsed successfully but was absent from the options passed to `agentExecCommand`.
- `node scripts/run-vitest.mjs src/cli/program/register.agent.test.ts src/commands/agent-exec.test.ts src/commands/agent-exec.agent-owner.test.ts src/agents/agent-scope-config.test.ts` (95 tests passed).
- `pnpm docs:check-mdx` (774 files passed).
- Focused `oxfmt --check` and `oxlint` passed for all touched files.
- `pnpm check` completed every preflight guard, all 94 package-lock validations, and core/UI/extensions/scripts/test typechecks. The unrelated full-repository core lint shard was manually stopped after 180 seconds with no diagnostics; focused lint passed.
- Source-built `openclaw agent exec --help` displays the new option and example.
- Commit `4c94f7bbf5` adds a real child-process E2E with an installed proof harness, two explicit agents, no system owner, `--agent beta`, and an explicit `--cwd` override. The focused E2E passed and captured this redacted child stdout:

  ```json
  {
    "ok": true,
    "status": "ok",
    "final": "SELECTED_AGENT_OK agent=beta workspace=<tmp>/workspaces/override",
    "model": "proof-model",
    "provider": "exec-proof",
    "sessionId": "exec-proof-session"
  }
  ```

- A live source CLI smoke with an explicit two-agent config and no system owner selected `beta`, passed owner/auth admission without the reported 401, and entered the native Codex app-server path. The app-server did not return a final response within the 120-second smoke window, so this is recorded as boundary evidence rather than a successful model E2E.
