### PR TITLE
fix(ci): restore core lint on main

### DIFF
--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -1,6 +1,5 @@
 // Session reset policy resolves automatic freshness for direct, group, and thread sessions.
 import type { SessionConfig, SessionResetConfig } from "../types.base.js";
-import { DEFAULT_IDLE_MINUTES } from "./types.js";
 
 export type SessionResetMode = "none" | "daily" | "idle";
 type SessionStaleReason = Exclude<SessionResetMode, "none">;
@@ -22,6 +21,7 @@ export type SessionFreshness = {
 
 const DEFAULT_RESET_MODE: SessionResetMode = "none";
 const DEFAULT_RESET_AT_HOUR = 4;
+const DEFAULT_IDLE_MINUTES = 0;
 
 /** Returns the most recent daily reset boundary for the supplied wall-clock time. */
 function resolveDailyResetAtMs(now: number, atHour: number): number {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -943,4 +943,3 @@ export type SessionSystemPromptReport = {
 };
 
 export const DEFAULT_RESET_TRIGGERS = ["/new", "/reset"];
-export const DEFAULT_IDLE_MINUTES = 0;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main's `check-lint-core-5` job failed after two independently green session changes composed into a 701-line `src/config/sessions/types.ts`, one line above the production limit.

## Why This Change Was Made

The reset-policy-only idle default now lives with the reset policy that consumes it. This removes the stale cross-module export, restores the 700-line session-types budget, and preserves the intentionally non-augmentable `InternalSessionEntryCore` contract used by plugin slot reservation.

## User Impact

No runtime behavior changes. Main's core lint gate is restored without suppressing or raising the line limit.

## Evidence

- Before: main run https://github.com/openclaw/openclaw/actions/runs/32026312951, job `check-lint-core-5`, failed at exact SHA `e6616fdc4c4c3dd94437813238e36a5a8fb6abdf` with `src/config/sessions/types.ts:946:39 File has too many lines (701)`.
- Focused exact stripe: `node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=5/5 --threads=1` — 0 warnings, 0 errors across 3,352 files.
- Focused behavior: `pnpm test src/config/sessions/reset-policy.test.ts` — 13 passed.
- Changed gate: `pnpm check:changed -- src/config/sessions/reset-policy.ts src/config/sessions/types.ts` — passed on Blacksmith Testbox (`tbx_01m07t6rt7rnhy1a6we7y4svft`), including format, core/core-test typechecks, lint, deadcode, max-lines ratchet, database-first, and import-cycle guards.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +1/-2 (net -1). Tests: +0/-0.
