### PR TITLE
test(ui): enforce that no offered side panel dead-ends when opened cold

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
@@ -8,26 +9,39 @@ import {
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
-  name: "chat sidebar panel contract",
+  name: "chat sidebar cold-open invariant",
   startServerBeforeBrowser: true,
 });
+
+const ONE_PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nPcAAAAASUVORK5CYII=",
+  "base64",
+);
 
 type ColdOpenOutcome = {
   outcome: "content" | "generic-empty";
   emptyStateOffersAction: boolean;
 };
 
-const expectedColdOpenOutcomes: Record<string, ColdOpenOutcome> = {
-  Review: { outcome: "generic-empty", emptyStateOffersAction: false },
-  Terminal: { outcome: "content", emptyStateOffersAction: false },
-  Browser: { outcome: "generic-empty", emptyStateOffersAction: true },
-  // Files deliberately defaults to the project browser when the session has no items.
-  Files: { outcome: "content", emptyStateOffersAction: false },
-  "Side chat": { outcome: "generic-empty", emptyStateOffersAction: false },
-  Tasks: { outcome: "generic-empty", emptyStateOffersAction: false },
-  Desktop: { outcome: "content", emptyStateOffersAction: false },
-  Discussion: { outcome: "generic-empty", emptyStateOffersAction: true },
-};
+const offeredSlotLabels = [
+  "Review",
+  "Terminal",
+  "Browser",
+  "Files",
+  "Side chat",
+  "Tasks",
+  "Desktop",
+  "Discussion",
+] as const;
+
+type OfferedSlotLabel = (typeof offeredSlotLabels)[number];
+
+const actionlessEmptyStateAllowlist = new Set<OfferedSlotLabel>([
+  // Review: no git checkout, nothing to diff.
+  "Review",
+  // Tasks: no background tasks, nothing to inspect.
+  "Tasks",
+]);
 
 function coldOpenScenario(): ControlUiMockGatewayScenario {
   return {
@@ -39,6 +53,7 @@ function coldOpenScenario(): ControlUiMockGatewayScenario {
       "environments.list",
       "session.discussion.info",
       "session.discussion.open",
+      "sessions.companion.state",
       "sessions.diff",
       "sessions.files.list",
       "tasks.list",
@@ -77,11 +92,138 @@ function coldOpenScenario(): ControlUiMockGatewayScenario {
   };
 }
 
-async function openColdSidebar(page: Page) {
-  const gateway = await installMockGateway(page, coldOpenScenario());
+function populatedColdOpenScenario(): ControlUiMockGatewayScenario {
+  const sparse = coldOpenScenario();
+  return {
+    ...sparse,
+    methodResponses: {
+      ...sparse.methodResponses,
+      "browser.request": {
+        cases: [
+          {
+            match: { method: "GET", path: "/tabs" },
+            response: {
+              running: true,
+              tabs: [
+                {
+                  targetId: "target-1",
+                  tabId: "tab-1",
+                  title: "OpenClaw",
+                  url: "https://example.test/",
+                },
+              ],
+            },
+          },
+          {
+            match: { method: "POST", path: "/screenshot" },
+            response: {
+              path: "/proof/browser.png",
+              targetId: "target-1",
+              url: "https://example.test/",
+            },
+          },
+        ],
+      },
+      "environments.list": {
+        environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
+      },
+      "session.discussion.info": {
+        embedUrl: "https://discussion.example/embed/thread/session",
+        openUrl: "https://discussion.example/session",
+        state: "open",
+      },
+      "sessions.companion.state": {
+        exchanges: [
+          {
+            question: "What changed?",
+            answer: "Every offered panel now opens with useful content.",
+            ts: Date.now() - 1_000,
+          },
+        ],
+      },
+      "sessions.diff": {
+        additions: 1,
+        baseRef: "main",
+        branch: "feature/sidebar-invariant",
+        deletions: 0,
+        files: [
+          {
+            additions: 1,
+            deletions: 0,
+            patch: [
+              "diff --git a/README.md b/README.md",
+              "--- a/README.md",
+              "+++ b/README.md",
+              "@@ -1 +1,2 @@",
+              " OpenClaw",
+              "+Cold-open invariant",
+              "",
+            ].join("\n"),
+            path: "README.md",
+            status: "modified",
+          },
+        ],
+        root: "/tmp/checkout",
+        sessionKey: "main",
+      },
+      "sessions.files.list": {
+        browser: {
+          entries: [{ kind: "file", name: "README.md", path: "README.md" }],
+          path: "",
+        },
+        files: [
+          {
+            kind: "modified",
+            missing: false,
+            name: "README.md",
+            path: "/tmp/checkout/README.md",
+            size: 128,
+          },
+        ],
+        gitCheckout: true,
+        root: "/tmp/checkout",
+        sessionKey: "main",
+      },
+      "tasks.list": {
+        tasks: [
+          {
+            agentId: "main",
+            createdAt: Date.now() - 2_000,
+            id: "task-sidebar-invariant",
+            kind: "subagent",
+            ownerKey: "main",
+            progressSummary: "Checking every offered panel",
+            runtime: "subagent",
+            startedAt: Date.now() - 1_000,
+            status: "running",
+            taskId: "task-sidebar-invariant",
+            title: "Verify cold-open behavior",
+            updatedAt: Date.now(),
+          },
+        ],
+      },
+      "terminal.open": {
+        agentId: "main",
+        confined: false,
+        cwd: "/tmp/checkout",
+        sessionId: "cold-open-terminal",
+        shell: "/bin/zsh",
+      },
+    },
+    workspace: "/tmp/checkout",
+    workspaceGit: true,
+  };
+}
+
+async function openColdSidebar(page: Page, scenario = coldOpenScenario()) {
+  await page.route("**/__openclaw__/assistant-media?*", (route) =>
+    route.fulfill({ body: ONE_PIXEL_PNG, contentType: "image/png" }),
+  );
+  const gateway = await installMockGateway(page, scenario);
   await page.goto(`${suite.server.baseUrl}chat`);
   await waitForControlUiGatewayReady(page);
   await gateway.waitForRequest("session.discussion.info");
+  await gateway.waitForRequest("sessions.companion.state");
   await gateway.waitForRequest("sessions.files.list");
   await page.getByRole("button", { name: "Side panel", exact: true }).first().click();
   const choices = page.locator(".side-panel-empty__type");
@@ -98,8 +240,42 @@ async function readColdOpenOutcome(page: Page): Promise<ColdOpenOutcome> {
   return {
     outcome: genericEmptyState ? "generic-empty" : "content",
     emptyStateOffersAction:
-      genericEmptyState && (await emptyState.locator('[slot="action"]').count()) > 0,
+      genericEmptyState &&
+      (await activePanel.locator('[slot="action"], a[href], button:not([disabled])').count()) > 0,
   };
+}
+
+async function offeredLabels(page: Page, scenario: ControlUiMockGatewayScenario) {
+  const choices = await openColdSidebar(page, scenario);
+  return choices.locator(".side-panel-type-option__label").allTextContents();
+}
+
+async function readSlotColdOpenOutcome(
+  label: OfferedSlotLabel,
+  scenario: ControlUiMockGatewayScenario,
+  expectedOutcome?: ColdOpenOutcome["outcome"],
+): Promise<ColdOpenOutcome> {
+  const context = await suite.newBrowserContext({ serviceWorkers: "block" });
+  try {
+    const page = await context.newPage();
+    const choices = await openColdSidebar(page, scenario);
+    await choices.filter({ hasText: label }).click();
+    if (expectedOutcome) {
+      await expect
+        .poll(() => readColdOpenOutcome(page), { message: `${label} cold-open outcome` })
+        .toMatchObject({ outcome: expectedOutcome });
+    } else {
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+    }
+    return await readColdOpenOutcome(page);
+  } finally {
+    await suite.closeBrowserContext(context);
+  }
 }
 
 suite.define(() => {
@@ -126,28 +302,48 @@ suite.define(() => {
     await suite.closeBrowserContext(context);
   });
 
-  it("accounts for every offered slot when opened cold", async () => {
+  it("renders content for every offered slot with backing data", async () => {
     const probeContext = await suite.newBrowserContext({ serviceWorkers: "block" });
-    const probePage = await probeContext.newPage();
-    const choices = await openColdSidebar(probePage);
-    const offered = await choices.locator(".side-panel-type-option__label").allTextContents();
-    await suite.closeBrowserContext(probeContext);
-
-    expect(offered).toEqual(Object.keys(expectedColdOpenOutcomes));
-
-    const outcomes: Record<string, ColdOpenOutcome> = {};
-    for (const label of offered) {
-      const context = await suite.newBrowserContext({ serviceWorkers: "block" });
-      const page = await context.newPage();
-      const coldChoices = await openColdSidebar(page);
-      await coldChoices.filter({ hasText: label }).click();
-      await expect
-        .poll(() => readColdOpenOutcome(page), { message: `${label} cold-open outcome` })
-        .toEqual(expectedColdOpenOutcomes[label]);
-      outcomes[label] = await readColdOpenOutcome(page);
-      await suite.closeBrowserContext(context);
+    try {
+      const offered = await offeredLabels(
+        await probeContext.newPage(),
+        populatedColdOpenScenario(),
+      );
+      expect(offered).toEqual(offeredSlotLabels);
+    } finally {
+      await suite.closeBrowserContext(probeContext);
     }
 
-    expect(outcomes).toEqual(expectedColdOpenOutcomes);
+    for (const label of offeredSlotLabels) {
+      expect(
+        await readSlotColdOpenOutcome(label, populatedColdOpenScenario(), "content"),
+        `${label} must render content when its backing capability has data`,
+      ).toEqual({ outcome: "content", emptyStateOffersAction: false });
+    }
+  });
+
+  it("keeps generic empty states actionable or explicitly allowlisted", async () => {
+    const probeContext = await suite.newBrowserContext({ serviceWorkers: "block" });
+    try {
+      const offered = await offeredLabels(await probeContext.newPage(), coldOpenScenario());
+      expect(offered).toEqual(offeredSlotLabels);
+    } finally {
+      await suite.closeBrowserContext(probeContext);
+    }
+
+    const observedActionlessEmptyStates: OfferedSlotLabel[] = [];
+    for (const label of offeredSlotLabels) {
+      const outcome = await readSlotColdOpenOutcome(label, coldOpenScenario());
+      if (outcome.outcome !== "generic-empty" || outcome.emptyStateOffersAction) {
+        continue;
+      }
+      expect(
+        actionlessEmptyStateAllowlist.has(label),
+        `${label} renders the generic empty state without an action`,
+      ).toBe(true);
+      observedActionlessEmptyStates.push(label);
+    }
+
+    expect(observedActionlessEmptyStates).toEqual([...actionlessEmptyStateAllowlist]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`chat-sidebar-panel-contract.e2e.test.ts` was introduced in #124950 as a *characterization* test: it
recorded what each offered side-panel slot does when opened cold, including the answers that were wrong on
purpose, so the refactors in this series could not change behavior by accident. Four PRs later the wrong
answers are fixed, and a recording of current behavior is no longer the right shape — it documents the
present instead of preventing a repeat.

The bug class it needs to prevent is the one that shipped as #124824: a slot gets promoted to a
user-openable destination without anyone deciding what it shows when reached cold, and the result is a panel
named Review that renders "Open a change, file, image, or tool result to review it here." on a session full
of changes.

## Why This Change Was Made

The obvious invariant — "every offered slot renders content or an empty state with an action" — is not
directly enforceable. Some empty states are legitimately actionless: Review on a session with no git
checkout has nothing to diff, and inventing an action there would be worse than the placeholder. A test
demanding an action everywhere would either fail honest cases or get weakened until it meant nothing.

So it is two falsifiable parts:

1. **Capability present ⇒ content.** For every offered slot, in a scenario where its backing capability is
   advertised *and* has data, cold-open must render slot content and never the generic empty state. This is
   the actual anti-dead-end guarantee, and it is exactly what #124824 violated.
2. **No silent placeholder.** A slot rendering the generic empty state must name an action or appear in a
   short allowlist, each entry commented with why no action exists.

Both tests first assert the offered-slot list itself, so a newly added slot fails until it is explicitly
covered rather than silently escaping the sweep. The allowlist check is bidirectional — the final assertion
compares observed actionless empty states against the allowlist exactly — so a stale entry fails once its
slot is fixed and the list cannot rot.

Allowlist, in full:

- **Review** — no git checkout, nothing to diff.
- **Tasks** — no background tasks, nothing to inspect.

Side chat is deliberately *not* allowlisted: its starter questions are actionable controls, so it satisfies
part 2 on merit.

## User Impact

None — test-only. This PR ships zero production lines; it locks in the behavior the previous four
established.

## Evidence

A guard nobody has seen fail is an assumption, so the invariant was proven by breaking a slot on purpose.
Files' content resolution was temporarily disabled locally, producing this (then reverted):

```
× chat sidebar cold-open invariant > renders content for every offered slot with backing data
   → Files cold-open outcome: expected { outcome: 'generic-empty', …(1) } to match object { outcome: 'content' }
× chat sidebar cold-open invariant > keeps generic empty states actionable or explicitly allowlisted
   → Files renders the generic empty state without an action: expected false to be true
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

Both parts caught it, and each message names the offending slot.

Passing, with the rest of the series' guards unchanged:

```
 Test Files  3 passed (3)      Tests  14 passed (14)
 Test Files  2 passed (2)      Tests  33 passed (33)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `+0 / −0`, tests `+231 / −35`. Series production
total across all five PRs: −17 (#124950) +11 (#125019) +7 (#125105) −5 (#125138) +0 here = **net −4**.

No `CHANGELOG.md` edit — release-only per repo policy; test-only change.
