### PR TITLE
fix(agents): preserve user messages when runs fail

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -818,6 +818,52 @@ function setupAcpSession(): void {
   });
 }
 
+function createAcpUserTurnRecorder(options?: { persistError?: Error }) {
+  let persisted = false;
+  const persistApproved = vi.fn<UserTurnTranscriptRecorder["persistApproved"]>(async () => {
+    if (options?.persistError) {
+      throw options.persistError;
+    }
+    persisted = true;
+    return {
+      admission: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
+        generation: "test-generation",
+        entryId: "user-turn-1",
+        rawSeq: 1,
+        effectiveParentId: null,
+        activeMessagePosition: 0,
+        logicalTurnId: "user-turn-1:turn",
+        role: "user",
+      },
+      appended: true,
+      message: { role: "user", content: "hello", timestamp: 1 },
+      messageId: "user-turn-1",
+      sessionEntry: { sessionId: "session-1", updatedAt: 1 },
+      sessionFile: "agent:main:main",
+    };
+  });
+  const recorder = {
+    message: { role: "user", content: "hello", timestamp: 1 },
+    resolveMessage: async () => ({ role: "user", content: "hello", timestamp: 1 }) as const,
+    getAdmissionReceipt: () => undefined,
+    markRuntimePersistencePending: () => {},
+    markRuntimePersisted: () => {},
+    markBlocked: () => {},
+    hasPersisted: () => persisted,
+    isBlocked: () => false,
+    hasRuntimePersistencePending: () => false,
+    waitForRuntimePersistence: async () => {},
+    persistApproved,
+    persistBlocked: async () => undefined,
+    persistFallback: async () => undefined,
+  } satisfies UserTurnTranscriptRecorder;
+  return { persistApproved, recorder };
+}
+
 const requireRecord = createRequireRecord("object", "expected-label-object");
 
 function requireArray(value: unknown, label: string): unknown[] {
@@ -973,7 +1019,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       const parent = parentChannel ? entries[parentChannel] : undefined;
       return parent ? { channel, model: parent, matchKey: parentChannel } : null;
     });
-    state.acpRunTurnMock.mockImplementation(async (params: unknown) => {
+    state.acpRunTurnMock.mockReset().mockImplementation(async (params: unknown) => {
       const onEvent = (params as { onEvent?: (event: unknown) => void }).onEvent;
       onEvent?.({ type: "text_delta", stream: "output", text: "done" });
       onEvent?.({ type: "done", stopReason: "end_turn" });
@@ -4759,6 +4805,61 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
 
     expect(onExecutionStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start direct ACP when durable user-turn admission fails", async () => {
+    setupAcpSession();
+    const persistenceError = new Error("user turn persistence failed");
+    const { persistApproved, recorder } = createAcpUserTurnRecorder({
+      persistError: persistenceError,
+    });
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        sessionKey: "agent:main:main",
+        userTurnTranscriptRecorder: recorder,
+      }),
+    ).rejects.toThrow("user turn persistence failed");
+
+    expect(persistApproved).toHaveBeenCalledOnce();
+    expect(state.acpRunTurnMock).not.toHaveBeenCalled();
+    expect(state.persistAcpTurnTranscriptMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the direct ACP user turn admitted when runtime execution fails", async () => {
+    setupAcpSession();
+    const { persistApproved, recorder } = createAcpUserTurnRecorder();
+    state.acpRunTurnMock.mockRejectedValueOnce(new Error("ACP runtime failed"));
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        sessionKey: "agent:main:main",
+        userTurnTranscriptRecorder: recorder,
+      }),
+    ).rejects.toThrow("ACP runtime failed");
+
+    expect(persistApproved).toHaveBeenCalledOnce();
+    expect(persistApproved.mock.invocationCallOrder[0]).toBeLessThan(
+      state.acpRunTurnMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(state.persistAcpTurnTranscriptMock).not.toHaveBeenCalled();
+  });
+
+  it("mirrors only the assistant after direct ACP admits the user turn", async () => {
+    setupAcpSession();
+    const { recorder } = createAcpUserTurnRecorder();
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: "agent:main:main",
+      userTurnTranscriptRecorder: recorder,
+    });
+
+    expect(state.persistAcpTurnTranscriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ skipUserTurn: true }),
+    );
   });
 
   it("keeps session provenance for internal ACP turns", async () => {

--- a/src/agents/command/acp-execution.ts
+++ b/src/agents/command/acp-execution.ts
@@ -23,6 +23,7 @@ import {
 } from "./runtime-loaders.js";
 import { resolveInternalSessionEffectsSource } from "./session-helpers.js";
 import type { AgentCommandOpts } from "./types.js";
+import { prepareAgentCommandUserTurnRecorder } from "./user-turn-recorder.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
@@ -73,9 +74,30 @@ export async function runAcpAgentCommand(params: {
   });
 
   const visibleTextAccumulator = attemptExecutionRuntime.createAcpVisibleTextAccumulator();
+  const userTurnTranscriptRecorder =
+    !params.suppressVisibleSessionEffects &&
+    (params.opts.userTurnTranscriptRecorder || params.storePath)
+      ? prepareAgentCommandUserTurnRecorder({
+          errorContext: "ACP user turn transcript",
+          opts: params.opts,
+          target: {
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionEntry: params.sessionEntry,
+            sessionStore: params.sessionStore,
+            storePath: params.storePath,
+            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+            cwd: params.workspaceDir,
+            config: params.cfg,
+          },
+          transcriptBody: params.transcriptBody,
+          useProvidedRecorder: true,
+        }).recorder
+      : undefined;
   let stopReason: string | undefined;
   let resultStatus: "completed" | "cancelled" | undefined;
   let terminalOutcome: "blocked" | undefined;
+  let sessionEntry = params.sessionEntry;
   try {
     const {
       resolveAcpAgentPolicyError,
@@ -102,6 +124,24 @@ export async function runAcpAgentCommand(params: {
     const acpImageAttachments = resolveInlineAgentImageAttachments(params.opts.images);
     assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
     const admittedRunContext = await params.preparedRunAdmission.admit("acp");
+    if (userTurnTranscriptRecorder) {
+      const persisted = await userTurnTranscriptRecorder.persistApproved({
+        cwd: params.workspaceDir,
+      });
+      if (
+        !persisted &&
+        !userTurnTranscriptRecorder.hasPersisted() &&
+        (await userTurnTranscriptRecorder.resolveMessage())
+      ) {
+        // A before_message_write rejection is terminal for this user row. Do not
+        // let the success mirror restore the unapproved prompt after execution.
+        userTurnTranscriptRecorder.markBlocked();
+      }
+      if (persisted?.sessionEntry) {
+        sessionEntry = persisted.sessionEntry;
+      }
+    }
+    assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
     await params.acpManager.runTurn({
       admittedRunContext,
       cfg: params.cfg,
@@ -181,7 +221,6 @@ export async function runAcpAgentCommand(params: {
   const finalTextRaw = visibleTextAccumulator.finalizeRaw();
   const finalText = visibleTextAccumulator.finalize();
   const terminalReply = visibleTextAccumulator.finalizeReplySnapshot();
-  let sessionEntry = params.sessionEntry;
   try {
     const { resolveAcpSessionCwd } = await loadAcpSessionIdentifiersRuntime();
     const internalSource = params.suppressVisibleSessionEffects
@@ -223,6 +262,10 @@ export async function runAcpAgentCommand(params: {
       threadId: params.opts.threadId,
       sessionCwd: resolveAcpSessionCwd(params.acpResolution.meta) ?? params.workspaceDir,
       config: params.cfg,
+      ...(userTurnTranscriptRecorder?.hasPersisted() === true ||
+      userTurnTranscriptRecorder?.isBlocked() === true
+        ? { skipUserTurn: true }
+        : {}),
     });
     if (!internalTarget) {
       sessionEntry = transcriptResult.sessionEntry;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2101,58 +2101,75 @@ describe("CLI attempt execution", () => {
     });
   });
 
-  it("mirrors only the CLI reply when the shared recorder already persisted the user turn", async () => {
-    const sessionKey = "agent:main:direct:cli-recorder-owned-user";
-    const sessionFile = path.join(tmpDir, "session-cli-recorder-owned-user.jsonl");
-    const sessionEntry = makeSessionEntry("session-cli-recorder-owned-user", { sessionFile });
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await writeSessionStoreSeed(sessionStore);
-    await appendTranscriptMessage(
-      { agentId: "main", sessionId: sessionEntry.sessionId, sessionKey, storePath },
-      {
-        message: {
-          role: "user",
-          content: "canonical current ask",
-          timestamp: Date.now(),
+  it.each(["CLI", "ACP"] as const)(
+    "mirrors only the %s reply when the shared recorder already persisted the user turn",
+    async (runtime) => {
+      const runtimeId = runtime.toLowerCase();
+      const sessionKey = `agent:main:direct:${runtimeId}-recorder-owned-user`;
+      const sessionFile = path.join(tmpDir, `session-${runtimeId}-recorder-owned-user.jsonl`);
+      const sessionEntry = makeSessionEntry(`session-${runtimeId}-recorder-owned-user`, {
+        sessionFile,
+      });
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+      await writeSessionStoreSeed(sessionStore);
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId: sessionEntry.sessionId, sessionKey, storePath },
+        {
+          message: {
+            role: "user",
+            content: "canonical current ask",
+            timestamp: Date.now(),
+          },
+          cwd: tmpDir,
         },
-        cwd: tmpDir,
-      },
-    );
+      );
 
-    await persistCliTurnTranscript({
-      body: "canonical current ask",
-      result: makeCliResult("hello from cli"),
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      userMessage: {
-        role: "user",
-        content: "duplicate custom ask",
-        timestamp: Date.now(),
-      },
-      skipUserTurn: true,
-    });
-
-    const messages = await readSessionMessages(
-      formatSqliteSessionFileMarker({
-        agentId: "main",
+      const transcript = {
+        body: "canonical current ask",
+        finalText: `hello from ${runtimeId}`,
         sessionId: sessionEntry.sessionId,
+        sessionKey,
+        sessionEntry,
+        sessionStore,
         storePath,
-      }),
-    );
-    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
-    expect(messages).toContainEqual(
-      expect.objectContaining({
-        role: "assistant",
-        content: [{ type: "text", text: "hello from cli" }],
-      }),
-    );
-  });
+        sessionAgentId: "main",
+        sessionCwd: tmpDir,
+        config: {},
+        skipUserTurn: true,
+      };
+      if (runtime === "CLI") {
+        await persistCliTurnTranscript({
+          ...transcript,
+          result: makeCliResult(transcript.finalText),
+          userMessage: {
+            role: "user",
+            content: "duplicate custom ask",
+            timestamp: Date.now(),
+          },
+        });
+      } else {
+        await persistAcpTurnTranscript({
+          ...transcript,
+          userInput: { text: "duplicate custom ask" },
+        });
+      }
+
+      const messages = await readSessionMessages(
+        formatSqliteSessionFileMarker({
+          agentId: "main",
+          sessionId: sessionEntry.sessionId,
+          storePath,
+        }),
+      );
+      expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: transcript.finalText }],
+        }),
+      );
+    },
+  );
 
   it("does not append a CLI assistant already owned by the runtime", async () => {
     const sessionKey = "agent:main:direct:runtime-owned-assistant";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -430,10 +430,16 @@ export async function persistAcpTurnTranscript(params: {
   threadId?: string | number;
   sessionCwd: string;
   config: OpenClawConfig;
+  skipUserTurn?: boolean;
 }): Promise<PersistTextTurnTranscriptResult> {
+  const { skipUserTurn, userInput, ...transcript } = params;
   return await persistTextTurnTranscript({
-    ...params,
-    ...(params.userInput ? { userMessage: buildPersistedUserTurnMessage(params.userInput) } : {}),
+    ...transcript,
+    body: skipUserTurn ? "" : transcript.body,
+    transcriptBody: skipUserTurn ? undefined : transcript.transcriptBody,
+    ...(!skipUserTurn && userInput
+      ? { userMessage: buildPersistedUserTurnMessage(userInput) }
+      : {}),
     assistant: {
       api: "openai-responses",
       provider: "openclaw",

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -8,7 +8,6 @@ import {
   ModelSelectionLockedError,
   isModelSelectionLocked,
 } from "../../sessions/model-overrides.js";
-import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import {
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
@@ -27,7 +26,6 @@ import {
   type EmbeddedAgentRunEntryTerminal,
 } from "../embedded-agent-runner/run-entry.js";
 import { resolveFastModeState } from "../fast-mode.js";
-import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
 import { prepareInternalSessionEffectsSession } from "../internal-session-effects.js";
 import { LiveSessionModelSwitchError } from "../live-model-switch.js";
 import { findModelInCatalog, modelSupportsInput } from "../model-catalog-lookup.js";
@@ -61,6 +59,7 @@ import { loadAttemptExecutionRuntime, type AgentAttemptResult } from "./runtime-
 import { resolveInternalSessionEffectsSource } from "./session-helpers.js";
 import type { EmbeddedSessionState } from "./session-preparation.js";
 import type { AgentCommandOpts } from "./types.js";
+import { prepareAgentCommandUserTurnRecorder } from "./user-turn-recorder.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 const MAX_LIVE_SWITCH_RETRIES = 5;
@@ -161,25 +160,10 @@ export async function runEmbeddedAgentAttempt(params: {
     lifecycleEnded: false,
   };
   const attemptLifecycleCallbacks = createAgentAttemptLifecycleCallbacks(attemptLifecycleState);
-  const transcriptMedia = params.opts.transcriptMedia ?? [];
-  const hasTranscriptMedia = transcriptMedia.length > 0;
-  const suppressUserTurnPersistence =
-    params.opts.suppressPromptPersistence === true ||
-    (params.opts.transcriptMessage === "" && !hasTranscriptMedia);
-  const recorderTranscriptText = transcriptBody || undefined;
-  const userTurnTranscriptRecorder =
-    (internalSessionTarget ? undefined : params.opts.userTurnTranscriptRecorder) ??
-    createUserTurnTranscriptRecorder({
-      ...(!suppressUserTurnPersistence && (recorderTranscriptText || hasTranscriptMedia)
-        ? {
-            input: {
-              text: recorderTranscriptText,
-              ...(hasTranscriptMedia ? { media: transcriptMedia } : {}),
-              senderIsOwner: params.opts.senderIsOwner,
-              ...(params.opts.inputProvenance ? { provenance: params.opts.inputProvenance } : {}),
-            },
-          }
-        : {}),
+  const { recorder: userTurnTranscriptRecorder, suppressUserTurnPersistence } =
+    prepareAgentCommandUserTurnRecorder({
+      errorContext: "agent command user turn transcript",
+      opts: params.opts,
       target: {
         sessionId: internalSessionTarget?.sessionId ?? sessionId,
         agentId: internalSessionTarget?.agentId ?? sessionAgentId,
@@ -190,12 +174,9 @@ export async function runEmbeddedAgentAttempt(params: {
         cwd: cwd ?? workspaceDir,
         config: cfg,
       },
-      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
-      errorContext: "agent command user turn transcript",
+      transcriptBody,
+      useProvidedRecorder: internalSessionTarget === undefined,
     });
-  if (suppressUserTurnPersistence) {
-    userTurnTranscriptRecorder.markBlocked();
-  }
   const lifecycle = createAgentCommandLifecycle({
     runId,
     lifecycleGeneration: () => lifecycleGeneration,

--- a/src/agents/command/user-turn-recorder.ts
+++ b/src/agents/command/user-turn-recorder.ts
@@ -1,0 +1,45 @@
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import type {
+  UserTurnTranscriptRecorder,
+  UserTurnTranscriptTarget,
+} from "../../sessions/user-turn-transcript.types.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
+import type { AgentCommandOpts } from "./types.js";
+
+export function prepareAgentCommandUserTurnRecorder(params: {
+  errorContext: string;
+  opts: AgentCommandOpts;
+  target: UserTurnTranscriptTarget;
+  transcriptBody: string;
+  useProvidedRecorder: boolean;
+}): {
+  recorder: UserTurnTranscriptRecorder;
+  suppressUserTurnPersistence: boolean;
+} {
+  const transcriptMedia = params.opts.transcriptMedia ?? [];
+  const suppressUserTurnPersistence =
+    params.opts.suppressPromptPersistence === true ||
+    (params.opts.transcriptMessage === "" && transcriptMedia.length === 0);
+  const transcriptText = params.transcriptBody || undefined;
+  const recorder =
+    (params.useProvidedRecorder ? params.opts.userTurnTranscriptRecorder : undefined) ??
+    createUserTurnTranscriptRecorder({
+      ...(!suppressUserTurnPersistence && (transcriptText || transcriptMedia.length > 0)
+        ? {
+            input: {
+              text: transcriptText,
+              ...(transcriptMedia.length > 0 ? { media: transcriptMedia } : {}),
+              senderIsOwner: params.opts.senderIsOwner,
+              ...(params.opts.inputProvenance ? { provenance: params.opts.inputProvenance } : {}),
+            },
+          }
+        : {}),
+      target: params.target,
+      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+      errorContext: params.errorContext,
+    });
+  if (suppressUserTurnPersistence) {
+    recorder.markBlocked();
+  }
+  return { recorder, suppressUserTurnPersistence };
+}

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -2,8 +2,12 @@
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../../agents/failover-error.js";
-import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadTranscriptEvents,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
@@ -619,6 +623,63 @@ describe("runReplyAgent runtime config", () => {
     expect(result.text).toContain("/new");
     const metadata = getReplyPayloadMetadata(result);
     expect(metadata?.deliverDespiteSourceReplySuppression).toBe(true);
+  });
+
+  it("persists the user turn before returning a preflight compaction failure", async () => {
+    await withTestDir({ prefix: "openclaw-preflight-admission-" }, async (tempDir) => {
+      const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+        shouldFollowup: false,
+        isActive: false,
+      });
+      const sessionKey = "agent:main:telegram:default:direct:test";
+      const sessionEntry: SessionEntry = { sessionId: "session-1", updatedAt: 1 };
+      const sessionStore = { [sessionKey]: sessionEntry };
+      const storePath = join(tempDir, "sessions.json");
+      await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
+      replyParams.sessionKey = sessionKey;
+      replyParams.storePath = storePath;
+      replyParams.sessionEntry = sessionEntry;
+      replyParams.sessionStore = sessionStore;
+      followupRun.userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+        input: { text: "hello", idempotencyKey: "msg-1", timestamp: 123 },
+        target: {
+          sessionId: "session-1",
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          storePath,
+          agentId: "main",
+          cwd: tempDir,
+        },
+      });
+      runPreflightCompactionIfNeededMock.mockRejectedValue(
+        new Error("Preflight compaction required but failed: auth profile mismatch"),
+      );
+      runMemoryFlushIfNeededMock.mockResolvedValue({ sessionEntry, outcome: "skipped" });
+
+      const result = await runReplyAgent(replyParams);
+
+      expect(result).toMatchObject({ text: expect.stringContaining("Context is too large") });
+      expect(executeAgentTurnMock).not.toHaveBeenCalled();
+      const messages = (
+        await loadTranscriptEvents({
+          agentId: "main",
+          sessionId: "session-1",
+          sessionKey,
+          storePath,
+        })
+      ).flatMap((event) =>
+        typeof event === "object" && event !== null && "message" in event ? [event.message] : [],
+      );
+      expect(messages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "hello",
+          idempotencyKey: "msg-1",
+          timestamp: 123,
+        }),
+      ]);
+    });
   });
 
   it("does not resolve secrets before the enqueue-followup queue path", async () => {

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -65,6 +65,7 @@ type ExecutePreparedReplyAgentRunInput = Pick<
   | "typingMode"
 > & {
   activeSessionStore: Record<string, SessionEntry> | undefined;
+  persistUserTurn: ReturnType<typeof createReplyRestartRecoveryClaimController>["persistUserTurn"];
   admitUserTurn: ReturnType<typeof createReplyRestartRecoveryClaimController>["admitUserTurn"];
   applyReplyToMode: (payload: ReplyPayload) => ReplyPayload;
   beginBeforeAgentReply: ReturnType<
@@ -104,6 +105,7 @@ export async function executePreparedReplyAgentRun(
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     activeSessionStore,
+    persistUserTurn,
     admitUserTurn: admitUserTurnWithRecovery,
     applyReplyToMode,
     beginBeforeAgentReply: beginBeforeAgentReplyWithRecovery,
@@ -244,6 +246,7 @@ export async function executePreparedReplyAgentRun(
       !replyOperation.abortSignal.aborted &&
       isLikelyContextOverflowError(String(err));
     if (!canRotateAfterPreflightFailure) {
+      await persistUserTurn(followupRun.userTurnTranscriptRecorder);
       throw err;
     }
     logVerbose(`Preflight compaction could not recover exhausted memory flush: ${String(err)}`);
@@ -490,6 +493,7 @@ export function createReplyAgentRestartRecoveryController(
       }).sameChannelThreadRequired
     : undefined;
   const {
+    persistUserTurn,
     admitUserTurn,
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,
@@ -558,6 +562,7 @@ export function createReplyAgentRestartRecoveryController(
     ...(storePath ? { storePath } : {}),
   });
   return {
+    persistUserTurn,
     admitUserTurn,
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -491,6 +491,7 @@ export async function runReplyAgent(
     return value;
   };
   const {
+    persistUserTurn,
     admitUserTurn,
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,
@@ -553,6 +554,7 @@ export async function runReplyAgent(
   try {
     return await executePreparedReplyAgentRun({
       activeSessionStore,
+      persistUserTurn,
       admitUserTurn,
       applyReplyToMode,
       beginBeforeAgentReply,

--- a/src/auto-reply/reply/followup-turn-admission.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type { FollowupRun } from "./queue.js";
 
 const state = vi.hoisted(() => ({
@@ -105,6 +106,30 @@ function createDefaults(overrides: Record<string, unknown> = {}) {
     sessionKey: "main",
     ...overrides,
   };
+}
+
+function createPersistingRecorder() {
+  let persisted = false;
+  const persistApproved = vi.fn<UserTurnTranscriptRecorder["persistApproved"]>(async () => {
+    persisted = true;
+    return undefined;
+  });
+  const recorder = {
+    message: { role: "user", content: "queued prompt", timestamp: 1 },
+    resolveMessage: async () => undefined,
+    getAdmissionReceipt: () => undefined,
+    markRuntimePersistencePending: () => {},
+    markRuntimePersisted: () => {},
+    markBlocked: () => {},
+    hasPersisted: () => persisted,
+    isBlocked: () => false,
+    hasRuntimePersistencePending: () => false,
+    waitForRuntimePersistence: async () => {},
+    persistApproved,
+    persistBlocked: async () => undefined,
+    persistFallback: async () => undefined,
+  } satisfies UserTurnTranscriptRecorder;
+  return { persistApproved, recorder };
 }
 
 beforeEach(() => {
@@ -978,6 +1003,42 @@ describe("admitFollowupTurn", () => {
       turn: { preflightFailurePayload: { text: "preflight failed" } },
     });
     expect(operation.fail).toHaveBeenCalledWith("run_failed", expect.any(Error));
+  });
+
+  it("persists a queued user turn before returning its preflight failure", async () => {
+    const operation = createOperation("admitted-session");
+    const admittedEntry: SessionEntry = { sessionId: "admitted-session", updatedAt: 1 };
+    const sessionStore = { main: admittedEntry };
+    const { persistApproved, recorder } = createPersistingRecorder();
+    state.admitReply.mockResolvedValue({ status: "owned", operation, sessionEntry: admittedEntry });
+    state.loadEntry.mockReturnValue(admittedEntry);
+    state.preflight.mockRejectedValue(new Error("preflight failed"));
+    const queued = createRun();
+    queued.userTurnTranscriptRecorder = recorder;
+
+    const result = await admitFollowupTurn({
+      queued,
+      defaults: createDefaults({
+        sessionEntry: admittedEntry,
+        sessionStore,
+        storePath: "/tmp/sessions.json",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      kind: "admitted",
+      turn: { preflightFailurePayload: { text: "preflight failed" } },
+    });
+    expect(persistApproved).toHaveBeenCalledWith({
+      expectedSessionId: "admitted-session",
+      target: expect.objectContaining({
+        sessionId: "admitted-session",
+        sessionKey: "main",
+        sessionEntry: admittedEntry,
+        sessionStore: expect.any(Object),
+        storePath: "/tmp/sessions.json",
+      }),
+    });
   });
 
   it("refreshes send policy before returning a preflight failure", async () => {

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -440,6 +440,33 @@ export async function admitFollowupTurn(params: {
       if (error instanceof FollowupSessionGenerationInvalidatedError) {
         throw error;
       }
+      const recorder = turn.queued.userTurnTranscriptRecorder;
+      if (recorder && !recorder.hasPersisted()) {
+        const currentEntry = session.current();
+        const result = await recorder.persistApproved({
+          ...(currentEntry && replySessionKey
+            ? {
+                target: {
+                  sessionId: operation.sessionId,
+                  sessionKey: replySessionKey,
+                  sessionEntry: currentEntry,
+                  sessionStore,
+                  ...(params.defaults.storePath ? { storePath: params.defaults.storePath } : {}),
+                  agentId: turn.queued.run.agentId,
+                  cwd: turn.queued.run.workspaceDir,
+                  config,
+                },
+              }
+            : {}),
+          expectedSessionId: operation.sessionId,
+        });
+        if (result?.sessionEntry) {
+          session.adopt(result.sessionEntry);
+        }
+        if (!result && !recorder.hasPersisted()) {
+          throw new Error("session changed before durable user-turn admission", { cause: error });
+        }
+      }
       operation.fail("run_failed", error);
       const admittedVerboseLevel = session.current()?.verboseLevel ?? turn.queued.run.verboseLevel;
       const text = buildPreflightCompactionFailureText(formatErrorMessage(error), {

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -21,6 +21,7 @@ import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 
 type ReplyRestartRecoveryClaimController = {
+  persistUserTurn: (recorder?: UserTurnTranscriptRecorder) => Promise<void>;
   admitUserTurn: (
     recorder?: UserTurnTranscriptRecorder,
   ) => Promise<"admitted" | "duplicate-source">;
@@ -172,23 +173,33 @@ export function createReplyRestartRecoveryClaimController(params: {
     return persisted;
   };
 
-  const persistUserTurnOnly = async (
+  const persistUserTurn = async (
     recorder: UserTurnTranscriptRecorder | undefined,
-    sessionId: string,
   ): Promise<void> => {
     if (!recorder || recorder.hasPersisted()) {
       return;
     }
-    const entry = params.getEntry();
-    const target =
-      entry && params.sessionKey && params.storePath
-        ? params.resolveUserTurnTarget?.({
-            entry,
-            sessionId,
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-          })
-        : undefined;
+    if (!params.sessionKey || !params.storePath) {
+      await recorder.persistApproved();
+      return;
+    }
+    const sessionId = params.getSessionId();
+    const entry =
+      loadSessionEntry({
+        storePath: params.storePath,
+        sessionKey: params.sessionKey,
+        clone: false,
+        hydrateSkillPromptRefs: false,
+      }) ?? params.getEntry();
+    if (!entry || entry.sessionId !== sessionId) {
+      throw new Error("session changed before durable user-turn admission");
+    }
+    const target = params.resolveUserTurnTarget?.({
+      entry,
+      sessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    });
     const result = await recorder.persistApproved({ target, expectedSessionId: sessionId });
     if (!result) {
       throw new Error("session changed before durable user-turn admission");
@@ -200,7 +211,7 @@ export function createReplyRestartRecoveryClaimController(params: {
 
   const admitUserTurn: ReplyRestartRecoveryClaimController["admitUserTurn"] = async (recorder) => {
     if (!params.sessionKey || !params.storePath) {
-      await recorder?.persistApproved();
+      await persistUserTurn(recorder);
       return "admitted";
     }
     const sessionId = params.getSessionId();
@@ -283,7 +294,7 @@ export function createReplyRestartRecoveryClaimController(params: {
     if (!recoverableDeliveryContext && !activeClaimRunId) {
       // Source-less scheduled/ambient runs may execute, but cannot own a
       // channel recovery claim that would be impossible to correlate after restart.
-      await persistUserTurnOnly(recorder, sessionId);
+      await persistUserTurn(recorder);
       return "admitted";
     }
     const updatedAt = Date.now();
@@ -507,6 +518,7 @@ export function createReplyRestartRecoveryClaimController(params: {
   };
 
   return {
+    persistUserTurn,
     admitUserTurn,
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,


### PR DESCRIPTION
Closes #86592

## What Problem This Solves

Fixes an issue where accepted user messages could disappear from session history when required preflight compaction or a direct ACP run failed. Missing user turns left restart recovery, history replay, and later compaction with an incomplete conversation record.

## Why This Change Was Made

Durably admit the user turn at the failure boundary for ordinary replies, queued follow-ups, and direct ACP execution while preserving session-generation fences and private internal-session effects. Successful ACP completion now mirrors only the assistant after the shared recorder owns the user row, and embedded/direct agent commands share one recorder-construction path.

## User Impact

Failed agent runs retain the triggering user message exactly once, so later recovery and compaction can operate on complete conversation history instead of silently losing the inbound turn. Suppressed prompts and internal model runs remain hidden from the visible session.

## Evidence

- Before the production change, focused regressions failed at the ordinary preflight, queued preflight, and direct ACP admission boundaries.
- `pnpm vitest run src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts src/auto-reply/reply/followup-turn-admission.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/attempt-execution.cli.test.ts` — 533 passed on the final rebased head.
- `pnpm tsgo:core` — passed.
- Targeted `oxlint`, formatting, `git diff --check`, and max-lines ratchet — passed.
- Production LOC: net +121. Tests: net +240. The production growth adds three durable admission boundaries and one shared recorder owner while removing the duplicated embedded recorder construction.
- No live Telegram/ACP provider run was performed; the failure ordering and exactly-once behavior are covered with deterministic SQLite-backed owner-boundary regressions.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, authentication details, tokens, and raw tool output omitted

[user]
新开分支修复86592

[assistant]
两条路径的共同点已经确认，但不能简单把完整 admission 整体前移：预压缩可能旋转 session，过早写入会把用户消息留在旧 transcript；完整 admission 还会过早设置 restart-recovery claim。修复会限定为“预压缩失败时只落盘用户 turn”，成功路径继续在最终 session 上原子认领；队列 follow-up 的同类失败也一并覆盖。direct ACP 则在策略/运行前使用已有 recorder 落盘，成功收尾只再写 assistant，避免重复 user turn。

[assistant]
旧代码上的失败证明已经成立：新增的行为点按预期失败。生产修复已按 owner 边界接入。

[assistant]
最新 upstream 基线上的回归已全部通过（533/533），类型检查和目标 lint 也通过。

[assistant]
已在新分支完成 #86592 修复：覆盖普通 preflight、queued follow-up 和 direct ACP 三条用户消息丢失路径；统一 recorder 构造并防止成功路径重复写入。

[user]
完成推送

[assistant]
提交身份、最新 upstream 基线和待提交文件已重新核对；只提交 #86592 修复，不包含原有未跟踪目录。

[assistant]
分支已成功推到 origin，并核对远端 SHA 与本地提交一致。

[user]
创建pr

[assistant]
将创建 maintainer-facing Draft PR，检查重复 PR、提交作者和准确验证证据；标题不带 agent 品牌，并验证 maintainer edits。

[user]
加入
````

</details>
<!-- agent-transcript:end -->
