### PR TITLE
fix(state): migrate legacy state for explicit multi-agent setups

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -360,7 +360,10 @@ describe("codex doctor contract", () => {
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
 
-  it("preserves ambiguous shared-root bindings for explicit multi-agent configs", async () => {
+  it.each([
+    ["without a system agent", undefined],
+    ["with a missing system agent", { systemAgent: { agentId: "missing" } }],
+  ] as const)("preserves ambiguous shared-root bindings %s", async (_label, defaults) => {
     const fixture = await createBindingMigrationFixture({
       legacySharedRoot: true,
       name: "explicit-owner",
@@ -376,7 +379,7 @@ describe("codex doctor contract", () => {
     const params = {
       ...fixture.params,
       config: {
-        agents: { ownership: "explicit" as const, entries: { main: {}, ops: {} } },
+        agents: { ownership: "explicit" as const, defaults, entries: { main: {}, ops: {} } },
       },
     };
 
@@ -392,6 +395,58 @@ describe("codex doctor contract", () => {
     await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
+  it("migrates a shared-root binding to the configured system agent", async () => {
+    const sessionKey = "legacy";
+    const fixture = await createBindingMigrationFixture({
+      legacySharedRoot: true,
+      name: "system-agent-owner",
+      sessionIndex: {
+        [sessionKey]: {
+          sessionId: "system-agent-owner",
+          sessionFile: "system-agent-owner.jsonl",
+          updatedAt: 1,
+        },
+      },
+      threadId: "thread-system-agent-owner",
+    });
+    const params = {
+      ...fixture.params,
+      config: {
+        agents: {
+          ownership: "explicit" as const,
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: {}, blocker: {}, digest: {} },
+        },
+      },
+    };
+
+    await expect(fixture.migration.migrateLegacyState(params)).resolves.toMatchObject({
+      changes: [expect.stringContaining("Migrated 1")],
+      warnings: [],
+    });
+    await expect(
+      openBindingStore(fixture.env).lookup(
+        bindingStoreKey({
+          kind: "session",
+          agentId: "main",
+          sessionId: "system-agent-owner",
+          sessionKey,
+        }),
+      ),
+    ).resolves.toMatchObject({ sessionId: "system-agent-owner" });
+    expect(
+      getSessionEntry({
+        agentId: "main",
+        env: fixture.env,
+        sessionKey,
+        storePath: fixture.storePath,
+      }),
+    ).toMatchObject({ agentHarnessId: "codex" });
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
@@ -413,7 +468,11 @@ describe("codex doctor contract", () => {
     const params = {
       ...fixture.params,
       config: {
-        agents: { ownership: "explicit" as const, entries: { main: {}, ops: {} } },
+        agents: {
+          ownership: "explicit" as const,
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: {}, ops: {} },
+        },
       },
     };
 

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { withFileLock, type FileLockOptions } from "openclaw/plugin-sdk/file-lock";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import {
   archiveLegacyStateSource,
   legacyStateFileExists,
@@ -423,11 +424,11 @@ async function resolveLegacySessionFileLocator(
   return candidate;
 }
 
-function resolveLegacyBindingOwnerAgentId(params: {
+function tryResolveLegacyBindingOwnerAgentId(params: {
   sessionKey: string;
   config: MigrationEnvironment["config"];
   storeAgentIds?: Set<string>;
-}): string {
+}): string | undefined {
   if (params.sessionKey.trim().toLowerCase().startsWith("agent:")) {
     return resolveSessionAgentIds({
       sessionKey: params.sessionKey,
@@ -435,24 +436,27 @@ function resolveLegacyBindingOwnerAgentId(params: {
     }).sessionAgentId;
   }
   const storeAgentId = params.storeAgentIds?.size === 1 ? [...params.storeAgentIds][0] : undefined;
-  return resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.config,
-    ...(storeAgentId ? { agentId: storeAgentId } : {}),
-  }).sessionAgentId;
-}
-
-function tryResolveLegacyBindingOwnerAgentId(
-  params: Parameters<typeof resolveLegacyBindingOwnerAgentId>[0],
-): string | undefined {
-  try {
-    return resolveLegacyBindingOwnerAgentId(params);
-  } catch (error) {
-    if ((error as { code?: unknown }).code === "AGENT_SELECTION_REQUIRED") {
-      return undefined;
+  const configuredAgentId = params.config.agents?.defaults?.systemAgent?.agentId?.trim();
+  const systemAgentId =
+    !storeAgentId && configuredAgentId ? normalizeAgentId(configuredAgentId) : undefined;
+  const fallbackAgentIds =
+    systemAgentId && listAgentIds(params.config).includes(systemAgentId)
+      ? [undefined, systemAgentId]
+      : [undefined];
+  for (const fallbackAgentId of fallbackAgentIds) {
+    try {
+      return resolveSessionAgentIds({
+        sessionKey: params.sessionKey,
+        config: params.config,
+        ...(storeAgentId ? { agentId: storeAgentId } : fallbackAgentId ? { fallbackAgentId } : {}),
+      }).sessionAgentId;
+    } catch (error) {
+      if ((error as { code?: unknown }).code !== "AGENT_SELECTION_REQUIRED") {
+        throw error;
+      }
     }
-    throw error;
   }
+  return undefined;
 }
 
 function copyBindingForSession(stored: MigratedBindingRow, sessionId: string): MigratedBindingRow {

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -271,7 +271,6 @@ describe.concurrent("gateway startup-migration refusal", () => {
       gateway: { mode: "local", auth: { mode: "none" } },
       agents: {
         ownership: "explicit",
-        defaults: { systemAgent: { agentId: "main" } },
         entries: { main: {}, blocker: {}, digest: {} },
       },
     } satisfies OpenClawConfig;

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { listAgentIds, tryResolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
   discardLegacyRegistryWorktrees,
@@ -281,8 +282,9 @@ function createPluginDoctorStateMigrationContext(
 }
 
 function tryResolveDoctorStateMigrationAgentId(cfg: OpenClawConfig): string | undefined {
-  const agentId = tryResolveLegacyCompatibilityAgentId(cfg);
-  return agentId ? normalizeAgentId(agentId) : undefined;
+  const agentId =
+    tryResolveLegacyCompatibilityAgentId(cfg) ?? tryResolveSystemAgentTargetAgentId(cfg);
+  return agentId && listAgentIds(cfg).includes(agentId) ? agentId : undefined;
 }
 
 function tryResolveDoctorSessionMigrationAgentId(cfg: OpenClawConfig): string | undefined {

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -976,39 +976,112 @@ describe("state migrations", () => {
     },
   );
 
-  it("keeps unresolved legacy agent files advisory at startup and actionable in Doctor", async () => {
+  it.each([
+    ["without a system agent", undefined],
+    ["with a missing system agent", { systemAgent: { agentId: "missing" } }],
+  ] as const)(
+    "keeps unresolved legacy agent files advisory at startup and actionable in Doctor %s",
+    async (_label, defaults) => {
+      const root = await createTempDir();
+      const stateDir = path.join(root, ".openclaw");
+      const env = createEnv(stateDir);
+      const cfg: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          defaults,
+          entries: { main: {}, blocker: {}, digest: {} },
+        },
+      };
+      const legacyAgentPath = path.join(stateDir, "agent", "settings.json");
+      fsSync.mkdirSync(path.dirname(legacyAgentPath), { recursive: true });
+      fsSync.writeFileSync(legacyAgentPath, '{"legacy":true}\n');
+
+      const automatic = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+
+      expect(automatic.warnings).toEqual([]);
+      expect(automatic.notices).toContain(
+        "Deferred legacy agent/session migration: select an agent owner",
+      );
+      expect(fsSync.readFileSync(legacyAgentPath, "utf8")).toBe('{"legacy":true}\n');
+
+      resetAutoMigrateLegacyStateForTest();
+      const doctor = await autoMigrateLegacyState({
+        cfg,
+        env,
+        homedir: () => root,
+        doctorOnlyStateMigrations: true,
+      });
+      expect(doctor.warnings).toContain(
+        "Deferred legacy agent/session migration: select an agent owner",
+      );
+      expect(doctor.notices ?? []).not.toContain(
+        "Deferred legacy agent/session migration: select an agent owner",
+      );
+      expect(fsSync.readFileSync(legacyAgentPath, "utf8")).toBe('{"legacy":true}\n');
+    },
+  );
+
+  it.each([
+    {
+      label: "the configured system agent",
+      targetAgentId: "main",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: {}, blocker: {}, digest: {} },
+        },
+      } as OpenClawConfig,
+    },
+    {
+      label: "the legacy compatibility owner before the configured system agent",
+      targetAgentId: "legacy",
+      cfg: {
+        agents: {
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { legacy: { default: true }, main: {} },
+        },
+      } as OpenClawConfig,
+    },
+  ])("migrates legacy shared agent and session state to $label", async ({ cfg, targetAgentId }) => {
     const root = await createTempDir();
     const stateDir = path.join(root, ".openclaw");
     const env = createEnv(stateDir);
-    const cfg: OpenClawConfig = {
-      agents: { ownership: "explicit", entries: { main: {}, blocker: {}, digest: {} } },
-    };
-    const legacyPath = path.join(stateDir, "agent", "settings.json");
-    fsSync.mkdirSync(path.dirname(legacyPath), { recursive: true });
-    fsSync.writeFileSync(legacyPath, '{"legacy":true}\n');
-
-    const automatic = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
-
-    expect(automatic.warnings).toEqual([]);
-    expect(automatic.notices).toContain(
-      "Deferred legacy agent/session migration: select an agent owner",
+    const legacySessionsDir = path.join(stateDir, "sessions");
+    const legacyAgentDir = path.join(stateDir, "agent");
+    await fs.mkdir(legacySessionsDir, { recursive: true });
+    await fs.mkdir(legacyAgentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(legacySessionsDir, "sessions.json"),
+      JSON.stringify({ legacy: { sessionId: "legacy-session", updatedAt: 1 } }),
+      "utf8",
     );
-    expect(fsSync.readFileSync(legacyPath, "utf8")).toBe('{"legacy":true}\n');
-
-    resetAutoMigrateLegacyStateForTest();
-    const doctor = await autoMigrateLegacyState({
+    await fs.writeFile(path.join(legacySessionsDir, "legacy-session.jsonl"), "{}\n", "utf8");
+    await fs.writeFile(path.join(legacyAgentDir, "settings.json"), '{"legacy":true}\n', "utf8");
+    const result = await autoMigrateLegacyState({
       cfg,
       env,
       homedir: () => root,
-      doctorOnlyStateMigrations: true,
+      now: () => 1234,
     });
-    expect(doctor.warnings).toContain(
+
+    expect(result.warnings).not.toContain(
       "Deferred legacy agent/session migration: select an agent owner",
     );
-    expect(doctor.notices ?? []).not.toContain(
+    expect(result.notices ?? []).not.toContain(
       "Deferred legacy agent/session migration: select an agent owner",
     );
-    expect(fsSync.readFileSync(legacyPath, "utf8")).toBe('{"legacy":true}\n');
+    await expect(
+      fs.readFile(
+        path.join(stateDir, "agents", targetAgentId, "sessions", "legacy-session.jsonl"),
+        "utf8",
+      ),
+    ).resolves.toBe("{}\n");
+    await expect(
+      fs.readFile(path.join(stateDir, "agents", targetAgentId, "agent", "settings.json"), "utf8"),
+    ).resolves.toContain('"legacy":true');
+    await expectMissingPath(path.join(legacySessionsDir, "sessions.json"));
+    await expectMissingPath(legacyAgentDir);
   });
 
   it("keeps unreadable legacy agent databases blocking", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an explicit multi-agent installation with `agents.defaults.systemAgent.agentId` configured could still refuse Gateway readiness during an upgrade when legacy shared agent/session state remained. Doctor reported `select an agent owner` even though the operator had already configured that owner.

The same ambiguity left legacy shared Codex binding sidecars unmigrated.

## Why This Change Was Made

Legacy compatibility ownership continues to win when present. Otherwise, Doctor now uses the configured system agent only when that normalized ID exists in the roster. The Codex migration preserves agent-key and unique-store ownership, then retries an ambiguous shared root with that same validated system agent.

Missing or invalid system-agent targets remain advisory and deferred. Runtime routing, default-agent semantics, and the public Plugin SDK are unchanged.

Production delta: +26/-20, net +6. The remaining growth is the explicit roster validation and bounded ambiguity-only retry; tests add the valid-owner and missing/invalid-owner contracts.

## User Impact

Operators can upgrade explicit multi-agent installations without temporarily reintroducing retired default-agent markers. Legacy shared sessions, agent state, and Codex bindings migrate to the configured system agent, while genuinely ownerless state remains untouched with actionable guidance.

## Evidence

- Live pre-fix behavior: startup refused readiness with the deferred-owner warning despite a valid configured system agent; providing the same owner through a temporary compatibility config allowed the supported migration to complete.
- Focused final-tree proof: 131 tests passed across core state migrations, startup preflight, and the Codex Doctor contract.
- Changed-path gate, formatting, typechecks, lint, database-first/import-cycle guards, and `git diff --check` passed.
- Structured autoreview passed with no accepted/actionable findings.
- The positive automatic-migration regression fails on current main with the deferred-owner warning.

Codex dependency gate: inspected upstream commit `4861236f06d0`, including `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`, `codex-rs/app-server/src/request_processors/thread_processor.rs`, and rollout recorder/storage surfaces. Upstream owns thread IDs and rollout storage, but not OpenClaw's binding-sidecar or agent-ownership policy.