### PR TITLE
fix(telegram): unify targeted command grammar

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-buffer.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.ts
@@ -362,11 +362,13 @@ export function createTelegramInboundBuffers({
   };
   const handleTextFragment = async (params: TelegramTextFragmentInput): Promise<boolean> => {
     const text = typeof params.msg.text === "string" ? params.msg.text : undefined;
-    const isCommandLike = (text ?? "").trim().startsWith("/");
+    const isCommand = getTelegramTextParts(params.msg).entities.some(
+      (entity) => entity.type === "bot_command" && entity.offset === 0,
+    );
     const senderId = params.msg.from?.id != null ? String(params.msg.from.id) : "unknown";
     const threadId = params.resolvedThreadId ?? params.dmThreadId;
     const key = `text:${params.chatId}:${threadId ?? "main"}:${senderId}`;
-    if (text && !isCommandLike && !params.isAbortControlMessage) {
+    if (text && !isCommand && !params.isAbortControlMessage) {
       const nowMs = Date.now();
       const existing = textBuffer.get(key);
       if (existing) {

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -281,21 +281,40 @@ describe("telegram text fragments", () => {
   });
 
   const TEXT_FRAGMENT_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
-
-  it(
-    "buffers near-limit text and processes sequential parts as one message",
-    async () => {
-      const { handler, replySpy } = await createBotHandlerWithOptions({});
-      const quote = "FRAGMENT_REPLY_QUOTE";
-      const part1 = `${"A".repeat(4050)} ${quote}`;
-      const part2 = "B".repeat(50);
-      const firstMessage = {
+  const buildNearLimitMessage = (params: {
+    messageId: number;
+    prefix?: string;
+    suffix?: string;
+    entities?: Array<{ type: "bot_command"; offset: number; length: number }>;
+  }) => {
+    const text = `${params.prefix ?? ""}${"A".repeat(4050)}${params.suffix ?? ""}`;
+    return {
+      text,
+      message: {
         chat: { id: 42, type: "private" as const },
         from: { id: 777, is_bot: false as const, first_name: "Ada" },
-        message_id: 10,
+        message_id: params.messageId,
         date: 1736380800,
-        text: part1,
-      };
+        text,
+        ...(params.entities ? { entities: params.entities } : {}),
+      },
+    };
+  };
+
+  it.each([
+    { label: "plain", prefix: "" },
+    { label: "slash-prefixed non-command", prefix: "/not_a_command " },
+  ])(
+    "buffers $label near-limit text and processes sequential parts as one message",
+    async ({ prefix }) => {
+      const { handler, replySpy } = await createBotHandlerWithOptions({});
+      const quote = "FRAGMENT_REPLY_QUOTE";
+      const { text: part1, message: firstMessage } = buildNearLimitMessage({
+        messageId: 10,
+        prefix,
+        suffix: ` ${quote}`,
+      });
+      const part2 = "B".repeat(50);
       const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
@@ -314,7 +333,7 @@ describe("telegram text fragments", () => {
             date: 1736380801,
             text: part2,
             reply_to_message: { ...firstMessage, reply_to_message: undefined },
-            quote: { text: quote, position: 4051 },
+            quote: { text: quote, position: part1.indexOf(quote) },
           },
           me: { username: "openclaw_bot" },
           getFile: async () => ({}),
@@ -336,6 +355,28 @@ describe("telegram text fragments", () => {
         setTimeoutSpy.mockRestore();
         clearTimeoutSpy.mockRestore();
       }
+    },
+    TEXT_FRAGMENT_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "processes leading Telegram bot commands immediately without static registration",
+    async () => {
+      const { handler, replySpy } = await createBotHandlerWithOptions({});
+      const command = "/deploy@openclaw_bot";
+      const { message } = buildNearLimitMessage({
+        messageId: 20,
+        prefix: `${command} `,
+        entities: [{ type: "bot_command", offset: 0, length: command.length }],
+      });
+
+      await handler({
+        message,
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
     },
     TEXT_FRAGMENT_TEST_TIMEOUT_MS,
   );

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -148,7 +148,18 @@ describe("getTelegramSequentialKey", () => {
           text: "/steer@vacs_tars_bot keep going",
         }),
       },
-      "telegram:-100:control",
+      "telegram:-100:topic:5907",
+    ],
+    [
+      {
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/queue@some_other_bot status",
+        }),
+      },
+      "telegram:-100:topic:5907",
     ],
     [
       {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -105,47 +105,14 @@ export function isTelegramReadOnlyControlLaneText(params: {
   return command?.category === "status" && TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS.has(command.key);
 }
 
-function isTelegramTargetedStopCommand(rawText?: string, botUsername?: string): boolean {
-  const trimmed = rawText?.trim();
-  if (!trimmed) {
-    return false;
-  }
-  // Isolated ingress may not have getMe() metadata yet. A targeted Telegram
-  // /stop@bot command still needs the control lane so it can cancel a busy turn.
-  const match = trimmed.match(/^\/stop@([A-Za-z0-9_]+)(?:$|\s|[.!?…,，。;；:：'"’”)\]}])/iu);
-  if (!match) {
-    return false;
-  }
-  const normalizedBotUsername = botUsername?.trim().toLowerCase();
-  if (!normalizedBotUsername) {
-    return true;
-  }
-  return match[1]?.toLowerCase() === normalizedBotUsername;
-}
-
 function resolveTelegramCommandAliasForControlLane(
   rawText?: string,
   botUsername?: string,
 ): string | undefined {
   const trimmed = rawText?.trim();
-  if (!trimmed?.startsWith("/")) {
+  if (!trimmed) {
     return undefined;
   }
-
-  const targetedMatch = trimmed.match(
-    /^\/([A-Za-z0-9_-]+)(?:@([A-Za-z0-9_]+))?(?:$|\s|[.!?…,，。;；:：'"’”)\]}])/iu,
-  );
-  const targetBotUsername = targetedMatch?.[2]?.trim().toLowerCase();
-  const normalizedBotUsername = botUsername?.trim().toLowerCase();
-  if (targetBotUsername && normalizedBotUsername && targetBotUsername !== normalizedBotUsername) {
-    return undefined;
-  }
-
-  if (targetBotUsername && !normalizedBotUsername) {
-    const commandAlias = `/${targetedMatch?.[1]?.toLowerCase() ?? ""}`;
-    return commandAlias === "/" ? undefined : commandAlias;
-  }
-
   return (
     maybeResolveTextAlias(
       normalizeCommandBody(trimmed, botUsername ? { botUsername } : undefined),
@@ -168,15 +135,12 @@ function isTelegramActiveRunControlLaneText(params: {
 }
 
 function isTelegramControlLaneText(params: { rawText?: string; botUsername?: string }): boolean {
-  if (
-    isAbortRequestText(
-      params.rawText,
-      params.botUsername ? { botUsername: params.botUsername } : undefined,
-    )
-  ) {
-    return true;
-  }
-  if (isTelegramTargetedStopCommand(params.rawText, params.botUsername)) {
+  // Live polling and webhook admission already have bot identity. In defensive pre-identity
+  // paths, accepting every @target admits foreign-bot commands; only canonical aborts fence.
+  const abortCommandOptions = params.botUsername
+    ? { botUsername: params.botUsername }
+    : { targetedCommandMode: "pre-identity" as const };
+  if (isAbortRequestText(params.rawText, abortCommandOptions)) {
     return true;
   }
   if (isTelegramActiveRunControlLaneText(params)) {

--- a/extensions/telegram/src/telegram-ingress-supersede.test.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.test.ts
@@ -241,6 +241,35 @@ describe("telegram ingress supersede policy", () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      name: "does not supersede an identityless foreign targeted command",
+      text: "/queue@OtherBot",
+      entityText: "/queue@OtherBot",
+      expected: false,
+    },
+    {
+      name: "keeps identityless targeted aborts pessimistic",
+      text: "/stop@OtherBot!",
+      entityText: "/stop@OtherBot",
+      expected: true,
+    },
+  ])("$name", async ({ text, entityText, expected }) => {
+    const update = messageUpdate({
+      updateId: 2,
+      text,
+      senderId: OWNER_ID,
+      entities: [{ type: "bot_command", offset: 0, length: entityText.length }],
+    });
+
+    expect(
+      await shouldSupersede(
+        record("2", update),
+        claim("1", messageUpdate({ updateId: 1, text: "prior", senderId: OWNER_ID })),
+      ),
+    ).toBe(expected);
+  });
+
   it("does not supersede when a bot_command entity appears inside ordinary text", async () => {
     const ourBotAuth = {
       ...auth,

--- a/extensions/telegram/src/telegram-ingress-supersede.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.ts
@@ -27,31 +27,25 @@ function isRecognizedTelegramTextCommand(rawText: string, botUsername?: string):
   );
 }
 
-/**
- * Whether a bot_command entity (or slash token) targets this bot.
- * Same target rule as normalizeCommandBody: untargeted commands match any bot;
- * @OtherBot is ignored when our identity is known.
- */
+/** Whether a bot_command entity is untargeted or addressed to the known bot identity. */
 function isTelegramCommandTargetedAtBot(commandText: string, botUsername?: string): boolean {
   const trimmed = commandText.trim();
   if (!trimmed.startsWith("/")) {
     return false;
   }
-  // normalizeCommandBody only strips @bot when the target equals botUsername.
-  // A non-matching @target leaves the body as `/cmd@other`, which is not ours.
   const normalized = normalizeCommandBody(
     trimmed,
     botUsername ? { botUsername } : undefined,
   ).trim();
-  if (!normalized.startsWith("/")) {
+  if (!normalized.startsWith("/") || normalized === "/") {
     return false;
   }
-  // Untargeted, or successfully stripped for this bot.
-  if (!/^\/[^\s@]+@/u.test(normalized)) {
-    return true;
-  }
-  // Identity unknown: keep untargeted-permissive behavior for pre-getMe drains.
-  return !botUsername?.trim();
+  const preIdentityNormalized = normalizeCommandBody(trimmed, {
+    targetedCommandMode: "pre-identity",
+  }).trim();
+  // Pre-identity mode strips valid @targets. A changed result means the target is
+  // unresolved or foreign; equality means untargeted or a known matching target.
+  return normalized === preIdentityNormalized;
 }
 
 /** True when the update carries a bot_command entity addressed to this bot. */
@@ -158,6 +152,9 @@ export function createShouldSupersedeTelegramSpooledPending(
       return false;
     }
     const commandOptions = auth.botUsername ? { botUsername: auth.botUsername } : undefined;
+    const abortCommandOptions = auth.botUsername
+      ? { botUsername: auth.botUsername }
+      : { targetedCommandMode: "pre-identity" as const };
     if (
       isBtwRequestText(text, commandOptions) ||
       isTelegramReadOnlyControlLaneText({
@@ -169,7 +166,7 @@ export function createShouldSupersedeTelegramSpooledPending(
     }
     // Abort, static text alias, or native bot_command entity (incl. skill commands)
     // addressed to this bot. Never bare `/` prefixes without a bot_command entity.
-    const isAbort = isAbortRequestText(text, commandOptions);
+    const isAbort = isAbortRequestText(text, abortCommandOptions);
     const isCommand =
       isRecognizedTelegramTextCommand(text, auth.botUsername) ||
       updateHasBotCommandEntityForBot(newUpdate, auth.botUsername);

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -28,6 +28,9 @@ type CommandRegistryLookup = {
 
 let cachedRegistryLookup: CommandRegistryLookup | undefined;
 
+const TARGETED_COMMAND_BODY_RE =
+  /^\/([^\s@]+)@([A-Za-z0-9_]+)(?=$|\s|[.!?！？…,，。;；:：'"’”)\]}])([\s\S]*)$/u;
+
 function appendMultilineTail(head: string, tail: string | undefined, spec?: TextAliasSpec): string {
   if (!tail) {
     return head;
@@ -105,11 +108,14 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
     : singleLine;
 
   const normalizedBotUsername = normalizeOptionalLowercaseString(options?.botUsername);
-  const mentionMatch = normalizedBotUsername
-    ? normalized.match(/^\/([^\s@]+)@([^\s]+)(.*)$/)
-    : null;
+  const mentionMatch = normalized.match(TARGETED_COMMAND_BODY_RE);
+  const targetBotUsername = normalizeOptionalLowercaseString(mentionMatch?.[2]);
+  const targetMatchesBot =
+    normalizedBotUsername !== undefined && targetBotUsername === normalizedBotUsername;
+  const resolveBeforeIdentity =
+    normalizedBotUsername === undefined && options?.targetedCommandMode === "pre-identity";
   const commandBody =
-    mentionMatch && normalizeLowercaseStringOrEmpty(mentionMatch[2]) === normalizedBotUsername
+    mentionMatch && (targetMatchesBot || resolveBeforeIdentity)
       ? `/${mentionMatch[1]}${mentionMatch[3] ?? ""}`
       : normalized;
 

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -660,6 +660,21 @@ describe("commands registry", () => {
     );
   });
 
+  it("normalizes targeted command bodies before bot identity only when requested", () => {
+    expect(
+      normalizeCommandBody("/help@unresolved_bot", {
+        targetedCommandMode: "pre-identity",
+      }),
+    ).toBe("/help");
+    expect(normalizeCommandBody("/help@unresolved_bot")).toBe("/help@unresolved_bot");
+    expect(
+      normalizeCommandBody("/help@some_other_bot", {
+        botUsername: "openclaw_bot",
+        targetedCommandMode: "pre-identity",
+      }),
+    ).toBe("/help@some_other_bot");
+  });
+
   it("keeps unregistered dock underscore aliases unchanged", () => {
     expect(normalizeCommandBody("/dock_telegram")).toBe("/dock_telegram");
   });

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -96,6 +96,8 @@ export type NativeCommandSpec = {
 /** Extra context used when normalizing slash command text. */
 export type CommandNormalizeOptions = {
   botUsername?: string;
+  /** Strip an explicit command target only while channel bot identity is unavailable. */
+  targetedCommandMode?: "pre-identity";
 };
 
 /** Cached exact/regex command detector built from current registry aliases. */

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -450,6 +450,27 @@ describe("abort detection", () => {
     expect(isAbortRequestText(" توقف ")).toBe(true);
     expect(isAbortRequestText("/stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
     expect(isAbortRequestText("/Stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
+    expect(
+      isAbortRequestText("/stop@unresolved_bot", {
+        targetedCommandMode: "pre-identity",
+      }),
+    ).toBe(true);
+    expect(
+      isAbortRequestText("/stop@unresolved_bot!", {
+        targetedCommandMode: "pre-identity",
+      }),
+    ).toBe(true);
+    expect(
+      isAbortRequestText("/queue@unresolved_bot", {
+        targetedCommandMode: "pre-identity",
+      }),
+    ).toBe(false);
+    expect(
+      isAbortRequestText("/stop@some_other_bot", {
+        botUsername: "openclaw_bot",
+        targetedCommandMode: "pre-identity",
+      }),
+    ).toBe(false);
 
     expect(isAbortRequestText("/status")).toBe(false);
     expect(isAbortRequestText("wait")).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram messages targeted at a bot could be routed inconsistently before bot identity was available. In particular, a command such as `/queue@SomeOtherBot` could be treated as an OpenClaw control command, while targeted abort handling depended on a separate hard-coded `/stop` grammar that could drift from the canonical abort policy.

It also fixes fragment handling that treated every slash-prefixed message as a command, preventing long ordinary text such as `/not_a_command …` from being coalesced even when Telegram did not mark it as a command.

## Why This Change Was Made

The shared command parser now owns Telegram-style `/<command>@<bot>` normalization, including an explicit pre-identity mode used only by canonical abort detection. Telegram no longer maintains private target or stop regexes: known bot identity still rejects foreign targets, while identityless active-run and read-only targets remain non-control.

Fragment buffering now follows Telegram's typed `bot_command` entity instead of inferring command intent from a raw `/` prefix or from the built-in command registry. This keeps plugin and skill commands immediate without misclassifying slash-prefixed ordinary text.

### Deferred owner call: buttons-only payloads

This PR intentionally leaves the existing buttons-only payload disagreement unchanged so the command-grammar repair can land independently.

- **Synthesize an anchor:** `normalizeTelegramMetadataOnlyPayload` preserves native buttons-only payloads by adding `Choose an option.`, matching `canonicalizeTelegramPresentationPayload`; buttons are always visible across delivery funnels.
- **Document and drop:** remove the native-buttons anchor branch and make authored text or `fallbackText` a required contract; buttons-only payloads are intentionally suppressed.

Which cross-funnel product contract should the follow-up adopt?

## Maintainer Decisions

- **Shared SDK contract approved:** keep `CommandNormalizeOptions.targetedCommandMode: "pre-identity"` as the narrow, opt-in command-normalization capability for channels whose bot identity is not yet available. Known identity takes precedence, foreign targets remain intact, and focused shared-owner coverage protects the contract.
- **Real Telegram proof gap accepted for this landing:** the QA Convex credential was unavailable after both the non-interactive Molty lookup and an explicitly approved desktop 1Password attempt. The deterministic owner-boundary regressions, real Telegram entity shapes, exact-head CI, and full Testbox gate are accepted as proof for this maintainer-authored repair. This is not represented as live Telegram proof.
- **Buttons-only payload behavior remains undecided:** no buttons-only code changes are included; the two options above remain the separate owner call.

## User Impact

Telegram control-lane routing now follows one command grammar. Foreign or unresolved targeted commands no longer bypass normal topic sequencing, targeted abort aliases cannot silently drift from the shared abort owner, slash-prefixed non-command fragments coalesce correctly, and real Telegram commands still dispatch immediately.

## Evidence

- Pre-fix owner/lane regression run: 2 failed, 71 passed. The new command-owner and abort cases failed because pre-identity targeted normalization did not exist.
- Pre-fix fragment regression run: 1 failed, 7 passed. Slash-prefixed non-command fragments dispatched twice instead of coalescing.
- Post-fix focused tests: 73 command/abort tests passed; 60 Telegram sequential-key tests passed; 17 Telegram ingress-supersede tests passed.
- Post-fix fragment E2E: 8 passed locally and on Blacksmith Testbox `tbx_01m07mky3dp4n7fp3pt7mm5pnb` ([run](https://github.com/openclaw/openclaw/actions/runs/32020839366)).
- Full changed gate: green in the same Blacksmith Testbox run, including typecheck, lint, import-cycle, architecture, and guard lanes.
- Formatting: all eight touched files pass `oxfmt --check`.
- Final Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +35/-64 (net -29). Tests: +131/-14.
- Real Telegram proof: blocked on this workstation because the QA Convex credential file is absent and the consented desktop 1Password sign-in did not complete; no personal account or credential workaround was used.

AI-assisted; the author reviewed the implementation, dependency boundary, and proof.

