### PR TITLE
improve(ui): redesign tool calls as lightweight transcript activity

### DIFF
--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -92,18 +92,18 @@ suite.define(() => {
       "Tool output",
       "Tool output",
     ]);
-    // Each failure keeps only its per-call badge even when its turn later
-    // recovers; both row summaries otherwise render neutral.
+    // Collapsed rows stay neutral even when the call failed; the failure is
+    // recorded as the expanded body's outcome, with the reported exit code.
     const summaryClasses = await page
       .locator(".chat-tool-msg-summary")
       .evaluateAll((nodes) => nodes.map((node) => node.className));
     expect(summaryClasses).toHaveLength(2);
     expect(summaryClasses[0]).not.toContain("chat-tool-msg-summary--error");
     expect(summaryClasses[1]).not.toContain("chat-tool-msg-summary--error");
-    expect(await page.locator(".chat-tool-row__badge").allTextContents()).toEqual([
-      "failed",
-      "failed",
-    ]);
+    await page.locator(".chat-tool-msg-summary").first().click();
+    await expect
+      .poll(() => page.locator(".chat-tool-card__outcome").first().textContent())
+      .toBe("Exit code 1");
     await context.close();
   });
 
@@ -175,7 +175,7 @@ suite.define(() => {
     const activityGeometry = await activity.evaluate((node) => {
       const container = node.closest<HTMLElement>(".chat-activity-group");
       const label = node.querySelector<HTMLElement>(".chat-activity-group__label");
-      const chevron = node.querySelector<HTMLElement>(".chat-inline-disclosure__chevron");
+      const chevron = node.querySelector<HTMLElement>(".chat-tool-row__chevron");
       if (!container || !label || !chevron) {
         throw new Error("Expected compact activity disclosure parts");
       }
@@ -201,11 +201,13 @@ suite.define(() => {
 
     const rows = page.locator(".chat-activity-group__body .chat-tool-msg-summary");
     expect(await rows.count()).toBe(2);
-    expect(await rows.locator(".chat-inline-disclosure__chevron").count()).toBe(2);
+    expect(await rows.locator(".chat-tool-row__chevron").count()).toBe(2);
     expect(await page.locator(".chat-tool-msg-summary__label", { hasText: "Tool" }).count()).toBe(
       0,
     );
-    await rows.first().click();
+    // File rows put the workspace link inside the row, so toggle from the icon
+    // edge instead of the row centre to avoid opening the linked file.
+    await rows.first().click({ position: { x: 4, y: 4 } });
     expect(await page.getByText("offset:", { exact: true }).count()).toBe(1);
     expect(await page.getByText("limit:", { exact: true }).count()).toBe(1);
     const patchRow = rows.filter({ hasText: "2 files" });
@@ -385,7 +387,8 @@ suite.define(() => {
     await card.waitFor();
     expect(await card.getByText("query:", { exact: true }).count()).toBe(1);
     expect(await card.getByText("example", { exact: true }).count()).toBe(1);
-    await card.getByText("Tool output", { exact: true }).waitFor();
+    // Plain output needs no "Tool output" header; the payload is the content.
+    expect(await card.getByText("Tool output", { exact: true }).count()).toBe(0);
     await card.getByText("Native result payload", { exact: true }).waitFor();
     await captureToolActivityProof(page, "native-result-before-call-expanded");
     await context.close();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5762,6 +5762,8 @@ export const en: TranslationMap = {
       attemptedChanges: "Attempted changes",
       failed: "failed",
       running: "Running",
+      completed: "Completed",
+      exitCode: "Exit code {code}",
       noOutputFailed: "No output — tool failed.",
       noOutputSucceeded: "No output — tool completed successfully.",
       noResult: "No result available.",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -243,6 +243,8 @@ export type ToolCard = {
   details?: unknown;
   /** Monotonic edit counts while a live tool call is still receiving input. */
   liveDiffStat?: { added: number; removed: number };
+  /** Producer-reported process exit code, when the result supplies one. */
+  exitCode?: number;
   isError?: boolean;
   /** True when the card comes from the live tool stream of the current run. */
   live?: boolean;

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -59,6 +59,18 @@ function coerceArgs(value: unknown): unknown {
   }
 }
 
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return null;
+  }
+  try {
+    return readRecord(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
 function extractToolText(item: Record<string, unknown>): string | undefined {
   if (typeof item.text === "string") {
     return item.text;
@@ -84,6 +96,17 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
 function readToolErrorFlag(value: Record<string, unknown>): boolean | undefined {
   const raw = value.isError ?? value.is_error;
   return typeof raw === "boolean" ? raw : undefined;
+}
+
+function readToolExitCode(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const record = readRecord(value);
+    const exitCode = record?.exitCode ?? record?.exit_code;
+    if (typeof exitCode === "number" && Number.isInteger(exitCode)) {
+      return exitCode;
+    }
+  }
+  return undefined;
 }
 
 const TOOL_NOT_FOUND_PATTERN = /^tool not found\.?$/i;
@@ -356,6 +379,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
       const details = item.details ?? m.details;
       const preview = extractCanvasFromDetails(details) ?? extractToolPreview(text, name);
       const isError = readToolErrorFlag(item) ?? messageIsError;
+      const exitCode = readToolExitCode(item, details, text ? parseJsonRecord(text) : undefined, m);
       if (existing) {
         fallbackMatchedCards.add(existing);
         existing.callId ??= callId;
@@ -374,6 +398,9 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
         if (isError !== undefined) {
           existing.isError = isError;
         }
+        if (exitCode !== undefined) {
+          existing.exitCode = exitCode;
+        }
         continue;
       }
       cards.push({
@@ -385,6 +412,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
         ...(details !== undefined ? { details } : {}),
         messageId: transcriptMessageId,
         ...(isError !== undefined ? { isError } : {}),
+        ...(exitCode !== undefined ? { exitCode } : {}),
         preview,
       });
     }
@@ -405,6 +433,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
       "tool";
     const text = extractTextCached(message) ?? undefined;
     const callId = resolveToolCallId({}, m);
+    const exitCode = readToolExitCode(m, m.details, text ? parseJsonRecord(text) : undefined);
     cards.push({
       id: resolveToolCardId({}, m, 0, prefix),
       ...(callId ? { callId } : {}),
@@ -414,6 +443,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
       ...(m.details !== undefined ? { details: m.details } : {}),
       messageId: transcriptMessageId,
       ...(messageIsError !== undefined ? { isError: messageIsError } : {}),
+      ...(exitCode !== undefined ? { exitCode } : {}),
       preview: extractCanvasFromDetails(m.details) ?? extractToolPreview(text, name),
     });
   }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -203,35 +203,39 @@ function activityAlignmentHtml() {
     <div class="chat-thread" role="log">
       <div class="chat-thread-inner">
         <div class="chat-group tool chat-group--activity">
-          <div class="chat-avatar tool">A</div>
           <div class="chat-group-messages">
             <div class="chat-activity-group is-open">
               <button class="chat-inline-disclosure chat-activity-group__summary" type="button" aria-expanded="true">
                 <span class="chat-activity-group__icon">${iconSvg()}</span>
-                <span class="chat-activity-group__label">Activity: 2 tools</span>
-                <span class="chat-inline-disclosure__chevron">${iconSvg()}</span>
+                <span class="chat-tool-disclosure__content">
+                  <span class="chat-activity-group__label">Activity: 2 tools</span>
+                </span>
+                <span class="chat-tool-row__chevron">${iconSvg()}</span>
               </button>
               <div class="chat-activity-group__body">
                 <div class="chat-bubble chat-bubble--tool-shell" data-activity-call-row>
                   <div class="chat-tools-inline">
                     <div class="chat-tool-msg-collapse">
-                      <button class="chat-inline-disclosure chat-tool-msg-summary" type="button" aria-expanded="false">
+                      <button class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row" type="button" aria-expanded="false">
                         <span class="chat-tool-msg-summary__icon">${iconSvg()}</span>
-                        <span class="chat-tool-msg-summary__label">Bash</span>
-                        <span class="chat-tool-msg-summary__names">search a deliberately long workspace path without extra card chrome</span>
-                        <span class="chat-inline-disclosure__chevron">${iconSvg()}</span>
+                        <span class="chat-tool-disclosure__content">
+                          <span class="chat-tool-msg-summary__label">Bash</span>
+                          <span class="chat-tool-msg-summary__names">search a deliberately long workspace path without extra card chrome</span>
+                        </span>
+                        <span class="chat-tool-row__chevron">${iconSvg()}</span>
                       </button>
                     </div>
                   </div>
                 </div>
                 <div class="chat-bubble chat-bubble--tool-shell">
                   <div class="chat-tool-msg-collapse">
-                    <button class="chat-inline-disclosure chat-tool-msg-summary" data-failed-call-row type="button" aria-expanded="false">
+                    <button class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row" data-failed-call-row type="button" aria-expanded="false">
                       <span class="chat-tool-msg-summary__icon">${iconSvg()}</span>
-                      <span class="chat-tool-msg-summary__label">Bash</span>
-                      <span class="chat-tool-msg-summary__names">Bash</span>
-                      <span class="chat-inline-disclosure__chevron">${iconSvg()}</span>
-                      <span class="chat-tool-row__badge">failed</span>
+                      <span class="chat-tool-disclosure__content">
+                        <span class="chat-tool-msg-summary__label">Bash</span>
+                        <span class="chat-tool-msg-summary__names">Bash</span>
+                      </span>
+                      <span class="chat-tool-row__chevron">${iconSvg()}</span>
                     </button>
                   </div>
                 </div>
@@ -1198,7 +1202,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const styles = await page.evaluate(() => {
         const activity = document.querySelector<HTMLElement>(".chat-activity-group__summary")!;
         const label = activity.querySelector<HTMLElement>(".chat-activity-group__label")!;
-        const chevron = activity.querySelector<HTMLElement>(".chat-inline-disclosure__chevron")!;
+        const chevron = activity.querySelector<HTMLElement>(".chat-tool-row__chevron")!;
         return {
           activity: getComputedStyle(activity).userSelect,
           activityBackground: getComputedStyle(activity).backgroundColor,
@@ -1210,7 +1214,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(styles).toEqual({
         activity: "text",
         activityBackground: "rgba(0, 0, 0, 0)",
-        chevronGap: 8,
+        // Summary gap (8px) less the chevron's own -3px inset.
+        chevronGap: 5,
         tool: "text",
       });
     } finally {
@@ -1284,7 +1289,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           <div class="chat-thread chat-thread--direct" role="log">
             <div class="chat-thread-inner">
               <div class="chat-group tool">
-                <div class="chat-avatar tool">A</div>
                 <div class="chat-group-messages" data-tool-lane>
                   <div class="chat-bubble chat-bubble--tool-shell" data-tool-shell>
                     <div class="chat-tool-msg-collapse">Tool output</div>
@@ -1292,7 +1296,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                 </div>
               </div>
               <div class="chat-group tool chat-group--activity">
-                <div class="chat-avatar tool">A</div>
                 <div class="chat-group-messages" data-activity-lane>
                   <div class="chat-activity-group">Activity</div>
                 </div>

--- a/ui/src/pages/chat/components/chat-diff-render.ts
+++ b/ui/src/pages/chat/components/chat-diff-render.ts
@@ -9,12 +9,9 @@ import type { DiffLine, DiffStat } from "../../../lib/chat/tool-call-diff.ts";
 export function renderDiffStatChips(stat: DiffStat & { modified?: number }) {
   // Tool cards omit `modified`; keep their original template byte-for-byte.
   if (stat.modified === undefined) {
-    if (stat.added === 0 && stat.removed === 0) {
-      return nothing;
-    }
     return html`<span class="chat-diffstat">
-      ${stat.added > 0 ? html`<span class="chat-diffstat__add">+${stat.added}</span>` : nothing}
-      ${stat.removed > 0 ? html`<span class="chat-diffstat__del">-${stat.removed}</span>` : nothing}
+      <span class="chat-diffstat__add">+${stat.added}</span>
+      <span class="chat-diffstat__del">-${stat.removed}</span>
     </span>`;
   }
   if (stat.added === 0 && stat.removed === 0 && !stat.modified) {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -63,6 +63,7 @@ import {
   renderRawOutputToggle,
   renderToolCard,
   renderToolPreview,
+  isRunningToolCard,
   resolveCollapsedToolDetail,
   shouldToggleSelectableDisclosure,
   syncToolDisclosureOverflow,
@@ -325,7 +326,9 @@ export function renderGroupedMessage(
   }
 
   const toolMessageDisclosureId = `toolmsg:${messageKey}`;
-  const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
+  const toolMessageExpanded =
+    toolCards.some((card) => isRunningToolCard(card, opts.runActive)) ||
+    (opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false);
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
   const singleToolDisplay = singleToolCard

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -27,6 +27,7 @@ import {
   formatDistinctCollapsedToolSummaryText,
   formatCollapsedToolPreviewText,
   formatCollapsedToolSummaryText,
+  isToolCardError,
 } from "../../../lib/chat/tool-cards.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
@@ -62,6 +63,7 @@ import {
   renderExpandedToolCardContent,
   renderRawOutputToggle,
   renderToolCard,
+  renderToolOutcome,
   renderToolPreview,
   isRunningToolCard,
   resolveCollapsedToolDetail,
@@ -331,6 +333,10 @@ export function renderGroupedMessage(
     (opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false);
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
+  // One expanded card already closes with its own outcome line; every other
+  // shape renders inline rows only, so the message body records the failure.
+  const expandsSingleToolCard = Boolean(singleToolCard) && !markdown && !hasImages;
+  const failedToolCard = expandsSingleToolCard ? undefined : toolCards.find(isToolCardError);
   const singleToolDisplay = singleToolCard
     ? resolveToolDisplay({
         name: singleToolCard.name,
@@ -527,7 +533,7 @@ export function renderGroupedMessage(
                           ? renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
                           : nothing}
                       ${hasToolCards
-                        ? singleToolCard && !markdown && !hasImages
+                        ? expandsSingleToolCard && singleToolCard
                           ? renderExpandedToolCardContent(
                               singleToolCard,
                               opts.sessionKey,
@@ -551,6 +557,9 @@ export function renderGroupedMessage(
                               embedSandboxMode: opts.embedSandboxMode ?? "scripts",
                               allowExternalEmbedUrls: opts.allowExternalEmbedUrls ?? false,
                             })
+                        : nothing}
+                      ${failedToolCard
+                        ? renderToolOutcome("failed", failedToolCard.exitCode)
                         : nothing}
                     </div>
                   `

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -27,7 +27,6 @@ import {
   formatDistinctCollapsedToolSummaryText,
   formatCollapsedToolPreviewText,
   formatCollapsedToolSummaryText,
-  isToolCardError,
 } from "../../../lib/chat/tool-cards.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
@@ -66,6 +65,7 @@ import {
   renderToolPreview,
   resolveCollapsedToolDetail,
   shouldToggleSelectableDisclosure,
+  syncToolDisclosureOverflow,
 } from "./chat-tool-cards.ts";
 
 function renderChatIcon(name: string) {
@@ -328,7 +328,6 @@ export function renderGroupedMessage(
   const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
-  const toolMessageHasError = toolCards.some(isToolCardError);
   const singleToolDisplay = singleToolCard
     ? resolveToolDisplay({
         name: singleToolCard.name,
@@ -467,6 +466,8 @@ export function renderGroupedMessage(
                 class="chat-inline-disclosure chat-tool-msg-summary"
                 type="button"
                 aria-expanded=${String(toolMessageExpanded)}
+                @pointerenter=${syncToolDisclosureOverflow}
+                @focus=${syncToolDisclosureOverflow}
                 @click=${(event: MouseEvent) => {
                   if (shouldToggleSelectableDisclosure(event)) {
                     opts.onToggleToolMessageExpanded?.(toolMessageDisclosureId);
@@ -474,18 +475,15 @@ export function renderGroupedMessage(
                 }}
               >
                 <span class="chat-tool-msg-summary__icon">${toolMessageIcon}</span>
-                <span class="chat-tool-msg-summary__label">${toolMessageLabel}</span>
-                ${toolSummaryLabel
-                  ? html`<span class="chat-tool-msg-summary__names">${toolSummaryLabel}</span>`
-                  : toolPreview
-                    ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
-                    : nothing}
-                <span class="chat-inline-disclosure__chevron" aria-hidden="true"
-                  >${icons.chevronDown}</span
-                >
-                ${toolMessageHasError
-                  ? html`<span class="chat-tool-row__badge">${t("chat.toolCards.failed")}</span>`
-                  : nothing}
+                <span class="chat-tool-disclosure__content">
+                  <span class="chat-tool-msg-summary__label">${toolMessageLabel}</span>
+                  ${toolSummaryLabel
+                    ? html`<span class="chat-tool-msg-summary__names">${toolSummaryLabel}</span>`
+                    : toolPreview
+                      ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
+                      : nothing}
+                </span>
+                <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
               </button>
               ${toolMessageExpanded
                 ? html`

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -37,10 +37,7 @@ import {
   type StreamGroupOptions,
   type StreamGroupPart,
 } from "./chat-message-stream.ts";
-import {
-  extractGroupMeta,
-  renderMessageMeta,
-} from "./chat-message-timestamp.ts";
+import { extractGroupMeta, renderMessageMeta } from "./chat-message-timestamp.ts";
 import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar.ts";
 import {
   isRunningToolCard,
@@ -278,8 +275,7 @@ export function renderActivityGroup(
                 >${groupSummaryLabel}</span
               >
             </span>
-            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span
-            >
+            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
           </button>
           <div class="chat-activity-group__body" id=${activityBodyId} ?hidden=${!activityExpanded}>
             ${activityExpanded

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -250,7 +250,8 @@ export function renderActivityGroup(
     : summarizeToolGroup(cards.map((card) => ({ name: card.name, args: card.args })));
   const activityDisclosureId = `activity:${firstGroup.key}`;
   const activityBodyId = `activity-body-${fnv1aUtf16(firstGroup.key).toString(16)}`;
-  const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? false;
+  const activityExpanded =
+    Boolean(runningCard) || (opts.isToolMessageExpanded?.(activityDisclosureId) ?? false);
   return html`
     <div
       class="chat-group tool chat-group--activity chat-group--with-footer"

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -39,7 +39,6 @@ import {
 } from "./chat-message-stream.ts";
 import {
   extractGroupMeta,
-  renderChatTimestamp,
   renderMessageMeta,
 } from "./chat-message-timestamp.ts";
 import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar.ts";
@@ -47,6 +46,7 @@ import {
   isRunningToolCard,
   resolveToolRowText,
   shouldToggleSelectableDisclosure,
+  syncToolDisclosureOverflow,
 } from "./chat-tool-cards.ts";
 import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 
@@ -251,32 +251,11 @@ export function renderActivityGroup(
   const activityDisclosureId = `activity:${firstGroup.key}`;
   const activityBodyId = `activity-body-${fnv1aUtf16(firstGroup.key).toString(16)}`;
   const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? false;
-  const showAvatarGutter = opts.showAvatarGutter !== false;
-  const assistantName = opts.assistantName ?? "Assistant";
-
   return html`
     <div
       class="chat-group tool chat-group--activity chat-group--with-footer"
       data-chat-row-key=${firstGroup.key}
     >
-      ${showAvatarGutter &&
-      (normalizeRoleForGrouping(firstGroup.role) !== "assistant" ||
-        opts.showAssistantAvatar !== false)
-        ? renderChatAvatar(
-            firstGroup.role,
-            {
-              name: assistantName,
-              avatar: opts.assistantAvatar ?? null,
-            },
-            {
-              name: opts.userName ?? null,
-              avatar: opts.userAvatar ?? null,
-            },
-            opts.basePath,
-            opts.assistantAttachmentAuthToken,
-            firstGroup.sender,
-          )
-        : nothing}
       <div class="chat-group-messages">
         <div class="chat-activity-group ${activityExpanded ? "is-open" : ""}">
           <button
@@ -284,6 +263,8 @@ export function renderActivityGroup(
             type="button"
             aria-expanded=${String(activityExpanded)}
             aria-controls=${activityBodyId}
+            @pointerenter=${syncToolDisclosureOverflow}
+            @focus=${syncToolDisclosureOverflow}
             @click=${(event: MouseEvent) => {
               if (shouldToggleSelectableDisclosure(event)) {
                 opts.onToggleToolMessageExpanded?.(activityDisclosureId, activityExpanded);
@@ -291,11 +272,12 @@ export function renderActivityGroup(
             }}
           >
             <span class="chat-activity-group__icon">${icons.activity}</span>
-            <span class="chat-activity-group__label" title=${groupSummaryLabel}
-              >${groupSummaryLabel}</span
-            >
-            <span class="chat-inline-disclosure__chevron" aria-hidden="true"
-              >${icons.chevronDown}</span
+            <span class="chat-tool-disclosure__content">
+              <span class="chat-activity-group__label" title=${groupSummaryLabel}
+                >${groupSummaryLabel}</span
+              >
+            </span>
+            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span
             >
           </button>
           <div class="chat-activity-group__body" id=${activityBodyId} ?hidden=${!activityExpanded}>
@@ -313,10 +295,6 @@ export function renderActivityGroup(
               : nothing}
           </div>
         </div>
-      </div>
-      <div class="chat-group-footer">
-        <span class="chat-sender-name">${t("chat.messages.activity")}</span>
-        ${renderChatTimestamp(firstGroup.timestamp)}
       </div>
     </div>
   `;
@@ -436,7 +414,9 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${group.key}
     >
-      ${showAvatarGutter && (normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
+      ${normalizedRole !== "tool" &&
+      showAvatarGutter &&
+      (normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
         ? renderChatAvatar(
             group.role,
             {
@@ -491,44 +471,46 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
             ? renderTurnRecapRow(opts.turnRecap, { presentation: "continuation" })
             : nothing}
       </div>
-      <div
-        class="chat-group-footer ${persistUserIdentity
-          ? "chat-group-footer--persistent-identity"
-          : ""}"
-      >
-        <div class="chat-group-footer__meta">
-          ${hasUserFooterActions
-            ? html`
-                <div
-                  class="chat-group-footer-actions"
-                  data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
-                >
-                  ${footerActionDetails?.replyTarget && opts.onReply
-                    ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
-                    : nothing}
-                  ${opts.onRewind
-                    ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
-                    : nothing}
-                </div>
-              `
-            : nothing}
-          ${normalizedRole === "user" && !showAvatarGutter
-            ? renderChatAuthorAvatar(group.sender)
-            : nothing}
-          <span class="chat-sender-name">${who}</span>
-          ${renderMessageMeta(group.timestamp, meta)}
-        </div>
-        ${normalizedRole !== "user" && footerActionDetails
-          ? html`
-              <div
-                class="chat-group-footer-actions"
-                data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
-              >
-                ${renderMessageActionButtons(footerActionDetails, opts)}
-              </div>
-            `
-          : nothing}
-      </div>
+      ${normalizedRole === "tool"
+        ? nothing
+        : html`<div
+            class="chat-group-footer ${persistUserIdentity
+              ? "chat-group-footer--persistent-identity"
+              : ""}"
+          >
+            <div class="chat-group-footer__meta">
+              ${hasUserFooterActions
+                ? html`
+                    <div
+                      class="chat-group-footer-actions"
+                      data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+                    >
+                      ${footerActionDetails?.replyTarget && opts.onReply
+                        ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
+                        : nothing}
+                      ${opts.onRewind
+                        ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
+                        : nothing}
+                    </div>
+                  `
+                : nothing}
+              ${normalizedRole === "user" && !showAvatarGutter
+                ? renderChatAuthorAvatar(group.sender)
+                : nothing}
+              <span class="chat-sender-name">${who}</span>
+              ${renderMessageMeta(group.timestamp, meta)}
+            </div>
+            ${normalizedRole !== "user" && footerActionDetails
+              ? html`
+                  <div
+                    class="chat-group-footer-actions"
+                    data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+                  >
+                    ${renderMessageActionButtons(footerActionDetails, opts)}
+                  </div>
+                `
+              : nothing}
+          </div>`}
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -11,10 +11,7 @@ import { renderGroupedMessage } from "./chat-message-bubble.ts";
 import { renderChatTimestamp } from "./chat-message-timestamp.ts";
 import { renderChatQuestionSummary } from "./chat-question-card.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
-import {
-  shouldToggleSelectableDisclosure,
-  syncToolDisclosureOverflow,
-} from "./chat-tool-cards.ts";
+import { shouldToggleSelectableDisclosure, syncToolDisclosureOverflow } from "./chat-tool-cards.ts";
 import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
 
 /** A contiguous run of in-flight streaming items rendered under one assistant group. */

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -11,7 +11,10 @@ import { renderGroupedMessage } from "./chat-message-bubble.ts";
 import { renderChatTimestamp } from "./chat-message-timestamp.ts";
 import { renderChatQuestionSummary } from "./chat-question-card.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
-import { shouldToggleSelectableDisclosure } from "./chat-tool-cards.ts";
+import {
+  shouldToggleSelectableDisclosure,
+  syncToolDisclosureOverflow,
+} from "./chat-tool-cards.ts";
 import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
 
 /** A contiguous run of in-flight streaming items rendered under one assistant group. */
@@ -156,25 +159,26 @@ export function renderWorkGroupSummary(
   const label = duration ? t("chat.workRun.workedFor", { duration }) : t("chat.workRun.worked");
   return html`
     <div class="chat-group tool chat-group--work" data-chat-row-key=${item.key}>
-      <span class="chat-work-group__gutter" aria-hidden="true"></span>
       <div class="chat-group-messages">
         <div class="chat-activity-group chat-work-group ${opts.expanded ? "is-open" : ""}">
           <button
             class="chat-inline-disclosure chat-activity-group__summary"
             type="button"
             aria-expanded=${String(opts.expanded)}
+            @pointerenter=${syncToolDisclosureOverflow}
+            @focus=${syncToolDisclosureOverflow}
             @click=${(event: MouseEvent) => {
               if (shouldToggleSelectableDisclosure(event)) {
                 opts.onToggle();
               }
             }}
           >
-            <span class="chat-activity-group__icon">${icons.check}</span>
-            <span class="chat-activity-group__label" title=${label}>${label}</span>
-            <span class="chat-inline-disclosure__chevron" aria-hidden="true"
-              >${icons.chevronDown}</span
-            >
+            <span class="chat-tool-disclosure__content">
+              <span class="chat-activity-group__label" title=${label}>${label}</span>
+            </span>
+            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
           </button>
+          <div class="chat-work-group__separator" aria-hidden="true"></div>
         </div>
       </div>
     </div>

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2359,8 +2359,8 @@ describe("grouped chat rendering", () => {
       ".chat-activity-group__summary",
       HTMLButtonElement,
     );
-    expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
-    expect(activitySummary.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".chat-activity-group.is-open")).not.toBeNull();
+    expect(activitySummary.getAttribute("aria-expanded")).toBe("true");
     expect(activitySummary.getAttribute("aria-label")).toBeNull();
     expect(activitySummary.classList.contains("chat-activity-group__summary--error")).toBe(false);
     expect(container.querySelector(".chat-activity-group__label")?.textContent).toBe(
@@ -2425,7 +2425,7 @@ describe("grouped chat rendering", () => {
     );
     expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
     expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(0);
-    expect(container.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(container.querySelector(".chat-tool-row__badge")).toBeNull();
 
     render(
       renderActivityGroup([successful, failed], {
@@ -2591,7 +2591,7 @@ describe("grouped chat rendering", () => {
       "failed",
     );
     expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(0);
-    expect(container.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(container.querySelector(".chat-tool-row__badge")).toBeNull();
     // Command calls render a `$ command` row instead of the tool-name label.
     expect(summaries[0]?.querySelector(".chat-tool-row__cmd")?.textContent).toBe("run fallback");
   });

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2425,7 +2425,6 @@ describe("grouped chat rendering", () => {
     );
     expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
     expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(0);
-    expect(container.querySelector(".chat-tool-row__badge")).toBeNull();
 
     render(
       renderActivityGroup([successful, failed], {
@@ -2591,7 +2590,6 @@ describe("grouped chat rendering", () => {
       "failed",
     );
     expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(0);
-    expect(container.querySelector(".chat-tool-row__badge")).toBeNull();
     // Command calls render a `$ command` row instead of the tool-name label.
     expect(summaries[0]?.querySelector(".chat-tool-row__cmd")?.textContent).toBe("run fallback");
   });
@@ -2642,9 +2640,8 @@ describe("grouped chat rendering", () => {
     expect(kvRow?.querySelector(".chat-tool-kv__key")?.textContent).toBe("url:");
     expect(kvRow?.querySelector(".chat-tool-kv__value")?.textContent).toBe("https://example.com");
     const blocks = Array.from(container.querySelectorAll(".chat-tool-card__block"));
-    expect(
-      blocks.map((block) => block.querySelector(".chat-tool-card__block-label")?.textContent),
-    ).toEqual(["Tool output"]);
+    // Plain output is the block's default content, so it carries no header.
+    expect(blocks[0]?.querySelector(".chat-tool-card__block-label")).toBeNull();
     expect(blocks[0]?.querySelector("code")?.textContent).toBe("Opened page");
   });
 
@@ -2895,7 +2892,7 @@ describe("grouped chat rendering", () => {
     expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
-  it("marks status-only standalone tool-result summaries with only a failed badge", () => {
+  it("keeps status-only standalone tool-result summaries neutral until expanded", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const onToggleToolMessageExpanded = vi.fn();
@@ -2922,7 +2919,6 @@ describe("grouped chat rendering", () => {
     expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
       "sessions_spawn",
     );
-    expect(summary.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
     selectText(expectElement(summary, ".chat-tool-msg-summary__label", HTMLElement));
     pointerClick(summary);
     expect(onToggleToolMessageExpanded).not.toHaveBeenCalled();
@@ -2938,10 +2934,32 @@ describe("grouped chat rendering", () => {
     summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
     expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(false);
     expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool output");
-    expect(summary.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    // The failure stays recorded: the expanded body closes with the outcome.
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
     expect(
       JSON.parse(container.querySelector(".chat-json-content code")?.textContent ?? "{}"),
     ).toEqual({ status: "error" });
+    container.remove();
+  });
+
+  it("surfaces a producer-reported exit code in the expanded failure outcome", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const groups = [
+      createMessageGroup(
+        createToolResultMessage(
+          "call-exit-code",
+          "shell",
+          JSON.stringify({ status: "failed", exitCode: 1 }),
+          { id: "tool-exit-code" },
+        ),
+        "tool",
+      ),
+    ];
+
+    renderMessageGroups(container, groups, { isToolMessageExpanded: () => true });
+
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("Exit code 1");
     container.remove();
   });
 

--- a/ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
@@ -1,0 +1,209 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderToolCard } from "./chat-tool-cards.ts";
+
+// Outcome presentation for tool cards: neutral collapsed rows, the expanded
+// outcome line, and the compact progress_card receipt.
+describe("tool-card outcomes", () => {
+  it("renders error details with the failure outcome in the expanded body", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:1",
+          name: "web_search",
+          args: { query: "python stable version" },
+          inputText: '{\n  "query": "python stable version"\n}',
+          outputText: JSON.stringify({
+            error: "missing_brave_api_key",
+            message: "BRAVE_API_KEY is not configured",
+          }),
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    const summaryButton = container.querySelector("button.chat-tool-msg-summary");
+    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
+      "Web Search",
+    );
+    const expandedCard = container.querySelector(".chat-tool-card");
+    expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
+    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
+    expect(
+      Array.from(container.querySelectorAll(".chat-tool-card__block-label")).map(
+        (label) => label.textContent,
+      ),
+    ).toContain("Tool error");
+  });
+
+  it("renders a neutral summary for a status-only error payload", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:status-only",
+          name: "sessions_spawn",
+          outputText: JSON.stringify({ status: "error" }),
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    const summary = container.querySelector(".chat-tool-msg-summary");
+    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Sub-agent");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
+    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
+  });
+
+  it("renders a neutral summary when output is the literal 'Tool not found'", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:2",
+          name: "Unknown",
+          outputText: "Tool not found",
+        },
+        { expanded: false, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    const summaryButton = container.querySelector("button.chat-tool-msg-summary");
+    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
+      "Unknown",
+    );
+    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
+  });
+
+  it("renders a neutral summary when the tool card has an explicit error flag", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:explicit",
+          name: "lookup",
+          outputText: "lookup failed",
+          isError: true,
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    const summary = container.querySelector(".chat-tool-msg-summary");
+    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Lookup");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
+    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
+  });
+
+  it("renders a plain error detail when a failed tool has no output", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:no-output",
+          name: "lookup",
+          isError: true,
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
+    expect(container.querySelector(".chat-tool-card__block-label")?.textContent).toBe("Tool error");
+    expect(container.querySelector(".chat-tool-card__block-content")?.textContent).toBe(
+      "No output — tool failed.",
+    );
+  });
+
+  it("respects an explicit success flag even when the payload looks like an error", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:status-false",
+          name: "web_search",
+          outputText: JSON.stringify({
+            error: "missing_brave_api_key",
+          }),
+          isError: false,
+        },
+        { expanded: false, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Web Search");
+    expect(container.textContent).not.toContain("Tool error");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
+  });
+
+  it("renders successful output without redundant Tool output labelling", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:ok:1",
+          name: "browser.open",
+          outputText: "Opened page",
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Opened page");
+    expect(container.textContent).not.toContain("Tool output");
+    expect(container.textContent).not.toContain("Tool error");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
+    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
+  });
+
+  it.each([
+    {
+      args: {
+        markdown: "Implementation is moving.",
+        plan: [
+          { step: "Inspect", status: "completed" },
+          { step: "Implement", status: "in_progress" },
+          { step: "Verify", status: "pending" },
+        ],
+      },
+      expected: "Progress updated — 1/3 · Implement",
+    },
+    { args: { markdown: "Waiting on review." }, expected: "Progress note updated" },
+  ])("renders progress_card as a compact receipt: $expected", ({ args, expected }) => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: `progress:${expected}`,
+          name: "progress_card",
+          args,
+          outputText: "Progress card updated",
+          completed: true,
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent?.trim()).toBe(expected);
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
+    expect(container.textContent).not.toContain("Waiting on review.");
+  });
+});

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -159,9 +159,7 @@ describe("tool-cards", () => {
       "https://example.com",
     );
     const blocks = Array.from(container.querySelectorAll(".chat-tool-card__block"));
-    expect(
-      blocks.map((block) => block.querySelector(".chat-tool-card__block-label")?.textContent),
-    ).toEqual(["Tool output"]);
+    expect(blocks[0]?.querySelector(".chat-tool-card__block-label")).toBeNull();
     expect(blocks[0]?.querySelector("code")?.textContent).toBe("Opened page");
   });
 
@@ -225,6 +223,7 @@ describe("tool-cards", () => {
 
   it("labels a completed Codex file creation from its recorded operation", () => {
     const container = document.createElement("div");
+    const onOpenWorkspaceFile = vi.fn();
     render(
       renderToolCard(
         {
@@ -241,13 +240,69 @@ describe("tool-cards", () => {
           },
           completed: true,
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { expanded: false, onOpenWorkspaceFile, onToggleExpanded: vi.fn() },
       ),
       container,
     );
 
     expect(container.querySelector(".chat-tool-row__verb")?.textContent).toBe("Created");
-    expect(container.querySelector(".chat-tool-row__target")?.textContent).toBe("new.ts");
+    expect(container.querySelector(".chat-tool-row__file-link")?.textContent?.trim()).toBe(
+      "new.ts",
+    );
+    container.querySelector<HTMLButtonElement>(".chat-tool-row__file-link")?.click();
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith({ path: "src/new.ts" });
+  });
+
+  it.each([
+    {
+      label: "multi-file",
+      patch: [
+        "*** Begin Patch",
+        "*** Update File: src/a.ts",
+        "@@",
+        "-old",
+        "+new",
+        "*** Add File: src/b.ts",
+        "+added",
+        "*** End Patch",
+      ].join("\n"),
+      target: "2 files",
+    },
+    {
+      label: "moved",
+      patch: [
+        "*** Begin Patch",
+        "*** Update File: src/old.ts",
+        "*** Move to: src/new.ts",
+        "@@",
+        "-old",
+        "+new",
+        "*** End Patch",
+      ].join("\n"),
+      target: "old.ts → new.ts",
+    },
+  ])("keeps $label patch summaries non-navigable", ({ patch, target }) => {
+    const container = document.createElement("div");
+    const onOpenWorkspaceFile = vi.fn();
+    const onToggleExpanded = vi.fn();
+    render(
+      renderToolCard(
+        {
+          id: `msg:patch:${target}`,
+          name: "apply_patch",
+          args: { patch },
+          completed: true,
+        },
+        { expanded: false, onOpenWorkspaceFile, onToggleExpanded },
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-tool-row--file")).toBeNull();
+    expect(container.querySelector(".chat-tool-row__target")?.textContent).toBe(target);
+    container.querySelector<HTMLButtonElement>(".chat-tool-msg-summary")?.click();
+    expect(onToggleExpanded).toHaveBeenCalledOnce();
+    expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
 
   it("renders edit and write rows from their result outcome", () => {
@@ -336,9 +391,10 @@ describe("tool-cards", () => {
         );
         expect(container.querySelector(".chat-diff")?.getAttribute("aria-label")).toBe(state.label);
         expect(container.querySelector(".chat-diffstat") !== null).toBe(state.hasStat);
-        expect(container.querySelector(".chat-tool-row__badge")?.textContent === "failed").toBe(
-          state.failed,
-        );
+        expect(container.querySelector(".chat-tool-row__badge")).toBeNull();
+        if (state.failed) {
+          expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
+        }
         expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
       }
     }
@@ -702,7 +758,7 @@ describe("tool-cards", () => {
 
     expect(rawToggle!.getAttribute("aria-expanded")).toBe("true");
     expect(rawBody!.hidden).toBe(false);
-    expect(rawBody!.querySelector(".chat-tool-card__block-label")?.textContent).toBe("Tool output");
+    expect(rawBody!.querySelector(".chat-tool-card__block-label")).toBeNull();
     expect(rawBody!.querySelector("code.markdown-block-art")).toBeNull();
     expect(JSON.parse(rawBody!.querySelector("code")?.textContent ?? "{}")).toEqual({
       kind: "canvas",
@@ -799,7 +855,7 @@ describe("tool-cards", () => {
     expect(sidebar.entryUrl).toBe("/__openclaw__/canvas/documents/cv_sidebar/index.html");
   });
 
-  it("renders error details with only a failed summary badge", () => {
+  it("renders error details with the failure outcome in the expanded body", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -823,10 +879,11 @@ describe("tool-cards", () => {
     expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
       "Web Search",
     );
-    expect(summaryButton?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(summaryButton?.querySelector(".chat-tool-row__badge")).toBeNull();
     const expandedCard = container.querySelector(".chat-tool-card");
     expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
     expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
     expect(
       Array.from(container.querySelectorAll(".chat-tool-card__block-label")).map(
         (label) => label.textContent,
@@ -850,9 +907,10 @@ describe("tool-cards", () => {
 
     const summary = container.querySelector(".chat-tool-msg-summary");
     expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Sub-agent");
-    expect(summary?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(summary?.querySelector(".chat-tool-row__badge")).toBeNull();
     expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
     expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
   });
 
   it("renders a neutral summary when output is the literal 'Tool not found'", () => {
@@ -874,7 +932,8 @@ describe("tool-cards", () => {
     expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
       "Unknown",
     );
-    expect(summaryButton?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(summaryButton?.querySelector(".chat-tool-row__badge")).toBeNull();
+    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
   });
 
   it("renders a neutral summary when the tool card has an explicit error flag", () => {
@@ -894,9 +953,10 @@ describe("tool-cards", () => {
 
     const summary = container.querySelector(".chat-tool-msg-summary");
     expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Lookup");
-    expect(summary?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(summary?.querySelector(".chat-tool-row__badge")).toBeNull();
     expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
     expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
   });
 
   it("renders a plain error detail when a failed tool has no output", () => {
@@ -943,7 +1003,7 @@ describe("tool-cards", () => {
     expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
-  it("keeps Tool output labelling for successful results", () => {
+  it("renders successful output without redundant Tool output labelling", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -957,7 +1017,8 @@ describe("tool-cards", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tool output");
+    expect(container.textContent).toContain("Opened page");
+    expect(container.textContent).not.toContain("Tool output");
     expect(container.textContent).not.toContain("Tool error");
     expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
     expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -281,6 +281,13 @@ describe("tool-cards", () => {
       ].join("\n"),
       target: "old.ts → new.ts",
     },
+    {
+      // A successful delete removes its own target, so the workspace loader
+      // would only ever report "Failed to load".
+      label: "deleted",
+      patch: ["*** Begin Patch", "*** Delete File: src/gone.ts", "*** End Patch"].join("\n"),
+      target: "gone.ts",
+    },
   ])("keeps $label patch summaries non-navigable", ({ patch, target }) => {
     const container = document.createElement("div");
     const onOpenWorkspaceFile = vi.fn();
@@ -391,7 +398,6 @@ describe("tool-cards", () => {
         );
         expect(container.querySelector(".chat-diff")?.getAttribute("aria-label")).toBe(state.label);
         expect(container.querySelector(".chat-diffstat") !== null).toBe(state.hasStat);
-        expect(container.querySelector(".chat-tool-row__badge")).toBeNull();
         if (state.failed) {
           expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
         }
@@ -853,210 +859,6 @@ describe("tool-cards", () => {
     expect(sidebar.kind).toBe("canvas");
     expect(sidebar.docId).toBe("cv_sidebar");
     expect(sidebar.entryUrl).toBe("/__openclaw__/canvas/documents/cv_sidebar/index.html");
-  });
-
-  it("renders error details with the failure outcome in the expanded body", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:err:1",
-          name: "web_search",
-          args: { query: "python stable version" },
-          inputText: '{\n  "query": "python stable version"\n}',
-          outputText: JSON.stringify({
-            error: "missing_brave_api_key",
-            message: "BRAVE_API_KEY is not configured",
-          }),
-        },
-        { expanded: true, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    const summaryButton = container.querySelector("button.chat-tool-msg-summary");
-    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(false);
-    expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
-      "Web Search",
-    );
-    expect(summaryButton?.querySelector(".chat-tool-row__badge")).toBeNull();
-    const expandedCard = container.querySelector(".chat-tool-card");
-    expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
-    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
-    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
-    expect(
-      Array.from(container.querySelectorAll(".chat-tool-card__block-label")).map(
-        (label) => label.textContent,
-      ),
-    ).toContain("Tool error");
-  });
-
-  it("renders a neutral summary for a status-only error payload", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:err:status-only",
-          name: "sessions_spawn",
-          outputText: JSON.stringify({ status: "error" }),
-        },
-        { expanded: true, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    const summary = container.querySelector(".chat-tool-msg-summary");
-    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Sub-agent");
-    expect(summary?.querySelector(".chat-tool-row__badge")).toBeNull();
-    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
-    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
-    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
-  });
-
-  it("renders a neutral summary when output is the literal 'Tool not found'", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:err:2",
-          name: "Unknown",
-          outputText: "Tool not found",
-        },
-        { expanded: false, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    const summaryButton = container.querySelector("button.chat-tool-msg-summary");
-    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(false);
-    expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
-      "Unknown",
-    );
-    expect(summaryButton?.querySelector(".chat-tool-row__badge")).toBeNull();
-    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
-  });
-
-  it("renders a neutral summary when the tool card has an explicit error flag", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:err:explicit",
-          name: "lookup",
-          outputText: "lookup failed",
-          isError: true,
-        },
-        { expanded: true, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    const summary = container.querySelector(".chat-tool-msg-summary");
-    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Lookup");
-    expect(summary?.querySelector(".chat-tool-row__badge")).toBeNull();
-    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
-    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
-    expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
-  });
-
-  it("renders a plain error detail when a failed tool has no output", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:err:no-output",
-          name: "lookup",
-          isError: true,
-        },
-        { expanded: true, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
-    expect(container.querySelector(".chat-tool-card__block-label")?.textContent).toBe("Tool error");
-    expect(container.querySelector(".chat-tool-card__block-content")?.textContent).toBe(
-      "No output — tool failed.",
-    );
-  });
-
-  it("respects an explicit success flag even when the payload looks like an error", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:err:status-false",
-          name: "web_search",
-          outputText: JSON.stringify({
-            error: "missing_brave_api_key",
-          }),
-          isError: false,
-        },
-        { expanded: false, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    expect(container.textContent).toContain("Web Search");
-    expect(container.textContent).not.toContain("Tool error");
-    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
-    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
-  });
-
-  it("renders successful output without redundant Tool output labelling", () => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: "msg:ok:1",
-          name: "browser.open",
-          outputText: "Opened page",
-        },
-        { expanded: true, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    expect(container.textContent).toContain("Opened page");
-    expect(container.textContent).not.toContain("Tool output");
-    expect(container.textContent).not.toContain("Tool error");
-    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
-    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
-  });
-
-  it.each([
-    {
-      args: {
-        markdown: "Implementation is moving.",
-        plan: [
-          { step: "Inspect", status: "completed" },
-          { step: "Implement", status: "in_progress" },
-          { step: "Verify", status: "pending" },
-        ],
-      },
-      expected: "Progress updated — 1/3 · Implement",
-    },
-    { args: { markdown: "Waiting on review." }, expected: "Progress note updated" },
-  ])("renders progress_card as a compact receipt: $expected", ({ args, expected }) => {
-    const container = document.createElement("div");
-    render(
-      renderToolCard(
-        {
-          id: `progress:${expected}`,
-          name: "progress_card",
-          args,
-          outputText: "Progress card updated",
-          completed: true,
-        },
-        { expanded: true, onToggleExpanded: vi.fn() },
-      ),
-      container,
-    );
-
-    expect(container.textContent?.trim()).toBe(expected);
-    expect(container.querySelector("button")).toBeNull();
-    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
-    expect(container.textContent).not.toContain("Waiting on review.");
   });
 
   it("does not add a full-message request for ambiguous tool details", () => {

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -631,7 +631,12 @@ function resolveToolWorkspaceFilePath(card: ToolCard, view: ToolCallView): strin
     }
   }
   const fallback = `${view.targetDetail ? `${view.targetDetail}/` : ""}${view.target ?? ""}`;
-  return fallback.trim() || null;
+  const fallbackPath = fallback.trim();
+  if (view.fileOperations) {
+    const operation = view.fileOperations.length === 1 ? view.fileOperations[0] : undefined;
+    return operation?.path === fallbackPath ? operation.path : null;
+  }
+  return fallbackPath || null;
 }
 
 function renderToolWorkspaceFilePath(

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -305,7 +305,7 @@ function compactToolTarget(target: string, kind: ToolCallView["kind"]): string {
   if (kind !== "edit" && kind !== "write") {
     return target;
   }
-  return target.split(/[\\/]/u).filter(Boolean).at(-1) ?? target;
+  return target.split(/[\\/]/u).findLast(Boolean) ?? target;
 }
 
 export function syncToolDisclosureOverflow(event: Event): void {

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -435,6 +435,43 @@ function renderProgressCardReceipt(card: ToolCard, outcome: ToolCardOutcome) {
   </div>`;
 }
 
+function renderFileToolRowContent(
+  card: ToolCard,
+  view: ToolCallView,
+  outcome: ToolCardOutcome,
+  workspaceFilePath: string | null,
+  onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void,
+) {
+  const verb = resolveToolRowVerb(view, outcome);
+  if (!verb || !view.target) {
+    return renderToolRowContent(card, view, outcome);
+  }
+  const stat =
+    outcome === "succeeded"
+      ? view.stat
+      : outcome === "running"
+        ? card.liveDiffStat
+        : undefined;
+  const filename = compactToolTarget(view.target, view.kind);
+  return html`
+    <span class="chat-tool-row__verb">${verb}</span>
+    ${workspaceFilePath && onOpenWorkspaceFile
+      ? html`<button
+          class="chat-tool-row__file-link"
+          type="button"
+          title=${t("chat.toolCards.openFile")}
+          @click=${(event: MouseEvent) => {
+            event.stopPropagation();
+            onOpenWorkspaceFile({ path: workspaceFilePath });
+          }}
+        >
+          ${filename}
+        </button>`
+      : html`<span class="chat-tool-row__target">${filename}</span>`}
+    ${stat ? renderDiffStatChips(stat) : nothing}
+  `;
+}
+
 // ── Command syntax highlighting ──
 
 type CommandToken = { text: string; cls: "name" | "flag" | "str" | "num" | "op" | "plain" | "ws" };
@@ -616,9 +653,28 @@ function renderToolWorkspaceFilePath(
     : html`<div class="chat-tool-card__detail">${label}</div>`;
 }
 
-function renderTerminalBlock(command: string, output: string | undefined, isError: boolean) {
+function renderToolOutcome(outcome: ToolCardOutcome, exitCode?: number) {
+  const label =
+    outcome === "failed"
+      ? exitCode === undefined
+        ? t("chat.toolCards.failed")
+        : t("chat.toolCards.exitCode", { code: String(exitCode) })
+      : outcome === "running"
+        ? t("chat.toolCards.running")
+        : outcome === "succeeded"
+          ? t("chat.toolCards.completed")
+          : null;
+  return label ? html`<div class="chat-tool-card__outcome">${label}</div>` : nothing;
+}
+
+function renderTerminalBlock(
+  command: string,
+  output: string | undefined,
+  outcome: ToolCardOutcome,
+  exitCode?: number,
+) {
   return html`
-    <div class="chat-tool-term ${isError ? "chat-tool-term--error" : ""}">
+    <div class="chat-tool-term">
       <div class="chat-tool-term__cmd">
         <span class="chat-tool-term__prompt">$</span
         ><code>${renderHighlightedCommand(command)}</code>
@@ -626,9 +682,7 @@ function renderTerminalBlock(command: string, output: string | undefined, isErro
       ${output?.trim()
         ? html`<pre class="chat-tool-term__out"><code>${output}</code></pre>`
         : nothing}
-      ${isError
-        ? html`<div class="chat-tool-card__outcome">${t("chat.toolCards.failed")}</div>`
-        : nothing}
+      ${renderToolOutcome(outcome, exitCode)}
     </div>
   `;
 }
@@ -713,20 +767,51 @@ export function renderToolCard(
   const display = resolveToolDisplay({ name: card.name, args: card.args, detailMode: "explain" });
   const isError = outcome === "failed";
   const isRunning = outcome === "running";
+  const expanded = opts.expanded || isRunning;
   const icon = TOOL_ROW_ICONS[view.kind] ?? display.icon;
+  const workspaceFilePath =
+    view.kind === "edit" || view.kind === "write" ? resolveToolWorkspaceFilePath(card, view) : null;
+  const isFileMutation = Boolean(workspaceFilePath && (view.kind === "edit" || view.kind === "write"));
 
   return html`
     <div
-      class="chat-tool-msg-collapse chat-tool-msg-collapse--manual ${opts.expanded
+      class="chat-tool-msg-collapse chat-tool-msg-collapse--manual ${expanded
         ? "is-open"
         : ""}"
     >
-      <button
+      ${isFileMutation
+        ? html`<div
+            class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row chat-tool-row--file ${isRunning
+              ? "chat-tool-row--running"
+              : ""}"
+            @pointerenter=${syncToolDisclosureOverflow}
+            @focusin=${syncToolDisclosureOverflow}
+          >
+            <button
+              class="chat-tool-row__toggle"
+              type="button"
+              aria-expanded=${String(expanded)}
+              aria-label=${resolveToolRowText(card, opts.runActive)}
+              @click=${() => opts.onToggleExpanded(card.id)}
+            ></button>
+            <span class="chat-tool-msg-summary__icon">${renderToolIcon(icon)}</span>
+            <span class="chat-tool-disclosure__content"
+              >${renderFileToolRowContent(
+                card,
+                view,
+                outcome,
+                workspaceFilePath,
+                opts.onOpenWorkspaceFile,
+              )}</span
+            >
+            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
+          </div>`
+        : html`<button
         class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row ${isRunning
           ? "chat-tool-row--running"
           : ""}"
         type="button"
-        aria-expanded=${String(opts.expanded)}
+        aria-expanded=${String(expanded)}
         @pointerenter=${syncToolDisclosureOverflow}
         @focus=${syncToolDisclosureOverflow}
         @click=${(event: MouseEvent) => {
@@ -740,8 +825,8 @@ export function renderToolCard(
           >${renderToolRowContent(card, view, outcome)}</span
         >
         <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
-      </button>
-      ${opts.expanded
+      </button>`}
+      ${expanded
         ? html`
             <div class="chat-tool-msg-body">
               ${renderExpandedToolCardContent(
@@ -853,7 +938,8 @@ export function renderExpandedToolCardContent(
         ${renderTerminalBlock(
           view.command,
           card.outputText,
-          isError,
+          outcome,
+          card.exitCode,
         )}
         ${Object.keys(extraArgs).length > 0 ? renderArgsKeyValueList(extraArgs) : nothing}
       </div>
@@ -874,6 +960,7 @@ export function renderExpandedToolCardContent(
           <div class="chat-tool-card__actions">${diffCopyAction}${sidebarAction}</div>
         </div>
         ${renderDiffBlock(view.diff, outcome)}
+        ${renderToolOutcome(outcome, card.exitCode)}
         ${isError && hasOutput
           ? renderToolDataBlock({ label: t("chat.toolCards.toolError"), text: card.outputText! })
           : hasOutput
@@ -927,6 +1014,7 @@ export function renderExpandedToolCardContent(
               text: t("chat.toolCards.noOutputFailed"),
             })
           : nothing}
+      ${renderToolOutcome(outcome, card.exitCode)}
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -201,20 +201,19 @@ export function renderRawOutputToggle(text: string) {
         <span>${t("chat.toolCards.rawDetails")}</span>
         <span class="chat-inline-disclosure__chevron" aria-hidden="true">${icons.chevronDown}</span>
       </button>
-      <div class="chat-tool-card__raw-body" hidden>
-        ${renderToolDataBlock({ label: t("chat.toolCards.toolOutput"), text })}
-      </div>
+      <div class="chat-tool-card__raw-body" hidden>${renderToolDataBlock({ text })}</div>
     </div>
   `;
 }
 
-function renderToolDataBlock(params: { label: string; text: string }) {
+// Plain tool output is the block's default content, so it carries no header;
+// only input/error blocks need a label to stay distinguishable.
+function renderToolDataBlock(params: { label?: string; text: string }) {
   const { label, text } = params;
   const codeClass = isMarkdownBlockArtText(text) ? "markdown-block-art" : "";
-  const showLabel = label !== t("chat.toolCards.toolOutput");
   return html`
     <div class="chat-tool-card__block">
-      ${showLabel
+      ${label
         ? html`<div class="chat-tool-card__block-header">
             <span class="chat-tool-card__block-icon">${icons.zap}</span>
             <span class="chat-tool-card__block-label">${label}</span>
@@ -418,19 +417,12 @@ function renderProgressCardReceipt(card: ToolCard, outcome: ToolCardOutcome) {
           : markdown
             ? t("sessionProgressCard.receipt.noteUpdated")
             : t("sessionProgressCard.receipt.cleared");
+  // The label already names the running/failed state, so the row stays neutral
+  // like every other transcript activity row instead of adding its own chrome.
   return html`<div class="chat-tool-msg-collapse chat-progress-card-receipt">
     <div class="chat-tool-msg-summary chat-tool-row" role="status">
       <span class="chat-tool-msg-summary__icon">${renderToolIcon("listChecks")}</span>
       <span class="chat-tool-msg-summary__label">${label}</span>
-      ${outcome === "failed"
-        ? html`<span class="chat-tool-row__badge">${t("chat.toolCards.failed")}</span>`
-        : nothing}
-      ${outcome === "running"
-        ? html`<span
-            class="chat-tool-row__spinner"
-            aria-label=${t("chat.toolCards.running")}
-          ></span>`
-        : nothing}
     </div>
   </div>`;
 }
@@ -621,6 +613,12 @@ function extraArgsBeyondRowTarget(
 }
 
 function resolveToolWorkspaceFilePath(card: ToolCard, view: ToolCallView): string | null {
+  const singleOperation = view.fileOperations?.length === 1 ? view.fileOperations[0] : undefined;
+  // A delete removes its own target, so the workspace loader would always
+  // report "Failed to load"; the row keeps its disclosure but no file action.
+  if (singleOperation?.operation === "delete") {
+    return null;
+  }
   const args = asNullableRecord(card.args);
   if (args) {
     for (const key of ["path", "file_path", "filePath", "notebook_path"]) {
@@ -632,9 +630,10 @@ function resolveToolWorkspaceFilePath(card: ToolCard, view: ToolCallView): strin
   }
   const fallback = `${view.targetDetail ? `${view.targetDetail}/` : ""}${view.target ?? ""}`;
   const fallbackPath = fallback.trim();
+  // Aggregate patch labels ("2 files", "a.ts → b.ts") name no single file, so
+  // only a recorded operation matching the rendered path stays navigable.
   if (view.fileOperations) {
-    const operation = view.fileOperations.length === 1 ? view.fileOperations[0] : undefined;
-    return operation?.path === fallbackPath ? operation.path : null;
+    return singleOperation?.path === fallbackPath ? singleOperation.path : null;
   }
   return fallbackPath || null;
 }
@@ -658,7 +657,8 @@ function renderToolWorkspaceFilePath(
     : html`<div class="chat-tool-card__detail">${label}</div>`;
 }
 
-function renderToolOutcome(outcome: ToolCardOutcome, exitCode?: number) {
+/** Neutral end-state line every expanded tool surface closes with. */
+export function renderToolOutcome(outcome: ToolCardOutcome, exitCode?: number) {
   const label =
     outcome === "failed"
       ? exitCode === undefined
@@ -985,7 +985,7 @@ export function renderExpandedToolCardContent(
                   ? renderToolWorkspaceFilePath(detail, workspaceFilePath, onOpenWorkspaceFile)
                   : html`<div class="chat-tool-card__detail">${detail}</div>`
                 : nothing}
-              ${sidebarAction}
+              <div class="chat-tool-card__actions">${sidebarAction}</div>
             </div>
           `
         : nothing}
@@ -1001,7 +1001,7 @@ export function renderExpandedToolCardContent(
         ? card.preview
           ? html`${visiblePreview} ${renderRawOutputToggle(card.outputText!)}`
           : renderToolDataBlock({
-              label: t(isError ? "chat.toolCards.toolError" : "chat.toolCards.toolOutput"),
+              ...(isError ? { label: t("chat.toolCards.toolError") } : {}),
               text: card.outputText!,
             })
         : isError

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -6,6 +6,7 @@ import { icons, type IconName } from "../../../components/icons.ts";
 import { isMarkdownBlockArtText } from "../../../components/markdown-text.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
+import { copyToClipboard } from "../../../lib/clipboard.ts";
 import type { ToolCard, ToolCardOutcome } from "../../../lib/chat/chat-types.ts";
 import { resolveToolCallView, type ToolCallView } from "../../../lib/chat/tool-call-view.ts";
 import {
@@ -210,12 +211,15 @@ export function renderRawOutputToggle(text: string) {
 function renderToolDataBlock(params: { label: string; text: string }) {
   const { label, text } = params;
   const codeClass = isMarkdownBlockArtText(text) ? "markdown-block-art" : "";
+  const showLabel = label !== t("chat.toolCards.toolOutput");
   return html`
     <div class="chat-tool-card__block">
-      <div class="chat-tool-card__block-header">
-        <span class="chat-tool-card__block-icon">${icons.zap}</span>
-        <span class="chat-tool-card__block-label">${label}</span>
-      </div>
+      ${showLabel
+        ? html`<div class="chat-tool-card__block-header">
+            <span class="chat-tool-card__block-icon">${icons.zap}</span>
+            <span class="chat-tool-card__block-label">${label}</span>
+          </div>`
+        : nothing}
       <pre class="chat-tool-card__block-content"><code class=${codeClass}>${text}</code></pre>
     </div>
   `;
@@ -294,20 +298,31 @@ const TOOL_ROW_ICONS: Partial<Record<ToolCallView["kind"], string>> = {
 };
 
 function firstCommandLine(command: string): string {
-  const line = command.split("\n")[0]?.trim() ?? "";
-  return truncateUtf16Safe(line, 120);
+  return command.split("\n")[0]?.trim() ?? "";
+}
+
+function compactToolTarget(target: string, kind: ToolCallView["kind"]): string {
+  if (kind !== "edit" && kind !== "write") {
+    return target;
+  }
+  return target.split(/[\\/]/u).filter(Boolean).at(-1) ?? target;
+}
+
+export function syncToolDisclosureOverflow(event: Event): void {
+  const disclosure = event.currentTarget;
+  if (!(disclosure instanceof HTMLElement)) {
+    return;
+  }
+  const content = disclosure.querySelector<HTMLElement>(".chat-tool-disclosure__content");
+  disclosure.classList.toggle(
+    "chat-tool-disclosure--overflowing",
+    Boolean(content && content.scrollWidth > content.clientWidth),
+  );
 }
 
 function renderToolRowContent(card: ToolCard, view: ToolCallView, outcome: ToolCardOutcome) {
   if (view.kind === "command" && view.command) {
     const commandPreview = firstCommandLine(view.command);
-    const aiTitle = getToolCallTitle(card.name, card.args);
-    if (aiTitle) {
-      return html`
-        <span class="chat-tool-row__title">${aiTitle}</span>
-        <code class="chat-tool-row__cmd chat-tool-row__cmd--secondary">${commandPreview}</code>
-      `;
-    }
     return html`
       <span class="chat-tool-row__prompt" aria-hidden="true">$</span>
       <code class="chat-tool-row__cmd">${renderHighlightedCommand(commandPreview)}</code>
@@ -324,9 +339,9 @@ function renderToolRowContent(card: ToolCard, view: ToolCallView, outcome: ToolC
           : undefined;
     return html`
       <span class="chat-tool-row__verb">${verb}</span>
-      <span class="chat-tool-row__target">${view.target}</span>
+      <span class="chat-tool-row__target">${compactToolTarget(view.target, view.kind)}</span>
       ${stat ? renderDiffStatChips(stat) : nothing}
-      ${view.targetDetail
+      ${view.targetDetail && view.kind !== "edit" && view.kind !== "write"
         ? html`<span class="chat-tool-row__detail">${view.targetDetail}</span>`
         : nothing}
     `;
@@ -611,8 +626,17 @@ function renderTerminalBlock(command: string, output: string | undefined, isErro
       ${output?.trim()
         ? html`<pre class="chat-tool-term__out"><code>${output}</code></pre>`
         : nothing}
+      ${isError
+        ? html`<div class="chat-tool-card__outcome">${t("chat.toolCards.failed")}</div>`
+        : nothing}
     </div>
   `;
+}
+
+function serializeDiff(lines: readonly { kind: string; text: string }[]): string {
+  return lines
+    .map((line) => `${line.kind === "add" ? "+" : line.kind === "del" ? "-" : " "}${line.text}`)
+    .join("\n");
 }
 
 export function resolveCollapsedToolDetail(card: ToolCard, displayDetail: string | undefined) {
@@ -703,6 +727,8 @@ export function renderToolCard(
           : ""}"
         type="button"
         aria-expanded=${String(opts.expanded)}
+        @pointerenter=${syncToolDisclosureOverflow}
+        @focus=${syncToolDisclosureOverflow}
         @click=${(event: MouseEvent) => {
           if (shouldToggleSelectableDisclosure(event)) {
             opts.onToggleExpanded(card.id);
@@ -710,17 +736,10 @@ export function renderToolCard(
         }}
       >
         <span class="chat-tool-msg-summary__icon">${renderToolIcon(icon)}</span>
-        ${renderToolRowContent(card, view, outcome)}
-        <span class="chat-inline-disclosure__chevron" aria-hidden="true">${icons.chevronDown}</span>
-        ${isError
-          ? html`<span class="chat-tool-row__badge">${t("chat.toolCards.failed")}</span>`
-          : nothing}
-        ${isRunning
-          ? html`<span
-              class="chat-tool-row__spinner"
-              aria-label=${t("chat.toolCards.running")}
-            ></span>`
-          : nothing}
+        <span class="chat-tool-disclosure__content"
+          >${renderToolRowContent(card, view, outcome)}</span
+        >
+        <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
       </button>
       ${opts.expanded
         ? html`
@@ -792,20 +811,33 @@ export function renderExpandedToolCardContent(
     : nothing;
   const sidebarAction = canOpenSidebar
     ? html`
-        <div class="chat-tool-card__actions">
-          <openclaw-tooltip content=${t("chat.toolCards.openDetails")}>
+        <openclaw-tooltip content=${t("chat.toolCards.openDetails")}>
+          <button
+            class="chat-tool-card__action-btn"
+            type="button"
+            @click=${() => onOpenSidebar?.(sidebarActionContent)}
+            aria-label=${t("chat.toolCards.openDetails")}
+          >
+            <span class="chat-tool-card__action-icon">${icons.panelRightOpen}</span>
+          </button>
+        </openclaw-tooltip>
+      `
+    : nothing;
+  const diffCopyAction =
+    view.diff && view.diff.length > 0
+      ? html`
+          <openclaw-tooltip content=${t("common.copy")}>
             <button
               class="chat-tool-card__action-btn"
               type="button"
-              @click=${() => onOpenSidebar?.(sidebarActionContent)}
-              aria-label=${t("chat.toolCards.openDetails")}
+              @click=${() => void copyToClipboard(serializeDiff(view.diff ?? []))}
+              aria-label=${t("common.copy")}
             >
-              <span class="chat-tool-card__action-icon">${icons.panelRightOpen}</span>
+              <span class="chat-tool-card__action-icon">${icons.copy}</span>
             </button>
           </openclaw-tooltip>
-        </div>
-      `
-    : nothing;
+        `
+      : nothing;
 
   // Command calls render terminal-style: `$ command` + raw output. Remaining
   // args (workdir, timeout, env…) stay visible as key-value rows so identical
@@ -817,10 +849,10 @@ export function renderExpandedToolCardContent(
     );
     return html`
       <div class="chat-tool-card chat-tool-card--flush ${isError ? "chat-tool-card--error" : ""}">
-        ${sidebarAction}
+        <div class="chat-tool-card__actions">${sidebarAction}</div>
         ${renderTerminalBlock(
           view.command,
-          card.outputText ?? (isError ? t("chat.toolCards.noOutputFailed") : undefined),
+          card.outputText,
           isError,
         )}
         ${Object.keys(extraArgs).length > 0 ? renderArgsKeyValueList(extraArgs) : nothing}
@@ -835,11 +867,11 @@ export function renderExpandedToolCardContent(
       <div class="chat-tool-card ${isError ? "chat-tool-card--error" : ""}">
         <div class="chat-tool-card__header">
           ${renderToolWorkspaceFilePath(
-            `${view.targetDetail ? `${view.targetDetail}/` : ""}${view.target ?? ""}`,
+            workspaceFilePath ?? view.target ?? "",
             workspaceFilePath,
             onOpenWorkspaceFile,
           )}
-          ${sidebarAction}
+          <div class="chat-tool-card__actions">${diffCopyAction}${sidebarAction}</div>
         </div>
         ${renderDiffBlock(view.diff, outcome)}
         ${isError && hasOutput

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -6,7 +6,6 @@ import { icons, type IconName } from "../../../components/icons.ts";
 import { isMarkdownBlockArtText } from "../../../components/markdown-text.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
-import { copyToClipboard } from "../../../lib/clipboard.ts";
 import type { ToolCard, ToolCardOutcome } from "../../../lib/chat/chat-types.ts";
 import { resolveToolCallView, type ToolCallView } from "../../../lib/chat/tool-call-view.ts";
 import {
@@ -23,6 +22,7 @@ import {
   resolveToolDisplay,
   type EmbedSandboxMode,
 } from "../../../lib/chat/tool-display.ts";
+import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { getToolCallTitle } from "../tool-titles.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -765,7 +765,6 @@ export function renderToolCard(
   }
   const view = resolveToolCallView({ name: card.name, args: card.args, details: card.details });
   const display = resolveToolDisplay({ name: card.name, args: card.args, detailMode: "explain" });
-  const isError = outcome === "failed";
   const isRunning = outcome === "running";
   const expanded = opts.expanded || isRunning;
   const icon = TOOL_ROW_ICONS[view.kind] ?? display.icon;
@@ -776,11 +775,7 @@ export function renderToolCard(
   const isFileRow = Boolean(workspaceFilePath);
 
   return html`
-    <div
-      class="chat-tool-msg-collapse chat-tool-msg-collapse--manual ${expanded
-        ? "is-open"
-        : ""}"
-    >
+    <div class="chat-tool-msg-collapse chat-tool-msg-collapse--manual ${expanded ? "is-open" : ""}">
       ${isFileRow
         ? html`<div
             class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row chat-tool-row--file ${isRunning
@@ -809,25 +804,25 @@ export function renderToolCard(
             <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
           </div>`
         : html`<button
-        class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row ${isRunning
-          ? "chat-tool-row--running"
-          : ""}"
-        type="button"
-        aria-expanded=${String(expanded)}
-        @pointerenter=${syncToolDisclosureOverflow}
-        @focus=${syncToolDisclosureOverflow}
-        @click=${(event: MouseEvent) => {
-          if (shouldToggleSelectableDisclosure(event)) {
-            opts.onToggleExpanded(card.id);
-          }
-        }}
-      >
-        <span class="chat-tool-msg-summary__icon">${renderToolIcon(icon)}</span>
-        <span class="chat-tool-disclosure__content"
-          >${renderToolRowContent(card, view, outcome)}</span
-        >
-        <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
-      </button>`}
+            class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row ${isRunning
+              ? "chat-tool-row--running"
+              : ""}"
+            type="button"
+            aria-expanded=${String(expanded)}
+            @pointerenter=${syncToolDisclosureOverflow}
+            @focus=${syncToolDisclosureOverflow}
+            @click=${(event: MouseEvent) => {
+              if (shouldToggleSelectableDisclosure(event)) {
+                opts.onToggleExpanded(card.id);
+              }
+            }}
+          >
+            <span class="chat-tool-msg-summary__icon">${renderToolIcon(icon)}</span>
+            <span class="chat-tool-disclosure__content"
+              >${renderToolRowContent(card, view, outcome)}</span
+            >
+            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
+          </button>`}
       ${expanded
         ? html`
             <div class="chat-tool-msg-body">
@@ -937,12 +932,7 @@ export function renderExpandedToolCardContent(
     return html`
       <div class="chat-tool-card chat-tool-card--flush ${isError ? "chat-tool-card--error" : ""}">
         <div class="chat-tool-card__actions">${sidebarAction}</div>
-        ${renderTerminalBlock(
-          view.command,
-          card.outputText,
-          outcome,
-          card.exitCode,
-        )}
+        ${renderTerminalBlock(view.command, card.outputText, outcome, card.exitCode)}
         ${Object.keys(extraArgs).length > 0 ? renderArgsKeyValueList(extraArgs) : nothing}
       </div>
     `;
@@ -961,8 +951,7 @@ export function renderExpandedToolCardContent(
           )}
           <div class="chat-tool-card__actions">${diffCopyAction}${sidebarAction}</div>
         </div>
-        ${renderDiffBlock(view.diff, outcome)}
-        ${renderToolOutcome(outcome, card.exitCode)}
+        ${renderDiffBlock(view.diff, outcome)} ${renderToolOutcome(outcome, card.exitCode)}
         ${isError && hasOutput
           ? renderToolDataBlock({ label: t("chat.toolCards.toolError"), text: card.outputText! })
           : hasOutput

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -449,7 +449,7 @@ function renderFileToolRowContent(
   const stat =
     outcome === "succeeded"
       ? view.stat
-      : outcome === "running"
+      : outcome === "running" && (view.kind === "edit" || view.kind === "write")
         ? card.liveDiffStat
         : undefined;
   const filename = compactToolTarget(view.target, view.kind);
@@ -770,8 +770,10 @@ export function renderToolCard(
   const expanded = opts.expanded || isRunning;
   const icon = TOOL_ROW_ICONS[view.kind] ?? display.icon;
   const workspaceFilePath =
-    view.kind === "edit" || view.kind === "write" ? resolveToolWorkspaceFilePath(card, view) : null;
-  const isFileMutation = Boolean(workspaceFilePath && (view.kind === "edit" || view.kind === "write"));
+    view.kind === "read" || view.kind === "edit" || view.kind === "write"
+      ? resolveToolWorkspaceFilePath(card, view)
+      : null;
+  const isFileRow = Boolean(workspaceFilePath);
 
   return html`
     <div
@@ -779,7 +781,7 @@ export function renderToolCard(
         ? "is-open"
         : ""}"
     >
-      ${isFileMutation
+      ${isFileRow
         ? html`<div
             class="chat-inline-disclosure chat-tool-msg-summary chat-tool-row chat-tool-row--file ${isRunning
               ? "chat-tool-row--running"

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -57,6 +57,7 @@ export type ToolStreamEntry = {
   /** Monotonic edit counts received while the tool arguments stream. */
   liveDiffStat?: DiffStat;
   isError?: boolean;
+  exitCode?: number;
   /** True once a result event landed, even when the output text is empty. */
   resultReceived?: boolean;
   startedAt: number;
@@ -280,6 +281,7 @@ function buildToolStreamMessage(entry: ToolStreamEntry): Record<string, unknown>
       text: entry.output ?? "",
       ...(entry.details !== undefined ? { details: entry.details } : {}),
       ...(entry.isError !== undefined ? { isError: entry.isError } : {}),
+      ...(entry.exitCode !== undefined ? { exitCode: entry.exitCode } : {}),
     });
   }
   return {
@@ -1029,6 +1031,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   const resultDetails = phase === "result" ? readRecord(data.result)?.details : undefined;
   const resultIsError =
     phase === "result" && typeof data.isError === "boolean" ? data.isError : undefined;
+  const resultRecord = phase === "result" ? readRecord(data.result) : undefined;
+  const resultExitCode = resultRecord?.exitCode;
+  const exitCode =
+    typeof resultExitCode === "number" && Number.isInteger(resultExitCode)
+      ? resultExitCode
+      : undefined;
   const liveDiffStat = phase === "input_delta" ? readLiveDiffStat(data.diff) : undefined;
   if (name === "session_status" && phase === "result") {
     syncSessionStatusModelOverride(host, data);
@@ -1047,6 +1055,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       output: output || undefined,
       ...(resultDetails !== undefined ? { details: resultDetails } : {}),
       ...(resultIsError !== undefined ? { isError: resultIsError } : {}),
+      ...(exitCode !== undefined ? { exitCode } : {}),
       ...(liveDiffStat ? { liveDiffStat } : {}),
       ...(phase === "result" ? { resultReceived: true } : {}),
       startedAt: typeof payload.ts === "number" ? payload.ts : now,
@@ -1068,6 +1077,9 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     }
     if (resultIsError !== undefined) {
       entry.isError = resultIsError;
+    }
+    if (exitCode !== undefined) {
+      entry.exitCode = exitCode;
     }
     if (liveDiffStat) {
       entry.liveDiffStat = liveDiffStat;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -110,8 +110,8 @@
 .chat-group.tool {
   --chat-message-column-max: var(--chat-message-max-width, min(980px, 100%));
   display: block;
-  margin-inline: 0;
-  padding-inline-start: 46px;
+  margin-inline-start: 0;
+  padding-inline-start: 0;
 }
 
 .chat-group.tool.chat-group--with-footer {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -108,7 +108,18 @@
 }
 
 .chat-group.tool {
-  --chat-message-column-max: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
+  --chat-message-column-max: var(--chat-message-max-width, min(980px, 100%));
+  display: block;
+  margin-inline: 0;
+  padding-inline-start: 46px;
+}
+
+.chat-group.tool.chat-group--with-footer {
+  display: block;
+}
+
+.chat-group.tool.chat-group--with-footer > .chat-group-messages {
+  max-width: var(--chat-message-column-max);
 }
 
 .chat-group.user .chat-group-footer {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -275,11 +275,6 @@
   color: inherit;
 }
 
-.chat-tool-row__cmd--secondary {
-  flex: 0 1 auto;
-  color: color-mix(in srgb, var(--muted) 85%, var(--text) 15%);
-}
-
 .chat-tool-row__verb {
   flex-shrink: 0;
   font: inherit;
@@ -314,7 +309,10 @@
    correct in both themes. Scoped to no-preference so reduced-motion users
    keep plain static text and syntax colors. */
 @media (prefers-reduced-motion: no-preference) {
-  .chat-tool-row--running .chat-tool-row__verb {
+  /* Whichever element names the work in progress: the action verb on file rows,
+     the command itself on terminal rows. Syntax tokens inherit `color`, so the
+     clipped gradient paints their glyphs too. */
+  .chat-tool-row--running :is(.chat-tool-row__verb, .chat-tool-row__cmd) {
     background-image: linear-gradient(
       90deg,
       var(--text) 0%,
@@ -638,41 +636,6 @@
   border-bottom: 1px solid var(--border);
 }
 
-.chat-tool-card__tabs {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-}
-
-.chat-tool-card__tab {
-  padding: 6px 10px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--muted);
-  font: 12px/1 var(--font-body);
-  cursor: var(--cursor-action);
-}
-
-.chat-tool-card__tab[aria-selected="true"] {
-  background: color-mix(in srgb, var(--text) 9%, transparent);
-  color: var(--text);
-}
-
-.chat-tool-card__tab-panel[hidden] {
-  display: none;
-}
-
-.chat-tool-card__tab-panel {
-  min-width: 0;
-}
-
-.chat-tool-card__empty {
-  padding: 12px 14px 16px;
-  color: var(--muted);
-  font-size: 12px;
-}
-
 /* Cards whose body is a single block (terminal, diff) skip the header row and
    float the side-panel action over the block instead. */
 .chat-tool-card--flush {
@@ -693,9 +656,10 @@
   transition: opacity 120ms ease-out;
 }
 
-.chat-tool-card__header .chat-tool-card__action-btn {
-  width: 28px;
-  height: 28px;
+/* Header actions sit in a bordered row, so they run one size smaller than the
+   free-floating ones; the command reservation below tracks whichever applies. */
+.chat-tool-card__header {
+  --chat-tool-action-size: 28px;
 }
 
 .chat-tool-card__header:hover > .chat-tool-card__actions,
@@ -703,8 +667,10 @@
   opacity: 1;
 }
 
+/* Reserve the floating action box (button + its 6px inset) plus the block's own
+   12px padding so command text never runs underneath it. */
 .chat-tool-card--flush:has(> .chat-tool-card__actions) .chat-tool-term__cmd {
-  padding-right: 42px;
+  padding-right: calc(var(--chat-tool-action-size, 40px) + 18px);
 }
 
 .chat-tool-card--flush:hover > .chat-tool-card__actions,
@@ -731,8 +697,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: var(--chat-tool-action-size, 40px);
+  height: var(--chat-tool-action-size, 40px);
   padding: 0;
   border: 0;
   border-radius: var(--radius-sm);
@@ -845,21 +811,6 @@
   word-break: break-word;
   overflow: auto;
   max-height: min(520px, 60vh);
-}
-
-.chat-tool-card__plain-output {
-  margin: 0;
-  padding: 12px 14px 14px;
-  overflow: auto;
-  color: var(--muted);
-  font: 12px/1.5 var(--mono);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
-.chat-tool-card__plain-output code {
-  color: inherit;
-  font: inherit;
 }
 
 .chat-tool-card__block-content code {
@@ -1110,7 +1061,7 @@
 /* Keep the activity summary, call bubbles, and flat result rows on one width.
    Include the role classes so this wins over the generic tool-group rule. */
 .chat-group.tool.chat-group--activity .chat-group-messages {
-  max-width: var(--chat-message-max-width, min(980px, 100%));
+  max-width: var(--chat-message-max-width, min(760px, 100%));
 }
 
 .chat-activity-group {
@@ -1161,25 +1112,6 @@
   padding-left: 0;
   border-left: 0;
   overflow-y: auto;
-  mask-image: none;
-}
-
-.chat-activity-group__body.has-scroll-bottom:not(.has-scroll-top) {
-  mask-image: linear-gradient(to bottom, var(--text) calc(100% - 44px), transparent 100%);
-}
-
-.chat-activity-group__body.has-scroll-top:not(.has-scroll-bottom) {
-  mask-image: linear-gradient(to bottom, transparent 0, var(--text) 44px);
-}
-
-.chat-activity-group__body.has-scroll-top.has-scroll-bottom {
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0,
-    var(--text) 44px,
-    var(--text) calc(100% - 44px),
-    transparent 100%
-  );
 }
 
 /* Completed-turn work rollup: slim "Worked for X" disclosure standing in for

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -94,7 +94,7 @@
   gap: 7px;
   width: fit-content;
   max-width: 100%;
-  padding: 5px 0;
+  padding: 3px 0;
   list-style: none;
   appearance: none;
   -webkit-appearance: none;
@@ -1146,7 +1146,7 @@
 .chat-activity-group__body {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0;
   max-height: min(420px, 58vh);
   margin: 6px 0 0;
   padding-left: 0;

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -190,7 +190,13 @@
 }
 
 .chat-activity-group__body .chat-tool-msg-summary:hover .chat-tool-row__chevron,
-.chat-activity-group__body .chat-tool-msg-summary:focus-within .chat-tool-row__chevron {
+.chat-activity-group__body .chat-tool-msg-summary:focus-within .chat-tool-row__chevron,
+.chat-activity-group__body
+  .chat-tool-msg-summary:has([aria-expanded="true"])
+  .chat-tool-row__chevron,
+.chat-activity-group__body
+  .chat-tool-msg-summary[aria-expanded="true"]
+  .chat-tool-row__chevron {
   opacity: 1;
 }
 

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -175,8 +175,7 @@
   transform: rotate(90deg);
 }
 
-.chat-tool-row--file:has(.chat-tool-row__toggle[aria-expanded="true"])
-  .chat-tool-row__chevron {
+.chat-tool-row--file:has(.chat-tool-row__toggle[aria-expanded="true"]) .chat-tool-row__chevron {
   transform: rotate(90deg);
 }
 
@@ -194,9 +193,7 @@
 .chat-activity-group__body
   .chat-tool-msg-summary:has([aria-expanded="true"])
   .chat-tool-row__chevron,
-.chat-activity-group__body
-  .chat-tool-msg-summary[aria-expanded="true"]
-  .chat-tool-row__chevron {
+.chat-activity-group__body .chat-tool-msg-summary[aria-expanded="true"] .chat-tool-row__chevron {
   opacity: 1;
 }
 

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -75,7 +75,7 @@
   --chat-tool-activity-color: color-mix(in srgb, var(--muted) 88%, transparent);
 
   font-family: var(--font-body);
-  font-size: var(--control-ui-text-sm);
+  font-size: calc(var(--control-ui-text-sm) + 1px);
   font-weight: 400;
   line-height: 1.5;
   color: var(--chat-tool-activity-color);

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -626,6 +626,10 @@
 }
 
 .chat-tool-card__header {
+  /* Header actions sit in a bordered row, so they run one size smaller than the
+     free-floating ones; the flush command reservation tracks whichever applies. */
+  --chat-tool-action-size: 28px;
+
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -654,12 +658,6 @@
 .chat-tool-card__header > .chat-tool-card__actions {
   opacity: 0;
   transition: opacity 120ms ease-out;
-}
-
-/* Header actions sit in a bordered row, so they run one size smaller than the
-   free-floating ones; the command reservation below tracks whichever applies. */
-.chat-tool-card__header {
-  --chat-tool-action-size: 28px;
 }
 
 .chat-tool-card__header:hover > .chat-tool-card__actions,

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -112,7 +112,53 @@
   height: 16px;
 }
 
+.chat-tool-row--file {
+  position: relative;
+}
+
+.chat-tool-row__toggle {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: transparent;
+  cursor: var(--cursor-action);
+}
+
+.chat-tool-row--file > :not(.chat-tool-row__toggle) {
+  position: relative;
+  pointer-events: none;
+}
+
+.chat-tool-row--file .chat-tool-row__file-link {
+  pointer-events: auto;
+}
+
+.chat-tool-row__file-link {
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: 500 calc(var(--control-ui-text-sm) - 1px) var(--mono);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+  text-underline-offset: 2px;
+  white-space: nowrap;
+  cursor: var(--cursor-action);
+}
+
+.chat-tool-row__file-link:hover,
+.chat-tool-row__file-link:focus-visible {
+  text-decoration-color: currentColor;
+}
+
 .chat-inline-disclosure[aria-expanded="true"] .chat-tool-row__chevron {
+  transform: rotate(90deg);
+}
+
+.chat-tool-row--file:has(.chat-tool-row__toggle[aria-expanded="true"])
+  .chat-tool-row__chevron {
   transform: rotate(90deg);
 }
 
@@ -574,6 +620,16 @@
   transition: opacity 120ms ease;
 }
 
+.chat-tool-card__header > .chat-tool-card__actions {
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+
+.chat-tool-card__header:hover > .chat-tool-card__actions,
+.chat-tool-card__header:focus-within > .chat-tool-card__actions {
+  opacity: 1;
+}
+
 .chat-tool-card--flush:has(> .chat-tool-card__actions) .chat-tool-term__cmd {
   padding-right: 42px;
 }
@@ -584,7 +640,8 @@
 }
 
 @media (pointer: coarse) {
-  .chat-tool-card--flush > .chat-tool-card__actions {
+  .chat-tool-card--flush > .chat-tool-card__actions,
+  .chat-tool-card__header > .chat-tool-card__actions {
     opacity: 1;
   }
 }
@@ -1028,16 +1085,14 @@
   padding-bottom: 8px;
 }
 
-.chat-work-group__gutter {
-  flex: 0 0 36px;
-}
-
-.chat-thread--direct .chat-work-group__gutter {
-  display: none;
-}
-
 .chat-work-group .chat-activity-group__label {
   color: var(--muted);
+}
+
+.chat-work-group__separator {
+  width: 100%;
+  height: 1px;
+  background: var(--border);
 }
 
 /* Reading indicator = working claw: the brand pincer claws in place where the

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -72,11 +72,62 @@
 
 .chat-tool-msg-summary {
   gap: 7px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 5px 0;
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   list-style: none;
   appearance: none;
   -webkit-appearance: none;
+}
+
+.chat-tool-disclosure__content {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.chat-tool-row__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  margin-inline-start: 2px;
+  color: var(--muted);
+  opacity: 0.55;
+  transition:
+    opacity 150ms ease-out,
+    transform 150ms ease-out;
+}
+
+.chat-tool-row__chevron svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-inline-disclosure[aria-expanded="true"] .chat-tool-row__chevron {
+  transform: rotate(90deg);
+}
+
+.chat-inline-disclosure:hover .chat-tool-row__chevron,
+.chat-inline-disclosure:focus-visible .chat-tool-row__chevron {
+  opacity: 1;
+}
+
+.chat-tool-disclosure--overflowing {
+  width: 100%;
+}
+
+.chat-tool-disclosure--overflowing .chat-tool-disclosure__content {
+  flex: 1 1 auto;
+  mask-image: linear-gradient(to right, var(--text) calc(100% - 28px), transparent);
 }
 
 .chat-tool-msg-summary::-webkit-details-marker {
@@ -103,12 +154,12 @@
   stroke-linejoin: round;
 }
 
-/* Collapsed rows clamp to one line; the full text is available on expand. */
+/* Collapsed rows stay on one line; measured overflow gets a fade while the
+   complete value remains available in the expanded detail. */
 .chat-tool-msg-summary__label {
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 500;
   color: var(--text);
@@ -119,7 +170,6 @@
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--mono);
   font-size: calc(var(--control-ui-text-sm) - 1px);
@@ -132,14 +182,13 @@
   font-family: var(--mono);
   font-size: calc(var(--control-ui-text-sm) - 1px);
   font-weight: 600;
-  color: color-mix(in srgb, var(--ok) 70%, var(--muted) 30%);
+  color: var(--muted);
 }
 
 .chat-tool-row__title {
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 500;
   color: var(--text);
@@ -149,7 +198,6 @@
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--mono);
   font-size: calc(var(--control-ui-text-sm) - 1px);
@@ -171,7 +219,6 @@
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--mono);
   font-size: calc(var(--control-ui-text-sm) - 1px);
@@ -183,7 +230,6 @@
   flex: 0 1 auto;
   min-width: 24px;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--mono);
   font-size: calc(var(--control-ui-text-sm) - 1px);
@@ -191,7 +237,7 @@
 }
 
 .chat-tool-row--running .chat-tool-msg-summary__icon {
-  color: var(--accent-2);
+  color: var(--muted);
 }
 
 /* Active-task text wave: a subtle left-to-right color sweep across the
@@ -200,14 +246,7 @@
    correct in both themes. Scoped to no-preference so reduced-motion users
    keep plain static text and syntax colors. */
 @media (prefers-reduced-motion: no-preference) {
-  .chat-tool-row--running
-    :is(
-      .chat-tool-msg-summary__label,
-      .chat-tool-row__title,
-      .chat-tool-row__verb,
-      .chat-tool-row__target,
-      .chat-tool-row__cmd:not(.chat-tool-row__cmd--secondary)
-    ) {
+  .chat-tool-row--running .chat-tool-row__verb {
     background-image: linear-gradient(
       90deg,
       var(--text) 0%,
@@ -221,12 +260,6 @@
     background-clip: text;
     color: transparent;
     animation: chatToolRowTextWave 2.2s ease-in-out infinite;
-  }
-
-  /* Syntax-highlight tokens go transparent while running so the parent's
-     clipped gradient paints their glyphs; token colors return on completion. */
-  .chat-tool-row--running .chat-tool-row__cmd:not(.chat-tool-row__cmd--secondary) > span {
-    color: transparent;
   }
 }
 
@@ -242,46 +275,6 @@
   }
 }
 
-.chat-tool-row__spinner {
-  flex-shrink: 0;
-  width: 7px;
-  height: 7px;
-  border-radius: var(--radius-full, 999px);
-  background: var(--accent-2);
-  animation: chatToolRowPulse 1.1s ease-in-out infinite;
-}
-
-@keyframes chatToolRowPulse {
-  0%,
-  100% {
-    opacity: 0.35;
-    transform: scale(0.85);
-  }
-
-  50% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .chat-tool-row__spinner {
-    animation: none;
-    opacity: 0.8;
-  }
-}
-
-.chat-tool-row__badge {
-  flex-shrink: 0;
-  padding: 1px 6px;
-  border-radius: var(--radius-full, 999px);
-  background: color-mix(in srgb, var(--destructive) 14%, transparent);
-  color: var(--destructive);
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1.5;
-}
-
 /* ── Diffstat chips (+N -M) ── */
 .chat-diffstat {
   display: inline-flex;
@@ -291,13 +284,21 @@
   font-family: var(--mono);
   font-size: calc(var(--control-ui-text-sm) - 1px);
   font-weight: 600;
+  color: var(--muted);
 }
 
-.chat-diffstat__add {
+.chat-diffstat__add,
+.chat-diffstat__del {
+  color: inherit;
+}
+
+.chat-tool-msg-summary:hover .chat-diffstat__add,
+.chat-tool-msg-summary:focus-visible .chat-diffstat__add {
   color: var(--ok);
 }
 
-.chat-diffstat__del {
+.chat-tool-msg-summary:hover .chat-diffstat__del,
+.chat-tool-msg-summary:focus-visible .chat-diffstat__del {
   color: var(--destructive);
 }
 
@@ -387,9 +388,8 @@
 
 /* ── Terminal-style command block ── */
 .chat-tool-term {
-  margin-top: 6px;
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--secondary) 82%, transparent);
+  margin-top: 0;
+  background: transparent;
   overflow: hidden;
 }
 
@@ -413,7 +413,7 @@
 .chat-tool-term__prompt {
   flex-shrink: 0;
   font-weight: 600;
-  color: color-mix(in srgb, var(--ok) 70%, var(--muted) 30%);
+  color: var(--muted);
   user-select: none;
 }
 
@@ -434,8 +434,11 @@
   padding-bottom: 10px;
 }
 
-.chat-tool-term--error .chat-tool-term__out {
-  color: color-mix(in srgb, var(--destructive) 70%, var(--text) 30%);
+.chat-tool-card__outcome {
+  padding: 7px 12px 9px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
 }
 
 /* Command/diff text reuses <code> for semantics only; kill the markdown pill. */
@@ -452,16 +455,16 @@
 
 /* ── Command token colors (display-only highlighting) ── */
 .chat-cmd--name {
-  color: var(--accent-2);
+  color: inherit;
   font-weight: 600;
 }
 
 .chat-cmd--str {
-  color: color-mix(in srgb, var(--ok) 78%, var(--text) 22%);
+  color: inherit;
 }
 
 .chat-cmd--num {
-  color: color-mix(in srgb, var(--accent) 82%, var(--text) 18%);
+  color: inherit;
 }
 
 .chat-cmd--flag {
@@ -469,7 +472,7 @@
 }
 
 .chat-cmd--op {
-  color: color-mix(in srgb, var(--accent-2) 60%, var(--muted) 40%);
+  color: inherit;
 }
 
 /* ── Key-value args (generic tools) ── */
@@ -508,7 +511,19 @@
   box-sizing: border-box;
   min-width: 0;
   max-width: 100%;
-  padding: 2px 8px 8px 24px;
+  margin-top: 5px;
+  padding: 0;
+  overflow: auto;
+  max-height: min(520px, 60vh);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: transparent;
+}
+
+.chat-tool-msg-body .chat-diff {
+  margin-top: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .chat-bubble--tool-shell .chat-tool-msg-body > .chat-text {
@@ -537,9 +552,11 @@
 .chat-tool-card__header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   min-width: 0;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border);
 }
 
 /* Cards whose body is a single block (terminal, diff) skip the header row and
@@ -584,8 +601,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 40px;
+  height: 40px;
   padding: 0;
   border: 0;
   border-radius: var(--radius-sm);
@@ -610,8 +627,8 @@
 }
 
 .chat-tool-card__action-icon svg {
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;
@@ -622,7 +639,7 @@
 .chat-tool-card__detail {
   flex: 1 1 auto;
   min-width: 0;
-  font-size: var(--control-ui-text-sm);
+  font: 11px/1.4 var(--mono);
   color: var(--muted);
 }
 
@@ -631,20 +648,20 @@
   padding: 0;
   border: 0;
   background: transparent;
-  font: inherit;
+  font: 11px/1.4 var(--mono);
   text-align: left;
   cursor: var(--cursor-action);
 }
 
 .chat-tool-card__detail-link:hover,
 .chat-tool-card__detail-link:focus-visible {
-  color: var(--accent);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  color: var(--text);
+  text-decoration: none;
 }
 
 .chat-tool-card__block {
-  margin-top: 8px;
+  margin: 0;
+  padding: 10px 12px;
   min-width: 0;
 }
 
@@ -687,9 +704,9 @@
   max-width: 100%;
   min-width: 0;
   margin: 0;
-  padding: 10px 12px;
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--secondary) 82%, transparent);
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--text);
   font-size: 12px;
   line-height: 1.45;
@@ -948,7 +965,7 @@
 /* Keep the activity summary, call bubbles, and flat result rows on one width.
    Include the role classes so this wins over the generic tool-group rule. */
 .chat-group.tool.chat-group--activity .chat-group-messages {
-  max-width: var(--chat-message-max-width, min(760px, 100%));
+  max-width: var(--chat-message-max-width, min(980px, 100%));
 }
 
 .chat-activity-group {
@@ -988,19 +1005,20 @@
   font-size: var(--control-ui-text-sm);
   font-weight: 600;
   line-height: 1.4;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Rows form a flat indented list below the summary. The rail marks the group
-   extent while shared row hover pills remain free of per-row chrome. */
+/* Parent and child rows share one icon/text grid; order and whitespace carry
+   hierarchy without shrinking the available command width. */
 .chat-activity-group__body {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  margin: 4px 0 0 10px;
-  padding-left: 10px;
-  border-left: 2px solid color-mix(in srgb, var(--border) 82%, transparent);
+  max-height: min(420px, 58vh);
+  margin: 5px 0 0;
+  padding-left: 0;
+  border-left: 0;
+  overflow-y: auto;
 }
 
 /* Completed-turn work rollup: slim "Worked for X" disclosure standing in for

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1160,11 +1160,11 @@
   flex-direction: column;
   gap: 0;
   max-height: min(420px, 58vh);
-  margin: 6px 0 0;
+  margin: 0;
   padding-left: 0;
   border-left: 0;
   overflow-y: auto;
-  mask-image: linear-gradient(to bottom, transparent 0, var(--text) 0, var(--text) 100%, transparent 100%);
+  mask-image: none;
 }
 
 .chat-activity-group__body.has-scroll-bottom:not(.has-scroll-top) {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -114,9 +114,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 16px;
-  width: 16px;
-  height: 16px;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
   margin-inline-start: -3px;
   color: var(--muted);
   opacity: 0.55;
@@ -125,16 +125,9 @@
     transform 150ms ease-out;
 }
 
-.chat-activity-group__summary .chat-tool-row__chevron,
-.chat-activity-group__summary .chat-tool-row__chevron svg {
+.chat-tool-row__chevron svg {
   width: 14px;
   height: 14px;
-  flex-basis: 14px;
-}
-
-.chat-tool-row__chevron svg {
-  width: 16px;
-  height: 16px;
 }
 
 .chat-tool-row--file {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -70,15 +70,22 @@
   margin-top: 0;
 }
 
+.chat-tool-msg-summary,
+.chat-activity-group__summary {
+  --chat-tool-activity-color: color-mix(in srgb, var(--muted) 88%, transparent);
+
+  font-family: var(--font-body);
+  font-size: var(--control-ui-text-sm);
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--chat-tool-activity-color);
+}
+
 .chat-tool-msg-summary {
   gap: 7px;
   width: fit-content;
   max-width: 100%;
   padding: 5px 0;
-  font-family: var(--font-body);
-  font-size: var(--control-ui-text-sm);
-  font-weight: 400;
-  line-height: 1.5;
   list-style: none;
   appearance: none;
   -webkit-appearance: none;
@@ -148,7 +155,7 @@
   padding: 0;
   border: 0;
   background: transparent;
-  color: var(--muted);
+  color: inherit;
   font: inherit;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 18%, transparent);
@@ -217,7 +224,7 @@
   overflow: hidden;
   white-space: nowrap;
   font: inherit;
-  color: var(--text);
+  color: inherit;
 }
 
 .chat-tool-msg-summary__names,
@@ -234,7 +241,7 @@
 .chat-tool-row__prompt {
   flex-shrink: 0;
   font: inherit;
-  color: var(--muted);
+  color: inherit;
 }
 
 .chat-tool-row__title {
@@ -251,9 +258,7 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font-family: var(--mono);
-  font-size: inherit;
-  color: var(--muted);
+  color: inherit;
 }
 
 .chat-tool-row__cmd--secondary {
@@ -264,7 +269,7 @@
 .chat-tool-row__verb {
   flex-shrink: 0;
   font: inherit;
-  color: var(--muted);
+  color: inherit;
 }
 
 .chat-tool-row__target {
@@ -273,7 +278,7 @@
   overflow: hidden;
   white-space: nowrap;
   font: inherit;
-  color: var(--muted);
+  color: inherit;
 }
 
 .chat-tool-row__detail {
@@ -282,7 +287,7 @@
   overflow: hidden;
   white-space: nowrap;
   font: inherit;
-  color: color-mix(in srgb, var(--muted) 88%, var(--text) 12%);
+  color: inherit;
 }
 
 .chat-tool-row--running .chat-tool-msg-summary__icon {
@@ -492,6 +497,7 @@
 /* Command/diff text reuses <code> for semantics only; kill the markdown pill. */
 .chat-tool-row__cmd,
 .chat-tool-row__cmd code,
+.chat-tool-row__cmd span,
 .chat-tool-term__cmd code,
 .chat-tool-term__out code {
   background: none;
@@ -499,6 +505,16 @@
   padding: 0;
   font-size: inherit;
   color: inherit;
+}
+
+.chat-tool-row__cmd,
+.chat-tool-row__cmd code,
+.chat-tool-row__cmd span {
+  font-family: var(--mono);
+  font-size: var(--control-ui-text-sm);
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0;
 }
 
 /* ── Command token colors (display-only highlighting) ── */
@@ -1098,7 +1114,6 @@
 .chat-activity-group__summary {
   gap: 8px;
   padding-block: 5px;
-  color: var(--text);
 }
 
 .chat-activity-group__icon {
@@ -1123,9 +1138,7 @@
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  font-size: inherit;
-  font-weight: 400;
-  line-height: 1.4;
+  font: inherit;
   white-space: nowrap;
 }
 
@@ -1169,11 +1182,11 @@
 }
 
 .chat-work-group .chat-activity-group__label {
-  color: color-mix(in srgb, var(--muted) 88%, transparent);
+  color: inherit;
 }
 
 .chat-group--activity .chat-activity-group__label {
-  color: color-mix(in srgb, var(--muted) 88%, transparent);
+  color: inherit;
 }
 
 .chat-work-group__separator {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -596,6 +596,10 @@
   background: transparent;
 }
 
+.chat-activity-group__body .chat-tool-msg-collapse.is-open {
+  margin-bottom: 8px;
+}
+
 .chat-tool-msg-body .chat-diff {
   margin-top: 0;
   border-radius: 0;

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -185,6 +185,15 @@
   opacity: 1;
 }
 
+.chat-activity-group__body .chat-tool-row__chevron {
+  opacity: 0;
+}
+
+.chat-activity-group__body .chat-tool-msg-summary:hover .chat-tool-row__chevron,
+.chat-activity-group__body .chat-tool-msg-summary:focus-within .chat-tool-row__chevron {
+  opacity: 1;
+}
+
 .chat-tool-disclosure--overflowing {
   width: 100%;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -75,7 +75,9 @@
   width: fit-content;
   max-width: 100%;
   padding: 5px 0;
+  font-family: var(--font-body);
   font-size: var(--control-ui-text-sm);
+  font-weight: 400;
   line-height: 1.5;
   list-style: none;
   appearance: none;
@@ -85,7 +87,7 @@
 .chat-tool-disclosure__content {
   display: inline-flex;
   align-items: baseline;
-  gap: 7px;
+  gap: 6px;
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
@@ -99,12 +101,19 @@
   flex: 0 0 16px;
   width: 16px;
   height: 16px;
-  margin-inline-start: 2px;
+  margin-inline-start: -3px;
   color: var(--muted);
   opacity: 0.55;
   transition:
     opacity 150ms ease-out,
     transform 150ms ease-out;
+}
+
+.chat-activity-group__summary .chat-tool-row__chevron,
+.chat-activity-group__summary .chat-tool-row__chevron svg {
+  width: 14px;
+  height: 14px;
+  flex-basis: 14px;
 }
 
 .chat-tool-row__chevron svg {
@@ -139,10 +148,10 @@
   padding: 0;
   border: 0;
   background: transparent;
-  color: var(--text);
-  font: 500 calc(var(--control-ui-text-sm) - 1px) var(--mono);
+  color: var(--muted);
+  font: inherit;
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 18%, transparent);
   text-underline-offset: 2px;
   white-space: nowrap;
   cursor: var(--cursor-action);
@@ -173,7 +182,7 @@
 
 .chat-tool-disclosure--overflowing .chat-tool-disclosure__content {
   flex: 1 1 auto;
-  mask-image: linear-gradient(to right, var(--text) calc(100% - 28px), transparent);
+  mask-image: linear-gradient(to right, var(--text) calc(100% - 44px), transparent 100%);
 }
 
 .chat-tool-msg-summary::-webkit-details-marker {
@@ -184,15 +193,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
   color: var(--muted);
   flex-shrink: 0;
 }
 
 .chat-tool-msg-summary__icon svg {
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;
@@ -207,7 +216,7 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font-weight: 500;
+  font: inherit;
   color: var(--text);
 }
 
@@ -217,17 +226,14 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
+  font: inherit;
   color: color-mix(in srgb, var(--muted) 82%, var(--text) 18%);
 }
 
 /* ── Kind-aware tool rows ── */
 .chat-tool-row__prompt {
   flex-shrink: 0;
-  font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
-  font-weight: 600;
+  font: inherit;
   color: var(--muted);
 }
 
@@ -236,7 +242,7 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font-weight: 500;
+  font: inherit;
   color: var(--text);
 }
 
@@ -246,8 +252,8 @@
   overflow: hidden;
   white-space: nowrap;
   font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
-  color: var(--text);
+  font-size: inherit;
+  color: var(--muted);
 }
 
 .chat-tool-row__cmd--secondary {
@@ -257,8 +263,8 @@
 
 .chat-tool-row__verb {
   flex-shrink: 0;
-  font-weight: 500;
-  color: var(--text);
+  font: inherit;
+  color: var(--muted);
 }
 
 .chat-tool-row__target {
@@ -266,10 +272,8 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
-  font-weight: 500;
-  color: var(--text);
+  font: inherit;
+  color: var(--muted);
 }
 
 .chat-tool-row__detail {
@@ -277,8 +281,7 @@
   min-width: 24px;
   overflow: hidden;
   white-space: nowrap;
-  font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
+  font: inherit;
   color: color-mix(in srgb, var(--muted) 88%, var(--text) 12%);
 }
 
@@ -328,8 +331,6 @@
   gap: 4px;
   flex-shrink: 0;
   font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
-  font-weight: 600;
   color: var(--muted);
 }
 
@@ -481,10 +482,11 @@
 }
 
 .chat-tool-card__outcome {
-  padding: 7px 12px 9px;
+  padding: 7px 14px 9px;
   border-top: 1px solid var(--border);
   color: var(--muted);
   font-size: 11px;
+  text-align: end;
 }
 
 /* Command/diff text reuses <code> for semantics only; kill the markdown pill. */
@@ -502,22 +504,26 @@
 /* ── Command token colors (display-only highlighting) ── */
 .chat-cmd--name {
   color: inherit;
-  font-weight: 600;
+  font: inherit;
 }
 
 .chat-cmd--str {
+  font: inherit;
   color: inherit;
 }
 
 .chat-cmd--num {
+  font: inherit;
   color: inherit;
 }
 
 .chat-cmd--flag {
-  color: color-mix(in srgb, var(--muted) 70%, var(--text) 30%);
+  font: inherit;
+  color: inherit;
 }
 
 .chat-cmd--op {
+  font: inherit;
   color: inherit;
 }
 
@@ -561,8 +567,9 @@
   padding: 0;
   overflow: auto;
   max-height: min(520px, 60vh);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--text) 22%, transparent);
+  border-radius: calc(14px * var(--openclaw-corner-radius-scale));
+  corner-shape: superellipse(1.5);
   background: transparent;
 }
 
@@ -575,6 +582,7 @@
 .chat-bubble--tool-shell .chat-tool-msg-body > .chat-text {
   max-height: min(46vh, 540px);
   margin: 0;
+  padding: 12px 14px 14px;
   overflow: auto;
   font-family: var(--mono);
   font-size: 12px;
@@ -601,8 +609,44 @@
   align-items: center;
   gap: 10px;
   min-width: 0;
-  padding: 9px 12px;
+  min-height: 30px;
+  padding: 4px 8px 4px 14px;
   border-bottom: 1px solid var(--border);
+}
+
+.chat-tool-card__tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.chat-tool-card__tab {
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  font: 12px/1 var(--font-body);
+  cursor: var(--cursor-action);
+}
+
+.chat-tool-card__tab[aria-selected="true"] {
+  background: color-mix(in srgb, var(--text) 9%, transparent);
+  color: var(--text);
+}
+
+.chat-tool-card__tab-panel[hidden] {
+  display: none;
+}
+
+.chat-tool-card__tab-panel {
+  min-width: 0;
+}
+
+.chat-tool-card__empty {
+  padding: 12px 14px 16px;
+  color: var(--muted);
+  font-size: 12px;
 }
 
 /* Cards whose body is a single block (terminal, diff) skip the header row and
@@ -623,6 +667,11 @@
 .chat-tool-card__header > .chat-tool-card__actions {
   opacity: 0;
   transition: opacity 120ms ease-out;
+}
+
+.chat-tool-card__header .chat-tool-card__action-btn {
+  width: 28px;
+  height: 28px;
 }
 
 .chat-tool-card__header:hover > .chat-tool-card__actions,
@@ -772,6 +821,21 @@
   word-break: break-word;
   overflow: auto;
   max-height: min(520px, 60vh);
+}
+
+.chat-tool-card__plain-output {
+  margin: 0;
+  padding: 12px 14px 14px;
+  overflow: auto;
+  color: var(--muted);
+  font: 12px/1.5 var(--mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.chat-tool-card__plain-output code {
+  color: inherit;
+  font: inherit;
 }
 
 .chat-tool-card__block-content code {
@@ -1046,8 +1110,8 @@
 }
 
 .chat-activity-group__icon svg {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   fill: none;
   stroke: currentColor;
   stroke-width: 1.8px;
@@ -1059,8 +1123,8 @@
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  font-size: var(--control-ui-text-sm);
-  font-weight: 600;
+  font-size: inherit;
+  font-weight: 400;
   line-height: 1.4;
   white-space: nowrap;
 }
@@ -1072,10 +1136,29 @@
   flex-direction: column;
   gap: 2px;
   max-height: min(420px, 58vh);
-  margin: 5px 0 0;
+  margin: 6px 0 0;
   padding-left: 0;
   border-left: 0;
   overflow-y: auto;
+  mask-image: linear-gradient(to bottom, transparent 0, var(--text) 0, var(--text) 100%, transparent 100%);
+}
+
+.chat-activity-group__body.has-scroll-bottom:not(.has-scroll-top) {
+  mask-image: linear-gradient(to bottom, var(--text) calc(100% - 44px), transparent 100%);
+}
+
+.chat-activity-group__body.has-scroll-top:not(.has-scroll-bottom) {
+  mask-image: linear-gradient(to bottom, transparent 0, var(--text) 44px);
+}
+
+.chat-activity-group__body.has-scroll-top.has-scroll-bottom {
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    var(--text) 44px,
+    var(--text) calc(100% - 44px),
+    transparent 100%
+  );
 }
 
 /* Completed-turn work rollup: slim "Worked for X" disclosure standing in for
@@ -1086,7 +1169,11 @@
 }
 
 .chat-work-group .chat-activity-group__label {
-  color: var(--muted);
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
+}
+
+.chat-group--activity .chat-activity-group__label {
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
 }
 
 .chat-work-group__separator {
@@ -2127,7 +2214,7 @@ openclaw-tooltip.chat-tasks-status__preview {
 
 @media (max-width: 768px) {
   .chat-tool-msg-body {
-    padding-left: 16px;
+    padding-left: 0;
   }
 
   .chat-json-content {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -81,6 +81,15 @@
   color: var(--chat-tool-activity-color);
 }
 
+.chat-tool-msg-summary :where(span, code, button),
+.chat-activity-group__summary :where(span, code, button) {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+}
+
 .chat-tool-msg-summary {
   gap: 7px;
   width: fit-content;
@@ -505,16 +514,6 @@
   padding: 0;
   font-size: inherit;
   color: inherit;
-}
-
-.chat-tool-row__cmd,
-.chat-tool-row__cmd code,
-.chat-tool-row__cmd span {
-  font-family: var(--mono);
-  font-size: var(--control-ui-text-sm);
-  font-weight: 400;
-  line-height: 1.5;
-  letter-spacing: 0;
 }
 
 /* ── Command token colors (display-only highlighting) ── */


### PR DESCRIPTION
Closes #125223

## What Problem This Solves

Resolves a problem where users reviewing tool-heavy Control UI transcripts see tool calls presented as separate authored turns with gear avatars, `Activity` identity metadata, nested tree chrome, distant disclosures, saturated command styling, prominent failure badges, and repetitive file paths. The excess hierarchy makes activity harder to scan than the surrounding assistant flow.

## Why This Change Was Made

Tool calls now render as lightweight transcript activity without a pseudo-avatar gutter while preserving renderer data, counters, grouping, and raw detail access. Collapsed rows are flat and neutral; measured overflow alone activates a trailing fade; Lucide chevrons follow fitting content; expanded output uses one bounded muted-border surface; file rows link basenames through the existing workspace file action and show explicit `+N -N`; running activity opens while active and returns to the collapsed default after completion; and every expanded tool surface closes with a neutral outcome line that carries producer-reported exit codes when available.

This PR is the visual implementation plan for transcript thesis 8, adjustments 14 and 15. It intentionally does not alter terminal interaction ownership, semantic naming, `commandActions`, grouping, protocol, terminal ownership, filename drawer APIs, live turn summaries, reply behavior, or queue behavior.

## User Impact

Tool activity reads as part of the assistant turn instead of competing with it as a stack of cards. Long commands remain complete and accessible, file edits are compact and navigable, contextual actions stay hidden until hover or focus, running rows animate only the element that names the work (the action verb on file rows, the command on terminal rows), and failures stay inspectable without alarming compact rows. Completed `Worked for` summaries drop the redundant check and retain a stable separator above their expanded content.

## Evidence

- Source review covered the current tool row, standalone tool message, activity group, expanded command/output, inline diff, and file counter render paths.
- Visual verification of every redesigned state in both themes is in the screenshot grid comment below.
- Focused local proof: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-tool-cards.test.ts ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts ui/src/pages/chat/components/chat-message.test.ts` (224 passed).
- Types: `node scripts/run-tsgo.mjs -p tsconfig.ui.json`, `-p test/tsconfig/tsconfig.core.test.ui-other.json`, `-p test/tsconfig/tsconfig.core.test.ui-pages-e2e.json` — all clean.
- Copy: `node --import tsx scripts/control-ui-i18n-verify.ts verify` — clean.
- Browser and Control UI E2E lanes are hosted-CI proof on the exact head; this maintainer host has no Chromium install.
- Production LOC: `+606/-333` (net `+273`). Tests: `+340/-244` (net `+96`).
- The dirty `lane-transcript` worktree was inspected only as integrated design evidence; this branch re-derived and implemented the owner changes from current `main` without cherry-picking.

## Follow-ups

- `chat.messages.activity` is now unreferenced after the activity group lost its identity footer; left in place because the copy verifier does not flag unused keys and removing it is unrelated cleanup.
