### PR TITLE
fix(talk): recognize agent-scoped browser gateway control

### DIFF
--- a/extensions/openai/realtime-voice-provider-routing.test.ts
+++ b/extensions/openai/realtime-voice-provider-routing.test.ts
@@ -450,6 +450,43 @@ describe("OpenAI realtime voice provider routing", () => {
     ).not.toHaveProperty("supportsGatewayControl");
   });
 
+  it("advertises GA Gateway control from the requested agent's Platform auth", () => {
+    isProviderAuthProfileConfiguredMock.mockImplementation(
+      ({ agentDir, profileTypes }: { agentDir?: string; profileTypes?: readonly string[] }) =>
+        agentDir === "/tmp/openclaw-molty-agent" && profileTypes?.includes("api_key") === true,
+    );
+    const { broker } = createQuicksilverBrowserBrokerFixture();
+    const provider = buildOpenAIRealtimeVoiceProvider({
+      quicksilverBrowserSessionBroker: broker,
+    });
+    const cfg = {
+      agents: {
+        list: [
+          { id: "helper", agentDir: "/tmp/openclaw-helper-agent" },
+          { id: "molty", agentDir: "/tmp/openclaw-molty-agent" },
+        ],
+      },
+    } as never;
+    const resolveCapabilities =
+      readInternalRealtimeVoiceProviderApi(provider).resolveBrowserSessionCapabilities;
+
+    expect(
+      resolveCapabilities({
+        cfg,
+        providerConfig: {},
+        agentId: "molty",
+        model: "gpt-realtime-2.1",
+      }),
+    ).toMatchObject({ supportsGatewayControl: true });
+    expect(
+      resolveCapabilities({
+        cfg,
+        providerConfig: {},
+        model: "gpt-realtime-2.1",
+      }),
+    ).not.toHaveProperty("supportsGatewayControl");
+  });
+
   it("uses ChatGPT OAuth as the browser-only fallback for GA realtime", async () => {
     const oauthToken = createTestJwt({
       "https://api.openai.com/auth": { chatgpt_account_id: "account-123" },

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -93,6 +93,7 @@ type OpenAIInternalRealtimeVoiceProviderApi = {
   resolveBrowserSessionCapabilities?: (ctx: {
     cfg?: RealtimeVoiceBrowserSessionCreateRequest["cfg"];
     providerConfig: RealtimeVoiceProviderConfig;
+    agentId?: string;
     model?: string;
   }) => OpenAIInternalRealtimeVoiceCapabilities;
   isGatewayRelayConfigured?: (ctx: {
@@ -449,7 +450,7 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
           hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId }))
       );
     },
-    resolveBrowserSessionCapabilities: ({ cfg, providerConfig, model }) => {
+    resolveBrowserSessionCapabilities: ({ cfg, providerConfig, agentId, model }) => {
       const config = normalizeProviderConfig(providerConfig);
       if (isSupportedOpenAIGptLiveModel(model ?? config.model)) {
         return {
@@ -460,7 +461,7 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
       return {
         ...OPENAI_REALTIME_CAPABILITIES,
         ...(options?.quicksilverBrowserSessionBroker !== undefined &&
-        hasOpenAIRealtimePlatformAuthInput({ configuredApiKey: config.apiKey, cfg })
+        hasOpenAIRealtimePlatformAuthInput({ configuredApiKey: config.apiKey, cfg, agentId })
           ? { supportsGatewayControl: true }
           : {}),
       };

--- a/extensions/openai/realtime-voice-test-support.ts
+++ b/extensions/openai/realtime-voice-test-support.ts
@@ -105,6 +105,7 @@ type InternalRealtimeVoiceProviderApi = {
   resolveBrowserSessionCapabilities: (ctx: {
     cfg?: object;
     providerConfig: Record<string, unknown>;
+    agentId?: string;
     model?: string;
   }) => {
     handlesAgentConsult?: boolean;

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -209,6 +209,7 @@ export const talkClientHandlers: GatewayRequestHandlers = {
         provider: resolution.provider,
         providerConfig: resolution.providerConfig,
         cfg: runtimeConfig,
+        agentId: requestedAgentId,
         model: launchOptions.model,
         surface: "browser-session",
       });

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -616,7 +616,7 @@ describe("talk.catalog handler", () => {
       expect.objectContaining({ surface: "gateway-relay" }),
     );
     expect(mocks.resolveRealtimeVoiceProviderCapabilities).toHaveBeenCalledWith(
-      expect.objectContaining({ surface: "gateway-relay" }),
+      expect.objectContaining({ agentId: expect.any(String), surface: "gateway-relay" }),
     );
     expect(isConfigured).toHaveBeenCalledWith(expect.not.objectContaining({ surface: "bridge" }));
     const catalog = expectRespondOk(respond);
@@ -2976,7 +2976,7 @@ describe("talk.client.create handler", () => {
       expect.objectContaining({ providerConfigOverrides: { model: "gpt-live-1" } }),
     );
     expect(mocks.resolveRealtimeVoiceProviderCapabilities).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "gpt-live-1" }),
+      expect.objectContaining({ agentId: "main", model: "gpt-live-1" }),
     );
     const createInput = mockCallArg(createBrowserSession) as Record<string, unknown>;
     expectRecordFields(createInput, {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -364,6 +364,7 @@ function buildTalkCatalog(config: OpenClawConfig) {
           provider,
           providerConfig,
           cfg: config,
+          agentId: realtimeAgentId,
           surface: realtimeSurface,
         });
         const entry: Record<string, unknown> = {

--- a/src/talk/provider-internal.ts
+++ b/src/talk/provider-internal.ts
@@ -43,6 +43,7 @@ type InternalRealtimeVoiceProviderApi = {
   resolveBrowserSessionCapabilities?: (ctx: {
     cfg?: OpenClawConfig;
     providerConfig: RealtimeVoiceProviderConfig;
+    agentId?: string;
     /** Effective per-session model after request overrides. */
     model?: string;
   }) => InternalRealtimeVoiceProviderCapabilities;
@@ -98,12 +99,14 @@ export function resolveInternalRealtimeVoiceBrowserSessionCapabilities(params: {
   provider: RealtimeVoiceProviderPlugin;
   cfg?: OpenClawConfig;
   providerConfig: RealtimeVoiceProviderConfig;
+  agentId?: string;
   model?: string;
 }): InternalRealtimeVoiceProviderCapabilities | undefined {
   return readInternalRealtimeVoiceProviderApi(params.provider)?.resolveBrowserSessionCapabilities?.(
     {
       cfg: params.cfg,
       providerConfig: params.providerConfig,
+      agentId: params.agentId,
       model: params.model,
     },
   );

--- a/src/talk/provider-resolver.test.ts
+++ b/src/talk/provider-resolver.test.ts
@@ -17,6 +17,7 @@ function attachInternalRealtimeVoiceProviderApi(
     }) => boolean;
     resolveBrowserSessionCapabilities?: (ctx: {
       providerConfig: Record<string, unknown>;
+      agentId?: string;
       model?: string;
     }) => object;
     isGatewayRelayConfigured?: (ctx: {
@@ -314,11 +315,12 @@ describe("realtime voice provider resolver", () => {
     };
     attachInternalRealtimeVoiceProviderApi(provider, {
       isBrowserSessionConfigured: () => true,
-      resolveBrowserSessionCapabilities: ({ providerConfig, model }) => ({
+      resolveBrowserSessionCapabilities: ({ providerConfig, agentId, model }) => ({
         transports: ["webrtc"],
         inputAudioFormats: [],
         outputAudioFormats: [],
         supportsVideoFrames: providerConfig.authMode !== "native" && model === "gpt-live-1",
+        supportsGatewayControl: agentId === "molty",
       }),
     });
 
@@ -330,13 +332,22 @@ describe("realtime voice provider resolver", () => {
         surface: "browser-session",
       })?.supportsVideoFrames,
     ).toBe(false);
+    const scopedCapabilities = resolveRealtimeVoiceProviderCapabilities({
+      provider,
+      providerConfig: { authMode: "oauth" },
+      agentId: "molty",
+      model: "gpt-live-1",
+      surface: "browser-session",
+    });
+    expect(scopedCapabilities?.supportsVideoFrames).toBe(true);
+    expect(scopedCapabilities?.supportsGatewayControl).toBe(true);
     expect(
       resolveRealtimeVoiceProviderCapabilities({
         provider,
         providerConfig: { authMode: "oauth" },
         model: "gpt-live-1",
         surface: "browser-session",
-      })?.supportsVideoFrames,
-    ).toBe(true);
+      })?.supportsGatewayControl,
+    ).toBe(false);
   });
 });

--- a/src/talk/provider-resolver.ts
+++ b/src/talk/provider-resolver.ts
@@ -47,6 +47,8 @@ export function resolveRealtimeVoiceProviderCapabilities(params: {
   provider: RealtimeVoiceProviderPlugin;
   providerConfig: RealtimeVoiceProviderConfig;
   cfg?: OpenClawConfig;
+  /** Host-selected agent scope for provider capability evaluation. */
+  agentId?: string;
   /** Effective per-session model after request overrides. */
   model?: string;
   surface?: "browser-session" | "gateway-relay" | "bridge";


### PR DESCRIPTION
Follow-up to https://github.com/openclaw/openclaw/pull/125111

## What Problem This Solves

Fixes an issue where browser Talk sessions requesting `gateway-control-v1` could reject a routed agent as unsupported when that agent owned the only configured OpenAI Platform profile. Provider readiness and browser-session authentication already used the routed agent, but capability evaluation silently fell back to the unscoped auth store.

## Why This Change Was Made

The host-selected agent now flows through the generic realtime capability context into the provider-owned OpenAI browser capability check. The field remains optional, so callers and providers without a route-owned agent retain the existing unscoped behavior.

## User Impact

Multi-agent browser realtime sessions can use Gateway-controlled OpenAI audio when the selected agent owns the relevant Platform credential, instead of failing before session creation with a misleading unsupported-capability error.

## Evidence

- Pre-fix regression proof: the generic resolver test failed because scoped gateway control resolved `false`; the OpenAI provider test failed because agent-only Platform auth did not advertise gateway control; the Gateway handler tests failed because capability resolution omitted the selected agent.
- `node scripts/run-vitest.mjs src/talk/provider-resolver.test.ts extensions/openai/realtime-voice-provider-routing.test.ts src/gateway/server-methods/talk.test.ts` — 107 tests passed across 3 shards.
- `node scripts/check-changed.mjs -- <9 changed paths>` — passed all selected core, core-test, extension, and extension-test checks.
- `pnpm plugin-sdk:surface:check` — passed; no public Plugin SDK surface changed.
- `oxfmt --check <9 changed paths>` and `git diff --check` — passed.
- Fresh autoreview — clean, no accepted/actionable findings.

The affected capability decision is entirely local and occurs before any external provider request; focused owner-boundary tests reproduce the exact credential-scope failure without requiring a live OpenAI session.

AI-assisted: yes. The implementation, regression proof, and final diff were maintainer-reviewed.
