### PR TITLE
fix(macos): avoid codesign metadata SIGPIPE

### DIFF
--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -275,8 +275,17 @@ sign_plain_item() {
   codesign_with_timestamp_retry --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --sign "$IDENTITY" "$target"
 }
 
+codesign_metadata_value() {
+  local target="$1" key="$2" metadata
+  metadata="$(codesign -dv --verbose=4 "$target" 2>&1)" || {
+    local rc=$?
+    return "$rc"
+  }
+  awk -F= -v key="$key" '$1 == key && !found { print $2; found = 1 }' <<<"$metadata"
+}
+
 team_id_for() {
-  codesign -dv --verbose=4 "$1" 2>&1 | awk -F= '/^TeamIdentifier=/{print $2; exit}'
+  codesign_metadata_value "$1" TeamIdentifier
 }
 
 verify_team_ids() {
@@ -334,7 +343,7 @@ verify_elevation_signature() {
   fi
 
   local authority
-  authority="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 | awk -F= '/^Authority=/{print $2; exit}')"
+  authority="$(codesign_metadata_value "$APP_BUNDLE" Authority)"
   if [[ "$authority" != "$ELEVATION_IDENTITY" ]]; then
     echo "ERROR: Elevation host requires '$ELEVATION_IDENTITY', got '${authority:-not set}'." >&2
     exit 1

--- a/test/scripts/codesign-mac-app.test.ts
+++ b/test/scripts/codesign-mac-app.test.ts
@@ -101,6 +101,37 @@ fi
   chmodSync(fakeCodesign, 0o755);
 }
 
+function installElevationFakeCodesign(binDir: string) {
+  const fakeCodesign = path.join(binDir, "codesign");
+  writeFileSync(
+    fakeCodesign,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+for arg in "$@"; do
+  if [ "$arg" = "-dv" ]; then
+    printf '%s\n' 'TeamIdentifier=FWJYW4S8P8' >&2
+    if [ "\${CODESIGN_FAKE_NO_AUTHORITY:-0}" != "1" ]; then
+      printf '%s\n' 'Authority=Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)' >&2
+    fi
+    if [ "\${CODESIGN_FAKE_SECOND_AUTHORITY:-0}" = "1" ]; then
+      printf '%s\n' 'Authority=Unexpected Secondary Authority' >&2
+    fi
+    for i in $(seq 1 20000); do
+      printf 'Metadata-%s=value\n' "$i" >&2
+    done
+    if [ "\${CODESIGN_FAKE_FAIL_AFTER_METADATA:-0}" = "1" ]; then
+      exit 7
+    fi
+    exit 0
+  fi
+done
+exit 0
+`,
+  );
+  chmodSync(fakeCodesign, 0o755);
+}
+
 describe("codesign-mac-app temp file hygiene", () => {
   it("does not generate unused entitlement plist files", () => {
     const script = readFileSync(scriptPath, "utf8");
@@ -261,6 +292,88 @@ describe("codesign-mac-app temp file hygiene", () => {
     expect(elevationProfile).not.toContain("com.apple.security.automation.apple-events");
     expect(script).toContain("verify_elevation_signature");
     expect(script).toContain('assert_no_apple_events_entitlement "$APP_BUNDLE"');
+  });
+
+  it("consumes complete codesign metadata under pipefail before validating authority", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-elevation-metadata-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installElevationFakeCodesign(binDir);
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODESIGN_FAKE_SECOND_AUTHORITY: "1",
+        OPENCLAW_MAC_SIGNING_VARIANT: "elevation-host",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SIGN_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
+        TMPDIR: tempRoot,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toContain(`Codesign complete for ${app}`);
+    expect(result.stderr).not.toContain("Elevation host requires");
+  });
+
+  it("preserves the precise diagnostic when codesign omits Authority", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-elevation-no-authority-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installElevationFakeCodesign(binDir);
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODESIGN_FAKE_NO_AUTHORITY: "1",
+        OPENCLAW_MAC_SIGNING_VARIANT: "elevation-host",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SIGN_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
+        TMPDIR: tempRoot,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("got 'not set'");
+  });
+
+  it("preserves a codesign failure after metadata output", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-elevation-failed-metadata-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installElevationFakeCodesign(binDir);
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODESIGN_FAKE_FAIL_AFTER_METADATA: "1",
+        OPENCLAW_MAC_SIGNING_VARIANT: "elevation-host",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SIGN_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
+        TMPDIR: tempRoot,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).not.toContain(`Codesign complete for ${app}`);
+    expect(result.stderr).toContain("got 'not set'");
   });
 
   it("retries only transient Apple timestamp failures", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a valid elevation-host release build exited with status 141 immediately after signing when the signing verifier ran under `pipefail`. The failure prevented packaging and notarization even though the Foundation signature and Team ID were correct.

## Why This Change Was Made

The verifier now consumes the complete `codesign -dv` metadata stream before selecting the first Team ID or signing authority. This avoids SIGPIPE from an early-exit consumer while preserving a real `codesign` failure and the existing missing-authority diagnostic.

## User Impact

Maintainers can produce the signed OpenClaw elevation package without a false post-sign failure. Runtime behavior is unchanged.

## Evidence

- `pnpm exec vitest run test/scripts/codesign-mac-app.test.ts` — 15/15
- `node scripts/run-vitest.mjs run test/scripts/codesign-mac-app.test.ts test/scripts/mac-elevation-host.test.ts` — 104/104 at exact head
- regression coverage includes 20,000 trailing metadata lines, multiple authorities, missing authority, and a nonzero `codesign` exit after metadata output
- native disposable-app signing with the exact branch script passed deep/strict verification, Foundation Team/Authority validation, and a zero-hit Apple Events entitlement scan; proof log SHA-256 `cd9b0029b66f37d89778a5e251e894f86245d6df8601be8786e55da9ec65d6c5`
- exact-head macOS Swift and 117 additional hosted checks are green; macOS Node remains queued for Blacksmith runner capacity
- `git diff --check`
- Autoreview through P2: clean
