### PR TITLE
fix(update): keep a committed post-core result when stopping the child signals

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2211,6 +2211,29 @@ describe("update-cli", () => {
     );
   });
 
+  it("honors a committed post-core result when stopping the child delivers a signal", async () => {
+    // The poll owns the settle: it stops the child only after claiming the result. Stopping
+    // delivers SIGTERM, so an unclaimed exit handler would reject an update the child already
+    // committed and then roll its plugin index back.
+    const { root } = setupUpdatedRootRefresh();
+    readPackageVersion.mockImplementation(async (pkgRoot: string) =>
+      pkgRoot === root ? "0.0.1" : "2026.5.28",
+    );
+    spawn.mockImplementationOnce((_command: string, _args: string[], options: unknown) => {
+      const child = new EventEmitter() as EventEmitter & { kill: () => void };
+      const resultPath = (options as { env: Record<string, string> }).env[
+        "OPENCLAW_UPDATE_POST_CORE_RESULT_PATH"
+      ];
+      fsSync.writeFileSync(resultPath, JSON.stringify({ status: "ok" }), "utf8");
+      child.kill = () => {
+        child.emit("exit", null, "SIGTERM");
+      };
+      return child;
+    });
+
+    await expect(updateCommand({ yes: true, restart: false })).resolves.not.toThrow();
+  });
+
   it("keeps a child-committed plugin index when the post-core handoff is signaled", async () => {
     const { root } = setupUpdatedRootRefresh();
     readPackageVersion.mockImplementation(async (pkgRoot: string) =>

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2221,9 +2221,10 @@ describe("update-cli", () => {
     );
     spawn.mockImplementationOnce((_command: string, _args: string[], options: unknown) => {
       const child = new EventEmitter() as EventEmitter & { kill: () => void };
-      const resultPath = (options as { env: Record<string, string> }).env[
-        "OPENCLAW_UPDATE_POST_CORE_RESULT_PATH"
-      ];
+      const resultPath = expectDefined(
+        (options as { env: Record<string, string> }).env["OPENCLAW_UPDATE_POST_CORE_RESULT_PATH"],
+        "post-core result path test invariant",
+      );
       fsSync.writeFileSync(resultPath, JSON.stringify({ status: "ok" }), "utf8");
       child.kill = () => {
         child.emit("exit", null, "SIGTERM");

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -607,8 +607,11 @@ export async function continuePostCoreUpdateInFreshProcess(params: {
             if (!pluginUpdate) {
               return;
             }
-            stopPostCoreUpdateChild(child);
+            // Claim the settle before stopping: the stop delivers a signal, and the exit
+            // handler below rejects on any signal it still owns. Stopping first would fail
+            // an update this child already committed and roll its plugin index back.
             finish({ kind: "plugin-update", pluginUpdate });
+            stopPostCoreUpdateChild(child);
           })
           .catch(() => undefined);
       }, POST_CORE_UPDATE_RESULT_POLL_MS);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw update` could fail an update its post-core child had
already completed successfully, reporting
`post-update process terminated by signal SIGTERM` and then rolling the plugin index
back to its pre-update state. The window is timing-dependent, so it shows up on loaded
or slow machines and is invisible on a fast one.

## Why This Change Was Made

The post-core wait settles from three places: a result-file poll, the child's `error`
event, and the child's `exit` event. The poll called `stopPostCoreUpdateChild(child)`
*before* claiming the settle:

```ts
if (!pluginUpdate) return;
stopPostCoreUpdateChild(child);      // delivers a signal
finish({ kind: "plugin-update", pluginUpdate });   // claims settle
```

Stopping the child delivers a signal, and the `exit` handler rejects on any signal it
still owns. Between those two lines the settle is unclaimed, so the child's own
signal-driven exit could win and reject a run whose child had already written a valid
result. The outer `catch` then calls `restoreTentativePluginIndex()`, discarding
successful work.

The fix reorders the two statements so the poll claims the settle first; the exit
handler then sees `settled` and returns. Pure reordering — **net zero production
lines** (+4/−1, three of which are the invariant comment).

Non-goal: this does not change what happens when the child dies by signal *without*
committing a result; that path still fails and rolls back, which is correct.

## User Impact

An update whose post-core child commits its plugin work is no longer failed and rolled
back because the parent's own stop raced the settle. Operators stop seeing spurious
`terminated by signal SIGTERM` failures from updates that actually succeeded.

## Evidence

Deterministic regression test (`honors a committed post-core result when stopping the
child delivers a signal`): the child writes its result file, then the parent's stop
delivers `SIGTERM`. On pre-fix code it fails with exactly the production symptom:

```
AssertionError: promise rejected "Error: post-update process terminated by …" instead of resolving
Caused by: Error: post-update process terminated by signal SIGTERM
```

With the fix: `src/cli/update-cli.test.ts` → `241 passed (241)`.

Full `cli` lane:
- macOS: `214 passed | 1 skipped`; the 3 failing files (`daemon`, `logs-cli.runtime`,
  `channels-list-catalog-row-discovery`) fail identically on clean `main` and pass on Linux.
- Linux (Blacksmith Testbox `tbx_01m079ysh68gn77t9pszpzsv5t`): `217 passed | 1 skipped`, exit 0.

Provenance: this is the error that leaked across test boundaries in the `agentic-cli`
shard on 2026-08-17 (run 31997770370, job 95284409469). Its stack showed
`update-command-post-core.ts:630` rejecting from one test's child while a *different*
test was running, cascading into 34 failures in `src/cli/update-cli.test.ts` — all of
them service/post-core cases. I reproduced the underlying race deterministically; I am
not claiming it is provably the sole cause of that particular cascade, but it is a real
ordering defect that produces exactly that error, and it stands on its own as a
correctness fix.

Codex autoreview: clean, no accepted/actionable findings.
