### PR TITLE
docs(completion): document ZDOTDIR startup profile

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -38,7 +38,7 @@ The install writes a small `# OpenClaw Completion` block into your shell profile
 | bash       | `~/.bashrc` (falls back to `~/.bash_profile` when `~/.bashrc` is missing)                                                                                                                  |
 | fish       | `~/.config/fish/config.fish`                                                                                                                                                               |
 | powershell | `~/.config/powershell/Microsoft.PowerShell_profile.ps1` (on Windows: `Documents/PowerShell/Microsoft.PowerShell_profile.ps1`, or `Documents/WindowsPowerShell/...` for Windows PowerShell) |
-| zsh        | `~/.zshrc`                                                                                                                                                                                 |
+| zsh        | `$ZDOTDIR/.zshrc` when `ZDOTDIR` is defined; otherwise `~/.zshrc` (an empty `ZDOTDIR` resolves to `/.zshrc`)                                                                               |
 
 Profile changes are staged beside the destination and atomically replace it only after a complete durable write. A failed install leaves an existing profile unchanged.
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the completion guide always documented `~/.zshrc` even though OpenClaw honors Zsh's `ZDOTDIR` startup-directory setting.

## Why This Change Was Made

The profile table now matches `resolveCompletionProfilePath` in `src/cli/completion-runtime.ts`: a nonempty `ZDOTDIR` selects `$ZDOTDIR/.zshrc`, an unset variable selects `~/.zshrc`, and the existing set-but-empty runtime contract selects `/.zshrc`.

No runtime behavior changes. Targeted GitHub searches found no open issue or PR implementing this correction.

## User Impact

Users with a custom Zsh startup directory can now see where `openclaw completion --install` writes its profile block.

## Evidence

- Existing runtime regression: `src/cli/completion-runtime.test.ts` covers configured, unset, and set-but-empty `ZDOTDIR`
- `node scripts/check-docs-mdx.mjs docs README.md` — 774 files passed
- `node scripts/docs-link-audit.mjs` — 6,499 internal links checked, 0 broken
- `node --import tsx scripts/format-docs.mts --check` — 758 files clean
- `git diff --check` — clean
- Fresh independent autoreview — no accepted/actionable findings
