### PR TITLE
fix(memory-wiki): exclude vault's own pages from unsafe-local import

### DIFF
--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -206,6 +206,74 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     ).resolves.toContain("remember this");
   });
 
+  it("skips generated source pages copied into a configured path", async () => {
+    const privateDir = await createPrivateDir("copied-vault");
+    const sourcePaths = [
+      path.join(privateDir, "legitimate.md"),
+      path.join(privateDir, "bridge-not-generated.md"),
+      path.join(privateDir, "unsafe-local-not-generated.md"),
+    ];
+    await Promise.all(
+      sourcePaths.map((sourcePath) => fs.writeFile(sourcePath, `# ${path.basename(sourcePath)}\n`)),
+    );
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("copied-vault-target"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [privateDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    const generatedPage = first.pagePaths.find((pagePath) => pagePath.includes("legitimate-md"));
+    expect(generatedPage).toBeDefined();
+    const copiedPage = path.join(privateDir, "mirror", generatedPage!);
+    await fs.mkdir(path.dirname(copiedPage), { recursive: true });
+    await fs.copyFile(path.join(vaultDir, generatedPage!), copiedPage);
+
+    const second = await syncMemoryWikiUnsafeLocalSources(config);
+
+    expect(second.artifactCount).toBe(sourcePaths.length);
+    expect(second.importedCount).toBe(0);
+    expect(second.skippedCount).toBe(sourcePaths.length);
+    expect(second.pagePaths).toHaveLength(sourcePaths.length);
+  });
+
+  it("skips a configured source whose canonical path is inside the active vault", async () => {
+    const privateDir = await createPrivateDir("canonical-vault");
+    const sourcePath = path.join(privateDir, "legitimate.md");
+    await fs.writeFile(sourcePath, "# legitimate\n", "utf8");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("canonical-vault-target"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [sourcePath],
+        },
+      },
+    });
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    const generatedPage = path.join(vaultDir, first.pagePaths[0] ?? "");
+    const configWithVaultPage = {
+      ...config,
+      unsafeLocal: {
+        ...config.unsafeLocal,
+        paths: [sourcePath, generatedPage],
+      },
+    };
+
+    const second = await syncMemoryWikiUnsafeLocalSources(configWithVaultPage);
+
+    expect(second.artifactCount).toBe(1);
+    expect(second.importedCount).toBe(0);
+    expect(second.skippedCount).toBe(1);
+    expect(second.pagePaths).toHaveLength(1);
+  });
+
   it("caps composed unsafe-local filenames to the filesystem component limit", async () => {
     const privateDir = await createPrivateDir(`${"漢".repeat(50)}-private`);
     const nestedDir = path.join(privateDir, `${"語".repeat(50)}-nested`);

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -14,6 +14,7 @@ import {
   renderMarkdownFence,
   renderWikiMarkdown,
   slugifyWikiSegment,
+  toWikiPageSummary,
 } from "./markdown.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
@@ -38,6 +39,7 @@ type UnsafeLocalArtifactCollection = {
 };
 
 const DIRECTORY_TEXT_EXTENSIONS = new Set([".json", ".jsonl", ".md", ".txt", ".yaml", ".yml"]);
+const GENERATED_IMPORTED_SOURCE_PREFIXES = ["bridge-", "unsafe-local-"];
 const UNSAFE_LOCAL_SYNC_CONCURRENCY = 16;
 
 function detectFenceLanguage(filePath: string): string {
@@ -73,6 +75,7 @@ async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
 
 async function collectUnsafeLocalArtifacts(
   configuredPaths: string[],
+  vaultRootKey: string,
 ): Promise<UnsafeLocalArtifactCollection> {
   const artifacts: UnsafeLocalArtifact[] = [];
   const unavailableConfiguredPaths: string[] = [];
@@ -108,6 +111,20 @@ async function collectUnsafeLocalArtifacts(
 
   const deduped = new Map<string, UnsafeLocalArtifact>();
   for (const artifact of artifacts) {
+    if (isPathInside(vaultRootKey, artifact.syncKey)) {
+      continue;
+    }
+    const sourceName = normalizeLowercaseStringOrEmpty(path.basename(artifact.absolutePath));
+    if (GENERATED_IMPORTED_SOURCE_PREFIXES.some((prefix) => sourceName.startsWith(prefix))) {
+      const sourcePage = toWikiPageSummary({
+        absolutePath: artifact.absolutePath,
+        relativePath: `sources/${sourceName}`,
+        raw: await fs.readFile(artifact.absolutePath, "utf8"),
+      });
+      if (sourcePage?.importedSourceBody) {
+        continue;
+      }
+    }
     deduped.set(artifact.syncKey, artifact);
   }
   return { artifacts: [...deduped.values()], unavailableConfiguredPaths };
@@ -226,8 +243,10 @@ export async function syncMemoryWikiUnsafeLocalSources(
     };
   }
 
+  const vaultRootKey = await resolveArtifactKey(config.vault.path);
   const { artifacts, unavailableConfiguredPaths } = await collectUnsafeLocalArtifacts(
     config.unsafeLocal.paths,
+    vaultRootKey,
   );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
   let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;


### PR DESCRIPTION
Closes #125139

## What Problem This Solves

In unsafe-local mode, a backup or mirror of the Memory Wiki vault can sit below a configured scan path. The importer treated each copied generated source page as a new source because the copy had a different canonical path. Repeated import and status runs then created nested `unsafe-local-` pages without a bound.

## Why This Change Was Made

The unsafe-local collector owns source eligibility. It now rejects two forms of self-import before deduplication and persistence:

- Any source whose canonical path is inside the active vault.
- Any copied `bridge-` or `unsafe-local-` page whose content matches the existing generated-source wrapper contract.

The filename gate limits content parsing to names produced by OpenClaw. A legitimate file with the same prefix remains importable unless it also has the complete generated wrapper. Isolated mode has no local import path. Bridge mode keeps its existing canonical vault containment rule.

## User Impact

Unsafe-local import and status runs no longer multiply copied generated vault pages. Legitimate files, including ordinary files named with `bridge-` or `unsafe-local-` prefixes, remain eligible.

## Evidence

Live filesystem and command-registration proof used the same import, mirror-copy, status, mirror-refresh, and import cycle on both revisions:

| Revision | First import | Status after copied vault | Import after refreshed copy |
| --- | --- | --- | --- |
| `1505218b3e42` (`main`) | 1 artifact | 7 generated sources | 13 artifacts, 6 new |
| `467c544a03a9` (fixed) | 1 artifact | 6 generated sources | 6 artifacts, 0 new |

The six retained artifacts in the fixed run are the legitimate source plus five ordinary vault scaffold or log files from the copied tree. Their generated source pages stay at six after the mirror refresh. The recursive generated pages are excluded.

Regression proof:

- A physical copy at a different canonical path fails before the fix with 4 artifacts instead of 3, then passes after the fix.
- An active-vault page configured by its canonical path fails before the fix with 2 artifacts instead of 1, then passes after the fix.
- `node scripts/run-vitest.mjs extensions/memory-wiki/src`: 39 files and 466 tests passed.
- Focused format, Oxlint, max-lines, assertion-safety, dead-export, import-cycle, and conflict-marker checks passed.
- Production delta: +19 lines. Test delta: +68 lines. The production growth adds canonical containment and reuses the existing generated-page classifier; filename prefiltering avoids rereading normal Markdown sources.

Hosted CI owns TypeScript type-check and build validation for this host.

---

This PR was drafted with AI assistance (Claude). The maintainer repair preserved Raj Muppala's authorship and replaced the stale patch with the current-main implementation and proof.
