### PR TITLE
feat(plugin-sdk): export saveMediaSource from media-store

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -328,7 +328,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/media-runtime` | Deprecated broad media barrel including `saveRemoteMedia`, `saveResponseMedia`, `readRemoteMediaBuffer`, and deprecated `fetchRemoteMedia`; prefer `plugin-sdk/media-store`, `plugin-sdk/media-mime`, `plugin-sdk/outbound-media`, and capability runtime subpaths, and prefer store helpers before buffer reads when a URL should become OpenClaw media |
     | `plugin-sdk/media-local-roots` | Focused `getAgentScopedMediaLocalRoots(...)` and policy-aware `getAgentScopedMediaLocalRootsForSources(...)` helpers for plugin-owned local media reads |
     | `plugin-sdk/media-mime` | Narrow MIME normalization, file-extension mapping, MIME detection, and media-kind helpers |
-    | `plugin-sdk/media-store` | Narrow media store helpers such as `saveMediaBuffer` and `saveMediaStream` |
+    | `plugin-sdk/media-store` | Narrow media store helpers such as `saveMediaBuffer`, `saveMediaStream`, and `saveMediaSource` (local path or HTTP(S) URL into managed media with core's SSRF, byte, redirect, and timeout limits) |
     | `plugin-sdk/media-generation-runtime` | Private-local after July 2026; Shared media-generation failover helpers, candidate selection, and missing-model messaging |
     | `plugin-sdk/media-understanding` | Deprecated compatibility facade for media-understanding provider types and helpers; new providers register through the injected plugin API and keep request helpers plugin-owned |
     | `plugin-sdk/text-chunking` | Outbound text and offset-preserving range chunking, markdown chunking/render helpers, quote-aware HTML tag tokenization, markdown table conversion, directive-tag stripping, and safe-text utilities |

--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -1,7 +1,7 @@
 // Qa Channel tests cover inbound plugin behavior.
 import path from "node:path";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
-import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
+import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setQaChannelRuntime } from "../api.js";
@@ -34,8 +34,8 @@ vi.mock("openclaw/plugin-sdk/outbound-media", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
+vi.mock("openclaw/plugin-sdk/media-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-store")>()),
   saveMediaBuffer: vi.fn(async () => ({
     id: "stored-audio.ogg",
     path: "/tmp/openclaw-media/stored-audio.ogg",

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -8,11 +8,8 @@ import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  getAgentScopedMediaLocalRoots,
-  saveMediaBuffer,
-  saveMediaSource,
-} from "openclaw/plugin-sdk/media-runtime";
+import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-local-roots";
+import { saveMediaBuffer, saveMediaSource } from "openclaw/plugin-sdk/media-store";
 import {
   sanitizeQaBusToolCallArguments,
   type QaBusToolCall,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -294,7 +294,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +3: two focused primitives and the closed read-only SecretRef result contract.
       // -2: remove obsolete transcript display helper exports.
       // +2: lightweight agent config resolution and nonthrowing default-agent lookup.
-      4327,
+      // +1: focused media-store URL/path ingestion (saveMediaSource) off the deprecated barrel.
+      4328,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -374,7 +375,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: bounded provider stream and read-only SecretRef resolver.
       // -1: remove the obsolete transcript tool-call predicate.
       // +2: lightweight agent config resolution and nonthrowing default-agent lookup.
-      2571,
+      // +1: focused media-store URL/path ingestion (saveMediaSource) off the deprecated barrel.
+      2572,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/media-store.ts
+++ b/src/plugin-sdk/media-store.ts
@@ -4,6 +4,7 @@ export {
   readMediaBuffer,
   resolveMediaBufferPath,
   saveMediaBuffer,
+  saveMediaSource,
   saveMediaStream,
 } from "../media/store.js";
 export type { SavedMedia } from "../media/store.js";


### PR DESCRIPTION
## What Problem This Solves

Plugins holding a remote HTTP(S) URL (for example an MCP `resource_link` or a signed URL in `structuredContent`) had no non-deprecated Plugin SDK path to turn it into managed media. `saveMediaSource` was only exported from the `@deprecated` `openclaw/plugin-sdk/media-runtime` barrel, while `docs/plugins/sdk-subpaths.md` told plugins to prefer `plugin-sdk/media-store` "when a URL should become OpenClaw media" — a subpath that had no URL helper. Fixes #125259.

## Why This Change Was Made

`saveMediaSource` (`src/media/store.ts`) already carries the guarded ingestion path (pinned-host SSRF check, byte cap, five-redirect cap, 30s header/idle timeouts, MIME detection, managed UUID storage). Re-exporting it from the focused subpath lets plugins follow the barrel's stated migration direction instead of duplicating security-sensitive fetch code. The bundled `qa-channel` plugin was itself still importing it via the deprecated barrel; it now uses `media-store` + `media-local-roots`.

## User Impact

Plugin authors: `import { saveMediaSource } from "openclaw/plugin-sdk/media-store"` now works. No runtime behavior change; no new agent tool, provider parsing, auto-download, or destination path. Deprecated `media-runtime` export is untouched.

Production LOC: +1 re-export, +2 annotated surface-budget lines; qa-channel import move net -3. Test: 3 lines (mock repointed to `media-store`).

## Evidence

- `pnpm plugin-sdk:surface:check` green (budget +1 public / +1 callable, annotated in `scripts/plugin-sdk-surface-report.mts`).
- `pnpm tsgo:core`, `pnpm tsgo:extensions` green.
- `pnpm test extensions/qa-channel src/plugin-sdk` green (66 tests; qa-channel `inbound.test.ts` mock repointed to `media-store`).
- `pnpm tsgo:extensions:test` green.
- oxfmt / oxlint on touched files clean.
