### PR TITLE
fix: recovery no longer claims interrupted commands succeeded

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -464,6 +464,7 @@ export class CodexToolTranscriptProjection {
           name,
           text: formatMissingToolResultError({ id, name }),
           isError: true,
+          details: { reason: "missing_tool_result" },
         });
       }
     }

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -509,6 +509,7 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
     expect(toolResultMessage.toolCallId).toBe("cmd-denied");
     expect(toolResultMessage.toolName).toBe("bash");
     expect(toolResultMessage.isError).toBe(true);
+    expect(toolResultMessage.details).toEqual({ reason: "missing_tool_result" });
     const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
     expect(JSON.stringify(toolResultContent)).toContain("matching tool.result");
     const finalAssistant = requireRecord(result.messagesSnapshot[3], "final assistant message");

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -151,7 +151,7 @@ export function makeMissingToolResult(params: {
     toolCallId: params.toolCallId,
     toolName: params.toolName ?? "unknown",
     content: [{ type: "text", text: params.text ?? DEFAULT_MISSING_TOOL_RESULT_TEXT }],
-    details: { [SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY]: true },
+    details: { [SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY]: true, reason: "missing_tool_result" },
     isError: true,
     timestamp: Date.now(),
   } as ToolResultMessage;

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -2,6 +2,7 @@
 import { isReplayUnsafeAssistantError } from "../../../llm/utils/retry.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
+import { FAILED_TOOL_OUTCOME_INSTRUCTION } from "../../tool-outcome-instructions.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
   hasCompletedMessagingToolDeliveryEvidence,
@@ -339,7 +340,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
     return null;
   }
   return hasSettledTerminalToolFailure
-    ? `${SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If any tool failed, state that failure plainly and do not claim it succeeded.`
+    ? `${SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} ${FAILED_TOOL_OUTCOME_INSTRUCTION}`
     : SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION;
 }
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -2,7 +2,7 @@
 import { isReplayUnsafeAssistantError } from "../../../llm/utils/retry.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
-import { FAILED_TOOL_OUTCOME_INSTRUCTION } from "../../tool-outcome-instructions.js";
+import { TOOL_FAILURE_INSTRUCTION } from "../../tool-outcome-instructions.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
   hasCompletedMessagingToolDeliveryEvidence,
@@ -340,7 +340,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
     return null;
   }
   return hasSettledTerminalToolFailure
-    ? `${SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} ${FAILED_TOOL_OUTCOME_INSTRUCTION}`
+    ? `${SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} ${TOOL_FAILURE_INSTRUCTION}`
     : SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION;
 }
 

--- a/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
@@ -281,9 +281,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       );
 
       expect(instruction).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
-      expect(instruction).toContain(
-        "If any tool failed, state that failure plainly and do not claim it completed or succeeded.",
-      );
+      expect(instruction).toContain("If a tool failed, say so; never claim completion or success.");
     },
   );
 

--- a/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
@@ -282,7 +282,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
       expect(instruction).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
       expect(instruction).toContain(
-        "If any tool failed, state that failure plainly and do not claim it succeeded.",
+        "If any tool failed, state that failure plainly and do not claim it completed or succeeded.",
       );
     },
   );

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -46,8 +46,8 @@ const log = createSubsystemLogger("main-session-restart-recovery");
 const RESTART_RECOVERY_RESUME_MESSAGE = formatSystemTurnPrompt(
   "Your previous turn was interrupted by a gateway restart while " +
     "OpenClaw was waiting on tool/model work. Continue from the existing " +
-    "transcript and finish the interrupted response. Treat any interrupted tool call without " +
-    `a successful matching result as having an unknown outcome. ${TOOL_FAILURE_INSTRUCTION}`,
+    "transcript and finish the interrupted response. Treat a tool result marked interrupted or " +
+    `missing as having an unknown outcome. ${TOOL_FAILURE_INSTRUCTION}`,
 );
 
 type RestartRecoveryTerminalStatus = "error" | "ok" | "timeout";

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -26,7 +26,7 @@ import {
   type DeliveryContext,
 } from "../../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
-import { FAILED_TOOL_OUTCOME_INSTRUCTION } from "../tool-outcome-instructions.js";
+import { TOOL_FAILURE_INSTRUCTION } from "../tool-outcome-instructions.js";
 import { buildMainSessionRecoveryClearPatch } from "./main-session-recovery-clear.js";
 import {
   repairMainSessionRecoveryMutation,
@@ -47,7 +47,7 @@ const RESTART_RECOVERY_RESUME_MESSAGE = formatSystemTurnPrompt(
   "Your previous turn was interrupted by a gateway restart while " +
     "OpenClaw was waiting on tool/model work. Continue from the existing " +
     "transcript and finish the interrupted response. Treat any interrupted tool call without " +
-    `a successful matching result as having an unknown outcome. ${FAILED_TOOL_OUTCOME_INSTRUCTION}`,
+    `a successful matching result as having an unknown outcome. ${TOOL_FAILURE_INSTRUCTION}`,
 );
 
 type RestartRecoveryTerminalStatus = "error" | "ok" | "timeout";

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -26,6 +26,7 @@ import {
   type DeliveryContext,
 } from "../../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
+import { FAILED_TOOL_OUTCOME_INSTRUCTION } from "../tool-outcome-instructions.js";
 import { buildMainSessionRecoveryClearPatch } from "./main-session-recovery-clear.js";
 import {
   repairMainSessionRecoveryMutation,
@@ -45,7 +46,8 @@ const log = createSubsystemLogger("main-session-restart-recovery");
 const RESTART_RECOVERY_RESUME_MESSAGE = formatSystemTurnPrompt(
   "Your previous turn was interrupted by a gateway restart while " +
     "OpenClaw was waiting on tool/model work. Continue from the existing " +
-    "transcript and finish the interrupted response.",
+    "transcript and finish the interrupted response. Treat any interrupted tool call without " +
+    `a successful matching result as having an unknown outcome. ${FAILED_TOOL_OUTCOME_INSTRUCTION}`,
 );
 
 type RestartRecoveryTerminalStatus = "error" | "ok" | "timeout";

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -343,14 +343,12 @@ function requiresRestartSafeToolResult(message: unknown): boolean {
     return false;
   }
   const record = message as Record<string, unknown>;
-  if (record.isError === true) {
-    return !isAgentToolReplaySafe({ name: normalizeOptionalString(record.toolName) });
-  }
   const details = record.details;
   if (!details || typeof details !== "object") {
     return false;
   }
-  return (details as { status?: unknown }).status === "approval-pending";
+  const status = details as { reason?: unknown; status?: unknown };
+  return status.reason === "missing_tool_result" || status.status === "approval-pending";
 }
 
 type MainSessionResumePolicy =

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -338,11 +338,15 @@ function isRestartAbortedWaitResultArtifact(message: unknown, waitMessage: unkno
   return Boolean(toolCallId && waitCall?.toolCallId === toolCallId);
 }
 
-function isApprovalPendingToolResult(message: unknown): boolean {
+function requiresRestartSafeToolResult(message: unknown): boolean {
   if (!message || typeof message !== "object" || getMessageRole(message) !== "toolResult") {
     return false;
   }
-  const details = (message as { details?: unknown }).details;
+  const record = message as Record<string, unknown>;
+  if (record.isError === true) {
+    return !isAgentToolReplaySafe({ name: normalizeOptionalString(record.toolName) });
+  }
+  const details = record.details;
   if (!details || typeof details !== "object") {
     return false;
   }
@@ -474,7 +478,7 @@ export function resolveMainSessionResumePolicy(
   if (!lastMeaningful || !isResumableTailMessage(lastMeaningful)) {
     return { action: "resume", forceRestartSafeTools: false };
   }
-  if (isApprovalPendingToolResult(lastMeaningful)) {
+  if (requiresRestartSafeToolResult(lastMeaningful)) {
     return { action: "resume", forceRestartSafeTools: true };
   }
   // A later tool result can hide the checkpoint at the transcript tail; keep

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -4792,6 +4792,26 @@ describe("main-session-restart-recovery", () => {
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
+  it("reports an interrupted native tool outcome as unknown", async () => {
+    await writeMainSessionTranscript([
+      { role: "user", content: "run the command" },
+      createAssistantToolCallMessage([
+        { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
+      ]),
+      {
+        role: "toolResult",
+        toolName: "bash",
+        toolCallId: "call-bash-1",
+        content: "native tool call had no matching result",
+        isError: true,
+      },
+    ]);
+
+    await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
+    expect(gatewayParams().message).toContain("unknown outcome");
+    expect(gatewayParams().message).toContain("do not claim it completed or succeeded");
+  });
+
   it("keeps a dangling side-effecting call in an aborted tail restricted", async () => {
     await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -4809,7 +4809,8 @@ describe("main-session-restart-recovery", () => {
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
     expect(gatewayParams().message).toContain("unknown outcome");
-    expect(gatewayParams().message).toContain("do not claim it completed or succeeded");
+    expect(gatewayParams().message).toContain("never claim completion or success");
+    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
   it("keeps a dangling side-effecting call in an aborted tail restricted", async () => {

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -4803,6 +4803,7 @@ describe("main-session-restart-recovery", () => {
         toolName: "bash",
         toolCallId: "call-bash-1",
         content: "native tool call had no matching result",
+        details: { reason: "missing_tool_result" },
         isError: true,
       },
     ]);
@@ -4811,6 +4812,26 @@ describe("main-session-restart-recovery", () => {
     expect(gatewayParams().message).toContain("unknown outcome");
     expect(gatewayParams().message).toContain("never claim completion or success");
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+  });
+
+  it("keeps a confirmed native tool failure distinct from an unknown outcome", async () => {
+    await writeMainSessionTranscript([
+      { role: "user", content: "run the command" },
+      createAssistantToolCallMessage([
+        { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "false" } },
+      ]),
+      {
+        role: "toolResult",
+        toolName: "bash",
+        toolCallId: "call-bash-1",
+        content: "command failed with exit code 1",
+        details: { reason: "nonzero_exit" },
+        isError: true,
+      },
+    ]);
+
+    await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
+    expect(gatewayParams()).not.toHaveProperty("forceRestartSafeTools");
   });
 
   it("keeps a dangling side-effecting call in an aborted tail restricted", async () => {

--- a/src/agents/tool-outcome-instructions.ts
+++ b/src/agents/tool-outcome-instructions.ts
@@ -1,2 +1,2 @@
-export const FAILED_TOOL_OUTCOME_INSTRUCTION =
-  "If any tool failed, state that failure plainly and do not claim it completed or succeeded.";
+export const TOOL_FAILURE_INSTRUCTION =
+  "If a tool failed, say so; never claim completion or success.";

--- a/src/agents/tool-outcome-instructions.ts
+++ b/src/agents/tool-outcome-instructions.ts
@@ -1,0 +1,2 @@
+export const FAILED_TOOL_OUTCOME_INSTRUCTION =
+  "If any tool failed, state that failure plainly and do not claim it completed or succeeded.";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resuming a Codex-backed session after a Gateway restart could be told that an interrupted command completed even though OpenClaw had recorded the command result as an error with no matching native result.

## Why This Change Was Made

The shared main-session recovery prompt now treats tool results marked interrupted or missing as unknown and reuses the existing failed-tool instruction that forbids completion or success claims. Synthetic missing-result producers carry the existing `missing_tool_result` fact into the transcript, so the common recovery owner restricts only genuinely unknown outcomes while keeping confirmed failures distinct.

Production LOC: +15/-7 (net +8) | Tests: +44/-3

## User Impact

After a restart interrupts a tool call, recovery reports that the outcome is unknown or blocked instead of inventing a successful completion. Operators can verify the external state before deciding whether to retry side-effecting work.

## Evidence

- Live pre-fix probe: an isolated Gateway was terminated while native bash ran `sleep 60 && echo done`; the transcript recorded `isError=true` and no successful result, but recovery replied `Command completed: done`.
- Live post-fix probe: the same interruption recorded the same error, and recovery replied `The command’s outcome is unknown because the gateway restarted before a successful result was recorded. I can’t claim it completed.`
- Codex `0.147.0` contract: [`thread_lifecycle.rs:860`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server/src/request_processors/thread_lifecycle.rs#L860-L870) rewrites stale in-progress turns to `Interrupted`; [`thread_resume.rs:3040`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server/tests/suite/v2/thread_resume.rs#L3040-L3140) proves first resume, second resume, and read all preserve that status. Native resume therefore supplies no successful command outcome for OpenClaw to infer.
- The new boundary regression failed first on the missing unknown-outcome instruction, then on the missing restart-safe restriction; both assertions now pass.
- `node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts` — 158 passed.
- Resume-policy, settled-tool, transcript-repair, and Codex projector suites — 141 passed.
- `node scripts/check-changed.mjs` — passed.
- Autoreview — clean, no accepted/actionable findings.
