### PR TITLE
test(unit-fast): isolate computer-tool.test-helpers consumers

### DIFF
--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -312,6 +312,9 @@ describe("unit-fast vitest lane", () => {
       "src/acp/translator.error-kind.test.ts",
       "src/agents/auth-profiles/oauth-refresh-error.test.ts",
       "src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts",
+      "src/agents/tools/computer-tool.context.test.ts",
+      "src/agents/tools/computer-tool.schema.test.ts",
+      "src/agents/tools/computer-tool.v2.test.ts",
       "src/auto-reply/reply/agent-runner-execution-runtime.test.ts",
     ];
     for (const file of files) {

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -255,7 +255,7 @@ const disqualifyingPatterns = [
 ];
 
 const statefulTestHelperImportPattern =
-  /\bfrom\s+["']([^"']*(?:test-support|\.harness|message-action-runner\.test-helpers)(?:\.js|\.ts)?)["']/gu;
+  /\bfrom\s+["']([^"']*(?:test-support|\.harness|message-action-runner\.test-helpers|computer-tool\.test-helpers)(?:\.js|\.ts)?)["']/gu;
 const statefulTestHelperByKey = new Map();
 
 function importsStatefulTestHelper(cwd, file, source) {


### PR DESCRIPTION
## What Problem This Solves

`src/agents/tools/computer-tool.v2.test.ts` (8 cases) fails inside the full `pnpm test:unit:fast` suite with `GatewayCredentialsRequiredError: gateway node.list requires credentials before opening a websocket`, while passing in isolation (8/8).

Root cause: the unit-fast shard classifier routes tests that import a **stateful** helper (helper source matches a disqualifying pattern like `vi.mock(` / top-level dynamic `import`) to the **isolated** pool via `statefulTestHelperImportPattern` (`test/vitest/vitest.unit-fast-paths.mjs`). `computer-tool.test-helpers` is stateful — it sets up `vi.mock("./gateway.js")`, `vi.mock("./nodes-utils.js")` and top-level `await import(...)` — but was **missing** from that pattern. Its consumers (`computer-tool.v2/schema/context.test.ts`) therefore classified with empty `reasons`, fell into the shared `isolate:false` pool, and relied on `vi.mock` against a shared module registry. When another test file loaded the real `./gateway.js` / `./nodes-utils.js` in the same worker first, the mock was bypassed and the real gateway path ran.

This is an order/worker-scheduling-dependent failure (latent flake), not a constant red on main CI.

## Why This Change Was Made

Add `computer-tool\.test-helpers` to `statefulTestHelperImportPattern`, mirroring the existing `message-action-runner\.test-helpers` entry. Consumers now classify `inIsolated=true` and run in the isolated pool where the mock is honored. This is the intended use of the existing classification mechanism — `computer-tool.test-helpers` was simply omitted.

No production code or test assertions change; only shard routing for the three consumer files.

## User Impact

Removes a latent isolation flake in the fast unit shard. Contributors running `pnpm test:unit:fast` no longer hit spurious `GatewayCredentialsRequiredError` failures from `computer-tool.v2.test.ts` depending on worker scheduling. The affected tests continue to run (now isolated) and still pass.

## Evidence

On `main` (`83d279a`), Node 24.15.0 (SQLite 3.51.3):

- Before:
  - `pnpm test:unit:fast` → 8 failures in `src/agents/tools/computer-tool.v2.test.ts` (`GatewayCredentialsRequiredError: gateway node.list requires credentials...`), stack through `loadNodes` → `callGatewayTool` → real `callGateway`.
  - `pnpm test:unit:fast -- src/agents/tools/computer-tool.v2.test.ts` (alone) → `8 passed (8)`.
  - Classifier: `computer-tool.v2.test.ts` → `reasons=[]` → `inUnitFast=true, inIsolated=false` (shared `isolate:false` pool). Helper `computer-tool.test-helpers.ts` → `["module-mocking","vitest-mock-api","dynamic-import"]` (stateful).
- After:
  - Consumers `computer-tool.v2/schema/context.test.ts` → `inUnitFast=true, inIsolated=true`.
  - `vitest --isolate <three consumers>` → `3 passed (3)`, `Tests 16 passed (16)`.
  - `pnpm test:unit:fast` → the computer-tool failures are gone; the suite's only remaining failures are the unrelated `test/ui.presenter-next-run.test.ts` (locale) and `test/scripts/resolve-openclaw-ref.test.ts` (git <2.28 `init -b`), addressed separately.

## Checklist

- [x] Focused, minimal change to test shard classification (1 file, +1/-1).
- [x] No production code or `CHANGELOG.md` edit (per contributor guide).
- [x] Marked as AI-assisted.

AI-assisted.

### Maintainer exact-head proof (2026-08-20)

- Reviewed head: `9e00ba02a777edaba615015ac6079cd02d266ede`.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/32345454458 (`tbx_01m0f22xjh9epth2jddac2jrba`, exit 0).
- `node scripts/run-vitest.mjs test/vitest-unit-fast-config.test.ts`: 13/13 passed.
- `pnpm test:unit:fast`: 1,254 files passed, 2 skipped; 14,067 tests passed, 7 skipped.
- Production LOC: 0. Test support: +4/-1 across the matcher and exact owner regression.

Punchcard-Session: ember-willow-valley-9r
