### PR TITLE
fix: report session changes during deletion

### DIFF
--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -71,7 +71,6 @@ export type DeleteSessionEntryLifecycleResult = {
   deleted: boolean;
   expectedEntryMismatch?: true;
   deletedEntry?: SessionEntry;
-  deletedSessionFile?: string;
   deletedSessionId?: string;
 };
 

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -12,6 +12,7 @@ import {
   loadSessionEntry,
   loadTranscriptEvents,
   replaceSessionEntry,
+  replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "./session-accessor.js";
 import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-state.js";
@@ -582,6 +583,40 @@ describe("SQLite lifecycle cleanup races", () => {
     await expect(
       loadTranscriptEvents({ sessionKey, sessionId: sessionIds[2]!, storePath }),
     ).resolves.toEqual([{ ...events[2]!, content: "concurrent transcript" }]);
+  });
+
+  it("reports an entry replacement during final transcript materialization", async () => {
+    const sessionKey = "agent:main:entry-materialization-race";
+    const sessionId = "entry-materialization-run";
+    const events = [{ type: "session" as const, id: sessionId, content: "original transcript" }];
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
+    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
+    const currentEntry = loadSessionEntry({ sessionKey, storePath });
+    if (!currentEntry) {
+      throw new Error("expected current guarded entry");
+    }
+    const replacementEntry = { ...currentEntry, label: "concurrent replacement" };
+    archiveMaterializationHook.afterMaterialize = () => {
+      replaceSessionEntrySync({ sessionKey, storePath }, replacementEntry);
+    };
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      expectedEntry: currentEntry,
+      expectedTranscript: { eventJson: [JSON.stringify(events[0])], sessionId },
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    });
+
+    expect(result).toEqual({
+      archivedTranscripts: [],
+      deleted: false,
+      expectedEntryMismatch: true,
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toEqual(replacementEntry);
+    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(
+      events,
+    );
   });
 
   it("releases the store writer while lifecycle cleanup archives a transcript", async () => {

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -12,6 +12,7 @@ import {
   loadSessionEntry,
   loadTranscriptEvents,
   replaceSessionEntry,
+  replaceTranscriptEventsSync,
 } from "./session-accessor.js";
 import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-state.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
@@ -528,6 +529,59 @@ describe("SQLite lifecycle cleanup races", () => {
     await expect(deletion).resolves.toMatchObject({ deleted: true });
     await expect(writer).resolves.toMatchObject({ label: "progressed" });
     expect(progressedDuringMaterialization).toBe(true);
+  });
+
+  it("reports a transcript guard mismatch after publishing earlier history", async () => {
+    const sessionKey = "agent:main:historical-guard-race";
+    const sessionIds = ["historical-guard-first", "historical-guard-second", "guard-current"];
+    const events = sessionIds.map((sessionId) => ({
+      type: "session" as const,
+      id: sessionId,
+      content: `${sessionId} transcript`,
+    }));
+    for (const [index, sessionId] of sessionIds.entries()) {
+      await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: index + 1 });
+      await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, [events[index]!]);
+    }
+    const currentEntry = loadSessionEntry({ sessionKey, storePath });
+    if (!currentEntry) {
+      throw new Error("expected current guarded entry");
+    }
+    let materializations = 0;
+    archiveMaterializationHook.afterMaterialize = () => {
+      materializations += 1;
+      if (materializations === 2) {
+        replaceTranscriptEventsSync({ sessionKey, sessionId: sessionIds[2]!, storePath }, [
+          { ...events[2]!, content: "concurrent transcript" },
+        ]);
+      }
+    };
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      expectedEntry: currentEntry,
+      expectedTranscript: {
+        eventJson: [JSON.stringify(events[2])],
+        sessionId: sessionIds[2]!,
+      },
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    });
+
+    expect(result).toMatchObject({ deleted: false, expectedEntryMismatch: true });
+    expect(result.archivedTranscripts).toHaveLength(1);
+    expect(materializations).toBe(2);
+    expect(loadSessionEntry({ sessionKey, storePath })).toEqual(currentEntry);
+    const archivedSessionId = result.archivedTranscripts[0]?.sessionId;
+    expect(sessionIds.slice(0, 2)).toContain(archivedSessionId);
+    for (const [index, historicalSessionId] of sessionIds.slice(0, 2).entries()) {
+      await expect(
+        loadTranscriptEvents({ sessionKey, sessionId: historicalSessionId, storePath }),
+      ).resolves.toEqual(historicalSessionId === archivedSessionId ? [] : [events[index]!]);
+    }
+    await expect(
+      loadTranscriptEvents({ sessionKey, sessionId: sessionIds[2]!, storePath }),
+    ).resolves.toEqual([{ ...events[2]!, content: "concurrent transcript" }]);
   });
 
   it("releases the store writer while lifecycle cleanup archives a transcript", async () => {

--- a/src/config/sessions/session-accessor.sqlite-entry-equality.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-equality.ts
@@ -1,5 +1,10 @@
 import type { SessionEntry } from "./types.js";
 
+type SqliteLifecycleTargetSnapshot = {
+  primary: { entry: SessionEntry; key: string } | undefined;
+  rows: Array<{ entry: SessionEntry; sessionKey: string }>;
+};
+
 export function sqliteSessionEntriesEqual(
   left: SessionEntry | undefined,
   right: SessionEntry | undefined,
@@ -33,5 +38,16 @@ export function sqliteSessionSnapshotRowsEqual(
         row.sessionKey === right[index]?.sessionKey &&
         sqliteSessionEntriesEqual(row.entry, right[index]?.entry),
     )
+  );
+}
+
+export function sqliteLifecycleTargetSnapshotsEqual(
+  expected: SqliteLifecycleTargetSnapshot,
+  current: SqliteLifecycleTargetSnapshot,
+): boolean {
+  return (
+    expected.primary?.key === current.primary?.key &&
+    sqliteSessionEntriesEqual(expected.primary?.entry, current.primary?.entry) &&
+    sqliteSessionSnapshotRowsEqual(expected.rows, current.rows)
   );
 }

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -16,6 +16,7 @@ import {
   trackSessionEntryCacheWrite,
 } from "./session-accessor.sqlite-entry-cache.js";
 import {
+  sqliteLifecycleTargetSnapshotsEqual,
   sqliteSessionEntriesEqual,
   sqliteSessionSnapshotRowsEqual,
 } from "./session-accessor.sqlite-entry-equality.js";
@@ -346,16 +347,6 @@ export function assertLifecycleTargetSnapshotUnchanged(
   if (!sqliteLifecycleTargetSnapshotsEqual(expected, current)) {
     throw new SqliteSessionMutationConflictError(operationLabel);
   }
-}
-
-export function sqliteLifecycleTargetSnapshotsEqual(
-  expected: SqliteLifecycleTargetSnapshot,
-  current: SqliteLifecycleTargetSnapshot,
-): boolean {
-  const primaryMatches =
-    expected.primary?.key === current.primary?.key &&
-    sqliteSessionEntriesEqual(expected.primary?.entry, current.primary?.entry);
-  return primaryMatches && sqliteSessionSnapshotRowsEqual(expected.rows, current.rows);
 }
 
 export function normalizeLifecycleTarget(target: { canonicalKey: string; storeKeys: string[] }): {

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -343,12 +343,19 @@ export function assertLifecycleTargetSnapshotUnchanged(
   current: SqliteLifecycleTargetSnapshot,
   operationLabel: string,
 ): void {
+  if (!sqliteLifecycleTargetSnapshotsEqual(expected, current)) {
+    throw new SqliteSessionMutationConflictError(operationLabel);
+  }
+}
+
+export function sqliteLifecycleTargetSnapshotsEqual(
+  expected: SqliteLifecycleTargetSnapshot,
+  current: SqliteLifecycleTargetSnapshot,
+): boolean {
   const primaryMatches =
     expected.primary?.key === current.primary?.key &&
     sqliteSessionEntriesEqual(expected.primary?.entry, current.primary?.entry);
-  if (!primaryMatches || !sqliteSessionSnapshotRowsEqual(expected.rows, current.rows)) {
-    throw new SqliteSessionMutationConflictError(operationLabel);
-  }
+  return primaryMatches && sqliteSessionSnapshotRowsEqual(expected.rows, current.rows);
 }
 
 export function normalizeLifecycleTarget(target: { canonicalKey: string; storeKeys: string[] }): {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -296,6 +296,8 @@ async function deleteSqliteSessionEntryLifecycleInternal(
   }
 }
 
+const DELETE_EXPECTED_ENTRY_MISMATCH = Symbol("delete-expected-entry-mismatch");
+
 async function deleteSqliteSessionEntryLifecycleLocked(
   resolved: ReturnType<typeof resolveSqliteStoreScope>,
   params: DeleteSessionEntryLifecycleParams,
@@ -310,7 +312,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       return null;
     }
     if (!shouldDeleteSqliteSessionEntryLifecycle(database, current.entry, params)) {
-      return null;
+      return DELETE_EXPECTED_ENTRY_MISMATCH;
     }
     if (current.entry.modelSelectionLocked === true && !allowLockedEntryRemoval) {
       throw new Error(MODEL_SELECTION_LOCK_REMOVAL_MESSAGE);
@@ -383,6 +385,10 @@ async function deleteSqliteSessionEntryLifecycleLocked(
     await publishSessionStateArchives(resolved, []);
     return { archivedTranscripts: [], deleted: false };
   }
+  if (prepared === DELETE_EXPECTED_ENTRY_MISMATCH) {
+    await publishSessionStateArchives(resolved, []);
+    return expectedEntryMismatchResult([]);
+  }
 
   const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
   for (const sessionId of prepared.historicalGenerationIds) {
@@ -394,7 +400,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         "delete session entry",
       );
       if (!shouldDeleteSqliteSessionEntryLifecycle(database, prepared.current.entry, params)) {
-        return null;
+        return DELETE_EXPECTED_ENTRY_MISMATCH;
       }
       const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
         database,
@@ -421,12 +427,14 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         sessionId,
       });
     });
+    if (plan === DELETE_EXPECTED_ENTRY_MISMATCH) {
+      return expectedEntryMismatchResult(historicalArchivedTranscripts);
+    }
     if (!plan) {
       continue;
     }
     const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
-    const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () => {
-      let committed: SessionLifecycleArchivedTranscript[] = [];
+    const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () =>
       runOpenClawAgentWriteTransaction((transactionDb) => {
         assertLifecycleTargetSnapshotUnchanged(
           prepared.targetSnapshot,
@@ -436,7 +444,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         if (
           !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, prepared.current.entry, params)
         ) {
-          return;
+          return DELETE_EXPECTED_ENTRY_MISMATCH;
         }
         const fenceAtDelete = collectAdmissionProtectedSessionIds({
           database: transactionDb,
@@ -447,10 +455,12 @@ async function deleteSqliteSessionEntryLifecycleLocked(
             `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
           );
         }
-        committed = deleteMaterializedSessionStatePlans(transactionDb, materializedGeneration);
-      }, toDatabaseOptions(resolved));
-      return committed;
-    });
+        return deleteMaterializedSessionStatePlans(transactionDb, materializedGeneration);
+      }, toDatabaseOptions(resolved)),
+    );
+    if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
+      return expectedEntryMismatchResult(historicalArchivedTranscripts);
+    }
     // Publish each committed generation immediately: a later archive or
     // transaction failure aborts the deletion, and observers must still see
     // the removals that already happened (retry completes the remainder).
@@ -462,12 +472,8 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   // Archive materialization is the expensive phase. It must run between short
   // writer-lane sections so unrelated writes to this store can keep progressing.
   const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
-  const result = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    let committed: DeleteSessionEntryLifecycleResult = {
-      archivedTranscripts: [],
-      deleted: false,
-    };
-    runOpenClawAgentWriteTransaction((transactionDb) => {
+  const result = await runExclusiveSqliteSessionWrite(resolved, async () =>
+    runOpenClawAgentWriteTransaction<DeleteSessionEntryLifecycleResult>((transactionDb) => {
       const transactionSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
       assertLifecycleTargetSnapshotUnchanged(
         prepared.targetSnapshot,
@@ -476,7 +482,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       );
       const transactionEntry = transactionSnapshot.primary?.entry;
       if (!shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)) {
-        return;
+        return expectedEntryMismatchResult([]);
       }
       const archivedTranscripts = deleteMaterializedSessionStatePlans(
         transactionDb,
@@ -494,7 +500,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         ...params.target.storeKeys,
         ...transactionSnapshot.rows.map((row) => row.sessionKey),
       ]);
-      committed = {
+      return {
         archivedTranscripts,
         deleted: true,
         deletedEntry: cloneSessionEntry(prepared.current.entry),
@@ -502,9 +508,8 @@ async function deleteSqliteSessionEntryLifecycleLocked(
           ? { deletedSessionId: prepared.current.entry.sessionId }
           : {}),
       };
-    }, toDatabaseOptions(resolved));
-    return committed;
-  });
+    }, toDatabaseOptions(resolved)),
+  );
   if (result.deleted) {
     emitSessionIdentityMutation({
       kind: "delete",
@@ -525,6 +530,12 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   // the result after the final emit so callers still see every archive.
   result.archivedTranscripts.push(...historicalArchivedTranscripts);
   return result;
+}
+
+function expectedEntryMismatchResult(
+  archivedTranscripts: SessionLifecycleArchivedTranscript[],
+): DeleteSessionEntryLifecycleResult {
+  return { archivedTranscripts, deleted: false, expectedEntryMismatch: true };
 }
 
 /** Deletes one persisted session entry using SQLite session rows. */

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -29,12 +29,12 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import { sqliteSessionEntriesEqual } from "./session-accessor.sqlite-entry-equality.js";
 import {
-  assertLifecycleTargetSnapshotUnchanged,
   assertLifecycleTargetUnchanged,
   deleteLifecycleTargetRows,
   deleteLegacySessionEntryRows,
   readLifecycleTargetSnapshot,
   rehomeSessionWindows,
+  sqliteLifecycleTargetSnapshotsEqual,
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitArchivedTranscriptUpdates } from "./session-accessor.sqlite-events.js";
@@ -394,12 +394,11 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   for (const sessionId of prepared.historicalGenerationIds) {
     const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
       const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-      assertLifecycleTargetSnapshotUnchanged(
-        prepared.targetSnapshot,
-        readLifecycleTargetSnapshot(database, params.target),
-        "delete session entry",
-      );
-      if (!shouldDeleteSqliteSessionEntryLifecycle(database, prepared.current.entry, params)) {
+      const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+      if (
+        !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+        !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot.primary?.entry, params)
+      ) {
         return DELETE_EXPECTED_ENTRY_MISMATCH;
       }
       const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
@@ -436,13 +435,14 @@ async function deleteSqliteSessionEntryLifecycleLocked(
     const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
     const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () =>
       runOpenClawAgentWriteTransaction((transactionDb) => {
-        assertLifecycleTargetSnapshotUnchanged(
-          prepared.targetSnapshot,
-          readLifecycleTargetSnapshot(transactionDb, params.target),
-          "delete session entry",
-        );
+        const targetSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
         if (
-          !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, prepared.current.entry, params)
+          !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+          !shouldDeleteSqliteSessionEntryLifecycle(
+            transactionDb,
+            targetSnapshot.primary?.entry,
+            params,
+          )
         ) {
           return DELETE_EXPECTED_ENTRY_MISMATCH;
         }
@@ -475,13 +475,11 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   const result = await runExclusiveSqliteSessionWrite(resolved, async () =>
     runOpenClawAgentWriteTransaction<DeleteSessionEntryLifecycleResult>((transactionDb) => {
       const transactionSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
-      assertLifecycleTargetSnapshotUnchanged(
-        prepared.targetSnapshot,
-        transactionSnapshot,
-        "delete session entry",
-      );
       const transactionEntry = transactionSnapshot.primary?.entry;
-      if (!shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)) {
+      if (
+        !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, transactionSnapshot) ||
+        !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)
+      ) {
         return expectedEntryMismatchResult([]);
       }
       const archivedTranscripts = deleteMaterializedSessionStatePlans(

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -27,14 +27,16 @@ import type {
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
 } from "./session-accessor.sqlite-contract.js";
-import { sqliteSessionEntriesEqual } from "./session-accessor.sqlite-entry-equality.js";
+import {
+  sqliteLifecycleTargetSnapshotsEqual,
+  sqliteSessionEntriesEqual,
+} from "./session-accessor.sqlite-entry-equality.js";
 import {
   assertLifecycleTargetUnchanged,
   deleteLifecycleTargetRows,
   deleteLegacySessionEntryRows,
   readLifecycleTargetSnapshot,
   rehomeSessionWindows,
-  sqliteLifecycleTargetSnapshotsEqual,
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitArchivedTranscriptUpdates } from "./session-accessor.sqlite-events.js";

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -450,7 +450,6 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
             sessionKey: target.canonicalKey ?? key,
             sessionId: result.deletedSessionId,
             storePath,
-            sessionFile: result.deletedSessionFile,
             agentId: target.agentId,
             reason: "deleted",
             archivedTranscripts: result.archivedTranscripts,

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -36,6 +36,25 @@ import {
   directSessionReq,
 } from "./test/server-sessions.test-helpers.js";
 
+const sessionArchiveMaterializationHook = vi.hoisted(() => ({
+  afterMaterialize: undefined as (() => void) | undefined,
+}));
+
+vi.mock("../config/sessions/session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../config/sessions/session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    materializeSessionStateDeletePlans: async (
+      ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
+    ) => {
+      const result = await actual.materializeSessionStateDeletePlans(...args);
+      sessionArchiveMaterializationHook.afterMaterialize?.();
+      return result;
+    },
+  };
+});
+
 const {
   createConfiguredGlobalAgentSessionStore,
   createSessionStoreDir,
@@ -44,6 +63,7 @@ const {
 } = setupGatewaySessionsTestHarness();
 
 afterEach(() => {
+  sessionArchiveMaterializationHook.afterMaterialize = undefined;
   closeOpenClawStateDatabaseForTest();
 });
 
@@ -459,6 +479,45 @@ test("sessions.delete reports an exact-entry replacement after cleanup", async (
     sessionId,
     updatedAt,
   });
+});
+
+test("sessions.delete reports an exact-entry replacement during transcript materialization", async () => {
+  const sessionKey = "agent:main:cron:materialization-race";
+  const sessionId = "materialization-race-run";
+  const lifecycleRevision = "materialization-race-revision";
+  const updatedAt = 1_737_600_000_000;
+  const { storePath } = await createSessionStoreDir();
+  const events = [{ type: "session" as const, id: sessionId, content: "original transcript" }];
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision, updatedAt }),
+    },
+  });
+  await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
+  sessionArchiveMaterializationHook.afterMaterialize = () => {
+    replaceSessionEntrySync(
+      { sessionKey, storePath },
+      sessionStoreEntry(sessionId, {
+        label: "concurrent replacement",
+        lifecycleRevision,
+        updatedAt,
+      }),
+    );
+  };
+
+  await expectSessionDeleteChanged({
+    key: sessionKey,
+    expectedLifecycleRevision: lifecycleRevision,
+    expectedSessionId: sessionId,
+  });
+
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    label: "concurrent replacement",
+    lifecycleRevision,
+    sessionId,
+    updatedAt,
+  });
+  await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(events);
 });
 
 test("sessions.delete includes cleanup-owned row changes in its guarded deletion", async () => {

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -1,20 +1,17 @@
 // Session delete lifecycle tests protect transcript deletion, ACP metadata,
 // active-run cleanup, hooks, thread bindings, and browser/MCP cleanup.
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import { afterEach, expect, test, vi } from "vitest";
 import {
   readAcpSessionMeta,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
-import { getRegistryWorktree } from "../agents/worktrees/registry.js";
-import { managedWorktrees } from "../agents/worktrees/service.js";
 import {
   loadSessionEntry,
   loadTranscriptEvents,
   replaceSessionEntry,
+  replaceSessionEntrySync,
 } from "../config/sessions/session-accessor.js";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.sqlite-transcript-write.js";
 import {
@@ -22,8 +19,8 @@ import {
   runExclusiveSessionLifecycleMutation,
 } from "../sessions/session-lifecycle-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { embeddedRunMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
+import type { SessionMutationAuthorization } from "./server-methods/shared-types.js";
+import { embeddedRunMock, rpcReq, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
   sessionLifecycleHookMocks,
@@ -45,29 +42,6 @@ const {
   openClient,
   resetConfiguredGlobalAgentSessionStore,
 } = setupGatewaySessionsTestHarness();
-const execFileAsync = promisify(execFile);
-
-async function initializeRemoteBackedGitWorkspace(root: string): Promise<string> {
-  const workspace = path.join(root, "workspace");
-  const remote = path.join(root, "remote.git");
-  await fs.mkdir(workspace, { recursive: true });
-  await execFileAsync("git", ["-C", workspace, "init", "-b", "main"]);
-  await execFileAsync("git", ["-C", workspace, "config", "user.name", "OpenClaw Test"]);
-  await execFileAsync("git", [
-    "-C",
-    workspace,
-    "config",
-    "user.email",
-    "openclaw-test@example.invalid",
-  ]);
-  await fs.writeFile(path.join(workspace, "README.md"), "base\n");
-  await execFileAsync("git", ["-C", workspace, "add", "README.md"]);
-  await execFileAsync("git", ["-C", workspace, "commit", "-m", "initial"]);
-  await execFileAsync("git", ["clone", "--bare", workspace, remote]);
-  await execFileAsync("git", ["-C", workspace, "remote", "add", "origin", remote]);
-  await execFileAsync("git", ["-C", workspace, "push", "-u", "origin", "main"]);
-  return await fs.realpath(workspace);
-}
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
@@ -100,6 +74,23 @@ async function expectSessionDeleteSucceeds(request: SessionDeleteRequest) {
   return deleted;
 }
 
+async function expectSessionDeleteChanged(
+  request: SessionDeleteRequest,
+  authorization?: SessionMutationAuthorization,
+) {
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    request,
+    authorization ? { sessionMutationAuthorization: authorization } : undefined,
+  );
+  expect(deleted.ok).toBe(false);
+  expect(deleted.error?.message).toBe(`Session ${request.key} changed before deletion. Retry.`);
+  expect((deleted.error as { details?: unknown } | undefined)?.details).toEqual({
+    reason: "session-changed",
+  });
+  return deleted;
+}
+
 async function seedSubagentWorkerSession() {
   const { dir } = await createSessionStoreDir();
   await writeSingleLineSession(dir, "sess-subagent", "hello");
@@ -117,87 +108,6 @@ function expectThreadBindingsUnbound(targetSessionKey: string) {
     reason: "session-delete",
   });
 }
-
-test("sessions.delete snapshots and removes session worktrees", async () => {
-  const openClawState = await createOpenClawTestState({
-    layout: "state-only",
-    prefix: "openclaw-delete-worktree-",
-  });
-  const root = openClawState.root;
-  const workspace = await initializeRemoteBackedGitWorkspace(root);
-  closeOpenClawStateDatabaseForTest();
-  testState.agentConfig = { workspace };
-  await createSessionStoreDir();
-  let dirtyWorktreeId: string | undefined;
-  try {
-    const adminClient = { connect: { scopes: ["operator.admin"] } } as never;
-    await fs.writeFile(path.join(workspace, "local-base.txt"), "inherited local commit\n");
-    await execFileAsync("git", ["-C", workspace, "add", "local-base.txt"]);
-    await execFileAsync("git", ["-C", workspace, "commit", "-m", "local base"]);
-    const clean = await directSessionReq<{
-      key: string;
-      worktree: { id: string; path: string; branch: string };
-    }>("sessions.create", { agentId: "main", worktree: true }, { client: adminClient });
-    expect(clean.ok).toBe(true);
-    const cleanKey = clean.payload?.key;
-    const cleanWorktree = clean.payload?.worktree;
-    expect(cleanKey).toBeTruthy();
-    expect(cleanWorktree).toBeTruthy();
-
-    await expectSessionDeleteSucceeds({ key: cleanKey! });
-
-    await expect(fs.access(cleanWorktree!.path)).rejects.toThrow();
-    expect(getRegistryWorktree(process.env, cleanWorktree!.id)).toMatchObject({
-      removedAt: expect.any(Number),
-      snapshotRef: expect.stringMatching(/^refs\/openclaw\/snapshots\//),
-    });
-    const registered = await execFileAsync("git", [
-      "-C",
-      workspace,
-      "worktree",
-      "list",
-      "--porcelain",
-    ]);
-    expect(registered.stdout).not.toContain(cleanWorktree!.path);
-    const branch = await execFileAsync("git", [
-      "-C",
-      workspace,
-      "branch",
-      "--list",
-      cleanWorktree!.branch,
-    ]);
-    expect(branch.stdout.trim()).toBe("");
-
-    const dirty = await directSessionReq<{
-      key: string;
-      worktree: { id: string; path: string; branch: string };
-    }>("sessions.create", { agentId: "main", worktree: true }, { client: adminClient });
-    expect(dirty.ok).toBe(true);
-    const dirtyKey = dirty.payload?.key;
-    const dirtyWorktree = dirty.payload?.worktree;
-    dirtyWorktreeId = dirtyWorktree?.id;
-    await fs.writeFile(path.join(dirtyWorktree!.path, "dirty.txt"), "keep me\n");
-
-    await expectSessionDeleteSucceeds({ key: dirtyKey! });
-
-    await expect(fs.access(dirtyWorktree!.path)).rejects.toThrow();
-    expect(getRegistryWorktree(process.env, dirtyWorktree!.id)).toMatchObject({
-      removedAt: expect.any(Number),
-      snapshotRef: expect.stringMatching(/^refs\/openclaw\/snapshots\//),
-    });
-    dirtyWorktreeId = undefined;
-  } finally {
-    if (
-      dirtyWorktreeId &&
-      getRegistryWorktree(process.env, dirtyWorktreeId)?.removedAt === undefined
-    ) {
-      await managedWorktrees.remove({ id: dirtyWorktreeId, reason: "test-cleanup", force: true });
-    }
-    closeOpenClawStateDatabaseForTest();
-    testState.agentConfig = undefined;
-    await openClawState.cleanup();
-  }
-});
 
 test("sessions.delete rejects main and aborts active runs", async () => {
   const { dir } = await createSessionStoreDir();
@@ -396,14 +306,9 @@ test("sessions.delete rejects a stale expected session id without interrupting i
   });
 
   try {
-    const deleted = await directSessionReq("sessions.delete", {
+    await expectSessionDeleteChanged({
       key: sessionKey,
       expectedSessionId: "sess-stale",
-    });
-    expect(deleted.ok).toBe(false);
-    expect(deleted.error?.message).toBe(`Session ${sessionKey} changed before deletion. Retry.`);
-    expect((deleted.error as { details?: unknown } | undefined)?.details).toEqual({
-      reason: "session-changed",
     });
     expect(interrupted).toBe(false);
   } finally {
@@ -492,14 +397,13 @@ test("sessions.delete rejects a replacement with the same updated-at timestamp",
   });
 
   try {
-    const deleted = await directSessionReq("sessions.delete", {
+    await expectSessionDeleteChanged({
       key: sessionKey,
       expectedSessionId: "stale-run",
       expectedLifecycleRevision: "stale-revision",
       expectedSessionUpdatedAt: updatedAt,
     });
 
-    expect(deleted.ok).toBe(false);
     expect(interrupted).toBe(false);
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
       lifecycleRevision: "replacement-revision",
@@ -509,6 +413,52 @@ test("sessions.delete rejects a replacement with the same updated-at timestamp",
   } finally {
     admission.release();
   }
+});
+
+test("sessions.delete reports an exact-entry replacement after cleanup", async () => {
+  const sessionKey = "agent:main:cron:cleanup-race";
+  const sessionId = "cleanup-race-run";
+  const lifecycleRevision = "cleanup-race-revision";
+  const updatedAt = 1_737_600_000_000;
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision, updatedAt }),
+    },
+  });
+  let cleanupReached = false;
+  let replaced = false;
+  bundleMcpRuntimeMocks.disposeSessionMcpRuntime.mockImplementationOnce(async () => {
+    cleanupReached = true;
+  });
+  const assertCurrent = vi.fn(() => {
+    if (!cleanupReached || replaced) {
+      return;
+    }
+    replaced = true;
+    replaceSessionEntrySync(
+      { sessionKey, storePath },
+      sessionStoreEntry(sessionId, {
+        label: "concurrent replacement",
+        lifecycleRevision,
+        updatedAt,
+      }),
+    );
+  });
+
+  await expectSessionDeleteChanged(
+    { key: sessionKey, expectedLifecycleRevision: lifecycleRevision, expectedSessionId: sessionId },
+    { assertCurrent, assertTargetCurrent: vi.fn() },
+  );
+
+  expect(cleanupReached).toBe(true);
+  expect(replaced).toBe(true);
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    label: "concurrent replacement",
+    lifecycleRevision,
+    sessionId,
+    updatedAt,
+  });
 });
 
 test("sessions.delete includes cleanup-owned row changes in its guarded deletion", async () => {

--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -49,6 +49,92 @@ async function initializeRemoteBackedGitWorkspace(root: string): Promise<string>
   return await fs.realpath(workspace);
 }
 
+test("sessions.delete snapshots and removes session worktrees", async () => {
+  const openClawState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-delete-worktree-",
+  });
+  const workspace = await initializeRemoteBackedGitWorkspace(openClawState.root);
+  closeOpenClawStateDatabaseForTest();
+  testState.agentConfig = { workspace };
+  await createSessionStoreDir();
+  let dirtyWorktreeId: string | undefined;
+  try {
+    const adminClient = { connect: { scopes: ["operator.admin"] } } as never;
+    await fs.writeFile(path.join(workspace, "local-base.txt"), "inherited local commit\n");
+    await execFileAsync("git", ["-C", workspace, "add", "local-base.txt"]);
+    await execFileAsync("git", ["-C", workspace, "commit", "-m", "local base"]);
+    const clean = await directSessionReq<{
+      key: string;
+      worktree: { id: string; path: string; branch: string };
+    }>("sessions.create", { agentId: "main", worktree: true }, { client: adminClient });
+    expect(clean.ok).toBe(true);
+    const cleanKey = clean.payload?.key;
+    const cleanWorktree = clean.payload?.worktree;
+    expect(cleanKey).toBeTruthy();
+    expect(cleanWorktree).toBeTruthy();
+
+    await expect(directSessionReq("sessions.delete", { key: cleanKey! })).resolves.toMatchObject({
+      ok: true,
+      payload: { deleted: true },
+    });
+
+    await expect(fs.access(cleanWorktree!.path)).rejects.toThrow();
+    expect(getRegistryWorktree(process.env, cleanWorktree!.id)).toMatchObject({
+      removedAt: expect.any(Number),
+      snapshotRef: expect.stringMatching(/^refs\/openclaw\/snapshots\//),
+    });
+    const registered = await execFileAsync("git", [
+      "-C",
+      workspace,
+      "worktree",
+      "list",
+      "--porcelain",
+    ]);
+    expect(registered.stdout).not.toContain(cleanWorktree!.path);
+    const branch = await execFileAsync("git", [
+      "-C",
+      workspace,
+      "branch",
+      "--list",
+      cleanWorktree!.branch,
+    ]);
+    expect(branch.stdout.trim()).toBe("");
+
+    const dirty = await directSessionReq<{
+      key: string;
+      worktree: { id: string; path: string; branch: string };
+    }>("sessions.create", { agentId: "main", worktree: true }, { client: adminClient });
+    expect(dirty.ok).toBe(true);
+    const dirtyKey = dirty.payload?.key;
+    const dirtyWorktree = dirty.payload?.worktree;
+    dirtyWorktreeId = dirtyWorktree?.id;
+    await fs.writeFile(path.join(dirtyWorktree!.path, "dirty.txt"), "keep me\n");
+
+    await expect(directSessionReq("sessions.delete", { key: dirtyKey! })).resolves.toMatchObject({
+      ok: true,
+      payload: { deleted: true },
+    });
+
+    await expect(fs.access(dirtyWorktree!.path)).rejects.toThrow();
+    expect(getRegistryWorktree(process.env, dirtyWorktree!.id)).toMatchObject({
+      removedAt: expect.any(Number),
+      snapshotRef: expect.stringMatching(/^refs\/openclaw\/snapshots\//),
+    });
+    dirtyWorktreeId = undefined;
+  } finally {
+    if (
+      dirtyWorktreeId &&
+      getRegistryWorktree(process.env, dirtyWorktreeId)?.removedAt === undefined
+    ) {
+      await managedWorktrees.remove({ id: dirtyWorktreeId, reason: "test-cleanup", force: true });
+    }
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = undefined;
+    await openClawState.cleanup();
+  }
+});
+
 test("sessions.delete keeps same-key successor worktree creation behind exact cleanup", async () => {
   const openClawState = await createOpenClawTestState({
     layout: "state-only",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a concurrent session replacement after delete validation could silently return `ok: true` with `deleted: false` while the session survived. That false success was indistinguishable from the intentional missing-session no-op and gave operators and clients no signal to retry.

## Why This Change Was Made

The SQLite session lifecycle now records an expected-entry mismatch at every guarded deletion phase, including target-snapshot changes after transcript materialization, preserves any historical archives already committed before a later mismatch, and keeps only the authoritative-entry-absent case benign. The producerless file-era `deletedSessionFile` result field and gateway consumer were removed.

During landing, mainline maintenance PR #125185 independently restored the `OPENCLAW_*` shrink-only ratchet to the actual 501-name production surface. This branch is rebased onto that maintenance; it is not part of the product behavior change.

## User Impact

Operators and clients now receive the retryable `session-changed` error when a session is replaced during deletion instead of receiving false success.

## Evidence

Before the initial fix, the gateway boundary regression expected `ok: false` but received `ok: true` after replacing the exact row once cleanup had captured the expected entry. The added post-materialization owner and Gateway regressions then failed on the intermediate patch with `SqliteSessionMutationConflictError`, proving the late snapshot conflict identified by ClawSweeper; both pass after translating that conflict at the lifecycle owner.

- `node scripts/run-vitest.mjs src/gateway/server.sessions.delete-lifecycle.test.ts src/gateway/server.sessions.delete-worktree-lifecycle.test.ts src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts` — 44 tests passed across two shards (28 gateway, 16 runtime-config).
- `node scripts/check-changed.mjs --dry-run -- <eight changed files>` — selected core and coreTests lanes.
- `node scripts/check-changed.mjs -- <eight changed files>` — exit 0; the environment ratchet reports `OPENCLAW_* count 501/501`, with format, type, lint, max-lines, dead-code, database-first, import-cycle, and boundary guards green.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean after the ClawSweeper repair, no accepted/actionable findings.

Production LOC: +69/-46 (net +23). Tests: +302/-118 (net +184, including the existing worktree deletion test move). PR tooling LOC: +0/-0. The positive production delta adds one reusable snapshot predicate in the mainline equality owner and complete mismatch propagation at the three late lifecycle checkpoints; placing it there also preserves the 700-line entry-store ceiling after #125057. The absorbed mainline ratchet maintenance in #125185 was tooling-only +2/-2 and is verified here by the green 501/501 gate.

Regression provenance: PR #113075 / commit c440ae3e866 removed the legacy producer on 2026-07-23; PR #113233 / commit 4273ca9dbd9 carried the stale file-era `deletedSessionFile` residue forward.

No live proof was run: this is a deterministic internal lifecycle ownership race covered at both the direct SQLite owner boundary and the Gateway RPC boundary.

## AI Assistance

AI-assisted. I reviewed and understand the change. No transcript or session logs are included.
