### PR TITLE
docs(install): avoid rerunning onboarding after hosted installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,17 @@ script contract, Docker, Nix, and other deployment paths.
 
 ## Quick start
 
+On a fresh install, the installer scripts start onboarding automatically.
+Complete the wizard they open. If you installed the package directly with npm,
+pnpm, or Bun, run:
+
 ```bash
 openclaw onboard --install-daemon
+```
+
+After onboarding:
+
+```bash
 openclaw gateway status
 openclaw dashboard
 ```

--- a/docs/install/digitalocean.md
+++ b/docs/install/digitalocean.md
@@ -48,8 +48,8 @@ DigitalOcean is a straightforward paid VPS path. For cheaper or free options:
     curl -fsSL https://deb.nodesource.com/setup_26.x | bash -
     apt install -y nodejs
 
-    # Install OpenClaw
-    curl -fsSL https://openclaw.ai/install.sh | bash
+    # Install OpenClaw; run onboarding later as the non-root owner.
+    curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
 
     # Create the non-root user that will own OpenClaw state and services.
     adduser openclaw

--- a/docs/install/raspberry-pi.md
+++ b/docs/install/raspberry-pi.md
@@ -91,7 +91,7 @@ Run a persistent, always-on OpenClaw Gateway on a Raspberry Pi. Since the Pi is 
 
   <Step title="Install OpenClaw">
     ```bash
-    curl -fsSL https://openclaw.ai/install.sh | bash
+    curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
     ```
   </Step>
 

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -49,16 +49,13 @@ Need to install Node? See [Node setup](/install/node).
     </Note>
 
   </Step>
-  <Step title="Run onboarding">
-    ```bash
-    openclaw onboard --install-daemon
-    ```
-
-    The wizard walks you through choosing a model provider, setting an API key,
-    and configuring the Gateway. QuickStart is usually only a few minutes, but
-    provider sign-in, channel pairing, daemon install, network downloads, skills,
-    or optional plugins can make full onboarding take longer. Skip optional
-    steps and return later with `openclaw configure`.
+  <Step title="Complete onboarding">
+    The installer starts the onboarding wizard automatically. Follow it to choose
+    a model provider, set an API key, and configure the Gateway. QuickStart is
+    usually only a few minutes, but provider sign-in, channel pairing, daemon
+    install, network downloads, skills, or optional plugins can make full
+    onboarding take longer. Skip optional steps and return later with
+    `openclaw configure`.
 
     See [Onboarding (CLI)](/start/wizard) for the full reference.
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where fresh-install guidance told users to run onboarding after the hosted installer had already launched it, causing users to enter the classic onboarding flow a second time.

## Why This Change Was Made

The hosted Unix and PowerShell installers already start onboarding on interactive fresh installs (`scripts/install.sh` and `scripts/install.ps1`). The quick-start docs now tell those users to complete the wizard that opens, while direct npm/pnpm/Bun installs retain the explicit `openclaw onboard --install-daemon` command. Raspberry Pi and DigitalOcean guides now pass `--no-onboard` because they intentionally run onboarding in a later step (and, on DigitalOcean, under a different non-root owner).

No runtime behavior changes. Targeted GitHub searches found no open PR implementing this correction.

## User Impact

Fresh hosted-installer users no longer rerun onboarding unnecessarily. Deferred and direct-package installation paths still show an explicit, intentional onboarding command.

## Evidence

- `node scripts/check-docs-mdx.mjs docs README.md` — 774 files passed
- `node scripts/docs-link-audit.mjs` — 6,499 internal links checked, 0 broken
- `node --import tsx scripts/format-docs.mts --check` — 758 files clean
- `git diff --check` — clean
- Fresh independent autoreview — no accepted/actionable findings
