### PR TITLE
improve(ui): simplify Markdown table styling

### DIFF
--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -1,5 +1,6 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
@@ -23,6 +24,29 @@ export type MessageReplyTarget = {
 };
 
 const MAX_JSON_AUTOPARSE_CHARS = 20_000;
+const initializedTableViewports = new WeakSet<HTMLElement>();
+
+function syncMarkdownTableOverflow(root?: Element) {
+  root?.querySelectorAll<HTMLElement>(".chat-markdown-table__viewport").forEach((viewport) => {
+    const shell = viewport.parentElement;
+    if (!shell) {
+      return;
+    }
+    const sync = () => {
+      const remaining = viewport.scrollWidth - viewport.clientWidth;
+      const hasOverflow = remaining > 1;
+      shell.classList.toggle("has-overflow", hasOverflow);
+      shell.classList.toggle("is-scrolled-start", hasOverflow && viewport.scrollLeft > 1);
+      shell.classList.toggle("is-scrolled-end", hasOverflow && viewport.scrollLeft < remaining - 1);
+    };
+    if (!initializedTableViewports.has(viewport)) {
+      initializedTableViewports.add(viewport);
+      viewport.addEventListener("scroll", sync, { passive: true });
+      new ResizeObserver(sync).observe(viewport);
+    }
+    sync();
+  });
+}
 
 /**
  * Detect whether a trimmed string is a JSON object or array.
@@ -299,17 +323,24 @@ export function renderMarkdownText(
 ) {
   const wrapTables = (value: string) =>
     value
-      .replaceAll("<table>", '<div class="chat-markdown-table"><table>')
-      .replaceAll("</table>", "</table></div>");
+      .replaceAll(
+        "<table>",
+        '<div class="chat-markdown-table"><div class="chat-markdown-table__viewport"><table>',
+      )
+      .replaceAll("</table>", "</table></div></div>");
   if (isStreaming) {
     return html`
-      <div class="chat-text" dir="${detectTextDirection(markdown)}">
+      <div
+        ${ref(syncMarkdownTableOverflow)}
+        class="chat-text"
+        dir="${detectTextDirection(markdown)}"
+      >
         ${unsafeHTML(wrapTables(toStreamingMarkdownHtml(markdown, markdownRenderOptions)))}
       </div>
     `;
   }
   return html`
-    <div class="chat-text" dir="${detectTextDirection(markdown)}">
+    <div ${ref(syncMarkdownTableOverflow)} class="chat-text" dir="${detectTextDirection(markdown)}">
       ${unsafeHTML(wrapTables(toSanitizedMarkdownHtml(markdown, markdownRenderOptions)))}
     </div>
   `;

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -36,8 +36,8 @@ function syncMarkdownTableOverflow(root?: Element) {
       const remaining = viewport.scrollWidth - viewport.clientWidth;
       const hasOverflow = remaining > 1;
       shell.classList.toggle("has-overflow", hasOverflow);
-      shell.classList.toggle("is-scrolled-start", hasOverflow && viewport.scrollLeft > 1);
-      shell.classList.toggle("is-scrolled-end", hasOverflow && viewport.scrollLeft < remaining - 1);
+      shell.classList.toggle("has-overflow-left", hasOverflow && viewport.scrollLeft > 1);
+      shell.classList.toggle("has-overflow-right", hasOverflow && viewport.scrollLeft < remaining - 1);
     };
     if (!initializedTableViewports.has(viewport)) {
       initializedTableViewports.add(viewport);

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -297,16 +297,20 @@ export function renderMarkdownText(
   isStreaming: boolean,
   markdownRenderOptions?: MarkdownRenderOptions,
 ) {
+  const wrapTables = (value: string) =>
+    value
+      .replaceAll("<table>", '<div class="chat-markdown-table"><table>')
+      .replaceAll("</table>", "</table></div>");
   if (isStreaming) {
     return html`
       <div class="chat-text" dir="${detectTextDirection(markdown)}">
-        ${unsafeHTML(toStreamingMarkdownHtml(markdown, markdownRenderOptions))}
+        ${unsafeHTML(wrapTables(toStreamingMarkdownHtml(markdown, markdownRenderOptions)))}
       </div>
     `;
   }
   return html`
     <div class="chat-text" dir="${detectTextDirection(markdown)}">
-      ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
+      ${unsafeHTML(wrapTables(toSanitizedMarkdownHtml(markdown, markdownRenderOptions)))}
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -1,6 +1,5 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
-import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
@@ -24,29 +23,6 @@ export type MessageReplyTarget = {
 };
 
 const MAX_JSON_AUTOPARSE_CHARS = 20_000;
-const initializedTableViewports = new WeakSet<HTMLElement>();
-
-function syncMarkdownTableOverflow(root?: Element) {
-  root?.querySelectorAll<HTMLElement>(".chat-markdown-table__viewport").forEach((viewport) => {
-    const shell = viewport.parentElement;
-    if (!shell) {
-      return;
-    }
-    const sync = () => {
-      const remaining = viewport.scrollWidth - viewport.clientWidth;
-      const hasOverflow = remaining > 1;
-      shell.classList.toggle("has-overflow", hasOverflow);
-      shell.classList.toggle("has-overflow-left", hasOverflow && viewport.scrollLeft > 1);
-      shell.classList.toggle("has-overflow-right", hasOverflow && viewport.scrollLeft < remaining - 1);
-    };
-    if (!initializedTableViewports.has(viewport)) {
-      initializedTableViewports.add(viewport);
-      viewport.addEventListener("scroll", sync, { passive: true });
-      new ResizeObserver(sync).observe(viewport);
-    }
-    sync();
-  });
-}
 
 /**
  * Detect whether a trimmed string is a JSON object or array.
@@ -321,27 +297,16 @@ export function renderMarkdownText(
   isStreaming: boolean,
   markdownRenderOptions?: MarkdownRenderOptions,
 ) {
-  const wrapTables = (value: string) =>
-    value
-      .replaceAll(
-        "<table>",
-        '<div class="chat-markdown-table"><div class="chat-markdown-table__viewport"><table>',
-      )
-      .replaceAll("</table>", "</table></div></div>");
   if (isStreaming) {
     return html`
-      <div
-        ${ref(syncMarkdownTableOverflow)}
-        class="chat-text"
-        dir="${detectTextDirection(markdown)}"
-      >
-        ${unsafeHTML(wrapTables(toStreamingMarkdownHtml(markdown, markdownRenderOptions)))}
+      <div class="chat-text" dir="${detectTextDirection(markdown)}">
+        ${unsafeHTML(toStreamingMarkdownHtml(markdown, markdownRenderOptions))}
       </div>
     `;
   }
   return html`
-    <div ${ref(syncMarkdownTableOverflow)} class="chat-text" dir="${detectTextDirection(markdown)}">
-      ${unsafeHTML(wrapTables(toSanitizedMarkdownHtml(markdown, markdownRenderOptions)))}
+    <div class="chat-text" dir="${detectTextDirection(markdown)}">
+      ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
     </div>
   `;
 }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -185,7 +185,6 @@
 
 .chat-thread .chat-bubble .chat-text :where(table) {
   width: max-content;
-  min-width: 100%;
   margin: 0;
   border: 0;
   border-collapse: collapse;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -169,22 +169,41 @@
 /* Transcript tables use horizontal structure instead of a nested card surface.
    Local cover gradients reveal only the edge that still has scrollable content. */
 .chat-thread .chat-bubble .chat-markdown-table {
+  position: relative;
   width: 100%;
   margin-block: 1.25em;
+}
+
+.chat-thread .chat-bubble .chat-markdown-table__viewport {
+  width: 100%;
   overflow-x: auto;
-  background:
-    linear-gradient(to right, var(--bg) 30%, transparent) left / 32px 100% local,
-    linear-gradient(to left, var(--bg) 30%, transparent) right / 32px 100% local,
-    linear-gradient(to right, color-mix(in srgb, var(--bg) 8%, transparent), transparent) left / 32px
-      100% scroll,
-    linear-gradient(to left, color-mix(in srgb, var(--text) 14%, transparent), transparent) right /
-      32px 100% scroll;
-  background-repeat: no-repeat;
   scrollbar-width: thin;
+}
+
+.chat-thread .chat-bubble .chat-markdown-table::before,
+.chat-thread .chat-bubble .chat-markdown-table::after {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  bottom: 0;
+  width: 32px;
+  pointer-events: none;
+  content: "";
+}
+
+.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-start::before {
+  left: 0;
+  background: linear-gradient(to right, var(--bg), transparent);
+}
+
+.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-end::after {
+  right: 0;
+  background: linear-gradient(to left, var(--bg), transparent);
 }
 
 .chat-thread .chat-bubble .chat-text :where(table) {
   width: max-content;
+  min-width: 100%;
   margin: 0;
   border: 0;
   border-collapse: collapse;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -227,9 +227,6 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
-  width: max-content;
-  min-width: clamp(10rem, 18vw, 20rem);
-  max-width: 24rem;
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
   overflow-wrap: break-word;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -181,10 +181,12 @@
 }
 
 .chat-thread .chat-bubble .chat-markdown-table.has-overflow-left .chat-markdown-table__viewport {
+  -webkit-mask-image: linear-gradient(to right, transparent, black 32px);
   mask-image: linear-gradient(to right, transparent, black 32px);
 }
 
 .chat-thread .chat-bubble .chat-markdown-table.has-overflow-right .chat-markdown-table__viewport {
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
   mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
 }
 
@@ -192,6 +194,13 @@
   .chat-bubble
   .chat-markdown-table.has-overflow-left.has-overflow-right
   .chat-markdown-table__viewport {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent,
+    black 32px,
+    black calc(100% - 32px),
+    transparent
+  );
   mask-image: linear-gradient(
     to right,
     transparent,
@@ -203,7 +212,7 @@
 
 .chat-thread .chat-bubble .chat-text :where(table) {
   display: table;
-  width: 100%;
+  width: max-content;
   min-width: 100%;
   margin: 0;
   border: 0;
@@ -218,6 +227,7 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
+  width: max-content;
   min-width: 8rem;
   max-width: 24rem;
   border-right: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -98,17 +98,18 @@
   margin-top: 0.75em;
 }
 
-/* Tables retain spacing even when first or last so their horizontal structure
-   stays distinct from adjacent prose. */
+/* Tables retain top margin even when first; the adjacent-block rule above gives
+   tables the same rhythm when they follow another Markdown block. */
 .chat-text :where(table) {
-  margin-block: 1.25em;
-  border: 0;
-  border-collapse: collapse;
+  margin-top: 0.75em;
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  border-radius: var(--radius-md);
+  border-collapse: separate;
   border-spacing: 0;
   width: fit-content;
   max-width: 100%;
-  background: transparent;
-  box-shadow: none;
+  background: color-mix(in srgb, var(--accent) 2%, var(--bg-elevated));
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 4%, transparent);
   font-size: 13px;
   display: block;
   overflow-x: auto;
@@ -116,8 +117,8 @@
 
 .chat-text :where(th, td) {
   padding: 8px 12px;
-  border-right: 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 42%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
   text-align: left;
   vertical-align: middle;
 }
@@ -137,20 +138,59 @@
 }
 
 .chat-text :where(th) {
-  border-bottom-color: var(--border-strong);
-  background: transparent;
+  border-bottom-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 10%, var(--secondary)),
+    color-mix(in srgb, var(--accent) 6%, var(--secondary))
+  );
   color: var(--text-strong);
   font-family: var(--font-body);
   font-weight: 600;
 }
 
-.chat-text :where(tbody tr:nth-child(even), tbody tr:hover) {
-  background: transparent;
+.chat-text :where(tbody tr) {
+  transition: background var(--duration-fast) ease;
+}
+
+.chat-text :where(tbody tr:nth-child(even)) {
+  background: color-mix(in srgb, var(--accent) 3%, transparent);
+}
+
+.chat-text :where(tbody tr:hover) {
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-elevated));
 }
 
 .chat-text :where(tbody td:first-child) {
   color: var(--text-strong);
   font-weight: 500;
+}
+
+/* Transcript tables use horizontal structure instead of a nested card surface. */
+.chat-thread .chat-bubble .chat-text :where(table) {
+  margin-block: 1.25em;
+  border: 0;
+  border-collapse: collapse;
+  background: transparent;
+  box-shadow: none;
+}
+
+.chat-thread .chat-bubble .chat-text :where(th, td) {
+  border-right: 0;
+  border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
+}
+
+.chat-thread .chat-bubble .chat-text :where(th) {
+  border-bottom-color: var(--border-strong);
+  background: transparent;
+}
+
+.chat-thread .chat-bubble .chat-text :where(tbody tr) {
+  transition: none;
+}
+
+.chat-thread .chat-bubble .chat-text :where(tbody tr:nth-child(even), tbody tr:hover) {
+  background: transparent;
 }
 
 :is(.chat-text, .chat-thinking) {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -180,17 +180,17 @@
   scrollbar-width: thin;
 }
 
-.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-start .chat-markdown-table__viewport {
+.chat-thread .chat-bubble .chat-markdown-table.has-overflow-left .chat-markdown-table__viewport {
   mask-image: linear-gradient(to right, transparent, black 32px);
 }
 
-.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-end .chat-markdown-table__viewport {
+.chat-thread .chat-bubble .chat-markdown-table.has-overflow-right .chat-markdown-table__viewport {
   mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
 }
 
 .chat-thread
   .chat-bubble
-  .chat-markdown-table.is-scrolled-start.is-scrolled-end
+  .chat-markdown-table.has-overflow-left.has-overflow-right
   .chat-markdown-table__viewport {
   mask-image: linear-gradient(
     to right,
@@ -210,6 +210,10 @@
   background: transparent;
   box-shadow: none;
   overflow: visible;
+}
+
+.chat-thread .chat-bubble .chat-text :where(table, thead, tbody, tr, th, td) {
+  background: transparent;
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -228,7 +228,7 @@
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
   width: max-content;
-  min-width: 8rem;
+  min-width: clamp(10rem, 18vw, 20rem);
   max-width: 24rem;
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -237,6 +237,10 @@
   word-break: normal;
 }
 
+.chat-thread .chat-bubble .chat-text :where(th:first-child, td:first-child) {
+  padding-inline-start: 0;
+}
+
 .chat-thread .chat-bubble .chat-text :where(th) {
   border-bottom-color: var(--border-strong);
   background: transparent;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -166,52 +166,10 @@
   font-weight: 500;
 }
 
-/* Transcript tables use horizontal structure instead of a nested card surface.
-   Local cover gradients reveal only the edge that still has scrollable content. */
-.chat-thread .chat-bubble .chat-markdown-table {
-  position: relative;
-  width: 100%;
-  margin-block: 1.25em;
-}
-
-.chat-thread .chat-bubble .chat-markdown-table__viewport {
-  width: 100%;
-  overflow-x: auto;
-  scrollbar-width: thin;
-}
-
-.chat-thread .chat-bubble .chat-markdown-table.has-overflow-left .chat-markdown-table__viewport {
-  -webkit-mask-image: linear-gradient(to right, transparent, black 32px);
-  mask-image: linear-gradient(to right, transparent, black 32px);
-}
-
-.chat-thread .chat-bubble .chat-markdown-table.has-overflow-right .chat-markdown-table__viewport {
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
-  mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
-}
-
-.chat-thread
-  .chat-bubble
-  .chat-markdown-table.has-overflow-left.has-overflow-right
-  .chat-markdown-table__viewport {
-  -webkit-mask-image: linear-gradient(
-    to right,
-    transparent,
-    black 32px,
-    black calc(100% - 32px),
-    transparent
-  );
-  mask-image: linear-gradient(
-    to right,
-    transparent,
-    black 32px,
-    black calc(100% - 32px),
-    transparent
-  );
-}
-
 .chat-thread .chat-bubble .chat-text :where(table) {
   display: table;
+  overflow-x: auto;
+  scrollbar-width: thin;
   width: max-content;
   min-width: 100%;
   margin: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -227,6 +227,7 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
+  padding-block: 10px;
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
   overflow-wrap: break-word;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -202,7 +202,7 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(table) {
-  width: max-content;
+  width: 100%;
   min-width: 100%;
   margin: 0;
   border: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -168,8 +168,6 @@
 
 .chat-thread .chat-bubble .chat-text :where(table) {
   display: table;
-  overflow-x: auto;
-  scrollbar-width: thin;
   width: max-content;
   min-width: 100%;
   margin: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -217,10 +217,12 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
+  min-width: 8rem;
+  max-width: 24rem;
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
-  overflow-wrap: normal;
-  white-space: nowrap;
+  overflow-wrap: break-word;
+  white-space: normal;
   word-break: normal;
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -220,6 +220,7 @@
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
   overflow-wrap: normal;
+  white-space: nowrap;
   word-break: normal;
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -180,25 +180,25 @@
   scrollbar-width: thin;
 }
 
-.chat-thread .chat-bubble .chat-markdown-table::before,
-.chat-thread .chat-bubble .chat-markdown-table::after {
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  bottom: 0;
-  width: 32px;
-  pointer-events: none;
-  content: "";
+.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-start .chat-markdown-table__viewport {
+  mask-image: linear-gradient(to right, transparent, black 32px);
 }
 
-.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-start::before {
-  left: 0;
-  background: linear-gradient(to right, var(--bg), transparent);
+.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-end .chat-markdown-table__viewport {
+  mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
 }
 
-.chat-thread .chat-bubble .chat-markdown-table.is-scrolled-end::after {
-  right: 0;
-  background: linear-gradient(to left, var(--bg), transparent);
+.chat-thread
+  .chat-bubble
+  .chat-markdown-table.is-scrolled-start.is-scrolled-end
+  .chat-markdown-table__viewport {
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black 32px,
+    black calc(100% - 32px),
+    transparent
+  );
 }
 
 .chat-thread .chat-bubble .chat-text :where(table) {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -227,7 +227,7 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
-  padding-block: 10px;
+  padding-block: 12px;
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
   overflow-wrap: break-word;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -202,6 +202,7 @@
 }
 
 .chat-thread .chat-bubble .chat-text :where(table) {
+  display: table;
   width: 100%;
   min-width: 100%;
   margin: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -166,18 +166,39 @@
   font-weight: 500;
 }
 
-/* Transcript tables use horizontal structure instead of a nested card surface. */
-.chat-thread .chat-bubble .chat-text :where(table) {
+/* Transcript tables use horizontal structure instead of a nested card surface.
+   Local cover gradients reveal only the edge that still has scrollable content. */
+.chat-thread .chat-bubble .chat-markdown-table {
+  width: 100%;
   margin-block: 1.25em;
+  overflow-x: auto;
+  background:
+    linear-gradient(to right, var(--bg) 30%, transparent) left / 32px 100% local,
+    linear-gradient(to left, var(--bg) 30%, transparent) right / 32px 100% local,
+    linear-gradient(to right, color-mix(in srgb, var(--bg) 8%, transparent), transparent) left / 32px
+      100% scroll,
+    linear-gradient(to left, color-mix(in srgb, var(--text) 14%, transparent), transparent) right /
+      32px 100% scroll;
+  background-repeat: no-repeat;
+  scrollbar-width: thin;
+}
+
+.chat-thread .chat-bubble .chat-text :where(table) {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
   border: 0;
   border-collapse: collapse;
   background: transparent;
   box-shadow: none;
+  overflow: visible;
 }
 
 .chat-thread .chat-bubble .chat-text :where(th, td) {
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 .chat-thread .chat-bubble .chat-text :where(th) {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -98,18 +98,17 @@
   margin-top: 0.75em;
 }
 
-/* Tables retain top margin even when first; the adjacent-block rule above gives
-   tables the same rhythm when they follow another Markdown block. */
+/* Tables retain spacing even when first or last so their horizontal structure
+   stays distinct from adjacent prose. */
 .chat-text :where(table) {
-  margin-top: 0.75em;
-  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
-  border-radius: var(--radius-md);
-  border-collapse: separate;
+  margin-block: 1.25em;
+  border: 0;
+  border-collapse: collapse;
   border-spacing: 0;
   width: fit-content;
   max-width: 100%;
-  background: color-mix(in srgb, var(--accent) 2%, var(--bg-elevated));
-  box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 4%, transparent);
+  background: transparent;
+  box-shadow: none;
   font-size: 13px;
   display: block;
   overflow-x: auto;
@@ -117,8 +116,8 @@
 
 .chat-text :where(th, td) {
   padding: 8px 12px;
-  border-right: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
-  border-bottom: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+  border-right: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 42%, transparent);
   text-align: left;
   vertical-align: middle;
 }
@@ -138,27 +137,15 @@
 }
 
 .chat-text :where(th) {
-  border-bottom-color: color-mix(in srgb, var(--accent) 28%, var(--border));
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--accent) 10%, var(--secondary)),
-    color-mix(in srgb, var(--accent) 6%, var(--secondary))
-  );
+  border-bottom-color: var(--border-strong);
+  background: transparent;
   color: var(--text-strong);
   font-family: var(--font-body);
   font-weight: 600;
 }
 
-.chat-text :where(tbody tr) {
-  transition: background var(--duration-fast) ease;
-}
-
-.chat-text :where(tbody tr:nth-child(even)) {
-  background: color-mix(in srgb, var(--accent) 3%, transparent);
-}
-
-.chat-text :where(tbody tr:hover) {
-  background: color-mix(in srgb, var(--accent) 7%, var(--bg-elevated));
+.chat-text :where(tbody tr:nth-child(even), tbody tr:hover) {
+  background: transparent;
 }
 
 .chat-text :where(tbody td:first-child) {


### PR DESCRIPTION
Closes #125218

## What Problem This Solves

Resolves a problem where Markdown tables in the Control UI transcript appear as heavy nested cards because they combine a filled surface, outer and vertical borders, zebra striping, and hover fills. Their tight vertical spacing also makes them stick to adjacent prose.

## Why This Change Was Made

This change makes transcript tables transparent, removes their outer and vertical borders and row fills, strengthens only the divider below the header, and leaves body-row separators extremely subtle. It also increases block spacing above and below tables while preserving the existing compact and wide-content sizing and horizontal overflow behavior.

Plan and scope:

1. Keep the change in the table-owned CSS rules in `ui/src/styles/chat/text.css`.
2. Preserve current `fit-content`, `max-width`, block display, and horizontal scrolling behavior.
3. Exclude overflow fades, breakout, copy/fullscreen controls, dialog/lightbox behavior, and `X`/`Esc` dismissal for a separate table-interactions change.

## User Impact

Markdown tables now read as part of the surrounding response rather than a nested card. Header and row boundaries remain legible without vertical grid lines or interactive row fills, and added whitespace separates tables from adjacent prose.

## Evidence

- Source inspection confirms the change is limited to the transcript table rules in `ui/src/styles/chat/text.css`.
- Diff size: production CSS `+13/-26`; no tests or generated files changed.
- Local tests, build, checks, lint, format, install, screenshots, autoreview, and CI monitoring were intentionally not run for this task.
- The two canonical reference images were unavailable at their temporary filesystem paths during implementation. The complete written design contract and read-only lab CSS were used as evidence; no screenshot proof is attached.
