### PR TITLE
fix(browser): clean up direct relay during shutdown

### DIFF
--- a/extensions/browser/plugin-registration.shutdown.test.ts
+++ b/extensions/browser/plugin-registration.shutdown.test.ts
@@ -1,0 +1,74 @@
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerBrowserPlugin } from "./plugin-registration.js";
+
+const runtimeMocks = vi.hoisted(() => ({
+  handleGatewayExtensionUpgrade: vi.fn(async () => true),
+  stopBrowserControlService: vi.fn(async () => undefined),
+}));
+
+vi.mock("./register.runtime.js", () => ({
+  stopBrowserControlService: runtimeMocks.stopBrowserControlService,
+}));
+
+vi.mock("./src/browser/extension-relay/gateway-relay-route.js", () => ({
+  handleGatewayExtensionUpgrade: runtimeMocks.handleGatewayExtensionUpgrade,
+}));
+
+vi.mock("./src/browser/session-tab-store.js", () => ({
+  initializeBrowserSessionTabStore: vi.fn(),
+}));
+
+vi.mock("./src/browser/system-profile-import-state.js", () => ({
+  configureSystemProfileImportStateStore: vi.fn(),
+}));
+
+function registerLifecycleCallbacks() {
+  let route: Parameters<OpenClawPluginApi["registerHttpRoute"]>[0] | undefined;
+  let service: OpenClawPluginService | undefined;
+  registerBrowserPlugin(
+    createTestPluginApi({
+      runtime: {
+        state: { openKeyedStore: vi.fn() },
+      } as never,
+      registerHttpRoute(value) {
+        route = value;
+      },
+      registerService(value) {
+        service = value;
+      },
+    }),
+  );
+  if (!route?.handleUpgrade || !service?.stop) {
+    throw new Error("expected browser relay route and service lifecycle");
+  }
+  return { handleUpgrade: route.handleUpgrade, stop: service.stop };
+}
+
+describe("browser relay shutdown registration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps shutdown lazy until direct relay activity prepares teardown", async () => {
+    const coldLifecycle = registerLifecycleCallbacks();
+
+    await coldLifecycle.stop({} as never);
+
+    expect(runtimeMocks.stopBrowserControlService).not.toHaveBeenCalled();
+
+    const { handleUpgrade, stop } = registerLifecycleCallbacks();
+    const req = {} as IncomingMessage;
+    const socket = {} as Duplex;
+    const head = Buffer.alloc(0);
+
+    await expect(handleUpgrade(req, socket, head)).resolves.toBe(true);
+    await stop({} as never);
+
+    expect(runtimeMocks.handleGatewayExtensionUpgrade).toHaveBeenCalledWith(req, socket, head);
+    expect(runtimeMocks.stopBrowserControlService).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -277,6 +277,8 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
       res.end("Upgrade Required: connect the OpenClaw Chrome extension over WebSocket.");
     },
     handleUpgrade: async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+      // Direct relay activity prepares the teardown module consumed by lazy service shutdown.
+      await loadBrowserRegistrationRuntimeModule();
       const { handleGatewayExtensionUpgrade } =
         await import("./src/browser/extension-relay/gateway-relay-route.js");
       return await handleGatewayExtensionUpgrade(req, socket, head);


### PR DESCRIPTION
Refs #124582

## What Problem This Solves

Fixes an issue where a Gateway that accepted a direct Browser extension relay connection could skip Browser relay cleanup during shutdown or restart. The direct `/browser/extension` path could own live WebSocket clients and Browser control state while the lazy Browser service still appeared unused.

## Why This Change Was Made

The direct upgrade handler imported the relay route without preparing the Browser registration runtime. The service shutdown owner checks that existing lazy runtime with `peek()`, so it returned before the canonical `stopBrowserControlService` teardown.

The best fix is to prepare the existing registration runtime before direct relay activity creates Browser-owned state. This preserves cold startup laziness and routes shutdown through the existing control-service/relay cleanup owner. I rejected eagerly loading Browser at plugin registration, adding a second lifecycle flag, and disposing relay state directly from the route because those options either break laziness or duplicate teardown policy.

This is a narrow follow-up to the unresolved exact-head P1 on #124582. Credit to @steipete for the prepared Gateway shutdown work and for landing the owner boundary this repair completes.

## User Impact

Gateway shutdown and restart now close Browser relay clients and Browser control state after direct extension relay use. Browser remains unloaded when operators do not use it.

## Evidence

- Parent red on current-main owner behavior: `node scripts/run-vitest.mjs extensions/browser/plugin-registration.shutdown.test.ts` ran 2 tests with 1 pass and 1 failure; after a direct upgrade, the expected canonical stop call was `1` but observed `0`. The cold-shutdown control passed.
- Exact post-fast-forward green on Node 24.15: `node scripts/run-vitest.mjs extensions/browser/plugin-registration.shutdown.test.ts extensions/browser/index.test.ts extensions/browser/src/plugin-service.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts` passed 4 files and 42 tests.
- The current single regression case is self-contained: it proves cold stop stays lazy, then advances through direct relay activity and proves canonical teardown runs. The Browser test runner resets modules and mocks between files.
- `pnpm format extensions/browser/plugin-registration.ts extensions/browser/plugin-registration.shutdown.test.ts` passed.
- `node scripts/run-oxlint.mjs --openclaw-focused-config extensions/browser/plugin-registration.ts extensions/browser/plugin-registration.shutdown.test.ts` passed.
- `git diff --check` passed.
- Local changed-lane guards and Browser diagnostics passed. The broad extensions type preparation remained blocked only by unrelated current-checkout base diagnostics in `extensions/cua-computer/**` / `packages/terminal-core/src/ansi.ts`; exact-head CI is authoritative for those shared lanes.
- Dirty autoreview: clean, no accepted/actionable finding. Independent read-only Codex review: clean, no P0/P1 finding.
- Production LOC: `+2/-0` (one invariant comment and one existing-loader call). Test LOC: `+74/-0`. No dependency, config, SDK, protocol, schema, or public API change.


### Real Gateway and direct WebSocket proof

- Exact PR head: `3870829db9447feb84a4af34d415a29d719fdc30`; Node `v24.19.0`; OpenClaw `2026.8.1 (3870829)`.
- Inspectable proof: [successful Actions run](https://github.com/Alix-007/openclaw/actions/runs/32025171818) using the [proof-only harness and workflow](https://github.com/Alix-007/openclaw/tree/9177f62a2c810beafff1e56c4980ee79f30b882f). The workflow copies the harness aside, checks out the exact PR head, then runs a real built Gateway and a real direct relay WebSocket client.
- Cold service stop: Browser registration-runtime resolves `0`; direct-relay events `0`; relay and Gateway ports both closed. This proves the repair preserves lazy Browser startup.
- After direct `/browser/extension` activity: the client opened, then Gateway shutdown produced `browser.runtime.resolve -> direct.handleUpgrade -> direct.socket.terminate -> direct.server.close`; the client received close code `1001` with reason `relay stopped`; relay and Gateway ports both closed.
- Test result: `1` file / `1` test passed; behavior `48.96s`; exact-head build and full proof `436.61s`.
- Artifact `pr125176-browser-relay-shutdown-proof-32025171818-1` is attached to the run. Archive SHA-256: `5ff42f51f1d53ba19e91848a36fd7b579673ff0febdd44a775fb5b452ebc8aeb`. `result.json` SHA-256: `b3fe9f4b08f4b9fd40e6bfbe01c343956593d0d9a8a337cb22c4af117688e4b5`; full `run.log` SHA-256: `972231dbf7b42e44babcc2246f19a00dcad0510bf0734d456292c28597271773`.
