### PR TITLE
Show worktree option only for Git group folders

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -90,17 +90,13 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   }
 
   async listSessionGroupFolders(path?: string): Promise<FsListDirResult> {
-    const gateway = this.context?.gateway;
-    const client = gateway?.snapshot.client;
-    if (!gateway || gateway.snapshot.phase !== "connected" || !client) {
+    const sessions = this.context?.sessions;
+    const scope = sessions?.captureConnectionScope();
+    if (!sessions || !scope) {
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
-    const result = await client.request<FsListDirResult>("fs.listDir", path ? { path } : {});
-    if (
-      this.context?.gateway !== gateway ||
-      gateway.snapshot.phase !== "connected" ||
-      gateway.snapshot.client !== client
-    ) {
+    const result = await scope.client.request<FsListDirResult>("fs.listDir", path ? { path } : {});
+    if (this.context?.sessions !== sessions || !sessions.isConnectionScopeCurrent(scope)) {
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
     return result;
@@ -116,20 +112,16 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           ? "not_git"
           : "unavailable";
     }
-    const gateway = this.context?.gateway;
-    const client = gateway?.snapshot.client;
-    if (!gateway || gateway.snapshot.phase !== "connected" || !client) {
+    const sessions = this.context?.sessions;
+    const scope = sessions?.captureConnectionScope();
+    if (!sessions || !scope) {
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
-    const result = await client.request<WorktreesBranchesResult>("worktrees.branches", {
+    const result = await scope.client.request<WorktreesBranchesResult>("worktrees.branches", {
       repoRoot: requestedPath,
       includeRepositoryStatus: true,
     });
-    if (
-      this.context?.gateway !== gateway ||
-      gateway.snapshot.phase !== "connected" ||
-      gateway.snapshot.client !== client
-    ) {
+    if (this.context?.sessions !== sessions || !sessions.isConnectionScopeCurrent(scope)) {
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
     return result.repositoryStatus === "git" || result.repositoryStatus === "not_git"

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1,6 +1,10 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { state } from "lit/decorators.js";
-import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
+import type {
+  FsListDirResult,
+  WorktreeRepositoryStatus,
+  WorktreesBranchesResult,
+} from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { isSessionRouteId, pathForRoute } from "../app-route-paths.ts";
 import { beginNativeWindowDragFromTopInset } from "../app/native-window-drag.ts";
@@ -86,15 +90,51 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   }
 
   async listSessionGroupFolders(path?: string): Promise<FsListDirResult> {
-    const scope = this.sessionData.beginSessionMutation();
-    if (!scope) {
+    const gateway = this.context?.gateway;
+    const client = gateway?.snapshot.client;
+    if (!gateway || gateway.snapshot.phase !== "connected" || !client) {
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
-    const result = await scope.client.request<FsListDirResult>("fs.listDir", path ? { path } : {});
-    if (!this.sessionData.isSessionMutationScopeCurrent(scope)) {
+    const result = await client.request<FsListDirResult>("fs.listDir", path ? { path } : {});
+    if (
+      this.context?.gateway !== gateway ||
+      gateway.snapshot.phase !== "connected" ||
+      gateway.snapshot.client !== client
+    ) {
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
     return result;
+  }
+
+  async inspectSessionGroupRepository(path?: string): Promise<WorktreeRepositoryStatus> {
+    const requestedPath = path?.trim();
+    const agent = this.activeChipAgent().agent;
+    if (!requestedPath) {
+      return agent?.workspaceGit === true
+        ? "git"
+        : agent?.workspaceGit === false
+          ? "not_git"
+          : "unavailable";
+    }
+    const gateway = this.context?.gateway;
+    const client = gateway?.snapshot.client;
+    if (!gateway || gateway.snapshot.phase !== "connected" || !client) {
+      throw new Error(t("sessionsView.groupDefaultsStale"));
+    }
+    const result = await client.request<WorktreesBranchesResult>("worktrees.branches", {
+      repoRoot: requestedPath,
+      includeRepositoryStatus: true,
+    });
+    if (
+      this.context?.gateway !== gateway ||
+      gateway.snapshot.phase !== "connected" ||
+      gateway.snapshot.client !== client
+    ) {
+      throw new Error(t("sessionsView.groupDefaultsStale"));
+    }
+    return result.repositoryStatus === "git" || result.repositoryStatus === "not_git"
+      ? result.repositoryStatus
+      : "unavailable";
   }
 
   // Lazy: the controller pulls core token-suppression modules that must stay

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -1,5 +1,6 @@
 import { readMissingScopeError } from "@openclaw/gateway-client/browser";
 import { html, nothing, render } from "lit";
+import { ref } from "lit/directives/ref.js";
 import type {
   FsListDirResult,
   WorktreeRepositoryStatus,
@@ -13,6 +14,7 @@ import { renderPlaceBrowser } from "../pages/new-session/place-browser.ts";
 import "../styles/new-session.css";
 import { icons } from "./icons.ts";
 import "./modal-dialog.ts";
+import { syncDropdownItemRadio } from "./web-awesome.ts";
 import "./web-awesome-popover.ts";
 
 export type SessionGroupDefaults = { cwd: string; worktree: boolean };
@@ -137,12 +139,47 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
       paint();
     };
 
-    const handleModeChange = (event: Event) => {
-      const select = event.currentTarget;
-      if (!(select instanceof HTMLSelectElement)) {
+    const handleModeSelect = (event: CustomEvent<{ item: Element }>) => {
+      const value = event.detail.item.getAttribute("value");
+      if (value !== "local" && value !== "worktree") {
         return;
       }
-      selectWorktree(select.value === "worktree");
+      selectWorktree(value === "worktree");
+    };
+
+    const focusSelectedMode = (event: Event) => {
+      if (!(event.currentTarget instanceof HTMLElement)) {
+        return;
+      }
+      const items = Array.from(
+        event.currentTarget.querySelectorAll<HTMLElement & { active: boolean }>(
+          "wa-dropdown-item[data-environment-mode]",
+        ),
+      );
+      const selected = items.find((item) => item.hasAttribute("data-selected")) ?? items[0];
+      if (!selected) {
+        return;
+      }
+      for (const item of items) {
+        item.active = item === selected;
+      }
+      selected.focus({ preventScroll: true });
+    };
+
+    const handleModeKeydown = (event: KeyboardEvent) => {
+      if (!(event.currentTarget instanceof HTMLElement)) {
+        return;
+      }
+      const dropdown = event.currentTarget as HTMLElement & { open?: boolean };
+      if (event.key !== "Escape" || !dropdown.open) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      dropdown.open = false;
+      dropdown
+        .querySelector<HTMLElement>("#session-group-defaults-mode-trigger")
+        ?.focus({ preventScroll: true });
     };
 
     const loadDirectory = async (path?: string) => {
@@ -192,6 +229,21 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
         : null;
       const environmentState =
         repositoryStatus === "checking" ? "checking" : repositoryStatus === "git" ? "git" : "local";
+      const environmentOptions = [
+        {
+          value: "local",
+          label: t("sessionsView.groupDefaultsLocal"),
+          description: t("newSession.runsDirectlyNote"),
+          icon: icons.monitor,
+        },
+        {
+          value: "worktree",
+          label: t("sessionsView.groupDefaultsWorktree"),
+          description: t("sessionsView.groupDefaultsWorktreeHint"),
+          icon: icons.gitBranch,
+        },
+      ] as const;
+      const selectedEnvironment = environmentOptions[worktree ? 1 : 0];
       render(
         html`
           <openclaw-modal-dialog
@@ -303,20 +355,62 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
                   >
                     ${repositoryStatus === "git"
                       ? html`
-                          <select
-                            class="session-group-defaults__mode-select"
-                            name="mode"
+                          <wa-dropdown
+                            class="session-group-defaults__mode-dropdown"
+                            placement="bottom-start"
                             aria-label=${t("sessionsView.groupDefaultsMode")}
-                            ?disabled=${submitting}
-                            @change=${handleModeChange}
+                            @wa-select=${handleModeSelect}
+                            @wa-after-show=${focusSelectedMode}
+                            @keydown=${handleModeKeydown}
                           >
-                            <option value="local" ?selected=${!worktree}>
-                              ${t("sessionsView.groupDefaultsLocal")}
-                            </option>
-                            <option value="worktree" ?selected=${worktree}>
-                              ${t("sessionsView.groupDefaultsWorktree")}
-                            </option>
-                          </select>
+                            <button
+                              id="session-group-defaults-mode-trigger"
+                              slot="trigger"
+                              type="button"
+                              class="session-group-defaults__resolved-mode session-group-defaults__mode-trigger"
+                              data-value=${selectedEnvironment.value}
+                              aria-label=${`${t("sessionsView.groupDefaultsMode")}: ${selectedEnvironment.label}`}
+                              ?disabled=${submitting}
+                            >
+                              <span class="new-session-page__target-icon" aria-hidden="true"
+                                >${selectedEnvironment.icon}</span
+                              >
+                              <span class="session-group-defaults__resolved-copy">
+                                <strong>${selectedEnvironment.label}</strong>
+                                <small>${selectedEnvironment.description}</small>
+                              </span>
+                              <span class="new-session-page__trigger-chevron" aria-hidden="true"
+                                >${icons.chevronDown}</span
+                              >
+                            </button>
+                            ${environmentOptions.map((option) => {
+                              const selected = option === selectedEnvironment;
+                              return html`
+                                <wa-dropdown-item
+                                  class="session-group-defaults__mode-option"
+                                  data-environment-mode=${option.value}
+                                  ?data-selected=${selected}
+                                  aria-label=${`${option.label}, ${option.description}`}
+                                  value=${option.value}
+                                  type="checkbox"
+                                  .checked=${selected}
+                                  ?disabled=${submitting}
+                                  ${ref((element) => syncDropdownItemRadio(element, selected))}
+                                >
+                                  <span
+                                    slot="icon"
+                                    class="new-session-page__target-icon session-group-defaults__mode-option-icon"
+                                    aria-hidden="true"
+                                    >${option.icon}</span
+                                  >
+                                  <span class="session-group-defaults__resolved-copy">
+                                    <strong>${option.label}</strong>
+                                    <small>${option.description}</small>
+                                  </span>
+                                </wa-dropdown-item>
+                              `;
+                            })}
+                          </wa-dropdown>
                         `
                       : html`
                           <div

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -1,6 +1,9 @@
 import { readMissingScopeError } from "@openclaw/gateway-client/browser";
 import { html, nothing, render } from "lit";
-import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
+import type {
+  FsListDirResult,
+  WorktreeRepositoryStatus,
+} from "../../../packages/gateway-protocol/src/index.js";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { renderSessionMenuItem } from "../pages/new-session/cloud-target.ts";
@@ -18,6 +21,7 @@ type Options = {
   group: string;
   defaults: SessionGroupDefaults;
   listDirectory: (path?: string) => Promise<FsListDirResult>;
+  inspectRepository: (path?: string) => Promise<WorktreeRepositoryStatus>;
   submit: (defaults: SessionGroupDefaults) => Promise<string | null>;
 };
 
@@ -32,6 +36,9 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
   document.body.append(host);
   return new Promise<void>((resolve) => {
     let cwd = options.defaults.cwd;
+    let worktree = false;
+    let repositoryStatus: WorktreeRepositoryStatus | "checking" = "checking";
+    let repositoryRequestToken = 0;
     let submitting = false;
     let failure: string | null = null;
     let browserVisible = false;
@@ -44,6 +51,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
 
     const finish = () => {
       browserRequestToken += 1;
+      repositoryRequestToken += 1;
       render(nothing, host);
       host.remove();
       active = false;
@@ -55,15 +63,13 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
       if (submitting) {
         return;
       }
-      const form = event.currentTarget as HTMLFormElement;
-      const data = new FormData(form);
       submitting = true;
       failure = null;
       paint();
       try {
         failure = await options.submit({
           cwd: cwd.trim(),
-          worktree: data.get("mode") === "worktree",
+          worktree: repositoryStatus === "git" && worktree,
         });
       } catch (error) {
         failure = formatUiError(error);
@@ -99,6 +105,44 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
       cwd = path.trim();
       showPickerRoot();
       closePicker();
+      void inspectRepository(false);
+    };
+
+    const inspectRepository = async (restoreSavedWorktree: boolean) => {
+      const requestToken = ++repositoryRequestToken;
+      repositoryStatus = "checking";
+      worktree = false;
+      failure = null;
+      paint();
+      try {
+        const status = await options.inspectRepository(cwd.trim() || undefined);
+        if (requestToken !== repositoryRequestToken) {
+          return;
+        }
+        repositoryStatus = status;
+        worktree = status === "git" && restoreSavedWorktree && options.defaults.worktree;
+      } catch {
+        if (requestToken !== repositoryRequestToken) {
+          return;
+        }
+        repositoryStatus = "unavailable";
+        worktree = false;
+      }
+      paint();
+    };
+
+    const selectWorktree = (value: boolean) => {
+      worktree = value;
+      failure = null;
+      paint();
+    };
+
+    const handleModeChange = (event: Event) => {
+      const select = event.currentTarget;
+      if (!(select instanceof HTMLSelectElement)) {
+        return;
+      }
+      selectWorktree(select.value === "worktree");
     };
 
     const loadDirectory = async (path?: string) => {
@@ -146,6 +190,8 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
       const usableBrowserPath = isAbsolutePath(browserPathDraft.trim())
         ? browserPathDraft.trim()
         : null;
+      const environmentState =
+        repositoryStatus === "checking" ? "checking" : repositoryStatus === "git" ? "git" : "local";
       render(
         html`
           <openclaw-modal-dialog
@@ -158,19 +204,22 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
               finish();
             }}
           >
-            <form class="exec-approval-card" @submit=${handleSubmit}>
+            <form class="exec-approval-card session-group-defaults" @submit=${handleSubmit}>
               <div class="exec-approval-header">
-                <div class="exec-approval-title">
-                  ${t("sessionsView.groupDefaultsTitle", { group: options.group })}
+                <div>
+                  <div class="exec-approval-title">
+                    ${t("sessionsView.groupDefaultsTitle", { group: options.group })}
+                  </div>
+                  <div class="exec-approval-sub">${t("sessionsView.groupDefaultsDescription")}</div>
                 </div>
               </div>
-              <div class="field">
-                <span>${t("sessionsView.groupDefaultsCwd")}</span>
-                <span class="new-session-page__select">
+              <div class="session-group-defaults__fields">
+                <div class="field">
+                  <span>${t("sessionsView.groupDefaultsCwd")}</span>
                   <button
                     id="session-group-defaults-folder-trigger"
                     type="button"
-                    class="new-session-page__trigger"
+                    class="new-session-page__trigger session-group-defaults__folder"
                     aria-label="${t("sessionsView.groupDefaultsCwd")}: ${folderLabel}"
                     aria-haspopup="dialog"
                     ?disabled=${submitting}
@@ -178,88 +227,135 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
                     <span class="new-session-page__target-icon" aria-hidden="true"
                       >${icons.folder}</span
                     >
-                    <span class="new-session-page__trigger-label">${folderLabel}</span>
+                    <span class="session-group-defaults__folder-copy">
+                      <strong>${folderLabel}</strong>
+                      <small title=${trimmedCwd || nothing}
+                        >${trimmedCwd || t("sessionsView.groupDefaultsCwdHint")}</small
+                      >
+                    </span>
                     <span class="new-session-page__trigger-chevron" aria-hidden="true"
                       >${icons.chevronDown}</span
                     >
                   </button>
-                </span>
-                <wa-popover
-                  class="new-session-page__select new-session-page__project-popover new-session-page__picker-popover session-group-defaults__folder-popover"
-                  for="session-group-defaults-folder-trigger"
-                  placement="bottom-start"
-                  without-arrow
-                  @wa-hide=${showPickerRoot}
-                >
-                  ${browserVisible
-                    ? renderPlaceBrowser({
-                        listing: browserListing,
-                        target: browserTarget,
-                        loading: browserLoading,
-                        error: browserError,
-                        pathDraft: browserPathDraft,
-                        usablePath: usableBrowserPath,
-                        registerProjectPath: null,
-                        registeringProject: false,
-                        onPathDraftChange: (value) => {
-                          browserPathDraft = value;
-                          paint();
-                        },
-                        onNavigate: (path) => void loadDirectory(path),
-                        onBack: showPickerRoot,
-                        onRegisterProject: () => undefined,
-                        onClose: showPickerRoot,
-                        onApplyFolder: applyFolder,
-                      })
-                    : html`
-                        <div class="new-session-page__picker-root">
-                          ${renderSessionMenuItem(
-                            {
-                              value: "agent-workspace",
-                              label: t("sessionsView.groupDefaultsCwdPlaceholder"),
-                              icon: icons.folder,
-                              checked: !trimmedCwd,
-                              onSelect: () => applyFolder(""),
-                            },
-                            submitting,
-                          )}
-                          <button
-                            type="button"
-                            class="session-menu__item"
-                            data-value="browse"
-                            aria-pressed="false"
-                            ?disabled=${submitting}
-                            @click=${showBrowser}
-                          >
-                            <span class="session-menu__check" aria-hidden="true"></span>
-                            <span class="session-menu__text">${t("newSession.browse")}</span>
-                            <span class="new-session-page__menu-chevron" aria-hidden="true"
-                              >${icons.chevronRight}</span
+                  <wa-popover
+                    class="new-session-page__select new-session-page__project-popover new-session-page__picker-popover session-group-defaults__folder-popover"
+                    for="session-group-defaults-folder-trigger"
+                    placement="bottom-start"
+                    without-arrow
+                    @wa-hide=${showPickerRoot}
+                  >
+                    ${browserVisible
+                      ? renderPlaceBrowser({
+                          listing: browserListing,
+                          target: browserTarget,
+                          loading: browserLoading,
+                          error: browserError,
+                          pathDraft: browserPathDraft,
+                          usablePath: usableBrowserPath,
+                          registerProjectPath: null,
+                          registeringProject: false,
+                          onPathDraftChange: (value) => {
+                            browserPathDraft = value;
+                            paint();
+                          },
+                          onNavigate: (path) => void loadDirectory(path),
+                          onBack: showPickerRoot,
+                          onRegisterProject: () => undefined,
+                          onClose: showPickerRoot,
+                          onApplyFolder: applyFolder,
+                        })
+                      : html`
+                          <div class="new-session-page__picker-root">
+                            ${renderSessionMenuItem(
+                              {
+                                value: "agent-workspace",
+                                label: t("sessionsView.groupDefaultsCwdPlaceholder"),
+                                icon: icons.folder,
+                                checked: !trimmedCwd,
+                                onSelect: () => applyFolder(""),
+                              },
+                              submitting,
+                            )}
+                            <button
+                              type="button"
+                              class="session-menu__item"
+                              data-value="browse"
+                              aria-pressed="false"
+                              ?disabled=${submitting}
+                              @click=${showBrowser}
                             >
-                          </button>
-                        </div>
-                      `}
-                </wa-popover>
-                <span class="muted" title=${trimmedCwd || nothing}
-                  >${trimmedCwd || t("sessionsView.groupDefaultsCwdHint")}</span
-                >
+                              <span class="session-menu__check" aria-hidden="true"></span>
+                              <span class="session-menu__text">${t("newSession.browse")}</span>
+                              <span class="new-session-page__menu-chevron" aria-hidden="true"
+                                >${icons.chevronRight}</span
+                              >
+                            </button>
+                          </div>
+                        `}
+                  </wa-popover>
+                </div>
+                <div class="field">
+                  <span>${t("sessionsView.groupDefaultsMode")}</span>
+                  <div
+                    class="session-group-defaults__environment"
+                    data-session-group-environment=${environmentState}
+                    aria-live="polite"
+                  >
+                    ${repositoryStatus === "git"
+                      ? html`
+                          <select
+                            class="session-group-defaults__mode-select"
+                            name="mode"
+                            aria-label=${t("sessionsView.groupDefaultsMode")}
+                            ?disabled=${submitting}
+                            @change=${handleModeChange}
+                          >
+                            <option value="local" ?selected=${!worktree}>
+                              ${t("sessionsView.groupDefaultsLocal")}
+                            </option>
+                            <option value="worktree" ?selected=${worktree}>
+                              ${t("sessionsView.groupDefaultsWorktree")}
+                            </option>
+                          </select>
+                        `
+                      : html`
+                          <div
+                            class="session-group-defaults__resolved-mode"
+                            role=${repositoryStatus === "checking" ? "status" : nothing}
+                          >
+                            <span class="new-session-page__target-icon" aria-hidden="true"
+                              >${repositoryStatus === "checking"
+                                ? icons.gitBranch
+                                : icons.monitor}</span
+                            >
+                            <span class="session-group-defaults__resolved-copy">
+                              <strong
+                                >${repositoryStatus === "checking"
+                                  ? t("newSession.checkingGit")
+                                  : t("sessionsView.groupDefaultsLocal")}</strong
+                              >
+                              ${repositoryStatus === "checking"
+                                ? nothing
+                                : html`<small
+                                    >${repositoryStatus === "unavailable"
+                                      ? t("newSession.gitCheckUnavailable")
+                                      : t("newSession.runsDirectlyNote")}</small
+                                  >`}
+                            </span>
+                          </div>
+                        `}
+                  </div>
+                </div>
               </div>
-              <label class="field">
-                <span>${t("sessionsView.groupDefaultsMode")}</span>
-                <select name="mode" ?disabled=${submitting}>
-                  <option value="local" ?selected=${!options.defaults.worktree}>
-                    ${t("sessionsView.groupDefaultsLocal")}
-                  </option>
-                  <option value="worktree" ?selected=${options.defaults.worktree}>
-                    ${t("sessionsView.groupDefaultsWorktree")}
-                  </option>
-                </select>
-              </label>
               ${failure
                 ? html`<div class="exec-approval-error" role="alert">${failure}</div>`
                 : nothing}
               <div class="exec-approval-actions">
-                <button type="submit" class="btn primary" ?disabled=${submitting}>
+                <button
+                  type="submit"
+                  class="btn primary"
+                  ?disabled=${submitting || repositoryStatus === "checking"}
+                >
                   ${t("common.save")}
                 </button>
                 <button type="button" class="btn" ?disabled=${submitting} @click=${finish}>
@@ -273,6 +369,6 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
       );
     }
 
-    paint();
+    void inspectRepository(true);
   });
 }

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -62,7 +62,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
 
     const handleSubmit = async (event: Event) => {
       event.preventDefault();
-      if (submitting) {
+      if (submitting || repositoryStatus === "checking" || repositoryStatus === "unavailable") {
         return;
       }
       submitting = true;
@@ -448,10 +448,25 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
                 <button
                   type="submit"
                   class="btn primary"
-                  ?disabled=${submitting || repositoryStatus === "checking"}
+                  ?disabled=${submitting ||
+                  repositoryStatus === "checking" ||
+                  repositoryStatus === "unavailable"}
                 >
                   ${t("common.save")}
                 </button>
+                ${repositoryStatus === "unavailable"
+                  ? html`
+                      <button
+                        type="button"
+                        class="btn"
+                        ?disabled=${submitting}
+                        @click=${() =>
+                          void inspectRepository(cwd.trim() === options.defaults.cwd.trim())}
+                      >
+                        ${t("common.retry")}
+                      </button>
+                    `
+                  : nothing}
                 <button type="button" class="btn" ?disabled=${submitting} @click=${finish}>
                   ${t("common.cancel")}
                 </button>

--- a/ui/src/components/session-organizer-controller-types.ts
+++ b/ui/src/components/session-organizer-controller-types.ts
@@ -1,5 +1,8 @@
 import type { ReactiveControllerHost } from "lit";
-import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
+import type {
+  FsListDirResult,
+  WorktreeRepositoryStatus,
+} from "../../../packages/gateway-protocol/src/index.js";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
 import type {
   SidebarRecentSession,
@@ -26,6 +29,7 @@ export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
   findSidebarSessionByKey(sessionKey: string): SidebarRecentSession | undefined;
   knownSessionGroups(): string[];
   listSessionGroupFolders(path?: string): Promise<FsListDirResult>;
+  inspectSessionGroupRepository(path?: string): Promise<WorktreeRepositoryStatus>;
   sessionGroupDefaults(name: string): { cwd: string; worktree: boolean } | null;
   knownSessionCatalogIds(): string[];
   knownSectionOrder(): string[];

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -43,7 +43,6 @@ type SessionOrganizerOperations = typeof import("./session-organizer-operations.
 type InputDialogOpener = (typeof import("./input-dialog.ts"))["showInputDialog"];
 type SessionGroupDefaultsDialogOpener =
   (typeof import("./session-group-defaults-dialog.ts"))["showSessionGroupDefaultsDialog"];
-
 /** Custom session groups, collapse state, and drag-and-drop assignment. */
 export class SessionOrganizerController {
   collapsedSessionSections = loadStoredCollapsedSessionSections();
@@ -529,6 +528,7 @@ export class SessionOrganizerController {
         group,
         defaults,
         listDirectory: (path) => this.host.listSessionGroupFolders(path),
+        inspectRepository: (path) => this.host.inspectSessionGroupRepository(path),
         submit: async (nextDefaults) => {
           const scope = this.host.sessionData.beginSessionMutation();
           if (!scope || !this.host.sessionGroupDefaults(group)) {

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -186,6 +186,66 @@ suite.define(() => {
     }
   });
 
+  it("blocks saving a worktree default until repository inspection succeeds", async () => {
+    const groupCwd = "/home/peter/client-work";
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([]),
+        "worktrees.branches": {
+          branches: [],
+          repositoryStatus: "unavailable",
+        },
+      },
+      sessionGroups: ["Client work"],
+      sessionGroupDefaults: { "Client work": { cwd: groupCwd, worktree: true } },
+      workspace: "/home/peter/openclaw",
+      workspaceGit: true,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const group = page.locator('[data-session-section="category:Client work"]');
+      await group.waitFor({ state: "visible", timeout: 10_000 });
+      await group.locator(".sidebar-recent-sessions__head").hover();
+      await group.getByRole("button", { name: "Group options for Client work" }).click();
+      await page.getByRole("menuitem", { name: "New session defaults…" }).click();
+      const dialog = page.locator(
+        `openclaw-modal-dialog[label='New session defaults for "Client work"']`,
+      );
+      await dialog.waitFor({ state: "visible" });
+
+      const environment = dialog.locator("[data-session-group-environment]");
+      await expect.poll(() => environment.textContent()).toContain("Couldn't verify Git");
+      const save = dialog.getByRole("button", { name: "Save" });
+      await expect.poll(() => save.isDisabled()).toBe(true);
+      expect(await gateway.getRequests("sessions.groups.update")).toHaveLength(0);
+
+      await gateway.setMethodResponse("worktrees.branches", {
+        branches: [{ kind: "local", name: "main" }],
+        defaultBranch: "main",
+        repositoryStatus: "git",
+      });
+      await dialog.getByRole("button", { name: "Retry" }).click();
+      const modeTrigger = dialog.locator("#session-group-defaults-mode-trigger");
+      await expect.poll(() => modeTrigger.getAttribute("data-value")).toBe("worktree");
+      await expect.poll(() => save.isEnabled()).toBe(true);
+      await save.click();
+      expect((await gateway.waitForRequest("sessions.groups.update")).params).toMatchObject({
+        name: "Client work",
+        cwd: groupCwd,
+        worktree: true,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("omits the group category for a legacy Gateway", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -13,6 +13,11 @@ suite.define(() => {
     const workspace = "/home/peter/openclaw";
     const initialGroupCwd = "/home/peter";
     const groupCwd = "/home/peter/client-work";
+    const gitRepository = {
+      branches: [{ kind: "local", name: "main" }],
+      defaultBranch: "main",
+      repositoryStatus: "git",
+    };
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -30,9 +35,13 @@ suite.define(() => {
         "sessions.create": { key: "agent:main:client-work", runStarted: true },
         "sessions.list": sessionsListResponse([]),
         "worktrees.branches": {
-          branches: [{ kind: "local", name: "main" }],
-          defaultBranch: "main",
-          repositoryStatus: "git",
+          cases: [
+            {
+              match: { repoRoot: initialGroupCwd },
+              response: { branches: [], repositoryStatus: "not_git" },
+            },
+            { match: { repoRoot: groupCwd }, response: gitRepository },
+          ],
         },
       },
       sessionGroups: ["Client work"],
@@ -53,6 +62,20 @@ suite.define(() => {
         `openclaw-modal-dialog[label='New session defaults for "Client work"']`,
       );
       await dialog.waitFor({ state: "visible" });
+      expect((await gateway.waitForRequest("worktrees.branches")).params).toMatchObject({
+        repoRoot: initialGroupCwd,
+        includeRepositoryStatus: true,
+      });
+      const environment = dialog.locator("[data-session-group-environment]");
+      await expect
+        .poll(() => environment.getAttribute("data-session-group-environment"))
+        .toBe("local");
+      await expect.poll(() => dialog.locator('select[name="mode"]').count()).toBe(0);
+      await expect.poll(() => environment.getByRole("button").count()).toBe(0);
+      const localEnvironmentBox = await environment
+        .locator(".session-group-defaults__resolved-mode")
+        .boundingBox();
+      expect(localEnvironmentBox?.height).toBe(56);
       const folderTrigger = dialog.locator("#session-group-defaults-folder-trigger");
       await expect.poll(() => folderTrigger.getAttribute("aria-label")).toContain("peter");
       await folderTrigger.click();
@@ -90,7 +113,20 @@ suite.define(() => {
       await page.setViewportSize({ height: 900, width: 1280 });
       await expect.poll(() => folderTrigger.textContent()).toContain("client-work");
       await expect.poll(() => dialog.locator('input[name="cwd"]').count()).toBe(0);
-      await dialog.locator('select[name="mode"]').selectOption("worktree");
+      await expect
+        .poll(async () => (await gateway.getRequests("worktrees.branches")).at(-1)?.params)
+        .toMatchObject({ repoRoot: groupCwd, includeRepositoryStatus: true });
+      await expect
+        .poll(async () => ({
+          state: await environment.getAttribute("data-session-group-environment"),
+          text: await environment.textContent(),
+        }))
+        .toMatchObject({ state: "git" });
+      const modeSelect = environment.locator('select[name="mode"]');
+      await expect.poll(() => modeSelect.inputValue()).toBe("local");
+      expect((await modeSelect.boundingBox())?.height).toBe(localEnvironmentBox?.height);
+      await modeSelect.selectOption("worktree");
+      await expect.poll(() => modeSelect.inputValue()).toBe("worktree");
       await dialog.getByRole("button", { name: "Save" }).click();
       expect((await gateway.waitForRequest("sessions.groups.update")).params).toMatchObject({
         name: "Client work",
@@ -315,7 +351,14 @@ suite.define(() => {
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.groups.update"],
-      methodResponses: { "sessions.list": sessionsListResponse([]) },
+      methodResponses: {
+        "sessions.list": sessionsListResponse([]),
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+      },
       sessionGroups: ["Client work"],
       sessionGroupDefaults: { "Client work": { cwd: groupCwd, worktree: true } },
       workspace: "/home/peter/openclaw",
@@ -333,7 +376,9 @@ suite.define(() => {
         `openclaw-modal-dialog[label='New session defaults for "Client work"']`,
       );
       await dialog.waitFor({ state: "visible" });
-      await dialog.locator('select[name="mode"]').selectOption("local");
+      const modeSelect = dialog.locator('select[name="mode"]');
+      await modeSelect.waitFor({ state: "visible" });
+      await modeSelect.selectOption("local");
       await dialog.getByRole("button", { name: "Save" }).click();
       await gateway.waitForRequest("sessions.groups.update");
       await gateway.rejectDeferred("sessions.groups.update", {
@@ -344,7 +389,7 @@ suite.define(() => {
       const alert = dialog.getByRole("alert");
       await alert.waitFor({ state: "visible" });
       await expect.poll(() => alert.textContent()).toContain("rejected group defaults");
-      await expect.poll(() => dialog.locator('select[name="mode"]').inputValue()).toBe("local");
+      await expect.poll(() => modeSelect.inputValue()).toBe("local");
 
       await dialog.getByRole("button", { name: "Save" }).click();
       await expect
@@ -373,7 +418,14 @@ suite.define(() => {
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.groups.defaults"],
-      methodResponses: { "sessions.list": sessionsListResponse([]) },
+      methodResponses: {
+        "sessions.list": sessionsListResponse([]),
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+      },
       sessionGroups: ["Client work"],
       sessionGroupDefaults: { "Client work": { cwd: groupCwd, worktree: true } },
       workspace: "/home/peter/openclaw",

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -70,12 +70,15 @@ suite.define(() => {
       await expect
         .poll(() => environment.getAttribute("data-session-group-environment"))
         .toBe("local");
-      await expect.poll(() => dialog.locator('select[name="mode"]').count()).toBe(0);
+      await expect
+        .poll(() => dialog.locator("wa-dropdown.session-group-defaults__mode-dropdown").count())
+        .toBe(0);
       await expect.poll(() => environment.getByRole("button").count()).toBe(0);
-      const localEnvironmentBox = await environment
-        .locator(".session-group-defaults__resolved-mode")
-        .boundingBox();
-      expect(localEnvironmentBox?.height).toBe(56);
+      const localEnvironment = environment.locator(".session-group-defaults__resolved-mode");
+      await expect
+        .poll(async () => (await localEnvironment.boundingBox())?.height)
+        .toBeCloseTo(56, 1);
+      const localEnvironmentBox = await localEnvironment.boundingBox();
       const folderTrigger = dialog.locator("#session-group-defaults-folder-trigger");
       await expect.poll(() => folderTrigger.getAttribute("aria-label")).toContain("peter");
       await folderTrigger.click();
@@ -122,11 +125,28 @@ suite.define(() => {
           text: await environment.textContent(),
         }))
         .toMatchObject({ state: "git" });
-      const modeSelect = environment.locator('select[name="mode"]');
-      await expect.poll(() => modeSelect.inputValue()).toBe("local");
-      expect((await modeSelect.boundingBox())?.height).toBe(localEnvironmentBox?.height);
-      await modeSelect.selectOption("worktree");
-      await expect.poll(() => modeSelect.inputValue()).toBe("worktree");
+      const modeDropdown = environment.locator("wa-dropdown.session-group-defaults__mode-dropdown");
+      const modeTrigger = modeDropdown.locator("#session-group-defaults-mode-trigger");
+      await expect.poll(() => modeTrigger.getAttribute("data-value")).toBe("local");
+      await expect.poll(() => modeTrigger.textContent()).toContain("Runs directly");
+      expect((await modeTrigger.boundingBox())?.height).toBeCloseTo(
+        localEnvironmentBox?.height ?? 0,
+        1,
+      );
+      await modeTrigger.click();
+      const worktreeOption = modeDropdown.getByRole("menuitemradio", {
+        name: /Worktree.*isolated Git worktree/i,
+      });
+      await expect.poll(() => worktreeOption.locator('[slot="icon"]').count()).toBe(1);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => modeTrigger.getAttribute("aria-expanded")).toBe("false");
+      await expect
+        .poll(() => modeTrigger.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await expect.poll(() => dialog.isVisible()).toBe(true);
+      await modeTrigger.click();
+      await worktreeOption.click();
+      await expect.poll(() => modeTrigger.getAttribute("data-value")).toBe("worktree");
       await dialog.getByRole("button", { name: "Save" }).click();
       expect((await gateway.waitForRequest("sessions.groups.update")).params).toMatchObject({
         name: "Client work",
@@ -376,9 +396,11 @@ suite.define(() => {
         `openclaw-modal-dialog[label='New session defaults for "Client work"']`,
       );
       await dialog.waitFor({ state: "visible" });
-      const modeSelect = dialog.locator('select[name="mode"]');
-      await modeSelect.waitFor({ state: "visible" });
-      await modeSelect.selectOption("local");
+      const modeDropdown = dialog.locator("wa-dropdown.session-group-defaults__mode-dropdown");
+      const modeTrigger = modeDropdown.locator("#session-group-defaults-mode-trigger");
+      await modeTrigger.waitFor({ state: "visible" });
+      await modeTrigger.click();
+      await modeDropdown.getByRole("menuitemradio", { name: /Local.*Runs directly/i }).click();
       await dialog.getByRole("button", { name: "Save" }).click();
       await gateway.waitForRequest("sessions.groups.update");
       await gateway.rejectDeferred("sessions.groups.update", {
@@ -389,7 +411,7 @@ suite.define(() => {
       const alert = dialog.getByRole("alert");
       await alert.waitFor({ state: "visible" });
       await expect.poll(() => alert.textContent()).toContain("rejected group defaults");
-      await expect.poll(() => modeSelect.inputValue()).toBe("local");
+      await expect.poll(() => modeTrigger.getAttribute("data-value")).toBe("local");
 
       await dialog.getByRole("button", { name: "Save" }).click();
       await expect
@@ -483,7 +505,11 @@ suite.define(() => {
           dialog.locator("#session-group-defaults-folder-trigger").getAttribute("aria-label"),
         )
         .toContain("client-work");
-      await expect.poll(() => dialog.locator('select[name="mode"]').inputValue()).toBe("worktree");
+      await expect
+        .poll(() =>
+          dialog.locator("#session-group-defaults-mode-trigger").getAttribute("data-value"),
+        )
+        .toBe("worktree");
       expect(await gateway.getRequests("sessions.groups.update")).toHaveLength(0);
       await dialog.getByRole("button", { name: "Cancel" }).click();
     } finally {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1100,6 +1100,7 @@ export const en: TranslationMap = {
     groupDefaultsMode: "Environment",
     groupDefaultsLocal: "Local",
     groupDefaultsWorktree: "Worktree",
+    groupDefaultsWorktreeHint: "Runs each session in an isolated Git worktree.",
     groupDefaultsFailed: "Could not save the group defaults.",
     groupDefaultsStale: "Gateway connection replaced before the defaults were saved. Try again.",
     renameGroupMenu: "Rename group…",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1093,6 +1093,7 @@ export const en: TranslationMap = {
     newSessionInGroup: "New session in {group}",
     groupDefaultsMenu: "New session defaults…",
     groupDefaultsTitle: 'New session defaults for "{group}"',
+    groupDefaultsDescription: "Choose where new sessions in this group start.",
     groupDefaultsCwd: "Working directory",
     groupDefaultsCwdPlaceholder: "Use the agent workspace",
     groupDefaultsCwdHint: "Leave empty to use the selected agent's workspace.",

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -479,6 +479,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     get canonicalListRevision() {
       return canonicalListRevision;
     },
+    captureConnectionScope: () => connection.capture(),
+    isConnectionScopeCurrent: (scope) => connection.isCurrent(scope),
     list: roster.list,
     listSnapshot: (scope) => roster.listSnapshot(scope),
     subscribeList(scope, listener) {

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -155,6 +155,10 @@ export type SessionCapability = {
   readonly state: SessionState;
   /** Advances only when a canonical sessions.list result is published. */
   readonly canonicalListRevision: number;
+  /** Captures the current Gateway connection generation for read-only requests. */
+  captureConnectionScope: () => SessionConnectionScope | null;
+  /** Whether a captured read-only request still belongs to the active connection. */
+  isConnectionScopeCurrent: (scope: SessionConnectionScope) => boolean;
   list: (options?: SessionListOptions) => Promise<SessionsListResult | null>;
   listSnapshot: (scope: SessionListScope) => SessionListSnapshot;
   subscribeList: (

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -343,14 +343,75 @@ html.openclaw-native-macos .new-session-page__incognito-rail {
   background: color-mix(in srgb, var(--card) 82%, var(--bg) 18%);
 }
 
-.session-group-defaults__resolved-mode > .new-session-page__target-icon {
+.session-group-defaults__resolved-mode > .new-session-page__target-icon,
+.session-group-defaults__mode-option-icon {
   display: inline-flex;
   color: var(--muted);
 }
 
-.session-group-defaults .session-group-defaults__mode-select {
+.session-group-defaults__mode-dropdown {
+  display: block;
   width: 100%;
-  height: 56px;
+  container-type: inline-size;
+}
+
+.session-group-defaults__mode-dropdown::part(menu) {
+  width: min(100cqw, calc(100vw - 48px));
+  padding: var(--menu-padding);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--menu-radius);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-md);
+  color: var(--text);
+}
+
+.session-group-defaults__mode-trigger {
+  grid-template-columns: 18px minmax(0, 1fr) 14px;
+  width: 100%;
+  min-height: 56px;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: var(--cursor-action);
+  box-shadow: inset 0 1px 0 var(--card-highlight);
+}
+
+@media (hover: hover) {
+  .session-group-defaults__mode-trigger:hover:not(:disabled) {
+    border-color: color-mix(in srgb, var(--accent) 35%, var(--input));
+    background: color-mix(in srgb, var(--bg-hover) 65%, var(--card));
+  }
+}
+
+.session-group-defaults__mode-trigger:focus-visible {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: var(--focus-ring);
+}
+
+.session-group-defaults__mode-trigger:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.session-group-defaults__mode-trigger .new-session-page__trigger-chevron {
+  display: inline-flex;
+  color: var(--muted);
+}
+
+.session-group-defaults__mode-option {
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+
+.session-group-defaults__mode-option::part(label) {
+  width: 100%;
+  min-width: 0;
+}
+
+.session-group-defaults__mode-option .session-group-defaults__resolved-copy {
+  padding: 3px 0;
 }
 
 /* Menu panel anchored under its trigger; item rows reuse the shared

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -258,6 +258,101 @@ html.openclaw-native-macos .new-session-page__incognito-rail {
   height: 12px;
 }
 
+.session-group-defaults .exec-approval-header {
+  margin-bottom: 18px;
+}
+
+.session-group-defaults__fields {
+  display: grid;
+  gap: 16px;
+}
+
+.session-group-defaults__folder {
+  width: 100%;
+  height: auto;
+  min-height: 56px;
+  justify-content: flex-start;
+  padding: 9px 12px;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  color: var(--text);
+  box-shadow: inset 0 1px 0 var(--card-highlight);
+}
+
+@media (hover: hover) {
+  .session-group-defaults__folder:hover:not(:disabled) {
+    border-color: color-mix(in srgb, var(--accent) 35%, var(--input));
+    background: color-mix(in srgb, var(--bg-hover) 65%, var(--card));
+  }
+}
+
+.session-group-defaults__folder:focus-visible {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: var(--focus-ring);
+}
+
+.session-group-defaults__folder-copy,
+.session-group-defaults__resolved-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  text-align: left;
+}
+
+.session-group-defaults__folder-copy {
+  flex: 1 1 auto;
+}
+
+.session-group-defaults__folder-copy strong,
+.session-group-defaults__resolved-copy strong {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.session-group-defaults__folder-copy small,
+.session-group-defaults__resolved-copy small {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.session-group-defaults__folder-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-group-defaults__folder .new-session-page__trigger-chevron {
+  margin-left: auto;
+}
+
+.session-group-defaults__resolved-mode {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 56px;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--card) 82%, var(--bg) 18%);
+}
+
+.session-group-defaults__resolved-mode > .new-session-page__target-icon {
+  display: inline-flex;
+  color: var(--muted);
+}
+
+.session-group-defaults .session-group-defaults__mode-select {
+  width: 100%;
+  height: 56px;
+}
+
 /* Menu panel anchored under its trigger; item rows reuse the shared
    .session-menu__* geometry so its panel and hover pills stay concentric. */
 wa-popover.new-session-page__select {

--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -277,6 +277,38 @@ describe("AppSidebar group mutation collapsed state", () => {
     );
   });
 
+  it("rejects repository inspection from a retired same-client connection", async () => {
+    const inspection = deferred<{
+      branches: Array<{ kind: "local"; name: string }>;
+      defaultBranch: string;
+      repositoryStatus: "git";
+    }>();
+    const client = {
+      request: async (method: string) => {
+        if (method === "worktrees.branches") {
+          return await inspection.promise;
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      },
+    } as GatewayBrowserClient;
+    const gatewayHarness = createGatewayHarness(client);
+    const harness = createSessionsHarness("main", ["agent:main:main"]);
+    const { sidebar } = await mountSidebar(gatewayHarness.gateway, harness.sessions);
+
+    const pending = sidebar.inspectSessionGroupRepository("/repos/client");
+    gatewayHarness.publish({ phase: "stopped" });
+    gatewayHarness.publish({ phase: "connected" });
+    inspection.resolve({
+      branches: [{ kind: "local", name: "main" }],
+      defaultBranch: "main",
+      repositoryStatus: "git",
+    });
+
+    await expect(pending).rejects.toThrow(
+      "Gateway connection replaced before the defaults were saved. Try again.",
+    );
+  });
+
   it("leaves the catalog alone when the delete confirm is cancelled", async () => {
     const { sidebar, harness } = await mountCollapsedGroup({});
     const menu = await openGroupMenu(sidebar);

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -75,6 +75,7 @@ export type SidebarLifecycleState = HTMLElement & {
     home: string;
     entries: Array<{ name: string; path: string; type: "directory" | "file" }>;
   }>;
+  inspectSessionGroupRepository(path?: string): Promise<"git" | "not_git" | "unavailable">;
   requestUpdate: () => void;
   updateComplete: Promise<boolean>;
   updateAvailable: { currentVersion: string; latestVersion: string; channel: string } | null;

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -318,6 +318,10 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     get canonicalListRevision() {
       return canonicalListRevision;
     },
+    captureConnectionScope: () => scopedSessions?.captureConnectionScope() ?? null,
+    isConnectionScopeCurrent: (
+      scope: Parameters<SessionCapability["isConnectionScopeCurrent"]>[0],
+    ) => scopedSessions?.isConnectionScopeCurrent(scope) ?? false,
     subscribe(listener: (next: SessionState) => void) {
       listeners.add(listener);
       return () => listeners.delete(listener);


### PR DESCRIPTION
## New behavior

Session-group defaults now offer a worktree only when the selected working directory is a Git repository.

- Non-Git folders show Local as the resolved environment, without a dropdown that cannot change anything.
- Saving a confirmed non-Git folder intentionally persists Local, replacing any stale Worktree default for that folder.
- Git folders reveal a rich Local/Worktree dropdown with icons and a short explanation for each option.
- The open dropdown matches the working-directory field width.
- Both environment states stay 56 px tall, so the modal does not jump while repository detection resolves.
- An unrelated session refresh no longer discards a valid repository check and incorrectly hides the worktree option.
- A real Gateway reconnect rejects folder and repository results from the previous connection generation, even when the browser client is reused.
- If repository inspection is unavailable, Save stays disabled and Retry preserves the existing default until the check succeeds.

## Visual proof

### Before — direct base

[pr125280-before-direct-base.webm](https://github.com/user-attachments/assets/84e2b180-342d-4b8d-a678-1539b226c233)

**What this shows:** The direct-base modal always exposes Local/Worktree, including for the initial non-Git folder, and uses the older working-directory layout.

**State:** Direct `main` base; synthetic `Client work` group; `/home/peter` non-Git folder followed by `/home/peter/client-work` Git folder; 1280×900 Chromium recording.

### After — this PR

[pr125280-after-rich-full-width-dropdown.webm](https://github.com/user-attachments/assets/cb8026f9-3dee-4fc2-8061-216109c5fe93)

**What this shows:** The initial non-Git folder resolves to static Local. Choosing the synthetic Git folder reveals the full-width rich Environment dropdown, including the Local and Worktree descriptions, and Worktree can be selected without shifting the modal.

**State:** PR branch; same synthetic group, folders, mock Gateway, viewport, and interaction as the direct-base recording.

### Unavailable inspection safeguard

![The modal disables Save and offers Retry when Git inspection is unavailable](https://github.com/user-attachments/assets/90e6faf4-8ae7-4555-9a6d-2c8f622db47c)

**What this shows:** A temporary repository-inspection failure cannot overwrite a saved Worktree default: Save is disabled and Retry is available.

## How to verify

1. Open **New session defaults…** for a session group whose saved folder is not a Git repository.
2. Confirm Environment shows static **Local** with no dropdown.
3. Choose a Git working directory through the folder picker.
4. Confirm Environment becomes a **Local / Worktree** dropdown at the same height.
5. Open it and confirm the menu matches the field width, then select **Worktree**.
6. If repository inspection fails, confirm Save is disabled and Retry restores the saved selection once inspection succeeds.

## Implementation note

Folder and repository requests use the session capability's Gateway connection generation. Real reconnects invalidate stale results, while unrelated session refreshes do not make the worktree option disappear.
