### PR TITLE
fix(ui): keep streamed replies ordered across steering

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3791,7 +3791,7 @@ src/sessions/session-upstream-links.ts	2
 src/sessions/session-upstream-monitor.ts	2
 src/sessions/user-turn-transcript-runtime-context.ts	2
 src/sessions/user-turn-transcript.media-normalize.ts	2
-src/sessions/user-turn-transcript.ts	12
+src/sessions/user-turn-transcript.ts	11
 src/shared/account-enabled.ts	1
 src/shared/assistant-error-format.ts	3
 src/shared/bounded-serial-queue.ts	1

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3791,7 +3791,7 @@ src/sessions/session-upstream-links.ts	2
 src/sessions/session-upstream-monitor.ts	2
 src/sessions/user-turn-transcript-runtime-context.ts	2
 src/sessions/user-turn-transcript.media-normalize.ts	2
-src/sessions/user-turn-transcript.ts	15
+src/sessions/user-turn-transcript.ts	12
 src/shared/account-enabled.ts	1
 src/shared/assistant-error-format.ts	3
 src/shared/bounded-serial-queue.ts	1
@@ -4175,7 +4175,7 @@ ui/src/pages/chat/chat-command-executor.ts	1
 ui/src/pages/chat/chat-composer-capability-host.ts	4
 ui/src/pages/chat/chat-gateway.ts	2
 ui/src/pages/chat/chat-history-retry.ts	1
-ui/src/pages/chat/chat-history.ts	7
+ui/src/pages/chat/chat-history.ts	6
 ui/src/pages/chat/chat-page-retained-sessions.ts	1
 ui/src/pages/chat/chat-page.ts	1
 ui/src/pages/chat/chat-pane-board.ts	2
@@ -4247,7 +4247,7 @@ ui/src/pages/chat/route.ts	2
 ui/src/pages/chat/run-lifecycle.ts	1
 ui/src/pages/chat/scroll.ts	2
 ui/src/pages/chat/session-cache.ts	2
-ui/src/pages/chat/stream-reconciliation.ts	18
+ui/src/pages/chat/stream-reconciliation.ts	12
 ui/src/pages/chat/tool-stream.ts	8
 ui/src/pages/chat/workspace-conflict.ts	2
 ui/src/pages/config/config-page.ts	1

--- a/src/auto-reply/reply/reply-run-registry.message-injection.ts
+++ b/src/auto-reply/reply/reply-run-registry.message-injection.ts
@@ -188,10 +188,9 @@ export function beginReplyMessageInjectionTarget(
   }
   const targetRunId = normalizeOptionalString(resolved.backend.runId);
   const userTurnTranscriptRecorder = queueOptions?.userTurnTranscriptRecorder;
-  // The backend selected at the final admission check owns steering provenance.
-  // Leaf-bound callers may omit a run id, and a captured operation can reattach
-  // before injection, so request metadata and the earlier target snapshot are insufficient.
-  userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(targetRunId);
+  // The backend selected at the final admission check owns steering identity.
+  // Durable provenance is confirmed only after this exact queue operation proves
+  // transcript commitment; acceptance alone is insufficient.
   // Injection is user input, not run evidence: stamping activity here would let
   // sub-10-minute user messages re-arm a wedged run's staleness window forever.
   // Invoke before the first await. The capability owns the final synchronous
@@ -218,7 +217,6 @@ export function beginReplyMessageInjectionTarget(
     queued = resolved.injection.queueMessage(text, runtimeQueueOptions);
   } catch (error) {
     settleAcceptance(false);
-    userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(undefined);
     const immediateRejection = {
       status: "rejected" as const,
       reason: "runtime_rejected" as const,
@@ -231,16 +229,19 @@ export function beginReplyMessageInjectionTarget(
     };
   }
   const outcome = queued.then(
-    (result): ReplyMessageInjectionOutcome => {
+    async (result): Promise<ReplyMessageInjectionOutcome> => {
       settleAcceptance(true);
-      if (result?.transcriptCommit === "unconfirmed") {
-        userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(undefined);
+      if (
+        targetRunId &&
+        queueOptions?.waitForTranscriptCommit === true &&
+        result?.transcriptCommit !== "unconfirmed"
+      ) {
+        await userTurnTranscriptRecorder?.confirmSteerTargetRunIdForPersistence?.(targetRunId);
       }
       return result ? { status: "accepted", result } : { status: "accepted" };
     },
     (error: unknown): ReplyMessageInjectionOutcome => {
       settleAcceptance(false);
-      userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(undefined);
       return {
         status: "rejected",
         reason: "runtime_rejected",

--- a/src/auto-reply/reply/reply-run-registry.message-injection.ts
+++ b/src/auto-reply/reply/reply-run-registry.message-injection.ts
@@ -186,6 +186,12 @@ export function beginReplyMessageInjectionTarget(
       outcome: Promise.resolve(immediateRejection),
     };
   }
+  const targetRunId = normalizeOptionalString(resolved.backend.runId);
+  const userTurnTranscriptRecorder = queueOptions?.userTurnTranscriptRecorder;
+  // The backend selected at the final admission check owns steering provenance.
+  // Leaf-bound callers may omit a run id, and a captured operation can reattach
+  // before injection, so request metadata and the earlier target snapshot are insufficient.
+  userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(targetRunId);
   // Injection is user input, not run evidence: stamping activity here would let
   // sub-10-minute user messages re-arm a wedged run's staleness window forever.
   // Invoke before the first await. The capability owns the final synchronous
@@ -212,13 +218,14 @@ export function beginReplyMessageInjectionTarget(
     queued = resolved.injection.queueMessage(text, runtimeQueueOptions);
   } catch (error) {
     settleAcceptance(false);
+    userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(undefined);
     const immediateRejection = {
       status: "rejected" as const,
       reason: "runtime_rejected" as const,
       errorMessage: String(error),
     };
     return {
-      targetRunId: target.runId,
+      targetRunId,
       acceptance: acceptance.promise,
       outcome: Promise.resolve(immediateRejection),
     };
@@ -226,10 +233,14 @@ export function beginReplyMessageInjectionTarget(
   const outcome = queued.then(
     (result): ReplyMessageInjectionOutcome => {
       settleAcceptance(true);
+      if (result?.transcriptCommit === "unconfirmed") {
+        userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(undefined);
+      }
       return result ? { status: "accepted", result } : { status: "accepted" };
     },
     (error: unknown): ReplyMessageInjectionOutcome => {
       settleAcceptance(false);
+      userTurnTranscriptRecorder?.setSteerTargetRunIdForPersistence?.(undefined);
       return {
         status: "rejected",
         reason: "runtime_rejected",
@@ -238,7 +249,7 @@ export function beginReplyMessageInjectionTarget(
     },
   );
   return {
-    targetRunId: target.runId,
+    targetRunId,
     acceptance: acceptance.promise,
     outcome,
   };

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-rewrite.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-rewrite.ts
@@ -1,0 +1,65 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
+import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
+import {
+  getSessionKysely,
+  resolveSqliteTranscriptScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+import { readTranscriptGenerationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
+import { rewriteSqliteTranscriptEventRowsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import type { TranscriptEntryAnchor } from "./transcript-entry-anchor.js";
+
+type TranscriptMessageAnchorRewriteResult<TMessage> = {
+  generation: string;
+  message: TMessage;
+};
+
+/** Rewrites one exact anchored message without rejecting unrelated later appends. */
+export async function rewriteTranscriptMessageAtAnchor<TMessage>(
+  anchor: TranscriptEntryAnchor,
+  rewriteMessage: (message: unknown) => TMessage | undefined,
+): Promise<TranscriptMessageAnchorRewriteResult<TMessage> | null> {
+  const resolved = resolveSqliteTranscriptScope(anchor);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: TranscriptMessageAnchorRewriteResult<TMessage> | null = null;
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        const row = executeSqliteQueryTakeFirstSync(
+          database.db,
+          getSessionKysely(database.db)
+            .selectFrom("transcript_events")
+            .select("event_json")
+            .where("session_id", "=", resolved.sessionId)
+            .where("seq", "=", anchor.rawSeq),
+        );
+        if (!row) {
+          return;
+        }
+        const event = JSON.parse(row.event_json) as unknown;
+        if (!isRecord(event) || event.type !== "message" || event.id !== anchor.entryId) {
+          return;
+        }
+        const message = rewriteMessage(event.message);
+        if (message === undefined) {
+          return;
+        }
+        rewriteSqliteTranscriptEventRowsInTransaction(database, resolved, [
+          {
+            event: { ...event, message },
+            expectedEventJson: row.event_json,
+            seq: anchor.rawSeq,
+          },
+        ]);
+        const generation = readTranscriptGenerationInTransaction(database, resolved.sessionId);
+        if (generation) {
+          result = { generation, message };
+        }
+      },
+      toDatabaseOptions(resolved),
+      { operationLabel: "session.transcript.message-rewrite" },
+    );
+    return result;
+  });
+}

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -14,6 +14,7 @@ import {
   readTranscriptStatsSync,
   readTranscriptEventAtSeqSync,
 } from "./session-accessor.sqlite-read.js";
+import { rewriteTranscriptMessageAtAnchor } from "./session-accessor.sqlite-transcript-message-rewrite.js";
 import {
   appendTranscriptEvent,
   appendTranscriptEventSync,
@@ -57,6 +58,7 @@ export {
   replaceTranscriptEvents,
   replaceTranscriptEventsSync,
   rewriteTranscriptEventRowsExact,
+  rewriteTranscriptMessageAtAnchor,
   resolveTranscriptSessionKeyBySessionId,
   withTranscriptWriteLock,
   withTranscriptWriteTransaction,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -237,6 +237,7 @@ export {
   replaceTranscriptEvents,
   replaceTranscriptEventsSync,
   rewriteTranscriptEventRowsExact,
+  rewriteTranscriptMessageAtAnchor,
   resolveTranscriptSessionKeyBySessionId,
   trimSessionTranscriptForManualCompact,
   withTranscriptWriteLock,

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -242,6 +242,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
                 counts: { tool: 0, block: 0, final: 0 },
               };
             }
+            userTurnRecorder.setSteerTargetRunIdForPersistence?.(undefined);
           }
           applyChatSendManagedMedia(ctx, await pluginBoundMediaPromise);
           const dispatchInbound = () =>

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -242,7 +242,6 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
                 counts: { tool: 0, block: 0, final: 0 },
               };
             }
-            userTurnRecorder.setSteerTargetRunIdForPersistence?.(undefined);
           }
           applyChatSendManagedMedia(ctx, await pluginBoundMediaPromise);
           const dispatchInbound = () =>

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -222,6 +222,9 @@ async function handleChatSendWithOptions(
       return;
     }
     messageInjectionAttempt = preAckInjection.attempt;
+    if (!messageInjectionAttempt) {
+      userTurnRecorder.setSteerTargetRunIdForPersistence?.(undefined);
+    }
 
     const serverTiming = shouldIncludeChatSendAckServerTiming(clientInfo)
       ? {

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -222,10 +222,6 @@ async function handleChatSendWithOptions(
       return;
     }
     messageInjectionAttempt = preAckInjection.attempt;
-    if (!messageInjectionAttempt) {
-      userTurnRecorder.setSteerTargetRunIdForPersistence?.(undefined);
-    }
-
     const serverTiming = shouldIncludeChatSendAckServerTiming(clientInfo)
       ? {
           receivedToAckMs: roundedChatSendTimingMs(performance.now() - chatSendReceivedAtMs),

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -86,7 +86,7 @@ function resolveChatSendToolAuthorityOverlay(params: {
 export function createChatSendMessageInjectionStarter(params: {
   target: ReplyMessageInjectionTarget | undefined;
   request: Pick<NormalizedChatSendRequest, "p" | "rawMessage" | "supportsTaskSuggestions">;
-  session: Pick<PreparedChatSendSession, "cfg" | "entry" | "expectedRunId">;
+  session: Pick<PreparedChatSendSession, "cfg" | "entry">;
   turn: ReturnType<typeof prepareChatSendUserTurn>;
   imageOrder: ReplyBackendQueueMessageOptions["imageOrder"];
   userTurnTranscriptRecorder: NonNullable<
@@ -107,9 +107,6 @@ export function createChatSendMessageInjectionStarter(params: {
       inlineMode: p.queueMode,
     });
     const text = ctx.BodyForAgent ?? ctx.Body ?? rawMessage;
-    params.userTurnTranscriptRecorder.setSteerTargetRunIdForPersistence?.(
-      params.session.expectedRunId,
-    );
     const attempt = beginReplyMessageInjectionTarget(
       params.target,
       p.replyToId

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -125,9 +125,6 @@ export function createChatSendMessageInjectionStarter(params: {
         userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
       },
     );
-    if (!attempt) {
-      params.userTurnTranscriptRecorder.setSteerTargetRunIdForPersistence?.(undefined);
-    }
     return attempt;
   };
 }

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -86,10 +86,12 @@ function resolveChatSendToolAuthorityOverlay(params: {
 export function createChatSendMessageInjectionStarter(params: {
   target: ReplyMessageInjectionTarget | undefined;
   request: Pick<NormalizedChatSendRequest, "p" | "rawMessage" | "supportsTaskSuggestions">;
-  session: Pick<PreparedChatSendSession, "cfg" | "entry">;
+  session: Pick<PreparedChatSendSession, "cfg" | "entry" | "expectedRunId">;
   turn: ReturnType<typeof prepareChatSendUserTurn>;
   imageOrder: ReplyBackendQueueMessageOptions["imageOrder"];
-  userTurnTranscriptRecorder: ReplyBackendQueueMessageOptions["userTurnTranscriptRecorder"];
+  userTurnTranscriptRecorder: NonNullable<
+    ReplyBackendQueueMessageOptions["userTurnTranscriptRecorder"]
+  >;
 }) {
   const { p, rawMessage, supportsTaskSuggestions } = params.request;
   const { cfg, entry } = params.session;
@@ -105,7 +107,10 @@ export function createChatSendMessageInjectionStarter(params: {
       inlineMode: p.queueMode,
     });
     const text = ctx.BodyForAgent ?? ctx.Body ?? rawMessage;
-    return beginReplyMessageInjectionTarget(
+    params.userTurnTranscriptRecorder.setSteerTargetRunIdForPersistence?.(
+      params.session.expectedRunId,
+    );
+    const attempt = beginReplyMessageInjectionTarget(
       params.target,
       p.replyToId
         ? buildChatSendReplyInjectionText({ body: text, cfg, ctx, sessionEntry: entry })
@@ -123,6 +128,10 @@ export function createChatSendMessageInjectionStarter(params: {
         userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
       },
     );
+    if (!attempt) {
+      params.userTurnTranscriptRecorder.setSteerTargetRunIdForPersistence?.(undefined);
+    }
+    return attempt;
   };
 }
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2085,6 +2085,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await waitForAssertion(() => expect(mockState.messageReceivedCalls).toHaveLength(1));
     expect(readPersistedUserMessages()).toHaveLength(1);
     expect(readPersistedUserMessages()[0]?.content).toBe("hello");
+    expect(readPersistedUserMessages()[0]?.["__openclaw"]).toMatchObject({
+      steerTargetRunId: "active-run",
+    });
     expect(queueMessage).toHaveBeenCalledWith(
       "hello",
       expect.objectContaining({
@@ -2281,6 +2284,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(dispatchCallsBefore + 1);
     expect(mockState.lastMessageInjectionAttempted).toBe(true);
     expect(readPersistedUserMessages()).toHaveLength(1);
+    expect(
+      (readPersistedUserMessages()[0]?.["__openclaw"] as Record<string, unknown> | undefined)
+        ?.steerTargetRunId,
+    ).toBeUndefined();
     const broadcasts = context.broadcast.mock.calls.map(
       ([, payload]) => payload as Record<string, unknown>,
     );
@@ -7402,6 +7409,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(typeof message?.timestamp).toBe("number");
     const persistedUser = readPersistedUserMessages()[0];
     expect(persistedUser?.content).toBe("quick command");
+    expect(
+      (persistedUser?.["__openclaw"] as Record<string, unknown> | undefined)?.steerTargetRunId,
+    ).toBeUndefined();
     expect(getTotalPendingReplies()).toBe(0);
   });
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2088,6 +2088,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(readPersistedUserMessages()[0]?.["__openclaw"]).toMatchObject({
       steerTargetRunId: "active-run",
     });
+    const userUpdates = mockState.emittedTranscriptUpdates.filter(
+      (update) => userUpdateMessage(update)?.role === "user",
+    );
+    expect(userUpdates).toHaveLength(2);
+    expect(userUpdateMessage(userUpdates[0])).not.toHaveProperty("__openclaw.steerTargetRunId");
+    expect(userUpdateMessage(userUpdates[1])).toHaveProperty(
+      "__openclaw.steerTargetRunId",
+      "active-run",
+    );
     expect(queueMessage).toHaveBeenCalledWith(
       "hello",
       expect.objectContaining({
@@ -2441,9 +2450,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
     bindTestToolAuthority(first);
     first.setPhase("running");
-    const queueMessage = vi.fn((_text: string, options?: ReplyBackendQueueMessageOptions) => {
+    const queueMessage = vi.fn(async (_text: string, options?: ReplyBackendQueueMessageOptions) => {
       options?.onQueueAccepted?.(true);
-      return delivery.promise;
+      await options?.userTurnTranscriptRecorder?.persistApproved();
+      return await delivery.promise;
     });
     first.attachBackend({
       kind: "embedded",
@@ -2457,6 +2467,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       requestParams: { expectedRunId: "active-run", queueMode: "steer" },
       waitFor: "none",
     });
+    await waitForAssertion(() => expect(readPersistedUserMessages()).toHaveLength(1));
+    expect(readPersistedUserMessages()[0]).not.toHaveProperty("__openclaw.steerTargetRunId");
     first.complete();
     const successorCancel = vi.fn();
     const successor = replyRunRegistry.begin({

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2107,6 +2107,43 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(context.broadcast).toHaveBeenCalledOnce();
   });
 
+  it("records the resolved run for accepted leaf-only steering", async () => {
+    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-leaf-steer-provenance-");
+    const { send } = createChatRequestFixture();
+    const operation = replyRunRegistry.begin({
+      sessionKey: "agent:main:main",
+      sessionId: mockState.sessionId,
+      resetTriggered: false,
+      originatingLeafEntryId: null,
+    });
+    bindTestToolAuthority(operation);
+    operation.setPhase("running");
+    const queueMessage = vi.fn(async (_text: string, options?: ReplyBackendQueueMessageOptions) => {
+      await options?.userTurnTranscriptRecorder?.persistApproved();
+    });
+    operation.attachBackend({
+      kind: "embedded",
+      runId: "active-run",
+      cancel: () => {},
+      messageInjection: { isAvailable: () => true, queueMessage },
+    });
+
+    try {
+      await send({
+        idempotencyKey: "idem-leaf-steer-provenance",
+        requestParams: { expectedLeafEntryId: null, queueMode: "steer" },
+      });
+    } finally {
+      operation.complete();
+    }
+
+    expect(queueMessage).toHaveBeenCalledOnce();
+    expect(readPersistedUserMessages()).toHaveLength(1);
+    expect(readPersistedUserMessages()[0]?.["__openclaw"]).toMatchObject({
+      steerTargetRunId: "active-run",
+    });
+  });
+
   it("hydrates and accepts reply injection before ACK without waiting for delivery", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-reply-steer-");
     mockState.hasMessageReceivedHooks = true;
@@ -2450,6 +2487,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(successor.result).toBeNull();
     expect(successorCancel).not.toHaveBeenCalled();
     expect(mockState.lastDispatchCtx).toBeUndefined();
+    const persistedUsers = readPersistedUserMessages();
+    expect(persistedUsers).toHaveLength(1);
+    expect(
+      (persistedUsers[0]?.["__openclaw"] as Record<string, unknown> | undefined)?.steerTargetRunId,
+    ).toBeUndefined();
     successor.complete();
   });
 

--- a/src/sessions/user-turn-transcript.metadata.ts
+++ b/src/sessions/user-turn-transcript.metadata.ts
@@ -1,9 +1,22 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import type { UserTurnInput } from "./user-turn-transcript.types.js";
+import type { AgentMessage } from "../../packages/agent-core/src/types.js";
+import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
+import type {
+  PersistedUserTurnMessage,
+  UserTurnInput,
+  UserTurnMessagePersistenceParams,
+} from "./user-turn-transcript.types.js";
 
 const REPLY_PREVIEW_TEXT_MAX_CHARS = 2000;
 const REPLY_PREVIEW_SENDER_MAX_CHARS = 200;
+const STEER_TARGET_RUN_ID_MAX_CHARS = 512;
+
+export function normalizePersistedSteerTargetRunId(value: unknown): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  return normalized && normalized.length <= STEER_TARGET_RUN_ID_MAX_CHARS ? normalized : undefined;
+}
 
 function buildUserTurnSenderMeta(
   sender: UserTurnInput["sender"],
@@ -28,6 +41,7 @@ export function buildPersistedUserTurnMetadata(
   const replyToId = normalizeOptionalString(input.replyToId);
   const replyPreviewText = normalizeOptionalString(input.replyToPreview?.text);
   const replyPreviewSender = normalizeOptionalString(input.replyToPreview?.senderLabel);
+  const steerTargetRunId = normalizePersistedSteerTargetRunId(input.steerTargetRunId);
   return {
     // Privileged synthetic handoffs may execute owner tools but never author trusted memory.
     ...(input.senderIsOwner === undefined
@@ -54,6 +68,7 @@ export function buildPersistedUserTurnMetadata(
         }
       : {}),
     ...(input.transport ? { transport: input.transport } : {}),
+    ...(steerTargetRunId ? { steerTargetRunId } : {}),
     ...(normalizedMedia.length > 0 ? { media: normalizedMedia } : {}),
     ...(input.mediaImageLayout
       ? {
@@ -68,4 +83,131 @@ export function buildPersistedUserTurnMetadata(
         }
       : {}),
   };
+}
+
+type AgentMessageWithOpenClawMetadata = AgentMessage & {
+  __openclaw?: Record<string, unknown>;
+};
+
+export function rewritePersistedSteerTargetRunId(
+  message: PersistedUserTurnMessage | undefined,
+  targetRunId: string | null | undefined,
+): PersistedUserTurnMessage | undefined {
+  if (!message || targetRunId === undefined) {
+    return message;
+  }
+  const metadata = { ...message["__openclaw"] };
+  delete metadata.steerTargetRunId;
+  if (targetRunId) {
+    metadata.steerTargetRunId = targetRunId;
+  }
+  const nextMessage = { ...message };
+  delete nextMessage["__openclaw"];
+  if (Object.keys(metadata).length > 0) {
+    nextMessage["__openclaw"] = metadata;
+  }
+  return nextMessage;
+}
+
+/** Restores producer metadata that write hooks must not be able to forge or erase. */
+export function restorePreparedUserTurnOperationalMetaForRuntime(params: {
+  runtimeMessage: AgentMessage;
+  preparedMessage?: PersistedUserTurnMessage;
+}): AgentMessage {
+  if (!params.preparedMessage || params.runtimeMessage.role !== "user") {
+    return params.runtimeMessage;
+  }
+  const preparedMeta = params.preparedMessage["__openclaw"];
+  const senderIsOwner = preparedMeta?.senderIsOwner;
+  const steerTargetRunId = normalizePersistedSteerTargetRunId(preparedMeta?.steerTargetRunId);
+  const nextMessage: AgentMessageWithOpenClawMetadata = { ...params.runtimeMessage };
+  const runtimeMeta = { ...nextMessage["__openclaw"] };
+  delete runtimeMeta.steerTargetRunId;
+  if (steerTargetRunId) {
+    runtimeMeta.steerTargetRunId = steerTargetRunId;
+  }
+  if (typeof senderIsOwner === "boolean") {
+    runtimeMeta.senderIsOwner = senderIsOwner;
+  }
+  delete nextMessage["__openclaw"];
+  if (Object.keys(runtimeMeta).length > 0) {
+    nextMessage["__openclaw"] = runtimeMeta;
+  }
+  return nextMessage;
+}
+
+/** Applies before-message hooks while preserving user-turn transcript metadata. */
+export function preparePersistedUserTurnMessageForTranscriptWrite(
+  message: PersistedUserTurnMessage,
+  params: Pick<UserTurnMessagePersistenceParams, "agentId" | "sessionKey" | "beforeMessageWrite">,
+): PersistedUserTurnMessage | undefined {
+  if (!params.beforeMessageWrite) {
+    return message;
+  }
+  const originalIdempotencyKey = Reflect.get(message, "idempotencyKey");
+  const idempotencyKey =
+    typeof originalIdempotencyKey === "string" ? originalIdempotencyKey : undefined;
+  const provenance = normalizeInputProvenance(Reflect.get(message, "provenance"));
+  const originalMeta = message["__openclaw"];
+  const senderIsOwner = originalMeta?.senderIsOwner;
+  const replyToId = normalizeOptionalString(originalMeta?.replyToId);
+  const originalReplyPreview = asOptionalRecord(originalMeta?.replyToPreview);
+  const replyPreviewText = normalizeOptionalString(originalReplyPreview?.text);
+  const replyPreviewSender = normalizeOptionalString(originalReplyPreview?.senderLabel);
+  const replyToPreview = replyPreviewText
+    ? {
+        text: replyPreviewText,
+        ...(replyPreviewSender ? { senderLabel: replyPreviewSender } : {}),
+      }
+    : undefined;
+  const originalTransport = originalMeta?.transport;
+  const steerTargetRunId = normalizePersistedSteerTargetRunId(originalMeta?.steerTargetRunId);
+  const lateMedia = originalMeta?.lateMedia === true;
+  const originalMedia = originalMeta?.media;
+  const media = Array.isArray(originalMedia) ? structuredClone(originalMedia) : undefined;
+  const originalMediaImageLayout = originalMeta?.mediaImageLayout;
+  const mediaImageLayout =
+    originalMediaImageLayout === undefined ? undefined : structuredClone(originalMediaImageLayout);
+  // Hooks receive the original message object and may mutate nested metadata in
+  // place. Snapshot transport correlation before handing them that reference.
+  const originalTransportRecord = asOptionalRecord(originalTransport);
+  const transport = originalTransportRecord ? { ...originalTransportRecord } : undefined;
+  const nextMessage = params.beforeMessageWrite({
+    message,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+  if (nextMessage?.role !== "user") {
+    return undefined;
+  }
+  const preparedUserMessage = provenance
+    ? applyInputProvenanceToUserMessage(nextMessage, provenance)
+    : nextMessage;
+  if (preparedUserMessage.role !== "user") {
+    return undefined;
+  }
+  const nextUserMessage: PersistedUserTurnMessage = { ...preparedUserMessage };
+  const protectedMeta: Record<string, unknown> = {
+    ...nextUserMessage["__openclaw"],
+    ...(typeof senderIsOwner === "boolean" ? { senderIsOwner } : {}),
+    ...(replyToId ? { replyToId } : {}),
+    ...(replyToPreview ? { replyToPreview } : {}),
+    ...(transport ? { transport } : {}),
+    ...(lateMedia ? { lateMedia: true } : {}),
+    ...(media === undefined ? {} : { media }),
+    ...(mediaImageLayout === undefined ? {} : { mediaImageLayout }),
+  };
+  delete protectedMeta.steerTargetRunId;
+  if (steerTargetRunId) {
+    protectedMeta.steerTargetRunId = steerTargetRunId;
+  }
+  const protectedMessage: PersistedUserTurnMessage = {
+    ...nextUserMessage,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+  };
+  delete protectedMessage["__openclaw"];
+  if (Object.keys(protectedMeta).length > 0) {
+    protectedMessage["__openclaw"] = protectedMeta;
+  }
+  return protectedMessage;
 }

--- a/src/sessions/user-turn-transcript.metadata.ts
+++ b/src/sessions/user-turn-transcript.metadata.ts
@@ -41,7 +41,6 @@ export function buildPersistedUserTurnMetadata(
   const replyToId = normalizeOptionalString(input.replyToId);
   const replyPreviewText = normalizeOptionalString(input.replyToPreview?.text);
   const replyPreviewSender = normalizeOptionalString(input.replyToPreview?.senderLabel);
-  const steerTargetRunId = normalizePersistedSteerTargetRunId(input.steerTargetRunId);
   return {
     // Privileged synthetic handoffs may execute owner tools but never author trusted memory.
     ...(input.senderIsOwner === undefined
@@ -68,7 +67,6 @@ export function buildPersistedUserTurnMetadata(
         }
       : {}),
     ...(input.transport ? { transport: input.transport } : {}),
-    ...(steerTargetRunId ? { steerTargetRunId } : {}),
     ...(normalizedMedia.length > 0 ? { media: normalizedMedia } : {}),
     ...(input.mediaImageLayout
       ? {

--- a/src/sessions/user-turn-transcript.persistence.test.ts
+++ b/src/sessions/user-turn-transcript.persistence.test.ts
@@ -366,4 +366,68 @@ describe("persistUserTurnTranscript", () => {
     ]);
     expect(hookCalls).toBe(1);
   });
+
+  it.each([
+    {
+      name: "restores an erased producer target",
+      producerTarget: "active-run",
+      hookTarget: undefined,
+      expectedTarget: "active-run",
+    },
+    {
+      name: "rejects a replacement target",
+      producerTarget: "active-run",
+      hookTarget: "forged-run",
+      expectedTarget: "active-run",
+    },
+    {
+      name: "rejects a target forged without producer provenance",
+      producerTarget: undefined,
+      hookTarget: "forged-run",
+      expectedTarget: undefined,
+    },
+  ])(
+    "$name across before_message_write",
+    async ({ producerTarget, hookTarget, expectedTarget }) => {
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([
+          {
+            hookName: "before_message_write",
+            handler: (event) => {
+              const message = (event as { message: Record<string, unknown> }).message;
+              const metadata = {
+                ...(message["__openclaw"] as Record<string, unknown> | undefined),
+              };
+              delete metadata.steerTargetRunId;
+              return {
+                message: castAgentMessage({
+                  ...message,
+                  __openclaw: {
+                    ...metadata,
+                    ...(hookTarget ? { steerTargetRunId: hookTarget } : {}),
+                  },
+                }),
+              };
+            },
+          },
+        ]),
+      );
+      const dir = tempDirs.make("openclaw-user-turn-steer-target-hook-");
+      const target = createSqliteTranscriptTarget({ dir });
+
+      await persistUserTurnTranscript({
+        ...target,
+        input: {
+          text: "steer or queue",
+          idempotencyKey: "chat-run-steer-target:user",
+          ...(producerTarget ? { steerTargetRunId: producerTarget } : {}),
+        },
+        beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+      });
+
+      const [message] = await readTranscriptMessages(target);
+      const metadata = message?.["__openclaw"] as Record<string, unknown> | undefined;
+      expect(metadata?.steerTargetRunId).toBe(expectedTarget);
+    },
+  );
 });

--- a/src/sessions/user-turn-transcript.persistence.test.ts
+++ b/src/sessions/user-turn-transcript.persistence.test.ts
@@ -12,6 +12,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../agents/harness/hook-helpers.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { loadTranscriptEvents } from "../config/sessions/session-accessor.js";
+import { createUserTurnTranscriptRecorder } from "./user-turn-transcript.js";
 import { persistUserTurnTranscript } from "./user-turn-transcript.test-support.js";
 
 describe("persistUserTurnTranscript", () => {
@@ -415,15 +416,18 @@ describe("persistUserTurnTranscript", () => {
       const dir = tempDirs.make("openclaw-user-turn-steer-target-hook-");
       const target = createSqliteTranscriptTarget({ dir });
 
-      await persistUserTurnTranscript({
-        ...target,
+      const recorder = createUserTurnTranscriptRecorder({
         input: {
           text: "steer or queue",
           idempotencyKey: "chat-run-steer-target:user",
-          ...(producerTarget ? { steerTargetRunId: producerTarget } : {}),
         },
+        target,
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
       });
+      if (producerTarget) {
+        await recorder.confirmSteerTargetRunIdForPersistence?.(producerTarget);
+      }
+      await recorder.persistApproved();
 
       const [message] = await readTranscriptMessages(target);
       const metadata = message?.["__openclaw"] as Record<string, unknown> | undefined;

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -544,6 +544,41 @@ describe("user turn transcript persistence", () => {
       });
     });
 
+    it("adds confirmed steering provenance after runtime persistence", async () => {
+      const dir = tempDirs.make("openclaw-user-turn-recorder-confirm-steer-");
+      const target = createSqliteTranscriptTarget({ dir });
+      const input = {
+        text: "tighten the answer",
+        idempotencyKey: "confirm-steer:user",
+        sender: { id: "operator-1", name: "Operator" },
+      };
+      const recorder = createUserTurnTranscriptRecorder({ input, target });
+      const persisted = await persistUserTurnTranscript({ ...target, input });
+      expect(persisted).toBeDefined();
+      recorder.markRuntimePersisted(persisted?.message, persisted?.admission);
+      const initialGeneration = recorder.getAdmissionReceipt()?.generation;
+
+      await recorder.confirmSteerTargetRunIdForPersistence?.("active-run");
+
+      expect(recorder.getAdmissionReceipt()?.generation).not.toBe(initialGeneration);
+      expect(recorder.getPersistedMessage?.()).toMatchObject({
+        __openclaw: {
+          senderId: "operator-1",
+          senderName: "Operator",
+          steerTargetRunId: "active-run",
+        },
+      });
+      await expect(readTranscriptMessages(target)).resolves.toEqual([
+        expect.objectContaining({
+          __openclaw: {
+            senderId: "operator-1",
+            senderName: "Operator",
+            steerTargetRunId: "active-run",
+          },
+        }),
+      ]);
+    });
+
     it("waits for a deferred projection rebuild before returning admission identity", async () => {
       const dir = tempDirs.make("openclaw-user-turn-recorder-projection-");
       const target = createSqliteTranscriptTarget({ dir });

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -6,7 +6,9 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { AgentMessage } from "../../packages/agent-core/src/types.js";
 import {
   persistSessionTranscriptTurn,
+  publishTranscriptUpdate,
   readActiveTranscriptEntryAnchor,
+  rewriteTranscriptMessageAtAnchor,
   type TranscriptEntryAnchor,
   type SessionTranscriptTurnPersistOptions,
 } from "../config/sessions/session-accessor.js";
@@ -160,8 +162,8 @@ function resolvePersistedUserTurnMessage(
   return params.message ?? (params.input ? buildPersistedUserTurnMessage(params.input) : undefined);
 }
 
-function isUserMessage(message: AgentMessage): message is PersistedUserTurnMessage {
-  return (message as { role?: unknown }).role === "user";
+function isUserMessage(message: unknown): message is PersistedUserTurnMessage {
+  return asOptionalRecord(message)?.role === "user";
 }
 
 function buildLateResolvedMediaMessage(params: {
@@ -325,6 +327,39 @@ async function resolveUserTurnTranscriptTarget(
   return typeof target === "function" ? await target() : target;
 }
 
+async function confirmPersistedSteerTargetRunId(params: {
+  admission: UserTurnTranscriptAdmissionReceipt;
+  targetRunId: string;
+}): Promise<
+  | {
+      admission: UserTurnTranscriptAdmissionReceipt;
+      message: PersistedUserTurnMessage;
+    }
+  | undefined
+> {
+  const rewritten = await rewriteTranscriptMessageAtAnchor(params.admission, (message) => {
+    if (!isUserMessage(message)) {
+      return undefined;
+    }
+    const currentTarget = normalizePersistedSteerTargetRunId(
+      message["__openclaw"]?.steerTargetRunId,
+    );
+    return currentTarget === params.targetRunId
+      ? undefined
+      : rewritePersistedSteerTargetRunId(message, params.targetRunId);
+  });
+  if (!rewritten) {
+    return undefined;
+  }
+  const admission = { ...params.admission, generation: rewritten.generation };
+  await publishTranscriptUpdate(admission, {
+    message: rewritten.message,
+    messageId: admission.entryId,
+    messageSeq: admission.activeMessagePosition + 1,
+  });
+  return { admission, message: rewritten.message };
+}
+
 export function createUserTurnTranscriptRecorder(
   params: CreateUserTurnTranscriptRecorderParams,
 ): UserTurnTranscriptRecorder {
@@ -345,7 +380,7 @@ export function createUserTurnTranscriptRecorder(
   let admissionHandler: ((admission: UserTurnTranscriptAdmissionReceipt) => void) | undefined;
   let resolvedBeforeProvider = false;
   let replacementText: string | undefined;
-  let steerTargetRunIdOverride: string | null | undefined;
+  let confirmedSteerTargetRunId: string | undefined;
 
   const applyReplacementText = (
     candidate: PersistedUserTurnMessage | undefined,
@@ -357,7 +392,7 @@ export function createUserTurnTranscriptRecorder(
   };
 
   const applyMessageOverrides = (candidate: PersistedUserTurnMessage | undefined) =>
-    rewritePersistedSteerTargetRunId(applyReplacementText(candidate), steerTargetRunIdOverride);
+    rewritePersistedSteerTargetRunId(applyReplacementText(candidate), confirmedSteerTargetRunId);
 
   const handlePersistenceError = (error: unknown) => {
     if (params.onPersistenceError) {
@@ -569,13 +604,42 @@ export function createUserTurnTranscriptRecorder(
       message = applyMessageOverrides(message);
       resolvedMessagePromise = undefined;
     },
-    setSteerTargetRunIdForPersistence: (targetRunId) => {
-      if (persisted || runtimePersisted) {
+    confirmSteerTargetRunIdForPersistence: async (targetRunId) => {
+      const normalizedTargetRunId = normalizePersistedSteerTargetRunId(targetRunId);
+      if (!normalizedTargetRunId || confirmedSteerTargetRunId === normalizedTargetRunId) {
         return;
       }
-      steerTargetRunIdOverride = normalizePersistedSteerTargetRunId(targetRunId) ?? null;
+      confirmedSteerTargetRunId = normalizedTargetRunId;
       message = applyMessageOverrides(message);
       resolvedMessagePromise = undefined;
+
+      const pendingSelfPersistence = selfPersistencePromise;
+      await waitForRuntimePersistence();
+      await pendingSelfPersistence?.catch(() => undefined);
+      if (!admissionReceipt) {
+        return;
+      }
+      try {
+        const confirmed = await confirmPersistedSteerTargetRunId({
+          admission: admissionReceipt,
+          targetRunId: normalizedTargetRunId,
+        });
+        if (!confirmed) {
+          return;
+        }
+        admissionReceipt = confirmed.admission;
+        admittedMessage = confirmed.message;
+        runtimePersistedMessage = confirmed.message;
+        if (persistedResult) {
+          persistedResult = {
+            ...persistedResult,
+            admission: confirmed.admission,
+            message: confirmed.message,
+          };
+        }
+      } catch (error) {
+        handlePersistenceError(error);
+      }
     },
     getPersistedMessage: () =>
       admittedMessage ?? runtimePersistedMessage ?? persistedResult?.message,

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -12,13 +12,19 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { waitForSessionTranscriptProjection } from "../config/sessions/session-transcript-reconcile.js";
 import { readPersistedMediaFacts, type MediaFact } from "../media/media-facts.js";
-import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
+import { applyInputProvenanceToUserMessage } from "./input-provenance.js";
 import { resolveUserTurnTranscriptAdmission } from "./user-turn-transcript-admission.js";
 import {
   normalizeStructuredMediaEntryForTranscript,
   resolveTranscriptMediaPath,
 } from "./user-turn-transcript.media-normalize.js";
-import { buildPersistedUserTurnMetadata } from "./user-turn-transcript.metadata.js";
+import {
+  buildPersistedUserTurnMetadata,
+  normalizePersistedSteerTargetRunId,
+  preparePersistedUserTurnMessageForTranscriptWrite,
+  restorePreparedUserTurnOperationalMetaForRuntime,
+  rewritePersistedSteerTargetRunId,
+} from "./user-turn-transcript.metadata.js";
 import type {
   CreateUserTurnTranscriptRecorderParams,
   PersistUserTurnTranscriptParams,
@@ -39,6 +45,11 @@ export type {
   UserTurnInput,
   UserTurnTranscriptRecorder,
 } from "./user-turn-transcript.types.js";
+
+export {
+  preparePersistedUserTurnMessageForTranscriptWrite,
+  restorePreparedUserTurnOperationalMetaForRuntime,
+};
 
 export function buildRunUserTurnIdempotencyKey(runId: string): string {
   return `${runId}:user`;
@@ -235,100 +246,6 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   } as AgentMessage;
 }
 
-/** Restores only auth state that write hooks must not be able to forge or erase. */
-export function restorePreparedUserTurnOperationalMetaForRuntime(params: {
-  runtimeMessage: AgentMessage;
-  preparedMessage?: PersistedUserTurnMessage;
-}): AgentMessage {
-  if (!params.preparedMessage || !isUserMessage(params.runtimeMessage)) {
-    return params.runtimeMessage;
-  }
-  const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
-  const senderIsOwner = preparedMeta?.senderIsOwner;
-  if (typeof senderIsOwner !== "boolean") {
-    return params.runtimeMessage;
-  }
-  return {
-    ...params.runtimeMessage,
-    __openclaw: { ...readOpenClawMessageMeta(params.runtimeMessage), senderIsOwner },
-  } as AgentMessage;
-}
-
-/** Applies before-message hooks while preserving user-turn transcript metadata. */
-export function preparePersistedUserTurnMessageForTranscriptWrite(
-  message: PersistedUserTurnMessage,
-  params: Pick<UserTurnMessagePersistenceParams, "agentId" | "sessionKey" | "beforeMessageWrite">,
-): PersistedUserTurnMessage | undefined {
-  if (!params.beforeMessageWrite) {
-    return message;
-  }
-  const originalIdempotencyKey = Reflect.get(message, "idempotencyKey");
-  const idempotencyKey =
-    typeof originalIdempotencyKey === "string" ? originalIdempotencyKey : undefined;
-  const provenance = normalizeInputProvenance(Reflect.get(message, "provenance"));
-  const originalMeta = readOpenClawMessageMeta(message);
-  const senderIsOwner = originalMeta?.senderIsOwner;
-  const replyToId = normalizeOptionalString(originalMeta?.replyToId);
-  const originalReplyPreview = asOptionalRecord(originalMeta?.replyToPreview);
-  const replyPreviewText = normalizeOptionalString(originalReplyPreview?.text);
-  const replyPreviewSender = normalizeOptionalString(originalReplyPreview?.senderLabel);
-  const replyToPreview = replyPreviewText
-    ? {
-        text: replyPreviewText,
-        ...(replyPreviewSender ? { senderLabel: replyPreviewSender } : {}),
-      }
-    : undefined;
-  const originalTransport = originalMeta?.transport;
-  const lateMedia = originalMeta?.lateMedia === true;
-  const originalMedia = originalMeta?.media;
-  const media = Array.isArray(originalMedia) ? structuredClone(originalMedia) : undefined;
-  const originalMediaImageLayout = originalMeta?.mediaImageLayout;
-  const mediaImageLayout =
-    originalMediaImageLayout === undefined ? undefined : structuredClone(originalMediaImageLayout);
-  // Hooks receive the original message object and may mutate nested metadata in
-  // place. Snapshot transport correlation before handing them that reference.
-  const originalTransportRecord = asOptionalRecord(originalTransport);
-  const transport = originalTransportRecord ? { ...originalTransportRecord } : undefined;
-  const nextMessage = params.beforeMessageWrite({
-    message,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-  if (nextMessage?.role !== "user") {
-    return undefined;
-  }
-  const nextUserMessage = provenance
-    ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
-    : nextMessage;
-  if (
-    !idempotencyKey &&
-    typeof senderIsOwner !== "boolean" &&
-    !replyToId &&
-    !replyToPreview &&
-    !transport &&
-    !lateMedia &&
-    media === undefined &&
-    mediaImageLayout === undefined
-  ) {
-    return nextUserMessage;
-  }
-  const protectedMeta = {
-    ...readOpenClawMessageMeta(nextUserMessage),
-    ...(typeof senderIsOwner === "boolean" ? { senderIsOwner } : {}),
-    ...(replyToId ? { replyToId } : {}),
-    ...(replyToPreview ? { replyToPreview } : {}),
-    ...(transport ? { transport } : {}),
-    ...(lateMedia ? { lateMedia: true } : {}),
-    ...(media === undefined ? {} : { media }),
-    ...(mediaImageLayout === undefined ? {} : { mediaImageLayout }),
-  };
-  return {
-    ...nextUserMessage,
-    ...(idempotencyKey ? { idempotencyKey } : {}),
-    ...(Object.keys(protectedMeta).length > 0 ? { __openclaw: protectedMeta } : {}),
-  } as PersistedUserTurnMessage;
-}
-
 // Store-backed persistence resolves the current session transcript file lazily
 // so callers can pass a session entry/store without knowing the final path.
 async function persistUserTurnTranscript(
@@ -428,6 +345,7 @@ export function createUserTurnTranscriptRecorder(
   let admissionHandler: ((admission: UserTurnTranscriptAdmissionReceipt) => void) | undefined;
   let resolvedBeforeProvider = false;
   let replacementText: string | undefined;
+  let steerTargetRunIdOverride: string | null | undefined;
 
   const applyReplacementText = (
     candidate: PersistedUserTurnMessage | undefined,
@@ -437,6 +355,9 @@ export function createUserTurnTranscriptRecorder(
     }
     return { ...candidate, content: replacementText };
   };
+
+  const applyMessageOverrides = (candidate: PersistedUserTurnMessage | undefined) =>
+    rewritePersistedSteerTargetRunId(applyReplacementText(candidate), steerTargetRunIdOverride);
 
   const handlePersistenceError = (error: unknown) => {
     if (params.onPersistenceError) {
@@ -454,7 +375,7 @@ export function createUserTurnTranscriptRecorder(
 
   const resolveMessageForPersistence = async (): Promise<PersistedUserTurnMessage | undefined> => {
     if (params.message || !params.resolveInput) {
-      return applyReplacementText(message);
+      return applyMessageOverrides(message);
     }
     if (!resolvedMessagePromise) {
       resolvedMessagePromise = (async () => {
@@ -466,10 +387,10 @@ export function createUserTurnTranscriptRecorder(
               input: resolvedInput ?? params.input,
             }) ?? message;
           resolvedBeforeProvider = !sentToProvider;
-          return applyReplacementText(resolvedMessage);
+          return applyMessageOverrides(resolvedMessage);
         } catch (error) {
           handlePersistenceError(error);
-          return applyReplacementText(message);
+          return applyMessageOverrides(message);
         }
       })();
     }
@@ -645,7 +566,15 @@ export function createUserTurnTranscriptRecorder(
         return;
       }
       replacementText = text;
-      message = applyReplacementText(message);
+      message = applyMessageOverrides(message);
+      resolvedMessagePromise = undefined;
+    },
+    setSteerTargetRunIdForPersistence: (targetRunId) => {
+      if (persisted || runtimePersisted) {
+        return;
+      }
+      steerTargetRunIdOverride = normalizePersistedSteerTargetRunId(targetRunId) ?? null;
+      message = applyMessageOverrides(message);
       resolvedMessagePromise = undefined;
     },
     getPersistedMessage: () =>

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -30,7 +30,9 @@ export type PersistedUserTurnMediaInput = Pick<
   workspaceDir?: string | null;
 };
 
-export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }>;
+export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }> & {
+  __openclaw?: Record<string, unknown>;
+};
 
 export type UserTurnInput = {
   text?: string | null;
@@ -61,6 +63,8 @@ export type UserTurnInput = {
     replyToId?: string;
     threadId?: string;
   };
+  /** Presentation provenance for a user turn consumed by an exact active run. */
+  steerTargetRunId?: string;
 };
 
 export type UserTurnTranscriptUpdateMode = "inline" | "none";
@@ -156,6 +160,8 @@ export type UserTurnTranscriptRecorder = {
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
   /** Replaces generated current-turn text before runtime persistence/provider submission. */
   replaceTextBeforePersistence?: (text: string) => void;
+  /** Sets exact-run steering provenance while the injection attempt owns persistence. */
+  setSteerTargetRunIdForPersistence?: (targetRunId: string | undefined) => void;
   getPersistedMessage?: () => PersistedUserTurnMessage | undefined;
   getAdmissionReceipt: () => UserTurnTranscriptAdmissionReceipt | undefined;
   setAdmissionHandler?: (handler: (admission: UserTurnTranscriptAdmissionReceipt) => void) => void;

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -63,8 +63,6 @@ export type UserTurnInput = {
     replyToId?: string;
     threadId?: string;
   };
-  /** Presentation provenance for a user turn consumed by an exact active run. */
-  steerTargetRunId?: string;
 };
 
 export type UserTurnTranscriptUpdateMode = "inline" | "none";
@@ -160,8 +158,8 @@ export type UserTurnTranscriptRecorder = {
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
   /** Replaces generated current-turn text before runtime persistence/provider submission. */
   replaceTextBeforePersistence?: (text: string) => void;
-  /** Sets exact-run steering provenance while the injection attempt owns persistence. */
-  setSteerTargetRunIdForPersistence?: (targetRunId: string | undefined) => void;
+  /** Confirms exact-run steering provenance after transcript commitment is proven. */
+  confirmSteerTargetRunIdForPersistence?: (targetRunId: string) => Promise<void>;
   getPersistedMessage?: () => PersistedUserTurnMessage | undefined;
   getAdmissionReceipt: () => UserTurnTranscriptAdmissionReceipt | undefined;
   setAdmissionHandler?: (handler: (admission: UserTurnTranscriptAdmissionReceipt) => void) => void;

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -18,7 +18,8 @@ import {
   type SidebarSessionActivePanels,
   type SidebarSessionLayouts,
 } from "../pages/chat/sidebar-layout-persistence.ts";
-import { normalizeChatSplitLayout, type ChatSplitLayout } from "../pages/chat/split-layout.ts";
+import { normalizeChatSplitLayout } from "../pages/chat/split-layout-persistence.ts";
+import type { ChatSplitLayout } from "../pages/chat/split-layout.ts";
 import { resolveControlUiBasePath } from "./browser.ts";
 import { parseImportedCustomTheme, type ImportedCustomTheme } from "./custom-theme.ts";
 import { parseThemeSelection, type ThemeMode, type ThemeName } from "./theme.ts";

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -19,7 +19,7 @@ import {
   type SidebarSessionLayouts,
 } from "../pages/chat/sidebar-layout-persistence.ts";
 import { normalizeChatSplitLayout } from "../pages/chat/split-layout-persistence.ts";
-import type { ChatSplitLayout } from "../pages/chat/split-layout.ts";
+import type { ChatSplitLayout } from "../pages/chat/split-layout-types.ts";
 import { resolveControlUiBasePath } from "./browser.ts";
 import { parseImportedCustomTheme, type ImportedCustomTheme } from "./custom-theme.ts";
 import { parseThemeSelection, type ThemeMode, type ThemeName } from "./theme.ts";

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -120,6 +120,36 @@ suite.define(() => {
       });
       await page.getByText(preSteerReply, { exact: true }).waitFor({ timeout: 10_000 });
 
+      const queuedFollowUp = "queued follow-up before steer";
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [activeRunId],
+        clientRunId: "queued-run",
+        hasActiveRun: true,
+        message: {
+          __openclaw: {
+            id: "persisted-queued-user",
+            idempotencyKey: "queued-run:user",
+            seq: 3,
+          },
+          content: [{ text: queuedFollowUp, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "persisted-queued-user",
+        messageSeq: 3,
+        session: {
+          activeRunIds: [activeRunId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await page.getByText(queuedFollowUp, { exact: true }).waitFor({ timeout: 10_000 });
+      await expectChatBubbleAbove(page, preSteerReply, queuedFollowUp);
+
       const followUp = "tighten the active plan";
       await page.locator(".agent-chat__composer-combobox textarea").fill(followUp);
       await page.getByRole("button", { name: "Steer into the active run" }).click();
@@ -147,7 +177,8 @@ suite.define(() => {
         .poll(() => page.locator(".chat-thread .chat-group.user", { hasText: followUp }).count())
         .toBe(1);
       await expectChatBubbleAbove(page, originalPrompt, preSteerReply);
-      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, preSteerReply, queuedFollowUp);
+      await expectChatBubbleAbove(page, queuedFollowUp, followUp);
 
       await gateway.emitGatewayEvent("session.message", {
         activeRunIds: [activeRunId],
@@ -157,7 +188,7 @@ suite.define(() => {
           __openclaw: {
             id: "persisted-steer-user",
             idempotencyKey: `${steerRunId}:user`,
-            seq: 3,
+            seq: 4,
             steerTargetRunId: activeRunId,
           },
           content: [{ text: followUp, type: "text" }],
@@ -165,7 +196,7 @@ suite.define(() => {
           timestamp: Date.now(),
         },
         messageId: "persisted-steer-user",
-        messageSeq: 3,
+        messageSeq: 4,
         session: {
           activeRunIds: [activeRunId],
           hasActiveRun: true,
@@ -197,7 +228,8 @@ suite.define(() => {
       });
       await page.locator(".chat-bubble", { hasText: postSteerReply }).waitFor({ timeout: 10_000 });
       await expectChatBubbleAbove(page, originalPrompt, preSteerReply);
-      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, preSteerReply, queuedFollowUp);
+      await expectChatBubbleAbove(page, queuedFollowUp, followUp);
       await expectChatBubbleAbove(page, followUp, postSteerReply);
       const authoritativeMessages = [
         {
@@ -218,9 +250,19 @@ suite.define(() => {
         },
         {
           __openclaw: {
+            id: "persisted-queued-user",
+            idempotencyKey: "queued-run:user",
+            seq: 3,
+          },
+          content: [{ text: queuedFollowUp, type: "text" }],
+          role: "user",
+          timestamp: 250,
+        },
+        {
+          __openclaw: {
             id: "persisted-steer-user",
             idempotencyKey: `${steerRunId}:user`,
-            seq: 3,
+            seq: 4,
             steerTargetRunId: activeRunId,
           },
           content: [{ text: followUp, type: "text" }],
@@ -228,7 +270,7 @@ suite.define(() => {
           timestamp: 50,
         },
         {
-          __openclaw: { id: "persisted-post-steer", idempotencyKey: activeRunId, seq: 4 },
+          __openclaw: { id: "persisted-post-steer", idempotencyKey: activeRunId, seq: 5 },
           content: [{ text: terminalPostSteerReply, type: "text" }],
           role: "assistant",
           timestamp: 300,
@@ -256,7 +298,8 @@ suite.define(() => {
       await page
         .locator(".chat-bubble", { hasText: terminalPostSteerReply })
         .waitFor({ timeout: 10_000 });
-      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, preSteerReply, queuedFollowUp);
+      await expectChatBubbleAbove(page, queuedFollowUp, followUp);
       await expectChatBubbleAbove(page, followUp, postSteerReply);
 
       await page.reload();
@@ -264,7 +307,8 @@ suite.define(() => {
         .locator(".chat-bubble", { hasText: terminalPostSteerReply })
         .waitFor({ timeout: 10_000 });
       await expectChatBubbleAbove(page, originalPrompt, preSteerReply);
-      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, preSteerReply, queuedFollowUp);
+      await expectChatBubbleAbove(page, queuedFollowUp, followUp);
       await expectChatBubbleAbove(page, followUp, postSteerReply);
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -44,7 +44,7 @@ async function expectChatBubbleAbove(page: Page, upperText: string, lowerText: s
 }
 
 suite.define(() => {
-  it("steers ordinary follow-ups when the server default is steer", async () => {
+  it("keeps cumulative assistant output ordered across a consumed steer", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -106,6 +106,20 @@ suite.define(() => {
       });
       await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
 
+      const preSteerReply = "Assistant output before the steer.";
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: preSteerReply,
+        message: {
+          content: [{ text: preSteerReply, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId: activeRunId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await page.getByText(preSteerReply, { exact: true }).waitFor({ timeout: 10_000 });
+
       const followUp = "tighten the active plan";
       await page.locator(".agent-chat__composer-combobox textarea").fill(followUp);
       await page.getByRole("button", { name: "Steer into the active run" }).click();
@@ -123,6 +137,18 @@ suite.define(() => {
         timeout: 10_000,
       });
       await queue.getByText(followUp).waitFor({ timeout: 10_000 });
+      await gateway.emitGatewayEvent("chat", {
+        runId: steerRunId,
+        sessionKey: "main",
+        state: "final",
+      });
+      await queue.getByText(followUp).waitFor({ state: "detached", timeout: 10_000 });
+      await expect
+        .poll(() => page.locator(".chat-thread .chat-group.user", { hasText: followUp }).count())
+        .toBe(1);
+      await expectChatBubbleAbove(page, originalPrompt, preSteerReply);
+      await expectChatBubbleAbove(page, preSteerReply, followUp);
+
       await gateway.emitGatewayEvent("session.message", {
         activeRunIds: [activeRunId],
         clientRunId: activeRunId,
@@ -131,14 +157,15 @@ suite.define(() => {
           __openclaw: {
             id: "persisted-steer-user",
             idempotencyKey: `${steerRunId}:user`,
-            seq: 2,
+            seq: 3,
+            steerTargetRunId: activeRunId,
           },
           content: [{ text: followUp, type: "text" }],
           role: "user",
           timestamp: Date.now(),
         },
         messageId: "persisted-steer-user",
-        messageSeq: 2,
+        messageSeq: 3,
         session: {
           activeRunIds: [activeRunId],
           hasActiveRun: true,
@@ -150,11 +177,95 @@ suite.define(() => {
         sessionKey: "main",
       });
 
-      await queue.getByText(followUp).waitFor({ state: "detached", timeout: 10_000 });
       await expect
         .poll(() => page.locator(".chat-thread .chat-group.user", { hasText: followUp }).count())
         .toBe(1);
-      await expectChatBubbleAbove(page, originalPrompt, followUp);
+      const postSteerReply = "Assistant output after the steer.";
+      const cumulativeReply = `${preSteerReply} ${postSteerReply}`;
+      const terminalPostSteerReply = `${postSteerReply} Final unseen suffix.`;
+      const terminalReply = `${preSteerReply} ${terminalPostSteerReply}`;
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: ` ${postSteerReply}`,
+        message: {
+          content: [{ text: cumulativeReply, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId: activeRunId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await page.locator(".chat-bubble", { hasText: postSteerReply }).waitFor({ timeout: 10_000 });
+      await expectChatBubbleAbove(page, originalPrompt, preSteerReply);
+      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, followUp, postSteerReply);
+      const authoritativeMessages = [
+        {
+          __openclaw: {
+            id: "persisted-original-user",
+            idempotencyKey: `${activeRunId}:user`,
+            seq: 1,
+          },
+          content: [{ text: originalPrompt, type: "text" }],
+          role: "user",
+          timestamp: 100,
+        },
+        {
+          __openclaw: { id: "persisted-pre-steer", idempotencyKey: activeRunId, seq: 2 },
+          content: [{ text: preSteerReply, type: "text" }],
+          role: "assistant",
+          timestamp: 200,
+        },
+        {
+          __openclaw: {
+            id: "persisted-steer-user",
+            idempotencyKey: `${steerRunId}:user`,
+            seq: 3,
+            steerTargetRunId: activeRunId,
+          },
+          content: [{ text: followUp, type: "text" }],
+          role: "user",
+          timestamp: 50,
+        },
+        {
+          __openclaw: { id: "persisted-post-steer", idempotencyKey: activeRunId, seq: 4 },
+          content: [{ text: terminalPostSteerReply, type: "text" }],
+          role: "assistant",
+          timestamp: 300,
+        },
+      ];
+      const terminalHistory = {
+        messages: authoritativeMessages,
+        sessionId: "control-ui-e2e-session",
+        sessionInfo: {
+          activeRunIds: [],
+          hasActiveRun: false,
+          key: "main",
+          kind: "direct",
+          status: "done",
+          updatedAt: Date.now(),
+        },
+        thinkingLevel: null,
+      };
+      await gateway.setMethodResponse("chat.history", terminalHistory);
+      await gateway.setMethodResponse("chat.startup", terminalHistory);
+      await gateway.emitChatFinal({ runId: activeRunId, text: terminalReply });
+      await page
+        .getByRole("button", { name: "Stop generating" })
+        .waitFor({ state: "detached", timeout: 10_000 });
+      await page
+        .locator(".chat-bubble", { hasText: terminalPostSteerReply })
+        .waitFor({ timeout: 10_000 });
+      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, followUp, postSteerReply);
+
+      await page.reload();
+      await page
+        .locator(".chat-bubble", { hasText: terminalPostSteerReply })
+        .waitFor({ timeout: 10_000 });
+      await expectChatBubbleAbove(page, originalPrompt, preSteerReply);
+      await expectChatBubbleAbove(page, preSteerReply, followUp);
+      await expectChatBubbleAbove(page, followUp, postSteerReply);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -125,6 +125,12 @@ export type ChatStreamSegment = {
   text: string;
   ts: number;
   runId?: string;
+  /** Persisted user send that causally precedes this transient output. */
+  afterBoundaryRunId?: string;
+  /** Persisted user send that causally follows this transient output. */
+  boundaryRunId?: string;
+  /** Ordering-only boundary with no renderable assistant text. */
+  boundaryMarker?: true;
   toolCallId?: string;
   itemId?: string;
 };
@@ -133,8 +139,11 @@ export function streamSegmentHasItemId(segment: { itemId?: unknown }): boolean {
   return typeof segment.itemId === "string" && segment.itemId.trim().length > 0;
 }
 
-export function streamSegmentUsesAccumulatedText(segment: { itemId?: unknown }): boolean {
-  return !streamSegmentHasItemId(segment);
+export function streamSegmentUsesAccumulatedText(segment: {
+  itemId?: unknown;
+  boundaryMarker?: unknown;
+}): boolean {
+  return segment.boundaryMarker !== true && !streamSegmentHasItemId(segment);
 }
 
 /** Advance the accumulated-text tracker only when the segment genuinely

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -960,7 +960,7 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatMessages).toEqual([]);
   });
 
-  it("uses an already-persisted steer to recover the active stream boundary", () => {
+  it("preserves an already-recorded stream boundary for a persisted steer", () => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
@@ -995,9 +995,21 @@ describe("handleChatGatewayEvent", () => {
         },
       ],
     }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
+      chatStreamSegments: Array<{
+        text: string;
+        ts: number;
+        itemId: string;
+        boundaryRunId: string;
+      }>;
     };
-    state.chatStreamSegments = [{ text: "Looking into it.", ts: 2, itemId: "preamble-1" }];
+    state.chatStreamSegments = [
+      {
+        text: "Looking into it.",
+        ts: 2,
+        itemId: "preamble-1",
+        boundaryRunId: "steer-send-1",
+      },
+    ];
 
     handleChatGatewayEvent(state, {
       runId: "run-1",
@@ -1012,6 +1024,47 @@ describe("handleChatGatewayEvent", () => {
     expectTextChatMessage(state.chatMessages[1], "assistant", "Looking into it.");
     expectTextChatMessage(state.chatMessages[2], "user", "Focus on deployment");
     expectTextChatMessage(state.chatMessages[3], "assistant", "Final answer.");
+  });
+
+  it("keeps a terminal-only suffix after a steer with no post-boundary delta", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [
+        createTextChatMessage("user", "Ask", { idempotencyKey: "run-1:user" }, 1),
+        createTextChatMessage("user", "Steer", { idempotencyKey: "steer-1:user" }, 3),
+      ],
+      chatStream: null,
+      chatStreamStartedAt: null,
+    }) as ChatState & {
+      chatStreamSegments: Array<{
+        text: string;
+        ts: number;
+        runId: string;
+        boundaryRunId: string;
+      }>;
+    };
+    state.chatStreamSegments = [
+      { text: "Before steer.", ts: 2, runId: "run-1", boundaryRunId: "steer-1" },
+    ];
+
+    handleChatGatewayEvent(state, {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: createTextChatMessage(
+        "assistant",
+        "Before steer. Final unseen suffix.",
+        undefined,
+        4,
+      ),
+    });
+
+    expect(state.chatMessages).toHaveLength(4);
+    expectTextChatMessage(state.chatMessages[0], "user", "Ask");
+    expectTextChatMessage(state.chatMessages[1], "assistant", "Before steer.");
+    expectTextChatMessage(state.chatMessages[2], "user", "Steer");
+    expectTextChatMessage(state.chatMessages[3], "assistant", "Final unseen suffix.");
   });
 
   it("clears keyed commentary when chatPersistCommentary is false", () => {

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -19,8 +19,8 @@ import {
 } from "./chat-history.ts";
 import {
   getChatSessionProjection,
+  publishChatSessionProjectionMessages,
   readChatSessionProjectionScope,
-  reduceChatSessionProjection,
   setChatSessionProjection,
 } from "./history-merge.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
@@ -30,12 +30,16 @@ import {
   retireSteeredChipsForTerminalRun,
 } from "./steer-lifecycle.ts";
 import {
+  latestStreamBoundaryRunId,
+  reconcileTerminalStreamBoundary,
+} from "./stream-causal-boundary.ts";
+import {
   appendTerminalAssistantMessage,
   clearToolStreamSegments,
   hasVisibleStreamParts,
-  streamReconciliationStartIndex,
   terminalMessageReplacesVisibleStream,
 } from "./stream-reconciliation.ts";
+import { discardStreamSegmentIndexes } from "./stream-segment-pruning.ts";
 import {
   authoritativeHistoryAppliedForRun,
   rememberLiveTerminalRun,
@@ -212,11 +216,7 @@ function appendCachedChatMessage(
   );
 }
 
-function handleChatEvent(
-  state: ChatState,
-  payload?: ChatEventPayload,
-  opts?: { keyedStreamStartIndex?: number },
-) {
+function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!payload) {
     return null;
   }
@@ -250,11 +250,13 @@ function handleChatEvent(
     message: Record<string, unknown>,
     visibleMessages: unknown[],
     runId: string | null | undefined,
+    retainSupersededMessages = false,
   ): void => {
     const event = payload as ChatEventPayload & { messageId?: unknown; messageSeq?: unknown };
-    reduceChatSessionProjection(
-      state,
-      {
+    publishChatSessionProjectionMessages(state, visibleMessages, {
+      scope,
+      retainSupersededMessages,
+      event: {
         type: "messagePersisted",
         message,
         envelope: {
@@ -263,8 +265,7 @@ function handleChatEvent(
           ...(event.messageSeq === undefined ? {} : { messageSeq: event.messageSeq }),
         },
       },
-      { scope, messages: visibleMessages.slice(0, -1) },
-    );
+    });
   };
   const projectedRun =
     payload.runId && payload.state !== "status"
@@ -339,12 +340,12 @@ function handleChatEvent(
   }
 
   const terminalRunId = payload.runId ?? state.chatRunId;
+  const terminalAfterBoundaryRunId = latestStreamBoundaryRunId(state);
   const materializeVisibleStream = (
     materializeOpts: Parameters<typeof materializeVisibleAssistantStreamMessages>[2] = {},
   ) =>
     materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
       ...materializeOpts,
-      keyedStartIndex: opts?.keyedStreamStartIndex,
     });
   const reconcileTerminalRun = (
     outcome: "done" | "interrupted",
@@ -392,24 +393,53 @@ function handleChatEvent(
       // History already owns this run's terminal message. Discard the live
       // projection; reconcileTerminalRun below clears its remaining stream.
       clearToolStreamSegments(state);
-    } else if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      if (
-        hasVisibleStreamParts(state, {
-          includeCurrent: false,
-          isHiddenStreamText: isHiddenAssistantStreamText,
-        })
-      ) {
-        state.chatMessages = materializeVisibleStream({ includeCurrent: false });
-        clearToolStreamSegments(state);
-      }
-      const liveFinal = rememberLiveTerminalRun(finalMessage, terminalRunId);
-      publishVisibleFinal(
-        finalMessage,
-        appendTerminalAssistantMessage(state.chatMessages, liveFinal),
-        terminalRunId,
-      );
     } else {
-      state.chatMessages = materializeVisibleStream();
+      const boundary = finalMessage
+        ? reconcileTerminalStreamBoundary(finalMessage, state)
+        : { kind: "none" as const };
+      if (boundary.kind === "split") {
+        // Same-run assistant rows share one cumulative reducer identity. Keep the
+        // authoritative prefix stable and project the complete terminal tail after it.
+        discardStreamSegmentIndexes(state, boundary.replacedSegmentIndexes);
+        let visibleMessages = materializeVisibleStream({ includeCurrent: false });
+        clearToolStreamSegments(state);
+        if (boundary.tailMessage && !shouldHideAssistantChatMessage(boundary.tailMessage)) {
+          visibleMessages = appendTerminalAssistantMessage(
+            visibleMessages,
+            rememberLiveTerminalRun(
+              boundary.tailMessage,
+              terminalRunId,
+              boundary.afterBoundaryRunId,
+            ),
+          );
+          publishVisibleFinal(boundary.tailMessage, visibleMessages, terminalRunId, true);
+        } else {
+          publishChatSessionProjectionMessages(state, visibleMessages, { scope });
+        }
+      } else if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
+        let visibleMessages = state.chatMessages;
+        if (
+          hasVisibleStreamParts(state, {
+            includeCurrent: true,
+            isHiddenStreamText: isHiddenAssistantStreamText,
+          })
+        ) {
+          visibleMessages = materializeVisibleStream();
+          clearToolStreamSegments(state);
+        }
+        const liveFinal = rememberLiveTerminalRun(
+          finalMessage,
+          terminalRunId,
+          terminalAfterBoundaryRunId,
+        );
+        publishVisibleFinal(
+          finalMessage,
+          appendTerminalAssistantMessage(visibleMessages, liveFinal),
+          terminalRunId,
+        );
+      } else {
+        state.chatMessages = materializeVisibleStream();
+      }
     }
     if (payload.yielded === true && payload.stopReason === "end_turn") {
       reconcileChatRunLifecycle(state, {
@@ -430,7 +460,10 @@ function handleChatEvent(
         replacementMessages: [normalizedMessage],
         includeCurrent: false,
       });
-      state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, normalizedMessage);
+      state.chatMessages = appendTerminalAssistantMessage(
+        state.chatMessages,
+        rememberLiveTerminalRun(normalizedMessage, terminalRunId, terminalAfterBoundaryRunId),
+      );
     } else {
       state.chatMessages = materializeVisibleStream();
     }
@@ -467,7 +500,11 @@ function handleChatEvent(
           }
           state.chatMessages = appendTerminalAssistantMessage(
             state.chatMessages,
-            visiblePayloadMessage,
+            rememberLiveTerminalRun(
+              visiblePayloadMessage,
+              terminalRunId,
+              terminalAfterBoundaryRunId,
+            ),
           );
         } else {
           state.chatMessages = materializeVisibleStream({ includeCurrent: true });
@@ -494,7 +531,6 @@ function handleChatEvent(
 
 export function handleChatGatewayEvent(state: ChatState, payload?: ChatEventPayload) {
   const activeRunIdBeforeEvent = state.chatRunId;
-  let terminalKeyedStreamStartIndex: number | undefined;
   const terminalEventMatchesChat =
     isTerminalChatState(payload?.state) &&
     payload !== undefined &&
@@ -505,34 +541,14 @@ export function handleChatGatewayEvent(state: ChatState, payload?: ChatEventPayl
       (typeof payload.runId === "string" && payload.runId === activeRunIdBeforeEvent));
   const terminalOwnsActiveRun =
     terminalEventMatchesChat && !isEventForDifferentActiveRun(payload, activeRunIdBeforeEvent);
-  const localOnlySteerBoundary = terminalOwnsActiveRun
-    ? streamReconciliationStartIndex(state.chatMessages)
-    : undefined;
   // An accepted steer terminal is keyed by the steer request while the chip
   // also tracks the active target run. Reconcile either identity before the
   // generic different-run path ignores the terminal and leaves stale status.
-  let firstPersistedSteerIndex = terminalOwnsActiveRun
-    ? retireSteeredChipsForTerminalRun(state, payload?.runId)
-    : undefined;
-  const requestRunSteerIndex = terminalEventMatchesChat
-    ? retireSteeredChipsForRequestRun(state, payload?.runId)
-    : undefined;
-  if (
-    requestRunSteerIndex !== undefined &&
-    (firstPersistedSteerIndex === undefined || requestRunSteerIndex < firstPersistedSteerIndex)
-  ) {
-    firstPersistedSteerIndex = requestRunSteerIndex;
-  }
   if (terminalOwnsActiveRun) {
-    // The active stream belongs to the user boundary that preceded any steer
-    // chip retired below. Preserve that boundary through terminal materialization.
-    terminalKeyedStreamStartIndex =
-      firstPersistedSteerIndex === undefined
-        ? localOnlySteerBoundary
-        : streamReconciliationStartIndex(state.chatMessages, firstPersistedSteerIndex);
+    retireSteeredChipsForTerminalRun(state, payload?.runId);
   }
-  const result = handleChatEvent(state, payload, {
-    keyedStreamStartIndex: terminalKeyedStreamStartIndex,
-  });
-  return result;
+  if (terminalEventMatchesChat) {
+    retireSteeredChipsForRequestRun(state, payload?.runId);
+  }
+  return handleChatEvent(state, payload);
 }

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -1,10 +1,17 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { extractText } from "../../lib/chat/message-extract.ts";
 import { handleChatGatewayEvent } from "./chat-gateway.ts";
 import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import { buildChatItems } from "./chat-thread-build.ts";
+import {
+  getChatSessionProjection,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+  setChatSessionProjection,
+} from "./history-merge.ts";
 import { handleAgentEvent, type ToolStreamEntry } from "./tool-stream.ts";
 
 type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
@@ -226,7 +233,10 @@ describe("chat history in-flight assistant recovery", () => {
       {
         role: "user",
         content: "Also check the result.",
-        __openclaw: { idempotencyKey: "run-steer:user" },
+        __openclaw: {
+          idempotencyKey: "run-steer:user",
+          steerTargetRunId: "run-reconnected",
+        },
       },
     ];
     history.inFlightRun!.text = "Saved opening. Still working after the steer.";
@@ -237,6 +247,198 @@ describe("chat history in-flight assistant recovery", () => {
     expect(state.chatRunId).toBe("run-reconnected");
     expect(state.chatStream).toBe(" Still working after the steer.");
     expect(state.chatMessages).toEqual(history.messages);
+  });
+
+  it("replaces a pre-steer segment while retaining only the post-steer live tail", async () => {
+    const history = activeHistory("run-reconnected");
+    const originalUser = {
+      role: "user",
+      content: "Start working.",
+      __openclaw: { idempotencyKey: "run-reconnected:user" },
+    };
+    const steerUser = {
+      role: "user",
+      content: "Also check the result.",
+      __openclaw: {
+        idempotencyKey: "run-steer:user",
+        steerTargetRunId: "run-reconnected",
+      },
+    };
+    history.messages = [
+      originalUser,
+      {
+        role: "assistant",
+        content: "Saved opening.",
+        __openclaw: { idempotencyKey: "run-reconnected" },
+      },
+      steerUser,
+    ];
+    history.inFlightRun!.text = "Saved opening. Still working after the steer.";
+    const state = createState(history);
+    state.chatMessages = [originalUser, steerUser];
+    state.chatRunId = "run-reconnected";
+    handleChatGatewayEvent(state, {
+      runId: "run-reconnected",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Saved opening. Still working after the steer.",
+      message: {
+        role: "assistant",
+        content: "Saved opening. Still working after the steer.",
+      },
+    });
+    state.chatStreamSegments = [
+      {
+        text: "Saved opening.",
+        ts: 2,
+        runId: "run-reconnected",
+        boundaryRunId: "run-steer",
+      },
+    ];
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual(history.messages);
+    expect(state.chatStreamSegments).toEqual([
+      expect.objectContaining({
+        text: "",
+        boundaryMarker: true,
+        boundaryRunId: "run-steer",
+      }),
+    ]);
+    expect(state.chatStream).toBe(" Still working after the steer.");
+
+    handleChatGatewayEvent(state, {
+      runId: "run-reconnected",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Saved opening. Still working after the steer." }],
+      },
+    });
+    expect(state.chatMessages).toHaveLength(4);
+    expect(state.chatMessages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Still working after the steer." }],
+    });
+  });
+
+  it("falls back from a trimmed live boundary to the persisted cumulative prefix", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      {
+        role: "user",
+        content: "Start working.",
+        __openclaw: { idempotencyKey: "run-reconnected:user", seq: 1 },
+      },
+      {
+        role: "assistant",
+        content: "Saved opening.",
+        __openclaw: { id: "saved-opening", idempotencyKey: "run-reconnected", seq: 2 },
+      },
+      {
+        role: "user",
+        content: "Also check the result.",
+        __openclaw: {
+          idempotencyKey: "run-steer:user",
+          seq: 3,
+          steerTargetRunId: "run-reconnected",
+        },
+      },
+      {
+        role: "user",
+        content: "Queued follow-up.",
+        __openclaw: { idempotencyKey: "queued-run:user", seq: 4 },
+      },
+    ];
+    history.inFlightRun!.text = "Saved opening. Trimmed live tail.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+    expect(state.chatStream).toBe(" Trimmed live tail.");
+    const renderedBeforeTerminal = buildChatItems({
+      paneId: "reconnected-steer-boundary",
+      sessionKey: state.sessionKey,
+      runId: state.chatRunId,
+      messages: state.chatMessages,
+      toolMessages: state.chatToolMessages,
+      streamSegments: state.chatStreamSegments,
+      stream: state.chatStream,
+      streamStartedAt: state.chatStreamStartedAt,
+      showToolCalls: true,
+    }).flatMap((item) =>
+      item.kind === "group"
+        ? item.messages.map(({ message }) => extractText(message))
+        : item.kind === "stream"
+          ? [item.text.trim()]
+          : [],
+    );
+    expect(renderedBeforeTerminal).toEqual([
+      "Start working.",
+      "Saved opening.",
+      "Also check the result.",
+      "Trimmed live tail.",
+      "Queued follow-up.",
+    ]);
+    handleChatGatewayEvent(state, {
+      runId: "run-reconnected",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Saved opening. Trimmed live tail. Final unseen suffix.",
+          },
+        ],
+      },
+    });
+
+    expect(
+      state.chatMessages.map((message) => ({
+        role: (message as { role?: unknown }).role,
+        text: extractText(message),
+      })),
+    ).toEqual([
+      { role: "user", text: "Start working." },
+      { role: "assistant", text: "Saved opening." },
+      { role: "user", text: "Also check the result." },
+      { role: "assistant", text: "Trimmed live tail. Final unseen suffix." },
+      { role: "user", text: "Queued follow-up." },
+    ]);
+
+    reduceChatSessionProjection(
+      state,
+      {
+        type: "messagePersisted",
+        message: {
+          role: "user",
+          content: "Later authoritative user.",
+          __openclaw: {
+            id: "later-authoritative-user",
+            idempotencyKey: "later-run:user",
+            seq: 6,
+          },
+        },
+        envelope: { messageId: "later-authoritative-user", messageSeq: 6 },
+      },
+      { scope: readChatSessionProjectionScope(state), runActive: false },
+    );
+
+    const visible = state.chatMessages.map((message) => extractText(message));
+    expect(visible).toEqual([
+      "Start working.",
+      "Saved opening.",
+      "Also check the result.",
+      "Trimmed live tail. Final unseen suffix.",
+      "Queued follow-up.",
+      "Later authoritative user.",
+    ]);
+    expect(
+      visible.filter((text) => text === "Trimmed live tail. Final unseen suffix."),
+    ).toHaveLength(1);
   });
 
   it("does not trim a matching assistant prefix owned by an earlier run", async () => {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,7 +1,4 @@
-import {
-  readSessionMessageIdentity,
-  readSessionMessageSequence,
-} from "@openclaw/gateway-client/browser";
+import { readSessionMessageSequence } from "@openclaw/gateway-client/browser";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -70,17 +67,25 @@ import {
 } from "./session-message-cache.ts";
 import { retirePersistedSteeredChips } from "./steer-lifecycle.ts";
 import {
+  latestPersistedSteerBoundary,
+  markChatStreamAfterBoundary,
+  resolveCumulativeAssistantTail,
+} from "./stream-causal-boundary.ts";
+import {
   clearToolStreamSegments,
   currentLiveToolCallIds,
   hasVisibleStreamParts,
   historyReplacedVisibleStream,
   materializeVisibleStreamState,
   maybeResetToolStream,
-  persistedCurrentToolStreamIds,
-  prunePersistedToolStreamMessages,
   visibleCurrentAssistantStreamTail,
 } from "./stream-reconciliation.ts";
+import {
+  pruneHistoryReplacedStreamSegments,
+  prunePersistedToolStreamMessages,
+} from "./stream-segment-pruning.ts";
 import { reconcileAuthoritativeTerminalHistory } from "./terminal-message-identity.ts";
+import { persistedCurrentToolStreamIds } from "./tool-stream-identity.ts";
 import { handleAgentEvent, normalizePlanSnapshot, type PlanStatus } from "./tool-stream.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
@@ -242,7 +247,6 @@ export function materializeVisibleAssistantStreamMessages(
     requirePersistedTool?: boolean;
     replacementMessages?: unknown[];
     persistCommentary?: boolean;
-    keyedStartIndex?: number;
   } = {},
 ): unknown[] {
   return materializeVisibleStreamState(messages, state, {
@@ -328,79 +332,7 @@ function resolveInFlightAssistantTail(
   ) {
     return null;
   }
-
-  // A steered user turn can follow an assistant from the still-active run.
-  // Persisted run identity, not the latest user boundary, owns that prefix.
-  const ownedPrefixIndex = messages.findIndex((message) => {
-    const identity = readSessionMessageIdentity(message);
-    const persistedText = identity?.runId === runId ? extractText(message) : null;
-    return (
-      identity?.role === "assistant" &&
-      Boolean(
-        persistedText &&
-        (bufferedText.startsWith(persistedText) || persistedText.startsWith(bufferedText)),
-      )
-    );
-  });
-  let turnStart = ownedPrefixIndex === -1 ? 0 : ownedPrefixIndex;
-  if (ownedPrefixIndex === -1) {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const message = messages[index];
-      if (
-        message &&
-        typeof message === "object" &&
-        normalizeLowercaseStringOrEmpty((message as Record<string, unknown>).role) === "user"
-      ) {
-        turnStart = index + 1;
-        break;
-      }
-    }
-  }
-
-  let persistedPrefixLength = 0;
-  for (let index = turnStart; index < messages.length; index += 1) {
-    const message = messages[index];
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const identity = readSessionMessageIdentity(message);
-    if (identity?.role !== "assistant" || (identity.runId && identity.runId !== runId)) {
-      continue;
-    }
-
-    const persistedText = extractText(message);
-    if (!persistedText) {
-      continue;
-    }
-    // One tool-using turn may persist several assistant segments; the Gateway
-    // buffer includes them all, so matching only its newest row duplicates text.
-    const remainingText = bufferedText.slice(persistedPrefixLength);
-    if (remainingText.startsWith(persistedText)) {
-      persistedPrefixLength += persistedText.length;
-      continue;
-    }
-    // History can persist past a live delta while its request is pending.
-    // That older cumulative buffer is already rendered by the persisted row.
-    if (persistedText.startsWith(remainingText)) {
-      return null;
-    }
-    const whitespace = /^\s+/u.exec(remainingText)?.[0];
-    if (persistedPrefixLength > 0 && whitespace) {
-      const remainingAfterWhitespace = remainingText.slice(whitespace.length);
-      if (remainingAfterWhitespace.startsWith(persistedText)) {
-        persistedPrefixLength += whitespace.length + persistedText.length;
-        continue;
-      }
-      if (persistedText.startsWith(remainingAfterWhitespace)) {
-        return null;
-      }
-    }
-    if (persistedPrefixLength > 0) {
-      break;
-    }
-  }
-
-  const tail = bufferedText.slice(persistedPrefixLength);
+  const tail = resolveCumulativeAssistantTail(messages, bufferedText, runId);
   return tail && !isHiddenAssistantStreamText(tail) ? tail : null;
 }
 
@@ -1631,7 +1563,7 @@ async function loadChatHistoryUncached(
     state.chatQueueModeOverride = res.sessionInfo?.queueMode;
     state.chatEffectiveQueueMode = res.sessionInfo?.effectiveQueueMode;
     const planStatusBeforeStreamReset = state.planStatus ?? null;
-    const activeStreamBeforeReset = state.chatRunId ? state.chatStream : null;
+    let activeStreamBeforeReset = state.chatRunId ? state.chatStream : null;
     const resetStream = !state.chatRunId || state.chatRunId === previousRunId;
     if (resetStream) {
       const streamReconciliation = {
@@ -1645,6 +1577,9 @@ async function loadChatHistoryUncached(
         state,
         streamReconciliation,
       );
+      if (pruneHistoryReplacedStreamSegments(state.chatMessages, state, streamReconciliation)) {
+        activeStreamBeforeReset = state.chatStream;
+      }
       const liveToolIds = currentLiveToolCallIds(state);
       if (state.chatRunId && (hasVisibleStream || liveToolIds.length > 0)) {
         state.chatRunStartup = { state: "activity", runId: state.chatRunId };
@@ -1761,6 +1696,14 @@ async function loadChatHistoryUncached(
       const tail = mergeInFlightAssistantTails(snapshotTail, liveTail);
       state.chatStream = tail;
       state.chatStreamStartedAt = snapshotStartedAt ?? state.chatStreamStartedAt ?? Date.now();
+      const persistedBoundary = latestPersistedSteerBoundary(state.chatMessages, inFlightRunId);
+      if (tail && persistedBoundary) {
+        markChatStreamAfterBoundary(state, {
+          runId: inFlightRunId,
+          boundaryRunId: persistedBoundary.runId,
+          timestamp: state.chatStreamStartedAt,
+        });
+      }
       state.chatRunStartup = { state: "activity", runId: inFlightRunId };
       // Disconnect cleanup intentionally removes transient activity rows while
       // retaining the owned run. Replay fills that gap; per-identity sequence

--- a/ui/src/pages/chat/chat-page-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-page-attachment-handoff.test.ts
@@ -11,7 +11,8 @@ vi.mock("../../app/native-gateways.runtime.ts", () => ({
 import type { ApplicationContext } from "../../app/context.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { ChatPage } from "./chat-page.ts";
-import { insertPane, type ChatSplitLayout } from "./split-layout.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
+import { insertPane } from "./split-layout.ts";
 
 type RenderedPane = HTMLElement & {
   paneId: string;

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -12,7 +12,7 @@ import { routeDraft } from "./route-draft.ts";
 import type { SessionChatRouteData } from "./route-loader.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
-import type { ChatSplitPane } from "./split-layout.ts";
+import type { ChatSplitPane } from "./split-layout-types.ts";
 
 type ChatPagePaneRenderOptions = {
   active: boolean;

--- a/ui/src/pages/chat/chat-page-retained-sessions.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.ts
@@ -6,7 +6,8 @@ import {
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { clearPaneSessionHandoff, clearPaneSessionHandoffs } from "./chat-pane-shared.ts";
 import type { ChatPaneElement } from "./route-draft-focus-handoff.ts";
-import { findPane, type ChatSplitLayout, type ChatSplitPane } from "./split-layout.ts";
+import type { ChatSplitLayout, ChatSplitPane } from "./split-layout-types.ts";
+import { findPane } from "./split-layout.ts";
 
 const RETAINED_SESSIONS_PER_PANE = 3;
 const SESSION_NAVIGATION_PREVIEW_TIMEOUT_MS = 5_000;

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -46,7 +46,8 @@ const sessionPath = (sessionKey: string) =>
   sessionNavigationTarget({ face: "chat", sessionKey, fallbackAgentId: "main" }).options.pathname;
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import type { SplitDropZone } from "./split-drop-zone.ts";
-import { insertPane, type ChatSplitLayout } from "./split-layout.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
+import { insertPane } from "./split-layout.ts";
 
 type RenderedPane = HTMLElement & {
   paneId: string;

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -37,6 +37,7 @@ import {
   type SplitDropRect,
   type SplitDropZone,
 } from "./split-drop-zone.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
 import {
   applyUiCommandToSplitLayout,
   closePane,
@@ -50,7 +51,6 @@ import {
   singlePaneLayout,
   splitRatio,
   splitWeight,
-  type ChatSplitLayout,
 } from "./split-layout.ts";
 
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -21,7 +21,7 @@ import {
 import { createTestChatPane } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
-import type { ChatSplitLayout } from "./split-layout.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
 
 function storedAttachment(id: string, mimeType = "image/png"): ChatAttachment {
   return registerChatAttachmentPayload({

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -6,7 +6,8 @@ import {
 } from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
-import { panesOf, type ChatSplitLayout, visiblePanesOf } from "./split-layout.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
+import { panesOf, visiblePanesOf } from "./split-layout.ts";
 
 export type ChatAttachmentGatewayOwner = ApplicationContext["gateway"]["snapshot"]["client"];
 

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -14,6 +14,7 @@ import {
   buildSlashCommandsFromEntries,
   replaceSlashCommands,
 } from "../../lib/chat/commands.ts";
+import { extractText } from "../../lib/chat/message-extract.ts";
 import { createResolvedModelPatch } from "../../test-helpers/chat-model.ts";
 import {
   createTestGatewayClient,
@@ -40,6 +41,7 @@ import {
 } from "./chat-session.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { buildChatItems } from "./chat-thread-build.ts";
 import {
   admitStoredChatComposerQueueItem,
   listStoredChatOutboxes,
@@ -9217,9 +9219,14 @@ describe("handleSendChat", () => {
 
   it("removes queued steer indicators when chat.send returns terminal ok", async () => {
     const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
+    let steerRequestRunId: string | undefined;
     const host = makeChatHost({
       requestHandlers: {
-        "chat.send": { status: "ok", runId: "steer-ok" },
+        "chat.send": (params: unknown) => {
+          const payload = requireRecord(params, "terminal steer payload");
+          steerRequestRunId = String(payload.idempotencyKey);
+          return { status: "ok", runId: "steer-ok" };
+        },
       },
       chatRunId: "run-1",
       chatDisplayedLeafEntryId: "leaf-active",
@@ -9232,7 +9239,39 @@ describe("handleSendChat", () => {
     await steerQueuedChatMessage(host, "queued-1");
 
     expect(host.chatRunId).toBe("run-1");
-    expect(host.chatStream).toBe("Working...");
+    expect(host.chatStream).toBeNull();
+    expect(host.chatStreamSegments).toEqual([
+      {
+        text: "Working...",
+        ts: expect.any(Number),
+        runId: "run-1",
+        boundaryRunId: steerRequestRunId,
+      },
+    ]);
+    expect(host.chatMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        __openclaw: { idempotencyKey: `${steerRequestRunId}:user` },
+      }),
+    ]);
+    const renderedText = buildChatItems({
+      paneId: "terminal-steer",
+      sessionKey: host.sessionKey,
+      runId: host.chatRunId,
+      messages: host.chatMessages,
+      toolMessages: host.chatToolMessages,
+      streamSegments: host.chatStreamSegments,
+      stream: host.chatStream,
+      streamStartedAt: host.chatStreamStartedAt,
+      showToolCalls: true,
+    }).flatMap((item) =>
+      item.kind === "stream"
+        ? [item.text]
+        : item.kind === "group"
+          ? item.messages.map(({ message }) => extractText(message))
+          : [],
+    );
+    expect(renderedText).toEqual(["Working...", "tighten the plan"]);
     expect(host.chatQueue).toStrictEqual([]);
     expect(host.applySettings).toHaveBeenCalledWith(
       expect.objectContaining({ lastActiveSessionKey: "agent:main:main" }),

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -58,6 +58,7 @@ import {
   retireSteeredChipsForTerminalRun,
 } from "./steer-lifecycle.ts";
 import { isAckedSteeredChip } from "./steered-chip.ts";
+import { persistedSteerTargetRunId, rolloverChatStream } from "./stream-causal-boundary.ts";
 import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
 
@@ -122,11 +123,25 @@ function applyLiveSessionMessage(
     },
   };
   const scope = readChatSessionProjectionScope(state, { agentId: resolveChatAgentId(state) });
-  reduceChatSessionProjection(
+  const previousMessageCount = state.chatMessages.length;
+  const projection = reduceChatSessionProjection(
     state,
     { type: "messagePersisted", message, envelope: event },
     { scope, runActive },
   );
+  if (
+    incoming.role === "user" &&
+    runActive === true &&
+    state.chatRunId &&
+    incoming.runId &&
+    persistedSteerTargetRunId(message) === state.chatRunId &&
+    projection.messages.length > previousMessageCount
+  ) {
+    rolloverChatStream(state, {
+      runId: state.chatRunId,
+      boundaryRunId: incoming.runId,
+    });
+  }
 }
 
 function selectedGlobalEventAgentId(state: ChatPageHost, agentId: string | null): string {

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -8,7 +8,11 @@ import type {
 import type { ApplicationContext } from "../../app/context.ts";
 import type { UiSettings } from "../../app/settings.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
-import type { ChatComposerMemoryFallback, ChatGuardianNotice } from "../../lib/chat/chat-types.ts";
+import type {
+  ChatComposerMemoryFallback,
+  ChatGuardianNotice,
+  ChatStreamSegment,
+} from "../../lib/chat/chat-types.ts";
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import type { ChatState } from "./chat-history.ts";
 import type { ChatRealtimeState } from "./chat-realtime.ts";
@@ -78,7 +82,7 @@ export type ChatPageHost = ChatHost &
     pendingSessionMessageReloadSessionKey: string | null;
     chatSubmitGuards: Map<string, Promise<void>>;
     chatSendTimingsByRun: Map<string, ChatSendTimingEntry>;
-    chatStreamSegments: Array<{ text: string; ts: number }>;
+    chatStreamSegments: ChatStreamSegment[];
     toolStreamById: Map<string, ToolStreamEntry>;
     toolStreamOrder: string[];
     toolStreamSyncTimer: number | null;

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -352,6 +352,107 @@ describe("canonical session message recovery", () => {
     );
   });
 
+  it("keeps pre-steer output above an earlier ordinary queued user", () => {
+    const activeRunId = "active-run";
+    const originalPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Original prompt" }],
+      timestamp: 100,
+      __openclaw: {
+        id: "original-user",
+        idempotencyKey: `${activeRunId}:user`,
+        seq: 1,
+      },
+    };
+    const { state } = createSessionEventState({
+      connected: false,
+      chatMessages: [originalPrompt],
+      chatRunId: activeRunId,
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "delta",
+        deltaText: "Before steer.",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Before steer." }],
+        },
+      },
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: "queued-run",
+        hasActiveRun: true,
+        messageId: "ordinary-queued-user",
+        messageSeq: 2,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Queued follow-up" }],
+          timestamp: 200,
+          __openclaw: {
+            id: "ordinary-queued-user",
+            idempotencyKey: "queued-run:user",
+            seq: 2,
+          },
+        },
+      },
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: "steer-run",
+        hasActiveRun: true,
+        messageId: "persisted-steer-user",
+        messageSeq: 3,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Steer prompt" }],
+          timestamp: 300,
+          __openclaw: {
+            id: "persisted-steer-user",
+            idempotencyKey: "steer-run:user",
+            seq: 3,
+            steerTargetRunId: activeRunId,
+          },
+        },
+      },
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "delta",
+        deltaText: " After steer.",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Before steer. After steer." }],
+        },
+      },
+    });
+
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Original prompt" },
+      { role: "assistant", text: "Before steer." },
+      { role: "user", text: "Queued follow-up" },
+      { role: "user", text: "Steer prompt" },
+      { role: "assistant", text: "After steer." },
+    ]);
+  });
+
   it("keeps a previous run final before a newer active user turn", () => {
     const previousUser = {
       role: "user",

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -10,6 +10,8 @@ import {
   replaceSlashCommands,
   SLASH_COMMANDS,
 } from "../../lib/chat/commands.ts";
+import { extractText } from "../../lib/chat/message-extract.ts";
+import { applyRemoteSlashCommandsResult } from "./chat-commands.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
@@ -21,6 +23,8 @@ import {
   retireChatMetadataRequests,
 } from "./chat-state-refresh.ts";
 import { resolveChatAvatarUrl, selectedChatSessionRow } from "./chat-state-route.ts";
+import { buildChatItems } from "./chat-thread-build.ts";
+import { getChatSessionProjection } from "./history-merge.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
 
 beforeEach(() => {
@@ -60,6 +64,28 @@ describe("canonical session message recovery", () => {
       ...overrides,
     } as unknown as ChatPageHost;
     return { request, state };
+  }
+
+  function renderedTranscript(state: ChatPageHost) {
+    return buildChatItems({
+      paneId: "test",
+      sessionKey: state.sessionKey,
+      runId: state.chatRunId,
+      messages: state.chatMessages,
+      toolMessages: state.chatToolMessages,
+      streamSegments: state.chatStreamSegments,
+      stream: state.chatStream,
+      streamStartedAt: state.chatStreamStartedAt,
+      showToolCalls: true,
+    }).flatMap((item) => {
+      if (item.kind === "group") {
+        return item.messages.map(({ message }) => ({
+          role: item.role,
+          text: extractText(message),
+        }));
+      }
+      return item.kind === "stream" ? [{ role: "assistant", text: item.text }] : [];
+    });
   }
 
   it("rejects envelope-only sequence for an incomplete imported user identity", () => {
@@ -105,6 +131,226 @@ describe("canonical session message recovery", () => {
     expect(state.chatMessages[0]).toMatchObject({
       __openclaw: { importedFrom: "claude-cli", externalId: "source-local-user", seq: 3 },
     });
+  });
+
+  it("keeps cumulative assistant output split across an authoritative steer", () => {
+    const activeRunId = "active-run";
+    const steerRunId = "steer-request";
+    const originalPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Original prompt" }],
+      timestamp: 100,
+      __openclaw: {
+        id: "original-user",
+        idempotencyKey: `${activeRunId}:user`,
+        seq: 1,
+      },
+    };
+    const { state } = createSessionEventState({
+      connected: false,
+      chatMessages: [originalPrompt],
+      chatQueue: [
+        {
+          id: "landed-steer",
+          text: "Steer prompt",
+          createdAt: 50,
+          kind: "steered",
+          pendingRunId: steerRunId,
+          sendRunId: steerRunId,
+          steerTargetRunId: activeRunId,
+          sessionKey: "agent:main:main",
+        },
+      ],
+      chatRunId: activeRunId,
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "delta",
+        deltaText: "Before steer.",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Before steer." }],
+        },
+      },
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: steerRunId,
+        state: "final",
+      },
+    });
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Original prompt" },
+      { role: "assistant", text: "Before steer." },
+      { role: "user", text: "Steer prompt" },
+    ]);
+    expect(state.chatRunId).toBe(activeRunId);
+    expect(state.chatQueue).toEqual([]);
+    const segmentsAfterRequestBoundary = state.chatStreamSegments;
+
+    const steerEvent = {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: activeRunId,
+        hasActiveRun: true,
+        messageId: "persisted-steer-user",
+        messageSeq: 2,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Steer prompt" }],
+          timestamp: 50,
+          __openclaw: {
+            id: "persisted-steer-user",
+            idempotencyKey: `${steerRunId}:user`,
+            seq: 2,
+            steerTargetRunId: activeRunId,
+          },
+        },
+      },
+    } satisfies Parameters<typeof handlePageGatewayEvent>[1];
+    handlePageGatewayEvent(state, steerEvent);
+    expect(state.chatStreamSegments).toBe(segmentsAfterRequestBoundary);
+    expect(
+      state.chatMessages.filter((message) => extractText(message) === "Steer prompt"),
+    ).toHaveLength(1);
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "delta",
+        deltaText: " After steer.",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Before steer. After steer." }],
+        },
+      },
+    });
+
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Original prompt" },
+      { role: "assistant", text: "Before steer." },
+      { role: "user", text: "Steer prompt" },
+      { role: "assistant", text: "After steer." },
+    ]);
+
+    handlePageGatewayEvent(state, steerEvent);
+    expect(state.chatStreamSegments).toBe(segmentsAfterRequestBoundary);
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Before steer. After steer. Final unseen suffix." }],
+        },
+      },
+    });
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Original prompt" },
+      { role: "assistant", text: "Before steer." },
+      { role: "user", text: "Steer prompt" },
+      { role: "assistant", text: "After steer. Final unseen suffix." },
+    ]);
+  });
+
+  it("keeps an ordinary queued user after the active run assistant", () => {
+    const activeRunId = "active-run";
+    const originalPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Original prompt" }],
+      __openclaw: {
+        id: "original-user",
+        idempotencyKey: `${activeRunId}:user`,
+        seq: 1,
+      },
+    };
+    const { state } = createSessionEventState({
+      connected: false,
+      chatMessages: [originalPrompt],
+      chatRunId: activeRunId,
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "delta",
+        deltaText: "Active reply.",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Active reply." }],
+        },
+      },
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: "queued-run",
+        hasActiveRun: true,
+        messageId: "ordinary-queued-user",
+        messageSeq: 2,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Queued follow-up" }],
+          __openclaw: {
+            id: "ordinary-queued-user",
+            idempotencyKey: "queued-run:user",
+            seq: 2,
+          },
+        },
+      },
+    });
+
+    expect(state.chatStream).toBe("Active reply.");
+    expect(state.chatStreamSegments).toEqual([]);
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Active reply. Final suffix." }],
+        },
+      },
+    });
+
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Original prompt" },
+      { role: "assistant", text: "Active reply. Final suffix." },
+      { role: "user", text: "Queued follow-up" },
+    ]);
+    expect(getChatSessionProjection(state, state.chatMessages).messages).toEqual(
+      state.chatMessages,
+    );
   });
 
   it("keeps a previous run final before a newer active user turn", () => {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -11,7 +11,6 @@ import {
   SLASH_COMMANDS,
 } from "../../lib/chat/commands.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
-import { applyRemoteSlashCommandsResult } from "./chat-commands.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -1,10 +1,5 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  isToolCallContentType,
-  isToolResultContentType,
-  resolveToolUseId,
-} from "../../../../src/chat/tool-content.js";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import { t } from "../../i18n/index.ts";
 import {
@@ -65,10 +60,9 @@ import { chatMessagesContainQueuedSend } from "./steer-lifecycle.ts";
 import { resolveSystemNoticeKind } from "./system-notice-kinds.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
 import {
+  buildLiveRenderedToolRefs,
   buildToolStreamIdentity,
-  extractToolMessageRefs,
-  resolveMatchingLiveToolIdentity,
-  type LiveToolStreamRef,
+  removeLiveToolBlocksFromHistory,
 } from "./tool-stream-identity.ts";
 import type { PlanStatus } from "./tool-stream.ts";
 
@@ -190,51 +184,10 @@ function resolveRunInsertionBounds(
   return currentTurnBounds?.afterKey ? { beforeKey: currentTurnBounds.afterKey } : null;
 }
 
-function liveRenderedToolRefs(toolMessages: unknown[]): LiveToolStreamRef[] {
-  const refs: LiveToolStreamRef[] = [];
-  const seen = new Set<string>();
-  for (const [index, message] of toolMessages.entries()) {
-    for (const ref of extractToolMessageRefs(message)) {
-      const key = JSON.stringify([ref.runId ?? null, ref.id]);
-      if (seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-      refs.push({ ...ref, identity: `live:${index}:${key}` });
-    }
-  }
-  return refs;
-}
-
-function removeLiveToolBlocksFromHistory(
-  message: unknown,
-  liveToolRefs: LiveToolStreamRef[],
-): unknown {
-  const record = asRecord(message);
-  if (!record || !Array.isArray(record.content) || liveToolRefs.length === 0) {
-    return message;
-  }
-  const topLevelToolId = resolveToolUseId({ ...record, id: undefined });
-  const topLevelRunId = normalizeOptionalString(record.runId);
-  const content = record.content.filter((block) => {
-    const entry = asRecord(block);
-    if (!entry || (!isToolCallContentType(entry.type) && !isToolResultContentType(entry.type))) {
-      return true;
-    }
-    const id = resolveToolUseId(entry) ?? topLevelToolId;
-    if (!id) {
-      return true;
-    }
-    const runId = normalizeOptionalString(entry.runId) ?? topLevelRunId;
-    return !resolveMatchingLiveToolIdentity({ id, ...(runId ? { runId } : {}) }, liveToolRefs);
-  });
-  return content.length === record.content.length ? message : { ...record, content };
-}
-
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
   const tools = props.toolMessages.filter((message) => asRecord(message) !== null);
-  const liveToolRefs = liveRenderedToolRefs(tools);
+  const liveToolRefs = buildLiveRenderedToolRefs(tools);
   const history = props.messages
     .filter(
       (message) =>

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -720,11 +720,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         startedAt: timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now()),
         isStreaming: true,
       };
-      const afterBoundaryBounds = latestBoundaryRunId
-        ? findRunTurnBounds(items, latestBoundaryRunId)
-        : null;
-      if (afterBoundaryBounds) {
-        const { maximum } = insertionIndexesForBounds(items, afterBoundaryBounds);
+      const liveTurnRunId = latestBoundaryRunId ?? normalizeOptionalString(props.runId);
+      const liveTurnBounds = liveTurnRunId ? findRunTurnBounds(items, liveTurnRunId) : null;
+      if (liveTurnBounds) {
+        const { maximum } = insertionIndexesForBounds(items, liveTurnBounds);
         items.splice(maximum, 0, liveStreamItem);
       } else {
         items.push(liveStreamItem);

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -65,6 +65,7 @@ import { chatMessagesContainQueuedSend } from "./steer-lifecycle.ts";
 import { resolveSystemNoticeKind } from "./system-notice-kinds.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
 import {
+  buildToolStreamIdentity,
   extractToolMessageRefs,
   resolveMatchingLiveToolIdentity,
   type LiveToolStreamRef,
@@ -487,27 +488,66 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     (item) => item.kind !== "message" || hasRenderableNormalizedMessage(item.message),
   );
   const segments = props.streamSegments;
+  const afterBoundaryBySegment = new Map<ChatStreamSegment, string>();
+  let latestBoundaryRunId: string | undefined;
+  for (const segment of segments) {
+    const afterBoundaryRunId =
+      normalizeOptionalString(segment.afterBoundaryRunId) ?? latestBoundaryRunId;
+    if (afterBoundaryRunId) {
+      afterBoundaryBySegment.set(segment, afterBoundaryRunId);
+    }
+    latestBoundaryRunId = normalizeOptionalString(segment.boundaryRunId) ?? latestBoundaryRunId;
+  }
   const keyedSegments = segments.filter(streamSegmentHasItemId);
-  const indexedSegments = segments.filter((segment) => !streamSegmentHasItemId(segment));
+  const indexedSegments = segments.filter(
+    (segment) => !streamSegmentHasItemId(segment) && segment.boundaryMarker !== true,
+  );
   const toolItems = tools.map((message, index) => ({
     key: toolKeys[index] ?? messageKey(message, index + history.length),
     message,
   }));
-  const toolKeysByCallId = new Map<string, string>();
+  const toolKeysByIdentity = new Map<string, string>();
+  const uniqueToolKeysByCallId = new Map<string, string | null>();
+  const addUniqueBareValue = (
+    values: Map<string, string | null>,
+    toolCallId: string,
+    value: string,
+  ) => values.set(toolCallId, values.has(toolCallId) ? null : value);
   for (const tool of toolItems) {
-    const toolCallId = asRecord(tool.message)?.toolCallId;
+    const toolRecord = asRecord(tool.message);
+    const toolCallId = normalizeOptionalString(toolRecord?.toolCallId);
     if (typeof toolCallId === "string" && toolCallId.trim()) {
-      toolKeysByCallId.set(toolCallId.trim(), tool.key);
+      const runId = normalizeOptionalString(toolRecord?.runId);
+      if (runId) {
+        toolKeysByIdentity.set(buildToolStreamIdentity(runId, toolCallId), tool.key);
+      }
+      addUniqueBareValue(uniqueToolKeysByCallId, toolCallId, tool.key);
     }
   }
   const maxLen = Math.max(indexedSegments.length, tools.length);
   let previousAccumulatedStreamText: string | null = null;
   const toolStreamPredecessors = new Map<string, string>();
   const projectionInsertionBounds = new Map<string, TurnInsertionBounds>();
-  const applyRunBounds = (key: string, runId: unknown) => {
+  const applyRunBounds = (
+    key: string,
+    runId: unknown,
+    boundaryRunId?: string,
+    afterBoundaryRunId?: string,
+  ) => {
     const bounds = resolveRunInsertionBounds(items, runId, props.runId, currentTurnBounds);
-    if (bounds) {
-      projectionInsertionBounds.set(key, bounds);
+    const boundaryKey = boundaryRunId
+      ? findRunTurnBounds(items, boundaryRunId)?.afterKey
+      : undefined;
+    const afterBounds = afterBoundaryRunId
+      ? findRunTurnBounds(items, afterBoundaryRunId)
+      : undefined;
+    if (bounds || boundaryKey || afterBounds) {
+      projectionInsertionBounds.set(key, {
+        ...bounds,
+        ...(afterBounds?.afterKey ? { afterKey: afterBounds.afterKey } : {}),
+        ...(afterBounds?.beforeKey ? { beforeKey: afterBounds.beforeKey } : {}),
+        ...(boundaryKey ? { beforeKey: boundaryKey } : {}),
+      });
     }
   };
   if (!searchFiltering) {
@@ -517,6 +557,43 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       applyRunBounds(item.key, notice.runId);
     }
   }
+  const toolBoundariesByIdentity = new Map<string, string>();
+  const uniqueToolBoundariesByCallId = new Map<string, string | null>();
+  const toolAfterBoundariesByIdentity = new Map<string, string>();
+  const uniqueToolAfterBoundariesByCallId = new Map<string, string | null>();
+  for (const segment of indexedSegments) {
+    const toolCallId = normalizeOptionalString(segment.toolCallId);
+    const boundaryRunId = normalizeOptionalString(segment.boundaryRunId);
+    const afterBoundaryRunId = afterBoundaryBySegment.get(segment);
+    if (!toolCallId) {
+      continue;
+    }
+    const runId = normalizeOptionalString(segment.runId);
+    if (runId && boundaryRunId) {
+      toolBoundariesByIdentity.set(buildToolStreamIdentity(runId, toolCallId), boundaryRunId);
+    }
+    if (boundaryRunId) {
+      addUniqueBareValue(uniqueToolBoundariesByCallId, toolCallId, boundaryRunId);
+    }
+    if (runId && afterBoundaryRunId) {
+      toolAfterBoundariesByIdentity.set(
+        buildToolStreamIdentity(runId, toolCallId),
+        afterBoundaryRunId,
+      );
+    }
+    if (afterBoundaryRunId) {
+      addUniqueBareValue(uniqueToolAfterBoundariesByCallId, toolCallId, afterBoundaryRunId);
+    }
+  }
+  const resolveScopedValue = (
+    exact: ReadonlyMap<string, string>,
+    bare: ReadonlyMap<string, string | null>,
+    runId: string | undefined,
+    toolCallId: string,
+  ) =>
+    (runId ? exact.get(buildToolStreamIdentity(runId, toolCallId)) : undefined) ??
+    bare.get(toolCallId) ??
+    undefined;
   for (let i = 0; i < maxLen; i++) {
     if (i < indexedSegments.length) {
       const segment = indexedSegments[i];
@@ -544,9 +621,21 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           isStreaming: false,
         };
         timestampedProjectionItems.push(streamItem);
-        applyRunBounds(streamItem.key, segment.runId);
+        applyRunBounds(
+          streamItem.key,
+          segment.runId,
+          segment.boundaryRunId,
+          afterBoundaryBySegment.get(segment),
+        );
         const toolCallId = segment.toolCallId?.trim();
-        const toolKey = toolCallId ? toolKeysByCallId.get(toolCallId) : undefined;
+        const toolKey = toolCallId
+          ? resolveScopedValue(
+              toolKeysByIdentity,
+              uniqueToolKeysByCallId,
+              normalizeOptionalString(segment.runId),
+              toolCallId,
+            )
+          : undefined;
         if (toolKey) {
           // Gateway and browser clocks can disagree. Keep the assistant text that
           // introduced a tool causally before its card even when timestamps do not.
@@ -562,7 +651,29 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         message: tool.message,
       };
       timestampedProjectionItems.push(toolItem);
-      applyRunBounds(toolItem.key, asRecord(tool.message)?.runId);
+      const toolRecord = asRecord(tool.message);
+      const toolCallId = normalizeOptionalString(toolRecord?.toolCallId);
+      const toolRunId = normalizeOptionalString(toolRecord?.runId);
+      applyRunBounds(
+        toolItem.key,
+        toolRunId,
+        toolCallId
+          ? resolveScopedValue(
+              toolBoundariesByIdentity,
+              uniqueToolBoundariesByCallId,
+              toolRunId,
+              toolCallId,
+            )
+          : undefined,
+        toolCallId
+          ? resolveScopedValue(
+              toolAfterBoundariesByIdentity,
+              uniqueToolAfterBoundariesByCallId,
+              toolRunId,
+              toolCallId,
+            )
+          : undefined,
+      );
     }
   }
   for (const segment of keyedSegments) {
@@ -578,7 +689,12 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       isStreaming: false,
     };
     timestampedProjectionItems.push(commentaryItem);
-    applyRunBounds(commentaryItem.key, segment.runId);
+    applyRunBounds(
+      commentaryItem.key,
+      segment.runId,
+      segment.boundaryRunId,
+      afterBoundaryBySegment.get(segment),
+    );
   }
 
   for (const prompt of props.questionPrompts ?? []) {
@@ -644,13 +760,22 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
     if (visibleText.length > 0 && !stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
       const liveProgress = resolveProgress();
-      items.push({
+      const liveStreamItem: ChatItem = {
         kind: "stream",
         key: liveProgress.key,
         text: visibleText,
         startedAt: timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now()),
         isStreaming: true,
-      });
+      };
+      const afterBoundaryBounds = latestBoundaryRunId
+        ? findRunTurnBounds(items, latestBoundaryRunId)
+        : null;
+      if (afterBoundaryBounds) {
+        const { maximum } = insertionIndexesForBounds(items, afterBoundaryBounds);
+        items.splice(maximum, 0, liveStreamItem);
+      } else {
+        items.push(liveStreamItem);
+      }
     }
   }
   if (showWorkingIndicator) {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -262,6 +262,105 @@ describe("assistant commentary grouping", () => {
     resetChatThreadState(paneId);
   });
 
+  it("scopes reused live tool IDs to their own run boundaries", () => {
+    const sharedToolCallId = "call-shared";
+    const groups = messageGroups({
+      runId: "run-a",
+      messages: [
+        userMessage("Run A", 1, { __openclaw: { idempotencyKey: "run-a:user" } }),
+        userMessage("Steer A", 2, { __openclaw: { idempotencyKey: "steer-a:user" } }),
+        userMessage("Run B", 3, { __openclaw: { idempotencyKey: "run-b:user" } }),
+        userMessage("Steer B", 4, { __openclaw: { idempotencyKey: "steer-b:user" } }),
+      ],
+      streamSegments: [
+        {
+          text: "Run A output",
+          ts: 100,
+          runId: "run-a",
+          toolCallId: sharedToolCallId,
+          boundaryRunId: "steer-a",
+        },
+        {
+          text: "Run B output",
+          ts: 101,
+          runId: "run-b",
+          toolCallId: sharedToolCallId,
+          boundaryRunId: "steer-b",
+        },
+      ],
+      toolMessages: [
+        toolResultMessage(sharedToolCallId, "shell", "Run A tool", 100, { runId: "run-a" }),
+        toolResultMessage(sharedToolCallId, "shell", "Run B tool", 101, { runId: "run-b" }),
+      ],
+    });
+    const groupIndex = (predicate: (message: Record<string, unknown>) => boolean) =>
+      groups.findIndex((group) =>
+        group.messages.some(({ message }) => predicate(requireRecord(message))),
+      );
+
+    const runAToolIndex = groupIndex((message) => message.runId === "run-a");
+    const runBToolIndex = groupIndex((message) => message.runId === "run-b");
+    const steerAIndex = groupIndex((message) => message.content === "Steer A");
+    const steerBIndex = groupIndex((message) => message.content === "Steer B");
+    expect(runAToolIndex).toBeGreaterThanOrEqual(0);
+    expect(runBToolIndex).toBeGreaterThanOrEqual(0);
+    expect(runAToolIndex).toBeLessThan(steerAIndex);
+    expect(runBToolIndex).toBeLessThan(steerBIndex);
+  });
+
+  it("keeps a post-steer tool segment and card after a textless steer", () => {
+    const toolCallId = "call-after-steer";
+    const items = buildCachedChatItems(
+      createProps({
+        runId: "active-run",
+        messages: [
+          userMessage("Original", 1, {
+            __openclaw: { idempotencyKey: "active-run:user" },
+          }),
+          userMessage("Steer", 2, {
+            __openclaw: {
+              idempotencyKey: "steer-run:user",
+              steerTargetRunId: "active-run",
+            },
+          }),
+        ],
+        streamSegments: [
+          {
+            text: "",
+            ts: 2,
+            runId: "active-run",
+            boundaryRunId: "steer-run",
+            boundaryMarker: true,
+          },
+          {
+            text: "After steer",
+            ts: 3,
+            runId: "active-run",
+            afterBoundaryRunId: "steer-run",
+            toolCallId,
+          },
+        ],
+        toolMessages: [
+          toolResultMessage(toolCallId, "shell", "Tool after steer", 4, {
+            runId: "active-run",
+          }),
+        ],
+      }),
+    );
+    const itemText = (item: (typeof items)[number]) =>
+      item.kind === "stream"
+        ? item.text
+        : item.kind === "group"
+          ? item.messages.map(({ message }) => JSON.stringify(message)).join(" ")
+          : "";
+    const steerIndex = items.findIndex((item) => itemText(item).includes("Steer"));
+    const segmentIndex = items.findIndex((item) => itemText(item).includes("After steer"));
+    const toolIndex = items.findIndex((item) => itemText(item).includes("Tool after steer"));
+
+    expect(segmentIndex).toBeGreaterThan(steerIndex);
+    expect(toolIndex).toBeGreaterThan(steerIndex);
+  });
+
   it("keeps current live work above a future queued user turn when it becomes stable", () => {
     const paneId = "clock-skew-future-queue-transition";
     const activeUser = userMessage("Active prompt", 2_000, {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -431,6 +431,30 @@ describe("assistant commentary grouping", () => {
     resetChatThreadState(paneId);
   });
 
+  it("keeps an active stream above an already persisted queued user", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        runId: "run-active",
+        messages: [
+          userMessage("Active prompt", 2_000, {
+            __openclaw: { idempotencyKey: "run-active:user" },
+          }),
+          userMessage("Queued follow-up", 3_000, {
+            __openclaw: { idempotencyKey: "run-future:user" },
+          }),
+        ],
+        stream: "Current partial reply",
+        streamStartedAt: 1_000,
+      }),
+    );
+
+    expect(items.map((item) => (item.kind === "group" ? item.role : item.kind))).toEqual([
+      "user",
+      "stream",
+      "user",
+    ]);
+  });
+
   it("keeps current-run segments below their user boundary under clock skew", () => {
     const items = buildCachedChatItems(
       createProps({

--- a/ui/src/pages/chat/chat-viewer-presence.ts
+++ b/ui/src/pages/chat/chat-viewer-presence.ts
@@ -1,6 +1,7 @@
 import type { ApplicationGateway } from "../../app/gateway.ts";
 import { sessionViewerPresenceForGateway } from "../../lib/session-viewer-presence.ts";
-import { visiblePanesOf, type ChatSplitLayout } from "./split-layout.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
+import { visiblePanesOf } from "./split-layout.ts";
 
 /** Moves a mounted chat page's viewer declaration between gateway lifecycles. */
 export class ChatViewerPresenceController {

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -106,6 +106,69 @@ export function setChatSessionProjection(owner: object, projection: SessionProje
   chatSessionProjections.set(owner, projection);
 }
 
+/** Publish one exact live transcript order without dropping reducer-owned entry identity. */
+export function publishChatSessionProjectionMessages(
+  owner: ChatSessionProjectionOwner,
+  messages: readonly unknown[],
+  options: {
+    event?: SessionProjectionEvent;
+    retainSupersededMessages?: boolean;
+    scope?: SessionProjectionScope;
+  } = {},
+): SessionProjectionState {
+  const scope = options.scope ?? readChatSessionProjectionScope(owner);
+  const base = getChatSessionProjection(owner, owner.chatMessages, scope);
+  const current = options.event ? reduceSessionProjection(base, { ...options.event, scope }) : base;
+  const eventMessage = options.event?.type === "messagePersisted" ? options.event.message : null;
+  const currentMessages = new Set(current.entries.map((entry) => entry.message));
+  const supersededMessages = options.retainSupersededMessages
+    ? new Set<unknown>()
+    : new Set(
+        base.entries
+          .filter((entry) => !currentMessages.has(entry.message))
+          .map((entry) => entry.message),
+      );
+  const eventAccepted = eventMessage === null || currentMessages.has(eventMessage);
+  const acceptedMessages: unknown[] = [];
+  let eventPublished = false;
+  for (const message of messages) {
+    if (supersededMessages.has(message)) {
+      if (eventAccepted && eventMessage !== null && !eventPublished) {
+        acceptedMessages.push(eventMessage);
+        eventPublished = true;
+      }
+      continue;
+    }
+    if (message === eventMessage) {
+      if (!eventAccepted || eventPublished) {
+        continue;
+      }
+      eventPublished = true;
+    }
+    acceptedMessages.push(message);
+  }
+  const remainingEntries = [...current.entries];
+  const seeded = createSessionProjection(scope, acceptedMessages);
+  const entries = seeded.entries.map((seededEntry) => {
+    const existingIndex = remainingEntries.findIndex(
+      (entry) => entry.message === seededEntry.message,
+    );
+    if (existingIndex < 0) {
+      return seededEntry;
+    }
+    return remainingEntries.splice(existingIndex, 1)[0] ?? seededEntry;
+  });
+  const projection: SessionProjectionState = {
+    ...current,
+    scope: { ...current.scope, ...scope },
+    entries,
+    messages: entries.map((entry) => entry.message),
+  };
+  setChatSessionProjection(owner, projection);
+  owner.chatMessages = [...projection.messages];
+  return projection;
+}
+
 function adoptInitialUserMessage(
   message: unknown,
   envelope: SessionMessageEnvelope | undefined,

--- a/ui/src/pages/chat/split-drop-zone.ts
+++ b/ui/src/pages/chat/split-drop-zone.ts
@@ -1,4 +1,4 @@
-import type { ChatSplitEdge } from "./split-layout.ts";
+import type { ChatSplitEdge } from "./split-layout-types.ts";
 
 export type SplitDropZone = { kind: "edge"; edge: ChatSplitEdge } | { kind: "center" };
 export type SplitDropRect = { left: number; top: number; width: number; height: number };

--- a/ui/src/pages/chat/split-layout-persistence.ts
+++ b/ui/src/pages/chat/split-layout-persistence.ts
@@ -1,0 +1,123 @@
+import { expectDefined, isRecord } from "@openclaw/normalization-core";
+import type { ChatSplitLayout, ChatSplitPane } from "./split-layout.ts";
+
+type ChatSplitColumn = ChatSplitLayout["columns"][number];
+
+export function normalizeSplitLayoutWeights(weights: number[]): number[] {
+  const total = weights.reduce((sum, weight) => sum + weight, 0);
+  return weights.map((weight) => weight / total);
+}
+
+export function splitLayoutNumericSuffix(id: string, prefix: string): number {
+  const match = new RegExp(`^${prefix}(\\d+)$`, "u").exec(id);
+  return match ? Number(match[1]) : 0;
+}
+
+function readWeights(value: unknown, length: number): number[] {
+  if (
+    !Array.isArray(value) ||
+    value.length !== length ||
+    value.some((weight) => typeof weight !== "number" || !Number.isFinite(weight) || weight <= 0)
+  ) {
+    return Array.from({ length }, () => 1 / length);
+  }
+  return normalizeSplitLayoutWeights(value);
+}
+
+function uniqueId(value: unknown, used: Set<string>, next: () => string): string {
+  const candidate = typeof value === "string" ? value.trim() : "";
+  if (candidate && !used.has(candidate)) {
+    used.add(candidate);
+    return candidate;
+  }
+  let generated = next();
+  while (used.has(generated)) {
+    generated = next();
+  }
+  used.add(generated);
+  return generated;
+}
+
+export function normalizeChatSplitLayout(value: unknown): ChatSplitLayout | undefined {
+  if (!isRecord(value) || !Array.isArray(value.columns)) {
+    return undefined;
+  }
+  const rawColumns = value.columns.filter(isRecord);
+  let paneSequence = rawColumns.reduce((max, rawColumn) => {
+    if (!Array.isArray(rawColumn.panes)) {
+      return max;
+    }
+    return rawColumn.panes.reduce((paneMax, rawPane) => {
+      if (!isRecord(rawPane) || typeof rawPane.id !== "string") {
+        return paneMax;
+      }
+      return Math.max(paneMax, splitLayoutNumericSuffix(rawPane.id.trim(), "p"));
+    }, max);
+  }, 0);
+  let columnSequence = rawColumns.reduce(
+    (max, rawColumn) =>
+      typeof rawColumn.id === "string"
+        ? Math.max(max, splitLayoutNumericSuffix(rawColumn.id.trim(), "c"))
+        : max,
+    0,
+  );
+  const usedPaneIds = new Set<string>();
+  const usedColumnIds = new Set<string>();
+  const columns: ChatSplitColumn[] = [];
+  const sourceColumnIndexes: number[] = [];
+  for (const [columnIndex, rawColumn] of rawColumns.entries()) {
+    if (!Array.isArray(rawColumn.panes)) {
+      continue;
+    }
+    const panes: ChatSplitPane[] = [];
+    const sourcePaneIndexes: number[] = [];
+    for (const [paneIndex, rawPane] of rawColumn.panes.entries()) {
+      if (!isRecord(rawPane) || typeof rawPane.sessionKey !== "string") {
+        continue;
+      }
+      const sessionKey = rawPane.sessionKey.trim();
+      if (!sessionKey) {
+        continue;
+      }
+      panes.push({
+        id: uniqueId(rawPane.id, usedPaneIds, () => `p${++paneSequence}`),
+        sessionKey,
+      });
+      sourcePaneIndexes.push(paneIndex);
+    }
+    if (panes.length === 0) {
+      continue;
+    }
+    const rawPaneWeights = readWeights(rawColumn.paneWeights, rawColumn.panes.length);
+    const paneWeights = normalizeSplitLayoutWeights(
+      sourcePaneIndexes.map((index) =>
+        expectDefined(rawPaneWeights[index], "normalized split pane source weight"),
+      ),
+    );
+    columns.push({
+      id: uniqueId(rawColumn.id, usedColumnIds, () => `c${++columnSequence}`),
+      panes,
+      paneWeights,
+    });
+    sourceColumnIndexes.push(columnIndex);
+  }
+  if (columns.length === 0) {
+    return undefined;
+  }
+  const rawColumnWeights = readWeights(value.columnWeights, rawColumns.length);
+  const columnWeights = normalizeSplitLayoutWeights(
+    sourceColumnIndexes.map((index) =>
+      expectDefined(rawColumnWeights[index], "normalized split column source weight"),
+    ),
+  );
+  const allPanes = columns.flatMap((column) => column.panes);
+  if (allPanes.length < 2) {
+    return undefined;
+  }
+  const requestedActivePaneId =
+    typeof value.activePaneId === "string" ? value.activePaneId.trim() : "";
+  const activePaneId = allPanes.some((pane) => pane.id === requestedActivePaneId)
+    ? requestedActivePaneId
+    : expectDefined(allPanes[0], "normalized split layout first pane").id;
+  return { columns, columnWeights, activePaneId };
+}

--- a/ui/src/pages/chat/split-layout-persistence.ts
+++ b/ui/src/pages/chat/split-layout-persistence.ts
@@ -1,7 +1,5 @@
 import { expectDefined, isRecord } from "@openclaw/normalization-core";
-import type { ChatSplitLayout, ChatSplitPane } from "./split-layout.ts";
-
-type ChatSplitColumn = ChatSplitLayout["columns"][number];
+import type { ChatSplitColumn, ChatSplitLayout, ChatSplitPane } from "./split-layout-types.ts";
 
 export function normalizeSplitLayoutWeights(weights: number[]): number[] {
   const total = weights.reduce((sum, weight) => sum + weight, 0);

--- a/ui/src/pages/chat/split-layout-types.ts
+++ b/ui/src/pages/chat/split-layout-types.ts
@@ -1,0 +1,15 @@
+export type ChatSplitPane = { id: string; sessionKey: string };
+
+export type ChatSplitColumn = {
+  id: string;
+  panes: ChatSplitPane[];
+  paneWeights: number[];
+};
+
+export type ChatSplitEdge = "left" | "right" | "up" | "down";
+
+export type ChatSplitLayout = {
+  columns: ChatSplitColumn[];
+  columnWeights: number[];
+  activePaneId: string;
+};

--- a/ui/src/pages/chat/split-layout.test.ts
+++ b/ui/src/pages/chat/split-layout.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
+import { normalizeChatSplitLayout } from "./split-layout-persistence.ts";
 import {
   applyUiCommandToSplitLayout,
   closePane,
   findPane,
   insertPane,
-  normalizeChatSplitLayout,
   panesOf,
   resizeColumns,
   resizePanes,

--- a/ui/src/pages/chat/split-layout.test.ts
+++ b/ui/src/pages/chat/split-layout.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { normalizeChatSplitLayout } from "./split-layout-persistence.ts";
+import type { ChatSplitLayout } from "./split-layout-types.ts";
 import {
   applyUiCommandToSplitLayout,
   closePane,
@@ -11,7 +12,6 @@ import {
   resizePanes,
   setActivePane,
   setPaneSession,
-  type ChatSplitLayout,
 } from "./split-layout.ts";
 
 function createSinglePaneLayout(sessionKey: string): ChatSplitLayout {

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -1,5 +1,9 @@
 import type { UiCommand } from "@openclaw/gateway-protocol";
-import { expectDefined, isRecord } from "@openclaw/normalization-core";
+import { expectDefined } from "@openclaw/normalization-core";
+import {
+  normalizeSplitLayoutWeights,
+  splitLayoutNumericSuffix,
+} from "./split-layout-persistence.ts";
 
 export type ChatSplitPane = { id: string; sessionKey: string };
 type ChatSplitColumn = { id: string; panes: ChatSplitPane[]; paneWeights: number[] };
@@ -46,23 +50,9 @@ function cloneLayout(layout: ChatSplitLayout): ChatSplitLayout {
   };
 }
 
-function equalWeights(length: number): number[] {
-  return Array.from({ length }, () => 1 / length);
-}
-
-function normalizedWeights(weights: number[]): number[] {
-  const total = weights.reduce((sum, weight) => sum + weight, 0);
-  return weights.map((weight) => weight / total);
-}
-
-function numericSuffix(id: string, prefix: string): number {
-  const match = new RegExp(`^${prefix}(\\d+)$`, "u").exec(id);
-  return match ? Number(match[1]) : 0;
-}
-
 function nextColumnId(layout: ChatSplitLayout): string {
   const max = layout.columns.reduce(
-    (current, column) => Math.max(current, numericSuffix(column.id, "c")),
+    (current, column) => Math.max(current, splitLayoutNumericSuffix(column.id, "c")),
     0,
   );
   return `c${max + 1}`;
@@ -70,7 +60,7 @@ function nextColumnId(layout: ChatSplitLayout): string {
 
 function nextPaneId(layout: ChatSplitLayout): string {
   const max = panesOf(layout).reduce(
-    (current, pane) => Math.max(current, numericSuffix(pane.id, "p")),
+    (current, pane) => Math.max(current, splitLayoutNumericSuffix(pane.id, "p")),
     0,
   );
   return `p${max + 1}`;
@@ -181,12 +171,12 @@ export function closePane(layout: ChatSplitLayout, paneId: string): ChatSplitLay
     next.columns.splice(location.columnIndex, 1);
     next.columnWeights.splice(location.columnIndex, 1);
   } else {
-    column.paneWeights = normalizedWeights(column.paneWeights);
+    column.paneWeights = normalizeSplitLayoutWeights(column.paneWeights);
   }
   if (panesOf(next).length <= 1) {
     return undefined;
   }
-  next.columnWeights = normalizedWeights(next.columnWeights);
+  next.columnWeights = normalizeSplitLayoutWeights(next.columnWeights);
   next.activePaneId = nextActivePaneId;
   return next;
 }
@@ -281,111 +271,4 @@ export function resizePanes(
     column.paneWeights = resizePair(column.paneWeights, boundaryIndex, pairRatio);
   }
   return next;
-}
-
-function readWeights(value: unknown, length: number): number[] {
-  if (
-    !Array.isArray(value) ||
-    value.length !== length ||
-    value.some((weight) => typeof weight !== "number" || !Number.isFinite(weight) || weight <= 0)
-  ) {
-    return equalWeights(length);
-  }
-  return normalizedWeights(value);
-}
-
-function uniqueId(value: unknown, used: Set<string>, next: () => string): string {
-  const candidate = typeof value === "string" ? value.trim() : "";
-  if (candidate && !used.has(candidate)) {
-    used.add(candidate);
-    return candidate;
-  }
-  let generated = next();
-  while (used.has(generated)) {
-    generated = next();
-  }
-  used.add(generated);
-  return generated;
-}
-
-export function normalizeChatSplitLayout(value: unknown): ChatSplitLayout | undefined {
-  if (!isRecord(value) || !Array.isArray(value.columns)) {
-    return undefined;
-  }
-  const rawColumns = value.columns.filter(isRecord);
-  let paneSequence = rawColumns.reduce((max, rawColumn) => {
-    if (!Array.isArray(rawColumn.panes)) {
-      return max;
-    }
-    return rawColumn.panes.reduce((paneMax, rawPane) => {
-      if (!isRecord(rawPane) || typeof rawPane.id !== "string") {
-        return paneMax;
-      }
-      return Math.max(paneMax, numericSuffix(rawPane.id.trim(), "p"));
-    }, max);
-  }, 0);
-  let columnSequence = rawColumns.reduce((max, rawColumn) => {
-    return typeof rawColumn.id === "string"
-      ? Math.max(max, numericSuffix(rawColumn.id.trim(), "c"))
-      : max;
-  }, 0);
-  const usedPaneIds = new Set<string>();
-  const usedColumnIds = new Set<string>();
-  const columns: ChatSplitColumn[] = [];
-  const sourceColumnIndexes: number[] = [];
-  for (const [columnIndex, rawColumn] of rawColumns.entries()) {
-    if (!Array.isArray(rawColumn.panes)) {
-      continue;
-    }
-    const panes: ChatSplitPane[] = [];
-    const sourcePaneIndexes: number[] = [];
-    for (const [paneIndex, rawPane] of rawColumn.panes.entries()) {
-      if (!isRecord(rawPane) || typeof rawPane.sessionKey !== "string") {
-        continue;
-      }
-      const sessionKey = rawPane.sessionKey.trim();
-      if (!sessionKey) {
-        continue;
-      }
-      panes.push({
-        id: uniqueId(rawPane.id, usedPaneIds, () => `p${++paneSequence}`),
-        sessionKey,
-      });
-      sourcePaneIndexes.push(paneIndex);
-    }
-    if (panes.length === 0) {
-      continue;
-    }
-    const rawPaneWeights = readWeights(rawColumn.paneWeights, rawColumn.panes.length);
-    const paneWeights = normalizedWeights(
-      sourcePaneIndexes.map((index) =>
-        expectDefined(rawPaneWeights[index], "normalized split pane source weight"),
-      ),
-    );
-    columns.push({
-      id: uniqueId(rawColumn.id, usedColumnIds, () => `c${++columnSequence}`),
-      panes,
-      paneWeights,
-    });
-    sourceColumnIndexes.push(columnIndex);
-  }
-  if (columns.length === 0) {
-    return undefined;
-  }
-  const rawColumnWeights = readWeights(value.columnWeights, rawColumns.length);
-  const columnWeights = normalizedWeights(
-    sourceColumnIndexes.map((index) =>
-      expectDefined(rawColumnWeights[index], "normalized split column source weight"),
-    ),
-  );
-  const allPanes = columns.flatMap((column) => column.panes);
-  if (allPanes.length < 2) {
-    return undefined;
-  }
-  const requestedActivePaneId =
-    typeof value.activePaneId === "string" ? value.activePaneId.trim() : "";
-  const activePaneId = allPanes.some((pane) => pane.id === requestedActivePaneId)
-    ? requestedActivePaneId
-    : expectDefined(allPanes[0], "normalized split layout first pane").id;
-  return { columns, columnWeights, activePaneId };
 }

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -4,15 +4,12 @@ import {
   normalizeSplitLayoutWeights,
   splitLayoutNumericSuffix,
 } from "./split-layout-persistence.ts";
-
-export type ChatSplitPane = { id: string; sessionKey: string };
-type ChatSplitColumn = { id: string; panes: ChatSplitPane[]; paneWeights: number[] };
-export type ChatSplitEdge = "left" | "right" | "up" | "down";
-export type ChatSplitLayout = {
-  columns: ChatSplitColumn[];
-  columnWeights: number[];
-  activePaneId: string;
-};
+import type {
+  ChatSplitColumn,
+  ChatSplitEdge,
+  ChatSplitLayout,
+  ChatSplitPane,
+} from "./split-layout-types.ts";
 
 export function singlePaneLayout(
   columnId: string,

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -40,7 +40,13 @@ import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./h
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll, type ChatScrollHost } from "./scroll.ts";
 import { appendChatMessageToCache, readChatMessagesFromCache } from "./session-message-cache.ts";
-import { ackSteeredChip, buildInflightSteerChip, isAckedSteeredChip } from "./steered-chip.ts";
+import {
+  ackSteeredChip,
+  buildInflightSteerChip,
+  isAckedSteeredChip,
+  isSteeredQueueItem,
+} from "./steered-chip.ts";
+import { rolloverChatStream } from "./stream-causal-boundary.ts";
 import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
 type SteerLifecycleHost = ChatState &
@@ -216,6 +222,7 @@ export function preserveQueuedUserTurn(state: SteerLifecycleHost, item: ChatQueu
   };
   if (visibleSessionMatches(state, sessionKey, item.agentId)) {
     if (!chatMessagesContainQueuedSend(state.chatMessages, item, true)) {
+      const previousMessageCount = state.chatMessages.length;
       const scope = readChatSessionProjectionScope(state, {
         sessionKey,
         agentId: item.agentId,
@@ -227,6 +234,13 @@ export function preserveQueuedUserTurn(state: SteerLifecycleHost, item: ChatQueu
         { type: "sendPending", runId, message: userMessage },
         { scope },
       );
+      if (
+        state.chatMessages.length > previousMessageCount &&
+        isSteeredQueueItem(item) &&
+        state.chatRunId
+      ) {
+        rolloverChatStream(state, { runId: state.chatRunId, boundaryRunId: runId });
+      }
     }
     return;
   }
@@ -243,46 +257,29 @@ export function preserveQueuedUserTurn(state: SteerLifecycleHost, item: ChatQueu
 export function retireSteeredChipsForTerminalRun(
   state: SteerLifecycleHost,
   runId: string | undefined,
-): number | undefined {
+): void {
   if (!runId) {
-    return undefined;
+    return;
   }
-  let firstPersistedSteerIndex: number | undefined;
   for (const item of state.chatQueue) {
     if (isAckedSteeredChip(item) && item.pendingRunId === runId) {
-      const persistedIndex = findQueuedSendMessageIndex(state.chatMessages, item, true);
-      if (
-        persistedIndex >= 0 &&
-        (firstPersistedSteerIndex === undefined || persistedIndex < firstPersistedSteerIndex)
-      ) {
-        firstPersistedSteerIndex = persistedIndex;
-      }
       preserveQueuedUserTurn(state, item);
     }
   }
   clearPendingQueueItemsForRun(state, runId);
-  return firstPersistedSteerIndex;
 }
 
 export function retireSteeredChipsForRequestRun(
   state: SteerLifecycleHost,
   runId: string | undefined,
-): number | undefined {
+): void {
   if (!runId) {
-    return undefined;
+    return;
   }
   const landed = state.chatQueue.filter(
     (item) => isAckedSteeredChip(item) && item.sendRunId === runId,
   );
-  let firstPersistedSteerIndex: number | undefined;
   for (const item of landed) {
-    const persistedIndex = findQueuedSendMessageIndex(state.chatMessages, item, true);
-    if (
-      persistedIndex >= 0 &&
-      (firstPersistedSteerIndex === undefined || persistedIndex < firstPersistedSteerIndex)
-    ) {
-      firstPersistedSteerIndex = persistedIndex;
-    }
     preserveQueuedUserTurn(state, item);
   }
   if (landed.length > 0) {
@@ -296,7 +293,6 @@ export function retireSteeredChipsForRequestRun(
       releaseChatAttachmentPayloads(excludeComposerAttachments(state, item.attachments));
     }
   }
-  return firstPersistedSteerIndex;
 }
 
 export function retirePersistedSteeredChips(state: SteerLifecycleHost): void {

--- a/ui/src/pages/chat/stream-causal-boundary.ts
+++ b/ui/src/pages/chat/stream-causal-boundary.ts
@@ -16,6 +16,7 @@ export type StreamCausalBoundaryState = {
 };
 
 type StreamRolloverState = {
+  chatMessages?: unknown[];
   chatRunId: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
@@ -361,6 +362,40 @@ export function reconcileTerminalStreamBoundary(
   };
 }
 
+// An ordinary queued user is a hard ceiling for text produced before a later steer.
+// Preserve the first intervening user instead of relabeling that text as pre-steer output.
+function interveningUserBoundaryRunId(params: {
+  messages: unknown[] | undefined;
+  runId: string;
+  boundaryRunId: string;
+  afterBoundaryRunId?: string;
+}): string | undefined {
+  const messages = params.messages;
+  if (!messages) {
+    return undefined;
+  }
+  const boundaryIndex = messages.findIndex(
+    (message) => userTurnSendIdentity(message) === `send:${params.boundaryRunId}`,
+  );
+  const floorRunId = params.afterBoundaryRunId ?? params.runId;
+  const floorIndex = messages.findIndex(
+    (message) => userTurnSendIdentity(message) === `send:${floorRunId}`,
+  );
+  if (floorIndex < 0 || boundaryIndex <= floorIndex) {
+    return undefined;
+  }
+  for (let index = floorIndex + 1; index < boundaryIndex; index += 1) {
+    if (readSessionMessageIdentity(messages[index])?.role !== "user") {
+      continue;
+    }
+    const identity = userTurnSendIdentity(messages[index]);
+    if (identity?.startsWith("send:")) {
+      return identity.slice("send:".length);
+    }
+  }
+  return undefined;
+}
+
 /** Closes cumulative assistant output at a tool or persisted user boundary. */
 export function rolloverChatStream(
   host: StreamRolloverState,
@@ -384,29 +419,21 @@ export function rolloverChatStream(
   }
   const hasStream = typeof host.chatStream === "string";
   const hasStreamText = hasStream && Boolean(host.chatStream?.trim());
-  if (options.boundaryRunId) {
+  const streamBoundaryRunId = options.boundaryRunId
+    ? (interveningUserBoundaryRunId({
+        messages: host.chatMessages,
+        runId: options.runId,
+        boundaryRunId: options.boundaryRunId,
+        afterBoundaryRunId: previousBoundaryRunId,
+      }) ?? options.boundaryRunId)
+    : undefined;
+  if (streamBoundaryRunId) {
     const previousBoundaryIndex = segments.findLastIndex((segment) => segment.boundaryRunId);
     segments = segments.map((segment, index) =>
       index <= previousBoundaryIndex || segment.boundaryRunId
         ? segment
-        : { ...segment, boundaryRunId: options.boundaryRunId },
+        : { ...segment, boundaryRunId: streamBoundaryRunId },
     );
-    if (
-      !hasStreamText &&
-      !segments.some((segment) => segment.boundaryRunId === options.boundaryRunId)
-    ) {
-      segments = [
-        ...segments,
-        {
-          text: "",
-          ts: host.chatStreamStartedAt ?? options.timestamp ?? Date.now(),
-          runId: options.runId,
-          boundaryRunId: options.boundaryRunId,
-          boundaryMarker: true,
-          ...(previousBoundaryRunId ? { afterBoundaryRunId: previousBoundaryRunId } : {}),
-        },
-      ];
-    }
   }
   if (hasStreamText) {
     segments = [
@@ -416,8 +443,26 @@ export function rolloverChatStream(
         ts: host.chatStreamStartedAt ?? options.timestamp ?? Date.now(),
         runId: options.runId,
         ...(previousBoundaryRunId ? { afterBoundaryRunId: previousBoundaryRunId } : {}),
-        ...(options.boundaryRunId ? { boundaryRunId: options.boundaryRunId } : {}),
+        ...(streamBoundaryRunId ? { boundaryRunId: streamBoundaryRunId } : {}),
         ...(options.toolCallId ? { toolCallId: options.toolCallId } : {}),
+      },
+    ];
+  }
+  if (
+    options.boundaryRunId &&
+    !segments.some((segment) => segment.boundaryRunId === options.boundaryRunId)
+  ) {
+    const markerAfterBoundaryRunId =
+      streamBoundaryRunId !== options.boundaryRunId ? streamBoundaryRunId : previousBoundaryRunId;
+    segments = [
+      ...segments,
+      {
+        text: "",
+        ts: host.chatStreamStartedAt ?? options.timestamp ?? Date.now(),
+        runId: options.runId,
+        boundaryRunId: options.boundaryRunId,
+        boundaryMarker: true,
+        ...(markerAfterBoundaryRunId ? { afterBoundaryRunId: markerAfterBoundaryRunId } : {}),
       },
     ];
   }

--- a/ui/src/pages/chat/stream-causal-boundary.ts
+++ b/ui/src/pages/chat/stream-causal-boundary.ts
@@ -1,0 +1,431 @@
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  advanceAccumulatedStreamText,
+  streamSegmentUsesAccumulatedText,
+  type ChatStreamSegment,
+} from "../../lib/chat/chat-types.ts";
+import { extractText } from "../../lib/chat/message-extract.ts";
+import { userTurnSendIdentity } from "./chat-thread-items.ts";
+
+export type StreamCausalBoundaryState = {
+  chatMessages?: unknown[];
+  chatRunId?: string | null;
+  chatStreamSegments?: ChatStreamSegment[];
+};
+
+type StreamRolloverState = {
+  chatRunId: string | null;
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  chatStreamSegments?: ChatStreamSegment[];
+};
+
+function lastUserMessageIndex(messages: unknown[], beforeIndex = messages.length): number {
+  for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    if (readSessionMessageIdentity(messages[index])?.role === "user") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+export function persistedSteerTargetRunId(message: unknown): string | null {
+  const metadata = asNullableRecord(asNullableRecord(message)?.["__openclaw"]);
+  return normalizeOptionalString(metadata?.steerTargetRunId) ?? null;
+}
+
+export function latestPersistedSteerBoundary(
+  messages: unknown[],
+  activeRunId: string,
+): { index: number; runId: string } | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (
+      readSessionMessageIdentity(messages[index])?.role !== "user" ||
+      persistedSteerTargetRunId(messages[index]) !== activeRunId
+    ) {
+      continue;
+    }
+    const identity = userTurnSendIdentity(messages[index]);
+    if (identity?.startsWith("send:")) {
+      return { index, runId: identity.slice("send:".length) };
+    }
+  }
+  return null;
+}
+
+export function latestStreamBoundaryRunId(state: StreamCausalBoundaryState): string | undefined {
+  const segments = state.chatStreamSegments ?? [];
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const boundaryRunId = normalizeOptionalString(segments[index]?.boundaryRunId);
+    if (boundaryRunId) {
+      return boundaryRunId;
+    }
+  }
+  return undefined;
+}
+
+export function streamCausalInterval(
+  messages: unknown[],
+  part: { afterBoundaryRunId?: string; boundaryRunId?: string; runId?: string },
+): { start: number; end: number } {
+  const afterBoundaryIdentity = part.afterBoundaryRunId ? `send:${part.afterBoundaryRunId}` : null;
+  const afterBoundaryIndex = afterBoundaryIdentity
+    ? messages.findIndex((message) => userTurnSendIdentity(message) === afterBoundaryIdentity)
+    : -1;
+  const boundaryIdentity = part.boundaryRunId ? `send:${part.boundaryRunId}` : null;
+  const boundaryIndex = boundaryIdentity
+    ? messages.findIndex((message) => userTurnSendIdentity(message) === boundaryIdentity)
+    : -1;
+  if (boundaryIndex >= 0) {
+    return {
+      start:
+        afterBoundaryIndex >= 0
+          ? afterBoundaryIndex + 1
+          : lastUserMessageIndex(messages, boundaryIndex) + 1,
+      end: boundaryIndex,
+    };
+  }
+  if (afterBoundaryIndex >= 0) {
+    const end = messages.findIndex(
+      (message, index) =>
+        index > afterBoundaryIndex && readSessionMessageIdentity(message)?.role === "user",
+    );
+    return { start: afterBoundaryIndex + 1, end: end >= 0 ? end : messages.length };
+  }
+  const runIdentity = part.runId ? `send:${part.runId}` : null;
+  const runUserIndex = runIdentity
+    ? messages.findIndex((message) => userTurnSendIdentity(message) === runIdentity)
+    : -1;
+  if (runUserIndex >= 0) {
+    const end = messages.findIndex(
+      (message, index) =>
+        index > runUserIndex && readSessionMessageIdentity(message)?.role === "user",
+    );
+    return { start: runUserIndex + 1, end: end >= 0 ? end : messages.length };
+  }
+  const end = messages.length;
+  return { start: lastUserMessageIndex(messages, end) + 1, end };
+}
+
+export function streamCausalInsertIndex(
+  messages: unknown[],
+  desiredTimestamp: number,
+  startIndex: number,
+  endIndex: number,
+  readTimestamp: (message: unknown) => number | null,
+): number {
+  for (let index = startIndex; index < endIndex; index++) {
+    const timestamp = readTimestamp(messages[index]);
+    if (timestamp != null && timestamp > desiredTimestamp) {
+      return index;
+    }
+  }
+  return endIndex;
+}
+
+export function streamCausalTimestamp(
+  messages: unknown[],
+  index: number,
+  desiredTimestamp: number,
+  readTimestamp: (message: unknown) => number | null,
+): number {
+  let previousTimestamp: number | null = null;
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    previousTimestamp = readTimestamp(messages[cursor]);
+    if (previousTimestamp != null) {
+      break;
+    }
+  }
+  let nextTimestamp: number | null = null;
+  for (let cursor = index; cursor < messages.length; cursor += 1) {
+    nextTimestamp = readTimestamp(messages[cursor]);
+    if (nextTimestamp != null) {
+      break;
+    }
+  }
+  if (previousTimestamp != null && desiredTimestamp <= previousTimestamp) {
+    const afterPrevious = previousTimestamp + 1;
+    return nextTimestamp != null && afterPrevious >= nextTimestamp
+      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
+      : afterPrevious;
+  }
+  if (nextTimestamp != null && desiredTimestamp >= nextTimestamp) {
+    const beforeNext = nextTimestamp - 1;
+    return previousTimestamp != null && beforeNext <= previousTimestamp
+      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
+      : beforeNext;
+  }
+  return desiredTimestamp;
+}
+
+export function resolveCumulativeAssistantTail(
+  messages: unknown[],
+  cumulativeText: string,
+  runId: string,
+  endIndex = messages.length,
+): string | null {
+  let ownedPrefixIndex = -1;
+  for (let index = 0; index < endIndex; index += 1) {
+    const message = messages[index];
+    const identity = readSessionMessageIdentity(message);
+    const persistedText = identity?.runId === runId ? extractText(message) : null;
+    if (
+      identity?.role === "assistant" &&
+      persistedText &&
+      (cumulativeText.startsWith(persistedText) || persistedText.startsWith(cumulativeText))
+    ) {
+      ownedPrefixIndex = index;
+      break;
+    }
+  }
+  const turnStart =
+    ownedPrefixIndex >= 0 ? ownedPrefixIndex : lastUserMessageIndex(messages, endIndex) + 1;
+  let persistedPrefixLength = 0;
+  for (let index = turnStart; index < endIndex; index += 1) {
+    const identity = readSessionMessageIdentity(messages[index]);
+    if (identity?.role !== "assistant" || (identity.runId && identity.runId !== runId)) {
+      continue;
+    }
+    const persistedText = extractText(messages[index]);
+    if (!persistedText) {
+      continue;
+    }
+    const remaining = cumulativeText.slice(persistedPrefixLength);
+    if (remaining.startsWith(persistedText)) {
+      persistedPrefixLength += persistedText.length;
+      continue;
+    }
+    if (persistedText.startsWith(remaining)) {
+      return null;
+    }
+    const whitespace = persistedPrefixLength > 0 ? /^\s+/u.exec(remaining)?.[0] : undefined;
+    if (whitespace && remaining.slice(whitespace.length).startsWith(persistedText)) {
+      persistedPrefixLength += whitespace.length + persistedText.length;
+      continue;
+    }
+    if (whitespace && persistedText.startsWith(remaining.slice(whitespace.length))) {
+      return null;
+    }
+    if (persistedPrefixLength > 0) {
+      break;
+    }
+  }
+  return cumulativeText.slice(persistedPrefixLength);
+}
+
+function persistedBoundaryPrefix(state: StreamCausalBoundaryState, terminalText: string) {
+  const messages = state.chatMessages;
+  const activeRunId = state.chatRunId;
+  if (!Array.isArray(messages) || !activeRunId) {
+    return null;
+  }
+  const boundary = latestPersistedSteerBoundary(messages, activeRunId);
+  if (!boundary || boundary.index <= 0) {
+    return null;
+  }
+  const tail = resolveCumulativeAssistantTail(messages, terminalText, activeRunId, boundary.index);
+  if (tail === terminalText) {
+    return null;
+  }
+  return {
+    boundaryRunId: boundary.runId,
+    prefix: tail === null ? terminalText : terminalText.slice(0, terminalText.length - tail.length),
+  };
+}
+
+export function markChatStreamAfterBoundary(
+  host: StreamRolloverState,
+  options: { runId: string; boundaryRunId: string; timestamp?: number },
+): void {
+  if (
+    host.chatRunId !== options.runId ||
+    latestStreamBoundaryRunId(host) === options.boundaryRunId
+  ) {
+    return;
+  }
+  const previousBoundaryRunId = latestStreamBoundaryRunId(host);
+  host.chatStreamSegments = [
+    ...(host.chatStreamSegments ?? []),
+    {
+      text: "",
+      ts: options.timestamp ?? Date.now(),
+      runId: options.runId,
+      boundaryRunId: options.boundaryRunId,
+      boundaryMarker: true,
+      ...(previousBoundaryRunId ? { afterBoundaryRunId: previousBoundaryRunId } : {}),
+    },
+  ];
+}
+
+function replaceTerminalText(
+  message: Record<string, unknown>,
+  text: string,
+): Record<string, unknown> {
+  if (Array.isArray(message.content)) {
+    let replaced = false;
+    const content = message.content.flatMap((block) => {
+      const entry = asNullableRecord(block);
+      if (!entry) {
+        return [block];
+      }
+      const textBlock =
+        (entry.type === "text" || entry.type === "input_text" || entry.type === "output_text") &&
+        typeof entry.text === "string";
+      if (!textBlock) {
+        return [block];
+      }
+      if (replaced) {
+        return [];
+      }
+      replaced = true;
+      return [{ ...entry, text }];
+    });
+    if (replaced) {
+      return { ...message, content };
+    }
+  }
+  if (typeof message.content === "string") {
+    return { ...message, content: text };
+  }
+  return typeof message.text === "string" ? { ...message, text } : message;
+}
+
+type TerminalStreamBoundaryReconciliation =
+  | { kind: "none" }
+  | {
+      kind: "split";
+      afterBoundaryRunId: string;
+      replacedSegmentIndexes: number[];
+      tailMessage: Record<string, unknown> | null;
+    };
+
+type TerminalBoundaryCandidate = {
+  boundaryRunId: string;
+  prefix: string;
+};
+
+function terminalBoundaryCandidateMatches(
+  candidate: TerminalBoundaryCandidate | null,
+  terminalText: string,
+): candidate is TerminalBoundaryCandidate {
+  return Boolean(candidate?.boundaryRunId && terminalText.startsWith(candidate.prefix));
+}
+
+/** Reconciles a run-level cumulative terminal against its last persisted steer. */
+export function reconcileTerminalStreamBoundary(
+  message: Record<string, unknown>,
+  state: StreamCausalBoundaryState,
+): TerminalStreamBoundaryReconciliation {
+  const terminalText = extractText(message);
+  if (!terminalText) {
+    return { kind: "none" };
+  }
+  let accumulatedText: string | null = null;
+  const accumulatedSegmentIndexes: number[] = [];
+  let liveBoundary: (TerminalBoundaryCandidate & { segmentIndexes: number[] }) | null = null;
+  for (const [segmentIndex, segment] of (state.chatStreamSegments ?? []).entries()) {
+    if (streamSegmentUsesAccumulatedText(segment) && typeof segment.text === "string") {
+      const nextAccumulatedText = advanceAccumulatedStreamText(accumulatedText, segment.text);
+      if (nextAccumulatedText !== accumulatedText) {
+        accumulatedSegmentIndexes.push(segmentIndex);
+      }
+      accumulatedText = nextAccumulatedText;
+    }
+    const boundaryRunId = normalizeOptionalString(segment.boundaryRunId);
+    if (boundaryRunId && accumulatedText) {
+      liveBoundary = {
+        boundaryRunId,
+        prefix: accumulatedText,
+        segmentIndexes: [...accumulatedSegmentIndexes],
+      };
+    }
+  }
+  const persistedBoundary = persistedBoundaryPrefix(state, terminalText);
+  const selectedBoundary = terminalBoundaryCandidateMatches(liveBoundary, terminalText)
+    ? liveBoundary
+    : terminalBoundaryCandidateMatches(persistedBoundary, terminalText)
+      ? persistedBoundary
+      : null;
+  if (!selectedBoundary) {
+    return { kind: "none" };
+  }
+  const tail = terminalText.slice(selectedBoundary.prefix.length).trimStart();
+  return {
+    kind: "split",
+    afterBoundaryRunId: selectedBoundary.boundaryRunId,
+    replacedSegmentIndexes:
+      selectedBoundary === persistedBoundary && liveBoundary ? liveBoundary.segmentIndexes : [],
+    tailMessage: tail ? replaceTerminalText(message, tail) : null,
+  };
+}
+
+/** Closes cumulative assistant output at a tool or persisted user boundary. */
+export function rolloverChatStream(
+  host: StreamRolloverState,
+  options: {
+    runId: string;
+    boundaryRunId?: string;
+    toolCallId?: string;
+    timestamp?: number;
+  },
+): void {
+  if (host.chatRunId !== options.runId) {
+    return;
+  }
+  let segments = host.chatStreamSegments ?? [];
+  let previousBoundaryRunId: string | undefined;
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    previousBoundaryRunId = normalizeOptionalString(segments[index]?.boundaryRunId);
+    if (previousBoundaryRunId) {
+      break;
+    }
+  }
+  const hasStream = typeof host.chatStream === "string";
+  const hasStreamText = hasStream && Boolean(host.chatStream?.trim());
+  if (options.boundaryRunId) {
+    const previousBoundaryIndex = segments.findLastIndex((segment) => segment.boundaryRunId);
+    segments = segments.map((segment, index) =>
+      index <= previousBoundaryIndex || segment.boundaryRunId
+        ? segment
+        : { ...segment, boundaryRunId: options.boundaryRunId },
+    );
+    if (
+      !hasStreamText &&
+      !segments.some((segment) => segment.boundaryRunId === options.boundaryRunId)
+    ) {
+      segments = [
+        ...segments,
+        {
+          text: "",
+          ts: host.chatStreamStartedAt ?? options.timestamp ?? Date.now(),
+          runId: options.runId,
+          boundaryRunId: options.boundaryRunId,
+          boundaryMarker: true,
+          ...(previousBoundaryRunId ? { afterBoundaryRunId: previousBoundaryRunId } : {}),
+        },
+      ];
+    }
+  }
+  if (hasStreamText) {
+    segments = [
+      ...segments,
+      {
+        text: host.chatStream ?? "",
+        ts: host.chatStreamStartedAt ?? options.timestamp ?? Date.now(),
+        runId: options.runId,
+        ...(previousBoundaryRunId ? { afterBoundaryRunId: previousBoundaryRunId } : {}),
+        ...(options.boundaryRunId ? { boundaryRunId: options.boundaryRunId } : {}),
+        ...(options.toolCallId ? { toolCallId: options.toolCallId } : {}),
+      },
+    ];
+  }
+  host.chatStreamSegments = segments;
+  if (!hasStream) {
+    return;
+  }
+  host.chatStream = null;
+  // The closed segment owns elapsed time; a later cumulative tail must not restart the run clock.
+  host.chatStreamStartedAt = null;
+}

--- a/ui/src/pages/chat/stream-reconciliation.test.ts
+++ b/ui/src/pages/chat/stream-reconciliation.test.ts
@@ -1,14 +1,18 @@
 // @vitest-environment node
 // Control UI tests cover stream reconciliation behavior.
 import { describe, expect, it } from "vitest";
+import { reconcileTerminalStreamBoundary, rolloverChatStream } from "./stream-causal-boundary.ts";
 import {
   appendTerminalAssistantMessage,
   historyReplacedVisibleStream,
   materializeVisibleStreamState,
-  persistedCurrentToolStreamIds,
-  prunePersistedToolStreamMessages,
 } from "./stream-reconciliation.ts";
-import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
+import {
+  discardStreamSegmentIndexes,
+  prunePersistedToolStreamMessages,
+} from "./stream-segment-pruning.ts";
+import { rememberLiveTerminalRun } from "./terminal-message-identity.ts";
+import { buildToolStreamIdentity, persistedCurrentToolStreamIds } from "./tool-stream-identity.ts";
 
 type StreamReconciliationState = Parameters<typeof materializeVisibleStreamState>[1];
 
@@ -18,9 +22,7 @@ const visibleStreamOptions = {
   persistCommentary: true,
 };
 
-function makeIdleStreamState<
-  T extends Omit<Partial<StreamReconciliationState>, "chatStream" | "chatStreamStartedAt">,
->(overrides: T) {
+function makeIdleStreamState<T extends Record<string, unknown>>(overrides: T) {
   return {
     chatStream: null,
     chatStreamStartedAt: null,
@@ -119,7 +121,12 @@ describe("stream reconciliation", () => {
   it("does not replay a keyed preamble across a same-run steer boundary", () => {
     const state = makeIdleStreamState({
       chatStreamSegments: [
-        { text: "already visible", ts: 2, itemId: "preamble-1" },
+        {
+          text: "already visible",
+          ts: 2,
+          itemId: "preamble-1",
+          boundaryRunId: "steer-run",
+        },
         { text: "distinct item", ts: 4, itemId: "preamble-2" },
         { text: "already visible", ts: 5 },
       ],
@@ -136,13 +143,15 @@ describe("stream reconciliation", () => {
           source: "segment",
         },
       },
-      { role: "user", content: "steer this run", timestamp: 3 },
+      {
+        role: "user",
+        content: "steer this run",
+        timestamp: 3,
+        __openclaw: { idempotencyKey: "steer-run:user" },
+      },
     ];
 
-    const next = materializeVisibleStreamState(messages, state, {
-      ...visibleStreamOptions,
-      keyedStartIndex: 1,
-    });
+    const next = materializeVisibleStreamState(messages, state, visibleStreamOptions);
 
     expect(next.map(messageText)).toEqual([
       "original ask",
@@ -156,20 +165,32 @@ describe("stream reconciliation", () => {
   it("recomputes the unkeyed boundary after keyed insertions before a steer", () => {
     const state = makeIdleStreamState({
       chatStreamSegments: [
-        { text: "first keyed", ts: 2, itemId: "preamble-1" },
-        { text: "repeatable", ts: 3, itemId: "preamble-2" },
+        {
+          text: "first keyed",
+          ts: 2,
+          itemId: "preamble-1",
+          boundaryRunId: "steer-run",
+        },
+        {
+          text: "repeatable",
+          ts: 3,
+          itemId: "preamble-2",
+          boundaryRunId: "steer-run",
+        },
         { text: "repeatable", ts: 5 },
       ],
     });
     const messages = [
       { role: "user", content: "original ask", timestamp: 1 },
-      { role: "user", content: "steer this run", timestamp: 4 },
+      {
+        role: "user",
+        content: "steer this run",
+        timestamp: 4,
+        __openclaw: { idempotencyKey: "steer-run:user" },
+      },
     ];
 
-    const next = materializeVisibleStreamState(messages, state, {
-      ...visibleStreamOptions,
-      keyedStartIndex: 1,
-    });
+    const next = materializeVisibleStreamState(messages, state, visibleStreamOptions);
 
     expect(next.map(messageText)).toEqual([
       "original ask",
@@ -199,6 +220,34 @@ describe("stream reconciliation", () => {
     expect(state.chatToolMessages).toEqual([]);
     expect(state.toolStreamById.size).toBe(0);
     expect(state.toolStreamOrder).toEqual([]);
+  });
+
+  it("rebases surviving accumulated segments after discarding an earlier prefix", () => {
+    const state = makeIdleStreamState({
+      chatStreamSegments: [
+        {
+          text: "Before steer.",
+          ts: 1,
+          runId: "active-run",
+          boundaryRunId: "steer-run",
+        },
+        {
+          text: "Before steer. After steer.",
+          ts: 2,
+          runId: "active-run",
+          afterBoundaryRunId: "steer-run",
+        },
+      ],
+    });
+
+    discardStreamSegmentIndexes(state, [0]);
+
+    expect(state.chatStreamSegments).toEqual([
+      expect.objectContaining({
+        text: "After steer.",
+        afterBoundaryRunId: "steer-run",
+      }),
+    ]);
   });
 
   it("prunes only the persisted run when sibling tools share a call id", () => {
@@ -382,6 +431,201 @@ describe("stream reconciliation", () => {
     ]);
   });
 
+  it("keeps an interrupted run fallback outside a later terminal run", () => {
+    const userA = {
+      role: "user",
+      content: "Run A",
+      timestamp: 1,
+      __openclaw: { idempotencyKey: "run-a:user" },
+    };
+    const fallbackA = materializeVisibleStreamState(
+      [userA],
+      {
+        chatRunId: "run-a",
+        chatStream: "Interrupted A",
+        chatStreamStartedAt: 2,
+        chatStreamSegments: [],
+      },
+      visibleStreamOptions,
+    )[1];
+    const userB = {
+      role: "user",
+      content: "Run B",
+      timestamp: 3,
+      __openclaw: { idempotencyKey: "run-b:user" },
+    };
+    const terminalB = rememberLiveTerminalRun(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Finished B" }],
+        timestamp: 4,
+      },
+      "run-b",
+    );
+
+    const next = appendTerminalAssistantMessage([userA, fallbackA, userB], terminalB);
+
+    expect(next.map(messageText)).toEqual(["Run A", "Interrupted A", "Run B", "Finished B"]);
+  });
+
+  it.each([
+    { name: "as the live stream", rollIntoToolSegment: false },
+    { name: "after a tool boundary rollover", rollIntoToolSegment: true },
+  ])("keeps output after a textless steer $name", ({ rollIntoToolSegment }) => {
+    const state: StreamReconciliationState & Parameters<typeof rolloverChatStream>[0] = {
+      chatRunId: "active-run",
+      chatStream: null,
+      chatStreamStartedAt: null,
+      chatStreamSegments: [],
+    };
+    const messages = [
+      {
+        role: "user",
+        content: "Original",
+        timestamp: 1,
+        __openclaw: { idempotencyKey: "active-run:user" },
+      },
+      {
+        role: "user",
+        content: "Steer",
+        timestamp: 2,
+        __openclaw: { idempotencyKey: "steer-run:user", steerTargetRunId: "active-run" },
+      },
+    ];
+
+    rolloverChatStream(state, { runId: "active-run", boundaryRunId: "steer-run" });
+    expect(state.chatStreamSegments).toEqual([
+      expect.objectContaining({
+        text: "",
+        boundaryMarker: true,
+        boundaryRunId: "steer-run",
+      }),
+    ]);
+    state.chatStream = "After steer";
+    state.chatStreamStartedAt = 3;
+    if (rollIntoToolSegment) {
+      rolloverChatStream(state, { runId: "active-run", toolCallId: "call-1", timestamp: 4 });
+    }
+
+    const next = materializeVisibleStreamState(messages, state, visibleStreamOptions);
+
+    expect(next.map(messageText)).toEqual(["Original", "Steer", "After steer"]);
+  });
+
+  it("reconciles a causal stream segment only inside its persisted user interval", () => {
+    const state = {
+      chatStream: "Before steer. After steer.",
+      chatStreamStartedAt: 4,
+      chatStreamSegments: [
+        {
+          text: "Before steer.",
+          ts: 3,
+          runId: "active-run",
+          boundaryRunId: "steer-run",
+        },
+      ],
+    } satisfies StreamReconciliationState & {
+      chatStreamSegments: Array<{
+        text: string;
+        ts: number;
+        runId: string;
+        boundaryRunId: string;
+      }>;
+    };
+    const messages = [
+      {
+        role: "user",
+        content: "Original prompt",
+        timestamp: 2,
+        __openclaw: { idempotencyKey: "active-run:user" },
+      },
+      {
+        role: "assistant",
+        content: "Before steer.",
+        timestamp: 100,
+        __openclaw: { idempotencyKey: "active-run" },
+      },
+      {
+        role: "user",
+        content: "Steer prompt",
+        timestamp: 1,
+        __openclaw: { idempotencyKey: "steer-run:user" },
+      },
+    ];
+
+    expect(historyReplacedVisibleStream(messages, state, visibleStreamOptions)).toBe(false);
+    expect(
+      materializeVisibleStreamState(messages, state, {
+        ...visibleStreamOptions,
+        includeCurrent: false,
+      }).map(messageText),
+    ).toEqual(["Original prompt", "Before steer.", "Steer prompt"]);
+    expect(
+      reconcileTerminalStreamBoundary(
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Before steer. After steer." }],
+        },
+        state,
+      ),
+    ).toMatchObject({
+      kind: "split",
+      tailMessage: { content: [{ type: "text", text: "After steer." }] },
+    });
+  });
+
+  it("composes cumulative stream intervals across multiple steers", () => {
+    const state = {
+      chatStream: "First. Second. Third.",
+      chatStreamStartedAt: 6,
+      chatStreamSegments: [
+        {
+          text: "First.",
+          ts: 5,
+          runId: "active-run",
+          boundaryRunId: "steer-one",
+        },
+        {
+          text: "First. Second.",
+          ts: 4,
+          runId: "active-run",
+          boundaryRunId: "steer-two",
+        },
+      ],
+    } satisfies StreamReconciliationState & {
+      chatStreamSegments: Array<{
+        text: string;
+        ts: number;
+        runId: string;
+        boundaryRunId: string;
+      }>;
+    };
+    const messages = [
+      {
+        role: "user",
+        content: "Original prompt",
+        timestamp: 3,
+        __openclaw: { idempotencyKey: "active-run:user" },
+      },
+      {
+        role: "user",
+        content: "First steer",
+        timestamp: 2,
+        __openclaw: { idempotencyKey: "steer-one:user" },
+      },
+      {
+        role: "user",
+        content: "Second steer",
+        timestamp: 1,
+        __openclaw: { idempotencyKey: "steer-two:user" },
+      },
+    ];
+
+    expect(
+      materializeVisibleStreamState(messages, state, visibleStreamOptions).map(messageText),
+    ).toEqual(["Original prompt", "First.", "First steer", "Second.", "Second steer", "Third."]);
+  });
+
   it("does not treat matching terminal text as a keyed preamble replacement", () => {
     const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "before tool", ts: 2, itemId: "preamble-1" }],
@@ -527,5 +771,38 @@ describe("stream reconciliation", () => {
     });
 
     expect(next.map(messageText)).toEqual(["latest ask", "draft answer\nfinal answer"]);
+  });
+
+  it("sequentially consumes incremental tool fallbacks before one terminal", () => {
+    const state = {
+      chatRunId: "active-run",
+      chatStream: null,
+      chatStreamStartedAt: null,
+      chatStreamSegments: [
+        { text: "A", ts: 2, runId: "active-run", toolCallId: "call-a" },
+        { text: "A B", ts: 3, runId: "active-run", toolCallId: "call-b" },
+      ],
+    } satisfies StreamReconciliationState;
+    const messages = [
+      {
+        role: "user",
+        content: "latest ask",
+        timestamp: 1,
+        __openclaw: { idempotencyKey: "active-run:user" },
+      },
+    ];
+    const materialized = materializeVisibleStreamState(messages, state, visibleStreamOptions);
+    const terminal = rememberLiveTerminalRun(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "A B Final" }],
+        timestamp: 4,
+      },
+      "active-run",
+    );
+
+    const next = appendTerminalAssistantMessage(materialized, terminal);
+
+    expect(next.map(messageText)).toEqual(["latest ask", "A B Final"]);
   });
 });

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -1,5 +1,6 @@
-// Control UI chat module implements stream reconciliation behavior.
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -12,25 +13,28 @@ import {
 } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import {
+  streamCausalInsertIndex,
+  streamCausalInterval,
+  streamCausalTimestamp,
+  type StreamCausalBoundaryState,
+} from "./stream-causal-boundary.ts";
+import {
+  readLiveTerminalAfterBoundaryRunId,
+  readLiveTerminalRunId,
+} from "./terminal-message-identity.ts";
+import {
   extractToolMessageRefs,
   resolveLiveToolStreamRefs,
   resolveMatchingLiveToolIdentity,
 } from "./tool-stream-identity.ts";
 import { resetToolStream } from "./tool-stream.ts";
 
-type StreamReconciliationState = {
+type StreamReconciliationState = StreamCausalBoundaryState & {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
 };
 
 type ToolStreamHost = StreamReconciliationState & {
-  chatStreamSegments?: Array<{
-    text?: unknown;
-    ts?: unknown;
-    runId?: unknown;
-    toolCallId?: unknown;
-    itemId?: unknown;
-  }>;
   chatToolMessages?: unknown[];
   toolStreamById?: Map<string, unknown>;
   toolStreamOrder?: unknown[];
@@ -41,20 +45,21 @@ type VisibleAssistantStreamPart = {
   replacementText: string;
   source: "segment" | "current";
   timestamp: number;
+  segmentIndex?: number;
   itemId?: string;
   runId?: string;
+  afterBoundaryRunId?: string;
+  boundaryRunId?: string;
   toolCallId?: string;
 };
 
 type AssistantMessageVisibility = (message: unknown) => boolean;
 type StreamVisibility = (stream: string) => boolean;
-
 type MaterializeVisibleStreamOptions = {
   includeCurrent?: boolean;
   requirePersistedTool?: boolean;
   replacementMessages?: unknown[];
   persistCommentary?: boolean;
-  keyedStartIndex?: number;
   isHiddenAssistantMessage: AssistantMessageVisibility;
   isHiddenStreamText: StreamVisibility;
 };
@@ -62,9 +67,7 @@ type MaterializeVisibleStreamOptions = {
 export function currentLiveToolCallIds(state: StreamReconciliationState): string[] {
   const toolHost = state as ToolStreamHost;
   return Array.isArray(toolHost.toolStreamOrder)
-    ? toolHost.toolStreamOrder.filter(
-        (value): value is string => typeof value === "string" && value.trim().length > 0,
-      )
+    ? toolHost.toolStreamOrder.filter((v): v is string => normalizeOptionalString(v) !== undefined)
     : [];
 }
 
@@ -80,13 +83,6 @@ function lastUserMessageIndex(messages: unknown[]): number {
     }
   }
   return -1;
-}
-
-export function streamReconciliationStartIndex(
-  messages: unknown[],
-  beforeIndex = messages.length,
-): number {
-  return lastUserMessageIndex(messages.slice(0, beforeIndex)) + 1;
 }
 
 export function maybeResetToolStream(
@@ -117,32 +113,14 @@ export function clearToolStreamSegments(state: StreamReconciliationState) {
   }
 }
 
-export function persistedCurrentToolStreamIds(
-  messages: unknown[],
-  state: StreamReconciliationState,
-): Set<string> {
-  const liveToolRefs = resolveLiveToolStreamRefs(state);
-  const matchedToolIds = new Set<string>();
-  if (liveToolRefs.length === 0) {
-    return matchedToolIds;
-  }
-  for (const message of messages.slice(lastUserMessageIndex(messages) + 1)) {
-    for (const ref of extractToolMessageRefs(message)) {
-      const identity = resolveMatchingLiveToolIdentity(ref, liveToolRefs);
-      if (identity) {
-        matchedToolIds.add(identity);
-      }
-    }
-  }
-  return matchedToolIds;
-}
-
 function buildAssistantStreamMessage(
   stream: string,
   replacementText = stream,
   timestamp = Date.now(),
   source: VisibleAssistantStreamPart["source"] = "current",
   itemId?: string,
+  runId?: string,
+  afterBoundaryRunId?: string,
 ): Record<string, unknown> {
   return {
     role: "assistant",
@@ -152,56 +130,88 @@ function buildAssistantStreamMessage(
       replacementText,
       source,
       ...(itemId ? { itemId } : {}),
+      ...(runId ? { runId } : {}),
+      ...(afterBoundaryRunId ? { afterBoundaryRunId } : {}),
     },
   };
 }
 
-function streamFallbackReplacementText(message: unknown): string | null {
-  if (!message || typeof message !== "object") {
-    return null;
-  }
-  const fallback = (message as { openclawStreamFallback?: unknown }).openclawStreamFallback;
-  if (!fallback || typeof fallback !== "object") {
-    return null;
-  }
-  const replacementText = (fallback as { replacementText?: unknown }).replacementText;
-  if (typeof replacementText === "string" && replacementText.trim()) {
-    return replacementText.trim();
-  }
-  return extractText(message)?.trim() ?? null;
-}
-
-function terminalMessageReplacesStreamFallback(message: unknown, fallback: unknown): boolean {
-  const fallbackText = streamFallbackReplacementText(fallback);
-  if (!fallbackText) {
-    return false;
-  }
-  const metadata = (fallback as { openclawStreamFallback?: unknown }).openclawStreamFallback;
-  const source =
-    metadata && typeof metadata === "object"
-      ? (metadata as { source?: unknown }).source
-      : undefined;
-  const itemId =
-    metadata && typeof metadata === "object"
-      ? (metadata as { itemId?: unknown }).itemId
-      : undefined;
-  if (source === "segment" && typeof itemId === "string" && itemId.trim()) {
-    return false;
-  }
-  const terminalText = extractText(message)?.trim();
-  return Boolean(
-    terminalText && (terminalText === fallbackText || terminalText.startsWith(fallbackText)),
-  );
+function unkeyedStreamFallbackMetadata(message: unknown): Record<string, unknown> | null {
+  const metadata = asNullableRecord(asNullableRecord(message)?.openclawStreamFallback);
+  return metadata && !normalizeOptionalString(metadata.itemId) ? metadata : null;
 }
 
 export function appendTerminalAssistantMessage(messages: unknown[], message: unknown): unknown[] {
-  const retainedMessages = messages.filter((existing, index) => {
-    if (index <= lastUserMessageIndex(messages)) {
-      return true;
+  const identity = readSessionMessageIdentity(message);
+  const terminalRunId =
+    (identity?.role === "assistant" ? identity.runId : null) ?? readLiveTerminalRunId(message);
+  let afterBoundaryRunId = readLiveTerminalAfterBoundaryRunId(message) ?? undefined;
+  if (terminalRunId) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const existing = messages[index];
+      const fallback = unkeyedStreamFallbackMetadata(existing);
+      if (!fallback || normalizeOptionalString(fallback.runId) !== terminalRunId) {
+        continue;
+      }
+      afterBoundaryRunId =
+        normalizeOptionalString(fallback.afterBoundaryRunId) ?? afterBoundaryRunId;
+      break;
     }
-    return !terminalMessageReplacesStreamFallback(message, existing);
+  }
+  const interval = streamCausalInterval(messages, {
+    ...(terminalRunId ? { runId: terminalRunId } : {}),
+    ...(afterBoundaryRunId ? { afterBoundaryRunId } : {}),
   });
-  return [...retainedMessages, message];
+  const terminalText = extractText(message)?.trim() ?? "";
+  const removedIndexes = new Set<number>();
+  const currentFallbackIndexes: number[] = [];
+  let terminalCursor = 0;
+  for (let index = interval.start; index < interval.end; index += 1) {
+    const existing = messages[index];
+    const fallback = unkeyedStreamFallbackMetadata(existing);
+    if (!fallback) {
+      continue;
+    }
+    if (fallback.source === "current") {
+      currentFallbackIndexes.push(index);
+    }
+    const visibleText = extractText(existing)?.trim();
+    if (!visibleText) {
+      continue;
+    }
+    const remainingTerminal = terminalText.slice(terminalCursor);
+    const leadingWhitespace = /^\s*/u.exec(remainingTerminal)?.[0].length ?? 0;
+    if (!remainingTerminal.slice(leadingWhitespace).startsWith(visibleText)) {
+      continue;
+    }
+    removedIndexes.add(index);
+    terminalCursor += leadingWhitespace + visibleText.length;
+  }
+  const onlyCurrentFallbackIndex = currentFallbackIndexes[0];
+  if (
+    removedIndexes.size === 0 &&
+    currentFallbackIndexes.length === 1 &&
+    onlyCurrentFallbackIndex !== undefined
+  ) {
+    removedIndexes.add(onlyCurrentFallbackIndex);
+  }
+  const retainedInterval: unknown[] = [];
+  let insertIndex: number | null = null;
+  for (let index = interval.start; index < interval.end; index += 1) {
+    if (removedIndexes.has(index)) {
+      insertIndex ??= retainedInterval.length;
+    } else {
+      retainedInterval.push(messages[index]);
+    }
+  }
+  const targetIndex = insertIndex ?? retainedInterval.length;
+  return [
+    ...messages.slice(0, interval.start),
+    ...retainedInterval.slice(0, targetIndex),
+    message,
+    ...retainedInterval.slice(targetIndex),
+    ...messages.slice(interval.end),
+  ];
 }
 
 function visibleAssistantStreamText(
@@ -219,12 +229,13 @@ function hasAssistantStreamReplacement(
   stream: string,
   isHiddenAssistantMessage: AssistantMessageVisibility,
   startIndex: number,
+  endIndex = messages.length,
 ): boolean {
   const expected = stream.trim();
   if (!expected) {
     return false;
   }
-  return messages.slice(startIndex).some((message) => {
+  return messages.slice(startIndex, endIndex).some((message) => {
     if (!message || typeof message !== "object") {
       return false;
     }
@@ -256,11 +267,14 @@ function hasKeyedAssistantStreamReplacement(
   messages: unknown[],
   itemId: string,
   startIndex: number,
+  endIndex = messages.length,
 ): boolean {
-  return messages.slice(startIndex).some((message) => streamFallbackItemId(message) === itemId);
+  return messages
+    .slice(startIndex, endIndex)
+    .some((message) => streamFallbackItemId(message) === itemId);
 }
 
-function visibleAssistantStreamParts(
+export function visibleAssistantStreamParts(
   state: StreamReconciliationState,
   opts: Pick<MaterializeVisibleStreamOptions, "includeCurrent" | "isHiddenStreamText">,
 ): VisibleAssistantStreamPart[] {
@@ -272,7 +286,8 @@ function visibleAssistantStreamParts(
     ? streamHost.chatStreamSegments
     : [];
   let toolIndexedSegmentIndex = 0;
-  for (const segment of segments) {
+  let latestBoundaryRunId: string | undefined;
+  for (const [segmentIndex, segment] of segments.entries()) {
     if (!segment || typeof segment.text !== "string") {
       continue;
     }
@@ -285,7 +300,10 @@ function visibleAssistantStreamParts(
       usesItemId && typeof segment.itemId === "string" ? segment.itemId.trim() : undefined;
     const indexedToolRef = usesItemId ? undefined : liveToolRefs[toolIndexedSegmentIndex];
     const segmentRunId = normalizeOptionalString(segment.runId) ?? indexedToolRef?.runId;
-    if (!usesItemId) {
+    const afterBoundaryRunId =
+      normalizeOptionalString(segment.afterBoundaryRunId) ?? latestBoundaryRunId;
+    const boundaryRunId = normalizeOptionalString(segment.boundaryRunId);
+    if (!usesItemId && segment.boundaryMarker !== true) {
       toolIndexedSegmentIndex += 1;
     }
     const usesAccumulatedText = streamSegmentUsesAccumulatedText(segment);
@@ -298,15 +316,21 @@ function visibleAssistantStreamParts(
         text: visible,
         replacementText: segment.text,
         source: "segment",
+        segmentIndex,
         timestamp:
           typeof segment.ts === "number" && Number.isFinite(segment.ts) ? segment.ts : Date.now(),
         ...(itemId ? { itemId } : {}),
         ...(segmentRunId ? { runId: segmentRunId } : {}),
+        ...(afterBoundaryRunId ? { afterBoundaryRunId } : {}),
+        ...(boundaryRunId ? { boundaryRunId } : {}),
         toolCallId: explicitToolCallId ?? indexedToolRef?.id,
       });
     }
     if (usesAccumulatedText) {
       previousText = advanceAccumulatedStreamText(previousText, segment.text);
+    }
+    if (boundaryRunId) {
+      latestBoundaryRunId = boundaryRunId;
     }
   }
   if (opts.includeCurrent !== false && typeof state.chatStream === "string") {
@@ -320,6 +344,8 @@ function visibleAssistantStreamParts(
         replacementText: state.chatStream,
         source: "current",
         timestamp: state.chatStreamStartedAt ?? Date.now(),
+        ...(state.chatRunId ? { runId: state.chatRunId } : {}),
+        ...(latestBoundaryRunId ? { afterBoundaryRunId: latestBoundaryRunId } : {}),
       });
     }
   }
@@ -349,14 +375,15 @@ export function visibleCurrentAssistantStreamTail(
   );
 }
 
-function hasAssistantStreamPartReplacement(
+export function hasAssistantStreamPartReplacement(
   messages: unknown[],
   part: VisibleAssistantStreamPart,
   isHiddenAssistantMessage: AssistantMessageVisibility,
   startIndex: number,
+  endIndex = messages.length,
 ): boolean {
   if (part.itemId) {
-    return hasKeyedAssistantStreamReplacement(messages, part.itemId, startIndex);
+    return hasKeyedAssistantStreamReplacement(messages, part.itemId, startIndex, endIndex);
   }
   return (
     hasAssistantStreamReplacement(
@@ -364,7 +391,15 @@ function hasAssistantStreamPartReplacement(
       part.replacementText,
       isHiddenAssistantMessage,
       startIndex,
-    ) || hasAssistantStreamReplacement(messages, part.text, isHiddenAssistantMessage, startIndex)
+      endIndex,
+    ) ||
+    hasAssistantStreamReplacement(
+      messages,
+      part.text,
+      isHiddenAssistantMessage,
+      startIndex,
+      endIndex,
+    )
   );
 }
 
@@ -400,14 +435,16 @@ export function historyReplacedVisibleStream(
     parts.length > 0 &&
     (requiredParts.length > 0 ||
       hasVisibleAssistantMessageAfterUser(messages, opts.isHiddenAssistantMessage)) &&
-    requiredParts.every((part) =>
-      hasAssistantStreamPartReplacement(
+    requiredParts.every((part) => {
+      const interval = streamCausalInterval(messages, part);
+      return hasAssistantStreamPartReplacement(
         messages,
         part,
         opts.isHiddenAssistantMessage,
-        streamReconciliationStartIndex(messages),
-      ),
-    )
+        interval.start,
+        interval.end,
+      );
+    })
   );
 }
 
@@ -453,6 +490,7 @@ function currentToolStreamMessageIndex(
   messages: unknown[],
   state: StreamReconciliationState,
   startIndex: number,
+  endIndex: number,
   toolCallId?: string,
   runId?: string,
 ): number {
@@ -468,7 +506,7 @@ function currentToolStreamMessageIndex(
   if (liveToolIds.size === 0) {
     return -1;
   }
-  for (let index = startIndex; index < messages.length; index++) {
+  for (let index = startIndex; index < endIndex; index++) {
     if (
       extractToolMessageRefs(messages[index]).some((ref) => {
         const identity = resolveMatchingLiveToolIdentity(ref, liveToolRefs);
@@ -481,59 +519,12 @@ function currentToolStreamMessageIndex(
   return -1;
 }
 
-function insertMessageAtIndex(messages: unknown[], message: unknown, index: number): unknown[] {
-  return [...messages.slice(0, index), message, ...messages.slice(index)];
-}
-
-function timestampOrderedInsertIndex(
-  messages: unknown[],
-  desiredTimestamp: number,
-  startIndex: number,
-): number {
-  for (let index = startIndex; index < messages.length; index++) {
-    const timestamp = messageTimestampMs(messages[index]);
-    if (timestamp != null && timestamp > desiredTimestamp) {
-      return index;
-    }
-  }
-  return messages.length;
-}
-
 function messageTimestampMs(message: unknown): number | null {
   if (!message || typeof message !== "object") {
     return null;
   }
   const record = message as { timestamp?: unknown; ts?: unknown };
   return asFiniteNumber(record.timestamp) ?? asFiniteNumber(record.ts) ?? null;
-}
-
-function timestampForInsertedVisibleStream(
-  messages: unknown[],
-  index: number,
-  desiredTimestamp: number,
-): number {
-  const previousTimestamp = messages
-    .slice(0, index)
-    .toReversed()
-    .map(messageTimestampMs)
-    .find((timestamp): timestamp is number => timestamp != null);
-  const nextTimestamp = messages
-    .slice(index)
-    .map(messageTimestampMs)
-    .find((timestamp): timestamp is number => timestamp != null);
-  if (previousTimestamp != null && desiredTimestamp <= previousTimestamp) {
-    const afterPrevious = previousTimestamp + 1;
-    return nextTimestamp != null && afterPrevious >= nextTimestamp
-      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
-      : afterPrevious;
-  }
-  if (nextTimestamp != null && desiredTimestamp >= nextTimestamp) {
-    const beforeNext = nextTimestamp - 1;
-    return previousTimestamp != null && beforeNext <= previousTimestamp
-      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
-      : beforeNext;
-  }
-  return desiredTimestamp;
 }
 
 export function materializeVisibleStreamState(
@@ -543,31 +534,37 @@ export function materializeVisibleStreamState(
 ): unknown[] {
   let nextMessages = messages;
   const persistCommentary = opts.persistCommentary === true;
+  const replacementMessages = opts.replacementMessages;
   for (const part of visibleAssistantStreamParts(state, opts)) {
     if (!persistCommentary && part.itemId) {
       continue;
     }
-    const replacementMessages = opts.replacementMessages ?? [];
-    const defaultStartIndex = streamReconciliationStartIndex(nextMessages);
-    const startIndex = part.itemId
-      ? (opts.keyedStartIndex ?? defaultStartIndex)
-      : defaultStartIndex;
+    const replacementCandidates = replacementMessages?.length
+      ? [...nextMessages, ...replacementMessages]
+      : nextMessages;
+    const replacementInterval = streamCausalInterval(replacementCandidates, part);
     if (
       hasAssistantStreamPartReplacement(
-        [...nextMessages, ...replacementMessages],
+        replacementCandidates,
         part,
         opts.isHiddenAssistantMessage,
-        startIndex,
+        replacementInterval.start,
+        replacementInterval.end,
       )
     ) {
       continue;
     }
+    const interval =
+      replacementCandidates === nextMessages
+        ? replacementInterval
+        : streamCausalInterval(nextMessages, part);
     const toolIndex =
       part.source === "segment" && part.toolCallId
         ? currentToolStreamMessageIndex(
             nextMessages,
             state,
-            startIndex,
+            interval.start,
+            interval.end,
             part.toolCallId,
             part.runId,
           )
@@ -579,84 +576,28 @@ export function materializeVisibleStreamState(
       toolIndex >= 0
         ? toolIndex
         : part.source === "segment"
-          ? timestampOrderedInsertIndex(nextMessages, part.timestamp, startIndex)
-          : nextMessages.length;
+          ? streamCausalInsertIndex(
+              nextMessages,
+              part.timestamp,
+              interval.start,
+              interval.end,
+              messageTimestampMs,
+            )
+          : interval.end;
     const streamMessage = buildAssistantStreamMessage(
       part.text,
       part.replacementText,
-      timestampForInsertedVisibleStream(nextMessages, insertIndex, part.timestamp),
+      streamCausalTimestamp(nextMessages, insertIndex, part.timestamp, messageTimestampMs),
       part.source,
       part.itemId,
+      part.runId,
+      part.afterBoundaryRunId,
     );
-    nextMessages = insertMessageAtIndex(nextMessages, streamMessage, insertIndex);
+    nextMessages = [
+      ...nextMessages.slice(0, insertIndex),
+      streamMessage,
+      ...nextMessages.slice(insertIndex),
+    ];
   }
   return nextMessages;
-}
-
-export function prunePersistedToolStreamMessages(
-  state: StreamReconciliationState,
-  persistedToolIds: Set<string>,
-) {
-  if (persistedToolIds.size === 0) {
-    return;
-  }
-  const toolHost = state as ToolStreamHost;
-  const liveToolRefs = resolveLiveToolStreamRefs(state);
-  if (toolHost.toolStreamById instanceof Map) {
-    for (const id of persistedToolIds) {
-      toolHost.toolStreamById.delete(id);
-    }
-  }
-  if (Array.isArray(toolHost.toolStreamOrder)) {
-    toolHost.toolStreamOrder = toolHost.toolStreamOrder.filter(
-      (id): id is string => typeof id === "string" && !persistedToolIds.has(id),
-    );
-  }
-  if (Array.isArray(toolHost.chatToolMessages)) {
-    toolHost.chatToolMessages = toolHost.chatToolMessages.filter((message) => {
-      const refs = extractToolMessageRefs(message);
-      return refs.every((ref) => {
-        const identity = resolveMatchingLiveToolIdentity(ref, liveToolRefs);
-        return identity === undefined || !persistedToolIds.has(identity);
-      });
-    });
-  }
-  if (!Array.isArray(toolHost.chatStreamSegments)) {
-    return;
-  }
-  let lastPrunedAccumulatedText: string | null = null;
-  let toolIndexedSegmentIndex = 0;
-  toolHost.chatStreamSegments = toolHost.chatStreamSegments.flatMap((segment) => {
-    const explicitToolCallId =
-      typeof segment.toolCallId === "string" && segment.toolCallId.trim()
-        ? segment.toolCallId.trim()
-        : null;
-    const usesItemId = streamSegmentHasItemId(segment);
-    const indexedToolRef = usesItemId ? undefined : liveToolRefs[toolIndexedSegmentIndex];
-    if (!usesItemId) {
-      toolIndexedSegmentIndex += 1;
-    }
-    const segmentRunId = normalizeOptionalString(segment.runId);
-    const toolIdentity = explicitToolCallId
-      ? resolveMatchingLiveToolIdentity(
-          {
-            id: explicitToolCallId,
-            ...(segmentRunId ? { runId: segmentRunId } : {}),
-          },
-          liveToolRefs,
-        )
-      : indexedToolRef?.identity;
-    const text = typeof segment.text === "string" ? segment.text : "";
-    if (toolIdentity && persistedToolIds.has(toolIdentity)) {
-      if (streamSegmentUsesAccumulatedText(segment)) {
-        lastPrunedAccumulatedText = advanceAccumulatedStreamText(lastPrunedAccumulatedText, text);
-      }
-      return [];
-    }
-    const nextText =
-      lastPrunedAccumulatedText && streamSegmentUsesAccumulatedText(segment)
-        ? trimAccumulatedStreamPrefix(text, lastPrunedAccumulatedText)
-        : text;
-    return [{ ...segment, text: nextText }];
-  });
 }

--- a/ui/src/pages/chat/stream-segment-pruning.ts
+++ b/ui/src/pages/chat/stream-segment-pruning.ts
@@ -1,0 +1,173 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  advanceAccumulatedStreamText,
+  streamSegmentHasItemId,
+  streamSegmentUsesAccumulatedText,
+  trimAccumulatedStreamPrefix,
+  type ChatStreamSegment,
+} from "../../lib/chat/chat-types.ts";
+import { streamCausalInterval, type StreamCausalBoundaryState } from "./stream-causal-boundary.ts";
+import {
+  hasAssistantStreamPartReplacement,
+  visibleAssistantStreamParts,
+  visibleCurrentAssistantStreamTail,
+} from "./stream-reconciliation.ts";
+import {
+  extractToolMessageRefs,
+  resolveLiveToolStreamRefs,
+  resolveMatchingLiveToolIdentity,
+} from "./tool-stream-identity.ts";
+
+type StreamSegmentPruningState = StreamCausalBoundaryState & {
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  chatToolMessages?: unknown[];
+  toolStreamById?: Map<string, unknown>;
+  toolStreamOrder?: unknown[];
+};
+
+type AssistantMessageVisibility = (message: unknown) => boolean;
+type StreamVisibility = (stream: string) => boolean;
+
+function pruneAccumulatedStreamSegments(
+  segments: readonly ChatStreamSegment[],
+  shouldPrune: (segment: ChatStreamSegment, index: number) => boolean,
+): ChatStreamSegment[] {
+  let removedAccumulatedPrefix: string | null = null;
+  return segments.flatMap((segment, index) => {
+    if (shouldPrune(segment, index)) {
+      if (streamSegmentUsesAccumulatedText(segment)) {
+        removedAccumulatedPrefix = advanceAccumulatedStreamText(
+          removedAccumulatedPrefix,
+          segment.text,
+        );
+      }
+      return [];
+    }
+    if (!removedAccumulatedPrefix || !streamSegmentUsesAccumulatedText(segment)) {
+      return [segment];
+    }
+    return [
+      { ...segment, text: trimAccumulatedStreamPrefix(segment.text, removedAccumulatedPrefix) },
+    ];
+  });
+}
+
+export function discardStreamSegmentIndexes(
+  state: StreamCausalBoundaryState,
+  discardedIndexes: readonly number[],
+): void {
+  if (!state.chatStreamSegments || discardedIndexes.length === 0) {
+    return;
+  }
+  const discarded = new Set(discardedIndexes);
+  state.chatStreamSegments = pruneAccumulatedStreamSegments(
+    state.chatStreamSegments,
+    (_segment, index) => discarded.has(index),
+  );
+}
+
+export function pruneHistoryReplacedStreamSegments(
+  messages: unknown[],
+  state: StreamSegmentPruningState,
+  opts: {
+    isHiddenAssistantMessage: AssistantMessageVisibility;
+    isHiddenStreamText: StreamVisibility;
+    persistCommentary?: boolean;
+  },
+): boolean {
+  if (!Array.isArray(state.chatStreamSegments)) {
+    return false;
+  }
+  const replacedIndexes = new Set<number>();
+  for (const part of visibleAssistantStreamParts(state, {
+    includeCurrent: false,
+    isHiddenStreamText: opts.isHiddenStreamText,
+  })) {
+    if (part.segmentIndex === undefined || (part.itemId && opts.persistCommentary !== true)) {
+      continue;
+    }
+    const interval = streamCausalInterval(messages, part);
+    if (
+      hasAssistantStreamPartReplacement(
+        messages,
+        part,
+        opts.isHiddenAssistantMessage,
+        interval.start,
+        interval.end,
+      )
+    ) {
+      replacedIndexes.add(part.segmentIndex);
+    }
+  }
+  if (replacedIndexes.size === 0) {
+    return false;
+  }
+  const currentTail = visibleCurrentAssistantStreamTail(state, opts.isHiddenStreamText);
+  state.chatStreamSegments = pruneAccumulatedStreamSegments(
+    state.chatStreamSegments,
+    (_segment, index) => replacedIndexes.has(index),
+  );
+  if (typeof state.chatStream === "string") {
+    state.chatStream = currentTail;
+    if (currentTail === null) {
+      state.chatStreamStartedAt = null;
+    }
+  }
+  return true;
+}
+
+export function prunePersistedToolStreamMessages(
+  state: StreamSegmentPruningState,
+  persistedToolIds: Set<string>,
+) {
+  if (persistedToolIds.size === 0) {
+    return;
+  }
+  const liveToolRefs = resolveLiveToolStreamRefs(state);
+  if (state.toolStreamById instanceof Map) {
+    for (const id of persistedToolIds) {
+      state.toolStreamById.delete(id);
+    }
+  }
+  if (Array.isArray(state.toolStreamOrder)) {
+    state.toolStreamOrder = state.toolStreamOrder.filter(
+      (id): id is string => typeof id === "string" && !persistedToolIds.has(id),
+    );
+  }
+  if (Array.isArray(state.chatToolMessages)) {
+    state.chatToolMessages = state.chatToolMessages.filter((message) => {
+      const refs = extractToolMessageRefs(message);
+      return refs.every((ref) => {
+        const identity = resolveMatchingLiveToolIdentity(ref, liveToolRefs);
+        return identity === undefined || !persistedToolIds.has(identity);
+      });
+    });
+  }
+  if (!Array.isArray(state.chatStreamSegments)) {
+    return;
+  }
+  let toolIndexedSegmentIndex = 0;
+  state.chatStreamSegments = pruneAccumulatedStreamSegments(state.chatStreamSegments, (segment) => {
+    if (segment.boundaryMarker === true) {
+      return false;
+    }
+    const explicitToolCallId = normalizeOptionalString(segment.toolCallId);
+    const usesItemId = streamSegmentHasItemId(segment);
+    const indexedToolRef = usesItemId ? undefined : liveToolRefs[toolIndexedSegmentIndex];
+    if (!usesItemId) {
+      toolIndexedSegmentIndex += 1;
+    }
+    const segmentRunId = normalizeOptionalString(segment.runId);
+    const toolIdentity = explicitToolCallId
+      ? resolveMatchingLiveToolIdentity(
+          {
+            id: explicitToolCallId,
+            ...(segmentRunId ? { runId: segmentRunId } : {}),
+          },
+          liveToolRefs,
+        )
+      : indexedToolRef?.identity;
+    return Boolean(toolIdentity && persistedToolIds.has(toolIdentity));
+  });
+}

--- a/ui/src/pages/chat/terminal-message-identity.ts
+++ b/ui/src/pages/chat/terminal-message-identity.ts
@@ -2,7 +2,9 @@ import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 
-const liveTerminalRunIds = new WeakMap<object, string>();
+type LiveTerminalIdentity = { runId: string; afterBoundaryRunId?: string };
+
+const liveTerminalIdentities = new WeakMap<object, LiveTerminalIdentity>();
 const authoritativeTerminals = new WeakMap<object, AuthoritativeTerminal>();
 
 type AuthoritativeTerminal = {
@@ -16,17 +18,33 @@ type AuthoritativeTerminal = {
 export function rememberLiveTerminalRun(
   message: unknown,
   runId: string | null | undefined,
+  afterBoundaryRunId?: string,
 ): unknown {
   if (runId && message && typeof message === "object") {
-    liveTerminalRunIds.set(message, runId);
+    liveTerminalIdentities.set(message, {
+      runId,
+      ...(afterBoundaryRunId ? { afterBoundaryRunId } : {}),
+    });
   }
   return message;
 }
 
 export function isLiveTerminalForRun(message: unknown, runId: string): boolean {
   return Boolean(
-    message && typeof message === "object" && liveTerminalRunIds.get(message) === runId,
+    message && typeof message === "object" && liveTerminalIdentities.get(message)?.runId === runId,
   );
+}
+
+export function readLiveTerminalRunId(message: unknown): string | null {
+  return message && typeof message === "object"
+    ? (liveTerminalIdentities.get(message)?.runId ?? null)
+    : null;
+}
+
+export function readLiveTerminalAfterBoundaryRunId(message: unknown): string | null {
+  return message && typeof message === "object"
+    ? (liveTerminalIdentities.get(message)?.afterBoundaryRunId ?? null)
+    : null;
 }
 
 export function rememberAuthoritativeTerminal(options: {

--- a/ui/src/pages/chat/tool-stream-identity.ts
+++ b/ui/src/pages/chat/tool-stream-identity.ts
@@ -125,3 +125,27 @@ export function resolveMatchingLiveToolIdentity(
   );
   return matches.length === 1 ? matches[0]?.identity : undefined;
 }
+
+export function persistedCurrentToolStreamIds(
+  messages: unknown[],
+  state: LiveToolStreamHost,
+): Set<string> {
+  const liveToolRefs = resolveLiveToolStreamRefs(state);
+  const matchedToolIds = new Set<string>();
+  if (liveToolRefs.length === 0) {
+    return matchedToolIds;
+  }
+  const lastUserIndex = messages.findLastIndex((message) => {
+    const role = asToolRecord(message)?.role;
+    return typeof role === "string" && normalizeRoleForGrouping(role).toLowerCase() === "user";
+  });
+  for (const message of messages.slice(lastUserIndex + 1)) {
+    for (const ref of extractToolMessageRefs(message)) {
+      const identity = resolveMatchingLiveToolIdentity(ref, liveToolRefs);
+      if (identity) {
+        matchedToolIds.add(identity);
+      }
+    }
+  }
+  return matchedToolIds;
+}

--- a/ui/src/pages/chat/tool-stream-identity.ts
+++ b/ui/src/pages/chat/tool-stream-identity.ts
@@ -12,7 +12,7 @@ type ToolMessageRef = {
   runId?: string;
 };
 
-export type LiveToolStreamRef = ToolMessageRef & {
+type LiveToolStreamRef = ToolMessageRef & {
   identity: string;
 };
 
@@ -124,6 +124,47 @@ export function resolveMatchingLiveToolIdentity(
       liveRef.id === ref.id && (!ref.runId || !liveRef.runId || liveRef.runId === ref.runId),
   );
   return matches.length === 1 ? matches[0]?.identity : undefined;
+}
+
+export function buildLiveRenderedToolRefs(toolMessages: unknown[]): LiveToolStreamRef[] {
+  const refs: LiveToolStreamRef[] = [];
+  const seen = new Set<string>();
+  for (const [index, message] of toolMessages.entries()) {
+    for (const ref of extractToolMessageRefs(message)) {
+      const key = JSON.stringify([ref.runId ?? null, ref.id]);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      refs.push({ ...ref, identity: `live:${index}:${key}` });
+    }
+  }
+  return refs;
+}
+
+export function removeLiveToolBlocksFromHistory(
+  message: unknown,
+  liveToolRefs: LiveToolStreamRef[],
+): unknown {
+  const record = asToolRecord(message);
+  if (!record || !Array.isArray(record.content) || liveToolRefs.length === 0) {
+    return message;
+  }
+  const topLevelToolId = resolveToolUseId({ ...record, id: undefined });
+  const topLevelRunId = normalizeOptionalString(record.runId);
+  const content = record.content.filter((block) => {
+    const entry = asToolRecord(block);
+    if (!entry || !isToolMessageContentBlock(entry)) {
+      return true;
+    }
+    const id = resolveToolUseId(entry) ?? topLevelToolId;
+    if (!id) {
+      return true;
+    }
+    const runId = normalizeOptionalString(entry.runId) ?? topLevelRunId;
+    return !resolveMatchingLiveToolIdentity({ id, ...(runId ? { runId } : {}) }, liveToolRefs);
+  });
+  return content.length === record.content.length ? message : { ...record, content };
 }
 
 export function persistedCurrentToolStreamIds(

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -17,6 +17,7 @@ import { formatUnknownText, truncateText } from "../../lib/format.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { uiSessionEventMatches } from "../../lib/sessions/session-key.ts";
 import type { ChatRunStartupState } from "./chat-run-startup.ts";
+import { rolloverChatStream } from "./stream-causal-boundary.ts";
 import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 
 const TOOL_STREAM_LIMIT = 50;
@@ -1113,24 +1114,8 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
 
   const now = Date.now();
   if (!entry) {
-    // Commit any in-progress streaming text as a segment so it renders
-    // above the tool card instead of below it.
-    if (
-      host.chatRunId &&
-      payload.runId === host.chatRunId &&
-      host.chatStream &&
-      host.chatStream.trim().length > 0
-    ) {
-      const segmentStartedAt = host.chatStreamStartedAt ?? now;
-      host.chatStreamSegments = [
-        ...host.chatStreamSegments,
-        { text: host.chatStream, ts: segmentStartedAt, runId: payload.runId, toolCallId },
-      ];
-      host.chatStream = null;
-      // The segment becomes the elapsed-time owner after the live tail is flushed.
-      // Preserve the run start or replaying a tool event resets the working timer.
-      host.chatStreamStartedAt = null;
-    }
+    // Commit in-progress text so it remains causally above the tool card.
+    rolloverChatStream(host, { runId: payload.runId, toolCallId, timestamp: now });
     entry = {
       toolCallId,
       runId: payload.runId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where steering an active Control UI run could move already-visible assistant text below the steered user message, then continue streaming into the middle of the transcript. The ordering could change again when the terminal payload or authoritative history arrived, producing duplicated, missing, or misplaced reply fragments.

## Why This Change Was Made

The Gateway's durable transcript order was already correct, but the Control UI stored stable transcript rows and cumulative live assistant text in separate projections without a durable causal boundary. This change records exact-run steering provenance when the user turn is consumed, carries that fact through transcript persistence, and gives live streams, tool boundaries, terminal tails, and history reconciliation one causal ordering model. Ordinary queued follow-ups are explicitly not treated as steering boundaries.

The provenance is owned by the final resolved injection backend rather than optional client request metadata. Durable provenance is added to the exact anchored user row only after transcript commitment is confirmed; unconfirmed acceptance never writes a boundary marker. The implementation is provider-neutral and matches the upstream steering contract: steering acceptance does not preempt the current sampling/tool continuation; the consumed user input becomes the boundary before the next model request.

To keep the Control UI startup budget green, persisted split-layout normalization was also separated from the interactive layout module so settings startup no longer pulls that command surface into the initial bundle.

AI-assisted; the complete code and behavior were independently reviewed and verified.

## User Impact

When a user steers while an answer is streaming, everything produced before the steer stays above the user message and everything produced afterward stays below it. The order remains stable across delayed persistence, tools, terminal-only suffixes, multiple steers, reconnect/history reload, textless pre-steer states, later queued turns, leaf-only steering, and unconfirmed transcript commits.

## Evidence

Pre-fix regression:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-state.test.ts -t 'keeps cumulative assistant output split across an authoritative steer'`
- Failed before the repair with the steer rendered before the already-visible assistant prefix.

Exact head `84e85acb43cf`:

- Full steering producer and transcript suites: 341 tests passed.
- Rebased chat thread/state conflict surfaces: 226 tests passed.
- Post-rebase stream/tool reconciliation sweep: 255 tests passed.
- Queued-user causal ordering sweep: 452 tests passed; both new regressions failed before the repair for the intended ordering reason.
- Control UI browser E2E lane: all 7 tests passed, including live stream → persisted queued user → consumed steer → terminal history/reload.
- Core and UI changed gates passed: formatting, typechecks, lint/max-lines, assertion ratchets, dead exports, plugin boundaries, database guards, import cycles, and i18n verification.
- `pnpm ui:build` — startup JS gzip 338,387 B, 2,254 B below the current committed baseline plus tolerance; no budget increase.
- Codex autoreview at P1: confirmation-owned provenance repair clean; post-rebase UI ownership cleanup clean.
- Exact-head required CI: run [32031696002](https://github.com/openclaw/openclaw/actions/runs/32031696002) completed green.

Earlier comprehensive branch proof:

- Focused session/Gateway/UI regressions: 660 tests passed.
- `node scripts/run-vitest.mjs test/gateway-steer-fifo.e2e.test.ts -- -t 'finishes a running tool, skips its sequential tail, and injects an exact UI steer once'` — 1 passed, 4 skipped; real isolated Gateway + mock provider.
- `OPENCLAW_CAPTURE_UI_PROOF=1 ... chat-flow.active-run-follow-ups.e2e.test.ts -t 'keeps cumulative assistant output ordered across a consumed steer'` — 1 passed, 6 skipped.
- `pnpm build` completed successfully.
- The exact curated changed gate was green across core/UI typechecks, lint, dead exports, import cycles, i18n, schema, and repository guards. Remote Testbox/Daytona capacity was unavailable, so trusted-source fallback ran the same curated gate locally.

Sanitized after-state screenshot:

![Steering order after repair](https://github.com/user-attachments/assets/bdd76fce-092c-44e7-a058-60f4a5bcc8f5)

Browser recording of the repaired flow:

https://github.com/user-attachments/assets/d7cb20bd-6501-4746-ba6c-bd00949909a4

The original report screenshot is not attached because it contains private workspace/session identifiers. The failing pre-fix regression above is the sanitized before-proof.

Production LOC: +1746/-726 (net +1020) | Tests: +1403/-39 (net +1364) | Tooling baseline: +3/-3 (net 0).

The positive production delta is the new causal-boundary capability the old model could not represent: producer-owned confirmed-steer provenance plus one canonical stream reconciliation path across live, tool, terminal, projection, and history owners. The change also deletes the previous terminal index special case and consolidates cumulative-tail and segment-pruning logic.
