### PR TITLE
fix: source-external plugins fail after packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Source-external plugin runtime resolution:** keep packaged runtime entries and roots aligned when deployment replaces a flat build with a standalone plugin package, preventing valid plugins such as iMessage from failing startup boundary checks.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Source-external plugin runtime resolution:** keep packaged runtime entries and roots aligned when deployment replaces a flat build with a standalone plugin package, preventing valid plugins such as iMessage from failing startup boundary checks.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/plugins/plugin-runtime-artifact-resolution.test.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.test.ts
@@ -107,6 +107,60 @@ describe("resolvePluginRuntimeArtifact", () => {
     expect(resolved.source).not.toBe(fs.realpathSync(packageLocalSource));
   });
 
+  it.each([
+    { entryKind: "runtime" as const, sourceName: "index.ts", artifactName: "index.js" },
+    {
+      entryKind: "setup" as const,
+      sourceName: "setup-entry.ts",
+      artifactName: "setup-entry.js",
+    },
+  ])(
+    "keeps source-external $entryKind entries inside their selected root after packaging",
+    ({ entryKind, sourceName, artifactName }) => {
+      const fixture = createBundledPluginFixture();
+      const packageRoot = path.dirname(path.dirname(fixture.rootDir));
+      const source = path.join(fixture.rootDir, sourceName);
+      if (source !== fixture.source) {
+        fs.writeFileSync(source, "export default { register() {} };\n");
+      }
+      const stagingSource = path.join(
+        packageRoot,
+        "dist-runtime",
+        "extensions",
+        "fixture",
+        artifactName,
+      );
+      fs.mkdirSync(path.dirname(stagingSource), { recursive: true });
+      fs.writeFileSync(
+        stagingSource,
+        `export * from "../../../dist/extensions/fixture/${artifactName}";\n`,
+      );
+      fs.rmSync(path.dirname(fixture.builtSource), { recursive: true });
+      const packagedSource = path.join(
+        packageRoot,
+        "dist",
+        "extensions",
+        "fixture",
+        "dist",
+        artifactName,
+      );
+      fs.mkdirSync(path.dirname(packagedSource), { recursive: true });
+      fs.writeFileSync(packagedSource, 'module.exports = { id: "packed" };\n');
+
+      const resolved = resolvePluginRuntimeArtifact({
+        pluginId: "fixture",
+        entryKind,
+        rootDir: fixture.rootDir,
+        source,
+        origin: "bundled",
+        preferBuiltPluginArtifacts: true,
+        packageManifest: { build: { bundledDist: false } },
+      });
+
+      expect(resolved).toEqual({ source: fs.realpathSync(source), rootDir: fixture.rootDir });
+    },
+  );
+
   it("aliases different physical inputs for the same logical runtime entry", () => {
     const fixture = createBundledPluginFixture();
     const first = resolveFixture({

--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -117,13 +117,12 @@ function resolvePreferredBuiltRuntimeArtifact(params: {
     }
     return { source, rootDir };
   }
-  // Source-external plugins can leave package-local npm build output behind.
-  // Keep source authoritative over that output, but allow the lifecycle-owned root
-  // build to provide the fresh JavaScript artifact used by source checkouts.
-  const packageLocalArtifactSource =
-    params.packageManifest?.build?.bundledDist === false
-      ? null
-      : resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
+  // Source-external plugins keep source authoritative over package-local output;
+  // only the lifecycle-owned canonical root build may replace that pair.
+  const sourceExternal = params.packageManifest?.build?.bundledDist === false;
+  const packageLocalArtifactSource = sourceExternal
+    ? null
+    : resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
   if (packageLocalArtifactSource) {
     return { source: packageLocalArtifactSource, rootDir };
   }
@@ -140,9 +139,9 @@ function resolvePreferredBuiltRuntimeArtifact(params: {
     return { source, rootDir };
   }
   const artifactRelativePath = rewriteBundledRuntimeArtifactRelativePath(relativeSource);
-  // The runtime overlay is a staging fallback. Final canonicalization maps it
-  // to the matching root build when both exist, so one build owns execution.
-  for (const artifactRootName of ["dist-runtime", "dist"] as const) {
+  // Source-external packaging can replace the flat root build while leaving its
+  // staging wrapper behind, so only bundled artifacts may fall back to dist-runtime.
+  for (const artifactRootName of sourceExternal ? ["dist"] : ["dist-runtime", "dist"]) {
     const artifactRoot = path.join(
       packageRoot,
       artifactRootName,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where source-external bundled plugins could fail to initialize after a deployment replaced their flat root-build output with a standalone packaged runtime. The affected Gateway reported that the plugin entry escaped its root; iMessage then stayed unavailable even though its package was valid.

## Why This Change Was Made

Source-external plugins still prefer the lifecycle-owned flat `dist` build over potentially stale package-local output. They no longer fall back to the staging-only `dist-runtime` wrapper: packaging may legitimately replace the wrapper's flat target, so that wrapper cannot own a valid entry/root pair after the replacement. When the canonical flat build is absent, resolution keeps the original source entry and root together.

## User Impact

Operators can deploy a standalone packaged runtime for a source-external plugin without the Gateway rejecting that plugin during startup boundary validation. Regular bundled plugins, workspace plugins, valid flat root builds, and dist-only installs retain their existing resolution behavior.

## Evidence

- Pre-fix focused Testbox run reproduced the live shape: the new regression failed with `source=dist-runtime/extensions/fixture/index.js` and `rootDir=dist/extensions/fixture` while the other nine resolver tests passed: https://github.com/openclaw/openclaw/actions/runs/32009870929
- Post-fix focused Testbox run passed all 10 resolver tests: https://github.com/openclaw/openclaw/actions/runs/32010048070
- The final regression table covers both runtime and setup entries; current main's valid flat-build precedence remains covered separately.
- `git diff --check` passed.
- Codex autoreview reported no accepted/actionable findings on the final patch (confidence 0.97).

Provenance: regression introduced by #124639 (`eeffa53b2048a29bbb6df0bff6c600f4d3072bf8`).
