### PR TITLE
feat: add Critical Apply transaction contracts

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -175,6 +175,12 @@ const rootEntries = [
   "src/cli/plugins-list-format.ts!",
   "src/infra/warning-filter.ts!",
   "src/infra/command-explainer/index.ts!",
+  // Critical Apply staged contract/schema roots are intentionally private until
+  // service/package/Gateway integration lands in a later PR. Model them as roots
+  // so production deadcode checks keep the files audited without forcing an
+  // activation/export surface in this contract-only slice.
+  "src/critical-apply/contracts.ts!",
+  "src/critical-apply/validators.ts!",
   // Runtime modules loaded by path or namespace; static export tracing cannot see their contract.
   // Jiti virtualizes openclaw/plugin-sdk/agent-sessions through this cycle-safe barrel.
   "src/agents/sessions/extension-sdk.ts!",

--- a/src/critical-apply/contracts.test.ts
+++ b/src/critical-apply/contracts.test.ts
@@ -11,7 +11,9 @@ import {
   validateCriticalApplyTransactionShape,
 } from "./validators.js";
 
-function validTransaction(overrides: Partial<CriticalApplyTransaction> = {}): CriticalApplyTransaction {
+function validTransaction(
+  overrides: Partial<CriticalApplyTransaction> = {},
+): CriticalApplyTransaction {
   return {
     schema: CRITICAL_APPLY_CONTRACT_VERSION,
     id: "m10-fixture",

--- a/src/critical-apply/contracts.test.ts
+++ b/src/critical-apply/contracts.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  CRITICAL_APPLY_CONTRACT_VERSION,
+  type CriticalApplyTransaction,
+  ZERO_CRITICAL_APPLY_SIDE_EFFECTS,
+} from "./contracts.js";
+import {
+  assertOnlyZeroCriticalApplySideEffects,
+  assertValidCriticalApplyTransactionShape,
+  CRITICAL_APPLY_ZERO_SIDE_EFFECT_ERROR,
+  validateCriticalApplyTransactionShape,
+} from "./validators.js";
+
+function validTransaction(overrides: Partial<CriticalApplyTransaction> = {}): CriticalApplyTransaction {
+  return {
+    schema: CRITICAL_APPLY_CONTRACT_VERSION,
+    id: "m10-fixture",
+    disabledByDefault: true,
+    terminal: "PASS",
+    sourceAuthority: {
+      repo: "https://github.com/openclaw/openclaw.git",
+      commit: "eeef4864494f859838fec1586bedbab1f8fa5702",
+      tree: "1b7a4b7a7341497f3c5b441ece5d3b93111630a0",
+      packageName: "openclaw",
+      packageVersion: "2026.5.7",
+    },
+    targetAuthority: {
+      targetRoot: "/example/target/root",
+      packageRoot: "/example/target/root/lib/node_modules/openclaw",
+      binPath: "/example/target/root/bin/openclaw",
+    },
+    restorePoint: {
+      path: "/example/restore-point",
+      sha256: "abc123",
+      createdAt: "2026-08-17T07:17:00.000Z",
+      maxAgeSeconds: 3600,
+    },
+    rollbackPlanPath: "/example/rollback.json",
+    maintenanceLockPath: "/example/critical-apply.lock",
+    precheckReceiptPath: "/example/precheck.json",
+    postcheckReceiptPath: "/example/postcheck.json",
+    watcher: {
+      id: "watcher-1",
+      kind: "independent-check",
+      receiptPath: "/example/watcher.json",
+    },
+    sideEffects: ZERO_CRITICAL_APPLY_SIDE_EFFECTS,
+    ...overrides,
+  };
+}
+
+describe("Critical Apply contract validators", () => {
+  it.each(["PASS", "HOLD", "FAIL", "ABORT"] as const)("accepts %s terminal", (terminal) => {
+    expect(validateCriticalApplyTransactionShape(validTransaction({ terminal }))).toEqual([]);
+  });
+
+  it("requires disabled-by-default transactions", () => {
+    const tx = validTransaction({ disabledByDefault: false as true });
+    expect(validateCriticalApplyTransactionShape(tx)).toContain("disabledByDefault must be true");
+  });
+
+  it("rejects non-zero side-effect counters", () => {
+    expect(() =>
+      assertOnlyZeroCriticalApplySideEffects({
+        ...ZERO_CRITICAL_APPLY_SIDE_EFFECTS,
+        productionMutations: 1,
+      }),
+    ).toThrow(CRITICAL_APPLY_ZERO_SIDE_EFFECT_ERROR);
+  });
+
+  it("requires source, target, restore, rollback, lock, precheck, postcheck, and watcher fields", () => {
+    const tx = validTransaction({
+      sourceAuthority: { repo: "", commit: "", tree: "" },
+      targetAuthority: { targetRoot: "" },
+      restorePoint: { path: "", sha256: "", createdAt: "", maxAgeSeconds: 3600 },
+      rollbackPlanPath: "",
+      maintenanceLockPath: "",
+      precheckReceiptPath: "",
+      postcheckReceiptPath: "",
+      watcher: { id: "", kind: "independent-check" },
+    });
+    expect(validateCriticalApplyTransactionShape(tx)).toEqual(
+      expect.arrayContaining([
+        "sourceAuthority.repo is required",
+        "sourceAuthority.commit is required",
+        "sourceAuthority.tree is required",
+        "targetAuthority.targetRoot is required",
+        "restorePoint.path is required",
+        "restorePoint.sha256 is required",
+        "rollbackPlanPath is required",
+        "maintenanceLockPath is required",
+        "precheckReceiptPath is required",
+        "postcheckReceiptPath is required",
+        "watcher.id is required",
+      ]),
+    );
+  });
+
+  it("throws a combined validation error for malformed transactions", () => {
+    expect(() => assertValidCriticalApplyTransactionShape(validTransaction({ id: "" }))).toThrow(
+      "Invalid Critical Apply transaction: id is required",
+    );
+  });
+});

--- a/src/critical-apply/contracts.ts
+++ b/src/critical-apply/contracts.ts
@@ -1,0 +1,69 @@
+export const CRITICAL_APPLY_CONTRACT_VERSION = "critical_apply.transaction.v1" as const;
+
+export const CRITICAL_APPLY_TERMINALS = ["PASS", "HOLD", "FAIL", "ABORT"] as const;
+export type CriticalApplyTerminal = (typeof CRITICAL_APPLY_TERMINALS)[number];
+
+export type CriticalApplySourceAuthority = Readonly<{
+  repo: string;
+  commit: string;
+  tree: string;
+  packageName?: string;
+  packageVersion?: string;
+}>;
+
+export type CriticalApplyTargetAuthority = Readonly<{
+  targetRoot: string;
+  packageRoot?: string;
+  binPath?: string;
+  allowedRootSha256?: string;
+}>;
+
+export type CriticalApplyRestorePoint = Readonly<{
+  path: string;
+  sha256: string;
+  createdAt: string;
+  maxAgeSeconds: number;
+}>;
+
+export type CriticalApplyWatcher = Readonly<{
+  id: string;
+  kind: "independent-check" | "durable-observer";
+  expectedAt?: string;
+  receiptPath?: string;
+}>;
+
+export type CriticalApplySideEffectCounters = Readonly<{
+  sourceEdits: number;
+  gitCommitPushPrMerge: number;
+  packageInstallApplyBuild: number;
+  gatewayRestartConfigCronMutation: number;
+  systemctlActions: number;
+  providerOrLiveSmokeCalls: number;
+  productionMutations: number;
+}>;
+
+export type CriticalApplyTransaction = Readonly<{
+  schema: typeof CRITICAL_APPLY_CONTRACT_VERSION;
+  id: string;
+  disabledByDefault: true;
+  terminal: CriticalApplyTerminal;
+  sourceAuthority: CriticalApplySourceAuthority;
+  targetAuthority: CriticalApplyTargetAuthority;
+  restorePoint: CriticalApplyRestorePoint;
+  rollbackPlanPath: string;
+  maintenanceLockPath: string;
+  precheckReceiptPath: string;
+  postcheckReceiptPath: string;
+  watcher: CriticalApplyWatcher;
+  sideEffects: CriticalApplySideEffectCounters;
+}>;
+
+export const ZERO_CRITICAL_APPLY_SIDE_EFFECTS: CriticalApplySideEffectCounters = Object.freeze({
+  sourceEdits: 0,
+  gitCommitPushPrMerge: 0,
+  packageInstallApplyBuild: 0,
+  gatewayRestartConfigCronMutation: 0,
+  systemctlActions: 0,
+  providerOrLiveSmokeCalls: 0,
+  productionMutations: 0,
+});

--- a/src/critical-apply/validators.ts
+++ b/src/critical-apply/validators.ts
@@ -1,0 +1,100 @@
+import {
+  CRITICAL_APPLY_CONTRACT_VERSION,
+  CRITICAL_APPLY_TERMINALS,
+  type CriticalApplySideEffectCounters,
+  type CriticalApplyTransaction,
+} from "./contracts.js";
+
+export const CRITICAL_APPLY_ZERO_SIDE_EFFECT_ERROR =
+  "Critical Apply transaction must keep all side-effect counters at zero for a contract/schema-only boundary.";
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0;
+}
+
+export function hasOnlyZeroCriticalApplySideEffects(
+  counters: CriticalApplySideEffectCounters,
+): boolean {
+  return Object.values(counters).every((value) => value === 0);
+}
+
+export function assertOnlyZeroCriticalApplySideEffects(
+  counters: CriticalApplySideEffectCounters,
+): void {
+  if (!hasOnlyZeroCriticalApplySideEffects(counters)) {
+    throw new Error(CRITICAL_APPLY_ZERO_SIDE_EFFECT_ERROR);
+  }
+}
+
+export function validateCriticalApplyTransactionShape(
+  transaction: CriticalApplyTransaction,
+): string[] {
+  const errors: string[] = [];
+  if (transaction.schema !== CRITICAL_APPLY_CONTRACT_VERSION) {
+    errors.push("schema must be critical_apply.transaction.v1");
+  }
+  if (!isNonEmptyString(transaction.id)) {
+    errors.push("id is required");
+  }
+  if (transaction.disabledByDefault !== true) {
+    errors.push("disabledByDefault must be true");
+  }
+  if (!CRITICAL_APPLY_TERMINALS.includes(transaction.terminal)) {
+    errors.push("terminal must be PASS, HOLD, FAIL, or ABORT");
+  }
+  if (!isNonEmptyString(transaction.sourceAuthority.repo)) {
+    errors.push("sourceAuthority.repo is required");
+  }
+  if (!isNonEmptyString(transaction.sourceAuthority.commit)) {
+    errors.push("sourceAuthority.commit is required");
+  }
+  if (!isNonEmptyString(transaction.sourceAuthority.tree)) {
+    errors.push("sourceAuthority.tree is required");
+  }
+  if (!isNonEmptyString(transaction.targetAuthority.targetRoot)) {
+    errors.push("targetAuthority.targetRoot is required");
+  }
+  if (!isNonEmptyString(transaction.restorePoint.path)) {
+    errors.push("restorePoint.path is required");
+  }
+  if (!isNonEmptyString(transaction.restorePoint.sha256)) {
+    errors.push("restorePoint.sha256 is required");
+  }
+  if (!isNonEmptyString(transaction.rollbackPlanPath)) {
+    errors.push("rollbackPlanPath is required");
+  }
+  if (!isNonEmptyString(transaction.maintenanceLockPath)) {
+    errors.push("maintenanceLockPath is required");
+  }
+  if (!isNonEmptyString(transaction.precheckReceiptPath)) {
+    errors.push("precheckReceiptPath is required");
+  }
+  if (!isNonEmptyString(transaction.postcheckReceiptPath)) {
+    errors.push("postcheckReceiptPath is required");
+  }
+  if (!isNonEmptyString(transaction.watcher.id)) {
+    errors.push("watcher.id is required");
+  }
+  for (const [key, value] of Object.entries(transaction.sideEffects)) {
+    if (!isNonNegativeInteger(value)) {
+      errors.push(`sideEffects.${key} must be a non-negative integer`);
+    }
+  }
+  if (!hasOnlyZeroCriticalApplySideEffects(transaction.sideEffects)) {
+    errors.push(CRITICAL_APPLY_ZERO_SIDE_EFFECT_ERROR);
+  }
+  return errors;
+}
+
+export function assertValidCriticalApplyTransactionShape(
+  transaction: CriticalApplyTransaction,
+): void {
+  const errors = validateCriticalApplyTransactionShape(transaction);
+  if (errors.length > 0) {
+    throw new Error(`Invalid Critical Apply transaction: ${errors.join("; ")}`);
+  }
+}

--- a/src/critical-apply/validators.ts
+++ b/src/critical-apply/validators.ts
@@ -13,7 +13,7 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 function isNonNegativeInteger(value: unknown): value is number {
-  return Number.isInteger(value) && (value as number) >= 0;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 export function hasOnlyZeroCriticalApplySideEffects(


### PR DESCRIPTION
## What Problem This Solves

Critical Apply production/runtime work needs a small, typed contract surface before any future service, package, Gateway, or activation behavior can be safely proposed upstream. This PR adds the first private, disabled-by-default transaction contract slice so future implementation work can bind authority, restore-point, watcher, receipt, and zero-side-effect expectations to explicit runtime types and validators instead of ad-hoc evidence text.

## Summary

Adds the first disabled-by-default Critical Apply runtime contract/schema slice under a private `src/critical-apply/` namespace:

- typed transaction/source/target/restore/watcher/side-effect contracts
- pure validation helpers for required authority/receipt fields and zero side-effect assertions
- colocated unit coverage for terminals, disabled-by-default guard, required fields, side-effect boundaries, and malformed input rejection

## Scope

This PR creates only:

- `src/critical-apply/contracts.ts`
- `src/critical-apply/validators.ts`
- `src/critical-apply/contracts.test.ts`

Explicitly deferred:

- public/plugin SDK exports
- config schema integration
- gateway/service/package behavior
- runtime activation or default enablement
- production apply/restart behavior

## Evidence

Local evidence from the evidence-local OpenClaw runtime checkout:

- Initial contract slice validation: `src/critical-apply/contracts.test.ts`, 1 file / 8 tests passed, Vitest v4.1.5.
- Rebased validation after updating the PR branch: `src/critical-apply/contracts.test.ts`, 1 file / 8 tests passed, Vitest v4.1.10.
- Rebased PR branch commit: `35c4f9628210ed97e5b4d145d71ed8ab66e7a1b3`.
- Rebased parent/base snapshot used for local validation: `ee86b24ac17086401c76a92153bc611e02bc313a`.
- Commit scope stayed exact: three added files under `src/critical-apply/`, 273 insertions.

## Safety notes

- no Gateway/config/cron/systemctl/provider/live smoke changes
- no package build/apply/install to production roots
- no production mutation
- no activation path added
