### PR TITLE
fix: keep image compression policy consistent during plugin reloads

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -771,6 +771,12 @@ describe("resolveBundledProviderStaticCatalogModel", () => {
 
   it("resolves exact rows from bundled provider static catalogs", async () => {
     const cfg = { plugins: { entries: { google: { enabled: true } } } };
+    const metadataSnapshot = {
+      plugins: [],
+      owners: {},
+      index: {},
+      manifestRegistry: { plugins: [] },
+    } as never;
     const provider = {
       id: "google",
       pluginId: "google",
@@ -807,6 +813,7 @@ describe("resolveBundledProviderStaticCatalogModel", () => {
       provider: "google",
       modelId: "gemini-3.1-pro-preview",
       cfg,
+      metadataSnapshot,
     });
 
     expect(model).toMatchObject({
@@ -837,6 +844,7 @@ describe("resolveBundledProviderStaticCatalogModel", () => {
       requireCompleteDiscoveryEntryCoverage: true,
       discoveryEntriesOnly: true,
       includeManifestModelCatalogProviders: false,
+      pluginMetadataSnapshot: metadataSnapshot,
     });
     expect(providerMocks.runProviderStaticCatalog).toHaveBeenCalledWith({ provider });
   });

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -731,6 +731,7 @@ export async function resolveBundledProviderStaticCatalogModel(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }): Promise<ProviderRuntimeModel | undefined> {
   return createBundledProviderStaticCatalogModelResolver(params)(params);
 }

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -365,6 +365,7 @@ export function resolveBundledStaticCatalogModel(
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
     includeRuntimeDiscovery?: boolean;
+    metadataSnapshot?: PluginMetadataSnapshot;
   },
 ): ProviderRuntimeModel | undefined {
   return createBundledStaticCatalogModelResolver({
@@ -373,6 +374,7 @@ export function resolveBundledStaticCatalogModel(
     ...(params.includeRuntimeDiscovery !== undefined
       ? { includeRuntimeDiscovery: params.includeRuntimeDiscovery }
       : {}),
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
     ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
   })(params);
 }

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1033,6 +1033,19 @@ describe("resolveModel", () => {
   });
 
   it("resolves opt-in provider static catalog rows while skipping agent discovery", async () => {
+    const metadataSnapshot = { plugins: [] } as never;
+    const preparedModelRuntime = {
+      agentDir: "/tmp/agent",
+      activeProjectKeys: [],
+      allowGatewaySubagentBinding: false,
+      config: {},
+      authModes: {},
+      metadataSnapshot,
+      modelCatalog: { entries: [], routeVariants: [] },
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
+    } satisfies PreparedModelRuntimeSnapshot;
     resolveBundledProviderStaticCatalogModelMock.mockResolvedValueOnce({
       provider: "google",
       id: "gemini-3.1-pro-preview",
@@ -1053,6 +1066,7 @@ describe("resolveModel", () => {
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
+        preparedModelRuntime,
         runtimeHooks: createRuntimeHooks(),
         skipAgentDiscovery: true,
       },
@@ -1073,12 +1087,14 @@ describe("resolveModel", () => {
       cfg: undefined,
       workspaceDir: undefined,
       includeRuntimeDiscovery: true,
+      metadataSnapshot,
     });
     expect(resolveBundledProviderStaticCatalogModelMock).toHaveBeenCalledWith({
       provider: "google",
       modelId: "gemini-3.1-pro-preview",
       cfg: undefined,
       workspaceDir: undefined,
+      metadataSnapshot,
     });
     expect(discoverAuthStorage).not.toHaveBeenCalled();
     expect(discoverModels).not.toHaveBeenCalled();

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -319,6 +319,7 @@ export async function resolveModelAsync(
     authProfileMode: options?.authProfileMode,
     preferredProfile: options?.preferredProfile,
   });
+  const preparedMetadataSnapshot = preparedModelRuntime?.metadataSnapshot;
   let staticCatalogLookup: Promise<ProviderRuntimeModel | undefined> | undefined;
   const resolveStaticCatalogModel = async () => {
     if (!options?.allowBundledStaticCatalogFallback) {
@@ -334,6 +335,7 @@ export async function resolveModelAsync(
         cfg,
         workspaceDir,
         includeRuntimeDiscovery: true,
+        ...(preparedMetadataSnapshot ? { metadataSnapshot: preparedMetadataSnapshot } : {}),
       });
       if (manifestModel) {
         return manifestModel;
@@ -343,6 +345,7 @@ export async function resolveModelAsync(
         modelId: normalizedRef.model,
         cfg,
         workspaceDir,
+        ...(preparedMetadataSnapshot ? { metadataSnapshot: preparedMetadataSnapshot } : {}),
       });
     })();
     return await staticCatalogLookup;

--- a/src/agents/tools/image-tool.test-support.ts
+++ b/src/agents/tools/image-tool.test-support.ts
@@ -13,7 +13,6 @@ import type {
   describeImagesWithModel,
   MediaUnderstandingProvider,
 } from "../../plugin-sdk/media-understanding.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import type { resolveBundledStaticCatalogModel } from "../embedded-agent-runner/model.static-catalog.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
@@ -52,7 +51,7 @@ type ResolveImageCompressionPolicy = (params: {
   imageCount: number;
   agentDir?: string;
   workspaceDir?: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
 }) => Promise<ImageCompressionPolicy>;
 
 type ImageToolProviderDeps = {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -22,6 +22,7 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import { minimaxUnderstandImage } from "../minimax-vlm.js";
+import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import {
   createContainerWorkspaceSandboxFsBridge,
   createHostSandboxFsBridge,
@@ -3155,28 +3156,11 @@ describe("image compression policy", () => {
   it("keeps runtime augmentation pinned to the prepared plugin generation", async () => {
     const provider = "prepared-image-provider";
     const model = "prepared-image-model";
-    const cfg = {
-      models: {
-        providers: {
-          [provider]: {
-            baseUrl: "https://prepared-image.example.test/v1",
-            api: "openai-completions",
-            models: [
-              {
-                id: model,
-                name: "Prepared image model",
-                reasoning: false,
-                input: ["text", "image"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 128_000,
-                maxTokens: 8_192,
-              },
-            ],
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
-    const createSnapshot = (runtimeAugment: boolean) => {
+    const cfg = {} satisfies OpenClawConfig;
+    const createSnapshot = (
+      runtimeAugment: boolean,
+      imagePolicy: { maxBytes: number; tokenMode: "detail" | "provider" },
+    ) => {
       const plugin = {
         id: "prepared-image-plugin",
         enabledByDefault: true,
@@ -3191,11 +3175,18 @@ describe("image compression policy", () => {
         manifestPath: "/fake/prepared-image-plugin/openclaw.plugin.json",
         modelCatalog: {
           runtimeAugment,
+          discovery: { [provider]: "static" },
           providers: {
             [provider]: {
               baseUrl: "https://prepared-image.example.test/v1",
               api: "openai-completions",
-              models: [{ id: model, name: "Prepared image model" }],
+              models: [
+                {
+                  id: model,
+                  name: "Prepared image model",
+                  mediaInput: { image: imagePolicy },
+                },
+              ],
             },
           },
         },
@@ -3205,21 +3196,46 @@ describe("image compression policy", () => {
         manifestRegistry: { plugins: [plugin], diagnostics: [] },
       });
     };
-    const preparedSnapshot = createSnapshot(false);
-    const currentSnapshot = createSnapshot(true);
+    const preparedSnapshot = createSnapshot(true, {
+      maxBytes: 1_000_000,
+      tokenMode: "detail",
+    });
+    const currentSnapshot = createSnapshot(false, {
+      maxBytes: 2_000_000,
+      tokenMode: "provider",
+    });
+    const preparedModelRuntime = {
+      agentDir: "/fake/prepared-image-agent",
+      activeProjectKeys: [],
+      allowGatewaySubagentBinding: false,
+      config: cfg,
+      authModes: {},
+      metadataSnapshot: preparedSnapshot,
+      modelCatalog: { entries: [], routeVariants: [] },
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
+    } satisfies PreparedModelRuntimeSnapshot;
     const hookModes: Array<boolean | undefined> = [];
+    const forwardedPreparedRuntimes: Array<PreparedModelRuntimeSnapshot | undefined> = [];
     installImageUnderstandingProviderDeps([], {
       resolveModelAsync: async (resolvedProvider, resolvedModel, _agentDir, _cfg, options) => {
         hookModes.push(options?.skipProviderRuntimeHooks);
+        forwardedPreparedRuntimes.push(options?.preparedModelRuntime);
+        const usesPreparedGeneration = options?.preparedModelRuntime === preparedModelRuntime;
         return {
           model: {
             id: resolvedModel,
             provider: resolvedProvider,
             input: ["text", "image"],
             mediaInput: {
-              image: options?.skipProviderRuntimeHooks
-                ? { maxBytes: 1_000_000 }
-                : { maxSidePx: 4096 },
+              image: usesPreparedGeneration
+                ? options?.skipProviderRuntimeHooks
+                  ? { preferredSidePx: 1_280 }
+                  : { maxPixels: 2_000_000, maxSidePx: 1_536 }
+                : options?.skipProviderRuntimeHooks
+                  ? { preferredSidePx: 2_560 }
+                  : { maxPixels: 8_000_000, maxSidePx: 4_096 },
             },
           } as never,
           authStorage: {} as never,
@@ -3237,13 +3253,22 @@ describe("image compression policy", () => {
           cfg,
           imageModelConfig: { primary: `${provider}/${model}` },
           imageCount: 1,
-          metadataSnapshot: preparedSnapshot,
+          preparedModelRuntime,
         }),
       ).resolves.toEqual({
         imageCount: 1,
-        models: [{ maxBytes: 1_000_000 }],
+        models: [
+          {
+            maxBytes: 1_000_000,
+            maxPixels: 2_000_000,
+            maxSidePx: 1_536,
+            preferredSidePx: 1_280,
+            tokenMode: "detail",
+          },
+        ],
       });
-      expect(hookModes).toEqual([true]);
+      expect(hookModes).toEqual([true, false]);
+      expect(forwardedPreparedRuntimes).toEqual([preparedModelRuntime, preparedModelRuntime]);
     } finally {
       currentLease.release();
     }

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -16,7 +16,10 @@ import type {
   ImagesDescriptionRequest,
   MediaUnderstandingProvider,
 } from "../../plugin-sdk/media-understanding.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+import {
+  getCurrentPluginMetadataSnapshot,
+  installTemporaryCurrentPluginMetadataSnapshot,
+} from "../../plugins/current-plugin-metadata-snapshot.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
@@ -654,6 +657,7 @@ function installImageUnderstandingProviderDeps(
     resolveModelAsync?: NonNullable<
       Parameters<typeof testing.setProviderDepsForTest>[0]
     >["resolveModelAsync"];
+    useDefaultResolveModelAsync?: boolean;
   },
 ) {
   imageProviderHarness.setProviders(providers);
@@ -687,7 +691,9 @@ function installImageUnderstandingProviderDeps(
         providerId,
         imageProviderHarness.buildProviderRegistry(),
       ),
-    resolveModelAsync: options?.resolveModelAsync ?? resolveConfiguredImageModelForTest,
+    ...(options?.useDefaultResolveModelAsync
+      ? {}
+      : { resolveModelAsync: options?.resolveModelAsync ?? resolveConfiguredImageModelForTest }),
     ...(options?.resolveImageCompressionPolicy
       ? { resolveImageCompressionPolicy: options.resolveImageCompressionPolicy }
       : {}),
@@ -3156,10 +3162,15 @@ describe("image compression policy", () => {
   it("keeps runtime augmentation pinned to the prepared plugin generation", async () => {
     const provider = "prepared-image-provider";
     const model = "prepared-image-model";
+    const workspaceDir = "/fake/prepared-image-workspace";
     const cfg = {} satisfies OpenClawConfig;
     const createSnapshot = (
       runtimeAugment: boolean,
-      imagePolicy: { maxBytes: number; tokenMode: "detail" | "provider" },
+      imagePolicy: {
+        maxBytes: number;
+        preferredSidePx: number;
+        tokenMode: "detail" | "provider";
+      },
     ) => {
       const plugin = {
         id: "prepared-image-plugin",
@@ -3194,18 +3205,22 @@ describe("image compression policy", () => {
       return createPluginMetadataSnapshot({
         config: cfg,
         manifestRegistry: { plugins: [plugin], diagnostics: [] },
+        workspaceDir,
       });
     };
     const preparedSnapshot = createSnapshot(true, {
       maxBytes: 1_000_000,
+      preferredSidePx: 1_280,
       tokenMode: "detail",
     });
     const currentSnapshot = createSnapshot(false, {
       maxBytes: 2_000_000,
+      preferredSidePx: 2_560,
       tokenMode: "provider",
     });
     const preparedModelRuntime = {
       agentDir: "/fake/prepared-image-agent",
+      workspaceDir,
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,
       config: cfg,
@@ -3216,60 +3231,45 @@ describe("image compression policy", () => {
       inlineProviderModels: [],
       createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
     } satisfies PreparedModelRuntimeSnapshot;
-    const hookModes: Array<boolean | undefined> = [];
-    const forwardedPreparedRuntimes: Array<PreparedModelRuntimeSnapshot | undefined> = [];
+    const modelModule = await import("../embedded-agent-runner/model.js");
+    const resolveModelAsyncSpy = vi.spyOn(modelModule, "resolveModelAsync");
     installImageUnderstandingProviderDeps([], {
-      resolveModelAsync: async (resolvedProvider, resolvedModel, _agentDir, _cfg, options) => {
-        hookModes.push(options?.skipProviderRuntimeHooks);
-        forwardedPreparedRuntimes.push(options?.preparedModelRuntime);
-        const usesPreparedGeneration = options?.preparedModelRuntime === preparedModelRuntime;
-        return {
-          model: {
-            id: resolvedModel,
-            provider: resolvedProvider,
-            input: ["text", "image"],
-            mediaInput: {
-              image: usesPreparedGeneration
-                ? options?.skipProviderRuntimeHooks
-                  ? { preferredSidePx: 1_280 }
-                  : { maxPixels: 2_000_000, maxSidePx: 1_536 }
-                : options?.skipProviderRuntimeHooks
-                  ? { preferredSidePx: 2_560 }
-                  : { maxPixels: 8_000_000, maxSidePx: 4_096 },
-            },
-          } as never,
-          authStorage: {} as never,
-          modelRegistry: {} as never,
-        };
-      },
+      useDefaultResolveModelAsync: true,
     });
     const currentLease = installTemporaryCurrentPluginMetadataSnapshot(currentSnapshot, {
       config: cfg,
+      workspaceDir,
     });
 
     try {
+      expect(getCurrentPluginMetadataSnapshot({ config: cfg, workspaceDir })).toBe(currentSnapshot);
       await expect(
         testing.resolveImageCompressionPolicy({
           cfg,
           imageModelConfig: { primary: `${provider}/${model}` },
           imageCount: 1,
           preparedModelRuntime,
+          workspaceDir,
         }),
       ).resolves.toEqual({
         imageCount: 1,
         models: [
           {
             maxBytes: 1_000_000,
-            maxPixels: 2_000_000,
-            maxSidePx: 1_536,
             preferredSidePx: 1_280,
             tokenMode: "detail",
           },
         ],
       });
-      expect(hookModes).toEqual([true, false]);
-      expect(forwardedPreparedRuntimes).toEqual([preparedModelRuntime, preparedModelRuntime]);
+      expect(resolveModelAsyncSpy).toHaveBeenCalledTimes(2);
+      expect(
+        resolveModelAsyncSpy.mock.calls.map((call) => call[4]?.skipProviderRuntimeHooks),
+      ).toEqual([true, false]);
+      for (const call of resolveModelAsyncSpy.mock.calls) {
+        expect(call[4]?.preparedModelRuntime).toBe(preparedModelRuntime);
+      }
     } finally {
+      resolveModelAsyncSpy.mockRestore();
       currentLease.release();
     }
   });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -32,8 +32,6 @@ import {
 import { resolvePluginCapabilityProvider } from "../../plugins/capability-provider-runtime.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
-import { isPluginMetadataSnapshotCompatible } from "../../plugins/plugin-metadata-snapshot.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
@@ -475,6 +473,7 @@ function resolveBundledStaticCompressionModelPolicy(params: {
   provider: string;
   model: string;
   workspaceDir?: string;
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
 }): ImageCompressionModelPolicy {
   const model = imageToolProviderDeps.resolveBundledStaticCatalogModel({
     provider: params.provider,
@@ -482,6 +481,9 @@ function resolveBundledStaticCompressionModelPolicy(params: {
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
     includeRuntimeDiscovery: true,
+    ...(params.preparedModelRuntime
+      ? { metadataSnapshot: params.preparedModelRuntime.metadataSnapshot }
+      : {}),
   });
   return model?.mediaInput?.image ?? {};
 }
@@ -490,26 +492,15 @@ function providerUsesRuntimeModelAugment(params: {
   cfg?: OpenClawConfig;
   provider: string;
   workspaceDir?: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
 }): boolean {
   const provider = normalizeMediaProviderId(params.provider);
   if (!provider) {
     return false;
   }
   const config = params.cfg ?? {};
-  const preparedSnapshot =
-    params.metadataSnapshot &&
-    params.metadataSnapshot.pluginIds === undefined &&
-    isPluginMetadataSnapshotCompatible({
-      snapshot: params.metadataSnapshot,
-      config,
-      env: process.env,
-      workspaceDir: params.workspaceDir,
-    })
-      ? params.metadataSnapshot
-      : undefined;
   const snapshot =
-    preparedSnapshot ??
+    params.preparedModelRuntime?.metadataSnapshot ??
     getCurrentPluginMetadataSnapshot({
       config,
       env: process.env,
@@ -556,6 +547,7 @@ async function resolveCompressionModelPolicyWithHooks(params: {
   model: string;
   agentDir?: string;
   workspaceDir?: string;
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
   skipProviderRuntimeHooks: boolean;
 }): Promise<ImageCompressionModelPolicy> {
   try {
@@ -569,6 +561,9 @@ async function resolveCompressionModelPolicyWithHooks(params: {
         skipProviderRuntimeHooks: params.skipProviderRuntimeHooks,
         skipAgentDiscovery: true,
         workspaceDir: params.workspaceDir,
+        ...(params.preparedModelRuntime
+          ? { preparedModelRuntime: params.preparedModelRuntime }
+          : {}),
       },
     );
     return (resolved.model as ProviderRuntimeModel | undefined)?.mediaInput?.image ?? {};
@@ -583,7 +578,7 @@ async function resolveCompressionModelPolicy(params: {
   model: string;
   agentDir?: string;
   workspaceDir?: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
 }): Promise<ImageCompressionModelPolicy> {
   const configuredStaticPolicy = await resolveCompressionModelPolicyWithHooks({
     ...params,
@@ -599,7 +594,7 @@ async function resolveCompressionModelPolicy(params: {
       cfg: params.cfg,
       provider: params.provider,
       workspaceDir: params.workspaceDir,
-      metadataSnapshot: params.metadataSnapshot,
+      preparedModelRuntime: params.preparedModelRuntime,
     })
   ) {
     return staticPolicy;
@@ -618,7 +613,7 @@ async function resolveImageCompressionPolicy(params: {
   imageCount: number;
   agentDir?: string;
   workspaceDir?: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
 }): Promise<ImageCompressionPolicy> {
   const modelCandidates = resolveCompressionModelCandidates(params);
   const quality = params.cfg?.agents?.defaults?.imageQuality;
@@ -630,7 +625,7 @@ async function resolveImageCompressionPolicy(params: {
         model: candidate.model,
         agentDir: params.agentDir,
         workspaceDir: params.workspaceDir,
-        metadataSnapshot: params.metadataSnapshot,
+        preparedModelRuntime: params.preparedModelRuntime,
       });
     }),
   );
@@ -1013,7 +1008,7 @@ export function createImageTool(options?: {
           imageCount: imageInputs.length,
           agentDir,
           workspaceDir: options?.workspaceDir,
-          metadataSnapshot: options?.preparedModelRuntime?.metadataSnapshot,
+          preparedModelRuntime: options?.preparedModelRuntime,
         });
         imageRoute = { kind: "fallback", imageModelConfig, imageCompression };
       }

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -481,9 +481,7 @@ function resolveBundledStaticCompressionModelPolicy(params: {
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
     includeRuntimeDiscovery: true,
-    ...(params.preparedModelRuntime
-      ? { metadataSnapshot: params.preparedModelRuntime.metadataSnapshot }
-      : {}),
+    metadataSnapshot: params.preparedModelRuntime?.metadataSnapshot,
   });
   return model?.mediaInput?.image ?? {};
 }


### PR DESCRIPTION
Related: #125090

## What Problem This Solves

Fixes an issue where image preprocessing could combine compression limits from two plugin lifecycle generations when an admitted agent run overlapped a plugin metadata refresh. The run's augmentation decision stayed on its prepared generation, but static model metadata could be read from the replacement generation.

## Why This Change Was Made

The complete compression-policy path now carries the caller-owned prepared model runtime. Direct static catalog resolution and hook-aware model resolution both consume that exact generation, with no new cache, fallback, compatibility path, or image-specific lifecycle owner. The original ClawSweeper P1 was addressed at the model-resolution owner: both internal static fallbacks now consume the prepared metadata snapshot, and the lifecycle regression exercises the real resolver rather than a stub.

## User Impact

Image compression remains consistent with the model and plugin generation admitted for the run during reload overlap. There is no config, API, protocol, storage, or dependency change.

## Evidence

- Before the complete repair, the real-resolver lifecycle regression failed on `e04402ce6095` with generation B (`maxBytes: 2000000`, `preferredSidePx: 2560`, `tokenMode: provider`) instead of generation A (`1000000`, `1280`, `detail`).
- Final named real-resolver lifecycle regression — 1 passed.
- `node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts` — 101 passed.
- Model resolver suite — 150 passed.
- Static catalog suite — 28 passed.
- Final `node scripts/check-changed.mjs` run — core and coreTests passed, including format, production/test type checking, lint, dead exports, guards, and import cycles.
- Complete `git diff --check` passed.
- Production LOC: +19/-20 (net -1). Tests/test support: +97/-49 (net +48).
- Codex-backed autoreview clean.

AI-assisted: yes. The code, lifecycle ownership, and proof were reviewed and understood before publication. Agent transcript omitted by default.
