### PR TITLE
fix(sessions): stop max-lines compaction backup leaks

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -300,8 +300,8 @@ openclaw sessions compact "agent:work:main" --agent work --json
 - Without `--max-lines`, the Gateway LLM-summarizes the transcript. The CLI
   does not impose a client deadline by default; the Gateway owns the
   configured compaction lifecycle.
-- With `--max-lines <n>`, it truncates to the last `n` transcript lines and
-  archives the prior transcript as a `.bak` sidecar.
+- With `--max-lines <n>`, it permanently truncates the SQLite transcript to the
+  last `n` lines. This path does not create a backup archive.
 - `--agent <id>`: agent that owns the session; required for `global` keys.
 - `--url` / `--token` / `--password`: Gateway connection overrides.
 - `--timeout <ms>`: optional client-side RPC timeout in milliseconds.
@@ -345,7 +345,6 @@ Example truncate response (`--max-lines 200`):
   "ok": true,
   "key": "agent:main:main",
   "compacted": true,
-  "archived": "/home/user/.openclaw/agents/main/sessions/transcripts/<id>.jsonl.bak",
   "kept": 200
 }
 ```

--- a/src/commands/sessions-compact.test.ts
+++ b/src/commands/sessions-compact.test.ts
@@ -160,23 +160,6 @@ describe("sessionsCompactCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("prints the archive path exactly as returned by the RPC", async () => {
-    const archived = "/state/agents/main/sessions/sess-1.jsonl.bak.2026-07-19T00-00-00.000Z.zst";
-    callGatewayCli.mockResolvedValue({
-      ok: true,
-      key: "agent:main:main",
-      compacted: true,
-      kept: 50,
-      archived,
-    });
-    const runtime = createRuntime();
-
-    await sessionsCompactCommand({ key: "agent:main:main", maxLines: 50 }, runtime);
-
-    expect(runtime.exit).not.toHaveBeenCalled();
-    expect(joinedArgs(runtime.log)).toContain(`Archived transcript: ${archived}`);
-  });
-
   it("forwards agentId and maxLines to the RPC params", async () => {
     callGatewayCli.mockResolvedValue({
       ok: true,

--- a/src/commands/sessions-compact.ts
+++ b/src/commands/sessions-compact.ts
@@ -28,7 +28,6 @@ type SessionsCompactResult = {
   compacted?: boolean;
   reason?: string;
   kept?: number;
-  archived?: string;
   result?: {
     tokensBefore?: number;
     tokensAfter?: number;
@@ -125,7 +124,4 @@ export async function sessionsCompactCommand(
   }
 
   runtime.log(describeCompaction(result ?? {}, opts.key));
-  if (result?.archived) {
-    runtime.log(`Archived transcript: ${result.archived}`);
-  }
 }

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -39,9 +39,13 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
   );
 }
 
-/** Returns true for retained reset/delete transcript archives counted by the session budget. */
+/** Returns true for retained archives and disposable legacy compact backups pruned at high water. */
 export function isRetainedSessionTranscriptArchiveName(fileName: string): boolean {
-  return hasArchiveSuffix(fileName, "deleted") || hasArchiveSuffix(fileName, "reset");
+  return (
+    hasArchiveSuffix(fileName, "deleted") ||
+    hasArchiveSuffix(fileName, "reset") ||
+    hasArchiveSuffix(fileName, "bak")
+  );
 }
 
 /** Returns true for migration rollback archives retained beside their legacy source. */

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -317,7 +317,7 @@ export async function hasRetainedSessionTranscriptArchives(storePath: string): P
   return files.some((file) => isRetainedSessionTranscriptArchiveName(file.name));
 }
 
-/** Removes oldest retained reset/delete archives, remeasuring physical usage after each file. */
+/** Removes oldest retained archives and legacy compact backups, remeasuring after each file. */
 export async function pruneSessionTranscriptArchivesToHighWater(params: {
   excludeNames?: ReadonlySet<string>;
   highWaterBytes: number;

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -6,7 +6,6 @@ import {
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { clearAllCliSessions } from "./cli-session-binding.js";
-import { writeTranscriptArchive } from "./session-accessor.sqlite-archive.js";
 import type {
   SessionTranscriptAccessScope,
   SessionTranscriptTurnMessageAppend,
@@ -36,7 +35,6 @@ import {
 } from "./session-accessor.sqlite-read.js";
 import {
   cloneSessionEntry,
-  resolveSqliteTranscriptArchiveDirectory,
   resolveSqliteTranscriptScope,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
@@ -64,7 +62,6 @@ import {
   sessionMatchesExpectedTranscriptTurn,
 } from "./session-transcript-turn-state.js";
 import type { TranscriptEntryAnchor } from "./transcript-entry-anchor.js";
-import { serializeJsonlLines } from "./transcript-jsonl.js";
 import {
   SessionTranscriptWriterClaimReboundError,
   withOwnedSessionTranscriptWriterFence,
@@ -190,7 +187,7 @@ export async function trimTranscriptForManualCompact(
   scope: SessionTranscriptAccessScope,
   selectRetainedLines: (lines: readonly string[]) => readonly string[] | null,
   options: { nowMs?: number } = {},
-): Promise<{ trimmed: false } | { archivedPath: string; kept: number; trimmed: true }> {
+): Promise<{ trimmed: false } | { kept: number; trimmed: true }> {
   const resolved = resolveSqliteTranscriptScope(scope);
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
@@ -207,14 +204,6 @@ export async function trimTranscriptForManualCompact(
       );
     }
     const retainedEvents = retainedLines.map((line) => JSON.parse(line) as TranscriptEvent);
-    const archivedPath = writeTranscriptArchive({
-      archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-      content: serializeJsonlLines(lines),
-      reason: "bak",
-      sessionId: resolved.sessionId,
-    });
-    // Published archives can be reused by another process before this commit.
-    // Retain them on failure so a sibling operation never loses its durable proof.
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
@@ -253,7 +242,7 @@ export async function trimTranscriptForManualCompact(
       currentIdentity = readSessionIdentitySnapshot(writeDatabase, identityKeys);
     }, toDatabaseOptions(resolved));
     emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
-    return { archivedPath, kept: retainedLines.length, trimmed: true };
+    return { kept: retainedLines.length, trimmed: true };
   });
 }
 

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -27,7 +27,6 @@ import {
   deliveryContextFromSession,
   sessionDeliveryRoute,
 } from "../../utils/delivery-context.shared.js";
-import { readSessionArchiveContentSync } from "./archive-compression.js";
 import {
   applySessionEntryReplacements,
   applySessionPatchProjections,
@@ -2815,17 +2814,6 @@ describe("session accessor seam", () => {
 
     unsubscribe();
     expect(result).toMatchObject({ compacted: true, kept: 3 });
-    const archived = result.compacted ? result.archived : "";
-    expect(path.basename(archived)).toMatch(
-      new RegExp(`^${sessionId}\\.jsonl\\.bak\\.\\d{4}-\\d{2}-\\d{2}T`),
-    );
-    expect(fs.realpathSync(path.dirname(archived))).toBe(fs.realpathSync(tempDir));
-    expect(fs.existsSync(archived)).toBe(true);
-    const archivedRecords = readSessionArchiveContentSync(archived)
-      .split("\n")
-      .filter((line) => line.length > 0)
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
-    expect(archivedRecords).toEqual(transcriptRecords);
     const trimmedRecords = (await loadTranscriptEvents(scope)) as Array<Record<string, unknown>>;
     expect(trimmedRecords).toMatchObject([
       { type: "session", id: sessionId },
@@ -2843,27 +2831,6 @@ describe("session accessor seam", () => {
     expect(updatedEntry?.totalTokens).toBeUndefined();
     expect(updatedEntry?.totalTokensFresh).toBeUndefined();
     expect(updates).toEqual([]);
-  });
-
-  it("keeps every transcript row when the manual compact backup cannot be written", async () => {
-    const sessionId = "44444444-4444-4444-8444-444444444444";
-    const stateDir = path.join(tempDir, "state-root");
-    const scope = {
-      agentId: "main",
-      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-      sessionId,
-      sessionKey: "agent:main:main",
-    };
-    const records = createManualCompactRecords(sessionId);
-    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
-    await replaceTranscriptEvents(scope, records as Parameters<typeof replaceTranscriptEvents>[1]);
-    const archiveDirPath = path.join(stateDir, "agents", "main", "sessions");
-    fs.writeFileSync(archiveDirPath, "not a directory");
-
-    await expect(trimSessionTranscriptForManualCompact(scope, { maxLines: 3 })).rejects.toThrow();
-
-    expect((await loadTranscriptEvents(scope)).length).toBe(5);
-    expect(await loadTranscriptEvents(scope)).toEqual(records);
   });
 
   it("keeps no-op manual compaction tolerant of a missing current session entry", async () => {
@@ -2921,13 +2888,6 @@ describe("session accessor seam", () => {
 
     expect(await loadTranscriptEvents(scope)).toEqual(records);
     expect(loadSessionEntry(scope)).toEqual(entryBeforeCompact);
-    const archiveNames = fs.readdirSync(tempDir).filter((name) => name.includes(".bak."));
-    expect(archiveNames).toHaveLength(1);
-    expect(
-      readSessionArchiveContentSync(
-        path.join(tempDir, expectDefined(archiveNames[0], "manual compact archive name")),
-      ),
-    ).toBe(`${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
   });
 
   it.each([
@@ -2935,24 +2895,15 @@ describe("session accessor seam", () => {
       name: "rejects a manual compact when session metadata changes after its snapshot",
       sessionId: "88888888-8888-4888-8888-888888888888",
       conflict: "metadata",
-      reuseArchive: false,
     },
     {
-      name: "preserves the backup and rows written after the manual compact snapshot",
+      name: "preserves rows written after the manual compact snapshot",
       sessionId: "55555555-5555-4555-8555-555555555555",
       conflict: "transcript",
-      reuseArchive: false,
     },
-    {
-      name: "preserves a reused manual compact backup when the rewrite conflicts",
-      sessionId: "66666666-6666-4666-8666-666666666666",
-      conflict: "transcript",
-      reuseArchive: true,
-    },
-  ] as const)("$name", async ({ sessionId, conflict, reuseArchive }) => {
+  ] as const)("$name", async ({ sessionId, conflict }) => {
     const scope = { agentId: "main", sessionId, sessionKey: "agent:main:main", storePath };
     const records = createManualCompactRecords(sessionId);
-    const archiveContent = `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
     await upsertSessionEntryCore(
       scope,
       conflict === "metadata"
@@ -2960,10 +2911,6 @@ describe("session accessor seam", () => {
         : { sessionId, updatedAt: 1 },
     );
     await replaceTranscriptEvents(scope, records as Parameters<typeof replaceTranscriptEvents>[1]);
-    const existingArchive = path.join(tempDir, `${sessionId}.jsonl.bak.preexisting`);
-    if (reuseArchive) {
-      fs.writeFileSync(existingArchive, archiveContent);
-    }
 
     const expectedError =
       conflict === "metadata"
@@ -3007,18 +2954,6 @@ describe("session accessor seam", () => {
       expect(remaining).toHaveLength(6);
       expect(remaining.slice(0, 5)).toEqual(records);
       expect(remaining[5]).toMatchObject({ id: "late-append" });
-    }
-    if (reuseArchive) {
-      expect(fs.existsSync(existingArchive)).toBe(true);
-      expect(readSessionArchiveContentSync(existingArchive)).toBe(archiveContent);
-    } else {
-      const archiveNames = fs.readdirSync(tempDir).filter((name) => name.includes(".bak."));
-      expect(archiveNames).toHaveLength(1);
-      expect(
-        readSessionArchiveContentSync(
-          path.join(tempDir, expectDefined(archiveNames[0], "manual compact archive name")),
-        ),
-      ).toBe(archiveContent);
     }
   });
 

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -116,7 +116,7 @@ export async function trimSessionTranscriptForManualCompact(
     return declined;
   }
 
-  return { archived: trimmed.archivedPath, compacted: true, kept: trimmed.kept };
+  return { compacted: true, kept: trimmed.kept };
 }
 
 function parseManualCompactTranscriptRecord(line: string): Record<string, unknown> | null {

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -440,7 +440,6 @@ export type SessionTranscriptManualTrimResult =
       kept: number;
     }
   | {
-      archived: string;
       compacted: true;
       kept: number;
     };

--- a/src/config/sessions/session-history-eviction.test.ts
+++ b/src/config/sessions/session-history-eviction.test.ts
@@ -143,7 +143,16 @@ describe("SQLite historical session disk budget", () => {
     expect(sessionExists(sessionId)).toBe(false);
   });
 
-  it("removes counted archives before evicting searchable history", async () => {
+  it.each([
+    {
+      archiveName: "already-extracted.jsonl.deleted.2026-01-01T00-00-00.000Z",
+      kind: "deleted transcript archive",
+    },
+    {
+      archiveName: `legacy-compact.jsonl.bak.2026-01-01T00-00-00.000Z.${"a".repeat(32)}.zst`,
+      kind: "legacy compact backup",
+    },
+  ])("removes a $kind before evicting searchable history", async ({ archiveName }) => {
     await createHistoricalTranscript({
       content: "keep searchable history",
       nextSessionId: "archive-live",
@@ -152,10 +161,7 @@ describe("SQLite historical session disk budget", () => {
       updatedAt: 1,
     });
     database().walMaintenance.checkpoint();
-    const oldArchive = path.join(
-      tempDir,
-      "already-extracted.jsonl.deleted.2026-01-01T00-00-00.000Z",
-    );
+    const oldArchive = path.join(tempDir, archiveName);
     fs.writeFileSync(oldArchive, Buffer.alloc(256 * 1024));
     const before = await measureSessionPhysicalDiskUsage(storePath);
 

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -326,7 +326,7 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
                 key: target.canonicalKey,
                 compacted: trimResult.compacted,
                 ...(trimResult.compacted
-                  ? { archived: trimResult.archived, kept: trimResult.kept }
+                  ? { kept: trimResult.kept }
                   : "kept" in trimResult
                     ? { kept: trimResult.kept }
                     : { reason: "no transcript" }),

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -16,7 +16,6 @@ import {
   getFollowupQueue,
 } from "../auto-reply/reply/queue/state.js";
 import type { SessionCompactionCheckpoint } from "../config/sessions.js";
-import { readSessionArchiveContentSync } from "../config/sessions/archive-compression.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
@@ -1734,7 +1733,7 @@ test("sessions.patch waits for terminal compaction before archiving the session"
   ws.close();
 });
 
-test("sessions.compact maxLines trims SQLite transcript rows and archives the full pre-compaction transcript", async () => {
+test("sessions.compact maxLines trims SQLite transcript rows without creating a transcript archive", async () => {
   const { dir, storePath } = await createSessionStoreDir();
   await seedSessionEntry({
     entry: sessionStoreEntry("sess-main", {
@@ -1754,20 +1753,12 @@ test("sessions.compact maxLines trims SQLite transcript rows and archives the fu
     storePath,
     totalLines: 500,
   });
-  const original = await loadTranscriptRows({
-    sessionId: "sess-main",
-    sessionKey: "agent:main:main",
-    storePath,
-  });
-  expect(original).toHaveLength(500);
-
   const { ws } = await openClient();
   const compacted = await rpcReq<{
     ok: true;
     key: string;
     compacted: boolean;
     kept?: number;
-    archived?: string;
   }>(ws, "sessions.compact", { key: "main", maxLines: 50 });
 
   expect(compacted.ok).toBe(true);
@@ -1788,15 +1779,8 @@ test("sessions.compact maxLines trims SQLite transcript rows and archives the fu
   expect(retained.at(-1)).toMatchObject({
     message: { content: "line-498" },
   });
-  const archived = compacted.payload?.archived ?? "";
-  expect(path.basename(archived)).toMatch(/^sess-main\.jsonl\.bak\.\d{4}-\d{2}-\d{2}T/);
-  expect(await fs.realpath(path.dirname(archived))).toBe(await fs.realpath(dir));
-  await expect(fs.stat(archived)).resolves.toMatchObject({ mode: expect.any(Number) });
-  const archivedEvents = readSessionArchiveContentSync(archived)
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line) as Record<string, unknown>);
-  expect(archivedEvents).toEqual(original);
+  expect(compacted.payload).not.toHaveProperty("archived");
+  expect((await fs.readdir(dir)).some((name) => name.includes(".jsonl.bak."))).toBe(false);
   await expect(fs.readdir(dir)).resolves.not.toContain("sess-main.jsonl");
   const trimmedEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
   expect(trimmedEntry?.cliSessionIds).toBeUndefined();


### PR DESCRIPTION
Related: #111122

## What Problem This Solves

Fixes an issue where users running `openclaw sessions compact <key> --max-lines N` would create a new `.bak` transcript sidecar on every compaction. Session maintenance counted those files against the disk budget but could not reclaim them, so repeated manual compaction could evict other sessions' retained history while still leaving the store over budget.

## Why This Change Was Made

Manual max-lines compaction now trims the canonical SQLite transcript directly without creating or returning a backup sidecar. Existing legacy compact backups are eligible for the normal high-water archive sweep, so they are removed before searchable SQLite history under disk pressure. Historical `.bak` filename recognition remains intact so those artifacts are never mistaken for active transcripts. The CLI docs now state explicitly that max-lines truncation is permanent and does not create a backup archive.

Owner decision: permanent max-lines truncation is intentional. The archive behavior from #111122 reached beta tags but no stable release, and keeping an OpenClaw-owned JSONL recovery sidecar would preserve the file-era runtime state that the database-first contract removes. The ClawSweeper request to restore archive creation is therefore deliberately skipped; its narrower cleanup finding is addressed by reclaiming existing legacy `.bak` files before any session history.

## User Impact

Repeated manual compaction no longer accumulates disk-budget-charged backup files. Operators still get the retained-line count, but no `Archived transcript:` path is reported because no archive is created. Existing legacy compact backups remain recognizable and are reclaimed by the disk-budget sweep before searchable session history.

## Evidence

- Pre-fix regression: the updated Gateway test failed because `sessions.compact` returned an `archived` path and wrote a `.jsonl.bak.*` file.
- Focused tests: `node scripts/run-vitest.mjs src/config/sessions/session-history-eviction.test.ts src/config/sessions/artifacts.test.ts src/config/sessions/disk-budget.test.ts src/config/sessions/session-accessor.test.ts src/gateway/server.sessions.compaction.test.ts src/commands/sessions-compact.test.ts` (186 tests passed).
- Legacy cleanup regression: on the pre-fix PR head, an oversized `.bak` archive caused one searchable history entry to be evicted; after the fix, the backup file is removed, zero session entries are removed, and searchable history remains.
- Build: `pnpm build`.
- Full changed gate: `node scripts/check-changed.mjs -- <12 touched paths>` passed, including formatting, production/test typechecks, lint, env/max-lines/assertion ratchets, database-first, dependency, dead-export, and import-cycle guards.
- Docs: `pnpm docs:check-mdx`, `pnpm docs:check-links`, and `pnpm docs:check-i18n-glossary`.
- Live built CLI/Gateway: seeded an isolated session with seven transcript rows, ran `openclaw sessions compact agent:main:main --max-lines 3`, observed `Compacted session agent:main:main (kept 3 lines).`, verified the Gateway returned only the retained header plus the last two messages, found no `.jsonl.bak.*` artifact under the isolated state directory, and confirmed a second run reported `No compaction needed for session agent:main:main.`
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; maintainer-reviewed and live-verified.
