### PR TITLE
fix(canvas): omit deleted snapshot paths

### DIFF
--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -41,7 +41,14 @@ const mocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
   imageResultFromFile: vi.fn<
     typeof import("openclaw/plugin-sdk/channel-actions").imageResultFromFile
-  >(async (params) => ({ content: [], details: params })),
+  >(async (params) => {
+    const details = params.details ?? {};
+    const media = details.media as Record<string, unknown> | undefined;
+    return {
+      content: [],
+      details: { path: params.path, ...details, media: { ...media, mediaUrl: params.path } },
+    };
+  }),
   listNodes: vi.fn(async () => []),
   resolveNodeIdFromList: vi.fn(() => "node-1"),
   saveMediaBuffer: vi.fn<typeof import("openclaw/plugin-sdk/media-store").saveMediaBuffer>(
@@ -338,10 +345,10 @@ describe("Canvas tool", () => {
       path?: string;
       media?: { mediaUrl?: string; outbound?: boolean };
     };
-    expect(details.path).toBe(savedPath);
-    expect(details.media).toEqual({ mediaUrl: savedPath, outbound: false });
+    expect(details).not.toHaveProperty("path");
+    expect(details.media).toEqual({ outbound: false });
+    expect(details.media).not.toHaveProperty("mediaUrl");
     expect(result.details).toMatchObject({ node: "node-1", format: "png" });
-    expect(details.path).not.toMatch(/openclaw-canvas-snapshot-/);
     expect(result.content).toContainEqual(
       expect.objectContaining({ type: "image", mimeType: "image/png" }),
     );

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -277,18 +277,16 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
             "canvas",
             CANVAS_SNAPSHOT_MAX_BYTES,
           );
+          const details = { node, format: payload.format, media: { outbound: false } };
           try {
             const result = await imageResultFromFile({
               label: "canvas:snapshot",
               path: saved.path,
               // Rendered pages are model observations, never automatic outbound attachments.
-              details: { node, format: payload.format, media: { outbound: false } },
+              details,
               imageSanitization,
             });
-            const details = result.details as { path?: string; media: { mediaUrl?: string } };
-            delete details.path;
-            delete details.media.mediaUrl;
-            return result;
+            return { ...result, details };
           } finally {
             // The model-visible image is hydrated above; the staging path is not returned.
             await removeCanvasSnapshotFile(saved.path);

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -278,15 +278,19 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
             CANVAS_SNAPSHOT_MAX_BYTES,
           );
           try {
-            return await imageResultFromFile({
+            const result = await imageResultFromFile({
               label: "canvas:snapshot",
               path: saved.path,
               // Rendered pages are model observations, never automatic outbound attachments.
               details: { node, format: payload.format, media: { outbound: false } },
               imageSanitization,
             });
+            const details = result.details as { path?: string; media: { mediaUrl?: string } };
+            delete details.path;
+            delete details.media.mediaUrl;
+            return result;
           } finally {
-            // imageResultFromFile hydrates the model-visible image before returning.
+            // The model-visible image is hydrated above; the staging path is not returned.
             await removeCanvasSnapshotFile(saved.path);
           }
         }


### PR DESCRIPTION
Related: #125126

## What Problem This Solves
Fixes an issue where Canvas snapshots returned a path and media URL after the snapshot staging file had already been deleted, leaving agents and callers with stale result facts.

## Why This Change Was Made
Keep the inline image and canonical node/format/media policy, but remove only the file-backed path fields before returning the result. The staging file remains unlinked in `finally`. This is AI-assisted maintainer work.

## User Impact
Canvas snapshot results no longer advertise an unusable file path. Agents still receive the image itself and the facts needed to continue safely.

## Evidence
- Pre-fix owner-boundary proof: `node scripts/run-vitest.mjs extensions/canvas/src/tool.test.ts` failed the new assertion because `details.path` still contained the deleted snapshot path (43 passed, 1 failed).
- Focused post-fix proof: the same command passed all 44 Canvas tests, including inline image content, node/format metadata, `media.outbound: false`, no outbound artifact, and deleted staging-file verification.
- `node_modules/.bin/oxfmt --check extensions/canvas/src/tool.ts extensions/canvas/src/tool.test.ts` passed.
- `node scripts/run-oxlint.mjs extensions/canvas/src/tool.ts extensions/canvas/src/tool.test.ts` passed.
- `pnpm check:assertion-safety --base origin/main` passed after the result handling was simplified to avoid a new assertion.
- `git diff --check` passed.
- `node scripts/check-changed.mjs --dry-run -- extensions/canvas/src/tool.ts extensions/canvas/src/tool.test.ts` classified `extensions, extensionTests` successfully.
- Fresh Codex-backed autoreview with `--mode uncommitted` was clean with no accepted/actionable findings.
- Production LOC: +5/-3 (net +2). Tests: +11/-4 (net +7).
- This is the result-contract follow-up to #125126. No isolated paired Canvas node was available in this clone/runtime; the deterministic private snapshot owner-boundary test exercises the exact returned result and cleanup behavior.
