### PR TITLE
fix(gateway): read only the visible-message tail for session previews

### DIFF
--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -1,8 +1,10 @@
 /**
  * Gateway session preview resolve tests.
  */
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+import * as resetWindow from "../config/sessions/session-accessor.sqlite-reset-window.js";
 import type { GatewayClient } from "./server-methods/types.js";
+import * as sessionDisplayProjection from "./session-display-projection.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import { rpcReq, writeSessionStore } from "./test-helpers.js";
 import {
@@ -75,6 +77,218 @@ test("sessions.preview returns transcript previews", async () => {
     { role: "assistant", text: "Hi" },
     { role: "assistant", text: "Forecast ready" },
   ]);
+});
+
+test("sessions.preview grows the read window past a toolcall-heavy tail to fill the limit", async () => {
+  // The preview reader reads only the visible-message tail and grows it backwards
+  // when projection filters out toolcall/control messages, so a toolcall-heavy tail
+  // still yields `limit` displayable items rather than stopping short.
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-preview-tail";
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": sessionStoreEntry(sessionId),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    messages: [
+      { role: "user", content: "msg-1" },
+      { role: "assistant", content: "msg-2" },
+      { role: "user", content: "msg-3" },
+      { role: "assistant", content: "msg-4" },
+      { role: "user", content: "msg-5" },
+      // Trailing toolcalls that projection filters out; the window must cross
+      // these to reach the earlier displayable messages.
+      { role: "assistant", content: [{ type: "toolcall", name: "t-1" }] },
+      { role: "assistant", content: [{ type: "toolcall", name: "t-2" }] },
+      { role: "assistant", content: [{ type: "toolcall", name: "t-3" }] },
+    ],
+  });
+
+  const preview = await directSessionReq<{
+    previews: Array<{
+      key: string;
+      status: string;
+      items: Array<{ role: string; text: string }>;
+    }>;
+  }>("sessions.preview", { keys: ["main"], limit: 3, maxChars: 120 });
+  expect(preview.ok).toBe(true);
+  const entry = preview.payload?.previews[0];
+  expect(entry?.status).toBe("ok");
+  expect(entry?.items).toEqual([
+    { role: "user", text: "msg-3" },
+    { role: "assistant", text: "msg-4" },
+    { role: "user", text: "msg-5" },
+  ]);
+});
+
+test("sessions.preview reads a bounded visible-message tail instead of the full transcript", async () => {
+  // Regression guard for the bounded-tail performance fix. The previous
+  // implementation read every visible message event on the active path before
+  // discarding all but the last `limit` projected items, so read/parse work
+  // scaled with total transcript length. The fix reads only a tail window and
+  // grows it backwards. The distinguishing invariant is the *first* read
+  // range: the legacy full scan starts at `[0, total)` (range == total), while
+  // the bounded reader starts at the tail with range <= `limit`.
+  //
+  // This assertion fails on the prior full scan (first range == total) and
+  // passes once the bounded-tail reader is in place (first range <= limit).
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-preview-bounded-read";
+  const transcriptSize = 2000;
+  const previewLimit = 5;
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": sessionStoreEntry(sessionId),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    messages: Array.from({ length: transcriptSize }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `msg-${index}`,
+    })),
+  });
+
+  const readRanges: Array<{ start: number; endExclusive: number }> = [];
+  const spy = vi
+    .spyOn(resetWindow, "readVisibleMessageRange")
+    .mockImplementation((_projection, start, endExclusive) => {
+      readRanges.push({ start, endExclusive });
+      // Defer to the original by re-reading through the unspied module path is
+      // not available here; returning [] is sufficient because this guard only
+      // asserts read-range shape, not preview content (content correctness is
+      // covered by the tests above).
+      return [];
+    });
+
+  const preview = await directSessionReq<{
+    previews: Array<{ status: string; items: unknown[] }>;
+  }>("sessions.preview", { keys: ["main"], limit: previewLimit, maxChars: 120 });
+  spy.mockRestore();
+
+  expect(preview.ok).toBe(true);
+  expect(readRanges.length).toBeGreaterThan(0);
+  const firstRead = readRanges[0];
+  const firstRange = firstRead ? firstRead.endExclusive - firstRead.start : 0;
+  // The bounded reader's first read must be the tail window, never the whole
+  // transcript. The legacy full scan would make this equal to `transcriptSize`.
+  expect(firstRange).toBeLessThanOrEqual(previewLimit);
+  // The growth is bounded: doubling from `limit` reaches `total` in
+  // ceil(log2(total / limit)) steps, so a generous fixed cap guards against an
+  // unbounded/linear scan regressing in the future.
+  expect(readRanges.length).toBeLessThan(30);
+});
+
+test("sessions.preview never rereads overlapping tail ranges on an all-filtered tail", async () => {
+  // Regression guard for the non-overlapping expansion. When the tail is made
+  // entirely of non-displayable messages (toolcalls), projection yields zero
+  // items and the window must grow all the way to the start. The prior
+  // doubling loop reread the entire suffix on every iteration, so total read
+  // work peaked at ~2x the transcript. The fix reads only each newly uncovered
+  // prefix interval, so total read positions never exceed one full scan.
+  //
+  // This assertion fails on the overlapping expansion (total read > transcript
+  // size) and passes once each expansion reads only the new prefix.
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-preview-non-overlapping";
+  const transcriptSize = 2000;
+  const previewLimit = 5;
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": sessionStoreEntry(sessionId),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    messages: Array.from({ length: transcriptSize }, () => ({
+      role: "assistant",
+      content: [{ type: "toolcall", name: "tc" }],
+    })),
+  });
+
+  const readRanges: Array<{ start: number; endExclusive: number }> = [];
+  const spy = vi
+    .spyOn(resetWindow, "readVisibleMessageRange")
+    .mockImplementation((_projection, start, endExclusive) => {
+      readRanges.push({ start, endExclusive });
+      return [];
+    });
+
+  const preview = await directSessionReq<{
+    previews: Array<{ status: string; items: unknown[] }>;
+  }>("sessions.preview", { keys: ["main"], limit: previewLimit, maxChars: 120 });
+  spy.mockRestore();
+
+  expect(preview.ok).toBe(true);
+  expect(readRanges.length).toBeGreaterThan(0);
+  const totalReadPositions = readRanges.reduce(
+    (sum, range) => sum + (range.endExclusive - range.start),
+    0,
+  );
+  // The non-overlapping reader reads each position at most once, so total read
+  // work is bounded by one full scan. The prior overlapping loop read
+  // ~2.28x transcriptSize here.
+  expect(totalReadPositions).toBeLessThanOrEqual(transcriptSize);
+});
+
+test("sessions.preview never reprojects messages on an all-filtered tail", async () => {
+  // Regression guard for the non-repeating projection. When the tail is made
+  // entirely of non-displayable messages (toolcalls), projection yields zero
+  // items and the window must grow all the way to the start. The prior
+  // implementation re-ran projection over the entire accumulated suffix on
+  // every expansion, so total projection work peaked at ~2x the transcript.
+  // The fix projects only each newly uncovered prefix interval, so every
+  // message is projected at most once.
+  //
+  // This assertion fails on the reprojecting implementation (projection count
+  // > transcript size) and passes once each expansion projects only the new
+  // prefix.
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-preview-no-reproject";
+  const transcriptSize = 2000;
+  const previewLimit = 5;
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": sessionStoreEntry(sessionId),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    messages: Array.from({ length: transcriptSize }, () => ({
+      role: "assistant",
+      content: [{ type: "toolcall", name: "tc" }],
+    })),
+  });
+
+  const spy = vi
+    .spyOn(sessionDisplayProjection, "projectSessionDisplayMessage")
+    .mockImplementation(() => null);
+
+  const preview = await directSessionReq<{
+    previews: Array<{ status: string; items: unknown[] }>;
+  }>("sessions.preview", { keys: ["main"], limit: previewLimit, maxChars: 120 });
+  const projectionCalls = spy.mock.calls.length;
+  spy.mockRestore();
+
+  expect(preview.ok).toBe(true);
+  // Each message is projected at most once, so total projection calls are
+  // bounded by one full scan. The prior reprojecting loop called
+  // ~2.28x transcriptSize here.
+  expect(projectionCalls).toBeLessThanOrEqual(transcriptSize);
 });
 
 test("sessions.resolve by sessionId ignores fuzzy-search list limits and returns the exact match", async () => {

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -127,16 +127,8 @@ test("sessions.preview grows the read window past a toolcall-heavy tail to fill 
 });
 
 test("sessions.preview reads a bounded visible-message tail instead of the full transcript", async () => {
-  // Regression guard for the bounded-tail performance fix. The previous
-  // implementation read every visible message event on the active path before
-  // discarding all but the last `limit` projected items, so read/parse work
-  // scaled with total transcript length. The fix reads only a tail window and
-  // grows it backwards. The distinguishing invariant is the *first* read
-  // range: the legacy full scan starts at `[0, total)` (range == total), while
-  // the bounded reader starts at the tail with range <= `limit`.
-  //
-  // This assertion fails on the prior full scan (first range == total) and
-  // passes once the bounded-tail reader is in place (first range <= limit).
+  // Regression guard: the bounded-tail reader's first read must be a tail window (range <= limit),
+  // not a full scan (range == total). Also verifies preview content is correct.
   const { storePath } = await createSessionStoreDir();
   const sessionId = "sess-preview-bounded-read";
   const transcriptSize = 2000;
@@ -158,45 +150,35 @@ test("sessions.preview reads a bounded visible-message tail instead of the full 
   });
 
   const readRanges: Array<{ start: number; endExclusive: number }> = [];
+  const originalRead = resetWindow.readVisibleMessageRange;
   const spy = vi
     .spyOn(resetWindow, "readVisibleMessageRange")
-    .mockImplementation((_projection, start, endExclusive) => {
+    .mockImplementation((projection, start, endExclusive) => {
       readRanges.push({ start, endExclusive });
-      // Defer to the original by re-reading through the unspied module path is
-      // not available here; returning [] is sufficient because this guard only
-      // asserts read-range shape, not preview content (content correctness is
-      // covered by the tests above).
-      return [];
+      return originalRead(projection, start, endExclusive);
     });
 
   const preview = await directSessionReq<{
-    previews: Array<{ status: string; items: unknown[] }>;
+    previews: Array<{ status: string; items: Array<{ role: string; text: string }> }>;
   }>("sessions.preview", { keys: ["main"], limit: previewLimit, maxChars: 120 });
   spy.mockRestore();
 
   expect(preview.ok).toBe(true);
+  // Verify preview content correctness, not just read-range shape.
+  const items = preview.payload?.previews[0]?.items ?? [];
+  expect(items.length).toBeLessThanOrEqual(previewLimit);
+  expect(items[items.length - 1]?.text).toContain(`msg-${transcriptSize - 1}`);
+  // The bounded reader's first read must be the tail window, never the whole transcript.
   expect(readRanges.length).toBeGreaterThan(0);
   const firstRead = readRanges[0];
   const firstRange = firstRead ? firstRead.endExclusive - firstRead.start : 0;
-  // The bounded reader's first read must be the tail window, never the whole
-  // transcript. The legacy full scan would make this equal to `transcriptSize`.
   expect(firstRange).toBeLessThanOrEqual(previewLimit);
-  // The growth is bounded: doubling from `limit` reaches `total` in
-  // ceil(log2(total / limit)) steps, so a generous fixed cap guards against an
-  // unbounded/linear scan regressing in the future.
   expect(readRanges.length).toBeLessThan(30);
 });
 
 test("sessions.preview never rereads overlapping tail ranges on an all-filtered tail", async () => {
-  // Regression guard for the non-overlapping expansion. When the tail is made
-  // entirely of non-displayable messages (toolcalls), projection yields zero
-  // items and the window must grow all the way to the start. The prior
-  // doubling loop reread the entire suffix on every iteration, so total read
-  // work peaked at ~2x the transcript. The fix reads only each newly uncovered
-  // prefix interval, so total read positions never exceed one full scan.
-  //
-  // This assertion fails on the overlapping expansion (total read > transcript
-  // size) and passes once each expansion reads only the new prefix.
+  // Regression guard: non-overlapping expansion reads each position at most once (total <= transcriptSize).
+  // Also verifies all-filtered tail yields zero preview items.
   const { storePath } = await createSessionStoreDir();
   const sessionId = "sess-preview-non-overlapping";
   const transcriptSize = 2000;
@@ -218,11 +200,12 @@ test("sessions.preview never rereads overlapping tail ranges on an all-filtered 
   });
 
   const readRanges: Array<{ start: number; endExclusive: number }> = [];
+  const originalRead = resetWindow.readVisibleMessageRange;
   const spy = vi
     .spyOn(resetWindow, "readVisibleMessageRange")
-    .mockImplementation((_projection, start, endExclusive) => {
+    .mockImplementation((projection, start, endExclusive) => {
       readRanges.push({ start, endExclusive });
-      return [];
+      return originalRead(projection, start, endExclusive);
     });
 
   const preview = await directSessionReq<{
@@ -231,14 +214,14 @@ test("sessions.preview never rereads overlapping tail ranges on an all-filtered 
   spy.mockRestore();
 
   expect(preview.ok).toBe(true);
+  // All-filtered tail yields zero preview items (toolcalls are not displayable).
+  expect(preview.payload?.previews[0]?.items ?? []).toHaveLength(0);
   expect(readRanges.length).toBeGreaterThan(0);
   const totalReadPositions = readRanges.reduce(
     (sum, range) => sum + (range.endExclusive - range.start),
     0,
   );
-  // The non-overlapping reader reads each position at most once, so total read
-  // work is bounded by one full scan. The prior overlapping loop read
-  // ~2.28x transcriptSize here.
+  // The non-overlapping reader reads each position at most once.
   expect(totalReadPositions).toBeLessThanOrEqual(transcriptSize);
 });
 

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -12,12 +12,20 @@ import {
   type TranscriptEvent,
 } from "../config/sessions/session-accessor.js";
 import {
+  withCurrentProjectionSnapshot,
+  type CurrentTranscriptProjection,
+} from "../config/sessions/session-accessor.sqlite-active-projection.js";
+import {
   readRecentSessionTranscriptHistoryEvents,
   readSessionTranscriptHistoryEventById,
   readSessionTranscriptHistoryEventCount,
   readSessionTranscriptHistoryEventPage,
   readSessionTranscriptHistoryEvents,
 } from "../config/sessions/session-accessor.sqlite-history-events.js";
+import {
+  readVisibleMessageRange,
+  resolveVisibleMessagePositions,
+} from "../config/sessions/session-accessor.sqlite-reset-window.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { aggregateSqliteUsageSnapshots } from "./session-transcript-derived-readers.js";
 import {
@@ -260,7 +268,63 @@ function buildSqlitePreviewItems(
   maxItems: number,
   maxChars: number,
 ): SessionPreviewItem[] {
-  return buildSessionPreviewItems(readSqliteMessagesSync(target), maxItems, maxChars);
+  // Read only the visible-message tail instead of the whole transcript. The
+  // previous implementation read every message event on the active path and
+  // then discarded all but the last `maxItems` projected items, which scaled
+  // memory and synchronous parse cost with total transcript length for a
+  // preview that only ever inspects the tail.
+  //
+  // `buildSessionPreviewItems` slices the *projected* items, not the messages,
+  // so a toolcall/control-heavy tail can yield fewer items than messages. Grow
+  // the window backwards until enough items survive projection (or the whole
+  // transcript is covered, which is exactly the legacy behavior).
+  //
+  // Each expansion reads only the newly uncovered prefix interval and projects
+  // only those new messages, prepending the surviving items to the accumulated
+  // tail. Every message is read and projected at most once, so an all-filtered
+  // tail never does more read or projection work than the legacy single full
+  // scan (prior revisions reread/reprojected the entire suffix on every
+  // iteration, peaking at ~2x total).
+  return withCurrentProjectionSnapshot(toTranscriptReadScope(target), (projection) => {
+    const visible = resolveVisibleMessagePositions(projection);
+    const total = visible.total;
+    if (total === 0) {
+      return [];
+    }
+    let windowSize = Math.min(maxItems, total);
+    let items = buildSessionPreviewItems(
+      readVisibleMessageTailAsMessages(projection, total - windowSize, total),
+      maxItems,
+      maxChars,
+    );
+    while (items.length < maxItems && windowSize < total) {
+      const previousSize = windowSize;
+      windowSize = Math.min(windowSize * 2, total);
+      // Read and project only the newly uncovered earlier interval; the suffix
+      // items already projected stay in position. `buildSessionPreviewItems`
+      // slices its own output to `maxItems`, so an over-long prefix is trimmed
+      // to the tail exactly as the outer accumulation would.
+      const uncoveredPrefixItems = buildSessionPreviewItems(
+        readVisibleMessageTailAsMessages(projection, total - windowSize, total - previousSize),
+        maxItems,
+        maxChars,
+      );
+      items = uncoveredPrefixItems.concat(items);
+      if (items.length > maxItems) {
+        items = items.slice(-maxItems);
+      }
+    }
+    return items;
+  });
+}
+
+function readVisibleMessageTailAsMessages(
+  projection: CurrentTranscriptProjection,
+  start: number,
+  endExclusive: number,
+): unknown[] {
+  const events = readVisibleMessageRange(projection, start, endExclusive);
+  return extractMessageRecordsFromEventEntries(events).map(sqliteRecordMessageWithSeq);
 }
 
 /** Reads display messages asynchronously through the reader seam. */


### PR DESCRIPTION
## What Problem This Solves

Loading the message preview for a long session froze the gateway main thread and ballooned memory, because the preview reader loaded and parsed the *entire* transcript just to keep the last dozen items. This change reads only the visible-message tail, so preview cost scales with the preview limit instead of total transcript length.

- **Problem:** `buildSqlitePreviewItems` called `readSqliteMessagesSync(target)`, which reads every message event on the active transcript path (`readSessionTranscriptMessageEvents` → `readVisibleMessageRange(projection, 0, visible.total)`, all `event_json` rows pulled and `JSON.parse`d synchronously), then handed the full array to `buildSessionPreviewItems`, which iterates every message through `projectSessionDisplayMessage` and finally `items.slice(-maxItems)`. For a `sessions.preview` RPC (scope `operator.read`) against a multi-thousand-message session, the gateway loaded, parsed, and projected the whole transcript on the main thread only to discard all but the last `maxItems` items.
- **Solution:** Read only the visible-message tail via `readVisibleMessageRange(projection, total - windowSize, total)` and grow the window backwards (doubling) when projection filters out toolcall/control messages, until enough items survive projection or the whole transcript is covered. When the window reaches `total`, the result is byte-for-byte identical to the legacy full-scan slice.
- **What changed:** `src/gateway/session-transcript-readers.ts` — `buildSqlitePreviewItems` rewritten to wrap `withCurrentProjectionSnapshot` + `resolveVisibleMessagePositions` and read a bounded tail through a small `readVisibleMessageTailAsMessages` helper that reuses `extractMessageRecordsFromEventEntries` + `sqliteRecordMessageWithSeq` (same message-shaping as the full-scan path). Each backwards-growth step projects only the newly uncovered prefix interval via `buildSessionPreviewItems` (the existing pure projection+slicing function, now reused as the per-window projector) and prepends the surviving items, so every message is read and projected at most once. `src/gateway/server.sessions.preview-resolve.test.ts` — four regression tests: one asserting the window grows past a toolcall-heavy tail to fill the limit, plus three spy-based guards asserting the first read range ≤ `limit`, no overlapping tail rereads, and no message reprojection on an all-filtered tail.
- **What did NOT change:** `buildSessionPreviewItems` (the pure projection+slicing function — still exported and unit-tested in `session-utils.fs.test.ts`; it is now *called* by `buildSqlitePreviewItems` instead of being bypassed), `readSqliteMessagesSync` (still used by usage-snapshot aggregation, which legitimately needs the full transcript), the `sessions.preview` RPC contract, and the `talk-client` realtime-context call site (benefits automatically).

## Why This Change Was Made

The preview is a tail-only view by definition, so reading the full transcript was an accidental O(total) cost inherited from the sqlite storage migration (#98236). The bounded tail reuses the existing canonical reader (`readVisibleMessageRange` / `resolveVisibleMessagePositions`) that the full-scan path already used internally — the fix is the same function with a non-zero `start`, so kept/reset-window boundary handling is identical.

- **Best fix:** Yes. The alternative of switching to `readRecentSessionTranscriptActiveEvents` was rejected because that reader returns raw active events (including control events) ordered by `active_position`, whereas the legacy path reads *visible messages* via `readVisibleMessageRange`; mixing the two would change which rows are visible after a reset window. Reusing `readVisibleMessageRange` with a bounded range preserves the exact visible-message semantics.
- **Risk / non-goals:** A transcript whose entire tail is non-displayable (e.g. trailing toolcalls only) forces the window to grow to `total`, which is exactly the legacy behavior — no regression, just no improvement for that pathological case. The doubling strategy bounds the number of re-reads to O(log N), and each expansion reads/projects only the newly uncovered prefix interval (never the already-projected suffix), so total read and projection work is bounded by one full scan even in the all-filtered case. The extra `withCurrentProjectionSnapshot` wrapper in `buildSqlitePreviewItems` is the same snapshot the full-scan path already opens inside `readSessionTranscriptMessageEvents`, so no additional transaction or lock is introduced.

## User Impact

Operators browsing the session list (Control UI / CLI) no longer incur gateway main-thread stalls or memory spikes when previewing long-running sessions. The realtime voice context (`talk-client`) path, which shares the same reader to seed initial items, also stays cheap for long sessions.

## Evidence

**Live command verification (5000-message fixture, `node`/vitest run against worktree source):**

A proof test seeded a 5000-message session (alternating user/assistant text + 2 trailing toolcalls) and called the public reader `readSessionPreviewItemsFromTranscript(scope, 12, 240)`. Per-call latency measured with `performance.now()` (5 runs averaged after a warm-up call), across transcript sizes:

```text
preview per-call ms by transcript size: {
  '500':  2.87,   # post-fix (bounded tail)
  '2500': 3.04,
  '5000': 2.99,
}
```

Post-fix latency is **flat** as the transcript grows — the bounded tail does not scale with total length.

**Pre-fix (source reverted via `git stash push -- src/gateway/session-transcript-readers.ts`, proof test kept) — bug reproduction:**

```text
preview per-call ms by transcript size: {
  '500':  7.86,   # pre-fix (full scan)
  '2500': 24.09,
  '5000': 39.82,
}
```

Pre-fix latency grows ~linearly (5000-msg call is 5.07× slower than the 500-msg call). The post-fix proof assertion `expect(perSize[5000]).toBeLessThan(perSize[500] * 3)` **fails on pre-fix code** (39.82 > 23.59) and **passes on post-fix code**.

**Behavior equivalence (pre-fix vs post-fix return identical items):**

Both implementations, run against the same 5000-message fixture, return the exact same 12 preview items (`proof-msg-4988` … `proof-msg-4999`), skipping the trailing toolcalls. The fix changes *how many* messages are read, not *which* items are returned.

**Regression tests (credible failure guards):**

`sessions.preview grows the read window past a toolcall-heavy tail to fill the limit` (5 displayable messages + 3 trailing toolcalls, `limit: 3`):
- Post-fix: returns `[msg-3, msg-4, msg-5]` (window crosses the trailing toolcalls) → PASS.
- Simplified bounded tail (no backwards-growth loop, same fixture): returns `status: "empty"` because the last 3 messages are all filtered toolcalls → FAIL. Confirms the test guards the growth behavior, not a tautology.

Three spy-based performance guards (2000-message fixture, `limit: 5`) that each fail on the prior buggy revision and pass on the fix:
- `sessions.preview reads a bounded visible-message tail instead of the full transcript` — spies `readVisibleMessageRange`, asserts the *first* read range ≤ `limit` (legacy full scan reads `[0, total)` → range == 2000 > 5 → FAIL).
- `sessions.preview never rereads overlapping tail ranges on an all-filtered tail` — asserts total read positions ≤ transcript size (prior overlapping expansion reread the suffix each step, peaking at ~2.28× total → FAIL).
- `sessions.preview never reprojects messages on an all-filtered tail` — spies `projectSessionDisplayMessage`, asserts total projection calls ≤ transcript size (prior reprojecting loop re-ran projection over the accumulated suffix each step, peaking at ~2.28× total → FAIL).

**Focused test results (worktree, `node scripts/run-vitest.mjs`):**

```text
src/gateway/server.sessions.preview-resolve.test.ts          13 passed
src/gateway/session-utils.fs.test.ts                         83 passed
src/gateway/server-methods/sessions-read.test.ts             (included in 118 below)
src/gateway/server.sessions.store-rpc.test.ts                (included in 118 below)
Total across the 4 files: 118 passed / 0 failed
```

**What was not tested:** Real gateway RPC over the wire (the reader seam is exercised directly through the same SQLite projection the gateway uses). Concurrent `sessions.preview` calls during an active session reset (the reset-window projection is shared with the legacy path, so concurrency semantics are unchanged). Sessions larger than 5000 messages (the scaling proof at 500/2500/5000 demonstrates flatness; larger sizes follow the same bounded-tail logic).

**Open PR collision check:** Searched open PRs and recently merged PRs touching `src/gateway/session-transcript-readers.ts` and the preview read path (`gh search prs --state open -- "session-transcript-readers"`, `gh search prs --state merged -- "sessions preview transcript"`). No open or merged PR touched the preview read path. The last change to `buildSqlitePreviewItems` was the sqlite storage migration (#98236); `#125123` (perf: reduce chat history read-path work) optimized the chat-history path but did not touch the preview path.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (glm-5.2)
- Prompts / session excerpts: focused on reading the preview read path and reusing the existing bounded visible-message reader; full session available on request.
- Confirmed understanding of code changes: Yes — can explain every line. `buildSqlitePreviewItems` opens the projection snapshot, resolves visible-message positions, reads a bounded `[total - windowSize, total)` tail via `readVisibleMessageRange` (same function the legacy full-scan used with `[0, total]`), shapes messages through the same `extractMessageRecordsFromEventEntries` + `sqliteRecordMessageWithSeq` pipeline, and grows `windowSize` backwards (doubling) — projecting only the newly uncovered prefix interval via `buildSessionPreviewItems` each step and prepending the surviving items — until `maxItems` projected items accumulate or `windowSize` reaches `total` (legacy-equivalent). Every message is read and projected at most once.
- autoreview: N/A (focused tests + before/after timing proof + credible-failure guard used instead).

