### PR TITLE
fix(config): reuse protocol session visibility type

### DIFF
--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -42,7 +42,6 @@ export type { SessionToolOverrides } from "./session-tool-overrides.js";
 export type SessionScope = "per-sender" | "global";
 export type SessionChatType = ChatType;
 export const SESSION_TOTAL_TOKENS_VERSION = 1 as const;
-type SessionVisibility = "shared" | "read-only" | "suggest" | "draft";
 
 export type SessionOrigin = {
   label?: string;
@@ -307,7 +306,7 @@ type SessionEntryCore = SessionRestartRecoveryState &
   SessionEntryProvenance &
   Pick<SessionRow, "permissionMode" | "sessionRoot"> & {
     /** Collaboration mode. Missing legacy values are equivalent to "shared". */
-    visibility?: SessionVisibility;
+    visibility?: SessionRow["visibility"];
     /**
      * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
      * Stored on the main session entry.


### PR DESCRIPTION
## What Problem This Solves

The current `main` CI run fails the core lint stripe because `src/config/sessions/types.ts` reached 701 counted production lines against the 700-line limit.

## Root Cause

Session visibility duplicated the canonical protocol union locally. A recent adjacent type expansion pushed the file over the existing ratchet.

## Fix

Derive `SessionEntryCore.visibility` from `SessionRow["visibility"]` and remove the duplicate local union. This preserves behavior while making the gateway protocol the single type owner.

Production delta: net -1 line. No test or changelog change is needed for this type-only CI repair.

## Evidence

- Reproduced before the change: core oxlint stripe 5/5 reported 701 lines with a maximum of 700.
- `node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=5/5 --threads=1`
- `pnpm exec oxfmt --check src/config/sessions/types.ts`
- `git diff --check`
- `node scripts/check-changed.mjs`
- Autoreview: clean, no accepted or actionable findings.
