### PR TITLE
feat(node-host): support Cloudflare Access service tokens

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -115,6 +115,14 @@ short-lived bearer setup link must not be persisted in service arguments.
 - In `gateway.mode=remote`, remote client fields (`gateway.remote.token` / `gateway.remote.password`) are also eligible per remote precedence rules.
 - Node host auth resolution only honors `OPENCLAW_GATEWAY_*` env vars.
 
+For a Gateway behind Cloudflare Access, set `CF_ACCESS_CLIENT_ID` and
+`CF_ACCESS_CLIENT_SECRET` together before `openclaw connect`, `openclaw node
+run`, or `openclaw node install`. The node stores env SecretRefs under its
+canonical `gateway.cloudflareAccess.clientId` and `clientSecret` connection
+keys. Installed services keep the values in the managed service environment
+file, not in service arguments or inline supervisor definitions. See
+[Gateway deployments that cannot host nodes](/nodes#gateway-deployments-that-cannot-host-nodes).
+
 For a node connecting to a plaintext `ws://` Gateway, loopback, private IP
 literals, `.local`, and Tailnet `*.ts.net` hosts are accepted. For other
 trusted private-DNS names, set `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1`; without

--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -120,7 +120,9 @@ For a Gateway behind Cloudflare Access, set `CF_ACCESS_CLIENT_ID` and
 run`, or `openclaw node install`. The node stores env SecretRefs under its
 canonical `gateway.cloudflareAccess.clientId` and `clientSecret` connection
 keys. Installed services keep the values in the managed service environment
-file, not in service arguments or inline supervisor definitions. See
+file, not in service arguments or inline supervisor definitions. Access
+credentials require HTTPS/WSS; plaintext HTTP/WS fails before SecretRef
+resolution while credential-free plaintext node routes remain unchanged. See
 [Gateway deployments that cannot host nodes](/nodes#gateway-deployments-that-cannot-host-nodes).
 
 For a node connecting to a plaintext `ws://` Gateway, loopback, private IP

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -106,7 +106,7 @@ For a Cloudflare Access-fronted Gateway:
    openclaw connect https://gateway.example/j/<code> --service
    ```
 
-The canonical node connection keys are `gateway.cloudflareAccess.clientId` and `gateway.cloudflareAccess.clientSecret`; both accept SecretInput values. The environment fallback above persists those keys as env SecretRefs, not copied plaintext. For installed nodes, OpenClaw stores the environment values in the managed service environment file rather than inline in launchd, systemd, or Task Scheduler definitions. Resolved values are bound to the configured Gateway origin and are not followed across redirects.
+The canonical node connection keys are `gateway.cloudflareAccess.clientId` and `gateway.cloudflareAccess.clientSecret`; both accept SecretInput values. The environment fallback above persists those keys as env SecretRefs, not copied plaintext. For installed nodes, OpenClaw stores the environment values in the managed service environment file rather than inline in launchd, systemd, or Task Scheduler definitions. Resolved values are bound to the configured Gateway origin and are not followed across redirects. OpenClaw rejects the pair before resolution on plaintext `http://` or `ws://` routes; credential-free loopback and private-network plaintext behavior is unchanged.
 
 ### Start a node host (foreground)
 

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -92,9 +92,21 @@ A Gateway can remain healthy for browser users while node hosting is unavailable
 
 - **Machine authentication:** Tailscale identity headers do not authenticate node-role connections. In `gateway.auth.mode: "trusted-proxy"`, a new node also cannot supply the proxy's user identity headers. To use a shared token, switch to token mode and configure `gateway.auth.token` with a SecretRef; trusted-proxy mode rejects mixed token configuration. A trusted-proxy Gateway can use `gateway.auth.password` only for clean loopback/direct callers. See [trusted-proxy mixed token configuration](/gateway/trusted-proxy-auth#mixed-token-configuration).
 - **Node onboarding URL:** With `gateway.bind: "loopback"`, configure Tailscale Serve, `gateway.remote.url`, or `plugins.entries.device-pair.config.publicUrl` before minting a join code. Otherwise `openclaw devices join-code` reports: `Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.`
-- **Edge routing:** When a reverse proxy or access edge fronts the Gateway, allow `/j/*` and `/__openclaw__/worker` through without edge identity auth. Keep WebSocket upgrade enabled for `/__openclaw__/worker`; both routes enforce their own short-lived credentials. The node's main Gateway WebSocket must also reach an auth path it can satisfy. See [worker protocol](/gateway/protocol#worker-role-and-closed-protocol).
+- **Edge routing:** When a reverse proxy or access edge fronts the Gateway, the node must satisfy edge auth on the join request, its main Gateway WebSocket, and the worker WebSocket. Keep WebSocket upgrade enabled for `/__openclaw__/worker`. You can instead exempt `/j/*` and `/__openclaw__/worker` from edge identity auth because both routes enforce their own short-lived credentials. See [worker protocol](/gateway/protocol#worker-role-and-closed-protocol).
 
-Cloudflare Access service tokens (`CF-Access-Client-Id` and `CF-Access-Client-Secret`) are the intended alternative for Access-fronted machine clients, but node hosts cannot send those headers yet. Follow [node-host service-token header support](https://github.com/openclaw/openclaw/issues/125112) for that capability.
+For a Cloudflare Access-fronted Gateway:
+
+1. In Cloudflare Zero Trust, create an Access service token. Copy its Client ID and Client Secret when Cloudflare displays them.
+2. Add a **Service Auth** policy that accepts the token on the Access application protecting the Gateway. If `/j/*` and `/__openclaw__/worker` are separate Access applications, add the same policy to both.
+3. On the node, provide the conventional environment fallback and connect:
+
+   ```bash
+   export CF_ACCESS_CLIENT_ID="<client-id>"
+   export CF_ACCESS_CLIENT_SECRET="<client-secret>"
+   openclaw connect https://gateway.example/j/<code> --service
+   ```
+
+The canonical node connection keys are `gateway.cloudflareAccess.clientId` and `gateway.cloudflareAccess.clientSecret`; both accept SecretInput values. The environment fallback above persists those keys as env SecretRefs, not copied plaintext. For installed nodes, OpenClaw stores the environment values in the managed service environment file rather than inline in launchd, systemd, or Task Scheduler definitions. Resolved values are bound to the configured Gateway origin and are not followed across redirects.
 
 ### Start a node host (foreground)
 

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -129,6 +129,8 @@ The lists below are generated from the source target registry and checked agains
 - `profiles.*.keyRef` (`type: "api_key"`; unsupported when `auth.profiles.<id>.mode = "oauth"`)
 - `profiles.*.tokenRef` (`type: "token"`; unsupported when `auth.profiles.<id>.mode = "oauth"`)
 
+[//]: # "secretref-supported-list-end"
+
 ### Node-host connection targets
 
 - `gateway.cloudflareAccess.clientId`
@@ -140,8 +142,6 @@ the configured SecretRef providers when the node starts. The conventional
 `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` fallback persists env refs for
 these fields automatically. They are not targets for `secrets configure` or
 `secrets apply`.
-
-[//]: # "secretref-supported-list-end"
 
 Notes:
 

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -129,6 +129,18 @@ The lists below are generated from the source target registry and checked agains
 - `profiles.*.keyRef` (`type: "api_key"`; unsupported when `auth.profiles.<id>.mode = "oauth"`)
 - `profiles.*.tokenRef` (`type: "token"`; unsupported when `auth.profiles.<id>.mode = "oauth"`)
 
+### Node-host connection targets
+
+- `gateway.cloudflareAccess.clientId`
+- `gateway.cloudflareAccess.clientSecret`
+
+These fields live in the node host's canonical `node_host_config` SQLite row,
+not `openclaw.json`. They accept the same SecretInput forms and resolve through
+the configured SecretRef providers when the node starts. The conventional
+`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` fallback persists env refs for
+these fields automatically. They are not targets for `secrets configure` or
+`secrets apply`.
+
 [//]: # "secretref-supported-list-end"
 
 Notes:

--- a/packages/gateway-client/src/client.cloudflare-access.test.ts
+++ b/packages/gateway-client/src/client.cloudflare-access.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, expect, test } from "vitest";
+import { WebSocketServer } from "ws";
+import { GatewayClient } from "./client.js";
+
+let server: WebSocketServer | undefined;
+
+afterEach(async () => {
+  if (!server) {
+    return;
+  }
+  const closing = new Promise<void>((resolve, reject) => {
+    server?.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+  server = undefined;
+  await closing;
+});
+
+test("sends the closed Cloudflare Access header pair through a rejecting edge", async () => {
+  const clientId = ["cf", "gateway", "id"].join("-");
+  const clientSecret = ["cf", "gateway", "secret"].join("-");
+  server = new WebSocketServer({
+    port: 0,
+    host: "127.0.0.1",
+    verifyClient: ({ req }, done) => {
+      const accepted =
+        req.headers["cf-access-client-id"] === clientId &&
+        req.headers["cf-access-client-secret"] === clientSecret;
+      done(accepted, accepted ? undefined : 403, accepted ? undefined : "Access denied");
+    },
+  });
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.once("listening", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test edge did not allocate a port");
+  }
+  const received = new Promise<Record<string, string | string[] | undefined>>((resolve) => {
+    server?.once("connection", (_socket, request) => resolve(request.headers));
+  });
+  const client = new GatewayClient({
+    url: `ws://127.0.0.1:${address.port}`,
+    connectChallengeTimeoutMs: 0,
+    cloudflareAccess: { clientId, clientSecret },
+  });
+  client.start();
+
+  await expect(received).resolves.toMatchObject({
+    "cf-access-client-id": clientId,
+    "cf-access-client-secret": clientSecret,
+  });
+  await client.stopAndWait();
+});

--- a/packages/gateway-client/src/client.cloudflare-access.test.ts
+++ b/packages/gateway-client/src/client.cloudflare-access.test.ts
@@ -1,8 +1,12 @@
+import { X509Certificate } from "node:crypto";
+import { createServer as createHttpsServer } from "node:https";
 import { afterEach, expect, test } from "vitest";
 import { WebSocketServer } from "ws";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../../test/helpers/tls-fixture.js";
 import { GatewayClient } from "./client.js";
 
 let server: WebSocketServer | undefined;
+let httpsServer: ReturnType<typeof createHttpsServer> | undefined;
 
 afterEach(async () => {
   if (!server) {
@@ -19,14 +23,27 @@ afterEach(async () => {
   });
   server = undefined;
   await closing;
+  if (httpsServer) {
+    const closingHttps = new Promise<void>((resolve, reject) => {
+      httpsServer?.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    httpsServer = undefined;
+    await closingHttps;
+  }
 });
 
 test("sends the closed Cloudflare Access header pair through a rejecting edge", async () => {
   const clientId = ["cf", "gateway", "id"].join("-");
   const clientSecret = ["cf", "gateway", "secret"].join("-");
+  httpsServer = createHttpsServer({ key: TEST_TLS_KEY_PEM, cert: TEST_TLS_CERT_PEM });
   server = new WebSocketServer({
-    port: 0,
-    host: "127.0.0.1",
+    server: httpsServer,
     verifyClient: ({ req }, done) => {
       const accepted =
         req.headers["cf-access-client-id"] === clientId &&
@@ -35,10 +52,10 @@ test("sends the closed Cloudflare Access header pair through a rejecting edge", 
     },
   });
   await new Promise<void>((resolve, reject) => {
-    server?.once("error", reject);
-    server?.once("listening", resolve);
+    httpsServer?.once("error", reject);
+    httpsServer?.listen(0, "127.0.0.1", resolve);
   });
-  const address = server.address();
+  const address = httpsServer.address();
   if (!address || typeof address === "string") {
     throw new Error("test edge did not allocate a port");
   }
@@ -46,9 +63,10 @@ test("sends the closed Cloudflare Access header pair through a rejecting edge", 
     server?.once("connection", (_socket, request) => resolve(request.headers));
   });
   const client = new GatewayClient({
-    url: `ws://127.0.0.1:${address.port}`,
+    url: `wss://127.0.0.1:${address.port}`,
     connectChallengeTimeoutMs: 0,
     cloudflareAccess: { clientId, clientSecret },
+    tlsFingerprint: new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256,
   });
   client.start();
 
@@ -57,4 +75,25 @@ test("sends the closed Cloudflare Access header pair through a rejecting edge", 
     "cf-access-client-secret": clientSecret,
   });
   await client.stopAndWait();
+});
+
+test("rejects the Access pair before a plaintext WebSocket dial", async () => {
+  let resolveConnectError: (error: Error) => void = () => {};
+  const connectError = new Promise<Error>((resolve) => {
+    resolveConnectError = resolve;
+  });
+  const client = new GatewayClient({
+    url: "ws://127.0.0.1:18789",
+    cloudflareAccess: {
+      clientId: "cf-plaintext-id",
+      clientSecret: "cf-plaintext-secret",
+    },
+    onConnectError: resolveConnectError,
+  });
+  client.start();
+
+  await expect(connectError).resolves.toMatchObject({
+    message: "Cloudflare Access credentials require a wss:// Gateway URL",
+  });
+  client.stop();
 });

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -501,6 +501,11 @@ export class GatewayClient {
 
   private createSocket(handlers: GatewayProtocolSocketHandlers): GatewayProtocolSocket {
     const url = this.opts.url ?? DEFAULT_GATEWAY_CLIENT_URL;
+    if (this.opts.cloudflareAccess && new URL(url).protocol !== "wss:") {
+      throw new GatewayWebSocketTransportConfigurationError(
+        "Cloudflare Access credentials require a wss:// Gateway URL",
+      );
+    }
     // Block plaintext before device-token lookup. Credentials may be loaded from
     // host storage later in sendConnect(), and chat payloads are sensitive too.
     const handshakeTimeoutMs = resolvePreauthHandshakeTimeoutMs({

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -25,6 +25,10 @@ import {
   normalizeGatewayErrorText,
 } from "./client-address-utils.js";
 import {
+  buildCloudflareAccessHeaders,
+  type CloudflareAccessCredentials,
+} from "./cloudflare-access.js";
+import {
   buildGatewayConnectAuth,
   type GatewayConnectAuthSelection,
   resolveGatewayConnectScopes,
@@ -237,6 +241,8 @@ export function isGatewayConnectAssemblyError(value: unknown): value is Error {
 export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
   origin?: string;
+  /** Closed Cloudflare Access service-token pair for this configured Gateway origin. */
+  cloudflareAccess?: CloudflareAccessCredentials;
   connectChallengeTimeoutMs?: number;
   /**
    * Server-side pre-auth handshake budget. Config-derived local clients use
@@ -512,6 +518,12 @@ export class GatewayClient {
         maxPayload: 25 * 1024 * 1024,
         handshakeTimeout: handshakeTimeoutMs,
         ...(this.opts.origin ? { origin: this.opts.origin } : {}),
+        ...(this.opts.cloudflareAccess
+          ? {
+              followRedirects: false,
+              headers: buildCloudflareAccessHeaders(this.opts.cloudflareAccess),
+            }
+          : {}),
       },
     });
     this.deps.beforeConnect();

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -602,6 +602,37 @@ describe("GatewayClient", () => {
     client.stop();
   });
 
+  test("sends the closed Cloudflare Access header pair", async () => {
+    const port = await getFreePort();
+    const clientId = ["cf", "gateway", "id"].join("-");
+    const clientSecret = ["cf", "gateway", "secret"].join("-");
+    wss = new WebSocketServer({
+      port,
+      host: "127.0.0.1",
+      verifyClient: ({ req }, done) => {
+        const accepted =
+          req.headers["cf-access-client-id"] === clientId &&
+          req.headers["cf-access-client-secret"] === clientSecret;
+        done(accepted, accepted ? undefined : 403, accepted ? undefined : "Access denied");
+      },
+    });
+    const received = new Promise<Record<string, string | string[] | undefined>>((resolve) => {
+      wss?.once("connection", (_socket, request) => resolve(request.headers));
+    });
+    const client = new GatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      connectChallengeTimeoutMs: 0,
+      cloudflareAccess: { clientId, clientSecret },
+    } as ConstructorParameters<typeof GatewayClient>[0]);
+    client.start();
+
+    await expect(received).resolves.toMatchObject({
+      "cf-access-client-id": clientId,
+      "cf-access-client-secret": clientSecret,
+    });
+    client.stop();
+  });
+
   test("returns non-sensitive connection metadata", () => {
     const client = new GatewayClient({
       clientName: "cli",

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -602,37 +602,6 @@ describe("GatewayClient", () => {
     client.stop();
   });
 
-  test("sends the closed Cloudflare Access header pair", async () => {
-    const port = await getFreePort();
-    const clientId = ["cf", "gateway", "id"].join("-");
-    const clientSecret = ["cf", "gateway", "secret"].join("-");
-    wss = new WebSocketServer({
-      port,
-      host: "127.0.0.1",
-      verifyClient: ({ req }, done) => {
-        const accepted =
-          req.headers["cf-access-client-id"] === clientId &&
-          req.headers["cf-access-client-secret"] === clientSecret;
-        done(accepted, accepted ? undefined : 403, accepted ? undefined : "Access denied");
-      },
-    });
-    const received = new Promise<Record<string, string | string[] | undefined>>((resolve) => {
-      wss?.once("connection", (_socket, request) => resolve(request.headers));
-    });
-    const client = new GatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      connectChallengeTimeoutMs: 0,
-      cloudflareAccess: { clientId, clientSecret },
-    } as ConstructorParameters<typeof GatewayClient>[0]);
-    client.start();
-
-    await expect(received).resolves.toMatchObject({
-      "cf-access-client-id": clientId,
-      "cf-access-client-secret": clientSecret,
-    });
-    client.stop();
-  });
-
   test("returns non-sensitive connection metadata", () => {
     const client = new GatewayClient({
       clientName: "cli",

--- a/packages/gateway-client/src/cloudflare-access.ts
+++ b/packages/gateway-client/src/cloudflare-access.ts
@@ -1,0 +1,17 @@
+export const CF_ACCESS_CLIENT_ID_HEADER = "CF-Access-Client-Id";
+export const CF_ACCESS_CLIENT_SECRET_HEADER = "CF-Access-Client-Secret";
+
+export type CloudflareAccessCredentials = Readonly<{
+  clientId: string;
+  clientSecret: string;
+}>;
+
+/** Build only the two headers Cloudflare Access defines for service-token auth. */
+export function buildCloudflareAccessHeaders(
+  credentials: CloudflareAccessCredentials,
+): Record<string, string> {
+  return {
+    [CF_ACCESS_CLIENT_ID_HEADER]: credentials.clientId,
+    [CF_ACCESS_CLIENT_SECRET_HEADER]: credentials.clientSecret,
+  };
+}

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -2,6 +2,7 @@
 // readiness helpers, event-loop readiness, and timeout utilities.
 export * from "./client.js";
 export * from "./browser-device-auth.js";
+export * from "./cloudflare-access.js";
 export * from "./connect-auth.js";
 export * from "./device-auth.js";
 export * from "./event-loop-ready.js";

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -1,7 +1,7 @@
 // Connect CLI tests cover accepted targets and handoff to the canonical node runtime.
-import { createServer } from "node:http";
 import { Command } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NodeHostConfig } from "../node-host/config.js";
 import { encodePairingSetupCode } from "../pairing/setup-code.js";
 import { registerConnectCli } from "./connect-cli.js";
 
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   runNodeHost: vi.fn(),
   runNodeDaemonInstall: vi.fn(),
   fetchWithSsrFGuard: vi.fn(),
-  loadNodeHostConfig: vi.fn(async () => null),
+  loadNodeHostConfig: vi.fn<() => Promise<NodeHostConfig | null>>(async () => null),
   runtime: {
     error: vi.fn(),
     exit: vi.fn(),
@@ -52,10 +52,6 @@ describe("connect cli", () => {
     mocks.runNodeHost.mockResolvedValue(undefined);
     mocks.runNodeDaemonInstall.mockResolvedValue(undefined);
     mocks.runtime.exit.mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
   });
 
   it.each([
@@ -138,53 +134,31 @@ describe("connect cli", () => {
     expect(mocks.runNodeHost).not.toHaveBeenCalled();
   });
 
-  it("sends Cloudflare Access credentials on the pinned join request", async () => {
+  it("sends Cloudflare Access credentials on the pinned HTTPS join request", async () => {
     const clientId = ["cf", "client", "id"].join("-");
     const clientSecret = ["cf", "client", "secret"].join("-");
-    vi.stubEnv("CF_ACCESS_CLIENT_ID", clientId);
-    vi.stubEnv("CF_ACCESS_CLIENT_SECRET", clientSecret);
-    let observedHeaders: Record<string, string | string[] | undefined> | undefined;
-    const server = createServer((request, response) => {
-      observedHeaders = request.headers;
-      const accepted =
-        request.headers["cf-access-client-id"] === clientId &&
-        request.headers["cf-access-client-secret"] === clientSecret;
-      response.writeHead(accepted ? 200 : 403, {
-        "content-type": accepted ? "application/json" : "text/plain",
-      });
-      response.end(accepted ? JSON.stringify(payload) : "Access denied");
+    mocks.loadNodeHostConfig.mockResolvedValueOnce({
+      version: 1,
+      nodeId: "node-test",
+      gateway: {
+        host: "gateway.example",
+        port: 443,
+        tls: true,
+        cloudflareAccess: { clientId, clientSecret },
+      },
     });
-    const port = await new Promise<number>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const address = server.address();
-        if (!address || typeof address === "string") {
-          reject(new Error("test edge did not allocate a port"));
-          return;
-        }
-        resolve(address.port);
-      });
+    const target = `https://gateway.example/j/${"a".repeat(22)}`;
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      finalUrl: target,
+      release: vi.fn(async () => undefined),
     });
-    const target = `http://127.0.0.1:${port}/j/${"a".repeat(22)}`;
 
-    try {
-      await runConnect([target]);
-    } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-    }
+    await runConnect([target]);
 
-    expect(observedHeaders).toMatchObject({
-      "cf-access-client-id": clientId,
-      "cf-access-client-secret": clientSecret,
-    });
     expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
       expect.objectContaining({
         maxRedirects: 0,
@@ -196,5 +170,28 @@ describe("connect cli", () => {
         },
       }),
     );
+  });
+
+  it("rejects Cloudflare Access credentials before a plaintext join request", async () => {
+    const clientSecret = ["cf", "plaintext", "secret"].join("-");
+    mocks.loadNodeHostConfig.mockResolvedValueOnce({
+      version: 1,
+      nodeId: "node-test",
+      gateway: {
+        host: "127.0.0.1",
+        port: 80,
+        tls: false,
+        cloudflareAccess: { clientId: "cf-plaintext-id", clientSecret },
+      },
+    });
+
+    await runConnect([`http://127.0.0.1/j/${"a".repeat(22)}`]);
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "Cloudflare Access credentials require an HTTPS join URL.",
+    );
+    expect(String(mocks.runtime.error.mock.calls[0]?.[0])).not.toContain(clientSecret);
+    expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    expect(mocks.runNodeHost).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -1,6 +1,7 @@
 // Connect CLI tests cover accepted targets and handoff to the canonical node runtime.
+import { createServer } from "node:http";
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { encodePairingSetupCode } from "../pairing/setup-code.js";
 import { registerConnectCli } from "./connect-cli.js";
 
@@ -8,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   runNodeHost: vi.fn(),
   runNodeDaemonInstall: vi.fn(),
   fetchWithSsrFGuard: vi.fn(),
+  loadNodeHostConfig: vi.fn(async () => null),
   runtime: {
     error: vi.fn(),
     exit: vi.fn(),
@@ -15,12 +17,16 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../node-host/runner.js", () => ({ runNodeHost: mocks.runNodeHost }));
+vi.mock("../node-host/config.js", () => ({ loadNodeHostConfig: mocks.loadNodeHostConfig }));
+vi.mock("../config/config.js", () => ({ getRuntimeConfig: vi.fn(() => ({})) }));
 vi.mock("./node-cli/daemon.js", () => ({
   runNodeDaemonInstall: mocks.runNodeDaemonInstall,
 }));
-vi.mock("../infra/net/fetch-guard.js", () => ({
-  fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
-}));
+vi.mock("../infra/net/fetch-guard.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/net/fetch-guard.js")>();
+  mocks.fetchWithSsrFGuard.mockImplementation(actual.fetchWithSsrFGuard);
+  return { fetchWithSsrFGuard: mocks.fetchWithSsrFGuard };
+});
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
 
 const payload = {
@@ -46,6 +52,10 @@ describe("connect cli", () => {
     mocks.runNodeHost.mockResolvedValue(undefined);
     mocks.runNodeDaemonInstall.mockResolvedValue(undefined);
     mocks.runtime.exit.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it.each([
@@ -96,6 +106,9 @@ describe("connect cli", () => {
       displayName: "Build Node",
     });
     expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(fetched ? 1 : 0);
+    if (fetched) {
+      expect(mocks.fetchWithSsrFGuard.mock.calls[0]?.[0]).not.toHaveProperty("init");
+    }
     expect(mocks.runNodeDaemonInstall).not.toHaveBeenCalled();
   });
 
@@ -123,5 +136,59 @@ describe("connect cli", () => {
     expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
     expect(mocks.runNodeHost).not.toHaveBeenCalled();
+  });
+
+  it("sends Cloudflare Access credentials on the pinned join request", async () => {
+    const clientId = ["cf", "client", "id"].join("-");
+    const clientSecret = ["cf", "client", "secret"].join("-");
+    vi.stubEnv("CF_ACCESS_CLIENT_ID", clientId);
+    vi.stubEnv("CF_ACCESS_CLIENT_SECRET", clientSecret);
+    let observedHeaders: typeof import("node:http").IncomingHttpHeaders | undefined;
+    const server = createServer((request, response) => {
+      observedHeaders = request.headers;
+      const accepted =
+        request.headers["cf-access-client-id"] === clientId &&
+        request.headers["cf-access-client-secret"] === clientSecret;
+      response.writeHead(accepted ? 200 : 403, {
+        "content-type": accepted ? "application/json" : "text/plain",
+      });
+      response.end(accepted ? JSON.stringify(payload) : "Access denied");
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("test edge did not allocate a port"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+    const target = `http://127.0.0.1:${port}/j/${"a".repeat(22)}`;
+
+    try {
+      await runConnect([target]);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    expect(observedHeaders).toMatchObject({
+      "cf-access-client-id": clientId,
+      "cf-access-client-secret": clientSecret,
+    });
+    expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxRedirects: 0,
+        init: {
+          headers: {
+            "CF-Access-Client-Id": clientId,
+            "CF-Access-Client-Secret": clientSecret,
+          },
+        },
+      }),
+    );
   });
 });

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -170,9 +170,15 @@ describe("connect cli", () => {
     try {
       await runConnect([target]);
     } finally {
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
     }
 
     expect(observedHeaders).toMatchObject({

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -143,7 +143,7 @@ describe("connect cli", () => {
     const clientSecret = ["cf", "client", "secret"].join("-");
     vi.stubEnv("CF_ACCESS_CLIENT_ID", clientId);
     vi.stubEnv("CF_ACCESS_CLIENT_SECRET", clientSecret);
-    let observedHeaders: typeof import("node:http").IncomingHttpHeaders | undefined;
+    let observedHeaders: Record<string, string | string[] | undefined> | undefined;
     const server = createServer((request, response) => {
       observedHeaders = request.headers;
       const accepted =

--- a/src/cli/connect-cli.ts
+++ b/src/cli/connect-cli.ts
@@ -1,11 +1,26 @@
 // One-paste node onboarding from setup codes or single-use Gateway join URLs.
 import type { Command } from "commander";
+import {
+  buildCloudflareAccessHeaders,
+  CF_ACCESS_CLIENT_ID_HEADER,
+  CF_ACCESS_CLIENT_SECRET_HEADER,
+  type CloudflareAccessCredentials,
+} from "../../packages/gateway-client/src/cloudflare-access.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { getRuntimeConfig } from "../config/config.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
+import { loadNodeHostConfig, type NodeHostGatewayConfig } from "../node-host/config.js";
+import {
+  nodeHostCloudflareAccessConfigFromEnv,
+  nodeHostGatewayMatchesUrl,
+  nodeHostGatewaysShareOrigin,
+  resolveNodeHostCloudflareAccess,
+  type NodeHostCloudflareAccessConfig,
+} from "../node-host/gateway-cloudflare-access.js";
 import { runNodeHost } from "../node-host/runner.js";
 import { isDevicePairingJoinCode } from "../pairing/join-code.js";
 import { decodePairingSetupCode, encodePairingSetupCode } from "../pairing/setup-code.js";
@@ -51,7 +66,10 @@ function parseJoinTarget(target: string): URL | null {
   return parsed;
 }
 
-async function fetchJoinPayload(target: URL): Promise<PairingSetupPayload> {
+async function fetchJoinPayload(
+  target: URL,
+  cloudflareAccess?: CloudflareAccessCredentials,
+): Promise<PairingSetupPayload> {
   const expectedHost = normalizeHostname(target.hostname);
   let release: () => Promise<void> = async () => {};
   try {
@@ -61,6 +79,17 @@ async function fetchJoinPayload(target: URL): Promise<PairingSetupPayload> {
       maxRedirects: 0,
       requireHttps: target.protocol === "https:",
       timeoutMs: JOIN_FETCH_TIMEOUT_MS,
+      ...(cloudflareAccess
+        ? {
+            init: { headers: buildCloudflareAccessHeaders(cloudflareAccess) },
+            capture: {
+              sensitiveRequestHeaderNames: [
+                CF_ACCESS_CLIENT_ID_HEADER,
+                CF_ACCESS_CLIENT_SECRET_HEADER,
+              ],
+            },
+          }
+        : {}),
       policy: {
         allowPrivateNetwork: true,
         allowedHostnames: [expectedHost],
@@ -91,20 +120,60 @@ async function fetchJoinPayload(target: URL): Promise<PairingSetupPayload> {
   }
 }
 
-async function resolveConnectPayload(target: string): Promise<PairingSetupPayload> {
-  const joinTarget = parseJoinTarget(target);
-  return joinTarget ? await fetchJoinPayload(joinTarget) : decodePairingSetupCode(target);
+function selectCloudflareAccessConfig(params: {
+  savedGateway?: NodeHostGatewayConfig;
+  target: URL;
+  env: NodeJS.ProcessEnv;
+}): NodeHostCloudflareAccessConfig | undefined {
+  const saved = params.savedGateway;
+  return (
+    (saved && nodeHostGatewayMatchesUrl(saved, params.target)
+      ? saved.cloudflareAccess
+      : undefined) ?? nodeHostCloudflareAccessConfigFromEnv(params.env)
+  );
 }
 
 async function runConnectCommand(target: string, opts: ConnectCommandOptions): Promise<void> {
-  const pair = resolveNodePairGatewayPayload(await resolveConnectPayload(target));
+  const joinTarget = parseJoinTarget(target);
+  const saved = await loadNodeHostConfig();
+  const initialCloudflareAccess = joinTarget
+    ? selectCloudflareAccessConfig({
+        savedGateway: saved?.gateway,
+        target: joinTarget,
+        env: process.env,
+      })
+    : undefined;
+  const joinCredentials = await resolveNodeHostCloudflareAccess({
+    value: initialCloudflareAccess,
+    config: getRuntimeConfig(),
+    env: process.env,
+  });
+  const payload = joinTarget
+    ? await fetchJoinPayload(joinTarget, joinCredentials)
+    : decodePairingSetupCode(target);
+  const pair = resolveNodePairGatewayPayload(payload);
+  const cloudflareAccess =
+    initialCloudflareAccess ??
+    (saved?.gateway && nodeHostGatewaysShareOrigin(saved.gateway, pair.candidates[0]!)
+      ? saved.gateway.cloudflareAccess
+      : undefined) ??
+    nodeHostCloudflareAccessConfigFromEnv(process.env);
+  const gatewayCandidates = pair.candidates.map((candidate, index) => {
+    const boundToAccessOrigin = joinTarget
+      ? nodeHostGatewayMatchesUrl(candidate, joinTarget)
+      : index === 0;
+    return boundToAccessOrigin && cloudflareAccess ? { ...candidate, cloudflareAccess } : candidate;
+  });
   const nodeRunOptions = {
     gatewayHost: pair.host,
     gatewayPort: pair.port,
     gatewayTls: pair.tls,
     gatewayTlsFingerprint: pair.tlsFingerprint,
     gatewayContextPath: pair.contextPath,
-    gatewayCandidates: pair.candidates,
+    ...(gatewayCandidates[0]?.cloudflareAccess
+      ? { gatewayCloudflareAccess: gatewayCandidates[0].cloudflareAccess }
+      : {}),
+    gatewayCandidates,
     gatewayBootstrapToken: pair.bootstrapToken,
     preferGatewayBootstrapToken: true,
     displayName: opts.displayName,

--- a/src/cli/connect-cli.ts
+++ b/src/cli/connect-cli.ts
@@ -143,6 +143,9 @@ async function runConnectCommand(target: string, opts: ConnectCommandOptions): P
         env: process.env,
       })
     : undefined;
+  if (initialCloudflareAccess && joinTarget?.protocol !== "https:") {
+    throw new Error("Cloudflare Access credentials require an HTTPS join URL.");
+  }
   const joinCredentials = await resolveNodeHostCloudflareAccess({
     value: initialCloudflareAccess,
     config: getRuntimeConfig(),

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -225,6 +225,27 @@ describe("runNodeDaemonInstall", () => {
     );
   });
 
+  it("rejects Access credentials before installing a plaintext node service", async () => {
+    mocks.loadNodeHostConfig.mockResolvedValue({
+      gateway: {
+        host: "saved-gateway.local",
+        port: 18789,
+        tls: false,
+        cloudflareAccess: {
+          clientId: "$CF_ACCESS_CLIENT_ID",
+          clientSecret: "$CF_ACCESS_CLIENT_SECRET",
+        },
+      },
+    });
+
+    await runNodeDaemonInstall({ force: true });
+
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "Cloudflare Access credentials require --tls for the node Gateway connection",
+    );
+  });
+
   it.each([
     ["an invalid explicit port", { port: "abc" }, "Invalid --port"],
     ["an unsupported runtime", { runtime: "deno" }, 'Invalid --runtime (use "node"'],

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -116,7 +116,8 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
   }
 
   const config = await loadNodeHostConfig();
-  const { host, port, contextPath, tls, tlsFingerprint } = resolveNodeGatewayOptions(opts, config);
+  const { host, port, contextPath, tls, tlsFingerprint, cloudflareAccess } =
+    resolveNodeGatewayOptions(opts, config);
   if (!Number.isFinite(port ?? Number.NaN) || (port ?? 0) <= 0 || (port ?? 0) > 65_535) {
     fail(
       opts.port !== undefined
@@ -127,6 +128,10 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
   }
   if (opts.tls === false && opts.tlsFingerprint !== undefined) {
     fail("--no-tls cannot be combined with --tls-fingerprint");
+    return;
+  }
+  if (cloudflareAccess && tls !== true) {
+    fail("Cloudflare Access credentials require --tls for the node Gateway connection");
     return;
   }
 

--- a/src/cli/node-cli/gateway-options.ts
+++ b/src/cli/node-cli/gateway-options.ts
@@ -1,5 +1,9 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { NodeHostConfig, NodeHostGatewayConfig } from "../../node-host/config.js";
+import {
+  nodeHostCloudflareAccessConfigFromEnv,
+  nodeHostGatewaysShareOrigin,
+} from "../../node-host/gateway-cloudflare-access.js";
 import { decodePairingSetupCode } from "../../pairing/setup-code.js";
 import { parsePort } from "../daemon-cli/shared.js";
 
@@ -62,6 +66,7 @@ export function resolveNodeGatewayOptions(
   options: NodeGatewayOptions,
   config: NodeHostConfig | null,
   pair?: NodePairGatewayOptions,
+  env: NodeJS.ProcessEnv = process.env,
 ) {
   const baselineHost = pair?.host ?? config?.gateway?.host ?? "127.0.0.1";
   const baselinePort = pair?.port ?? config?.gateway?.port ?? 18789;
@@ -90,6 +95,20 @@ export function resolveNodeGatewayOptions(
     options.contextPath !== undefined ||
     options.tls !== undefined ||
     options.tlsFingerprint !== undefined;
+  const savedGatewayMatchesBaseline =
+    !pair ||
+    (config?.gateway !== undefined &&
+      nodeHostGatewaysShareOrigin(config.gateway, pair.candidates[0]!));
+  const cloudflareAccess =
+    (!endpointChanged && savedGatewayMatchesBaseline
+      ? config?.gateway?.cloudflareAccess
+      : undefined) ?? nodeHostCloudflareAccessConfigFromEnv(env);
+  const gatewayCandidates =
+    pair && !hasExplicitEndpoint
+      ? pair.candidates.map((candidate, index) =>
+          index === 0 && cloudflareAccess ? { ...candidate, cloudflareAccess } : candidate,
+        )
+      : undefined;
 
   return {
     host,
@@ -97,6 +116,7 @@ export function resolveNodeGatewayOptions(
     contextPath,
     tls,
     tlsFingerprint,
-    gatewayCandidates: pair && !hasExplicitEndpoint ? pair.candidates : undefined,
+    cloudflareAccess,
+    gatewayCandidates,
   };
 }

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -72,7 +72,7 @@ export function registerNodeCli(program: Command) {
         return;
       }
       const existing = await loadNodeHostConfig();
-      const { host, port, contextPath, tls, tlsFingerprint, gatewayCandidates } =
+      const { host, port, contextPath, tls, tlsFingerprint, cloudflareAccess, gatewayCandidates } =
         resolveNodeGatewayOptions(opts, existing, pair);
       if (port === null) {
         defaultRuntime.error(formatInvalidPortOption("--port"));
@@ -90,6 +90,7 @@ export function registerNodeCli(program: Command) {
         gatewayTls: tls,
         gatewayTlsFingerprint: tlsFingerprint,
         gatewayContextPath: contextPath,
+        gatewayCloudflareAccess: cloudflareAccess,
         gatewayCandidates,
         gatewayBootstrapToken: pair?.bootstrapToken,
         preferGatewayBootstrapToken: pair !== undefined,

--- a/src/commands/doctor-node-hosting-preconditions.test.ts
+++ b/src/commands/doctor-node-hosting-preconditions.test.ts
@@ -81,7 +81,7 @@ describe("node-hosting preconditions", () => {
     });
 
     expect(findings.find((finding) => finding.requirement === "machine-client-auth")?.fixHint).toBe(
-      "Switch gateway.auth.mode to token and configure gateway.auth.token as a SecretRef so machine clients can authenticate as devices. Keep trusted-proxy only if machine clients use a clean loopback/direct gateway.auth.password path. Cloudflare Access service tokens are the alternative for Access-fronted gateways, but node-host support for CF-Access-Client-Id / CF-Access-Client-Secret is not implemented yet.",
+      "Switch gateway.auth.mode to token and configure gateway.auth.token as a SecretRef so machine clients can authenticate as devices. Keep trusted-proxy only if machine clients use a clean loopback/direct gateway.auth.password path. For Access-fronted gateways, configure the node gateway.cloudflareAccess.clientId / clientSecret SecretInputs or set CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET before openclaw connect.",
     );
     expect(findings.find((finding) => finding.requirement === "node-onboarding-url")).toMatchObject(
       {

--- a/src/commands/doctor-node-hosting-preconditions.ts
+++ b/src/commands/doctor-node-hosting-preconditions.ts
@@ -56,7 +56,7 @@ export function collectNodeHostingPreconditionFindings(
       path: "gateway.auth",
       requirement: "machine-client-auth",
       fixHint:
-        "Switch gateway.auth.mode to token and configure gateway.auth.token as a SecretRef so machine clients can authenticate as devices. Keep trusted-proxy only if machine clients use a clean loopback/direct gateway.auth.password path. Cloudflare Access service tokens are the alternative for Access-fronted gateways, but node-host support for CF-Access-Client-Id / CF-Access-Client-Secret is not implemented yet.",
+        "Switch gateway.auth.mode to token and configure gateway.auth.token as a SecretRef so machine clients can authenticate as devices. Keep trusted-proxy only if machine clients use a clean loopback/direct gateway.auth.password path. For Access-fronted gateways, configure the node gateway.cloudflareAccess.clientId / clientSecret SecretInputs or set CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET before openclaw connect.",
     });
   }
   if (lacksNodeOnboardingUrl(cfg)) {

--- a/src/commands/node-daemon-install-helpers.test.ts
+++ b/src/commands/node-daemon-install-helpers.test.ts
@@ -59,6 +59,8 @@ describe("buildNodeInstallPlan", () => {
     expect(plan.environmentValueSources).toEqual({
       OPENCLAW_GATEWAY_TOKEN: "file",
       OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret
+      CF_ACCESS_CLIENT_ID: "file",
+      CF_ACCESS_CLIENT_SECRET: "file", // pragma: allowlist secret
     });
     expect(mocks.resolvePreferredNodePath).not.toHaveBeenCalled();
     expect(mocks.buildNodeServiceEnvironment).toHaveBeenCalledWith({
@@ -129,6 +131,8 @@ describe("buildNodeInstallPlan", () => {
     expect(plan.environmentValueSources).toEqual({
       OPENCLAW_GATEWAY_TOKEN: "file",
       OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret
+      CF_ACCESS_CLIENT_ID: "file",
+      CF_ACCESS_CLIENT_SECRET: "file", // pragma: allowlist secret
     });
   });
 });

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -25,6 +25,8 @@ function buildNodeInstallEnvironmentValueSources(): Record<
   return {
     OPENCLAW_GATEWAY_TOKEN: "file",
     OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret
+    CF_ACCESS_CLIENT_ID: "file",
+    CF_ACCESS_CLIENT_SECRET: "file", // pragma: allowlist secret
   };
 }
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -798,6 +798,18 @@ describe("buildNodeServiceEnvironment", () => {
     expect(env.OPENCLAW_GATEWAY_PASSWORD).toBe("node-password");
   });
 
+  it("passes through the Cloudflare Access service-token pair for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        CF_ACCESS_CLIENT_ID: " cf-client-id ",
+        CF_ACCESS_CLIENT_SECRET: " cf-client-secret ",
+      },
+    });
+    expect(env.CF_ACCESS_CLIENT_ID).toBe("cf-client-id");
+    expect(env.CF_ACCESS_CLIENT_SECRET).toBe("cf-client-secret");
+  });
+
   it("passes through OPENCLAW_ALLOW_INSECURE_PRIVATE_WS for node services", () => {
     const env = buildNodeServiceEnvironment({
       env: { HOME: "/home/user", OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: " 1 " },

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -382,11 +382,15 @@ export function buildNodeServiceEnvironment(params: {
   );
   const gatewayToken = normalizeOptionalString(env.OPENCLAW_GATEWAY_TOKEN);
   const gatewayPassword = normalizeOptionalString(env.OPENCLAW_GATEWAY_PASSWORD);
+  const cloudflareAccessClientId = normalizeOptionalString(env.CF_ACCESS_CLIENT_ID);
+  const cloudflareAccessClientSecret = normalizeOptionalString(env.CF_ACCESS_CLIENT_SECRET);
   const allowInsecurePrivateWs = normalizeOptionalString(env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS);
   return {
     ...buildCommonServiceEnvironment(env, sharedEnv),
     OPENCLAW_GATEWAY_TOKEN: gatewayToken,
     OPENCLAW_GATEWAY_PASSWORD: gatewayPassword,
+    CF_ACCESS_CLIENT_ID: cloudflareAccessClientId,
+    CF_ACCESS_CLIENT_SECRET: cloudflareAccessClientSecret,
     OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: allowInsecurePrivateWs,
     ...resolveNodeServiceIdentityEnvironment(),
   };

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -2317,7 +2317,7 @@ describe("GatewayClient connect auth payload", () => {
   it("never logs a registered Cloudflare Access credential from connection errors", async () => {
     const clientSecret = ["cf", "redaction", "secret"].join("-");
     const client = new GatewayClient({
-      url: "ws://127.0.0.1:18789",
+      url: "wss://gateway.example",
       cloudflareAccess: { clientId: "cf-redaction-id", clientSecret },
       deviceIdentity: null,
     });

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -2314,6 +2314,31 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
+  it("never logs a registered Cloudflare Access credential from connection errors", async () => {
+    const clientSecret = ["cf", "redaction", "secret"].join("-");
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      cloudflareAccess: { clientId: "cf-redaction-id", clientSecret },
+      deviceIdentity: null,
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitConnectFailure(
+      ws,
+      connect.id,
+      { code: "AUTH_UNAUTHORIZED" },
+      `edge rejected service token ${clientSecret}`,
+    );
+
+    await waitForFast(() => {
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+    });
+    const logged = String(logErrorMock.mock.calls.at(-1)?.[0] ?? "");
+    expect(logged).toContain("edge rejected service token");
+    expect(logged).not.toContain(clientSecret);
+    client.stop();
+  });
+
   it("uses explicit shared password and does not inject stored device token", () => {
     loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
     const client = new GatewayClient({

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -30,6 +30,7 @@ import {
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { logDebug, logError } from "../logger.js";
 import { redactToolPayloadText } from "../logging/redact.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { VERSION } from "../version.js";
 
 export {
@@ -114,6 +115,10 @@ export class GatewayClient {
     const suppressOriginDeviceAuth = Boolean(
       deviceAuthScope && (baseOptions.token?.trim() || baseOptions.password?.trim()),
     );
+    if (baseOptions.cloudflareAccess) {
+      registerSecretValueForRedaction(baseOptions.cloudflareAccess.clientId);
+      registerSecretValueForRedaction(baseOptions.cloudflareAccess.clientSecret);
+    }
     this.#client = new BaseGatewayClient({
       ...baseOptions,
       clientVersion: baseOptions.clientVersion ?? VERSION,

--- a/src/infra/state-migrations.node-host.test.ts
+++ b/src/infra/state-migrations.node-host.test.ts
@@ -87,6 +87,7 @@ describe("legacy node-host Doctor migration", () => {
           gateway_tls: 0,
           gateway_tls_fingerprint: fixtureDigest,
           gateway_context_path: "/openclaw-gw",
+          gateway_cloudflare_access_json: null,
           updated_at_ms: params.updatedAtMs,
         }),
     );

--- a/src/infra/state-migrations.node-host.ts
+++ b/src/infra/state-migrations.node-host.ts
@@ -178,18 +178,19 @@ function rowToCanonicalState(row: {
   if (row.gateway_tls !== null && row.gateway_tls !== 0 && row.gateway_tls !== 1) {
     throw new Error("invalid canonical node-host SQLite gateway tls");
   }
+  const cloudflareAccess =
+    row.gateway_cloudflare_access_json === null
+      ? undefined
+      : normalizeNodeHostCloudflareAccessConfig(
+          JSON.parse(row.gateway_cloudflare_access_json) as unknown,
+        );
   const gateway: NodeHostGatewayConfig = {
     host: nullableNonEmptyString(row.gateway_host, "gateway_host"),
     port: row.gateway_port ?? undefined,
     tls: row.gateway_tls === null ? undefined : row.gateway_tls === 1,
     tlsFingerprint: nullableNonEmptyString(row.gateway_tls_fingerprint, "gateway_tls_fingerprint"),
     contextPath: nullableNonEmptyString(row.gateway_context_path, "gateway_context_path"),
-    cloudflareAccess:
-      row.gateway_cloudflare_access_json === null
-        ? undefined
-        : normalizeNodeHostCloudflareAccessConfig(
-            JSON.parse(row.gateway_cloudflare_access_json) as unknown,
-          ),
+    ...(cloudflareAccess ? { cloudflareAccess } : {}),
   };
   return {
     config: {

--- a/src/infra/state-migrations.node-host.ts
+++ b/src/infra/state-migrations.node-host.ts
@@ -9,6 +9,7 @@ import {
   type NodeHostConfig,
   type NodeHostGatewayConfig,
 } from "../node-host/config.js";
+import { normalizeNodeHostCloudflareAccessConfig } from "../node-host/gateway-cloudflare-access.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import {
@@ -159,6 +160,7 @@ function rowToCanonicalState(row: {
   gateway_tls: number | null;
   gateway_tls_fingerprint: string | null;
   gateway_context_path: string | null;
+  gateway_cloudflare_access_json: string | null;
   updated_at_ms: number;
 }): CanonicalNodeHostState {
   if (row.version !== 1 || !row.node_id.trim()) {
@@ -182,6 +184,12 @@ function rowToCanonicalState(row: {
     tls: row.gateway_tls === null ? undefined : row.gateway_tls === 1,
     tlsFingerprint: nullableNonEmptyString(row.gateway_tls_fingerprint, "gateway_tls_fingerprint"),
     contextPath: nullableNonEmptyString(row.gateway_context_path, "gateway_context_path"),
+    cloudflareAccess:
+      row.gateway_cloudflare_access_json === null
+        ? undefined
+        : normalizeNodeHostCloudflareAccessConfig(
+            JSON.parse(row.gateway_cloudflare_access_json) as unknown,
+          ),
   };
   return {
     config: {
@@ -202,7 +210,9 @@ function configsEqual(left: NodeHostConfig, right: NodeHostConfig): boolean {
     left.gateway?.port === right.gateway?.port &&
     left.gateway?.tls === right.gateway?.tls &&
     left.gateway?.tlsFingerprint === right.gateway?.tlsFingerprint &&
-    left.gateway?.contextPath === right.gateway?.contextPath
+    left.gateway?.contextPath === right.gateway?.contextPath &&
+    JSON.stringify(left.gateway?.cloudflareAccess) ===
+      JSON.stringify(right.gateway?.cloudflareAccess)
   );
 }
 
@@ -222,6 +232,9 @@ function writeCanonicalState(
     gateway_tls: gateway?.tls === undefined ? null : gateway.tls ? 1 : 0,
     gateway_tls_fingerprint: gateway?.tlsFingerprint ?? null,
     gateway_context_path: gateway?.contextPath ?? null,
+    gateway_cloudflare_access_json: gateway?.cloudflareAccess
+      ? JSON.stringify(gateway.cloudflareAccess)
+      : null,
     updated_at_ms: state.updatedAtMs,
   };
   const { config_key: _configKey, ...updates } = row;

--- a/src/node-host/config.test.ts
+++ b/src/node-host/config.test.ts
@@ -160,6 +160,14 @@ describe("node-host SQLite config", () => {
         tls: false,
         tlsFingerprint: fixtureDigest,
         contextPath: "/openclaw-gw",
+        cloudflareAccess: {
+          clientId: { source: "env", provider: "default", id: "CF_ACCESS_CLIENT_ID" },
+          clientSecret: {
+            source: "env",
+            provider: "default",
+            id: "CF_ACCESS_CLIENT_SECRET",
+          },
+        },
       },
       env,
       nowMs: 1_234,
@@ -176,6 +184,14 @@ describe("node-host SQLite config", () => {
         tls: false,
         tlsFingerprint: fixtureDigest,
         contextPath: "/openclaw-gw",
+        cloudflareAccess: {
+          clientId: { source: "env", provider: "default", id: "CF_ACCESS_CLIENT_ID" },
+          clientSecret: {
+            source: "env",
+            provider: "default",
+            id: "CF_ACCESS_CLIENT_SECRET",
+          },
+        },
       },
     });
     closeOpenClawStateDatabaseForTest();
@@ -230,6 +246,36 @@ describe("node-host SQLite config", () => {
       .db.prepare("PRAGMA table_info(node_host_config)")
       .all() as Array<{ name?: unknown }>;
     expect(columns).toContainEqual(expect.objectContaining({ name: "gateway_context_path" }));
+  });
+
+  it("adds the Cloudflare Access column to an existing state database", async () => {
+    const { env } = makeTestEnv();
+    const database = openOpenClawStateDatabase({ env });
+    database.db.exec("ALTER TABLE node_host_config DROP COLUMN gateway_cloudflare_access_json;");
+    closeOpenClawStateDatabaseForTest();
+
+    const configured = await configureNodeHost({
+      fallbackDisplayName: "node",
+      gateway: {
+        cloudflareAccess: {
+          clientId: "$CF_ACCESS_CLIENT_ID",
+          clientSecret: "$CF_ACCESS_CLIENT_SECRET",
+        },
+      },
+      env,
+      nowMs: 1,
+    });
+
+    expect(configured.gateway?.cloudflareAccess).toEqual({
+      clientId: { source: "env", provider: "default", id: "CF_ACCESS_CLIENT_ID" },
+      clientSecret: { source: "env", provider: "default", id: "CF_ACCESS_CLIENT_SECRET" },
+    });
+    const columns = openOpenClawStateDatabase({ env })
+      .db.prepare("PRAGMA table_info(node_host_config)")
+      .all() as Array<{ name?: unknown }>;
+    expect(columns).toContainEqual(
+      expect.objectContaining({ name: "gateway_cloudflare_access_json" }),
+    );
   });
 
   it("keeps the first committed implicit node id across processes", async () => {
@@ -294,6 +340,7 @@ describe("node-host SQLite config", () => {
               gateway_tls: null,
               gateway_tls_fingerprint: null,
               gateway_context_path: null,
+              gateway_cloudflare_access_json: null,
               updated_at_ms: 1,
             }),
         );
@@ -326,6 +373,7 @@ describe("node-host SQLite config", () => {
               gateway_tls: null,
               gateway_tls_fingerprint: null,
               gateway_context_path: null,
+              gateway_cloudflare_access_json: null,
               updated_at_ms: 1,
             }),
         );

--- a/src/node-host/config.ts
+++ b/src/node-host/config.ts
@@ -147,13 +147,14 @@ function rowToNodeHostConfig(row: NodeHostConfigRuntimeRow): NodeHostConfig {
   if (row.installed_apps_sharing !== 0 && row.installed_apps_sharing !== 1) {
     throw new Error("invalid node-host SQLite row: installed_apps_sharing must be 0 or 1");
   }
+  const cloudflareAccess = parseCloudflareAccessJson(row.gateway_cloudflare_access_json);
   const gateway: NodeHostGatewayConfig = {
     host: optionalNonEmptyString(row.gateway_host, "gateway_host"),
     port: validatePort(row.gateway_port, "SQLite gateway_port"),
     tls: row.gateway_tls === null ? undefined : row.gateway_tls === 1,
     tlsFingerprint: optionalNonEmptyString(row.gateway_tls_fingerprint, "gateway_tls_fingerprint"),
     contextPath: optionalNonEmptyString(row.gateway_context_path, "gateway_context_path"),
-    cloudflareAccess: parseCloudflareAccessJson(row.gateway_cloudflare_access_json),
+    ...(cloudflareAccess ? { cloudflareAccess } : {}),
   };
   const hasGateway = Object.values(gateway).some((value) => value !== undefined);
   return {

--- a/src/node-host/config.ts
+++ b/src/node-host/config.ts
@@ -16,6 +16,10 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import {
+  normalizeNodeHostCloudflareAccessConfig,
+  type NodeHostCloudflareAccessConfig,
+} from "./gateway-cloudflare-access.js";
 
 /** Gateway endpoint metadata persisted with node-host config. */
 export type NodeHostGatewayConfig = {
@@ -25,6 +29,8 @@ export type NodeHostGatewayConfig = {
   tlsFingerprint?: string;
   /** Gateway WebSocket context path (e.g. "/openclaw-gw"). */
   contextPath?: string;
+  /** Cloudflare Access service-token inputs bound to this exact Gateway origin. */
+  cloudflareAccess?: NodeHostCloudflareAccessConfig;
 };
 
 export type NodeHostConfig = {
@@ -99,6 +105,21 @@ function optionalInputString(value: string | undefined): string | undefined {
   return normalized || undefined;
 }
 
+function parseCloudflareAccessJson(
+  value: string | null,
+): NodeHostCloudflareAccessConfig | undefined {
+  if (value === null) {
+    return undefined;
+  }
+  try {
+    return normalizeNodeHostCloudflareAccessConfig(JSON.parse(value) as unknown);
+  } catch (error) {
+    throw new Error("invalid node-host SQLite row: gateway_cloudflare_access_json", {
+      cause: error,
+    });
+  }
+}
+
 function validatePort(value: number | null | undefined, label: string): number | undefined {
   if (value === null || value === undefined) {
     return undefined;
@@ -132,6 +153,7 @@ function rowToNodeHostConfig(row: NodeHostConfigRuntimeRow): NodeHostConfig {
     tls: row.gateway_tls === null ? undefined : row.gateway_tls === 1,
     tlsFingerprint: optionalNonEmptyString(row.gateway_tls_fingerprint, "gateway_tls_fingerprint"),
     contextPath: optionalNonEmptyString(row.gateway_context_path, "gateway_context_path"),
+    cloudflareAccess: parseCloudflareAccessJson(row.gateway_cloudflare_access_json),
   };
   const hasGateway = Object.values(gateway).some((value) => value !== undefined);
   return {
@@ -150,6 +172,7 @@ function normalizeGatewayConfig(gateway: NodeHostGatewayConfig): NodeHostGateway
     tls: gateway.tls,
     tlsFingerprint: optionalInputString(gateway.tlsFingerprint),
     contextPath: optionalInputString(gateway.contextPath),
+    cloudflareAccess: normalizeNodeHostCloudflareAccessConfig(gateway.cloudflareAccess),
   };
   return Object.values(normalized).some((value) => value !== undefined) ? normalized : undefined;
 }
@@ -170,6 +193,9 @@ function configToRow(params: {
     gateway_tls: gateway?.tls === undefined ? null : gateway.tls ? 1 : 0,
     gateway_tls_fingerprint: gateway?.tlsFingerprint ?? null,
     gateway_context_path: gateway?.contextPath ?? null,
+    gateway_cloudflare_access_json: gateway?.cloudflareAccess
+      ? JSON.stringify(gateway.cloudflareAccess)
+      : null,
     installed_apps_sharing: params.config.installedAppsSharing ? 1 : 0,
     updated_at_ms: params.updatedAtMs,
   };
@@ -192,6 +218,7 @@ function readNodeHostConfigRow(
         "gateway_tls",
         "gateway_tls_fingerprint",
         "gateway_context_path",
+        "gateway_cloudflare_access_json",
         "installed_apps_sharing",
         "updated_at_ms",
       ])

--- a/src/node-host/gateway-candidate-connection.test.ts
+++ b/src/node-host/gateway-candidate-connection.test.ts
@@ -31,7 +31,11 @@ const candidates = [
   { host: "gateway.tailnet.example", port: 443, tls: true },
 ];
 
-function createConnection() {
+function createConnection(
+  cloudflareAccessByCandidate?: Parameters<
+    typeof createNodeHostGatewayCandidateConnection
+  >[0]["cloudflareAccessByCandidate"],
+) {
   const callbacks = {
     onEvent: vi.fn(),
     onHelloOk: vi.fn(),
@@ -45,6 +49,7 @@ function createConnection() {
     connection: createNodeHostGatewayCandidateConnection({
       candidates,
       clientOptions: {},
+      cloudflareAccessByCandidate,
       ...callbacks,
     }),
   };
@@ -175,5 +180,23 @@ describe("gateway candidate connection", () => {
     await Promise.resolve();
 
     expect(mocks.clients).toHaveLength(1);
+  });
+
+  it("never carries origin-bound Access credentials to another candidate host", async () => {
+    const credentials = { clientId: "cf-pinned-id", clientSecret: "cf-pinned-secret" };
+    createConnection(new Map([[candidates[0]!, credentials]]));
+
+    expect(mocks.options[0]?.cloudflareAccess).toEqual(credentials);
+    mocks.options[0]?.onClose?.(1006, "transport unavailable", {
+      phase: "pre-hello",
+      socketOpened: false,
+      transportValidated: false,
+      connectRequestSent: false,
+      transientPreHelloCleanClose: false,
+    });
+    await vi.waitFor(() => expect(mocks.clients).toHaveLength(2));
+
+    expect(mocks.options[1]?.url).toBe("wss://gateway.tailnet.example:443");
+    expect(mocks.options[1]?.cloudflareAccess).toBeUndefined();
   });
 });

--- a/src/node-host/gateway-candidate-connection.ts
+++ b/src/node-host/gateway-candidate-connection.ts
@@ -1,3 +1,4 @@
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import {
   GatewayClient,
   type GatewayClientCloseInfo,
@@ -15,6 +16,7 @@ type CandidateConnectionOptions = Omit<
   GatewayClientOptions,
   | "url"
   | "tlsFingerprint"
+  | "cloudflareAccess"
   | "onEvent"
   | "onHelloOk"
   | "onConnectError"
@@ -24,9 +26,15 @@ type CandidateConnectionOptions = Omit<
 
 type GatewayCandidateConnectionParams = {
   candidates: readonly NodeHostGatewayConfig[];
+  cloudflareAccessByCandidate?: ReadonlyMap<NodeHostGatewayConfig, CloudflareAccessCredentials>;
   clientOptions: CandidateConnectionOptions;
   onEvent: (event: GatewayCandidateEvent) => void;
-  onHelloOk: (hello: GatewayCandidateHello, url: string, tlsFingerprint?: string) => void;
+  onHelloOk: (
+    hello: GatewayCandidateHello,
+    url: string,
+    tlsFingerprint?: string,
+    cloudflareAccess?: CloudflareAccessCredentials,
+  ) => void;
   onConnectError: (error: Error) => void;
   onReconnectPaused: (info: GatewayReconnectPausedInfo) => void;
   onClose: (code: number, reason: string, info?: GatewayClientCloseInfo) => void;
@@ -70,10 +78,12 @@ export function createNodeHostGatewayCandidateConnection(params: GatewayCandidat
       throw new Error(`node host gateway candidate ${candidateIndex} is unavailable`);
     }
     const url = formatGatewayCandidateUrl(candidate);
+    const cloudflareAccess = params.cloudflareAccessByCandidate?.get(candidate);
     const candidateClient = new GatewayClient({
       ...params.clientOptions,
       url,
       tlsFingerprint: candidate.tlsFingerprint,
+      ...(cloudflareAccess ? { cloudflareAccess } : {}),
       onEvent: (event) => {
         if (currentCandidateIndex === candidateIndex) {
           params.onEvent(event);
@@ -87,7 +97,7 @@ export function createNodeHostGatewayCandidateConnection(params: GatewayCandidat
           winnerSelected = true;
           params.onWinningCandidate(candidate);
         }
-        params.onHelloOk(hello, url, candidate.tlsFingerprint);
+        params.onHelloOk(hello, url, candidate.tlsFingerprint, cloudflareAccess);
       },
       onConnectError: (error) => {
         if (currentCandidateIndex === candidateIndex) {

--- a/src/node-host/gateway-cloudflare-access.test.ts
+++ b/src/node-host/gateway-cloudflare-access.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isSecretValueRegisteredForRedaction } from "../logging/secret-redaction-registry.js";
+import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import {
+  nodeHostCloudflareAccessConfigFromEnv,
+  nodeHostGatewayMatchesUrl,
+  resolveNodeHostCloudflareAccess,
+} from "./gateway-cloudflare-access.js";
+
+describe("node-host Cloudflare Access credentials", () => {
+  afterEach(() => {
+    resetSecretRedactionRegistryForTest();
+  });
+
+  it("persists conventional environment fallback as SecretRefs and resolves it", async () => {
+    const clientId = ["cf", "node", "id"].join("-");
+    const clientSecret = ["cf", "node", "secret"].join("-");
+    const env = {
+      CF_ACCESS_CLIENT_ID: clientId,
+      CF_ACCESS_CLIENT_SECRET: clientSecret,
+    };
+    const value = nodeHostCloudflareAccessConfigFromEnv(env);
+
+    expect(value).toEqual({
+      clientId: { source: "env", provider: "default", id: "CF_ACCESS_CLIENT_ID" },
+      clientSecret: { source: "env", provider: "default", id: "CF_ACCESS_CLIENT_SECRET" },
+    });
+    await expect(resolveNodeHostCloudflareAccess({ value, config: {}, env })).resolves.toEqual({
+      clientId,
+      clientSecret,
+    });
+    expect(isSecretValueRegisteredForRedaction(clientId)).toBe(true);
+    expect(isSecretValueRegisteredForRedaction(clientSecret)).toBe(true);
+  });
+
+  it("fails closed when only half of the credential pair is configured", () => {
+    expect(() =>
+      nodeHostCloudflareAccessConfigFromEnv({ CF_ACCESS_CLIENT_ID: "client-id-only" }),
+    ).toThrow("CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be configured together");
+  });
+
+  it("matches only the configured Gateway origin", () => {
+    const gateway = { host: "gateway.example", port: 443, tls: true };
+    expect(nodeHostGatewayMatchesUrl(gateway, new URL("https://gateway.example/j/code"))).toBe(
+      true,
+    );
+    expect(nodeHostGatewayMatchesUrl(gateway, new URL("https://other.example/j/code"))).toBe(false);
+    expect(nodeHostGatewayMatchesUrl(gateway, new URL("https://gateway.example:8443/j/code"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/node-host/gateway-cloudflare-access.ts
+++ b/src/node-host/gateway-cloudflare-access.ts
@@ -9,8 +9,8 @@ import {
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { materializeSecretInput } from "../secrets/resolve-secret-input-string.js";
 
-export const CF_ACCESS_CLIENT_ID_ENV = "CF_ACCESS_CLIENT_ID";
-export const CF_ACCESS_CLIENT_SECRET_ENV = "CF_ACCESS_CLIENT_SECRET";
+const CF_ACCESS_CLIENT_ID_ENV = "CF_ACCESS_CLIENT_ID";
+const CF_ACCESS_CLIENT_SECRET_ENV = "CF_ACCESS_CLIENT_SECRET";
 
 export type NodeHostCloudflareAccessConfig = {
   clientId: SecretInput;

--- a/src/node-host/gateway-cloudflare-access.ts
+++ b/src/node-host/gateway-cloudflare-access.ts
@@ -1,0 +1,131 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  coerceSecretRef,
+  normalizeSecretInputString,
+  type SecretInput,
+} from "../config/types.secrets.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { materializeSecretInput } from "../secrets/resolve-secret-input-string.js";
+
+export const CF_ACCESS_CLIENT_ID_ENV = "CF_ACCESS_CLIENT_ID";
+export const CF_ACCESS_CLIENT_SECRET_ENV = "CF_ACCESS_CLIENT_SECRET";
+
+export type NodeHostCloudflareAccessConfig = {
+  clientId: SecretInput;
+  clientSecret: SecretInput;
+};
+
+function normalizeCloudflareAccessSecretInput(value: unknown, path: string): SecretInput {
+  const ref = coerceSecretRef(value);
+  if (ref) {
+    return ref;
+  }
+  const literal = normalizeSecretInputString(value);
+  if (literal) {
+    return literal;
+  }
+  throw new Error(`invalid node-host ${path}: expected a non-empty SecretInput`);
+}
+
+export function normalizeNodeHostCloudflareAccessConfig(
+  value: unknown,
+): NodeHostCloudflareAccessConfig | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (
+    !isRecord(value) ||
+    Object.keys(value).length !== 2 ||
+    !("clientId" in value) ||
+    !("clientSecret" in value)
+  ) {
+    throw new Error(
+      "invalid node-host gateway.cloudflareAccess: expected clientId and clientSecret",
+    );
+  }
+  return {
+    clientId: normalizeCloudflareAccessSecretInput(
+      value.clientId,
+      "gateway.cloudflareAccess.clientId",
+    ),
+    clientSecret: normalizeCloudflareAccessSecretInput(
+      value.clientSecret,
+      "gateway.cloudflareAccess.clientSecret",
+    ),
+  };
+}
+
+/** Persist conventional environment fallback as refs, never as copied plaintext. */
+export function nodeHostCloudflareAccessConfigFromEnv(
+  env: NodeJS.ProcessEnv,
+): NodeHostCloudflareAccessConfig | undefined {
+  const clientId = normalizeSecretInputString(env[CF_ACCESS_CLIENT_ID_ENV]);
+  const clientSecret = normalizeSecretInputString(env[CF_ACCESS_CLIENT_SECRET_ENV]);
+  if (!clientId && !clientSecret) {
+    return undefined;
+  }
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      `${CF_ACCESS_CLIENT_ID_ENV} and ${CF_ACCESS_CLIENT_SECRET_ENV} must be configured together`,
+    );
+  }
+  return {
+    clientId: { source: "env", provider: "default", id: CF_ACCESS_CLIENT_ID_ENV },
+    clientSecret: { source: "env", provider: "default", id: CF_ACCESS_CLIENT_SECRET_ENV },
+  };
+}
+
+export async function resolveNodeHostCloudflareAccess(params: {
+  value?: NodeHostCloudflareAccessConfig;
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<CloudflareAccessCredentials | undefined> {
+  if (!params.value) {
+    return undefined;
+  }
+  const [clientId, clientSecret] = await Promise.all([
+    materializeSecretInput({
+      config: params.config,
+      value: params.value.clientId,
+      env: params.env,
+    }),
+    materializeSecretInput({
+      config: params.config,
+      value: params.value.clientSecret,
+      env: params.env,
+    }),
+  ]);
+  if (!clientId || !clientSecret) {
+    throw new Error("node-host Cloudflare Access credentials resolved empty");
+  }
+  registerSecretValueForRedaction(clientId);
+  registerSecretValueForRedaction(clientSecret);
+  return { clientId, clientSecret };
+}
+
+export function nodeHostGatewayMatchesUrl(
+  gateway: { host?: string; port?: number; tls?: boolean },
+  target: URL,
+): boolean {
+  const host = gateway.host ?? "127.0.0.1";
+  const urlHost =
+    host.includes(":") && !(host.startsWith("[") && host.endsWith("]")) ? `[${host}]` : host;
+  const protocol = gateway.tls ? "https:" : "http:";
+  const port = gateway.port ?? (gateway.tls ? 443 : 80);
+  const configured = new URL(`${protocol}//${urlHost}:${port}`);
+  return configured.protocol === target.protocol && configured.host === target.host;
+}
+
+export function nodeHostGatewaysShareOrigin(
+  left: { host?: string; port?: number; tls?: boolean },
+  right: { host?: string; port?: number; tls?: boolean },
+): boolean {
+  const host = right.host ?? "127.0.0.1";
+  const urlHost =
+    host.includes(":") && !(host.startsWith("[") && host.endsWith("]")) ? `[${host}]` : host;
+  const protocol = right.tls ? "https:" : "http:";
+  const port = right.port ?? (right.tls ? 443 : 80);
+  return nodeHostGatewayMatchesUrl(left, new URL(`${protocol}//${urlHost}:${port}`));
+}

--- a/src/node-host/invoke-agent-cli-claude-handler.ts
+++ b/src/node-host/invoke-agent-cli-claude-handler.ts
@@ -1,3 +1,4 @@
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import type { DesktopHostConfig } from "../config/types.desktop.js";
 import { createExecApprovalPolicySnapshot } from "../infra/exec-approvals.js";
 import type { scanInstalledApps } from "../infra/installed-apps.js";
@@ -28,6 +29,7 @@ export type NodeHostInvokeRuntime = {
   scanInstalledApps?: typeof scanInstalledApps;
   gatewayUrl?: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   desktopHostConfig?: DesktopHostConfig;
   emitProgress?: (text: string) => Promise<void>;
 };

--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -98,6 +98,7 @@ async function invokePrivate(params: {
   supervisor?: NodeWorkerSupervisorControl;
   gatewayUrl?: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: { clientId: string; clientSecret: string };
   workspace?: NodeWorkerWorkspaceRuntime;
 }) {
   const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
@@ -118,6 +119,9 @@ async function invokePrivate(params: {
       gatewayUrl: params.gatewayUrl ?? "wss://gateway.example/tenant",
       ...(params.gatewayTlsFingerprint
         ? { gatewayTlsFingerprint: params.gatewayTlsFingerprint }
+        : {}),
+      ...(params.gatewayCloudflareAccess
+        ? { gatewayCloudflareAccess: params.gatewayCloudflareAccess }
         : {}),
     },
   );
@@ -222,12 +226,20 @@ describe("node-host worker supervisor commands", () => {
       bundleInstaller: { ensure },
       gatewayUrl: "wss://gateway.example/tenant",
       gatewayTlsFingerprint: "aa:bb:cc",
+      gatewayCloudflareAccess: {
+        clientId: "cf-bundle-id",
+        clientSecret: "cf-bundle-secret",
+      },
     });
 
     expect(ensure).toHaveBeenCalledWith({
       input,
       gatewayUrl: "wss://gateway.example/tenant",
       gatewayTlsFingerprint: "aa:bb:cc",
+      gatewayCloudflareAccess: {
+        clientId: "cf-bundle-id",
+        clientSecret: "cf-bundle-secret",
+      },
       signal: undefined,
     });
     expect(pluginHandle).not.toHaveBeenCalled();
@@ -406,12 +418,20 @@ describe("node-host worker supervisor commands", () => {
       supervisor,
       gatewayUrl: "wss://gateway.example/tenant/",
       gatewayTlsFingerprint: "aa:bb:cc",
+      gatewayCloudflareAccess: {
+        clientId: "cf-worker-id",
+        clientSecret: "cf-worker-secret",
+      },
     });
 
     expect(supervisorMocks(supervisor).launch.mock.calls[0]?.[1]).toEqual({
       kind: "websocket",
       url: "wss://gateway.example/tenant/__openclaw__/worker",
       tlsFingerprint: "aa:bb:cc",
+      cloudflareAccess: {
+        clientId: "cf-worker-id",
+        clientSecret: "cf-worker-secret",
+      },
     });
   });
 

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -622,6 +622,7 @@ async function dispatchInvoke(
     workspace: runtime.workerWorkspace,
     gatewayUrl: runtime.gatewayUrl,
     gatewayTlsFingerprint: runtime.gatewayTlsFingerprint,
+    gatewayCloudflareAccess: runtime.gatewayCloudflareAccess,
     signal: runtime.signal,
   });
   if (workerSupervisorResult.handled) {

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -151,24 +151,23 @@ describe("node worker bundle installer", () => {
     ).resolves.toContain(fixture.input.build.bundleHash);
   });
 
-  it("sends the Cloudflare Access pair on the bundle transfer", async () => {
+  it("rejects the Cloudflare Access pair before a plaintext bundle transfer", async () => {
     const fixture = await bundleFixture();
     const served = await serve(fixture.archive, fixture.input.archive.token);
     const installer = new NodeWorkerBundleInstaller({ root });
 
-    await installer.ensure({
-      input: fixture.input,
-      gatewayUrl: served.gatewayUrl,
-      gatewayCloudflareAccess: {
-        clientId: "cf-bundle-id",
-        clientSecret: "cf-bundle-secret",
-      },
-    });
+    await expect(
+      installer.ensure({
+        input: fixture.input,
+        gatewayUrl: served.gatewayUrl,
+        gatewayCloudflareAccess: {
+          clientId: "cf-bundle-id",
+          clientSecret: "cf-bundle-secret",
+        },
+      }),
+    ).rejects.toThrow("worker-bundle-install-failed: Cloudflare Access credentials require HTTPS");
 
-    expect(served.requests.mock.calls[0]?.[1]).toMatchObject({
-      "cf-access-client-id": "cf-bundle-id",
-      "cf-access-client-secret": "cf-bundle-secret",
-    });
+    expect(served.requests).not.toHaveBeenCalled();
   });
 
   it("reports installed only after full bundle validation", async () => {

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -92,7 +92,7 @@ describe("node worker bundle installer", () => {
   async function serve(archive: Buffer, token: string, declaredBytes = archive.byteLength) {
     const requests = vi.fn();
     server = http.createServer((req, res) => {
-      requests(req.url, req.headers.authorization);
+      requests(req.url, req.headers);
       if (req.headers.authorization !== `Bearer ${token}`) {
         res.writeHead(404).end();
         return;
@@ -149,6 +149,26 @@ describe("node worker bundle installer", () => {
         "utf8",
       ),
     ).resolves.toContain(fixture.input.build.bundleHash);
+  });
+
+  it("sends the Cloudflare Access pair on the bundle transfer", async () => {
+    const fixture = await bundleFixture();
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({ root });
+
+    await installer.ensure({
+      input: fixture.input,
+      gatewayUrl: served.gatewayUrl,
+      gatewayCloudflareAccess: {
+        clientId: "cf-bundle-id",
+        clientSecret: "cf-bundle-secret",
+      },
+    });
+
+    expect(served.requests.mock.calls[0]?.[1]).toMatchObject({
+      "cf-access-client-id": "cf-bundle-id",
+      "cf-access-client-secret": "cf-bundle-secret",
+    });
   });
 
   it("reports installed only after full bundle validation", async () => {

--- a/src/node-host/node-worker-bundle-installer.ts
+++ b/src/node-host/node-worker-bundle-installer.ts
@@ -313,7 +313,9 @@ export class NodeWorkerBundleInstaller {
           throw new NodeWorkerBundleInstallError(
             error.reason === "tls-fingerprint-mismatch"
               ? "worker-bundle-install-failed: gateway TLS fingerprint mismatch"
-              : "worker-bundle-install-failed: gateway transfer is unavailable",
+              : error.reason === "cloudflare-access-requires-tls"
+                ? "worker-bundle-install-failed: Cloudflare Access credentials require HTTPS"
+                : "worker-bundle-install-failed: gateway transfer is unavailable",
             { cause: error },
           );
         }

--- a/src/node-host/node-worker-bundle-installer.ts
+++ b/src/node-host/node-worker-bundle-installer.ts
@@ -7,6 +7,7 @@ import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import { promisify } from "node:util";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import {
   validateWorkerAdmissionHandshake,
   type WorkerAdmissionHandshake,
@@ -65,6 +66,7 @@ async function responseBody(response: IncomingMessage, maxBytes = 64 * 1024): Pr
 async function downloadBundle(params: {
   gatewayUrl: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   input: NodeWorkerBundleInstallInput;
   destination: string;
   signal?: AbortSignal;
@@ -72,6 +74,7 @@ async function downloadBundle(params: {
   const response = await openNodeWorkerTransferHttpRequest({
     gatewayUrl: params.gatewayUrl,
     tlsFingerprint: params.gatewayTlsFingerprint,
+    cloudflareAccess: params.gatewayCloudflareAccess,
     routePath: nodeWorkerBundleTransferPath(params.input.build.bundleHash),
     method: "GET",
     token: params.input.archive.token,
@@ -243,6 +246,7 @@ export class NodeWorkerBundleInstaller {
     input: NodeWorkerBundleInstallInput;
     gatewayUrl: string;
     gatewayTlsFingerprint?: string;
+    gatewayCloudflareAccess?: CloudflareAccessCredentials;
     signal?: AbortSignal;
   }): Promise<WorkerAdmissionHandshake> {
     const { input } = params;
@@ -271,6 +275,7 @@ export class NodeWorkerBundleInstaller {
           await downloadBundle({
             gatewayUrl: params.gatewayUrl,
             gatewayTlsFingerprint: params.gatewayTlsFingerprint,
+            gatewayCloudflareAccess: params.gatewayCloudflareAccess,
             input,
             destination: archivePath,
             signal: params.signal,

--- a/src/node-host/node-worker-output.ts
+++ b/src/node-host/node-worker-output.ts
@@ -13,13 +13,16 @@ export type NodeWorkerCredentialScrubber = {
 };
 
 export function createNodeWorkerCredentialScrubber(
-  credential: string,
+  credentials: string | readonly string[],
 ): NodeWorkerCredentialScrubber {
-  const representations = new Set([
-    credential,
-    encodeURIComponent(credential),
-    JSON.stringify(credential).slice(1, -1),
-  ]);
+  const values = typeof credentials === "string" ? [credentials] : credentials;
+  const representations = new Set(
+    values.flatMap((credential) => [
+      credential,
+      encodeURIComponent(credential),
+      JSON.stringify(credential).slice(1, -1),
+    ]),
+  );
   const ordered = [...representations].toSorted((left, right) => right.length - left.length);
   return {
     maxRepresentationBytes: Math.max(

--- a/src/node-host/node-worker-supervisor-commands.ts
+++ b/src/node-host/node-worker-supervisor-commands.ts
@@ -1,3 +1,4 @@
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import { WORKER_PUBLIC_INGRESS_PATH } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import {
   NODE_WORKER_BUNDLE_INSTALL_COMMAND,
@@ -69,6 +70,7 @@ type NodeWorkerSupervisorCommandResult =
 function resolveWorkerConnectionEndpoint(params: {
   gatewayUrl?: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
 }): WorkerConnectionEndpoint {
   if (!params.gatewayUrl) {
     throw new Error("node worker gateway connection unavailable");
@@ -91,6 +93,7 @@ function resolveWorkerConnectionEndpoint(params: {
     ...(gateway.protocol === "wss:" && params.gatewayTlsFingerprint
       ? { tlsFingerprint: params.gatewayTlsFingerprint }
       : {}),
+    ...(params.gatewayCloudflareAccess ? { cloudflareAccess: params.gatewayCloudflareAccess } : {}),
   });
   if (!endpoint) {
     throw new Error("node worker gateway connection could not form a worker endpoint");
@@ -107,6 +110,7 @@ export async function invokeNodeWorkerSupervisorCommand(params: {
   workspace?: NodeWorkerWorkspaceRuntime;
   gatewayUrl?: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   signal?: AbortSignal;
 }): Promise<NodeWorkerSupervisorCommandResult> {
   const recognized =
@@ -149,6 +153,9 @@ export async function invokeNodeWorkerSupervisorCommand(params: {
           ...(params.gatewayTlsFingerprint
             ? { gatewayTlsFingerprint: params.gatewayTlsFingerprint }
             : {}),
+          ...(params.gatewayCloudflareAccess
+            ? { gatewayCloudflareAccess: params.gatewayCloudflareAccess }
+            : {}),
           signal: params.signal,
         }),
       };
@@ -165,6 +172,9 @@ export async function invokeNodeWorkerSupervisorCommand(params: {
                 url: params.gatewayUrl,
                 ...(params.gatewayTlsFingerprint
                   ? { tlsFingerprint: params.gatewayTlsFingerprint }
+                  : {}),
+                ...(params.gatewayCloudflareAccess
+                  ? { cloudflareAccess: params.gatewayCloudflareAccess }
                   : {}),
               }
             : undefined,

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -474,10 +474,9 @@ class NodeWorkerSupervisor {
       params.descriptor.connectionEndpoint.kind === "websocket"
         ? params.descriptor.connectionEndpoint.cloudflareAccess
         : undefined;
-    const sensitiveValues = [
-      credential,
-      ...(cloudflareAccess ? [cloudflareAccess.clientId, cloudflareAccess.clientSecret] : []),
-    ];
+    const sensitiveValues = cloudflareAccess
+      ? [credential, cloudflareAccess.clientId, cloudflareAccess.clientSecret]
+      : [credential];
     const scrubber = createNodeWorkerCredentialScrubber(sensitiveValues);
     // Turn cancellation can beat the child's admission retry deadline. Retain the
     // producer's latest cause so the durable terminal receipt does not become generic.

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -470,10 +470,8 @@ class NodeWorkerSupervisor {
     supervisor: NodeWorkerProcessIdentity;
   }): Promise<NodeWorkerLaunchReceipt> {
     const credential = params.descriptor.admission.credential;
-    const cloudflareAccess =
-      params.descriptor.connectionEndpoint.kind === "websocket"
-        ? params.descriptor.connectionEndpoint.cloudflareAccess
-        : undefined;
+    const endpoint = params.descriptor.connectionEndpoint;
+    const cloudflareAccess = endpoint.kind === "websocket" ? endpoint.cloudflareAccess : undefined;
     const sensitiveValues = cloudflareAccess
       ? [credential, cloudflareAccess.clientId, cloudflareAccess.clientSecret]
       : [credential];

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -470,11 +470,21 @@ class NodeWorkerSupervisor {
     supervisor: NodeWorkerProcessIdentity;
   }): Promise<NodeWorkerLaunchReceipt> {
     const credential = params.descriptor.admission.credential;
-    const scrubber = createNodeWorkerCredentialScrubber(credential);
+    const cloudflareAccess =
+      params.descriptor.connectionEndpoint.kind === "websocket"
+        ? params.descriptor.connectionEndpoint.cloudflareAccess
+        : undefined;
+    const sensitiveValues = [
+      credential,
+      ...(cloudflareAccess ? [cloudflareAccess.clientId, cloudflareAccess.clientSecret] : []),
+    ];
+    const scrubber = createNodeWorkerCredentialScrubber(sensitiveValues);
     // Turn cancellation can beat the child's admission retry deadline. Retain the
     // producer's latest cause so the durable terminal receipt does not become generic.
     const connectionFailure: { errorText?: string } = {};
-    registerSecretValueForRedaction(credential);
+    for (const value of sensitiveValues) {
+      registerSecretValueForRedaction(value);
+    }
     let adapter: ChildAdapter;
     try {
       const entry = resolveNodeWorkerEntry({

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -34,6 +34,12 @@ const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
 const transferLog = createSubsystemLogger("node-host/worker-workspace");
 
+export type NodeWorkerTransferGateway = {
+  url: string;
+  tlsFingerprint?: string;
+  cloudflareAccess?: CloudflareAccessCredentials;
+};
+
 async function readResponseBody(response: IncomingMessage, maxBytes: number): Promise<Buffer> {
   const chunks: Buffer[] = [];
   let total = 0;

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -612,6 +612,12 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
       throw error;
     }
     if (error instanceof NodeWorkerTransferHttpError) {
+      if (error.reason === "cloudflare-access-requires-tls") {
+        throw new NodeWorkerWorkspaceTransferError(
+          "workspace-transfer-failed: Cloudflare Access credentials require HTTPS",
+          { cause: error },
+        );
+      }
       if (error.reason === "tls-fingerprint-mismatch") {
         throw new NodeWorkerWorkspaceTransferError(
           "workspace-transfer-failed: gateway TLS fingerprint mismatch",

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import {
   MAX_WORKSPACE_MANIFEST_BYTES,
   MAX_WORKSPACE_INVENTORY_TOTAL_BYTES,
@@ -359,6 +360,7 @@ async function replaceWorkspace(workspaceDir: string, staging: string): Promise<
 async function downloadWorkspace(params: {
   gatewayUrl: string;
   tlsFingerprint?: string;
+  cloudflareAccess?: CloudflareAccessCredentials;
   environmentId: string;
   workspaceDir: string;
   manifestHome: string;
@@ -371,6 +373,7 @@ async function downloadWorkspace(params: {
     {
       gatewayUrl: params.gatewayUrl,
       tlsFingerprint: params.tlsFingerprint,
+      cloudflareAccess: params.cloudflareAccess,
       routePath: nodeWorkspaceTransferManifestPath(
         params.environmentId,
         params.transfer.manifestRef,
@@ -397,6 +400,7 @@ async function downloadWorkspace(params: {
         request: {
           gatewayUrl: params.gatewayUrl,
           tlsFingerprint: params.tlsFingerprint,
+          cloudflareAccess: params.cloudflareAccess,
           routePath: nodeWorkspaceTransferPackPath(
             params.environmentId,
             params.transfer.manifestRef,
@@ -432,6 +436,7 @@ async function downloadWorkspace(params: {
         request: {
           gatewayUrl: params.gatewayUrl,
           tlsFingerprint: params.tlsFingerprint,
+          cloudflareAccess: params.cloudflareAccess,
           routePath: nodeWorkspaceTransferBlobPath(params.environmentId, entry.sha256),
           method: "GET",
           token: params.transfer.token,
@@ -486,6 +491,7 @@ async function uploadFile(request: ClientRequest, filePath: string): Promise<voi
 async function uploadWorkspace(params: {
   gatewayUrl: string;
   tlsFingerprint?: string;
+  cloudflareAccess?: CloudflareAccessCredentials;
   environmentId: string;
   workspaceDir: string;
   manifestHome: string;
@@ -533,6 +539,7 @@ async function uploadWorkspace(params: {
   const response = await openNodeWorkerTransferHttpRequest({
     gatewayUrl: params.gatewayUrl,
     tlsFingerprint: params.tlsFingerprint,
+    cloudflareAccess: params.cloudflareAccess,
     routePath: nodeWorkspaceTransferReconcilePath(
       params.environmentId,
       params.transfer.baseManifestRef,
@@ -572,6 +579,7 @@ async function uploadWorkspace(params: {
 export async function runNodeWorkerWorkspaceTransfer(params: {
   gatewayUrl: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   environmentId: string;
   workspaceDir: string;
   manifestHome: string;
@@ -584,11 +592,13 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
       ? await downloadWorkspace({
           ...params,
           tlsFingerprint: params.gatewayTlsFingerprint,
+          cloudflareAccess: params.gatewayCloudflareAccess,
           transfer: params.transfer,
         })
       : await uploadWorkspace({
           ...params,
           tlsFingerprint: params.gatewayTlsFingerprint,
+          cloudflareAccess: params.gatewayCloudflareAccess,
           transfer: params.transfer,
         });
   } catch (error) {

--- a/src/node-host/node-worker-transfer-http.ts
+++ b/src/node-host/node-worker-transfer-http.ts
@@ -2,6 +2,10 @@ import { once } from "node:events";
 import http, { type ClientRequest, type IncomingMessage } from "node:http";
 import https from "node:https";
 import type { TLSSocket } from "node:tls";
+import {
+  buildCloudflareAccessHeaders,
+  type CloudflareAccessCredentials,
+} from "../../packages/gateway-client/src/cloudflare-access.js";
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 
 type NodeWorkerTransferHttpErrorReason =
@@ -124,6 +128,7 @@ export type NodeWorkerTransferHttpRequest = {
   routePath: string;
   method: "GET" | "POST";
   token: string;
+  cloudflareAccess?: CloudflareAccessCredentials;
   headers?: Record<string, string>;
   signal?: AbortSignal;
   writeBody?: (request: ClientRequest) => Promise<void>;
@@ -136,7 +141,11 @@ export async function openNodeWorkerTransferHttpRequest(
   const transport = url.protocol === "https:" ? https : http;
   const request = transport.request(url, {
     method: params.method,
-    headers: { authorization: `Bearer ${params.token}`, ...params.headers },
+    headers: {
+      ...params.headers,
+      authorization: `Bearer ${params.token}`,
+      ...(params.cloudflareAccess ? buildCloudflareAccessHeaders(params.cloudflareAccess) : {}),
+    },
     signal: params.signal,
     ...(url.protocol === "https:" && params.tlsFingerprint
       ? { rejectUnauthorized: false, session: Buffer.alloc(0) }

--- a/src/node-host/node-worker-transfer-http.ts
+++ b/src/node-host/node-worker-transfer-http.ts
@@ -10,6 +10,7 @@ import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 
 type NodeWorkerTransferHttpErrorReason =
   | "invalid-gateway-transport"
+  | "cloudflare-access-requires-tls"
   | "invalid-tls-fingerprint"
   | "tls-fingerprint-mismatch";
 
@@ -138,6 +139,12 @@ export async function openNodeWorkerTransferHttpRequest(
   params: NodeWorkerTransferHttpRequest,
 ): Promise<IncomingMessage> {
   const url = transferUrl(params.gatewayUrl, params.routePath);
+  if (params.cloudflareAccess && url.protocol !== "https:") {
+    throw new NodeWorkerTransferHttpError(
+      "cloudflare-access-requires-tls",
+      "Cloudflare Access credentials require HTTPS worker transfer",
+    );
+  }
   const transport = url.protocol === "https:" ? https : http;
   const request = transport.request(url, {
     method: params.method,

--- a/src/node-host/node-worker-workspace.ts
+++ b/src/node-host/node-worker-workspace.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import { resolveStateDir } from "../config/paths.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
@@ -20,6 +19,7 @@ import type {
 } from "../worker/node-workspace-retain-protocol.js";
 import { snapshotNodeWorkerEnv } from "./node-worker-environment.js";
 import {
+  type NodeWorkerTransferGateway,
   runNodeWorkerWorkspaceTransfer,
   serializeNodeWorkerWorkspace,
 } from "./node-worker-transfer-client.js";
@@ -618,11 +618,7 @@ export class NodeWorkerWorkspaceRuntime {
   async exec(
     input: NodeWorkerWorkspaceExecInput,
     signal?: AbortSignal,
-    gateway?: {
-      url: string;
-      tlsFingerprint?: string;
-      cloudflareAccess?: CloudflareAccessCredentials;
-    },
+    gateway?: NodeWorkerTransferGateway,
   ): Promise<NodeWorkerWorkspaceExecResult> {
     const environmentHash = hashPathComponent(input.environmentId, 16);
     const sessionHash = hashPathComponent(input.sessionId, 32);

--- a/src/node-host/node-worker-workspace.ts
+++ b/src/node-host/node-worker-workspace.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import { resolveStateDir } from "../config/paths.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
@@ -617,7 +618,11 @@ export class NodeWorkerWorkspaceRuntime {
   async exec(
     input: NodeWorkerWorkspaceExecInput,
     signal?: AbortSignal,
-    gateway?: { url: string; tlsFingerprint?: string },
+    gateway?: {
+      url: string;
+      tlsFingerprint?: string;
+      cloudflareAccess?: CloudflareAccessCredentials;
+    },
   ): Promise<NodeWorkerWorkspaceExecResult> {
     const environmentHash = hashPathComponent(input.environmentId, 16);
     const sessionHash = hashPathComponent(input.sessionId, 32);
@@ -668,6 +673,7 @@ export class NodeWorkerWorkspaceRuntime {
           const stdout = await runNodeWorkerWorkspaceTransfer({
             gatewayUrl: gateway.url,
             gatewayTlsFingerprint: gateway.tlsFingerprint,
+            gatewayCloudflareAccess: gateway.cloudflareAccess,
             environmentId: input.environmentId,
             workspaceDir: workspacePath,
             manifestHome: sessionRoot,

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -255,6 +255,13 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       )
     : [gateway];
 
+  const plaintextAccessCandidate = gatewayCandidates.find(
+    (candidate) => candidate.cloudflareAccess && candidate.tls !== true,
+  );
+  if (plaintextAccessCandidate) {
+    throw new Error("Cloudflare Access credentials require a TLS Gateway connection");
+  }
+
   const resolvedCloudflareAccess = await Promise.all(
     gatewayCandidates.map(
       async (candidate) =>

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -1,5 +1,6 @@
 /** CLI runner for node-host stdin/stdout command dispatch. */
 import { isDeepStrictEqual } from "node:util";
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -23,6 +24,10 @@ import { VERSION } from "../version.js";
 import { configureNodeHost, type NodeHostGatewayConfig } from "./config.js";
 import { createNodeHostGatewayCandidateConnection } from "./gateway-candidate-connection.js";
 import {
+  resolveNodeHostCloudflareAccess,
+  type NodeHostCloudflareAccessConfig,
+} from "./gateway-cloudflare-access.js";
+import {
   coerceNodeInvokeCancelPayload,
   coerceNodeInvokeInputPayload,
   coerceNodeInvokePayload,
@@ -35,6 +40,7 @@ type NodeHostRunOptions = {
   gatewayPort: number;
   gatewayTls?: boolean;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: NodeHostCloudflareAccessConfig;
   gatewayCandidates?: NodeHostGatewayConfig[];
   gatewayBootstrapToken?: string;
   preferGatewayBootstrapToken?: boolean;
@@ -221,12 +227,14 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   // Operator-approved startup is a second authorized entry point for Doctor-owned
   // state migrators. Runtime invokes those owners here and never migrates inline.
   await runStartupMigrations({ log: { info: writeStderrLine, warn: writeStderrLine } });
+  const cfg = getRuntimeConfig();
   const plannedGateway: NodeHostGatewayConfig = {
     host: opts.gatewayHost,
     port: opts.gatewayPort,
-    tls: opts.gatewayTls ?? getRuntimeConfig().gateway?.tls?.enabled ?? false,
+    tls: opts.gatewayTls ?? cfg.gateway?.tls?.enabled ?? false,
     tlsFingerprint: opts.gatewayTlsFingerprint,
     contextPath: opts.gatewayContextPath,
+    cloudflareAccess: opts.gatewayCloudflareAccess,
   };
   const fallbackDisplayName = await getMachineDisplayName();
   const config = await configureNodeHost({
@@ -239,9 +247,31 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const nodeId = config.nodeId;
   const displayName = config.displayName ?? fallbackDisplayName;
   const gateway = config.gateway ?? plannedGateway;
-  const gatewayCandidates = opts.gatewayCandidates?.length ? opts.gatewayCandidates : [gateway];
+  const gatewayCandidates = opts.gatewayCandidates?.length
+    ? opts.gatewayCandidates.map((candidate, index) =>
+        index === 0 && gateway.cloudflareAccess && !candidate.cloudflareAccess
+          ? { ...candidate, cloudflareAccess: gateway.cloudflareAccess }
+          : candidate,
+      )
+    : [gateway];
 
-  const cfg = getRuntimeConfig();
+  const resolvedCloudflareAccess = await Promise.all(
+    gatewayCandidates.map(
+      async (candidate) =>
+        await resolveNodeHostCloudflareAccess({
+          value: candidate.cloudflareAccess,
+          config: cfg,
+          env: process.env,
+        }),
+    ),
+  );
+  const cloudflareAccessByCandidate = new Map<NodeHostGatewayConfig, CloudflareAccessCredentials>();
+  gatewayCandidates.forEach((candidate, index) => {
+    const credentials = resolvedCloudflareAccess[index];
+    if (credentials) {
+      cloudflareAccessByCandidate.set(candidate, credentials);
+    }
+  });
   const preparedRuntime = await prepareNodeHostRuntime({
     config: cfg,
     env: process.env,
@@ -505,6 +535,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
 
   const client = createNodeHostGatewayCandidateConnection({
     candidates: gatewayCandidates,
+    cloudflareAccessByCandidate,
     clientOptions: {
       token: token || undefined,
       bootstrapToken: opts.gatewayBootstrapToken,
@@ -551,9 +582,13 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
         void activeRuntime.invoke(payload);
       }
     },
-    onHelloOk: (hello, url, tlsFingerprint) => {
+    onHelloOk: (hello, url, tlsFingerprint, cloudflareAccess) => {
       writeStderrLine(`node host gateway connected: ${url}`);
-      activeRuntime.updateGatewayConnection({ url, ...(tlsFingerprint ? { tlsFingerprint } : {}) });
+      activeRuntime.updateGatewayConnection({
+        url,
+        ...(tlsFingerprint ? { tlsFingerprint } : {}),
+        ...(cloudflareAccess ? { cloudflareAccess } : {}),
+      });
       gatewayConnectionGeneration += 1;
       gatewayHelloReceived = true;
       connectedGatewayProtocol = hello.protocol;

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -1,5 +1,6 @@
 /** Transport-independent CLI node-host runtime shared by Gateway and app workers. */
 import fs from "node:fs";
+import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { SkillBinTrustEntry } from "../infra/exec-approvals.js";
@@ -70,7 +71,11 @@ type ActiveNodeHostRuntime = {
   handleInput(invokeId: string, seq: number, payloadJSON: string): void;
   cancel(invokeId: string): void;
   cancelAll(): void;
-  updateGatewayConnection(connection?: { url: string; tlsFingerprint?: string }): void;
+  updateGatewayConnection(connection?: {
+    url: string;
+    tlsFingerprint?: string;
+    cloudflareAccess?: CloudflareAccessCredentials;
+  }): void;
   close(): Promise<void>;
 };
 
@@ -342,7 +347,13 @@ export async function prepareNodeHostRuntime(params?: {
       };
       let currentPluginNodeHost = pluginNodeHost;
       let currentManifest = manifest;
-      let gatewayConnection: { url: string; tlsFingerprint?: string } | undefined;
+      let gatewayConnection:
+        | {
+            url: string;
+            tlsFingerprint?: string;
+            cloudflareAccess?: CloudflareAccessCredentials;
+          }
+        | undefined;
       let manager: NodeHostMcpManager | undefined;
       let closing = false;
       let closePromise: Promise<void> | undefined;
@@ -443,6 +454,9 @@ export async function prepareNodeHostRuntime(params?: {
               ...(gatewayConnection?.url ? { gatewayUrl: gatewayConnection.url } : {}),
               ...(gatewayConnection?.tlsFingerprint
                 ? { gatewayTlsFingerprint: gatewayConnection.tlsFingerprint }
+                : {}),
+              ...(gatewayConnection?.cloudflareAccess
+                ? { gatewayCloudflareAccess: gatewayConnection.cloudflareAccess }
                 : {}),
               ...(config.desktop?.host ? { desktopHostConfig: config.desktop.host } : {}),
               ...(progress ? { emitProgress: (text) => progress.write(text) } : {}),

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -280,6 +280,7 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
   db.exec("DROP INDEX IF EXISTS idx_diagnostic_events_scope_created;");
   ensureColumn(db, "worktrees", "provisioned_paths_json TEXT");
   ensureColumn(db, "node_host_config", "gateway_context_path TEXT");
+  ensureColumn(db, "node_host_config", "gateway_cloudflare_access_json TEXT");
   ensureColumn(db, "node_host_config", "installed_apps_sharing INTEGER NOT NULL DEFAULT 0");
   ensureColumn(db, "apns_registrations", "relay_origin TEXT");
   ensureColumn(db, "device_pairing_pending", "refreshed_at_ms INTEGER");

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -968,6 +968,7 @@ export interface NativeHookRelayBridges {
 export interface NodeHostConfig {
   config_key: string;
   display_name: string | null;
+  gateway_cloudflare_access_json: string | null;
   gateway_context_path: string | null;
   gateway_host: string | null;
   gateway_port: number | null;

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -909,6 +909,7 @@ CREATE TABLE IF NOT EXISTS node_host_config (
   gateway_tls INTEGER,
   gateway_tls_fingerprint TEXT,
   gateway_context_path TEXT,
+  gateway_cloudflare_access_json TEXT,
   installed_apps_sharing INTEGER NOT NULL DEFAULT 0,
   updated_at_ms INTEGER NOT NULL
 ) STRICT;

--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -85,6 +85,14 @@ describe("worker launch descriptor", () => {
       },
       {
         kind: "websocket",
+        url: "ws://127.0.0.1/__openclaw__/worker",
+        cloudflareAccess: {
+          clientId: "cf-worker-plaintext-id",
+          clientSecret: "cf-worker-plaintext-secret",
+        },
+      },
+      {
+        kind: "websocket",
         url: "wss://gateway.example/__openclaw__/worker",
         tlsFingerprint: "",
       },

--- a/src/worker/worker-connection-endpoint.test.ts
+++ b/src/worker/worker-connection-endpoint.test.ts
@@ -29,6 +29,7 @@ describe("worker connection endpoint", () => {
     expect(endpoint).toBeDefined();
 
     const target = resolveWorkerConnectionTarget(endpoint!);
+    expect(target.options.headers).toBeUndefined();
     const checkServerIdentity = (hostname: string, cert: CertMeta) =>
       target.options.checkServerIdentity?.(hostname, cert);
     expect(target.options.rejectUnauthorized).toBe(false);
@@ -47,6 +48,22 @@ describe("worker connection endpoint", () => {
       _socket: { getPeerCertificate: () => ({ fingerprint256: fingerprint }) },
     } as unknown as WebSocket;
     expect(target.validateSocket(socket)).toBeNull();
+  });
+
+  it("carries the closed Cloudflare Access credential pair to the worker upgrade", () => {
+    const clientId = ["cf", "worker", "id"].join("-");
+    const clientSecret = ["cf", "worker", "secret"].join("-");
+    const endpoint = parseWorkerConnectionEndpoint({
+      kind: "websocket",
+      url: "wss://gateway.example/__openclaw__/worker",
+      cloudflareAccess: { clientId, clientSecret },
+    });
+
+    expect(endpoint).toBeDefined();
+    expect(resolveWorkerConnectionTarget(endpoint!).options.headers).toEqual({
+      "CF-Access-Client-Id": clientId,
+      "CF-Access-Client-Secret": clientSecret,
+    });
   });
 
   it("rejects public plaintext while retaining the private-network break-glass", () => {

--- a/src/worker/worker-connection-endpoint.test.ts
+++ b/src/worker/worker-connection-endpoint.test.ts
@@ -3,6 +3,7 @@ import type { CertMeta, WebSocket } from "ws";
 import {
   parseWorkerConnectionEndpoint,
   resolveWorkerConnectionTarget,
+  type WorkerConnectionEndpoint,
 } from "./worker-connection-endpoint.js";
 
 describe("worker connection endpoint", () => {
@@ -75,5 +76,21 @@ describe("worker connection endpoint", () => {
     expect(() =>
       resolveWorkerConnectionTarget(endpoint, { OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1" }),
     ).not.toThrow();
+  });
+
+  it("rejects Access credentials on plaintext worker endpoints", () => {
+    const endpoint = {
+      kind: "websocket" as const,
+      url: "ws://127.0.0.1/__openclaw__/worker",
+      cloudflareAccess: {
+        clientId: "cf-worker-plaintext-id",
+        clientSecret: "cf-worker-plaintext-secret",
+      },
+    };
+
+    expect(parseWorkerConnectionEndpoint(endpoint)).toBeUndefined();
+    expect(() => resolveWorkerConnectionTarget(endpoint as WorkerConnectionEndpoint)).toThrow(
+      "Cloudflare Access credentials require a wss:// worker endpoint",
+    );
   });
 });

--- a/src/worker/worker-connection-endpoint.ts
+++ b/src/worker/worker-connection-endpoint.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ClientOptions, WebSocket } from "ws";
 import {
+  buildCloudflareAccessHeaders,
+  type CloudflareAccessCredentials,
+} from "../../packages/gateway-client/src/cloudflare-access.js";
+import {
   GatewayWebSocketTransportConfigurationError,
   resolveGatewayWebSocketTransport,
 } from "../../packages/gateway-client/src/websocket-transport.js";
@@ -17,7 +21,12 @@ export class WorkerConnectionEndpointError extends Error {
 
 export type WorkerConnectionEndpoint =
   | { kind: "unix"; socketPath: string }
-  | { kind: "websocket"; url: string; tlsFingerprint?: string };
+  | {
+      kind: "websocket";
+      url: string;
+      tlsFingerprint?: string;
+      cloudflareAccess?: CloudflareAccessCredentials;
+    };
 
 function hasExactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []) {
   const allowed = new Set([...required, ...optional]);
@@ -44,7 +53,7 @@ function parseWebSocketEndpoint(
   value: Record<string, unknown>,
 ): WorkerConnectionEndpoint | undefined {
   if (
-    !hasExactKeys(value, ["kind", "url"], ["tlsFingerprint"]) ||
+    !hasExactKeys(value, ["kind", "url"], ["tlsFingerprint", "cloudflareAccess"]) ||
     value.kind !== "websocket" ||
     typeof value.url !== "string" ||
     value.url.length > 4_096 ||
@@ -53,6 +62,10 @@ function parseWebSocketEndpoint(
         value.tlsFingerprint.trim().length === 0 ||
         value.tlsFingerprint.length > 256))
   ) {
+    return undefined;
+  }
+  const cloudflareAccess = parseCloudflareAccessCredentials(value.cloudflareAccess);
+  if (value.cloudflareAccess !== undefined && !cloudflareAccess) {
     return undefined;
   }
   let url: URL;
@@ -76,7 +89,27 @@ function parseWebSocketEndpoint(
     kind: "websocket",
     url: value.url,
     ...(value.tlsFingerprint === undefined ? {} : { tlsFingerprint: value.tlsFingerprint }),
+    ...(cloudflareAccess ? { cloudflareAccess } : {}),
   };
+}
+
+function parseCloudflareAccessCredentials(value: unknown): CloudflareAccessCredentials | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["clientId", "clientSecret"]) ||
+    typeof value.clientId !== "string" ||
+    value.clientId.trim().length === 0 ||
+    value.clientId.length > 4_096 ||
+    typeof value.clientSecret !== "string" ||
+    value.clientSecret.trim().length === 0 ||
+    value.clientSecret.length > 4_096
+  ) {
+    return undefined;
+  }
+  return { clientId: value.clientId, clientSecret: value.clientSecret };
 }
 
 export function parseWorkerConnectionEndpoint(
@@ -110,7 +143,12 @@ export function resolveWorkerConnectionTarget(
       url: endpoint.url,
       tlsFingerprint: endpoint.tlsFingerprint,
       env,
-      options: {},
+      options: endpoint.cloudflareAccess
+        ? {
+            followRedirects: false,
+            headers: buildCloudflareAccessHeaders(endpoint.cloudflareAccess),
+          }
+        : {},
     });
     return { url: endpoint.url, ...transport };
   } catch (error) {

--- a/src/worker/worker-connection-endpoint.ts
+++ b/src/worker/worker-connection-endpoint.ts
@@ -81,7 +81,8 @@ function parseWebSocketEndpoint(
     url.search !== "" ||
     url.hash !== "" ||
     !url.pathname.endsWith(WORKER_PUBLIC_INGRESS_PATH) ||
-    (value.tlsFingerprint !== undefined && url.protocol !== "wss:")
+    (value.tlsFingerprint !== undefined && url.protocol !== "wss:") ||
+    (cloudflareAccess !== undefined && url.protocol !== "wss:")
   ) {
     return undefined;
   }
@@ -137,6 +138,11 @@ export function resolveWorkerConnectionTarget(
       options: {},
       validateSocket: () => null,
     };
+  }
+  if (endpoint.cloudflareAccess && new URL(endpoint.url).protocol !== "wss:") {
+    throw new WorkerConnectionEndpointError(
+      "Cloudflare Access credentials require a wss:// worker endpoint",
+    );
   }
   try {
     const transport = resolveGatewayWebSocketTransport({

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdtemp, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import { createWorkerConnection, type WorkerConnectionState } from "./worker-connection.js";
@@ -55,6 +56,13 @@ export async function runWorkerDescriptor(
     browserRuntime?: WorkerBrowserRuntime;
   } = {},
 ): Promise<WorkerRuntimeResult> {
+  if (
+    descriptor.connectionEndpoint.kind === "websocket" &&
+    descriptor.connectionEndpoint.cloudflareAccess
+  ) {
+    registerSecretValueForRedaction(descriptor.connectionEndpoint.cloudflareAccess.clientId);
+    registerSecretValueForRedaction(descriptor.connectionEndpoint.cloudflareAccess.clientSecret);
+  }
   const workspaceDir = await assertWorkspaceDirectory(descriptor.assignment.workspaceDir);
   const stateDir = await mkdtemp(path.join(tmpdir(), "openclaw-worker-"));
   await chmod(stateDir, 0o700);


### PR DESCRIPTION
Closes #125112

AI-assisted: yes. The implementation and evidence were reviewed with the repository autoreview workflow.

## What Problem This Solves

Resolves a problem where headless node hosts could not connect to a Gateway protected by Cloudflare Access. The join request, long-lived node WebSocket, and worker child WebSocket had no supported way to send the Access service-token pair, so a node could appear to enroll and then fail when worker dispatch reached the protected edge.

The production symptom was `trusted_proxy_missing_header_cf-access-jwt-assertion role=node auth=none device=yes` on an Access-fronted Gateway. Cloudflare documents Service Auth policies and the `CF-Access-Client-Id` / `CF-Access-Client-Secret` request headers for automated clients: https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/

## Why This Change Was Made

The node host now owns one closed `cloudflareAccess` credential pair alongside its canonical Gateway connection metadata. `gateway.cloudflareAccess.clientId` and `gateway.cloudflareAccess.clientSecret` accept SecretInput values; the conventional `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` fallback persists env SecretRefs rather than copied plaintext.

Resolved values are rejected before SecretRef resolution on plaintext join/node candidates, registered with the exact-value redactor, and bound to the configured secure Gateway origin. Every credential-bearing transport independently requires HTTPS/WSS, and redirect following is disabled where the pair is attached. The same prepared credentials flow through node-owned bundle/workspace transfers and the sealed worker launch descriptor, so the child `/__openclaw__/worker` dial cannot lose edge authentication at dispatch. No Gateway-side authentication behavior changed.

## User Impact

Operators can run `openclaw connect`, foreground node hosts, installed node services, and hosted worker turns against an Access-fronted Gateway without exempting the machine routes or changing the Gateway away from trusted-proxy auth. Installed services store fallback values in the managed environment file, not process arguments or inline launchd/systemd/Task Scheduler definitions.

Doctor and node documentation now point to the working configuration and include the Cloudflare Service Auth setup recipe.

## Evidence

- Pre-fix regression captured independently on all three required legs:
  - join fetch omitted the Access pair;
  - node Gateway WebSocket omitted the pair;
  - worker endpoint rejected the credential field.
- Final focused boundary suite passed three consecutive times: 7 routed Vitest shards and 372 assertions per pass, covering the header-checking join edge, node WebSocket, origin pinning, SecretRef persistence/resolution, worker descriptor/dial, bundle transfer, managed service env policy, doctor text, and log redaction.
- HTTPS/WSS-only refinement adds positive WSS edge proof plus plaintext-negative coverage for join, node, worker, transfer, and installed-service paths.
- The CI-discovered stale plaintext URL in the redaction regression was corrected; that exact test passed three times and the full `src/gateway/client.test.ts` file passed 95/95.
- `pnpm check:changed`
- `pnpm build`
- `pnpm db:kysely:check`
- `pnpm docs:check-links`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check`
- Final branch autoreview: clean, no accepted/actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32023038857

The integration proof uses local Access-style HTTPS/WSS edges that return 403 unless the exact two headers are present. ClawSweeper's optional rank-up move requested an actual Cloudflare Service Auth run. The maintainer accepts the local rejecting-edge proof for this merge because the real deployment symptom and Cloudflare mechanism were already verified, while no disposable production Access token/policy was available to the test environment. No production service-token value was used or logged.

Production LOC: +542/-35 (net +507) | Tests: +442/-6 (net +436) | Docs: +36/-2 (net +34) | Generated: +1/-0. The production growth is the new credential/config contract, same-version nullable SQLite persistence, three transport boundaries, and child-process redaction/transfer continuity; it does not add an arbitrary-header or compatibility path.
