### PR TITLE
fix(cli): refuse live state reset and uninstall

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -252,10 +252,22 @@ enum DeviceIdentitySQLiteStore {
         return authoritative.identity
     }
 
+    static func resolveStateDatabaseCoordinatorURL(
+        databaseURL: URL,
+        runtimeDirectory: URL,
+        uid: uid_t) -> URL
+    {
+        let canonicalDatabasePath = self.canonicalExistingAncestorPath(databaseURL)
+        let digest = SHA256.hash(data: Data(canonicalDatabasePath.utf8))
+        let pathHash = digest.prefix(4).map { String(format: "%02x", $0) }.joined()
+        return runtimeDirectory.standardizedFileURL
+            .appendingPathComponent("openclaw-state-locks-\(uid)", isDirectory: true)
+            .appendingPathComponent("state-lifecycle.\(pathHash).lock.sqlite", isDirectory: false)
+    }
+
     static func resolveDeviceIdentityCoordinatorURLs(
         databaseURL: URL,
         destinationStateDirURL: URL,
-        temporaryDirectory: URL,
         uid: uid_t) -> [URL]
     {
         let canonicalDatabasePath = self.canonicalExistingAncestorPath(databaseURL)
@@ -266,35 +278,32 @@ enum DeviceIdentitySQLiteStore {
         let canonicalStateDirURL = URL(
             fileURLWithPath: self.canonicalExistingAncestorPath(destinationStateDirURL),
             isDirectory: true)
-        let orderedURLs = [
-            temporaryDirectory.standardizedFileURL
-                .appendingPathComponent(suffix, isDirectory: true)
-                .appendingPathComponent(filename, isDirectory: false),
+        return [
             canonicalStateDirURL
                 .appendingPathComponent("tmp", isDirectory: true)
                 .appendingPathComponent(suffix, isDirectory: true)
                 .appendingPathComponent(filename, isDirectory: false),
         ]
-        var seen: Set<String> = []
-        return orderedURLs.filter { seen.insert(self.canonicalExistingAncestorPath($0)).inserted }
     }
 
     private static func acquireIdentityCoordinator(
         databaseURL: URL,
         destinationStateDirURL: URL) throws -> IdentityCoordinator
     {
-        let coordinatorURLs = self.resolveDeviceIdentityCoordinatorURLs(
+        let coordinatorURLs = [
+            self.resolveStateDatabaseCoordinatorURL(
+                databaseURL: databaseURL,
+                runtimeDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+                uid: getuid()),
+        ] + self.resolveDeviceIdentityCoordinatorURLs(
             databaseURL: databaseURL,
             destinationStateDirURL: destinationStateDirURL,
-            temporaryDirectory: FileManager.default.temporaryDirectory,
             uid: getuid())
         for coordinatorURL in coordinatorURLs {
             try self.secureCoordinatorDirectory(coordinatorURL.deletingLastPathComponent())
         }
         var databases: [OpaquePointer] = []
         do {
-            // v2026.7.2-beta.4 through beta.7 use process temp. Keep it first until
-            // those builds are no longer rolling-upgrade peers.
             for coordinatorURL in coordinatorURLs {
                 try databases.append(self.acquireIdentityCoordinator(at: coordinatorURL))
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -2,6 +2,9 @@ import CryptoKit
 import Darwin
 import Foundation
 import OpenClawNativeState
+#if canImport(Security)
+import Security
+#endif
 import SQLite3
 
 enum DeviceIdentitySQLiteStore {
@@ -13,6 +16,20 @@ enum DeviceIdentitySQLiteStore {
     private static let maximumLegacyIdentityBytes = 64 * 1024
     private static let doctorClaimSuffix = ".doctor-importing"
     private static let nativeClaimSuffix = ".native-importing"
+    private static let appSandboxed: Bool = {
+        #if os(macOS) && canImport(Security)
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            return ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] != nil
+        }
+        let value = SecTaskCopyValueForEntitlement(
+            task,
+            "com.apple.security.app-sandbox" as CFString,
+            nil)
+        return (value as? Bool) == true
+        #else
+        return true
+        #endif
+    }()
 
     private struct LegacyClaim {
         let source: DeviceIdentityPaths.LegacyIdentitySource
@@ -252,6 +269,19 @@ enum DeviceIdentitySQLiteStore {
         return authoritative.identity
     }
 
+    static func resolveStateLifecycleRuntimeDirectory(
+        destinationStateDirURL: URL,
+        appSandboxed: Bool) -> URL
+    {
+        if !appSandboxed {
+            return URL(fileURLWithPath: "/tmp", isDirectory: true)
+        }
+        // Sandboxed app and extension processes share the selected state container,
+        // while global /tmp is not a writable cross-process namespace for them.
+        return destinationStateDirURL.standardizedFileURL
+            .appendingPathComponent("tmp", isDirectory: true)
+    }
+
     static func resolveStateDatabaseCoordinatorURL(
         databaseURL: URL,
         runtimeDirectory: URL,
@@ -293,7 +323,9 @@ enum DeviceIdentitySQLiteStore {
         let coordinatorURLs = [
             self.resolveStateDatabaseCoordinatorURL(
                 databaseURL: databaseURL,
-                runtimeDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+                runtimeDirectory: self.resolveStateLifecycleRuntimeDirectory(
+                    destinationStateDirURL: destinationStateDirURL,
+                    appSandboxed: self.appSandboxed),
                 uid: getuid()),
         ] + self.resolveDeviceIdentityCoordinatorURLs(
             databaseURL: databaseURL,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -276,8 +276,8 @@ enum DeviceIdentitySQLiteStore {
         if !appSandboxed {
             return URL(fileURLWithPath: "/tmp", isDirectory: true)
         }
-        // Sandboxed app and extension processes share the selected state container,
-        // while global /tmp is not a writable cross-process namespace for them.
+        // Sandboxed app and extension processes share container-owned state that Node cannot
+        // traverse. CLI-shared macOS state is unentitled and uses the common /tmp namespace.
         return destinationStateDirURL.standardizedFileURL
             .appendingPathComponent("tmp", isDirectory: true)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityCoordinatorContractTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityCoordinatorContractTests.swift
@@ -35,6 +35,19 @@ private enum DeviceIdentityCoordinatorContractFixtureLoader {
 }
 
 struct DeviceIdentityCoordinatorContractTests {
+    @Test func `uses a sandbox writable lifecycle runtime`() {
+        let stateDirectory = URL(fileURLWithPath: "/sandbox/group/OpenClaw", isDirectory: true)
+
+        #expect(
+            DeviceIdentitySQLiteStore.resolveStateLifecycleRuntimeDirectory(
+                destinationStateDirURL: stateDirectory,
+                appSandboxed: true).path == "/sandbox/group/OpenClaw/tmp")
+        #expect(
+            DeviceIdentitySQLiteStore.resolveStateLifecycleRuntimeDirectory(
+                destinationStateDirURL: stateDirectory,
+                appSandboxed: false).path == "/tmp")
+    }
+
     @Test func `matches shared ordered path vector`() throws {
         let fixture = try DeviceIdentityCoordinatorContractFixtureLoader.load()
         let databaseURL = URL(fileURLWithPath: fixture.databasePath)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityCoordinatorContractTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityCoordinatorContractTests.swift
@@ -6,8 +6,9 @@ import Testing
 private struct DeviceIdentityCoordinatorContractFixture: Decodable {
     let databasePath: String
     let stateDirectory: String
-    let temporaryDirectory: String
+    let runtimeDirectory: String
     let uid: UInt32
+    let stateCoordinatorPath: String
     let orderedExpectedPaths: [String]
 }
 
@@ -36,12 +37,17 @@ private enum DeviceIdentityCoordinatorContractFixtureLoader {
 struct DeviceIdentityCoordinatorContractTests {
     @Test func `matches shared ordered path vector`() throws {
         let fixture = try DeviceIdentityCoordinatorContractFixtureLoader.load()
+        let databaseURL = URL(fileURLWithPath: fixture.databasePath)
         let resolved = DeviceIdentitySQLiteStore.resolveDeviceIdentityCoordinatorURLs(
-            databaseURL: URL(fileURLWithPath: fixture.databasePath),
+            databaseURL: databaseURL,
             destinationStateDirURL: URL(fileURLWithPath: fixture.stateDirectory, isDirectory: true),
-            temporaryDirectory: URL(fileURLWithPath: fixture.temporaryDirectory, isDirectory: true),
+            uid: uid_t(fixture.uid))
+        let stateCoordinator = DeviceIdentitySQLiteStore.resolveStateDatabaseCoordinatorURL(
+            databaseURL: databaseURL,
+            runtimeDirectory: URL(fileURLWithPath: fixture.runtimeDirectory, isDirectory: true),
             uid: uid_t(fixture.uid))
 
+        #expect(stateCoordinator.path == fixture.stateCoordinatorPath)
         #expect(resolved.map(\.path) == fixture.orderedExpectedPaths)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -471,9 +471,8 @@ struct DeviceIdentityStoreTests {
         let coordinatorURLs = DeviceIdentitySQLiteStore.resolveDeviceIdentityCoordinatorURLs(
             databaseURL: fixture.databaseURL,
             destinationStateDirURL: fixture.destination,
-            temporaryDirectory: FileManager.default.temporaryDirectory,
             uid: getuid())
-        #expect(coordinatorURLs.count == 2)
+        #expect(coordinatorURLs.count == 1)
         for coordinatorURL in coordinatorURLs {
             let coordinatorDirectoryMode = try #require(
                 FileManager.default.attributesOfItem(

--- a/docs/cli/reset.md
+++ b/docs/cli/reset.md
@@ -38,6 +38,7 @@ openclaw reset --scope full --yes --non-interactive
 ## Notes
 
 - Run `openclaw backup create` first for a restorable snapshot before removing local state.
+- Before removing the state directory, `full` requires exclusive state ownership. If an unmanaged or externally supervised Gateway is still running, reset refuses and asks you to stop it first.
 - Workspace setup state and attestations are rows in the shared SQLite database, so `full` removes them with the state directory; there are no current attestation sidecar files to remove separately.
 - Without `--scope`, `openclaw reset` prompts interactively for the scope to remove.
 - `--non-interactive` is only valid when both `--scope` and `--yes` are set.

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -42,6 +42,9 @@ openclaw uninstall --dry-run
 
 - Run `openclaw backup create` first for a restorable snapshot before removing
   state or workspaces.
+- Before removing state, `--state` requires exclusive state ownership. If an
+  unmanaged or externally supervised Gateway is still running, uninstall
+  refuses and asks you to stop it first.
 - `--state` preserves configured workspace directories unless `--workspace` is
   also selected.
 

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -115,6 +115,10 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   },
   { commandPath: ["message"], policy: { loadPlugins: "never" } },
   { commandPath: ["docs"], policy: { configGuard: "skip" } },
+  // Destructive maintenance owns a validity-aware, non-observing config read.
+  // Startup migrations would mutate the SQLite state these commands may refuse to remove.
+  { commandPath: ["reset"], policy: { configGuard: "skip" } },
+  { commandPath: ["uninstall"], policy: { configGuard: "skip" } },
   {
     commandPath: ["channels"],
     policy: {

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -32,6 +32,8 @@ describe("command-startup-policy", () => {
       ["config", "validate"],
       ["config", "schema"],
       ["docs"],
+      ["reset"],
+      ["uninstall"],
       ["agent", "exec"],
       ["status"],
       ["agents", "bindings"],

--- a/src/commands/cleanup-command.test-support.ts
+++ b/src/commands/cleanup-command.test-support.ts
@@ -3,7 +3,8 @@ import { vi } from "vitest";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 
-const resolveCleanupPlanFromDisk = vi.fn();
+const resolveCleanupPlanForDryRun = vi.fn();
+export const resolveCleanupPlanForRemoval = vi.fn();
 const removePath = vi.fn();
 export const listAgentSessionDirs = vi.fn();
 export const prepareLegacyWorkspaceStateReset = vi.fn();
@@ -28,6 +29,7 @@ vi.mock("../config/config.js", () => ({
   get isNixMode() {
     return cleanupConfigState.isNixMode;
   },
+  resolveConfigPath: () => "/tmp/.openclaw/openclaw.json",
 }));
 
 vi.mock("../daemon/service.js", () => ({
@@ -35,7 +37,8 @@ vi.mock("../daemon/service.js", () => ({
 }));
 
 vi.mock("./cleanup-plan.js", () => ({
-  resolveCleanupPlanFromDisk,
+  resolveCleanupPlanForDryRun,
+  resolveCleanupPlanForRemoval,
 }));
 
 vi.mock("./cleanup-utils.js", () => ({
@@ -51,14 +54,16 @@ export function createCleanupCommandRuntime() {
 
 export function resetCleanupCommandMocks() {
   vi.clearAllMocks();
-  resolveCleanupPlanFromDisk.mockReturnValue({
+  const cleanupPlan = {
     stateDir: "/tmp/.openclaw",
     configPath: "/tmp/.openclaw/openclaw.json",
     oauthDir: "/tmp/.openclaw/credentials",
     configInsideState: true,
     oauthInsideState: true,
     workspaceDirs: ["/tmp/.openclaw/workspace"],
-  });
+  };
+  resolveCleanupPlanForDryRun.mockResolvedValue(cleanupPlan);
+  resolveCleanupPlanForRemoval.mockReturnValue(cleanupPlan);
   removePath.mockResolvedValue({ ok: true });
   listAgentSessionDirs.mockResolvedValue(["/tmp/.openclaw/agents/main/sessions"]);
   prepareLegacyWorkspaceStateReset.mockImplementation((workspaceDir: string) => ({ workspaceDir }));

--- a/src/commands/cleanup-command.test-support.ts
+++ b/src/commands/cleanup-command.test-support.ts
@@ -63,7 +63,7 @@ export function resetCleanupCommandMocks() {
     workspaceDirs: ["/tmp/.openclaw/workspace"],
   };
   resolveCleanupPlanForDryRun.mockResolvedValue(cleanupPlan);
-  resolveCleanupPlanForRemoval.mockReturnValue(cleanupPlan);
+  resolveCleanupPlanForRemoval.mockResolvedValue(cleanupPlan);
   removePath.mockResolvedValue({ ok: true });
   listAgentSessionDirs.mockResolvedValue(["/tmp/.openclaw/agents/main/sessions"]);
   prepareLegacyWorkspaceStateReset.mockImplementation((workspaceDir: string) => ({ workspaceDir }));

--- a/src/commands/cleanup-live-state.test.ts
+++ b/src/commands/cleanup-live-state.test.ts
@@ -1,0 +1,211 @@
+// Destructive cleanup must not remove state owned by an independently running Gateway.
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNonExitingRuntime } from "../runtime.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+
+const gatewayService = vi.hoisted(() => ({
+  notLoadedText: "is not installed",
+  isLoaded: vi.fn(async () => false),
+  stop: vi.fn(async () => undefined),
+  uninstall: vi.fn(async () => undefined),
+}));
+const configState = vi.hoisted(() => ({ isNixMode: false }));
+const resolveCleanupPlanForDryRun = vi.hoisted(() => vi.fn());
+const resolveCleanupPlanForRemoval = vi.hoisted(() => vi.fn());
+
+vi.mock("../config/config.js", () => ({
+  get isNixMode() {
+    return configState.isNixMode;
+  },
+  resolveConfigPath: () => "/tmp/.openclaw/openclaw.json",
+}));
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => gatewayService,
+}));
+vi.mock("./cleanup-plan.js", () => ({
+  resolveCleanupPlanForDryRun,
+  resolveCleanupPlanForRemoval,
+}));
+
+const { resetCommand } = await import("./reset.js");
+const { uninstallCommand } = await import("./uninstall.js");
+
+const liveOwners = new Set<ChildProcess>();
+const testStates = new Set<OpenClawTestState>();
+
+async function stopLiveStateOwner(child: ChildProcess): Promise<void> {
+  liveOwners.delete(child);
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.send?.("close");
+  const forceKill = setTimeout(() => child.kill("SIGKILL"), 5_000);
+  try {
+    await once(child, "exit");
+  } finally {
+    clearTimeout(forceKill);
+  }
+}
+
+afterEach(async () => {
+  const results = await Promise.allSettled([
+    ...[...liveOwners].map((child) => stopLiveStateOwner(child)),
+    ...[...testStates].map((state) => state.cleanup()),
+  ]);
+  liveOwners.clear();
+  testStates.clear();
+  configState.isNixMode = false;
+  vi.clearAllMocks();
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      "live cleanup test teardown failed",
+    );
+  }
+});
+
+async function startLiveStateOwner(state: OpenClawTestState): Promise<ChildProcess> {
+  const lockModuleUrl = pathToFileURL(path.resolve("src/infra/gateway-lock.ts")).href;
+  const script = `
+    import path from "node:path";
+    import { DatabaseSync } from "node:sqlite";
+    const { acquireGatewayLock } = await import(${JSON.stringify(lockModuleUrl)});
+    const lock = await acquireGatewayLock({ allowInTests: true, env: process.env, port: 18789 });
+    if (!lock) throw new Error("live owner did not acquire the Gateway lock");
+    const databasePath = path.join(process.env.OPENCLAW_STATE_DIR, "state", "openclaw.sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.exec("PRAGMA journal_mode = WAL; CREATE TABLE live_owner (value TEXT); INSERT INTO live_owner VALUES ('held');");
+    process.send?.("ready");
+    process.on("message", async (message) => {
+      if (message !== "close") return;
+      database.close();
+      await lock.release().catch(() => undefined);
+      process.exit(0);
+    });
+    setInterval(() => {}, 1_000);
+  `;
+  const env = { ...state.env };
+  delete env.NODE_ENV;
+  delete env.VITEST;
+  delete env.VITEST_POOL_ID;
+  delete env.VITEST_WORKER_ID;
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script, "openclaw", "gateway"],
+    { cwd: path.resolve("."), env, stdio: ["ignore", "ignore", "pipe", "ipc"] },
+  );
+  liveOwners.add(child);
+  const stderr: Buffer[] = [];
+  child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+  await Promise.race([
+    once(child, "message").then(([message]) => {
+      if (message !== "ready") {
+        throw new Error(`unexpected live owner message: ${String(message)}`);
+      }
+    }),
+    once(child, "exit").then(([code, signal]) => {
+      throw new Error(
+        `live state owner exited before ready (${code ?? signal}): ${Buffer.concat(stderr).toString("utf8")}`,
+      );
+    }),
+  ]);
+  return child;
+}
+
+async function readFiles(paths: readonly string[]): Promise<Buffer[]> {
+  return await Promise.all(paths.map((filePath) => fs.readFile(filePath)));
+}
+
+describe("destructive cleanup with a live unmanaged state owner", () => {
+  it.each([
+    {
+      command: "unmanaged reset --scope full",
+      nixMode: false,
+      preservesWorkspace: false,
+      serviceChecks: 1,
+      run: (runtime: ReturnType<typeof createNonExitingRuntime>) =>
+        resetCommand(runtime, { scope: "full", yes: true, nonInteractive: true }),
+    },
+    {
+      command: "Nix reset --scope full",
+      nixMode: true,
+      preservesWorkspace: false,
+      serviceChecks: 0,
+      run: (runtime: ReturnType<typeof createNonExitingRuntime>) =>
+        resetCommand(runtime, { scope: "full", yes: true, nonInteractive: true }),
+    },
+    {
+      command: "uninstall --state",
+      nixMode: false,
+      preservesWorkspace: true,
+      serviceChecks: 0,
+      run: (runtime: ReturnType<typeof createNonExitingRuntime>) =>
+        uninstallCommand(runtime, { state: true, yes: true, nonInteractive: true }),
+    },
+  ])(
+    "refuses $command until the SQLite owner exits",
+    async ({ nixMode, preservesWorkspace, run, serviceChecks }) => {
+      const state = await createOpenClawTestState({
+        prefix: "openclaw-cleanup-live-state-",
+        layout: "split",
+        scenario: "minimal",
+        applyEnv: true,
+      });
+      testStates.add(state);
+      configState.isNixMode = nixMode;
+      const workspacePath = state.statePath("workspace", "project.bin");
+      const markerPath = await state.writeText("keep.txt", "preserved");
+      await fs.mkdir(path.dirname(workspacePath), { recursive: true });
+      await fs.writeFile(workspacePath, Buffer.from([0, 1, 2, 3, 255]));
+      resolveCleanupPlanForRemoval.mockReturnValue({
+        stateDir: state.stateDir,
+        configPath: state.configPath,
+        oauthDir: state.statePath("credentials"),
+        configInsideState: false,
+        oauthInsideState: true,
+        workspaceDirs: [path.dirname(workspacePath)],
+      });
+
+      const databasePath = state.statePath("state", "openclaw.sqlite");
+      await fs.mkdir(path.dirname(databasePath), { recursive: true });
+      const owner = await startLiveStateOwner(state);
+      const livePaths = [databasePath, `${databasePath}-wal`, `${databasePath}-shm`];
+      const liveBytes = await readFiles(livePaths);
+
+      const blockedRuntime = createNonExitingRuntime();
+      vi.spyOn(blockedRuntime, "log").mockImplementation(() => {});
+      vi.spyOn(blockedRuntime, "error").mockImplementation(() => {});
+      await expect(run(blockedRuntime)).rejects.toThrow(/Gateway|state directory/i);
+      expect(gatewayService.isLoaded).toHaveBeenCalledTimes(serviceChecks);
+      expect(owner.exitCode).toBeNull();
+      await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("preserved");
+      await expect(readFiles(livePaths)).resolves.toEqual(liveBytes);
+
+      await stopLiveStateOwner(owner);
+      const offlineRuntime = createNonExitingRuntime();
+      vi.spyOn(offlineRuntime, "log").mockImplementation(() => {});
+      vi.spyOn(offlineRuntime, "error").mockImplementation(() => {});
+      await expect(run(offlineRuntime)).resolves.toBeUndefined();
+
+      if (preservesWorkspace) {
+        await expect(fs.readFile(workspacePath)).resolves.toEqual(Buffer.from([0, 1, 2, 3, 255]));
+        await expect(fs.access(markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+        for (const filePath of livePaths) {
+          await expect(fs.access(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+      } else {
+        await expect(fs.access(state.stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      await expect(fs.access(state.configPath)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+});

--- a/src/commands/cleanup-live-state.test.ts
+++ b/src/commands/cleanup-live-state.test.ts
@@ -18,23 +18,16 @@ const gatewayService = vi.hoisted(() => ({
   uninstall: vi.fn(async () => undefined),
 }));
 const configState = vi.hoisted(() => ({ isNixMode: false }));
-const resolveCleanupPlanForDryRun = vi.hoisted(() => vi.fn());
-const resolveCleanupPlanForRemoval = vi.hoisted(() => vi.fn());
 
-vi.mock("../config/config.js", () => ({
+vi.mock("../config/config.js", async () => ({
+  ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
   get isNixMode() {
     return configState.isNixMode;
   },
-  resolveConfigPath: () => "/tmp/.openclaw/openclaw.json",
 }));
 vi.mock("../daemon/service.js", () => ({
   resolveGatewayService: () => gatewayService,
 }));
-vi.mock("./cleanup-plan.js", () => ({
-  resolveCleanupPlanForDryRun,
-  resolveCleanupPlanForRemoval,
-}));
-
 const { resetCommand } = await import("./reset.js");
 const { uninstallCommand } = await import("./uninstall.js");
 
@@ -162,24 +155,20 @@ describe("destructive cleanup with a live unmanaged state owner", () => {
       });
       testStates.add(state);
       configState.isNixMode = nixMode;
-      const workspacePath = state.statePath("workspace", "project.bin");
+      const workspacePath = path.join(state.workspaceDir, "project.bin");
+      await state.writeConfig({
+        agents: { entries: { main: { default: true, workspace: state.workspaceDir } } },
+      });
       const markerPath = await state.writeText("keep.txt", "preserved");
       await fs.mkdir(path.dirname(workspacePath), { recursive: true });
       await fs.writeFile(workspacePath, Buffer.from([0, 1, 2, 3, 255]));
-      resolveCleanupPlanForRemoval.mockReturnValue({
-        stateDir: state.stateDir,
-        configPath: state.configPath,
-        oauthDir: state.statePath("credentials"),
-        configInsideState: false,
-        oauthInsideState: true,
-        workspaceDirs: [path.dirname(workspacePath)],
-      });
 
       const databasePath = state.statePath("state", "openclaw.sqlite");
       await fs.mkdir(path.dirname(databasePath), { recursive: true });
       const owner = await startLiveStateOwner(state);
       const livePaths = [databasePath, `${databasePath}-wal`, `${databasePath}-shm`];
       const liveBytes = await readFiles(livePaths);
+      const configBytes = await fs.readFile(state.configPath);
 
       const blockedRuntime = createNonExitingRuntime();
       vi.spyOn(blockedRuntime, "log").mockImplementation(() => {});
@@ -189,6 +178,7 @@ describe("destructive cleanup with a live unmanaged state owner", () => {
       expect(owner.exitCode).toBeNull();
       await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("preserved");
       await expect(readFiles(livePaths)).resolves.toEqual(liveBytes);
+      await expect(fs.readFile(state.configPath)).resolves.toEqual(configBytes);
 
       await stopLiveStateOwner(owner);
       const offlineRuntime = createNonExitingRuntime();
@@ -208,4 +198,38 @@ describe("destructive cleanup with a live unmanaged state owner", () => {
       await expect(fs.access(state.configPath)).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
+
+  it("preserves state when workspace configuration is invalid", async () => {
+    const state = await createOpenClawTestState({
+      prefix: "openclaw-cleanup-invalid-config-",
+      layout: "split",
+      scenario: "minimal",
+      applyEnv: true,
+    });
+    testStates.add(state);
+    const workspaceDir = state.statePath("nested-workspace");
+    const workspacePath = path.join(workspaceDir, "project.bin");
+    const markerPath = await state.writeText("keep.txt", "preserved");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(workspacePath, Buffer.from([9, 8, 7, 6]));
+    await fs.writeFile(
+      state.configPath,
+      `{"agents":{"entries":{"main":{"workspace":${JSON.stringify(workspaceDir)}}}`,
+    );
+    const configBytes = await fs.readFile(state.configPath);
+    const runtime = createNonExitingRuntime();
+    vi.spyOn(runtime, "log").mockImplementation(() => {});
+    vi.spyOn(runtime, "error").mockImplementation(() => {});
+
+    await expect(
+      uninstallCommand(runtime, { state: true, yes: true, nonInteractive: true }),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("workspace configuration could not be resolved"),
+    );
+    await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("preserved");
+    await expect(fs.readFile(workspacePath)).resolves.toEqual(Buffer.from([9, 8, 7, 6]));
+    await expect(fs.readFile(state.configPath)).resolves.toEqual(configBytes);
+  });
 });

--- a/src/commands/cleanup-plan.ts
+++ b/src/commands/cleanup-plan.ts
@@ -1,15 +1,40 @@
 // Resolves cleanup inputs from current OpenClaw config and state paths.
 import {
   getRuntimeConfig,
+  readSourceConfigBestEffort,
   resolveConfigPath,
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { SqliteCoordinatorError } from "../infra/sqlite-coordinator.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { buildCleanupPlan } from "./cleanup-utils.js";
 
+function hasSqliteCoordinatorCause(error: unknown, seen = new Set<unknown>()): boolean {
+  if (error instanceof SqliteCoordinatorError) {
+    return true;
+  }
+  if (!error || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  if (error instanceof AggregateError) {
+    return error.errors.some((cause) => hasSqliteCoordinatorCause(cause, seen));
+  }
+  return error instanceof Error && hasSqliteCoordinatorCause(error.cause, seen);
+}
+
+function buildCleanupPlanForConfig(cfg: OpenClawConfig) {
+  const stateDir = resolveStateDir();
+  const configPath = resolveConfigPath();
+  const oauthDir = resolveOAuthDir();
+  const plan = buildCleanupPlan({ cfg, stateDir, configPath, oauthDir });
+  return { cfg, stateDir, configPath, oauthDir, ...plan };
+}
+
 /** Build the cleanup plan for the current runtime config/state/credential paths on disk. */
-export function resolveCleanupPlanFromDisk(): {
+function resolveCleanupPlanFromDisk(): {
   cfg: OpenClawConfig;
   stateDir: string;
   configPath: string;
@@ -18,10 +43,26 @@ export function resolveCleanupPlanFromDisk(): {
   oauthInsideState: boolean;
   workspaceDirs: string[];
 } {
-  const cfg = getRuntimeConfig();
-  const stateDir = resolveStateDir();
-  const configPath = resolveConfigPath();
-  const oauthDir = resolveOAuthDir();
-  const plan = buildCleanupPlan({ cfg, stateDir, configPath, oauthDir });
-  return { cfg, stateDir, configPath, oauthDir, ...plan };
+  return buildCleanupPlanForConfig(getRuntimeConfig());
+}
+
+/** Build a read-only cleanup preview without recording config health state. */
+export async function resolveCleanupPlanForDryRun() {
+  return buildCleanupPlanForConfig(await readSourceConfigBestEffort());
+}
+
+/** Resolve a destructive cleanup plan or report live state ownership consistently. */
+export function resolveCleanupPlanForRemoval(runtime: RuntimeEnv) {
+  try {
+    return resolveCleanupPlanFromDisk();
+  } catch (error) {
+    if (!hasSqliteCoordinatorCause(error)) {
+      throw error;
+    }
+    runtime.error(
+      "Cannot remove OpenClaw state while the Gateway or another state operation owns this state directory. Stop the Gateway and retry.",
+    );
+    runtime.exit(1);
+    return undefined;
+  }
 }

--- a/src/commands/cleanup-plan.ts
+++ b/src/commands/cleanup-plan.ts
@@ -1,28 +1,21 @@
 // Resolves cleanup inputs from current OpenClaw config and state paths.
 import {
-  getRuntimeConfig,
+  readConfigFileSnapshot,
   readSourceConfigBestEffort,
   resolveConfigPath,
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/config.js";
+import { formatConfigIssueSummary } from "../config/issue-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { SqliteCoordinatorError } from "../infra/sqlite-coordinator.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { buildCleanupPlan } from "./cleanup-utils.js";
 
-function hasSqliteCoordinatorCause(error: unknown, seen = new Set<unknown>()): boolean {
-  if (error instanceof SqliteCoordinatorError) {
-    return true;
-  }
-  if (!error || seen.has(error)) {
-    return false;
-  }
-  seen.add(error);
-  if (error instanceof AggregateError) {
-    return error.errors.some((cause) => hasSqliteCoordinatorCause(cause, seen));
-  }
-  return error instanceof Error && hasSqliteCoordinatorCause(error.cause, seen);
+function affectsWorkspaceDiscovery(path: string): boolean {
+  return (
+    path === "agents.defaults.workspace" ||
+    (path.startsWith("agents.entries.") && path.endsWith(".workspace"))
+  );
 }
 
 function buildCleanupPlanForConfig(cfg: OpenClawConfig) {
@@ -33,36 +26,25 @@ function buildCleanupPlanForConfig(cfg: OpenClawConfig) {
   return { cfg, stateDir, configPath, oauthDir, ...plan };
 }
 
-/** Build the cleanup plan for the current runtime config/state/credential paths on disk. */
-function resolveCleanupPlanFromDisk(): {
-  cfg: OpenClawConfig;
-  stateDir: string;
-  configPath: string;
-  oauthDir: string;
-  configInsideState: boolean;
-  oauthInsideState: boolean;
-  workspaceDirs: string[];
-} {
-  return buildCleanupPlanForConfig(getRuntimeConfig());
-}
-
 /** Build a read-only cleanup preview without recording config health state. */
 export async function resolveCleanupPlanForDryRun() {
   return buildCleanupPlanForConfig(await readSourceConfigBestEffort());
 }
 
-/** Resolve a destructive cleanup plan or report live state ownership consistently. */
-export function resolveCleanupPlanForRemoval(runtime: RuntimeEnv) {
-  try {
-    return resolveCleanupPlanFromDisk();
-  } catch (error) {
-    if (!hasSqliteCoordinatorCause(error)) {
-      throw error;
-    }
+/** Resolve destructive cleanup inputs without mutating the state being guarded. */
+export async function resolveCleanupPlanForRemoval(runtime: RuntimeEnv) {
+  const snapshot = await readConfigFileSnapshot({ observe: false, pluginValidation: "core-only" });
+  const workspaceWarnings = snapshot.warnings.filter((issue) =>
+    affectsWorkspaceDiscovery(issue.path),
+  );
+  if (!snapshot.valid || workspaceWarnings.length > 0) {
+    const issues = snapshot.valid ? workspaceWarnings : snapshot.issues;
+    const issueSummary = formatConfigIssueSummary(issues) ?? "configuration read failed";
     runtime.error(
-      "Cannot remove OpenClaw state while the Gateway or another state operation owns this state directory. Stop the Gateway and retry.",
+      `Cannot safely remove OpenClaw state because workspace configuration could not be resolved: ${issueSummary}. Fix the configuration and retry.`,
     );
     runtime.exit(1);
     return undefined;
   }
+  return buildCleanupPlanForConfig(snapshot.runtimeConfig);
 }

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -261,6 +261,48 @@ describe("cleanup path removals", () => {
     },
   );
 
+  it("preserves linked paths when guarded state removal fails", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-state-failure-"));
+    const stateDir = path.join(tmpRoot, "state");
+    const configPath = path.join(tmpRoot, "openclaw.json");
+    const oauthDir = path.join(tmpRoot, "credentials");
+    const oauthPath = path.join(oauthDir, "token.json");
+    const markerPath = path.join(stateDir, "marker.txt");
+    await fs.mkdir(stateDir);
+    await fs.mkdir(oauthDir);
+    await fs.writeFile(markerPath, "remove me");
+    await fs.writeFile(configPath, "{}\n");
+    await fs.writeFile(oauthPath, "keep me");
+    const realRm = fs.rm;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === markerPath) {
+        throw new Error("simulated state removal failure");
+      }
+      return await realRm(target, options);
+    });
+
+    try {
+      await expect(
+        removeStateAndLinkedPaths(
+          {
+            stateDir,
+            configPath,
+            oauthDir,
+            configInsideState: false,
+            oauthInsideState: false,
+          },
+          runtime,
+        ),
+      ).rejects.toThrow(/Failed to remove non-preserved OpenClaw state/);
+
+      await expect(fs.readFile(configPath, "utf8")).resolves.toBe("{}\n");
+      await expect(fs.readFile(oauthPath, "utf8")).resolves.toBe("keep me");
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
   it("rejects a preserved workspace overlapping the active lock before cleanup", async () => {
     const runtime = createRuntimeMock();
     const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-lock-overlap-"));

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -6,6 +6,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveGatewayLockDir } from "../config/paths.js";
+import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
@@ -126,32 +128,175 @@ describe("cleanup path removals", () => {
     expect(stateRemoved).toBe(true);
   });
 
-  it("reports when the state directory survives removal", async () => {
+  it("keeps the canonical state lock visible until state removal completes", async () => {
     const runtime = createRuntimeMock();
-    const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("permission denied"));
+    const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-lock-visible-"));
+    const stateDir = path.join(tmpRoot, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const markerPath = path.join(stateDir, "keep.txt");
+    await fs.mkdir(stateDir);
+    await fs.writeFile(configPath, "{}");
+    await fs.writeFile(markerPath, "remove me");
+    let continueRemoval = () => {};
+    const removalMayContinue = new Promise<void>((resolve) => {
+      continueRemoval = resolve;
+    });
+    let markRemovalStarted = () => {};
+    const removalStarted = new Promise<void>((resolve) => {
+      markRemovalStarted = resolve;
+    });
+    const realRm = fs.rm;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === markerPath) {
+        markRemovalStarted();
+        await removalMayContinue;
+      }
+      return await realRm(target, options);
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
 
     try {
-      const stateRemoved = await removeStateAndLinkedPaths(
+      const cleanup = removeStateAndLinkedPaths(
         {
-          stateDir: "/tmp/openclaw-cleanup-state-failure",
-          configPath: "/tmp/openclaw-cleanup-state-failure/openclaw.json",
-          oauthDir: "/tmp/openclaw-cleanup-state-failure/credentials",
+          stateDir,
+          configPath,
+          oauthDir: path.join(stateDir, "credentials"),
           configInsideState: true,
           oauthInsideState: true,
         },
         runtime,
       );
-      expect(stateRemoved).toBe(false);
+      await removalStarted;
+
+      await expect(
+        acquireGatewayLock({
+          allowInTests: true,
+          env,
+          pollIntervalMs: 2,
+          timeoutMs: 15,
+        }),
+      ).rejects.toBeInstanceOf(GatewayLockError);
+
+      continueRemoval();
+      await expect(cleanup).resolves.toBe(true);
+      await expect(fs.access(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
+      continueRemoval();
       rmSpy.mockRestore();
     }
   });
 
+  it("fails without removing state recreated during cleanup finalization", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-recreated-state-"));
+    const stateDir = path.join(tmpRoot, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const lockDir = resolveGatewayLockDir(stateDir);
+    const recreatedPath = path.join(lockDir, "new-owner.txt");
+    await fs.mkdir(stateDir);
+    await fs.writeFile(configPath, "{}");
+    const realRmdir = fs.rmdir;
+    const rmdirSpy = vi.spyOn(fs, "rmdir").mockImplementation(async (target) => {
+      if (target === path.dirname(lockDir)) {
+        await fs.mkdir(lockDir, { recursive: true });
+        await fs.writeFile(recreatedPath, "active");
+      }
+      return await realRmdir(target);
+    });
+
+    try {
+      await expect(
+        removeStateAndLinkedPaths(
+          {
+            stateDir,
+            configPath,
+            oauthDir: path.join(stateDir, "credentials"),
+            configInsideState: true,
+            oauthInsideState: true,
+          },
+          runtime,
+        ),
+      ).rejects.toThrow(/interrupted by a new state operation/);
+      await expect(fs.readFile(recreatedPath, "utf8")).resolves.toBe("active");
+    } finally {
+      rmdirSpy.mockRestore();
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "cleans a state directory reached through a symbolic-link alias",
+    async () => {
+      const runtime = createRuntimeMock();
+      const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-alias-"));
+      const stateDir = path.join(tmpRoot, "state");
+      const stateAlias = path.join(tmpRoot, "state-alias");
+      const configPath = path.join(tmpRoot, "openclaw.json");
+      await fs.mkdir(stateDir);
+      await fs.writeFile(path.join(stateDir, "marker.txt"), "remove me");
+      await fs.writeFile(configPath, "{}");
+      await fs.symlink(stateDir, stateAlias, "dir");
+
+      await expect(
+        removeStateAndLinkedPaths(
+          {
+            stateDir: stateAlias,
+            configPath,
+            oauthDir: path.join(stateAlias, "credentials"),
+            configInsideState: false,
+            oauthInsideState: true,
+          },
+          runtime,
+        ),
+      ).resolves.toBe(true);
+
+      await expect(fs.access(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.lstat(stateAlias)).rejects.toMatchObject({ code: "ENOENT" });
+      await fs.mkdir(stateAlias);
+      await expect(fs.stat(stateAlias).then((stat) => stat.isDirectory())).resolves.toBe(true);
+      await expect(fs.access(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it("rejects a preserved workspace overlapping the active lock before cleanup", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-lock-overlap-"));
+    const stateDir = path.join(tmpRoot, "state");
+    const configPath = path.join(tmpRoot, "openclaw.json");
+    const workspaceDir = path.join(resolveGatewayLockDir(stateDir), "workspace");
+    const workspaceFile = path.join(workspaceDir, "project.txt");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(workspaceFile, "keep me");
+    await fs.writeFile(configPath, "{}");
+
+    await expect(
+      removeStateAndLinkedPaths(
+        {
+          stateDir,
+          configPath,
+          oauthDir: path.join(stateDir, "credentials"),
+          configInsideState: false,
+          oauthInsideState: true,
+        },
+        runtime,
+        { preservePaths: [workspaceDir] },
+      ),
+    ).rejects.toThrow(/overlaps the active state lock/);
+
+    await expect(fs.readFile(workspaceFile, "utf8")).resolves.toBe("keep me");
+    await expect(fs.readFile(configPath, "utf8")).resolves.toBe("{}");
+  });
+
   it("preserves nested workspace paths during state-only removal", async () => {
     const runtime = createRuntimeMock();
-    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-"));
+    const tmpRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-")),
+    );
     const stateDir = path.join(tmpRoot, ".openclaw");
-    const workspaceDir = path.join(stateDir, "workspace");
+    const workspaceDir = path.join(stateDir, "tmp", "workspace");
     const workspaceFile = path.join(workspaceDir, "project.txt");
     const configPath = path.join(stateDir, "openclaw.json");
     const cacheFile = path.join(stateDir, "cache.json");

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -1,7 +1,10 @@
 // Cleanup utility tests cover filesystem cleanup helpers, temp paths, and command runtime behavior.
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -12,6 +15,50 @@ import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function attemptGatewayLockInChild(env: NodeJS.ProcessEnv): Promise<string> {
+  const lockModuleUrl = pathToFileURL(path.resolve("src/infra/gateway-lock.ts")).href;
+  const script = `
+    const { acquireGatewayLock } = await import(${JSON.stringify(lockModuleUrl)});
+    const report = (message) => process.send?.(message, () => process.exit(0));
+    try {
+      const lock = await acquireGatewayLock({
+        allowInTests: true,
+        env: process.env,
+        pollIntervalMs: 2,
+        timeoutMs: 15,
+      });
+      await lock?.release();
+      report("acquired");
+    } catch {
+      report("blocked");
+    }
+  `;
+  const childEnv = { ...env };
+  delete childEnv.NODE_ENV;
+  delete childEnv.VITEST;
+  delete childEnv.VITEST_POOL_ID;
+  delete childEnv.VITEST_WORKER_ID;
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script, "openclaw", "gateway"],
+    { cwd: path.resolve("."), env: childEnv, stdio: ["ignore", "ignore", "pipe", "ipc"] },
+  );
+  const stderr: Buffer[] = [];
+  child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+  const message = await Promise.race([
+    once(child, "message").then(([value]) => String(value)),
+    once(child, "exit").then(([code, signal]) => {
+      throw new Error(
+        `Gateway lock probe exited before reporting (${code ?? signal}): ${Buffer.concat(stderr).toString("utf8")}`,
+      );
+    }),
+  ]);
+  if (child.exitCode === null && child.signalCode === null) {
+    await once(child, "exit");
+  }
+  return message;
+}
 
 const workspaceStateMocks = vi.hoisted(() => ({
   deleteWorkspaceState: vi.fn(),
@@ -184,6 +231,64 @@ describe("cleanup path removals", () => {
       continueRemoval();
       await expect(cleanup).resolves.toBe(true);
       await expect(fs.access(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      continueRemoval();
+      rmSpy.mockRestore();
+    }
+  });
+
+  it("retains external Gateway ownership through linked-path cleanup", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.realpath(tempDirs.make("openclaw-cleanup-finalization-lock-"));
+    const stateDir = path.join(tmpRoot, "state");
+    const configPath = path.join(tmpRoot, "openclaw.json");
+    const markerPath = path.join(stateDir, "marker.txt");
+    await fs.mkdir(stateDir);
+    await fs.writeFile(markerPath, "remove me");
+    await fs.writeFile(configPath, "{}\n");
+    let continueRemoval = () => {};
+    const removalMayContinue = new Promise<void>((resolve) => {
+      continueRemoval = resolve;
+    });
+    let markLinkedRemovalStarted = () => {};
+    const linkedRemovalStarted = new Promise<void>((resolve) => {
+      markLinkedRemovalStarted = resolve;
+    });
+    const realRm = fs.rm;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === configPath) {
+        markLinkedRemovalStarted();
+        await removalMayContinue;
+      }
+      return await realRm(target, options);
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+
+    try {
+      const cleanup = removeStateAndLinkedPaths(
+        {
+          stateDir,
+          configPath,
+          oauthDir: path.join(stateDir, "credentials"),
+          configInsideState: false,
+          oauthInsideState: true,
+        },
+        runtime,
+      );
+      await linkedRemovalStarted;
+
+      const lockAttempt = await attemptGatewayLockInChild(env);
+      continueRemoval();
+      const [cleanupResult] = await Promise.allSettled([cleanup]);
+
+      expect(lockAttempt).toBe("blocked");
+      expect(cleanupResult).toEqual({ status: "fulfilled", value: true });
+      await expect(fs.access(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(configPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       continueRemoval();
       rmSpy.mockRestore();

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -1,4 +1,5 @@
 // Shared destructive-cleanup planning and guarded removal helpers.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
@@ -12,8 +13,11 @@ import {
   prepareWorkspaceStateDeletion,
 } from "../agents/workspace-state-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { isPathInside } from "../infra/path-guards.js";
+import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
+import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
+import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { resolveHomeDir, shortenHomeInString } from "../utils.js";
 
 type RemovalResult = {
@@ -38,6 +42,9 @@ type StateRemovalOptions = {
   dryRun?: boolean;
   preservePaths?: readonly string[];
 };
+
+const STATE_CLEANUP_LOCK_TIMEOUT_MS = 250;
+const STATE_CLEANUP_LOCK_POLL_INTERVAL_MS = 25;
 
 function collectWorkspaceDirs(cfg: OpenClawConfig | undefined): string[] {
   const dirs = new Set<string>();
@@ -123,6 +130,18 @@ export async function removePath(
   }
 }
 
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.lstat(target);
+    return true;
+  } catch (error) {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function existingPaths(paths: readonly string[]): Promise<string[]> {
   const existing: string[] = [];
   for (const target of paths) {
@@ -138,6 +157,39 @@ async function existingPaths(paths: readonly string[]): Promise<string[]> {
     }
   }
   return existing;
+}
+
+// Service-manager status is advisory; the state lock also covers externally supervised Gateways.
+async function acquireStateCleanupOwnership(cleanup: CleanupResolvedPaths) {
+  const env = {
+    ...process.env,
+    OPENCLAW_CONFIG_PATH: cleanup.configPath,
+    OPENCLAW_STATE_DIR: cleanup.stateDir,
+  };
+  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
+  try {
+    lock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      pollIntervalMs: STATE_CLEANUP_LOCK_POLL_INTERVAL_MS,
+      // Shipped readers validate this role as any live OpenClaw process. A new
+      // wire role would let mixed-version Gateways misclassify cleanup as stale.
+      role: "agent-embedded",
+      timeoutMs: STATE_CLEANUP_LOCK_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (error instanceof GatewayLockError) {
+      throw new Error(
+        "Cannot remove OpenClaw state while the Gateway or another state maintenance command owns this state directory. Stop the Gateway and retry.",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (!lock) {
+    throw new Error("Cannot remove OpenClaw state without exclusive state ownership.");
+  }
+  return lock;
 }
 
 function shouldPreservePath(target: string, preservePaths: readonly string[]): boolean {
@@ -185,7 +237,10 @@ async function removePathPreserving(
     }
     const entries = await fs.readdir(resolved);
     for (const entry of entries) {
-      await removePathPreserving(path.join(resolved, entry), preservePaths, runtime);
+      const result = await removePathPreserving(path.join(resolved, entry), preservePaths, runtime);
+      if (!result.ok) {
+        return result;
+      }
     }
     runtime.log(`Removed contents of ${displayLabel}`);
     return { ok: true };
@@ -195,41 +250,205 @@ async function removePathPreserving(
   }
 }
 
+async function detachStateLockDirectory(
+  lockDir: string,
+  stateDir: string,
+  runtime: RuntimeEnv,
+): Promise<string> {
+  const tombstone = path.join(
+    path.dirname(stateDir),
+    `.${path.basename(stateDir)}-locks.cleanup-${randomUUID()}`,
+  );
+  try {
+    await fs.rename(lockDir, tombstone);
+    return tombstone;
+  } catch (error) {
+    const message = `Failed to finalize OpenClaw state cleanup because the lock directory changed: ${String(error)}`;
+    runtime.error(message);
+    throw new Error(message, { cause: error });
+  }
+}
+
+async function removeStateDirectoryAlias(
+  requestedStateDir: string,
+  stateDir: string,
+): Promise<void> {
+  if (requestedStateDir === stateDir) {
+    return;
+  }
+  try {
+    if ((await fs.lstat(requestedStateDir)).isSymbolicLink()) {
+      await fs.unlink(requestedStateDir);
+    }
+  } catch (error) {
+    if (!hasNodeErrorCode(error, "ENOENT")) {
+      throw error;
+    }
+  }
+}
+
+async function removeEmptyStateAncestors(startDir: string, stateDir: string): Promise<boolean> {
+  for (let current = startDir; isPathWithin(current, stateDir); current = path.dirname(current)) {
+    try {
+      await fs.rmdir(current);
+    } catch (error) {
+      if (hasNodeErrorCode(error, "ENOENT")) {
+        continue;
+      }
+      if (hasNodeErrorCode(error, "ENOTEMPTY") || hasNodeErrorCode(error, "EEXIST")) {
+        return false;
+      }
+      throw error;
+    }
+    if (current === stateDir) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function removeLinkedCleanupPaths(
+  cleanup: CleanupResolvedPaths,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const externalPaths = [
+    cleanup.configInsideState ? undefined : cleanup.configPath,
+    cleanup.oauthInsideState ? undefined : cleanup.oauthDir,
+  ].filter((target): target is string => target !== undefined);
+  for (const target of externalPaths) {
+    if (!(await removePath(target, runtime, { label: target })).ok) {
+      throw new Error(`Failed to remove linked cleanup path: ${shortenHomeInString(target)}`);
+    }
+  }
+}
+
 /** Remove state plus config/OAuth paths, preserving selected paths nested inside state. */
 export async function removeStateAndLinkedPaths(
   cleanup: CleanupResolvedPaths,
   runtime: RuntimeEnv,
   opts?: StateRemovalOptions,
 ): Promise<boolean> {
-  const stateDir = path.resolve(cleanup.stateDir);
-  const preservePaths = (
-    opts?.dryRun
-      ? (opts.preservePaths ?? []).map((target) => path.resolve(target))
-      : await existingPaths(opts?.preservePaths ?? [])
-  ).filter((target) => isPathWithin(target, stateDir));
-  const stateRemoval =
-    preservePaths.length > 0
-      ? await removePathPreserving(stateDir, preservePaths, runtime, {
-          dryRun: opts?.dryRun,
-          label: cleanup.stateDir,
-        })
-      : await removePath(cleanup.stateDir, runtime, {
-          dryRun: opts?.dryRun,
-          label: cleanup.stateDir,
-        });
-  if (!cleanup.configInsideState) {
-    await removePath(cleanup.configPath, runtime, {
-      dryRun: opts?.dryRun,
-      label: cleanup.configPath,
-    });
+  const requestedStateDir = path.resolve(cleanup.stateDir);
+  const requestedPreservePaths = opts?.dryRun
+    ? (opts.preservePaths ?? []).map((target) => path.resolve(target))
+    : await existingPaths(opts?.preservePaths ?? []);
+  if (opts?.dryRun) {
+    const preservePaths = requestedPreservePaths.filter((target) =>
+      isPathWithin(target, requestedStateDir),
+    );
+    const stateRemoval =
+      preservePaths.length > 0
+        ? await removePathPreserving(requestedStateDir, preservePaths, runtime, {
+            dryRun: true,
+            label: cleanup.stateDir,
+          })
+        : await removePath(cleanup.stateDir, runtime, {
+            dryRun: true,
+            label: cleanup.stateDir,
+          });
+    if (!cleanup.configInsideState) {
+      await removePath(cleanup.configPath, runtime, { dryRun: true, label: cleanup.configPath });
+    }
+    if (!cleanup.oauthInsideState) {
+      await removePath(cleanup.oauthDir, runtime, { dryRun: true, label: cleanup.oauthDir });
+    }
+    return stateRemoval.ok;
   }
-  if (!cleanup.oauthInsideState) {
-    await removePath(cleanup.oauthDir, runtime, {
-      dryRun: opts?.dryRun,
-      label: cleanup.oauthDir,
-    });
+  if (isUnsafeRemovalTarget(requestedStateDir)) {
+    runtime.error(`Refusing to remove unsafe path: ${shortenHomeInString(cleanup.stateDir)}`);
+    return false;
   }
-  return stateRemoval.ok;
+
+  const lock = await acquireStateCleanupOwnership(cleanup);
+  let lockHeld = true;
+  let stateCoordinator: ReturnType<typeof acquireStateDatabaseCoordinator> | undefined;
+  const releaseLock = async () => {
+    if (!lockHeld) {
+      return;
+    }
+    lockHeld = false;
+    await lock.release();
+  };
+  const releaseStateCoordinator = () => {
+    const held = stateCoordinator;
+    stateCoordinator = undefined;
+    held?.release();
+  };
+  try {
+    const stateDir = lock.stateDir;
+    if (isUnsafeRemovalTarget(stateDir)) {
+      throw new Error(`Refusing to remove unsafe path: ${shortenHomeInString(stateDir)}`);
+    }
+    const lockDir = path.dirname(lock.stateLockPath);
+    if (!isPathWithin(lockDir, stateDir)) {
+      throw new Error("Cannot remove OpenClaw state because its active lock is outside state.");
+    }
+    const databasePath = resolveOpenClawStateSqlitePath({
+      ...process.env,
+      OPENCLAW_STATE_DIR: stateDir,
+    });
+    stateCoordinator = acquireStateDatabaseCoordinator({
+      databasePath,
+      busyTimeoutMs: 0,
+    });
+    const preservePaths = requestedPreservePaths
+      .map((target) =>
+        isPathWithin(target, requestedStateDir)
+          ? path.join(stateDir, path.relative(requestedStateDir, target))
+          : target,
+      )
+      .filter((target) => isPathWithin(target, stateDir));
+    const overlappingPreservePath = preservePaths.find(
+      (target) => isPathWithin(target, lockDir) || isPathWithin(lockDir, target),
+    );
+    if (overlappingPreservePath) {
+      throw new Error(
+        `Cannot remove OpenClaw state while preserving ${shortenHomeInString(overlappingPreservePath)} because it overlaps the active state lock. Move the workspace outside the lock directory and retry.`,
+      );
+    }
+    await removeLinkedCleanupPaths(cleanup, runtime);
+    const stateRemoval = await removePathPreserving(
+      stateDir,
+      [...preservePaths, lockDir],
+      runtime,
+      { label: cleanup.stateDir },
+    );
+    if (!stateRemoval.ok) {
+      throw new Error("Failed to remove non-preserved OpenClaw state while ownership was held.");
+    }
+
+    // The external lifecycle coordinator remains held through lock-directory
+    // detachment and state-root removal. Windows releases only the in-tree handles first.
+    if (process.platform === "win32") {
+      await lock.releaseInTree();
+    }
+    const lockTombstone = await detachStateLockDirectory(lockDir, stateDir, runtime);
+    if (process.platform !== "win32") {
+      await releaseLock();
+    }
+    if (!(await removePath(lockTombstone, runtime, { label: "detached state locks" })).ok) {
+      throw new Error(`Failed to remove detached state locks at ${lockTombstone}.`);
+    }
+
+    const stateDirRemoved = await removeEmptyStateAncestors(path.dirname(lockDir), stateDir);
+    const newStateOperationStarted =
+      (await pathExists(lockDir)) || (preservePaths.length === 0 && !stateDirRemoved);
+    if (newStateOperationStarted) {
+      throw new Error(
+        "OpenClaw state cleanup was interrupted by a new state operation. Stop other OpenClaw commands and retry.",
+      );
+    }
+    if (stateDirRemoved) {
+      await removeStateDirectoryAlias(requestedStateDir, stateDir);
+    }
+    return true;
+  } finally {
+    try {
+      releaseStateCoordinator();
+    } finally {
+      await releaseLock();
+    }
+  }
 }
 
 /** Remove all workspace directories selected by the cleanup plan. */

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -406,7 +406,6 @@ export async function removeStateAndLinkedPaths(
         `Cannot remove OpenClaw state while preserving ${shortenHomeInString(overlappingPreservePath)} because it overlaps the active state lock. Move the workspace outside the lock directory and retry.`,
       );
     }
-    await removeLinkedCleanupPaths(cleanup, runtime);
     const stateRemoval = await removePathPreserving(
       stateDir,
       [...preservePaths, lockDir],
@@ -441,6 +440,7 @@ export async function removeStateAndLinkedPaths(
     if (stateDirRemoved) {
       await removeStateDirectoryAlias(requestedStateDir, stateDir);
     }
+    await removeLinkedCleanupPaths(cleanup, runtime);
     return true;
   } finally {
     try {

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -416,15 +416,10 @@ export async function removeStateAndLinkedPaths(
       throw new Error("Failed to remove non-preserved OpenClaw state while ownership was held.");
     }
 
-    // The external lifecycle coordinator remains held through lock-directory
-    // detachment and state-root removal. Windows releases only the in-tree handles first.
-    if (process.platform === "win32") {
-      await lock.releaseInTree();
-    }
+    // Drop only the removable in-tree handles; external Gateway presence stays held
+    // through finalization so a new owner cannot start inside the cleanup window.
+    await lock.releaseInTree();
     const lockTombstone = await detachStateLockDirectory(lockDir, stateDir, runtime);
-    if (process.platform !== "win32") {
-      await releaseLock();
-    }
     if (!(await removePath(lockTombstone, runtime, { label: "detached state locks" })).ok) {
       throw new Error(`Failed to remove detached state locks at ${lockTombstone}.`);
     }

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -8,6 +8,7 @@ import {
   removeStateAndLinkedPaths,
   removeWorkspaceDirs,
   resetCleanupCommandMocks,
+  resolveCleanupPlanForRemoval,
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
 
@@ -46,6 +47,20 @@ describe("resetCommand", () => {
 
     expect(removeStateAndLinkedPaths).not.toHaveBeenCalled();
     expect(removeWorkspaceDirs).not.toHaveBeenCalled();
+  });
+
+  it("stops the managed Gateway before loading the destructive cleanup plan", async () => {
+    gatewayService.stop.mockImplementation(async () => {
+      expect(resolveCleanupPlanForRemoval).not.toHaveBeenCalled();
+    });
+
+    await resetCommand(runtime, {
+      scope: "full",
+      yes: true,
+      nonInteractive: true,
+    });
+
+    expect(resolveCleanupPlanForRemoval).toHaveBeenCalledOnce();
   });
 
   it("recommends creating a backup before state-destructive reset scopes", async () => {

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -11,10 +11,10 @@ import {
   stylePromptTitle,
 } from "../../packages/terminal-core/src/prompt-style.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { isNixMode } from "../config/config.js";
+import { isNixMode, resolveConfigPath } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveCleanupPlanFromDisk } from "./cleanup-plan.js";
+import { resolveCleanupPlanForDryRun, resolveCleanupPlanForRemoval } from "./cleanup-plan.js";
 import {
   listAgentSessionDirs,
   removePath,
@@ -125,23 +125,28 @@ export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
   }
 
   const dryRun = Boolean(opts.dryRun);
-  const { stateDir, configPath, oauthDir, configInsideState, oauthInsideState, workspaceDirs } =
-    resolveCleanupPlanFromDisk();
-
-  if (scope !== "config") {
-    logBackupRecommendation(runtime);
-    if (dryRun) {
-      runtime.log("[dry-run] stop gateway service");
-    } else if (!(await stopGatewayIfRunning(runtime))) {
-      runtime.exit(1);
-      return;
-    }
-  }
-
   if (scope === "config") {
+    const configPath = resolveConfigPath();
     await removePath(configPath, runtime, { dryRun, label: configPath });
     return;
   }
+
+  logBackupRecommendation(runtime);
+  if (dryRun) {
+    runtime.log("[dry-run] stop gateway service");
+  } else if (!(await stopGatewayIfRunning(runtime))) {
+    runtime.exit(1);
+    return;
+  }
+
+  const cleanupPlan = dryRun
+    ? await resolveCleanupPlanForDryRun()
+    : resolveCleanupPlanForRemoval(runtime);
+  if (!cleanupPlan) {
+    return;
+  }
+  const { stateDir, configPath, oauthDir, configInsideState, oauthInsideState, workspaceDirs } =
+    cleanupPlan;
 
   if (scope === "config+creds+sessions") {
     await removePath(configPath, runtime, { dryRun, label: configPath });

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -141,7 +141,7 @@ export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
 
   const cleanupPlan = dryRun
     ? await resolveCleanupPlanForDryRun()
-    : resolveCleanupPlanForRemoval(runtime);
+    : await resolveCleanupPlanForRemoval(runtime);
   if (!cleanupPlan) {
     return;
   }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -201,7 +201,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
   const cleanupPlan = removesLocalData
     ? dryRun
       ? await resolveCleanupPlanForDryRun()
-      : resolveCleanupPlanForRemoval(runtime)
+      : await resolveCleanupPlanForRemoval(runtime)
     : undefined;
   if (removesLocalData && !cleanupPlan) {
     return;

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -18,7 +18,7 @@ import { resolveGatewayService } from "../daemon/service.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveHomeDir, shortenHomeInString } from "../utils.js";
-import { resolveCleanupPlanFromDisk } from "./cleanup-plan.js";
+import { resolveCleanupPlanForDryRun, resolveCleanupPlanForRemoval } from "./cleanup-plan.js";
 import { removePath, removeStateAndLinkedPaths, removeWorkspaceDirs } from "./cleanup-utils.js";
 
 type UninstallScope = "service" | "state" | "workspace" | "app";
@@ -181,10 +181,9 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
 
   const dryRun = Boolean(opts.dryRun);
   let stateRemoved = false;
-  const { stateDir, configPath, oauthDir, configInsideState, oauthInsideState, workspaceDirs } =
-    resolveCleanupPlanFromDisk();
+  const removesLocalData = scopes.has("state") || scopes.has("workspace");
 
-  if (scopes.has("state") || scopes.has("workspace")) {
+  if (removesLocalData) {
     logBackupRecommendation(runtime);
   }
 
@@ -199,7 +198,18 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
     }
   }
 
-  if (scopes.has("state")) {
+  const cleanupPlan = removesLocalData
+    ? dryRun
+      ? await resolveCleanupPlanForDryRun()
+      : resolveCleanupPlanForRemoval(runtime)
+    : undefined;
+  if (removesLocalData && !cleanupPlan) {
+    return;
+  }
+
+  if (scopes.has("state") && cleanupPlan) {
+    const { stateDir, configPath, oauthDir, configInsideState, oauthInsideState, workspaceDirs } =
+      cleanupPlan;
     if (!scopes.has("workspace")) {
       for (const workspaceDir of workspaceDirs) {
         const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
@@ -222,8 +232,8 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
     );
   }
 
-  if (scopes.has("workspace")) {
-    await removeWorkspaceDirs(workspaceDirs, runtime, {
+  if (scopes.has("workspace") && cleanupPlan) {
+    await removeWorkspaceDirs(cleanupPlan.workspaceDirs, runtime, {
       dryRun,
       removeStateRows: !scopes.has("state") || !stateRemoved,
     });
@@ -235,9 +245,9 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
 
   runtime.log("CLI still installed. Remove via npm/pnpm if desired.");
 
-  if (scopes.has("state") && !scopes.has("workspace")) {
+  if (scopes.has("state") && !scopes.has("workspace") && cleanupPlan) {
     const home = resolveHomeDir();
-    if (home && workspaceDirs.some((dir) => dir.startsWith(path.resolve(home)))) {
+    if (home && cleanupPlan.workspaceDirs.some((dir) => dir.startsWith(path.resolve(home)))) {
       runtime.log("Tip: workspaces were preserved. Re-run with --workspace to remove them.");
     }
   }

--- a/src/infra/device-identity-coordinator-paths.ts
+++ b/src/infra/device-identity-coordinator-paths.ts
@@ -19,23 +19,15 @@ export function resolveDeviceIdentityCoordinatorPath(
 export function resolveDeviceIdentityCoordinatorPaths(params: {
   databasePath: string;
   stateDir: string;
-  temporaryDirectory: string;
   uid: number | undefined;
 }): string[] {
-  const suffix = params.uid === undefined ? "openclaw" : `openclaw-${params.uid}`;
-  const filename = resolveDeviceIdentityCoordinatorFilename(params.databasePath);
+  // The process-temp bridge existed only in v2026.8.1-beta.2; current runtimes
+  // use the state-local identity lock behind the shared lifecycle coordinator.
   const canonicalStateDir = resolvePathViaExistingAncestorSync(params.stateDir);
-  const orderedPaths = [
-    path.join(path.resolve(params.temporaryDirectory), suffix, filename),
-    path.join(resolveGatewayLockDir(canonicalStateDir, params.uid), filename),
+  return [
+    path.join(
+      resolveGatewayLockDir(canonicalStateDir, params.uid),
+      resolveDeviceIdentityCoordinatorFilename(params.databasePath),
+    ),
   ];
-  const seen = new Set<string>();
-  return orderedPaths.filter((coordinatorPath) => {
-    const canonicalPath = resolvePathViaExistingAncestorSync(coordinatorPath);
-    if (seen.has(canonicalPath)) {
-      return false;
-    }
-    seen.add(canonicalPath);
-    return true;
-  });
 }

--- a/src/infra/device-identity-coordinator.contract.test.ts
+++ b/src/infra/device-identity-coordinator.contract.test.ts
@@ -4,12 +4,14 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { resolveDeviceIdentityCoordinatorPaths } from "./device-identity-coordinator-paths.js";
+import { resolveStateDatabaseCoordinatorPath } from "./state-database-coordinator.js";
 
 type ContractFixture = {
   databasePath: string;
   stateDirectory: string;
-  temporaryDirectory: string;
+  runtimeDirectory: string;
   uid: number;
+  stateCoordinatorPath: string;
   orderedExpectedPaths: string[];
 };
 
@@ -23,28 +25,19 @@ const fixture = JSON.parse(
 describe.skipIf(process.platform === "win32")("device identity coordinator contract", () => {
   it("matches the shared ordered path vector", () => {
     expect(
-      resolveDeviceIdentityCoordinatorPaths({
+      resolveStateDatabaseCoordinatorPath({
         databasePath: fixture.databasePath,
-        stateDir: fixture.stateDirectory,
-        temporaryDirectory: fixture.temporaryDirectory,
+        runtimeDirectory: fixture.runtimeDirectory,
         uid: fixture.uid,
       }),
-    ).toEqual(fixture.orderedExpectedPaths);
-  });
-
-  it("deduplicates coincident process-temp and state-local paths", () => {
-    const stateLocalPath = fixture.orderedExpectedPaths[1];
-    if (!stateLocalPath) {
-      throw new Error("state-local fixture path is unavailable");
-    }
+    ).toBe(fixture.stateCoordinatorPath);
     expect(
       resolveDeviceIdentityCoordinatorPaths({
         databasePath: fixture.databasePath,
         stateDir: fixture.stateDirectory,
-        temporaryDirectory: path.join(fixture.stateDirectory, "tmp"),
         uid: fixture.uid,
       }),
-    ).toEqual([stateLocalPath]);
+    ).toEqual(fixture.orderedExpectedPaths);
   });
 
   it("canonicalizes database and state paths through existing symlink ancestors", async () => {
@@ -52,11 +45,25 @@ describe.skipIf(process.platform === "win32")("device identity coordinator contr
       const rootDir = fs.realpathSync.native(rawRootDir);
       const canonicalStateDir = path.join(rootDir, "canonical-state");
       const aliasedStateDir = path.join(rootDir, "aliased-state");
-      const temporaryDirectory = path.join(rootDir, "process-temp");
+      const runtimeDirectory = path.join(rootDir, "runtime");
       fs.mkdirSync(canonicalStateDir);
+      fs.mkdirSync(runtimeDirectory);
       fs.symlinkSync(canonicalStateDir, aliasedStateDir);
 
-      const common = { temporaryDirectory, uid: fixture.uid };
+      const common = { uid: fixture.uid };
+      expect(
+        resolveStateDatabaseCoordinatorPath({
+          ...common,
+          databasePath: path.join(aliasedStateDir, "state", "openclaw.sqlite"),
+          runtimeDirectory,
+        }),
+      ).toBe(
+        resolveStateDatabaseCoordinatorPath({
+          ...common,
+          databasePath: path.join(canonicalStateDir, "state", "openclaw.sqlite"),
+          runtimeDirectory,
+        }),
+      );
       expect(
         resolveDeviceIdentityCoordinatorPaths({
           ...common,

--- a/src/infra/device-identity-coordinator.ts
+++ b/src/infra/device-identity-coordinator.ts
@@ -1,4 +1,3 @@
-import os from "node:os";
 import path from "node:path";
 import {
   resolveDeviceIdentityCoordinatorPath,
@@ -9,6 +8,11 @@ import {
   ensurePrivateSqliteCoordinatorDirectory,
   SqliteCoordinatorError,
 } from "./sqlite-coordinator.js";
+import {
+  acquireStateDatabaseCoordinator,
+  resolveStateDatabaseCoordinatorPath,
+  resolveStateLifecycleRuntimeDirectory,
+} from "./state-database-coordinator.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 
@@ -79,22 +83,38 @@ export function acquireDeviceIdentityCoordinator(params: DeviceIdentityCoordinat
       : resolveDeviceIdentityCoordinatorPaths({
           databasePath: params.databasePath,
           stateDir: params.stateDir,
-          temporaryDirectory: os.tmpdir(),
           uid: typeof process.getuid === "function" ? process.getuid() : undefined,
         });
   for (const coordinatorPath of coordinatorPaths) {
     ensurePrivateDeviceIdentityCoordinatorDirectory(path.dirname(coordinatorPath));
   }
+  const stateCoordinatorPath = resolveStateDatabaseCoordinatorPath({
+    databasePath: params.databasePath,
+    runtimeDirectory: resolveStateLifecycleRuntimeDirectory(),
+    uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+  });
   const coordinators: Array<{ release: () => void }> = [];
   try {
-    // v2026.7.2-beta.4 through beta.7 use process temp. Keep it first until
-    // those builds are no longer rolling-upgrade peers.
+    // The external lifecycle coordinator remains stable while cleanup detaches state-local locks.
+    coordinators.push(
+      acquireStateDatabaseCoordinator({
+        databasePath: params.databasePath,
+        coordinatorPath: stateCoordinatorPath,
+        busyTimeoutMs: timeout,
+      }),
+    );
     for (const coordinatorPath of coordinatorPaths) {
       coordinators.push(acquireCoordinator(coordinatorPath, timeout));
     }
   } catch (error) {
     const cleanupErrors = releaseCoordinators(coordinators);
     if (cleanupErrors.length === 0) {
+      if (error instanceof SqliteCoordinatorError) {
+        throw new DeviceIdentityCoordinatorError(
+          "device identity migration or creation already owns this state database",
+          error,
+        );
+      }
       throw error;
     }
     const message =

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -1,6 +1,5 @@
 // Covers default device identity SQLite path under the state dir.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveGatewayLockDir } from "../config/paths.js";
@@ -44,11 +43,8 @@ describe("device identity state dir defaults", () => {
     await withTempDir("openclaw-identity-env-state-", async (rootDir) => {
       const stateDir = path.join(rootDir, "selected-state");
       const fakeHome = path.join(rootDir, "home");
-      const legacyTmpDir = path.join(rootDir, "legacy-process-tmp");
       fs.mkdirSync(stateDir, { recursive: true });
       fs.mkdirSync(fakeHome, { recursive: true });
-      fs.mkdirSync(legacyTmpDir, { recursive: true });
-      vi.spyOn(os, "tmpdir").mockReturnValue(legacyTmpDir);
       const env = {
         ...process.env,
         HOME: fakeHome,
@@ -58,25 +54,18 @@ describe("device identity state dir defaults", () => {
 
       loadOrCreateDeviceIdentity({ env });
 
-      const coordinatorPaths = resolveDeviceIdentityCoordinatorPaths({
+      const coordinatorPath = resolveDeviceIdentityCoordinatorPaths({
         databasePath: path.join(stateDir, "state", "openclaw.sqlite"),
         stateDir,
-        temporaryDirectory: legacyTmpDir,
         uid: typeof process.getuid === "function" ? process.getuid() : undefined,
-      });
-      const processTempPath = coordinatorPaths[0];
-      const stateLocalPath = coordinatorPaths[1];
-      if (!processTempPath || !stateLocalPath) {
-        throw new Error("coordinator bridge paths are unavailable");
+      })[0];
+      if (!coordinatorPath) {
+        throw new Error("state-local coordinator path is unavailable");
       }
       const stateCoordinators = fs
-        .readdirSync(path.dirname(stateLocalPath))
-        .filter((entry) => entry.startsWith("device-identity."));
-      const processTempCoordinators = fs
-        .readdirSync(path.dirname(processTempPath))
+        .readdirSync(path.dirname(coordinatorPath))
         .filter((entry) => entry.startsWith("device-identity."));
       expect(stateCoordinators).toHaveLength(1);
-      expect(processTempCoordinators).toEqual(stateCoordinators);
       expect(fs.existsSync(path.join(fakeHome, ".openclaw"))).toBe(false);
     });
   });

--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -2,7 +2,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -275,94 +274,12 @@ describe("device identity SQLite store", () => {
     });
   });
 
-  it("bridges process-temp and state-local coordinator owners", async () => {
-    await withTempDir("openclaw-device-identity-bridge-", async (rawRootDir) => {
-      const rootDir = fs.realpathSync.native(rawRootDir);
-      const databasePath = path.join(rootDir, "selected-state", "state", "openclaw.sqlite");
-      const stateDir = path.join(rootDir, "selected-state");
-      const temporaryDirectory = path.join(rootDir, "process-temp");
-      fs.mkdirSync(temporaryDirectory, { recursive: true });
-      vi.spyOn(os, "tmpdir").mockReturnValue(temporaryDirectory);
-
-      const paths = resolveDeviceIdentityCoordinatorPaths({
-        databasePath,
-        stateDir,
-        temporaryDirectory,
-        uid: typeof process.getuid === "function" ? process.getuid() : undefined,
-      });
-      expect(paths).toHaveLength(2);
-      const processTempPath = paths[0];
-      const stateLocalPath = paths[1];
-      if (!processTempPath || !stateLocalPath) {
-        throw new Error("coordinator bridge paths are unavailable");
-      }
-      const processTempLockDir = path.dirname(processTempPath);
-      const stateLockDir = path.dirname(stateLocalPath);
-
-      const stateOnly = acquireDeviceIdentityCoordinator({
-        databasePath,
-        lockDir: stateLockDir,
-        busyTimeoutMs: 0,
-      });
-      try {
-        expect(() =>
-          acquireDeviceIdentityCoordinator({ databasePath, stateDir, busyTimeoutMs: 0 }),
-        ).toThrow(/migration or creation already owns this state database/);
-        const oldAfterPartialFailure = acquireDeviceIdentityCoordinator({
-          databasePath,
-          lockDir: processTempLockDir,
-          busyTimeoutMs: 0,
-        });
-        oldAfterPartialFailure.release();
-      } finally {
-        stateOnly.release();
-      }
-
-      const dual = acquireDeviceIdentityCoordinator({ databasePath, stateDir, busyTimeoutMs: 0 });
-      try {
-        expect(() =>
-          acquireDeviceIdentityCoordinator({
-            databasePath,
-            lockDir: processTempLockDir,
-            busyTimeoutMs: 0,
-          }),
-        ).toThrow(/migration or creation already owns this state database/);
-        expect(() =>
-          acquireDeviceIdentityCoordinator({
-            databasePath,
-            lockDir: stateLockDir,
-            busyTimeoutMs: 0,
-          }),
-        ).toThrow(/migration or creation already owns this state database/);
-      } finally {
-        dual.release();
-      }
-
-      const oldRuntime = acquireDeviceIdentityCoordinator({
-        databasePath,
-        lockDir: processTempLockDir,
-        busyTimeoutMs: 0,
-      });
-      const transitionalRuntime = acquireDeviceIdentityCoordinator({
-        databasePath,
-        lockDir: stateLockDir,
-        busyTimeoutMs: 0,
-      });
-      transitionalRuntime.release();
-      oldRuntime.release();
-    });
-  });
-
   it("reads a missing database without creating identity state or coordinator locks", async () => {
     await withTempDir("openclaw-device-identity-readonly-", async (rootDir) => {
-      const temporaryDirectory = path.join(rootDir, "tmp");
-      fs.mkdirSync(temporaryDirectory);
-      vi.spyOn(os, "tmpdir").mockReturnValue(temporaryDirectory);
       const options = storeOptions(rootDir);
       const coordinatorPaths = resolveDeviceIdentityCoordinatorPaths({
         databasePath: options.path!,
         stateDir: rootDir,
-        temporaryDirectory,
         uid: typeof process.getuid === "function" ? process.getuid() : undefined,
       });
 

--- a/src/infra/gateway-lock.state-dir.test.ts
+++ b/src/infra/gateway-lock.state-dir.test.ts
@@ -21,6 +21,31 @@ afterEach(() => {
 });
 
 describe("gateway lock state directory", () => {
+  it("releases in-tree locks separately from Gateway lifecycle ownership", async () => {
+    await withTempDir("openclaw-gateway-lock-release-", async (root) => {
+      const stateDir = path.join(await fs.realpath(root), "state");
+      const configPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(configPath, "{}", "utf8");
+      const lock = expectGatewayLock(
+        await acquireGatewayLock({
+          allowInTests: true,
+          env: {
+            ...process.env,
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: stateDir,
+          },
+          timeoutMs: 30,
+        }),
+      );
+
+      await lock.releaseInTree();
+      await expect(fs.access(lock.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(lock.stateLockPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await lock.release();
+    });
+  });
+
   it("keeps lock, coordinator, and reclaim paths inside the selected state", async () => {
     await withTempDir("openclaw-gateway-lock-state-", async (root) => {
       const canonicalRoot = await fs.realpath(root);
@@ -47,6 +72,7 @@ describe("gateway lock state directory", () => {
       const lockDir = resolveGatewayLockDir(stateDir);
       const stateLockPath = path.join(lockDir, "gateway.state.lock");
       try {
+        expect(lock.stateDir).toBe(stateDir);
         expect(lock.stateLockPath).toBe(stateLockPath);
         expect(path.dirname(lock.lockPath)).toBe(lockDir);
         expect(path.basename(lock.lockPath)).toMatch(/^gateway\.[0-9a-f]{8}\.lock$/u);

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -22,6 +22,7 @@ import {
   parseProcCmdline,
 } from "./gateway-process-argv.js";
 import { tryAcquireExclusiveSqliteCoordinator } from "./node-sqlite.js";
+import { acquireGatewayLifecycleCoordinator } from "./state-database-coordinator.js";
 import {
   readWindowsProcessArgsSync,
   readWindowsProcessStartTimeSync,
@@ -63,6 +64,8 @@ type GatewayLockHandle = {
   lockPath: string;
   stateLockPath: string;
   configPath: string;
+  stateDir: string;
+  releaseInTree: () => Promise<void>;
   release: () => Promise<void>;
 };
 
@@ -389,20 +392,59 @@ export async function acquireGatewayLock(
   const role = opts.role ?? "gateway";
   const ownerId = randomUUID();
   const paths = resolveGatewayLockPaths(env, opts.lockDir);
-  const stateLock = await acquireLockFile({
-    ...opts,
-    configPath: paths.configPath,
-    env,
-    lockPath: paths.stateLockPath,
-    role,
-    stateDir: paths.stateDir,
-    ownerId,
-  });
+  let stateLifecycle: ReturnType<typeof acquireGatewayLifecycleCoordinator>;
+  try {
+    stateLifecycle = acquireGatewayLifecycleCoordinator({
+      databasePath: path.join(paths.stateDir, "state", "openclaw.sqlite"),
+      busyTimeoutMs: opts.timeoutMs,
+    });
+  } catch (error) {
+    throw new GatewayLockError("failed to acquire gateway state ownership", error);
+  }
+  let stateLock: Awaited<ReturnType<typeof acquireLockFile>>;
+  try {
+    stateLock = await acquireLockFile({
+      ...opts,
+      configPath: paths.configPath,
+      env,
+      lockPath: paths.stateLockPath,
+      role,
+      stateDir: paths.stateDir,
+      ownerId,
+    });
+  } catch (error) {
+    stateLifecycle.release();
+    throw error;
+  }
   const shouldAcquireConfigLock = role !== "gateway" || env.OPENCLAW_ALLOW_MULTI_GATEWAY !== "1";
   if (!shouldAcquireConfigLock) {
+    let inTreeReleased = false;
+    const releaseInTree = async () => {
+      if (inTreeReleased) {
+        return;
+      }
+      inTreeReleased = true;
+      await stateLock.release();
+    };
     return {
       ...stateLock,
+      stateDir: paths.stateDir,
       stateLockPath: stateLock.lockPath,
+      releaseInTree,
+      release: async () => {
+        let releaseError: unknown;
+        await releaseInTree().catch((error: unknown) => {
+          releaseError = error;
+        });
+        try {
+          stateLifecycle.release();
+        } catch (error) {
+          releaseError ??= error;
+        }
+        if (releaseError) {
+          throw new GatewayLockError("failed to release gateway state ownership", releaseError);
+        }
+      },
     };
   }
 
@@ -416,26 +458,55 @@ export async function acquireGatewayLock(
       stateDir: paths.stateDir,
       ownerId,
     });
+    let inTreeReleased = false;
+    const releaseInTree = async () => {
+      if (inTreeReleased) {
+        return;
+      }
+      inTreeReleased = true;
+      let releaseError: Error | undefined;
+      try {
+        await configLock.release();
+      } catch (error) {
+        releaseError =
+          error instanceof Error
+            ? error
+            : new GatewayLockError("failed to release config lock", error);
+      }
+      try {
+        await stateLock.release();
+      } catch (error) {
+        releaseError ??=
+          error instanceof Error
+            ? error
+            : new GatewayLockError("failed to release state lock", error);
+      }
+      if (releaseError) {
+        throw releaseError;
+      }
+    };
     return {
       ...configLock,
+      stateDir: paths.stateDir,
       stateLockPath: stateLock.lockPath,
+      releaseInTree,
       release: async () => {
         let releaseError: Error | undefined;
         try {
-          await configLock.release();
+          await releaseInTree();
         } catch (error) {
           releaseError =
             error instanceof Error
               ? error
-              : new GatewayLockError("failed to release config lock", error);
+              : new GatewayLockError("failed to release in-tree gateway locks", error);
         }
         try {
-          await stateLock.release();
+          stateLifecycle.release();
         } catch (error) {
           releaseError ??=
             error instanceof Error
               ? error
-              : new GatewayLockError("failed to release state lock", error);
+              : new GatewayLockError("failed to release state lifecycle", error);
         }
         if (releaseError) {
           throw releaseError;
@@ -444,6 +515,11 @@ export async function acquireGatewayLock(
     };
   } catch (error) {
     await stateLock.release().catch(() => undefined);
+    try {
+      stateLifecycle.release();
+    } catch {
+      // Preserve the original lock acquisition failure.
+    }
     throw error;
   }
 }
@@ -456,7 +532,7 @@ async function acquireLockFile(
     stateDir: string;
     ownerId: string;
   },
-): Promise<Omit<GatewayLockHandle, "stateLockPath">> {
+): Promise<Omit<GatewayLockHandle, "releaseInTree" | "stateDir" | "stateLockPath">> {
   const timeoutMs = resolveTimerTimeoutMs(opts.timeoutMs, DEFAULT_TIMEOUT_MS, 0);
   const pollIntervalMs = resolvePositiveTimerTimeoutMs(
     opts.pollIntervalMs,
@@ -535,14 +611,14 @@ async function acquireLockFile(
           configPath,
           release: async () => {
             let releaseError: unknown;
-            await lock.release().catch((error: unknown) => {
-              releaseError = error;
-            });
             try {
               coordinator.release();
             } catch (error) {
-              releaseError ??= error;
+              releaseError = error;
             }
+            await lock.release().catch((error: unknown) => {
+              releaseError ??= error;
+            });
             if (releaseError) {
               throw new GatewayLockError(
                 `failed to release gateway lock at ${lockPath}`,

--- a/src/infra/state-database-coordinator.test.ts
+++ b/src/infra/state-database-coordinator.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  acquireGatewayLifecycleCoordinator,
+  acquireStateDatabaseCoordinator,
+} from "./state-database-coordinator.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("state database coordinator", () => {
+  it("reference-counts same-process owners", async () => {
+    const root = tempDirs.make("openclaw-state-database-coordinator-");
+    const databasePath = path.join(root, "selected-state", "state", "openclaw.sqlite");
+    const runtimeDirectory = path.join(root, "runtime");
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const first = acquireStateDatabaseCoordinator({
+      databasePath,
+      runtimeDirectory,
+      busyTimeoutMs: 0,
+    });
+    const nested = acquireStateDatabaseCoordinator({
+      databasePath,
+      runtimeDirectory,
+      busyTimeoutMs: 0,
+    });
+
+    first.release();
+    nested.release();
+
+    const next = acquireStateDatabaseCoordinator({
+      databasePath,
+      runtimeDirectory,
+      busyTimeoutMs: 0,
+    });
+    next.release();
+  });
+
+  it("keeps Gateway presence independent from short state operations", async () => {
+    const root = tempDirs.make("openclaw-gateway-lifecycle-coordinator-");
+    const databasePath = path.join(root, "state", "openclaw.sqlite");
+    const runtimeDirectory = path.join(root, "runtime");
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const gateway = acquireGatewayLifecycleCoordinator({
+      databasePath,
+      runtimeDirectory,
+      busyTimeoutMs: 0,
+    });
+    const state = acquireStateDatabaseCoordinator({
+      databasePath,
+      runtimeDirectory,
+      busyTimeoutMs: 0,
+    });
+
+    state.release();
+    gateway.release();
+  });
+});

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -1,0 +1,114 @@
+// Coordinates Gateway presence and shared-state lifecycle operations outside removable state.
+import os from "node:os";
+import path from "node:path";
+import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
+import { sha256HexPrefixCore } from "./crypto-digest.js";
+import { tryAcquireExclusiveSqliteCoordinator } from "./node-sqlite.js";
+import {
+  ensurePrivateSqliteCoordinatorDirectory,
+  SqliteCoordinatorError,
+} from "./sqlite-coordinator.js";
+
+const heldCoordinators = new Map<
+  string,
+  { coordinator: { release: () => void }; references: number }
+>();
+
+type CoordinatorFamily = "gateway-lifecycle" | "state-lifecycle";
+type CoordinatorOptions = {
+  databasePath: string;
+  coordinatorPath?: string;
+  runtimeDirectory?: string;
+  uid?: number;
+  busyTimeoutMs?: number;
+};
+
+export function resolveStateLifecycleRuntimeDirectory(): string {
+  return process.platform === "win32"
+    ? path.join(os.homedir(), "AppData", "Local", "OpenClaw", "locks")
+    : "/tmp";
+}
+
+function resolveLifecycleCoordinatorPath(
+  family: CoordinatorFamily,
+  params: { databasePath: string; runtimeDirectory: string; uid: number | undefined },
+): string {
+  const canonicalDatabasePath = resolvePathViaExistingAncestorSync(params.databasePath);
+  const canonicalRuntimeDirectory = resolvePathViaExistingAncestorSync(params.runtimeDirectory);
+  // The predecessor state-local coordinator shipped only in v2026.8.1-beta.2.
+  // Keep one current stable runtime path; beta-only peers are not upgrade-compatible.
+  const suffix =
+    params.uid === undefined ? "openclaw-state-locks" : `openclaw-state-locks-${params.uid}`;
+  return path.join(
+    canonicalRuntimeDirectory,
+    suffix,
+    `${family}.${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite`,
+  );
+}
+
+export function resolveStateDatabaseCoordinatorPath(params: {
+  databasePath: string;
+  runtimeDirectory: string;
+  uid: number | undefined;
+}): string {
+  return resolveLifecycleCoordinatorPath("state-lifecycle", params);
+}
+
+function acquireLifecycleCoordinator(
+  family: CoordinatorFamily,
+  params: CoordinatorOptions,
+): { path: string; release: () => void } {
+  const coordinatorPath =
+    params.coordinatorPath ??
+    resolveLifecycleCoordinatorPath(family, {
+      databasePath: params.databasePath,
+      runtimeDirectory: params.runtimeDirectory ?? resolveStateLifecycleRuntimeDirectory(),
+      uid: params.uid ?? (typeof process.getuid === "function" ? process.getuid() : undefined),
+    });
+  const held = heldCoordinators.get(coordinatorPath);
+  if (held) {
+    held.references += 1;
+  } else {
+    ensurePrivateSqliteCoordinatorDirectory(path.dirname(coordinatorPath), `${family} coordinator`);
+    const coordinator = tryAcquireExclusiveSqliteCoordinator(coordinatorPath, {
+      busyTimeoutMs: params.busyTimeoutMs,
+    });
+    if (!coordinator) {
+      throw new SqliteCoordinatorError(`another OpenClaw process owns ${family}`);
+    }
+    heldCoordinators.set(coordinatorPath, { coordinator, references: 1 });
+  }
+
+  let released = false;
+  return {
+    path: coordinatorPath,
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      const current = heldCoordinators.get(coordinatorPath);
+      if (!current) {
+        return;
+      }
+      current.references -= 1;
+      if (current.references > 0) {
+        return;
+      }
+      heldCoordinators.delete(coordinatorPath);
+      try {
+        current.coordinator.release();
+      } catch (error) {
+        throw new SqliteCoordinatorError(`failed to release ${family} coordinator`, error);
+      }
+    },
+  };
+}
+
+export function acquireGatewayLifecycleCoordinator(params: CoordinatorOptions) {
+  return acquireLifecycleCoordinator("gateway-lifecycle", params);
+}
+
+export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
+  return acquireLifecycleCoordinator("state-lifecycle", params);
+}

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1157,12 +1157,10 @@ function runConcurrentSchemaProbe(params: {
     const coordinatorContracts =
       mode === "fresh"
         ? await Promise.all([
-            import(new URL("../config/paths.ts", moduleUrl).href),
             import(new URL("../infra/boundary-path.ts", moduleUrl).href),
             import(new URL("../infra/crypto-digest.ts", moduleUrl).href),
             import(new URL("../infra/sqlite-coordinator.ts", moduleUrl).href),
             import(new URL("./openclaw-state-db-contract.ts", moduleUrl).href),
-            import(new URL("./openclaw-state-db.paths.ts", moduleUrl).href),
           ])
         : undefined;
 
@@ -1226,18 +1224,20 @@ function runConcurrentSchemaProbe(params: {
         throw new Error("fresh initialization coordinator contracts are unavailable");
       }
       const [
-        { resolveGatewayLockDir },
         { resolvePathViaExistingAncestorSync },
         { sha256HexPrefixCore },
         { ensurePrivateSqliteCoordinatorDirectory },
         { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS },
-        { resolveOpenClawStateDirForDatabasePath },
       ] = coordinatorContracts;
       const canonicalDatabasePath = resolvePathViaExistingAncestorSync(databasePath);
-      const stateDir = resolveOpenClawStateDirForDatabasePath(canonicalDatabasePath);
+      const canonicalRuntimeDirectory = resolvePathViaExistingAncestorSync("/tmp");
+      const suffix = typeof process.getuid === "function"
+        ? \`openclaw-state-locks-\${process.getuid()}\`
+        : "openclaw-state-locks";
       const coordinatorPath = path.join(
-        resolveGatewayLockDir(stateDir),
-        \`state-ownership.\${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite\`,
+        canonicalRuntimeDirectory,
+        suffix,
+        \`state-lifecycle.\${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite\`,
       );
       ensurePrivateSqliteCoordinatorDirectory(
         path.dirname(coordinatorPath),

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -9,7 +9,6 @@ import {
   readConfigHealthStateFromStore,
   writeConfigHealthStateToStore,
 } from "../config/io.health-state.js";
-import { resolveGatewayLockDir } from "../config/paths.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import { requireNodeSqlite, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
@@ -94,10 +93,15 @@ function snapshotSqliteFamily(databasePath: string) {
 
 function resolveExpectedOwnershipCoordinatorPath(databasePath: string): string {
   const canonicalDatabasePath = resolvePathViaExistingAncestorSync(databasePath);
-  const stateDir = resolveOpenClawStateDirForDatabasePath(canonicalDatabasePath);
+  const canonicalRuntimeDirectory = resolvePathViaExistingAncestorSync("/tmp");
+  const suffix =
+    typeof process.getuid === "function"
+      ? `openclaw-state-locks-${process.getuid()}`
+      : "openclaw-state-locks";
   return path.join(
-    resolveGatewayLockDir(stateDir),
-    `state-ownership.${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite`,
+    canonicalRuntimeDirectory,
+    suffix,
+    `state-lifecycle.${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite`,
   );
 }
 
@@ -499,7 +503,7 @@ describe("external shared-state ownership", () => {
     expect(fs.readdirSync(stateDir)).toEqual(["state"]);
   });
 
-  it("keeps one state-local coordinator across temporary-directory environments", () => {
+  it("uses one external coordinator path across temporary-directory environments", () => {
     const env = createEnv();
     const databasePath = openOpenClawStateDatabase({ env }).path;
     closeOpenClawStateDatabaseForTest();
@@ -516,7 +520,6 @@ describe("external shared-state ownership", () => {
       );
       expect(fs.existsSync(coordinatorPath)).toBe(true);
     }
-    expect(fs.readdirSync(path.dirname(coordinatorPath))).toEqual([path.basename(coordinatorPath)]);
   });
 
   it("closes an unpublished fresh handle when coordinator release fails", () => {

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -93,7 +94,11 @@ function snapshotSqliteFamily(databasePath: string) {
 
 function resolveExpectedOwnershipCoordinatorPath(databasePath: string): string {
   const canonicalDatabasePath = resolvePathViaExistingAncestorSync(databasePath);
-  const canonicalRuntimeDirectory = resolvePathViaExistingAncestorSync("/tmp");
+  const runtimeDirectory =
+    process.platform === "win32"
+      ? path.join(os.homedir(), "AppData", "Local", "OpenClaw", "locks")
+      : "/tmp";
+  const canonicalRuntimeDirectory = resolvePathViaExistingAncestorSync(runtimeDirectory);
   const suffix =
     typeof process.getuid === "function"
       ? `openclaw-state-locks-${process.getuid()}`

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -2,28 +2,20 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { resolveGatewayLockDir } from "../config/paths.js";
-import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
-import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
-import {
-  openNodeSqliteDatabase,
-  tryAcquireExclusiveSqliteCoordinator,
-} from "../infra/node-sqlite.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   createSqliteLifecycleAggregateError,
-  ensurePrivateSqliteCoordinatorDirectory,
   runWithSqliteCoordinator,
-  SqliteCoordinatorError,
 } from "../infra/sqlite-coordinator.js";
 import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
 } from "../infra/sqlite-readonly-location.js";
+import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
-import { resolveOpenClawStateDirForDatabasePath } from "./openclaw-state-db.paths.js";
 
 export const STATE_SUPERVISION_KEY = "gateway.supervision";
 const MAX_OWNERSHIP_TIMESTAMP_MS = 8_640_000_000_000_000;
@@ -178,30 +170,13 @@ function inspectOpenClawStateOwnershipAtPathWhileCoordinatorHeld(
   }
 }
 
-function resolveOpenClawStateOwnershipCoordinatorPath(databasePath: string): string {
-  const canonicalDatabasePath = resolvePathViaExistingAncestorSync(databasePath);
-  const stateDir = resolveOpenClawStateDirForDatabasePath(canonicalDatabasePath);
-  return path.join(
-    resolveGatewayLockDir(stateDir),
-    `state-ownership.${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite`,
-  );
-}
-
 function acquireOpenClawStateOwnershipCoordinator(databasePath: string): {
   release: () => void;
 } {
-  const coordinatorPath = resolveOpenClawStateOwnershipCoordinatorPath(databasePath);
-  ensurePrivateSqliteCoordinatorDirectory(
-    path.dirname(coordinatorPath),
-    "state ownership coordinator",
-  );
-  const coordinator = tryAcquireExclusiveSqliteCoordinator(coordinatorPath, {
+  return acquireStateDatabaseCoordinator({
+    databasePath,
     busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   });
-  if (!coordinator) {
-    throw new SqliteCoordinatorError("another OpenClaw process is changing shared state ownership");
-  }
-  return coordinator;
 }
 
 export function runWithOpenClawStateOwnershipCoordinator<T>(

--- a/test/fixtures/device-identity-coordinator-contract.json
+++ b/test/fixtures/device-identity-coordinator-contract.json
@@ -1,10 +1,10 @@
 {
   "databasePath": "/openclaw-device-identity-contract/state/openclaw.sqlite",
   "stateDirectory": "/openclaw-device-identity-contract",
-  "temporaryDirectory": "/openclaw-device-identity-contract-temp",
+  "runtimeDirectory": "/openclaw-state-runtime",
   "uid": 501,
+  "stateCoordinatorPath": "/openclaw-state-runtime/openclaw-state-locks-501/state-lifecycle.e5c82e32.lock.sqlite",
   "orderedExpectedPaths": [
-    "/openclaw-device-identity-contract-temp/openclaw-501/device-identity.e5c82e32.lock.sqlite",
     "/openclaw-device-identity-contract/tmp/openclaw-501/device-identity.e5c82e32.lock.sqlite"
   ]
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw reset --scope full` and `openclaw uninstall --state` could remove the selected state directory while an unmanaged, Nix-managed, or otherwise service-manager-undetected Gateway still owned the live SQLite database and its WAL/SHM files.

This change does not attribute that command path to the 2026-08-17 Molty incident; command-history proof would be required for that conclusion.

## Why This Change Was Made

Destructive maintenance now owns the lifecycle boundary rather than trusting service-manager status. A stable Gateway-presence coordinator fences live Gateway instances, while a separate state-operation coordinator covers short SQLite mutations. Cleanup holds both through state removal, in-tree lock detachment, linked-path cleanup, and finalization; linked config/OAuth files are removed only after guarded state cleanup succeeds.

The CLI startup catalog skips the normal migration/observation bootstrap for reset and uninstall, because that bootstrap itself writes shared SQLite state. The command then performs a validity-aware, non-observing config snapshot read: malformed, unreadable, include-broken, or unresolved workspace configuration fails closed before deletion. Non-sandboxed macOS clients that can share CLI state use the common lifecycle namespace; sandboxed Apple app/extension state remains container-owned and uses a sandbox-writable coordinator.

Cleanup canonicalizes state aliases, preserves unselected workspaces, rejects workspace paths overlapping active locks, and retains external Gateway ownership until every destructive phase is complete. Beta-only predecessor coordinator paths are intentionally hard-cut under the repository compatibility policy.

AI-assisted: yes. The implementation was independently reviewed through the repository autoreview gate, including P1 findings and repairs.

## User Impact

Operators now get an actionable nonzero refusal instead of live-state deletion or even incidental WAL mutation when a Gateway still owns the selected state. Legitimate offline full reset and state-only uninstall continue to work; state-only uninstall preserves configured workspaces. Invalid workspace configuration also fails closed rather than guessing which nested paths are safe to delete.

## Evidence

- Production LOC: +614/-140 (net +474) | Tests/support: +721/-148 (net +573) | Docs: +4/-0. The production growth establishes the missing cross-process/cross-language lifecycle owner, two-phase finalization, non-observing command startup, and validity-aware workspace preservation.
- Pre-fix regression proof: unmanaged reset, Nix reset, and state-only uninstall all proceeded instead of refusing. Separate injected regressions proved external linked paths were deleted before later cleanup failure, a competing Gateway could acquire during finalization, runtime config planning mutated live WAL/SHM, and best-effort parsing deleted state when workspace configuration was malformed.
- Final focused proof: 91 TypeScript tests and 42 Swift tests pass across command startup policy, cleanup commands, Gateway ownership, shared-state coordination, device identity, canonical aliases, workspace preservation, malformed-config refusal, and sandbox/non-sandbox coordinator selection.
- Formatting and `git diff --check` pass. The full changed gate also passed during the repair sequence; final exact-head GitHub CI is attached to the SHA below.
- P1 branch autoreview: clean, no accepted/actionable findings.
- Exact-head source-blind CLI validation passes on `13a073f2b7196802155980080d39e082a6a4e595`: unmanaged full reset, Nix full reset, and state-only uninstall all exit nonzero with owner-lock guidance while marker, main DB, WAL, SHM, and config remain byte-for-byte identical. The owner remains healthy; SQLite reports `journal_mode=wal` and `quick_check=ok`. Malformed workspace-bearing config also refuses without changing recursive state/workspace manifests. Stopped-owner full reset removes state, and offline state-only uninstall removes state/config while preserving the configured external workspace. Only high ephemeral ports were used; port 18789 was never requested; all processes and fixtures were cleaned up.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32033275831 is green, including native Windows and macOS jobs.
