### PR TITLE
fix(state): keep unresolved legacy agent state advisory

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -179,6 +179,57 @@ describe("doctor invalid config process exit", () => {
 });
 
 describe.concurrent("gateway startup-migration refusal", () => {
+  it("reaches readiness with unresolved legacy agent files left for Doctor", async () => {
+    const root = await fs.promises.realpath(tempDirs.make("openclaw-unresolved-agent-ready-"));
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    const legacyPath = path.join(stateDir, "agent", "settings.json");
+    const config = {
+      gateway: { mode: "local", auth: { mode: "none" } },
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, blocker: {}, digest: {} },
+      },
+    } satisfies OpenClawConfig;
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      NO_COLOR: "1",
+    };
+    delete env.NODE_ENV;
+    delete env.OPENCLAW_HOME;
+    delete env.VITEST;
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    fs.writeFileSync(legacyPath, '{"legacy":true}\n');
+    const preflightUrl = new URL("./doctor-config-preflight.ts", import.meta.url).href;
+    const script = `
+      const { runDoctorConfigPreflight } = await import(${JSON.stringify(preflightUrl)});
+      await runDoctorConfigPreflight({
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        observe: false,
+        requireStartupMigrationCheckpoint: true,
+      });
+      console.log("__READY__");
+    `;
+
+    const result = await runIsolatedModuleScript(env, script, { timeoutMs: 60_000 });
+    const output = `${result.stderr}\n${result.stdout}`;
+
+    expect(result.stdout, output).toContain("__READY__");
+    expect(output).toContain("Deferred legacy agent/session migration: select an agent owner");
+    expect(fs.readFileSync(legacyPath, "utf8")).toBe('{"legacy":true}\n');
+    expect(hasActiveStartupMigrationLease({ env })).toBe(false);
+  }, 75_000);
+
   it("exits cleanly after reporting the refusal once and releasing its lease", async () => {
     const temporaryRoot = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), "openclaw-startup-migration-exit-"),

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -12,6 +12,7 @@ import { resolveGatewayLockDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasActiveStartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
+import { ensureOpenClawAgentDatabaseSchema } from "../state/openclaw-agent-db.js";
 
 const STARTUP_REFUSAL =
   "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.";
@@ -121,6 +122,24 @@ function seedPluginStateConflict(stateDir: string): void {
   }
 }
 
+function seedOwnerlessSchemaOnlyAgentDatabase(stateDir: string): string {
+  const databasePath = path.join(stateDir, "agent", "openclaw-agent.sqlite");
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  const database = new DatabaseSync(databasePath);
+  try {
+    ensureOpenClawAgentDatabaseSchema(database, {
+      agentId: "openclaw",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      path: databasePath,
+      register: false,
+    });
+    database.prepare("UPDATE schema_meta SET agent_id = NULL WHERE meta_key = 'primary'").run();
+  } finally {
+    database.close();
+  }
+  return databasePath;
+}
+
 describe("doctor invalid config process exit", () => {
   it("exits after a complete best-effort report for an unparseable config", () => {
     const root = fs.realpathSync(tempDirs.make("openclaw-doctor-invalid-config-exit-"));
@@ -179,6 +198,70 @@ describe("doctor invalid config process exit", () => {
 });
 
 describe.concurrent("gateway startup-migration refusal", () => {
+  it("refuses readiness for a schema-only legacy agent database without an owner", () => {
+    const root = fs.realpathSync(tempDirs.make("openclaw-ownerless-agent-refusal-"));
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    const config = {
+      gateway: { mode: "local", auth: { mode: "none" } },
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, blocker: {}, digest: {} },
+      },
+    } satisfies OpenClawConfig;
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      NO_COLOR: "1",
+    };
+    delete env.NODE_ENV;
+    delete env.OPENCLAW_HOME;
+    delete env.VITEST;
+
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    const databasePath = seedOwnerlessSchemaOnlyAgentDatabase(stateDir);
+    const preflightUrl = new URL("./doctor-config-preflight.ts", import.meta.url).href;
+    const script = `
+      const { runDoctorConfigPreflight } = await import(${JSON.stringify(preflightUrl)});
+      try {
+        await runDoctorConfigPreflight({
+          migrateLegacyConfig: false,
+          invalidConfigNote: false,
+          observe: false,
+          requireStartupMigrationCheckpoint: true,
+        });
+        console.log("__READY__");
+      } catch (error) {
+        console.error("__REFUSED__", error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+      }
+    `;
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { cwd: path.resolve("."), encoding: "utf8", env, timeout: 60_000 },
+    );
+    const output = `${result.stderr}\n${result.stdout}`;
+
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(1);
+    expect(result.stdout, output).not.toContain("__READY__");
+    expect(result.stderr, output).toContain("__REFUSED__");
+    expect(result.stderr, output).toContain(STARTUP_REFUSAL);
+    expect(result.stderr, output).toContain(STARTUP_RECOVERY);
+    expect(result.stderr, output).toContain("agent schema owner is missing or blank");
+    expect(fs.existsSync(databasePath)).toBe(true);
+    expect(hasActiveStartupMigrationLease({ env })).toBe(false);
+  }, 75_000);
+
   it("reaches readiness with unresolved legacy agent files left for Doctor", async () => {
     const root = await fs.promises.realpath(tempDirs.make("openclaw-unresolved-agent-ready-"));
     const stateDir = path.join(root, "state");

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -78,13 +78,9 @@ import {
   detectLegacyExecApprovals,
   migrateLegacyExecApprovals,
 } from "./state-migrations.exec-approvals.js";
+import { migrationFileExists, readSessionStoreJson5, safeReadDir } from "./state-migrations.fs.js";
 import {
-  existsDir,
-  migrationFileExists,
-  readSessionStoreJson5,
-  safeReadDir,
-} from "./state-migrations.fs.js";
-import {
+  inspectLegacyAgentDir,
   migrateLegacyAgentDir,
   migrateLegacySessions,
 } from "./state-migrations.legacy-sessions.js";
@@ -211,6 +207,8 @@ const autoMigrateChecked = new Set<string>();
 
 const PLUGIN_DOCTOR_MIGRATION_LOCK_TIMEOUT_MS = 250;
 const PLUGIN_DOCTOR_MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
+const DEFERRED_LEGACY_OWNER_MESSAGE =
+  "Deferred legacy agent/session migration: select an agent owner";
 
 export function resetAutoMigrateLegacyStateForTest(): void {
   autoMigrateChecked.clear();
@@ -456,7 +454,8 @@ export async function detectLegacyStateMigrations(params: {
 
   const legacyAgentDir = path.join(stateDir, "agent");
   const targetAgentDir = path.join(stateDir, "agents", targetAgentId, "agent");
-  const hasLegacyAgentDir = existsDir(legacyAgentDir);
+  const legacyAgentDirInspection = inspectLegacyAgentDir(legacyAgentDir);
+  const hasLegacyAgentDir = legacyAgentDirInspection.status === "payload";
   const pluginStateSidecarPath = resolveLegacyPluginStateSidecarPath(stateDir);
   const hasPluginStateSidecar = migrationFileExists(pluginStateSidecarPath);
   const hasPendingPluginStateSidecarArchive = hasPendingSqliteSidecarArchive(
@@ -647,10 +646,18 @@ export async function detectLegacyStateMigrations(params: {
     Boolean(sessionMigrationAgentId) &&
     (hasLegacySessions || legacyKeys.length > 0 || hasStaleSessionFiles);
   const agentDirHasLegacy = Boolean(migrationAgentId) && hasLegacyAgentDir;
-  const deferred =
-    (!sessionMigrationAgentId &&
-      (hasLegacySessions || legacyKeys.length > 0 || hasStaleSessionFiles)) ||
-    (!migrationAgentId && hasLegacyAgentDir);
+  const deferredSessions =
+    !sessionMigrationAgentId &&
+    (hasLegacySessions || legacyKeys.length > 0 || hasStaleSessionFiles);
+  const deferredAgentDir = !migrationAgentId && hasLegacyAgentDir;
+  const deferredWarnings =
+    deferredSessions || (deferredAgentDir && params.doctorOnlyStateMigrations === true)
+      ? [DEFERRED_LEGACY_OWNER_MESSAGE]
+      : [];
+  const deferredNotices =
+    deferredAgentDir && params.doctorOnlyStateMigrations !== true
+      ? [DEFERRED_LEGACY_OWNER_MESSAGE]
+      : [];
   const preview: string[] = [];
   if (sessionsHaveLegacy && hasLegacySessions) {
     preview.push(`- Sessions: ${sessionsLegacyDir} → ${sessionsTargetDir}`);
@@ -863,9 +870,10 @@ export async function detectLegacyStateMigrations(params: {
     warnings: [
       ...pluginPlanWarnings,
       ...legacySessionSurfaces.failures,
-      ...(deferred ? ["Deferred legacy agent/session migration: select an agent owner"] : []),
+      ...(legacyAgentDirInspection.status === "failed" ? [legacyAgentDirInspection.warning] : []),
+      ...deferredWarnings,
     ],
-    notices: [],
+    notices: deferredNotices,
     preview,
   };
 }

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { SessionEntry } from "../config/sessions.js";
 import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { readExistingAgentSchemaMeta } from "../state/openclaw-agent-db-schema-helpers.js";
 import { isErrno } from "./errors.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { resolveSqliteDatabaseFilePaths } from "./sqlite-files.js";
@@ -73,13 +74,17 @@ export function inspectLegacyAgentDir(
   try {
     const opened = openNodeSqliteDatabase(databasePath, { readOnly: true });
     database = opened;
-    const schemaOwner = opened // sqlite-allow-raw -- Read-only legacy schema ownership inspection.
-      .prepare("SELECT 1 FROM schema_meta WHERE meta_key = 'primary' AND role = 'agent' LIMIT 1")
-      .get();
-    if (!schemaOwner) {
+    const schemaOwner = readExistingAgentSchemaMeta(opened);
+    if (!schemaOwner || schemaOwner.role !== "agent") {
       return legacyAgentInspectionFailure(
         `legacy agent database ${databasePath}`,
         "agent schema ownership metadata is missing",
+      );
+    }
+    if (!schemaOwner.agentId) {
+      return legacyAgentInspectionFailure(
+        `legacy agent database ${databasePath}`,
+        "agent schema owner is missing or blank",
       );
     }
     const tableNames = opened // sqlite-allow-raw -- Read-only legacy migration payload inspection.

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -2,6 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import type { SessionEntry } from "../config/sessions.js";
 import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { resolveSqliteDatabaseFilePaths } from "./sqlite-files.js";
+import { quoteSqliteIdentifier } from "./sqlite-schema-sql.js";
 import {
   ensureMigrationDir,
   migrationFileExists,
@@ -26,6 +29,79 @@ import {
 } from "./state-migrations.session-store.js";
 import type { PreparedLegacySessionSurfaces } from "./state-migrations.session-surfaces.js";
 import type { LegacyStateDetection } from "./state-migrations.types.js";
+
+const LEGACY_AGENT_DATABASE_BASENAME = "openclaw-agent.sqlite";
+
+function legacyAgentInspectionFailure(subject: string, error: unknown) {
+  return { status: "failed", warning: `Failed inspecting ${subject}: ${String(error)}` } as const;
+}
+
+export function inspectLegacyAgentDir(
+  legacyDir: string,
+): { status: "empty" | "payload" } | { status: "failed"; warning: string } {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(legacyDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { status: "empty" };
+    }
+    return legacyAgentInspectionFailure(`legacy agent directory ${legacyDir}`, error);
+  }
+  if (entries.length === 0) {
+    return { status: "empty" };
+  }
+
+  const databasePath = path.join(legacyDir, LEGACY_AGENT_DATABASE_BASENAME);
+  const databaseFiles = new Set(
+    resolveSqliteDatabaseFilePaths(databasePath).map((pathname) => path.basename(pathname)),
+  );
+  const hasFilePayload = entries.some((entry) => !databaseFiles.has(entry.name));
+  const hasDatabaseFiles = entries.some((entry) => databaseFiles.has(entry.name));
+  if (!hasDatabaseFiles) {
+    return { status: hasFilePayload ? "payload" : "empty" };
+  }
+  if (!migrationFileExists(databasePath)) {
+    return legacyAgentInspectionFailure(
+      `legacy agent database ${databasePath}`,
+      "main database is missing or not a regular file",
+    );
+  }
+
+  let database: ReturnType<typeof openNodeSqliteDatabase> | undefined;
+  try {
+    const opened = openNodeSqliteDatabase(databasePath, { readOnly: true });
+    database = opened;
+    const schemaOwner = opened // sqlite-allow-raw -- Read-only legacy schema ownership inspection.
+      .prepare("SELECT 1 FROM schema_meta WHERE meta_key = 'primary' AND role = 'agent' LIMIT 1")
+      .get();
+    if (!schemaOwner) {
+      return legacyAgentInspectionFailure(
+        `legacy agent database ${databasePath}`,
+        "agent schema ownership metadata is missing",
+      );
+    }
+    const tables = opened // sqlite-allow-raw -- Read-only legacy migration payload inspection.
+      .prepare(
+        // The excluded singleton rows are seeded schema controls, not user payload.
+        `SELECT name FROM pragma_table_list
+         WHERE schema = 'main' AND type IN ('table', 'virtual')
+           AND substr(name, 1, 7) <> 'sqlite_'
+           AND name NOT IN ('schema_meta', 'session_key_contract', 'memory_index_state')`,
+      )
+      .all() as Array<{ name: string }>;
+    const hasPayload = tables.some(({ name }) =>
+      opened // sqlite-allow-raw -- pragma-owned names stay quoted inside this bounded probe.
+        .prepare(`SELECT 1 FROM ${quoteSqliteIdentifier(name)} LIMIT 1`)
+        .get(),
+    );
+    return { status: hasPayload || hasFilePayload ? "payload" : "empty" };
+  } catch (error) {
+    return legacyAgentInspectionFailure(`legacy agent database ${databasePath}`, error);
+  } finally {
+    database?.close();
+  }
+}
 
 function normalizeMergedSessionStore(
   merged: Record<string, SessionEntryLike>,

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { SessionEntry } from "../config/sessions.js";
 import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { isErrno } from "./errors.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { resolveSqliteDatabaseFilePaths } from "./sqlite-files.js";
 import { quoteSqliteIdentifier } from "./sqlite-schema-sql.js";
@@ -43,7 +44,7 @@ export function inspectLegacyAgentDir(
   try {
     entries = fs.readdirSync(legacyDir, { withFileTypes: true });
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+    if (isErrno(error) && error.code === "ENOENT") {
       return { status: "empty" };
     }
     return legacyAgentInspectionFailure(`legacy agent directory ${legacyDir}`, error);
@@ -81,7 +82,7 @@ export function inspectLegacyAgentDir(
         "agent schema ownership metadata is missing",
       );
     }
-    const tables = opened // sqlite-allow-raw -- Read-only legacy migration payload inspection.
+    const tableNames = opened // sqlite-allow-raw -- Read-only legacy migration payload inspection.
       .prepare(
         // The excluded singleton rows are seeded schema controls, not user payload.
         `SELECT name FROM pragma_table_list
@@ -89,8 +90,13 @@ export function inspectLegacyAgentDir(
            AND substr(name, 1, 7) <> 'sqlite_'
            AND name NOT IN ('schema_meta', 'session_key_contract', 'memory_index_state')`,
       )
-      .all() as Array<{ name: string }>;
-    const hasPayload = tables.some(({ name }) =>
+      .all()
+      .flatMap((row) =>
+        row && typeof row === "object" && "name" in row && typeof row.name === "string"
+          ? [row.name]
+          : [],
+      );
+    const hasPayload = tableNames.some((name) =>
       opened // sqlite-allow-raw -- pragma-owned names stay quoted inside this bounded probe.
         .prepare(`SELECT 1 FROM ${quoteSqliteIdentifier(name)} LIMIT 1`)
         .get(),

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -19,6 +19,8 @@ import type {
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  ensureOpenClawAgentDatabaseSchema,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -456,6 +458,23 @@ function createEnv(stateDir: string): NodeJS.ProcessEnv {
   };
 }
 
+function seedSchemaOnlyLegacyAgentDatabase(stateDir: string): string {
+  const databasePath = path.join(stateDir, "agent", "openclaw-agent.sqlite");
+  fsSync.mkdirSync(path.dirname(databasePath), { recursive: true });
+  const database = new DatabaseSync(databasePath);
+  try {
+    ensureOpenClawAgentDatabaseSchema(database, {
+      agentId: "openclaw",
+      env: createEnv(stateDir),
+      path: databasePath,
+      register: false,
+    });
+  } finally {
+    database.close();
+  }
+  return databasePath;
+}
+
 type VoiceWakeRoutingTestDatabase = Pick<
   OpenClawStateKyselyDatabase,
   "voicewake_routing_config" | "voicewake_routing_routes"
@@ -876,6 +895,99 @@ describe("state migrations", () => {
     expect(result.notices).toEqual([
       expect.stringContaining("legacy main rows have no unambiguous configured owner"),
     ]);
+  });
+
+  it("ignores a schema-only legacy agent database without selecting an owner", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { main: {}, blocker: {}, digest: {} } },
+    };
+    const databasePath = seedSchemaOnlyLegacyAgentDatabase(stateDir);
+
+    const result = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.notices ?? []).not.toContain(
+      "Deferred legacy agent/session migration: select an agent owner",
+    );
+    expect(fsSync.existsSync(databasePath)).toBe(true);
+    expect(fsSync.existsSync(path.join(stateDir, "agents", "main", "agent"))).toBe(false);
+    const database = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(database.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(database.prepare("SELECT COUNT(*) AS count FROM session_nodes").get()).toEqual({
+        count: 0,
+      });
+      expect(database.prepare("SELECT COUNT(*) AS count FROM auth_profile_store").get()).toEqual({
+        count: 0,
+      });
+    } finally {
+      database.close();
+    }
+  });
+
+  it("keeps unresolved legacy agent files advisory at startup and actionable in Doctor", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { main: {}, blocker: {}, digest: {} } },
+    };
+    const legacyPath = path.join(stateDir, "agent", "settings.json");
+    fsSync.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fsSync.writeFileSync(legacyPath, '{"legacy":true}\n');
+
+    const automatic = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+
+    expect(automatic.warnings).toEqual([]);
+    expect(automatic.notices).toContain(
+      "Deferred legacy agent/session migration: select an agent owner",
+    );
+    expect(fsSync.readFileSync(legacyPath, "utf8")).toBe('{"legacy":true}\n');
+
+    resetAutoMigrateLegacyStateForTest();
+    const doctor = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      doctorOnlyStateMigrations: true,
+    });
+    expect(doctor.warnings).toContain(
+      "Deferred legacy agent/session migration: select an agent owner",
+    );
+    expect(doctor.notices ?? []).not.toContain(
+      "Deferred legacy agent/session migration: select an agent owner",
+    );
+    expect(fsSync.readFileSync(legacyPath, "utf8")).toBe('{"legacy":true}\n');
+  });
+
+  it("keeps unreadable legacy agent databases blocking", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { main: {}, blocker: {}, digest: {} } },
+    };
+    const databasePath = path.join(stateDir, "agent", "openclaw-agent.sqlite");
+    fsSync.mkdirSync(path.dirname(databasePath), { recursive: true });
+    fsSync.writeFileSync(databasePath, "not a SQLite database");
+    const settingsPath = path.join(stateDir, "agent", "settings.json");
+    fsSync.writeFileSync(settingsPath, '{"legacy":true}\n');
+
+    const result = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("Failed inspecting legacy agent database"),
+    );
+    expect(result.notices ?? []).not.toContain(
+      "Deferred legacy agent/session migration: select an agent owner",
+    );
+    expect(fsSync.readFileSync(databasePath, "utf8")).toBe("not a SQLite database");
+    expect(fsSync.readFileSync(settingsPath, "utf8")).toBe('{"legacy":true}\n');
   });
 
   it("detects no plugin-state migration warnings after the startup lease creates fresh state", async () => {

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -458,7 +458,10 @@ function createEnv(stateDir: string): NodeJS.ProcessEnv {
   };
 }
 
-function seedSchemaOnlyLegacyAgentDatabase(stateDir: string): string {
+function seedSchemaOnlyLegacyAgentDatabase(
+  stateDir: string,
+  options: { agentId?: string | null } = {},
+): string {
   const databasePath = path.join(stateDir, "agent", "openclaw-agent.sqlite");
   fsSync.mkdirSync(path.dirname(databasePath), { recursive: true });
   const database = new DatabaseSync(databasePath);
@@ -469,6 +472,11 @@ function seedSchemaOnlyLegacyAgentDatabase(stateDir: string): string {
       path: databasePath,
       register: false,
     });
+    if (options.agentId !== undefined) {
+      database
+        .prepare("UPDATE schema_meta SET agent_id = ? WHERE meta_key = 'primary'")
+        .run(options.agentId);
+    }
   } finally {
     database.close();
   }
@@ -929,6 +937,44 @@ describe("state migrations", () => {
       database.close();
     }
   });
+
+  it.each([null, "", "   "])(
+    "keeps a schema-only legacy agent database with invalid owner %j blocking",
+    async (agentId) => {
+      const root = await createTempDir();
+      const stateDir = path.join(root, ".openclaw");
+      const env = createEnv(stateDir);
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { main: {}, blocker: {}, digest: {} } },
+      };
+      const databasePath = seedSchemaOnlyLegacyAgentDatabase(stateDir, { agentId });
+
+      const automatic = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+
+      expect(automatic.warnings).toContainEqual(
+        expect.stringContaining("agent schema owner is missing or blank"),
+      );
+      expect(automatic.notices ?? []).not.toContain(
+        "Deferred legacy agent/session migration: select an agent owner",
+      );
+      expect(fsSync.existsSync(databasePath)).toBe(true);
+      expect(fsSync.existsSync(path.join(stateDir, "agents", "main", "agent"))).toBe(false);
+
+      resetAutoMigrateLegacyStateForTest();
+      const doctor = await autoMigrateLegacyState({
+        cfg,
+        env,
+        homedir: () => root,
+        doctorOnlyStateMigrations: true,
+      });
+      expect(doctor.warnings).toContainEqual(
+        expect.stringContaining("agent schema owner is missing or blank"),
+      );
+      expect(doctor.notices ?? []).not.toContain(
+        "Deferred legacy agent/session migration: select an agent owner",
+      );
+    },
+  );
 
   it("keeps unresolved legacy agent files advisory at startup and actionable in Doctor", async () => {
     const root = await createTempDir();

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import { MEMORY_INDEX_CHUNK_PROVENANCE_TABLE } from "../../packages/memory-host-sdk/src/host/memory-schema-provenance.js";
 import { MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE } from "../../packages/memory-host-sdk/src/host/memory-schema-recall.js";
 import {
@@ -246,7 +247,7 @@ export function readExistingAgentSchemaMeta(db: DatabaseSync): ExistingAgentSche
     return null;
   }
   return {
-    agentId: typeof row.agent_id === "string" ? row.agent_id : null,
+    agentId: normalizeNullableString(row.agent_id),
     role: typeof row.role === "string" ? row.role : null,
     schemaVersion: typeof row.schema_version === "number" ? row.schema_version : null,
   };

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -4098,6 +4098,28 @@ describe("openclaw agent database", () => {
     });
   });
 
+  it.each([null, "", "   "])(
+    "treats schema metadata with invalid agent owner %j as unreadable",
+    (agentId) => {
+      const stateDir = createTempStateDir();
+      const database = openOpenClawAgentDatabase({
+        agentId: "worker-1",
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+      const databasePath = database.path;
+      closeOpenClawAgentDatabasesForTest();
+      const { DatabaseSync } = requireNodeSqlite();
+      const raw = new DatabaseSync(databasePath);
+      try {
+        raw.prepare("UPDATE schema_meta SET agent_id = ? WHERE meta_key = 'primary'").run(agentId);
+      } finally {
+        raw.close();
+      }
+
+      expect(inspectOpenClawAgentDatabaseOwner(databasePath)).toEqual({ status: "unreadable" });
+    },
+  );
+
   it("migrates compact v1 session tables before applying normalized indexes", () => {
     const stateDir = createTempStateDir();
     const databasePath = path.join(


### PR DESCRIPTION
## What Problem This Solves

Gateway startup treated any legacy `agent/` directory as migration payload. A current, schema-only `openclaw-agent.sqlite` therefore required an agent owner even when every domain table was empty. In an explicit multi-agent config, the safe no-write deferral was then returned as a warning, and startup refused readiness.

## Why This Change Was Made

Legacy agent-directory inspection now has three outcomes at the migration owner: empty, payload, or failed. Schema identity and the two schema-seeded singleton controls are not user payload; any other file or populated application table is. Missing or blank ownership metadata, orphan sidecars, corrupt SQLite, and inspection failures remain blocking.

Ownerless, data-bearing agent-directory residue is preserved in place and reported as an automatic notice, matching the unresolved legacy-main precedent in #123424. Explicit Doctor repair continues to report it as an actionable warning. Ownerless legacy session-file ambiguity remains blocking; this change does not broaden that policy.

The canonical schema metadata reader now normalizes null, empty, and whitespace agent owners consistently. Migration inspection reuses that owner contract, so malformed metadata cannot be misclassified as harmless schema residue.

## User Impact

Multi-agent Gateways no longer fail startup because an old agent database contains only initialized schema. Real unresolved state remains visible without being moved to a guessed owner, while invalid or unreadable databases still fail closed.

## Evidence

- Exact head: `254f2d3f3b5b16266ff32e4d66cd9fddd4e2b098`.
- Regression-first Testbox `tbx_01m07cam0z2wpzsm928qgwxyvd` / run https://github.com/openclaw/openclaw/actions/runs/32009077528: the schema-only and real-residue cases failed on the pre-fix head because both returned the blocking owner warning.
- Regression-first readiness Testbox `tbx_01m07cgb95y7m0f0wartqz51` / run https://github.com/openclaw/openclaw/actions/runs/32009323748: real preflight refused Gateway readiness on that warning.
- Regression-first invalid-owner proof on the prior head: null and empty schema owners produced no warning, and real preflight printed `__READY__` with exit 0.
- Exact-head focused full suite: `src/state/openclaw-agent-db.test.ts` 107 passed / 4 skipped; `src/infra/state-migrations.test.ts` 89 passed; `src/commands/doctor-config-preflight.process.test.ts` 7 passed.
- Exact-head six-file changed gate passed, including formatting, environment/max-lines/assertion ratchets, dependency pins, coercion policy, dead exports, core and test typechecks, lint, native schema version, database-first policy, and zero runtime import cycles.
- Earlier immutable Testbox focused proof: https://github.com/openclaw/openclaw/actions/runs/32018692401. Earlier complete changed gate: https://github.com/openclaw/openclaw/actions/runs/32016620133.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32021738250.
- Final autoreview: clean; no accepted/actionable findings, overall correctness 0.99.
- Production LOC: +110/-14 (net +96), implementing one read-only empty/payload/failed ownership boundary and sharing canonical agent-owner normalization. Tests: +314/-0.
- No live state or managed Gateway was mutated for proof; the isolated process regression exercises the real startup migration checkpoint and readiness decision.

AI-assisted: yes.
