### PR TITLE
fix(gateway): reject usage.cost agentScope=all with agentId

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -145,7 +145,15 @@ export const usageHandlers: GatewayRequestHandlers = {
     }
     const { startMs, endMs } = range;
     const agentId = normalizeOptionalString(params?.agentId);
-    const agentScope = params?.agentScope === "all" && !agentId ? "all" : undefined;
+    if (params?.agentScope === "all" && agentId) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "agentScope=all cannot be combined with agentId"),
+      );
+      return;
+    }
+    const agentScope = params?.agentScope === "all" ? "all" : undefined;
     let effectiveAgentId = agentId;
     if (!agentScope && !effectiveAgentId) {
       const requestedAgent = resolveRequestedSessionAgentId(config, "main");

--- a/src/gateway/server.usage-cost-agent-scope.test.ts
+++ b/src/gateway/server.usage-cost-agent-scope.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
+import { connectOk, installGatewayTestHooks, rpcReq } from "./test-helpers.js";
+import { withGatewayClient } from "./test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("gateway usage.cost agent scope", () => {
+  it("rejects conflicting scope selectors and preserves valid selectors", async () => {
+    await withGatewayClient(async (ws) => {
+      await connectOk(ws, { token: "secret", scopes: ["operator.read"] });
+
+      const conflict = await rpcReq(ws, "usage.cost", {
+        startDate: "2026-02-01",
+        endDate: "2026-02-02",
+        agentId: "main",
+        agentScope: "all",
+      });
+      expect(conflict).toMatchObject({
+        ok: false,
+        error: {
+          code: ErrorCodes.INVALID_REQUEST,
+          message: "agentScope=all cannot be combined with agentId",
+        },
+      });
+
+      for (const params of [
+        { agentId: "main" },
+        { agentScope: "all" },
+        { agentId: "  ", agentScope: "all" },
+      ]) {
+        const response = await rpcReq<{ totals?: { totalTokens?: number } }>(ws, "usage.cost", {
+          startDate: "2026-02-01",
+          endDate: "2026-02-02",
+          ...params,
+        });
+        expect(response.ok).toBe(true);
+        expect(response.payload?.totals).toEqual(expect.any(Object));
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #125268

## What Problem This Solves

`usage.cost` accepts either `agentId` for one agent or `agentScope: "all"` for every configured agent. A request with both selectors silently dropped `agentScope` and returned one agent's totals as `ok: true`.

That response can make a direct RPC client or custom dashboard show an incomplete total as a valid all-agent report.

## Why This Change Was Made

The Gateway method now rejects the contradictory selectors with `INVALID_REQUEST` and tells the caller to choose one scope.

Validation runs after the existing date and role-aware access checks, and before the cost cache loader. The existing `sessions.usage` rule remains separate because that method also accepts a session `key`.

Valid requests are unchanged:

- `agentId` alone returns that agent's totals.
- `agentScope: "all"` alone returns aggregate totals.
- A blank `agentId` is still treated as omitted.

## User Impact

Clients that send both selectors now receive an actionable error instead of a misleading success payload. Clients that send one valid selector need no change.

## Evidence

Current-main red at `a19ed2201c734ba4913355e2e47d187325e669a4`:

```text
Authenticated Gateway WebSocket request:
agentId="main" + agentScope="all"
Expected: INVALID_REQUEST
Actual: ok=true
Test Files 1 failed; Tests 1 failed
```

Repaired-head green at `9b36804b0a775a3ecd30da659fb08e8b7e35bb3c`:

```text
node scripts/run-vitest.mjs src/gateway/server.usage-cost-agent-scope.test.ts --reporter=verbose
Test Files 1 passed; Tests 1 passed
```

The same authenticated connection also proved agent-only, all-agent-only, and blank-agent plus all-agent requests still return totals.

Focused owner and sibling proof:

```text
node scripts/run-vitest.mjs src/gateway/server.usage-cost-agent-scope.test.ts src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts src/gateway/server-methods/usage.sessions-usage-cache.test.ts --reporter=dot
Test Files 4 passed; Tests 81 passed
```

The focused suite includes the role-aware test that denies aggregate cost access when an operator role hides sessions. Formatting, lint, import-cycle, schema-version, database-first, dependency, assertion-safety, dead-code, and other changed-scope repository guards also passed. Hosted CI owns TypeScript checks.

Production delta: +9/−1 lines. Test delta: +42 lines.

## AI-assisted development

An AI coding assistant helped refresh the original repair onto current `main`. The contributor remains the pull-request and source-commit author.
