### PR TITLE
perf(test): reuse SMS test modules

### DIFF
--- a/extensions/sms/src/channel.test.ts
+++ b/extensions/sms/src/channel.test.ts
@@ -1,16 +1,11 @@
 // Sms tests cover channel plugin behavior.
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { smsPlugin } from "./channel.js";
 import type { SmsDeliveryRecord } from "./delivery-observations.js";
 import type { probeSmsAccount as probeSmsAccountType } from "./status.js";
 import type { sendSmsViaTwilio as sendSmsViaTwilioType } from "./twilio.js";
-
-type ChannelModule = typeof import("./channel.js");
-type PlatformMessageNotDispatchedErrorConstructor =
-  (typeof import("openclaw/plugin-sdk/error-runtime"))["PlatformMessageNotDispatchedError"];
-
-let smsPlugin: ChannelModule["smsPlugin"];
-let PlatformMessageNotDispatchedError: PlatformMessageNotDispatchedErrorConstructor;
 
 const sendSmsViaTwilio = vi.hoisted(() =>
   vi.fn<typeof sendSmsViaTwilioType>(async ({ to, onPlatformSendDispatch }) => {
@@ -45,8 +40,25 @@ const probeSmsAccount = vi.hoisted(() =>
   })),
 );
 
-beforeEach(async () => {
-  vi.resetModules();
+vi.mock("./twilio.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./twilio.js")>()),
+  sendSmsViaTwilio,
+}));
+vi.mock("./media.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./media.js")>()),
+  prepareHostedSmsMedia: hostedMediaMocks.prepare,
+}));
+vi.mock("./delivery-observations.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./delivery-observations.js")>()),
+  listRecentSmsDeliveryRecords,
+  recordInitialSmsDeliveryResult,
+}));
+vi.mock("./status.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./status.js")>()),
+  probeSmsAccount,
+}));
+
+beforeEach(() => {
   sendSmsViaTwilio.mockReset();
   sendSmsViaTwilio.mockImplementation(async ({ to, onPlatformSendDispatch }) => {
     await onPlatformSendDispatch?.();
@@ -68,31 +80,10 @@ beforeEach(async () => {
   recordInitialSmsDeliveryResult.mockReset();
   recordInitialSmsDeliveryResult.mockResolvedValue(null);
   probeSmsAccount.mockClear();
-  vi.doMock("./twilio.js", () => ({
-    sendSmsViaTwilio,
-    TWILIO_MESSAGE_BODY_MAX_LENGTH: 1600,
-  }));
-  vi.doMock("./media.js", () => ({
-    prepareHostedSmsMedia: hostedMediaMocks.prepare,
-  }));
-  vi.doMock("./delivery-observations.js", () => ({
-    listRecentSmsDeliveryRecords,
-    recordInitialSmsDeliveryResult,
-  }));
-  vi.doMock("./status.js", () => ({
-    probeSmsAccount,
-    formatSmsProbeLines: vi.fn(() => []),
-  }));
-  ({ PlatformMessageNotDispatchedError } = await import("openclaw/plugin-sdk/error-runtime"));
-  ({ smsPlugin } = await import("./channel.js"));
 });
 
 afterEach(() => {
   vi.useRealTimers();
-  vi.doUnmock("./twilio.js");
-  vi.doUnmock("./media.js");
-  vi.doUnmock("./delivery-observations.js");
-  vi.doUnmock("./status.js");
 });
 
 describe("smsPlugin status", () => {

--- a/extensions/sms/src/send.test.ts
+++ b/extensions/sms/src/send.test.ts
@@ -1,18 +1,20 @@
 // Sms tests cover send plugin behavior.
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSmsAccount } from "./accounts.js";
+import {
+  prepareSmsMediaAttempt,
+  sendPreparedSmsMediaAttempt,
+  sendSmsTextChunks,
+  toSmsPlainText,
+} from "./send.js";
 import type { sendSmsViaTwilio as sendSmsViaTwilioType } from "./twilio.js";
 import type { ResolvedSmsAccount } from "./types.js";
 
 type SendModule = typeof import("./send.js");
 type SendSmsMediaParams = Parameters<SendModule["prepareSmsMediaAttempt"]>[0] &
   Omit<Parameters<SendModule["sendPreparedSmsMediaAttempt"]>[0], "attempt">;
-
-let sendSmsTextChunks: SendModule["sendSmsTextChunks"];
-let prepareSmsMediaAttempt: SendModule["prepareSmsMediaAttempt"];
-let sendPreparedSmsMediaAttempt: SendModule["sendPreparedSmsMediaAttempt"];
-let toSmsPlainText: SendModule["toSmsPlainText"];
-let resolveSmsAccount: (typeof import("./accounts.js"))["resolveSmsAccount"];
 
 const sendSmsViaTwilio = vi.hoisted(() =>
   vi.fn<typeof sendSmsViaTwilioType>(async ({ to, onPlatformSendDispatch }) => {
@@ -33,8 +35,28 @@ const hostedMediaMocks = vi.hoisted(() => {
 const recordInitialSmsDeliveryResult = vi.hoisted(() => vi.fn(async () => null));
 const deliveryWarn = vi.hoisted(() => vi.fn());
 
-beforeEach(async () => {
-  vi.resetModules();
+vi.mock("./twilio.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./twilio.js")>()),
+  sendSmsViaTwilio,
+}));
+vi.mock("./media.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./media.js")>()),
+  prepareHostedSmsMedia: hostedMediaMocks.prepare,
+}));
+vi.mock("./delivery-observations.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./delivery-observations.js")>()),
+  recordInitialSmsDeliveryResult,
+}));
+vi.mock("./runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./runtime.js")>()),
+  getSmsRuntime: () => ({
+    logging: {
+      getChildLogger: () => ({ warn: deliveryWarn }),
+    },
+  }),
+}));
+
+beforeEach(() => {
   sendSmsViaTwilio.mockReset();
   sendSmsViaTwilio.mockImplementation(async ({ to, onPlatformSendDispatch }) => {
     await onPlatformSendDispatch?.();
@@ -50,33 +72,9 @@ beforeEach(async () => {
   recordInitialSmsDeliveryResult.mockReset();
   recordInitialSmsDeliveryResult.mockResolvedValue(null);
   deliveryWarn.mockClear();
-  vi.doMock("./twilio.js", () => ({
-    sendSmsViaTwilio,
-    TWILIO_MESSAGE_BODY_MAX_LENGTH: 1600,
-  }));
-  vi.doMock("./media.js", () => ({
-    prepareHostedSmsMedia: hostedMediaMocks.prepare,
-  }));
-  vi.doMock("./delivery-observations.js", () => ({
-    recordInitialSmsDeliveryResult,
-  }));
-  vi.doMock("./runtime.js", () => ({
-    getSmsRuntime: () => ({
-      logging: {
-        getChildLogger: () => ({ warn: deliveryWarn }),
-      },
-    }),
-  }));
-  ({ prepareSmsMediaAttempt, sendPreparedSmsMediaAttempt, sendSmsTextChunks, toSmsPlainText } =
-    await import("./send.js"));
-  ({ resolveSmsAccount } = await import("./accounts.js"));
 });
 
 afterEach(() => {
-  vi.doUnmock("./twilio.js");
-  vi.doUnmock("./media.js");
-  vi.doUnmock("./delivery-observations.js");
-  vi.doUnmock("./runtime.js");
   delete process.env.TWILIO_ACCOUNT_SID;
   delete process.env.TWILIO_AUTH_TOKEN;
   delete process.env.TWILIO_PHONE_NUMBER;
@@ -408,7 +406,6 @@ describe("sendSmsTextChunks", () => {
 
 describe("sendSmsMedia", () => {
   it("preserves existing pre-dispatch proof from hosted-media staging", async () => {
-    const { PlatformMessageNotDispatchedError } = await import("openclaw/plugin-sdk/error-runtime");
     const rejection = new PlatformMessageNotDispatchedError("unsupported hosted media", {
       cause: new Error("unsupported content type"),
       retryable: false,


### PR DESCRIPTION
## What Problem This Solves

The 33 SMS test cases rebuilt the broad SMS SDK module graph for every case, making this focused suite slower and substantially more memory-hungry than the behavior under test required.

## Why This Change Was Made

Hoist partial-real mocks and static owner-module imports so the suite reuses the expensive module graph. The partial-real boundaries preserve the real Twilio constants and status formatting, while each test still owns and resets its mocks, environment, and timers.

## User Impact

There is no production or user-visible behavior change. Maintainers get faster, lower-memory SMS test feedback with the same assertions and isolation. This is test-only, so no changelog entry is needed.

## Evidence

- Diff: two test files, +51/-63; production +0/-0; no assertions removed.
- Controlled run: https://github.com/openclaw/openclaw/actions/runs/32005274561
  - wall mean: 24.37s -> 23.72s (-0.65s, -2.7%; accepted absolute bar)
  - Vitest: -1.02s (-4.8%)
  - test body: 8.29s -> 0.305s (-96.3%)
  - RSS: 2,646,986 -> 1,447,478 KiB (-45.3%, about 1.2 GiB)
  - final exact-tree wall: 22.30s
- Fault injection: post-dispatch error identity and probe remaining-budget checks failed correctly.
- Focused pair: 33/33 passed.
- Three-run leakage check: 99/99 passed.
- Full SMS suite: 341/341 passed.
- Changed gate: https://github.com/openclaw/openclaw/actions/runs/32005923888 (green).
- Review: proxy/state boundaries inspected; deslop made no edits; autoreview clean at 0.99 confidence.
