### PR TITLE
fix(voice-call): honor routed agent credentials for realtime calls

### DIFF
--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -1,6 +1,3 @@
-import { promises as fs } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
@@ -11,6 +8,7 @@ import type {
   RealtimeVoiceBridge,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import type { VoiceCallStateRuntime } from "./runtime-state.js";
@@ -70,6 +68,8 @@ function createRealtimeProvider(params: {
   };
 }
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 afterEach(() => {
   mocks.resolveConfiguredRealtimeVoiceProvider.mockReset();
   resetPluginStateStoreForTests();
@@ -77,7 +77,7 @@ afterEach(() => {
 
 describe("voice-call realtime route ownership", () => {
   it("selects provider readiness and bridge auth from each inbound number owner", async () => {
-    const storePath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-routing-"));
+    const storePath = tempDirs.make("openclaw-voice-routing-");
     const sockets: WebSocket[] = [];
     const servers: Array<Awaited<ReturnType<typeof startUpgradeWsServer>>> = [];
     let runtime: VoiceCallRuntime | undefined;
@@ -210,7 +210,6 @@ describe("voice-call realtime route ownership", () => {
       }
       await Promise.all(servers.map((server) => server.close()));
       resetPluginStateStoreForTests();
-      await fs.rm(storePath, { recursive: true, force: true });
     }
   });
 });

--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -1,0 +1,216 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type {
+  RealtimeVoiceBridge,
+  RealtimeVoiceProviderPlugin,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import type { VoiceCallStateRuntime } from "./runtime-state.js";
+import { createVoiceCallRuntime, type VoiceCallRuntime } from "./runtime.js";
+import { createVoiceCallBaseConfig } from "./test-fixtures.js";
+import { connectWs, startUpgradeWsServer, waitForClose } from "./websocket-test-support.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveConfiguredRealtimeVoiceProvider: vi.fn(),
+}));
+
+vi.mock("./realtime-voice.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./realtime-voice.runtime.js")>();
+  return {
+    ...actual,
+    resolveConfiguredRealtimeVoiceProvider: mocks.resolveConfiguredRealtimeVoiceProvider,
+  };
+});
+
+function createStateRuntime(): VoiceCallStateRuntime["state"] {
+  return {
+    resolveStateDir: () => "",
+    openKeyedStore: (() => {
+      throw new Error("openKeyedStore is not used by realtime routing tests");
+    }) as VoiceCallStateRuntime["state"]["openKeyedStore"],
+    openSyncKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateSyncKeyedStoreForTests<T>("voice-call", options),
+    openChannelIngressQueue: (() => {
+      throw new Error("openChannelIngressQueue is not used by realtime routing tests");
+    }) as VoiceCallStateRuntime["state"]["openChannelIngressQueue"],
+    openChannelIngressDrain: (() => {
+      throw new Error("openChannelIngressDrain is not used by realtime routing tests");
+    }) as VoiceCallStateRuntime["state"]["openChannelIngressDrain"],
+  };
+}
+
+function createRealtimeProvider(params: {
+  id: string;
+  connect: ReturnType<typeof vi.fn<() => Promise<void>>>;
+}): RealtimeVoiceProviderPlugin {
+  return {
+    id: params.id,
+    label: params.id,
+    isConfigured: () => true,
+    createBridge: vi.fn(
+      (): RealtimeVoiceBridge => ({
+        connect: params.connect,
+        sendAudio: vi.fn(),
+        setMediaTimestamp: vi.fn(),
+        submitToolResult: vi.fn(),
+        acknowledgeMark: vi.fn(),
+        close: vi.fn(),
+        isConnected: () => true,
+        triggerGreeting: vi.fn(),
+      }),
+    ),
+  };
+}
+
+afterEach(() => {
+  mocks.resolveConfiguredRealtimeVoiceProvider.mockReset();
+  resetPluginStateStoreForTests();
+});
+
+describe("voice-call realtime route ownership", () => {
+  it("selects provider readiness and bridge auth from each inbound number owner", async () => {
+    const storePath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-routing-"));
+    const sockets: WebSocket[] = [];
+    const servers: Array<Awaited<ReturnType<typeof startUpgradeWsServer>>> = [];
+    let runtime: VoiceCallRuntime | undefined;
+    const salesConnect = vi.fn(async () => {});
+    const supportConnect = vi.fn(async () => {});
+    const salesProvider = createRealtimeProvider({ id: "openai", connect: salesConnect });
+    const supportProvider = createRealtimeProvider({ id: "xai", connect: supportConnect });
+    const registrations = new Map([
+      [
+        "sales",
+        {
+          provider: salesProvider,
+          providerConfig: { credentialOwner: "sales", model: "gpt-realtime" },
+        },
+      ],
+      [
+        "support",
+        {
+          provider: supportProvider,
+          providerConfig: { credentialOwner: "support", model: "grok-voice" },
+        },
+      ],
+    ]);
+    mocks.resolveConfiguredRealtimeVoiceProvider.mockImplementation(
+      ({ agentId }: { agentId?: string }) => {
+        const registration = agentId ? registrations.get(agentId) : undefined;
+        if (!registration) {
+          throw new Error(`No simulated realtime credentials for ${agentId ?? "unknown"}`);
+        }
+        return registration;
+      },
+    );
+
+    try {
+      const config = createVoiceCallBaseConfig();
+      config.agentId = "main";
+      config.store = storePath;
+      config.inboundPolicy = "open";
+      config.maxConcurrentCalls = 2;
+      config.staleCallReaperSeconds = 0;
+      config.serve = { ...config.serve, port: 0 };
+      config.realtime.enabled = true;
+      config.numbers = {
+        "+15550001001": { agentId: "sales" },
+        "+15550001002": { agentId: "support" },
+      };
+      const fullConfig = {
+        agents: {
+          list: [{ id: "main", default: true }, { id: "sales" }, { id: "support" }],
+        },
+      } as OpenClawConfig;
+
+      runtime = await createVoiceCallRuntime({
+        config,
+        coreConfig: fullConfig,
+        fullConfig,
+        agentRuntime: {} as never,
+        stateRuntime: createStateRuntime(),
+      });
+      expect(mocks.resolveConfiguredRealtimeVoiceProvider).not.toHaveBeenCalled();
+
+      const handler = runtime.webhookServer.getRealtimeHandler();
+      if (!handler) {
+        throw new Error("expected realtime handler");
+      }
+      const routes = [
+        { to: "+15550001001", callSid: "CA-sales", streamSid: "MZ-sales" },
+        { to: "+15550001002", callSid: "CA-support", streamSid: "MZ-support" },
+      ];
+      for (const route of routes) {
+        const { streamUrl } = handler.issueStreamSession({
+          providerName: "twilio",
+          direction: "inbound",
+          from: "+15550009999",
+          to: route.to,
+        });
+        const server = await startUpgradeWsServer({
+          urlPath: new URL(streamUrl).pathname,
+          onUpgrade: (request, socket, head) => {
+            handler.handleWebSocketUpgrade(request, socket, head);
+          },
+        });
+        servers.push(server);
+        const ws = await connectWs(server.url);
+        sockets.push(ws);
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: route.streamSid, callSid: route.callSid },
+          }),
+        );
+      }
+
+      await vi.waitFor(() => {
+        expect(salesProvider.createBridge).toHaveBeenCalledTimes(1);
+        expect(supportProvider.createBridge).toHaveBeenCalledTimes(1);
+        expect(salesConnect).toHaveBeenCalledTimes(1);
+        expect(supportConnect).toHaveBeenCalledTimes(1);
+      });
+      expect(salesProvider.createBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "sales",
+          providerConfig: { credentialOwner: "sales", model: "gpt-realtime" },
+        }),
+      );
+      expect(supportProvider.createBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "support",
+          providerConfig: { credentialOwner: "support", model: "grok-voice" },
+        }),
+      );
+      expect(
+        mocks.resolveConfiguredRealtimeVoiceProvider.mock.calls.map(
+          ([options]) => (options as { agentId?: string }).agentId,
+        ),
+      ).toEqual(["sales", "support"]);
+
+      for (const ws of sockets) {
+        const closed = waitForClose(ws);
+        ws.close(1000);
+        await closed;
+      }
+      await vi.waitFor(() => expect(runtime?.manager.getActiveCalls()).toHaveLength(0));
+    } finally {
+      await runtime?.stop();
+      for (const ws of sockets) {
+        if (ws.readyState !== WebSocket.CLOSED) {
+          ws.terminate();
+        }
+      }
+      await Promise.all(servers.map((server) => server.close()));
+      resetPluginStateStoreForTests();
+      await fs.rm(storePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -242,7 +242,7 @@ describe("createVoiceCallRuntime lifecycle", () => {
     mocks.realtimeHandlerCtorArgs.length = 0;
     mocks.realtimeHandlerRegisterToolHandler.mockReset();
     mocks.realtimeHandlerSetPublicUrl.mockReset();
-    mocks.resolveConfiguredRealtimeVoiceProvider.mockResolvedValue({
+    mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
       provider: { id: "openai" },
       providerConfig: { model: "gpt-realtime" },
     });
@@ -365,42 +365,95 @@ describe("createVoiceCallRuntime lifecycle", () => {
       } as never,
     });
 
-    const resolveInstructions = mocks.realtimeHandlerCtorArgs[0]?.[7];
-    expect(mocks.resolveConfiguredRealtimeVoiceProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "operator" }),
-    );
-    if (typeof resolveInstructions !== "function") {
-      throw new Error("expected per-call realtime instruction resolver");
+    const resolveCallRegistration = mocks.realtimeHandlerCtorArgs[0]?.[3];
+    expect(mocks.resolveConfiguredRealtimeVoiceProvider).not.toHaveBeenCalled();
+    if (typeof resolveCallRegistration !== "function") {
+      throw new Error("expected per-call realtime registration resolver");
     }
     expect(runtime.config.agentId).toBe("operator");
-    const defaultInstructions = resolveInstructions({
+    const defaultRegistration = resolveCallRegistration({
       callId: "call-default",
       direction: "outbound",
       from: "+15550001111",
       to: "+15550002222",
     });
-    expect(defaultInstructions).toContain("- Agent id: operator");
+    expect(defaultRegistration.agentId).toBe("operator");
+    expect(defaultRegistration.instructions).toContain("- Agent id: operator");
     expect(resolveAgentIdentity).toHaveBeenCalledWith(fullConfig, "operator");
 
-    const supportInstructions = resolveInstructions({
+    const supportRegistration = resolveCallRegistration({
       callId: "call-support",
       agentId: "support",
       direction: "outbound",
       from: "+15550001111",
       to: "+15550002222",
     });
-    expect(supportInstructions).toContain("- Agent id: support");
-    expect(supportInstructions).toContain("- Name: Support Voice");
-    expect(supportInstructions).not.toContain("Main Voice");
+    expect(supportRegistration.agentId).toBe("support");
+    expect(supportRegistration.instructions).toContain("- Agent id: support");
+    expect(supportRegistration.instructions).toContain("- Name: Support Voice");
+    expect(supportRegistration.instructions).not.toContain("Main Voice");
 
-    const unknownInstructions = resolveInstructions({
+    const unknownRegistration = resolveCallRegistration({
       callId: "call-unknown",
       agentId: "unknown",
       direction: "outbound",
       from: "+15550001111",
       to: "+15550002222",
     });
-    expect(unknownInstructions).not.toContain("OpenClaw agent voice context:");
+    expect(unknownRegistration.instructions).not.toContain("OpenClaw agent voice context:");
+  });
+
+  it("selects realtime provider readiness from the routed call owner", async () => {
+    const config = createBaseConfig();
+    config.agentId = "main";
+    config.realtime.enabled = true;
+    config.numbers["+15550009999"] = { agentId: "support" };
+    const fullConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "support" }] },
+    } as OpenClawConfig;
+    mocks.resolveConfiguredRealtimeVoiceProvider.mockImplementation(
+      ({ agentId }: { agentId?: string }) => {
+        if (agentId !== "support") {
+          throw new Error(`OpenAI realtime is not configured for ${agentId ?? "unknown"}`);
+        }
+        return {
+          provider: { id: "openai-support" },
+          providerConfig: { model: "gpt-realtime", owner: agentId },
+        };
+      },
+    );
+
+    await expect(
+      createVoiceCallRuntime({
+        config,
+        coreConfig: {} as OpenClawConfig,
+        fullConfig,
+        agentRuntime: {} as never,
+      }),
+    ).resolves.toMatchObject({ config: { agentId: "main" } });
+    expect(mocks.resolveConfiguredRealtimeVoiceProvider).not.toHaveBeenCalled();
+
+    const resolveCallRegistration = mocks.realtimeHandlerCtorArgs[0]?.[3];
+    if (typeof resolveCallRegistration !== "function") {
+      throw new Error("expected per-call realtime registration resolver");
+    }
+    const registration = resolveCallRegistration({
+      callId: "call-support",
+      agentId: "support",
+      direction: "inbound",
+      from: "+15550001234",
+      to: "+15550009999",
+      metadata: { numberRouteKey: "+15550009999" },
+    });
+
+    expect(registration).toMatchObject({
+      agentId: "support",
+      provider: { id: "openai-support" },
+      providerConfig: { model: "gpt-realtime", owner: "support" },
+    });
+    expect(mocks.resolveConfiguredRealtimeVoiceProvider).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ agentId: "support" }),
+    );
   });
 
   it.each(["twilio", "telnyx", "plivo"] as const)(

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -11,7 +11,6 @@ import {
   resolveRealtimeVoiceAgentConsultTools,
   resolveRealtimeVoiceAgentConsultToolsAllow,
   type RealtimeVoiceAgentConsultTranscriptEntry,
-  type ResolvedRealtimeVoiceProvider,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import type { OpenClawPluginApi } from "../api.js";
@@ -60,8 +59,6 @@ type Logger = {
   error: (message: string) => void;
   debug?: (message: string) => void;
 };
-
-type ResolvedRealtimeProvider = ResolvedRealtimeVoiceProvider;
 
 const REALTIME_VOICE_CONSULT_SYSTEM_PROMPT = [
   "You are the configured OpenClaw agent receiving delegated requests from a live phone voice bridge.",
@@ -229,19 +226,6 @@ async function resolveProvider(config: VoiceCallConfig): Promise<VoiceCallProvid
   }
 }
 
-async function resolveRealtimeProvider(params: {
-  config: VoiceCallConfig;
-  fullConfig: OpenClawConfig;
-}): Promise<ResolvedRealtimeProvider> {
-  const { resolveConfiguredRealtimeVoiceProvider } = await loadRealtimeVoiceRuntime();
-  return resolveConfiguredRealtimeVoiceProvider({
-    configuredProviderId: params.config.realtime.provider,
-    providerConfigs: params.config.realtime.providers,
-    cfg: params.fullConfig,
-    agentId: params.config.agentId,
-  });
-}
-
 function listRealtimeAgentIds(config: VoiceCallConfig, coreConfig: OpenClawConfig): string[] {
   const agentIds = new Set<string>([normalizeAgentId(config.agentId)]);
   for (const agent of coreConfig.agents?.list ?? []) {
@@ -348,12 +332,7 @@ export async function createVoiceCallRuntime(params: {
     setVoiceCallStateRuntime({ state: stateRuntime });
   }
   const manager = new CallManager(config, undefined, cfg.session);
-  const realtimeProvider = config.realtime.enabled
-    ? await resolveRealtimeProvider({
-        config,
-        fullConfig: cfg,
-      })
-    : null;
+  const realtimeVoiceRuntime = config.realtime.enabled ? await loadRealtimeVoiceRuntime() : null;
   const webhookServer = new VoiceCallWebhookServer(
     config,
     manager,
@@ -363,7 +342,7 @@ export async function createVoiceCallRuntime(params: {
     agentRuntime,
     log,
   );
-  if (realtimeProvider) {
+  if (realtimeVoiceRuntime) {
     const { RealtimeCallHandler } = await loadRealtimeHandler();
     const resolveRealtimeInstructions = await createRealtimeInstructionsResolver({
       config,
@@ -377,15 +356,30 @@ export async function createVoiceCallRuntime(params: {
         config.realtime.tools,
       ),
     };
+    const resolveCallRegistration = (call: CallRecord) => {
+      const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);
+      const effectiveConfig = resolveVoiceCallEffectiveConfig(config, numberRouteKey).config;
+      const agentId = resolveCallAgentId(call, effectiveConfig);
+      const resolved = realtimeVoiceRuntime.resolveConfiguredRealtimeVoiceProvider({
+        configuredProviderId: effectiveConfig.realtime.provider,
+        providerConfigs: effectiveConfig.realtime.providers,
+        cfg,
+        agentId,
+      });
+      return {
+        agentId,
+        provider: resolved.provider,
+        providerConfig: resolved.providerConfig,
+        instructions: resolveRealtimeInstructions(call),
+      };
+    };
     const realtimeHandler = new RealtimeCallHandler(
       realtimeConfig,
       manager,
       provider,
-      realtimeProvider.provider,
-      realtimeProvider.providerConfig,
+      resolveCallRegistration,
       config.serve.path,
       cfg,
-      resolveRealtimeInstructions,
     );
     if (config.realtime.toolPolicy !== "none") {
       realtimeHandler.registerToolHandler(
@@ -521,7 +515,7 @@ export async function createVoiceCallRuntime(params: {
     if (publicUrl) {
       provider.setPublicUrl?.(publicUrl);
     }
-    if (publicUrl && realtimeProvider) {
+    if (publicUrl && realtimeVoiceRuntime) {
       webhookServer.getRealtimeHandler()?.setPublicUrl(publicUrl);
     }
 
@@ -556,8 +550,8 @@ export async function createVoiceCallRuntime(params: {
       }
     }
 
-    if (realtimeProvider) {
-      log.info(`[voice-call] Realtime voice provider: ${realtimeProvider.provider.id}`);
+    if (realtimeVoiceRuntime) {
+      log.info("[voice-call] Realtime voice enabled");
     }
 
     await manager.initialize(provider, webhookUrl);

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -55,9 +55,36 @@ function createBridge(
   };
 }
 
+function makeRealtimeProvider(
+  createBridgeForCall: RealtimeVoiceProviderPlugin["createBridge"],
+): RealtimeVoiceProviderPlugin {
+  return {
+    id: "openai",
+    label: "OpenAI",
+    isConfigured: () => true,
+    createBridge: createBridgeForCall,
+  };
+}
+
+function makeCallRegistrationResolver(
+  provider: RealtimeVoiceProviderPlugin,
+): ConstructorParameters<typeof RealtimeCallHandler>[3] {
+  return (call) => ({
+    agentId: call.agentId ?? "main",
+    instructions: "Be helpful.",
+    provider,
+    providerConfig: { apiKey: "test-key" },
+  });
+}
+
 function createCarrierLifecycleHarness(
   createBridgeForCall: RealtimeVoiceProviderPlugin["createBridge"],
+  options: {
+    initialMessage?: string;
+    resolveCallRegistration?: ConstructorParameters<typeof RealtimeCallHandler>[3];
+  } = {},
 ) {
+  const realtimeProvider = makeRealtimeProvider(createBridgeForCall);
   const call: CallRecord = {
     callId: "call-startup",
     providerCallId: "CA-startup",
@@ -69,6 +96,7 @@ function createCarrierLifecycleHarness(
     startedAt: Date.now(),
     transcript: [],
     processedEventIds: [],
+    ...(options.initialMessage ? { metadata: { initialMessage: options.initialMessage } } : {}),
   };
   const processEvent = vi.fn();
   const hangupCall = vi.fn(async () => {});
@@ -79,13 +107,7 @@ function createCarrierLifecycleHarness(
       getCallByProviderCallId: vi.fn(() => call),
     } as unknown as CallManager,
     { name: "twilio", hangupCall } as unknown as VoiceCallProvider,
-    {
-      id: "openai",
-      label: "OpenAI",
-      isConfigured: () => true,
-      createBridge: createBridgeForCall,
-    },
-    { apiKey: "test-key" },
+    options.resolveCallRegistration ?? makeCallRegistrationResolver(realtimeProvider),
     "/voice/webhook",
   );
   return { call, handler, hangupCall, processEvent };
@@ -206,6 +228,144 @@ describe("RealtimeCallHandler lifecycle", () => {
     }
   });
 
+  it("ends an initial call when routed realtime admission fails", async () => {
+    const createBridgeForCall = vi.fn<RealtimeVoiceProviderPlugin["createBridge"]>();
+    const resolveCallRegistration = vi.fn(() => {
+      throw new Error("routed agent realtime is unavailable");
+    });
+    const { call, handler, hangupCall, processEvent } = createCarrierLifecycleHarness(
+      createBridgeForCall,
+      {
+        initialMessage: "Hello from the routed agent.",
+        resolveCallRegistration,
+      },
+    );
+    const { server, ws } = await connectCarrierStream(handler);
+
+    try {
+      const closed = waitForClose(ws);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-admission-failure", callSid: call.providerCallId },
+        }),
+      );
+
+      expect(await closed).toEqual({
+        code: 1011,
+        reason: "Check realtime configuration for routed agent",
+      });
+      expect(resolveCallRegistration).toHaveBeenCalledExactlyOnceWith(call);
+      expect(createBridgeForCall).not.toHaveBeenCalled();
+      expect(processEvent.mock.calls.map(([event]) => event.type)).toEqual([
+        "call.initiated",
+        "call.ended",
+      ]);
+      expect(processEvent.mock.calls.at(-1)?.[0]).toEqual(
+        expect.objectContaining({
+          callId: call.callId,
+          providerCallId: call.providerCallId,
+          reason: "error",
+        }),
+      );
+      expect(hangupCall).toHaveBeenCalledExactlyOnceWith({
+        callId: call.callId,
+        providerCallId: call.providerCallId,
+        reason: "error",
+      });
+      expect(call.metadata?.initialMessage).toBe("Hello from the routed agent.");
+      expect(handler.speak(call.callId, "still connected")).toEqual({
+        success: false,
+        error: "No active realtime bridge for call",
+      });
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
+  it("preserves the active predecessor when replacement admission fails", async () => {
+    const predecessorGreeting = vi.fn();
+    const realtimeProvider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      isConfigured: () => true,
+      createBridge: vi.fn(() =>
+        createBridge(vi.fn(), {
+          triggerGreeting: predecessorGreeting,
+        }),
+      ),
+    };
+    const resolveCallRegistration = vi
+      .fn<ConstructorParameters<typeof RealtimeCallHandler>[3]>()
+      .mockReturnValueOnce({
+        agentId: "main",
+        instructions: "Be helpful.",
+        provider: realtimeProvider,
+        providerConfig: { apiKey: "test-key" },
+      })
+      .mockImplementationOnce(() => {
+        throw new Error("replacement agent realtime is unavailable");
+      });
+    const { call, handler, hangupCall, processEvent } = createCarrierLifecycleHarness(
+      realtimeProvider.createBridge,
+      { resolveCallRegistration },
+    );
+    const predecessor = await connectCarrierStream(handler);
+    let replacement: Awaited<ReturnType<typeof connectCarrierStream>> | undefined;
+
+    try {
+      predecessor.ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-predecessor", callSid: call.providerCallId },
+        }),
+      );
+      await vi.waitFor(() => expect(realtimeProvider.createBridge).toHaveBeenCalledTimes(1));
+
+      replacement = await connectCarrierStream(handler);
+      const replacementClosed = waitForClose(replacement.ws);
+      replacement.ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-replacement-admission", callSid: call.providerCallId },
+        }),
+      );
+
+      expect(await replacementClosed).toEqual({
+        code: 1011,
+        reason: "Check realtime configuration for routed agent",
+      });
+      expect(resolveCallRegistration).toHaveBeenCalledTimes(2);
+      expect(realtimeProvider.createBridge).toHaveBeenCalledTimes(1);
+      expect(
+        processEvent.mock.calls.filter(([event]) => event.type === "call.answered"),
+      ).toHaveLength(1);
+      expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
+        0,
+      );
+      expect(hangupCall).not.toHaveBeenCalled();
+      expect(predecessor.ws.readyState).toBe(WebSocket.OPEN);
+      expect(handler.speak(call.callId, "predecessor remains connected")).toEqual({
+        success: true,
+      });
+      expect(predecessorGreeting).toHaveBeenCalledWith("predecessor remains connected");
+    } finally {
+      if (predecessor.ws.readyState !== WebSocket.CLOSED) {
+        predecessor.ws.terminate();
+      }
+      if (replacement && replacement.ws.readyState !== WebSocket.CLOSED) {
+        replacement.ws.terminate();
+      }
+      await handler.close();
+      await replacement?.server.close();
+      await predecessor.server.close();
+    }
+  });
+
   it("does not hang up a replacement when its stale predecessor rejects startup", async () => {
     let rejectStartup: (error: Error) => void = () => {};
     const pendingStartup = new Promise<void>((_resolve, reject) => {
@@ -299,13 +459,7 @@ describe("RealtimeCallHandler lifecycle", () => {
         stopListening: vi.fn(),
         getCallStatus: vi.fn(),
       } as unknown as VoiceCallProvider,
-      {
-        id: "openai",
-        label: "OpenAI",
-        isConfigured: () => true,
-        createBridge: createBridgeForCall,
-      },
-      { apiKey: "test-key" },
+      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
     );
     const { streamUrl } = handler.issueStreamSession();
@@ -414,13 +568,7 @@ describe("RealtimeCallHandler lifecycle", () => {
         stopListening: vi.fn(),
         getCallStatus: vi.fn(),
       } as unknown as VoiceCallProvider,
-      {
-        id: "openai",
-        label: "OpenAI",
-        isConfigured: () => true,
-        createBridge: createBridgeForCall,
-      },
-      { apiKey: "test-key" },
+      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
     );
     const { streamUrl } = handler.issueStreamSession();
@@ -507,13 +655,7 @@ describe("RealtimeCallHandler lifecycle", () => {
         stopListening: vi.fn(),
         getCallStatus: vi.fn(),
       } as unknown as VoiceCallProvider,
-      {
-        id: "openai",
-        label: "OpenAI",
-        isConfigured: () => true,
-        createBridge: createBridgeForCall,
-      },
-      { apiKey: "test-key" },
+      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
     );
     const consult = vi.fn(async () => ({ text: "This should not run." }));
@@ -628,13 +770,7 @@ describe("RealtimeCallHandler lifecycle", () => {
         stopListening: vi.fn(),
         getCallStatus: vi.fn(),
       } as unknown as VoiceCallProvider,
-      {
-        id: "openai",
-        label: "OpenAI",
-        isConfigured: () => true,
-        createBridge: createBridgeForCall,
-      },
-      { apiKey: "test-key" },
+      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
     );
     handler.registerToolHandler("openclaw_agent_consult", async (_args, _callId, context) => {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -91,6 +91,20 @@ const PROVIDER_WITH_LOCAL_BARGE_IN_CAPABILITIES = {
   supportsBargeIn: true,
 } satisfies NonNullable<RealtimeVoiceProviderPlugin["capabilities"]>;
 
+function makeCallRegistrationResolver(params: {
+  provider: RealtimeVoiceProviderPlugin;
+  providerConfig: Record<string, unknown>;
+  instructions: string;
+  resolveInstructions?: (call: CallRecord) => string;
+}) {
+  return (call: CallRecord) => ({
+    agentId: call.agentId ?? "main",
+    provider: params.provider,
+    providerConfig: params.providerConfig,
+    instructions: params.resolveInstructions?.(call) ?? params.instructions,
+  });
+}
+
 function makeHandler(
   overrides?: Partial<VoiceCallRealtimeConfig>,
   deps?: {
@@ -125,6 +139,8 @@ function makeHandler(
     providers: overrides?.providers ?? {},
     ...(overrides?.provider ? { provider: overrides.provider } : {}),
   };
+  const realtimeProvider = deps?.realtimeProvider ?? makeRealtimeProvider(() => makeBridge());
+  const providerConfig = deps?.providerConfig ?? { apiKey: "test-key" };
   return new RealtimeCallHandler(
     config,
     {
@@ -145,11 +161,14 @@ function makeHandler(
       getCallStatus: vi.fn(),
       ...deps?.provider,
     } as unknown as VoiceCallProvider,
-    deps?.realtimeProvider ?? makeRealtimeProvider(() => makeBridge()),
-    deps?.providerConfig ?? { apiKey: "test-key" },
+    makeCallRegistrationResolver({
+      provider: realtimeProvider,
+      providerConfig,
+      instructions: config.instructions,
+      resolveInstructions: deps?.resolveInstructions,
+    }),
     "/voice/webhook",
     undefined,
-    deps?.resolveInstructions,
   );
 }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -254,12 +254,14 @@ export type StreamSession = {
   streamUrl: string;
 };
 
-type CallRegistration = {
-  callId: string;
-  agentId?: string;
+type RealtimeCallRegistration = {
+  agentId: string;
   instructions: string;
-  initialGreetingInstructions?: string;
+  provider: RealtimeVoiceProviderPlugin;
+  providerConfig: RealtimeVoiceProviderConfig;
 };
+
+type ResolveRealtimeCallRegistration = (call: CallRecord) => RealtimeCallRegistration;
 
 type ActiveRealtimeVoiceBridge = RealtimeVoiceBridgeSession;
 
@@ -372,11 +374,9 @@ export class RealtimeCallHandler {
     private readonly config: VoiceCallRealtimeConfig,
     private readonly manager: CallManager,
     private readonly provider: VoiceCallProvider,
-    private readonly realtimeProvider: RealtimeVoiceProviderPlugin,
-    private readonly providerConfig: RealtimeVoiceProviderConfig,
+    private readonly resolveCallRegistration: ResolveRealtimeCallRegistration,
     private readonly servePath: string,
     private readonly coreConfig?: OpenClawConfig,
-    private readonly resolveInstructions?: (call: CallRecord) => string,
   ) {}
 
   setPublicUrl(url: string): void {
@@ -649,21 +649,67 @@ export class RealtimeCallHandler {
     callerMeta: Omit<PendingStreamToken, "expiry">,
     adapter: StreamFrameAdapter,
   ): ActiveRealtimeVoiceBridge | null {
-    const registration = this.registerCallInManager(callSid, callerMeta);
-    if (!registration) {
+    const preparedCall = this.prepareCallInManager(callSid, callerMeta);
+    if (!preparedCall) {
       ws.close(1008, "Caller rejected by policy");
       return null;
     }
 
-    const { callId, agentId, instructions, initialGreetingInstructions } = registration;
-    const callRecord = this.manager.getCallByProviderCallId(callSid);
+    const { callRecord } = preparedCall;
+    const callId = callRecord.callId;
+    const hadPredecessorOnAdmission = this.activeBridgesByCallId.has(callId);
+    let callEndEmitted = false;
+    const emitCallEnd = (reason: "completed" | "error") => {
+      if (callEndEmitted) {
+        return;
+      }
+      callEndEmitted = true;
+      this.endCallInManager(callSid, callId, reason);
+      if (reason !== "error") {
+        return;
+      }
+      void Promise.resolve(
+        this.provider.hangupCall({ callId, providerCallId: callSid, reason }),
+      ).catch((error: unknown) => {
+        console.warn(
+          `[voice-call] Failed to hang up realtime call ${callSid}: ${formatErrorMessage(error)}`,
+        );
+      });
+    };
+
+    let registration: RealtimeCallRegistration;
+    try {
+      registration = this.resolveCallRegistration(callRecord);
+    } catch (error) {
+      console.error(
+        `[voice-call] Failed to resolve realtime call registration callId=${callId} providerCallId=${callSid}: ${formatErrorMessage(error)}`,
+      );
+      if (!hadPredecessorOnAdmission) {
+        emitCallEnd("error");
+      }
+      ws.close(1011, "Check realtime configuration for routed agent");
+      return null;
+    }
+
+    const { baseFields, initialGreeting } = preparedCall;
+    if (callRecord.metadata) {
+      delete callRecord.metadata.initialMessage;
+    }
+    this.manager.processEvent({
+      id: `realtime-answered-${callSid}`,
+      callId,
+      type: "call.answered",
+      ...baseFields,
+    });
+    const { agentId, instructions, provider: realtimeProvider, providerConfig } = registration;
+    const initialGreetingInstructions = buildGreetingInstructions(instructions, initialGreeting);
     const harness = createRealtimeVoiceSessionHarness({
       talk: {
         sessionId: `voice-call:${callId}:realtime`,
         mode: "realtime",
         transport: "gateway-relay",
         brain: "agent-consult",
-        provider: this.realtimeProvider.id,
+        provider: realtimeProvider.id,
       },
       talkPayloads: {
         turnStarted: () => ({ callId, providerCallId: callSid }),
@@ -676,7 +722,7 @@ export class RealtimeCallHandler {
       onTalkEvent: (event) => appendRecentTalkEventMetadata(callRecord, event),
     });
     let providerHandlesInputAudioBargeIn =
-      this.realtimeProvider.capabilities?.handlesInputAudioBargeIn === true;
+      realtimeProvider.capabilities?.handlesInputAudioBargeIn === true;
     const cancelOutputAudioForBargeIn = (
       source: "local" | "provider",
       interruptProvider?: (audioPlaybackActive: boolean) => void,
@@ -718,24 +764,6 @@ export class RealtimeCallHandler {
     console.log(
       `[voice-call] Realtime bridge starting for call ${callId} (providerCallId=${callSid}, initialGreeting=${initialGreetingInstructions ? "queued" : "absent"})`,
     );
-    let callEndEmitted = false;
-    const emitCallEnd = (reason: "completed" | "error") => {
-      if (callEndEmitted) {
-        return;
-      }
-      callEndEmitted = true;
-      this.endCallInManager(callSid, callId, reason);
-      if (reason !== "error") {
-        return;
-      }
-      void Promise.resolve(
-        this.provider.hangupCall({ callId, providerCallId: callSid, reason }),
-      ).catch((error: unknown) => {
-        console.warn(
-          `[voice-call] Failed to hang up realtime call ${callSid}: ${formatErrorMessage(error)}`,
-        );
-      });
-    };
 
     const sendString = (message: string): boolean => {
       if (ws.readyState !== WebSocket.OPEN) {
@@ -780,10 +808,9 @@ export class RealtimeCallHandler {
       silenceFrames: 12,
     });
     const interruptResponseOnInputAudio =
-      typeof this.providerConfig.interruptResponseOnInputAudio === "boolean"
-        ? this.providerConfig.interruptResponseOnInputAudio
+      typeof providerConfig.interruptResponseOnInputAudio === "boolean"
+        ? providerConfig.interruptResponseOnInputAudio
         : undefined;
-    const hadPredecessorOnAdmission = this.activeBridgesByCallId.has(callId);
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
     // Provisional ownership accepts callbacks fired during createBridge. Commit
@@ -791,10 +818,10 @@ export class RealtimeCallHandler {
     const userTranscriptAdoption = this.beginUserTranscriptOwnerAdoption(callId);
     const userTranscriptOwner = userTranscriptAdoption.owner;
     const bridgeParams: Parameters<typeof harness.createBridge>[0] = {
-      provider: this.realtimeProvider,
+      provider: realtimeProvider,
       cfg: this.coreConfig,
       agentId,
-      providerConfig: this.providerConfig,
+      providerConfig,
       interruptResponseOnInputAudio,
       instructions,
       tools: this.config.tools,
@@ -1561,10 +1588,10 @@ export class RealtimeCallHandler {
     }
   }
 
-  private registerCallInManager(
+  private prepareCallInManager(
     callSid: string,
     callerMeta: Omit<PendingStreamToken, "expiry"> = {},
-  ): CallRegistration | null {
+  ) {
     const timestamp = Date.now();
     const baseFields = {
       providerCallId: callSid,
@@ -1583,24 +1610,7 @@ export class RealtimeCallHandler {
     console.log(
       `[voice-call] Realtime call ${callRecord.callId} initial greeting ${initialGreeting ? "queued" : "absent"}`,
     );
-    if (callRecord.metadata) {
-      delete callRecord.metadata.initialMessage;
-    }
-
-    this.manager.processEvent({
-      id: `realtime-answered-${callSid}`,
-      callId: callRecord.callId,
-      type: "call.answered",
-      ...baseFields,
-    });
-
-    const instructions = this.resolveInstructions?.(callRecord) ?? this.config.instructions;
-    return {
-      callId: callRecord.callId,
-      agentId: callRecord.agentId,
-      instructions,
-      initialGreetingInstructions: buildGreetingInstructions(instructions, initialGreeting),
-    };
+    return { callRecord, baseFields, initialGreeting };
   }
 
   private resolveRealtimeCall(

--- a/node-version.d.mts
+++ b/node-version.d.mts
@@ -10,4 +10,4 @@ export function isNodeVersionAtLeast(
   minimum: NodeReleaseVersion,
 ): boolean;
 export function isSupportedOpenClawNodeVersion(value: unknown): boolean;
-export const OPENCLAW_PROCESS_NODE_VERSION_CHECK: string;
+export const PROCESS_NODE_VERSION_CHECK: string;

--- a/node-version.mjs
+++ b/node-version.mjs
@@ -73,4 +73,4 @@ function renderProcessNodeVersionCheck() {
 
 // Worker bootstrap runs before OpenClaw is transferred. Carry the canonical
 // release policy as a self-contained expression instead of a second parser.
-export const OPENCLAW_PROCESS_NODE_VERSION_CHECK = renderProcessNodeVersionCheck();
+export const PROCESS_NODE_VERSION_CHECK = renderProcessNodeVersionCheck();

--- a/src/gateway/worker-environments/bootstrap.test.ts
+++ b/src/gateway/worker-environments/bootstrap.test.ts
@@ -5,7 +5,7 @@ import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import {
   isSupportedOpenClawNodeVersion,
-  OPENCLAW_PROCESS_NODE_VERSION_CHECK,
+  PROCESS_NODE_VERSION_CHECK,
 } from "../../../node-version.mjs";
 import { NODE_RELEASE_VERSION_CASES } from "../../../test/helpers/node-version-cases.js";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
@@ -392,15 +392,15 @@ describe("bootstrapWorker", () => {
     ).rejects.toThrow("Node 22.22.3+, 24.15.0+, or 25.9.0+ with WAL-reset-safe SQLite");
     expect(runner.calls).toHaveLength(2);
     expect(runner.calls[0]?.options.input).toContain(
-      `const nodeSafe = ${OPENCLAW_PROCESS_NODE_VERSION_CHECK};`,
+      `const nodeSafe = ${PROCESS_NODE_VERSION_CHECK};`,
     );
     expect(runner.calls[0]?.options.input).toContain("SELECT sqlite_version() AS version");
   });
 
   it("embeds a shell-safe Node release check matching the canonical contract", () => {
-    expect(OPENCLAW_PROCESS_NODE_VERSION_CHECK).not.toContain("'");
+    expect(PROCESS_NODE_VERSION_CHECK).not.toContain("'");
     for (const version of NODE_RELEASE_VERSION_CASES) {
-      const actual = runInNewContext(OPENCLAW_PROCESS_NODE_VERSION_CHECK, {
+      const actual = runInNewContext(PROCESS_NODE_VERSION_CHECK, {
         process: { versions: { node: version } },
       });
       expect(actual, version).toBe(isSupportedOpenClawNodeVersion(version));

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { OPENCLAW_PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
+import { PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
 import {
   type WorkerAdmissionHandshake,
   WORKER_PROTOCOL_MAX_FEATURE_LENGTH,
@@ -78,7 +78,7 @@ export function workerBootstrapOperationTimeoutMs(artifact: WorkerInstallationAr
 }
 
 const NODE_RUNTIME_CHECK_JS = String.raw`const parse = (value) => /^(\d+)\.(\d+)\.(\d+)$/.exec(value)?.slice(1).map(Number); const atLeast = (version, floor) => version[0] > floor[0] || (version[0] === floor[0] && (version[1] > floor[1] || (version[1] === floor[1] && version[2] >= floor[2])));
-const nodeSafe = ${OPENCLAW_PROCESS_NODE_VERSION_CHECK};
+const nodeSafe = ${PROCESS_NODE_VERSION_CHECK};
 if (!nodeSafe) process.exit(1);
 try { const { DatabaseSync } = require("node:sqlite"); const db = new DatabaseSync(":memory:");
   const sqlite = parse(String(db.prepare("SELECT sqlite_version() AS version").get()?.version ?? ""));


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/125111#issuecomment-5312685825

## What Problem This Solves

Fixes an issue where realtime phone calls routed by inbound number to a non-default agent could fail before the call arrived, or retain a provider selected for the wrong agent, when realtime credentials were agent-scoped.

## Why This Change Was Made

Realtime provider readiness and selection now happen after call registration, at the effective per-call route. The frozen call owner drives provider selection, normalized provider config, bridge authentication, capabilities, instructions, and interruption policy through one canonical registration; there is no fallback across agents. Provider-admission failure ends and hangs up an initial call visibly, while a failed replacement preserves its active predecessor.

The product repair is intentionally limited to the voice-call plugin lifecycle. It does not change config, protocol, SQLite, Plugin SDK, provider contracts, or the separate browser capability finding from #125111.

The branch also includes one behavior-neutral repair for a red `main` gate encountered during landing: a generated Node-version expression was exported with an `OPENCLAW_`-prefixed constant name and was therefore miscounted as a new environment variable. Renaming that internal export restores the 501/501 env-var budget without changing its generated bootstrap expression or raising a baseline.

## User Impact

Operators can route different phone numbers to agents that own different OpenAI or xAI realtime credentials. The plugin can start even when the top-level default agent has no realtime credentials, and a misconfigured routed agent now fails only its call instead of blocking the whole voice-call runtime or using another agent's provider selection.

## Evidence

Pre-fix regression:

- `node scripts/run-vitest.mjs extensions/voice-call/src/runtime.test.ts -t "selects realtime provider readiness from the routed call owner"` failed during runtime startup because readiness resolved `agentId: main`, producing `OpenAI realtime is not configured for main` before the routed call existed.

Post-fix proof:

- `node scripts/run-vitest.mjs extensions/voice-call/src/runtime.realtime-routing.test.ts extensions/voice-call/src/runtime.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts extensions/voice-call/src/manager/events.inbound.test.ts src/talk/provider-resolver.test.ts` — 93 tests passed across 2 shards.
- `pnpm test extensions/voice-call` — 649 tests passed across 61 files.
- `node scripts/check-changed.mjs -- <10 changed paths>` — passed the fail-safe all-lanes plan: env-var/max-lines/assertion ratchets, formatting, doctor/plugin boundaries, dead exports, temp-dir ownership, script erasability, database-first and sidecar guards, full core/UI/extension/script/root-test typechecks, full lint, and import cycles.
- `pnpm ui:build` on the rebased head — passed at 337,983 startup-JS gzip bytes, 584 bytes below the unchanged 338,567-byte limit. No UI or performance-baseline edit was needed.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/bootstrap.test.ts test/openclaw-launcher-version.e2e.test.ts src/infra/runtime-guard.test.ts` — 72 tests passed; the E2E lane rebuilt the current dist successfully.
- `node --import tsx scripts/check-env-var-count.mts --base origin/main` — 501/501 after the internal export rename; before the repair, current `main` reported 502/501.
- Source-blind behavior run: `pnpm test extensions/voice-call/src/runtime.realtime-routing.test.ts -- --reporter=verbose` — runtime started with no default-agent resolution, then two real loopback carrier WebSocket streams created the `sales`/OpenAI and `support`/xAI bridges and closed with no active calls.
- Fresh Codex autoreviews (`--max-priority P1`) — clean for both the voice owner-boundary repair and the final main-gate/test-cleanup changes; no accepted/actionable findings.

Proof gap: no external carrier number or live OpenAI/xAI credentials were available for this task, so no real telephone call was placed. The regression uses real runtime, manager, call registration, stream tokens, loopback WebSockets, and bridge connections with simulated agent-scoped credentials.

Production LOC: +93/-89 (net +4). Tests: +480/-57 (net +423).

AI-assisted: yes. The implementation was independently reviewed and the observable route behavior was validated against the contract above.
