### PR TITLE
improve(ui): simplify message chrome and actions

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -300,7 +300,7 @@
   padding: 4px;
   min-width: 24px;
   min-height: 24px;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-md);
   color: var(--muted);
   opacity: var(--chat-footer-disclosure-opacity, 0);
   pointer-events: var(--chat-footer-disclosure-pointer-events, none);
@@ -328,7 +328,7 @@
 .chat-group-footer button:hover,
 .chat-message-actions-row button:hover {
   opacity: 1 !important;
-  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  background: transparent;
   color: var(--accent);
 }
 
@@ -807,16 +807,21 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 .chat-group.user .chat-bubble:hover {
-  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
+  border-color: transparent;
+  box-shadow: none;
 }
 
-/* Light mode: restore borders. Order contract: stays below the role variants
-   above; it ties with .chat-group.user .chat-bubble on specificity and the
-   light skin must win (user bubbles render on var(--bg) in light mode). */
+/* Light mode: restore borders for surfaces that retain them. */
 :root[data-theme-mode="light"] .chat-bubble {
   border-color: var(--border);
   background: var(--bg);
   box-shadow: inset 0 1px 0 var(--card-highlight);
+}
+
+:root[data-theme-mode="light"] .chat-group.user .chat-bubble {
+  border-color: transparent;
+  background: var(--accent-subtle);
+  box-shadow: none;
 }
 
 :root[data-theme-mode="light"] .chat-bubble--tool-shell,
@@ -836,7 +841,7 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 .chat-group.user.chat-group--sender-tint .chat-bubble:hover {
-  border-color: hsl(var(--chat-sender-hue) 48% 55% / 0.4);
+  border-color: transparent;
 }
 
 .chat-group.user.chat-group--sender-tint .chat-sender-name {
@@ -845,13 +850,13 @@ img.chat-avatar.chat-avatar--logo {
 
 :root[data-theme-mode="light"] .chat-group.user.chat-group--sender-tint .chat-bubble {
   background: hsl(var(--chat-sender-hue) 65% 94%);
-  border-color: hsl(var(--chat-sender-hue) 45% 82%);
+  border-color: transparent;
 }
 
-/* Outranks the light skin above (it also sets border-color); without this the
-   tinted hover border never applies in light mode. */
+/* Keep tinted user turns borderless when the generic light hover skin applies. */
 :root[data-theme-mode="light"] .chat-group.user.chat-group--sender-tint .chat-bubble:hover {
-  border-color: hsl(var(--chat-sender-hue) 48% 62%);
+  border-color: transparent;
+  box-shadow: none;
 }
 
 :root[data-theme-mode="light"] .chat-group.user.chat-group--sender-tint .chat-sender-name {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3226,6 +3226,7 @@ td.data-table-key-col {
 :root[data-theme-mode="light"] .chat-line.user .chat-bubble {
   border-color: transparent;
   background: var(--accent-subtle);
+  box-shadow: none;
 }
 
 .chat-line.assistant .chat-bubble {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3224,7 +3224,7 @@ td.data-table-key-col {
 }
 
 :root[data-theme-mode="light"] .chat-line.user .chat-bubble {
-  border-color: color-mix(in srgb, var(--accent) 20%, transparent);
+  border-color: transparent;
   background: var(--accent-subtle);
 }
 


### PR DESCRIPTION
Closes #125235

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where user-message bubbles gain accent chrome on hover, message action icons gain a visible hover surface, and the light-theme loading placeholder restores an outline that is absent from the completed user turn. These treatments add visual weight and make loading and completed message geometry inconsistent.

## Why This Change Was Made

This ports the message-chrome owner choices from the canonical transcript Wave 1 planning context, section `PR — chrome e ações da mensagem`, adjustment 1. User bubbles and their loading placeholder remain borderless across dark and light themes, light mode retains its subtle fill, sender tints remain intact, and action controls keep their existing hit areas and focus-visible behavior while using a slightly rounder squircle with no hover surface.

Markdown content and all other transcript theses are intentionally out of scope.

## User Impact

User turns now keep a quieter, consistent borderless surface in normal, hover, and loading states. Transcript action icons remain discoverable and keyboard accessible without adding another visible button surface around the message.

## Evidence

- Duplicate search found no matching open issue or pull request; closed #85713 concerns invisible light-theme hover highlights rather than this borderless message-chrome design.
- Source inspection confirms the change is limited to the canonical grouped-message styles and the loading-skeleton user-bubble skin.
- The loading skeleton's width, alignment, fill, internal skeleton, and animation rules are unchanged.
- Production CSS delta: `+17/-12`; tests/generated files: `+0/-0`.
- Per request, no tests, builds, checks, lint, formatting, screenshots, local review, or CI watching were run. External review owns behavioral and visual proof.
- The two planning screenshots referenced by temporary local paths were unavailable when this PR was prepared. Before/after visual proof therefore remains outstanding.
