### PR TITLE
fix(ui): contain session suggestions to composer width

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1706,7 +1706,11 @@ button.chat-reply-preview--message:disabled {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 0 16px 8px;
+  box-sizing: border-box;
+  width: calc(100% - 36px);
+  max-width: var(--chat-thread-max-width, 48rem);
+  margin-inline: auto;
+  padding: 0 0 8px;
 }
 
 .session-suggestion {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -5287,6 +5287,10 @@ button.chat-pr__diff {
     gap: 6px;
   }
 
+  .session-suggestions {
+    width: calc(100% - 8px);
+  }
+
   .chat-run-error {
     width: calc(100% - 8px);
     margin: 6px 4px 0;


### PR DESCRIPTION
Closes #125224

## What Problem This Solves

Fixes an issue where users viewing session suggestions would see the suggestion rows extend beyond the narrower chat composer below them. The mismatch affected both actionable suggestions and suggestions in the `Dismissed` state, and the fixed wrapper padding could also place unnecessary horizontal pressure on narrow viewports.

## Why This Change Was Made

The session suggestions wrapper now uses the same responsive width, maximum width, and centered horizontal boundaries as the composer. The change is limited to list containment and alignment; it does not alter suggestion content, row height, controls, behavior, the composer, suggested tasks, sharing semantics, or typing indicators.

## User Impact

Session suggestions now align with the composer as one coherent input stack. On narrow viewports, the list uses the available width within the composer boundary without introducing horizontal overflow.

## Evidence

- Compared the current session-suggestions and composer sizing rules in `ui/src/styles/chat/layout.css`.
- Confirmed the wrapper now shares the composer's `calc(100% - 36px)` responsive width, `48rem` maximum width, and centered inline margins.
- Confirmed the diff changes only `.session-suggestions`; actionable and dismissed rows share this wrapper, while row and interaction styles remain untouched.
- Local tests, build, checks, lint, formatting, screenshots, review, and CI monitoring were intentionally not run for this publication.
