### PR TITLE
fix(onboard): keep completion permission errors nonfatal

### DIFF
--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
+import { isErrno } from "../infra/errors.js";
 import { pathExists } from "../utils.js";
 import { publishOutputFileAtomically } from "./output-file.runtime.js";
 
@@ -420,6 +421,15 @@ export async function usesSlowDynamicCompletion(
     }
   }
   return false;
+}
+
+const PROFILE_WRITE_ERROR_CODES = new Set(["EACCES", "EPERM", "EROFS"]);
+
+export function findCompletionProfileWriteError(err: unknown): NodeJS.ErrnoException | undefined {
+  if (isErrno(err) && PROFILE_WRITE_ERROR_CODES.has(err.code ?? "")) {
+    return err;
+  }
+  return err instanceof Error ? findCompletionProfileWriteError(err.cause) : undefined;
 }
 
 export async function installCompletion(shell: string, yes: boolean, binName = "openclaw") {

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -6,6 +6,7 @@ import { resolveCliName } from "../cli/cli-name.js";
 import {
   completionCacheExists,
   COMPLETION_SKIP_PLUGIN_COMMANDS_ENV,
+  findCompletionProfileWriteError,
   formatCompletionReloadCommand,
   installCompletion,
   isCompletionInstalled,
@@ -17,7 +18,6 @@ import {
   type CompletionShell,
 } from "../cli/completion-runtime.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
-import { isErrno } from "../infra/errors.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -31,15 +31,6 @@ type ShellCompletionStatusOptions = {
 export type CompletionCacheGenerationOptions = ShellCompletionStatusOptions & {
   generationMode: "core-only" | "full";
 };
-
-const PROFILE_WRITE_ERROR_CODES = new Set(["EACCES", "EPERM", "EROFS"]);
-
-function findProfileWriteError(err: unknown): NodeJS.ErrnoException | undefined {
-  if (isErrno(err) && PROFILE_WRITE_ERROR_CODES.has(err.code ?? "")) {
-    return err;
-  }
-  return err instanceof Error ? findProfileWriteError(err.cause) : undefined;
-}
 
 async function installCompletionForDoctor(
   shell: CompletionShell,
@@ -55,7 +46,7 @@ async function installCompletionForDoctor(
     );
   } catch (err) {
     // Completion is optional, but only profile permission failures are safe to downgrade.
-    const writeError = findProfileWriteError(err);
+    const writeError = findCompletionProfileWriteError(err);
     if (!writeError) {
       throw err;
     }

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -113,6 +113,8 @@ export const en = {
       cacheFailed: "Failed to generate completion cache. Run `{command}` later.",
       enable: "Enable {shell} shell completion for {cli}?",
       installed: "Shell completion installed. {reloadHint}",
+      profileNotWritable:
+        "Shell completion was not changed: {profile} is not writable. Run `{command}` against a writable profile file.",
       reloadPowerShell: "Restart your shell or run: {command}",
       reloadShell: "Restart your shell or run: source {profile}",
       title: "Shell completion",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -112,6 +112,8 @@ export const zh_CN = {
       cacheFailed: "生成 completion 缓存失败。稍后运行 `{command}`。",
       enable: "为 {cli} 启用 {shell} shell completion？",
       installed: "Shell completion 已安装。{reloadHint}",
+      profileNotWritable:
+        "Shell completion 未更改：{profile} 不可写。请对可写的 profile 文件运行 `{command}`。",
       reloadPowerShell: "重启 shell 或运行：{command}",
       reloadShell: "重启 shell 或运行：source {profile}",
       title: "Shell completion",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -112,6 +112,8 @@ export const zh_TW = {
       cacheFailed: "產生 completion 快取失敗。稍後執行 `{command}`。",
       enable: "為 {cli} 啟用 {shell} shell completion？",
       installed: "Shell completion 已安裝。{reloadHint}",
+      profileNotWritable:
+        "Shell completion 未變更：{profile} 無法寫入。請對可寫入的 profile 檔案執行 `{command}`。",
       reloadPowerShell: "重新啟動 shell 或執行：{command}",
       reloadShell: "重新啟動 shell 或執行：source {profile}",
       title: "Shell completion",

--- a/src/wizard/setup.completion.test.ts
+++ b/src/wizard/setup.completion.test.ts
@@ -50,6 +50,14 @@ function createDeps(shell: "zsh" | "bash" | "fish" | "powershell" = "zsh") {
   return deps;
 }
 
+function wrappedFsError(code: string, profilePath: string): Error {
+  const cause = Object.assign(new Error(`${code}: profile write failed`), {
+    code,
+    path: profilePath,
+  });
+  return new Error(`Failed to install completion: ${cause.message}`, { cause });
+}
+
 describe("setupWizardShellCompletion", () => {
   it("QuickStart: installs without prompting", async () => {
     const prompter = createPrompter();
@@ -75,6 +83,55 @@ describe("setupWizardShellCompletion", () => {
     expect(deps.ensureCompletionCacheExists).not.toHaveBeenCalled();
     expect(deps.installCompletion).not.toHaveBeenCalled();
     expect(prompter.note).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      description: "upgrading a slow shell profile",
+      profileInstalled: true,
+      usesSlowPattern: true,
+    },
+    {
+      description: "installing a new shell profile",
+      profileInstalled: false,
+      usesSlowPattern: false,
+    },
+  ])(
+    "keeps onboarding completion optional when $description is not writable",
+    async ({ profileInstalled, usesSlowPattern }) => {
+      const profilePath = "/tmp/read-only/.zshrc";
+      const prompter = createPrompter();
+      const deps = createDeps();
+      vi.mocked(deps.checkShellCompletionStatus!).mockResolvedValue({
+        shell: "zsh",
+        profileInstalled,
+        cacheExists: false,
+        cachePath: "/tmp/openclaw.zsh",
+        usesSlowPattern,
+      });
+      vi.mocked(deps.installCompletion!).mockRejectedValue(wrappedFsError("EACCES", profilePath));
+
+      await expect(
+        setupWizardShellCompletion({ flow: "quickstart", prompter, deps }),
+      ).resolves.not.toThrow();
+
+      expect(prompter.note).toHaveBeenCalledWith(
+        `Shell completion was not changed: ${profilePath} is not writable. Run \`openclaw completion --install\` against a writable profile file.`,
+        "Shell completion",
+      );
+    },
+  );
+
+  it("re-throws unexpected completion installation errors", async () => {
+    const prompter = createPrompter();
+    const deps = createDeps();
+    vi.mocked(deps.installCompletion!).mockRejectedValue(
+      wrappedFsError("ENOSPC", "/tmp/full/.zshrc"),
+    );
+
+    await expect(
+      setupWizardShellCompletion({ flow: "quickstart", prompter, deps }),
+    ).rejects.toThrow("ENOSPC");
   });
 
   it.each([

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -1,9 +1,11 @@
 // Setup completion helpers render completion instructions after onboarding.
 import { resolveCliName } from "../cli/cli-name.js";
 import {
+  findCompletionProfileWriteError,
   formatCompletionReloadCommand,
   installCompletion,
   resolveCompletionProfileHint,
+  resolveCompletionProfilePath,
 } from "../cli/completion-runtime.js";
 import type {
   CompletionCacheGenerationOptions,
@@ -42,6 +44,25 @@ export async function setupWizardShellCompletion(params: {
 
   const cliName = deps.resolveCliName();
   const completionStatus = await deps.checkShellCompletionStatus(cliName);
+  const installCompletionForSetup = async (): Promise<boolean> => {
+    try {
+      await deps.installCompletion(completionStatus.shell, true, cliName);
+      return true;
+    } catch (error) {
+      const writeError = findCompletionProfileWriteError(error);
+      if (!writeError) {
+        throw error;
+      }
+      await params.prompter.note(
+        t("wizard.completion.profileNotWritable", {
+          profile: writeError.path ?? resolveCompletionProfilePath(completionStatus.shell),
+          command: `${cliName} completion --install`,
+        }),
+        t("wizard.completion.title"),
+      );
+      return false;
+    }
+  };
   const generationOptions = { generationMode: "full" } as const;
   const ensureCompletionCache = async (): Promise<boolean> => {
     const cacheGenerated = await deps.ensureCompletionCacheExists(cliName, generationOptions);
@@ -60,7 +81,7 @@ export async function setupWizardShellCompletion(params: {
     // Case 1: Profile uses slow dynamic pattern - silently upgrade to cached version
     const cacheGenerated = await ensureCompletionCache();
     if (cacheGenerated) {
-      await deps.installCompletion(completionStatus.shell, true, cliName);
+      await installCompletionForSetup();
     }
     return;
   }
@@ -95,7 +116,10 @@ export async function setupWizardShellCompletion(params: {
     }
 
     // Install to shell profile
-    await deps.installCompletion(completionStatus.shell, true, cliName);
+    const completionInstalled = await installCompletionForSetup();
+    if (!completionInstalled) {
+      return;
+    }
 
     const shell = completionStatus.shell;
     const command = formatCompletionReloadCommand(shell, resolveCompletionProfileHint(shell));


### PR DESCRIPTION
## What Problem This Solves

Classic onboarding commits its durable setup before optional shell completion runs. If the selected shell profile is read-only, `EACCES`, `EPERM`, or `EROFS` currently escapes completion setup and suppresses the authoritative onboarding outro and optional TUI handoff even though setup already succeeded.

## Why This Change Was Made

This moves Doctor's existing narrow, cause-aware profile-write error classification into the completion runtime and reuses it from onboarding. Expected profile permission failures now produce an actionable localized note and allow finalization to continue; unexpected completion failures still propagate.

The classifier belongs with the completion profile owner rather than a caller-specific broad catch. Onboarding catches it only around profile installation, so unrelated status and cache failures retain their existing behavior.

## User Impact

Onboarding no longer appears to fail after a successful setup merely because shell completion cannot update a profile. Operators are told which profile was not writable and can retry `openclaw completion --install` against a writable profile later.

## Evidence

- `node scripts/run-vitest.mjs src/wizard/setup.completion.test.ts src/commands/doctor-completion.test.ts src/cli/completion-runtime.test.ts` — 3 files, 89 tests passed
- `node scripts/check-changed.mjs` — production typecheck, format, lint prechecks, and guard lanes passed; the broad core-test typecheck reached the unchanged baseline failure `ui/src/pages/chat/route-loader.ts(712,38): TS2339`
- exact-base confirmation: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.ui-pages-e2e.json --builders 1` at `7810edca33f866df373b32e1779f7ecd51fbf78e` reproduces the same unrelated `TS2339`
- autoreview — clean, no accepted/actionable findings