### PR TITLE
fix(ai): preserve final phase across resumed reasoning

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1538,7 +1538,7 @@ packages/ai/src/providers/mistral.ts	7
 packages/ai/src/providers/openai-chatgpt-responses-protocol.ts	1
 packages/ai/src/providers/openai-chatgpt-responses.ts	27
 packages/ai/src/providers/openai-completions-tool-calls.ts	5
-packages/ai/src/providers/openai-completions.ts	17
+packages/ai/src/providers/openai-completions.ts	16
 packages/ai/src/providers/openai-reasoning-effort.ts	6
 packages/ai/src/providers/openai-responses-shared.ts	7
 packages/ai/src/providers/openai-responses-tools.ts	2
@@ -1557,7 +1557,7 @@ packages/ai/src/transports/openai-compatible-conversation-turn.ts	2
 packages/ai/src/transports/openai-completions-compat.ts	2
 packages/ai/src/transports/openai-completions-params.ts	9
 packages/ai/src/transports/openai-completions-replay.ts	9
-packages/ai/src/transports/openai-completions-stream.ts	9
+packages/ai/src/transports/openai-completions-stream.ts	8
 packages/ai/src/transports/openai-completions-string-content.ts	5
 packages/ai/src/transports/openai-completions-transport.ts	9
 packages/ai/src/transports/openai-responses-client.ts	13

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -192,6 +192,14 @@ const openAiCoalescedReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiTypedReasoningChunks = [
+  makeOpenAiChunk({ content: { type: "reasoning", text: "First thought." } }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ content: { type: "reasoning", text: "Second thought." } }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -468,6 +476,26 @@ describe("provider and transport observable parity fixtures", () => {
           },
         ]);
       }
+
+      const typedReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiTypedReasoningChunks,
+      );
+      expect(typedReasoningResult.terminal.content).toEqual([
+        { type: "thinking", thinking: "First thought." },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        { type: "thinking", thinking: "Second thought." },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
 
       const hiddenReasoningResult = await runOpenAi(
         implementation,

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -235,6 +235,19 @@ const openAiOrderedVisibleReasoningDetailsChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiSplitVisibleReasoningDetailsChunks = [
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "response.output_text", text: "Visible first." }],
+  }),
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "reasoning.text", text: " Hidden second." }],
+  }),
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "response.text", text: " Visible third." }],
+  }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -692,23 +705,22 @@ describe("provider and transport observable parity fixtures", () => {
 
   it("preserves ordered visible OpenRouter reasoning details across both producers", async () => {
     for (const implementation of ["provider", "transport"] as const) {
-      const result = await runOpenAi(
-        implementation,
-        "success",
+      for (const chunks of [
         openAiOrderedVisibleReasoningDetailsChunks,
-        true,
-        openRouterModel,
-      );
+        openAiSplitVisibleReasoningDetailsChunks,
+      ]) {
+        const result = await runOpenAi(implementation, "success", chunks, true, openRouterModel);
 
-      expect(result.terminal.content).toEqual([
-        { type: "text", text: "Visible first." },
-        {
-          type: "thinking",
-          thinking: " Hidden second.",
-          thinkingSignature: "reasoning_details",
-        },
-        { type: "text", text: " Visible third." },
-      ]);
+        expect(result.terminal.content).toEqual([
+          { type: "text", text: "Visible first." },
+          {
+            type: "thinking",
+            thinking: " Hidden second.",
+            thinkingSignature: "reasoning_details",
+          },
+          { type: "text", text: " Visible third." },
+        ]);
+      }
     }
   });
 });

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -185,6 +185,13 @@ const openAiInterleavedReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiCoalescedReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ content: "Final.", reasoning_content: "Second thought." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -435,30 +442,32 @@ describe("provider and transport observable parity fixtures", () => {
 
   it("marks content interrupted by native reasoning as commentary", async () => {
     for (const implementation of ["provider", "transport"] as const) {
-      const result = await runOpenAi(implementation, "success", openAiInterleavedReasoningChunks);
+      for (const chunks of [openAiInterleavedReasoningChunks, openAiCoalescedReasoningChunks]) {
+        const result = await runOpenAi(implementation, "success", chunks);
 
-      expect(result.terminal.content).toEqual([
-        {
-          type: "thinking",
-          thinking: "First thought.",
-          thinkingSignature: "reasoning_content",
-        },
-        {
-          type: "text",
-          text: "Interim.",
-          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
-        },
-        {
-          type: "thinking",
-          thinking: "Second thought.",
-          thinkingSignature: "reasoning_content",
-        },
-        {
-          type: "text",
-          text: "Final.",
-          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
-        },
-      ]);
+        expect(result.terminal.content).toEqual([
+          {
+            type: "thinking",
+            thinking: "First thought.",
+            thinkingSignature: "reasoning_content",
+          },
+          {
+            type: "text",
+            text: "Interim.",
+            textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+          },
+          {
+            type: "thinking",
+            thinking: "Second thought.",
+            thinkingSignature: "reasoning_content",
+          },
+          {
+            type: "text",
+            text: "Final.",
+            textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+          },
+        ]);
+      }
 
       const hiddenReasoningResult = await runOpenAi(
         implementation,

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -81,6 +81,14 @@ const openAiModel = {
   maxTokens: 4096,
 } satisfies Model<"openai-completions">;
 
+const openRouterModel = {
+  ...openAiModel,
+  id: "openrouter/minimax/minimax-m2.7",
+  name: "MiniMax M2.7",
+  provider: "openrouter",
+  baseUrl: "https://openrouter.ai/api/v1",
+} satisfies Model<"openai-completions">;
+
 const context = {
   systemPrompt: "Be exact.",
   messages: [{ role: "user", content: "Find the answer.", timestamp: 1 }],
@@ -212,6 +220,17 @@ const openAiStructuredReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiOrderedVisibleReasoningDetailsChunks = [
+  makeOpenAiChunk({
+    reasoning_details: [
+      { type: "response.output_text", text: "Visible first." },
+      { type: "reasoning.text", text: " Hidden second." },
+      { type: "response.text", text: " Visible third." },
+    ],
+  }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -305,9 +324,11 @@ async function runOpenAi(
   outcome: ParityFixture["outcome"],
   chunks: readonly OpenAIChunk[] = openAiChunks,
   emitReasoning = true,
+  modelOverride?: Model<"openai-completions">,
 ): Promise<ParityOutput> {
   resetOpenAiMock(outcome, chunks);
-  const model = emitReasoning ? openAiModel : { ...openAiModel, reasoning: false };
+  const baseModel = modelOverride ?? openAiModel;
+  const model = emitReasoning ? baseModel : { ...baseModel, reasoning: false };
   const [{ streamOpenAICompletions }, { createOpenAICompletionsTransportStreamFn }] =
     await Promise.all([
       import("./providers/openai-completions.js"),
@@ -616,6 +637,28 @@ describe("provider and transport observable parity fixtures", () => {
           thinking: "Trailing thought.",
           thinkingSignature: "reasoning_content",
         },
+      ]);
+    }
+  });
+
+  it("preserves ordered visible OpenRouter reasoning details across both producers", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runOpenAi(
+        implementation,
+        "success",
+        openAiOrderedVisibleReasoningDetailsChunks,
+        true,
+        openRouterModel,
+      );
+
+      expect(result.terminal.content).toEqual([
+        { type: "text", text: "Visible first." },
+        {
+          type: "thinking",
+          thinking: " Hidden second.",
+          thinkingSignature: "reasoning_details",
+        },
+        { type: "text", text: " Visible third." },
       ]);
     }
   });

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -8,6 +8,7 @@ type OpenAIChunk = Record<string, unknown>;
 
 const openAiMockState = vi.hoisted(() => ({
   error: undefined as Error | undefined,
+  streamError: undefined as Error | undefined,
   chunks: [] as OpenAIChunk[],
   payloads: [] as unknown[],
 }));
@@ -25,6 +26,9 @@ vi.mock("openai", () => ({
             async *[Symbol.asyncIterator]() {
               for (const chunk of openAiMockState.chunks) {
                 yield chunk;
+              }
+              if (openAiMockState.streamError) {
+                throw openAiMockState.streamError;
               }
             },
           });
@@ -248,6 +252,12 @@ const openAiInterleavedThenTrailingReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiInterruptedErrorChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ reasoning_content: "Second thought." }),
+] satisfies OpenAIChunk[];
+
 const anthropicFailure = {
   status: 429,
   body: {
@@ -308,6 +318,7 @@ function resetOpenAiMock(
   chunks: readonly OpenAIChunk[] = openAiChunks,
 ): void {
   openAiMockState.payloads = [];
+  openAiMockState.streamError = undefined;
   openAiMockState.chunks = outcome === "success" ? [...chunks] : [];
   openAiMockState.error =
     outcome === "error"
@@ -326,8 +337,10 @@ async function runOpenAi(
   chunks: readonly OpenAIChunk[] = openAiChunks,
   emitReasoning = true,
   modelOverride?: Model<"openai-completions">,
+  streamError?: Error,
 ): Promise<ParityOutput> {
   resetOpenAiMock(outcome, chunks);
+  openAiMockState.streamError = streamError;
   const baseModel = modelOverride ?? openAiModel;
   const model = emitReasoning ? baseModel : { ...baseModel, reasoning: false };
   const [{ streamOpenAICompletions }, { createOpenAICompletionsTransportStreamFn }] =
@@ -639,6 +652,38 @@ describe("provider and transport observable parity fixtures", () => {
         {
           type: "thinking",
           thinking: "Trailing thought.",
+          thinkingSignature: "reasoning_content",
+        },
+      ]);
+    }
+  });
+
+  it("keeps interrupted text non-deliverable when the stream errors", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runOpenAi(
+        implementation,
+        "success",
+        openAiInterruptedErrorChunks,
+        true,
+        undefined,
+        new Error("synthetic interrupted stream"),
+      );
+
+      expect(result.terminal.stopReason).toBe("error");
+      expect(result.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
           thinkingSignature: "reasoning_content",
         },
       ]);

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -248,6 +248,19 @@ const openAiSplitVisibleReasoningDetailsChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiVisibleDetailBeforeInterruptedContentChunks = [
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "response.output_text", text: "Visible first." }],
+  }),
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "reasoning.text", text: " Hidden second." }],
+  }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ reasoning_content: "Hidden fourth." }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -721,6 +734,46 @@ describe("provider and transport observable parity fixtures", () => {
           { type: "text", text: " Visible third." },
         ]);
       }
+    }
+  });
+
+  it("preserves earlier visible details when later ordinary content is interrupted", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runOpenAi(
+        implementation,
+        "success",
+        openAiVisibleDetailBeforeInterruptedContentChunks,
+        true,
+        openRouterModel,
+      );
+
+      expect(result.terminal.content).toEqual([
+        {
+          type: "text",
+          text: "Visible first.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+        {
+          type: "thinking",
+          thinking: " Hidden second.",
+          thinkingSignature: "reasoning_details",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Hidden fourth.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-1","phase":"final_answer"}',
+        },
+      ]);
     }
   });
 });

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -294,6 +294,7 @@ async function observeStream(stream: AssistantMessageEventStreamLike): Promise<{
       "model",
       "responseId",
       "responseModel",
+      "openclawDelivery",
       "usage",
       "stopReason",
       "diagnostics",
@@ -585,6 +586,9 @@ describe("provider and transport observable parity fixtures", () => {
           textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
         },
       ]);
+      expect(hiddenReasoningResult.terminal.openclawDelivery).toEqual({
+        textPhaseRequiresTerminal: true,
+      });
 
       const trailingReasoningResult = await runOpenAi(
         implementation,

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -208,6 +208,15 @@ const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiInterleavedThenTrailingReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ reasoning_content: "Second thought." }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({ reasoning_content: "Trailing thought." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const anthropicFailure = {
   status: 429,
   body: {
@@ -534,6 +543,39 @@ describe("provider and transport observable parity fixtures", () => {
           thinkingSignature: "reasoning_content",
         },
         { type: "text", text: " " },
+      ]);
+
+      const interleavedThenTrailingReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiInterleavedThenTrailingReasoningChunks,
+      );
+      expect(interleavedThenTrailingReasoningResult.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Trailing thought.",
+          thinkingSignature: "reasoning_content",
+        },
       ]);
     }
   });

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -200,6 +200,18 @@ const openAiTypedReasoningChunks = [
   makeOpenAiChunk({}, "stop"),
 ] satisfies OpenAIChunk[];
 
+const openAiStructuredReasoningChunks = [
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "reasoning.text", text: "First thought." }],
+  }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({
+    reasoning_details: [{ type: "reasoning.text", text: "Second thought." }],
+  }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const openAiTrailingReasoningChunks = [
   makeOpenAiChunk({ reasoning_content: "First thought." }),
   makeOpenAiChunk({ content: "Answer." }),
@@ -499,6 +511,34 @@ describe("provider and transport observable parity fixtures", () => {
           textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
         },
         { type: "thinking", thinking: "Second thought." },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
+
+      const structuredReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiStructuredReasoningChunks,
+      );
+      expect(structuredReasoningResult.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_details",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
+          thinkingSignature: "reasoning_details",
+        },
         {
           type: "text",
           text: "Final.",

--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -166,6 +166,33 @@ const openAiChunks = [
   },
 ] satisfies OpenAIChunk[];
 
+function makeOpenAiChunk(
+  delta: Record<string, unknown>,
+  finishReason: string | null = null,
+): OpenAIChunk {
+  return {
+    id: "chatcmpl-parity",
+    model: "gpt-5.5-response",
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+const openAiInterleavedReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Interim." }),
+  makeOpenAiChunk({ reasoning_content: "Second thought." }),
+  makeOpenAiChunk({ content: "Final." }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
+const openAiTrailingReasoningChunks = [
+  makeOpenAiChunk({ reasoning_content: "First thought." }),
+  makeOpenAiChunk({ content: "Answer." }),
+  makeOpenAiChunk({ reasoning_content: "Trailing thought." }),
+  makeOpenAiChunk({ content: " " }),
+  makeOpenAiChunk({}, "stop"),
+] satisfies OpenAIChunk[];
+
 const anthropicFailure = {
   status: 429,
   body: {
@@ -220,9 +247,12 @@ async function observeStream(stream: AssistantMessageEventStreamLike): Promise<{
   };
 }
 
-function resetOpenAiMock(outcome: ParityFixture["outcome"]): void {
+function resetOpenAiMock(
+  outcome: ParityFixture["outcome"],
+  chunks: readonly OpenAIChunk[] = openAiChunks,
+): void {
   openAiMockState.payloads = [];
-  openAiMockState.chunks = outcome === "success" ? [...openAiChunks] : [];
+  openAiMockState.chunks = outcome === "success" ? [...chunks] : [];
   openAiMockState.error =
     outcome === "error"
       ? Object.assign(new Error("synthetic OpenAI rejection"), {
@@ -237,8 +267,11 @@ function resetOpenAiMock(outcome: ParityFixture["outcome"]): void {
 async function runOpenAi(
   implementation: "provider" | "transport",
   outcome: ParityFixture["outcome"],
+  chunks: readonly OpenAIChunk[] = openAiChunks,
+  emitReasoning = true,
 ): Promise<ParityOutput> {
-  resetOpenAiMock(outcome);
+  resetOpenAiMock(outcome, chunks);
+  const model = emitReasoning ? openAiModel : { ...openAiModel, reasoning: false };
   const [{ streamOpenAICompletions }, { createOpenAICompletionsTransportStreamFn }] =
     await Promise.all([
       import("./providers/openai-completions.js"),
@@ -246,12 +279,12 @@ async function runOpenAi(
     ]);
   const stream =
     implementation === "provider"
-      ? streamOpenAICompletions(openAiModel, context, {
+      ? streamOpenAICompletions(model, context, {
           apiKey: "sk-test",
           reasoningEffort: "medium",
         })
       : await Promise.resolve(
-          createOpenAICompletionsTransportStreamFn()(openAiModel, context, {
+          createOpenAICompletionsTransportStreamFn()(model, context, {
             apiKey: "sk-test",
             reasoningEffort: "medium",
           } as never),
@@ -398,5 +431,73 @@ describe("provider and transport observable parity fixtures", () => {
     ).toMatchFileSnapshot(
       path.join(import.meta.dirname, "../test/fixtures/provider-transport-parity", snapshot),
     );
+  });
+
+  it("marks content interrupted by native reasoning as commentary", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runOpenAi(implementation, "success", openAiInterleavedReasoningChunks);
+
+      expect(result.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "thinking",
+          thinking: "Second thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
+
+      const hiddenReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiInterleavedReasoningChunks,
+        false,
+      );
+      expect(hiddenReasoningResult.terminal.content).toEqual([
+        {
+          type: "text",
+          text: "Interim.",
+          textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+        },
+        {
+          type: "text",
+          text: "Final.",
+          textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+        },
+      ]);
+
+      const trailingReasoningResult = await runOpenAi(
+        implementation,
+        "success",
+        openAiTrailingReasoningChunks,
+      );
+      expect(trailingReasoningResult.terminal.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "First thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        { type: "text", text: "Answer." },
+        {
+          type: "thinking",
+          thinking: "Trailing thought.",
+          thinkingSignature: "reasoning_content",
+        },
+        { type: "text", text: " " },
+      ]);
+    }
   });
 });

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -258,6 +258,13 @@ export const streamOpenAICompletions: StreamFunction<
           });
         }
       };
+      const finishTextBlock = () => {
+        if (!textBlock) {
+          return;
+        }
+        finishBlock(textBlock);
+        textBlock = null;
+      };
       const ensureTextBlock = () => {
         if (!textBlock) {
           textBlock = { type: "text", text: "" };
@@ -328,6 +335,7 @@ export const streamOpenAICompletions: StreamFunction<
             if (!shouldEmitReasoning) {
               continue;
             }
+            finishTextBlock();
             const signature = reasoningDelta.signature;
             const thinkingSignature =
               model.provider === "opencode-go" && signature === "reasoning"
@@ -408,8 +416,7 @@ export const streamOpenAICompletions: StreamFunction<
         if (textBlock.text.trim()) {
           pendingInterruptedTextBlock = textBlock;
         }
-        finishBlock(textBlock);
-        textBlock = null;
+        finishTextBlock();
       };
       const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
         if (forceStrict || reasoningTagTextPartitioner.hasPending()) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -47,6 +47,7 @@ import {
   rememberPendingCommentaryTags,
   tagInterruptedTextPhases,
   tagPendingCommentaryText,
+  tagUnresolvedTextAsCommentary,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
@@ -653,6 +654,8 @@ export const streamOpenAICompletions: StreamFunction<
       const terminal = projectProviderError(error, options?.signal);
       Object.assign(output, terminal);
       finalizeOpenAICompletionsToolCalls(output, { allowSilentToolCallPromotion: false });
+      clearPendingCommentaryText(provisionalCommentaryTags);
+      tagUnresolvedTextAsCommentary(output);
       for (const block of output.content) {
         delete (block as { index?: number }).index;
         // Streaming scratch buffers are only used during parsing; never persist them.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -214,6 +214,7 @@ export const streamOpenAICompletions: StreamFunction<
       // *_end event is emitted exactly once.
       const finishedBlocks = new Set<StreamingBlock>();
       const contentIndices = new WeakMap<StreamingBlock, number>();
+      let explicitVisibleTextBlocks: Set<TextContent> | undefined;
       const appendBlock = (block: StreamingBlock) => {
         contentIndices.set(block, blocks.length);
         blocks.push(block);
@@ -276,6 +277,9 @@ export const streamOpenAICompletions: StreamFunction<
         if (!textBlock) {
           textBlock = { type: "text", text: "" };
           textBlockSource = source;
+          if (source === "reasoning_detail") {
+            (explicitVisibleTextBlocks ??= new Set()).add(textBlock);
+          }
           appendBlock(textBlock);
           stream.push({
             type: "text_start",
@@ -639,7 +643,11 @@ export const streamOpenAICompletions: StreamFunction<
         );
       }
       if (output.stopReason !== "toolUse" && confirmedInterruptedTextBlock) {
-        tagInterruptedTextPhases(output.content, confirmedInterruptedTextBlock);
+        tagInterruptedTextPhases(
+          output.content,
+          confirmedInterruptedTextBlock,
+          explicitVisibleTextBlocks,
+        );
       }
       // Tool completion is irreversible: confirm the terminal before closing
       // blocks, then preserve their original text/thinking/tool event order.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -189,7 +189,8 @@ export const streamOpenAICompletions: StreamFunction<
 
       let textBlock: TextContent | null = null;
       let thinkingBlock: ThinkingContent | null = null;
-      let lastInterruptedTextBlock: TextContent | null = null;
+      let pendingInterruptedTextBlock: TextContent | null = null;
+      let confirmedInterruptedTextBlock: TextContent | null = null;
       let hasFinishReason = false;
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
@@ -292,6 +293,10 @@ export const streamOpenAICompletions: StreamFunction<
         sealNativeReasoningBeforeText();
         const block = ensureTextBlock();
         block.text += delta;
+        if (pendingInterruptedTextBlock && delta.trim()) {
+          confirmedInterruptedTextBlock = pendingInterruptedTextBlock;
+          pendingInterruptedTextBlock = null;
+        }
         stream.push({
           type: "text_delta",
           contentIndex: getContentIndex(block),
@@ -376,7 +381,7 @@ export const streamOpenAICompletions: StreamFunction<
         // Resumed reasoning makes the preceding visible text interim. Preserve
         // the candidate boundary only if later text confirms a final answer.
         if (textBlock.text.trim()) {
-          lastInterruptedTextBlock = textBlock;
+          pendingInterruptedTextBlock = textBlock;
         }
         finishBlock(textBlock);
         textBlock = null;
@@ -604,8 +609,8 @@ export const streamOpenAICompletions: StreamFunction<
               : "Provider returned an invalid tool call"),
         );
       }
-      if (output.stopReason !== "toolUse" && lastInterruptedTextBlock) {
-        tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
+      if (output.stopReason !== "toolUse" && confirmedInterruptedTextBlock) {
+        tagInterruptedTextPhases(output.content, confirmedInterruptedTextBlock);
       }
       // Tool completion is irreversible: confirm the terminal before closing
       // blocks, then preserve their original text/thinking/tool event order.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -381,6 +381,16 @@ export const streamOpenAICompletions: StreamFunction<
         finishBlock(textBlock);
         textBlock = null;
       };
+      const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
+        if (forceStrict || reasoningTagTextPartitioner.hasPending()) {
+          reasoningTagTextPartitioner.markStrict();
+        }
+        // Let following text finish syntax already owned by the Markdown
+        // parser; otherwise packet batching cannot erase a lane boundary.
+        if (!hasFollowingVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
+          sealTextBeforeReasoning();
+        }
+      };
 
       const guardedOpenaiStream = withFirstStreamEventTimeout(hookedOpenAIStream, {
         provider: model.provider,
@@ -476,12 +486,7 @@ export const streamOpenAICompletions: StreamFunction<
             );
             const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
             if (foundReasoningField) {
-              reasoningTagTextPartitioner.markStrict();
-              // Let same-chunk text finish syntax already owned by the Markdown
-              // parser; otherwise packet batching cannot erase a lane boundary.
-              if (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
-                sealTextBeforeReasoning();
-              }
+              beginReasoning(hasSameChunkVisibleText, true);
             }
             if (shouldEmitReasoning && foundReasoningField) {
               const delta = deltaFields[foundReasoningField];
@@ -493,11 +498,13 @@ export const streamOpenAICompletions: StreamFunction<
                 appendThinkingDelta(thinkingSignature, delta);
               }
             }
-            for (const contentDelta of contentDeltas) {
+            const lastVisibleTextIndex = contentDeltas.findLastIndex(
+              (delta) => delta.kind === "text",
+            );
+            for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
               if (contentDelta.kind === "thinking") {
-                if (reasoningTagTextPartitioner.hasPending()) {
-                  reasoningTagTextPartitioner.markStrict();
-                }
+                const hasLaterVisibleText = contentDeltaIndex < lastVisibleTextIndex;
+                beginReasoning(hasLaterVisibleText);
                 if (shouldEmitReasoning) {
                   appendThinkingDelta(contentDelta.signature, contentDelta.text);
                 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -25,6 +25,7 @@ import {
   readOpenAICompletionsContentDeltas,
   readOpenAICompletionsReasoningBatch,
   type OpenAICompletionsContentDelta,
+  type OpenAICompletionsTextSource,
 } from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
@@ -197,6 +198,7 @@ export const streamOpenAICompletions: StreamFunction<
       >[number];
 
       let textBlock: TextContent | null = null;
+      let textBlockSource: OpenAICompletionsTextSource | undefined;
       let thinkingBlock: ThinkingContent | null = null;
       let pendingInterruptedTextBlock: TextContent | null = null;
       let confirmedInterruptedTextBlock: TextContent | null = null;
@@ -265,10 +267,15 @@ export const streamOpenAICompletions: StreamFunction<
         }
         finishBlock(textBlock);
         textBlock = null;
+        textBlockSource = undefined;
       };
-      const ensureTextBlock = () => {
+      const ensureTextBlock = (source: OpenAICompletionsTextSource | undefined) => {
+        if (textBlock && textBlockSource !== source) {
+          finishTextBlock();
+        }
         if (!textBlock) {
           textBlock = { type: "text", text: "" };
+          textBlockSource = source;
           appendBlock(textBlock);
           stream.push({
             type: "text_start",
@@ -305,9 +312,9 @@ export const streamOpenAICompletions: StreamFunction<
           thinkingBlock = null;
         }
       };
-      const appendTextDelta = (delta: string) => {
+      const appendTextDelta = (delta: string, source?: OpenAICompletionsTextSource) => {
         sealNativeReasoningBeforeText();
-        const block = ensureTextBlock();
+        const block = ensureTextBlock(source);
         block.text += delta;
         if (pendingInterruptedTextBlock && delta.trim()) {
           confirmedInterruptedTextBlock = pendingInterruptedTextBlock;
@@ -344,7 +351,7 @@ export const streamOpenAICompletions: StreamFunction<
                 : signature;
             appendThinkingDelta(thinkingSignature, reasoningDelta.text);
           } else {
-            appendTextDelta(reasoningDelta.text);
+            appendTextDelta(reasoningDelta.text, reasoningDelta.source);
           }
         }
       };
@@ -414,7 +421,7 @@ export const streamOpenAICompletions: StreamFunction<
         }
         // Resumed reasoning makes the preceding visible text interim. Preserve
         // the candidate boundary only if later text confirms a final answer.
-        if (textBlock.text.trim()) {
+        if (textBlockSource !== "reasoning_detail" && textBlock.text.trim()) {
           pendingInterruptedTextBlock = textBlock;
         }
         finishTextBlock();

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -23,6 +23,8 @@ import {
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
+  readOpenAICompletionsReasoningBatch,
+  type OpenAICompletionsContentDelta,
 } from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
@@ -150,6 +152,12 @@ export const streamOpenAICompletions: StreamFunction<
     try {
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
       const compat = resolveOpenAICompletionsCompat(model);
+      const visibleReasoningDetailTypes = new Set(compat.visibleReasoningDetailTypes);
+      const shouldEmitReasoning = Boolean(
+        model.reasoning &&
+        options?.reasoningEffort &&
+        isOpenAICompletionsThinkingEnabled(options.reasoningEffort),
+      );
       const cacheRetention = resolveCacheRetention(options?.cacheRetention);
       const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
       const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
@@ -314,6 +322,23 @@ export const streamOpenAICompletions: StreamFunction<
           partial: output,
         });
       };
+      const appendReasoningDeltas = (reasoningDeltas: readonly OpenAICompletionsContentDelta[]) => {
+        for (const reasoningDelta of reasoningDeltas) {
+          if (reasoningDelta.kind === "thinking") {
+            if (!shouldEmitReasoning) {
+              continue;
+            }
+            const signature = reasoningDelta.signature;
+            const thinkingSignature =
+              model.provider === "opencode-go" && signature === "reasoning"
+                ? "reasoning_content"
+                : signature;
+            appendThinkingDelta(thinkingSignature, reasoningDelta.text);
+          } else {
+            appendTextDelta(reasoningDelta.text);
+          }
+        }
+      };
       const ensureToolCallBlock = (toolCall: StreamingToolCallDelta) => {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;
@@ -465,47 +490,27 @@ export const streamOpenAICompletions: StreamFunction<
             choice.finish_reason,
           )) {
             const choiceDelta = normalizedDelta.delta;
-            // Some endpoints return reasoning in reasoning_content (llama.cpp),
-            // or reasoning (other openai compatible endpoints)
-            // Use the first non-empty reasoning field to avoid duplication
-            // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
-            const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
             const deltaFields = choiceDelta as Record<string, unknown>;
-            const shouldEmitReasoning = Boolean(
-              model.reasoning &&
-              options?.reasoningEffort &&
-              isOpenAICompletionsThinkingEnabled(options.reasoningEffort),
+            const reasoningBatch = readOpenAICompletionsReasoningBatch(
+              deltaFields,
+              visibleReasoningDetailTypes,
             );
-            let foundReasoningField: string | null = null;
-            for (const field of reasoningFields) {
-              const value = deltaFields[field];
-              if (typeof value === "string" && value.length > 0) {
-                foundReasoningField = field;
-                break;
-              }
-            }
+            const reasoningDeltas = reasoningBatch.deltas;
+            const hasReasoningThinking = reasoningBatch.hasThinking;
             const contentDeltas = readOpenAICompletionsContentDeltas(
               choiceDelta.content,
               choiceDelta.refusal,
-              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
+              reasoningBatch.mirroredThinking,
             );
-            const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
-            if (foundReasoningField) {
-              beginReasoning(hasSameChunkVisibleText, true);
-            }
-            if (shouldEmitReasoning && foundReasoningField) {
-              const delta = deltaFields[foundReasoningField];
-              if (typeof delta === "string" && delta.length > 0) {
-                const thinkingSignature =
-                  model.provider === "opencode-go" && foundReasoningField === "reasoning"
-                    ? "reasoning_content"
-                    : foundReasoningField;
-                appendThinkingDelta(thinkingSignature, delta);
-              }
-            }
             const lastVisibleTextIndex = contentDeltas.findLastIndex(
               (delta) => delta.kind === "text",
             );
+            const hasSameChunkVisibleText =
+              reasoningBatch.hasVisibleText || lastVisibleTextIndex !== -1;
+            if (hasReasoningThinking) {
+              beginReasoning(hasSameChunkVisibleText, true);
+              appendReasoningDeltas(reasoningDeltas);
+            }
             for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
               if (contentDelta.kind === "thinking") {
                 const hasLaterVisibleText = contentDeltaIndex < lastVisibleTextIndex;
@@ -514,8 +519,11 @@ export const streamOpenAICompletions: StreamFunction<
                   appendThinkingDelta(contentDelta.signature, contentDelta.text);
                 }
               } else {
-                appendPartitionedContent(contentDelta.text, Boolean(foundReasoningField));
+                appendPartitionedContent(contentDelta.text, hasReasoningThinking);
               }
+            }
+            if (!hasReasoningThinking) {
+              appendReasoningDeltas(reasoningDeltas);
             }
 
             const toolCallDeltas = normalizedDelta.toolCalls;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -419,6 +419,12 @@ export const streamOpenAICompletions: StreamFunction<
         finishTextBlock();
       };
       const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
+        if (!output.openclawDelivery?.textPhaseRequiresTerminal) {
+          output.openclawDelivery = {
+            ...output.openclawDelivery,
+            textPhaseRequiresTerminal: true,
+          };
+        }
         if (forceStrict || reasoningTagTextPartitioner.hasPending()) {
           reasoningTagTextPartitioner.markStrict();
         }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -43,6 +43,7 @@ import type {
 import {
   clearPendingCommentaryText,
   rememberPendingCommentaryTags,
+  tagInterruptedTextPhases,
   tagPendingCommentaryText,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
@@ -188,6 +189,7 @@ export const streamOpenAICompletions: StreamFunction<
 
       let textBlock: TextContent | null = null;
       let thinkingBlock: ThinkingContent | null = null;
+      let lastInterruptedTextBlock: TextContent | null = null;
       let hasFinishReason = false;
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
@@ -363,6 +365,22 @@ export const streamOpenAICompletions: StreamFunction<
           }
         }
       };
+      const sealTextBeforeReasoning = () => {
+        if (!textBlock && !reasoningTagTextPartitioner.hasPending()) {
+          return;
+        }
+        flushPartitionedContent();
+        if (!textBlock) {
+          return;
+        }
+        // Resumed reasoning makes the preceding visible text interim. Preserve
+        // the candidate boundary only if later text confirms a final answer.
+        if (textBlock.text.trim()) {
+          lastInterruptedTextBlock = textBlock;
+        }
+        finishBlock(textBlock);
+        textBlock = null;
+      };
 
       const guardedOpenaiStream = withFirstStreamEventTimeout(hookedOpenAIStream, {
         provider: model.provider,
@@ -451,8 +469,19 @@ export const streamOpenAICompletions: StreamFunction<
                 break;
               }
             }
+            const contentDeltas = readOpenAICompletionsContentDeltas(
+              choiceDelta.content,
+              choiceDelta.refusal,
+              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
+            );
+            const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
             if (foundReasoningField) {
               reasoningTagTextPartitioner.markStrict();
+              // Same-chunk text can complete buffered Markdown or tag syntax;
+              // only a standalone reasoning delta confirms a lane resumption.
+              if (!hasSameChunkVisibleText) {
+                sealTextBeforeReasoning();
+              }
             }
             if (shouldEmitReasoning && foundReasoningField) {
               const delta = deltaFields[foundReasoningField];
@@ -464,11 +493,7 @@ export const streamOpenAICompletions: StreamFunction<
                 appendThinkingDelta(thinkingSignature, delta);
               }
             }
-            for (const contentDelta of readOpenAICompletionsContentDeltas(
-              choiceDelta.content,
-              choiceDelta.refusal,
-              foundReasoningField ? [deltaFields[foundReasoningField] as string] : [],
-            )) {
+            for (const contentDelta of contentDeltas) {
               if (contentDelta.kind === "thinking") {
                 if (reasoningTagTextPartitioner.hasPending()) {
                   reasoningTagTextPartitioner.markStrict();
@@ -571,6 +596,9 @@ export const streamOpenAICompletions: StreamFunction<
               ? "Request was aborted"
               : "Provider returned an invalid tool call"),
         );
+      }
+      if (output.stopReason !== "toolUse" && lastInterruptedTextBlock) {
+        tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
       }
       // Tool completion is irreversible: confirm the terminal before closing
       // blocks, then preserve their original text/thinking/tool event order.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -477,9 +477,9 @@ export const streamOpenAICompletions: StreamFunction<
             const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
             if (foundReasoningField) {
               reasoningTagTextPartitioner.markStrict();
-              // Same-chunk text can complete buffered Markdown or tag syntax;
-              // only a standalone reasoning delta confirms a lane resumption.
-              if (!hasSameChunkVisibleText) {
+              // Let same-chunk text finish syntax already owned by the Markdown
+              // parser; otherwise packet batching cannot erase a lane boundary.
+              if (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
                 sealTextBeforeReasoning();
               }
             }

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
@@ -168,7 +168,7 @@ describe("openai completions stream", () => {
     expectRecordFields(output.content[0], expected);
   });
 
-  it("preserves reasoning_details item order when visible text and thinking are interleaved", async () => {
+  it("preserves explicitly visible reasoning_details without phase reclassification", async () => {
     const model = makeCompletionsModel({
       id: "openrouter/minimax/minimax-m2.7",
       name: "MiniMax M2.7",

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
@@ -233,6 +233,56 @@ describe("openai completions stream", () => {
     expectRecordFields(output.content[2], { type: "text", text: " Visible third." });
   });
 
+  it("phases text interrupted by resumed reasoning_details", async () => {
+    const model = makeCompletionsModel({
+      id: "openrouter/qwen/qwen3-235b-a22b",
+      name: "Qwen3 235B A22B",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+    const output = createAssistantOutput(model);
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({
+          reasoning_details: [{ type: "reasoning.text", text: "First thought." }],
+        }),
+        makeCompletionsChunk({ content: "Interim." }),
+        makeCompletionsChunk({
+          reasoning_details: [{ type: "reasoning.text", text: "Second thought." }],
+        }),
+        makeCompletionsChunk({ content: "Final." }),
+        makeCompletionsChunk({}, "stop"),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "First thought.",
+        thinkingSignature: "reasoning_details",
+      },
+      {
+        type: "text",
+        text: "Interim.",
+        textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+      },
+      {
+        type: "thinking",
+        thinking: "Second thought.",
+        thinkingSignature: "reasoning_details",
+      },
+      {
+        type: "text",
+        text: "Final.",
+        textSignature: '{"v":1,"id":"final-answer-0","phase":"final_answer"}',
+      },
+    ]);
+  });
+
   it("keeps fallback thinking when reasoning_details only carries visible text", async () => {
     const model = makeCompletionsModel({
       id: "openrouter/minimax/minimax-m2.7",

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -12,6 +12,7 @@ import {
   rememberPendingCommentaryTags,
   tagInterruptedTextPhases,
   tagPendingCommentaryText,
+  tagUnresolvedTextAsCommentary,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
@@ -577,6 +578,9 @@ export async function processCompletionsStream(
   }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);
+  }
+  if (output.stopReason === "error" || output.stopReason === "aborted") {
+    tagUnresolvedTextAsCommentary(output);
   }
   if (output.stopReason === "toolUse") {
     tagPendingCommentaryText(output.content);

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -116,6 +116,7 @@ export async function processCompletionsStream(
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
   const provisionalCommentaryTags: PendingCommentaryTags = new Map();
   const toolCallBlockIndices = new WeakMap<ToolCallBlock, number>();
+  let explicitVisibleTextBlocks: Set<TextBlock> | undefined;
   const normalizeToolCallDeltas = createOpenAICompletionsToolCallDeltaNormalizer();
   let sawStopFinishReason = false;
   let sawNativeToolCallDelta = false;
@@ -176,6 +177,9 @@ export async function processCompletionsStream(
     if (!currentBlock || currentBlock.type !== "text") {
       currentBlock = { type: "text", text: "" };
       currentTextSource = source;
+      if (source === "reasoning_detail") {
+        (explicitVisibleTextBlocks ??= new Set()).add(currentBlock);
+      }
       output.content.push(currentBlock);
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
     }
@@ -585,7 +589,11 @@ export async function processCompletionsStream(
     output.stopReason !== "error" &&
     output.stopReason !== "aborted"
   ) {
-    tagInterruptedTextPhases(output.content, confirmedInterruptedTextBlock);
+    tagInterruptedTextPhases(
+      output.content,
+      confirmedInterruptedTextBlock,
+      explicitVisibleTextBlocks,
+    );
   }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -34,6 +34,7 @@ import {
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
+  type OpenAICompletionsTextSource,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
 
@@ -105,6 +106,7 @@ export async function processCompletionsStream(
     | { type: "thinking"; thinking: string; thinkingSignature?: string }
     | ToolCallBlock
     | null = null;
+  let currentTextSource: OpenAICompletionsTextSource | undefined;
   let pendingInterruptedTextBlock: TextBlock | null = null;
   let confirmedInterruptedTextBlock: TextBlock | null = null;
   let pendingPostToolCallDeltas: CompletionsReasoningDelta[] = [];
@@ -131,7 +133,11 @@ export async function processCompletionsStream(
     }
     pendingPostToolCallBytes += nextBytes;
     const previous = pendingPostToolCallDeltas[pendingPostToolCallDeltas.length - 1];
-    if (!previous || previous.kind !== next.kind) {
+    if (
+      !previous ||
+      previous.kind !== next.kind ||
+      (previous.kind === "text" && next.kind === "text" && previous.source !== next.source)
+    ) {
       pendingPostToolCallDeltas.push(next);
       return;
     }
@@ -163,9 +169,13 @@ export async function processCompletionsStream(
       partial: output,
     });
   };
-  const appendTextDeltaInternal = (text: string) => {
+  const appendTextDeltaInternal = (text: string, source?: OpenAICompletionsTextSource) => {
+    if (currentBlock?.type === "text" && currentTextSource !== source) {
+      currentBlock = null;
+    }
     if (!currentBlock || currentBlock.type !== "text") {
       currentBlock = { type: "text", text: "" };
+      currentTextSource = source;
       output.content.push(currentBlock);
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
     }
@@ -194,7 +204,7 @@ export async function processCompletionsStream(
     pendingPostToolCallBytes = 0;
     for (const delta of bufferedDeltas) {
       if (delta.kind === "text") {
-        appendTextDeltaInternal(delta.text);
+        appendTextDeltaInternal(delta.text, delta.source);
       } else if (emitReasoning) {
         appendThinkingDeltaInternal(delta);
       }
@@ -205,9 +215,9 @@ export async function processCompletionsStream(
     flushPendingPostToolCallDeltas();
     appendThinkingDeltaInternal(reasoningDelta);
   };
-  const appendTextDelta = (text: string) => {
+  const appendTextDelta = (text: string, source?: OpenAICompletionsTextSource) => {
     flushPendingPostToolCallDeltas();
-    appendTextDeltaInternal(text);
+    appendTextDeltaInternal(text, source);
   };
   const appendVisibleTextDelta = (text: string) => {
     if (!text) {
@@ -229,7 +239,7 @@ export async function processCompletionsStream(
         continue;
       }
       if (reasoningDelta.kind === "text") {
-        appendTextDelta(reasoningDelta.text);
+        appendTextDelta(reasoningDelta.text, reasoningDelta.source);
       } else if (emitReasoning) {
         appendThinkingDelta(reasoningDelta);
       }
@@ -356,10 +366,11 @@ export async function processCompletionsStream(
     }
     // Resumed reasoning makes the preceding visible text interim. Preserve
     // the candidate boundary only if later text confirms a final answer.
-    if (currentBlock.text.trim()) {
+    if (currentTextSource !== "reasoning_detail" && currentBlock.text.trim()) {
       pendingInterruptedTextBlock = currentBlock;
     }
     currentBlock = null;
+    currentTextSource = undefined;
   };
   const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
     if (!output.openclawDelivery?.textPhaseRequiresTerminal) {

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -29,6 +29,7 @@ import {
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
+  readOpenAICompletionsReasoningBatch,
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
@@ -84,6 +85,7 @@ export async function processCompletionsStream(
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
   const emitReasoning = options?.emitReasoning ?? true;
   const compat = getCompat(model as OpenAIModeModel);
+  const visibleReasoningDetailTypes = new Set(compat.visibleReasoningDetailTypes);
   const shouldFilterDeepSeekDsmlText = compat.thinkingFormat === "deepseek";
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText ? createDeepSeekTextFilter() : null;
   const deepSeekToolCallRecoverer = shouldFilterDeepSeekDsmlText ? createDsmlRecoverer() : null;
@@ -214,6 +216,22 @@ export async function processCompletionsStream(
       queuePostToolCallDelta({ kind: "text", text });
     } else {
       appendTextDelta(text);
+    }
+  };
+  const appendReasoningDeltas = (reasoningDeltas: readonly CompletionsReasoningDelta[]) => {
+    for (const reasoningDelta of reasoningDeltas) {
+      if (reasoningDelta.kind === "thinking" && !emitReasoning) {
+        continue;
+      }
+      if (currentBlock?.type === "toolCall") {
+        queuePostToolCallDelta({ ...reasoningDelta });
+        continue;
+      }
+      if (reasoningDelta.kind === "text") {
+        appendTextDelta(reasoningDelta.text);
+      } else if (emitReasoning) {
+        appendThinkingDelta(reasoningDelta);
+      }
     }
   };
   const appendRecoveredToolCall = (toolCall: RecoveredDeepSeekDsmlToolCall) => {
@@ -410,52 +428,27 @@ export async function processCompletionsStream(
     }
     for (const normalizedDelta of normalizeToolCallDeltas(rawChoiceDelta, choice.finish_reason)) {
       const choiceDelta = normalizedDelta.delta;
-      const reasoningDeltas = getCompletionsReasoningDeltas(
+      const reasoningBatch = readOpenAICompletionsReasoningBatch(
         choiceDelta as Record<string, unknown>,
-        compat.visibleReasoningDetailTypes,
+        visibleReasoningDetailTypes,
       );
-      const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
+      const reasoningDeltas = reasoningBatch.deltas;
+      const hasReasoningThinking = reasoningBatch.hasThinking;
       // Share the content/refusal owner to avoid duplicate mirrored refusals.
       const contentDeltas = readOpenAICompletionsContentDeltas(
         choiceDelta.content,
         choiceDelta.refusal,
-        reasoningDeltas
-          .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
-          .map((reasoningDelta) => reasoningDelta.text),
+        reasoningBatch.mirroredThinking,
       );
-      const hasSameChunkVisibleText =
-        reasoningDeltas.some((delta) => delta.kind === "text") ||
-        contentDeltas.some((delta) => delta.kind === "text");
-      if (hasMirroredReasoning) {
-        beginReasoning(hasSameChunkVisibleText, true);
-      }
-      // Compat-classified visible details are explicit output items. Preserve
-      // their order with adjacent structured thinking instead of inferring commentary.
-      const appendReasoningDeltas = () => {
-        for (const reasoningDelta of reasoningDeltas) {
-          if (reasoningDelta.kind === "thinking" && !emitReasoning) {
-            continue;
-          }
-          if (currentBlock?.type === "toolCall") {
-            queuePostToolCallDelta({ ...reasoningDelta });
-            continue;
-          }
-          if (reasoningDelta.kind === "text") {
-            appendTextDelta(reasoningDelta.text);
-          } else if (emitReasoning) {
-            appendThinkingDelta(reasoningDelta);
-          }
-        }
-      };
-      // The dedicated field owns reasoning order/signature; a distinct content
-      // thought follows it, while an exact mirror was removed by the decoder.
-      if (hasMirroredReasoning) {
-        appendReasoningDeltas();
-      }
       const lastVisibleTextIndex = contentDeltas.findLastIndex((delta) => delta.kind === "text");
+      const hasSameChunkVisibleText = reasoningBatch.hasVisibleText || lastVisibleTextIndex !== -1;
+      if (hasReasoningThinking) {
+        beginReasoning(hasSameChunkVisibleText, true);
+        appendReasoningDeltas(reasoningDeltas);
+      }
       for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
         if (contentDelta.kind === "text") {
-          const routedDeltas = hasMirroredReasoning
+          const routedDeltas = hasReasoningThinking
             ? reasoningTagTextPartitioner.push(contentDelta.text)
             : reasoningTagTextPartitioner.pushVisible(contentDelta.text);
           for (const routedDelta of routedDeltas) {
@@ -467,8 +460,8 @@ export async function processCompletionsStream(
           appendRoutedContentDelta(contentDelta);
         }
       }
-      if (!hasMirroredReasoning) {
-        appendReasoningDeltas();
+      if (!hasReasoningThinking) {
+        appendReasoningDeltas(reasoningDeltas);
       }
       const toolCallDeltas = normalizedDelta.toolCalls;
       if (toolCallDeltas.length > 0) {
@@ -582,59 +575,6 @@ export async function processCompletionsStream(
   if (output.stopReason === "toolUse") {
     tagPendingCommentaryText(output.content);
   }
-}
-
-function getCompletionsReasoningDeltas(
-  delta: Record<string, unknown>,
-  visibleReasoningDetailTypes: readonly string[],
-): CompletionsReasoningDelta[] {
-  const output: CompletionsReasoningDelta[] = [];
-  const pushDelta = (next: CompletionsReasoningDelta) => {
-    const previous = output[output.length - 1];
-    if (!previous || previous.kind !== next.kind) {
-      output.push(next);
-      return;
-    }
-    if (next.kind === "thinking" && previous.kind === "thinking") {
-      if (previous.signature !== next.signature) {
-        output.push(next);
-        return;
-      }
-      previous.text += next.text;
-      return;
-    }
-    previous.text += next.text;
-  };
-  const reasoningDetails = delta.reasoning_details;
-  let usedReasoningThinkingDetails = false;
-  if (Array.isArray(reasoningDetails)) {
-    const visibleTypes = new Set(visibleReasoningDetailTypes);
-    for (const item of reasoningDetails) {
-      const detail = item as { type?: unknown; text?: unknown };
-      if (typeof detail.text !== "string" || !detail.text) {
-        continue;
-      }
-      if (detail.type === "reasoning.text") {
-        usedReasoningThinkingDetails = true;
-        pushDelta({ kind: "thinking", signature: "reasoning_details", text: detail.text });
-        continue;
-      }
-      if (typeof detail.type === "string" && visibleTypes.has(detail.type)) {
-        pushDelta({ kind: "text", text: detail.text });
-      }
-    }
-  }
-  if (!usedReasoningThinkingDetails) {
-    const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"] as const;
-    for (const field of reasoningFields) {
-      const value = delta[field];
-      if (typeof value === "string" && value.length > 0) {
-        pushDelta({ kind: "thinking", signature: field, text: value });
-        break;
-      }
-    }
-  }
-  return output;
 }
 
 function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -429,6 +429,8 @@ export async function processCompletionsStream(
       if (hasMirroredReasoning) {
         beginReasoning(hasSameChunkVisibleText, true);
       }
+      // Compat-classified visible details are explicit output items. Preserve
+      // their order with adjacent structured thinking instead of inferring commentary.
       const appendReasoningDeltas = () => {
         for (const reasoningDelta of reasoningDeltas) {
           if (reasoningDelta.kind === "thinking" && !emitReasoning) {

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -102,7 +102,8 @@ export async function processCompletionsStream(
     | { type: "thinking"; thinking: string; thinkingSignature?: string }
     | ToolCallBlock
     | null = null;
-  let lastInterruptedTextBlock: TextBlock | null = null;
+  let pendingInterruptedTextBlock: TextBlock | null = null;
+  let confirmedInterruptedTextBlock: TextBlock | null = null;
   let pendingPostToolCallDeltas: CompletionsReasoningDelta[] = [];
   let pendingPostToolCallBytes = 0;
   let isFlushingPendingPostToolCallDeltas = false;
@@ -166,6 +167,10 @@ export async function processCompletionsStream(
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
     }
     currentBlock.text += text;
+    if (pendingInterruptedTextBlock && text.trim()) {
+      confirmedInterruptedTextBlock = pendingInterruptedTextBlock;
+      pendingInterruptedTextBlock = null;
+    }
     pushStreamEvent({
       type: "text_delta",
       contentIndex: blockIndex(),
@@ -333,7 +338,7 @@ export async function processCompletionsStream(
     // Resumed reasoning makes the preceding visible text interim. Preserve
     // the candidate boundary only if later text confirms a final answer.
     if (currentBlock.text.trim()) {
-      lastInterruptedTextBlock = currentBlock;
+      pendingInterruptedTextBlock = currentBlock;
     }
     currentBlock = null;
   };
@@ -562,12 +567,12 @@ export async function processCompletionsStream(
     },
   });
   if (
-    lastInterruptedTextBlock &&
+    confirmedInterruptedTextBlock &&
     output.stopReason !== "toolUse" &&
     output.stopReason !== "error" &&
     output.stopReason !== "aborted"
   ) {
-    tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
+    tagInterruptedTextPhases(output.content, confirmedInterruptedTextBlock);
   }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -337,6 +337,16 @@ export async function processCompletionsStream(
     }
     currentBlock = null;
   };
+  const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
+    if (forceStrict || reasoningTagTextPartitioner.hasPending()) {
+      reasoningTagTextPartitioner.markStrict();
+    }
+    // Let following text finish syntax already owned by the Markdown
+    // parser; otherwise packet batching cannot erase a lane boundary.
+    if (!hasFollowingVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax()) {
+      sealTextBeforeReasoning();
+    }
+  };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   const guardedStream = withFirstStreamEventTimeout(responseStream as AsyncIterable<unknown>, {
     provider: model.provider,
@@ -400,9 +410,6 @@ export async function processCompletionsStream(
         compat.visibleReasoningDetailTypes,
       );
       const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
-      const hasDedicatedReasoning = reasoningDeltas.some(
-        (delta) => delta.kind === "thinking" && delta.signature !== "reasoning_details",
-      );
       // Share the content/refusal owner to avoid duplicate mirrored refusals.
       const contentDeltas = readOpenAICompletionsContentDeltas(
         choiceDelta.content,
@@ -411,17 +418,11 @@ export async function processCompletionsStream(
           .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
           .map((reasoningDelta) => reasoningDelta.text),
       );
-      const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
+      const hasSameChunkVisibleText =
+        reasoningDeltas.some((delta) => delta.kind === "text") ||
+        contentDeltas.some((delta) => delta.kind === "text");
       if (hasMirroredReasoning) {
-        reasoningTagTextPartitioner.markStrict();
-        // Let same-chunk text finish syntax already owned by the Markdown
-        // parser; otherwise packet batching cannot erase a lane boundary.
-        if (
-          hasDedicatedReasoning &&
-          (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax())
-        ) {
-          sealTextBeforeReasoning();
-        }
+        beginReasoning(hasSameChunkVisibleText, true);
       }
       const appendReasoningDeltas = () => {
         for (const reasoningDelta of reasoningDeltas) {
@@ -444,7 +445,8 @@ export async function processCompletionsStream(
       if (hasMirroredReasoning) {
         appendReasoningDeltas();
       }
-      for (const contentDelta of contentDeltas) {
+      const lastVisibleTextIndex = contentDeltas.findLastIndex((delta) => delta.kind === "text");
+      for (const [contentDeltaIndex, contentDelta] of contentDeltas.entries()) {
         if (contentDelta.kind === "text") {
           const routedDeltas = hasMirroredReasoning
             ? reasoningTagTextPartitioner.push(contentDelta.text)
@@ -453,9 +455,8 @@ export async function processCompletionsStream(
             appendPartitionedVisibleDelta(routedDelta);
           }
         } else {
-          if (reasoningTagTextPartitioner.hasPending()) {
-            reasoningTagTextPartitioner.markStrict();
-          }
+          const hasLaterVisibleText = contentDeltaIndex < lastVisibleTextIndex;
+          beginReasoning(hasLaterVisibleText);
           appendRoutedContentDelta(contentDelta);
         }
       }

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -10,6 +10,7 @@ import { mapOpenAIStopReason } from "../providers/openai-stop-reason.js";
 import {
   clearPendingCommentaryText,
   rememberPendingCommentaryTags,
+  tagInterruptedTextPhases,
   tagPendingCommentaryText,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
@@ -95,11 +96,13 @@ export async function processCompletionsStream(
     partialArgs: string;
     thoughtSignature?: string;
   };
+  type TextBlock = { type: "text"; text: string; textSignature?: string };
   let currentBlock:
-    | { type: "text"; text: string }
+    | TextBlock
     | { type: "thinking"; thinking: string; thinkingSignature?: string }
     | ToolCallBlock
     | null = null;
+  let lastInterruptedTextBlock: TextBlock | null = null;
   let pendingPostToolCallDeltas: CompletionsReasoningDelta[] = [];
   let pendingPostToolCallBytes = 0;
   let isFlushingPendingPostToolCallDeltas = false;
@@ -314,10 +317,25 @@ export async function processCompletionsStream(
     }
     appendThinkingDelta({ text: "" });
   };
-  const flushReasoningTagTextPartitionerAtEnd = () => {
+  const flushReasoningTagTextPartitioner = () => {
     for (const delta of reasoningTagTextPartitioner.flush()) {
       appendPartitionedVisibleDelta(delta);
     }
+  };
+  const sealTextBeforeReasoning = () => {
+    if (currentBlock?.type !== "text" && !reasoningTagTextPartitioner.hasPending()) {
+      return;
+    }
+    flushReasoningTagTextPartitioner();
+    if (currentBlock?.type !== "text") {
+      return;
+    }
+    // Resumed reasoning makes the preceding visible text interim. Preserve
+    // the candidate boundary only if later text confirms a final answer.
+    if (currentBlock.text.trim()) {
+      lastInterruptedTextBlock = currentBlock;
+    }
+    currentBlock = null;
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   const guardedStream = withFirstStreamEventTimeout(responseStream as AsyncIterable<unknown>, {
@@ -382,9 +400,9 @@ export async function processCompletionsStream(
         compat.visibleReasoningDetailTypes,
       );
       const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
-      if (hasMirroredReasoning) {
-        reasoningTagTextPartitioner.markStrict();
-      }
+      const hasDedicatedReasoning = reasoningDeltas.some(
+        (delta) => delta.kind === "thinking" && delta.signature !== "reasoning_details",
+      );
       // Share the content/refusal owner to avoid duplicate mirrored refusals.
       const contentDeltas = readOpenAICompletionsContentDeltas(
         choiceDelta.content,
@@ -393,6 +411,15 @@ export async function processCompletionsStream(
           .filter((reasoningDelta) => reasoningDelta.kind === "thinking")
           .map((reasoningDelta) => reasoningDelta.text),
       );
+      const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
+      if (hasMirroredReasoning) {
+        reasoningTagTextPartitioner.markStrict();
+        // Same-chunk text can complete buffered Markdown or tag syntax;
+        // only a standalone reasoning delta confirms a lane resumption.
+        if (hasDedicatedReasoning && !hasSameChunkVisibleText) {
+          sealTextBeforeReasoning();
+        }
+      }
       const appendReasoningDeltas = () => {
         for (const reasoningDelta of reasoningDeltas) {
           if (reasoningDelta.kind === "thinking" && !emitReasoning) {
@@ -435,7 +462,7 @@ export async function processCompletionsStream(
       const toolCallDeltas = normalizedDelta.toolCalls;
       if (toolCallDeltas.length > 0) {
         sawNativeToolCallDelta = true;
-        flushReasoningTagTextPartitionerAtEnd();
+        flushReasoningTagTextPartitioner();
         rememberPendingCommentaryTags(
           provisionalCommentaryTags,
           tagPendingCommentaryText(output.content),
@@ -502,7 +529,7 @@ export async function processCompletionsStream(
     emitReasoningUsageActivity(hasReasoningUsageActivity);
     await cooperativeScheduler.afterEvent();
   }
-  flushReasoningTagTextPartitionerAtEnd();
+  flushReasoningTagTextPartitioner();
   flushDeepSeekToolCallRecovererAtEnd();
   flushDeepSeekTextFilterAtEnd();
   currentBlock = null;
@@ -530,6 +557,14 @@ export async function processCompletionsStream(
       });
     },
   });
+  if (
+    lastInterruptedTextBlock &&
+    output.stopReason !== "toolUse" &&
+    output.stopReason !== "error" &&
+    output.stopReason !== "aborted"
+  ) {
+    tagInterruptedTextPhases(output.content, lastInterruptedTextBlock);
+  }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);
   }

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -414,9 +414,12 @@ export async function processCompletionsStream(
       const hasSameChunkVisibleText = contentDeltas.some((delta) => delta.kind === "text");
       if (hasMirroredReasoning) {
         reasoningTagTextPartitioner.markStrict();
-        // Same-chunk text can complete buffered Markdown or tag syntax;
-        // only a standalone reasoning delta confirms a lane resumption.
-        if (hasDedicatedReasoning && !hasSameChunkVisibleText) {
+        // Let same-chunk text finish syntax already owned by the Markdown
+        // parser; otherwise packet batching cannot erase a lane boundary.
+        if (
+          hasDedicatedReasoning &&
+          (!hasSameChunkVisibleText || !reasoningTagTextPartitioner.hasPendingSyntax())
+        ) {
           sealTextBeforeReasoning();
         }
       }

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -361,6 +361,12 @@ export async function processCompletionsStream(
     currentBlock = null;
   };
   const beginReasoning = (hasFollowingVisibleText: boolean, forceStrict = false) => {
+    if (!output.openclawDelivery?.textPhaseRequiresTerminal) {
+      output.openclawDelivery = {
+        ...output.openclawDelivery,
+        textPhaseRequiresTerminal: true,
+      };
+    }
     if (forceStrict || reasoningTagTextPartitioner.hasPending()) {
       reasoningTagTextPartitioner.markStrict();
     }

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 import { getEnvApiKey } from "../env-api-keys.js";
 import type { OpenAICompletionsOptions } from "../provider-options.js";
 import { finalizeOpenAICompletionsToolCalls } from "../providers/openai-completions-tool-calls.js";
+import { tagUnresolvedTextAsCommentary } from "../utils/assistant-text-phase.js";
 import {
   createFirstStreamEventAbortController,
   getFirstStreamEventTimeoutHandler,
@@ -286,6 +287,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           cleanup: () => {
             output.stopReason = options?.signal?.aborted ? "aborted" : "error";
             finalizeOpenAICompletionsToolCalls(output, { allowSilentToolCallPromotion: false });
+            tagUnresolvedTextAsCommentary(output);
           },
         });
       } finally {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -40,6 +40,120 @@ export type OpenAICompletionsContentDelta =
   | { kind: "thinking"; signature?: string; text: string }
   | { kind: "text"; text: string; source?: "refusal" };
 
+type OpenAICompletionsReasoningBatch = {
+  readonly deltas: readonly OpenAICompletionsContentDelta[];
+  readonly mirroredThinking: readonly string[];
+  readonly hasThinking: boolean;
+  readonly hasVisibleText: boolean;
+};
+
+type MutableOpenAICompletionsReasoningBatch = {
+  deltas: OpenAICompletionsContentDelta[];
+  mirroredThinking: string[];
+  hasThinking: boolean;
+  hasVisibleText: boolean;
+};
+
+const EMPTY_OPENAI_COMPLETIONS_REASONING_BATCH: OpenAICompletionsReasoningBatch = {
+  deltas: [],
+  mirroredThinking: [],
+  hasThinking: false,
+  hasVisibleText: false,
+};
+
+const OPENAI_COMPLETIONS_REASONING_FIELDS = [
+  "reasoning_content",
+  "reasoning",
+  "reasoning_text",
+] as const;
+
+function appendOpenAICompletionsReasoningDelta(
+  batch: MutableOpenAICompletionsReasoningBatch,
+  next: OpenAICompletionsContentDelta,
+): void {
+  if (next.kind === "thinking") {
+    batch.hasThinking = true;
+  } else {
+    batch.hasVisibleText = true;
+  }
+  const previous = batch.deltas[batch.deltas.length - 1];
+  if (!previous || previous.kind !== next.kind) {
+    batch.deltas.push(next);
+    if (next.kind === "thinking") {
+      batch.mirroredThinking.push(next.text);
+    }
+    return;
+  }
+  if (next.kind === "thinking" && previous.kind === "thinking") {
+    if (previous.signature !== next.signature) {
+      batch.deltas.push(next);
+      batch.mirroredThinking.push(next.text);
+      return;
+    }
+    previous.text += next.text;
+    batch.mirroredThinking[batch.mirroredThinking.length - 1] += next.text;
+    return;
+  }
+  previous.text += next.text;
+}
+
+function createOpenAICompletionsReasoningBatch(): MutableOpenAICompletionsReasoningBatch {
+  return {
+    deltas: [],
+    mirroredThinking: [],
+    hasThinking: false,
+    hasVisibleText: false,
+  };
+}
+
+export function readOpenAICompletionsReasoningBatch(
+  delta: Record<string, unknown>,
+  visibleReasoningDetailTypes: ReadonlySet<string>,
+): OpenAICompletionsReasoningBatch {
+  let batch: MutableOpenAICompletionsReasoningBatch | undefined;
+  const reasoningDetails = delta.reasoning_details;
+  let usedReasoningThinkingDetails = false;
+  if (Array.isArray(reasoningDetails)) {
+    for (const item of reasoningDetails) {
+      const detail = item as { type?: unknown; text?: unknown };
+      if (typeof detail.text !== "string" || !detail.text) {
+        continue;
+      }
+      if (detail.type === "reasoning.text") {
+        usedReasoningThinkingDetails = true;
+        batch ??= createOpenAICompletionsReasoningBatch();
+        appendOpenAICompletionsReasoningDelta(batch, {
+          kind: "thinking",
+          signature: "reasoning_details",
+          text: detail.text,
+        });
+        continue;
+      }
+      // Compat-classified visible details are explicit output items. Preserve
+      // their order with adjacent structured thinking instead of inferring commentary.
+      if (typeof detail.type === "string" && visibleReasoningDetailTypes.has(detail.type)) {
+        batch ??= createOpenAICompletionsReasoningBatch();
+        appendOpenAICompletionsReasoningDelta(batch, { kind: "text", text: detail.text });
+      }
+    }
+  }
+  if (!usedReasoningThinkingDetails) {
+    for (const field of OPENAI_COMPLETIONS_REASONING_FIELDS) {
+      const value = delta[field];
+      if (typeof value === "string" && value.length > 0) {
+        batch ??= createOpenAICompletionsReasoningBatch();
+        appendOpenAICompletionsReasoningDelta(batch, {
+          kind: "thinking",
+          signature: field,
+          text: value,
+        });
+        break;
+      }
+    }
+  }
+  return batch ?? EMPTY_OPENAI_COMPLETIONS_REASONING_BATCH;
+}
+
 type OpenAIModeCompatInput = Omit<OpenAICompletionsCompat, "thinkingFormat"> & {
   thinkingFormat?: string;
   requiresStringContent?: boolean;

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -7,6 +7,7 @@ import type {
   ToolCall,
   Usage,
 } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import { getAiTransportHost } from "../host.js";
 import { applyProviderReportedUsageCost, calculateCost } from "../model-utils.js";
@@ -115,7 +116,10 @@ export function readOpenAICompletionsReasoningBatch(
   let usedReasoningThinkingDetails = false;
   if (Array.isArray(reasoningDetails)) {
     for (const item of reasoningDetails) {
-      const detail = item as { type?: unknown; text?: unknown };
+      if (!isRecord(item)) {
+        continue;
+      }
+      const detail = item;
       if (typeof detail.text !== "string" || !detail.text) {
         continue;
       }

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -37,9 +37,11 @@ export const log = {
 
 export type { OpenAICompletionsOptions } from "../provider-options.js";
 
+export type OpenAICompletionsTextSource = "reasoning_detail" | "refusal";
+
 export type OpenAICompletionsContentDelta =
   | { kind: "thinking"; signature?: string; text: string }
-  | { kind: "text"; text: string; source?: "refusal" };
+  | { kind: "text"; text: string; source?: OpenAICompletionsTextSource };
 
 type OpenAICompletionsReasoningBatch = {
   readonly deltas: readonly OpenAICompletionsContentDelta[];
@@ -137,7 +139,11 @@ export function readOpenAICompletionsReasoningBatch(
       // their order with adjacent structured thinking instead of inferring commentary.
       if (typeof detail.type === "string" && visibleReasoningDetailTypes.has(detail.type)) {
         batch ??= createOpenAICompletionsReasoningBatch();
-        appendOpenAICompletionsReasoningDelta(batch, { kind: "text", text: detail.text });
+        appendOpenAICompletionsReasoningDelta(batch, {
+          kind: "text",
+          text: detail.text,
+          source: "reasoning_detail",
+        });
       }
     }
   }

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -6,6 +6,8 @@ type AssistantTextPhaseBlock = {
 
 export type PendingCommentaryTags = Map<AssistantTextPhaseBlock, string>;
 
+const EMPTY_ASSISTANT_TEXT_BLOCK_SET: ReadonlySet<unknown> = new Set();
+
 function isAssistantTextPhaseBlock(block: unknown): block is AssistantTextPhaseBlock {
   if (!block || typeof block !== "object") {
     return false;
@@ -47,6 +49,7 @@ export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): Pendi
 export function tagInterruptedTextPhases(
   content: ReadonlyArray<unknown>,
   interruptedText: unknown,
+  preservedVisibleText: ReadonlySet<unknown> = EMPTY_ASSISTANT_TEXT_BLOCK_SET,
 ): void {
   const interruptedTextIndex = content.indexOf(interruptedText);
   if (interruptedTextIndex === -1) {
@@ -61,8 +64,16 @@ export function tagInterruptedTextPhases(
   if (finalAnswerIndex === -1) {
     return;
   }
-  tagUnphasedText(content.slice(0, finalAnswerIndex), "commentary", "commentary");
-  tagUnphasedText(content.slice(finalAnswerIndex), "final_answer", "final-answer");
+  tagUnphasedText(
+    content.slice(0, finalAnswerIndex).filter((block) => !preservedVisibleText.has(block)),
+    "commentary",
+    "commentary",
+  );
+  tagUnphasedText(
+    content.filter((block, index) => index >= finalAnswerIndex || preservedVisibleText.has(block)),
+    "final_answer",
+    "final-answer",
+  );
 }
 
 /** Prevents unresolved completion text from becoming a fallback answer after stream failure. */

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -18,21 +18,51 @@ function encodeAssistantTextSignatureV1(id: string, phase?: "commentary" | "fina
   return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
 }
 
-/** Tags unphased narration before a tool-call event becomes consumer-visible. */
-export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): PendingCommentaryTags {
+function tagUnphasedText(
+  content: ReadonlyArray<unknown>,
+  phase: "commentary" | "final_answer",
+  idPrefix: string,
+): PendingCommentaryTags {
   const textBlocks = content.filter(isAssistantTextPhaseBlock);
-  let commentaryIndex = textBlocks.filter((block) => block.textSignature !== undefined).length;
+  let phaseIndex = textBlocks.filter((block) => block.textSignature !== undefined).length;
   const tagged: PendingCommentaryTags = new Map();
   for (const block of textBlocks) {
     if (block.text.trim().length === 0 || block.textSignature !== undefined) {
       continue;
     }
-    const signature = encodeAssistantTextSignatureV1(`commentary-${commentaryIndex}`, "commentary");
+    const signature = encodeAssistantTextSignatureV1(`${idPrefix}-${phaseIndex}`, phase);
     block.textSignature = signature;
     tagged.set(block, signature);
-    commentaryIndex += 1;
+    phaseIndex += 1;
   }
   return tagged;
+}
+
+/** Tags unphased narration before a tool-call event becomes consumer-visible. */
+export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): PendingCommentaryTags {
+  return tagUnphasedText(content, "commentary", "commentary");
+}
+
+/** Records the confirmed final-answer boundary after reasoning resumes. */
+export function tagInterruptedTextPhases(
+  content: ReadonlyArray<unknown>,
+  interruptedText: unknown,
+): void {
+  const interruptedTextIndex = content.indexOf(interruptedText);
+  if (interruptedTextIndex === -1) {
+    return;
+  }
+  const finalAnswerIndex = content.findIndex(
+    (block, index) =>
+      index > interruptedTextIndex &&
+      isAssistantTextPhaseBlock(block) &&
+      block.text.trim().length > 0,
+  );
+  if (finalAnswerIndex === -1) {
+    return;
+  }
+  tagUnphasedText(content.slice(0, finalAnswerIndex), "commentary", "commentary");
+  tagUnphasedText(content.slice(finalAnswerIndex), "final_answer", "final-answer");
 }
 
 /** Rolls back only the exact provisional signatures created by this transport turn. */

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -65,6 +65,16 @@ export function tagInterruptedTextPhases(
   tagUnphasedText(content.slice(finalAnswerIndex), "final_answer", "final-answer");
 }
 
+/** Prevents unresolved completion text from becoming a fallback answer after stream failure. */
+export function tagUnresolvedTextAsCommentary(message: {
+  content: ReadonlyArray<unknown>;
+  openclawDelivery?: { textPhaseRequiresTerminal?: true };
+}): void {
+  if (message.openclawDelivery?.textPhaseRequiresTerminal) {
+    tagUnphasedText(message.content, "commentary", "commentary");
+  }
+}
+
 /** Rolls back only the exact provisional signatures created by this transport turn. */
 export function clearPendingCommentaryText(tags: PendingCommentaryTags): void {
   for (const [block, signature] of tags) {

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -721,6 +721,19 @@ describe("createReasoningTagTextPartitioner", () => {
     expect(partitioner.isInsideReasoning()).toBe(false);
   });
 
+  it("distinguishes buffered syntax from strict visible text", () => {
+    const syntax = createReasoningTagTextPartitioner();
+    const visible = createReasoningTagTextPartitioner();
+
+    expect(syntax.pushVisible("Use `<thi")).toEqual([]);
+    expect(syntax.hasPendingSyntax()).toBe(true);
+
+    visible.markStrict();
+    expect(visible.pushVisible("Interim answer.")).toEqual([]);
+    expect(visible.hasPending()).toBe(true);
+    expect(visible.hasPendingSyntax()).toBe(false);
+  });
+
   it("accepts later content after an intermediate flush boundary", () => {
     const partitioner = createReasoningTagTextPartitioner();
 

--- a/packages/ai/test/fixtures/provider-transport-parity/openai-success.snap.txt
+++ b/packages/ai/test/fixtures/provider-transport-parity/openai-success.snap.txt
@@ -95,6 +95,9 @@
       "model": "gpt-5.5",
       "responseId": "chatcmpl-parity",
       "responseModel": "gpt-5.5-response",
+      "openclawDelivery": {
+        "textPhaseRequiresTerminal": true
+      },
       "usage": {
         "input": 6,
         "output": 4,
@@ -204,6 +207,9 @@
       "provider": "openai",
       "model": "gpt-5.5",
       "responseId": "chatcmpl-parity",
+      "openclawDelivery": {
+        "textPhaseRequiresTerminal": true
+      },
       "usage": {
         "input": 6,
         "output": 4,

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -349,6 +349,8 @@ export interface AssistantMessage {
     audioAsVoice?: true;
     replyToCurrent?: true;
     replyToId?: string;
+    /** Provider text phase is unresolved until the assistant turn reaches terminal state. */
+    textPhaseRequiresTerminal?: true;
     /** Parsed once at the assistant write boundary; delivery resolves policy from these facts. */
     tts?: AssistantDeliveryTtsFacts;
   };

--- a/packages/markdown-core/src/reasoning-tags.ts
+++ b/packages/markdown-core/src/reasoning-tags.ts
@@ -81,6 +81,8 @@ export interface ReasoningTagTextPartitioner {
   pushVisible(chunk: string): ReasoningTagTextDelta[];
   flush(): ReasoningTagTextDelta[];
   hasPending(): boolean;
+  /** Whether more input can change buffered Markdown or reasoning-tag ownership. */
+  hasPendingSyntax(): boolean;
   isInsideReasoning(): boolean;
 }
 
@@ -573,6 +575,11 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
         (holdStart !== undefined && holdStart < source.length) ||
         reduction.depth > 0 ||
         emitted < source.length
+      );
+    },
+    hasPendingSyntax() {
+      return (
+        pendingTagProbe !== undefined || heldBacktickStart !== undefined || reduction.depth > 0
       );
     },
     isInsideReasoning() {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -282,6 +282,12 @@ export function handleMessageUpdate(
   const skipLiveStream = ctx.params.suppressLiveStreamOutput === true;
   const shouldUsePhaseAwareBlockReply = Boolean(deliveryPhase);
 
+  // A completions stream cannot classify text interrupted by later reasoning
+  // until terminal. Keep that text out of live reply lanes until its phase resolves.
+  if (isPhasePendingReasoningCompletionsText) {
+    return;
+  }
+
   if (chunk) {
     ctx.state.deltaBuffer += chunk;
     if (!skipLiveStream && !shouldUsePhaseAwareBlockReply) {
@@ -291,9 +297,7 @@ export function handleMessageUpdate(
     }
   }
 
-  // A completions stream cannot classify text interrupted by later reasoning
-  // until terminal. Keep that text out of live reply lanes until its phase resolves.
-  if (skipLiveStream || isPhasePendingReasoningCompletionsText) {
+  if (skipLiveStream) {
     return;
   }
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -203,11 +203,10 @@ export function handleMessageUpdate(
   // early unphased deltas from durable block replies until that decision exists.
   const isPhasePendingAnthropicText =
     evtType !== "text_end" && !deliveryPhase && isAnthropicAssistantMessage(partialAssistant);
-  const isPhasePendingCompletionsText =
-    !deliveryPhase && isOpenAiCompletionsAssistantMessage(partialAssistant);
-  const isPhasePendingReasoningCompletionsText =
-    isPhasePendingCompletionsText &&
-    partialAssistant.openclawDelivery?.textPhaseRequiresTerminal === true;
+  const isCompletionsAssistant = isOpenAiCompletionsAssistantMessage(partialAssistant);
+  const isPhasePendingCompletionsText = !deliveryPhase && isCompletionsAssistant;
+  const isReasoningCompletionsText =
+    isCompletionsAssistant && partialAssistant.openclawDelivery?.textPhaseRequiresTerminal === true;
   const hasResponsesContentIndex =
     streamContentIndex !== undefined && isResponsesApiAssistantMessage(partialAssistant);
   let streamItemChanged = false;
@@ -284,7 +283,7 @@ export function handleMessageUpdate(
 
   // A completions stream cannot classify text interrupted by later reasoning
   // until terminal. Keep that text out of live reply lanes until its phase resolves.
-  if (isPhasePendingReasoningCompletionsText) {
+  if (isReasoningCompletionsText) {
     return;
   }
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -205,6 +205,9 @@ export function handleMessageUpdate(
     evtType !== "text_end" && !deliveryPhase && isAnthropicAssistantMessage(partialAssistant);
   const isPhasePendingCompletionsText =
     !deliveryPhase && isOpenAiCompletionsAssistantMessage(partialAssistant);
+  const isPhasePendingReasoningCompletionsText =
+    isPhasePendingCompletionsText &&
+    partialAssistant.openclawDelivery?.textPhaseRequiresTerminal === true;
   const hasResponsesContentIndex =
     streamContentIndex !== undefined && isResponsesApiAssistantMessage(partialAssistant);
   let streamItemChanged = false;
@@ -288,7 +291,9 @@ export function handleMessageUpdate(
     }
   }
 
-  if (skipLiveStream) {
+  // A completions stream cannot classify text interrupted by later reasoning
+  // until terminal. Keep that text out of live reply lanes until its phase resolves.
+  if (skipLiveStream || isPhasePendingReasoningCompletionsText) {
     return;
   }
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
@@ -342,27 +342,75 @@ describe("Chat Completions pre-tool narration", () => {
 
     expect(onPartialReply).not.toHaveBeenCalled();
 
+    const terminalMessage = {
+      ...message,
+      content: [
+        {
+          type: "text",
+          text: "Interim text.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Final text.",
+          textSignature: JSON.stringify({ v: 1, id: "final-0", phase: "final_answer" }),
+        },
+      ],
+    } as unknown as AssistantMessage;
+    emit({
+      type: "message_update",
+      message: terminalMessage,
+      assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "Final text." },
+    });
+    emit({ type: "message_end", message: terminalMessage });
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(postedText(onBlockReply)).toBe("Final text.");
+  });
+
+  it("does not deliver interrupted text when producer phase resolution ends in error", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onPartialReply = vi.fn();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-reasoning-error",
+      onPartialReply,
+      onBlockReply,
+      blockReplyBreak: "message_end",
+    });
+
+    const pendingMessage = {
+      role: "assistant",
+      api: "openai-completions",
+      openclawDelivery: { textPhaseRequiresTerminal: true },
+      content: [{ type: "text", text: "Interim text." }],
+    } as unknown as AssistantMessage;
+    emit({ type: "message_start", message: pendingMessage });
+    emit({
+      type: "message_update",
+      message: pendingMessage,
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Interim text." },
+    });
     emit({
       type: "message_end",
       message: {
-        ...message,
+        ...pendingMessage,
+        stopReason: "error",
+        errorMessage: "synthetic interrupted stream",
         content: [
           {
             type: "text",
             text: "Interim text.",
             textSignature: JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" }),
           },
-          {
-            type: "text",
-            text: "Final text.",
-            textSignature: JSON.stringify({ v: 1, id: "final-0", phase: "final_answer" }),
-          },
         ],
       },
     });
 
-    expect(onBlockReply).toHaveBeenCalledTimes(1);
-    expect(postedText(onBlockReply)).toBe("Final text.");
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
   });
 
   it("withholds pre-tool narration from durable text_end block replies", () => {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
@@ -315,13 +315,16 @@ function postedText(onBlockReply: ReturnType<typeof vi.fn>): string {
 }
 
 describe("Chat Completions pre-tool narration", () => {
-  it("withholds reasoning-associated unphased text from live partial replies", () => {
+  it("withholds reasoning-associated unphased text until terminal phase resolution", () => {
     const { session, emit } = createStubSessionHarness();
     const onPartialReply = vi.fn();
+    const onBlockReply = vi.fn();
     subscribeEmbeddedAgentSession({
       session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
       runId: "run-completions-reasoning-pending",
       onPartialReply,
+      onBlockReply,
+      blockReplyBreak: "message_end",
     });
 
     const message = {
@@ -338,6 +341,28 @@ describe("Chat Completions pre-tool narration", () => {
     });
 
     expect(onPartialReply).not.toHaveBeenCalled();
+
+    emit({
+      type: "message_end",
+      message: {
+        ...message,
+        content: [
+          {
+            type: "text",
+            text: "Interim text.",
+            textSignature: JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" }),
+          },
+          {
+            type: "text",
+            text: "Final text.",
+            textSignature: JSON.stringify({ v: 1, id: "final-0", phase: "final_answer" }),
+          },
+        ],
+      },
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(postedText(onBlockReply)).toBe("Final text.");
   });
 
   it("withholds pre-tool narration from durable text_end block replies", () => {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
@@ -315,6 +315,31 @@ function postedText(onBlockReply: ReturnType<typeof vi.fn>): string {
 }
 
 describe("Chat Completions pre-tool narration", () => {
+  it("withholds reasoning-associated unphased text from live partial replies", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onPartialReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-reasoning-pending",
+      onPartialReply,
+    });
+
+    const message = {
+      role: "assistant",
+      api: "openai-completions",
+      openclawDelivery: { textPhaseRequiresTerminal: true },
+      content: [{ type: "text", text: "Interim text." }],
+    } as unknown as AssistantMessage;
+    emit({ type: "message_start", message });
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Interim text." },
+    });
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+  });
+
   it("withholds pre-tool narration from durable text_end block replies", () => {
     const { session, emit } = createStubSessionHarness();
     const onBlockReply = vi.fn();
@@ -362,10 +387,12 @@ describe("Chat Completions pre-tool narration", () => {
   it("delivers permanently unphased ordinary text in prefix-before-suffix order", async () => {
     const { session, emit } = createStubSessionHarness();
     const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
     subscribeEmbeddedAgentSession({
       session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
       runId: "run-completions-answer",
       onBlockReply,
+      onPartialReply,
       blockReplyBreak: "text_end",
       blockReplyChunking: { minChars: 4, maxChars: 200 },
     });
@@ -384,6 +411,7 @@ describe("Chat Completions pre-tool narration", () => {
     emit({ type: "message_end", message: completionsAssistant("prefix suffix") });
 
     await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalled());
+    expect(onPartialReply).toHaveBeenCalledWith(expect.objectContaining({ text: "prefix" }));
     expect(postedText(onBlockReply)).toContain("prefix suffix");
   });
 


### PR DESCRIPTION
## Problem

OpenAI-compatible streams shaped as `reasoning -> interim content -> reasoning -> final content` left both text segments unphased. Final delivery therefore joined the interim text into the user-visible answer. The failure also occurred with coalesced packets, structured `reasoning_details`, hidden reasoning, and a trailing reasoning-only suffix.

## Root cause

The two OpenAI-completions producers decoded reasoning differently and treated resumed reasoning as another delta without closing the active text lane or retaining a boundary confirmed by later visible text. Packet boundaries accidentally determined text-block shape. The channel layer received ambiguous unphased text and correctly preserved it.

## Fix

- decode top-level and structured reasoning once at the shared OpenAI transport boundary
- split the active text lane at producer-owned reasoning boundaries
- retain pending and confirmed interruption boundaries separately
- tag interrupted text `commentary` and the confirmed suffix `final_answer`
- preserve encrypted tool signatures and compat-configured explicitly visible structured output
- preserve `visible -> thinking -> visible` structured-detail order identically in both producers
- preserve compat-declared visible-detail provenance across split packets
- record the unresolved phase at the producer and defer live reply delivery until terminal classification
- classify unresolved text as commentary on error or abort terminals
- cover both producers, hidden reasoning, coalesced packets, structured content, and trailing reasoning

Supersedes #96969 with a producer-owned fix. Thanks @SymbolStar for the report and reproduction analysis. Addresses #96849.

## Proof

- pre-fix owner test: SDK producer merged structured `Interim.Final.` into one unphased block
- exact-head focused suite: 6 requested files, 3 official Vitest shards, 170 tests passed
- errored interleave parity: both producers retain the interim block only as commentary; subscriber emits no reply
- broader focused suite before the final decoder-only consolidation: 17 files, 471 tests passed
- targeted Oxlint, Oxfmt, and `git diff --check`: passed
- assertion-safety ratchet: passed; baseline shrank for both touched producers
- Distill: zero findings on the exact diff
- Greybeard: zero findings on the exact diff
- exact-head hosted CI: 179 passed, 50 skipped, 0 failed; production and test typechecks passed
- unrelated hosted failure: Control UI startup gzip exceeded its budget in `build-artifacts`; this AI-only diff does not touch `ui/` or its assets, and the same failure reproduced across all three proof heads
- local repo-wide `pnpm tsgo`: blocked by untouched `packages/terminal-core/src/ansi.ts:194` (`TS2554`); hosted exact-head production and test type checks passed

Exact pushed head: `370f3067dfa71d7b80be1fe4da168bf0e160dc10`.

Production delta: +434/-146. Growth centralizes structured reasoning decoding, records pending/confirmed phase boundaries across the two existing producer implementations, retains explicit visible-detail provenance, exposes one allocation-free Markdown parser ownership fact, and carries one terminal-phase delivery fact. No channel/provider-specific guard or compatibility path. Test delta: +553/-6; assertion-safety baseline: +2/-2.

## Delivery policy

Phase-ambiguous OpenAI-compatible reasoning streams intentionally use terminal-only user-visible delivery. A transient interim message or edit is the reported bug, not an acceptable streaming state. Ordinary completions without the producer-owned terminal-phase fact retain live partial delivery; compat-declared explicit visible details retain their visible provenance.

## Phase-aware delivery contract

The owner regression drives both production producers through:

```text
reasoning_details(A) -> content(INTERIM) -> reasoning_details(B) -> content(FINAL) -> stop
```

Both now emit thinking A, `INTERIM` as `commentary`, thinking B, and `FINAL` as `final_answer`. Canonical delivery therefore returns only `FINAL`. A trailing reasoning-only suffix leaves the last confirmed final boundary intact.

Exact-head redacted trace through `processCompletionsStream` and the canonical embedded-agent delivery extractor:

```json
{
  "exactHead": "370f3067dfa71d7b80be1fe4da168bf0e160dc10",
  "transport": "openai-completions",
  "blocks": [
    { "type": "thinking", "text": "[redacted]" },
    { "type": "text", "text": "INTERMEDIATE_MARKER", "phase": "commentary" },
    { "type": "thinking", "text": "[redacted]" },
    { "type": "text", "text": "FINAL_MARKER", "phase": "final_answer" }
  ],
  "delivered": "FINAL_MARKER",
  "intermediateDelivered": false,
  "finalDelivered": true,
  "hiddenReasoningDelivered": false
}
```

## Exact-head Telegram proof

The real-user Telegram harness drove the changed `openai-completions` path on `370f3067dfa71d7b80be1fe4da168bf0e160dc10`. The fixture emitted hidden reasoning A, interim content, hidden reasoning B, then final content. Telegram recorded one SUT message at 4097 ms containing only `OPENCLAW_E2E_REASONING_FINAL`: zero edits, deletions, typing events, intermediate markers, or hidden-reasoning markers.

ClawSweeper rank-up skip: no separate Telegram Desktop transcript. The exact-head real-user TDLib recording is stronger for this defect because it exhaustively records transient messages, edits, deletions, and typing events while driving the changed provider path; a Desktop snapshot would duplicate the final-state evidence without proving those absences.

The ephemeral harness set `agents.defaults.heartbeat.target=none` with strict readback so an unrelated background heartbeat could not contaminate the turn. It recorded one provider request, drained zero pending updates, removed its scratch directory, and left no persistent config mutation.

## Pre-fix compatible-provider capture

Redacted Telegram harness capture on main drove the documented generic `openai-completions` route with:

```text
reasoning_content([redacted A]) -> content(INTERMEDIATE) ->
reasoning_content([redacted B]) -> content(FINAL)
```

Gateway evidence recorded `provider=openai` and `api=openai-completions`. Telegram received one final SUT message after 4111 ms containing both `INTERMEDIATE` and `FINAL`, with neither hidden reasoning marker. This proves the reported stream shape leaked interim visible content on main; it does not claim that the current MiniMax service still emits that shape. Bundled MiniMax defaults to `anthropic-messages`, while its optional OpenAI-compatible configuration remains documented.

## Overlap

Open PR #96969 is the only exact overlap. Its consumer heuristic drops legitimate unphased text across providers; this PR replaces it at the producer owner boundary. Broad searches found no second open repair.
