### PR TITLE
fix(cli): detect PowerShell completion on Windows

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -13,7 +13,7 @@ Generate shell completion scripts, cache them under OpenClaw state, and optional
 ## Usage
 
 ```bash
-openclaw completion                          # print zsh script to stdout
+openclaw completion                          # print the detected shell's script
 openclaw completion --shell fish             # print fish script
 openclaw completion --write-state            # cache scripts for all shells
 openclaw completion --write-state --install  # cache, then install in one step
@@ -22,14 +22,14 @@ openclaw completion --shell bash --write-state
 
 ## Options
 
-- `-s, --shell <shell>`: shell target (`zsh`, `bash`, `powershell`, `fish`; default: `zsh`)
+- `-s, --shell <shell>`: shell target (`zsh`, `bash`, `powershell`, `fish`; detected from `$SHELL`, otherwise PowerShell on Windows and zsh elsewhere)
 - `-i, --install`: install completion by adding a source line for the cached script to your shell profile
 - `--write-state`: write completion script(s) to `$OPENCLAW_STATE_DIR/completions` (default `~/.openclaw/completions`) without printing to stdout; with `--shell` writes only that shell, otherwise all four
 - `-y, --yes`: skip install confirmation prompts (non-interactive)
 
 ## Install flow
 
-`--install` points your profile at the cached script, so the cache must exist first: if it is missing, the command fails and tells you to run `openclaw completion --write-state`. Combine `--write-state --install` to do both in one step. Without `--shell`, `--install` detects the shell from `$SHELL` (falling back to zsh).
+`--install` points your profile at the cached script, so the cache must exist first: if it is missing, the command fails and tells you to run `openclaw completion --write-state`. Combine `--write-state --install` to do both in one step. Without `--shell`, the command preserves a recognized `$SHELL`; when `$SHELL` is missing or unrecognized, it defaults to PowerShell on Windows and zsh elsewhere.
 
 The install writes a small `# OpenClaw Completion` block into your shell profile and replaces any older slow `source <(openclaw completion ...)` lines with the cached source line:
 

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -91,7 +91,7 @@ describe("completion-cli", () => {
 
     expect(script).toContain('"[Gateway token]:token:"');
     expect(script).toContain(
-      '"[Shell to generate completion for (default: zsh)]:shell:(zsh bash powershell fish)"',
+      '"[Shell to generate completion for (default: detected)]:shell:(zsh bash powershell fish)"',
     );
   });
 
@@ -804,7 +804,7 @@ _openclaw_root_completion
     expect(fishScript).toContain(" -s s -l shell -r -f -a ");
     expect(fishScript).toContain(`"'zsh' 'bash' 'powershell' 'fish'"`);
     expect(zshScript).toContain(
-      `{--shell,-s}"[Shell to generate completion for (default: zsh)]:shell:(zsh bash powershell fish)"`,
+      `{--shell,-s}"[Shell to generate completion for (default: detected)]:shell:(zsh bash powershell fish)"`,
     );
     expect(zshScript).toContain('{--token,-t}"[Gateway token]:token:"');
   });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -183,9 +183,10 @@ export function registerCompletionCli(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/completion", "docs.openclaw.ai/cli/completion")}\n`,
     )
     .addOption(
-      new Option("-s, --shell <shell>", "Shell to generate completion for (default: zsh)").choices(
-        COMPLETION_SHELLS,
-      ),
+      new Option(
+        "-s, --shell <shell>",
+        "Shell to generate completion for (default: detected)",
+      ).choices(COMPLETION_SHELLS),
     )
     .option("-i, --install", "Install completion script to shell profile")
     .option(
@@ -206,7 +207,7 @@ export function registerCompletionCli(program: Command) {
         return;
       }
 
-      const shell = options.shell ?? "zsh";
+      const shell = options.shell ?? resolveShellFromEnv();
 
       // Completion needs the full Commander command tree (including nested subcommands).
       // Our CLI defaults to lazy registration for perf; force-register core commands here.

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -706,15 +706,45 @@ describe("completion-runtime", () => {
     },
   );
 
-  it("detects PowerShell shell names from Windows paths", () => {
-    expect(resolveShellFromEnv({ SHELL: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" })).toBe(
-      "powershell",
-    );
-    expect(
-      resolveShellFromEnv({
-        SHELL: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-      }),
-    ).toBe("powershell");
+  it.each([
+    {
+      name: "native Windows without SHELL",
+      env: {},
+      platform: "win32" as const,
+      expected: "powershell",
+    },
+    {
+      name: "native Windows with an unknown SHELL",
+      env: { SHELL: "C:\\Windows\\System32\\cmd.exe" },
+      platform: "win32" as const,
+      expected: "powershell",
+    },
+    {
+      name: "PowerShell Core from a Windows path",
+      env: { SHELL: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
+      platform: "win32" as const,
+      expected: "powershell",
+    },
+    {
+      name: "Windows PowerShell from a Windows path",
+      env: { SHELL: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" },
+      platform: "win32" as const,
+      expected: "powershell",
+    },
+    {
+      name: "recognized Bash on Windows",
+      env: { SHELL: "C:\\Program Files\\Git\\bin\\bash.exe" },
+      platform: "win32" as const,
+      expected: "bash",
+    },
+    {
+      name: "non-Windows without SHELL",
+      env: {},
+      platform: "linux" as const,
+      expected: "zsh",
+    },
+  ])("detects $name", ({ env, platform, expected }) => {
+    expect(resolveShellFromEnv(env, platform)).toBe(expected);
   });
 
   it("resolves Windows PowerShell and pwsh profile directories", () => {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -31,10 +31,13 @@ function resolveShellBasename(
   return normalizeLowercaseStringOrEmpty(basename.replace(/\.(?:exe|cmd|bat)$/i, ""));
 }
 
-/** Resolves the active shell from environment paths, defaulting to zsh for unknown shells. */
-export function resolveShellFromEnv(env: NodeJS.ProcessEnv = process.env): CompletionShell {
+/** Resolves the active shell from environment paths, using the platform's native default. */
+export function resolveShellFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): CompletionShell {
   const shellPath = normalizeOptionalString(env.SHELL) ?? "";
-  const shellName = shellPath ? resolveShellBasename(shellPath) : "";
+  const shellName = shellPath ? resolveShellBasename(shellPath, platform) : "";
   if (shellName === "zsh") {
     return "zsh";
   }
@@ -47,7 +50,7 @@ export function resolveShellFromEnv(env: NodeJS.ProcessEnv = process.env): Compl
   if (shellName === "pwsh" || shellName === "powershell") {
     return "powershell";
   }
-  return "zsh";
+  return platform === "win32" ? "powershell" : "zsh";
 }
 
 function sanitizeCompletionBasename(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native Windows users installing shell completion without `--shell` would get Zsh completion and `.zshrc` profile changes when their environment did not define `SHELL`, which is normal in PowerShell.

## Why This Change Was Made

Completion shell detection now keeps recognized explicit shell paths but uses the platform-native fallback: PowerShell on Windows and Zsh elsewhere. The shared owner is used by direct completion generation/install, Doctor, onboarding, and update flows.

AI-assisted.

## User Impact

Windows PowerShell users can install or generate completion without an explicit shell override and receive the correct PowerShell cache/profile integration. Explicit Bash, Fish, Zsh, and PowerShell selections remain unchanged.

## Evidence

Before the fix, missing or unknown `SHELL` on `win32` resolved to `zsh`. The regression matrix now covers native Windows without `SHELL`, an unknown Windows shell, PowerShell paths, Git Bash, and the non-Windows fallback.

- `node scripts/run-vitest.mjs src/cli/completion-runtime.test.ts src/cli/completion-cli.test.ts src/commands/doctor-completion.test.ts` — 160 passed, 39 skipped
- Targeted formatting, docs listing, typechecks, lint, import-cycle and changed-file guards passed
- `git diff --check` — passed
- Codex autoreview through P2 — clean, no actionable findings
