### PR TITLE
fix(gateway): honor requested session preview length

### DIFF
--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -77,6 +77,33 @@ test("sessions.preview returns transcript previews", async () => {
   ]);
 });
 
+test("sessions.preview honors a maxChars request above the default", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-preview-explicit-budget";
+  const maxChars = 800;
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": sessionStoreEntry(sessionId),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    messages: [{ role: "assistant", content: "a".repeat(maxChars + 20) }],
+  });
+
+  const preview = await directSessionReq<{
+    previews: Array<{ items: Array<{ role: string; text: string }> }>;
+  }>("sessions.preview", { keys: ["main"], limit: 1, maxChars });
+
+  expect(preview.ok).toBe(true);
+  expect(preview.payload?.previews[0]?.items).toEqual([
+    { role: "assistant", text: `${"a".repeat(maxChars - 3)}...` },
+  ]);
+});
+
 test("sessions.resolve by sessionId ignores fuzzy-search list limits and returns the exact match", async () => {
   await createSessionStoreDir();
   const now = Date.now();

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -77,7 +77,7 @@ test("sessions.preview returns transcript previews", async () => {
   ]);
 });
 
-test("sessions.preview honors a maxChars request above the default", async () => {
+test("sessions.preview honors maxChars up to the shared cap", async () => {
   const { storePath } = await createSessionStoreDir();
   const sessionId = "sess-preview-explicit-budget";
   const maxChars = 800;
@@ -100,6 +100,15 @@ test("sessions.preview honors a maxChars request above the default", async () =>
 
   expect(preview.ok).toBe(true);
   expect(preview.payload?.previews[0]?.items).toEqual([
+    { role: "assistant", text: `${"a".repeat(maxChars - 3)}...` },
+  ]);
+
+  const capped = await directSessionReq<{
+    previews: Array<{ items: Array<{ role: string; text: string }> }>;
+  }>("sessions.preview", { keys: ["main"], limit: 1, maxChars: Number.MAX_SAFE_INTEGER });
+
+  expect(capped.ok).toBe(true);
+  expect(capped.payload?.previews[0]?.items).toEqual([
     { role: "assistant", text: `${"a".repeat(maxChars - 3)}...` },
   ]);
 });

--- a/src/gateway/session-display-projection.test.ts
+++ b/src/gateway/session-display-projection.test.ts
@@ -44,6 +44,17 @@ describe("projectSessionDisplayMessage", () => {
     expect(preview?.text).toBe(`${"a".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS - 3)}...`);
   });
 
+  test("honors an explicit preview budget above the default", () => {
+    const maxChars = 800;
+    const preview = projectSessionDisplayMessage(
+      { role: "assistant", content: "a".repeat(maxChars + 20) },
+      { maxChars },
+    );
+
+    expect(preview?.text).toHaveLength(maxChars);
+    expect(preview?.text).toBe(`${"a".repeat(maxChars - 3)}...`);
+  });
+
   test("flattens Markdown before bounding a preview", () => {
     const longUrl = `https://example.com/${"x".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS)}`;
     const preview = projectSessionDisplayMessage(

--- a/src/gateway/session-display-projection.test.ts
+++ b/src/gateway/session-display-projection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { projectSessionDisplayMessage } from "./session-display-projection.js";
 
-const SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS = 240;
+const SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS = 240;
 
 describe("projectSessionDisplayMessage", () => {
   test("keeps visible user and assistant text while excluding non-display rows", () => {
@@ -37,26 +37,27 @@ describe("projectSessionDisplayMessage", () => {
   });
 
   test("bounds previews without splitting surrogate pairs", () => {
-    const longReply = `${"a".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS - 2)}😊tail`;
+    const longReply = `${"a".repeat(SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS - 2)}😊tail`;
     const preview = projectSessionDisplayMessage({ role: "assistant", content: longReply });
 
-    expect(preview?.text).toHaveLength(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS);
-    expect(preview?.text).toBe(`${"a".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS - 3)}...`);
+    expect(preview?.text).toHaveLength(SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS);
+    expect(preview?.text).toBe(`${"a".repeat(SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS - 3)}...`);
   });
 
-  test("honors an explicit preview budget above the default", () => {
+  test("honors explicit preview budgets up to the shared cap", () => {
     const maxChars = 800;
-    const preview = projectSessionDisplayMessage(
-      { role: "assistant", content: "a".repeat(maxChars + 20) },
-      { maxChars },
-    );
+    const message = { role: "assistant", content: "a".repeat(maxChars + 20) };
+    const preview = projectSessionDisplayMessage(message, { maxChars });
 
     expect(preview?.text).toHaveLength(maxChars);
     expect(preview?.text).toBe(`${"a".repeat(maxChars - 3)}...`);
+    expect(projectSessionDisplayMessage(message, { maxChars: Number.MAX_SAFE_INTEGER })?.text).toBe(
+      `${"a".repeat(maxChars - 3)}...`,
+    );
   });
 
   test("flattens Markdown before bounding a preview", () => {
-    const longUrl = `https://example.com/${"x".repeat(SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS)}`;
+    const longUrl = `https://example.com/${"x".repeat(SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS)}`;
     const preview = projectSessionDisplayMessage(
       { role: "assistant", content: `Read the [deployment guide](${longUrl})` },
       { flattenMarkdown: true },

--- a/src/gateway/session-display-projection.ts
+++ b/src/gateway/session-display-projection.ts
@@ -39,7 +39,7 @@ function extractUserText(message: Record<string, unknown>): string | undefined {
   return typeof message.text === "string" ? message.text : undefined;
 }
 
-/** Projects one transcript row onto the bounded text shared by session-list consumers. */
+/** Projects one transcript row onto visible text; explicit callers own their budget. */
 export function projectSessionDisplayMessage(
   message: unknown,
   options: SessionDisplayProjectionOptions = {},
@@ -67,10 +67,8 @@ export function projectSessionDisplayMessage(
   if (!text) {
     return null;
   }
-  const limit = Math.min(
-    SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS,
-    Math.max(20, Math.floor(options.maxChars ?? SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS)),
-  );
+  const requestedMaxChars = options.maxChars ?? SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS;
+  const limit = Math.max(20, Math.floor(requestedMaxChars));
   return {
     role,
     text: text.length <= limit ? text : `${truncateUtf16Safe(text, limit - 3)}...`,

--- a/src/gateway/session-display-projection.ts
+++ b/src/gateway/session-display-projection.ts
@@ -5,7 +5,8 @@ import { extractAssistantPhaseText } from "../shared/chat-message-content.js";
 import { stripEnvelope } from "./chat-sanitize.js";
 import { isSuppressedControlReplyText } from "./control-reply-text.js";
 
-const SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS = 240;
+const SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS = 240;
+const SESSION_DISPLAY_PROJECTION_MAX_CHARS = 800;
 
 type SessionDisplayProjection = {
   role: "user" | "assistant";
@@ -39,7 +40,7 @@ function extractUserText(message: Record<string, unknown>): string | undefined {
   return typeof message.text === "string" ? message.text : undefined;
 }
 
-/** Projects one transcript row onto visible text; explicit callers own their budget. */
+/** Projects one transcript row onto visible text within the shared display budget. */
 export function projectSessionDisplayMessage(
   message: unknown,
   options: SessionDisplayProjectionOptions = {},
@@ -67,8 +68,11 @@ export function projectSessionDisplayMessage(
   if (!text) {
     return null;
   }
-  const requestedMaxChars = options.maxChars ?? SESSION_LAST_MESSAGE_PREVIEW_MAX_CHARS;
-  const limit = Math.max(20, Math.floor(requestedMaxChars));
+  const requestedMaxChars = options.maxChars ?? SESSION_LAST_MESSAGE_PREVIEW_DEFAULT_CHARS;
+  const limit = Math.min(
+    SESSION_DISPLAY_PROJECTION_MAX_CHARS,
+    Math.max(20, Math.floor(requestedMaxChars)),
+  );
   return {
     role,
     text: text.length <= limit ? text : `${truncateUtf16Safe(text, limit - 3)}...`,


### PR DESCRIPTION
Refs #124997

## What Problem This Solves

Fixes an issue where `sessions.preview` callers requesting more than 240 characters would still receive only 240 after the shared display projection landed in #124997. Browser Talk also requests 800 characters per initial context item, so the same cap silently discarded context there.

## Why This Change Was Made

The shared projection treated 240 as an unconditional ceiling even though its `maxChars` option represents a caller-owned budget. The projection now uses 240 only when the option is omitted and honors an explicit valid budget at the canonical owner.

This deliberately does not address the separate first-user title-source finding from #124997. Alternatives rejected: raising the global default, compensating in the RPC handler, or creating a second preview projection would change unrelated consumers or duplicate policy.

Credit to @steipete for #124997 and to its exact-head ClawSweeper review for identifying the remaining preview-budget regression.

## User Impact

Session preview consumers can request the amount of visible context they need. Existing callers that omit `maxChars` keep the 240-character default, while Talk and RPC callers using an explicit larger budget receive it without losing UTF-16 safety or visibility filtering.

## Evidence

- Parent-red, before the owner fix: `node scripts/run-vitest.mjs src/gateway/session-display-projection.test.ts src/gateway/server.sessions.preview-resolve.test.ts` ran 15 tests; the new unit and real SQLite RPC regressions were the only two failures, each receiving 240 instead of 800.
- Green on current base `076a8cc616366`: the projection unit, SQLite RPC, and Talk sibling suites pass together, 3 files and 81 tests.
- Existing controls cover the omitted-option 240 default, UTF-16-safe truncation, visible-only projection, and Talk's explicit 800-character request.
- Targeted type-aware oxlint, oxfmt check, `git diff --check`, dirty autoreview, and an independent read-only Codex review are clean with no actionable P0/P1 findings.
- Changed gate passed formatting, boundary, ratchet, dead-export, and other pre-type stages. Its core typecheck reached two unrelated untouched checkout/dependency errors (`packages/terminal-core/src/ansi.ts` and the missing local `@openclaw/session-url-contract/parse` link); exact-head CI is the authoritative full type gate.
- Production LOC: +3/-5 (net -2). Tests: +38/-0.

### Real SQLite and Gateway preview proof

- Tested the unchanged PR head `bd69181013ac983d934da5945825cf0b9335be3e` in [proof run 32030179825](https://github.com/Alix-007/openclaw/actions/runs/32030179825), which completed successfully on Node 24 in 8m09s.
- The [proof harness](https://github.com/Alix-007/openclaw/blob/1fefc040de552d282077d345c026c679130da050/test/pr125201-session-preview-real-gateway-proof.e2e.test.ts) creates the real per-agent SQLite database through production session APIs, seeds two sessions and four transcript rows, starts a real child Gateway, and uses an authenticated `operator.read` WebSocket client for `sessions.preview`.
- Observed after the fix: `{ maxChars: 800 }` returned one visible assistant item with exactly 800 UTF-16 code units; omitting `maxChars` retained the 240-unit default; the surrogate-boundary fixture returned 239 units without an unpaired surrogate. The seeded tool-result rows remained excluded.
- Inspectable artifact: [`pr125201-session-preview-real-gateway-proof-32030179825-1`](https://github.com/Alix-007/openclaw/actions/runs/32030179825/artifacts/9288812406), archive digest `sha256:c7c89446013f9428cfd8ac507bbfd0ae2fedb5c716214ad2240e1e444d0b4573`. Downloaded hashes independently revalidated: `result.json` `543d573525f2f2682358137f0dce256ef86eb581b957df1f02f8cd589e68f1ed`; full `rpc-responses.json` `34c44ea8c464f3ca10cc87cbeeb7f430a0bd723a063ff45ec8717d9eb79429cc`; `run.log` `008c2cf66761915a3bde0c54ed97c97e5ec72164cdfd176f0b318b6320547984`.
- The proof is evidence-only on `alix/proof-125201`; the PR code/head was not changed.

### Oversized preview-budget exact-head proof

Exact repair head: `218fd13185c3945cf8c371a6c6ed4a81a7de5053` (unchanged).

On 2026-08-21, the exact head passed a clean, isolated direct-local-Docker fallback run on Node 24.19.0. The container used the default seccomp profile, had no host mounts, and received no credential-bearing environment variables. This is local Docker evidence, not AWS/Testbox remote proof.

The one-shot harness used production `upsertSessionEntryCore` and `persistSessionTranscriptTurn` writers to create the real per-agent SQLite database, verified the `SQLite format 3\0` header at `agents/main/agent/openclaw-agent.sqlite`, started a real child Gateway, completed token-authenticated WebSocket hello as `operator` with `operator.read`, and invoked `sessions.preview` through the public RPC path.

Observed result:

- Oversized request `maxChars: 50000`: exactly 800 UTF-16 code units, one visible assistant item, tool-result row excluded, no unpaired surrogate.
- Explicit ceiling control `maxChars: 800`: exactly 800 code units.
- Omitted-budget control: exactly 240 code units.
- Repo-native run: 1 file / 1 test passed; behavior portion 34.5s.
- Sanitized artifact SHA-256: `6782691da61336d6e876477dd50c3412da4e5fd9e0b767607168c1138a514d95`.
- Production LOC remains +6/-4 (net +2). Tests remain +53/-5 (net +48). The PR branch/head was not changed.

<details>
<summary>Sanitized exact-head <code>result.json</code></summary>

```json
{
  "schemaVersion": 1,
  "verdict": "PASS",
  "head": "218fd13185c3945cf8c371a6c6ed4a81a7de5053",
  "runtime": {
    "node": "v24.19.0",
    "platform": "linux"
  },
  "storage": {
    "engine": "SQLite",
    "agentId": "main",
    "databaseRelativePath": "agents/main/agent/openclaw-agent.sqlite",
    "sqliteHeader": "SQLite format 3\\0",
    "seededSessionEntries": 1,
    "seededTranscriptRows": 2
  },
  "gateway": {
    "childProcess": true,
    "bind": "loopback",
    "transport": "WebSocket",
    "authMode": "token",
    "authenticatedHello": true,
    "clientRole": "operator",
    "scopes": [
      "operator.read"
    ],
    "method": "sessions.preview"
  },
  "oversizedRequest": {
    "requestedMaxChars": 50000,
    "sourceCodeUnits": 1600,
    "returnedCodeUnits": 800,
    "expectedCap": 800,
    "visibleItems": 1,
    "excludedToolRows": 1,
    "utf16Safe": true,
    "returnedTextSha256": "cc1d624a46c2851322146c60f5260b4feae912d4716daae54512d4065cfa1fda",
    "response": {
      "key": "agent:main:proof:preview-cap",
      "status": "ok",
      "items": [
        {
          "role": "assistant",
          "text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
        }
      ]
    }
  },
  "controls": {
    "explicit800ReturnedCodeUnits": 800,
    "omittedBudgetReturnedCodeUnits": 240
  },
  "redaction": {
    "omitted": [
      "gateway token",
      "port",
      "pid",
      "hostname",
      "absolute paths"
    ]
  }
}
```

</details>
