### PR TITLE
refactor(gateway): carry authoritative read facts

### DIFF
--- a/src/agents/mcp-oauth-store.ts
+++ b/src/agents/mcp-oauth-store.ts
@@ -1,5 +1,4 @@
 // Canonical MCP OAuth session state. Legacy JSON import belongs to doctor only.
-import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
 import {
@@ -17,7 +16,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { ensureMcpOAuthPendingSchema } from "../state/openclaw-state-db-schema-additive.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -25,7 +24,6 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 
 type McpOAuthDatabase = Pick<
   OpenClawStateKyselyDatabase,
@@ -245,37 +243,33 @@ export function readMcpOAuthStore(storeKey: string): McpOAuthStore {
 
 /** Read status state without creating or repairing the shared database. */
 export function readMcpOAuthStoreReadOnly(storeKey: string): McpOAuthStore {
-  const databasePath = resolveOpenClawStateSqlitePath();
-  if (!fs.existsSync(databasePath)) {
-    return {};
-  }
-  return withOpenClawStateDatabaseReadOnly(({ db }) => {
-    if (!tableExists(db, "mcp_oauth_stores")) {
-      return {};
-    }
-    return readFromDatabase(db, storeKey);
-  });
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+      if (!tableExists(db, "mcp_oauth_stores")) {
+        return {};
+      }
+      return readFromDatabase(db, storeKey);
+    }) ?? {}
+  );
 }
 
 /** List canonical store keys matching one server/principal prefix without creating state. */
 export function listMcpOAuthStoreKeysByPrefix(prefix: string): string[] {
-  const databasePath = resolveOpenClawStateSqlitePath();
-  if (!fs.existsSync(databasePath)) {
-    return [];
-  }
-  return withOpenClawStateDatabaseReadOnly(({ db }) => {
-    if (!tableExists(db, "mcp_oauth_stores")) {
-      return [];
-    }
-    const rows = executeSqliteQuerySync(
-      db,
-      getNodeSqliteKysely<McpOAuthDatabase>(db)
-        .selectFrom("mcp_oauth_stores")
-        .select("store_key")
-        .orderBy("store_key", "asc"),
-    ).rows;
-    return rows.map((row) => row.store_key).filter((storeKey) => storeKey.startsWith(prefix));
-  });
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+      if (!tableExists(db, "mcp_oauth_stores")) {
+        return [];
+      }
+      const rows = executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<McpOAuthDatabase>(db)
+          .selectFrom("mcp_oauth_stores")
+          .select("store_key")
+          .orderBy("store_key", "asc"),
+      ).rows;
+      return rows.map((row) => row.store_key).filter((storeKey) => storeKey.startsWith(prefix));
+    }) ?? []
+  );
 }
 
 function ensurePendingSchema(database: DatabaseSync): void {
@@ -315,11 +309,7 @@ const MCP_OAUTH_PENDING_STATE_TTL_MS = 10 * 60 * 1000;
 export function readMcpOAuthPendingAuthorization(state: string): string | undefined {
   // Public unauthenticated callback path: must stay read-only. Table creation
   // belongs to start-authorization; an unknown state must not write anything.
-  const databasePath = resolveOpenClawStateSqlitePath();
-  if (!fs.existsSync(databasePath)) {
-    return undefined;
-  }
-  return withOpenClawStateDatabaseReadOnly(({ db }) => {
+  return withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
     if (!tableExists(db, "mcp_oauth_pending_authorizations")) {
       return undefined;
     }

--- a/src/agents/sandbox/registry.ts
+++ b/src/agents/sandbox/registry.ts
@@ -3,14 +3,12 @@
  *
  * Tracks runtime and browser containers in the shared state DB.
  */
-import fsSync from "node:fs";
 import type { Insertable, Selectable, Updateable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
-import { withOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import type { SandboxContainerEngineTarget } from "./container-engine.js";
 
 export type SandboxRegistryEntry = {
@@ -181,58 +179,56 @@ function readRegistryRows(
   kind: SandboxRegistryKind,
   filter?: { backendId: string; scopeKey: string },
 ): SandboxRegistryRow[] {
-  if (!fsSync.existsSync(resolveOpenClawStateSqlitePath(process.env))) {
-    return [];
-  }
   // CLI reads must not join the Gateway's writable SQLite lifecycle (#101290).
-  return withOpenClawStateDatabaseReadOnly(({ db }) => {
-    if (!tableExists(db, "sandbox_registry_entries")) {
-      return [];
-    }
-    const stateDb = getSandboxRegistryKysely(db);
-    let query = stateDb
-      .selectFrom("sandbox_registry_entries")
-      .selectAll()
-      .where("registry_kind", "=", kind);
-    if (filter) {
-      query = query
-        .where("session_key", "=", filter.scopeKey)
-        .where("backend_id", "=", filter.backendId);
-    }
-    return executeSqliteQuerySync(
-      db,
-      filter
-        ? query.orderBy("last_used_at_ms", "desc").orderBy("container_name", "asc")
-        : query.orderBy("container_name", "asc"),
-    ).rows;
-  });
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+      if (!tableExists(db, "sandbox_registry_entries")) {
+        return [];
+      }
+      const stateDb = getSandboxRegistryKysely(db);
+      let query = stateDb
+        .selectFrom("sandbox_registry_entries")
+        .selectAll()
+        .where("registry_kind", "=", kind);
+      if (filter) {
+        query = query
+          .where("session_key", "=", filter.scopeKey)
+          .where("backend_id", "=", filter.backendId);
+      }
+      return executeSqliteQuerySync(
+        db,
+        filter
+          ? query.orderBy("last_used_at_ms", "desc").orderBy("container_name", "asc")
+          : query.orderBy("container_name", "asc"),
+      ).rows;
+    }) ?? []
+  );
 }
 
 function readRegistryRow(
   kind: SandboxRegistryKind,
   containerName: string,
 ): SandboxRegistryRow | null {
-  if (!fsSync.existsSync(resolveOpenClawStateSqlitePath(process.env))) {
-    return null;
-  }
   // CLI reads must not join the Gateway's writable SQLite lifecycle (#101290).
-  return withOpenClawStateDatabaseReadOnly(({ db }) => {
-    if (!tableExists(db, "sandbox_registry_entries")) {
-      return null;
-    }
-    const stateDb = getSandboxRegistryKysely(db);
-    return (
-      executeSqliteQuerySync(
-        db,
-        stateDb
-          .selectFrom("sandbox_registry_entries")
-          .selectAll()
-          .where("registry_kind", "=", kind)
-          .where("container_name", "=", containerName)
-          .limit(1),
-      ).rows[0] ?? null
-    );
-  });
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+      if (!tableExists(db, "sandbox_registry_entries")) {
+        return null;
+      }
+      const stateDb = getSandboxRegistryKysely(db);
+      return (
+        executeSqliteQuerySync(
+          db,
+          stateDb
+            .selectFrom("sandbox_registry_entries")
+            .selectAll()
+            .where("registry_kind", "=", kind)
+            .where("container_name", "=", containerName)
+            .limit(1),
+        ).rows[0] ?? null
+      );
+    }) ?? null
+  );
 }
 
 function insertRegistryRowIfMissing(row: SandboxRegistryInsert): void {

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -14,12 +14,7 @@ import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { buildGatewayConnectionDetails, formatGatewayTransportErrorJson } from "../gateway/call.js";
-import {
-  ADMIN_SCOPE,
-  PAIRING_SCOPE,
-  READ_SCOPE,
-  type OperatorScope,
-} from "../gateway/method-scopes.js";
+import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import {
   approveDevicePairing,
@@ -38,8 +33,6 @@ import {
   type DevicePairingAccessSummary,
   type PendingDeviceApprovalKind,
 } from "../shared/device-pairing-access.js";
-import { parseNodeList } from "../shared/node-list-parse.js";
-import type { NodeListNode } from "../shared/node-list-types.js";
 import { formatCliCommand } from "./command-format.js";
 import { callGatewayFromCliWithTransport } from "./gateway-rpc.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
@@ -91,6 +84,8 @@ type PairedDevice = {
   scopes?: string[];
   remoteIp?: string;
   tokens?: DeviceTokenSummary[];
+  nodeSurface?: InfraPairedDevice["nodeSurface"];
+  pendingNodeSurface?: InfraPairedDevice["pendingNodeSurface"];
   createdAtMs?: number;
   approvedAtMs?: number;
 };
@@ -102,11 +97,13 @@ type DevicePairingList = {
 
 type ApprovePairingGatewayContext = {
   originalRequest: PendingDevice | null;
+  pairingList: DevicePairingList | null;
   scopes?: OperatorScope[];
 };
 
 type PendingNodeApprovalNotice = {
-  node: NodeListNode;
+  action: "approval" | "reapproval";
+  label: string;
   command: string;
   connectionReminder: string | null;
 };
@@ -138,12 +135,6 @@ const callGatewayCli = async (
     sharedStateMode: "read-only",
   });
 
-function isPendingNodeApprovalState(
-  state: unknown,
-): state is "pending-approval" | "pending-reapproval" {
-  return state === "pending-approval" || state === "pending-reapproval";
-}
-
 function buildNodeApproveCommand(opts: DevicesRpcOpts, requestId: string): string {
   const args = ["openclaw", "nodes", "approve", requestId];
   const timeout = normalizeOptionalString(opts.timeout);
@@ -163,120 +154,73 @@ function formatNodeConnectionFlagReminder(opts: DevicesRpcOpts): string | null {
     : null;
 }
 
-async function tryReadPendingNodeApprovals(opts: DevicesRpcOpts): Promise<NodeListNode[]> {
-  try {
-    return parseNodeList(
-      await callGatewayCli("node.list", opts, {}, { scopes: [READ_SCOPE, PAIRING_SCOPE] }),
-    ).filter(
-      (node) =>
-        isPendingNodeApprovalState(node.approvalState) &&
-        Boolean(normalizeOptionalString(node.pendingRequestId)),
-    );
-  } catch {
-    return [];
-  }
-}
-
-function pairedDeviceCanBeNode(device: PairedDevice): boolean {
-  return [device.role, ...(device.roles ?? [])].some(
-    (role) => normalizeOptionalString(role) === "node",
-  );
-}
-
 function stringsMatch(left: unknown, right: unknown): boolean {
   const normalizedLeft = normalizeOptionalString(left);
   const normalizedRight = normalizeOptionalString(right);
   return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
 }
 
-function nodeMatchesPairedDevice(node: NodeListNode, device: PairedDevice): boolean {
-  return stringsMatch(node.nodeId, device.deviceId) || stringsMatch(node.remoteIp, device.remoteIp);
-}
-
-function nodeMatchesQuery(node: NodeListNode, query: string): boolean {
+function pairedDeviceMatchesNodeApprovalQuery(device: PairedDevice, query: string): boolean {
   return (
-    stringsMatch(node.nodeId, query) ||
-    stringsMatch(node.remoteIp, query) ||
-    stringsMatch(node.pendingRequestId, query)
+    stringsMatch(device.deviceId, query) ||
+    stringsMatch(device.remoteIp, query) ||
+    stringsMatch(device.pendingNodeSurface?.requestId, query) ||
+    stringsMatch(device.pendingNodeSurface?.remoteIp, query)
   );
 }
 
-function pairedDeviceMatchesQuery(device: PairedDevice, query: string): boolean {
-  return stringsMatch(device.deviceId, query) || stringsMatch(device.remoteIp, query);
-}
-
-async function tryReadGatewayPairingList(opts: DevicesRpcOpts): Promise<DevicePairingList | null> {
-  try {
-    return parseDevicePairingList(
-      await callGatewayCli("device.pair.list", opts, {}, { scopes: [PAIRING_SCOPE] }),
-    );
-  } catch {
+function buildPendingNodeApprovalNotice(
+  device: PairedDevice,
+  opts: DevicesRpcOpts,
+): PendingNodeApprovalNotice | null {
+  const pending = device.pendingNodeSurface;
+  const requestId = normalizeOptionalString(pending?.requestId);
+  if (!pending || !requestId) {
     return null;
   }
-}
-
-function buildPendingNodeApprovalNoticesForOpts(
-  nodes: NodeListNode[],
-  opts: DevicesRpcOpts,
-): PendingNodeApprovalNotice[] {
-  return nodes.flatMap((node) => {
-    const requestId = normalizeOptionalString(node.pendingRequestId);
-    return requestId
-      ? [
-          {
-            node,
-            command: buildNodeApproveCommand(opts, requestId),
-            connectionReminder: formatNodeConnectionFlagReminder(opts),
-          },
-        ]
-      : [];
-  });
+  return {
+    action: device.nodeSurface ? "reapproval" : "approval",
+    label:
+      normalizeOptionalString(pending.displayName) ??
+      normalizeOptionalString(device.nodeSurface?.displayName) ??
+      normalizeOptionalString(device.displayName) ??
+      device.deviceId,
+    command: buildNodeApproveCommand(opts, requestId),
+    connectionReminder: formatNodeConnectionFlagReminder(opts),
+  };
 }
 
 function formatNodeApprovalNotice(notice: PendingNodeApprovalNotice): string {
-  const action = notice.node.approvalState === "pending-reapproval" ? "reapproval" : "approval";
-  const label = sanitizeForLog(
-    normalizeOptionalString(notice.node.displayName) ?? notice.node.nodeId,
-  );
-  const lines = [`Node ${action} pending for ${label}. Run ${sanitizeForLog(notice.command)}`];
+  const lines = [
+    `Node ${notice.action} pending for ${sanitizeForLog(notice.label)}. Run ${sanitizeForLog(notice.command)}`,
+  ];
   if (notice.connectionReminder) {
     lines.push(notice.connectionReminder);
   }
   return lines.join("\n");
 }
 
-async function findPairedDevicePendingNodeApprovalNotices(
+function findPairedDevicePendingNodeApprovalNotices(
   opts: DevicesRpcOpts,
   paired: PairedDevice[] | undefined,
-): Promise<PendingNodeApprovalNotice[]> {
-  const nodeDevices = (paired ?? []).filter(pairedDeviceCanBeNode);
-  if (nodeDevices.length === 0) {
-    return [];
-  }
-  const nodes = await tryReadPendingNodeApprovals(opts);
-  return buildPendingNodeApprovalNoticesForOpts(
-    nodes.filter((node) => nodeDevices.some((device) => nodeMatchesPairedDevice(node, device))),
-    opts,
-  );
+): PendingNodeApprovalNotice[] {
+  return (paired ?? []).flatMap((device) => {
+    const notice = buildPendingNodeApprovalNotice(device, opts);
+    return notice ? [notice] : [];
+  });
 }
 
-async function findQueryPendingNodeApprovalNotices(
+function findQueryPendingNodeApprovalNotices(
   opts: DevicesRpcOpts,
+  paired: PairedDevice[] | undefined,
   query: string,
-): Promise<PendingNodeApprovalNotice[]> {
-  const nodes = await tryReadPendingNodeApprovals(opts);
-  const directMatches = nodes.filter((node) => nodeMatchesQuery(node, query));
-  if (directMatches.length > 0) {
-    return buildPendingNodeApprovalNoticesForOpts(directMatches, opts);
-  }
-  const pairingList = await tryReadGatewayPairingList(opts);
-  const pairedMatches = (pairingList?.paired ?? []).filter((device) =>
-    pairedDeviceMatchesQuery(device, query),
-  );
-  return buildPendingNodeApprovalNoticesForOpts(
-    nodes.filter((node) => pairedMatches.some((device) => nodeMatchesPairedDevice(node, device))),
-    opts,
-  );
+): PendingNodeApprovalNotice[] {
+  return (paired ?? [])
+    .filter((device) => pairedDeviceMatchesNodeApprovalQuery(device, query))
+    .flatMap((device) => {
+      const notice = buildPendingNodeApprovalNotice(device, opts);
+      return notice ? [notice] : [];
+    });
 }
 
 function isDevicePairingApprovalDenied(error: unknown): boolean {
@@ -407,8 +351,9 @@ async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePair
 async function approvePairingWithFallback(
   opts: DevicesRpcOpts,
   requestId: string,
+  context: ApprovePairingGatewayContext,
 ): Promise<Record<string, unknown> | null> {
-  const { scopes, originalRequest } = await resolveApprovePairingGatewayContext(opts, requestId);
+  const { scopes, originalRequest } = context;
   try {
     return await callGatewayCli(
       "device.pair.approve",
@@ -446,6 +391,7 @@ async function approvePairingWithFallback(
         pending: local.pending as PendingDevice[],
         paired: local.paired.map((device) => redactLocalPairedDevice(device)),
       };
+      context.pairingList = localList;
       const replacement = findSameDeviceReplacementRequest({
         originalRequest,
         originalRequestId: requestId,
@@ -713,17 +659,18 @@ async function resolveApprovePairingGatewayContext(
     const list = await listPairingWithFallback(opts);
     const request = findPendingRequestById(list.pending, requestId);
     if (!request) {
-      return { originalRequest: null, scopes: undefined };
+      return { originalRequest: null, pairingList: list, scopes: undefined };
     }
     return {
       originalRequest: request,
+      pairingList: list,
       scopes: resolveApprovePairingScopesForRequest(
         request,
         lookupPairedDevice(indexPairedDevices(list.paired), request),
       ),
     };
   } catch {
-    return { originalRequest: null, scopes: undefined };
+    return { originalRequest: null, pairingList: null, scopes: undefined };
   }
 }
 
@@ -951,7 +898,7 @@ export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void>
     for (const row of rows) {
       defaultRuntime.log(`  ${row["Device ID"]}  ${row.Device}`);
     }
-    const nodeApprovalNotices = await findPairedDevicePendingNodeApprovalNotices(opts, list.paired);
+    const nodeApprovalNotices = findPairedDevicePendingNodeApprovalNotices(opts, list.paired);
     for (const notice of nodeApprovalNotices) {
       defaultRuntime.log(theme.warn(formatNodeApprovalNotice(notice)));
     }
@@ -1135,8 +1082,9 @@ export async function runDevicesApproveCommand(
     return;
   }
   let result: Record<string, unknown> | null;
+  const approvalContext = await resolveApprovePairingGatewayContext(opts, resolvedRequestId);
   try {
-    result = await approvePairingWithFallback(opts, resolvedRequestId);
+    result = await approvePairingWithFallback(opts, resolvedRequestId, approvalContext);
   } catch (error) {
     if (isScopeUpgradePendingApproval(error)) {
       defaultRuntime.error(
@@ -1151,7 +1099,11 @@ export async function runDevicesApproveCommand(
     defaultRuntime.error(
       `No pending device request matches ${sanitizeForLog(resolvedRequestId)}. Run ${formatCliCommand("openclaw devices list")} and retry with the current request ID.`,
     );
-    const nodeApprovalNotices = await findQueryPendingNodeApprovalNotices(opts, resolvedRequestId);
+    const nodeApprovalNotices = findQueryPendingNodeApprovalNotices(
+      opts,
+      approvalContext.pairingList?.paired,
+      resolvedRequestId,
+    );
     for (const notice of nodeApprovalNotices) {
       defaultRuntime.error(formatNodeApprovalNotice(notice));
     }

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -522,32 +522,23 @@ describe("devices cli approve", () => {
             displayName: "Colin's S25",
             remoteIp: "192.168.0.202",
             roles: ["node"],
+            nodeSurface: {
+              displayName: "Colin's S25",
+              createdAtMs: 1,
+              approvedAtMs: 1,
+            },
+            pendingNodeSurface: {
+              requestId: "node-req-1",
+              revision: "revision-1",
+              displayName: "Colin's S25",
+              remoteIp: "192.168.0.202",
+              ts: 2,
+            },
           }),
         ],
       })
       .mockRejectedValueOnce(new Error("device pairing approval denied"))
-      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" })
-      .mockResolvedValueOnce({
-        nodes: [
-          {
-            nodeId: "android-node",
-            displayName: "Colin's S25",
-            approvalState: "pending-reapproval",
-            pendingRequestId: "node-req-1",
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [
-          pairedDevice({
-            deviceId: "android-node",
-            displayName: "Colin's S25",
-            remoteIp: "192.168.0.202",
-            roles: ["node"],
-          }),
-        ],
-      });
+      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" });
 
     await runDevicesApprove([
       "192.168.0.202",
@@ -557,8 +548,7 @@ describe("devices cli approve", () => {
       "secret-token",
     ]);
 
-    expectGatewayCall(3, { method: "node.list" });
-    expectGatewayCall(4, { method: "device.pair.list" });
+    expect(callGateway).toHaveBeenCalledTimes(3);
     const errorOutput = readRuntimeErrorOutput();
     expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).toContain("Node reapproval pending for Colin's S25");
@@ -587,34 +577,11 @@ describe("devices cli approve", () => {
         ],
       })
       .mockRejectedValueOnce(new Error("device pairing approval denied"))
-      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" })
-      .mockResolvedValueOnce({
-        nodes: [
-          {
-            nodeId: "unrelated-node",
-            displayName: "Shared Phone",
-            remoteIp: "10.0.0.50",
-            approvalState: "pending-reapproval",
-            pendingRequestId: "node-req-unrelated",
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [
-          pairedDevice({
-            deviceId: "android-node",
-            displayName: "Shared Phone",
-            remoteIp: "192.168.0.202",
-            roles: ["node"],
-          }),
-        ],
-      });
+      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" });
 
     await runDevicesApprove(["192.168.0.202"]);
 
-    expectGatewayCall(3, { method: "node.list" });
-    expectGatewayCall(4, { method: "device.pair.list" });
+    expect(callGateway).toHaveBeenCalledTimes(3);
     const errorOutput = readRuntimeErrorOutput();
     expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).not.toContain("node-req-unrelated");
@@ -630,35 +597,20 @@ describe("devices cli approve", () => {
             deviceId: "paired-node",
             displayName: "Shared Phone",
             roles: ["node"],
+            pendingNodeSurface: {
+              requestId: "node-req-display-name",
+              revision: "revision-1",
+              displayName: "Shared Phone",
+              ts: 2,
+            },
           }),
         ],
       })
-      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" })
-      .mockResolvedValueOnce({
-        nodes: [
-          {
-            nodeId: "paired-node",
-            displayName: "Shared Phone",
-            approvalState: "pending-approval",
-            pendingRequestId: "node-req-display-name",
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [
-          pairedDevice({
-            deviceId: "paired-node",
-            displayName: "Shared Phone",
-            roles: ["node"],
-          }),
-        ],
-      });
+      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" });
 
     await runDevicesApprove(["Shared Phone"]);
 
-    expectGatewayCall(2, { method: "node.list" });
-    expectGatewayCall(3, { method: "device.pair.list" });
+    expect(callGateway).toHaveBeenCalledTimes(2);
     const errorOutput = readRuntimeErrorOutput();
     expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).not.toContain("node-req-display-name");
@@ -1080,30 +1032,30 @@ describe("devices cli list", () => {
   });
 
   it("shows pending node approval commands for paired node devices", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [
-          pairedDevice({
-            deviceId: "android-node",
+    callGateway.mockResolvedValueOnce({
+      pending: [],
+      paired: [
+        pairedDevice({
+          deviceId: "android-node",
+          displayName: "Colin's S25",
+          remoteIp: "192.168.0.202",
+          role: "node",
+          roles: [],
+          nodeSurface: {
             displayName: "Colin's S25",
-            remoteIp: "192.168.0.202",
-            role: "node",
-            roles: [],
-          }),
-        ],
-      })
-      .mockResolvedValueOnce({
-        nodes: [
-          {
-            nodeId: "android-node",
-            displayName: "Colin's S25",
-            remoteIp: "192.168.0.202",
-            approvalState: "pending-reapproval",
-            pendingRequestId: "node-req-1",
+            createdAtMs: 1,
+            approvedAtMs: 1,
           },
-        ],
-      });
+          pendingNodeSurface: {
+            requestId: "node-req-1",
+            revision: "revision-1",
+            displayName: "Colin's S25",
+            remoteIp: "192.168.0.202",
+            ts: 2,
+          },
+        }),
+      ],
+    });
 
     await runDevicesCommand([
       "list",
@@ -1113,7 +1065,7 @@ describe("devices cli list", () => {
       "secret-token",
     ]);
 
-    expectGatewayCall(1, { method: "node.list" });
+    expect(callGateway).toHaveBeenCalledOnce();
     const output = readRuntimeOutput();
     expect(output).toContain("Node reapproval pending for Colin's S25");
     expect(output).toContain("openclaw nodes approve node-req-1");
@@ -1125,34 +1077,22 @@ describe("devices cli list", () => {
   });
 
   it("does not show node approval commands for paired node devices when only display names match", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [
-          pairedDevice({
-            deviceId: "android-node",
-            displayName: "Shared Phone",
-            remoteIp: "192.168.0.202",
-            role: "node",
-            roles: [],
-          }),
-        ],
-      })
-      .mockResolvedValueOnce({
-        nodes: [
-          {
-            nodeId: "unrelated-node",
-            displayName: "Shared Phone",
-            remoteIp: "10.0.0.50",
-            approvalState: "pending-reapproval",
-            pendingRequestId: "node-req-unrelated",
-          },
-        ],
-      });
+    callGateway.mockResolvedValueOnce({
+      pending: [],
+      paired: [
+        pairedDevice({
+          deviceId: "android-node",
+          displayName: "Shared Phone",
+          remoteIp: "192.168.0.202",
+          role: "node",
+          roles: [],
+        }),
+      ],
+    });
 
     await runDevicesCommand(["list"]);
 
-    expectGatewayCall(1, { method: "node.list" });
+    expect(callGateway).toHaveBeenCalledOnce();
     const output = readRuntimeOutput();
     expect(output).not.toContain("node-req-unrelated");
     expect(output).not.toContain("openclaw nodes approve");

--- a/src/commands/doctor-session-incognito-key-repair-state.ts
+++ b/src/commands/doctor-session-incognito-key-repair-state.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { sql } from "kysely";
 import {
@@ -6,9 +5,8 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 
 export type ReservedKeyRename = { from: string; to: string };
 
@@ -187,14 +185,11 @@ export function readRepairJournal(database: DatabaseSync): ReservedKeyRename[] {
 }
 
 export function readRepairJournalReadOnly(env: NodeJS.ProcessEnv): ReservedKeyRename[] {
-  const statePath = resolveOpenClawStateSqlitePath(env);
-  if (!fs.existsSync(statePath)) {
-    return [];
-  }
-  return withOpenClawStateDatabaseReadOnly((database) => readRepairJournal(database.db), {
-    env,
-    path: statePath,
-  });
+  return (
+    withExistingOpenClawStateDatabaseReadOnly((database) => readRepairJournal(database.db), {
+      env,
+    }) ?? []
+  );
 }
 
 export function writeRepairJournal(

--- a/src/config/sessions/session-system-prompt-report.ts
+++ b/src/config/sessions/session-system-prompt-report.ts
@@ -1,0 +1,64 @@
+/** Persisted size and provenance summary for one assembled system prompt. */
+export type SessionSystemPromptReport = {
+  source: "run" | "estimate";
+  generatedAt: number;
+  sessionId?: string;
+  sessionKey?: string;
+  provider?: string;
+  model?: string;
+  workspaceDir?: string;
+  bootstrapMaxChars?: number;
+  bootstrapTotalMaxChars?: number;
+  bootstrapTruncation?: {
+    warningMode?: "off" | "once" | "always";
+    warningShown?: boolean;
+    promptWarningSignature?: string;
+    warningSignaturesSeen?: string[];
+    truncatedFiles?: number;
+    nearLimitFiles?: number;
+    totalNearLimit?: boolean;
+  };
+  sandbox?: {
+    mode?: string;
+    sandboxed?: boolean;
+  };
+  systemPrompt: {
+    chars: number;
+    projectContextChars: number;
+    nonProjectContextChars: number;
+    hash?: string;
+  };
+  currentTurn?: {
+    kind?: "user_request" | "room_event";
+    promptChars: number;
+    runtimeContextChars: number;
+    // Hook prepend/append context sent to the model but absent from the
+    // persisted transcript prompt; consumers add it on top of transcript sums.
+    modelOnlyPromptChars?: number;
+  };
+  injectedWorkspaceFiles: Array<{
+    name: string;
+    path: string;
+    missing: boolean;
+    rawChars: number;
+    injectedChars: number;
+    truncated: boolean;
+  }>;
+  skills: {
+    promptChars: number;
+    hash?: string;
+    entries: Array<{ name: string; blockChars: number }>;
+  };
+  tools: {
+    listChars: number;
+    schemaChars: number;
+    entries: Array<{
+      name: string;
+      summaryChars: number;
+      summaryHash?: string;
+      schemaChars: number;
+      schemaHash?: string;
+      propertiesCount?: number | null;
+    }>;
+  };
+};

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -35,9 +35,11 @@ import type {
   SessionParticipant,
 } from "./session-entry-provenance.js";
 import type { AgentPatchedSessionModelFallback } from "./session-model-fallback.js";
+import type { SessionSystemPromptReport } from "./session-system-prompt-report.js";
 import type { SessionToolOverrides } from "./session-tool-overrides.js";
 
 export type { SessionToolOverrides } from "./session-tool-overrides.js";
+export type { SessionSystemPromptReport } from "./session-system-prompt-report.js";
 
 export type SessionScope = "per-sender" | "global";
 export type SessionChatType = ChatType;
@@ -873,70 +875,6 @@ export type SessionSkillSnapshot = {
    */
   resolvedSkills?: Skill[];
   version?: number;
-};
-
-export type SessionSystemPromptReport = {
-  source: "run" | "estimate";
-  generatedAt: number;
-  sessionId?: string;
-  sessionKey?: string;
-  provider?: string;
-  model?: string;
-  workspaceDir?: string;
-  bootstrapMaxChars?: number;
-  bootstrapTotalMaxChars?: number;
-  bootstrapTruncation?: {
-    warningMode?: "off" | "once" | "always";
-    warningShown?: boolean;
-    promptWarningSignature?: string;
-    warningSignaturesSeen?: string[];
-    truncatedFiles?: number;
-    nearLimitFiles?: number;
-    totalNearLimit?: boolean;
-  };
-  sandbox?: {
-    mode?: string;
-    sandboxed?: boolean;
-  };
-  systemPrompt: {
-    chars: number;
-    projectContextChars: number;
-    nonProjectContextChars: number;
-    hash?: string;
-  };
-  currentTurn?: {
-    kind?: "user_request" | "room_event";
-    promptChars: number;
-    runtimeContextChars: number;
-    // Hook prepend/append context sent to the model but absent from the
-    // persisted transcript prompt; consumers add it on top of transcript sums.
-    modelOnlyPromptChars?: number;
-  };
-  injectedWorkspaceFiles: Array<{
-    name: string;
-    path: string;
-    missing: boolean;
-    rawChars: number;
-    injectedChars: number;
-    truncated: boolean;
-  }>;
-  skills: {
-    promptChars: number;
-    hash?: string;
-    entries: Array<{ name: string; blockChars: number }>;
-  };
-  tools: {
-    listChars: number;
-    schemaChars: number;
-    entries: Array<{
-      name: string;
-      summaryChars: number;
-      summaryHash?: string;
-      schemaChars: number;
-      schemaHash?: string;
-      propertiesCount?: number | null;
-    }>;
-  };
 };
 
 export const DEFAULT_RESET_TRIGGERS = ["/new", "/reset"];

--- a/src/fleet/registry.ts
+++ b/src/fleet/registry.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import type { Insertable, Selectable } from "kysely";
 import {
@@ -7,11 +6,10 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { allocateHostPort } from "./cell-profile.js";
 
 export type FleetCellRecord = {
@@ -87,22 +85,21 @@ function recordToRow(record: FleetCellRecord): Insertable<FleetCellsTable> {
 }
 
 export function listFleetCells(env: NodeJS.ProcessEnv = process.env): FleetCellRecord[] {
-  if (!fs.existsSync(resolveOpenClawStateSqlitePath(env))) {
-    return [];
-  }
   // CLI reads must not join the Gateway's writable SQLite lifecycle (#101290).
-  return withOpenClawStateDatabaseReadOnly(
-    ({ db }) => {
-      if (!tableExists(db, "fleet_cells")) {
-        return [];
-      }
-      const rows = executeSqliteQuerySync(
-        db,
-        kyselyFor(db).selectFrom("fleet_cells").selectAll().orderBy("tenant_id", "asc"),
-      ).rows;
-      return rows.map(rowToRecord);
-    },
-    { env },
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => {
+        if (!tableExists(db, "fleet_cells")) {
+          return [];
+        }
+        const rows = executeSqliteQuerySync(
+          db,
+          kyselyFor(db).selectFrom("fleet_cells").selectAll().orderBy("tenant_id", "asc"),
+        ).rows;
+        return rows.map(rowToRecord);
+      },
+      { env },
+    ) ?? []
   );
 }
 
@@ -110,11 +107,8 @@ export function getFleetCell(
   env: NodeJS.ProcessEnv,
   tenantId: string,
 ): FleetCellRecord | undefined {
-  if (!fs.existsSync(resolveOpenClawStateSqlitePath(env))) {
-    return undefined;
-  }
   // CLI reads must not join the Gateway's writable SQLite lifecycle (#101290).
-  return withOpenClawStateDatabaseReadOnly(
+  return withExistingOpenClawStateDatabaseReadOnly(
     ({ db }) => {
       if (!tableExists(db, "fleet_cells")) {
         return undefined;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -935,6 +935,12 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.password).toBeUndefined();
     expect(lastClientOptions?.scopes).toBeUndefined();
     expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
+    expect(lastClientOptions?.preparedDeviceAuth).toEqual({
+      token: "paired-device-token",
+      role: "operator",
+      scopes: ["operator.read", "operator.pairing"],
+      updatedAtMs: 123,
+    });
   });
 
   it("keeps explicit credentials and diagnostic scopes ahead of stored device auth", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -852,6 +852,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   connectionDetails: GatewayConnectionDetails;
   deviceIdentity: DeviceIdentity | null;
   deviceAuthScope?: string;
+  storedAuth?: DeviceAuthEntry;
   surfaceGatewayClientRequestErrors: boolean;
 }): Promise<T> {
   const {
@@ -867,6 +868,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
     safeTimerTimeoutMs,
     deviceIdentity,
     deviceAuthScope,
+    storedAuth,
     surfaceGatewayClientRequestErrors,
   } = params;
   return await new Promise<T>((resolve, reject) => {
@@ -957,6 +959,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       ...(Array.isArray(scopes) ? { scopes } : {}),
       deviceIdentity,
       ...(deviceAuthScope ? { deviceAuthScope } : {}),
+      ...(storedAuth ? { preparedDeviceAuth: storedAuth } : {}),
       ...(opts.sharedStateMode ? { sharedStateMode: opts.sharedStateMode } : {}),
       minProtocol: opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
@@ -1227,6 +1230,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     connectionDetails,
     deviceIdentity,
     deviceAuthScope,
+    ...(storedAuth ? { storedAuth } : {}),
     surfaceGatewayClientRequestErrors:
       useStoredDeviceAuth ||
       opts.requireLocalBackendSharedAuth === true ||

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1988,6 +1988,73 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
+  it.each([
+    { completion: "clear", deviceAuthScope: undefined, store: "device" },
+    { completion: "overwrite", deviceAuthScope: undefined, store: "device" },
+    { completion: "clear", deviceAuthScope: "wss://one.example/rpc", store: "origin" },
+    { completion: "overwrite", deviceAuthScope: "wss://one.example/rpc", store: "origin" },
+  ] as const)(
+    "does not $completion rotated $store auth after the prepared snapshot",
+    async ({ completion, deviceAuthScope }) => {
+      const preparedDeviceAuth = {
+        token: "prepared-device-token",
+        role: "operator",
+        scopes: ["operator.read"],
+        updatedAtMs: 123,
+      };
+      let durableToken: string | undefined = preparedDeviceAuth.token;
+      const clearTokenMock = deviceAuthScope
+        ? clearOriginDeviceTokenMock
+        : clearDeviceAuthTokenMock;
+      const storeTokenMock = deviceAuthScope
+        ? storeOriginDeviceTokenMock
+        : storeDeviceAuthTokenMock;
+      clearTokenMock.mockImplementation(({ expectedToken }: { expectedToken?: string }) => {
+        if (durableToken === expectedToken) {
+          durableToken = undefined;
+        }
+      });
+      storeTokenMock.mockImplementation(
+        ({ expectedToken, token }: { expectedToken?: string; token: string }) => {
+          if (durableToken === expectedToken) {
+            durableToken = token;
+          }
+        },
+      );
+      const client = createClientWithIdentity("device-1", () => {}, {
+        preparedDeviceAuth,
+        ...(deviceAuthScope ? { deviceAuthScope } : {}),
+      });
+
+      const { ws, connect } = startClientAndConnect({ client });
+      durableToken = "rotated-device-token";
+      if (completion === "clear") {
+        emitConnectFailure(ws, connect.id, { code: "AUTH_DEVICE_TOKEN_MISMATCH" });
+        await waitForFast(() => expect(clearTokenMock).toHaveBeenCalledOnce());
+      } else {
+        ws.emitMessage(
+          JSON.stringify({
+            type: "res",
+            id: connect.id,
+            ok: true,
+            payload: {
+              type: "hello-ok",
+              auth: {
+                role: "operator",
+                scopes: ["operator.write"],
+                deviceToken: "stale-request-replacement",
+              },
+            },
+          }),
+        );
+        await waitForFast(() => expect(storeTokenMock).toHaveBeenCalledOnce());
+      }
+
+      expect(durableToken).toBe("rotated-device-token");
+      client.stop();
+    },
+  );
+
   it("keeps read-only origin auth loads and hello tokens off writable host callbacks", async () => {
     loadOriginDeviceTokenReadOnlyMock.mockReturnValue({
       token: "stored-origin-token",

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1965,6 +1965,29 @@ describe("GatewayClient connect auth payload", () => {
     second.stop();
   });
 
+  it("uses prepared device auth without rereading the token store", () => {
+    const client = createClientWithIdentity("device-1", () => {}, {
+      preparedDeviceAuth: {
+        token: "prepared-device-token",
+        role: "operator",
+        scopes: ["operator.read"],
+        updatedAtMs: 123,
+      },
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    expect(connectFrameFrom(ws)).toMatchObject({
+      token: "prepared-device-token",
+      deviceToken: "prepared-device-token",
+    });
+    expect(loadDeviceAuthTokenMock).not.toHaveBeenCalled();
+    client.stop();
+  });
+
   it("keeps read-only origin auth loads and hello tokens off writable host callbacks", async () => {
     loadOriginDeviceTokenReadOnlyMock.mockReturnValue({
       token: "stored-origin-token",

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -31,6 +31,7 @@ import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { logDebug, logError } from "../logger.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import type { DeviceAuthEntry } from "../shared/device-auth.js";
 import { VERSION } from "../version.js";
 
 export {
@@ -48,6 +49,8 @@ export type GatewayClientOptions = BaseGatewayClientOptions & {
   deviceAuthScope?: string;
   /** Prevent this client lifecycle from creating or mutating shared state. */
   sharedStateMode?: "read-only";
+  /** Auth already resolved and validated by the one-shot call owner. */
+  preparedDeviceAuth?: DeviceAuthEntry;
 };
 
 function createOpenClawGatewayClientHostDeps(
@@ -55,6 +58,7 @@ function createOpenClawGatewayClientHostDeps(
   deviceAuthScope?: string,
   suppressOriginDeviceAuth = false,
   sharedStateMode?: "read-only",
+  preparedDeviceAuth?: DeviceAuthEntry,
 ): GatewayClientHostDeps {
   const readOnly = sharedStateMode === "read-only";
   const deviceAuthDeps: Pick<
@@ -82,13 +86,16 @@ function createOpenClawGatewayClientHostDeps(
           clearDeviceAuthToken: () => {},
         }
       : { loadDeviceAuthToken, storeDeviceAuthToken, clearDeviceAuthToken };
+  const preparedDeviceAuthDeps = preparedDeviceAuth
+    ? { ...deviceAuthDeps, loadDeviceAuthToken: () => preparedDeviceAuth }
+    : deviceAuthDeps;
   return {
     // This wrapper is the only place the package reaches into OpenClaw runtime
     // state. Keep device identity, token storage, proxy, and redaction here.
     loadOrCreateDeviceIdentity,
     signDevicePayload,
     publicKeyRawBase64UrlFromPem,
-    ...deviceAuthDeps,
+    ...preparedDeviceAuthDeps,
     beforeConnect: ensureInheritedManagedProxyRoutingActive,
     registerGatewayLoopbackBypass: registerManagedProxyGatewayLoopbackBypass,
     normalizeTlsFingerprint: (fingerprint) => normalizeFingerprint(fingerprint ?? ""),
@@ -101,7 +108,7 @@ function createOpenClawGatewayClientHostDeps(
           // Read-only is an authoritative lifecycle policy: caller overrides
           // must not restore identity creation or token writes behind it.
           loadOrCreateDeviceIdentity: () => loadDeviceIdentityIfPresent() ?? undefined,
-          ...deviceAuthDeps,
+          ...preparedDeviceAuthDeps,
         }
       : {}),
   };
@@ -111,7 +118,7 @@ export class GatewayClient {
   #client: BaseGatewayClient;
 
   constructor(opts: GatewayClientOptions) {
-    const { deviceAuthScope, sharedStateMode, ...baseOptions } = opts;
+    const { deviceAuthScope, preparedDeviceAuth, sharedStateMode, ...baseOptions } = opts;
     const suppressOriginDeviceAuth = Boolean(
       deviceAuthScope && (baseOptions.token?.trim() || baseOptions.password?.trim()),
     );
@@ -127,6 +134,7 @@ export class GatewayClient {
         deviceAuthScope,
         suppressOriginDeviceAuth,
         sharedStateMode,
+        preparedDeviceAuth,
       ),
     });
   }

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -61,6 +61,11 @@ function createOpenClawGatewayClientHostDeps(
   preparedDeviceAuth?: DeviceAuthEntry,
 ): GatewayClientHostDeps {
   const readOnly = sharedStateMode === "read-only";
+  // Prepared auth is immutable request input. Any later durable mutation must
+  // still match this token so a stale request cannot undo a concurrent rotation.
+  const rotationFence = preparedDeviceAuth
+    ? { expectedToken: preparedDeviceAuth.token }
+    : undefined;
   const deviceAuthDeps: Pick<
     GatewayClientHostDeps,
     "loadDeviceAuthToken" | "storeDeviceAuthToken" | "clearDeviceAuthToken"
@@ -74,10 +79,20 @@ function createOpenClawGatewayClientHostDeps(
               : loadOriginDeviceToken({ ...params, gatewayScope: deviceAuthScope }),
         storeDeviceAuthToken: readOnly
           ? () => {}
-          : (params) => storeOriginDeviceToken({ ...params, gatewayScope: deviceAuthScope }),
+          : (params) =>
+              storeOriginDeviceToken({
+                ...params,
+                gatewayScope: deviceAuthScope,
+                ...rotationFence,
+              }),
         clearDeviceAuthToken: readOnly
           ? () => {}
-          : (params) => clearOriginDeviceToken({ ...params, gatewayScope: deviceAuthScope }),
+          : (params) =>
+              clearOriginDeviceToken({
+                ...params,
+                gatewayScope: deviceAuthScope,
+                ...rotationFence,
+              }),
       }
     : readOnly
       ? {
@@ -85,7 +100,11 @@ function createOpenClawGatewayClientHostDeps(
           storeDeviceAuthToken: () => {},
           clearDeviceAuthToken: () => {},
         }
-      : { loadDeviceAuthToken, storeDeviceAuthToken, clearDeviceAuthToken };
+      : {
+          loadDeviceAuthToken,
+          storeDeviceAuthToken: (params) => storeDeviceAuthToken({ ...params, ...rotationFence }),
+          clearDeviceAuthToken: (params) => clearDeviceAuthToken({ ...params, ...rotationFence }),
+        };
   const preparedDeviceAuthDeps = preparedDeviceAuth
     ? { ...deviceAuthDeps, loadDeviceAuthToken: () => preparedDeviceAuth }
     : deviceAuthDeps;

--- a/src/infra/device-auth-store.test.ts
+++ b/src/infra/device-auth-store.test.ts
@@ -376,4 +376,71 @@ describe("infra/device-auth-store", () => {
       );
     });
   });
+
+  it("keeps credentials rotated after a stale request snapshot", async () => {
+    await withTempDir("openclaw-device-auth-rotation-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      const targets = [
+        {
+          name: "device",
+          load: () => loadDeviceAuthToken({ deviceId: "device-1", role: "operator", env }),
+          store: (token: string, expectedToken?: string) =>
+            storeDeviceAuthToken({
+              deviceId: "device-1",
+              role: "operator",
+              token,
+              scopes: ["operator.read"],
+              env,
+              ...(expectedToken === undefined ? {} : { expectedToken }),
+            }),
+          clear: (expectedToken: string) =>
+            clearDeviceAuthToken({
+              deviceId: "device-1",
+              role: "operator",
+              env,
+              expectedToken,
+            }),
+        },
+        {
+          name: "origin",
+          load: () =>
+            loadOriginDeviceToken({
+              gatewayScope: "wss://one.example",
+              deviceId: "device-1",
+              role: "operator",
+              env,
+            }),
+          store: (token: string, expectedToken?: string) =>
+            storeOriginDeviceToken({
+              gatewayScope: "wss://one.example",
+              deviceId: "device-1",
+              role: "operator",
+              token,
+              scopes: ["operator.read"],
+              env,
+              ...(expectedToken === undefined ? {} : { expectedToken }),
+            }),
+          clear: (expectedToken: string) =>
+            clearOriginDeviceToken({
+              gatewayScope: "wss://one.example",
+              deviceId: "device-1",
+              role: "operator",
+              env,
+              expectedToken,
+            }),
+        },
+      ];
+
+      for (const target of targets) {
+        const prepared = target.store(`${target.name}-prepared`);
+        const rotated = target.store(`${target.name}-rotated`);
+        expect(prepared).not.toBeNull();
+        expect(rotated).not.toBeNull();
+
+        expect(target.store(`${target.name}-stale-replacement`, prepared!.token)).toBeNull();
+        expect(target.clear(prepared!.token)).toBe(false);
+        expect(target.load()).toEqual(rotated);
+      }
+    });
+  });
 });

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -24,6 +24,12 @@ type DeviceAuthDatabase = Pick<
   OpenClawStateKyselyDatabase,
   "device_auth_tokens" | "gateway_origin_device_tokens"
 >;
+type DeviceAuthRow = {
+  token: string;
+  role: string;
+  scopes_json: string;
+  updated_at_ms: number;
+};
 // The Gateway lock makes state-directory contents process-stable. Cache both
 // outcomes to keep reconnects free of freshness polling; Doctor invalidates
 // the entry after its exclusive legacy import removes the retired file.
@@ -78,12 +84,7 @@ export function resetLegacyDeviceAuthPresenceCache(env: NodeJS.ProcessEnv): void
   legacyPresenceCache.delete(resolveStateDir(env));
 }
 
-function fromRow(row: {
-  token: string;
-  role: string;
-  scopes_json: string;
-  updated_at_ms: number;
-}): DeviceAuthEntry | null {
+function fromRow(row: DeviceAuthRow): DeviceAuthEntry | null {
   try {
     const scopes = JSON.parse(row.scopes_json) as unknown;
     if (!Array.isArray(scopes)) {
@@ -98,6 +99,37 @@ function fromRow(row: {
   } catch {
     return null;
   }
+}
+
+function readDeviceAuthTokenFromDatabase(
+  db: DatabaseSync,
+  params: { deviceId: string; role: string },
+): DeviceAuthEntry | null {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<DeviceAuthDatabase>(db)
+      .selectFrom("device_auth_tokens")
+      .select(["token", "role", "scopes_json", "updated_at_ms"])
+      .where("device_id", "=", params.deviceId)
+      .where("role", "=", normalizeDeviceAuthRole(params.role)),
+  );
+  return row ? fromRow(row) : null;
+}
+
+function readOriginDeviceTokenFromDatabase(
+  db: DatabaseSync,
+  params: { gatewayScope: string; deviceId: string; role: string },
+): DeviceAuthEntry | null {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<DeviceAuthDatabase>(db)
+      .selectFrom("gateway_origin_device_tokens")
+      .select(["token", "role", "scopes_json", "updated_at_ms"])
+      .where("gateway_scope", "=", params.gatewayScope)
+      .where("device_id", "=", params.deviceId)
+      .where("role", "=", normalizeDeviceAuthRole(params.role)),
+  );
+  return row ? fromRow(row) : null;
 }
 
 function createDeviceAuthEntry(params: {
@@ -121,15 +153,7 @@ export function loadDeviceAuthToken(params: {
 }): DeviceAuthEntry | null {
   assertNoLegacyDeviceAuth(params.env);
   const { db } = openOpenClawStateDatabase({ env: params.env });
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getNodeSqliteKysely<DeviceAuthDatabase>(db)
-      .selectFrom("device_auth_tokens")
-      .select(["token", "role", "scopes_json", "updated_at_ms"])
-      .where("device_id", "=", params.deviceId)
-      .where("role", "=", normalizeDeviceAuthRole(params.role)),
-  );
-  return row ? fromRow(row) : null;
+  return readDeviceAuthTokenFromDatabase(db, params);
 }
 
 /** Load one cached device-auth token without creating or joining writable state. */
@@ -142,15 +166,7 @@ export function loadDeviceAuthTokenReadOnly(params: {
   return (
     withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(
       ({ db }) => {
-        const row = executeSqliteQueryTakeFirstSync(
-          db,
-          getNodeSqliteKysely<DeviceAuthDatabase>(db)
-            .selectFrom("device_auth_tokens")
-            .select(["token", "role", "scopes_json", "updated_at_ms"])
-            .where("device_id", "=", params.deviceId)
-            .where("role", "=", normalizeDeviceAuthRole(params.role)),
-        );
-        return row ? fromRow(row) : null;
+        return readDeviceAuthTokenFromDatabase(db, params);
       },
       { env: params.env },
     ) ?? null
@@ -244,16 +260,7 @@ export function loadOriginDeviceToken(params: {
 }): DeviceAuthEntry | null {
   ensureOriginDeviceAuthSchema(params.env);
   const { db } = openOpenClawStateDatabase({ env: params.env });
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getNodeSqliteKysely<DeviceAuthDatabase>(db)
-      .selectFrom("gateway_origin_device_tokens")
-      .select(["token", "role", "scopes_json", "updated_at_ms"])
-      .where("gateway_scope", "=", params.gatewayScope)
-      .where("device_id", "=", params.deviceId)
-      .where("role", "=", normalizeDeviceAuthRole(params.role)),
-  );
-  return row ? fromRow(row) : null;
+  return readOriginDeviceTokenFromDatabase(db, params);
 }
 
 /** Load one origin-bound device token without schema creation or writable state access. */
@@ -267,16 +274,7 @@ export function loadOriginDeviceTokenReadOnly(params: {
   return (
     withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(
       ({ db }) => {
-        const row = executeSqliteQueryTakeFirstSync(
-          db,
-          getNodeSqliteKysely<DeviceAuthDatabase>(db)
-            .selectFrom("gateway_origin_device_tokens")
-            .select(["token", "role", "scopes_json", "updated_at_ms"])
-            .where("gateway_scope", "=", params.gatewayScope)
-            .where("device_id", "=", params.deviceId)
-            .where("role", "=", normalizeDeviceAuthRole(params.role)),
-        );
-        return row ? fromRow(row) : null;
+        return readOriginDeviceTokenFromDatabase(db, params);
       },
       { env: params.env },
     ) ?? null

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -200,34 +200,55 @@ export function storeDeviceAuthToken(params: {
   token: string;
   scopes?: string[];
   env?: NodeJS.ProcessEnv;
-}): DeviceAuthEntry {
+  expectedToken?: string;
+}): DeviceAuthEntry | null {
   assertNoLegacyDeviceAuth(params.env);
   const entry = createDeviceAuthEntry(params);
+  let stored = false;
   runOpenClawStateWriteTransaction(
     ({ db }) => {
-      executeSqliteQuerySync(
-        db,
-        getNodeSqliteKysely<DeviceAuthDatabase>(db)
-          .insertInto("device_auth_tokens")
-          .values({
-            device_id: params.deviceId,
-            role: entry.role,
-            token: entry.token,
-            scopes_json: JSON.stringify(entry.scopes),
-            updated_at_ms: entry.updatedAtMs,
-          })
-          .onConflict((conflict) =>
-            conflict.columns(["device_id", "role"]).doUpdateSet({
-              token: entry.token,
-              scopes_json: JSON.stringify(entry.scopes),
-              updated_at_ms: entry.updatedAtMs,
-            }),
-          ),
-      );
+      const kysely = getNodeSqliteKysely<DeviceAuthDatabase>(db);
+      // Fenced writes update only the row that supplied the request snapshot;
+      // they never upsert a row that another request rotated or removed.
+      const result =
+        params.expectedToken === undefined
+          ? executeSqliteQuerySync(
+              db,
+              kysely
+                .insertInto("device_auth_tokens")
+                .values({
+                  device_id: params.deviceId,
+                  role: entry.role,
+                  token: entry.token,
+                  scopes_json: JSON.stringify(entry.scopes),
+                  updated_at_ms: entry.updatedAtMs,
+                })
+                .onConflict((conflict) =>
+                  conflict.columns(["device_id", "role"]).doUpdateSet({
+                    token: entry.token,
+                    scopes_json: JSON.stringify(entry.scopes),
+                    updated_at_ms: entry.updatedAtMs,
+                  }),
+                ),
+            )
+          : executeSqliteQuerySync(
+              db,
+              kysely
+                .updateTable("device_auth_tokens")
+                .set({
+                  token: entry.token,
+                  scopes_json: JSON.stringify(entry.scopes),
+                  updated_at_ms: entry.updatedAtMs,
+                })
+                .where("device_id", "=", params.deviceId)
+                .where("role", "=", entry.role)
+                .where("token", "=", params.expectedToken),
+            );
+      stored = result.numAffectedRows === 1n;
     },
     { env: params.env },
   );
-  return entry;
+  return stored ? entry : null;
 }
 
 /** Remove one role token for the current gateway device from shared SQLite state. */
@@ -235,20 +256,25 @@ export function clearDeviceAuthToken(params: {
   deviceId: string;
   role: string;
   env?: NodeJS.ProcessEnv;
-}): void {
+  expectedToken?: string;
+}): boolean {
   assertNoLegacyDeviceAuth(params.env);
+  let cleared = false;
   runOpenClawStateWriteTransaction(
     ({ db }) => {
-      executeSqliteQuerySync(
-        db,
-        getNodeSqliteKysely<DeviceAuthDatabase>(db)
-          .deleteFrom("device_auth_tokens")
-          .where("device_id", "=", params.deviceId)
-          .where("role", "=", normalizeDeviceAuthRole(params.role)),
-      );
+      const baseQuery = getNodeSqliteKysely<DeviceAuthDatabase>(db)
+        .deleteFrom("device_auth_tokens")
+        .where("device_id", "=", params.deviceId)
+        .where("role", "=", normalizeDeviceAuthRole(params.role));
+      const query =
+        params.expectedToken === undefined
+          ? baseQuery
+          : baseQuery.where("token", "=", params.expectedToken);
+      cleared = executeSqliteQuerySync(db, query).numAffectedRows === 1n;
     },
     { env: params.env },
   );
+  return cleared;
 }
 
 /** Load one device token bound to an exact normalized gateway origin. */
@@ -289,35 +315,55 @@ export function storeOriginDeviceToken(params: {
   token: string;
   scopes?: string[];
   env?: NodeJS.ProcessEnv;
-}): DeviceAuthEntry {
+  expectedToken?: string;
+}): DeviceAuthEntry | null {
   ensureOriginDeviceAuthSchema(params.env);
   const entry = createDeviceAuthEntry(params);
+  let stored = false;
   runOpenClawStateWriteTransaction(
     ({ db }) => {
-      executeSqliteQuerySync(
-        db,
-        getNodeSqliteKysely<DeviceAuthDatabase>(db)
-          .insertInto("gateway_origin_device_tokens")
-          .values({
-            gateway_scope: params.gatewayScope,
-            device_id: params.deviceId,
-            role: entry.role,
-            token: entry.token,
-            scopes_json: JSON.stringify(entry.scopes),
-            updated_at_ms: entry.updatedAtMs,
-          })
-          .onConflict((conflict) =>
-            conflict.columns(["gateway_scope", "device_id", "role"]).doUpdateSet({
-              token: entry.token,
-              scopes_json: JSON.stringify(entry.scopes),
-              updated_at_ms: entry.updatedAtMs,
-            }),
-          ),
-      );
+      const kysely = getNodeSqliteKysely<DeviceAuthDatabase>(db);
+      const result =
+        params.expectedToken === undefined
+          ? executeSqliteQuerySync(
+              db,
+              kysely
+                .insertInto("gateway_origin_device_tokens")
+                .values({
+                  gateway_scope: params.gatewayScope,
+                  device_id: params.deviceId,
+                  role: entry.role,
+                  token: entry.token,
+                  scopes_json: JSON.stringify(entry.scopes),
+                  updated_at_ms: entry.updatedAtMs,
+                })
+                .onConflict((conflict) =>
+                  conflict.columns(["gateway_scope", "device_id", "role"]).doUpdateSet({
+                    token: entry.token,
+                    scopes_json: JSON.stringify(entry.scopes),
+                    updated_at_ms: entry.updatedAtMs,
+                  }),
+                ),
+            )
+          : executeSqliteQuerySync(
+              db,
+              kysely
+                .updateTable("gateway_origin_device_tokens")
+                .set({
+                  token: entry.token,
+                  scopes_json: JSON.stringify(entry.scopes),
+                  updated_at_ms: entry.updatedAtMs,
+                })
+                .where("gateway_scope", "=", params.gatewayScope)
+                .where("device_id", "=", params.deviceId)
+                .where("role", "=", entry.role)
+                .where("token", "=", params.expectedToken),
+            );
+      stored = result.numAffectedRows === 1n;
     },
     { env: params.env },
   );
-  return entry;
+  return stored ? entry : null;
 }
 
 /** Remove one device token only from its exact normalized gateway origin. */
@@ -326,19 +372,24 @@ export function clearOriginDeviceToken(params: {
   deviceId: string;
   role: string;
   env?: NodeJS.ProcessEnv;
-}): void {
+  expectedToken?: string;
+}): boolean {
   ensureOriginDeviceAuthSchema(params.env);
+  let cleared = false;
   runOpenClawStateWriteTransaction(
     ({ db }) => {
-      executeSqliteQuerySync(
-        db,
-        getNodeSqliteKysely<DeviceAuthDatabase>(db)
-          .deleteFrom("gateway_origin_device_tokens")
-          .where("gateway_scope", "=", params.gatewayScope)
-          .where("device_id", "=", params.deviceId)
-          .where("role", "=", normalizeDeviceAuthRole(params.role)),
-      );
+      const baseQuery = getNodeSqliteKysely<DeviceAuthDatabase>(db)
+        .deleteFrom("gateway_origin_device_tokens")
+        .where("gateway_scope", "=", params.gatewayScope)
+        .where("device_id", "=", params.deviceId)
+        .where("role", "=", normalizeDeviceAuthRole(params.role));
+      const query =
+        params.expectedToken === undefined
+          ? baseQuery
+          : baseQuery.where("token", "=", params.expectedToken);
+      cleared = executeSqliteQuerySync(db, query).numAffectedRows === 1n;
     },
     { env: params.env },
   );
+  return cleared;
 }

--- a/src/infra/startup-migration-checkpoint.ts
+++ b/src/infra/startup-migration-checkpoint.ts
@@ -1,13 +1,12 @@
 // Coordinates automatic state-migration and gateway-startup checkpoints in shared state.
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { hostname } from "node:os";
 import { performance } from "node:perf_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { withOpenClawStateStartupMigrationCheckpointDatabase } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -268,30 +267,28 @@ export function hasActiveStartupMigrationLease(
 ): boolean {
   const env = params.env ?? process.env;
   const nowMs = params.nowMs ?? Date.now();
-  const pathname = resolveOpenClawStateSqlitePath(env);
-  if (!existsSync(pathname)) {
-    return false;
-  }
-  return withOpenClawStateDatabaseReadOnly(
-    ({ db }) => {
-      const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
-      const lease = executeSqliteQueryTakeFirstSync(
-        db,
-        stateDb
-          .selectFrom("state_leases")
-          .select("payload_json as payloadJson")
-          .where("scope", "=", STARTUP_MIGRATION_LEASE_SCOPE)
-          .where("lease_key", "=", STARTUP_MIGRATION_LEASE_KEY)
-          .where("expires_at", ">", nowMs),
-      );
-      return Boolean(
-        lease &&
-        !isStartupMigrationLeaseOwnerDefinitelyGone(
-          parseStartupMigrationLeaseOwner(lease.payloadJson),
-        ),
-      );
-    },
-    { env },
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => {
+        const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
+        const lease = executeSqliteQueryTakeFirstSync(
+          db,
+          stateDb
+            .selectFrom("state_leases")
+            .select("payload_json as payloadJson")
+            .where("scope", "=", STARTUP_MIGRATION_LEASE_SCOPE)
+            .where("lease_key", "=", STARTUP_MIGRATION_LEASE_KEY)
+            .where("expires_at", ">", nowMs),
+        );
+        return Boolean(
+          lease &&
+          !isStartupMigrationLeaseOwnerDefinitelyGone(
+            parseStartupMigrationLeaseOwner(lease.payloadJson),
+          ),
+        );
+      },
+      { env },
+    ) ?? false
   );
 }
 

--- a/src/plugins/installed-plugin-index-record-state.ts
+++ b/src/plugins/installed-plugin-index-record-state.ts
@@ -1,13 +1,11 @@
-import fs from "node:fs";
 import { safeParseJson } from "@openclaw/normalization-core";
 import {
   inspectPluginInstallRecordMap,
   type PluginInstallRecordMapState,
 } from "../config/plugin-install-record-map.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   resolveInstalledPluginIndexStateDatabaseOptions,
-  resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store-path.js";
 
@@ -18,37 +16,38 @@ type InstalledPluginIndexRecordRow = {
 export function inspectPersistedInstalledPluginIndexInstallRecordsSync(
   options: InstalledPluginIndexStoreOptions = {},
 ): PluginInstallRecordMapState {
-  const storePath = resolveInstalledPluginIndexStorePath(options);
-  if (!fs.existsSync(storePath) || options.filePath?.endsWith(".json")) {
+  if (options.filePath?.endsWith(".json")) {
     return { status: "missing" };
   }
   try {
-    return withOpenClawStateDatabaseReadOnly(({ db }) => {
-      const hasTable = db
-        .prepare(
-          `SELECT 1
+    return (
+      withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+        const hasTable = db
+          .prepare(
+            `SELECT 1
              FROM sqlite_master
             WHERE type = 'table' AND name = 'installed_plugin_index'`,
-        )
-        .get();
-      if (!hasTable) {
-        return { status: "missing" };
-      }
-      const row = db
-        .prepare(
-          `
+          )
+          .get();
+        if (!hasTable) {
+          return { status: "missing" };
+        }
+        const row = db
+          .prepare(
+            `
             SELECT install_records_json
               FROM installed_plugin_index
              WHERE index_key = ?
           `,
-        )
-        .get("installed-plugin-index") as InstalledPluginIndexRecordRow | undefined;
-      if (!row) {
-        return { status: "missing" };
-      }
-      const parsed = safeParseJson(row.install_records_json);
-      return parsed === undefined ? { status: "invalid" } : inspectPluginInstallRecordMap(parsed);
-    }, resolveInstalledPluginIndexStateDatabaseOptions(options));
+          )
+          .get("installed-plugin-index") as InstalledPluginIndexRecordRow | undefined;
+        if (!row) {
+          return { status: "missing" };
+        }
+        const parsed = safeParseJson(row.install_records_json);
+        return parsed === undefined ? { status: "invalid" } : inspectPluginInstallRecordMap(parsed);
+      }, resolveInstalledPluginIndexStateDatabaseOptions(options)) ?? { status: "missing" }
+    );
   } catch {
     return { status: "invalid" };
   }

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -13,7 +13,7 @@ import {
   setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
@@ -348,13 +348,12 @@ function readPersistedInstalledPluginIndexFromSqlite(
   if (options.filePath?.endsWith(".json")) {
     return null;
   }
-  if (!existsSync(resolveInstalledPluginIndexStorePath(options))) {
-    return null;
-  }
   try {
-    return withOpenClawStateDatabaseReadOnly(
-      ({ db }) => parseInstalledPluginIndexSqliteRow(readInstalledPluginIndexRow(db)),
-      resolveInstalledPluginIndexStateDatabaseOptions(options),
+    return (
+      withExistingOpenClawStateDatabaseReadOnly(
+        ({ db }) => parseInstalledPluginIndexSqliteRow(readInstalledPluginIndexRow(db)),
+        resolveInstalledPluginIndexStateDatabaseOptions(options),
+      ) ?? null
     );
   } catch {
     return null;

--- a/src/state/config-machine-state.ts
+++ b/src/state/config-machine-state.ts
@@ -1,18 +1,16 @@
 // Machine-owned values retired from openclaw.json live in the shared state database.
-import { existsSync } from "node:fs";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 type ConfigMachineStateDatabase = Pick<OpenClawStateKyselyDatabase, "config_machine_state">;
 
@@ -37,11 +35,7 @@ export function readConfigMachineState<T>(
   key: string,
   options: OpenClawStateDatabaseOptions = {},
 ): T | undefined {
-  const pathname = options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env);
-  if (!existsSync(pathname)) {
-    return undefined;
-  }
-  return withOpenClawStateDatabaseReadOnly(({ db: database }) => {
+  return withExistingOpenClawStateDatabaseReadOnly(({ db: database }) => {
     if (!tableExists(database, "config_machine_state")) {
       return undefined;
     }

--- a/src/state/onboarding-recommendations.ts
+++ b/src/state/onboarding-recommendations.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { z } from "zod";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-store.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
@@ -7,14 +6,13 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 const OnboardingRecommendationMatchSchema = z.object({
   appLabel: z.string(),
@@ -114,40 +112,38 @@ function readOnboardingRecommendations(
   configKey: string,
   options: OpenClawStateDatabaseOptions = {},
 ): OnboardingRecommendationsRecord | null {
-  const pathname = options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env);
-  if (!existsSync(pathname)) {
-    return null;
-  }
   // CLI reads must not join the Gateway's writable SQLite lifecycle (#101290).
-  return withOpenClawStateDatabaseReadOnly(({ db: database }) => {
-    if (!tableExists(database, "onboarding_recommendations")) {
-      return null;
-    }
-    const db = getNodeSqliteKysely<OnboardingRecommendationsDatabase>(database);
-    const row = executeSqliteQueryTakeFirstSync(
-      database,
-      db
-        .selectFrom("onboarding_recommendations")
-        .select([
-          "inventory_hash",
-          "matches_json",
-          "offered_at_ms",
-          "accepted_at_ms",
-          "updated_at_ms",
-        ])
-        .where("config_key", "=", configKey),
-    );
-    if (!row) {
-      return null;
-    }
-    return {
-      inventoryHash: row.inventory_hash,
-      matches: OnboardingRecommendationMatchesSchema.parse(JSON.parse(row.matches_json)),
-      offeredAt: row.offered_at_ms,
-      acceptedAt: row.accepted_at_ms,
-      updatedAt: row.updated_at_ms,
-    };
-  }, options);
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db: database }) => {
+      if (!tableExists(database, "onboarding_recommendations")) {
+        return null;
+      }
+      const db = getNodeSqliteKysely<OnboardingRecommendationsDatabase>(database);
+      const row = executeSqliteQueryTakeFirstSync(
+        database,
+        db
+          .selectFrom("onboarding_recommendations")
+          .select([
+            "inventory_hash",
+            "matches_json",
+            "offered_at_ms",
+            "accepted_at_ms",
+            "updated_at_ms",
+          ])
+          .where("config_key", "=", configKey),
+      );
+      if (!row) {
+        return null;
+      }
+      return {
+        inventoryHash: row.inventory_hash,
+        matches: OnboardingRecommendationMatchesSchema.parse(JSON.parse(row.matches_json)),
+        offeredAt: row.offered_at_ms,
+        acceptedAt: row.accepted_at_ms,
+        updatedAt: row.updated_at_ms,
+      };
+    }, options) ?? null
+  );
 }
 
 function writeOnboardingRecommendationsOffer(

--- a/src/state/openclaw-agent-db-registry-listing.ts
+++ b/src/state/openclaw-agent-db-registry-listing.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, statSync } from "node:fs";
+import { lstatSync, statSync } from "node:fs";
 import path from "node:path";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
@@ -7,7 +7,7 @@ import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawRegisteredAgentDatabase,
 } from "./openclaw-agent-db-contract.js";
-import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import { detectOpenClawStateDatabaseSchemaMigrationsFromDatabase } from "./openclaw-state-db-schema-repair.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db.js";
@@ -117,17 +117,9 @@ export function listOpenClawRegisteredAgentDatabases(
       ? entries
       : entries.filter((entry) => entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION);
   }
-  if (!existsSync(pathname)) {
-    if (hasUnavailableMissingSqlitePath(pathname)) {
-      throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
-    }
-    memo.entries = [];
-    return [];
-  }
   // Discovery runs per row in list hot paths, so the legacy-schema gate and the
-  // query share one process-held state handle instead of opening two
-  // connections per call.
-  const entries = withOpenClawStateDatabaseReadOnly(({ db: database }) => {
+  // query share one process-held state handle instead of opening two connections.
+  const entries = withExistingOpenClawStateDatabaseReadOnly(({ db: database }) => {
     if (detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0) {
       throw new Error(
         `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
@@ -159,6 +151,13 @@ export function listOpenClawRegisteredAgentDatabases(
       sizeBytes: row.size_bytes,
     }));
   }, options);
+  if (entries === undefined) {
+    if (hasUnavailableMissingSqlitePath(pathname)) {
+      throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
+    }
+    memo.entries = [];
+    return [];
+  }
   memo.entries = entries;
   const cloned = cloneRegisteredAgentDatabases(entries);
   return options.includeIncompatibleSchemaVersions

--- a/src/tui/tui-last-session.ts
+++ b/src/tui/tui-last-session.ts
@@ -1,6 +1,5 @@
 // Stores and resolves the last TUI session per workspace.
 import { createHash } from "node:crypto";
-import fs from "node:fs";
 import { normalizeLowercaseStringOrEmpty as normalizeMarker } from "@openclaw/normalization-core/string-coerce";
 import {
   executeSqliteQuerySync,
@@ -8,11 +7,10 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
-import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import type { TuiSessionList } from "./tui-backend.js";
 import type { SessionScope } from "./tui-types.js";
 
@@ -65,24 +63,23 @@ export async function readTuiLastSessionKey(params: {
   stateDir?: string;
 }): Promise<string | null> {
   const options = stateDatabaseOptions(params.stateDir);
-  if (!fs.existsSync(resolveOpenClawStateSqlitePath(options.env))) {
-    return null;
-  }
   // CLI reads must not join the Gateway's writable SQLite lifecycle (#101290).
-  return withOpenClawStateDatabaseReadOnly(({ db }) => {
-    if (!tableExists(db, "tui_last_sessions")) {
-      return null;
-    }
-    const row = executeSqliteQueryTakeFirstSync(
-      db,
-      getNodeSqliteKysely<TuiLastSessionDatabase>(db)
-        .selectFrom("tui_last_sessions")
-        .select("session_key")
-        .where("scope_key", "=", params.scopeKey),
-    );
-    const sessionKey = row?.session_key.trim() ?? "";
-    return sessionKey && !isHeartbeatSessionKey(sessionKey) ? sessionKey : null;
-  }, options);
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+      if (!tableExists(db, "tui_last_sessions")) {
+        return null;
+      }
+      const row = executeSqliteQueryTakeFirstSync(
+        db,
+        getNodeSqliteKysely<TuiLastSessionDatabase>(db)
+          .selectFrom("tui_last_sessions")
+          .select("session_key")
+          .where("scope_key", "=", params.scopeKey),
+      );
+      const sessionKey = row?.session_key.trim() ?? "";
+      return sessionKey && !isHeartbeatSessionKey(sessionKey) ? sessionKey : null;
+    }, options) ?? null
+  );
 }
 
 /** Writes the remembered session key unless it is empty, unknown, or heartbeat-owned. */


### PR DESCRIPTION
## What Problem This Solves

Removes three families of read-path rediscovery that had drifted away from their authoritative producers:

- `devices` re-read `node.list` and joined node/device records by device ID or IP even though `device.pair.list` already carries approved and pending node surfaces.
- one-shot Gateway calls loaded and validated stored device auth, then discarded it and made the client read the same SQLite row again during connect.
- eleven shared-state readers checked filesystem existence themselves before entering the canonical read-only database lifecycle, duplicating missing/error handling and creating check/open races.

## Why This Change Was Made

Facts now cross the boundary that produced them. Device approval notices use `nodeSurface`/`pendingNodeSurface` from the pairing record; Gateway calls pass their prepared auth entry into the client host deps; writable and read-only device-auth loaders share one Kysely query owner; and all eleven existing-state readers use `withExistingOpenClawStateDatabaseReadOnly` for reuse, existence, forward-schema, corruption, and close handling.

The migrated readers are MCP OAuth, sandbox registry, Doctor incognito repair journal, fleet registry, startup migration lease, both installed-plugin index readers, config machine state, onboarding recommendations, registered agent databases, and TUI last-session state.

No protocol, config, SQLite schema/version, migration, dependency, or compatibility surface changes.

## User Impact

Device/node approval guidance no longer spends extra Gateway round trips or depends on inferred ID/IP joins. Read-only Gateway calls reuse the exact stored credential they already validated. CLI and metadata reads consistently avoid creating writable state while preserving missing-database fallbacks and non-missing filesystem failures.

Production LOC: +322/-404 (net -82) | Tests: +87/-118 (net -31).

## Evidence

- Pre-fix devices regression: `devices-cli.test.ts` observed 5/2 Gateway calls where the recorded-fact contract requires 3/1; 2 tests failed for the intended reason.
- Pre-fix prepared-auth regression: the call options dropped `preparedDeviceAuth`, and the client connect frame had no prepared token; 2 tests failed for the intended reason.
- Post-rebase focused proof: 15 test files across 8 routed Vitest shards, 399 tests passed (devices, Gateway call/client, device-auth store, and every reader owner).
- Post-rebase changed gate: `OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs` succeeded on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/32004752402. Core/core-test typechecks, three changed-file lint stripes, dead exports, import cycles, database-first, schema, sidecar, pairing, formatting, and selected guards passed.
- P1-depth structured autoreview on the exact branch diff: clean; no accepted/actionable findings.

Best-fix verdict: best. Each cleanup removes consumer inference or duplicate lifecycle/query ownership instead of adding a cache, fallback, or compatibility path. Missing-database behavior remains at the canonical helper, and stored credentials remain owned by the one-shot call that selected and validated them.
