### PR TITLE
fix(cron): preserve caller tool authority on job updates

### DIFF
--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -342,6 +342,69 @@ describe("buildGatewayCronService", () => {
     });
   });
 
+  it.each(["update", "updateWithPrecondition"] as const)(
+    "forwards authority options through the %s lifecycle wrapper",
+    async (method) => {
+      const cfg = createCronConfig(`server-cron-update-authority-${method}`);
+      loadConfigMock.mockReturnValue(cfg);
+      const state = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: () => {},
+      });
+      const owner = {
+        agentId: "main",
+        sessionKey: "agent:main:discord:group:ops",
+        accountId: "work",
+      };
+      const scheduledToolPolicy = {
+        version: 1 as const,
+        mode: "account" as const,
+        ownerSessionKey: owner.sessionKey,
+        ownerAccountId: owner.accountId,
+      };
+      let restarted: ReturnType<typeof buildGatewayCronService> | undefined;
+
+      try {
+        const job = await state.cron.add({
+          name: `authority ${method}`,
+          enabled: true,
+          owner,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "now",
+          payload: { kind: "systemEvent", text: "run" },
+        });
+        const commitGuard = vi.fn();
+        const patch = {
+          sessionTarget: "isolated" as const,
+          payload: { kind: "agentTurn" as const, message: "updated", toolsAllow: ["write"] },
+        };
+        const options = { scheduledToolPolicy, commitGuard };
+
+        if (method === "update") {
+          await state.cron.update(job.id, patch, options);
+        } else {
+          await state.cron.updateWithPrecondition(job.id, patch, () => undefined, options);
+        }
+
+        expect.soft(commitGuard).toHaveBeenCalledOnce();
+        state.cron.stop();
+        restarted = buildGatewayCronService({
+          cfg,
+          deps: {} as CliDeps,
+          broadcast: () => {},
+        });
+        expect((await restarted.cron.readJob(job.id))?.scheduledToolPolicy).toEqual(
+          scheduledToolPolicy,
+        );
+      } finally {
+        state.cron.stop();
+        restarted?.cron.stop();
+      }
+    },
+  );
+
   it("keeps sole-agent ownerless jobs dynamic across a restart and roster rename", async () => {
     const tmpDir = path.join(os.tmpdir(), `server-cron-sole-owner-${Date.now()}`);
     const store = path.join(tmpDir, "cron.json");

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1288,12 +1288,13 @@ export function buildGatewayCronService(params: {
     }
   };
   const updateCronWithPrecondition = cron.updateWithPrecondition.bind(cron);
-  cron.update = async (jobId, patch) => {
+  cron.update = async (jobId, patch, opts) => {
     let lifecycleStop: Promise<void> | undefined;
+    const routeAfterValidation = (current: CronJob, nowMs: number) => {
+      lifecycleStop = queueStreamStopAfterValidation(current, patch, nowMs);
+    };
     try {
-      const result = await updateCronWithPrecondition(jobId, patch, (current, nowMs) => {
-        lifecycleStop = queueStreamStopAfterValidation(current, patch, nowMs);
-      });
+      const result = await updateCronWithPrecondition(jobId, patch, routeAfterValidation, opts);
       await settleStopAfterCommittedUpdate(jobId, lifecycleStop);
       await routeLiveStreamJobLogged(jobId);
       return result;
@@ -1305,13 +1306,14 @@ export function buildGatewayCronService(params: {
       throw error;
     }
   };
-  cron.updateWithPrecondition = async (jobId, patch, precondition) => {
+  cron.updateWithPrecondition = async (jobId, patch, precondition, opts) => {
     let lifecycleStop: Promise<void> | undefined;
+    const routeAfterPrecondition = async (current: CronJob, nowMs: number) => {
+      await precondition(current, nowMs);
+      lifecycleStop = queueStreamStopAfterValidation(current, patch, nowMs);
+    };
     try {
-      const result = await updateCronWithPrecondition(jobId, patch, async (current, nowMs) => {
-        await precondition(current, nowMs);
-        lifecycleStop = queueStreamStopAfterValidation(current, patch, nowMs);
-      });
+      const result = await updateCronWithPrecondition(jobId, patch, routeAfterPrecondition, opts);
       await settleStopAfterCommittedUpdate(jobId, lifecycleStop);
       await routeLiveStreamJobLogged(jobId);
       return result;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent-runtime cron job updates that changed `payload.toolsAllow` could silently lose their caller-scoped mutation authority inside the Gateway's stream-lifecycle wrapper. The dropped options skipped the commit-time liveness guard, discarded runtime-authority capture, and could persist an account-restricted tool edit with trusted provenance.

## Why This Change Was Made

Both real Gateway cron update wrappers now accept and forward `CronUpdateOptions` unchanged to the canonical store-locked mutation owner. This restores the intended caller-authority plumbing; it does not create a new authority path or synthesize policy downstream.

The regression test uses the real `buildGatewayCronService` construction for both `update` and `updateWithPrecondition`, then reopens the persisted store to verify that the account-scoped scheduled-tool policy survived. It also proves the commit guard is consumed at the mutation boundary.

## User Impact

Account-scoped cron tool-cap edits remain account-scoped, stale agent-runtime callers are revalidated at commit, and fresh runtime-authority capture reaches the persisted job as intended. Operators do not need to change configuration.

## Evidence

- Pre-fix focused regression: both real wrapper cases failed because `commitGuard` was called 0 times; the test also checks the reopened persisted job retains the supplied account-scoped policy.
- `node scripts/run-vitest.mjs src/gateway/server-cron.test.ts` — 68 passed.
- `node_modules/.bin/oxfmt --check src/gateway/server-cron.ts src/gateway/server-cron.test.ts` — passed.
- `pnpm tsgo:core` — passed.
- `pnpm tsgo:core:test` — passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-cron.ts src/gateway/server-cron.test.ts` — passed.
- `pnpm check:wrapper-shadowing` — passed.
- `git diff --check` — passed.
- Fresh autoreview: no accepted/actionable findings.
- Focused security review: no new security findings.

Local `check:changed` stops at the existing repository env-var ratchet mismatch (`502` names versus budget `501`) before reaching this diff's lanes; the committed `origin/main` index has the same mismatch and the exact current-main CI run is green. This change adds no environment variable and does not touch the budget.

Production LOC: +11/-9 (net +2) | Tests: +63/-0

AI-assisted: yes.
