### PR TITLE
fix(sessions): preserve transcript idempotency keys

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2767,7 +2767,7 @@ src/config/sessions/session-accessor.sqlite-entry.ts	1
 src/config/sessions/session-accessor.sqlite-history-events.ts	2
 src/config/sessions/session-accessor.sqlite-message-cut.ts	1
 src/config/sessions/session-accessor.sqlite-parent-fork.ts	1
-src/config/sessions/session-accessor.sqlite-read.ts	12
+src/config/sessions/session-accessor.sqlite-read.ts	11
 src/config/sessions/session-accessor.sqlite-recovery.ts	1
 src/config/sessions/session-accessor.sqlite-reset-window.ts	3
 src/config/sessions/session-accessor.sqlite-session-row.ts	1

--- a/src/config/sessions/session-accessor.idempotency-redaction.test.ts
+++ b/src/config/sessions/session-accessor.idempotency-redaction.test.ts
@@ -1,0 +1,184 @@
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  appendTranscriptMessage,
+  appendTranscriptMessages,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+describe("SQLite transcript idempotency redaction", () => {
+  const tempDirs: string[] = [];
+  let storePath: string;
+
+  beforeEach(() => {
+    storePath = path.join(
+      makeTempDir(tempDirs, "openclaw-idempotency-redaction-"),
+      "sessions.json",
+    );
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    cleanupTempDirs(tempDirs);
+  });
+
+  it.each([
+    {
+      idempotencyKey: "7c311c86-7836-4f47-bffc-aa8c3cbf261e:user",
+      name: "credential-like UUID",
+    },
+    {
+      idempotencyKey: "sk-abcdef1234567890xyz:user",
+      name: "caller-supplied secret",
+    },
+  ])("keeps $name identity outside redacted event JSON", async ({ idempotencyKey }) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-redacted-replay",
+      sessionKey: "agent:main:redacted-replay",
+      storePath,
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const message = {
+      role: "user",
+      content: "same secret sk-abcdef1234567890xyz",
+      idempotencyKey,
+      timestamp: 1,
+    };
+    const first = await appendTranscriptMessage(scope, {
+      idempotencyLookup: "scan",
+      message,
+    });
+    const replay = await appendTranscriptMessage(scope, {
+      idempotencyLookup: "scan",
+      message,
+    });
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "idempotency redaction database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const stored = database.db
+      .prepare(
+        `SELECT identity.message_idempotency_key AS idempotencyKey,
+                event.event_json AS eventJson
+           FROM transcript_event_identities AS identity
+           JOIN transcript_events AS event
+             ON event.session_id = identity.session_id AND event.seq = identity.seq
+          WHERE identity.session_id = ? AND identity.event_id = ?`,
+      )
+      .get(scope.sessionId, first.messageId) as
+      | { eventJson: string; idempotencyKey: string }
+      | undefined;
+
+    expect(first.appended).toBe(true);
+    expect(JSON.stringify(first.message)).not.toContain(idempotencyKey);
+    expect(JSON.stringify(first.message)).not.toContain("sk-abcdef1234567890xyz");
+    expect(stored).toMatchObject({ idempotencyKey });
+    expect(stored?.eventJson).not.toContain(idempotencyKey);
+    expect(replay).toMatchObject({ appended: false, messageId: first.messageId });
+  });
+
+  it("replays a redacted assistant message through its raw identity index", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-redacted-assistant-replay",
+      sessionKey: "agent:main:redacted-assistant-replay",
+      storePath,
+    };
+    const idempotencyKey = "sk-abcdef1234567890xyz:assistant";
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "same secret sk-abcdef1234567890xyz" }],
+      idempotencyKey,
+      timestamp: 1,
+    };
+
+    const first = await appendTranscriptMessage(scope, {
+      idempotencyLookup: "scan-assistant",
+      message,
+    });
+    const replay = await appendTranscriptMessage(scope, {
+      idempotencyLookup: "scan-assistant",
+      message,
+    });
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "assistant idempotency redaction database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const stored = database.db
+      .prepare(
+        `SELECT identity.message_idempotency_key AS idempotencyKey,
+                event.event_json AS eventJson
+           FROM transcript_event_identities AS identity
+           JOIN transcript_events AS event
+             ON event.session_id = identity.session_id AND event.seq = identity.seq
+          WHERE identity.session_id = ? AND identity.event_id = ?`,
+      )
+      .get(scope.sessionId, first.messageId) as
+      | { eventJson: string; idempotencyKey: string }
+      | undefined;
+
+    expect(first.appended).toBe(true);
+    expect(replay).toMatchObject({ appended: false, messageId: first.messageId });
+    expect(JSON.stringify(first.message)).not.toContain(idempotencyKey);
+    expect(stored).toMatchObject({ idempotencyKey });
+    expect(stored?.eventJson).not.toContain(idempotencyKey);
+  });
+
+  it("preserves raw replay identity across a pre-redacted atomic batch", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-redacted-batch-replay",
+      sessionKey: "agent:main:redacted-batch-replay",
+      storePath,
+    };
+    const idempotencyKey = "sk-abcdef1234567890xyz:batch";
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const message = {
+      role: "user",
+      content: "same secret sk-abcdef1234567890xyz",
+      idempotencyKey,
+      timestamp: 1,
+    };
+
+    const [first] = await appendTranscriptMessages(scope, {
+      messages: [{ idempotencyLookup: "scan", message }],
+    });
+    const [replay] = await appendTranscriptMessages(scope, {
+      messages: [{ idempotencyLookup: "scan", message }],
+    });
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "batch idempotency redaction database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const stored = database.db
+      .prepare(
+        `SELECT identity.message_idempotency_key AS idempotencyKey,
+                event.event_json AS eventJson
+           FROM transcript_event_identities AS identity
+           JOIN transcript_events AS event
+             ON event.session_id = identity.session_id AND event.seq = identity.seq
+          WHERE identity.session_id = ? AND identity.event_id = ?`,
+      )
+      .get(scope.sessionId, expectDefined(first?.messageId, "batch first message id")) as
+      | { eventJson: string; idempotencyKey: string }
+      | undefined;
+
+    expect(first).toMatchObject({ appended: true });
+    expect(replay).toMatchObject({ appended: false, messageId: first?.messageId });
+    expect(stored).toMatchObject({ idempotencyKey });
+    expect(stored?.eventJson).not.toContain(idempotencyKey);
+    expect(stored?.eventJson).not.toContain("sk-abcdef1234567890xyz");
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -397,7 +397,7 @@ export async function findTranscriptEvent(
   return findTranscriptEventInDatabase(database, resolved.sessionId, match);
 }
 
-export function findTranscriptEventInDatabase(
+function findTranscriptEventInDatabase(
   database: OpenClawAgentDatabase,
   sessionId: string,
   match: (event: TranscriptEvent) => boolean,
@@ -434,12 +434,4 @@ export function readTranscriptEventMessage(
   return message && typeof message === "object" && !Array.isArray(message)
     ? (message as Record<string, unknown>)
     : undefined;
-}
-
-export function readTranscriptEventId(event: TranscriptEvent): string | undefined {
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
-    return undefined;
-  }
-  const id = (event as { id?: unknown }).id;
-  return typeof id === "string" && id.trim() ? id : undefined;
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -14,6 +14,7 @@ import {
   appendTranscriptEventInTransaction,
   ensureTranscriptHeader,
   readMessageIdempotencyKey,
+  readPreservedTranscriptMessageIdempotencyKey,
   readTranscriptIdentityByEventId,
   readTranscriptMessageByEventId,
   readTranscriptMessageByScopedIdempotencyKey,
@@ -68,7 +69,9 @@ export function appendTranscriptMessageInTransaction<TMessage>(
       messageId: found.messageId,
     };
   };
-  const idempotencyKey = readMessageIdempotencyKey(options.message);
+  const idempotencyKey =
+    readPreservedTranscriptMessageIdempotencyKey(options) ??
+    readMessageIdempotencyKey(options.message);
   if (idempotencyKey && options.idempotencyLookup !== "caller-checked") {
     const existing = readTranscriptMessageByScopedIdempotencyKey(
       database,
@@ -110,6 +113,7 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     dedupeByMessageIdempotency:
       options.idempotencyLookup !== "caller-checked" &&
       options.idempotencyLookup !== "scan-assistant",
+    ...(idempotencyKey ? { indexedMessageIdempotencyKey: idempotencyKey } : {}),
   });
   if (!appended && idempotencyKey && options.idempotencyLookup !== "caller-checked") {
     const existing = readTranscriptMessageByScopedIdempotencyKey(

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -11,12 +11,7 @@ import type {
   TranscriptEvent,
   TranscriptMessageAppendOptions,
 } from "./session-accessor.sqlite-contract.js";
-import {
-  findTranscriptEventInDatabase,
-  loadTranscriptEventsFromDatabase,
-  readTranscriptEventId,
-  readTranscriptEventMessage,
-} from "./session-accessor.sqlite-read.js";
+import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import {
   advanceTranscriptMutationAtInTransaction,
@@ -42,6 +37,24 @@ import {
 } from "./transcript-tree.js";
 import { resolveVisibleTranscriptAppendParentId } from "./transcript-visible-events.js";
 
+const indexedTranscriptMessageIdempotencyKey = Symbol("indexedTranscriptMessageIdempotencyKey");
+
+export function preserveIndexedTranscriptMessageIdempotencyKey<T extends object>(
+  value: T,
+  message: unknown,
+): T {
+  const idempotencyKey = readMessageIdempotencyKey(message);
+  if (idempotencyKey) {
+    Object.assign(value, { [indexedTranscriptMessageIdempotencyKey]: idempotencyKey });
+  }
+  return value;
+}
+
+export function readPreservedTranscriptMessageIdempotencyKey(value: object): string | undefined {
+  const key = Reflect.get(value, indexedTranscriptMessageIdempotencyKey);
+  return typeof key === "string" && key.trim() ? key : undefined;
+}
+
 export function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
@@ -49,6 +62,7 @@ export function appendTranscriptEventInTransaction(
   options: {
     allowStoredAlias?: boolean;
     dedupeByMessageIdempotency?: boolean;
+    indexedMessageIdempotencyKey?: string;
     onProjectionReconcileNeeded?: () => void;
     scheduleProjectionReconcile?: boolean;
     touchMutation?: boolean;
@@ -61,7 +75,14 @@ export function appendTranscriptEventInTransaction(
     allowStoredAlias: options.allowStoredAlias === true,
   });
   ensureTranscriptGenerationInTransaction(database, scope.sessionId);
-  const identity = readTranscriptEventIdentity(persistedEvent);
+  const persistedIdentity = readTranscriptEventIdentity(persistedEvent);
+  const identity = persistedIdentity
+    ? {
+        ...persistedIdentity,
+        messageIdempotencyKey:
+          options.indexedMessageIdempotencyKey ?? persistedIdentity.messageIdempotencyKey,
+      }
+    : undefined;
   if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
     return false;
   }
@@ -532,16 +553,9 @@ export function readTranscriptMessageByScopedIdempotencyKey(
   if (lookup !== "scan-assistant") {
     return readTranscriptMessageByIdempotencyKey(database, scope, idempotencyKey);
   }
-  const found = findTranscriptEventInDatabase(database, scope.sessionId, (event) => {
-    const message = readTranscriptEventMessage(event);
-    return message?.role === "assistant" && message.idempotencyKey === idempotencyKey;
-  });
-  if (!found) {
-    return undefined;
-  }
-  const message = readTranscriptEventMessage(found.event);
-  return message
-    ? { messageId: readTranscriptEventId(found.event) ?? idempotencyKey, message }
+  const found = readTranscriptMessageByIdempotencyKey(database, scope, idempotencyKey);
+  return found && isTranscriptAgentMessage(found.message) && found.message.role === "assistant"
+    ? found
     : undefined;
 }
 

--- a/src/config/sessions/session-accessor.transcript-turn.ts
+++ b/src/config/sessions/session-accessor.transcript-turn.ts
@@ -19,7 +19,10 @@ import {
   readCommittedTranscriptMessageSequence,
   rememberCommittedTranscriptMessageSequences,
 } from "./session-accessor.sqlite-transcript-sequences.js";
-import { redactTranscriptMessageForStorage } from "./session-accessor.sqlite-transcript-store.js";
+import {
+  preserveIndexedTranscriptMessageIdempotencyKey,
+  redactTranscriptMessageForStorage,
+} from "./session-accessor.sqlite-transcript-store.js";
 import { appendExpectedSessionTranscriptTurn } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSessionTranscriptRuntimeTarget } from "./session-accessor.transcript-target.js";
 import { appendTranscriptMessage, emitTranscriptUpdate } from "./session-accessor.transcript.js";
@@ -122,12 +125,17 @@ export async function appendTranscriptMessages<TMessage>(
     config: options.config,
     cwd: options.cwd,
     expectedSessionId,
-    messages: options.messages.map((append) => ({
-      ...append,
-      eventId: append.eventId ?? randomUUID(),
-      message: redactTranscriptMessageForStorage(append.message, options),
-      now: append.now ?? Date.now(),
-    })),
+    messages: options.messages.map((append) =>
+      preserveIndexedTranscriptMessageIdempotencyKey(
+        {
+          ...append,
+          eventId: append.eventId ?? randomUUID(),
+          message: redactTranscriptMessageForStorage(append.message, options),
+          now: append.now ?? Date.now(),
+        },
+        append.message,
+      ),
+    ),
     updateMode: "none",
   });
   if (turn.rejectedReason) {

--- a/src/gateway/server-methods/chat.inject.parentid.test.ts
+++ b/src/gateway/server-methods/chat.inject.parentid.test.ts
@@ -172,4 +172,37 @@ describe("gateway chat.inject transcript writes", () => {
       await cleanupFixture(fixture);
     }
   });
+
+  it("deduplicates a redacted injected assistant message by its raw identity", async () => {
+    const fixture = await createSqliteTranscriptFixture({
+      prefix: "openclaw-chat-inject-idempotency-redact-",
+      sessionId: "sess-idempotency-redact",
+    });
+    const idempotencyKey = "sk-proj-FAKEKEYFORTESTINGONLY1234567890:assistant";
+
+    try {
+      const params = {
+        agentId: fixture.agentId,
+        sessionId: fixture.sessionId,
+        sessionKey: fixture.sessionKey,
+        storePath: fixture.storePath,
+        message: "gateway retry",
+        idempotencyKey,
+      };
+      const first = await appendInjectedAssistantMessageToTranscript(params);
+      const replay = await appendInjectedAssistantMessageToTranscript(params);
+      const assistantEvents = (await readTranscriptEvents(fixture)).filter((event) => {
+        const message = event.message as { role?: unknown } | undefined;
+        return message?.role === "assistant";
+      });
+
+      expect(first.ok, first.error).toBe(true);
+      expect(replay.ok, replay.error).toBe(true);
+      expect(replay.messageId).toBe(first.messageId);
+      expect(assistantEvents).toHaveLength(1);
+      expect(JSON.stringify(assistantEvents)).not.toContain(idempotencyKey);
+    } finally {
+      await cleanupFixture(fixture);
+    }
+  });
 });


### PR DESCRIPTION
Closes #125214

## What Problem This Solves

Transcript storage redacts secret-shaped substrings before persistence. When a generated idempotency key matches that detector, the durable replay identity is mutated and exact replay/deduplication can fail.

## Why This Change Was Made

This candidate keeps persisted transcript event JSON redacted while carrying the original key to the existing SQLite identity owner during the append transaction. Single-message, atomic-batch, and Gateway-injected assistant retries then use that identity index for replay lookup.

The branch is deliberately **draft** after exact-head adversarial review found that the apparently narrow design crosses two Critical contracts:

- retaining an exact secret-shaped caller key in SQLite conflicts with the intended redaction-at-rest boundary;
- one globally unique raw-key identity cannot safely distinguish a user event and an assistant event that reuse the same key.

A robust repair likely needs a separately typed one-way identity field plus a database migration. That is a broader persistence contract and should not be invented in contributor polish without a domain maintainer choosing the seam.

## User Impact

If the final design is accepted, exact retries whose idempotency keys resemble secrets will deduplicate correctly without exposing the key in transcript event JSON. This draft is not ready to merge until the identity-at-rest and role-scoping contracts are resolved.

## Evidence

Exact rebased head: `9774b240630168e1103a0ff4c6956583d916556e`

- Focused transcript idempotency/redaction regression: 5/5 passed.
- Focused Gateway `chat.inject` regression: 4/4 passed.
- `pnpm check:changed` passed on the rebased candidate.
- `git diff --check` passed.
- Clean-context adversarial review identified the two unresolved Critical design issues above; they are intentionally not hidden behind green tests.

## Owner Acceptance Card

- **Intent:** preserve deterministic replay when an idempotency key is transformed by transcript redaction.
- **Assurance / blast radius:** Critical; transcript persistence, secret handling, and replay identity.
- **Strongest evidence:** real SQLite regressions cover user, assistant, and atomic-batch replay paths on the rebased head.
- **Known falsifier:** a secret-shaped key is recoverable from SQLite at rest, or a shared user/assistant key causes the assistant replay lookup to miss.
- **Rollback:** revert the candidate; no schema migration is present in this draft.
- **Remaining human decision:** choose whether exact raw identity metadata is acceptable at rest or sponsor a schema-separated one-way identity design with explicit role scoping and migration behavior.

AI-assisted: yes. Codex rebased, tested, and adversarially reviewed the candidate. The draft status is intentional pending a domain-competent maintainer decision on the dangerous boundary.
