### PR TITLE
fix(ci): record legitimate Control UI startup growth

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 337511,
-  "reason": "cloud worker settings navigation and machine selection",
-  "updatedAt": "2026-08-16"
+  "startupJsGzipBytes": 338704,
+  "reason": "session placement move controls",
+  "updatedAt": "2026-08-17"
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves the red `build-artifacts` job on `main`, where the Control UI startup-JavaScript gzip ratchet rejected a legitimate 219-byte increase from the session-placement move controls landed in #125036.

The last green push, [CI run 32005436217](https://github.com/openclaw/openclaw/actions/runs/32005436217) at `2a556234c`, measured 338,485 B against an effective limit of 338,567 B, leaving 82 B of headroom. [CI run 32005779745](https://github.com/openclaw/openclaw/actions/runs/32005779745) at `7fd6d0684` measured 338,704 B: 219 B larger and 137 B over the ratchet.

## Why This Change Was Made

The crossing change was `f59e945013d` / #125036. It adds the session-placement move controls and English strings without changing package or lockfile inputs. The move dialog and catalog helpers remain dynamically imported in separate lazy chunks, so this is legitimate feature growth rather than a duplicate dependency or unintended heavy startup import.

This updates only the CI-measured startup baseline from 337,511 B to 338,704 B. The fixed 350 KiB ceiling and 1,056 B platform/build variance tolerance remain unchanged.

This leaves 19,696 B of committed-baseline headroom under the 358,400 B hard cap. The maintainer explicitly approved recording the measured 338,704 B baseline; this records legitimate feature growth rather than silencing a regression.

Follow-up: #123709's pinned pre-C04 reader compatibility test cold-boots a historical checkout under TSX inside the unit shard. It took 54.7s in [run 32005779745](https://github.com/openclaw/openclaw/actions/runs/32005779745/job/95315424626) and 76.3s in [run 32006111932](https://github.com/openclaw/openclaw/actions/runs/32006111932/job/95317436154). Both `checks-node-compact-large-2` jobs passed, but this valuable downgrade proof should move to or be prebuilt in a dedicated compatibility/package lane rather than raising the 120s timeout.

## User Impact

No runtime behavior changes. Main CI accepts the intentionally larger Control UI startup bundle while retaining the existing hard performance ceiling.

## Evidence

- Before: 338,704 B versus 338,567 B effective limit, a 137 B overage in run 32005779745.
- After: `node --import tsx scripts/check-control-ui-performance.mts --json` reports no violations with the 338,704 B recorded baseline.
- `pnpm ui:build`
- `pnpm test test/scripts/control-ui-performance.test.ts` — 13 tests passed.
- `pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted ...` — clean, no accepted/actionable findings.
- Production LOC: +0/-0. Baseline metadata: +3/-3. Tests: +0/-0.

AI-assisted; the code path, bundle ownership, and CI provenance were manually inspected.

