### PR TITLE
fix(android): retain pinned sessions in compact picker

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -130,17 +130,21 @@ internal fun compactSessionChoices(
 ): List<ChatSessionEntry> {
   val mainKey = mainSessionKey.trim().ifEmpty { "main" }
   val current = currentSessionKey.trim().let { if (it == "main" && mainKey != "main") mainKey else it }
-  val pinnedRank =
-    listOf(mainKey, current)
-      .filter { it.isNotBlank() }
-      .distinct()
-      .withIndex()
-      .associate { it.value to it.index }
-  val unpinnedRank = pinnedRank.size
-
   return choices
     .withIndex()
-    .sortedWith(compareBy({ pinnedRank[it.value.key] ?: unpinnedRank }, { it.index }))
+    .sortedWith(
+      compareBy(
+        {
+          when {
+            it.value.key == mainKey -> 0
+            it.value.key == current -> 1
+            it.value.pinned == true -> 2
+            else -> 3
+          }
+        },
+        { it.index },
+      )
+    )
     .take(maxOptions)
     .map { it.value }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -52,7 +52,7 @@ private fun sessionBaseKey(key: String): String {
   return if (parts.size >= 3 && parts[0] == "agent") parts[2].trim() else normalized
 }
 
-/** Builds the selectable recent-session list while preserving the active session. */
+/** Builds the selectable recent-session list while preserving the active and pinned sessions. */
 fun resolveSessionChoices(
   currentSessionKey: String,
   sessions: List<ChatSessionEntry>,
@@ -71,7 +71,7 @@ fun resolveSessionChoices(
     if (aliasKey != null && entry.key == aliasKey) continue
     if (!isSelectableChatSession(entry.key, mainKey)) continue
     if (!seen.add(entry.key)) continue
-    if ((entry.updatedAtMs ?: 0L) < cutoff) continue
+    if (entry.pinned != true && (entry.updatedAtMs ?: 0L) < cutoff) continue
     recent.add(entry)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -143,9 +143,8 @@ internal fun compactSessionChoices(
           }
         },
         { it.index },
-      )
-    )
-    .take(maxOptions)
+      ),
+    ).take(maxOptions)
     .map { it.value }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -36,6 +36,22 @@ class SessionFiltersTest {
   }
 
   @Test
+  fun sessionChoicesIncludeStalePinnedSessions() {
+    val now = 1_700_000_000_000L
+    val stale = now - 26 * 60 * 60 * 1000L
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "main", updatedAtMs = stale),
+        ChatSessionEntry(key = "pinned-old", updatedAtMs = stale, pinned = true),
+        ChatSessionEntry(key = "old-unpinned", updatedAtMs = stale),
+      )
+
+    val result = resolveSessionChoices("main", sessions, mainSessionKey = "main", nowMs = now).map { it.key }
+
+    assertEquals(listOf("main", "pinned-old"), result)
+  }
+
+  @Test
   fun compactChoicesKeepMainAndCurrentWhileCappingRecentSessions() {
     val now = 1_700_000_000_000L
     val sessions =

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -77,6 +77,32 @@ class SessionFiltersTest {
   }
 
   @Test
+  fun compactChoicesPrioritizePinnedSessionsWithinTheCompactLimit() {
+    val now = 1_700_000_000_000L
+    val stale = now - 26 * 60 * 60 * 1000L
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "recent-1", updatedAtMs = now - 1),
+        ChatSessionEntry(key = "recent-2", updatedAtMs = now - 2),
+        ChatSessionEntry(key = "recent-3", updatedAtMs = now - 3),
+        ChatSessionEntry(key = "recent-4", updatedAtMs = now - 4),
+        ChatSessionEntry(key = "pinned-old", updatedAtMs = stale, pinned = true),
+        ChatSessionEntry(key = "main", updatedAtMs = now - 5),
+      )
+
+    val result =
+      resolveCompactSessionChoices(
+        currentSessionKey = "main",
+        sessions = sessions,
+        mainSessionKey = "main",
+        nowMs = now,
+        maxOptions = 5,
+      ).map { it.key }
+
+    assertEquals(listOf("main", "pinned-old", "recent-1", "recent-2", "recent-3"), result)
+  }
+
+  @Test
   fun sessionChoicesFilterAgentDeviceAndInternalSessions() {
     val now = 1_700_000_000_000L
     val recent = now - 10 * 60 * 1000L


### PR DESCRIPTION
## What Problem This Solves

Android’s compact chat session picker applies a 24-hour cutoff to sessions. Pinned sessions can therefore disappear even though the Gateway provides their `pinned` state.

Related issue: #119858

## What Changed

- Preserve pinned sessions regardless of age.
- Continue applying the 24-hour cutoff to ordinary unpinned sessions.
- Prioritize compact-picker entries in this order:
  1. Main session
  2. Current session
  3. Pinned sessions
  4. Ordinary recent sessions
- Preserve the existing five-entry compact-picker limit.
- Add regression coverage for stale pinned sessions being retained and prioritized over newer unpinned sessions.

This is intentionally limited to Android session-picker parity. It does not change the broader stale-session policy.

## Evidence

Files changed:

- `apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt`
- `apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt`

Commits:

- `6eb4ad28`
- `2bcacb6c`

Diff:

- 2 files changed
- 57 additions
- 11 deletions

Native Android validation:

- Samsung SM-A556E
- Android 14
- OpenClaw `2026.7.4` Play debug build
- Isolated local Gateway connected through ADB reverse
- Native Threads UI used to pin `New chat 2`
- After Gateway restart, the Chat picker retained and prioritized it:
  `Main → New chat 5 → New chat 2 → New chat 4`
- Live `sessions.list` confirmed `New chat 2` with `pinned: true`

The stale-age behavior is covered by the regression test; the device evidence verifies real pin persistence and compact-picker ordering.

## Validation

Passed:

- `:app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.SessionFiltersTest`
- `:app:assemblePlayDebug`

Both completed with `BUILD SUCCESSFUL`.