### PR TITLE
fix(test): standalone upgrade survivor repairs unreleased plugins

### DIFF
--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -58,6 +58,7 @@ LANE_ARTIFACT_SUFFIX="${LANE_ARTIFACT_SUFFIX//[^A-Za-z0-9_.-]/_}"
 ARTIFACT_DIR="${OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/upgrade-survivor/$LANE_ARTIFACT_SUFFIX}"
 DOCKER_RUN_USER_ARGS=()
 PREPUBLISH_PLUGIN_REGISTRY_ARGS=()
+AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT=""
 PROBE_ENV_ARGS=(
   -e OPENCLAW_UPGRADE_SURVIVOR_PROBE_TIMEOUT_MS="$PROBE_TIMEOUT_MS"
   -e OPENCLAW_UPGRADE_SURVIVOR_PROBE_ATTEMPT_TIMEOUT_MS="$PROBE_ATTEMPT_TIMEOUT_MS"
@@ -73,9 +74,10 @@ if [ -n "${OPENCLAW_UPGRADE_SURVIVOR_READYZ_ALLOW_DEGRADED:-}" ]; then
     -e OPENCLAW_UPGRADE_SURVIVOR_READYZ_ALLOW_DEGRADED="$OPENCLAW_UPGRADE_SURVIVOR_READYZ_ALLOW_DEGRADED"
   )
 fi
-if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+configure_prepublish_plugin_registry() {
+  local registry_dir="$1"
   PREPUBLISH_PLUGIN_REGISTRY_DIR="$(
-    cd "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR" && pwd
+    cd "$registry_dir" && pwd
   )"
   if [ ! -f "$PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" ]; then
     echo "Prepublish plugin registry manifest is missing." >&2
@@ -85,9 +87,15 @@ if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
     -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry
     -v "$PREPUBLISH_PLUGIN_REGISTRY_DIR:/tmp/openclaw-prepublish-plugin-registry:ro"
   )
+}
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  configure_prepublish_plugin_registry "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR"
 fi
 cleanup_outer() {
   docker_e2e_cleanup_package_tgz "${PACKAGE_TGZ:-}"
+  if [ -n "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT" ]; then
+    rm -rf "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT"
+  fi
 }
 trap cleanup_outer EXIT
 
@@ -130,17 +138,20 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
   DOCKER_E2E_PACKAGE_ARGS=()
   CANDIDATE_RAW="${OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE:-current}"
   CANDIDATE_KIND="npm"
+  CANDIDATE_IS_CURRENT=0
   CANDIDATE_SPEC=""
 
   if [ -n "${OPENCLAW_CURRENT_PACKAGE_TGZ:-}" ]; then
     PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz upgrade-survivor "$OPENCLAW_CURRENT_PACKAGE_TGZ")"
     docker_e2e_package_mount_args "$PACKAGE_TGZ"
     CANDIDATE_KIND="tarball"
+    CANDIDATE_IS_CURRENT=1
     CANDIDATE_SPEC="/tmp/openclaw-current.tgz"
   elif [ "$CANDIDATE_RAW" = "current" ]; then
     PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz upgrade-survivor)"
     docker_e2e_package_mount_args "$PACKAGE_TGZ"
     CANDIDATE_KIND="tarball"
+    CANDIDATE_IS_CURRENT=1
     CANDIDATE_SPEC="/tmp/openclaw-current.tgz"
   elif [[ "$CANDIDATE_RAW" == *.tgz ]]; then
     if [ ! -f "$CANDIDATE_RAW" ]; then
@@ -154,6 +165,20 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
   else
     CANDIDATE_KIND="npm"
     CANDIDATE_SPEC="$(normalize_npm_candidate "$CANDIDATE_RAW")"
+  fi
+
+  if [ "$CANDIDATE_IS_CURRENT" = "1" ] && [ -z "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+    AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT="$(
+      mktemp -d "${TMPDIR:-/tmp}/openclaw-upgrade-survivor-plugin-registry.XXXXXX"
+    )"
+    OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor \
+      OPENCLAW_DOCKER_ALL_LOG_DIR="$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT" \
+      OPENCLAW_DOCKER_ALL_TIMINGS=0 \
+      OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS="$BASELINE_SPEC" \
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS="$SCENARIO" \
+      node "$HARNESS_ROOT_DIR/scripts/test-docker-all.mjs" --prepare-plugin-registry
+    configure_prepublish_plugin_registry \
+      "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT/prepublish-plugin-registry"
   fi
 
   OPENCLAW_TEST_STATE_FUNCTION_B64="$(docker_e2e_test_state_function_b64)"

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -149,21 +149,28 @@ const IS_MAIN = (() => {
 
 function dockerAllUsage() {
   return [
-    "Usage: node scripts/test-docker-all.mjs [--plan-json | --prepare-only=<manifest>]",
+    "Usage: node scripts/test-docker-all.mjs [--plan-json | --prepare-only=<manifest> | --prepare-plugin-registry]",
     "",
     "Options:",
-    "  --plan-json    Print the resolved Docker E2E plan as JSON and exit.",
-    "  --prepare-only Prepare one immutable candidate manifest and exit.",
-    "  -h, --help     Show this help.",
+    "  --plan-json              Print the resolved Docker E2E plan as JSON and exit.",
+    "  --prepare-only=<manifest> Prepare one immutable candidate manifest and exit.",
+    "  --prepare-plugin-registry Prepare only the selected lanes' plugin registry.",
+    "  -h, --help               Show this help.",
     "",
     "Lane selection and scheduler settings are configured with OPENCLAW_DOCKER_ALL_* env vars.",
   ].join("\n");
 }
 
 export function parseDockerAllCliArgs(argv: readonly string[]) {
-  const options: { help: boolean; planJson: boolean; prepareOnly?: string } = {
+  const options: {
+    help: boolean;
+    planJson: boolean;
+    prepareOnly?: string;
+    preparePluginRegistry: boolean;
+  } = {
     help: false,
     planJson: false,
+    preparePluginRegistry: false,
   };
   for (const arg of argv) {
     if (arg === "--plan-json") {
@@ -173,19 +180,26 @@ export function parseDockerAllCliArgs(argv: readonly string[]) {
       if (!options.prepareOnly) {
         throw new Error(`--prepare-only requires a manifest path\n\n${dockerAllUsage()}`);
       }
+    } else if (arg === "--prepare-plugin-registry") {
+      options.preparePluginRegistry = true;
     } else if (arg === "--help" || arg === "-h") {
       options.help = true;
     } else {
       throw new Error(`unknown argument: ${arg}\n\n${dockerAllUsage()}`);
     }
   }
-  assert(!(options.planJson && options.prepareOnly), "conflicting plan/prep options");
+  assert(
+    [options.planJson, Boolean(options.prepareOnly), options.preparePluginRegistry].filter(Boolean)
+      .length <= 1,
+    "conflicting plan/prep options",
+  );
   return options;
 }
 
 let cliOptions: ReturnType<typeof parseDockerAllCliArgs> = {
   help: false,
   planJson: false,
+  preparePluginRegistry: false,
 };
 if (IS_MAIN) {
   try {
@@ -1207,7 +1221,7 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
   console.log(`==> OpenClaw package: ${baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ}`);
 }
 
-function preparePrepublishPluginRegistry(
+export function preparePrepublishPluginRegistry(
   plan: DockerCandidatePlan,
   logDir: string,
   sourceSha: string,
@@ -1834,6 +1848,19 @@ async function main() {
   const omittedUnsupportedLanes =
     omittedUnsupportedLaneNames.length > 0 ? omittedUnsupportedLaneNames : undefined;
 
+  if (cliOptions.preparePluginRegistry) {
+    if (!plan.needs.prepublishPluginRegistry) {
+      throw new Error("selected Docker lanes do not require a prepublish plugin registry");
+    }
+    const registry = preparePrepublishPluginRegistry(
+      plan,
+      logDir,
+      gitOutput(ROOT_DIR, ["rev-parse", "HEAD"]),
+      rootPackageVersion(ROOT_DIR),
+    );
+    process.stdout.write(`${JSON.stringify(registry)}\n`);
+    return;
+  }
   if (planJson) {
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
     return;

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -15,9 +15,13 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
-import { DEFAULT_RESOURCE_LIMITS } from "../../scripts/lib/docker-e2e-plan.mts";
+import {
+  DEFAULT_LIVE_RETRIES,
+  DEFAULT_RESOURCE_LIMITS,
+  resolveDockerE2ePlan,
+} from "../../scripts/lib/docker-e2e-plan.mts";
 import {
   appendBoundedShellCapture,
   buildLaneRerunCommand,
@@ -28,6 +32,7 @@ import {
   githubWorkflowRerunCommand,
   LOG_TAIL_MAX_BYTES,
   parseDockerAllCliArgs,
+  preparePrepublishPluginRegistry,
   resolveDockerPreflightPlatform,
   runCleanupSmokePhase,
   runShellCaptureCommand,
@@ -39,6 +44,14 @@ import {
 } from "../../scripts/test-docker-all.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createPrepublishPluginRegistryArtifact } = vi.hoisted(() => ({
+  createPrepublishPluginRegistryArtifact: vi.fn(),
+}));
+vi.mock("../../scripts/prepublish-plugin-registry-artifact.mjs", async (importOriginal) => ({
+  ...(await importOriginal()),
+  createPrepublishPluginRegistryArtifact,
+}));
 
 const limits = {
   resourceLimits: {
@@ -303,22 +316,34 @@ describe("scripts/test-docker-all scheduler", () => {
     expect(parseDockerAllCliArgs([])).toEqual({
       help: false,
       planJson: false,
+      preparePluginRegistry: false,
     });
     expect(parseDockerAllCliArgs(["--plan-json"])).toEqual({
       help: false,
       planJson: true,
+      preparePluginRegistry: false,
     });
     expect(parseDockerAllCliArgs(["--help"])).toEqual({
       help: true,
       planJson: false,
+      preparePluginRegistry: false,
     });
     expect(parseDockerAllCliArgs(["--prepare-only=/tmp/candidate.json"])).toEqual({
       help: false,
       planJson: false,
       prepareOnly: "/tmp/candidate.json",
+      preparePluginRegistry: false,
+    });
+    expect(parseDockerAllCliArgs(["--prepare-plugin-registry"])).toEqual({
+      help: false,
+      planJson: false,
+      preparePluginRegistry: true,
     });
     expect(() =>
       parseDockerAllCliArgs(["--plan-json", "--prepare-only=/tmp/candidate.json"]),
+    ).toThrow("conflicting plan/prep options");
+    expect(() =>
+      parseDockerAllCliArgs(["--prepare-only=/tmp/candidate.json", "--prepare-plugin-registry"]),
     ).toThrow("conflicting plan/prep options");
   });
 
@@ -331,7 +356,49 @@ describe("scripts/test-docker-all scheduler", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("--prepare-only=<manifest>");
+    expect(result.stdout).toContain("--prepare-plugin-registry");
     expect(result.stdout).toContain("OPENCLAW_DOCKER_ALL_* env vars");
+  });
+
+  it("passes the exact planner-selected survivor packages to registry preparation", () => {
+    const root = tempDirs.make("openclaw-standalone-survivor-registry-");
+    const plan = resolveDockerE2ePlan({
+      allowFrozenTargetScenarioOmissions: true,
+      includeOpenWebUI: false,
+      liveMode: "all",
+      liveRetries: DEFAULT_LIVE_RETRIES,
+      orderLanes: <T>(lanes: T[]) => lanes,
+      planReleaseAll: false,
+      profile: "all",
+      releaseChunk: "core",
+      selectedLaneNames: ["published-upgrade-survivor"],
+      timingStore: undefined,
+      upgradeSurvivorBaselines: "openclaw@2026.7.1-2",
+      upgradeSurvivorScenarios: "configured-plugin-installs",
+    }).plan;
+    createPrepublishPluginRegistryArtifact.mockReturnValue({
+      manifestSha256: "b".repeat(64),
+    });
+
+    const registry = preparePrepublishPluginRegistry(plan, root, "a".repeat(40), "2026.8.1");
+
+    expect(createPrepublishPluginRegistryArtifact).toHaveBeenCalledWith({
+      candidateVersion: "2026.8.1",
+      outputDir: path.join(root, "prepublish-plugin-registry"),
+      repoRoot: process.cwd(),
+      requiredPackages: [
+        "@openclaw/codex",
+        "@openclaw/discord",
+        "@openclaw/matrix",
+        "@openclaw/whatsapp",
+      ],
+      sourceSha: "a".repeat(40),
+    });
+    expect(registry).toEqual({
+      candidateVersion: "2026.8.1",
+      dir: path.join(root, "prepublish-plugin-registry"),
+      manifestSha256: "b".repeat(64),
+    });
   });
 
   it("rejects unknown CLI options without a stack trace", () => {

--- a/test/scripts/upgrade-survivor-plugin-registry.test.ts
+++ b/test/scripts/upgrade-survivor-plugin-registry.test.ts
@@ -1,0 +1,127 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const SCRIPT = resolve("scripts/e2e/upgrade-survivor-docker.sh");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function writeExecutable(path: string, source: string): void {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+function runSurvivor(overrides: NodeJS.ProcessEnv = {}) {
+  const root = tempDirs.make("openclaw-upgrade-survivor-registry-");
+  const binDir = join(root, "bin");
+  const captureDir = join(root, "capture");
+  const packageTarball = join(root, "openclaw-current.tgz");
+  mkdirSync(binDir);
+  mkdirSync(captureDir);
+  writeFileSync(packageTarball, "candidate");
+  writeExecutable(
+    join(binDir, "node"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" != */scripts/test-docker-all.mjs ]] || [ "\${2:-}" != "--prepare-plugin-registry" ]; then
+  exec "$REAL_NODE" "$@"
+fi
+printf '%s\n' "$*" >>"$CAPTURE_DIR/node-args"
+printf '%s|%s|%s\n' \
+  "$OPENCLAW_DOCKER_ALL_LANES" \
+  "$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS" \
+  "$OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS" >>"$CAPTURE_DIR/node-env"
+mkdir -p "$OPENCLAW_DOCKER_ALL_LOG_DIR/prepublish-plugin-registry"
+printf '{"packages":[]}\n' \
+  >"$OPENCLAW_DOCKER_ALL_LOG_DIR/prepublish-plugin-registry/prepublish-plugin-registry.json"
+printf '{"dir":"%s"}\n' "$OPENCLAW_DOCKER_ALL_LOG_DIR/prepublish-plugin-registry"
+`,
+  );
+  writeExecutable(
+    join(binDir, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$CAPTURE_DIR/docker-args"
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--cidfile" ]; then
+    printf 'fake-container\n' >"$arg"
+  fi
+  previous="$arg"
+done
+`,
+  );
+
+  const result = spawnSync("bash", [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CAPTURE_DIR: captureDir,
+      REAL_NODE: process.execPath,
+      OPENCLAW_CURRENT_PACKAGE_TGZ: packageTarball,
+      OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS: "1",
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_SKIP_PROVIDERS: "1",
+      OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR: join(root, "artifacts"),
+      OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: "openclaw@2026.7.1-2",
+      OPENCLAW_UPGRADE_SURVIVOR_E2E_SKIP_BUILD: "1",
+      OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE: "1",
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      TMPDIR: root,
+      ...overrides,
+    },
+    timeout: 30_000,
+  });
+  return { captureDir, packageTarball, result, root };
+}
+
+describe("standalone upgrade survivor plugin registry", () => {
+  it("prepares and mounts a planner-owned registry for the current candidate", () => {
+    const { captureDir, result } = runSurvivor({
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "configured-plugin-installs",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(join(captureDir, "node-args"), "utf8")).toContain(
+      "scripts/test-docker-all.mjs --prepare-plugin-registry",
+    );
+    expect(readFileSync(join(captureDir, "node-env"), "utf8")).toBe(
+      "published-upgrade-survivor|openclaw@2026.7.1-2|configured-plugin-installs\n",
+    );
+    expect(readFileSync(join(captureDir, "docker-args"), "utf8")).toContain(
+      ":/tmp/openclaw-prepublish-plugin-registry:ro",
+    );
+  });
+
+  it("preserves an explicitly supplied registry without preparing another", () => {
+    const registryDir = tempDirs.make("openclaw-external-plugin-registry-");
+    writeFileSync(join(registryDir, "prepublish-plugin-registry.json"), '{"external":true}\n');
+
+    const { captureDir, result } = runSurvivor({
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registryDir,
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "external-only-scenario",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(join(captureDir, "node-args"))).toBe(false);
+    expect(readFileSync(join(captureDir, "docker-args"), "utf8")).toContain(
+      `${registryDir}:/tmp/openclaw-prepublish-plugin-registry:ro`,
+    );
+  });
+
+  it("does not prepare a registry for a published candidate", () => {
+    const { captureDir, packageTarball, result } = runSurvivor({
+      OPENCLAW_CURRENT_PACKAGE_TGZ: undefined,
+      OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE: "openclaw@2026.8.1",
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "published-only-scenario",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(join(captureDir, "node-args"))).toBe(false);
+    expect(readFileSync(join(captureDir, "docker-args"), "utf8")).not.toContain(
+      "/tmp/openclaw-prepublish-plugin-registry",
+    );
+    expect(existsSync(packageTarball)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running a standalone published-baseline upgrade-survivor check against a current unreleased OpenClaw tarball could complete update, Doctor, and migration assertions, then fail Gateway startup when plugin repair requested an unpublished lockstep companion such as `@openclaw/codex` from public npm.

## Why This Change Was Made

The standalone survivor harness now asks the existing Docker E2E planner to prepare only its prepublish plugin registry, so package selection stays owned by `resolveDockerE2ePlan` and artifact creation stays owned by `createPrepublishPluginRegistryArtifact`. Automatic preparation applies only to current local candidates when no registry was supplied; externally supplied registries and published npm candidates keep their existing behavior.

## User Impact

Release and QA maintainers can run current-candidate upgrade-survivor checks directly instead of first reproducing the pooled scheduler's registry setup by hand. Product runtime behavior is unchanged.

## Evidence

- Real clean-checkout planner/artifact boundary: candidate `2026.8.1` produced a validated registry containing exactly `@openclaw/codex`, `@openclaw/discord`, `@openclaw/matrix`, and `@openclaw/whatsapp` for the canonical configured-plugin survivor scenario.
- `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1 node scripts/run-vitest.mjs test/scripts/upgrade-survivor-plugin-registry.test.ts test/scripts/docker-all-scheduler.test.ts test/scripts/docker-e2e-plan.test.ts test/scripts/prepublish-plugin-registry-artifact.test.ts` — 100/100 passed.
- `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1 OPENCLAW_DOCKER_ALL_DRY_RUN=1 node scripts/check-changed.mjs -- <changed files>` — passed format, script/test typechecks, script lint, boundaries, and scheduler dry-run without provider/channel requests.
- `bash -n scripts/e2e/upgrade-survivor-docker.sh` — passed.
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no actionable findings.
- Product/runtime LOC: +0/-0. Harness scripts: +61/-9. Tests: +196/-2.

The high-volume `sqlite-volume` scenario that exposed this gap remains in a separate unlanded QA harness stack; this change is planner-driven and does not duplicate that scenario or its package list.

AI-assisted: yes.

