### PR TITLE
fix(approval): reconcile omitted turn-source thread to topic session

### DIFF
--- a/extensions/telegram/src/approval-native.test.ts
+++ b/extensions/telegram/src/approval-native.test.ts
@@ -218,6 +218,104 @@ describe("telegram native approval adapter", () => {
     });
   });
 
+  it("reconciles an omitted turn-source thread to the persisted topic session for plugin approvals", async () => {
+    // Plugin approvals can carry the originating group but omit its thread metadata. The live
+    // turn-source target then lacks the forum topic the persisted session still owns, so the
+    // origin resolver must reconcile the coarse turn-source route to the topic-scoped session
+    // target instead of rejecting it and falling back to the approver DM.
+    const storePath = createTempStorePath();
+    await writeSessionEntry({
+      storePath,
+      sessionKey: "agent:main:telegram:group:-1003841603622:topic:928",
+      entry: {
+        sessionId: "sess",
+        updatedAt: Date.now(),
+        delivery: normalizeSessionDeliveryState({
+          context: {
+            channel: "telegram",
+            to: "-1003841603622",
+            accountId: "default",
+            threadId: 928,
+          },
+        }),
+      },
+    });
+
+    const target = await telegramApprovalCapability.native?.resolveOriginTarget?.({
+      cfg: {
+        ...buildConfig(),
+        session: { store: storePath },
+      },
+      accountId: "default",
+      approvalKind: "plugin",
+      request: {
+        id: "plugin:req-omit-thread",
+        request: {
+          title: "Plugin approval",
+          description: "Allow access",
+          turnSourceChannel: "telegram",
+          turnSourceTo: "telegram:-1003841603622",
+          turnSourceAccountId: "default",
+          sessionKey: "agent:main:telegram:group:-1003841603622:topic:928",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(target).toEqual({
+      to: "-1003841603622",
+      threadId: 928,
+    });
+  });
+
+  it("stays fail-closed when the turn-source thread explicitly conflicts with the persisted topic", async () => {
+    // An explicit thread mismatch (live topic 111 vs persisted topic 928) is a real disagreement,
+    // not an omitted dimension: the reconciler must keep returning null so delivery falls back to
+    // the approver DM rather than routing the prompt to the wrong topic.
+    const storePath = createTempStorePath();
+    await writeSessionEntry({
+      storePath,
+      sessionKey: "agent:main:telegram:group:-1003841603622:topic:928",
+      entry: {
+        sessionId: "sess",
+        updatedAt: Date.now(),
+        delivery: normalizeSessionDeliveryState({
+          context: {
+            channel: "telegram",
+            to: "-1003841603622",
+            accountId: "default",
+            threadId: 928,
+          },
+        }),
+      },
+    });
+
+    const target = await telegramApprovalCapability.native?.resolveOriginTarget?.({
+      cfg: {
+        ...buildConfig(),
+        session: { store: storePath },
+      },
+      accountId: "default",
+      approvalKind: "plugin",
+      request: {
+        id: "plugin:req-conflict-thread",
+        request: {
+          title: "Plugin approval",
+          description: "Allow access",
+          turnSourceChannel: "telegram",
+          turnSourceTo: "telegram:-1003841603622:topic:111",
+          turnSourceAccountId: "default",
+          sessionKey: "agent:main:telegram:group:-1003841603622:topic:928",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(target).toBeNull();
+  });
+
   it("marks DM-only telegram approvals to notify the origin chat after delivery", () => {
     const capabilities = telegramApprovalCapability.native?.describeDeliveryCapabilities({
       cfg: buildConfig(),

--- a/src/infra/exec-approval-session-target.ts
+++ b/src/infra/exec-approval-session-target.ts
@@ -40,6 +40,9 @@ type ApprovalRequestOriginTargetResolver<TTarget> = {
   resolveTurnSourceTarget: (request: ApprovalRequestLike) => TTarget | null;
   resolveSessionTarget: (sessionTarget: ExecApprovalSessionTarget) => TTarget | null;
   targetsMatch: (a: TTarget, b: TTarget) => boolean;
+  // Reconciles a coarse turn-source route (omitting an optional dimension such as a forum thread)
+  // to the persisted session target when strict targetsMatch fails; returning null stays fail-closed.
+  reconcileTargets?: (turnSourceTarget: TTarget, sessionTarget: TTarget) => TTarget | null;
   resolveFallbackTarget?: (request: ApprovalRequestLike) => TTarget | null;
 };
 
@@ -209,8 +212,9 @@ export function resolveApprovalRequestOriginTarget<TTarget>(
       : null;
 
   if (turnSourceTarget && sessionTarget && !params.targetsMatch(turnSourceTarget, sessionTarget)) {
-    // Avoid routing to an origin when live turn metadata disagrees with persisted session state.
-    return null;
+    // Omitted optional route dimensions (thread, account) mean "no opinion", not disagreement;
+    // reconcile a coarse turn-source route to the persisted session target before failing closed.
+    return params.reconcileTargets?.(turnSourceTarget, sessionTarget) ?? null;
   }
 
   return (

--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -23,7 +23,10 @@ import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import type { ChannelApprovalCapability, ChannelOutboundPayloadHint } from "./channel-contract.js";
-import { channelRouteTargetsMatchExact } from "./channel-route.js";
+import {
+  channelRouteTargetsMatchExact,
+  channelRouteTargetsShareConversation,
+} from "./channel-route.js";
 import type { OpenClawConfig } from "./config-runtime.js";
 import type { ReplyPayload } from "./reply-payload.js";
 
@@ -221,6 +224,12 @@ type BaseOriginResolverParams<TTarget> = {
   normalizeTarget?: NativeApprovalTargetNormalizer<TTarget>;
   /** Normalizes only matcher inputs when delivery target shape must stay native. */
   normalizeTargetForMatch?: NativeApprovalTargetNormalizer<TTarget>;
+  /**
+   * Reconciles a turn-source target with a session target that don't strictly match but are
+   * compatible coarse routes (e.g. a turn source omitting a forum thread the session carries).
+   * Returns the reconciled delivery target, or null to stay fail-closed.
+   */
+  reconcileTargets?: (turnSourceTarget: TTarget, sessionTarget: TTarget) => TTarget | null;
   /** Optional fallback target when neither turn-source nor session target resolves. */
   resolveFallbackTarget?: (request: ApprovalRequest) => TTarget | null;
 };
@@ -433,6 +442,48 @@ function nativeApprovalTargetMatcher(channel: string): (left: unknown, right: un
     isNativeApprovalTarget(left) &&
     isNativeApprovalTarget(right) &&
     nativeApprovalTargetsMatch({ channel, left, right });
+}
+
+/**
+ * Reconciler for native approval targets whose strict match failed. An omitted thread/account
+ * means "no opinion", not disagreement: a turn source omitting the forum thread is a parent
+ * route of the topic-scoped session, so delivery takes the thread-bearing target instead of
+ * falling back to an approver DM. Explicit conflicts (different room, or both threads/accounts
+ * present and differing) stay fail-closed.
+ */
+function nativeApprovalTargetReconciler(
+  channel: string,
+): (
+  turnSource: NativeApprovalTarget,
+  session: NativeApprovalTarget,
+) => NativeApprovalTarget | null {
+  return (turnSource, session) => {
+    if (
+      !channelRouteTargetsShareConversation({
+        left: {
+          channel,
+          to: turnSource.to,
+          accountId: turnSource.accountId,
+          threadId: turnSource.threadId,
+        },
+        right: {
+          channel,
+          to: session.to,
+          accountId: session.accountId,
+          threadId: session.threadId,
+        },
+      })
+    ) {
+      return null;
+    }
+    // Carry the thread from whichever target owns it; merge a present account from either side.
+    const threadBearer = turnSource.threadId != null ? turnSource : session;
+    return {
+      to: threadBearer.to,
+      accountId: turnSource.accountId ?? session.accountId,
+      threadId: turnSource.threadId ?? session.threadId,
+    };
+  };
 }
 
 /** Infer approval family from the request shape unless the caller already knows it. */
@@ -962,6 +1013,12 @@ function createOriginTargetResolver<TTarget>(
           normalizedLeft && normalizedRight && params.targetsMatch(normalizedLeft, normalizedRight),
         );
       },
+      // Reconcile runs only when strict targetsMatch already failed, so it receives the same
+      // output-normalized targets the helper holds and must return one for delivery.
+      reconcileTargets: params.reconcileTargets
+        ? (turnSourceTarget, sessionTarget) =>
+            normalizeTarget(params.reconcileTargets!(turnSourceTarget, sessionTarget))
+        : undefined,
       resolveFallbackTarget: params.resolveFallbackTarget
         ? (request) => normalizeTarget(params.resolveFallbackTarget?.(request) ?? null)
         : undefined,
@@ -992,6 +1049,7 @@ export function createChannelNativeOriginTargetResolver<TTarget>(
   return createOriginTargetResolver({
     ...params,
     targetsMatch: nativeApprovalTargetMatcher(params.channel),
+    reconcileTargets: params.reconcileTargets ?? nativeApprovalTargetReconciler(params.channel),
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Closes #125166.

A plugin approval originating in a Telegram forum topic can carry the originating group but omit its thread metadata (`turnSourceThreadId` absent). The native approval origin resolver compared the live turn-source target `{ to: group, threadId: undefined }` against the topic-scoped persisted session target `{ to: group, threadId: 928 }` with strict route equality. `threadIdsEqual(undefined, 928)` is false, so the resolver treated the omitted thread as a disagreement, returned `null`, and the delivery planner fell back to the configured approver DM. The approval prompt never reached the originating topic.

## Why This Change Was Made

The violated invariant is: **an omitted optional route dimension (forum thread, account) means "no opinion", not "disagreement".** A turn source that omits the thread is a *parent route* of the topic-scoped session target, not a conflicting one. `channelRoutesShareConversation` (`src/plugin-sdk/channel-route.ts`) already encodes exactly this parent/child semantic (`left.thread?.id == null || right.thread?.id == null` → compatible). The origin resolver was using only strict `channelRoutesMatchExact` and returning `null` on any mismatch, so it could not express "coarse turn-source route → reconcile to the refined session target."

The fix adds a reconcile step at the owner boundary:

- `resolveApprovalRequestOriginTarget` (`src/infra/exec-approval-session-target.ts`) gains an optional internal `reconcileTargets` callback. When strict `targetsMatch` fails, it calls `reconcileTargets` and returns its result, falling back to `null` (fail-closed) only when reconciliation is impossible. The callback type is on the internal (non-exported) `ApprovalRequestOriginTargetResolver`, so there is **zero SDK surface impact**.
- `nativeApprovalTargetReconciler` (`src/plugin-sdk/approval-native-helpers.ts`) is the default reconcile for native approval targets. It reuses `channelRoutesShareConversation` for the compatibility check (no new policy) and, on success, returns the thread-bearing target — carrying the thread from whichever side owns it and merging a present account from either side. Explicit conflicts (different room, or both threads/accounts present and differing) stay fail-closed via `channelRoutesShareConversation` returning false.
- The default native path in `createChannelNativeOriginTargetResolver` wires the reconciler; channels with custom `targetsMatch` (Slack) are unaffected, and the reconcile only runs after strict matching already failed.

This is the canonical owner-boundary repair, not a consumer-only guard. The narrower alternative — forcing `turnSourceThreadId` into every approval request or guarding only the DM fallback — would mask the root cause downstream and is forbidden by Repair Doctrine. The `nativeApprovalTargetReconciler` reuses the existing parent/child route abstraction rather than inventing duplicate policy.

### Sibling coverage

- **Slack** uses a custom `targetsMatch` (`slackTargetsMatch`), so it takes the custom path and never receives the default reconciler — unchanged.
- **Matrix** uses the default native path with `normalizeTargetForMatch` (alias-based matching). The reconciler receives output-normalized (native-id) targets and returns one, so delivery ids stay native; the reconcile only triggers when strict alias matching already failed. Matrix tests pass unchanged.
- **Standard native channels** (via `createNativeApprovalMessagingTargetResolvers`) strip `threadId` from both turn-source and session targets, so strict matching passes and the reconciler never runs — unchanged.
- Existing core origin tests that supply no `reconcileTargets` see `undefined ?? null` → `null`, identical to prior behavior.

## User Impact

On Telegram forum supergroups, a plugin approval whose live request omits the thread metadata (but whose session is topic-scoped) is now delivered back to the originating group and forum topic, matching the behavior of approvals that carry the thread explicitly. Approvers and topic participants see the prompt in-place instead of having to leave the topic for an approver DM. Explicit thread conflicts (live topic differs from persisted topic) still fail closed to the approver DM. No config migration or operator action is required.

## Evidence

### Pre-fix reproduction (regression test fails on unpatched code)

The new Telegram native approval test drives the real production chain — `telegramApprovalCapability.native.resolveOriginTarget` → real `createChannelNativeOriginTargetResolver` → real `nativeApprovalTargetReconciler` → real `resolveApprovalRequestOriginTarget` — with a topic-scoped persisted session (thread 928) and a plugin approval whose turn source carries the group but omits the thread. Run against unpatched `origin/main` (prod files stashed):

```
node scripts/run-vitest.mjs extensions/telegram/src/approval-native.test.ts -t "reconciles an omitted turn-source thread"
 FAIL  reconciles an omitted turn-source thread to the persisted topic session for plugin approvals
       Expected: { to: "-1003841603622", threadId: 928 }
       Received: null
 Tests  1 failed | 8 skipped (9)
```

`Received: null` is the bug: the origin resolver rejected the topic-scoped origin, so the planner would fall back to the approver DM.

### Post-fix (real-behavior proof + fail-closed preserved)

```
node scripts/run-vitest.mjs extensions/telegram/src/approval-native.test.ts
 Test Files  1 passed (1) | Tests  9 passed (9)
   # 7 existing + "reconciles an omitted turn-source thread" (→ { to, threadId: 928 })
   #          + "stays fail-closed when the turn-source thread explicitly conflicts" (→ null)
```

- **Reconcile (the fix):** omitted `turnSourceThreadId` + topic-scoped persisted session (thread 928) → origin target `{ to: "-1003841603622", threadId: 928 }` (reconciled to the thread-bearing session target). Pre-fix this was `null`.
- **Fail-closed preserved:** live topic 111 vs persisted topic 928 → origin target `null` (explicit conflict stays fail-closed; delivery falls back to approver DM rather than routing to the wrong topic).

### Sibling coverage (no regression)

```
node scripts/run-vitest.mjs src/infra/exec-approval-session-target.test.ts        # 20 passed
node scripts/run-vitest.mjs src/plugin-sdk/approval-native-helpers.test.ts        # 17 passed
node scripts/run-vitest.mjs extensions/matrix/src/approval-native.test.ts         # 13 passed
node scripts/run-vitest.mjs extensions/slack/src/approval-native.test.ts          # 33 passed
node scripts/run-vitest.mjs extensions/telegram/src/approval-native.test.ts       # 9 passed
```

### Typecheck

`pnpm tsgo:prod` reports zero errors in the touched files (`src/infra/exec-approval-session-target.ts`, `src/plugin-sdk/approval-native-helpers.ts`). The 10 errors the lane reports are all pre-existing in `extensions/cua-computer/` (`@trycua/cua-driver` missing `ActionResult` export) — an unrelated extension dependency type mismatch this PR does not touch.

### Production LOC

Net production delta: `+60` across `src/infra/exec-approval-session-target.ts` (+6 functional) and `src/plugin-sdk/approval-native-helpers.ts` (+54: the `nativeApprovalTargetReconciler` helper reusing `channelRoutesShareConversation`, the internal callback field, and default-path wiring). Test-only: `+98` in `extensions/telegram/src/approval-native.test.ts`. The positive production delta is the genuinely missing reconcile capability: the prior strict-match + null-return could not express coarse-route reconciliation, and the fix reuses the existing parent/child route abstraction rather than adding a guard or duplicate policy. A net-neutral refactor does not exist here — the reconcile is a new step at the owner boundary, not a reshape of existing structure.
