### PR TITLE
fix(ui): refresh startup budget baseline

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 338241,
+  "startupJsGzipBytes": 339585,
   "reason": "session placement move controls, ownership chips, assignment menus, and participant stack",
   "updatedAt": "2026-08-17"
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a clean Control UI production build on current `main` failed the startup JS gzip ratchet after the intentional session placement, ownership, assignment, and participant UI additions landed in #125057.

## Why This Change Was Made

The Node 24.15.0 build reproduces 339,585 B of startup JS gzip against the stale 338,241 B baseline plus 1,056 B tolerance. Inspection found no new accidental eager dependency: the affected session menu, owner chip, and participant facepile remain in their pre-existing startup ownership paths. This updates only the measured baseline through the repository baseline tool; tolerance and the 350 KiB hard ceiling are unchanged.

## User Impact

No production or test behavior changes. Clean package and CI builds no longer fail on the intentional Control UI startup bytes already present on `main`.

## Evidence

- Node `v24.15.0`, with `OPENCLAW_SKIP_PROVIDERS=1 OPENCLAW_SKIP_CHANNELS=1`
- Before: `pnpm ui:build` measured 339,585 B and failed by 288 B (`339,585 > 338,241 + 1,056`)
- After: `pnpm ui:build` passed at 339,577 B (`339,585 + 1,056` limit; build-to-build chunk-hash variance is covered by the existing tolerance)
- `pnpm check:changed` passed
- `git diff --check` passed
- Production LOC: +0/-0; test LOC: +0/-0; metadata only

AI-assisted change.
