### PR TITLE
fix(runtime): restore environment variable count ratchet

### DIFF
--- a/node-version.d.mts
+++ b/node-version.d.mts
@@ -10,4 +10,4 @@ export function isNodeVersionAtLeast(
   minimum: NodeReleaseVersion,
 ): boolean;
 export function isSupportedOpenClawNodeVersion(value: unknown): boolean;
-export const OPENCLAW_PROCESS_NODE_VERSION_CHECK: string;
+export const PROCESS_NODE_VERSION_CHECK: string;

--- a/node-version.mjs
+++ b/node-version.mjs
@@ -73,4 +73,4 @@ function renderProcessNodeVersionCheck() {
 
 // Worker bootstrap runs before OpenClaw is transferred. Carry the canonical
 // release policy as a self-contained expression instead of a second parser.
-export const OPENCLAW_PROCESS_NODE_VERSION_CHECK = renderProcessNodeVersionCheck();
+export const PROCESS_NODE_VERSION_CHECK = renderProcessNodeVersionCheck();

--- a/src/gateway/worker-environments/bootstrap.test.ts
+++ b/src/gateway/worker-environments/bootstrap.test.ts
@@ -5,7 +5,7 @@ import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import {
   isSupportedOpenClawNodeVersion,
-  OPENCLAW_PROCESS_NODE_VERSION_CHECK,
+  PROCESS_NODE_VERSION_CHECK,
 } from "../../../node-version.mjs";
 import { NODE_RELEASE_VERSION_CASES } from "../../../test/helpers/node-version-cases.js";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
@@ -392,15 +392,15 @@ describe("bootstrapWorker", () => {
     ).rejects.toThrow("Node 22.22.3+, 24.15.0+, or 25.9.0+ with WAL-reset-safe SQLite");
     expect(runner.calls).toHaveLength(2);
     expect(runner.calls[0]?.options.input).toContain(
-      `const nodeSafe = ${OPENCLAW_PROCESS_NODE_VERSION_CHECK};`,
+      `const nodeSafe = ${PROCESS_NODE_VERSION_CHECK};`,
     );
     expect(runner.calls[0]?.options.input).toContain("SELECT sqlite_version() AS version");
   });
 
   it("embeds a shell-safe Node release check matching the canonical contract", () => {
-    expect(OPENCLAW_PROCESS_NODE_VERSION_CHECK).not.toContain("'");
+    expect(PROCESS_NODE_VERSION_CHECK).not.toContain("'");
     for (const version of NODE_RELEASE_VERSION_CASES) {
-      const actual = runInNewContext(OPENCLAW_PROCESS_NODE_VERSION_CHECK, {
+      const actual = runInNewContext(PROCESS_NODE_VERSION_CHECK, {
         process: { versions: { node: version } },
       });
       expect(actual, version).toBe(isSupportedOpenClawNodeVersion(version));

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { OPENCLAW_PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
+import { PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
 import {
   type WorkerAdmissionHandshake,
   WORKER_PROTOCOL_MAX_FEATURE_LENGTH,
@@ -78,7 +78,7 @@ export function workerBootstrapOperationTimeoutMs(artifact: WorkerInstallationAr
 }
 
 const NODE_RUNTIME_CHECK_JS = String.raw`const parse = (value) => /^(\d+)\.(\d+)\.(\d+)$/.exec(value)?.slice(1).map(Number); const atLeast = (version, floor) => version[0] > floor[0] || (version[0] === floor[0] && (version[1] > floor[1] || (version[1] === floor[1] && version[2] >= floor[2])));
-const nodeSafe = ${OPENCLAW_PROCESS_NODE_VERSION_CHECK};
+const nodeSafe = ${PROCESS_NODE_VERSION_CHECK};
 if (!nodeSafe) process.exit(1);
 try { const { DatabaseSync } = require("node:sqlite"); const db = new DatabaseSync(":memory:");
   const sqlite = parse(String(db.prepare("SELECT sqlite_version() AS version").get()?.version ?? ""));


### PR DESCRIPTION
Related: #124812

## What Problem This Solves

Fixes an issue where the environment-variable count ratchet failed on current `main` because a non-environment exported identifier was mistaken for a new `OPENCLAW_*` variable.

## Why This Change Was Made

Renames the worker bootstrap expression export to the semantic `PROCESS_NODE_VERSION_CHECK` across its declaration, type, production consumer, and existing tests. The environment-variable budget remains unchanged, and runtime behavior is unchanged.

## User Impact

Maintainers can run the environment-variable count ratchet successfully again without raising its budget or treating an internal identifier as configuration surface.

## Evidence

- Before: `OPENCLAW_* count 502 exceeds budget 501`
- After: `node --import tsx scripts/check-env-var-count.mts --base origin/main` → `OPENCLAW_* count 501/501`
- `node scripts/run-vitest.mjs src/gateway/worker-environments/bootstrap.test.ts` → 36 passed
- `node scripts/check-changed.mjs -- node-version.mjs node-version.d.mts src/gateway/worker-environments/bootstrap.ts src/gateway/worker-environments/bootstrap.test.ts` → passed (ratchets, formatting, typechecks, lint, import cycles)
- Fresh autoreview: clean, no accepted/actionable findings; patch correct (0.99 confidence)
- Toolchain: Node v24.15.0, pnpm 11.15.1; `OPENCLAW_SKIP_PROVIDERS=1`, `OPENCLAW_SKIP_CHANNELS=1`
