### PR TITLE
refactor(approvals): consolidate channel approval kind

### DIFF
--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -15,7 +16,7 @@ type GoogleChatApprovalCardBinding = {
   token: string;
   accountId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   decision: ExecApprovalDecision;
   allowedDecisions: readonly ExecApprovalDecision[];
   spaceName: string;
@@ -43,7 +44,7 @@ type GoogleChatManualApprovalSuppressionPayload = {
 
 type GoogleChatManualApprovalFollowupSuppression = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalDecision[];
   expiresAtMs: number;
 };

--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -1,4 +1,5 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGoogleChatApprovalActionParameters,
@@ -23,7 +24,7 @@ type ApprovalDecision = "allow-once" | "allow-always" | "deny";
 function createApprovalResolveResult(params: {
   applied: boolean;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   decision: ApprovalDecision;
 }): ApprovalResolveResult {
   const presentation =
@@ -106,7 +107,7 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
       .mockImplementation(
         (params: {
           approvalId: string;
-          approvalKind: "exec" | "plugin";
+          approvalKind: ChannelApprovalKind;
           decision: ApprovalDecision;
         }) =>
           Promise.resolve(

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -1,5 +1,6 @@
 import type {
   ChannelApprovalCapabilityHandlerContext,
+  ChannelApprovalKind,
   ExpiredApprovalView,
   PendingApprovalView,
   ResolvedApprovalView,
@@ -43,7 +44,7 @@ type GoogleChatApprovalActionToken = {
 
 type GoogleChatPendingDelivery = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   expiresAtMs: number;
   cardsV2: GoogleChatCardV2[];
   actionTokens: GoogleChatApprovalActionToken[];

--- a/extensions/googlechat/src/approval-native.ts
+++ b/extensions/googlechat/src/approval-native.ts
@@ -1,6 +1,9 @@
 import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type {
+  ChannelApprovalKind,
+  ChannelApprovalNativeRuntimeAdapter,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
@@ -150,7 +153,7 @@ function resolveSessionGoogleChatOriginTarget(sessionTarget: {
 export function shouldHandleGoogleChatNativeApprovalRequest(params: {
   cfg: Parameters<typeof resolveGoogleChatAccount>[0]["cfg"];
   accountId?: string | null;
-  approvalKind?: "exec" | "plugin";
+  approvalKind?: ChannelApprovalKind;
   request: ApprovalRequest;
 }): boolean {
   return (

--- a/extensions/imessage/src/approval-handler.runtime.ts
+++ b/extensions/imessage/src/approval-handler.runtime.ts
@@ -3,6 +3,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import {
   buildChannelApprovalExpiredText,
   buildChannelApprovalResolvedText,
+  type ChannelApprovalKind,
   createChannelApprovalNativeRuntimeAdapter,
   type PendingApprovalView,
   resolvePreparedApprovalAccountId,
@@ -70,7 +71,7 @@ type PreparedIMessageApprovalTarget = {
 };
 type IMessageApprovalPromptBinding = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
 };
 type PendingIMessageApprovalEntry = {
@@ -93,7 +94,7 @@ type IMessageFinalPayload = {
 
 function buildPendingPayload(params: {
   request: ApprovalRequest;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   nowMs: number;
   view: PendingApprovalView;
 }): IMessagePendingDelivery {
@@ -225,7 +226,7 @@ async function deliverIMessageApprovalPoll(params: {
   cfg: OpenClawConfig;
   target: PreparedIMessageApprovalTarget;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   expiresAtMs: number;
   question: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
@@ -427,7 +428,7 @@ const eagerlyBoundApprovalEntries = new WeakSet<PendingIMessageApprovalEntry>();
 function bindIMessageApprovalEntry(params: {
   entry: PendingIMessageApprovalEntry;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   expiresAtMs: number;
   pollTargetWasRegisteredDuringDelivery?: boolean;

--- a/extensions/imessage/src/approval-native.test.ts
+++ b/extensions/imessage/src/approval-native.test.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 // Imessage tests cover approval native plugin behavior.
 import type {
   ExecApprovalRequest,
@@ -34,7 +35,7 @@ function buildConfig(
 }
 
 function buildTargetModeConfig(
-  approvalKind: "exec" | "plugin",
+  approvalKind: ChannelApprovalKind,
   targets: Array<{ channel: string; to: string; accountId?: string }>,
   params: { mode?: "targets" | "both"; imessage?: Partial<IMessageConfig> } = {},
 ) {
@@ -93,7 +94,7 @@ function buildPluginRequest(
 
 function nativeShouldHandle(params: {
   cfg: OpenClawConfig;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   request: ExecApprovalRequest | PluginApprovalRequest;
   accountId?: string | null;
 }) {
@@ -109,7 +110,7 @@ function nativeShouldHandle(params: {
 function getAvailability(
   cfg: OpenClawConfig,
   accountId = DEFAULT_ACCOUNT_ID,
-  approvalKind: "exec" | "plugin" = "exec",
+  approvalKind: ChannelApprovalKind = "exec",
 ) {
   return imessageApprovalCapability.getActionAvailabilityState?.({
     cfg,
@@ -122,7 +123,7 @@ function getAvailability(
 function describeDelivery(
   cfg: OpenClawConfig,
   request: ExecApprovalRequest | PluginApprovalRequest,
-  approvalKind: "exec" | "plugin" = "exec",
+  approvalKind: ChannelApprovalKind = "exec",
 ) {
   return imessageApprovalCapability.native?.describeDeliveryCapabilities({
     cfg,
@@ -166,7 +167,7 @@ function suppressTargetForwarding(
 
 function buildLocalApprovalPayload(
   params: {
-    approvalKind?: "exec" | "plugin";
+    approvalKind?: ChannelApprovalKind;
     agentId?: string | null;
     sessionKey?: string | null;
   } = {},

--- a/extensions/imessage/src/approval-polls.ts
+++ b/extensions/imessage/src/approval-polls.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 // Native Apple Messages poll bindings for approval prompts.
 //
 // Native polls replace tapback controls when the imsg bridge supports them.
@@ -47,7 +48,7 @@ const APPROVAL_DECISIONS = new Set<ExecApprovalReplyDecision>([
 /** JSON-safe: option pairs stay an array so the persistent store round-trips. */
 type IMessageApprovalPollTarget = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   optionDecisions: ReadonlyArray<readonly [string, ExecApprovalReplyDecision]>;
 };
 
@@ -161,7 +162,7 @@ function registerIMessageApprovalPollTarget(params: {
   conversation: IMessageApprovalConversationKey;
   pollGuid?: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   optionDecisions: ReadonlyArray<readonly [string, ExecApprovalReplyDecision]>;
   expiresAtMs: number;
 }): boolean {

--- a/extensions/imessage/src/approval-reaction-poll-targets.ts
+++ b/extensions/imessage/src/approval-reaction-poll-targets.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 // Imessage plugin module owns persisted approval reaction poll targets.
 import { readApprovalReactionDecisionList } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -27,7 +28,7 @@ export type PendingIMessageApprovalReactionPollTarget = {
   conversation: IMessageApprovalConversationKey;
   messageId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   expiresAtMs: number;
 };
@@ -169,7 +170,7 @@ export function recordIMessageApprovalReactionPollTarget(params: {
   conversation: IMessageApprovalConversationKey;
   messageId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
 }): { ttlMs: number; expiresAtMs: number } | null {

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -1,5 +1,6 @@
 // Imessage plugin module implements approval reactions behavior.
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   addApprovalReactionHintToText,
   approvalReactionDecisionSetsMatch,
@@ -47,7 +48,7 @@ const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
 type IMessageApprovalReactionResolution = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
 };
 type IMessageApprovalReactionHandleResult =
@@ -60,7 +61,7 @@ type IMessageApprovalReactionHandleResult =
     };
 
 type IMessageApprovalReactionTarget = ApprovalReactionTargetRecord & {
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
 };
 
 export type { IMessageApprovalConversationKey } from "./approval-target-keys.js";
@@ -187,7 +188,7 @@ function visibleApprovalBindingMatches(
 /** Preserve a validated typed approval binding until the iMessage GUID is known. */
 export function addIMessageApprovalReactionHintToStructuredPayload(params: {
   payload: ReplyPayload;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
 }): ReplyPayload | null {
   const metadata = readApprovalReactionPresentationBinding({
     payload: params.payload,
@@ -227,7 +228,7 @@ export function registerIMessageApprovalReactionTarget(params: {
   conversation: IMessageApprovalConversationKey;
   messageId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
 }): IMessageApprovalReactionTarget | null {

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -1,5 +1,6 @@
 // Imessage plugin module implements channel behavior.
 import { buildDmGroupAccountAllowlistAdapter } from "openclaw/plugin-sdk/allowlist-config-edit";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
   createMessageReceiptFromOutboundResults,
@@ -100,7 +101,7 @@ const loadIMessageQuestionReactionsModule = createLazyRuntimeModule(
 
 async function prepareForwardedIMessageApprovalPayload(params: {
   payload: Parameters<NonNullable<ChannelOutboundAdapter["beforeDeliverPayload"]>>[0]["payload"];
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
 }): Promise<void> {
   const prepared = (
     await loadIMessageApprovalReactionsModule()

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1,6 +1,7 @@
 // Imessage plugin module implements send behavior.
 import { constants, accessSync } from "node:fs";
 import { basename } from "node:path";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { addApprovalReactionHintToText } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
@@ -78,7 +79,7 @@ type IMessageSendTransport = "auto" | "bridge" | "applescript";
 
 type IMessageApprovalPromptBinding = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
 };
 

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -5,7 +5,10 @@ import {
   splitChannelApprovalCapability,
 } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type {
+  ChannelApprovalKind,
+  ChannelApprovalNativeRuntimeAdapter,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelNativeOriginTargetResolver,
   resolveApprovalRequestSessionConversation,
@@ -37,7 +40,6 @@ import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
 import type { CoreConfig } from "./types.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type ApprovalKind = "exec" | "plugin";
 type MatrixOriginTarget = { to: string; threadId?: string };
 
 function normalizeComparableTarget(value: string): string {
@@ -104,7 +106,7 @@ function availabilityState(enabled: boolean) {
 function hasMatrixApprovalApprovers(params: {
   cfg: CoreConfig;
   accountId?: string | null;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   return (
     getMatrixApprovalApprovers({
@@ -188,7 +190,7 @@ const resolveMatrixOriginTarget = createChannelNativeOriginTargetResolver({
 function resolveMatrixApproverDmTargets(params: {
   cfg: CoreConfig;
   accountId?: string | null;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   request: ApprovalRequest;
 }): { to: string }[] {
   if (!shouldHandleMatrixApprovalRequest(params)) {

--- a/extensions/matrix/src/approval-reaction-auth.ts
+++ b/extensions/matrix/src/approval-reaction-auth.ts
@@ -1,10 +1,9 @@
 // Matrix plugin module implements approval reaction auth behavior.
 import { resolveApprovalApprovers } from "openclaw/plugin-sdk/approval-auth-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { normalizeMatrixApproverId } from "./approval-ids.js";
 import { resolveMatrixAccount } from "./matrix/accounts.js";
 import type { CoreConfig } from "./types.js";
-
-type MatrixApprovalReactionKind = "exec" | "plugin";
 
 function normalizeMatrixExecApproverId(value: string | number): string | undefined {
   const normalized = normalizeMatrixApproverId(value);
@@ -14,7 +13,7 @@ function normalizeMatrixExecApproverId(value: string | number): string | undefin
 function getMatrixApprovalReactionApprovers(params: {
   cfg: CoreConfig;
   accountId?: string | null;
-  approvalKind: MatrixApprovalReactionKind;
+  approvalKind: ChannelApprovalKind;
 }): string[] {
   const account = resolveMatrixAccount(params).config;
   if (params.approvalKind === "plugin") {
@@ -34,7 +33,7 @@ export function isMatrixApprovalReactionAuthorizedSender(params: {
   cfg: CoreConfig;
   accountId?: string | null;
   senderId?: string | null;
-  approvalKind: MatrixApprovalReactionKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   const normalizedSenderId = params.senderId
     ? normalizeMatrixApproverId(params.senderId)

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 // Matrix plugin module implements approval reactions behavior.
 import { createApprovalReactionTargetStore } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
@@ -40,14 +41,14 @@ type MatrixApprovalReactionBinding = {
 
 type MatrixApprovalReactionResolution = {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
 };
 
 type MatrixApprovalReactionTarget = {
   accountId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   roomId: string;
   eventId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
@@ -198,7 +199,7 @@ export function registerMatrixApprovalReactionTarget(params: {
   roomId: string;
   eventId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
 }): void {
@@ -256,7 +257,7 @@ export function unregisterMatrixApprovalReactionTarget(params: {
 export async function unregisterMatrixApprovalReactionTargetsForApproval(params: {
   accountId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
 }): Promise<MatrixApprovalReactionTargetRef[]> {
   const accountId = normalizeAccountId(params.accountId);
   const approvalId = params.approvalId.trim();

--- a/extensions/matrix/src/exec-approvals.ts
+++ b/extensions/matrix/src/exec-approvals.ts
@@ -7,6 +7,7 @@ import {
   isChannelExecApprovalTargetRecipient,
   matchesApprovalRequestFilters,
 } from "openclaw/plugin-sdk/approval-client-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { doesApprovalRequestSelectChannelAccount } from "openclaw/plugin-sdk/approval-native-runtime";
 import type {
   ExecApprovalRequest,
@@ -20,8 +21,6 @@ import { resolveDefaultMatrixAccountId, resolveMatrixAccount } from "./matrix/ac
 import type { CoreConfig } from "./types.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type ApprovalKind = "exec" | "plugin";
-
 function normalizeMatrixExecApproverId(value: string | number): string | undefined {
   const normalized = normalizeMatrixApproverId(value);
   return normalized === "*" ? undefined : normalized;
@@ -46,7 +45,7 @@ function isMatrixExecApprovalAccountEligible(params: {
   cfg: OpenClawConfig;
   accountId: string;
   request: ApprovalRequest;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   const account = resolveMatrixAccount(params);
   if (!account.enabled || !account.configured) {
@@ -73,7 +72,7 @@ function matchesMatrixRequestAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   request: ApprovalRequest;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   const accountId = params.accountId ?? resolveDefaultMatrixAccountId(params.cfg);
   return doesApprovalRequestSelectChannelAccount({
@@ -101,7 +100,7 @@ export function getMatrixExecApprovalApprovers(params: {
 export function getMatrixApprovalApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): string[] {
   if (params.approvalKind === "plugin") {
     return getMatrixApprovalAuthApprovers({
@@ -145,7 +144,7 @@ export const resolveMatrixExecApprovalTarget = matrixExecApprovalProfile.resolve
 export function isMatrixApprovalClientEnabled(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   if (params.approvalKind === "exec") {
     return isMatrixExecApprovalClientEnabled(params);
@@ -176,7 +175,7 @@ export function isMatrixAnyApprovalClientEnabled(params: {
 export function shouldHandleMatrixApprovalRequest(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   request: ApprovalRequest;
 }): boolean {
   if (params.approvalKind !== "exec" && params.approvalKind !== "plugin") {

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -1,5 +1,6 @@
 // Matrix plugin module implements reaction events behavior.
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
@@ -51,7 +52,7 @@ async function retireMatrixApprovalReactionTargets(params: {
   roomId: string;
   targetEventId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   result: ApprovalResolveResult;
   logVerboseMessage: (message: string) => void;
 }): Promise<void> {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-approval.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-approval.ts
@@ -1,6 +1,7 @@
 // QA Lab Matrix plugin module implements scenario runtime approval behavior.
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { normalizeUniqueStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
 import {
@@ -24,7 +25,6 @@ const MATRIX_QA_APPROVAL_SHORT_WINDOW_MS = 4_000;
 const MATRIX_QA_APPROVAL_LONG_COMMAND_TEXT = "matrix approval chunk fallback ".repeat(40);
 
 type MatrixQaApprovalDecision = "allow-once" | "deny";
-type MatrixQaApprovalKind = "exec" | "plugin";
 type MatrixQaApprovalOptionReactionParams = {
   context: MatrixQaScenarioContext;
   emoji: string;
@@ -69,7 +69,7 @@ function hasObservedApprovalOptionReaction(params: MatrixQaApprovalOptionReactio
 
 function assertApprovalMetadata(params: {
   event: { approval?: unknown; eventId: string };
-  expectedKind: MatrixQaApprovalKind;
+  expectedKind: ChannelApprovalKind;
 }) {
   const approval =
     typeof params.event.approval === "object" && params.event.approval !== null
@@ -119,7 +119,7 @@ function isExpectedApprovalEvent(
   params: {
     context: MatrixQaScenarioContext;
     expectedApprovalId: string;
-    expectedKind: MatrixQaApprovalKind;
+    expectedKind: ChannelApprovalKind;
     roomId: string;
     threadRootEventId?: string;
   },
@@ -137,7 +137,7 @@ function isExpectedApprovalEvent(
 async function waitForApprovalEvent(params: {
   context: MatrixQaScenarioContext;
   expectedApprovalId: string;
-  expectedKind: MatrixQaApprovalKind;
+  expectedKind: ChannelApprovalKind;
   roomId: string;
   since?: string;
   threadRootEventId?: string;
@@ -176,7 +176,7 @@ async function waitForApprovalEvent(params: {
 async function waitForObservedApprovalEvent(params: {
   context: MatrixQaScenarioContext;
   expectedApprovalId: string;
-  expectedKind: MatrixQaApprovalKind;
+  expectedKind: ChannelApprovalKind;
   excludedRoomIds?: string[];
   roomIds: string[];
   timeoutMs: number;
@@ -394,7 +394,7 @@ async function requestPluginApproval(params: { context: MatrixQaScenarioContext;
 async function waitForApprovalDecision(params: {
   approvalId: string;
   context: MatrixQaScenarioContext;
-  kind: MatrixQaApprovalKind;
+  kind: ChannelApprovalKind;
 }) {
   const gatewayCall = requireMatrixQaGatewayCall(params.context);
   const method =
@@ -413,7 +413,7 @@ async function resolveApprovalDecision(params: {
   approvalId: string;
   context: MatrixQaScenarioContext;
   decision: MatrixQaApprovalDecision;
-  kind: MatrixQaApprovalKind;
+  kind: ChannelApprovalKind;
 }) {
   const gatewayCall = requireMatrixQaGatewayCall(params.context);
   const method = params.kind === "exec" ? "exec.approval.resolve" : "plugin.approval.resolve";

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/events.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/events.ts
@@ -1,4 +1,5 @@
 // Qa Lab Matrix module implements events behavior.
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 export type MatrixQaRoomEvent = {
   content?: Record<string, unknown>;
   event_id?: string;
@@ -29,7 +30,7 @@ type MatrixQaObservedApproval = {
   commandTextPreview?: string;
   hasCommandText?: boolean;
   id: string;
-  kind: "exec" | "plugin";
+  kind: ChannelApprovalKind;
   pluginId?: string;
   severity?: string;
   state?: string;

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.approval-checkpoint.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.approval-checkpoint.ts
@@ -1,6 +1,7 @@
 // QA Lab Slack approval checkpoint and gateway decision RPC.
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   formatApprovalResultValue,
@@ -9,7 +10,6 @@ import {
 import {
   SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS,
   SLACK_QA_APPROVAL_CHECKPOINT_DEFAULT_TIMEOUT_MS,
-  type SlackQaApprovalKind,
   type SlackQaApprovalDecision,
   type SlackQaApprovalScenarioRun,
   type SlackQaScenarioContext,
@@ -73,7 +73,7 @@ async function waitForSlackApprovalCheckpointAck(params: {
 
 export async function writeSlackApprovalCheckpoint(params: {
   approvalId: string;
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   channelId: string;
   decision?: SlackQaApprovalDecision;
   message: SlackMessage;
@@ -185,7 +185,7 @@ export async function requestSlackApproval(params: {
 export async function waitForApprovalDecision(params: {
   approvalId: string;
   context: Omit<SlackQaScenarioContext, "sentTs">;
-  kind: SlackQaApprovalKind;
+  kind: ChannelApprovalKind;
 }) {
   const method =
     params.kind === "exec" ? "exec.approval.waitDecision" : "plugin.approval.waitDecision";

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.approvals.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.approvals.ts
@@ -1,6 +1,7 @@
 // QA Lab Slack native approval observation and resolution.
 import { randomUUID } from "node:crypto";
 import type { WebClient } from "@slack/web-api";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { assertApprovalDecisionResult } from "../shared/live-approval-result.js";
 import {
   writeSlackApprovalCheckpoint,
@@ -9,7 +10,6 @@ import {
 } from "./slack-live.approval-checkpoint.js";
 import {
   SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS,
-  type SlackQaApprovalKind,
   type SlackQaApprovalDecision,
   type SlackQaApprovalScenarioRun,
   type SlackQaScenarioContext,
@@ -38,7 +38,7 @@ function resolveApprovalDecisionLabel(decision: SlackQaApprovalDecision) {
 }
 
 function resolveApprovalHeading(params: {
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   state: "pending" | "resolved";
   decision?: SlackQaApprovalDecision;
 }) {
@@ -81,7 +81,7 @@ function pushObservedApprovalMessage(params: {
 
 export async function waitForSlackApprovalPrompt(params: {
   approvalId?: string;
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   channelId: string;
   client: WebClient;
   decision: SlackQaApprovalDecision;
@@ -169,7 +169,7 @@ export async function waitForSlackApprovalPrompt(params: {
 }
 
 function matchesSlackApprovalPromptText(params: {
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   extraTextMatches?: string[];
   text: string;
   token?: string;
@@ -184,7 +184,7 @@ function matchesSlackApprovalPromptText(params: {
 }
 
 export async function waitForSlackApprovalResolvedUpdate(params: {
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   channelId: string;
   client: WebClient;
   decision: SlackQaApprovalDecision;
@@ -249,7 +249,7 @@ export async function waitForSlackApprovalResolvedUpdate(params: {
 
 function matchesSlackApprovalResolvedUpdate(params: {
   actionValues: string[];
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision: SlackQaApprovalDecision;
   extraTextMatches?: string[];
   text: string;
@@ -273,7 +273,7 @@ export async function resolveApprovalDecision(params: {
   approvalId: string;
   context: Omit<SlackQaScenarioContext, "sentTs">;
   decision: SlackQaApprovalDecision;
-  kind: SlackQaApprovalKind;
+  kind: ChannelApprovalKind;
 }) {
   const method = params.kind === "exec" ? "exec.approval.resolve" : "plugin.approval.resolve";
   return await params.context.gateway.call(

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -1,5 +1,6 @@
 // QA Lab Slack live domain contracts and wire schemas.
 import type { WebClient } from "@slack/web-api";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { z } from "zod";
 import type { startQaGatewayChild } from "../../gateway-child.js";
@@ -84,7 +85,6 @@ export const SLACK_QA_NATIVE_TABLE = {
 // These scenarios force the Codex harness, whose default provider set is intentionally narrow.
 const SLACK_QA_CODEX_PROVIDER_IDS = new Set(["codex", "openai"]);
 
-export type SlackQaApprovalKind = "exec" | "plugin";
 export type SlackQaApprovalDecision = "allow-always" | "allow-once" | "deny";
 export const SLACK_QA_APPROVAL_ACTION_PREFIX = "openclaw:approval:v1:";
 export const SlackQaApprovalActionValueSchema = z
@@ -149,7 +149,7 @@ export type SlackQaDirectTransportScenarioResult = {
 };
 
 export type SlackQaApprovalScenarioRun = {
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision: SlackQaApprovalDecision;
   kind: "approval";
   token: string;
@@ -243,7 +243,7 @@ export type SlackObservedMessage = {
 
 export type SlackApprovalArtifact = {
   approvalId: string;
-  approvalKind: SlackQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   appServerMethod?: SlackQaCodexApprovalMethod;
   channelId?: string;
   codexModelKey?: string;

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.approvals.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.approvals.ts
@@ -4,6 +4,7 @@ import type {
   WhatsAppQaDriverObservedMessage,
   WhatsAppQaDriverSession,
 } from "@openclaw/whatsapp/api.js";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   assertApprovalDecisionResult,
@@ -13,7 +14,6 @@ import {
 import type {
   WhatsAppObservedMessage,
   WhatsAppQaApprovalDecision,
-  WhatsAppQaApprovalKind,
   WhatsAppQaApprovalScenarioRun,
   WhatsAppQaGateway,
   WhatsAppQaScenarioMetadata,
@@ -84,7 +84,7 @@ async function requestWhatsAppApproval(params: {
 async function waitForApprovalDecision(params: {
   approvalId: string;
   gateway: WhatsAppQaGateway;
-  kind: WhatsAppQaApprovalKind;
+  kind: ChannelApprovalKind;
 }) {
   const method =
     params.kind === "exec" ? "exec.approval.waitDecision" : "plugin.approval.waitDecision";
@@ -102,7 +102,7 @@ async function resolveApprovalDecision(params: {
   approvalId: string;
   decision: WhatsAppQaApprovalDecision;
   gateway: WhatsAppQaGateway;
-  kind: WhatsAppQaApprovalKind;
+  kind: ChannelApprovalKind;
 }) {
   const method = params.kind === "exec" ? "exec.approval.resolve" : "plugin.approval.resolve";
   return await params.gateway.call(
@@ -117,7 +117,7 @@ async function resolveApprovalDecision(params: {
 
 function matchesWhatsAppApprovalPendingText(params: {
   approvalId: string;
-  approvalKind: WhatsAppQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   text: string;
   token: string;
 }) {
@@ -134,7 +134,7 @@ function matchesWhatsAppApprovalPendingText(params: {
 
 function matchesWhatsAppApprovalResolvedText(params: {
   approvalId: string;
-  approvalKind: WhatsAppQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision?: WhatsAppQaApprovalDecision;
   text: string;
 }) {
@@ -154,7 +154,7 @@ function matchesWhatsAppApprovalResolvedText(params: {
 
 function formatWhatsAppApprovalWaitDiagnostics(params: {
   approvalId: string;
-  approvalKind: WhatsAppQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision?: WhatsAppQaApprovalDecision;
   driver: WhatsAppQaDriverSession;
   observedAfter?: Date;
@@ -205,7 +205,7 @@ function formatWhatsAppApprovalWaitDiagnostics(params: {
 
 async function waitForWhatsAppApprovalMessage(params: {
   approvalId: string;
-  approvalKind: WhatsAppQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision?: WhatsAppQaApprovalDecision;
   driver: WhatsAppQaDriverSession;
   observedAfter?: Date;

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
@@ -3,6 +3,7 @@ import type {
   WhatsAppQaDriverObservedMessage,
   WhatsAppQaDriverSession,
 } from "@openclaw/whatsapp/api.js";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { startQaGatewayChild } from "../../gateway-child.js";
 export { toQaError as toWhatsAppQaError } from "../../errors.js";
 
@@ -14,7 +15,6 @@ export type WhatsAppQaRuntimeEnv = {
   groupJid?: string;
 };
 
-export type WhatsAppQaApprovalKind = "exec" | "plugin";
 export type WhatsAppQaApprovalDecision = "allow-once" | "deny";
 type WhatsAppQaApprovalDecisionMode = "reaction" | "rpc";
 type WhatsAppQaScenarioPosture = "direct-gateway" | "native-approval" | "user-path";
@@ -149,7 +149,7 @@ export type WhatsAppQaMessageScenarioRun = {
 };
 
 export type WhatsAppQaApprovalScenarioRun = {
-  approvalKind: WhatsAppQaApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision: WhatsAppQaApprovalDecision;
   decisionMode?: WhatsAppQaApprovalDecisionMode;
   kind: "approval";

--- a/extensions/signal/src/approval-native.test.ts
+++ b/extensions/signal/src/approval-native.test.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 // Signal tests cover approval native plugin behavior.
 import type {
   ExecApprovalRequest,
@@ -72,7 +73,7 @@ function buildPluginRequest(
 
 function nativeShouldHandle(params: {
   cfg: OpenClawConfig;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   request: ExecApprovalRequest | PluginApprovalRequest;
   accountId?: string | null;
 }) {
@@ -87,7 +88,7 @@ function nativeShouldHandle(params: {
 
 function buildLocalApprovalPayload(
   params: {
-    approvalKind?: "exec" | "plugin";
+    approvalKind?: ChannelApprovalKind;
     agentId?: string | null;
     sessionKey?: string | null;
   } = {},

--- a/extensions/signal/src/approval-reaction-routes.ts
+++ b/extensions/signal/src/approval-reaction-routes.ts
@@ -1,4 +1,5 @@
 import { matchesApprovalRequestFilters } from "openclaw/plugin-sdk/approval-client-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import {
@@ -27,7 +28,7 @@ export type SignalApprovalReactionRoute =
 
 function resolveApprovalForwardingConfig(params: {
   cfg: OpenClawConfig;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
 }): ApprovalForwardingConfig | undefined {
   return params.approvalKind === "plugin"
     ? params.cfg.approvals?.plugin
@@ -125,7 +126,7 @@ function hasMatchingSignalApprovalReactionTarget(params: {
 export function isSignalApprovalReactionRouteStillEnabled(params: {
   cfg: OpenClawConfig;
   target: {
-    approvalKind: "exec" | "plugin";
+    approvalKind: ChannelApprovalKind;
     route: SignalApprovalReactionRoute;
   };
 }): boolean {
@@ -158,7 +159,7 @@ export function buildTargetRoute(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   to: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   agentId?: string | null;
   sessionKey?: string | null;
 }): Extract<SignalApprovalReactionRoute, { deliveryMode: "target" }> | null {

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -1,5 +1,6 @@
 // Signal plugin module implements approval reactions behavior.
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   addApprovalReactionHintToText,
   createApprovalReactionTargetStore,
@@ -41,14 +42,13 @@ const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
 type SignalApprovalReactionResolution = {
   approvalId: string;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
   route: SignalApprovalReactionRoute;
 };
 
-type ApprovalKind = "exec" | "plugin";
 type SignalApprovalReactionTarget = ApprovalReactionTargetRecord<SignalApprovalReactionRoute> & {
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   targetAuthorKeys: readonly string[];
   route: SignalApprovalReactionRoute;
 };
@@ -222,7 +222,7 @@ export function registerSignalApprovalReactionTarget(params: {
   conversationKey: string;
   messageId: string;
   approvalId: string;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   targetAuthorKeys: readonly string[];
   route: SignalApprovalReactionRoute;

--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -1,6 +1,7 @@
 // Slack tests cover approval handler plugin behavior.
 import type {
   ApprovalActionView,
+  ChannelApprovalKind,
   ApprovalMetadataView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -66,7 +67,7 @@ const ACTION_PRESENTATION = {
 } as const satisfies Record<ApprovalDecision, Pick<ApprovalActionView, "label" | "style">>;
 
 function buildApprovalAction(
-  approvalKind: "exec" | "plugin",
+  approvalKind: ChannelApprovalKind,
   approvalId: string,
   decision: ApprovalDecision,
 ): ApprovalActionView {

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -3,6 +3,7 @@ import {
   isChannelExecApprovalClientEnabledFromConfig,
   matchesApprovalRequestFilters,
 } from "openclaw/plugin-sdk/approval-client-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createNativeApprovalChannelRouteGates,
   doesApprovalRequestSelectChannelAccount,
@@ -42,7 +43,6 @@ import {
   parseSlackTarget,
 } from "./target-parsing.js";
 
-export type SlackApprovalKind = "exec" | "plugin";
 export type SlackNativeApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
 export type SlackOriginTarget = {
   to: string;
@@ -334,7 +334,7 @@ function isSlackNativeApprovalAccountEligible(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   request: SlackNativeApprovalRequest;
-  approvalKind: SlackApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   const config = resolveSlackNativeApprovalConfig(params);
   const approverCount =
@@ -401,7 +401,7 @@ export function shouldHandleSlackPluginViaForwardingSession(params: {
 function isSlackNativeApprovalClientEnabled(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  approvalKind: SlackApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): boolean {
   if (params.approvalKind === "exec") {
     return isSlackExecApprovalClientEnabled(params);
@@ -428,7 +428,7 @@ export function isSlackAnyNativeApprovalClientEnabled(params: {
 export function shouldHandleSlackNativeApprovalRequest(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  approvalKind?: SlackApprovalKind;
+  approvalKind?: ChannelApprovalKind;
   request: SlackNativeApprovalRequest;
 }): boolean {
   const account = resolveSlackAccount(params);

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -1,7 +1,10 @@
 // Slack plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type {
+  ChannelApprovalKind,
+  ChannelApprovalNativeRuntimeAdapter,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelNativeOriginTargetResolver,
   createNativeApprovalForwardingFallbackSuppressor,
@@ -23,7 +26,6 @@ import {
   shouldHandleSlackNativeApprovalRequest,
   shouldHandleSlackPluginViaForwardingSession,
   slackTargetsMatch,
-  type SlackApprovalKind,
   type SlackNativeApprovalRequest,
   type SlackOriginTarget,
 } from "./approval-native-gates.js";
@@ -36,7 +38,6 @@ import {
 import { formatSlackTarget } from "./target-parsing.js";
 
 type ApprovalRequest = SlackNativeApprovalRequest;
-type ApprovalKind = SlackApprovalKind;
 type SlackSuppressionAccountInput = {
   target: { channel: string; accountId?: string | null };
   request: {
@@ -58,7 +59,7 @@ function resolveSlackNativeSuppressionAccountId({
 }
 
 function shouldConsiderSlackNativeForwardingSuppression(
-  input: SlackSuppressionAccountInput & { approvalKind: ApprovalKind },
+  input: SlackSuppressionAccountInput & { approvalKind: ChannelApprovalKind },
 ): boolean {
   const channel = normalizeMessageChannel(input.target.channel) ?? input.target.channel;
   if (channel !== "slack") {
@@ -90,7 +91,7 @@ const resolveSlackOriginTarget = createChannelNativeOriginTargetResolver({
 function resolveSlackApproverDmTargets(params: {
   cfg: Parameters<typeof shouldHandleSlackNativeApprovalRequest>[0]["cfg"];
   accountId?: string | null;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   request: ApprovalRequest;
 }): SlackOriginTarget[] {
   if (

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -2,6 +2,7 @@
 import type { AllMiddlewareArgs, SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { resolveCommandAuthorization } from "openclaw/plugin-sdk/command-auth-native";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
@@ -731,7 +732,7 @@ async function handleSlackLegacyApprovalInteraction(params: {
     accountId: params.ctx.accountId,
     senderId: params.parsed.userId,
   });
-  const resolveMethods: Array<"exec" | "plugin"> = [];
+  const resolveMethods: ChannelApprovalKind[] = [];
   if (execAuthorized) {
     resolveMethods.push("exec");
   }

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements approval handler behavior.
 import type {
   ChannelApprovalCapabilityHandlerContext,
+  ChannelApprovalKind,
   PendingApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
@@ -76,7 +77,7 @@ function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext):
 
 function buildPendingPayload(params: {
   request: ApprovalRequest;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   nowMs: number;
   view: PendingApprovalView;
 }): TelegramPendingDelivery {

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -3,6 +3,7 @@ import {
   resolveApprovalOverGateway,
   type ApprovalResolveResult,
 } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
@@ -46,8 +47,8 @@ type ResolveTelegramApprovalParams = {
   senderId?: string | null;
   gatewayUrl?: string;
 } & (
-  | { approvalKind: "exec" | "plugin"; resolveMethod?: never }
-  | { approvalKind?: never; resolveMethod: "exec" | "plugin" }
+  | { approvalKind: ChannelApprovalKind; resolveMethod?: never }
+  | { approvalKind?: never; resolveMethod: ChannelApprovalKind }
 );
 
 type ResolveTelegramApproval = (

--- a/extensions/telegram/src/bot-handlers.callback-router-controls.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router-controls.ts
@@ -3,6 +3,7 @@ import {
   resolveApprovalOverGateway,
   type ApprovalResolveResult,
 } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -230,7 +231,7 @@ export function createTelegramCallbackApprovalRuntime(params: {
   const handleLegacy = async (approvalCallback: LegacyApprovalCallback): Promise<void> => {
     const { execApprovalAuthorizedSender, pluginApprovalAuthorizedSender } =
       resolveApprovalAuthorizations();
-    const approvalKinds: Array<"exec" | "plugin"> = [];
+    const approvalKinds: ChannelApprovalKind[] = [];
     if (execApprovalAuthorizedSender || pluginApprovalAuthorizedSender) {
       approvalKinds.push("exec");
     }

--- a/extensions/whatsapp/src/approval-native.test.ts
+++ b/extensions/whatsapp/src/approval-native.test.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 // Whatsapp tests cover approval native plugin behavior.
 import type {
   ExecApprovalRequest,
@@ -69,7 +70,7 @@ function buildPluginRequest(
 
 function nativeShouldHandle(params: {
   cfg: OpenClawConfig;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   request: ExecApprovalRequest | PluginApprovalRequest;
   accountId?: string | null;
 }) {

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -1,7 +1,10 @@
 // Whatsapp plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapabilityFromForwardingRoutes } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type {
+  ChannelApprovalKind,
+  ChannelApprovalNativeRuntimeAdapter,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildApprovalReactionPromptPayloadForRequest } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import { buildTypedApprovalPresentation } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type {
@@ -79,7 +82,7 @@ const whatsappApproval = createApproverRestrictedNativeApprovalCapabilityFromFor
 
 function buildWhatsAppPendingPayload(
   params: { request: ExecApprovalRequest | PluginApprovalRequest; nowMs: number },
-  approvalKind: "exec" | "plugin",
+  approvalKind: ChannelApprovalKind,
 ) {
   const payload = buildApprovalReactionPromptPayloadForRequest(params);
   return {

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -1,5 +1,6 @@
 // Whatsapp plugin module implements approval reactions behavior.
 import type { WAMessage } from "baileys";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   approvalReactionDecisionSetsMatch,
   buildApprovalReactionDeliveredBindingMarker,
@@ -29,18 +30,16 @@ const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 const DELIVERY_BINDING_CHANNEL_DATA_KEY = "whatsappApprovalReactionBindingV1";
 
-type WhatsAppApprovalKind = "exec" | "plugin";
-
 type WhatsAppApprovalDeliveryBinding = ApprovalReactionDeliveryBinding;
 
 type WhatsAppApprovalReactionResolution = {
   approvalId: string;
-  approvalKind: WhatsAppApprovalKind;
+  approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
 };
 
 type WhatsAppApprovalReactionTarget = ApprovalReactionTargetRecord & {
-  approvalKind: WhatsAppApprovalKind;
+  approvalKind: ChannelApprovalKind;
 };
 
 type WhatsAppApprovalReactionEvent = {
@@ -226,7 +225,7 @@ export function registerWhatsAppApprovalReactionTarget(params: {
   remoteJid: string;
   messageId: string;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
 }): WhatsAppApprovalReactionTarget | null {

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -4,7 +4,7 @@
  * observability decisions shared across embedded-agent hot paths.
  */
 import type { TSchema } from "typebox";
-import type { ModelPickerAction } from "../../interactive/payload.js";
+import type { MessagePresentationAction } from "../../interactive/payload.js";
 import type {
   ModelApi,
   ProviderModelRouteRuntimePolicy,
@@ -101,48 +101,12 @@ type PreparedAgentRuntimeProviderHandle = AgentRuntimeProviderHandle & {
 
 type AgentRuntimeInteractiveButtonStyle = "primary" | "secondary" | "success" | "danger";
 
-type AgentRuntimeMessagePresentationAction =
-  | {
-      type: "command";
-      command: string;
-    }
-  | {
-      type: "callback";
-      value: string;
-    }
-  | {
-      type: "approval";
-      approvalId: string;
-      approvalKind: "exec" | "plugin";
-      decision: "allow-once" | "allow-always" | "deny";
-    }
-  | {
-      type: "question";
-      questionId: string;
-      optionValue: string;
-    }
-  | {
-      type: "url";
-      url: string;
-    }
-  | {
-      type: "web-app";
-      url: string;
-      widgetId?: string;
-    }
-  | {
-      type: "web-app";
-      url?: string;
-      widgetId: string;
-    }
-  | ModelPickerAction;
-
 /** Portable action control exposed to agent runtime reply payloads. */
 type AgentRuntimeMessagePresentationButton = {
   /** User-visible button label. */
   label: string;
   /** Typed action sent when pressed. */
-  action?: AgentRuntimeMessagePresentationAction;
+  action?: MessagePresentationAction;
   /** @deprecated Use action. */
   value?: string;
   /** @deprecated Use an action with type "url". */
@@ -164,10 +128,7 @@ type AgentRuntimeMessagePresentationOption = {
   /** User-visible option label. */
   label: string;
   /** Typed action sent when selected. */
-  action?: Extract<
-    AgentRuntimeMessagePresentationAction,
-    { type: "command" | "callback" | "model-picker" }
-  >;
+  action?: Extract<MessagePresentationAction, { type: "command" | "callback" | "model-picker" }>;
   /** @deprecated Use action. */
   value?: string;
 };

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -6,6 +6,7 @@ import type {
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import { markImplicitSameChatApprovalAuthorization } from "../../plugin-sdk/approval-auth-runtime.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
@@ -54,9 +55,11 @@ function expectApprovalResolverCall(params: {
   expect(request.clientDisplayName).toMatch(/^Chat approval \(.+\)$/);
 }
 
-type ApprovalKind = "exec" | "plugin";
 type ApprovalTestPolicy = Partial<
-  Record<ApprovalKind, { authorizedSenders: readonly string[]; accountId?: string; reply?: string }>
+  Record<
+    ChannelApprovalKind,
+    { authorizedSenders: readonly string[]; accountId?: string; reply?: string }
+  >
 >;
 
 const approvalPolicies = new WeakMap<OpenClawConfig, ApprovalTestPolicy>();
@@ -544,7 +547,7 @@ describe("handleApproveCommand", () => {
           plugin: {
             ...createChannelTestPluginBase({ id: "matrix", label: "Matrix" }),
             approvalCapability: {
-              authorizeActorAction: ({ approvalKind }: { approvalKind: "exec" | "plugin" }) =>
+              authorizeActorAction: ({ approvalKind }: { approvalKind: ChannelApprovalKind }) =>
                 approvalKind === "plugin"
                   ? { authorized: true }
                   : {

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -8,6 +8,7 @@ import {
 import { logVerbose } from "../../globals.js";
 import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { resolveApprovalOverGateway } from "../../infra/approval-gateway-resolver.js";
+import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveChannelAccountId } from "./channel-context.js";
@@ -87,7 +88,6 @@ function formatApprovalSubmitError(error: unknown): string {
   return formatErrorMessage(error);
 }
 
-type ApprovalKind = "exec" | "plugin";
 type ApproveCommandBehavior =
   | { kind: "allow" }
   | { kind: "ignore" }
@@ -96,7 +96,7 @@ type ApproveCommandBehavior =
 function resolveAuthorizedApprovalKinds(params: {
   execAuthorization: ReturnType<typeof resolveApprovalCommandAuthorization>;
   pluginAuthorization: ReturnType<typeof resolveApprovalCommandAuthorization>;
-}): ApprovalKind[] {
+}): ChannelApprovalKind[] {
   return [
     ...(params.execAuthorization.authorized ? (["exec"] as const) : []),
     ...(params.pluginAuthorization.authorized ? (["plugin"] as const) : []),
@@ -171,7 +171,7 @@ export async function handleApproveCommandFromContext(
   const approvalCapability = resolveChannelApprovalCapability(
     getChannelPlugin(params.command.channel),
   );
-  const commandBehaviors = new Map<ApprovalKind, ApproveCommandBehavior | undefined>();
+  const commandBehaviors = new Map<ChannelApprovalKind, ApproveCommandBehavior | undefined>();
   for (const approvalKind of ["exec", "plugin"] as const) {
     commandBehaviors.set(
       approvalKind,
@@ -197,7 +197,7 @@ export async function handleApproveCommandFromContext(
   };
 
   const resolvedBy = buildResolvedByLabel(params);
-  const callApprovalMethod = async (resolveMethod: ApprovalKind): Promise<void> => {
+  const callApprovalMethod = async (resolveMethod: ChannelApprovalKind): Promise<void> => {
     await resolveApprovalOverGateway({
       cfg: params.cfg,
       approvalId: parsed.id,

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -6,6 +6,7 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ReplyToMode } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import type { OutboundDeliveryResult } from "../../infra/outbound/deliver-types.js";
 import type { OutboundDeliveryFormattingOptions } from "../../infra/outbound/formatting.js";
 import type { OutboundIdentity } from "../../infra/outbound/identity-types.js";
@@ -136,10 +137,10 @@ export type ChannelDeliveryCapabilities = {
 export type ChannelOutboundPayloadHint =
   | {
       kind: "approval-pending";
-      approvalKind: "exec" | "plugin";
+      approvalKind: ChannelApprovalKind;
       nativeRouteActive?: boolean;
     }
-  | { kind: "approval-resolved"; approvalKind: "exec" | "plugin" };
+  | { kind: "approval-resolved"; approvalKind: ChannelApprovalKind };
 
 export type ChannelOutboundTargetRef = {
   channel: string;

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -615,7 +615,7 @@ export type ChannelApprovalCapability = ChannelApprovalAdapter & {
     accountId?: string | null;
     senderId?: string | null;
     action: "approve";
-    approvalKind: "exec" | "plugin";
+    approvalKind: ChannelApprovalKind;
   }) => {
     authorized: boolean;
     reason?: string;

--- a/src/gateway/exec-approval-ios-push.ts
+++ b/src/gateway/exec-approval-ios-push.ts
@@ -2,6 +2,7 @@
 // Sends APNs request/resolution wakes to paired operator devices.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/io.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { loadOrCreateProcessDeviceIdentity } from "../infra/device-identity.js";
 import {
   hasEffectivePairedDeviceRole,
@@ -79,7 +80,7 @@ type ApprovalRequestLike = { id: string };
 type ApprovalResolvedLike = { id: string };
 
 type ApprovalPushDriver<TRequest extends ApprovalRequestLike> = {
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   sendRequested: (params: {
     request: TRequest;
     target: DeliveryTarget;
@@ -171,7 +172,7 @@ async function resolvePairedTargets(params: {
 }
 
 async function resolveDeliveryPlan(params: {
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   requireApprovalScope: boolean;
   explicitNodeIds?: readonly string[];
   isTargetVisible?: (target: ApprovalPushTarget) => boolean;
@@ -284,7 +285,7 @@ async function sendApprovalPushes(params: {
   approvalId: string;
   plan: DeliveryPlan;
   log: GatewayLikeLogger;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   label: "request" | "cleanup";
   logThrown: boolean;
   send: ApprovalPushSender;

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createOperationalRunInstanceRef } from "../agents/admitted-run-context.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../infra/plugin-approval-canonical-decisions.js";
 import {
   MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
@@ -30,7 +31,7 @@ const tempDirs: string[] = [];
 
 const hasApprovalTurnSourceRouteMock = vi.hoisted(() =>
   vi.fn(
-    (params: { turnSourceChannel?: string | null; approvalKind?: "exec" | "plugin" }) =>
+    (params: { turnSourceChannel?: string | null; approvalKind?: ChannelApprovalKind }) =>
       params.approvalKind === "plugin" && params.turnSourceChannel === "tui",
   ),
 );

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -6,6 +6,7 @@ import {
   type AgentRunDelegatedAuthority,
   registerAgentRunDelegatedAuthorityClosedHandler,
 } from "../infra/agent-run-registry.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
 import {
@@ -204,7 +205,7 @@ export function createGatewayAuxHandlers(params: {
   );
   const pluginApprovalIosPushDelivery = createPluginApprovalIosPushDelivery({ log: params.log });
   type PendingAuthorityPublication = {
-    kind: "exec" | "plugin";
+    kind: ChannelApprovalKind;
     record: Parameters<typeof publishAppliedApprovalResolution>[0]["record"];
     liveRecord: Parameters<typeof publishAppliedApprovalResolution>[0]["liveRecord"];
   };
@@ -291,7 +292,7 @@ export function createGatewayAuxHandlers(params: {
   };
   const cancelRunBoundApprovals = (runId: string, context: GatewayRequestContext): number => {
     const publish = (
-      kind: "exec" | "plugin",
+      kind: ChannelApprovalKind,
       record: Parameters<typeof publishAppliedApprovalResolution>[0]["record"],
       liveRecord: Parameters<typeof publishAppliedApprovalResolution>[0]["liveRecord"],
     ) => {

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -6,12 +6,12 @@ import {
   type GatewayNativeApprovalMethod,
 } from "../infra/approval-gateway-runtime-methods.js";
 import type {
-  GatewayApprovalEventKind,
   GatewayApprovalEventSubscriber,
   GatewayApprovalRequest,
   GatewayApprovalResolved,
 } from "../infra/approval-gateway-runtime.types.js";
 import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-route-coordinator.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { createInternalAgentTurnFacade } from "./agent-turn/internal-facade.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
@@ -142,7 +142,7 @@ export function createGatewayInstanceRuntime(
   const releaseRecoveryRuntime = registerGatewayRecoveryRuntime(recovery);
 
   const publish = (
-    kind: GatewayApprovalEventKind,
+    kind: ChannelApprovalKind,
     callback: (subscriber: GatewayApprovalEventSubscriber) => void,
     shouldDeliver?: (subscriber: GatewayApprovalEventSubscriber) => boolean,
   ): number => {

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -1,13 +1,11 @@
 import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.js";
-import type {
-  GatewayApprovalEventKind,
-  GatewayNativeApprovalRuntime,
-} from "../infra/approval-gateway-runtime.types.js";
+import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
 
 export type GatewayApprovalEventPublisher = {
-  publishRequested: (kind: GatewayApprovalEventKind, request: unknown) => number;
-  publishResolved: (kind: GatewayApprovalEventKind, resolved: unknown) => void;
+  publishRequested: (kind: ChannelApprovalKind, request: unknown) => number;
+  publishResolved: (kind: ChannelApprovalKind, resolved: unknown) => void;
 };
 
 export type GatewayRecoveryRuntime = {

--- a/src/gateway/server-methods/approval-publication.ts
+++ b/src/gateway/server-methods/approval-publication.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 // Best-effort legacy approval resolution events after durable CAS wins.
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import type {
@@ -44,7 +45,7 @@ async function runSideEffect(params: {
 
 function runSynchronousSideEffect(params: {
   context: GatewayRequestContext;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   run: () => void;
 }): void {
   try {

--- a/src/gateway/server-methods/approval-record-lookup.ts
+++ b/src/gateway/server-methods/approval-record-lookup.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import type {
   ExecApprovalIdLookupResult,
   ExecApprovalManager,
@@ -77,9 +78,9 @@ export function isApprovalRecordVisibleToClient<TPayload>(params: {
 export function listVisiblePendingApprovalRequests<TPayload>(params: {
   manager: ExecApprovalManager<TPayload>;
   client?: GatewayClient | null;
-  approvalKind?: "exec" | "plugin";
+  approvalKind?: ChannelApprovalKind;
 }): Array<{
-  approvalKind?: "exec" | "plugin";
+  approvalKind?: ChannelApprovalKind;
   id: string;
   request: TPayload;
   createdAtMs: number;

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -8,6 +8,7 @@ import type {
   ValidationError,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { hasApprovalTurnSourceRoute } from "../../infra/approval-turn-source.js";
+import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequestPayload,
@@ -52,7 +53,7 @@ type ApprovalTurnSourceFields = {
 
 type RequestedApprovalEvent<
   TPayload extends ApprovalTurnSourceFields,
-  TKind extends "exec" | "plugin" = "exec" | "plugin",
+  TKind extends ChannelApprovalKind = ChannelApprovalKind,
 > = {
   approvalKind?: TKind;
   id: string;
@@ -143,7 +144,7 @@ export function registerPendingApprovalRecord<TPayload>(params: {
 /** Builds the gateway event payload broadcast when an approval starts waiting. */
 export function buildRequestedApprovalEvent<
   TPayload extends ApprovalTurnSourceFields,
-  TKind extends "exec" | "plugin",
+  TKind extends ChannelApprovalKind,
 >(
   record: ExecApprovalRecord<TPayload>,
   approvalKind?: TKind,
@@ -288,7 +289,7 @@ export async function handlePendingApprovalRequest<
   requestEventName: string;
   requestEvent: RequestedApprovalEvent<TPayload>;
   twoPhase: boolean;
-  approvalKind?: "exec" | "plugin";
+  approvalKind?: ChannelApprovalKind;
   deliverRequest: () => boolean | Promise<boolean>;
   afterDecision?: (
     decision: ExecApprovalDecision | null,
@@ -467,7 +468,7 @@ function respondRepeatedApprovalResolution<TPayload>(
 export async function handleApprovalResolve<
   TPayload extends ExecApprovalRequestPayload | PluginApprovalRequestPayload,
 >(params: {
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   manager: ExecApprovalManager<TPayload>;
   inputId: string;
   decision: ExecApprovalDecision;

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -2,7 +2,6 @@
 import type {
   ApprovalChannelReviewer,
   ApprovalDecision,
-  ApprovalKind,
   ApprovalResolveParams,
   ApprovalResolveResult,
 } from "../../packages/gateway-protocol/src/index.js";
@@ -13,6 +12,7 @@ import { withOperatorApprovalsGatewayClient } from "../gateway/operator-approval
 import { isApprovalNotFoundError } from "./approval-errors.js";
 import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
 import type { GatewayNativeApprovalMethod } from "./approval-gateway-runtime-methods.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 type ResolveApprovalOverGatewayBaseParams = {
   cfg: OpenClawConfig;
@@ -35,7 +35,7 @@ type ApprovalGatewayRuntime = {
 
 type CanonicalResolveApprovalOverGatewayParams = ResolveApprovalOverGatewayBaseParams & {
   /** Explicit owner required by the canonical approval resolver. */
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   gatewayRuntime?: ApprovalGatewayRuntime;
   allowPluginFallback?: never;
   resolveMethod?: never;
@@ -56,7 +56,7 @@ type LegacyResolveApprovalOverGatewayParams = ResolveApprovalOverGatewayBasePara
    * Explicit legacy owner. Omission retains the shipped id-based routing contract.
    * @deprecated Pass approvalKind so resolution uses the canonical approval service.
    */
-  resolveMethod?: "exec" | "plugin";
+  resolveMethod?: ChannelApprovalKind;
 };
 
 type ResolveApprovalOverGatewayParams =

--- a/src/infra/approval-gateway-runtime.types.ts
+++ b/src/infra/approval-gateway-runtime.types.ts
@@ -1,15 +1,14 @@
 import type { GatewayNativeApprovalMethod } from "./approval-gateway-runtime-methods.js";
 import type { ApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
-import type { ApprovalRequest } from "./approval-types.js";
+import type { ApprovalRequest, ChannelApprovalKind } from "./approval-types.js";
 import type { ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
-export type GatewayApprovalEventKind = "exec" | "plugin";
 export type GatewayApprovalRequest = ApprovalRequest;
 export type GatewayApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
 
 export type GatewayApprovalEventSubscriber = {
-  eventKinds: ReadonlySet<GatewayApprovalEventKind>;
+  eventKinds: ReadonlySet<ChannelApprovalKind>;
   shouldHandle: (request: GatewayApprovalRequest) => boolean;
   onRequested: (request: GatewayApprovalRequest) => void;
   onResolved: (resolved: GatewayApprovalResolved) => void;

--- a/src/infra/approval-handler-adapter-runtime.ts
+++ b/src/infra/approval-handler-adapter-runtime.ts
@@ -4,7 +4,7 @@ import type {
   ChannelApprovalNativeAvailabilityAdapter,
   ChannelApprovalNativeRuntimeAdapter,
 } from "./approval-handler-runtime-types.js";
-import type { ExecApprovalChannelRuntimeEventKind } from "./exec-approval-channel-runtime.types.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 /** Runtime-context capability key used by channels to register native approval resources. */
 export const CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY = "approval.native";
@@ -28,7 +28,7 @@ export function createLazyChannelApprovalNativeRuntimeAdapter<
   >;
   isConfigured: ChannelApprovalNativeAvailabilityAdapter["isConfigured"];
   shouldHandle: ChannelApprovalNativeAvailabilityAdapter["shouldHandle"];
-  eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
+  eventKinds?: readonly ChannelApprovalKind[];
   /** @deprecated Trusted compatibility override; omit to derive ownership from the payload. */
   resolveApprovalKind?: ChannelApprovalNativeRuntimeAdapter["resolveApprovalKind"];
 }): ChannelApprovalNativeRuntimeAdapter<

--- a/src/infra/approval-handler-runtime-types.ts
+++ b/src/infra/approval-handler-runtime-types.ts
@@ -8,7 +8,6 @@ import type {
   PendingApprovalView,
   ResolvedApprovalView,
 } from "./approval-view-model.types.js";
-import type { ExecApprovalChannelRuntimeEventKind } from "./exec-approval-channel-runtime.types.js";
 import type { ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
@@ -235,7 +234,7 @@ export type ChannelApprovalNativeRuntimeAdapter<
   TBinding = unknown,
   TFinalPayload = unknown,
 > = {
-  eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
+  eventKinds?: readonly ChannelApprovalKind[];
   /**
    * Trusted legacy ownership override retained for compatibility.
    * @deprecated Omit this so core derives approval ownership from the request payload.
@@ -264,7 +263,7 @@ export type ChannelApprovalNativeRuntimeSpec<
   TResolvedView extends ResolvedApprovalView = ResolvedApprovalView,
   TExpiredView extends ExpiredApprovalView = ExpiredApprovalView,
 > = {
-  eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
+  eventKinds?: readonly ChannelApprovalKind[];
   /**
    * Trusted legacy ownership override retained for compatibility.
    * @deprecated Omit this so core derives approval ownership from the request payload.

--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -35,7 +35,6 @@ import type {
   ResolvedApprovalView,
 } from "./approval-view-model.types.js";
 import type { ExecApprovalChannelRuntime } from "./exec-approval-channel-runtime.js";
-import type { ExecApprovalChannelRuntimeEventKind } from "./exec-approval-channel-runtime.types.js";
 
 export type {
   ApprovalActionView,
@@ -312,7 +311,7 @@ type ChannelApprovalHandlerRuntimeSpec<TRequest extends ApprovalRequest> = {
   clientDisplayName: string;
   cfg: OpenClawConfig;
   gatewayUrl?: string;
-  eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
+  eventKinds?: readonly ChannelApprovalKind[];
   channel?: string;
   channelLabel?: string;
   accountId?: string | null;

--- a/src/infra/approval-native-route-notice.ts
+++ b/src/infra/approval-native-route-notice.ts
@@ -2,6 +2,7 @@
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { formatHumanList } from "../shared/human-list.js";
 import type { ChannelApprovalNativePlannedTarget } from "./approval-native-delivery.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 /** Formats the human destination label for where native approval prompts were delivered. */
 export function describeApprovalDeliveryDestination(params: {
@@ -37,7 +38,7 @@ export function resolveAmbiguousApprovalRouteNoticeText(): string {
 /** Builds the fallback slash-command notice when native approval delivery fails. */
 export function resolveApprovalDeliveryFailedNoticeText(params: {
   approvalId: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   allowedDecisions?: readonly string[];
 }): string {
   const commandId =

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -25,7 +25,6 @@ import {
   type ExecApprovalChannelRuntime,
   type ExecApprovalChannelRuntimeAdapter,
 } from "./exec-approval-channel-runtime.js";
-import type { ExecApprovalChannelRuntimeEventKind } from "./exec-approval-channel-runtime.types.js";
 import type { ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
@@ -192,9 +191,7 @@ export function createChannelNativeApprovalRuntime<
   >,
 ): ExecApprovalChannelRuntime<TRequest, TResolved> {
   const nowMs = adapter.nowMs ?? Date.now;
-  const handledEventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(
-    adapter.eventKinds ?? ["exec"],
-  );
+  const handledEventKinds = new Set<ChannelApprovalKind>(adapter.eventKinds ?? ["exec"]);
   const gatewayRuntime = getGatewayNativeApprovalRuntime();
   const createRouteReporter =
     gatewayRuntime?.routeCoordinator.createReporter ?? createApprovalNativeRouteReporter;

--- a/src/infra/approval-turn-source.ts
+++ b/src/infra/approval-turn-source.ts
@@ -1,13 +1,14 @@
 // Checks whether an approval reply can route to the initiating turn source.
 import { getRuntimeConfig } from "../config/config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 import { resolveApprovalInitiatingSurfaceState } from "./exec-approval-surface.js";
 
 /** Returns whether approval replies can route back to the turn's initiating surface. */
 export function hasApprovalTurnSourceRoute(params: {
   turnSourceChannel?: string | null;
   turnSourceAccountId?: string | null;
-  approvalKind?: "exec" | "plugin";
+  approvalKind?: ChannelApprovalKind;
 }): boolean {
   const channel = normalizeMessageChannel(params.turnSourceChannel);
   // INTERNAL_MESSAGE_CHANNEL is webchat; web and TUI routes exist only while

--- a/src/infra/channel-approval-auth.test.ts
+++ b/src/infra/channel-approval-auth.test.ts
@@ -1,6 +1,7 @@
 // Tests channel approval authorization and sender validation.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createResolvedApproverActionAuthAdapter } from "../plugin-sdk/approval-auth-helpers.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 const getChannelPluginMock = vi.hoisted(() => vi.fn());
 
@@ -39,7 +40,7 @@ describe("resolveApprovalCommandAuthorization", () => {
           approvalKind,
         }: {
           action: "approve";
-          approvalKind: "exec" | "plugin";
+          approvalKind: ChannelApprovalKind;
         }) =>
           approvalKind === "plugin"
             ? { authorized: false, reason: "plugin denied" }

--- a/src/infra/channel-approval-auth.ts
+++ b/src/infra/channel-approval-auth.ts
@@ -3,6 +3,7 @@ import { getChannelPlugin, resolveChannelApprovalCapability } from "../channels/
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isImplicitSameChatApprovalAuthorization } from "../plugin-sdk/approval-auth-helpers.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 type ApprovalCommandAuthorization = {
   authorized: boolean;
@@ -16,7 +17,7 @@ export function resolveApprovalCommandAuthorization(params: {
   channel?: string | null;
   accountId?: string | null;
   senderId?: string | null;
-  kind: "exec" | "plugin";
+  kind: ChannelApprovalKind;
 }): ApprovalCommandAuthorization {
   const channel = normalizeMessageChannel(params.channel);
   if (!channel) {

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -16,20 +16,19 @@ import {
 import {
   normalizeApprovalRequest,
   type ApprovalRequestInput,
+  type ChannelApprovalKind,
   type NormalizedApprovalRequest,
 } from "./approval-types.js";
 import { formatErrorMessage } from "./errors.js";
 import type {
   ExecApprovalChannelRuntime,
   ExecApprovalChannelRuntimeAdapter,
-  ExecApprovalChannelRuntimeEventKind,
 } from "./exec-approval-channel-runtime.types.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalResolved } from "./plugin-approvals.js";
 export type {
   ExecApprovalChannelRuntime,
   ExecApprovalChannelRuntimeAdapter,
-  ExecApprovalChannelRuntimeEventKind,
 } from "./exec-approval-channel-runtime.types.js";
 
 type ApprovalRequestEvent = ApprovalRequestInput;
@@ -74,7 +73,7 @@ type PendingApprovalValue<TPending, TRequest extends ApprovalRequestEvent> = {
 };
 
 function resolveApprovalReplayMethods(
-  eventKinds: ReadonlySet<ExecApprovalChannelRuntimeEventKind>,
+  eventKinds: ReadonlySet<ChannelApprovalKind>,
 ): ApprovalReplayMethod[] {
   const methods: ApprovalReplayMethod[] = [];
   if (eventKinds.has("exec")) {
@@ -103,7 +102,7 @@ export function createExecApprovalChannelRuntime<
 ): ExecApprovalChannelRuntime<TRequest, TResolved> {
   const log = createSubsystemLogger(adapter.label);
   const nowMs = adapter.nowMs ?? Date.now;
-  const eventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(adapter.eventKinds ?? ["exec"]);
+  const eventKinds = new Set<ChannelApprovalKind>(adapter.eventKinds ?? ["exec"]);
   const configuredGatewayRuntime = getGatewayNativeApprovalRuntime();
   const pending = createPendingApprovalRegistry<PendingApprovalValue<TPending, TRequest>>();
   let gatewayClient: GatewayClient | null = null;

--- a/src/infra/exec-approval-channel-runtime.types.ts
+++ b/src/infra/exec-approval-channel-runtime.types.ts
@@ -1,14 +1,15 @@
 // Defines channel-native approval runtime contracts.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ApprovalRequestInput, NormalizedApprovalRequest } from "./approval-types.js";
+import type {
+  ApprovalRequestInput,
+  ChannelApprovalKind,
+  NormalizedApprovalRequest,
+} from "./approval-types.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalResolved } from "./plugin-approvals.js";
 
 type ApprovalRequestEvent = ApprovalRequestInput;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
-
-/** Approval event families a channel-native approval runtime can subscribe to. */
-export type ExecApprovalChannelRuntimeEventKind = "exec" | "plugin";
 
 /** Adapter implemented by a channel to deliver and finalize native approval prompts. */
 export type ExecApprovalChannelRuntimeAdapter<
@@ -21,7 +22,7 @@ export type ExecApprovalChannelRuntimeAdapter<
   cfg: OpenClawConfig;
   gatewayUrl?: string;
   /** Defaults to exec-only; include plugin when the adapter can handle plugin approvals. */
-  eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
+  eventKinds?: readonly ChannelApprovalKind[];
   isConfigured: () => boolean;
   shouldHandle: (request: NormalizedApprovalRequest<TRequest>) => boolean;
   deliverRequested: (request: NormalizedApprovalRequest<TRequest>) => Promise<TPending[]>;

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -25,6 +25,7 @@ import { formatFencedCodeBlock } from "../shared/markdown-code.js";
 import { createPendingApprovalRegistry } from "../shared/pending-approval-registry.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { matchesApprovalRequestFilters } from "./approval-request-filters.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 import {
   resolveExecApprovalCommandDisplay,
   sanitizeExecApprovalWarningText,
@@ -55,7 +56,6 @@ type ResolveSessionTargetFn = (params: {
   request: ExecApprovalRequest;
 }) => MaybePromise<ExecApprovalForwardTarget | null>;
 
-type ApprovalKind = "exec" | "plugin";
 type ForwardTarget = ExecApprovalForwardTarget & { source: "session" | "target" };
 
 type ApprovalRouteRequest = {
@@ -98,7 +98,7 @@ type ApprovalStrategy<
   TResolved,
   TRouteRequest extends ApprovalRouteRequest = ApprovalRouteRequest,
 > = {
-  kind: ApprovalKind;
+  kind: ChannelApprovalKind;
   config: (cfg: OpenClawConfig) => ExecApprovalForwardingConfig | undefined;
   getRequestId: (request: TRequest) => string;
   getResolvedId: (resolved: TResolved) => string;
@@ -198,7 +198,7 @@ function buildSyntheticApprovalRequest(routeRequest: ApprovalRouteRequest): Exec
 }
 
 function shouldSkipForwardingFallback(params: {
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   target: ExecApprovalForwardTarget;
   cfg: OpenClawConfig;
   routeRequest: ApprovalRouteRequest;
@@ -314,7 +314,7 @@ function normalizeTurnSourceChannel(value?: string | null): string | undefined {
 
 function normalizeForwardingTurnSourceChannel(
   value: string | null | undefined,
-  approvalKind: ApprovalKind,
+  approvalKind: ChannelApprovalKind,
 ): string | undefined {
   const normalized = normalizeTurnSourceChannel(value);
   if (approvalKind === "exec" && normalized && !isDeliverableMessageChannel(normalized)) {
@@ -504,7 +504,7 @@ function buildPluginResolvedPayload(params: {
 async function resolveForwardTargets(params: {
   cfg: OpenClawConfig;
   config?: ExecApprovalForwardingConfig;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   routeRequest: ApprovalRouteRequest;
   resolveSessionTarget: ResolveSessionTargetFn;
 }): Promise<ForwardTarget[]> {
@@ -710,7 +710,7 @@ function createApprovalStrategy<
   TRequest extends { id: string; request: ApprovalRouteRequestFields; expiresAtMs: number },
   TResolved extends { id: string; request?: ApprovalRouteRequestFields | null },
 >(params: {
-  kind: ApprovalKind;
+  kind: ChannelApprovalKind;
   config: (cfg: OpenClawConfig) => ExecApprovalForwardingConfig | undefined;
   buildExpiredText: (request: TRequest) => string;
   buildPendingPayload: (

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -14,6 +14,7 @@ import { formatHumanList } from "../shared/human-list.js";
 // Builds reply payloads for exec approval prompts and outcomes.
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
 import { formatApprovalDisplayPath } from "./approval-display-paths.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 import {
   describeNativeExecApprovalClientSetup,
   listNativeExecApprovalClientLabels,
@@ -34,7 +35,7 @@ export type ExecApprovalUnavailableReason =
 export type ExecApprovalReplyMetadata = {
   approvalId: string;
   approvalSlug: string;
-  approvalKind: "exec" | "plugin";
+  approvalKind: ChannelApprovalKind;
   agentId?: string;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
   sessionKey?: string;
@@ -202,7 +203,7 @@ export function buildExecApprovalActionDescriptors(
 /** Build approval descriptors with explicit owner-aware typed actions. */
 export function buildTypedApprovalActionDescriptors(
   params: BuildExecApprovalActionDescriptorsParams & {
-    approvalKind: "exec" | "plugin";
+    approvalKind: ChannelApprovalKind;
   },
 ): TypedApprovalActionDescriptor[] {
   const approvalId = params.approvalCommandId;
@@ -272,7 +273,7 @@ export function buildApprovalButtonPresentation(
 
 /** Build portable approval controls with explicit owner-aware typed actions. */
 export function buildTypedApprovalPresentation(
-  params: BuildApprovalPresentationParams & { approvalKind: "exec" | "plugin" },
+  params: BuildApprovalPresentationParams & { approvalKind: ChannelApprovalKind },
 ): MessagePresentation | undefined {
   return buildApprovalPresentationFromActionDescriptors(
     buildTypedApprovalActionDescriptors({

--- a/src/infra/exec-approval-surface.test.ts
+++ b/src/infra/exec-approval-surface.test.ts
@@ -1,5 +1,6 @@
 // Covers approval initiating-surface detection.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 const loadConfigMock = vi.hoisted(() => vi.fn());
 const getChannelPluginMock = vi.hoisted(() => vi.fn());
@@ -207,7 +208,7 @@ describe("resolveExecApprovalInitiatingSurfaceState", () => {
       meta: { label: "Matrix" },
       approvalCapability: {
         native: {},
-        getActionAvailabilityState: ({ approvalKind }: { approvalKind?: "exec" | "plugin" }) =>
+        getActionAvailabilityState: ({ approvalKind }: { approvalKind?: ChannelApprovalKind }) =>
           approvalKind === "plugin" ? { kind: "enabled" as const } : { kind: "disabled" as const },
       },
     });
@@ -229,7 +230,7 @@ describe("resolveExecApprovalInitiatingSurfaceState", () => {
   it("uses generic approval availability for plugin initiating surfaces", () => {
     const getExecInitiatingSurfaceState = vi.fn(() => ({ kind: "enabled" as const }));
     const getActionAvailabilityState = vi.fn(
-      ({ approvalKind }: { approvalKind?: "exec" | "plugin" }) =>
+      ({ approvalKind }: { approvalKind?: ChannelApprovalKind }) =>
         approvalKind === "plugin" ? { kind: "disabled" as const } : { kind: "enabled" as const },
     );
     getChannelPluginMock.mockReturnValue({

--- a/src/infra/exec-approval-surface.ts
+++ b/src/infra/exec-approval-surface.ts
@@ -11,14 +11,13 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../utils/message-channel.js";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 /** Native approval availability for the channel/account that initiated an approval. */
 export type ExecApprovalInitiatingSurfaceState =
   | { kind: "enabled"; channel: string | undefined; channelLabel: string; accountId?: string }
   | { kind: "disabled"; channel: string; channelLabel: string; accountId?: string }
   | { kind: "unsupported"; channel: string; channelLabel: string; accountId?: string };
-
-type ApprovalKind = "exec" | "plugin";
 
 function labelForChannel(channel?: string): string {
   if (channel === "tui") {
@@ -55,7 +54,7 @@ export function resolveApprovalInitiatingSurfaceState(params: {
   channel?: string | null;
   accountId?: string | null;
   cfg?: OpenClawConfig;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): ExecApprovalInitiatingSurfaceState {
   const channel = normalizeMessageChannel(params.channel);
   const channelLabel = labelForChannel(channel);

--- a/src/infra/push-apns-payloads.ts
+++ b/src/infra/push-apns-payloads.ts
@@ -1,6 +1,7 @@
 // Builds portable APNs payloads for alerts, wakes, and approval lifecycle events.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { ChannelApprovalKind } from "./approval-types.js";
 
 const EXEC_APPROVAL_GENERIC_ALERT_BODY = "Open OpenClaw to review this request.";
 const PLUGIN_APPROVAL_ALERT_BODY_MAX_LENGTH = 256;
@@ -59,7 +60,7 @@ export function resolveExecApprovalAlertBody(): string {
 }
 
 export function createApnsApprovalAlertPayload(params: {
-  kind: "exec" | "plugin";
+  kind: ChannelApprovalKind;
   approvalId: string;
   gatewayDeviceId: string;
   title: string;
@@ -94,7 +95,7 @@ export function resolvePluginApprovalAlertBody(description: string): string {
 }
 
 export function createApnsApprovalResolvedPayload(params: {
-  kind: "exec" | "plugin";
+  kind: ChannelApprovalKind;
   approvalId: string;
   gatewayDeviceId: string;
 }): object {

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -2,6 +2,7 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { ChannelApprovalKind } from "./approval-types.js";
 import type { DeviceIdentity } from "./device-identity.js";
 import { toErrorObject } from "./errors.js";
 import { getApnsBearerToken, type ApnsAuthConfig } from "./push-apns-auth.js";
@@ -658,7 +659,7 @@ export async function sendApnsPluginApprovalAlert(
 
 async function sendApnsApprovalResolvedWake(params: {
   transport: ApnsApprovalParams;
-  kind: "exec" | "plugin";
+  kind: ChannelApprovalKind;
 }): Promise<ApnsPushWakeResult> {
   return await sendApnsApprovalPush({
     transport: params.transport,

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { isWellFormedApprovalId } from "../../packages/gateway-protocol/src/schema/approval-id.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 
 const PRESENTATION_FALLBACK_CONTINUATION = Symbol.for(
   "openclaw.presentation.fallback-continuation",
@@ -84,7 +85,7 @@ export type MessagePresentationAction =
       /** Resolve one durable operator approval without exposing transport callback data. */
       type: "approval";
       approvalId: string;
-      approvalKind: "exec" | "plugin";
+      approvalKind: ChannelApprovalKind;
       decision: "allow-once" | "allow-always" | "deny";
     }
   | {

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -9,11 +9,11 @@ import {
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayClient } from "../gateway/client.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { VERSION } from "../version.js";
 import type {
   ApprovalDecision,
-  ApprovalKind,
   ChatHistoryResult,
   ClaudeChannelMode,
   ConversationDescriptor,
@@ -301,7 +301,7 @@ export class OpenClawChannelBridge {
 
   /** Forward an MCP approval decision to the matching Gateway approval resolver. */
   async respondToApproval(params: {
-    kind: ApprovalKind;
+    kind: ChannelApprovalKind;
     id: string;
     decision: ApprovalDecision;
   }): Promise<Record<string, unknown>> {
@@ -457,7 +457,7 @@ export class OpenClawChannelBridge {
     }
   }
 
-  private trackApproval(kind: ApprovalKind, payload: Record<string, unknown>): void {
+  private trackApproval(kind: ChannelApprovalKind, payload: Record<string, unknown>): void {
     if (this.closed) {
       return;
     }

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString as toText,
 } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 
 /**
  * Shared channel MCP contracts and normalization helpers.
@@ -82,14 +83,12 @@ export type SessionMessagePayload = {
   [key: string]: unknown;
 };
 
-/** Gateway approval family exposed through MCP. */
-export type ApprovalKind = "exec" | "plugin";
 /** Decision values accepted by Gateway approval resolvers. */
 export type ApprovalDecision = "allow-once" | "allow-always" | "deny";
 
 /** Approval request tracked locally while waiting for an MCP client decision. */
 export type PendingApproval = {
-  kind: ApprovalKind;
+  kind: ChannelApprovalKind;
   id: string;
   request?: Record<string, unknown>;
   createdAtMs?: number;

--- a/src/plugin-sdk/approval-auth-helpers.ts
+++ b/src/plugin-sdk/approval-auth-helpers.ts
@@ -1,9 +1,9 @@
 // Approval auth helpers resolve actor and channel identity for approval requests.
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { resolveApprovalApprovers } from "./approval-approvers.js";
 import type { OpenClawConfig } from "./config-runtime.js";
 
-type ApprovalKind = "exec" | "plugin";
 type ApproverInput = string | number;
 type ApprovalApproverInputs = {
   explicit?: readonly ApproverInput[] | null;
@@ -100,7 +100,7 @@ export function createResolvedApproverActionAuthAdapter(params: {
       /** Approval action being authorized. */
       action: "approve";
       /** Approval kind used in user-facing denial copy. */
-      approvalKind: ApprovalKind;
+      approvalKind: ChannelApprovalKind;
     }) {
       const approvers = params.resolveApprovers({ cfg, accountId });
       if (approvers.length === 0) {
@@ -167,7 +167,7 @@ export function createChannelApprovalAuth(params: {
         accountId?: string | null;
         senderId?: string | null;
         action: "approve";
-        approvalKind: ApprovalKind;
+        approvalKind: ChannelApprovalKind;
       }) {
         const inputs = params.resolveInputs(input);
         const approvers = resolveApprovalApprovers({

--- a/src/plugin-sdk/approval-delivery-helpers.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.ts
@@ -1,3 +1,4 @@
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 // Approval delivery helpers format approval prompts and results for channel plugins.
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
@@ -14,7 +15,6 @@ import type { OpenClawConfig } from "./config-runtime.js";
 import { normalizeMessageChannel } from "./routing.js";
 import { normalizeOptionalString } from "./string-coerce-runtime.js";
 
-type ApprovalKind = "exec" | "plugin";
 type NativeApprovalDeliveryMode = "dm" | "channel" | "both";
 type NativeApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
 type NativeApprovalSurface = "origin" | "approver-dm";
@@ -36,7 +36,7 @@ type DeliverySuppressionParams = {
   /** Full config used to inspect native approval delivery settings. */
   cfg: OpenClawConfig;
   /** Approval kind being delivered. */
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   /** Forwarding fallback target under consideration. */
   target: { channel: string; accountId?: string | null };
   /** Approval request metadata, including original turn source when available. */
@@ -80,14 +80,14 @@ type ApproverRestrictedNativeApprovalFlatParams = {
   resolveOriginTarget?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: NativeApprovalRequest;
   }) => NativeApprovalTarget | null | Promise<NativeApprovalTarget | null>;
   /** Resolves approver DM targets for native approval delivery. */
   resolveApproverDmTargets?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: NativeApprovalRequest;
   }) => NativeApprovalTarget[] | Promise<NativeApprovalTarget[]>;
   /** Whether DM-only native delivery should also notify the origin channel. */
@@ -142,7 +142,7 @@ type StandardNativeApprovalRoutingParams = {
   isOriginTargetAllowed?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind?: ApprovalKind;
+    approvalKind?: ChannelApprovalKind;
     request: NativeApprovalRequest;
     target: NativeApprovalTarget;
   }) => boolean;
@@ -312,7 +312,7 @@ function buildApproverRestrictedNativeApprovalCapability(
       accountId?: string | null;
       senderId?: string | null;
       action: "approve";
-      approvalKind: ApprovalKind;
+      approvalKind: ChannelApprovalKind;
     }) => {
       const authorized =
         approvalKind === "plugin"
@@ -332,7 +332,7 @@ function buildApproverRestrictedNativeApprovalCapability(
       cfg: OpenClawConfig;
       accountId?: string | null;
       action: "approve";
-      approvalKind?: ApprovalKind;
+      approvalKind?: ChannelApprovalKind;
     }) => availabilityState(hasConfiguredApprovers({ cfg, accountId })),
     getExecInitiatingSurfaceState: resolveExecInitiatingSurfaceState,
     describeExecApprovalSetup: params.describeExecApprovalSetup,
@@ -381,7 +381,7 @@ function buildApproverRestrictedNativeApprovalCapability(
             }: {
               cfg: OpenClawConfig;
               accountId?: string | null;
-              approvalKind: ApprovalKind;
+              approvalKind: ChannelApprovalKind;
               request: NativeApprovalRequest;
             }) => ({
               enabled: isExecInitiatingSurfaceEnabled({ cfg, accountId }),

--- a/src/plugin-sdk/approval-handler-runtime.ts
+++ b/src/plugin-sdk/approval-handler-runtime.ts
@@ -45,6 +45,7 @@ export {
   type PluginApprovalResolvedView,
   type ResolvedApprovalView,
 } from "../infra/approval-handler-runtime.js";
+export type { ChannelApprovalKind } from "../infra/approval-handler-runtime-types.js";
 export { resolveApprovalOverGateway } from "./approval-gateway-runtime.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;

--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -9,7 +9,7 @@ import type {
 } from "../config/types.approvals.js";
 import { doesApprovalRequestSelectChannelAccount } from "../infra/approval-request-account-binding.js";
 import { matchesApprovalRequestFilters } from "../infra/approval-request-filters.js";
-import { resolveApprovalRequestKind } from "../infra/approval-types.js";
+import { resolveApprovalRequestKind, type ChannelApprovalKind } from "../infra/approval-types.js";
 import {
   getExecApprovalReplyMetadata,
   type ExecApprovalReplyMetadata,
@@ -28,7 +28,6 @@ import type { OpenClawConfig } from "./config-runtime.js";
 import type { ReplyPayload } from "./reply-payload.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type ApprovalKind = "exec" | "plugin";
 type DeliverySuppressionInput = Parameters<
   NonNullable<
     NonNullable<ChannelApprovalCapability["delivery"]>["shouldSuppressForwardingFallback"]
@@ -46,7 +45,7 @@ type ChannelApprovalForwardTarget = DeliverySuppressionInput["target"];
 type ApprovalResolverParams = {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  approvalKind?: ApprovalKind;
+  approvalKind?: ChannelApprovalKind;
   request: ApprovalRequest;
 };
 
@@ -82,7 +81,7 @@ export type ChannelApprovalForwardingEligibilityParams = {
   /** Optional channel account id for account-scoped transport checks. */
   accountId?: string | null;
   /** Approval family whose forwarding config should be evaluated. */
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   /** Approval request being considered for native delivery. */
   request: ApprovalRequest;
 };
@@ -94,7 +93,7 @@ export type ChannelApprovalPotentialRouteParams = {
   /** Optional channel account id for account-scoped transport checks. */
   accountId?: string | null;
   /** Approval family whose forwarding config should be evaluated. */
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   /** When true, ignore explicit target routes and only consider session/native origin routes. */
   nativeSessionOnly?: boolean;
 };
@@ -120,19 +119,19 @@ type NativeApprovalForwardingFallbackSuppressorParams<TTarget extends NativeAppr
     request: ApprovalRequest;
   }) => string | null | undefined;
   resolveApprovalKind?: (params: {
-    approvalKind?: ApprovalKind;
+    approvalKind?: ChannelApprovalKind;
     request: ApprovalRequest;
-  }) => ApprovalKind;
+  }) => ChannelApprovalKind;
   isSessionRouteEligible: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => boolean;
   isExplicitTargetEligible?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
     target: NativeApprovalForwardTarget;
   }) => boolean;
@@ -140,19 +139,19 @@ type NativeApprovalForwardingFallbackSuppressorParams<TTarget extends NativeAppr
     forwardingTarget: TTarget;
     accountId?: string | null;
     target: NativeApprovalForwardTarget;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => TTarget | null;
   resolveOriginTarget: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => TTarget | null;
   resolveApproverDmTargets: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => readonly TTarget[];
   targetsMatch?: (left: TTarget, right: TTarget) => boolean;
@@ -173,7 +172,7 @@ type NativeApprovalChannelRouteGates = {
   canApprovalPotentiallyRouteToChannel: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     nativeSessionOnly?: boolean;
   }) => boolean;
   canAnyApprovalPotentiallyRouteToChannel: (params: {
@@ -188,20 +187,20 @@ type NativeApprovalChannelRouteGates = {
   isSessionApprovalEligible: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => boolean;
   isExplicitTargetEligible: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
     target: NativeApprovalForwardTarget;
   }) => boolean;
   shouldHandleApprovalRequest: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind?: ApprovalKind;
+    approvalKind?: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => boolean;
 };
@@ -439,8 +438,8 @@ function nativeApprovalTargetMatcher(channel: string): (left: unknown, right: un
 /** Infer approval family from the request shape unless the caller already knows it. */
 export function resolveApprovalKind(
   request: ApprovalRequest,
-  approvalKind?: ApprovalKind,
-): ApprovalKind {
+  approvalKind?: ChannelApprovalKind,
+): ChannelApprovalKind {
   if (approvalKind) {
     return approvalKind;
   }
@@ -449,7 +448,7 @@ export function resolveApprovalKind(
 
 function resolveApprovalForwardingConfig(params: {
   cfg: OpenClawConfig;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
 }): ExecApprovalForwardingConfig | undefined {
   return params.approvalKind === "plugin"
     ? params.cfg.approvals?.plugin
@@ -632,7 +631,7 @@ export function createChannelApprovalForwardingEvaluator(
   const shouldHandleRequest = (input: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind?: ApprovalKind;
+    approvalKind?: ChannelApprovalKind;
     request: ApprovalRequest;
   }): boolean =>
     isSessionEligible({
@@ -743,7 +742,7 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
   const canApprovalPotentiallyRouteToChannel = (input: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     nativeSessionOnly?: boolean;
   }): boolean => {
     return canApprovalPotentiallyRoute({
@@ -771,7 +770,7 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
   const isSessionApprovalEligible = (input: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }): boolean => {
     // Per-account runtimes report raw candidates here. The route coordinator rejects
@@ -804,7 +803,7 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
   const isExplicitTargetEligible = (input: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
     target: NativeApprovalForwardTarget;
   }): boolean => {
@@ -819,7 +818,7 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
   const shouldHandleApprovalRequest = (input: {
     cfg: OpenClawConfig;
     accountId?: string | null;
-    approvalKind?: ApprovalKind;
+    approvalKind?: ChannelApprovalKind;
     request: ApprovalRequest;
   }): boolean =>
     isSessionApprovalEligible({

--- a/src/plugin-sdk/approval-reaction-binding.ts
+++ b/src/plugin-sdk/approval-reaction-binding.ts
@@ -1,13 +1,12 @@
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import type { ExecApprovalReplyDecision } from "../infra/exec-approval-reply.js";
 import type { MessagePresentation } from "../interactive/payload.js";
 import type { ReplyPayload } from "./reply-payload.js";
 
-type ApprovalKind = "exec" | "plugin";
-
 /** Validated identity and decisions shared by typed approval delivery surfaces. */
 export type ApprovalReactionDeliveryBinding = {
   approvalId: string;
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   allowedDecisions: ExecApprovalReplyDecision[];
   approvalSlug?: string;
 };

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -1,6 +1,6 @@
 import { sanitizeForPromptLiteral } from "../agents/sanitize-for-prompt.js";
 import { formatApprovalDisplayPath } from "../infra/approval-display-paths.js";
-import { normalizeApprovalRequest } from "../infra/approval-types.js";
+import { normalizeApprovalRequest, type ChannelApprovalKind } from "../infra/approval-types.js";
 import { buildPendingApprovalView } from "../infra/approval-view-model.js";
 import type { ApprovalRequest, PendingApprovalView } from "../infra/approval-view-model.types.js";
 import {
@@ -10,10 +10,6 @@ import {
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-/**
- * @deprecated Compatibility subpath for shipped approval reaction helpers.
- * New plugin code should use the focused approval runtime/reply subpaths.
- */
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
 import {
   buildApprovalPendingReplyPayload,
@@ -32,7 +28,6 @@ export {
   type ApprovalReactionDeliveryBinding,
 } from "./approval-reaction-binding.js";
 
-type ApprovalKind = "exec" | "plugin";
 type KeyedStore<TValue> = {
   register(key: string, value: TValue, opts?: { ttlMs?: number }): Promise<void>;
   lookup(key: string): Promise<TValue | undefined>;
@@ -74,7 +69,7 @@ export type ApprovalReactionDecisionResolution = {
 export type ApprovalReactionTargetRecord<TRoute = unknown> = {
   approvalId: string;
   /** Explicit ownership; omission is supported only by the deprecated resolver. */
-  approvalKind?: ApprovalKind;
+  approvalKind?: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   route?: TRoute;
   expiresAtMs?: number;
@@ -84,7 +79,7 @@ export type ApprovalReactionTargetRecord<TRoute = unknown> = {
 export type ApprovalReactionTargetResolution<TRoute = unknown> =
   ApprovalReactionDecisionResolution & {
     approvalId: string;
-    approvalKind: ApprovalKind;
+    approvalKind: ChannelApprovalKind;
     route?: TRoute;
   };
 
@@ -256,7 +251,7 @@ function resolveApprovalReactionTargetInternal<TRoute>(params: {
 /** Resolve an explicitly typed target without deriving ownership from its id. */
 export function resolveTypedApprovalReactionTarget<TRoute = unknown>(params: {
   target:
-    | (ApprovalReactionTargetRecord<TRoute> & { approvalKind: ApprovalKind })
+    | (ApprovalReactionTargetRecord<TRoute> & { approvalKind: ChannelApprovalKind })
     | null
     | undefined;
   reactionKey: string;
@@ -276,7 +271,7 @@ function buildDecisionText(allowedDecisions: readonly ExecApprovalReplyDecision[
 }
 
 function buildManualInstructionSection(params: {
-  approvalKind: ApprovalKind;
+  approvalKind: ChannelApprovalKind;
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
 }): string[] {

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -1,5 +1,6 @@
 // Approval renderer helpers convert approval request data into channel-safe display text.
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import {
   buildApprovalButtonPresentation,
   buildTypedApprovalPresentation,
@@ -36,7 +37,7 @@ type BuildApprovalPendingReplyPayloadParams = {
 
 /** Build a shipped command-backed approval payload. */
 export function buildApprovalPendingReplyPayload(
-  params: BuildApprovalPendingReplyPayloadParams & { approvalKind?: "exec" | "plugin" },
+  params: BuildApprovalPendingReplyPayloadParams & { approvalKind?: ChannelApprovalKind },
 ): ReplyPayload {
   // Keep defaults aligned with the generic approval command UI when callers do
   // not provide request-scoped decision restrictions.
@@ -64,7 +65,7 @@ export function buildApprovalPendingReplyPayload(
 
 /** Build a pending approval payload with canonical typed decision actions. */
 export function buildTypedApprovalPendingReplyPayload(
-  params: BuildApprovalPendingReplyPayloadParams & { approvalKind: "exec" | "plugin" },
+  params: BuildApprovalPendingReplyPayloadParams & { approvalKind: ChannelApprovalKind },
 ): ReplyPayload {
   const payload = buildApprovalPendingReplyPayload(params);
   return {


### PR DESCRIPTION
## What Problem This Solves

Approval ownership had one canonical core type but dozens of file-local aliases and inline unions across core, the Plugin SDK, channel plugins, and QA contracts. The duplication made the approval contract easy to drift and left the canonical type unavailable to plugin callers.

## Why This Change Was Made

Expose `ChannelApprovalKind` through the existing approval-handler runtime SDK subpath, migrate genuine channel approval owner type positions to that spelling, remove obsolete aliases and the stale reaction-runtime deprecation note, and reuse the canonical presentation action union. Preserve runtime values, wire bytes, authorization, protocol, SQLite, and configuration behavior.

## User Impact

No runtime behavior change. Plugin and core developers now use one approval-kind type across approval delivery, reaction, forwarding, gateway, presentation, APNs, and QA surfaces.

## Evidence

- `node scripts/run-vitest.mjs src/infra/exec-approval-channel-runtime.test.ts src/plugin-sdk/approval-reaction-runtime.test.ts src/infra/push-apns.test.ts src/gateway/exec-approval-ios-push.test.ts src/gateway/server-methods/approval-shared.test.ts src/interactive/payload.test.ts extensions/googlechat/src/approval-card-click.test.ts extensions/imessage/src/approval-native.test.ts extensions/whatsapp/src/approval-native.test.ts extensions/slack/src/monitor/events/interactions.test.ts` — passed 285 tests across 8 Vitest shards.
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm plugin-sdk:surface:check` — passed; all 146 public Plugin SDK subpaths verified.
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs` — passed all selected core/core-test/extension/extension-test gates, including 0 runtime value import cycles.
- `node scripts/run-oxlint.mjs extensions/googlechat/src/approval-card-actions.ts extensions/googlechat/src/approval-native.ts extensions/imessage/src/channel.ts extensions/imessage/src/send.ts extensions/whatsapp/src/approval-native.ts extensions/slack/src/monitor/events/interactions.block-actions.ts extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-approval.ts extensions/qa-lab/src/live-transports/matrix/substrate/events.ts extensions/qa-lab/src/live-transports/slack/slack-live.approval-checkpoint.ts extensions/qa-lab/src/live-transports/slack/slack-live.approvals.ts extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.approvals.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts src/agents/runtime-plan/types.ts src/channels/plugins/outbound.types.ts src/gateway/exec-approval-ios-push.ts src/gateway/server-aux-handlers.ts src/gateway/server-methods/approval-publication.ts src/gateway/server-methods/approval-record-lookup.ts src/gateway/server-methods/approval-shared.ts src/infra/push-apns-payloads.ts src/infra/push-apns.ts src/interactive/payload.ts` — passed.
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm build` — passed in 7m16.8s; all 146 public Plugin SDK subpaths verified.
- `git diff --check origin/main...HEAD` — passed.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Production: +248/-267 (net -19). Tests: +29/-18. 77 changed files.

AI-assisted. Session logs are intentionally not attached.
