### PR TITLE
fix(heartbeat): avoid claiming excluded outcomes were recorded

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -2856,11 +2856,11 @@ describe("createCodexDynamicToolBridge", () => {
     expect(bridge.telemetry.messagingToolSentTargets).toEqual([]);
   });
 
-  it("records heartbeat response tool outcomes", async () => {
+  it("accepts heartbeat response tool outcomes", async () => {
     const bridge = createBridgeWithToolResult(
       HEARTBEAT_RESPONSE_TOOL_NAME,
-      textToolResult("Recorded.", {
-        status: "recorded",
+      textToolResult("Accepted.", {
+        status: "accepted",
         outcome: "needs_attention",
         notify: true,
         summary: "Build is blocked.",
@@ -2878,7 +2878,7 @@ describe("createCodexDynamicToolBridge", () => {
       arguments: {},
     });
 
-    expect(result).toEqual(expectInputText("Recorded."));
+    expect(result).toEqual(expectInputText("Accepted."));
     expect(bridge.telemetry.heartbeatToolResponse).toEqual({
       outcome: "needs_attention",
       notify: true,

--- a/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
+++ b/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
@@ -150,7 +150,7 @@ describe("subscribeEmbeddedAgentSession block reply rejections", () => {
       toolCallId: "heartbeat-1",
       result: {
         details: {
-          status: "recorded",
+          status: "accepted",
           outcome: "no_change",
           notify: false,
           summary: "Nothing needs attention.",

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1679,7 +1679,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   });
 
-  it("notifies the runner once when a heartbeat response tool result is recorded", async () => {
+  it("notifies the runner once when a heartbeat response tool result is accepted", async () => {
     const { session, emit } = createStubSessionHarness();
     const onHeartbeatToolResponse = vi.fn();
     const subscription = subscribeEmbeddedAgentSession({
@@ -1691,7 +1691,7 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     const result = {
       details: {
-        status: "recorded",
+        status: "accepted",
         outcome: "no_change",
         notify: false,
         summary: "Nothing needs attention.",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -344,7 +344,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "heartbeat_respond",
     label: "heartbeat_respond",
-    description: "Record heartbeat outcomes",
+    description: "Accept heartbeat outcomes for post-turn handling",
     sectionId: "automation",
     profiles: [],
     includeInOpenClawGroup: true,

--- a/src/agents/tools/heartbeat-response-tool.test.ts
+++ b/src/agents/tools/heartbeat-response-tool.test.ts
@@ -41,7 +41,7 @@ describe("createHeartbeatResponseTool", () => {
     expect(priority).not.toHaveProperty("anyOf");
   });
 
-  it("records a quiet heartbeat outcome", async () => {
+  it("accepts a quiet no-change outcome without claiming persistence", async () => {
     const tool = createHeartbeatResponseTool();
 
     const result = await tool.execute("call-1", {
@@ -52,10 +52,13 @@ describe("createHeartbeatResponseTool", () => {
 
     expect(tool.name).toBe(HEARTBEAT_RESPONSE_TOOL_NAME);
     const details = result.details as HeartbeatResponseDetails;
-    expect(details.status).toBe("recorded");
+    expect(details.status).toBe("accepted");
     expect(details.outcome).toBe("no_change");
     expect(details.notify).toBe(false);
     expect(details.summary).toBe("Nothing needs attention.");
+    expect(result.content).toEqual([
+      expect.objectContaining({ text: expect.stringContaining('"status": "accepted"') }),
+    ]);
   });
 
   it("rejects repeated heartbeat responses from the same tool instance", async () => {
@@ -75,7 +78,7 @@ describe("createHeartbeatResponseTool", () => {
         notify: false,
         summary: "Nothing needs attention.",
       }),
-    ).rejects.toThrow("heartbeat_respond already recorded");
+    ).rejects.toThrow("heartbeat_respond already accepted");
   });
 
   it("captures scratch without echoing future prompt content to the model", async () => {
@@ -98,7 +101,7 @@ describe("createHeartbeatResponseTool", () => {
     ]);
   });
 
-  it("accepts notification text and optional scheduling metadata", async () => {
+  it("accepts an urgent notification without claiming persistence", async () => {
     const tool = createHeartbeatResponseTool();
 
     const result = await tool.execute("call-1", {
@@ -111,13 +114,16 @@ describe("createHeartbeatResponseTool", () => {
     });
 
     const details = result.details as HeartbeatResponseDetails;
-    expect(details.status).toBe("recorded");
+    expect(details.status).toBe("accepted");
     expect(details.outcome).toBe("needs_attention");
     expect(details.notify).toBe(true);
     expect(details.summary).toBe("Build is blocked.");
     expect(details.notificationText).toBe("Build is blocked on missing credentials.");
     expect(details.priority).toBe("high");
     expect(details.nextCheck).toBe("2026-05-01T17:00:00Z");
+    expect(result.content).toEqual([
+      expect.objectContaining({ text: expect.stringContaining('"status": "accepted"') }),
+    ]);
   });
 
   it("rejects missing notify because quiet vs visible delivery must be explicit", async () => {

--- a/src/agents/tools/heartbeat-response-tool.ts
+++ b/src/agents/tools/heartbeat-response-tool.ts
@@ -1,7 +1,7 @@
 /**
  * Heartbeat response tool.
  *
- * Auto-reply heartbeat turns use this tool to record the agent's outcome,
+ * Auto-reply heartbeat turns use this tool to accept the agent's outcome,
  * notification decision, and next-check metadata exactly once per turn.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -45,7 +45,7 @@ function readRequiredBoolean(params: Record<string, unknown>, key: string): bool
   return raw;
 }
 
-/** Creates the one-shot heartbeat response recording tool for an auto-reply turn. */
+/** Creates the one-shot heartbeat response tool for an auto-reply turn. */
 export function createHeartbeatResponseTool(): AnyAgentTool {
   let recorded = false;
   return {
@@ -54,9 +54,9 @@ export function createHeartbeatResponseTool(): AnyAgentTool {
     // Heartbeat prompts instruct the model to call this one-shot tool; hiding
     // it behind tool search would break the heartbeat contract.
     catalogMode: "direct-only",
-    displaySummary: "Record heartbeat outcome/notify choice.",
+    displaySummary: "Accept heartbeat outcome/notify choice.",
     description:
-      "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
+      "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
     parameters: HeartbeatResponseToolSchema,
     execute: async (_toolCallId, args) => {
       if (!isRecord(args)) {
@@ -79,12 +79,12 @@ export function createHeartbeatResponseTool(): AnyAgentTool {
       if (recorded) {
         // One heartbeat turn should produce one decision; repeated calls can
         // otherwise overwrite the notify/no-notify choice.
-        throw new ToolInputError("heartbeat_respond already recorded for this turn");
+        throw new ToolInputError("heartbeat_respond already accepted for this turn");
       }
       recorded = true;
       const { scratch, ...publicResponse } = response;
-      const details = { status: "recorded" as const, ...publicResponse } as typeof response & {
-        status: "recorded";
+      const details = { status: "accepted" as const, ...publicResponse } as typeof response & {
+        status: "accepted";
       };
       if (scratch !== undefined) {
         // Keep future prompt content out of model-visible tool output and logs;
@@ -94,7 +94,7 @@ export function createHeartbeatResponseTool(): AnyAgentTool {
       return textResult(
         JSON.stringify(
           {
-            status: "recorded",
+            status: "accepted",
             ...publicResponse,
             ...(scratch !== undefined
               ? {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -6,7 +6,7 @@
       "name": "openclaw_direct",
       "tools": [
         {
-          "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
+          "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
           "inputSchema": {
             "additionalProperties": false,
             "properties": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54227,
-    "roughTokens": 13557
+    "chars": 54250,
+    "roughTokens": 13563
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82027,
-    "roughTokens": 20507
+    "chars": 82050,
+    "roughTokens": 20513
   },
   "userInputText": {
     "chars": 1271,
@@ -690,7 +690,7 @@ Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dyn
     "type": "function"
   },
   {
-    "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
+    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where heartbeat responses told the model `status: recorded` even when the outcome was intentionally excluded from the SQLite handoff. Live QA observed this for quiet `no_change` heartbeats and visible `needs_attention` notifications, leaving the model-facing result inconsistent with `heartbeat_outcomes`.

## Why This Change Was Made

The SQLite store remains scoped to meaningful silent work (`progress`, `done`, `blocked`, or silent `needs_attention`) that the next user turn needs as hidden context. `no_change` remains an operator heartbeat event, while `notify=true` remains owned by visible delivery. The tool now reports `status: accepted`, which accurately describes the only fact known at tool-call time before post-turn persistence or delivery.

This is AI-assisted. The implementation and storage/read lifecycle were reviewed against both OpenClaw runtimes and the Codex tool-output transport.

## User Impact

Models no longer receive a false persistence claim after quiet no-change checks or urgent visible notifications. Existing heartbeat delivery and next-turn silent-result handoff behavior are unchanged.

## Evidence

- Pre-fix: `node scripts/run-vitest.mjs src/agents/tools/heartbeat-response-tool.test.ts` failed both new regressions because the quiet and urgent cases returned `recorded` instead of `accepted`.
- Focused: `node scripts/run-vitest.mjs src/agents/tools/heartbeat-response-tool.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts src/infra/heartbeat-outcome-store.test.ts src/infra/heartbeat-runner.tool-response.test.ts` — 263 passed across four shards.
- Changed gate: `node scripts/check-changed.mjs` — passed core/extension typecheck, lint, architecture, SQLite, and guard lanes.
- Prompt contract: `pnpm prompt:snapshots:check` and `node scripts/run-vitest.mjs test/scripts/prompt-snapshots.test.ts` — current; 13 passed.
- Source-blind behavior probe: quiet `no_change` and urgent `needs_attention` both returned `status: accepted` with outcome, notify, and notification text preserved.
- Direct Codex contract inspection at `openai/codex@9ded177ce7c1c0bd2047f902936c177612ab3434`: [`JsonToolOutput::to_response_item`](https://github.com/openai/codex/blob/9ded177ce7c1c0bd2047f902936c177612ab3434/codex-rs/tools/src/tool_output.rs#L135-L152) sends the JSON value as model-facing text, while [`FunctionCallOutputPayload`](https://github.com/openai/codex/blob/9ded177ce7c1c0bd2047f902936c177612ab3434/codex-rs/protocol/src/models.rs#L1989-L2072) serializes that body directly on the function/custom-tool output wire contract and keeps success metadata internal.
- Autoreview: clean; no accepted/actionable findings.
- Production LOC: +9/-9 (net 0). Tests/generated proof: +24/-18 (net +6).
