### PR TITLE
feat(workboard): run attached automations after linked sessions finish

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -512,6 +512,8 @@ Archiving a session (Control UI, or `sessions.patch { key, archived: true, expec
 
 `openclaw automations run <jobId>` returns after enqueueing the manual run. Use `--wait` for shutdown hooks, maintenance scripts, or other automation that must block until the queued run finishes; it polls the returned `runId` (default timeout `10m`, poll interval `2s`) and exits `0` for status `ok`, non-zero for `error`, `skipped`, or a wait timeout.
 
+Direct Gateway event sources can use `cron.run` with `mode: "if-enabled"` to run immediately without overriding an operator-disabled or auto-disabled job. Explicit operator run-now commands continue to use `force`.
+
 The agent `automations` tool returns compact job summaries (`id`, `name`, `enabled`, `nextRunAtMs`, `scheduleKind`, `lastRunStatus`) from `automations(action: "list")`; use `automations(action: "get", jobId: "...")` for one full job definition. Direct Gateway callers can pass `compact: true` to `cron.list`; omitting it preserves the full response with delivery previews.
 
 `openclaw automations create` is an alias for `openclaw automations add`. New jobs can use a positional schedule (`"0 9 * * 1"`, `"every 1h"`, `"20m"`, or an ISO timestamp) followed by a positional agent prompt. Use `--webhook <url>` on `automations add|create` or `automations edit` to POST the finished run payload to an HTTP endpoint; webhook delivery cannot combine with chat delivery flags (`--announce`, `--channel`, `--to`, `--thread-id`, `--account`). On `automations edit`, `--clear-channel`, `--clear-to`, `--clear-thread-id`, and `--clear-account` unset those routing fields individually (each rejected alongside its matching set flag) — distinct from `--no-deliver`, which only disables runner fallback delivery.

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -113,8 +113,11 @@ parameters. Choosing **All boards** returns to `/workboard`.
 
 A board can store an `automationJobId` reference to the automation job that
 owns its AI-categorization prompt, model, schedule, and run history. The board
-page shows an **Automation** link when that reference is present. Deleting the
-board does not delete or otherwise mutate the operator-owned automation job.
+page shows an **Automation** link when that reference is present. Matching
+session events nudge the attached automation to run immediately, with events
+for the same board coalesced for 60 seconds. The automation's schedule remains
+the backstop. Deleting the board does not delete or otherwise mutate the
+operator-owned automation job.
 
 Cards are stored in the plugin's own Gateway state and move with the rest of
 that Gateway's OpenClaw state (see [Storage](#storage)).

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -116,7 +116,8 @@ owns its AI-categorization prompt, model, schedule, and run history. The board
 page shows an **Automation** link when that reference is present. Matching
 session events nudge the attached automation to run immediately, with events
 for the same board coalesced for 60 seconds. The automation's schedule remains
-the backstop. Deleting the board does not delete or otherwise mutate the
+the backstop. Disabled and auto-disabled automations are never nudged. Deleting
+the board does not delete or otherwise mutate the
 operator-owned automation job.
 
 Cards are stored in the plugin's own Gateway state and move with the rest of

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -1,6 +1,7 @@
 // Workboard plugin entrypoint registers its OpenClaw integration.
 import { definePluginEntry } from "./api.js";
 import { registerWorkboardGatewayMethods } from "./runtime-api.js";
+import { createWorkboardAutomationNudgeService } from "./src/automation-nudge.js";
 import { createWorkboardChangeEventService } from "./src/change-events.js";
 import { registerWorkboardCommand } from "./src/command.js";
 import { cleanupWorkboardRunWorktree } from "./src/dispatcher-workspace.js";
@@ -23,6 +24,10 @@ export default definePluginEntry({
   description: "Dashboard workboard for agent-owned issues and sessions.",
   register(api) {
     const store = WorkboardStore.openSqlite();
+    const automationNudge = createWorkboardAutomationNudgeService({
+      store,
+      gateway: api.runtime.gateway,
+    });
     api.session.controls.registerControlUiDescriptor({
       surface: "widget",
       id: "board",
@@ -44,6 +49,7 @@ export default definePluginEntry({
     registerWorkboardGatewayMethods({ api, store });
     registerWorkboardCommand({ api, store });
     api.registerService(createWorkboardChangeEventService(store));
+    api.registerService(automationNudge);
     api.registerService(
       createWorkboardLifecycleService({
         store,
@@ -52,7 +58,7 @@ export default definePluginEntry({
     );
     api.on("subagent_ended", async (event) => {
       await Promise.all([
-        syncWorkboardSubagentEnded({ store, event }),
+        syncWorkboardSubagentEnded({ store, event, onMatched: automationNudge.nudge }),
         event.runId
           ? cleanupWorkboardRunWorktree({
               store,
@@ -63,7 +69,12 @@ export default definePluginEntry({
       ]);
     });
     api.on("agent_end", async (event, context) => {
-      await syncWorkboardAgentEnded({ store, event, context });
+      await syncWorkboardAgentEnded({
+        store,
+        event,
+        context,
+        onMatched: automationNudge.nudge,
+      });
     });
     api.registerCli(
       async ({ program }) => {

--- a/extensions/workboard/src/automation-nudge.ts
+++ b/extensions/workboard/src/automation-nudge.ts
@@ -1,6 +1,7 @@
 import type { WorkboardCard } from "@openclaw/workboard-contract";
 import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawPluginApi, OpenClawPluginService } from "../api.js";
 import { cardBoardId } from "./store-card-helpers.js";
 import { MAX_CARDS } from "./store-constants.js";
@@ -41,9 +42,9 @@ function clearPendingBoardNudges(state: WorkboardAutomationNudgeState): void {
 }
 
 function getWorkboardAutomationNudgeState(): WorkboardAutomationNudgeState {
-  return resolveGlobalSingleton(
+  return resolveGlobalSingleton<WorkboardAutomationNudgeState>(
     WORKBOARD_AUTOMATION_NUDGE_STATE_KEY,
-    () => ({ pendingByBoard: new Map() }),
+    () => ({ pendingByBoard: new Map<string, PendingBoardNudge>() }),
     (state) => {
       state.owner = undefined;
       state.logger = undefined;
@@ -87,12 +88,7 @@ export function createWorkboardAutomationNudgeService(params: {
         { id: jobId, mode: "force" },
         { scopes: ["operator.admin"] },
       );
-      const runId =
-        result &&
-        typeof result === "object" &&
-        typeof (result as { runId?: unknown }).runId === "string"
-          ? (result as { runId: string }).runId
-          : undefined;
+      const runId = isRecord(result) && typeof result.runId === "string" ? result.runId : undefined;
       state.logger.info(
         `workboard automation nudge requested for board ${boardId}: job ${jobId}${runId ? ` run ${runId}` : ""}`,
       );

--- a/extensions/workboard/src/automation-nudge.ts
+++ b/extensions/workboard/src/automation-nudge.ts
@@ -85,9 +85,16 @@ export function createWorkboardAutomationNudgeService(params: {
     try {
       const result = await params.gateway.request(
         "cron.run",
-        { id: jobId, mode: "force" },
+        { id: jobId, mode: "if-enabled" },
         { scopes: ["operator.admin"] },
       );
+      if (isRecord(result) && result.ran === false) {
+        const reason = typeof result.reason === "string" ? result.reason : "not-run";
+        state.logger.warn(
+          `workboard automation nudge skipped for board ${boardId}: job ${jobId} ${reason}`,
+        );
+        return;
+      }
       const runId = isRecord(result) && typeof result.runId === "string" ? result.runId : undefined;
       state.logger.info(
         `workboard automation nudge requested for board ${boardId}: job ${jobId}${runId ? ` run ${runId}` : ""}`,

--- a/extensions/workboard/src/automation-nudge.ts
+++ b/extensions/workboard/src/automation-nudge.ts
@@ -1,4 +1,5 @@
 import type { WorkboardCard } from "@openclaw/workboard-contract";
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
 import type { OpenClawPluginApi, OpenClawPluginService } from "../api.js";
 import { cardBoardId } from "./store-card-helpers.js";
@@ -20,6 +21,37 @@ type PendingBoardNudge = {
   timer?: ReturnType<typeof setTimeout>;
 };
 
+type WorkboardAutomationNudgeState = {
+  owner?: object;
+  logger?: Parameters<OpenClawPluginService["start"]>[0]["logger"];
+  pendingByBoard: Map<string, PendingBoardNudge>;
+};
+
+const WORKBOARD_AUTOMATION_NUDGE_STATE_KEY = Symbol.for("openclaw.workboard.automationNudgeState");
+
+// Prepared model generations register fresh hook closures without starting their services.
+// Shared state lets those closures reach the active service owner and its debounce fence.
+function clearPendingBoardNudges(state: WorkboardAutomationNudgeState): void {
+  for (const pending of state.pendingByBoard.values()) {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+  }
+  state.pendingByBoard.clear();
+}
+
+function getWorkboardAutomationNudgeState(): WorkboardAutomationNudgeState {
+  return resolveGlobalSingleton(
+    WORKBOARD_AUTOMATION_NUDGE_STATE_KEY,
+    () => ({ pendingByBoard: new Map() }),
+    (state) => {
+      state.owner = undefined;
+      state.logger = undefined;
+      clearPendingBoardNudges(state);
+    },
+  );
+}
+
 function isCronOriginSession(sessionKey: string | undefined): boolean {
   const normalized = sessionKey?.trim();
   // Cron keys are raw `cron:*` before store canonicalization and agent-scoped
@@ -31,39 +63,53 @@ export function createWorkboardAutomationNudgeService(params: {
   store: WorkboardStore;
   gateway: Pick<OpenClawPluginApi["runtime"]["gateway"], "request">;
 }): WorkboardAutomationNudgeService {
-  let generation = 0;
-  let logger: Parameters<OpenClawPluginService["start"]>[0]["logger"] | undefined;
-  const pendingByBoard = new Map<string, PendingBoardNudge>();
+  const serviceOwner = {};
 
-  const nudgeBoard = async (boardId: string, jobId: string, owner: number) => {
-    if (generation !== owner || !logger || pendingByBoard.has(boardId)) {
+  const nudgeBoard = async (boardId: string, jobId: string, owner: object) => {
+    const state = getWorkboardAutomationNudgeState();
+    if (state.owner !== owner || !state.logger || state.pendingByBoard.has(boardId)) {
       return;
     }
-    if (pendingByBoard.size >= MAX_CARDS) {
-      logger?.warn(`workboard automation nudge skipped for board ${boardId}: debounce map full`);
+    if (state.pendingByBoard.size >= MAX_CARDS) {
+      state.logger.warn(
+        `workboard automation nudge skipped for board ${boardId}: debounce map full`,
+      );
       return;
     }
     const pending: PendingBoardNudge = {};
     const expiresAt = Date.now() + WORKBOARD_AUTOMATION_NUDGE_DEBOUNCE_MS;
     // The board entry owns both the in-flight request and its cooldown, so a
     // second lifecycle event can never overlap the first automation run request.
-    pendingByBoard.set(boardId, pending);
+    state.pendingByBoard.set(boardId, pending);
     try {
-      await params.gateway.request(
+      const result = await params.gateway.request(
         "cron.run",
         { id: jobId, mode: "force" },
         { scopes: ["operator.admin"] },
       );
+      const runId =
+        result &&
+        typeof result === "object" &&
+        typeof (result as { runId?: unknown }).runId === "string"
+          ? (result as { runId: string }).runId
+          : undefined;
+      state.logger.info(
+        `workboard automation nudge requested for board ${boardId}: job ${jobId}${runId ? ` run ${runId}` : ""}`,
+      );
     } catch (error) {
       // The automation schedule is the backstop; a nudge failure must not alter
       // lifecycle synchronization or card state.
-      logger?.warn(`workboard automation nudge failed for board ${boardId}: ${String(error)}`);
+      if (state.owner === owner) {
+        state.logger?.warn(
+          `workboard automation nudge failed for board ${boardId}: ${String(error)}`,
+        );
+      }
     } finally {
-      if (generation === owner && pendingByBoard.get(boardId) === pending) {
+      if (state.owner === owner && state.pendingByBoard.get(boardId) === pending) {
         pending.timer = setTimeout(
           () => {
-            if (pendingByBoard.get(boardId) === pending) {
-              pendingByBoard.delete(boardId);
+            if (state.pendingByBoard.get(boardId) === pending) {
+              state.pendingByBoard.delete(boardId);
             }
           },
           Math.max(0, expiresAt - Date.now()),
@@ -76,22 +122,29 @@ export function createWorkboardAutomationNudgeService(params: {
   return {
     id: "workboard-automation-nudge",
     start(ctx) {
-      generation += 1;
-      logger = ctx.logger;
+      const state = getWorkboardAutomationNudgeState();
+      clearPendingBoardNudges(state);
+      state.owner = serviceOwner;
+      state.logger = ctx.logger;
     },
     stop() {
-      generation += 1;
-      logger = undefined;
-      for (const pending of pendingByBoard.values()) {
-        if (pending.timer) {
-          clearTimeout(pending.timer);
-        }
+      const state = getWorkboardAutomationNudgeState();
+      if (state.owner !== serviceOwner) {
+        return;
       }
-      pendingByBoard.clear();
+      state.owner = undefined;
+      state.logger = undefined;
+      clearPendingBoardNudges(state);
     },
     async nudge(input) {
-      const owner = generation;
-      if (!logger || isCronOriginSession(input.sessionKey) || input.cards.length === 0) {
+      const state = getWorkboardAutomationNudgeState();
+      const owner = state.owner;
+      if (
+        !owner ||
+        !state.logger ||
+        isCronOriginSession(input.sessionKey) ||
+        input.cards.length === 0
+      ) {
         return;
       }
       try {
@@ -108,7 +161,9 @@ export function createWorkboardAutomationNudgeService(params: {
           }),
         );
       } catch (error) {
-        logger?.warn(`workboard automation nudge failed: ${String(error)}`);
+        if (state.owner === owner) {
+          state.logger?.warn(`workboard automation nudge failed: ${String(error)}`);
+        }
       }
     },
   };

--- a/extensions/workboard/src/automation-nudge.ts
+++ b/extensions/workboard/src/automation-nudge.ts
@@ -1,0 +1,115 @@
+import type { WorkboardCard } from "@openclaw/workboard-contract";
+import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
+import type { OpenClawPluginApi, OpenClawPluginService } from "../api.js";
+import { cardBoardId } from "./store-card-helpers.js";
+import { MAX_CARDS } from "./store-constants.js";
+import type { WorkboardStore } from "./store.js";
+
+const WORKBOARD_AUTOMATION_NUDGE_DEBOUNCE_MS = 60_000;
+
+type WorkboardAutomationNudgeInput = {
+  cards: readonly WorkboardCard[];
+  sessionKey?: string;
+};
+
+type WorkboardAutomationNudgeService = OpenClawPluginService & {
+  nudge: (input: WorkboardAutomationNudgeInput) => Promise<void>;
+};
+
+type PendingBoardNudge = {
+  timer?: ReturnType<typeof setTimeout>;
+};
+
+function isCronOriginSession(sessionKey: string | undefined): boolean {
+  const normalized = sessionKey?.trim();
+  // Cron keys are raw `cron:*` before store canonicalization and agent-scoped
+  // `agent:*:cron:*:run:*` afterward; accepting either here would self-trigger.
+  return normalized?.startsWith("cron:") === true || isCronSessionKey(normalized);
+}
+
+export function createWorkboardAutomationNudgeService(params: {
+  store: WorkboardStore;
+  gateway: Pick<OpenClawPluginApi["runtime"]["gateway"], "request">;
+}): WorkboardAutomationNudgeService {
+  let generation = 0;
+  let logger: Parameters<OpenClawPluginService["start"]>[0]["logger"] | undefined;
+  const pendingByBoard = new Map<string, PendingBoardNudge>();
+
+  const nudgeBoard = async (boardId: string, jobId: string, owner: number) => {
+    if (generation !== owner || !logger || pendingByBoard.has(boardId)) {
+      return;
+    }
+    if (pendingByBoard.size >= MAX_CARDS) {
+      logger?.warn(`workboard automation nudge skipped for board ${boardId}: debounce map full`);
+      return;
+    }
+    const pending: PendingBoardNudge = {};
+    const expiresAt = Date.now() + WORKBOARD_AUTOMATION_NUDGE_DEBOUNCE_MS;
+    // The board entry owns both the in-flight request and its cooldown, so a
+    // second lifecycle event can never overlap the first automation run request.
+    pendingByBoard.set(boardId, pending);
+    try {
+      await params.gateway.request(
+        "cron.run",
+        { id: jobId, mode: "force" },
+        { scopes: ["operator.admin"] },
+      );
+    } catch (error) {
+      // The automation schedule is the backstop; a nudge failure must not alter
+      // lifecycle synchronization or card state.
+      logger?.warn(`workboard automation nudge failed for board ${boardId}: ${String(error)}`);
+    } finally {
+      if (generation === owner && pendingByBoard.get(boardId) === pending) {
+        pending.timer = setTimeout(
+          () => {
+            if (pendingByBoard.get(boardId) === pending) {
+              pendingByBoard.delete(boardId);
+            }
+          },
+          Math.max(0, expiresAt - Date.now()),
+        );
+        pending.timer.unref?.();
+      }
+    }
+  };
+
+  return {
+    id: "workboard-automation-nudge",
+    start(ctx) {
+      generation += 1;
+      logger = ctx.logger;
+    },
+    stop() {
+      generation += 1;
+      logger = undefined;
+      for (const pending of pendingByBoard.values()) {
+        if (pending.timer) {
+          clearTimeout(pending.timer);
+        }
+      }
+      pendingByBoard.clear();
+    },
+    async nudge(input) {
+      const owner = generation;
+      if (!logger || isCronOriginSession(input.sessionKey) || input.cards.length === 0) {
+        return;
+      }
+      try {
+        const automationByBoard = new Map(
+          (await params.store.listBoards()).boards.flatMap((board) =>
+            board.automationJobId ? [[board.id, board.automationJobId] as const] : [],
+          ),
+        );
+        const boardIds = new Set(input.cards.map((card) => cardBoardId(card)));
+        await Promise.all(
+          [...boardIds].flatMap((boardId) => {
+            const jobId = automationByBoard.get(boardId);
+            return jobId ? [nudgeBoard(boardId, jobId, owner)] : [];
+          }),
+        );
+      } catch (error) {
+        logger?.warn(`workboard automation nudge failed: ${String(error)}`);
+      }
+    },
+  };
+}

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -1,5 +1,6 @@
 import type { WorkboardExecution, WorkboardStatus } from "@openclaw/workboard-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWorkboardAutomationNudgeService } from "./automation-nudge.js";
 import {
   createWorkboardLifecycleService,
   readWorkboardLifecycleSessions,
@@ -102,6 +103,126 @@ afterEach(() => {
 });
 
 describe("Workboard gateway lifecycle sync", () => {
+  it("nudges the attached board automation when a matching subagent ends", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
+    const sessionKey = "agent:main:subagent:workboard-planning-card-1";
+    const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+    const request = vi.fn().mockResolvedValue({ ok: true, ran: true });
+    const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
+    const context = { logger: { warn: vi.fn() } } as never;
+    await service.start(context);
+
+    await syncWorkboardSubagentEnded({
+      store,
+      event: { targetSessionKey: sessionKey, endedAt: card.updatedAt + 1, outcome: "ok" },
+      onMatched: service.nudge,
+    });
+    await service.stop?.(context);
+
+    expect(request).toHaveBeenCalledWith(
+      "cron.run",
+      { id: "job-categorize-planning", mode: "force" },
+      { scopes: ["operator.admin"] },
+    );
+  });
+
+  it("does not nudge a matching card whose board has no automation", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.upsertBoard({ id: "planning" });
+    const sessionKey = "agent:main:subagent:workboard-planning-card-2";
+    const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+    const request = vi.fn();
+    const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
+    const context = { logger: { warn: vi.fn() } } as never;
+    await service.start(context);
+
+    await syncWorkboardSubagentEnded({
+      store,
+      event: { targetSessionKey: sessionKey, endedAt: card.updatedAt + 1, outcome: "ok" },
+      onMatched: service.nudge,
+    });
+    await service.stop?.(context);
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each(["cron:job-categorize-planning", "agent:main:cron:job-categorize-planning:run:run-1"])(
+    "does not nudge from cron-originated session %s",
+    async (sessionKey) => {
+      const store = new WorkboardStore(createMemoryStore());
+      await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
+      const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+      const request = vi.fn();
+      const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
+      const context = { logger: { warn: vi.fn() } } as never;
+      await service.start(context);
+
+      await syncWorkboardSubagentEnded({
+        store,
+        event: { targetSessionKey: sessionKey, endedAt: card.updatedAt + 1, outcome: "ok" },
+        onMatched: service.nudge,
+      });
+      await service.stop?.(context);
+
+      expect(request).not.toHaveBeenCalled();
+    },
+  );
+
+  it("coalesces repeated board nudges within the debounce window", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
+    const sessionKey = "agent:main:subagent:workboard-planning-card-3";
+    const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+    let resolveRun: (value: unknown) => void = () => undefined;
+    const run = new Promise<unknown>((resolve) => {
+      resolveRun = resolve;
+    });
+    const request = vi.fn().mockReturnValue(run);
+    const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
+    const context = { logger: { warn: vi.fn() } } as never;
+    await service.start(context);
+    const event = {
+      targetSessionKey: sessionKey,
+      endedAt: card.updatedAt + 1,
+      outcome: "ok" as const,
+    };
+
+    const first = syncWorkboardSubagentEnded({ store, event, onMatched: service.nudge });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await syncWorkboardSubagentEnded({ store, event, onMatched: service.nudge });
+    resolveRun({ ok: true, ran: true });
+    await first;
+    await syncWorkboardSubagentEnded({ store, event, onMatched: service.nudge });
+    await service.stop?.(context);
+
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("swallows nudge failures without affecting lifecycle sync", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
+    const sessionKey = "agent:main:subagent:workboard-planning-card-4";
+    const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+    const request = vi.fn().mockRejectedValue(new Error("gateway unavailable"));
+    const warn = vi.fn();
+    const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
+    const context = { logger: { warn } } as never;
+    await service.start(context);
+
+    await expect(
+      syncWorkboardSubagentEnded({
+        store,
+        event: { targetSessionKey: sessionKey, endedAt: card.updatedAt + 1, outcome: "ok" },
+        onMatched: service.nudge,
+      }),
+    ).resolves.toBe(1);
+    await service.stop?.(context);
+
+    await expect(store.get(card.id)).resolves.toMatchObject({ status: "review" });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("workboard automation nudge failed"));
+  });
+
   it("moves a linked running card to review from the subagent hook without UI involvement", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const sessionKey = "agent:main:subagent:workboard-default-card-1";

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -123,7 +123,7 @@ describe("Workboard gateway lifecycle sync", () => {
 
     expect(request).toHaveBeenCalledWith(
       "cron.run",
-      { id: "job-categorize-planning", mode: "force" },
+      { id: "job-categorize-planning", mode: "if-enabled" },
       { scopes: ["operator.admin"] },
     );
     expect(info).toHaveBeenCalledWith(
@@ -159,7 +159,7 @@ describe("Workboard gateway lifecycle sync", () => {
     expect(activeRequest).not.toHaveBeenCalled();
     expect(generationRequest).toHaveBeenCalledWith(
       "cron.run",
-      { id: "job-categorize-planning", mode: "force" },
+      { id: "job-categorize-planning", mode: "if-enabled" },
       { scopes: ["operator.admin"] },
     );
   });
@@ -258,6 +258,32 @@ describe("Workboard gateway lifecycle sync", () => {
 
     await expect(store.get(card.id)).resolves.toMatchObject({ status: "review" });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("workboard automation nudge failed"));
+  });
+
+  it("logs disabled automation skips without affecting lifecycle sync", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
+    const sessionKey = "agent:main:subagent:workboard-planning-card-disabled";
+    const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+    const request = vi.fn().mockResolvedValue({ ok: true, ran: false, reason: "disabled" });
+    const warn = vi.fn();
+    const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
+    const context = { logger: { info: vi.fn(), warn } } as never;
+    await service.start(context);
+
+    await expect(
+      syncWorkboardSubagentEnded({
+        store,
+        event: { targetSessionKey: sessionKey, endedAt: card.updatedAt + 1, outcome: "ok" },
+        onMatched: service.nudge,
+      }),
+    ).resolves.toBe(1);
+    await service.stop?.(context);
+
+    await expect(store.get(card.id)).resolves.toMatchObject({ status: "review" });
+    expect(warn).toHaveBeenCalledWith(
+      "workboard automation nudge skipped for board planning: job job-categorize-planning disabled",
+    );
   });
 
   it("moves a linked running card to review from the subagent hook without UI involvement", async () => {

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -110,7 +110,8 @@ describe("Workboard gateway lifecycle sync", () => {
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
     const request = vi.fn().mockResolvedValue({ ok: true, ran: true });
     const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
-    const context = { logger: { warn: vi.fn() } } as never;
+    const info = vi.fn();
+    const context = { logger: { info, warn: vi.fn() } } as never;
     await service.start(context);
 
     await syncWorkboardSubagentEnded({
@@ -125,6 +126,42 @@ describe("Workboard gateway lifecycle sync", () => {
       { id: "job-categorize-planning", mode: "force" },
       { scopes: ["operator.admin"] },
     );
+    expect(info).toHaveBeenCalledWith(
+      "workboard automation nudge requested for board planning: job job-categorize-planning",
+    );
+  });
+
+  it("uses the active service owner from a prepared plugin generation", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.upsertBoard({ id: "planning", automationJobId: "job-categorize-planning" });
+    const sessionKey = "agent:main:subagent:workboard-planning-card-generation";
+    const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
+    const activeRequest = vi.fn();
+    const activeService = createWorkboardAutomationNudgeService({
+      store,
+      gateway: { request: activeRequest },
+    });
+    const generationRequest = vi.fn().mockResolvedValue({ ok: true, ran: true });
+    const generationService = createWorkboardAutomationNudgeService({
+      store,
+      gateway: { request: generationRequest },
+    });
+    const context = { logger: { info: vi.fn(), warn: vi.fn() } } as never;
+    await activeService.start(context);
+
+    await syncWorkboardSubagentEnded({
+      store,
+      event: { targetSessionKey: sessionKey, endedAt: card.updatedAt + 1, outcome: "ok" },
+      onMatched: generationService.nudge,
+    });
+    await activeService.stop?.(context);
+
+    expect(activeRequest).not.toHaveBeenCalled();
+    expect(generationRequest).toHaveBeenCalledWith(
+      "cron.run",
+      { id: "job-categorize-planning", mode: "force" },
+      { scopes: ["operator.admin"] },
+    );
   });
 
   it("does not nudge a matching card whose board has no automation", async () => {
@@ -134,7 +171,7 @@ describe("Workboard gateway lifecycle sync", () => {
     const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
     const request = vi.fn();
     const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
-    const context = { logger: { warn: vi.fn() } } as never;
+    const context = { logger: { info: vi.fn(), warn: vi.fn() } } as never;
     await service.start(context);
 
     await syncWorkboardSubagentEnded({
@@ -155,7 +192,7 @@ describe("Workboard gateway lifecycle sync", () => {
       const card = await createLinkedCard(store, { boardId: "planning", sessionKey });
       const request = vi.fn();
       const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
-      const context = { logger: { warn: vi.fn() } } as never;
+      const context = { logger: { info: vi.fn(), warn: vi.fn() } } as never;
       await service.start(context);
 
       await syncWorkboardSubagentEnded({
@@ -180,7 +217,7 @@ describe("Workboard gateway lifecycle sync", () => {
     });
     const request = vi.fn().mockReturnValue(run);
     const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
-    const context = { logger: { warn: vi.fn() } } as never;
+    const context = { logger: { info: vi.fn(), warn: vi.fn() } } as never;
     await service.start(context);
     const event = {
       targetSessionKey: sessionKey,
@@ -207,7 +244,7 @@ describe("Workboard gateway lifecycle sync", () => {
     const request = vi.fn().mockRejectedValue(new Error("gateway unavailable"));
     const warn = vi.fn();
     const service = createWorkboardAutomationNudgeService({ store, gateway: { request } });
-    const context = { logger: { warn } } as never;
+    const context = { logger: { info: vi.fn(), warn } } as never;
     await service.start(context);
 
     await expect(

--- a/extensions/workboard/src/lifecycle-sync.ts
+++ b/extensions/workboard/src/lifecycle-sync.ts
@@ -1,4 +1,8 @@
-import type { WorkboardExecutionStatus, WorkboardStatus } from "@openclaw/workboard-contract";
+import type {
+  WorkboardCard,
+  WorkboardExecutionStatus,
+  WorkboardStatus,
+} from "@openclaw/workboard-contract";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawPluginApi, OpenClawPluginService } from "../api.js";
 import {
@@ -36,6 +40,11 @@ type WorkboardLifecycleSessionSnapshot = {
   complete: boolean;
 };
 
+type WorkboardLifecycleMatchHandler = (input: {
+  cards: readonly WorkboardCard[];
+  sessionKey?: string;
+}) => Promise<void>;
+
 const LIFECYCLE_TARGETS = {
   running: { card: "running", execution: "running" },
   succeeded: { card: "review", execution: "review" },
@@ -69,17 +78,22 @@ async function syncWorkboardLifecycleEvent(params: {
   source: { sessionKey?: string; runId?: string };
   observation: WorkboardLifecycleObservation;
   now: number;
+  onMatched?: WorkboardLifecycleMatchHandler;
 }): Promise<number> {
-  let count = 0;
-  for (const card of await params.store.list()) {
-    if (card.metadata?.archivedAt || !workboardCardMatchesLifecycleLink(card, params.source)) {
-      continue;
-    }
-    if (await syncWorkboardCardLifecycle({ ...params, cardId: card.id })) {
-      count += 1;
-    }
-  }
-  return count;
+  const cards = (await params.store.list()).filter(
+    (card) => !card.metadata?.archivedAt && workboardCardMatchesLifecycleLink(card, params.source),
+  );
+  const updates = Promise.all(
+    cards.map(async (card) => await syncWorkboardCardLifecycle({ ...params, cardId: card.id })),
+  );
+  await Promise.all([
+    updates,
+    params.onMatched?.({
+      cards,
+      ...(params.source.sessionKey ? { sessionKey: params.source.sessionKey } : {}),
+    }),
+  ]);
+  return (await updates).filter(Boolean).length;
 }
 
 export async function syncWorkboardSubagentEnded(params: {
@@ -91,6 +105,7 @@ export async function syncWorkboardSubagentEnded(params: {
     outcome?: "ok" | "error" | "timeout" | "killed" | "reset" | "deleted";
   };
   now?: number;
+  onMatched?: WorkboardLifecycleMatchHandler;
 }): Promise<number> {
   const now = params.now ?? Date.now();
   return await syncWorkboardLifecycleEvent({
@@ -101,6 +116,7 @@ export async function syncWorkboardSubagentEnded(params: {
       sourceUpdatedAt: params.event.endedAt ?? now,
     },
     now,
+    ...(params.onMatched ? { onMatched: params.onMatched } : {}),
   });
 }
 
@@ -109,6 +125,7 @@ export async function syncWorkboardAgentEnded(params: {
   event: { runId?: string; success: boolean };
   context: { runId?: string; sessionKey?: string };
   now?: number;
+  onMatched?: WorkboardLifecycleMatchHandler;
 }): Promise<number> {
   const now = params.now ?? Date.now();
   return await syncWorkboardLifecycleEvent({
@@ -122,6 +139,7 @@ export async function syncWorkboardAgentEnded(params: {
       sourceUpdatedAt: now,
     },
     now,
+    ...(params.onMatched ? { onMatched: params.onMatched } : {}),
   });
 }
 

--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -355,6 +355,7 @@ describe("cron protocol validators", () => {
     expectCases(validateCronRunParams, true, [
       { id: "job-1", mode: "force", expectedProcessInstanceId: "process-1" },
       { jobId: "job-2", mode: "due" },
+      { jobId: "job-3", mode: "if-enabled" },
     ]);
     expectCases(validateCronRunParams, false, [{ id: "job-1", expectedProcessInstanceId: "" }]);
   });

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -719,9 +719,11 @@ export const CronUpdateParamsSchema = cronIdOrJobIdParams({
 /** Removes a cron job by id or legacy jobId alias. */
 export const CronRemoveParamsSchema = cronIdOrJobIdParams({});
 
-/** Runs a cron job immediately or only if due. */
+/** Runs a cron job immediately, immediately if enabled, or only if due. */
 export const CronRunParamsSchema = cronIdOrJobIdParams({
-  mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
+  mode: Type.Optional(
+    Type.Union([Type.Literal("due"), Type.Literal("force"), Type.Literal("if-enabled")]),
+  ),
   /** Rejects the mutation if the Gateway restarted after the caller's preflight. */
   expectedProcessInstanceId: Type.Optional(NonEmptyString),
 });

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -12,6 +12,7 @@ import * as runOps from "./service/ops-run.js";
 import {
   type CronAddOptions,
   type CronServiceDeps,
+  type CronRunMode,
   type CronUpdatePrecondition,
   type CronUpdateOptions,
   type CronWakeMode,
@@ -140,7 +141,7 @@ export class CronService implements CronServiceContract {
 
   async run(
     id: string,
-    mode?: "due" | "force",
+    mode?: CronRunMode,
     opts?: CronServiceRunOptions,
   ): Promise<CronServiceRunResult> {
     return await runOps.run(this.state, id, mode, opts);
@@ -148,7 +149,7 @@ export class CronService implements CronServiceContract {
 
   async enqueueRun(
     id: string,
-    mode?: "due" | "force",
+    mode?: CronRunMode,
     opts?: { commitGuard?: () => void },
   ): Promise<CronServiceRunResult> {
     const result = await runOps.enqueueRun(this.state, id, mode, opts);

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -24,8 +24,13 @@ import {
 } from "./run-admission.js";
 import { recomputeUnownedCronSchedules } from "./run-recovery.js";
 import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
-import type { CronEvent, CronServiceState, DeferredCronNotifications } from "./state.js";
-import { emit } from "./state.js";
+import type {
+  CronEvent,
+  CronRunMode,
+  CronServiceState,
+  DeferredCronNotifications,
+} from "./state.js";
+import { emit, isImmediateCronRunMode } from "./state.js";
 import { ensureLoaded, runPostPersistCronNotifications, warnIfDisabled } from "./store.js";
 import { tryCreateCronTaskRun, tryFinishCronTaskRun } from "./task-runs.js";
 import { applyJobResult, armTimer, type CronTriggerEvalOutcome } from "./timer.js";
@@ -36,6 +41,7 @@ type PreparedManualRun =
       ran: false;
       reason:
         | "already-running"
+        | "disabled"
         | "not-due"
         | "invalid-spec"
         | "restart-recovery-pending"
@@ -145,7 +151,7 @@ function admitsStreamSourceRun(
 async function skipInvalidPersistedManualRun(params: {
   state: CronServiceState;
   job: CronJob;
-  mode?: "due" | "force";
+  mode?: CronRunMode;
   runId?: string;
   terminalTracker?: ManualRunTerminalTracker;
   error: unknown;
@@ -168,7 +174,7 @@ async function skipInvalidPersistedManualRun(params: {
       endedAt,
     },
     {
-      scheduleMode: params.mode === "force" ? "preserve" : "advance",
+      scheduleMode: isImmediateCronRunMode(params.mode) ? "preserve" : "advance",
       deferredNotifications: postPersistNotifications,
     },
   );
@@ -220,9 +226,9 @@ async function skipInvalidPersistedManualRun(params: {
   armTimer(params.state);
 }
 
-function recomputeManualRunPreflight(state: CronServiceState, id: string, mode?: "due" | "force") {
+function recomputeManualRunPreflight(state: CronServiceState, id: string, mode?: CronRunMode) {
   const maintenance = recomputeUnownedCronSchedules(state, {
-    ...(mode === "force" ? { preserveExpiredPacedNextRunJobId: id } : {}),
+    ...(isImmediateCronRunMode(mode) ? { preserveExpiredPacedNextRunJobId: id } : {}),
     skipScheduleErrorHandling: true,
   });
   runPostPersistCronNotifications(state, maintenance.notifications);
@@ -232,7 +238,7 @@ function recomputeManualRunPreflight(state: CronServiceState, id: string, mode?:
 async function inspectManualRunPreflight(
   state: CronServiceState,
   id: string,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
   runId?: string,
   terminalTracker?: ManualRunTerminalTracker,
   streamScheduleKey?: string,
@@ -252,6 +258,9 @@ async function inspectManualRunPreflight(
     // persist does not block manual triggers for up to STUCK_RUN_MS (#17554).
     recomputeManualRunPreflight(state, id, mode);
     const job = findJobOrThrow(state, id);
+    if (mode === "if-enabled" && (!isJobEnabled(job) || job.state.autoDisabled)) {
+      return { ok: true, ran: false, reason: "disabled" } as const;
+    }
     if (!admitsStreamSourceRun(job, streamScheduleKey, streamSourceIdentity)) {
       return { ok: true, ran: false, reason: "not-due" } as const;
     }
@@ -265,7 +274,7 @@ async function inspectManualRunPreflight(
       return { ok: true, ran: false, reason: "already-running" as const };
     }
     const now = state.deps.nowMs();
-    const due = isJobDue(job, now, { forced: mode === "force" });
+    const due = isJobDue(job, now, { forced: isImmediateCronRunMode(mode) });
     if (!due) {
       return { ok: true, ran: false, reason: "not-due" } as const;
     }
@@ -276,7 +285,7 @@ async function inspectManualRunPreflight(
 export async function inspectManualRunDisposition(
   state: CronServiceState,
   id: string,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
 ): Promise<ManualRunDisposition | { ok: false }> {
   // Queue callers need a cheap eligibility check before entering the command
   // lane; the real reservation happens later under lock in prepareManualRun.
@@ -293,7 +302,7 @@ export async function inspectManualRunDisposition(
 export async function prepareManualRun(
   state: CronServiceState,
   id: string,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
   opts?: ManualRunOptions,
 ): Promise<PreparedManualRun> {
   const preflight = await inspectManualRunPreflight(
@@ -329,6 +338,9 @@ export async function prepareManualRun(
     await ensureLoaded(state, { skipRecompute: true });
     recomputeManualRunPreflight(state, id, mode);
     const job = findJobOrThrow(state, id);
+    if (mode === "if-enabled" && (!isJobEnabled(job) || job.state.autoDisabled)) {
+      return { ok: true, ran: false, reason: "disabled" } as const;
+    }
     if (!admitsStreamSourceRun(job, opts?.streamScheduleKey, opts?.streamSourceIdentity)) {
       return { ok: true, ran: false, reason: "not-due" as const };
     }
@@ -350,7 +362,7 @@ export async function prepareManualRun(
     }
     opts?.commitGuard?.();
     const reservationAt = state.deps.nowMs();
-    if (!isJobDue(job, reservationAt, { forced: mode === "force" })) {
+    if (!isJobDue(job, reservationAt, { forced: isImmediateCronRunMode(mode) })) {
       return { ok: true, ran: false, reason: "not-due" as const };
     }
     // Persist the queued marker before releasing lock so timer ticks that
@@ -358,7 +370,7 @@ export async function prepareManualRun(
     const [reserved] = await persistQueuedCronRunReservations({
       state,
       candidates: [job],
-      ...(mode === "force" ? { forcedJobIds: new Set([job.id]) } : {}),
+      ...(isImmediateCronRunMode(mode) ? { immediateJobIds: new Set([job.id]) } : {}),
       reservedAtMs: reservationAt,
     });
     if (!reserved) {
@@ -409,7 +421,7 @@ export async function prepareManualRun(
 export async function activatePreparedManualRun(
   state: CronServiceState,
   prepared: Extract<PreparedManualRun, { ran: true }>,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
 ): Promise<ActivatedManualRun | Extract<PreparedManualRun, { ran: false }>> {
   return await locked(state, async () => {
     // Reservations can wait behind another cron run. Reload under the service
@@ -435,6 +447,10 @@ export async function activatePreparedManualRun(
       await releasePreparedManualReservationWithRetry(state, prepared);
       return { ok: true, ran: false, reason: "not-due" } as const;
     }
+    if (mode === "if-enabled" && (!isJobEnabled(job) || job.state.autoDisabled)) {
+      await releasePreparedManualReservationWithRetry(state, prepared);
+      return { ok: true, ran: false, reason: "disabled" } as const;
+    }
     if (!admitsStreamSourceRun(job, prepared.streamScheduleKey, prepared.streamSourceIdentity)) {
       // This is reservation identity, not watcher ownership: a force run can
       // wait behind cron admission after its owner has stopped for replacement.
@@ -447,7 +463,7 @@ export async function activatePreparedManualRun(
     delete dueProbe.state.queuedAtMs;
     if (
       (prepared.wasEnabled && !isJobEnabled(job)) ||
-      !isJobDue(dueProbe, state.deps.nowMs(), { forced: mode === "force" })
+      !isJobDue(dueProbe, state.deps.nowMs(), { forced: isImmediateCronRunMode(mode) })
     ) {
       await releasePreparedManualReservationWithRetry(state, prepared);
       return { ok: true, ran: false, reason: "not-due" } as const;
@@ -500,8 +516,8 @@ export async function activatePreparedManualRun(
     // target writeback from disk without mutating the running object.
     const admittedJob = structuredClone(activatedJob);
     const executionJob = structuredClone(activatedJob);
-    if (mode === "force" && executionJob.trigger && !prepared.evaluateTrigger) {
-      // Force means run the payload now; strip the gate only from this snapshot
+    if (isImmediateCronRunMode(mode) && executionJob.trigger && !prepared.evaluateTrigger) {
+      // Immediate modes run the payload now; strip the gate only from this snapshot
       // so persisted trigger state and future due evaluations stay intact.
       delete executionJob.trigger;
     }

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -35,8 +35,13 @@ import {
 } from "./run-receipts.js";
 import { recomputeUnownedCronSchedules } from "./run-recovery.js";
 import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
-import type { CronServiceState, CronWakeMode, DeferredCronNotifications } from "./state.js";
-import { emit } from "./state.js";
+import type {
+  CronRunMode,
+  CronServiceState,
+  CronWakeMode,
+  DeferredCronNotifications,
+} from "./state.js";
+import { emit, isImmediateCronRunMode } from "./state.js";
 import { ensureLoaded, publishCronRuntimeRows, runPostPersistCronNotifications } from "./store.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
 import {
@@ -66,7 +71,7 @@ function applyManualRunOutcome(params: {
   startedAt: number;
   endedAt: number;
   triggerSkipped: boolean;
-  mode?: "due" | "force";
+  mode?: CronRunMode;
   deferredNotifications: DeferredCronNotifications;
 }): boolean {
   const scheduleOwnership = resolveCronRunScheduleOwnership({
@@ -82,8 +87,8 @@ function applyManualRunOutcome(params: {
   const scheduleMode =
     scheduleOwnership === "stale"
       ? "stale-preserve"
-      : params.mode === "force"
-        ? "force-preserve"
+      : isImmediateCronRunMode(params.mode)
+        ? "immediate-preserve"
         : "advance";
   if (params.triggerSkipped) {
     applyTriggerNoFireResult(
@@ -107,7 +112,7 @@ function applyManualRunOutcome(params: {
     params.job,
     { ...params.coreResult, startedAt: params.startedAt, endedAt: params.endedAt },
     {
-      scheduleMode: scheduleMode === "force-preserve" ? "preserve" : "advance",
+      scheduleMode: scheduleMode === "immediate-preserve" ? "preserve" : "advance",
       scheduleOwnership,
       scheduleOwnershipAtMs: params.prepared.scheduleOwnershipAtMs,
       deferredNotifications: params.deferredNotifications,
@@ -132,7 +137,7 @@ function applyManualRunOutcome(params: {
 async function finishPreparedManualRun(
   state: CronServiceState,
   prepared: ActivatedManualRun,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
 ): Promise<void> {
   const executionJob = prepared.executionJob;
   const startedAt = prepared.startedAt;
@@ -387,7 +392,7 @@ async function finishPreparedManualRun(
         publishCronRuntimeRows(state);
         const maintenance = recomputeUnownedCronSchedules(state, {
           recomputeExpired: true,
-          ...(mode === "force" ? { preserveExpiredPacedNextRunJobId: jobId } : {}),
+          ...(isImmediateCronRunMode(mode) ? { preserveExpiredPacedNextRunJobId: jobId } : {}),
         });
         runPostPersistCronNotifications(state, maintenance.notifications);
         applyCronRuntimeRowsToState(state, maintenance.jobs);
@@ -452,7 +457,7 @@ async function finishPreparedManualRun(
 export async function run(
   state: CronServiceState,
   id: string,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
   opts?: ManualRunOptions,
 ) {
   const prepared = await prepareManualRun(state, id, mode, opts);
@@ -495,7 +500,7 @@ export async function run(
 export async function enqueueRun(
   state: CronServiceState,
   id: string,
-  mode?: "due" | "force",
+  mode?: CronRunMode,
   opts?: { commitGuard?: () => void },
 ) {
   const disposition = await inspectManualRunDisposition(state, id, mode);

--- a/src/cron/service/ops.run-admission.test.ts
+++ b/src/cron/service/ops.run-admission.test.ts
@@ -54,7 +54,7 @@ function expectQueuedRunAck(result: unknown) {
 }
 
 describe("cron service run admission", () => {
-  it("rechecks a queued manual run after the job is disabled", async () => {
+  it("rechecks a queued if-enabled run after the job is disabled", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
@@ -77,6 +77,7 @@ describe("cron service run admission", () => {
     await blockerStarted.promise;
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const onEvent = vi.fn();
     const state = createAdmissionTestState({
       cronEnabled: true,
       storePath: store.storePath,
@@ -85,15 +86,24 @@ describe("cron service run admission", () => {
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
+      onEvent,
     });
 
-    expectQueuedRunAck(await enqueueRun(state, job.id, "due"));
+    expectQueuedRunAck(await enqueueRun(state, job.id, "if-enabled"));
     await update(state, job.id, { enabled: false });
     releaseBlocker.resolve();
     await blocker;
     await waitForActiveTasks(5_000);
 
     expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: job.id,
+        action: "finished",
+        status: "skipped",
+        error: "queued manual run skipped before execution: disabled",
+      }),
+    );
     clearCommandLane(CommandLane.Cron);
   });
 
@@ -700,6 +710,78 @@ describe("cron service run admission", () => {
 
     await expect(run(state, job.id, "force")).resolves.toEqual({ ok: true, ran: true });
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { label: "disabled", autoDisabled: false },
+    { label: "auto-disabled", autoDisabled: true },
+  ])("skips $label jobs in if-enabled mode", async ({ autoDisabled }) => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:06.550Z");
+    const job = createDueIsolatedJob({
+      id: `if-enabled-${autoDisabled ? "auto-disabled" : "disabled"}`,
+      nowMs: now,
+      nextRunAtMs: now + 3_600_000,
+    });
+    if (autoDisabled) {
+      job.enabled = true;
+      job.state.autoDisabled = {
+        reason: "consecutive-failures",
+        atMs: now - 1,
+        consecutiveErrors: 10,
+      };
+    } else {
+      job.enabled = false;
+    }
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const onEvent = vi.fn();
+    const state = createAdmissionTestState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      onEvent,
+    });
+
+    await expect(run(state, job.id, "if-enabled")).resolves.toEqual({
+      ok: true,
+      ran: false,
+      reason: "disabled",
+    });
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ action: "finished" }));
+  });
+
+  it("runs an enabled future job immediately in if-enabled mode without changing its schedule", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:06.575Z");
+    const nextRunAtMs = now + 3_600_000;
+    const job = createDueIsolatedJob({
+      id: "if-enabled-future",
+      nowMs: now,
+      nextRunAtMs,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createAdmissionTestState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await expect(run(state, job.id, "if-enabled")).resolves.toEqual({ ok: true, ran: true });
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    expect((await loadCronStore(store.storePath)).jobs[0]?.state.nextRunAtMs).toBe(nextRunAtMs);
   });
 
   it("keeps queued force runs for jobs disabled before reservation through maintenance", async () => {

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -263,7 +263,7 @@ export async function supersedeActivatedCronRun(params: {
 export async function persistQueuedCronRunReservations(params: {
   state: CronServiceState;
   candidates: readonly CronJob[];
-  forcedJobIds?: ReadonlySet<string>;
+  immediateJobIds?: ReadonlySet<string>;
   reservedAtMs: number;
 }): Promise<Array<{ job: CronJob; runReceipt: CronRunReceiptHandle }>> {
   const pendingJobs = new Map(params.candidates.map((job) => [job.id, structuredClone(job)]));
@@ -304,7 +304,7 @@ export async function persistQueuedCronRunReservations(params: {
               !job ||
               !planned ||
               job.enabled !== planned.enabled ||
-              (!params.forcedJobIds?.has(jobId) &&
+              (!params.immediateJobIds?.has(jobId) &&
                 job.state.nextRunAtMs !== planned.state.nextRunAtMs) ||
               job.state.lastRunAtMs !== planned.state.lastRunAtMs ||
               job.state.lastRunStatus !== planned.state.lastRunStatus ||

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -341,8 +341,12 @@ export function emit(state: CronServiceState, evt: CronEvent) {
   }
 }
 
-/** Direct-run mode: respect due time or force execution. */
-export type CronRunMode = "due" | "force";
+/** Direct-run mode: respect due time, force execution, or run immediately while enabled. */
+export type CronRunMode = "due" | "force" | "if-enabled";
+
+export function isImmediateCronRunMode(mode: CronRunMode | undefined): boolean {
+  return mode === "force" || mode === "if-enabled";
+}
 
 /** Main-session wake strategy used after enqueuing cron text. */
 export type CronWakeMode = "now" | "next-heartbeat";
@@ -364,6 +368,7 @@ export type CronStatusSummary = {
 export type CronRunResult =
   | { ok: true; ran: true }
   | { ok: true; enqueued: true; runId: string }
+  | { ok: true; ran: false; reason: "disabled" }
   | { ok: true; ran: false; reason: "not-due" }
   | { ok: true; ran: false; reason: "already-running" }
   | { ok: true; ran: false; reason: "restart-recovery-pending" }

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -332,7 +332,7 @@ export function applyJobResult(
         deferredNotifications: opts?.deferredNotifications,
       })
     ) {
-      // Keep this after the ownership and force-preserve gates: those paths
+      // Keep this after the ownership and immediate-preserve gates: those paths
       // restore schedule state and would otherwise silently undo the disable.
       state.deps.log.error(
         {
@@ -563,7 +563,7 @@ export function applyTriggerNoFireResult(
   job: CronJob,
   result: { startedAt: number; endedAt: number; triggerEval: CronTriggerEvalOutcome },
   opts?: {
-    scheduleMode?: "advance" | "force-preserve" | "stale-preserve";
+    scheduleMode?: "advance" | "immediate-preserve" | "stale-preserve";
     triggerOwnership?: CronTriggerOwnership;
     deferredNotifications?: DeferredCronNotifications;
   },
@@ -582,13 +582,13 @@ export function applyTriggerNoFireResult(
     job.state.lastFailureAlertAtMs = undefined;
     applyTriggerEvaluationState(job, result.triggerEval, result.endedAt);
   }
-  if (opts?.scheduleMode === "force-preserve" || opts?.scheduleMode === "stale-preserve") {
+  if (opts?.scheduleMode === "immediate-preserve" || opts?.scheduleMode === "stale-preserve") {
     job.state.nextRunAtMs = previousNextRunAtMs;
     job.state.pacedNextRunAtMs = previousPacedNextRunAtMs;
     // A stale wake preserves the operator's complete schedule; only an actual
     // force run may create the marker that exempts its slot from repair.
     job.state.forcePreservedNextRunAtMs =
-      opts.scheduleMode === "force-preserve"
+      opts.scheduleMode === "immediate-preserve"
         ? previousNextRunAtMs
         : previousForcePreservedNextRunAtMs;
     return;

--- a/src/cron/service/timer.pacing.test.ts
+++ b/src/cron/service/timer.pacing.test.ts
@@ -311,7 +311,7 @@ describe("applyJobResult dynamic cadence", () => {
         endedAt: ENDED_AT,
         triggerEval: { fired: false, stateChanged: false },
       },
-      { scheduleMode: "force-preserve" },
+      { scheduleMode: "immediate-preserve" },
     );
 
     expect(job.state.nextRunAtMs).toBe(pendingSlot);

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1132,7 +1132,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params as CronJobIdParams & {
-      mode?: "due" | "force";
+      mode?: "due" | "force" | "if-enabled";
       expectedProcessInstanceId?: string;
     };
     const callerScope = readCronCallerScope(client);

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1579,7 +1579,7 @@ describe("gateway server cron", () => {
     }
   });
 
-  test("bundled plugin runtime force-runs a persisted automation", async () => {
+  test("bundled plugin runtime runs enabled automations and skips disabled ones", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-plugin-runtime-",
       cronEnabled: true,
@@ -1608,31 +1608,34 @@ describe("gateway server cron", () => {
         getRuntimeConfig: cronState.getRuntimeConfig,
       } as never;
 
-      const runRes = await withPluginRuntimeGatewayRequestScope(
-        {
-          context,
-          client: {
-            connect: { scopes: ["operator.read"] },
-            internal: {
-              agentRuntimeIdentity: {
-                kind: "agentRuntime",
-                agentId: "foreign-agent",
-                sessionKey: "agent:foreign-agent:main",
-                turnSourceAccountId: "default",
+      const runThroughPlugin = async (id: string) =>
+        await withPluginRuntimeGatewayRequestScope(
+          {
+            context,
+            client: {
+              connect: { scopes: ["operator.read"] },
+              internal: {
+                agentRuntimeIdentity: {
+                  kind: "agentRuntime",
+                  agentId: "foreign-agent",
+                  sessionKey: "agent:foreign-agent:main",
+                  turnSourceAccountId: "default",
+                },
               },
-            },
-          } as never,
-          isWebchatConnect: () => false,
-          pluginId: "workboard",
-          pluginOrigin: "bundled",
-        },
-        async () =>
-          await runtime.gateway.request(
-            "cron.run",
-            { id: jobId, mode: "force" },
-            { scopes: ["operator.admin"] },
-          ),
-      );
+            } as never,
+            isWebchatConnect: () => false,
+            pluginId: "workboard",
+            pluginOrigin: "bundled",
+          },
+          async () =>
+            await runtime.gateway.request(
+              "cron.run",
+              { id, mode: "if-enabled" },
+              { scopes: ["operator.admin"] },
+            ),
+        );
+
+      const runRes = await runThroughPlugin(jobId);
 
       expect(runRes).toMatchObject({ ok: true, enqueued: true });
       await expect(finishedRun).resolves.toMatchObject({
@@ -1645,6 +1648,27 @@ describe("gateway server cron", () => {
       expect((runsRes.payload as { entries?: Array<{ jobId?: string }> }).entries).toEqual([
         expect.objectContaining({ jobId }),
       ]);
+
+      const disabledAddRes = await directCronReq(cronState, "cron.add", {
+        name: "disabled plugin runtime nudge",
+        enabled: false,
+        schedule: { kind: "cron", expr: "0 3 1 1 *", tz: "America/Los_Angeles" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "disabled plugin runtime nudge" },
+      });
+      const disabledJobId = expectCronJobIdFromResponse(disabledAddRes);
+      await expect(runThroughPlugin(disabledJobId)).resolves.toMatchObject({
+        ok: true,
+        ran: false,
+        reason: "disabled",
+      });
+      const disabledRuns = await directCronReq(cronState, "cron.runs", {
+        id: disabledJobId,
+        limit: 5,
+      });
+      expect(disabledRuns.ok).toBe(true);
+      expect((disabledRuns.payload as { entries?: unknown[] }).entries).toEqual([]);
     } finally {
       await cleanupCronTestRun({ cronState, prevSkipCron });
     }

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -11,6 +11,8 @@ import { resetConfigRuntimeState } from "../config/config.js";
 import { loadCronStore, saveCronStore } from "../cron/store.js";
 import type { GuardedFetchOptions } from "../infra/net/fetch-guard.js";
 import { peekSystemEvents } from "../infra/system-events.js";
+import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
 import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import { getGatewayProcessInstanceId } from "./process-instance.js";
 import type { GatewayCronState } from "./server-cron.js";
@@ -1574,6 +1576,77 @@ describe("gateway server cron", () => {
       expect(call?.sessionKey).toBe("agent:main:dingtalk:group:cid3tmd4xb19xjfk/wogxwy2a==");
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  });
+
+  test("bundled plugin runtime force-runs a persisted automation", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-plugin-runtime-",
+      cronEnabled: true,
+    });
+    const events = createCronEventCollector();
+    const cronState = await createDirectCronState({ broadcast: events["broadcast"] });
+
+    try {
+      const addRes = await directCronReq(cronState, "cron.add", {
+        name: "plugin runtime nudge",
+        enabled: true,
+        schedule: { kind: "cron", expr: "0 3 1 1 *", tz: "America/Los_Angeles" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "plugin runtime nudge" },
+      });
+      const jobId = expectCronJobIdFromResponse(addRes);
+      const finishedRun = events.wait(
+        (payload) => payload.jobId === jobId && payload.action === "finished",
+      );
+      const runtime = createPluginRuntime();
+      const context = {
+        cron: cronState.cron,
+        cronStorePath: cronState.storePath,
+        logGateway: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        getRuntimeConfig: cronState.getRuntimeConfig,
+      } as never;
+
+      const runRes = await withPluginRuntimeGatewayRequestScope(
+        {
+          context,
+          client: {
+            connect: { scopes: ["operator.read"] },
+            internal: {
+              agentRuntimeIdentity: {
+                kind: "agentRuntime",
+                agentId: "foreign-agent",
+                sessionKey: "agent:foreign-agent:main",
+                turnSourceAccountId: "default",
+              },
+            },
+          } as never,
+          isWebchatConnect: () => false,
+          pluginId: "workboard",
+          pluginOrigin: "bundled",
+        },
+        async () =>
+          await runtime.gateway.request(
+            "cron.run",
+            { id: jobId, mode: "force" },
+            { scopes: ["operator.admin"] },
+          ),
+      );
+
+      expect(runRes).toMatchObject({ ok: true, enqueued: true });
+      await expect(finishedRun).resolves.toMatchObject({
+        jobId,
+        action: "finished",
+        status: "ok",
+      });
+      const runsRes = await directCronReq(cronState, "cron.runs", { id: jobId, limit: 5 });
+      expect(runsRes.ok).toBe(true);
+      expect((runsRes.payload as { entries?: Array<{ jobId?: string }> }).entries).toEqual([
+        expect.objectContaining({ jobId }),
+      ]);
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
     }
   });
 

--- a/test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts
@@ -197,6 +197,75 @@ async function waitForWorktreeState(params: {
 
 describe("managed worktrees Workboard-owner product proof", () => {
   it(
+    "nudges a persisted future automation when a linked worker ends",
+    { timeout: 120_000 },
+    async () => {
+      const activeHarness = await startHarness();
+      const addResult = (await activeHarness.gateway.call("cron.add", {
+        name: "Workboard event nudge proof",
+        enabled: true,
+        schedule: { kind: "cron", expr: "0 3 1 1 *", tz: "America/Los_Angeles" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "Workboard event nudge proof" },
+      })) as { id: string };
+      const boardId = "qa-event-nudge";
+      await activeHarness.gateway.call("workboard.boards.upsert", {
+        id: boardId,
+        automationJobId: addResult.id,
+      });
+      const boards = (await activeHarness.gateway.call("workboard.boards.list", {})) as {
+        boards: Array<{ id: string; automationJobId?: string }>;
+      };
+      expect(boards.boards).toContainEqual(
+        expect.objectContaining({ id: boardId, automationJobId: addResult.id }),
+      );
+      const card = (await activeHarness.gateway.call("workboard.cards.create", {
+        title: "Event nudge lifecycle",
+        status: "ready",
+        agentId: "qa",
+        boardId,
+      })) as WorkboardCreateResult;
+
+      const dispatch = (await activeHarness.gateway.call("workboard.cards.dispatch", {
+        boardId,
+      })) as WorkboardDispatchResult;
+      expect(dispatch.startFailures).toEqual([]);
+      expect(dispatch.started).toEqual([
+        expect.objectContaining({ cardId: card.card.id, runId: expect.any(String) }),
+      ]);
+      const terminal = (await activeHarness.gateway.call(
+        "agent.wait",
+        { runId: dispatch.started[0]!.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      )) as GatewayRunResult;
+      expect(terminal.status).toBe("ok");
+
+      const deadline = Date.now() + 15_000;
+      let entries: unknown[] = [];
+      let lifecycleStatus: string | undefined;
+      while (Date.now() < deadline) {
+        const cards = (await activeHarness.gateway.call("workboard.cards.list", {
+          boardId,
+        })) as WorkboardListResult;
+        lifecycleStatus = cards.cards.find((entry) => entry.id === card.card.id)?.status;
+        const runs = (await activeHarness.gateway.call("cron.runs", {
+          id: addResult.id,
+          limit: 5,
+        })) as { entries?: unknown[] };
+        entries = runs.entries ?? [];
+        if (entries.length > 0) {
+          break;
+        }
+        await sleep(50);
+      }
+      expect(entries, `card=${String(lifecycleStatus)}\n${activeHarness.gateway.logs()}`).toEqual([
+        expect.objectContaining({ jobId: addResult.id, status: "ok" }),
+      ]);
+    },
+  );
+
+  it(
     "removes clean card worktrees and records dirty run-end retention",
     { timeout: 240_000 },
     async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Workboard board with an attached automation still waited for the automation's next schedule after a linked agent or subagent finished. The card lifecycle update reached `review`, but the categorization automation was not nudged from the prepared model generation that emitted the terminal hook.

Series context: #125023, #125076, #125094.

## Why This Change Was Made

Workboard now requests the board's operator-owned automation with the additive `cron.run` mode `if-enabled` when a matching linked session ends, with one process-wide lifecycle owner and a 60-second per-board debounce. Cron rechecks the authoritative enabled and auto-disabled state under its reservation lock before immediate admission. Prepared model generations register fresh hook closures without starting plugin services, so the active service logger, lifecycle fence, and debounce map are shared through the plugin SDK process singleton. Explicit operator `force` semantics are unchanged, cron-originated sessions remain excluded to prevent self-triggering, and the stored schedule remains the backstop.

## User Impact

Operators can attach an enabled automation to a Workboard board and have it react immediately when linked work finishes. Disabled and auto-disabled jobs are skipped with a typed non-error result; repeated events for the same board coalesce, failures and skips remain non-blocking for card lifecycle updates, and successful requests now leave an attributable log line with the returned automation run ID.

## Evidence

Boundary regression proof:

- `src/gateway/server.cron.test.ts` creates real far-future enabled and disabled cron rows and dispatches `cron.run` with `mode: "if-enabled"` through a bundled-plugin runtime request carrying an ambient foreign agent identity. It proves the trusted synthetic admin client reaches the real method router, runs the enabled row, and returns `reason: "disabled"` without history for the disabled row.
- `src/cron/service/ops.run-admission.test.ts` proves enabled, disabled, auto-disabled, and disable-after-enqueue behavior under cron's authoritative reservation and activation locks. Existing `force` coverage remains unchanged and still admits explicitly forced disabled jobs.
- `test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts` failed before the owner repair with the card at `review` and zero automation history; it passes after the repair through a real isolated Gateway, Workboard service/hook, persisted board/job, and mock provider.
- Root cause: `src/plugins/runtime/generation-scope.ts:18-45` carries the prepared registry, `src/plugins/hook-runner-global-state.ts:124-127` selects it for hook dispatch, and `extensions/workboard/src/automation-nudge.ts:30-52` now bridges those hook closures to the active service owner.

Focused exact-head checks:

- `node scripts/run-vitest.mjs extensions/workboard/src/lifecycle-sync.test.ts` — 41 passed.
- `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts -t 'bundled plugin runtime runs enabled automations and skips disabled ones'` — 1 passed.
- `node scripts/run-vitest.mjs src/cron/service/ops.run-admission.test.ts` — 20 passed.
- `pnpm protocol:check` — passed; additive schema member, no protocol version bump, Swift unchanged.
- `OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts -t 'nudges a persisted future automation when a linked worker ends'` — 1 passed.
- Fresh branch autoreview against `origin/main` — clean, no accepted/actionable findings.

Live isolated Gateway proof used `openai/gpt-5.6-luna`. Job `98fda088-8468-45a0-b82d-998074f3e90e` had schedule `0 3 1 1 *` in `America/Los_Angeles`, exact, with its next due time at `2027-01-01T11:00:00Z` (`Next in 137d` in the recorded UI). It started from the event nudge at `2026-08-17T01:10:13.413-07:00`, finished `ok` in 6.360 seconds, and moved `Rough customer follow-up` from `triage` to `todo`. The linked card reached `review`.

Gateway log correlation:

```text
2026-08-17T01:10:13.400-07:00 [plugins] workboard automation nudge requested for board peter-tasks: job 98fda088-8468-45a0-b82d-998074f3e90e run manual:98fda088-8468-45a0-b82d-998074f3e90e:1786954213396:1
2026-08-17T01:10:14.234-07:00 [provider-transport-fetch] [model-fetch] start provider=openai api=openai-responses model=gpt-5.6-luna method=POST url=https://api.openai.com/v1/responses timeoutMs=undefined proxy=none policy=custom
```

History verdict:

```text
runAt: 2026-08-17T01:10:13.413-07:00
finished: 2026-08-17T01:10:19.773-07:00
status: ok
summary: Moved “Rough customer follow-up” from triage to todo.
nextRunAt: 2027-01-01T03:00:00.000-08:00
```

The recorder's extra Automations-page text locator timed out after the mandated assertions passed. The final video frame visibly shows the Run history tab with `Peter tasks event clarifier · OK`, `gpt-5.6-luna`, `Run at 1:10:13 AM`, `Next in 137d`, and the successful move summary; coordinator review accepted the live gate.

https://github.com/user-attachments/assets/fbc8bd25-0191-4617-91e7-f0a52e079c5c
