### PR TITLE
fix(sessions): make deletion cleanup outcomes accurate

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13559,19 +13559,22 @@ public struct AgentsDeleteResult: Codable, Sendable {
     public let removedbindings: Int
     public let removed: [[String: AnyCodable]]?
     public let failed: [[String: AnyCodable]]?
+    public let purgefailed: Bool?
 
     public init(
         ok: Bool,
         agentid: String,
         removedbindings: Int,
         removed: [[String: AnyCodable]]? = nil,
-        failed: [[String: AnyCodable]]? = nil)
+        failed: [[String: AnyCodable]]? = nil,
+        purgefailed: Bool? = nil)
     {
         self.ok = ok
         self.agentid = agentid
         self.removedbindings = removedbindings
         self.removed = removed
         self.failed = failed
+        self.purgefailed = purgefailed
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -13580,6 +13583,7 @@ public struct AgentsDeleteResult: Codable, Sendable {
         case removedbindings = "removedBindings"
         case removed
         case failed
+        case purgefailed = "purgeFailed"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -93,6 +93,18 @@ describe("AgentsDeleteResultSchema", () => {
       removed: [{ path: "/state/agents/ops/agent", method: "trash" }],
       failed: [{ path: "/state/workspace-ops", reason: "trash unavailable" }],
     });
+    expectAccepted(AgentsDeleteResultSchema, {
+      ok: true,
+      agentId: "ops",
+      removedBindings: 1,
+      purgeFailed: true,
+    });
+    expectRejected(AgentsDeleteResultSchema, {
+      ok: true,
+      agentId: "ops",
+      removedBindings: 1,
+      purgeFailed: false,
+    });
   });
 });
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -180,6 +180,7 @@ export const AgentsDeleteResultSchema = closedObject({
       }),
     ),
   ),
+  purgeFailed: Type.Optional(Type.Literal(true)),
 });
 
 /** File metadata and optional content for agent-local editable files. */

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -64,6 +64,7 @@ type AgentsDeleteGatewayResult = {
   removedBindings: number;
   removed?: Array<{ path: string; method: "trash" | "missing" }>;
   failed?: Array<{ path: string; reason: string }>;
+  purgeFailed?: true;
 };
 
 function failAgentsDelete(opts: AgentsDeleteOptions, runtime: RuntimeEnv, message: string): void {
@@ -79,6 +80,14 @@ function failAgentsDelete(opts: AgentsDeleteOptions, runtime: RuntimeEnv, messag
 function logClearedOwnerRefs(runtime: RuntimeEnv, clearedOwnerRefs: readonly string[]): void {
   if (clearedOwnerRefs.length > 0) {
     runtime.log(`Cleared owner references: ${clearedOwnerRefs.join(", ")}`);
+  }
+}
+
+function logSessionPurgeWarning(runtime: RuntimeEnv, agentId: string, purgeFailed: boolean): void {
+  if (purgeFailed) {
+    runtime.error(
+      `Warning: session-store purge failed for deleted agent "${agentId}"; stale shared-store rows may remain.`,
+    );
   }
 }
 
@@ -245,11 +254,13 @@ export async function agentsDeleteCommand(
         clearedOwnerRefs: result.clearedOwnerRefs.length > 0 ? result.clearedOwnerRefs : undefined,
         removed: gatewayResult.removed,
         failed: gatewayResult.failed,
+        ...(gatewayResult.purgeFailed ? { purgeFailed: true } : {}),
         transport: "gateway",
       });
     } else {
       runtime.log(`Deleted agent: ${agentId}`);
       logClearedOwnerRefs(runtime, result.clearedOwnerRefs);
+      logSessionPurgeWarning(runtime, agentId, gatewayResult.purgeFailed === true);
       for (const failure of gatewayResult.failed ?? []) {
         runtime.error(
           `Warning: path could not be moved to Trash: ${failure.reason}; remove it manually at ${failure.path}`,
@@ -286,7 +297,7 @@ export async function agentsDeleteCommand(
   }
 
   // Purge session store entries for this agent so orphaned sessions cannot be targeted (#65524).
-  await purgeAgentSessionStoreEntries(cfg, agentId);
+  const purgeFailed = await purgeAgentSessionStoreEntries(cfg, agentId);
 
   const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
   // Only trash the workspace if no other agent can depend on that path (#70890).
@@ -340,9 +351,11 @@ export async function agentsDeleteCommand(
       removedBindings: result.removedBindings,
       removedAllow: result.removedAllow,
       clearedOwnerRefs: result.clearedOwnerRefs.length > 0 ? result.clearedOwnerRefs : undefined,
+      ...(purgeFailed ? { purgeFailed: true } : {}),
     });
   } else {
     runtime.log(`Deleted agent: ${agentId}`);
     logClearedOwnerRefs(runtime, result.clearedOwnerRefs);
+    logSessionPurgeWarning(runtime, agentId, purgeFailed);
   }
 }

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -417,6 +417,7 @@ describe("agents delete command", () => {
         removedBindings: 0,
         removed: [],
         failed: [{ path: workspace, reason: "trash unavailable" }],
+        purgeFailed: true,
       });
 
       await agentsDeleteCommand({ id: "ops", force: true }, runtime);
@@ -425,7 +426,31 @@ describe("agents delete command", () => {
       expect(runtime.error).toHaveBeenCalledWith(
         `Warning: path could not be moved to Trash: trash unavailable; remove it manually at ${workspace}`,
       );
+      expect(runtime.error).toHaveBeenCalledWith(
+        'Warning: session-store purge failed for deleted agent "ops"; stale shared-store rows may remain.',
+      );
       expect(runtime.exit).not.toHaveBeenCalled();
+    });
+  });
+
+  it("includes purge failure in delegated JSON output", async () => {
+    await withStateDirEnv("openclaw-agents-delete-gateway-purge-json-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main" }, { id: "ops" }] },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+      gatewayMocks.callGateway.mockResolvedValue({
+        ok: true,
+        agentId: "ops",
+        removedBindings: 0,
+        removed: [],
+        failed: [],
+        purgeFailed: true,
+      });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      expect(readJsonLogs()[0]).toMatchObject({ purgeFailed: true, transport: "gateway" });
     });
   });
 
@@ -475,6 +500,7 @@ describe("agents delete command", () => {
       expect(output?.workspaceRetained).toBe(true);
       expect(output?.workspaceRetainedReason).toBe("shared");
       expect(output?.transport).toBeUndefined();
+      expect(output).not.toHaveProperty("purgeFailed");
       expect(output?.clearedOwnerRefs).toEqual([
         "agents.defaults.heartbeat.agentId",
         "agents.defaults.systemAgent.agentId",

--- a/src/config/sessions/cleanup-service.agent-purge.test.ts
+++ b/src/config/sessions/cleanup-service.agent-purge.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLogger } from "../../logging/logger.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { purgeAgentSessionStoreEntries } from "./cleanup-service.js";
 
@@ -22,6 +24,11 @@ vi.mock("./session-accessor.js", () => sessionAccessorMocks);
 describe("purgeAgentSessionStoreEntries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("purges deleted-agent entries through the storage boundary", async () => {
@@ -35,7 +42,7 @@ describe("purgeAgentSessionStoreEntries", () => {
       },
     } satisfies OpenClawConfig;
 
-    await purgeAgentSessionStoreEntries(cfg, "ops");
+    await expect(purgeAgentSessionStoreEntries(cfg, "ops")).resolves.toBe(false);
 
     expect(sessionAccessorMocks.purgeDeletedAgentSessionEntries).toHaveBeenCalledWith({
       cfg,
@@ -44,5 +51,28 @@ describe("purgeAgentSessionStoreEntries", () => {
       storePath: "/tmp/openclaw-agent-purge-sessions.json",
     });
     expect(sessionAccessorMocks.applySessionEntryLifecycleMutation).not.toHaveBeenCalled();
+  });
+
+  it("treats an absent store as an already successful purge", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    await expect(purgeAgentSessionStoreEntries({}, "ops")).resolves.toBe(false);
+
+    expect(sessionAccessorMocks.purgeDeletedAgentSessionEntries).not.toHaveBeenCalled();
+  });
+
+  it("records a bounded warning and failure fact when storage purge fails", async () => {
+    const storePath = "/tmp/openclaw-agent-purge-failure-sessions.json";
+    const cfg = { session: { store: storePath } } satisfies OpenClawConfig;
+    const error = new Error("injected purge failure");
+    sessionAccessorMocks.purgeDeletedAgentSessionEntries.mockRejectedValueOnce(error);
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+
+    await expect(purgeAgentSessionStoreEntries(cfg, "ops")).resolves.toBe(true);
+
+    expect(warn).toHaveBeenCalledWith("session store purge failed during agent deletion", {
+      agentId: "ops",
+      error,
+      storePath,
+    });
   });
 });

--- a/src/config/sessions/cleanup-service.applied-summary.test.ts
+++ b/src/config/sessions/cleanup-service.applied-summary.test.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+
+const cleanupRace = vi.hoisted(() => ({
+  afterPreview: undefined as (() => void) | undefined,
+}));
+
+vi.mock("./disk-budget.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./disk-budget.js")>();
+  return {
+    ...actual,
+    pruneUnreferencedSessionArtifacts: vi.fn(async (params) => {
+      const result = await actual.pruneUnreferencedSessionArtifacts(params);
+      if (params.dryRun && cleanupRace.afterPreview) {
+        const afterPreview = cleanupRace.afterPreview;
+        cleanupRace.afterPreview = undefined;
+        afterPreview();
+      }
+      return result;
+    }),
+  };
+});
+
+import { runSessionsCleanup } from "./cleanup-service.js";
+import {
+  appendTranscriptMessageSync,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "./session-accessor.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("sessions cleanup applied summary", () => {
+  afterEach(() => {
+    cleanupRace.afterPreview = undefined;
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("reports authoritative counts when a preview removal becomes stale before apply", async () => {
+    const storePath = path.join(
+      tempDirs.make("openclaw-cleanup-applied-summary-"),
+      "agents",
+      "main",
+      "sessions",
+      "sessions.json",
+    );
+    const sessionKey = "agent:main:preview-became-live";
+    const sessionId = "preview-became-live";
+    const scope = { sessionId, sessionKey, storePath };
+    await replaceSessionEntry(scope, { sessionId, updatedAt: Date.now() });
+    cleanupRace.afterPreview = () => {
+      appendTranscriptMessageSync(scope, {
+        eventId: "message-after-preview",
+        message: { role: "user", content: [{ type: "text", text: "keep this session" }] },
+      });
+    };
+
+    const result = await runSessionsCleanup({
+      cfg: {},
+      opts: { enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(result.appliedSummaries[0]).toMatchObject({
+      applied: true,
+      appliedCount: 1,
+      beforeCount: 1,
+      afterCount: 1,
+      missing: 0,
+      wouldMutate: false,
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ sessionId });
+  });
+});

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -623,31 +623,31 @@ export async function runSessionsCleanup(params: {
         mode,
         maintenance,
       });
-      const preview = previewResults.find(
-        (result) => result.summary.storePath === target.storePath,
-      );
+      const missing = missingRemovals.filter(({ sessionKey }) =>
+        removedSessionKeys.has(sessionKey),
+      ).length;
+      const dmScopeRetired = dmScopeRetiredRemovals.filter(({ sessionKey }) =>
+        removedSessionKeys.has(sessionKey),
+      ).length;
+      const maintenanceRemovedEntries =
+        lifecycleResult.modelRunPruned + lifecycleResult.pruned + lifecycleResult.capped;
       const summary: SessionCleanupSummary = {
-        ...(preview?.summary ?? {
-          agentId: target.agentId,
-          storePath: target.storePath,
-          mode,
-          dryRun: false,
-          beforeCount: 0,
-          afterCount: 0,
-          missing: 0,
-          dmScopeRetired: 0,
-          modelRunPruned: 0,
-          pruned: 0,
-          capped: 0,
-          unreferencedArtifacts,
-          diskBudget: null,
-          wouldMutate: false,
-        }),
+        agentId: target.agentId,
+        storePath: target.storePath,
+        mode,
         dryRun: false,
+        beforeCount: lifecycleResult.beforeCount,
+        afterCount: lifecycleResult.afterCount,
+        missing,
+        dmScopeRetired,
+        modelRunPruned: lifecycleResult.modelRunPruned,
+        pruned: lifecycleResult.pruned,
+        capped: lifecycleResult.capped,
         unreferencedArtifacts,
         diskBudget: appliedDiskBudget,
         wouldMutate:
-          removedSessionKeys.size > 0 ||
+          lifecycleResult.removedEntries > 0 ||
+          maintenanceRemovedEntries > 0 ||
           unreferencedArtifacts.removedFiles > 0 ||
           (appliedDiskBudget?.removedEntries ?? 0) > 0 ||
           (appliedDiskBudget?.removedFiles ?? 0) > 0 ||
@@ -669,24 +669,37 @@ export async function runSessionsCleanup(params: {
 export async function purgeAgentSessionStoreEntries(
   cfg: OpenClawConfig,
   agentId: string,
-): Promise<void> {
+): Promise<boolean> {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  let storePath = typeof cfg.session?.store === "string" ? cfg.session.store : "<default>";
   try {
-    const normalizedAgentId = normalizeAgentId(agentId);
     const storeConfig = cfg.session?.store;
     const storeAgentId =
       typeof storeConfig === "string" && !storeConfig.includes("{agentId}")
         ? resolveSessionStoreCompatibilityAgentId(cfg)
         : normalizedAgentId;
-    const storePath = resolveSessionStorePathCore(cfg.session?.store, {
+    storePath = resolveSessionStorePathCore(cfg.session?.store, {
       agentId: normalizedAgentId,
     });
+    const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: storeAgentId,
+    }).path;
+    if (!sqlitePath || !fs.existsSync(sqlitePath)) {
+      return false;
+    }
     await purgeDeletedAgentSessionEntries({
       cfg,
       agentId: normalizedAgentId,
       storeAgentId,
       storePath,
     });
-  } catch (err) {
-    getLogger().debug("session store purge skipped during agent delete", err);
+    return false;
+  } catch (error) {
+    getLogger().warn("session store purge failed during agent deletion", {
+      agentId: normalizedAgentId,
+      error,
+      storePath,
+    });
+    return true;
   }
 }

--- a/src/config/sessions/conversation-delivery-store.test.ts
+++ b/src/config/sessions/conversation-delivery-store.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./conversation-delivery-store.js";
 import { resolveConversation } from "./conversation-registry.js";
 import {
+  applySessionEntryLifecycleMutation,
   deleteSessionEntryLifecycle,
   upsertSessionEntryCore as upsertCanonicalSessionEntry,
 } from "./session-accessor.js";
@@ -217,18 +218,15 @@ describe("conversation delivery store", () => {
         operationId: "operation-pruned-session",
         operationKind: "send",
         conversationRef,
+        sourceSessionKey: "agent:main:reef:direct:peer-agent",
         message: "hello",
       });
       markConversationDeliverySent(scope, "operation-pruned-session", "platform-pruned");
 
-      await deleteSessionEntryLifecycle({
+      await applySessionEntryLifecycleMutation({
         agentId: scope.agentId,
-        archiveTranscript: false,
         storePath: scope.storePath,
-        target: {
-          canonicalKey: "agent:main:reef:direct:peer-agent",
-          storeKeys: ["agent:main:reef:direct:peer-agent"],
-        },
+        maintenanceOverride: { mode: "enforce", pruneAfterMs: 1 },
       });
 
       expect(resolveConversation(scope, conversationRef)).toMatchObject({
@@ -240,6 +238,57 @@ describe("conversation delivery store", () => {
         channel: "reef",
         conversationRef,
         platformMessageId: "platform-pruned",
+        status: "sent",
+      });
+    });
+  });
+
+  it("removes source-bound delivery evidence when its session is fully deleted", async () => {
+    await withConversationStore(async ({ scope, conversationRef }) => {
+      const sessionKey = "agent:main:reef:direct:peer-agent";
+      beginConversationDeliveryOperation(scope, {
+        operationId: "operation-deleted-session",
+        operationKind: "send",
+        conversationRef,
+        sourceSessionKey: sessionKey,
+        message: "hello",
+      });
+      markConversationDeliverySent(scope, "operation-deleted-session", "platform-deleted");
+
+      await deleteSessionEntryLifecycle({
+        agentId: scope.agentId,
+        archiveTranscript: false,
+        deleteDeliveryArtifacts: true,
+        storePath: scope.storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+      });
+
+      expect(getConversationDeliveryOperation(scope, "operation-deleted-session")).toBeUndefined();
+      expect(resolveConversation(scope, conversationRef)).toMatchObject({ conversationRef });
+    });
+  });
+
+  it("retains source-bound delivery evidence for guarded lifecycle cleanup", async () => {
+    await withConversationStore(async ({ scope, conversationRef }) => {
+      const sessionKey = "agent:main:reef:direct:peer-agent";
+      beginConversationDeliveryOperation(scope, {
+        operationId: "operation-migrated-session",
+        operationKind: "send",
+        conversationRef,
+        sourceSessionKey: sessionKey,
+        message: "hello",
+      });
+      markConversationDeliverySent(scope, "operation-migrated-session", "platform-migrated");
+
+      await deleteSessionEntryLifecycle({
+        agentId: scope.agentId,
+        archiveTranscript: false,
+        storePath: scope.storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+      });
+
+      expect(getConversationDeliveryOperation(scope, "operation-migrated-session")).toMatchObject({
+        sourceSessionKey: sessionKey,
         status: "sent",
       });
     });

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -82,6 +82,8 @@ export type DeleteSessionEntryLifecycleParams = {
   archiveTranscript: boolean;
   /** Delete transcript rows without writing an archive artifact. */
   deleteTranscriptWithoutArchive?: boolean;
+  /** Full teardown only: delete durable operations sourced from this logical session. */
+  deleteDeliveryArtifacts?: boolean;
   /** Optional exact row guard checked under the storage writer lock. */
   expectedEntry?: SessionEntry;
   /** Optional exact ordered transcript guard checked in the deleting SQLite transaction. */
@@ -153,8 +155,12 @@ export type SessionArchivedTranscriptCleanupRule = {
 };
 
 export type SessionEntryLifecycleMutationResult = {
+  beforeCount: number;
   removedEntries: number;
   removedSessionKeys: string[];
+  modelRunPruned: number;
+  pruned: number;
+  capped: number;
   archivedTranscriptDirectories: string[];
   afterCount: number;
   artifactCleanupError?: unknown;

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -22,6 +22,9 @@ const archiveMaterializationHook = vi.hoisted(() => ({
   beforeMaterialize: undefined as (() => Promise<void>) | undefined,
   afterMaterialize: undefined as (() => void) | undefined,
 }));
+const archivePublicationHook = vi.hoisted(() => ({
+  failNext: undefined as Error | undefined,
+}));
 
 // Place test mutations after the real Worker finishes but before cleanup opens
 // its final transaction, without relying on cross-isolate filesystem timing.
@@ -40,6 +43,24 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./session-accessor.sqlite-archive-store.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./session-accessor.sqlite-archive-store.js")>();
+  return {
+    ...actual,
+    publishSessionStateArchives: async (
+      ...args: Parameters<typeof actual.publishSessionStateArchives>
+    ) => {
+      const error = archivePublicationHook.failNext;
+      archivePublicationHook.failNext = undefined;
+      if (error) {
+        throw error;
+      }
+      return await actual.publishSessionStateArchives(...args);
+    },
+  };
+});
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("SQLite lifecycle cleanup races", () => {
@@ -54,6 +75,7 @@ describe("SQLite lifecycle cleanup races", () => {
   afterEach(() => {
     archiveMaterializationHook.beforeMaterialize = undefined;
     archiveMaterializationHook.afterMaterialize = undefined;
+    archivePublicationHook.failNext = undefined;
     closeOpenClawAgentDatabasesForTest();
   });
 
@@ -673,6 +695,70 @@ describe("SQLite lifecycle cleanup races", () => {
     });
     await expect(writer).resolves.toMatchObject({ label: "progressed" });
     expect(progressedDuringMaterialization).toBe(true);
+  });
+
+  it("reports zero maintenance removals when final compare-and-delete does not commit", async () => {
+    const sessionKey = "agent:main:maintenance-compare-failed";
+    const entry = { sessionId: "maintenance-compare-failed", updatedAt: 1 };
+    await replaceSessionEntry({ sessionKey, storePath }, entry);
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+    }).path;
+    if (!databasePath) {
+      throw new Error("expected maintenance race database path");
+    }
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    let materializations = 0;
+    archiveMaterializationHook.afterMaterialize = () => {
+      materializations += 1;
+      if (materializations !== 2) {
+        return;
+      }
+      const changedEntry = { ...entry, label: "changed", updatedAt: 2 };
+      database.db
+        .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
+        .run(JSON.stringify(changedEntry), changedEntry.updatedAt, sessionKey);
+    };
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      maintenanceOverride: { mode: "enforce", pruneAfterMs: 1 },
+    });
+
+    expect(result).toMatchObject({
+      beforeCount: 1,
+      afterCount: 1,
+      removedEntries: 0,
+      removedSessionKeys: [],
+      modelRunPruned: 0,
+      pruned: 0,
+      capped: 0,
+    });
+    expect(materializations).toBe(2);
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ label: "changed" });
+  });
+
+  it("retains committed maintenance counts when archive publication fails", async () => {
+    const sessionKey = "agent:main:maintenance-publication-failed";
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId: "maintenance-publication-failed", updatedAt: 1 },
+    );
+    archivePublicationHook.failNext = new Error("injected archive publication failure");
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      maintenanceOverride: { mode: "enforce", pruneAfterMs: 1 },
+    });
+
+    expect(result).toMatchObject({
+      beforeCount: 1,
+      afterCount: 0,
+      modelRunPruned: 0,
+      pruned: 1,
+      capped: 0,
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
   });
 
   it("retains unplanned historical windows behind a placeholder node", async () => {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
@@ -1,3 +1,4 @@
+import type { SessionLifecycleArchivedTranscript } from "./session-accessor.lifecycle-types.js";
 import type { SessionStateDeletePlan } from "./session-accessor.sqlite-archive.js";
 import type { SessionEntryLifecycleRemoval } from "./session-accessor.sqlite-contract.js";
 import type { SessionResetBoundaryPlan } from "./session-reset-boundary-event.js";
@@ -9,9 +10,17 @@ export type SessionEntryRemovalPlan = {
   expectedEntry: SessionEntry | undefined;
   sessionKey: string;
 };
-export type SessionEntryMaintenancePlan = {
+type SessionEntryMaintenanceCounts = {
+  modelRunPruned: number;
+  pruned: number;
+  capped: number;
+};
+export type SessionEntryMaintenancePlan = SessionEntryMaintenanceCounts & {
   entryRemovals: SessionEntryRemovalPlan[];
   stateDeletePlans: SessionStateDeletePlan[];
+};
+export type SessionEntryMaintenanceResult = SessionEntryMaintenanceCounts & {
+  archivedTranscripts: SessionLifecycleArchivedTranscript[];
 };
 export type LifecycleArtifactCleanupPlan = {
   deletePlans: SessionStateDeletePlan[];

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -49,6 +49,7 @@ import {
   planSessionStateAfterEntryRemoval,
   readReferencedSessionIdsAfterTargetMutation,
 } from "./session-accessor.sqlite-lifecycle-state.js";
+import { deleteSessionDeliveryArtifacts } from "./session-accessor.sqlite-node-artifacts.js";
 import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import {
   cloneSessionEntry,
@@ -489,6 +490,12 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         ]),
       );
       deleteLifecycleTargetRows(transactionDb, params.target);
+      if (params.deleteDeliveryArtifacts === true) {
+        deleteSessionDeliveryArtifacts(transactionDb, params.target.canonicalKey, [
+          ...params.target.storeKeys,
+          ...transactionSnapshot.rows.map((row) => row.sessionKey),
+        ]);
+      }
       deleteSessionBoardRows(transactionDb, [
         params.target.canonicalKey,
         ...params.target.storeKeys,

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -22,7 +22,10 @@ import {
   planSessionStateDeleteIfUnreferenced,
   readSessionGenerationIdsForKeys,
 } from "./session-accessor.sqlite-lifecycle-state.js";
-import type { SessionEntryMaintenancePlan } from "./session-accessor.sqlite-lifecycle-types.js";
+import type {
+  SessionEntryMaintenancePlan,
+  SessionEntryMaintenanceResult,
+} from "./session-accessor.sqlite-lifecycle-types.js";
 import {
   cloneSessionEntry,
   getSessionKysely,
@@ -126,11 +129,11 @@ export function applySessionEntryMaintenance(
   },
 ): SessionEntryMaintenancePlan {
   if (params.skipMaintenance) {
-    return { entryRemovals: [], stateDeletePlans: [] };
+    return { entryRemovals: [], stateDeletePlans: [], modelRunPruned: 0, pruned: 0, capped: 0 };
   }
   const maintenance = params.maintenanceConfig ?? resolveMaintenanceConfig();
   if (maintenance.mode === "warn") {
-    return { entryRemovals: [], stateDeletePlans: [] };
+    return { entryRemovals: [], stateDeletePlans: [], modelRunPruned: 0, pruned: 0, capped: 0 };
   }
 
   // Count all rows before loading their payloads. Protection controls eviction candidates, not
@@ -158,7 +161,7 @@ export function applySessionEntryMaintenance(
       force: params.forceMaintenance,
     });
   if (!shouldMaintainStore) {
-    return { entryRemovals: [], stateDeletePlans: [] };
+    return { entryRemovals: [], stateDeletePlans: [], modelRunPruned: 0, pruned: 0, capped: 0 };
   }
 
   const store = loadSqliteSessionMaintenanceStore(database);
@@ -179,6 +182,7 @@ export function applySessionEntryMaintenance(
     }
   };
   let remainingEntryCount = entryCount;
+  let modelRunPruned = 0;
   if (
     shouldRunModelRunPrune({
       maintenance,
@@ -186,25 +190,29 @@ export function applySessionEntryMaintenance(
       force: params.forceMaintenance,
     })
   ) {
-    remainingEntryCount -= pruneStaleModelRunEntries(store, maintenance.modelRunPruneAfterMs, {
+    modelRunPruned = pruneStaleModelRunEntries(store, maintenance.modelRunPruneAfterMs, {
       log: false,
       onPruned: rememberRemovedEntry,
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
+    remainingEntryCount -= modelRunPruned;
   }
+  let pruned = 0;
   if (
     params.forceMaintenance === true ||
     hasStaleCandidate ||
     remainingEntryCount > maintenance.maxEntries
   ) {
-    remainingEntryCount -= pruneStaleEntries(store, maintenance.pruneAfterMs, {
+    pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
       log: false,
       onPruned: rememberRemovedEntry,
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
+    remainingEntryCount -= pruned;
   }
+  let capped = 0;
   if (
     shouldRunSessionEntryMaintenance({
       entryCount: remainingEntryCount,
@@ -212,7 +220,7 @@ export function applySessionEntryMaintenance(
       force: params.forceMaintenance,
     })
   ) {
-    capEntryCount(store, maintenance.maxEntries, {
+    capped = capEntryCount(store, maintenance.maxEntries, {
       log: false,
       onCapped: rememberRemovedEntry,
       preserveKeys,
@@ -241,18 +249,21 @@ export function applySessionEntryMaintenance(
     }
   }
   return {
-    entryRemovals: [...removedKeys].map((sessionKey) => ({
-      expectedEntry: removedEntriesByKey.get(sessionKey),
+    entryRemovals: [...removedEntriesByKey].map(([sessionKey, entry]) => ({
+      expectedEntry: entry,
       sessionKey,
     })),
     stateDeletePlans: deletePlans,
+    modelRunPruned,
+    pruned,
+    capped,
   };
 }
 
 export async function finalizeSessionEntryMaintenancePlansBestEffort(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   plans: readonly SessionEntryMaintenancePlan[],
-): Promise<SessionLifecycleArchivedTranscript[]> {
+): Promise<SessionEntryMaintenanceResult> {
   return await finalizeSqliteSessionEntryMaintenancePlansWithCommit(scope, plans, async (commit) =>
     commit(),
   );
@@ -262,7 +273,7 @@ export async function finalizeSessionEntryMaintenancePlansBestEffort(
 export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   plans: readonly SessionEntryMaintenancePlan[],
-): Promise<SessionLifecycleArchivedTranscript[]> {
+): Promise<SessionEntryMaintenanceResult> {
   return await finalizeSqliteSessionEntryMaintenancePlansWithCommit(
     scope,
     plans,
@@ -276,15 +287,30 @@ async function finalizeSqliteSessionEntryMaintenancePlansWithCommit(
   commit: (
     fn: () => SessionLifecycleArchivedTranscript[],
   ) => Promise<SessionLifecycleArchivedTranscript[]>,
-): Promise<SessionLifecycleArchivedTranscript[]> {
+): Promise<SessionEntryMaintenanceResult> {
   const entryRemovals = plans.flatMap((plan) => plan.entryRemovals);
   const stateDeletePlans = plans.flatMap((plan) => plan.stateDeletePlans);
+  const warn = (message: string, error: unknown) => {
+    getChildLogger({ subsystem: "session-sqlite" }).warn(message, {
+      agentId: scope.agentId,
+      error,
+      path: scope.path,
+      sessionIds: uniqueStrings(stateDeletePlans.map((plan) => plan.sessionId)),
+    });
+  };
+  const emptyResult: SessionEntryMaintenanceResult = {
+    archivedTranscripts: [],
+    modelRunPruned: 0,
+    pruned: 0,
+    capped: 0,
+  };
   if (entryRemovals.length === 0 && stateDeletePlans.length === 0) {
-    return [];
+    return emptyResult;
   }
+  let archivedTranscripts: SessionLifecycleArchivedTranscript[];
   try {
     const materializedPlans = await materializeSessionStateDeletePlans(stateDeletePlans);
-    const archivedTranscripts = await commit(() => {
+    archivedTranscripts = await commit(() => {
       let committed: SessionLifecycleArchivedTranscript[] = [];
       runOpenClawAgentWriteTransaction((database) => {
         assertPlannedLifecycleArtifactEntriesUnchanged(database, entryRemovals);
@@ -298,18 +324,26 @@ async function finalizeSqliteSessionEntryMaintenancePlansWithCommit(
       }, toDatabaseOptions(scope));
       return committed;
     });
-    emitCommittedSessionEntryRemovals(entryRemovals);
-    return await publishSessionStateArchives(scope, archivedTranscripts);
   } catch (error) {
-    getChildLogger({ subsystem: "session-sqlite" }).warn(
-      "SQLite session maintenance cleanup failed",
-      {
-        agentId: scope.agentId,
-        error,
-        path: scope.path,
-        sessionIds: uniqueStrings(stateDeletePlans.map((plan) => plan.sessionId)),
-      },
-    );
-    return [];
+    warn("SQLite session maintenance cleanup failed", error);
+    return emptyResult;
+  }
+  const committedCounts = plans.reduce(
+    (counts, plan) => ({
+      modelRunPruned: counts.modelRunPruned + plan.modelRunPruned,
+      pruned: counts.pruned + plan.pruned,
+      capped: counts.capped + plan.capped,
+    }),
+    { modelRunPruned: 0, pruned: 0, capped: 0 },
+  );
+  emitCommittedSessionEntryRemovals(entryRemovals);
+  try {
+    return {
+      archivedTranscripts: await publishSessionStateArchives(scope, archivedTranscripts),
+      ...committedCounts,
+    };
+  } catch (error) {
+    warn("SQLite session maintenance archive publication failed", error);
+    return { archivedTranscripts: [], ...committedCounts };
   }
 }

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -272,11 +272,13 @@ export async function applySessionEntryLifecycleMutation(params: {
     captureArtifactCleanupError(error);
   }
   const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let beforeCount = 0;
     const removedSessionKeys: string[] = [];
     let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
     const maintenancePlans: SessionEntryMaintenancePlan[] = [];
     runOpenClawAgentWriteTransaction((transactionDb) => {
       params.beforeCommitInTransaction?.();
+      beforeCount = readSessionEntryCount(transactionDb);
       const validatedRemovals = projected.removals.filter((removal) => {
         if (
           removalArchiveMaterializationFailed &&
@@ -430,9 +432,9 @@ export async function applySessionEntryLifecycleMutation(params: {
       );
     }, toDatabaseOptions(resolved));
     emitCommittedLifecycleIdentityMutations({ projected, removedSessionKeys });
-    return { archivedTranscripts, maintenancePlans, removedSessionKeys };
+    return { archivedTranscripts, beforeCount, maintenancePlans, removedSessionKeys };
   });
-  const maintenanceArchivedTranscripts =
+  const { archivedTranscripts: maintenanceArchivedTranscripts, ...maintenance } =
     await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
       resolved,
       committed.maintenancePlans,
@@ -470,8 +472,10 @@ export async function applySessionEntryLifecycleMutation(params: {
     }
   }
   return {
+    beforeCount: committed.beforeCount,
     removedEntries: committed.removedSessionKeys.length,
     removedSessionKeys: committed.removedSessionKeys,
+    ...maintenance,
     archivedTranscriptDirectories,
     afterCount,
     artifactCleanupError,
@@ -481,7 +485,7 @@ export async function applySessionEntryLifecycleMutation(params: {
 /** Purges entries owned by a deleted agent from SQLite session rows. */
 export async function purgeDeletedAgentSessionEntries(
   params: DeletedAgentSessionEntryPurgeParams,
-): Promise<SessionEntryLifecycleMutationResult> {
+): Promise<void> {
   const resolved = resolveSqliteStoreScope(params.storePath, { agentId: params.storeAgentId });
   const prepared = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
@@ -524,7 +528,6 @@ export async function purgeDeletedAgentSessionEntries(
   });
   const materializedPlans = await materializeSessionStateDeletePlans(prepared.deletePlans);
   const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const removedSessionKeys = prepared.entryRemovals.map((removal) => removal.sessionKey);
     let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
     const maintenancePlans: SessionEntryMaintenancePlan[] = [];
     runOpenClawAgentWriteTransaction((transactionDb) => {
@@ -561,25 +564,18 @@ export async function purgeDeletedAgentSessionEntries(
       );
     }, toDatabaseOptions(resolved));
     emitCommittedSessionEntryRemovals(prepared.entryRemovals);
-    return { archivedTranscripts, maintenancePlans, removedSessionKeys };
+    return { archivedTranscripts, maintenancePlans };
   });
-  const archivedTranscripts = [
-    ...(await publishSessionStateArchives(resolved, committed.archivedTranscripts)),
-    ...(await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
+  const { archivedTranscripts: maintenanceArchivedTranscripts } =
+    await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
       resolved,
       committed.maintenancePlans,
-    )),
+    );
+  const archivedTranscripts = [
+    ...(await publishSessionStateArchives(resolved, committed.archivedTranscripts)),
+    ...maintenanceArchivedTranscripts,
   ];
-  const afterCount = readSessionEntryCount(openOpenClawAgentDatabase(toDatabaseOptions(resolved)));
   emitArchivedTranscriptUpdates(archivedTranscripts);
-  return {
-    removedEntries: committed.removedSessionKeys.length,
-    removedSessionKeys: committed.removedSessionKeys,
-    archivedTranscriptDirectories: uniqueStrings(
-      archivedTranscripts.map((transcript) => path.dirname(transcript.archivedPath)),
-    ).toSorted(),
-    afterCount,
-  };
 }
 
 /** Fully replaces rows for one transcript in the additive SQLite transcript store. */

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -102,6 +102,7 @@ const mocks = vi.hoisted(() => ({
   })),
   rootWrite: vi.fn(async (_params?: unknown) => {}),
   migrateLegacyMainSessionKeys: vi.fn(),
+  purgeAgentSessionStoreEntries: vi.fn(async () => false),
 }));
 
 const RESERVED_SYSTEM_AGENT_IDS_FOR_TEST = ["openclaw", "crestodian"] as const; // reserved ids
@@ -188,6 +189,11 @@ vi.mock("../../agents/auth-profiles/path-resolve.js", async () => ({
 
 vi.mock("../../config/sessions/legacy-main-session-migration.js", () => ({
   migrateLegacyMainSessionKeys: mocks.migrateLegacyMainSessionKeys,
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions.js")>()),
+  purgeAgentSessionStoreEntries: mocks.purgeAgentSessionStoreEntries,
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -1335,6 +1341,7 @@ describe("agents.delete", () => {
       removedBindings: 2,
     });
     mocks.movePathToTrash.mockReset().mockResolvedValue("/trashed");
+    mocks.purgeAgentSessionStoreEntries.mockReset().mockResolvedValue(false);
   });
 
   it("rejects deleting the auth-inheritance owner before starting cleanup", async () => {
@@ -2816,6 +2823,7 @@ describe("agents.delete", () => {
       removedBindings: 2,
       failed: [],
     });
+    expect(result).not.toHaveProperty("purgeFailed");
     expect(result.removed).toEqual(
       expect.arrayContaining([
         { path: "/workspace/test-agent", method: "trash" },
@@ -2828,6 +2836,15 @@ describe("agents.delete", () => {
       allowedAgentRosterRemovals: ["test-agent"],
     });
     expect(mocks.movePathToTrash).toHaveBeenCalled();
+  });
+
+  it("reports a session purge failure without failing committed deletion", async () => {
+    mocks.purgeAgentSessionStoreEntries.mockResolvedValueOnce(true);
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await promise;
+
+    expectRespondOk(respond, { ok: true, purgeFailed: true });
   });
 
   it("sweeps WAL sidecars recreated between deletion preparation and cleanup", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1267,7 +1267,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
         // A journaled path is trash-eligible only while registry ownership still points at the
         // deleted agent; recovery must not consume a path claimed by a surviving agent.
         const agentDirRegistryPath = normalizeAgentDirRegistryPath(deleteResult.agentDir);
-        await purgeAgentSessionStoreEntries(lockedConfig, agentId);
+        const purgeFailed = await purgeAgentSessionStoreEntries(lockedConfig, agentId);
 
         const removed: AgentDeleteRemovedPath[] = [];
         const failed: AgentDeleteFailedPath[] = [];
@@ -1512,6 +1512,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
           removedBindings: deleteResult.removedBindings,
           removed,
           failed,
+          ...(purgeFailed ? { purgeFailed: true as const } : {}),
         };
       });
       respond(true, result, undefined);

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -415,6 +415,7 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
         const deletionParams = {
           agentId: target.agentId,
           archiveTranscript: incognito ? false : deleteTranscript,
+          deleteDeliveryArtifacts: true,
           deleteTranscriptWithoutArchive: incognito,
           expectedEntry: postCleanupEntry,
           expectedLifecycleRevision,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1386,6 +1386,7 @@ export async function performGatewaySessionReset(params: {
         const deleted = await deleteSessionEntryLifecycle({
           agentId: target.agentId,
           archiveTranscript: false,
+          deleteDeliveryArtifacts: true,
           deleteTranscriptWithoutArchive: true,
           expectedEntry: entry,
           expectedSessionId: entry.sessionId,


### PR DESCRIPTION
Related: #65524

## What Problem This Solves

Fixes three session-store cleanup gaps where operators could receive a successful or inaccurate outcome while stale state survived: agent deletion silently swallowed shared-store purge failures, explicit session deletion left source-bound conversation-delivery rows behind, and `sessions cleanup` reported preview counts after apply-time guards skipped removals.

## Why This Change Was Made

Deletion now records a bounded `purgeFailed: true` fact without falsely claiming the already-committed agent deletion failed. Explicit session teardown removes only delivery operations sourced from that logical session, while automatic pruning continues to retain durable idempotency evidence. Cleanup summaries are built from transaction-owned direct removals and maintenance counts that actually committed, rather than from the earlier preview snapshot.

## User Impact

Operators now see a warning and machine-readable result when agent session purging fails. Full session deletion no longer accumulates source-owned delivery rows, pruning still preserves retry evidence, and cleanup output accurately describes what the apply phase changed.

## Evidence

- Focused regressions: 182 tests passed across agent deletion, Gateway deletion, protocol validation, cleanup races, and conversation-delivery lifecycle.
- Sibling lifecycle/migration/cleanup coverage: 216 tests passed.
- `node scripts/check-changed.mjs` passed, including core/test typechecks, core and Swift lint, storage guards, and selected macOS smoke tests.
- `pnpm test:changed` passed 996 files and 11,838 tests before three current-main-identical Claw project tests failed only on the local case-insensitive macOS checkout; the two timing-sensitive SQLite failures from the loaded shard passed in an isolated rerun. A later main CI run with unchanged Claw sources and fixtures is green: https://github.com/openclaw/openclaw/actions/runs/32021976491.
- `pnpm build` passed.
- Gateway protocol registry, JSON generation, Swift check, Kotlin generation, and protocol-since guard passed.
- Fresh autoreview reported no accepted/actionable findings.
- Source-blind isolated behavior validation passed agent-delete omission/failure reporting, explicit-delete delivery cleanup, prune retention, and strict protocol decoding. The exact internal preview-to-commit race has deterministic owner-boundary regression coverage because no public surface can pause inside that interval.
- Production LOC: +154/-72 (net +82). Tests: +304/-8 (net +296). Generated Swift: +5/-1 (net +4).

AI-assisted; the final diff and behavior were independently reviewed and verified.
