### PR TITLE
fix(compaction): re-compact when last entry is a compaction record but context still exceeds window

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1497,7 +1497,7 @@ packages/acp-core/src/runtime/session-identity.ts	2
 packages/acp-core/src/types.ts	2
 packages/agent-core/src/agent-loop.ts	3
 packages/agent-core/src/harness/compaction/branch-summarization.ts	1
-packages/agent-core/src/harness/compaction/compaction.ts	5
+packages/agent-core/src/harness/compaction/compaction.ts	3
 packages/agent-core/src/harness/messages.ts	3
 packages/agent-core/src/harness/session/session.ts	1
 packages/agent-core/src/harness/session/tool-result-pairing.ts	17

--- a/packages/agent-core/src/harness/compaction/compaction-summary-cap.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-summary-cap.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantMessageEventStream } from "../../llm.js";
+import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm.js";
+import { compact } from "./compaction.js";
+import { createFileOps } from "./utils.js";
+
+const MAX_SUMMARY_CHARS = 16_000;
+const TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
+const TURN_CONTEXT_HEADING = "\n\n---\n\n**Turn Context (split turn):**\n\n";
+
+function createUsage(totalTokens: number): Usage {
+  return {
+    input: totalTokens,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    contextUsage: { state: "available", promptTokens: totalTokens, totalTokens },
+    totalTokens,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function createAssistant(text: string, usage: Usage): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "test-api",
+    provider: "test-provider",
+    model: "test-model",
+    usage,
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+describe("split-turn compaction summary cap", () => {
+  it("preserves the previous summary and latest split-turn context", async () => {
+    const model: Model = {
+      id: "summary-model",
+      name: "Summary Model",
+      api: "test-api",
+      provider: "test-provider",
+      baseUrl: "https://example.test",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 100_000,
+      maxTokens: 8_000,
+    };
+    let prefixSummary = "prefix summary";
+    const streamFn = vi.fn<StreamFn>(() => {
+      const stream = createAssistantMessageEventStream();
+      setTimeout(() => {
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: createAssistant(prefixSummary, createUsage(0)),
+        });
+        stream.end();
+      }, 5);
+      return stream;
+    });
+    const fileOps = createFileOps();
+    fileOps.read.add("src/read.ts");
+    fileOps.edited.add("src/write.ts");
+    const fileOperations =
+      "\n\n<read-files>\nsrc/read.ts\n</read-files>\n\n<modified-files>\nsrc/write.ts\n</modified-files>";
+    const nearCapPreviousSummary = `${"p".repeat(
+      MAX_SUMMARY_CHARS - fileOperations.length,
+    )}${fileOperations}`;
+    const runCompaction = (previousSummary = nearCapPreviousSummary) =>
+      compact(
+        {
+          firstKeptEntryId: "kept-entry",
+          messagesToSummarize: [],
+          turnPrefixMessages: [{ role: "user", content: "prefix", timestamp: 2 }],
+          isSplitTurn: true,
+          tokensBefore: 100,
+          previousSummary,
+          previousSummaryDetails: {
+            readFiles: ["src/read.ts"],
+            modifiedFiles: ["src/write.ts"],
+          },
+          fileOps,
+          settings: { enabled: true, reserveTokens: 1_000, keepRecentTokens: 100 },
+        },
+        model,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        streamFn,
+      );
+
+    const normalResult = await runCompaction(`previous summary${fileOperations}`);
+    expect(normalResult.ok).toBe(true);
+    if (!normalResult.ok) {
+      throw new Error("expected split-turn compaction to succeed");
+    }
+    expect(normalResult.value.summary).toBe(
+      "previous summary\n\n---\n\n**Turn Context (split turn):**\n\nprefix summary\n\n<read-files>\nsrc/read.ts\n</read-files>\n\n<modified-files>\nsrc/write.ts\n</modified-files>",
+    );
+
+    const nearCapResult = await runCompaction();
+    expect(nearCapResult.ok).toBe(true);
+    if (!nearCapResult.ok) {
+      throw new Error("expected split-turn compaction to succeed");
+    }
+    const persistedSummary = nearCapResult.value.summary;
+    expect(persistedSummary.length).toBeLessThanOrEqual(MAX_SUMMARY_CHARS);
+    expect(persistedSummary).toContain(TRUNCATED_MARKER);
+    expect(persistedSummary).toContain("prefix summary");
+    expect(persistedSummary.endsWith(fileOperations)).toBe(true);
+
+    const latestContextBudget =
+      MAX_SUMMARY_CHARS -
+      TRUNCATED_MARKER.length -
+      fileOperations.length -
+      Math.floor(MAX_SUMMARY_CHARS / 2);
+    prefixSummary = `${"x".repeat(latestContextBudget - TURN_CONTEXT_HEADING.length - 1)}🚀tail`;
+    const oversizedPrefixResult = await runCompaction();
+    expect(oversizedPrefixResult.ok).toBe(true);
+    if (!oversizedPrefixResult.ok) {
+      throw new Error("expected oversized split-turn compaction to succeed");
+    }
+    expect(oversizedPrefixResult.value.summary.length).toBeLessThanOrEqual(MAX_SUMMARY_CHARS);
+    expect(oversizedPrefixResult.value.summary).toMatch(/^p{100}/);
+    expect(oversizedPrefixResult.value.summary).toContain(TURN_CONTEXT_HEADING);
+    expect(oversizedPrefixResult.value.summary).toContain("x".repeat(100));
+    expect(oversizedPrefixResult.value.summary).not.toContain("🚀");
+    expect(oversizedPrefixResult.value.summary).toContain(TRUNCATED_MARKER);
+    expect(oversizedPrefixResult.value.summary).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(oversizedPrefixResult.value.summary).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    expect(oversizedPrefixResult.value.summary.endsWith(fileOperations)).toBe(true);
+    expect(streamFn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -646,6 +646,83 @@ describe("session-entry compaction budgeting", () => {
   });
 });
 
+describe("prepareCompaction when the last entry is a compaction record", () => {
+  // Regression for #120290: a compaction record as the last entry is not a no-op
+  // signal. The retained context (prior summary + kept recent turns + system prompt
+  // + injected files) can still exceed the window, so a second compaction that feeds
+  // the prior summary through UPDATE_SUMMARIZATION_PROMPT must remain possible when
+  // there is compactable content after the retained start.
+  const settings = {
+    enabled: true,
+    reserveTokens: 0,
+    keepRecentTokens: 1,
+  };
+
+  it("compacts when the last entry is a compaction record and new turns follow the retained start", () => {
+    const largeContent = "x".repeat(200_000);
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
+      {
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "entry-0",
+        timestamp: new Date(2).toISOString(),
+        summary: "earlier summary",
+        firstKeptEntryId: "entry-0",
+        tokensBefore: 200_000,
+      },
+      createMessageEntry({ role: "user", content: largeContent, timestamp: 3 }, 2),
+      createMessageEntry(createAssistant(largeContent, createUsage(10), 4), 3),
+      createMessageEntry({ role: "user", content: largeContent, timestamp: 5 }, 4),
+      createMessageEntry(createAssistant("recent reply tail", createUsage(10), 6), 5),
+      {
+        type: "compaction",
+        id: "compaction-2",
+        parentId: "entry-5",
+        timestamp: new Date(7).toISOString(),
+        summary: "later summary",
+        firstKeptEntryId: "entry-2",
+        tokensBefore: 200_000,
+      },
+    ];
+
+    const result = prepareCompaction(entries, settings);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.value) {
+      throw new Error("expected a trailing compaction record with new turns to remain compactable");
+    }
+    expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
+    // The most recent compaction record's summary must feed the next summary as
+    // previousSummary so UPDATE_SUMMARIZATION_PROMPT folds it in rather than dropping it.
+    expect(result.value.previousSummary).toBe("later summary");
+  });
+
+  it("still returns undefined when the last entry is a compaction record with nothing new to summarize", () => {
+    // A compaction record as the last entry, where its retained start points at
+    // itself and nothing follows: there is genuinely no compactable content, so
+    // the no-op path must still apply (avoids meaningless re-compaction).
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("earlier work", createUsage(10), 2), 1),
+      {
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "entry-1",
+        timestamp: new Date(3).toISOString(),
+        summary: "only a summary remains",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 10,
+      },
+    ];
+
+    const result = prepareCompaction(entries, settings);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok ? result.value : undefined).toBeUndefined();
+  });
+});
+
 describe("generateSummary thinking options", () => {
   it("consumes the decorated stream before reading its result", async () => {
     const model: Model = {

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -647,18 +647,15 @@ describe("session-entry compaction budgeting", () => {
 });
 
 describe("prepareCompaction when the last entry is a compaction record", () => {
-  // Regression for #120290: a compaction record as the last entry is not a no-op
-  // signal. The retained context (prior summary + kept recent turns + system prompt
-  // + injected files) can still exceed the window, so a second compaction that feeds
-  // the prior summary through UPDATE_SUMMARIZATION_PROMPT must remain possible when
-  // there is compactable content after the retained start.
   const settings = {
     enabled: true,
     reserveTokens: 0,
     keepRecentTokens: 1,
   };
-
-  it("compacts when the last entry is a compaction record and new turns follow the retained start", () => {
+  it.each([
+    { name: "ordinary", fromHook: false, compactable: true },
+    { name: "safeguard", fromHook: true, compactable: false },
+  ])("handles a $name trailing compaction boundary", ({ fromHook, compactable }) => {
     const largeContent = "x".repeat(200_000);
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
@@ -683,44 +680,85 @@ describe("prepareCompaction when the last entry is a compaction record", () => {
         summary: "later summary",
         firstKeptEntryId: "entry-2",
         tokensBefore: 200_000,
+        fromHook,
       },
     ];
 
     const result = prepareCompaction(entries, settings);
 
     expect(result.ok).toBe(true);
+    expect(Boolean(result.ok && result.value)).toBe(compactable);
+    if (!compactable) {
+      return;
+    }
     if (!result.ok || !result.value) {
       throw new Error("expected a trailing compaction record with new turns to remain compactable");
     }
     expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
-    // The most recent compaction record's summary must feed the next summary as
-    // previousSummary so UPDATE_SUMMARIZATION_PROMPT folds it in rather than dropping it.
     expect(result.value.previousSummary).toBe("later summary");
+    expect(result.value.firstKeptEntryId).not.toBe("entry-2");
+
+    const nextResult = prepareCompaction(
+      [
+        ...entries,
+        {
+          type: "compaction",
+          id: "compaction-3",
+          parentId: "compaction-2",
+          timestamp: new Date(8).toISOString(),
+          summary: "final summary",
+          firstKeptEntryId: result.value.firstKeptEntryId,
+          tokensBefore: result.value.tokensBefore,
+        },
+      ],
+      settings,
+    );
+
+    expect(nextResult.ok).toBe(true);
+    expect(nextResult.ok ? nextResult.value : undefined).toBeUndefined();
   });
 
-  it("still returns undefined when the last entry is a compaction record with nothing new to summarize", () => {
-    // A compaction record as the last entry, where its retained start points at
-    // itself and nothing follows: there is genuinely no compactable content, so
-    // the no-op path must still apply (avoids meaningless re-compaction).
-    const entries: SessionTreeEntry[] = [
-      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
-      createMessageEntry(createAssistant("earlier work", createUsage(10), 2), 1),
-      {
-        type: "compaction",
-        id: "compaction-1",
-        parentId: "entry-1",
-        timestamp: new Date(3).toISOString(),
-        summary: "only a summary remains",
-        firstKeptEntryId: "entry-1",
-        tokensBefore: 10,
-      },
-    ];
+  it.each([
+    { name: "non-record", details: "invalid" },
+    { name: "missing fields", details: { readFiles: ["src/read.ts"] } },
+    { name: "wrong field types", details: { readFiles: "src/read.ts", modifiedFiles: [] } },
+    {
+      name: "mixed element types",
+      details: { readFiles: ["src/read.ts", 1], modifiedFiles: ["src/write.ts"] },
+    },
+  ] satisfies Array<{ name: string; details: unknown }>)(
+    "ignores $name persisted compaction details",
+    ({ details }) => {
+      const largeContent = "x".repeat(200_000);
+      const entries: SessionTreeEntry[] = [
+        createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
+        {
+          type: "compaction",
+          id: "entry-1",
+          parentId: "entry-0",
+          timestamp: new Date(2).toISOString(),
+          summary: "earlier summary",
+          firstKeptEntryId: "entry-0",
+          tokensBefore: 200_000,
+          details,
+        },
+        createMessageEntry({ role: "user", content: largeContent, timestamp: 3 }, 2),
+        createMessageEntry(createAssistant(largeContent, createUsage(10), 4), 3),
+        createMessageEntry({ role: "user", content: "recent tail", timestamp: 5 }, 4),
+      ];
 
-    const result = prepareCompaction(entries, settings);
+      const result = prepareCompaction(entries, settings);
 
-    expect(result.ok).toBe(true);
-    expect(result.ok ? result.value : undefined).toBeUndefined();
-  });
+      expect(result.ok).toBe(true);
+      if (!result.ok || !result.value) {
+        throw new Error("expected malformed persisted details to be ignored");
+      }
+      expect(result.value.previousSummaryDetails).toBeUndefined();
+      expect([...result.value.fileOps.read]).toEqual([]);
+      expect([...result.value.fileOps.written]).toEqual([]);
+      expect([...result.value.fileOps.edited]).toEqual([]);
+    },
+  );
 });
 
 describe("generateSummary thinking options", () => {
@@ -937,7 +975,6 @@ describe("split-turn compaction", () => {
       }, 5);
       return stream;
     });
-
     const result = await compact(
       {
         firstKeptEntryId: "kept-entry",

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -703,11 +703,12 @@ export function prepareCompaction(
   pathEntries: SessionTreeEntry[],
   settings: CompactionSettings,
 ): Result<CompactionPreparation | undefined, CompactionError> {
-  if (
-    pathEntries.at(-1)?.type === "compaction" ||
-    pathEntries.at(-1)?.type === "reset" ||
-    pathEntries.length === 0
-  ) {
+  if (pathEntries.length === 0 || pathEntries.at(-1)?.type === "reset") {
+    // An empty branch or one ending in a reset has no compactable history on this
+    // branch. A compaction record as the last entry is NOT a no-op signal: the
+    // retained context (prior summary + kept recent turns + system prompt + injected
+    // files) can still exceed the window, so a second compaction that feeds the
+    // prior summary through UPDATE_SUMMARIZATION_PROMPT must remain possible.
     return ok(undefined);
   }
 

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -10,6 +10,7 @@ import {
   CHARS_PER_TOKEN_ESTIMATE,
   estimateStringChars,
 } from "@openclaw/normalization-core/cjk-chars";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentReasoningOption } from "../../reasoning.js";
 import {
@@ -22,7 +23,6 @@ import { convertToLlm, type HarnessMessage } from "../messages.js";
 import { buildSessionContext, projectSessionEntryMessage } from "../session/session.js";
 import { selectResetKeptEntries } from "../session/tool-result-pairing.js";
 import {
-  type CompactionEntry,
   CompactionError,
   err,
   InvalidSummaryOutputError,
@@ -50,16 +50,34 @@ export interface CompactionDetails {
   /** Files modified in the compacted history. */
   modifiedFiles: string[];
 }
+
+function parseCompactionDetails(value: unknown): CompactionDetails | undefined {
+  const details = asOptionalRecord(value);
+  if (
+    !details ||
+    !Array.isArray(details.readFiles) ||
+    !details.readFiles.every((file): file is string => typeof file === "string") ||
+    !Array.isArray(details.modifiedFiles) ||
+    !details.modifiedFiles.every((file): file is string => typeof file === "string")
+  ) {
+    return undefined;
+  }
+  return { readFiles: details.readFiles, modifiedFiles: details.modifiedFiles };
+}
+
 function extractFileOperations(
   messages: AgentMessage[],
   entries: SessionTreeEntry[],
   prevBoundaryIndex: number,
 ): FileOperations {
   const fileOps = createFileOps();
-  if (prevBoundaryIndex >= 0 && entries[prevBoundaryIndex]?.type === "compaction") {
-    const prevCompaction = entries[prevBoundaryIndex] as CompactionEntry;
-    if (!prevCompaction.fromHook && prevCompaction.details) {
-      mergeSummaryFileOperations(fileOps, prevCompaction.details as CompactionDetails);
+  if (prevBoundaryIndex >= 0) {
+    const prevCompaction = entries[prevBoundaryIndex];
+    if (prevCompaction?.type === "compaction" && !prevCompaction.fromHook) {
+      const details = parseCompactionDetails(prevCompaction.details);
+      if (details) {
+        mergeSummaryFileOperations(fileOps, details);
+      }
     }
   }
   for (const msg of messages) {
@@ -92,15 +110,21 @@ export interface CompactionResult<T = unknown> {
 export const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
 export const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
 
-export function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY_CHARS) {
+export function capCompactionSummary(
+  summary: string,
+  maxChars = MAX_COMPACTION_SUMMARY_CHARS,
+  preservedSuffix = "",
+) {
   if (maxChars <= 0 || summary.length <= maxChars) {
     return summary;
   }
-  if (maxChars < SUMMARY_TRUNCATED_MARKER.length) {
+  const suffix = preservedSuffix && summary.endsWith(preservedSuffix) ? preservedSuffix : "";
+  if (maxChars < SUMMARY_TRUNCATED_MARKER.length + suffix.length) {
     return truncateUtf16Safe(summary, maxChars);
   }
-  const budget = maxChars - SUMMARY_TRUNCATED_MARKER.length;
-  return `${truncateUtf16Safe(summary, budget)}${SUMMARY_TRUNCATED_MARKER}`;
+  const budget = maxChars - SUMMARY_TRUNCATED_MARKER.length - suffix.length;
+  const prefix = suffix ? summary.slice(0, -suffix.length) : summary;
+  return `${truncateUtf16Safe(prefix, budget)}${SUMMARY_TRUNCATED_MARKER}${suffix}`;
 }
 
 /** Compaction thresholds and retention settings. */
@@ -692,6 +716,8 @@ export interface CompactionPreparation {
   tokensBefore: number;
   /** Previous compaction summary used for iterative updates. */
   previousSummary?: string;
+  /** File metadata already appended to the previous compaction summary. */
+  previousSummaryDetails?: CompactionDetails;
   /** File operations extracted from summarized history. */
   fileOps: FileOperations;
   /** Settings used to prepare compaction. */
@@ -703,12 +729,13 @@ export function prepareCompaction(
   pathEntries: SessionTreeEntry[],
   settings: CompactionSettings,
 ): Result<CompactionPreparation | undefined, CompactionError> {
-  if (pathEntries.length === 0 || pathEntries.at(-1)?.type === "reset") {
-    // An empty branch or one ending in a reset has no compactable history on this
-    // branch. A compaction record as the last entry is NOT a no-op signal: the
-    // retained context (prior summary + kept recent turns + system prompt + injected
-    // files) can still exceed the window, so a second compaction that feeds the
-    // prior summary through UPDATE_SUMMARIZATION_PROMPT must remain possible.
+  const lastEntry = pathEntries.at(-1);
+  if (
+    !lastEntry ||
+    lastEntry.type === "reset" ||
+    (lastEntry.type === "compaction" && lastEntry.fromHook)
+  ) {
+    // Safeguard-owned compactions are anti-loop boundaries for the current turn.
     return ok(undefined);
   }
 
@@ -722,12 +749,16 @@ export function prepareCompaction(
   }
 
   let previousSummary: string | undefined;
+  let previousSummaryDetails: CompactionDetails | undefined;
   let effectiveEntries = pathEntries;
   let resetPreludeMessages: AgentMessage[] = [];
   let boundaryStart = 0;
   if (prevBoundaryIndex >= 0) {
     const prevBoundary = pathEntries[prevBoundaryIndex];
     previousSummary = prevBoundary?.type === "compaction" ? prevBoundary.summary : undefined;
+    if (prevBoundary?.type === "compaction" && !prevBoundary.fromHook) {
+      previousSummaryDetails = parseCompactionDetails(prevBoundary.details);
+    }
     const firstKeptEntryId =
       prevBoundary?.type === "compaction" || prevBoundary?.type === "reset"
         ? prevBoundary.firstKeptEntryId
@@ -828,6 +859,7 @@ export function prepareCompaction(
     isSplitTurn: cutPoint.isSplitTurn,
     tokensBefore,
     previousSummary,
+    previousSummaryDetails,
     fileOps,
     settings,
   });
@@ -869,6 +901,7 @@ export async function compact(
     isSplitTurn,
     tokensBefore,
     previousSummary,
+    previousSummaryDetails,
     fileOps,
     settings,
   } = preparation;
@@ -883,6 +916,13 @@ export async function compact(
   }
 
   const summarizeTurnPrefix = isSplitTurn && turnPrefixMessages.length > 0;
+  const previousFileOperations = previousSummaryDetails
+    ? formatFileOperations(previousSummaryDetails.readFiles, previousSummaryDetails.modifiedFiles)
+    : "";
+  const preservedPreviousSummary =
+    previousFileOperations && previousSummary?.endsWith(previousFileOperations)
+      ? previousSummary.slice(0, -previousFileOperations.length)
+      : previousSummary;
   const historyResult =
     messagesToSummarize.length > 0 || !summarizeTurnPrefix
       ? await generateSummary(
@@ -898,12 +938,12 @@ export async function compact(
           streamFn,
           runtime,
         )
-      : ok<string, CompactionError>("No prior history.");
+      : ok<string, CompactionError>(preservedPreviousSummary ?? "No prior history.");
   if (!historyResult.ok) {
     return err(historyResult.error);
   }
 
-  let summary = historyResult.value;
+  let latestContext = "";
   if (summarizeTurnPrefix) {
     const turnPrefixResult = await generateTurnPrefixSummary(
       turnPrefixMessages,
@@ -919,11 +959,26 @@ export async function compact(
     if (!turnPrefixResult.ok) {
       return err(turnPrefixResult.error);
     }
-    summary = `${summary}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.value}`;
+    latestContext = `\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.value}`;
   }
 
   const { readFiles, modifiedFiles } = computeFileLists(fileOps);
-  summary += formatFileOperations(readFiles, modifiedFiles);
+  const fileOperations = formatFileOperations(readFiles, modifiedFiles);
+  const preservedHistoryChars = Math.min(
+    historyResult.value.length,
+    Math.floor(MAX_COMPACTION_SUMMARY_CHARS / 2),
+  );
+  const latestContextBudget =
+    MAX_COMPACTION_SUMMARY_CHARS -
+    SUMMARY_TRUNCATED_MARKER.length -
+    fileOperations.length -
+    preservedHistoryChars;
+  latestContext = `${capCompactionSummary(latestContext, latestContextBudget)}${fileOperations}`;
+  const summary = capCompactionSummary(
+    `${historyResult.value}${latestContext}`,
+    MAX_COMPACTION_SUMMARY_CHARS,
+    latestContext,
+  );
 
   return ok({
     summary,


### PR DESCRIPTION
Related to #120290

## What Problem This Solves

A long-running session can sit above 100% of its context window while the compactor reports there is nothing to do, because compaction eligibility is decided by the *type of the last session entry* rather than by the *measured context size*.

- Problem: `prepareCompaction` short-circuits to `undefined` whenever the last entry is a `compaction` record, treating "last entry is a summary" as a proxy for "the session is already small enough." That proxy does not hold — the retained context (prior summary + kept recent turns + system prompt + injected files) can still exceed the compaction threshold. A session wedged at ~98% of its window is refused with `Already compacted` (manual) or silently `skipped` (auto), and only becomes eligible again once enough new turns append that the compaction record is no longer last (i.e. the session has to grow *further past* the ceiling before it can be rescued).
- Solution: Drop the last-entry-is-`compaction` short-circuit so the existing re-compaction path stays reachable. When the retained tail still has compactable content, the prior summary flows through `previousSummary` into `UPDATE_SUMMARIZATION_PROMPT`, folding the old summary into a fresh one instead of dropping it.
- What changed: `packages/agent-core/src/harness/compaction/compaction.ts` — the first guard in `prepareCompaction` now only returns `undefined` for an empty branch or a branch ending in `reset`; a trailing `compaction` record is no longer a no-op signal. Plus two regression tests in `compaction.test.ts`.
- What did NOT change: the empty-branch and last-entry-is-`reset` no-op guards; the `messagesToSummarize.length === 0` guard that still returns `undefined` when there is genuinely nothing new to summarize; the `previousSummary` / `UPDATE_SUMMARIZATION_PROMPT` mechanism (already present, just newly reachable); manual/auto call sites; the `shouldCompact` trigger logic.

## Why This Change Was Made

This is the minimal fix that unblocks the wedge without weakening the no-op path. The re-compaction machinery (`previousSummary` → `UPDATE_SUMMARIZATION_PROMPT`, with file-operation ratcheting across compactions) was already designed for "summarize a session that already has a summary" — it is the path Claude Code's own auto-compact takes via `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, and the same context-size-driven shape Codex uses when its native harness reports "did not reduce context" and falls back (`src/agents/command/cli-compaction.ts:545`). The only thing keeping that path unreachable here was the over-conservative first guard.

- Best fix: Yes — removing the short-circuit is strictly better than adding a parallel context-size check, because the walk already computes `tokensBefore` and already threads `previousSummary`; a second guard would duplicate that logic.
- Alternative considered: extend `prepareCompaction`'s signature to take a `contextWindow` and call `shouldCompact` at the guard. Rejected — it would touch three call sites for no behavioral gain, since the existing `messagesToSummarize.length === 0` guard already handles the true no-op.
- Risk / non-goals: A trailing `compaction` record with *no* new turns after the retained start still returns `undefined` (verified below), so there is no risk of meaningless re-compaction loops. The fix does not change when auto-compaction *triggers* (still `shouldCompact` on measured context), only what *eligibility* says once triggered. Provider/model behavior is untouched.

## User Impact

A session that has been compacted once but whose retained context still exceeds the window can now be compacted again instead of being refused with "Already compacted" (manual) or silently skipped (auto). Operators running long-lived sessions with large injected context sets and high `keepRecentTokens` will no longer see sessions wedge above 100% until they grow far enough past the ceiling to rescue themselves. No configuration, schema, or API surface changes.

## Evidence

Real runtime proof — `prepareCompaction` called directly via `node --import tsx` on three scenarios, before and after the fix:

```
PRE-FIX (origin/main):
last=compaction, new turns follow retained start     => undefined (no-op)          ← BUG: context over threshold, refused
last=compaction, nothing new to summarize            => undefined (no-op)          ← correct no-op preserved
last=reset                                           => undefined (no-op)          ← correct no-op preserved

POST-FIX (HEAD b390816):
last=compaction, new turns follow retained start     => preparation (summarize=2, previousSummary=set)  ← FIXED: re-compacts, folds prior summary
last=compaction, nothing new to summarize            => undefined (no-op)          ← no-op still preserved
last=reset                                           => undefined (no-op)          ← no-op still preserved
```

The first row is the regression: pre-fix returns `undefined` (the wedge from the issue — 98.3% context, refused as "Already compacted"); post-fix returns a preparation with `previousSummary` set, so `UPDATE_SUMMARIZATION_PROMPT` folds the old summary into a new one. The other two rows confirm the no-op path is unchanged.

Vitest regression suite (pre-fix the first test fails at the guard, post-fix all pass):

```
node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/ --run
 Test Files  5 passed (5)
      Tests  74 passed (74)

# Pre-fix verification (source reverted to origin/main for the compaction module):
node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts -t "last entry is a compaction record"
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 36 skipped   ← "compacts when ... new turns" fails; no-op test still passes
```

What was not tested: no live multi-agent gateway reproduction with a 200K-token session (the issue's production scenario). The fix is validated at the `prepareCompaction` unit boundary against the exact eligibility predicate the issue describes; the downstream `compact()` → `generateSummary(UPDATE_SUMMARIZATION_PROMPT, previousSummary)` path is unchanged existing code.

### Rebase onto current main (head `35d41a7b0de`)

Rebased the branch (original head `b390816` + maintainer commits `04cd66db` / `eb0bf7b7`) onto current `origin/main` (`6ea8a71`) to clear the previous DIRTY/CONFLICTING state. Conflict resolution in `compaction.ts` retained **both** current-main compaction safeguards that the prior dirty head was missing:

- `MAX_COMPACTION_SUMMARY_CHARS = 16_000` — persisted-summary cap (prevents unbounded replayed summaries)
- `consumeAgentCoreStream` — decorated-stream consumption before reading results (prevents compaction stalls)

The only conflict was an import-line overlap (main added `truncateUtf16Safe`; the maintainer's `validate persisted compaction details` commit added `asOptionalRecord`); both imports were kept.

Post-rebase verification on the rebased head:

```
# Conflict markers: none
node scripts/check-no-conflict-markers.mjs                         # ok

# Assertion-safety ratchet (vs origin/main)
node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main
# assertion SAFETY ratchet OK: 4281 files, 13500 grandfathered assertions.

# Compaction vitest shard (ClawSweeper acceptance criterion)
node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/ --run
#  Test Files  5 passed (5)
#       Tests  77 passed (77)   # was 74; +3 from the maintainer-added split-turn + validate-details coverage

# Lint / format on changed files
oxlint -c .oxlintrc.json packages/agent-core/src/harness/compaction/compaction.ts compaction.test.ts   # clean
oxfmt --check   packages/agent-core/src/harness/compaction/compaction.ts compaction.test.ts           # clean
```

Baseline note: `config/assertion-safety-baseline.txt` for this file shrinks `5 → 3`. The maintainer's `parseCompactionDetails` helper replaces two bare `as CompactionDetails` / `as CompactionEntry` casts with runtime-validated narrowing, so two previously-grandfathered assertions are intentionally gone; the baseline count was pruned to match (`--prune`). No assertions were silently dropped — the shrink corresponds 1:1 to casts replaced by the validating helper.

Mergeability after rebase: `mergeable: MERGEABLE` (was `CONFLICTING`), `mergeStateStatus: BEHIND` (was `DIRTY`).

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (Claude Code, glm-5.2 model via local bridge)
- Prompts / session excerpts: `/open-source-pr` workflow — Step 3 root-cause analysis of #120290, Step 4 design (surveyed how Claude Code's `CLAUDE_CODE_AUTO_COMPACT_WINDOW` and Codex's "did not reduce context → fallback" handle the same scenario, confirmed the `previousSummary` + `UPDATE_SUMMARIZATION_PROMPT` re-compaction path already exists), Step 5 implementation + pre/post-fix proof.
- Confirmed understanding of code changes: Yes — the change removes one `||` condition (`pathEntries.at(-1)?.type === "compaction"`) from `prepareCompaction`'s first guard so a trailing compaction record is no longer treated as a no-op signal; the existing `previousSummary` mechanism and `messagesToSummarize.length === 0` no-op guard handle the rest.
- autoreview: N/A (not run in this environment; `oxlint` + `oxfmt --check` clean on changed files, 74 compaction tests pass)

