### PR TITLE
test(ui): make formatNextRun weekday assertion locale-portable

### DIFF
--- a/test/ui.presenter-next-run.test.ts
+++ b/test/ui.presenter-next-run.test.ts
@@ -1,6 +1,6 @@
 // UI presenter next-run tests cover presenter scheduling output.
 import { describe, expect, it } from "vitest";
-import { t } from "../ui/src/i18n/index.ts";
+import { i18n, t } from "../ui/src/i18n/index.ts";
 import { formatNextRun } from "../ui/src/lib/presenter.ts";
 
 describe("formatNextRun", () => {
@@ -12,7 +12,10 @@ describe("formatNextRun", () => {
   it("includes weekday and relative time", () => {
     const ts = Date.UTC(2026, 1, 23, 15, 0, 0);
     const out = formatNextRun(ts);
-    const weekday = new Date(ts).toLocaleDateString(undefined, { weekday: "short" });
+    // formatNextRun formats the weekday through i18n.getLocale(); mirror that
+    // locale here instead of the ambient host locale so the assertion holds on
+    // non-en hosts (e.g. LANG=zh_CN.UTF-8).
+    const weekday = new Date(ts).toLocaleDateString(i18n.getLocale(), { weekday: "short" });
     expect(out.slice(0, weekday.length + 2)).toBe(`${weekday}, `);
     expect(out).toContain("(");
     expect(out).toContain(")");


### PR DESCRIPTION
## What Problem This Solves

`test/ui.presenter-next-run.test.ts > formatNextRun > includes weekday and relative time` fails on hosts whose default locale is not English.

The test computes the expected weekday with the ambient host locale:

```ts
const weekday = new Date(ts).toLocaleDateString(undefined, { weekday: "short" });
```

while `formatNextRun` formats the weekday through `i18n.getLocale()` (`ui/src/lib/format.ts` → `toLocaleDateString(i18n.getLocale(), …)`), whose default is `"en"`. When the ambient locale differs (e.g. `LANG=zh_CN.UTF-8` → `"周一"`), the two diverge and the slice assertion fails:

```
AssertionError: expected 'Mon,' to be '周一, ' // Object.is equality
Expected: "周一, "
Received: "Mon,"
```

This is green on `main` CI (en-locale runners), so it is not a red-on-main failure — it is a developer-portability gap that bites contributors running the suite locally on non-en hosts.

## Why This Change Was Made

Mirror `i18n.getLocale()` in the test so the expected weekday is produced from the same locale the presenter uses, instead of the ambient host locale. No production behavior change.

## User Impact

Contributors on non-English-locale machines can run `pnpm test:unit:fast` (and the broader unit suite) without this false failure. No runtime/presenter behavior is affected.

## Evidence

- Reproduced the failure on `main` (`83d279a`) with `LANG=zh_CN.UTF-8`:
  - Before: `Tests 1 failed` (`expected 'Mon,' to be '周一, '`).
- After this change, the targeted test passes under both locales:
  - `LANG=zh_CN.UTF-8` → `Tests 2 passed (2)`
  - `LANG=C` → `Tests 2 passed (2)`
  - via `pnpm test:unit:fast -- test/ui.presenter-next-run.test.ts` (Node 24.15.0, SQLite 3.51.3).
- Full `pnpm test:unit:fast` suite on `main`+this change: `1254 passed | 2 skipped`, 0 failures (under `LANG=zh_CN.UTF-8`).

## Checklist

- [x] Focused, minimal test-only change (1 file, +5/-2).
- [x] No `CHANGELOG.md` edit (per contributor guide).
- [x] Marked as AI-assisted.

AI-assisted.


<!-- Punchcard-Session: coral-brook-cedar-d7 -->
