### PR TITLE
fix(ci): restore environment variable count ratchet

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,5 +1,5 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it without owner approval.
 # Worker bundle installation no longer injects OPENCLAW_STATE_DIR into a remote npm process.
-# OPENCLAW_VERSION remains a supported runtime override after compile-time define retirement.
-502
+# The internal Node-version check no longer contributes a false OPENCLAW_* name.
+501


### PR DESCRIPTION
Related: #125175

## What Problem This Solves

Fixes an issue where the environment-variable count ratchet fails on current `main` because the recorded budget is one higher than the actual production-source count.

## Why This Change Was Made

Restores the shrink-only budget to the measured 501 names after the internal Node-version expression stopped using the `OPENCLAW_*` prefix. This preserves the ratchet invariant without adding configuration surface or changing runtime behavior.

## User Impact

Maintainers can run the environment-variable count gate successfully again, and future `OPENCLAW_*` growth remains visible instead of being hidden by an unused budget slot.

## Evidence

- Before on `e3d553b73419239a0231aaccd2a029983b9f2717`: `OPENCLAW_* count 501 is below budget 502`
- After: `node scripts/check-env-var-count.mts --base origin/main` reports `OPENCLAW_* count 501/501`
- `git diff --check` passes.
- Fresh Codex autoreview is clean with no accepted/actionable findings.

Production/config LOC: +2/-2 (net 0). Tests: unchanged.
