### PR TITLE
test: use per-run temp roots in update-cli and migrate suites

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -530,13 +530,18 @@ type UpdateCliScenario = {
 };
 
 describe("update-cli", () => {
-  const fixtureRoot = "/tmp/openclaw-update-tests";
+  // Per-run unique root: concurrent runs on one machine (CI shards, sibling checkouts) must
+  // never share fixture paths — some cases write real files and rm them in cleanup. Realpath'd
+  // because macOS os.tmpdir() is a /var -> /private/var symlink.
+  const fixtureRoot = fsSync.realpathSync(
+    fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-update-tests-")),
+  );
   let fixtureCount = 0;
   const tempDirsToCleanup = new Set<string>();
 
   const createCaseDir = (prefix: string) => {
     const dir = path.join(fixtureRoot, `${prefix}-${fixtureCount++}`);
-    // Tests only need a stable path; the directory does not have to exist because all I/O is mocked.
+    // Callers that only need a stable path skip creating it; real-I/O callers mkdir themselves.
     return dir;
   };
 
@@ -1481,8 +1486,9 @@ describe("update-cli", () => {
     setStdoutTty(false);
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     serviceEnvSnapshot.restore();
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 
   afterEach(async () => {
@@ -1662,7 +1668,8 @@ describe("update-cli", () => {
         candidate === path.join(root, "package.json") ||
         entrypoints.includes(candidate),
     );
-    const managedState = "/tmp/openclaw-update-tests/managed-profile";
+    const managedState = path.join(fixtureRoot, "managed-profile");
+    const personalState = path.join(fixtureRoot, "personal-profile");
     const managedConfig = {
       ...baseConfig,
       update: { channel: "beta" as const },
@@ -1717,8 +1724,8 @@ describe("update-cli", () => {
     await withEnvAsync(
       {
         OPENCLAW_PROFILE: "personal",
-        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
-        OPENCLAW_CONFIG_PATH: "/tmp/openclaw-update-tests/personal-profile/openclaw.json",
+        OPENCLAW_STATE_DIR: personalState,
+        OPENCLAW_CONFIG_PATH: path.join(personalState, "openclaw.json"),
         OPENCLAW_GATEWAY_PORT: "19111",
       },
       async () => {
@@ -1740,6 +1747,7 @@ describe("update-cli", () => {
   });
 
   it("keeps foreign-service updates in the caller profile", async () => {
+    const personalState = path.join(fixtureRoot, "personal-profile");
     const { root, entrypoints } = setupUpdatedRootRefresh();
     const foreignRoot = await createTrackedTempDir("openclaw-update-foreign-profile-");
     const foreignEntrypoint = path.join(foreignRoot, "dist", "index.js");
@@ -1762,7 +1770,7 @@ describe("update-cli", () => {
       programArguments: ["node", foreignEntrypoint, "gateway", "run"],
       environment: {
         OPENCLAW_PROFILE: "foreign",
-        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/foreign-profile",
+        OPENCLAW_STATE_DIR: path.join(fixtureRoot, "foreign-profile"),
         OPENCLAW_GATEWAY_PORT: "19333",
       },
     });
@@ -1776,7 +1784,7 @@ describe("update-cli", () => {
     await withEnvAsync(
       {
         OPENCLAW_PROFILE: "personal",
-        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
+        OPENCLAW_STATE_DIR: personalState,
         OPENCLAW_GATEWAY_PORT: "19111",
       },
       async () => {
@@ -1788,7 +1796,7 @@ describe("update-cli", () => {
     expect(serviceEnabled).not.toHaveBeenCalled();
     expect(spawnCall()?.[2]?.env).toMatchObject({
       OPENCLAW_PROFILE: "personal",
-      OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
+      OPENCLAW_STATE_DIR: personalState,
       OPENCLAW_GATEWAY_PORT: "19111",
     });
   });
@@ -1804,7 +1812,7 @@ describe("update-cli", () => {
         after: { sha: "new-managed-sha", version: "2026.4.27" },
       }),
     );
-    const managedState = "/tmp/openclaw-update-tests/fallback-managed";
+    const managedState = path.join(fixtureRoot, "fallback-managed");
     serviceReadCommand.mockResolvedValue({
       programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
       environment: {
@@ -1829,7 +1837,7 @@ describe("update-cli", () => {
     await withEnvAsync(
       {
         OPENCLAW_PROFILE: "personal",
-        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/fallback-personal",
+        OPENCLAW_STATE_DIR: path.join(fixtureRoot, "fallback-personal"),
         OPENCLAW_GATEWAY_PORT: "19111",
       },
       async () => {
@@ -1862,7 +1870,7 @@ describe("update-cli", () => {
         candidate === path.join(process.cwd(), "package.json") ||
         candidate === path.join(process.cwd(), "openclaw.mjs"),
     );
-    const managedState = "/tmp/openclaw-update-tests/restart-doctor-managed";
+    const managedState = path.join(fixtureRoot, "restart-doctor-managed");
     serviceReadCommand.mockResolvedValue({
       programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
       environment: {
@@ -1884,7 +1892,7 @@ describe("update-cli", () => {
     await withEnvAsync(
       {
         OPENCLAW_PROFILE: "personal",
-        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/restart-doctor-personal",
+        OPENCLAW_STATE_DIR: path.join(fixtureRoot, "restart-doctor-personal"),
         OPENCLAW_GATEWAY_PORT: "19111",
       },
       async () => {

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -37,8 +37,18 @@ vi.mock("../config/config.js", () => ({
   loadConfig: () => ({}),
 }));
 
+// Per-run unique + realpath'd state dir: the apply flow writes real report dirs under it and
+// the suite rm -rf's it, so concurrent runs on one machine must never share the root (macOS
+// os.tmpdir() is a /var -> /private/var symlink).
+const testStateDir = await vi.hoisted(async () => {
+  const { mkdtemp, realpath } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  return await realpath(await mkdtemp(join(tmpdir(), "openclaw-migrate-command-test-")));
+});
+
 vi.mock("../config/paths.js", () => ({
-  resolveStateDir: () => "/tmp/openclaw-migrate-command-test",
+  resolveStateDir: () => testStateDir,
 }));
 
 vi.mock("../cli/prompt.js", () => ({
@@ -290,7 +300,7 @@ describe("migrateApplyCommand", () => {
   const originalIsTty = process.stdin.isTTY;
 
   beforeEach(async () => {
-    await fs.rm("/tmp/openclaw-migrate-command-test", { force: true, recursive: true });
+    await fs.rm(testStateDir, { force: true, recursive: true });
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
       value: false,
@@ -317,7 +327,7 @@ describe("migrateApplyCommand", () => {
       configurable: true,
       value: originalIsTty,
     });
-    await fs.rm("/tmp/openclaw-migrate-command-test", { force: true, recursive: true });
+    await fs.rm(testStateDir, { force: true, recursive: true });
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## What Problem This Solves

`src/cli/update-cli.test.ts` anchored all its fixture paths to a fixed shared root (`/tmp/openclaw-update-tests`) with deterministic per-case names (`openclaw-updated-root-6`, ...). The suite's comment claimed all I/O was mocked, but `setupUpdatedRootRefresh` really writes entrypoint files and `package.json` under those paths and registers them for recursive `fs.rm` cleanup. Two concurrent runs on one machine (CI shards, sibling checkouts) generate byte-identical paths, so one run's cleanup deletes the other run's live fixtures mid-test — observed as 34 spurious failures on PR #124997 run 31992421445 while the same head was green locally.

A sibling sweep found one more instance of the same destructive class: `src/commands/migrate.test.ts` mocks `resolveStateDir` to a fixed `/tmp/openclaw-migrate-command-test`, the apply flow really `mkdir`s report dirs under it, and both `beforeEach` and `afterEach` recursively `rm` the shared root.

## Why This Change Was Made

Repo test rules require per-run `mkdtemp` + `fs.realpath`'d roots. Both suites now derive their root from `mkdtemp` under `os.tmpdir()`, realpath'd for the macOS `/var -> /private/var` symlink, and remove it on suite exit. The eleven inline `/tmp/openclaw-update-tests/...` profile literals in update-cli were rebased onto the per-run root so the whole suite shares one unique namespace. In migrate.test.ts the unique root is computed in an async `vi.hoisted` block because the `vi.mock` factory runs during static imports.

## User Impact

None at runtime — test-only change. CI shards and sibling checkouts sharing one machine no longer produce spurious cross-run failures in these suites.

## Evidence

- Forced reproduction: running the pre-fix update-cli suite while a background loop performed a sibling run's cleanup (`rm -rf /tmp/openclaw-update-tests` every 50ms) fails 3 tests; the fixed suite under identical interference passes 240/240.
- Two plain concurrent runs of each fixed suite pass: update-cli 240/240 + 240/240, migrate 40/40 + 40/40.
- `node scripts/check-changed.mjs -- <both files>` exit 0 (core-test typecheck shards, lint, deadcode, temp-dir report: no new warnings); oxfmt/oxlint clean.
- Fresh autoreview (Codex, gpt-5.6-sol, high): clean, no accepted/actionable findings.
- Survey of other suites: fixed `/tmp` literals elsewhere are mock-only strings; two additive-only (non-destructive) fixed-mkdir cases in `extensions/browser` are flagged as a follow-up rather than expanding this diff.

Production LOC: +0/-0 | Tests: +34/-16
