### PR TITLE
improve(ui): compose pull request session icons

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -175,6 +175,9 @@ export function renderRecentSession(params: {
   const pullRequestState = session.worktreeId
     ? host.sessionPullRequestIndicatorState(session.key, session.worktreeId)
     : "none";
+  // The leading PR glyph already communicates branch provenance; rendering
+  // forkSource beside the title would duplicate the same relationship.
+  const showForkSource = Boolean(session.forkSource) && pullRequestState === "none";
   const ownerAttribution = host.sessionsStatusFilter === "archived" ? "archived" : "created";
   const ownerActor = host.sessionOwnershipVisible
     ? host.sessionsStatusFilter === "archived"
@@ -305,7 +308,7 @@ export function renderRecentSession(params: {
                   title=${t("sessionsView.archived")}
                   >${icons.archive}</span
                 >`
-              : nothing}${session.forkSource
+              : nothing}${showForkSource
               ? html`<span
                   class="sidebar-session-fork-indicator"
                   role="img"

--- a/ui/src/components/session-glyph.ts
+++ b/ui/src/components/session-glyph.ts
@@ -8,15 +8,17 @@ export type SessionGlyphContent = TemplateResult | typeof nothing;
  * attention glyph). Callers can carry run state as a ring when that surface
  * owns activity in the leading slot. Circular content already fits the ring;
  * arbitrary square icons and thumbnails scale down so their corners stay
- * inside it.
+ * inside it. Composite states can preserve that artwork in the bottom-right
+ * overlay while a semantic state glyph takes the primary slot.
  */
 export function renderSessionGlyph(options: {
   content: SessionGlyphContent;
   running: boolean;
   circular?: boolean;
   badge?: SessionGlyphContent;
+  overlay?: SessionGlyphContent;
 }): TemplateResult {
-  const { content, running, circular = false, badge = nothing } = options;
+  const { content, running, circular = false, badge = nothing, overlay = nothing } = options;
   const modifiers = `${circular ? " session-glyph--circular" : ""}${running ? " session-glyph--running" : ""}`;
   return html`<span class="session-glyph${modifiers}">
     <span class="session-glyph__content">${content}</span>
@@ -28,6 +30,7 @@ export function renderSessionGlyph(options: {
         ></span>`
       : nothing}
     ${badge}
+    ${overlay === nothing ? nothing : html`<span class="session-glyph__overlay">${overlay}</span>`}
   </span>`;
 }
 

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -16,25 +16,8 @@ import { resolveSessionIconGlyph } from "./session-icon-glyph-registry.ts";
 import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import { renderSessionOwnerChip, type SessionCreatedActor } from "./session-owner-chip.ts";
 
-function renderGlyphBadge(
-  session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
-): SessionGlyphContent {
-  if (session.unread) {
-    return renderSessionUnreadBadge();
-  }
-  if (pullRequestState === "none") {
-    return nothing;
-  }
-  const label =
-    pullRequestState === "open" ? t("sessionsView.openPullRequest") : t("chat.pullRequests.merged");
-  return html`<span
-    class="session-glyph__badge sidebar-session-pr-indicator--${pullRequestState}"
-    data-session-pr-state=${pullRequestState}
-    role="img"
-    aria-label=${label}
-    title=${label}
-  ></span>`;
+function renderChildUnreadBadge(session: SidebarRecentSession): SessionGlyphContent {
+  return session.isChild && session.unread ? renderSessionUnreadBadge() : nothing;
 }
 
 function pullRequestStateLabel(
@@ -45,10 +28,7 @@ function pullRequestStateLabel(
     : t("chat.pullRequests.merged");
 }
 
-function renderPullRequestIndicator(
-  pullRequestState: SessionPullRequestIndicatorState,
-  showTitle = true,
-) {
+function renderPullRequestIndicator(pullRequestState: SessionPullRequestIndicatorState) {
   if (pullRequestState === "none") {
     return nothing;
   }
@@ -58,7 +38,7 @@ function renderPullRequestIndicator(
     data-session-pr-state=${pullRequestState}
     role="img"
     aria-label=${label}
-    title=${showTitle ? label : nothing}
+    title=${label}
     >${pullRequestState === "open" ? icons.gitPullRequest : icons.gitMerge}</span
   >`;
 }
@@ -69,15 +49,10 @@ function renderSessionTrailingState(
 ) {
   const sessionState = renderSessionState(session, false);
   const concurrentUnreadState = session.hasActiveRun ? renderSessionUnreadState(session) : nothing;
-  if (
-    pullRequestState === "none" &&
-    sessionState === nothing &&
-    concurrentUnreadState === nothing
-  ) {
+  if (sessionState === nothing && concurrentUnreadState === nothing) {
     return nothing;
   }
-  return html`${renderPullRequestIndicator(pullRequestState, false)} ${sessionState}
-  ${concurrentUnreadState}`;
+  return html`${sessionState} ${concurrentUnreadState}`;
 }
 
 function renderPersistentSessionIcon(icon: string) {
@@ -85,6 +60,35 @@ function renderPersistentSessionIcon(icon: string) {
   return glyph
     ? html`<span class="session-glyph__icon" aria-hidden="true">${glyph}</span>`
     : html`<span class="session-glyph__emoji" aria-hidden="true">${icon}</span>`;
+}
+
+type SessionLeadingArtwork = {
+  circular?: boolean;
+  content: SessionGlyphContent;
+  renderedOwnerId?: string;
+};
+
+function resolveSessionLeadingArtwork(
+  session: SidebarRecentSession,
+  ownerActor: SessionCreatedActor | null | undefined,
+  attribution: "created" | "archived",
+  ownerViewing?: boolean,
+): SessionLeadingArtwork | null {
+  if (session.attention.kind !== "none") {
+    return { content: renderSessionAttentionIcon(session.attention) };
+  }
+  if (session.icon) {
+    return { content: renderPersistentSessionIcon(session.icon) };
+  }
+  const ownerId = ownerActor?.id?.trim();
+  if (!session.isChild && ownerId) {
+    return {
+      circular: true,
+      content: renderSessionOwnerChip(ownerActor, "row", attribution, ownerViewing),
+      renderedOwnerId: ownerId,
+    };
+  }
+  return null;
 }
 
 export function describeSessionTrailingState(
@@ -117,41 +121,40 @@ export function renderSessionLeadingState(
   const trailingIndicator = session.isChild
     ? nothing
     : renderSessionTrailingState(session, pullRequestState);
-  // Transient attention always outranks the persistent decorative icon.
+  const artwork = resolveSessionLeadingArtwork(session, ownerActor, attribution, ownerViewing);
+  if (pullRequestState !== "none") {
+    return {
+      running,
+      leadingIndicator: renderSessionGlyph({
+        content: renderPullRequestIndicator(pullRequestState),
+        running: session.isChild && running,
+        badge: renderChildUnreadBadge(session),
+        overlay: artwork ? artwork.content : nothing,
+      }),
+      trailingIndicator,
+      ...(artwork?.renderedOwnerId ? { renderedOwnerId: artwork.renderedOwnerId } : {}),
+    };
+  }
+  // Transient attention outranks persistent artwork, but PR state remains the
+  // primary glyph so a forked PR never regresses to duplicate branch icons.
+  if (artwork) {
+    return {
+      running,
+      leadingIndicator: renderSessionGlyph({
+        content: artwork.content,
+        running: session.isChild && running,
+        circular: artwork.circular,
+        badge: renderChildUnreadBadge(session),
+      }),
+      trailingIndicator,
+      renderedOwnerId: artwork.renderedOwnerId,
+    };
+  }
   if (session.isChild) {
-    if (session.attention.kind !== "none") {
-      return {
-        running,
-        leadingIndicator: renderSessionGlyph({
-          content: renderSessionAttentionIcon(session.attention),
-          running,
-          badge: renderGlyphBadge(session, pullRequestState),
-        }),
-        trailingIndicator,
-      };
-    }
-    if (session.icon) {
-      return {
-        running,
-        leadingIndicator: renderSessionGlyph({
-          content: renderPersistentSessionIcon(session.icon),
-          running,
-          badge: renderGlyphBadge(session, pullRequestState),
-        }),
-        trailingIndicator,
-      };
-    }
     if (running) {
       return {
         running,
         leadingIndicator: renderSessionState(session),
-        trailingIndicator,
-      };
-    }
-    if (pullRequestState !== "none") {
-      return {
-        running,
-        leadingIndicator: renderPullRequestIndicator(pullRequestState),
         trailingIndicator,
       };
     }
@@ -163,40 +166,6 @@ export function renderSessionLeadingState(
     };
   }
 
-  if (session.attention.kind !== "none") {
-    return {
-      running,
-      leadingIndicator: renderSessionGlyph({
-        content: renderSessionAttentionIcon(session.attention),
-        running: false,
-      }),
-      trailingIndicator,
-    };
-  }
-  if (session.icon) {
-    return {
-      running,
-      leadingIndicator: renderSessionGlyph({
-        content: renderPersistentSessionIcon(session.icon),
-        running: false,
-      }),
-      trailingIndicator,
-    };
-  }
-  if (!session.isChild && ownerActor?.id?.trim()) {
-    return {
-      running,
-      leadingIndicator: renderSessionGlyph({
-        content: renderSessionOwnerChip(ownerActor, "row", attribution, ownerViewing),
-        running: false,
-        circular: true,
-      }),
-      trailingIndicator,
-      // Single source for facepile dedup: only the identity actually shown in
-      // the lead may be excluded, else attention/archived rows hide a viewer.
-      renderedOwnerId: ownerActor.id,
-    };
-  }
   return {
     running,
     leadingIndicator: nothing,

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import type { Locator, Page } from "playwright";
 import { expect } from "vitest";
+import type { SessionCreatedActor } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -51,6 +52,8 @@ export function sessionRow(
     childSessions?: string[];
     execNode?: string;
     forkSource?: { sessionKey: string; sessionId: string; entryId?: string };
+    icon?: string;
+    createdActor?: SessionCreatedActor;
     worktree?: { id?: string; branch?: string; repoRoot?: string };
   } = {},
 ) {
@@ -216,6 +219,17 @@ export async function captureUiProof(page: Page, fileName: string) {
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
+    path: path.join(uiProofArtifactDir, fileName),
+  });
+}
+
+export async function captureUiProofRegion(region: Locator, fileName: string) {
+  if (!captureUiProofEnabled) {
+    return;
+  }
+  await mkdir(uiProofArtifactDir, { recursive: true });
+  await region.screenshot({
+    animations: "disabled",
     path: path.join(uiProofArtifactDir, fileName),
   });
 }

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -3,6 +3,8 @@ import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gat
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
   actionOpacity,
+  captureUiProof,
+  captureUiProofRegion,
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
@@ -12,7 +14,186 @@ import {
 
 const suite = createSessionManagementE2eSuite();
 
+function pullRequestSnapshot(branch: string, state: "open" | "merged", number: number) {
+  return {
+    pullRequests: [
+      {
+        branch,
+        number,
+        owner: "openclaw",
+        repo: "openclaw",
+        state,
+        title: `${state === "open" ? "Open" : "Merged"} combination`,
+        url: `https://example.test/openclaw/openclaw/pull/${number}`,
+      },
+    ],
+    rateLimited: false,
+    status: "ready",
+  };
+}
+
 suite.define(() => {
+  it("composes pull-request state with each session identity without duplicate branch glyphs", async () => {
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const rows = [
+      {
+        branch: "feature/named-glyph",
+        key: "agent:main:pr-named-glyph",
+        label: "Open PR with named session icon",
+        state: "open" as const,
+        options: { icon: "braces" },
+      },
+      {
+        branch: "feature/emoji",
+        key: "agent:main:pr-emoji",
+        label: "Open PR with emoji session icon",
+        state: "open" as const,
+        options: { icon: "🦞" },
+      },
+      {
+        branch: "feature/owner",
+        key: "agent:main:pr-owner",
+        label: "Merged PR with owner session icon",
+        state: "merged" as const,
+        options: {
+          createdActor: { id: "designer", label: "Design Owner", type: "human" as const },
+        },
+      },
+      {
+        branch: "feature/plain",
+        key: "agent:main:pr-plain",
+        label: "Open PR without a session icon",
+        state: "open" as const,
+        options: {},
+      },
+    ];
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "sessions.patch",
+        SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+      ],
+      methodResponses: {
+        [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", Date.now(), {
+            createdActor: { id: "operator", label: "Operator", type: "human" },
+          }),
+          ...rows.map((row, index) =>
+            sessionRow(row.key, row.label, Date.now() - index - 1, {
+              forkSource: { sessionKey: "agent:main:main", sessionId: "source-session" },
+              worktree: { id: `worktree-${index}`, branch: row.branch, repoRoot: "/tmp/openclaw" },
+              ...row.options,
+            }),
+          ),
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const codingSection = page.locator('[data-session-section="work"]');
+      const codingToggle = codingSection.locator(".sidebar-session-group-toggle");
+      await codingToggle.waitFor({ state: "visible" });
+      await codingToggle.click();
+      await expect
+        .poll(async () => {
+          const requests = await gateway.getRequests(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+          return requests.some((request) => {
+            const sessionKeys = requireRecord(request.params).sessionKeys;
+            return Array.isArray(sessionKeys) && rows.every((row) => sessionKeys.includes(row.key));
+          });
+        })
+        .toBe(true);
+      await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+        sessions: Object.fromEntries(
+          rows.map((row, index) => [
+            row.key,
+            pullRequestSnapshot(row.branch, row.state, index + 1),
+          ]),
+        ),
+      });
+
+      for (const row of rows) {
+        const session = page.locator(`[data-session-key="${row.key}"]`);
+        const pullRequest = session.locator(
+          `.sidebar-session-indicator [data-session-pr-state="${row.state}"]`,
+        );
+        await expect.poll(() => pullRequest.isVisible()).toBe(true);
+        await expect.poll(() => session.locator(".sidebar-session-fork-indicator").count()).toBe(0);
+        await expect
+          .poll(() => session.locator(".session-row-state [data-session-pr-state]").count())
+          .toBe(0);
+      }
+      await expect
+        .poll(() =>
+          page
+            .locator('[data-session-key="agent:main:pr-named-glyph"] .session-glyph__overlay')
+            .isVisible(),
+        )
+        .toBe(true);
+      await expect
+        .poll(() =>
+          page
+            .locator('[data-session-key="agent:main:pr-emoji"] .session-glyph__overlay')
+            .isVisible(),
+        )
+        .toBe(true);
+      await expect
+        .poll(() =>
+          page
+            .locator(
+              '[data-session-key="agent:main:pr-owner"] .session-glyph__overlay .session-owner-chip',
+            )
+            .isVisible(),
+        )
+        .toBe(true);
+      for (const key of [
+        "agent:main:pr-named-glyph",
+        "agent:main:pr-emoji",
+        "agent:main:pr-owner",
+      ]) {
+        const session = page.locator(`[data-session-key="${key}"]`);
+        const [primaryBounds, overlayBounds] = await Promise.all([
+          session.locator("[data-session-pr-state]").boundingBox(),
+          session.locator(".session-glyph__overlay").boundingBox(),
+        ]);
+        if (!primaryBounds || !overlayBounds) {
+          throw new Error(`Expected visible composite PR geometry for ${key}`);
+        }
+        expect(overlayBounds.x).toBeGreaterThan(primaryBounds.x + primaryBounds.width / 2);
+        expect(overlayBounds.y).toBeGreaterThan(primaryBounds.y + primaryBounds.height / 2);
+      }
+      expect(
+        await page
+          .locator('[data-session-key="agent:main:pr-plain"] .session-glyph__overlay')
+          .count(),
+      ).toBe(0);
+      await captureUiProof(page, "sidebar-pr-session-icon-combinations-dark.png");
+      await captureUiProofRegion(
+        codingSection,
+        "sidebar-pr-session-icon-combinations-dark-closeup.png",
+      );
+      await page.emulateMedia({ colorScheme: "light" });
+      await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
+      await captureUiProof(page, "sidebar-pr-session-icon-combinations-light.png");
+      await captureUiProofRegion(
+        codingSection,
+        "sidebar-pr-session-icon-combinations-light-closeup.png",
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps action-only text widest at rest and swaps active state for actions", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
@@ -297,28 +478,32 @@ suite.define(() => {
       const state = row.locator(".session-row-state");
       await expect
         .poll(() =>
-          row.locator(".sidebar-recent-session__name .sidebar-session-fork-indicator").isVisible(),
+          row.locator(".sidebar-recent-session__name .sidebar-session-fork-indicator").count(),
         )
-        .toBe(true);
+        .toBe(0);
       await expect.poll(() => state.locator('[aria-label="Forked session"]').count()).toBe(0);
       await expect
-        .poll(() => state.locator("[data-session-pr-state='open']").isVisible())
+        .poll(() =>
+          row.locator(".sidebar-session-indicator [data-session-pr-state='open']").isVisible(),
+        )
         .toBe(true);
+      await expect.poll(() => state.locator("[data-session-pr-state]").count()).toBe(0);
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
       await expect.poll(() => state.locator(".session-unread-dot").isVisible()).toBe(true);
-      const [endcapBounds, openPullRequestBounds, spinnerBounds, unreadBounds] = await Promise.all([
+      const [endcapBounds, spinnerBounds, unreadBounds] = await Promise.all([
         row.locator(".sidebar-recent-session__details-endcap").boundingBox(),
-        state.locator("[data-session-pr-state='open'] svg").boundingBox(),
         state.locator(".session-run-spinner").boundingBox(),
         state.locator(".session-unread-dot").boundingBox(),
       ]);
-      if (!endcapBounds || !openPullRequestBounds || !spinnerBounds || !unreadBounds) {
+      if (!endcapBounds || !spinnerBounds || !unreadBounds) {
         throw new Error("Expected visible combined session state geometry");
       }
-      for (const iconBounds of [openPullRequestBounds, spinnerBounds, unreadBounds]) {
-        expect(iconBounds.x).toBeGreaterThanOrEqual(endcapBounds.x);
+      // Fractional flex distribution can move a 12px spinner by under two
+      // device pixels; larger drift would mean the endcap clips status again.
+      for (const iconBounds of [spinnerBounds, unreadBounds]) {
+        expect(iconBounds.x).toBeGreaterThanOrEqual(endcapBounds.x - 2);
         expect(iconBounds.x + iconBounds.width).toBeLessThanOrEqual(
-          endcapBounds.x + endcapBounds.width,
+          endcapBounds.x + endcapBounds.width + 2,
         );
       }
       const link = row.locator(".sidebar-recent-session__link");

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -146,6 +146,50 @@ openclaw-session-owner-chip {
   color: var(--accent);
 }
 
+.session-glyph__overlay {
+  position: absolute;
+  z-index: 2;
+  right: -4px;
+  bottom: -4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  overflow: hidden;
+  border: 1.5px solid var(--bg);
+  border-radius: var(--radius-full);
+  background: var(--bg);
+  box-shadow: 0 0 0 1px var(--border);
+  color: var(--text);
+}
+
+.session-glyph__overlay :is(.session-glyph__icon, .session-glyph__icon svg) {
+  width: 9px;
+  height: 9px;
+}
+
+.session-glyph__overlay .session-glyph__emoji {
+  font-size: 9px;
+}
+
+.session-glyph__overlay :is(openclaw-session-owner-chip, .session-owner-chip--row) {
+  width: 100%;
+  height: 100%;
+}
+
+.session-glyph__overlay .session-owner-chip--row {
+  border-width: 1px;
+  box-shadow: none;
+  font-size: 6px;
+}
+
+.session-glyph__overlay .sidebar-session-attention__icon,
+.session-glyph__overlay .sidebar-session-attention__icon svg {
+  width: 9px;
+  height: 9px;
+}
+
 .connect-splash__logo {
   width: 44px;
   height: 44px;

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -187,7 +187,7 @@ describe("AppSidebar session indicators", () => {
     const runningLead = runningRow?.querySelector(".sidebar-session-indicator");
     expect(pinnedLead).not.toBeNull();
     expect(pinnedLead?.innerHTML).toBe(runningLead?.innerHTML);
-    expect(pinnedLead?.querySelector("[data-session-pr-state]")).toBeNull();
+    expect(pinnedLead?.querySelector('[data-session-pr-state="open"]')).not.toBeNull();
     expect(pinnedRow?.querySelector(".session-row-state")).toBeNull();
   });
 
@@ -214,11 +214,15 @@ describe("AppSidebar session indicators", () => {
         row.status = "running";
         row.unread = true;
       } else if (row.key === keys.openPullRequest || row.key === keys.mergedPullRequest) {
+        row.icon = row.key === keys.openPullRequest ? "braces" : "🦞";
         row.worktree = {
           id: `wt-${row.key}`,
           branch: row.key.endsWith("open-pr") ? "feature/open" : "feature/merged",
           repoRoot: "/repo",
         };
+        if (row.key === keys.openPullRequest) {
+          row.forkSource = { sessionKey: "agent:main:main", sessionId: "source-session" };
+        }
       }
     }
     const request = vi.fn(() => Promise.resolve({ subscribed: true }));
@@ -322,12 +326,22 @@ describe("AppSidebar session indicators", () => {
 
     for (const key of [keys.openPullRequest, keys.mergedPullRequest]) {
       const row = sidebar.querySelector(`[data-session-key="${key}"]`);
-      expectEmptyLead(row);
-      expect(row?.querySelector(".session-row-state [data-session-pr-state]")).not.toBeNull();
+      expect(
+        row?.querySelector(".sidebar-session-indicator [data-session-pr-state]"),
+      ).not.toBeNull();
+      const overlay = row?.querySelector(".session-glyph__overlay");
+      expect(overlay).not.toBeNull();
+      expect(
+        overlay?.querySelector(
+          key === keys.openPullRequest ? ".session-glyph__icon svg" : ".session-glyph__emoji",
+        ),
+      ).not.toBeNull();
+      expect(row?.querySelector(".sidebar-session-fork-indicator")).toBeNull();
+      expect(row?.querySelector(".session-row-state [data-session-pr-state]")).toBeNull();
       expect(row?.querySelector("a")?.getAttribute("title")).toContain(
         key === keys.openPullRequest ? "Open PR" : "Merged",
       );
-      expect(row?.querySelector("[data-session-pr-state]")?.hasAttribute("title")).toBe(false);
+      expect(row?.querySelector("[data-session-pr-state]")?.hasAttribute("title")).toBe(true);
     }
 
     const openPullRequestRow = result.sessions.find((row) => row.key === keys.openPullRequest);
@@ -338,7 +352,11 @@ describe("AppSidebar session indicators", () => {
     sessions.publishList({ result });
     await waitForFast(() => {
       expect(sidebar.querySelector('[data-session-pr-state="open"]')).toBeNull();
-      expectEmptyLead(sidebar.querySelector(`[data-session-key="${keys.openPullRequest}"]`));
+      expect(
+        sidebar.querySelector(
+          `[data-session-key="${keys.openPullRequest}"] .session-glyph__icon svg`,
+        ),
+      ).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a Control UI sidebar problem where one pull-request session could show separate session, fork, and PR glyphs for the same work. The repeated branch-shaped status made the row noisy and left the strongest state signal in the second-line endcap.

## Why This Change Was Made

Promotes open or merged PR state to the leading glyph and preserves the existing session identity as a bottom-right overlay. Named glyphs, emoji, owner identity, attention, child run rings, and unread badges keep their established priority; fork provenance is hidden only while a PR already communicates that relationship.

## User Impact

PR sessions now read as one compact visual: PR state first, session identity second. Rows without a PR keep their existing fork, identity, run, and unread presentation.

## Evidence

### Before and after

| Reported duplicate state | Composite PR + session identity |
| --- | --- |
| ![](https://github.com/user-attachments/assets/501babd9-f175-41e0-beb2-b518cc2ea7d4) | ![](https://github.com/user-attachments/assets/96cf2002-b207-4095-8104-552da0c97b40) |

### Light theme and full UI

![](https://github.com/user-attachments/assets/ac6a4cac-d6c1-4171-b0ee-131436e642b5)

<details>
<summary>Full dark-theme browser capture</summary>

![](https://github.com/user-attachments/assets/3e258133-058d-4637-804e-f1d6b44f307e)

</details>

### Verification

- Current-main component suite: 264 passed.
- Current-main mocked-Gateway Chromium E2E: 5 passed, including named glyph, emoji, owner, no-identity, open/merged, fork, run, unread, dark, and light combinations.
- Direct AWS browser proof: [run_cc9b9c008c14](https://crabbox.openclaw.ai/portal/runs/run_cc9b9c008c14).
- Exact commit autoreview: clean; no accepted/actionable findings.
- Production LOC: +114/-95 (net +19). Tests and test support: +231/-14.

AI-assisted: yes. The implementation, review, and browser proof were produced with Codex; the final behavior was inspected against the real rendered UI.
