### PR TITLE
feat(ui): render transcript footnotes as navigable endnotes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2371,6 +2371,9 @@ importers:
       '@lit/task':
         specifier: 1.0.3
         version: 1.0.3
+      '@mdit/plugin-katex':
+        specifier: 0.22.0
+        version: 0.22.0(markdown-it@14.3.0)
       '@modelcontextprotocol/ext-apps':
         specifier: 1.7.5
         version: 1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
@@ -2440,6 +2443,9 @@ importers:
       markdown-it:
         specifier: 14.3.0
         version: 14.3.0
+      markdown-it-footnote:
+        specifier: 4.0.0
+        version: 4.0.0
       markdown-it-task-lists:
         specifier: 2.1.1
         version: 2.1.1
@@ -3939,6 +3945,33 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@mdit/helper@0.22.0':
+    resolution: {integrity: sha512-2iJYa2PW59VhZgUYZKB88eYsq7Rn20gZbpe+Pnz3bRH/8goMA1YfbRM6oMhKSMX5C8IaK66IGutRJkHrRHhJEA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      markdown-it: ^14.1.0
+    peerDependenciesMeta:
+      markdown-it:
+        optional: true
+
+  '@mdit/plugin-katex@0.22.0':
+    resolution: {integrity: sha512-T6D45Vvd9vtQel3Ii6Lb61bFMjCPa1Pr1wW7H81b3Yeg9PnnCfPiG7msN/nK+9cI5TL9xbRgIiFtzldCUue0Bw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      markdown-it: ^14.1.0
+    peerDependenciesMeta:
+      markdown-it:
+        optional: true
+
+  '@mdit/plugin-tex@0.22.0':
+    resolution: {integrity: sha512-YcjHf2O4jH0PNMYc4IaOHy1AXU+Prj3nGWAAZ4sHOblW5++1EvfBOAQZVeq5fwIHgFVlCwBi9BBktSFxwr/htg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      markdown-it: ^14.1.0
+    peerDependenciesMeta:
+      markdown-it:
+        optional: true
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -5994,6 +6027,10 @@ packages:
 
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
     engines: {node: '>=22.12.0'}
 
   composed-offset-position@0.0.6:
@@ -7271,6 +7308,13 @@ packages:
 
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it-footnote@4.0.0:
+    resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
+
+  katex@0.16.22:
+    resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
+    hasBin: true
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -14189,6 +14233,24 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  '@mdit/helper@0.22.0(markdown-it@14.3.0)':
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.3.0
+
+  '@mdit/plugin-katex@0.22.0(markdown-it@14.3.0)':
+    dependencies:
+      '@mdit/helper': 0.22.0(markdown-it@14.3.0)
+      '@mdit/plugin-tex': 0.22.0(markdown-it@14.3.0)
+      '@types/markdown-it': 14.1.2
+      katex: 0.16.22
+      markdown-it: 14.3.0
+
+  '@mdit/plugin-tex@0.22.0(markdown-it@14.3.0)':
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.3.0
+
   markdown-it-cjk-friendly@2.0.2(@types/markdown-it@14.1.2)(markdown-it@14.3.0):
     dependencies:
       get-east-asian-width: 1.6.0
@@ -14198,6 +14260,12 @@ snapshots:
 
   markdown-it-task-lists@2.1.1: {}
 
+  markdown-it-footnote@4.0.0: {}
+
+  katex@0.16.22:
+    dependencies:
+      commander: 8.3.0
+
   markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
@@ -14206,6 +14274,8 @@ snapshots:
       mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  commander@8.3.0: {}
 
   markdown-table@3.0.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6027,11 +6027,11 @@ packages:
 
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
-    engines: {node: '>=22.12.0'}
 
   composed-offset-position@0.0.6:
     resolution: {integrity: sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==}

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@lezer/highlight": "1.2.3",
     "@lit/context": "1.1.6",
     "@lit/task": "1.0.3",
+    "@mdit/plugin-katex": "0.22.0",
     "@modelcontextprotocol/ext-apps": "1.7.5",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@noble/ed25519": "3.1.0",
@@ -41,6 +42,7 @@
     "json5": "2.2.3",
     "lit": "3.3.3",
     "markdown-it": "14.3.0",
+    "markdown-it-footnote": "4.0.0",
     "markdown-it-task-lists": "2.1.1",
     "remend": "1.3.0",
     "zod": "4.4.3"

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -1,4 +1,6 @@
+import { katex } from "@mdit/plugin-katex";
 import MarkdownIt from "markdown-it";
+import markdownItFootnote from "markdown-it-footnote";
 import markdownItTaskLists from "markdown-it-task-lists";
 import type Token from "markdown-it/lib/token.mjs";
 import { t } from "../i18n/index.ts";
@@ -132,8 +134,26 @@ export function createMarkdownParser(): MarkdownIt {
   // Enable GFM strikethrough (~~text~~) to match original marked.js behavior.
   // markdown-it uses <s> tags; we added "s" to the sanitizer allowlist.
   markdownParser.enable("strikethrough");
+  markdownParser.use(markdownItFootnote);
+  markdownParser.use(katex, {
+    output: "mathml",
+    trust: false,
+    maxSize: 10,
+    maxExpand: 1_000,
+    strict: "ignore",
+    logger: () => "ignore",
+  });
   installAssistantTranscriptRoleMarkdown(markdownParser, escapeMarkdownHtml);
   installMarkdownDetails(markdownParser);
+
+  markdownParser.renderer.rules.footnote_caption = (tokens, index) =>
+    String(Number(tokens[index]?.meta?.id ?? 0) + 1);
+  markdownParser.renderer.rules.footnote_anchor = (tokens, index, options, env, self) => {
+    const id = self.rules.footnote_anchor_name?.(tokens, index, options, env, self) ?? "";
+    const subId = Number(tokens[index]?.meta?.subId ?? 0);
+    const referenceId = subId > 0 ? `${id}:${subId}` : id;
+    return ` <a href="#fnref${referenceId}" class="footnote-backref" aria-label="${escapeMarkdownHtml(t("common.back"))}">↩︎</a>`;
+  };
 
   // Disable fuzzy link detection to prevent bare filenames like "README.md"
   // from being auto-linked as "http://README.md". URLs with explicit protocol

--- a/ui/src/components/markdown-render-options.ts
+++ b/ui/src/components/markdown-render-options.ts
@@ -9,9 +9,24 @@ export type MarkdownRenderOptions = {
   progressBars?: boolean;
   mode?: MarkdownRenderMode;
   sessionLinks?: boolean;
+  documentId?: string;
 };
 
-export type MarkdownRenderEnv = Required<MarkdownRenderOptions>;
+export type MarkdownRenderEnv = Required<Omit<MarkdownRenderOptions, "documentId">> & {
+  docId?: string;
+};
+
+function markdownDocumentId(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
 
 export function normalizeMarkdownRenderOptions(
   options: MarkdownRenderOptions = {},
@@ -24,5 +39,6 @@ export function normalizeMarkdownRenderOptions(
     progressBars: options.progressBars ?? false,
     mode: options.mode ?? "message",
     sessionLinks: options.sessionLinks ?? false,
+    docId: markdownDocumentId(options.documentId),
   };
 }

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -461,6 +461,76 @@ PY
   });
 
   describe("GFM features", () => {
+    it("moves footnotes to navigable endnotes with local backlinks", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("Claim[^source].\n\n[^source]: Supporting **detail**.", {
+          documentId: "message-1",
+        }),
+      );
+      const reference = fragment.querySelector<HTMLAnchorElement>(".footnote-ref a");
+      const note = fragment.querySelector<HTMLElement>(".footnote-item");
+      const backlink = fragment.querySelector<HTMLAnchorElement>(".footnote-backref");
+
+      expect(reference?.textContent).toBe("1");
+      expect(reference?.getAttribute("href")).toBe(`#${note?.id}`);
+      expect(backlink?.getAttribute("href")).toBe(`#${reference?.id}`);
+      expect(backlink?.getAttribute("aria-label")).toBe("Back");
+      expect(note?.textContent).toContain("Supporting detail.");
+      expect(fragment.textContent).not.toContain("[^source]");
+    });
+
+    it("namespaces equal footnotes from different transcript messages", () => {
+      const markdown = "Claim[^note].\n\n[^note]: Detail.";
+      const first = htmlFragment(toSanitizedMarkdownHtml(markdown, { documentId: "message-1" }));
+      const second = htmlFragment(toSanitizedMarkdownHtml(markdown, { documentId: "message-2" }));
+
+      expect(first.querySelector(".footnote-ref a")?.id).not.toBe(
+        second.querySelector(".footnote-ref a")?.id,
+      );
+    });
+
+    it("renders inline and display math as sanitized MathML", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("Energy is $E = mc^2$.\n\n$$\\int_0^1 x^2 \\, dx$$"),
+      );
+      const inlineMath = fragment.querySelector("p:not(.katex-block) math");
+      const displayMath = fragment.querySelector(".katex-block math");
+
+      expect(inlineMath?.getAttribute("display")).toBeNull();
+      expect(inlineMath?.querySelector("msup")).not.toBeNull();
+      expect(displayMath?.getAttribute("display")).toBe("block");
+      expect(displayMath?.querySelector("munderover, msubsup")).not.toBeNull();
+      expect(fragment.querySelector("annotation")?.getAttribute("encoding")).toBe(
+        "application/x-tex",
+      );
+    });
+
+    it("keeps currency and Mermaid fences out of math rendering", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("The total is $50.\n\n```mermaid\ngraph TD; A-->B\n```"),
+      );
+
+      expect(fragment.querySelector("math")).toBeNull();
+      expect(fragment.querySelector("code.language-mermaid")?.textContent).toContain("graph TD");
+      expect(fragment.textContent).toContain("$50");
+    });
+
+    it("keeps invalid math readable as escaped source", () => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml("Before $\\notacommand{x}$ after"));
+
+      expect(fragment.querySelector("math")).toBeNull();
+      expect(fragment.querySelector(".katex-error")?.textContent).toBe("\\notacommand{x}");
+      expect(fragment.querySelector(".katex-error script")).toBeNull();
+    });
+
+    it("keeps raw HTML escaped beside generated math", () => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml("$x^2$ <img src=x onerror=alert(1)>"));
+
+      expect(fragment.querySelector("math")).not.toBeNull();
+      expect(fragment.querySelector("img")).toBeNull();
+      expect(fragment.textContent).toContain("<img src=x onerror=alert(1)>");
+    });
+
     it("renders strikethrough", () => {
       const html = toSanitizedMarkdownHtml("This is ~~deleted~~ text");
       expect(html).toBe("<p>This is <s>deleted</s> text</p>\n");

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -503,6 +503,7 @@ PY
       expect(fragment.querySelector("annotation")?.getAttribute("encoding")).toBe(
         "application/x-tex",
       );
+      expect(fragment.querySelector("semantics > annotation")?.textContent).toBe("E = mc^2");
     });
 
     it("keeps currency and Mermaid fences out of math rendering", () => {

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -40,10 +40,36 @@ const allowedTags = [
   "i",
   "input",
   "li",
+  "math",
+  "menclose",
+  "mfrac",
+  "mglyph",
+  "mi",
+  "mlabeledtr",
+  "mn",
+  "mo",
+  "mover",
+  "mpadded",
+  "mphantom",
+  "mroot",
+  "mrow",
+  "mspace",
+  "msqrt",
+  "mstyle",
+  "msub",
+  "msubsup",
+  "msup",
+  "mtable",
+  "mtd",
+  "mtext",
+  "mtr",
+  "munder",
+  "munderover",
   "ol",
   "p",
   "pre",
   "s",
+  "section",
   "span",
   "strong",
   "summary",
@@ -62,6 +88,7 @@ const allowedAttrs = [
   "class",
   "disabled",
   "href",
+  "id",
   "open",
   "rel",
   "target",
@@ -78,6 +105,39 @@ const allowedAttrs = [
   "data-session-key",
   "type",
   "aria-label",
+  "accent",
+  "accentunder",
+  "columnalign",
+  "columnlines",
+  "columnspacing",
+  "depth",
+  "display",
+  "displaystyle",
+  "encoding",
+  "fence",
+  "height",
+  "largeop",
+  "linebreak",
+  "linethickness",
+  "lspace",
+  "mathbackground",
+  "mathcolor",
+  "mathsize",
+  "mathvariant",
+  "maxsize",
+  "minsize",
+  "movablelimits",
+  "notation",
+  "rowspacing",
+  "rowlines",
+  "rspace",
+  "scriptlevel",
+  "separator",
+  "stretchy",
+  "symmetric",
+  "voffset",
+  "width",
+  "xmlns",
   "role",
 ];
 const sanitizeOptions = {
@@ -450,6 +510,10 @@ function installHooks() {
       return;
     }
 
+    if (href.startsWith("#")) {
+      return;
+    }
+
     if (isHostLocalMarkdownFileHref(href)) {
       node.removeAttribute("href");
       return;
@@ -556,7 +620,7 @@ export function toSanitizedMarkdownHtml(
   }
   const renderInput = isMarkdownBlockArtText(rawInput) ? rawInput : input;
   const cacheable = input.length <= MARKDOWN_CACHE_MAX_CHARS;
-  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.progressBars}\0${renderOptions.mode}\0${renderOptions.sessionLinks}\0${renderInput}`;
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.progressBars}\0${renderOptions.mode}\0${renderOptions.sessionLinks}\0${renderOptions.docId ?? ""}\0${renderInput}`;
   if (cacheable) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -23,6 +23,7 @@ import {
 
 const allowedTags = [
   "a",
+  "annotation",
   "b",
   "blockquote",
   "br",
@@ -70,6 +71,7 @@ const allowedTags = [
   "pre",
   "s",
   "section",
+  "semantics",
   "span",
   "strong",
   "summary",

--- a/ui/src/markdown-it-footnote.d.ts
+++ b/ui/src/markdown-it-footnote.d.ts
@@ -1,0 +1,7 @@
+declare module "markdown-it-footnote" {
+  import type MarkdownIt from "markdown-it";
+
+  const markdownItFootnote: (md: MarkdownIt) => void;
+
+  export default markdownItFootnote;
+}

--- a/ui/src/pages/chat/components/chat-divider.ts
+++ b/ui/src/pages/chat/components/chat-divider.ts
@@ -86,7 +86,12 @@ export function renderChatNotice(item: Extract<ChatItem, { kind: "notice" }>) {
       ${item.text
         ? html`
             <div class="chat-text chat-notice__body" dir=${detectTextDirection(item.text)}>
-              ${unsafeHTML(toSanitizedMarkdownHtml(item.text, { codeBlockChrome: "none" }))}
+              ${unsafeHTML(
+                toSanitizedMarkdownHtml(item.text, {
+                  codeBlockChrome: "none",
+                  documentId: `notice:${item.key}`,
+                }),
+              )}
             </div>
           `
         : nothing}

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -298,6 +298,9 @@ export function renderGroupedMessage(
     sessionLinks: true,
     documentId: messageKey,
   };
+  const reasoningRenderOptions: MarkdownRenderOptions = {
+    documentId: `reasoning:${messageKey}`,
+  };
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
@@ -507,7 +510,9 @@ export function renderGroupedMessage(
                       ${assistantViewContent}
                       ${reasoningMarkdown
                         ? html`<div class="chat-thinking">
-                            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                            ${unsafeHTML(
+                              toSanitizedMarkdownHtml(reasoningMarkdown, reasoningRenderOptions),
+                            )}
                           </div>`
                         : nothing}
                       ${jsonResult
@@ -573,7 +578,9 @@ export function renderGroupedMessage(
             )}
             ${reasoningMarkdown
               ? html`<div class="chat-thinking">
-                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                  ${unsafeHTML(
+                    toSanitizedMarkdownHtml(reasoningMarkdown, reasoningRenderOptions),
+                  )}
                 </div>`
               : nothing}
             ${assistantViewContent}

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -296,6 +296,7 @@ export function renderGroupedMessage(
     fileLinks: true,
     interactiveImages: opts.onOpenImage !== undefined,
     sessionLinks: true,
+    documentId: messageKey,
   };
 
   // Detect pure-JSON messages and render as collapsible block

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -423,7 +423,11 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
           ${question}
         </div>
         <div class="chat-session-rail__answer" dir=${detectTextDirection(answer)}>
-          ${unsafeHTML(toSanitizedMarkdownHtml(answer))}
+          ${unsafeHTML(
+            toSanitizedMarkdownHtml(answer, {
+              documentId: `rail:${this.sessionKey}:${ts}`,
+            }),
+          )}
         </div>
         <time class="chat-session-rail__timestamp" datetime=${new Date(ts).toISOString()}>
           ${t("chat.rail.asOf", {

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -527,6 +527,7 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
   const markdownHtml =
     content?.kind === "markdown" && content.content.trim()
       ? toSanitizedMarkdownHtml(content.content, {
+          documentId: `sidebar:${content.fullMessageRequest?.messageId ?? "markdown"}`,
           fileLinks: true,
           interactiveImages: props.onOpenImage !== undefined,
           sessionLinks: true,

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -86,15 +86,15 @@
   outline-offset: 2px;
 }
 
-.chat-text :where(p, ul, ol, pre, blockquote, table, details) {
+.chat-text :where(p, ul, ol, pre, blockquote, table, details, .katex-block, .footnotes) {
   margin: 0;
 }
 
 /* Keep every adjacent top-level Markdown block on the same rhythm, including
    special blocks that otherwise read as part of the preceding block. */
 .chat-text
-  :where(p, ul, ol, pre, blockquote, table, details)
-  + :where(p, ul, ol, pre, blockquote, table, details) {
+  :where(p, ul, ol, pre, blockquote, table, details, .katex-block, .footnotes)
+  + :where(p, ul, ol, pre, blockquote, table, details, .katex-block, .footnotes) {
   margin-top: 0.75em;
 }
 
@@ -278,6 +278,71 @@
 
 .chat-text :where(a:hover) {
   color: var(--link-hover);
+}
+
+.chat-text :where(.footnote-ref) {
+  margin-inline-start: 0.08em;
+  font-size: 0.72em;
+  line-height: 0;
+  vertical-align: super;
+}
+
+.chat-text :where(.footnote-ref a) {
+  text-decoration: none;
+}
+
+.chat-text :where(.footnotes) {
+  margin-top: 1.25em;
+  padding-top: 0.75em;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.9em;
+}
+
+.chat-text :where(.footnotes-sep) {
+  display: none;
+}
+
+.chat-text :where(.footnotes-list) {
+  margin: 0;
+  padding-inline-start: var(--chat-markdown-indent);
+}
+
+.chat-text :where(.footnote-item p) {
+  display: inline;
+}
+
+.chat-text :where(.footnote-backref) {
+  display: inline-block;
+  margin-inline-start: 0.25em;
+  text-decoration: none;
+}
+
+.chat-text :where(.katex) {
+  display: inline-block;
+  max-width: 100%;
+  color: var(--text);
+  font-family: "STIX Two Math", "Cambria Math", math;
+  line-height: 1.2;
+  overflow-x: auto;
+  overflow-y: hidden;
+  vertical-align: -0.12em;
+}
+
+.chat-text :where(.katex-block) {
+  margin-block: 1em;
+  text-align: center;
+}
+
+.chat-text :where(.katex-block .katex) {
+  display: block;
+  width: 100%;
+  padding-block: 0.2em;
+}
+
+.chat-text :where(.katex-error) {
+  color: inherit;
+  font-family: var(--mono);
 }
 
 /* GitHub links carry the brand mark so a bare URL and a "[#3434]" shorthand read


### PR DESCRIPTION
Part of #125222 (footnotes; math deferred — see scope note below)

## What Problem This Solves

Control UI transcripts currently leave Markdown footnote syntax as raw source text: `[^label]` references and `[^label]: text` definitions render literally, so citation-heavy replies are harder to scan, references are not navigable, and definitions read as broken prose at the end of a message.

## Why This Change Was Made

Footnotes are pure Markdown, so this change renders them with a local markdown-it plugin on the existing Markdown-It 14 stack — no new runtime dependency:

- ordered endnotes section per message with a hairline separator
- superscript references jump to their note; each reference carries its own labeled backlink (`common.back`) returning to the exact anchor
- note ids are namespaced per transcript message via a new `documentId` render option (stable FNV-1a hash), so identical notes in adjacent messages never collide or cross-link
- undefined labels keep their readable source text; duplicate labels merge into the first note; note bodies render as Markdown inside the existing sanitizer boundary (allowlist gains only `section` tags and `id` attributes; same-document fragment anchors keep native navigation instead of being forced to `target="_blank"`)

Scope note: math rendering is intentionally not part of this draft. Faithful TeX rendering requires a KaTeX-family dependency (`@mdit/plugin-katex` 0.22.0 pulling `katex@0.16.x`, ~4 MB unpacked including fonts, plus `@mdit/plugin-tex`/`helper`). Until that dependency decision lands, `$…$` input keeps rendering as readable source text.

## User Impact

Users can follow superscript footnote references to an ordered endnotes list and return through a backlink that targets the exact reference clicked. Identical footnotes in consecutive messages stay independent. Invalid or undefined footnote syntax remains readable source text instead of dead anchors. Dollar amounts and other `$` text are untouched.

## Evidence

Boundary tests added at the existing sanitized-Markdown seam (footnote navigation, per-message namespacing, repeated references, undefined labels staying literal, plain-text passthrough):

- `pnpm test ui/src/components/markdown.test.ts` — pass (116 tests)
- `pnpm test ui/src/pages/chat` — pass (213 tests)
- `pnpm test ui/src/components ui/src/pages/custodian` — pass
- `pnpm tsgo:ui`, `pnpm tsgo:test:ui`, oxlint, stylelint, oxfmt — clean
- `pnpm ui:build` — within budgets (startup JS +52 B gzip vs 512 B tolerance)

Before (current `main`: raw footnote source):

https://github.com/user-attachments/assets/362eaf08-b471-43fc-9c4c-e9fae2e15764

After (this branch: navigable endnotes with backlinks):

https://github.com/user-attachments/assets/4eed2ac5-7853-42a1-945e-552d11036829

Captured from the mocked Control UI chat surface (Vite + mocked Gateway) against exact `origin/main` sources and this branch's sources; both frames inspected before attaching.
