### PR TITLE
fix(exec): close the ATTACH DATABASE hole in the live-state sqlite guard

### DIFF
--- a/src/agents/bash-tools.exec-live-state-sqlite-guard.test.ts
+++ b/src/agents/bash-tools.exec-live-state-sqlite-guard.test.ts
@@ -74,6 +74,37 @@ describeNonWin("exec live OpenClaw state SQLite guard", () => {
     });
   });
 
+  it("detects ATTACH DATABASE references to the live state database", async () => {
+    await withTempDir("openclaw-exec-live-sqlite-attach-", async (root) => {
+      const stateDir = path.join(root, "state");
+      const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+      await fs.mkdir(path.dirname(databasePath), { recursive: true });
+      await fs.writeFile(databasePath, "fixture");
+      const scratchPath = path.join(root, "scratch.db");
+
+      const context = { stateDir, workdir: root };
+      await expect(
+        detectUnsafeExecControlShellCommand(
+          `sqlite3 ${quote(scratchPath)} ${quote(`ATTACH DATABASE '${databasePath}' AS live; INSERT INTO live.t VALUES (1);`)}`,
+          context,
+        ),
+      ).resolves.toBe("live-state-sqlite");
+      await expect(
+        detectUnsafeExecControlShellCommand(
+          `sqlite3 :memory: ${quote(`attach '${databasePath}' as x`)}`,
+          context,
+        ),
+      ).resolves.toBe("live-state-sqlite");
+      // A copy outside the state directory stays allowed.
+      await expect(
+        detectUnsafeExecControlShellCommand(
+          `sqlite3 ${quote(scratchPath)} ${quote(`ATTACH DATABASE '${scratchPath}' AS copy;`)}`,
+          context,
+        ),
+      ).resolves.toBeNull();
+    });
+  });
+
   it("detects relative and symlink-aliased live state targets", async () => {
     await withTempDir("openclaw-exec-live-sqlite-alias-", async (root) => {
       const stateDir = path.join(root, "state");

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -48,6 +48,11 @@ const SQLITE_OPEN_OPTIONS_WITH_VALUES = new Map<string, number>([
   ["textkey", 1],
 ]);
 
+// ATTACH [DATABASE] '<path>' | "<path>" | <bare-path> — case-insensitive, as
+// SQLite keywords are.
+const SQLITE_ATTACH_DATABASE_RE =
+  /\bATTACH(?:\s+DATABASE)?\s+(?:'([^']+)'|"([^"]+)"|([^\s;]+))/giu;
+
 function parseExecApprovalShellCommand(raw: string): ParsedExecApprovalCommand | null {
   const normalized = raw.trimStart();
   const match = normalized.match(
@@ -186,6 +191,16 @@ function parseSqliteDatabaseTokens(argv: string[]): string[] {
     const databaseToken = parseSqliteOpenCommandDatabaseToken(commandToken);
     if (databaseToken) {
       databaseTokens.push(databaseToken);
+    }
+    // SQL statements can attach another database file without ever naming it
+    // as an argv entry or .open target: sqlite3 scratch.db "ATTACH DATABASE
+    // '/state/live.db' AS live; ...". Extract those paths too, otherwise the
+    // live-state guard is trivially bypassed.
+    for (const match of commandToken.matchAll(SQLITE_ATTACH_DATABASE_RE)) {
+      const attachToken = match[1] ?? match[2] ?? match[3];
+      if (attachToken) {
+        databaseTokens.push(attachToken);
+      }
     }
   }
   return databaseTokens;


### PR DESCRIPTION
## Summary

fix(exec): close the `ATTACH DATABASE` hole in the live-state SQLite guard, so agent-run sqlite3 commands can't attach the live state database through SQL

## What Problem This Solves

A recent guard (`204416747e8`, #123816) blocks agent `exec` commands that open OpenClaw's live state database with the external `sqlite3` client — external clients bypass the runtime/version guard and can join the live WAL. The guard's own comment states that intent.

But `parseSqliteDatabaseTokens` only collects database paths from two places: argv filename arguments, and `.open` targets inside `-cmd` dot-commands. SQL statement arguments are never inspected, so this sails straight through:

```bash
sqlite3 /tmp/scratch.db "ATTACH DATABASE '/home/user/.openclaw/state/openclaw-state.db' AS live; INSERT INTO live.<table> VALUES (...);"
```

The main filename is outside the state directory, the SQL contains no `.open` — and `ATTACH` opens the live database in the same WAL mode, exactly what the guard exists to prevent. The guard is fully bypassed.

**代码证据**: `src/infra/exec-control-command-guard.ts` — `parseSqliteDatabaseTokens` iterates `commandTokens` only with `parseSqliteOpenCommandDatabaseToken` (matches `/^\.op(e(n)?)?$/`); no `ATTACH` handling anywhere in the file.

Trigger condition: any agent exec of `sqlite3` with an `ATTACH DATABASE '<state-db path>'` statement.

## Root Cause

- The guard was introduced in commit `204416747e8` (2026-08-14, #123816) with the two extraction paths above; SQL-level attachment was overlooked.
- Violated invariant: the guard must account for every way sqlite3 can open a database file — argv, dot-commands, and SQL. Covering two of three leaves the fence open.

## Why This Fix

- Option A (chosen): extract `ATTACH [DATABASE] '<path>' | "<path>" | <bare-path>` targets from SQL statement tokens with a narrow regex and feed them through the same expansion (`$OPENCLAW_STATE_DIR`, `~`, `file:` URLs) and canonical containment check as the other two paths. Minimal, reuses the existing pipeline.
- Option B: parse full SQL. Overkill — the guard only needs the attach target path.
- Not chosen: blocking all SQL-bearing invocations — breaks legitimate read-only inspection of private copies, which the guard explicitly allows (there is a test for it).

## User Impact

- Affected scenarios: agent exec tool usage of `sqlite3` on gateway hosts.
- Before: an agent (or a prompt-injected command) can read/write the live state database via `ATTACH`, bypassing the guard's fail-closed protection.
- After: such commands are detected as `live-state-sqlite` and blocked like the argv/`.open` variants; legitimate copies outside the state directory remain allowed.
- Behavior change: closes a guard bypass; no change for allowed usage.

## Evidence

Runs the real `detectUnsafeExecControlShellCommand` with a real temp state directory (Node v24, tsx) — no mocks.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-sqlite-guard-attach.mjs
FAIL ATTACH with quoted path to the live db
  detected: null (expected "live-state-sqlite")
FAIL lowercase attach to the live db
  detected: null (expected "live-state-sqlite")
PASS control: ATTACH of a private copy outside the state dir
PASS control: direct argv reference still detected
RESULT: 2 FAILURES (guard bypass present)
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-sqlite-guard-attach.mjs
PASS ATTACH with quoted path to the live db
PASS lowercase attach to the live db
PASS control: ATTACH of a private copy outside the state dir
PASS control: direct argv reference still detected
RESULT: ALL PASS
```

**What was not tested:** the end-to-end exec-tool integration path (its suite is POSIX-only and skipped on this Windows host); the guard function itself is exercised directly with real path canonicalization.

## Tests and Validation

- New regression test `detects ATTACH DATABASE references to the live state database` in `src/agents/bash-tools.exec-live-state-sqlite-guard.test.ts` (POSIX lane): quoted/unquoted/lowercase ATTACH to the live db detected; ATTACH of an outside-state copy still allowed.
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
