### PR TITLE
fix(macos): gateway process tests fail under configured host port

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -75,7 +75,10 @@ struct GatewayProcessManagerTests {
         try Data(config.utf8)
             .write(to: URL(fileURLWithPath: configPath))
         defer { try? FileManager.default.removeItem(atPath: configPath) }
-        return try await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath], body)
+        return try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": configPath,
+            "OPENCLAW_GATEWAY_PORT": nil,
+        ], body)
     }
 
     private func withLaunchAgentEnvironment<T>(


### PR DESCRIPTION
Closes #125270

## What Problem This Solves

Fixes an issue where contributors running the macOS Gateway process tests from an environment with `OPENCLAW_GATEWAY_PORT` configured would get deterministic readiness failures and accidental coupling to the host Gateway port/PID.

## Why This Change Was Made

The existing serialized fixture now clears `OPENCLAW_GATEWAY_PORT` in the same canonical `TestIsolation.withEnvValues` scope that installs its temporary config. That helper preserves and restores the caller value on success and error. This is test-only: production Gateway and configuration behavior are unchanged.

## User Impact

No runtime behavior changes. Contributors and pre-release test campaigns can run `GatewayProcessManagerTests` from a configured Gateway environment without the suite inheriting the live port.

## Evidence

- Exact head: `1c924f30b49c992be0beca9c069c49f155eba66a`, rebased onto `4fd208fc6064563815e10a53648728a7c98bd684`.
- Diff budget: **+4/-1, one test file, zero production lines**.
- Current-main red proof: the exact command failed 43 tests with 3 issues because `GatewayEnvironment.gatewayPort()` resolved ambient port `54321` instead of the fixture port: https://github.com/vincentkoc/openclaw/actions/runs/32346612875
- Exact-head green proof: `OPENCLAW_GATEWAY_PORT=54321 swift test --package-path apps/macos --filter GatewayProcessManagerTests` passed all 43 tests on `1c924f30b49c992be0beca9c069c49f155eba66a`: https://github.com/vincentkoc/openclaw/actions/runs/32347470932
- `swiftformat --lint apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift --config config/swiftformat` passes.
- `git diff --check` passes.
- P1 autoreview reports no accepted or actionable findings.

### Owner acceptance

- Assurance: Routine; isolated test-fixture environment handling, no runtime change.
- Strongest evidence: exact-head configured-port Swift test pass on GitHub-hosted macOS.
- Known gap/falsifier: an exact-head hosted `macos-swift` failure would invalidate the result.
- Rollback: revert the single test commit.
- Remaining decision: maintainer acceptance after exact-head CI and ClawSweeper complete.

AI-assisted: yes. Codex reproduced the ambient-port coupling, implemented the minimal fixture isolation, rebased onto current main, and reran exact-source red/green macOS proof.

Punchcard-Session: amber-cedar-orchard-ds
