### PR TITLE
fix: large videos play distorted with no log hint when ffprobe is missing

### DIFF
--- a/src/media/ffmpeg-exec.test.ts
+++ b/src/media/ffmpeg-exec.test.ts
@@ -17,10 +17,11 @@ vi.mock("../infra/resolve-system-bin.js", () => ({
 let parseFfprobeCodecAndSampleRate: typeof import("./ffmpeg-exec.js").parseFfprobeCodecAndSampleRate;
 let resolveFfmpegBin: typeof import("./ffmpeg-exec.js").resolveFfmpegBin;
 let runFfprobe: typeof import("./ffmpeg-exec.js").runFfprobe;
+let isMissingMediaSystemBinError: typeof import("./ffmpeg-exec.js").isMissingMediaSystemBinError;
 
 beforeAll(async () => {
   vi.resetModules();
-  ({ parseFfprobeCodecAndSampleRate, resolveFfmpegBin, runFfprobe } =
+  ({ parseFfprobeCodecAndSampleRate, resolveFfmpegBin, runFfprobe, isMissingMediaSystemBinError } =
     await import("./ffmpeg-exec.js"));
 });
 
@@ -141,5 +142,34 @@ describe("resolveFfmpegBin", () => {
 
     expect(resolveFfmpegBin()).toBe("/usr/bin/ffmpeg");
     expect(resolveSystemBinMock).toHaveBeenCalledWith("ffmpeg", { trust: "standard" });
+  });
+});
+
+describe("missing system binary error identity", () => {
+  it("marks an unresolvable binary with a stable code callers can branch on", () => {
+    resolveSystemBinMock.mockReturnValue(null);
+
+    let thrown: unknown;
+    try {
+      resolveFfmpegBin();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(isMissingMediaSystemBinError(thrown)).toBe(true);
+    expect((thrown as { code?: string }).code).toBe("ERR_MEDIA_SYSTEM_BIN_MISSING");
+    expect(String(thrown)).toContain("ffmpeg");
+  });
+
+  it("rejects unrelated failures and non-error values", async () => {
+    resolveSystemBinMock.mockReturnValue("/usr/bin/ffprobe");
+    runExecMock.mockRejectedValueOnce(new Error("Invalid data found when processing input"));
+
+    await expect(runFfprobe(["-version"])).rejects.toThrow("Invalid data found");
+    expect(isMissingMediaSystemBinError(new Error("ffprobe not found in trusted system"))).toBe(
+      false,
+    );
+    expect(isMissingMediaSystemBinError({ code: "ERR_MEDIA_SYSTEM_BIN_MISSING" })).toBe(false);
+    expect(isMissingMediaSystemBinError(undefined)).toBe(false);
   });
 });

--- a/src/media/ffmpeg-exec.ts
+++ b/src/media/ffmpeg-exec.ts
@@ -34,6 +34,25 @@ function resolveExecOptions(
   };
 }
 
+const MEDIA_SYSTEM_BIN_MISSING_ERROR_CODE = "ERR_MEDIA_SYSTEM_BIN_MISSING";
+
+/**
+ * True when a media helper failed because its system binary is not installed,
+ * rather than because the media itself could not be processed. Callers branch
+ * on this identity instead of the human-facing message, which is free to change.
+ */
+export function isMissingMediaSystemBinError(value: unknown): boolean {
+  try {
+    return (
+      value instanceof Error &&
+      "code" in value &&
+      value.code === MEDIA_SYSTEM_BIN_MISSING_ERROR_CODE
+    );
+  } catch {
+    return false;
+  }
+}
+
 function requireSystemBin(name: string): string {
   const resolved = resolveSystemBin(name, { trust: "standard" });
   if (!resolved) {
@@ -41,10 +60,12 @@ function requireSystemBin(name: string): string {
       process.platform === "darwin"
         ? "e.g. brew install ffmpeg"
         : "e.g. apt install ffmpeg / dnf install ffmpeg";
-    throw new Error(
+    const error = new Error(
       `${name} not found in trusted system directories. ` +
         `Install it via your system package manager (${hint}).`,
-    );
+    ) as Error & { code: string };
+    error.code = MEDIA_SYSTEM_BIN_MISSING_ERROR_CODE;
+    throw error;
   }
   return resolved;
 }

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -12,6 +12,14 @@ vi.mock("./ffmpeg-exec.js", () => ({
   runFfprobe,
 }));
 
+const { logWarn } = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn,
+}));
+
 let testDir = "";
 let songPath = "";
 let clipPath = "";
@@ -46,6 +54,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   runFfprobe.mockReset();
+  logWarn.mockReset();
 });
 
 async function probeMediaFile(filePath: string, kind: MediaProbeKind): Promise<MediaProbeResult> {
@@ -273,5 +282,32 @@ describe("probeVideoDimensions", () => {
       ],
       { input: buffer },
     );
+  });
+});
+
+describe("missing ffprobe operator warning", () => {
+  it("does not warn for ordinary probe failures", async () => {
+    runFfprobe.mockRejectedValue(new Error("Invalid data found when processing input"));
+
+    await expect(probeMediaFile(clipPath, "video")).resolves.toEqual({});
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns once, with operator guidance, when ffprobe is not installed", async () => {
+    runFfprobe.mockRejectedValue(
+      new Error(
+        "ffprobe not found in trusted system directories. " +
+          "Install it via your system package manager (e.g. apt install ffmpeg / dnf install ffmpeg).",
+      ),
+    );
+
+    await expect(probeMediaFile(clipPath, "video")).resolves.toEqual({});
+    await expect(probeMediaFile(songPath, "audio")).resolves.toEqual({});
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const message = String(logWarn.mock.calls[0]?.[0]);
+    expect(message).toContain("ffprobe is unavailable");
+    expect(message).toContain("width/height");
+    expect(message).toContain("Install ffmpeg");
   });
 });

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -8,7 +8,10 @@ const { runFfprobe } = vi.hoisted(() => ({
   runFfprobe: vi.fn(),
 }));
 
-vi.mock("./ffmpeg-exec.js", () => ({
+// Keep the real missing-binary error identity so the warning branch is exercised
+// against the producer contract rather than a test-local stand-in.
+vi.mock("./ffmpeg-exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./ffmpeg-exec.js")>()),
   runFfprobe,
 }));
 
@@ -295,9 +298,12 @@ describe("missing ffprobe operator warning", () => {
 
   it("warns once, with operator guidance, when ffprobe is not installed", async () => {
     runFfprobe.mockRejectedValue(
-      new Error(
-        "ffprobe not found in trusted system directories. " +
-          "Install it via your system package manager (e.g. apt install ffmpeg / dnf install ffmpeg).",
+      Object.assign(
+        new Error(
+          "ffprobe not found in trusted system directories. " +
+            "Install it via your system package manager (e.g. apt install ffmpeg / dnf install ffmpeg).",
+        ),
+        { code: "ERR_MEDIA_SYSTEM_BIN_MISSING" },
       ),
     );
 

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -5,6 +5,7 @@ import {
   asSafeIntegerInRange,
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { logWarn } from "../logger.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
@@ -155,6 +156,35 @@ function isMissingFdProtocolError(error: unknown): boolean {
   );
 }
 
+function isMissingFfprobeError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("ffprobe not found in trusted system directories")
+  );
+}
+
+let warnedMissingFfprobe = false;
+
+/**
+ * Probe failures intentionally degrade to absent fields, but a missing ffprobe
+ * binary silently disables ALL media metadata — Telegram video sends then omit
+ * width/height and clients render large videos with a wrong aspect ratio, with
+ * nothing in the logs pointing at the cause (the docker images do not bundle
+ * ffmpeg). Surface that one operator-fixable condition loudly, once.
+ */
+function warnOnceOnMissingFfprobe(error: unknown): void {
+  if (warnedMissingFfprobe || !isMissingFfprobeError(error)) {
+    return;
+  }
+  warnedMissingFfprobe = true;
+  logWarn(
+    "media: ffprobe is unavailable — media metadata probing is disabled. " +
+      "Video sends will omit width/height and may render with a wrong aspect ratio " +
+      "(e.g. on Telegram). Install ffmpeg to restore metadata probing; the docker " +
+      "images do not bundle it.",
+  );
+}
+
 async function probeMediaSource(
   source: FfprobeSource,
   kind: MediaProbeKind,
@@ -171,6 +201,7 @@ async function probeMediaSource(
     const stdout = await runProbe(source.kind === "fileDescriptor" ? "fd" : "pipe");
     return parseFfprobeMediaMetadata(stdout, kind);
   } catch (error) {
+    warnOnceOnMissingFfprobe(error);
     if (source.kind === "fileDescriptor" && isMissingFdProtocolError(error)) {
       try {
         return parseFfprobeMediaMetadata(await runProbe("pipe"), kind);

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -6,7 +6,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { logWarn } from "../logger.js";
-import { runFfprobe } from "./ffmpeg-exec.js";
+import { isMissingMediaSystemBinError, runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
 
@@ -156,13 +156,6 @@ function isMissingFdProtocolError(error: unknown): boolean {
   );
 }
 
-function isMissingFfprobeError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.message.includes("ffprobe not found in trusted system directories")
-  );
-}
-
 let warnedMissingFfprobe = false;
 
 /**
@@ -173,7 +166,8 @@ let warnedMissingFfprobe = false;
  * ffmpeg). Surface that one operator-fixable condition loudly, once.
  */
 function warnOnceOnMissingFfprobe(error: unknown): void {
-  if (warnedMissingFfprobe || !isMissingFfprobeError(error)) {
+  // Only runFfprobe reaches this owner, so a missing-binary identity is ffprobe.
+  if (warnedMissingFfprobe || !isMissingMediaSystemBinError(error)) {
     return;
   }
   warnedMissingFfprobe = true;


### PR DESCRIPTION
Closes #125252

## What Problem This Solves

Fixes an issue where operators of containerized deployments would see large Telegram videos play distorted (stretched/squashed) with **no log line pointing at the cause**. The docker images do not bundle ffmpeg, so a deployment without a manually installed/mounted ffprobe is in this state by default: every metadata probe fails silently and `sendVideo` goes out without `width`/`height`.

## Why This Change Was Made

Probe failures intentionally degrade to absent fields, and that stays unchanged — a corrupt file should not spam logs. But a missing ffprobe binary is not a per-file condition: it disables **all** media metadata until an operator acts, and today it is indistinguishable from silence. This change emits **one** actionable warning per process from the shared probe owner (`probeMediaSource`): "install ffmpeg; the docker images do not bundle it".

Per review, the condition is a producer-owned contract rather than prose matching: `ffmpeg-exec` stamps `ERR_MEDIA_SYSTEM_BIN_MISSING` on the error it throws when a binary cannot be resolved and exports `isMissingMediaSystemBinError()`; the probe branches on that identity, so rewording the installation hint can no longer silently remove the diagnostic. No behavior change otherwise; deliberately narrow (no doctor integration, no image change — those remain options on #125252 if maintainers want them).

## User Impact

Operators get a single clear log line naming the fix instead of a silent quality degradation their users notice first. Existing deployments with ffprobe present see no change.

## Evidence

- Unit tests: the warning fires exactly once across repeated probes and contains the operator guidance; ordinary probe failures stay silent. Producer-side tests cover the new error identity — the code is stamped on an unresolvable binary, and the guard rejects both message look-alikes and non-error values. Full `src/media` suite green (592 passed / 10 skipped); `oxfmt`, oxlint and `tsgo:core:test` clean locally.
- **After-fix runtime trace** — PR head in a clean `node:24-bookworm` container with **no ffmpeg/ffprobe installed**, driving `probeVideoDimensions()` twice via `node --import tsx`:

  ```
  === environment ===
  v24.19.0
  ffprobe: not installed
  ffmpeg: not installed
  === PR head ===
  c40eac54 fix(media): warn once when a missing ffprobe strips video metadata
  === trace: repeated probes without ffprobe ===
  [media] ffprobe is unavailable — media metadata probing is disabled. Video sends will omit width/height and may render with a wrong aspect ratio (e.g. on Telegram). Install ffmpeg to restore metadata probing; the docker images do not bundle it.
  probe #1 -> undefined
  probe #2 -> undefined
  process still healthy, sends would continue without dimensions
  ```

  Exactly one warning across repeated probes; both probes remain non-fatal.

CI note: the failing `check-lint-core-5` shard reports a pre-existing `max-lines` violation in `src/config/sessions/types.ts` on current main — a file this PR does not touch. Happy to rebase once main is green.
- Live evidence for the underlying failure is in #125252: same 44 MB MP4 through a real Telegram gateway stores 320×320 without ffprobe and 1920×1080 with it (read back via the Bot API `forwardMessage` response).

Related: #124733 (defense-in-depth fallback for the separately reported pipe-probe failure; this PR is the narrow shared-owner repair suggested by the ClawSweeper triage of #125252).
