### PR TITLE
docs: Fast mode is a provider tier, not typewriter speed

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -63,6 +63,7 @@ title: "Thinking levels"
 
 ## Fast mode (/fast)
 
+- Fast mode is a **provider request-tier** (and some model-alias) switch. It is not reply streaming, not channel typewriter speed, and not `blockStreaming*`. `/status` and session status showing `Fast: on|off|auto` mean the OpenClaw policy flag, not tokens-per-second. On models with no Fast mapping (many OpenAI-compatible and DeepSeek flash routes), enabling Fast changes the status flag but not perceived output speed. For channel bubble cadence, see [Streaming](/concepts/streaming).
 - Levels: `auto|on|off|default`.
 - Directive-only message toggles a session fast-mode override and replies `Fast mode set to auto.`, `Fast mode enabled.`, or `Fast mode disabled.`. Use `/fast default` to clear the session override and inherit the configured default; aliases include `inherit`, `clear`, `reset`, and `unpin`.
 - Send `/fast` (or `/fast status`) with no mode to see the current effective fast-mode state.
@@ -80,7 +81,7 @@ title: "Thinking levels"
 - For direct public `anthropic/*` requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, fast mode maps to Anthropic service tiers: `/fast on` sets `service_tier=auto`, `/fast off` sets `service_tier=standard_only`.
 - For `minimax/*` on the Anthropic-compatible path, `/fast on` (or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
 - Explicit Anthropic `serviceTier` / `service_tier` model params override the fast-mode default when both are set. OpenClaw still skips Anthropic service-tier injection for non-Anthropic proxy base URLs.
-- `/status` reports the resolved OpenClaw policy (`on`, `off`, or `auto`) and the selected runtime. It does not report the upstream service tier actually honored or returned for a completed request. See [OpenAI Fast mode](/providers/openai#advanced-configuration) for provider details.
+- `/status` reports the resolved OpenClaw policy (`on`, `off`, or `auto`) and the selected runtime. It does not report the upstream service tier actually honored or returned for a completed request, and it does not measure streaming or channel delivery speed. See [OpenAI Fast mode](/providers/openai#advanced-configuration) for provider details.
 
 ## Verbose directives (/verbose or /v)
 


### PR DESCRIPTION
Closes #125205

AI-assisted.

## What Problem This Solves

`/status` and session status show `Fast: on|off|auto`. Operators and in-channel agents read that as reply streaming / channel typewriter speed, then flip `fastModeDefault` expecting WeCom or Telegram bubbles to speed up.

On models with no Fast mapping (many OpenAI-compatible and DeepSeek flash routes), enabling Fast only changes the status flag. Perceived output speed stays the same.

## Why This Change Was Made

`docs/tools/thinking.md` already lists per-provider mappings (OpenAI priority, Anthropic `service_tier`, MiniMax highspeed) but never says what Fast is **not**. A one-line lead bullet and a tighter `/status` sentence close that gap without changing runtime.

## User Impact

People diagnosing “slow output” look at Streaming / `blockStreaming*` instead of burning a live config change on a no-op Fast toggle.

## Evidence

- Live OpenClaw `2026.7.2-beta.6` on WeCom + DeepSeek flash: ops agent recommended “open Fast” after `session_status` showed Fast off.
- After `openclaw config set agents.defaults.fastModeDefault true` (gateway said no restart needed), `/status` showed Fast on; same prompt felt unchanged.
- Fast resolution in-tree maps to provider params, not channel chunking.

Docs-only. No runtime, changelog, or test changes.

Allow edits from maintainers: yes.

Made with [Cursor](https://cursor.com)