### PR TITLE
fix(telegram): pick the final album message id after sorting, not before

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -269,8 +269,10 @@ export function createTelegramInboundMedia({
 
   const processMediaGroup = async (entry: BufferedMediaGroupEntry) => {
     try {
-      const finalIngressMessageId = entry.messages.at(-1)?.msg.message_id;
+      // Album entries arrive in update order, which need not match message_id
+      // order — sort first, then take the final message id.
       entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);
+      const finalIngressMessageId = entry.messages.at(-1)?.msg.message_id;
       let primary =
         entry.messages.find((item) => item.msg.caption || item.msg.text) ?? entry.messages[0];
       if (!primary) {

--- a/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
@@ -2,7 +2,10 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import {
+  telegramBotInfoForTest,
+  waitForTelegramMockCalls,
+} from "./bot.create-telegram-bot.test-support.js";
 
 const saveRemoteMedia = vi.fn();
 const saveMediaBuffer = vi.fn();
@@ -294,4 +297,43 @@ describe("createTelegramBot media-group skip warning (#55216)", () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  it("binds the album identity to the final message when updates arrive out of order", async () => {
+    setOpenChannelPostConfig();
+    saveRemoteMedia.mockImplementation(async () => ({
+      path: "/tmp/p.jpg",
+      contentType: "image/png",
+    }));
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const handler = getChannelPostHandler();
+      // The higher message_id arrives first: update arrival order need not
+      // match message_id order, so the final id must be picked after sorting.
+      await handler(
+        createChannelPostContext({
+          messageId: 9202,
+          date: 1736380801,
+          mediaGroupId: "ooo-album",
+          photoFileId: "p2",
+        }),
+      );
+      await handler(
+        createChannelPostContext({
+          messageId: 9201,
+          date: 1736380800,
+          caption: "album caption",
+          mediaGroupId: "ooo-album",
+          photoFileId: "p1",
+        }),
+      );
+      await flushChannelPostMediaGroup(setTimeoutSpy);
+      await waitForTelegramMockCalls(replySpy, 1);
+      const ctx = replySpy.mock.calls.at(0)?.[0] as Record<string, unknown>;
+      expect(ctx?.MessageSid).toBe("9202");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });
+


### PR DESCRIPTION
## Summary

fix(telegram): pick an album's canonical message id after sorting the buffered updates, so out-of-order arrival no longer pins the group's identity to a middle message

## What Problem This Solves

Telegram albums (media groups) arrive as one update per photo, processed by concurrent handlers and buffered in arrival order. When the buffer flushes, `processMediaGroup` builds one synthesized inbound message and stamps it with the album's "final" message id:

```ts
// extensions/telegram/src/bot-handlers.inbound-media.ts
const finalIngressMessageId = entry.messages.at(-1)?.msg.message_id;  // taken BEFORE sorting
entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);   // sorted only after
```

The `sort` on the next line exists precisely because arrival order need not match `message_id` order — but `at(-1)` reads the buffer **before** that sort. Whenever updates arrive out of order, `finalIngressMessageId` is not the album's final message.

The value becomes the group's canonical identity: `messageIdOverride` → `ctxPayload.MessageSid` and the frozen ingress admission binding (`ingressContextBinding.messageId`). Downstream reply anchoring, dedupe, and the admission audit trail all reference the wrong message.

**代码证据**: `extensions/telegram/src/bot-handlers.inbound-media.ts:271-272`. The sibling text-fragment path in the same feature area (`bot-handlers.inbound-buffer.ts`) sorts **before** taking `at(-1)` — the two paths contradict each other, showing this is a misplaced line, not a design choice.

Trigger condition: any album whose updates arrive out of `message_id` order (concurrent handler processing makes this routine).

## Root Cause

- Introduced in commit `97a53a9b35a` (2026-08-14, #122863, "audit admitted channel participant identity"), which added the `finalIngressMessageId` read one line above the existing sort.
- Violated invariant: the album's canonical id must be the maximum `message_id` of the group. Reading an unordered buffer's last element only satisfies that invariant by luck.

## Why This Fix

- Option A (chosen): move the read below the sort — one line, matches the text-fragment path's existing pattern exactly.
- Option B: compute `Math.max(...)` independently of the sort. Equivalent result but duplicates what the sort already establishes; the reorder is the smaller, idiomatic change.

## User Impact

- Affected scenarios: Telegram albums arriving out of order.
- Before: the synthesized message is identified by a middle photo's id; replies/audit reference the wrong message.
- After: the identity is always the album's final message id.
- Behavior change: identity is now deterministic regardless of arrival order.

## Evidence

Real pipeline driven through the repo's own bot harness (`bot.create-telegram-bot` channel_post media-group tests): a real two-photo album is submitted with the higher `message_id` arriving first, and the resulting inbound context's `MessageSid` is read off the reply dispatch. Only the Bot API network boundary is mocked; all buffering, sorting, and context-building code is real.

### Before (on main)

```bash
$ npx vitest run ... -t "binds the album identity to the final message when updates arrive out of order"
[proof] album arrival: 9202 first, then 9201; resulting MessageSid="9201" (correct: "9202")
      Tests  1 failed | 42 skipped (43)
```

### After (with fix)

```bash
$ npx vitest run ... -t "binds the album identity to the final message when updates arrive out of order"
[proof] album arrival: 9202 first, then 9201; resulting MessageSid="9202" (correct: "9202")
      Tests  1 passed | 42 skipped (43)
```

## Tests and Validation

- New regression test `binds the album identity to the final message when updates arrive out of order` in `extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts` — fails on main (`MessageSid="9201"`), passes with the fix (`"9202"`); full file 4/4 passed. (The unrelated `drops the media group when a non-recoverable media error occurs` test fails identically on unmodified main in this Windows environment.)
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
