### PR TITLE
chore(macos): pin Peekaboo 4.2.1 source

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "000000bde5955caf22291bddf4458c7a1f7ff8d1e501538e0ea1413cc68a251e",
+  "originHash" : "07a0ad2130048d602c404224b9c6b7a17ce9751536369cfec603701121bf93df",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "a2fb16764a7d1c53bf696127c287ba32703f614f"
+        "revision" : "a48c462c757acbf320b22a6c9b34852e26bcb763"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "a2fb16764a7d1c53bf696127c287ba32703f614f"),
+            revision: "a48c462c757acbf320b22a6c9b34852e26bcb763"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

The macOS companion still pins an older pre-elevation Peekaboo revision, so it does not build against the final 4.2.1 exact-window catalog and routing fixes required by the hardened elevation workflow.

## Why This Change Was Made

Pin Peekaboo to the final landed 4.2.1 source commit `a48c462c757acbf320b22a6c9b34852e26bcb763` and regenerate the SwiftPM lockfile. The resolver changes no transitive package states; the only lock state change is the exact Peekaboo revision.

The elevation merge already made the package source-stamp test derive its expected revision from `Package.resolved`, so no test-file update is needed.

## User Impact

OpenClaw's macOS companion now compiles against the finalized Peekaboo 4.2.1 automation behavior. There is no configuration, protocol, or user-interface change in OpenClaw itself.

AI-assisted: yes, with Codex. The final diff and dependency graph were inspected directly.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts` — 53/53 passed.
- `swift build --package-path apps/macos --product OpenClaw --configuration release` — passed; one pre-existing unused-result warning remains outside this diff.
- `swift package --package-path apps/macos resolve` — repeated resolve was byte-idempotent.
- Lockfile state comparison — only Peekaboo moved, from `a2fb16764a7d1c53bf696127c287ba32703f614f` to `a48c462c757acbf320b22a6c9b34852e26bcb763`; AXorcist remains 0.1.6 and swift-algorithms remains 1.2.1.
- `swiftformat --lint apps/macos/Package.swift --config config/swiftformat` and `git diff --check` — passed.
- Autoreview through P2 — clean, with no accepted/actionable findings.
