### PR TITLE
fix(configure): report failed remote health checks

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -42,7 +42,7 @@ const mocks = vi.hoisted(() => {
     note: vi.fn(),
     printWizardHeader: vi.fn(),
     probeGatewayReachable: vi.fn(),
-    waitForGatewayReachable: vi.fn(),
+    waitForGatewayReachable: vi.fn(async () => ({ ok: true })),
     resolveAdvertisedControlUiLinks: vi.fn(),
     resolveControlUiLinks: vi.fn(),
     resolveLocalControlUiProbeLinks: vi.fn(),
@@ -284,6 +284,7 @@ async function runWebConfigureWizard() {
 describe("runConfigureWizard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.healthCommand.mockReset();
     mocks.assertConfigPathForWrite.mockImplementation(() => {});
     mocks.resolvePluginContributionOwners.mockReturnValue(["firecrawl"]);
     mocks.resolveSearchProviderOptions.mockReturnValue([
@@ -427,6 +428,17 @@ describe("runConfigureWizard", () => {
       }),
       expect.anything(),
     );
+  });
+
+  it.each([false, true])("reports failed remote health checks (reachable: %s)", async (probeOk) => {
+    setupBaseWizardState();
+    queueWizardPrompts({ select: ["remote"], confirm: [] });
+    mocks.waitForGatewayReachable.mockResolvedValueOnce({ ok: probeOk });
+    mocks.healthCommand.mockRejectedValueOnce(new Error("health request failed"));
+
+    await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
+
+    expect(mocks.clackOutro).toHaveBeenCalledWith(expect.stringContaining("health check failed"));
   });
 
   it("skips remote health when a configured SecretRef is unresolved", async () => {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -62,6 +62,7 @@ import type { OnboardMode } from "./onboard-types.js";
 
 type ConfigureSectionChoice = WizardSection | "__continue";
 type SetupPluginConfigModule = typeof import("../wizard/setup.plugin-config.js");
+type GatewayHealthCheckOutcome = "succeeded" | "failed" | "skipped";
 
 const GATEWAY_HINT_PROBE_TIMEOUT_MS = 300;
 
@@ -101,7 +102,7 @@ async function runGatewayHealthCheck(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
   port: number;
-}): Promise<boolean> {
+}): Promise<GatewayHealthCheckOutcome> {
   const localLinks = resolveLocalControlUiProbeLinks({
     bind: params.cfg.gateway?.bind ?? "loopback",
     port: params.port,
@@ -143,7 +144,7 @@ async function runGatewayHealthCheck(params: {
       // A failed ref does not invalidate a resolved sibling config credential.
       // Skip only when generic health auth could otherwise recover ambient auth.
       if (!hasResolvedRemoteAuth) {
-        return false;
+        return "skipped";
       }
     }
     ({ token, password } = remoteProbeAuth.auth);
@@ -164,14 +165,16 @@ async function runGatewayHealthCheck(params: {
     password = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ?? configuredPassword;
   }
 
-  await waitForGatewayReachable({
-    url: wsUrl,
-    token,
-    password,
-    deadlineMs: 15_000,
-  });
-
   try {
+    const gatewayProbe = await waitForGatewayReachable({
+      url: wsUrl,
+      token,
+      password,
+      deadlineMs: 15_000,
+    });
+    if (!gatewayProbe.ok) {
+      throw new Error(gatewayProbe.detail ?? `gateway did not become reachable at ${wsUrl}`);
+    }
     await healthCommand(
       {
         json: false,
@@ -195,8 +198,9 @@ async function runGatewayHealthCheck(params: {
       ].join("\n"),
       "Health check help",
     );
+    return "failed";
   }
-  return true;
+  return "succeeded";
 }
 
 async function promptConfigureSection(
@@ -573,15 +577,17 @@ export async function runConfigureWizard(
       remoteConfig = committed.config;
       logConfigUpdated(runtime);
       if (selectedSections?.includes("health")) {
-        const healthCheckAttempted = await runGatewayHealthCheck({
+        const healthCheckOutcome = await runGatewayHealthCheck({
           cfg: remoteConfig,
           runtime,
           port: resolveGatewayPort(remoteConfig),
         });
         outro(
-          healthCheckAttempted
+          healthCheckOutcome === "succeeded"
             ? "Remote gateway configured and health check completed."
-            : "Remote gateway configured; health check skipped.",
+            : healthCheckOutcome === "failed"
+              ? "Remote gateway configured, but health check failed."
+              : "Remote gateway configured; health check skipped.",
         );
       } else {
         outro("Remote gateway configured.");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring a remote Gateway with `configure --section health` saw `health check completed` even when the reachability probe failed or the health command rejected.

## Why This Change Was Made

The configure-owned health check now returns a closed `succeeded | failed | skipped` outcome instead of a boolean that conflated attempted and successful checks. Failed reachability and health-command outcomes preserve the existing diagnostic output and now render an explicit failure summary; unresolved SecretRef checks remain explicitly skipped.

## User Impact

Operators now receive a truthful terminal result when a configured remote Gateway cannot be reached or fails its health check, instead of a false success message.

## Evidence

- Regression proof before the source fix: `src/commands/configure.wizard.test.ts` failed both injected cases because the wizard printed `Remote gateway configured and health check completed.`
- `node scripts/run-vitest.mjs src/commands/configure.wizard.test.ts` — 27/27 passed.
- `node scripts/check-changed.mjs -- src/commands/configure.wizard.ts src/commands/configure.wizard.test.ts` — passed all selected core/coreTests gates, including production/test typechecks and lint.
- Autoreview (`gpt-5.6-sol`, high): clean, correctness 0.99, no actionable findings.
- Production LOC: +19/-13 (net +6). Tests: +13/-1.

A live remote-Gateway CLI check was not run: deterministically exercising both failure boundaries requires either an injected transport or an intentionally failing external Gateway. The owner-boundary regression covers the exact terminal output without provider, credential, or network side effects.

AI-assisted: yes. I reviewed the owner, caller, reachability result contract, sibling health finalization behavior, and regression tests, and I understand the change.
