### PR TITLE
fix: tool-heavy sessions survive runtime cutover

### DIFF
--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -24,15 +24,19 @@ const sessionPromptStates = resolveGlobalSingleton(
   () => new Map<string, EmbeddedSessionPromptState>(),
 );
 
+export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
+  return {
+    replacements: new Map<string, AgentMessage>(),
+    frozen: new Set<string>(),
+    ambiguousBaseKeys: new Set<string>(),
+    sourceTextByKey: new Map<string, string[]>(),
+  };
+}
+
 function createSessionPromptState(): EmbeddedSessionPromptState {
   return {
     activeProjectKeys: [],
-    toolResults: {
-      replacements: new Map<string, AgentMessage>(),
-      frozen: new Set<string>(),
-      ambiguousBaseKeys: new Set<string>(),
-      sourceTextByKey: new Map<string, string[]>(),
-    },
+    toolResults: createToolResultPromptProjectionState(),
     sentUserTurnIds: new Set<string>(),
   };
 }

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3019,6 +3019,72 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(requireCompactEmbeddedAgentSessionCall().currentTokenCount).toBeGreaterThan(100_000);
   });
 
+  it.each([
+    ["below", 20_000, false],
+    ["above", 70_000, true],
+  ])(
+    "uses a provider usage anchor older than the scan window when pressure is %s threshold",
+    async (_label, providerPromptTokens, shouldCompact) => {
+      await writeTestSessionTranscript({
+        rootDir,
+        events: [
+          ...Array.from({ length: 50 }, () => ({
+            type: "message" as const,
+            message: { role: "user" as const, content: "x".repeat(8_192) },
+          })),
+          {
+            type: "message",
+            message: {
+              role: "assistant",
+              content: "usage anchor",
+              usage: {
+                input: providerPromptTokens,
+                output: 100,
+                totalTokens: providerPromptTokens + 100,
+                contextUsage: {
+                  state: "available",
+                  promptTokens: providerPromptTokens,
+                  totalTokens: providerPromptTokens + 100,
+                },
+              },
+            },
+          },
+          ...Array.from({ length: 520 }, () => ({
+            type: "message" as const,
+            message: { role: "user" as const, content: "x".repeat(64) },
+          })),
+        ],
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokensFresh: false,
+        agentHarnessId: "codex",
+        agentRuntimeOverride: "openclaw",
+      };
+
+      await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          provider: "openai",
+          model: "gpt-5.5",
+          sessionId: "session",
+          sessionKey: "main",
+        }),
+        defaultModel: "gpt-5.5",
+        modelContextTokens: 100_000,
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        sessionKey: "main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(shouldCompact ? 1 : 0);
+    },
+  );
+
   it("does not use the active run sessionFile when the session entry has no transcript path", async () => {
     const sessionFile = path.join(rootDir, "active-run-session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -10,6 +10,7 @@ import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   loadSessionEntry,
+  readSessionTranscriptMessageEvents,
   readSessionTranscriptActiveStats,
   readTranscriptStatsSync,
   upsertSessionEntryCore,
@@ -2860,6 +2861,123 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(entry).toBe(sessionEntry);
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["without provider usage", undefined],
+    ["after provider usage", 20_000],
+  ])(
+    "estimates Codex tool-result mirrors through the provider projection %s after runtime cutover",
+    async (_label, providerPromptTokens) => {
+      const storePath = path.join(rootDir, "sessions.json");
+      const sessionKey = "agent:main:telegram:default:direct:12345";
+      const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+      const output = "x".repeat(8_192);
+      await writeTestSessionTranscript({
+        rootDir,
+        sessionKey,
+        events: [
+          ...(providerPromptTokens === undefined
+            ? []
+            : [
+                {
+                  type: "message" as const,
+                  message: {
+                    role: "assistant" as const,
+                    content: "Codex usage anchor",
+                    usage: {
+                      input: providerPromptTokens,
+                      output: 100,
+                      totalTokens: providerPromptTokens + 100,
+                      contextUsage: {
+                        state: "available" as const,
+                        promptTokens: providerPromptTokens,
+                        totalTokens: providerPromptTokens + 100,
+                      },
+                    },
+                  },
+                },
+              ]),
+          ...Array.from({ length: 64 }, (_, index) => {
+            const toolCallId = `call-${index}`;
+            return [
+              {
+                type: "message" as const,
+                message: {
+                  role: "assistant" as const,
+                  content: [{ type: "toolCall", id: toolCallId, name: "exec", arguments: {} }],
+                  usage: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                    totalTokens: 0,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+                  },
+                },
+              },
+              {
+                type: "message" as const,
+                message: {
+                  role: "toolResult" as const,
+                  toolCallId,
+                  toolName: "exec",
+                  isError: false,
+                  content: [
+                    {
+                      type: "toolResult",
+                      id: toolCallId,
+                      name: "exec",
+                      toolName: "exec",
+                      toolCallId,
+                      toolUseId: toolCallId,
+                      tool_use_id: toolCallId,
+                      text: output,
+                      content: output,
+                    },
+                  ],
+                },
+              },
+            ];
+          }).flat(),
+        ],
+      });
+      const transcriptBefore = readSessionTranscriptMessageEvents(scope);
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokensFresh: false,
+        agentHarnessId: "codex",
+        agentRuntimeOverride: "openclaw",
+      };
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason: "guard_blocked",
+      });
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          provider: "openai",
+          model: "gpt-5.5",
+          sessionId: "session",
+          sessionKey,
+        }),
+        defaultModel: "gpt-5.5",
+        modelContextTokens: 128_000,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+      expect(readSessionTranscriptMessageEvents(scope)).toEqual(transcriptBefore);
+    },
+  );
 
   it("does not use the active run sessionFile when the session entry has no transcript path", async () => {
     const sessionFile = path.join(rootDir, "active-run-session.jsonl");

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3098,8 +3098,8 @@ describe("runMemoryFlushIfNeeded", () => {
         {
           type: "message",
           message: {
-            role: "tool",
-            content: `large interrupted tool output ${"x".repeat(450_000)}`,
+            role: "user",
+            content: `large follow-up ${"x".repeat(450_000)}`,
           },
         },
       ],
@@ -3155,8 +3155,8 @@ describe("runMemoryFlushIfNeeded", () => {
         {
           type: "message",
           message: {
-            role: "tool",
-            content: `moderate interrupted tool output ${"x".repeat(36_000)}`,
+            role: "user",
+            content: `moderate follow-up ${"x".repeat(36_000)}`,
           },
         },
       ],

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2979,6 +2979,46 @@ describe("runMemoryFlushIfNeeded", () => {
     },
   );
 
+  it("accounts for provider-visible history beyond the recent read bounds", async () => {
+    await writeTestSessionTranscript({
+      rootDir,
+      events: Array.from({ length: 250 }, (_, index) => ({
+        type: "message" as const,
+        message: {
+          role: "user" as const,
+          content: index < 50 ? "x".repeat(8_192) : "small",
+        },
+      })),
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+      agentHarnessId: "codex",
+      agentRuntimeOverride: "openclaw",
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      modelContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(requireCompactEmbeddedAgentSessionCall().currentTokenCount).toBeGreaterThan(100_000);
+  });
+
   it("does not use the active run sessionFile when the session entry has no transcript path", async () => {
     const sessionFile = path.join(rootDir, "active-run-session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -367,6 +367,16 @@ type SessionTranscriptUsageSnapshot = {
   trailingMessages: AgentMessage[];
 };
 
+function hasUsableProviderPromptUsage(
+  usage: SessionTranscriptUsageSnapshot | undefined,
+): usage is SessionTranscriptUsageSnapshot & { promptTokens: number } {
+  return (
+    typeof usage?.promptTokens === "number" &&
+    Number.isFinite(usage.promptTokens) &&
+    usage.promptTokens > 0
+  );
+}
+
 function isUnavailableContextBarrier(
   usage: NonNullable<ReturnType<typeof normalizeUsage>>,
 ): boolean {
@@ -482,15 +492,25 @@ function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): {
 
 function readSqliteSessionLogSnapshot(
   scope: { agentId?: string; sessionId: string; sessionKey?: string; storePath: string },
-  options: { includeByteSize: boolean; includeTurnTaint?: boolean; includeUsage: boolean },
+  options: {
+    includeByteSize: boolean;
+    includeTurnTaint?: boolean;
+    includeUsage: boolean;
+    usageEventLimit?: number;
+  },
 ): SessionLogSnapshot {
   const snapshot: SessionLogSnapshot = {};
   try {
     if (options.includeByteSize) {
-      snapshot.byteSize = readSessionTranscriptActiveStats(scope).sizeBytes;
+      const stats = readSessionTranscriptActiveStats(scope);
+      snapshot.byteSize = stats.sizeBytes;
+      snapshot.eventCount = stats.eventCount;
     }
     if (options.includeUsage || options.includeTurnTaint) {
-      const events = readRecentSessionTranscriptActiveEvents(scope, SQLITE_USAGE_TAIL_MAX_EVENTS);
+      const events = readRecentSessionTranscriptActiveEvents(
+        scope,
+        options.usageEventLimit ?? SQLITE_USAGE_TAIL_MAX_EVENTS,
+      );
       if (options.includeUsage) {
         snapshot.usage = deriveTranscriptUsageSnapshot(
           readLatestNonzeroUsageSnapshotFromTranscriptEvents(events),
@@ -513,6 +533,7 @@ function readSqliteSessionLogSnapshot(
 
 type SessionLogSnapshot = {
   byteSize?: number;
+  eventCount?: number;
   turnTainted?: boolean;
   usage?: SessionTranscriptUsageSnapshot;
 };
@@ -547,6 +568,7 @@ function readSessionLogSnapshot(params: {
   includeByteSize: boolean;
   includeTurnTaint?: boolean;
   includeUsage: boolean;
+  usageEventLimit?: number;
 }): SessionLogSnapshot {
   const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
   if (params.sessionId && params.storePath && agentId) {
@@ -615,20 +637,29 @@ async function estimatePromptTokensFromSessionTranscript(params: {
       includeByteSize: true,
       includeUsage: true,
     });
-    const usage = snapshot.usage;
-    const promptTokens = usage?.promptTokens;
+    let usage = snapshot.usage;
+    if (
+      !hasUsableProviderPromptUsage(usage) &&
+      typeof snapshot.eventCount === "number" &&
+      snapshot.eventCount > SQLITE_USAGE_TAIL_MAX_EVENTS
+    ) {
+      usage = readSessionLogSnapshot({
+        agentId: params.agentId,
+        sessionId,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        includeByteSize: false,
+        includeUsage: true,
+        usageEventLimit: snapshot.eventCount,
+      }).usage;
+    }
     const normalizedOutputTokens =
       typeof usage?.outputTokens === "number" &&
       Number.isFinite(usage.outputTokens) &&
       usage.outputTokens > 0
         ? Math.ceil(usage.outputTokens)
         : undefined;
-    if (
-      usage &&
-      typeof promptTokens === "number" &&
-      Number.isFinite(promptTokens) &&
-      promptTokens > 0
-    ) {
+    if (hasUsableProviderPromptUsage(usage)) {
       const trailingMessages = usage.trailingMessages;
       const trailingTokens = await estimateProviderPromptTokensFromMessages(
         trailingMessages,
@@ -638,7 +669,7 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         return undefined;
       }
       return {
-        promptTokens: Math.ceil(promptTokens) + trailingTokens,
+        promptTokens: Math.ceil(usage.promptTokens) + trailingTokens,
         promptTokenSource:
           trailingMessages.length > 0 ? "provider_usage_plus_prompt_projection" : "provider_usage",
         outputTokens: normalizedOutputTokens,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -653,9 +653,8 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         storePath: params.storePath,
       },
       {
-        mode: "recent",
-        maxMessages: 200,
-        maxBytes: 1024 * 1024,
+        mode: "full",
+        reason: "preflight-compaction-estimate",
       },
     )) as AgentMessage[];
     const estimatedTokens = await estimateProviderPromptTokensFromMessages(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -14,6 +14,7 @@ import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { isBenignCompactionSkipResult } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
+import { createToolResultPromptProjectionState } from "../../agents/embedded-agent-runner/session-prompt-state.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
@@ -81,6 +82,8 @@ import type { ReplyOperation } from "./reply-run-registry.js";
 import { incrementCompactionCount } from "./session-updates.js";
 
 type EmbeddedAgentRuntime = typeof import("../../agents/embedded-agent.js");
+type ToolResultTruncationRuntime =
+  typeof import("../../agents/embedded-agent-runner/tool-result-truncation.js");
 type UpdateSessionEntryParams = {
   storePath: string;
   sessionKey: string;
@@ -97,6 +100,9 @@ const MAX_FLUSH_ERROR_LENGTH = 200;
 
 const embeddedAgentRuntimeLoader = createLazyImportLoader<EmbeddedAgentRuntime>(
   () => import("../../agents/embedded-agent.js"),
+);
+const toolResultTruncationRuntimeLoader = createLazyImportLoader<ToolResultTruncationRuntime>(
+  () => import("../../agents/embedded-agent-runner/tool-result-truncation.js"),
 );
 
 function loadEmbeddedAgentRuntime(): Promise<EmbeddedAgentRuntime> {
@@ -355,11 +361,10 @@ function truncateMemoryFlushErrorMessage(err: unknown): string {
     : message;
 }
 
-/** Usage snapshot read from a session transcript before compaction. */
 type SessionTranscriptUsageSnapshot = {
   promptTokens?: number;
   outputTokens?: number;
-  trailingBytesTokens?: number;
+  trailingMessages: AgentMessage[];
 };
 
 function isUnavailableContextBarrier(
@@ -377,13 +382,12 @@ function isUnavailableContextBarrier(
 // transcript reads in time to flip memory-flush gating when needed.
 const TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS = 8192;
 const SQLITE_USAGE_TAIL_MAX_EVENTS = 512;
-const FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN = 4;
 
 function deriveTranscriptUsageSnapshot(
   snapshot:
     | {
         usage?: ReturnType<typeof normalizeUsage>;
-        trailingBytes?: number;
+        trailingMessages: AgentMessage[];
       }
     | undefined,
 ): SessionTranscriptUsageSnapshot | undefined {
@@ -403,20 +407,18 @@ function deriveTranscriptUsageSnapshot(
   return {
     promptTokens,
     outputTokens,
-    trailingBytesTokens:
-      typeof snapshot.trailingBytes === "number" &&
-      Number.isFinite(snapshot.trailingBytes) &&
-      snapshot.trailingBytes >= 0
-        ? Math.ceil(snapshot.trailingBytes / FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN)
-        : undefined,
+    trailingMessages: snapshot.trailingMessages,
   };
 }
 
-function readLatestNonzeroUsageSnapshotFromTranscriptEvents(
-  events: readonly unknown[],
-): { usage: NonNullable<ReturnType<typeof normalizeUsage>>; trailingBytes: number } | undefined {
+function readLatestNonzeroUsageSnapshotFromTranscriptEvents(events: readonly unknown[]):
+  | {
+      usage: NonNullable<ReturnType<typeof normalizeUsage>>;
+      trailingMessages: AgentMessage[];
+    }
+  | undefined {
   const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
-  let trailingBytes = 0;
+  const trailingMessages: AgentMessage[] = [];
   for (const event of activeEvents.toReversed()) {
     if (!event || typeof event !== "object" || Array.isArray(event)) {
       continue;
@@ -427,7 +429,7 @@ function readLatestNonzeroUsageSnapshotFromTranscriptEvents(
     }
     const message =
       record.message && typeof record.message === "object" && !Array.isArray(record.message)
-        ? (record.message as { api?: unknown; usage?: UsageLike })
+        ? (record.message as AgentMessage & { api?: unknown; usage?: UsageLike })
         : undefined;
     const rawUsage = message?.usage ?? record.usage;
     if (message?.api === "cli" && rawUsage && rawUsage.contextUsage === undefined) {
@@ -440,12 +442,10 @@ function readLatestNonzeroUsageSnapshotFromTranscriptEvents(
       return undefined;
     }
     if (usage && hasNonzeroUsage(usage)) {
-      return { usage, trailingBytes };
+      return { usage, trailingMessages: trailingMessages.toReversed() };
     }
     if (message) {
-      // Count later conversation content, not session metadata, when projecting
-      // context growth since the most recent authoritative provider usage.
-      trailingBytes += Buffer.byteLength(JSON.stringify(message), "utf8") + 1;
+      trailingMessages.push(message);
     }
   }
   return undefined;
@@ -565,17 +565,42 @@ function readSessionLogSnapshot(params: {
 
 type TranscriptTokenEstimate = {
   promptTokens: number;
+  promptTokenSource:
+    | "provider_usage"
+    | "provider_usage_plus_prompt_projection"
+    | "prompt_projection";
   outputTokens?: number;
   promptIncludesOutput?: boolean;
   transcriptByteSize?: number;
-  transcriptBytesTokens?: number;
 };
+
+async function estimateProviderPromptTokensFromMessages(
+  messages: AgentMessage[],
+  contextWindowTokens: number,
+): Promise<number | undefined> {
+  if (messages.length === 0) {
+    return 0;
+  }
+  const { truncateOversizedToolResultsInMessages } = await toolResultTruncationRuntimeLoader.load();
+  // Match first-dispatch trailing-result protection without freezing replacements
+  // owned by the embedded session.
+  const projected = truncateOversizedToolResultsInMessages(
+    messages,
+    contextWindowTokens,
+    undefined,
+    undefined,
+    createToolResultPromptProjectionState(),
+  ).messages;
+  const tokens = estimateMessagesTokens(projected);
+  return Number.isFinite(tokens) && tokens >= 0 ? Math.ceil(tokens) : undefined;
+}
 
 async function estimatePromptTokensFromSessionTranscript(params: {
   agentId?: string;
   sessionId?: string;
   sessionKey?: string;
   storePath?: string;
+  contextWindowTokens: number;
 }): Promise<TranscriptTokenEstimate | undefined> {
   const sessionId = normalizeOptionalString(params.sessionId);
   if (!sessionId) {
@@ -590,29 +615,34 @@ async function estimatePromptTokensFromSessionTranscript(params: {
       includeByteSize: true,
       includeUsage: true,
     });
-    const transcriptBytesTokens =
-      typeof snapshot.byteSize === "number" &&
-      Number.isFinite(snapshot.byteSize) &&
-      snapshot.byteSize > 0
-        ? Math.ceil(snapshot.byteSize / FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN)
+    const usage = snapshot.usage;
+    const promptTokens = usage?.promptTokens;
+    const normalizedOutputTokens =
+      typeof usage?.outputTokens === "number" &&
+      Number.isFinite(usage.outputTokens) &&
+      usage.outputTokens > 0
+        ? Math.ceil(usage.outputTokens)
         : undefined;
-    const promptTokens = snapshot.usage?.promptTokens;
-    const trailingBytesTokens = snapshot.usage?.trailingBytesTokens;
-    const outputTokens = snapshot.usage?.outputTokens;
     if (
+      usage &&
       typeof promptTokens === "number" &&
       Number.isFinite(promptTokens) &&
-      promptTokens > 0 &&
-      trailingBytesTokens === 0 &&
-      typeof outputTokens === "number" &&
-      Number.isFinite(outputTokens) &&
-      outputTokens > 0
+      promptTokens > 0
     ) {
+      const trailingMessages = usage.trailingMessages;
+      const trailingTokens = await estimateProviderPromptTokensFromMessages(
+        trailingMessages,
+        params.contextWindowTokens,
+      );
+      if (trailingTokens === undefined) {
+        return undefined;
+      }
       return {
-        promptTokens: Math.ceil(promptTokens),
-        outputTokens: Math.ceil(outputTokens),
+        promptTokens: Math.ceil(promptTokens) + trailingTokens,
+        promptTokenSource:
+          trailingMessages.length > 0 ? "provider_usage_plus_prompt_projection" : "provider_usage",
+        outputTokens: normalizedOutputTokens,
         transcriptByteSize: snapshot.byteSize,
-        transcriptBytesTokens,
       };
     }
     const messages = (await readSessionMessagesAsync(
@@ -628,40 +658,21 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         maxBytes: 1024 * 1024,
       },
     )) as AgentMessage[];
-    const estimatedMessageTokens = (() => {
-      if (messages.length === 0) {
-        return undefined;
-      }
-      const tokens = estimateMessagesTokens(messages);
-      return Number.isFinite(tokens) && tokens > 0 ? Math.ceil(tokens) : undefined;
-    })();
-    if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
-      const usagePromptTokens = Math.ceil(promptTokens) + (trailingBytesTokens ?? 0);
-      return {
-        promptTokens: Math.max(usagePromptTokens, estimatedMessageTokens ?? 0),
-        outputTokens:
-          typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens > 0
-            ? Math.ceil(outputTokens)
-            : undefined,
-        transcriptByteSize: snapshot.byteSize,
-        transcriptBytesTokens,
-      };
-    }
-    const estimatedTokens = estimatedMessageTokens ?? transcriptBytesTokens;
+    const estimatedTokens = await estimateProviderPromptTokensFromMessages(
+      messages,
+      params.contextWindowTokens,
+    );
     if (estimatedTokens === undefined) {
       return undefined;
     }
     return {
-      promptTokens: Math.ceil(estimatedTokens),
+      promptTokens: estimatedTokens,
+      promptTokenSource: "prompt_projection",
       // Full-message estimation already includes assistant content. Preserve
       // output only for projection against a separate persisted prompt fact.
       promptIncludesOutput: true,
-      outputTokens:
-        typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens > 0
-          ? Math.ceil(outputTokens)
-          : undefined,
+      outputTokens: normalizedOutputTokens,
       transcriptByteSize: snapshot.byteSize,
-      transcriptBytesTokens,
     };
   } catch {
     return undefined;
@@ -772,6 +783,7 @@ export async function runPreflightCompactionIfNeeded(params: {
           sessionId: entry.sessionId,
           sessionKey: compactionSessionKey,
           storePath: compactionStorePath,
+          contextWindowTokens,
         });
   const transcriptSizeSnapshot =
     shouldCheckActiveTranscriptBytes && transcriptUsageTokens?.transcriptByteSize === undefined
@@ -839,6 +851,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       `isHeartbeat=${params.isHeartbeat} isCli=${isCli} ` +
       `persistedFresh=${entry?.totalTokensFresh === true} ` +
       `transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} ` +
+      `transcriptPromptSource=${transcriptUsageTokens?.promptTokenSource ?? "undefined"} ` +
       `promptTokensEst=${promptTokenEstimate ?? "undefined"} ` +
       `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"} ` +


### PR DESCRIPTION
Fixes #125148

## What Problem This Solves

Fixes an issue where operators preserving a tool-heavy session while switching from the Codex runtime to the OpenClaw runtime could enter a repeated mandatory-compaction failure. The first OpenClaw turn failed before provider dispatch and required `/compact` or `/new`.

## Why This Change Was Made

Preflight measured the retained SQLite representation before the existing provider-bound tool-result projection. Codex mirror rows retain the same result in `text` and `content`, so storage bytes and unprojected results overstated model-visible pressure.

Preflight now estimates the same context-window-bounded, non-mutating tool-result projection used for provider dispatch. Provider usage remains the prefix anchor; only projected messages after that anchor are added. A recent scan keeps the normal fast path; if it misses an anchor, preflight scans the complete active path before falling back to the full active visible history. Raw transcript size remains available solely to the explicit byte fuse, and complete history remains unchanged.

PR #124267 overlaps provider-usage boundary accounting but does not project tool results. This change preserves that prefix/tail ownership while removing storage bytes from token pressure.

Production delta: +124/-77 (net +47). Test delta: +228/-4 (net +224). The production growth is the lazy canonical-projector integration, complete-path usage discovery, isolated projection-state factory, and diagnostic source; obsolete byte-token accounting was deleted.

### Preflight cost

The existing 512-event usage scan remains the normal path. A complete active-path scan occurs only when that tail contains no usable provider anchor and the active path is longer than 512 events. That slow path adds one linear read before the embedded runtime immediately opens and projects the same complete active transcript; it introduces no new unbounded history capability, retained cache, per-message query, or nested scan. If the complete scan finds an older provider anchor, only its post-anchor tail is projected. If it finds none, full provider-visible history is projected rather than silently treating the former 200-message/1 MiB tail as the whole prompt. The 250-message/~410 KiB beyond-bounds regression completes in the focused suite and proves this fallback without a multi-MiB fixture.

## User Impact

Tool-heavy preserved sessions can continue after a Codex-to-OpenClaw runtime cutover without an unrecoverable preflight loop. Diagnostics now distinguish provider-projected token estimates from retained transcript bytes.

## Evidence

- Pre-fix preserved-session Telegram trace on main `57e3ee6513be6559e27ad1231cdb791664edcd45`: 64 Codex command/results, 8,192 characters per mirrored result (524,288 total), identical session-key and session-id hashes across the runtime cutover, and unchanged 64/64 transcript pairs afterward. The first OpenClaw turn made 10 compaction-provider requests, then ended `guard_blocked` after `latest_user_ask_not_reflected`. Telegram showed: `⚠️ Context is too large and auto-compaction could not recover this turn. Try again, use /compact, or use /new to start a fresh session.` Redacted gateway-log digest: `0f606916360a7d274e31a305cf047a7e7047d6ed2d56029fae674b7c076fc25a`; provider-request digest: `73cfecab4d1033ef6626f608cdb9ecd2fe2574395b664fa83c44c8eb3c595eab`.
- After-fix preserved-session Telegram trace on exact head `57b15aefd518e64604f4593d45b99acdd1fa21b2`: the same 64/64 mirrored pairs and 524,288 result characters survived the cutover with identical session-key/session-id hashes and unchanged transcript digests. Preflight continued to one projected provider request instead of mandatory compaction. The real QA-user stream observed two SUT typing events followed by the fresh per-run marker after 1,691 ms; no edit, deletion, reconciliation, or extra provider request occurred. Verdict: `cutover-passed`. Redacted gateway-log digest: `92a1bfab8a12c140655d402cba8a59c46ee2ee3cf905ce5dfed654f99f4c1586`; provider-request digest: `ba654ba0cd23667b16008720617837a267c43ada6ea9e55eb9acf20acdf508ab`.
- Red: the owner-boundary regression failed both without and after provider usage with `Preflight compaction required but failed: guard_blocked`.
- Green: the same two cases pass with 64 mirrored call/result pairs (8,192 characters in both `text` and `content`); compaction is not invoked and all transcript rows remain unchanged.
- Red/green: a 250-message no-usage history proves pressure older than the former 200-message window triggers preflight compaction.
- Red/green: an anchor older than 512 events proves provider-covered history is excluded below threshold while post-anchor pressure still compacts above threshold.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/session-prompt-state.test.ts` — 148 passed.
- Targeted Oxfmt and Oxlint — clean.
- `pnpm tsgo:core` — passed.
- `pnpm check:test-types` — passed.
