### PR TITLE
fix(doctor): report refused config repairs as incomplete

### DIFF
--- a/src/commands/doctor-config-flow.validation-refusal.test.ts
+++ b/src/commands/doctor-config-flow.validation-refusal.test.ts
@@ -67,7 +67,7 @@ describe("doctor --fix with a validation-blocked candidate", () => {
         // The write must refuse gracefully — no throw, no change panel, no file write.
         await expect(runWriteConfigHealth(ctx)).resolves.toBeUndefined();
 
-        expect(ctx.configWriteBlockedByValidation).toBe(true);
+        expect(ctx.configWriteRefusal).toBe("validation");
         expect(ctx.configResultWriteCommitted).not.toBe(true);
         expect(noteMock.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
         const warning = noteMock.mock.calls.find(

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -31,11 +31,8 @@ export async function runWriteConfigHealth(
   ctx: DoctorHealthFlowContext,
   options: { runPostWriteRepairs?: boolean } = {},
 ): Promise<void> {
-  if (ctx.configWriteDeferredByCronOwnership === true) {
-    return;
-  }
-  if (ctx.configWriteBlockedByValidation === true) {
-    // The initial write already reported the validation refusal; retrying the
+  if (ctx.configWriteRefusal) {
+    // The initial write already reported the refusal; retrying the
     // same candidate would fail identically and duplicate the warning.
     return;
   }
@@ -103,7 +100,7 @@ export async function runWriteConfigHealth(
           ].join("\n"),
           "Doctor warnings",
         );
-        ctx.configWriteBlockedByValidation = true;
+        ctx.configWriteRefusal = "validation";
         return;
       }
       const { isCronOwnerWriteRefusalError } = await import("../config/io.cron-owner-refusal.js");
@@ -119,7 +116,7 @@ export async function runWriteConfigHealth(
         ].join("\n"),
         "Doctor warnings",
       );
-      ctx.configWriteDeferredByCronOwnership = true;
+      ctx.configWriteRefusal = "cron-owner-safety";
       return;
     }
     // The atomic write committed: repair panels queued by the config flow are now

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -39,10 +39,8 @@ export type DoctorHealthFlowContext = {
   cfgForPersistence: OpenClawConfig;
   /** The finalized config-flow candidate crossed the atomic writer boundary. */
   configResultWriteCommitted?: boolean;
-  /** Cron ownership could not be made safe, so every config write remains deferred this run. */
-  configWriteDeferredByCronOwnership?: true;
-  /** The repaired candidate failed write validation; nothing was persisted this run. */
-  configWriteBlockedByValidation?: true;
+  /** The requested config write was refused; later repairs must not consume its candidate. */
+  configWriteRefusal?: "validation" | "cron-owner-safety";
   /** One-shot repairs that require a durable config write have completed. */
   postConfigWriteRepairsCommitted?: boolean;
   sourceConfigValid: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1165,7 +1165,7 @@ describe("doctor health contributions", () => {
     // candidate config, so the loop stops before they persist state derived
     // from a config that never reached disk (same invariant as cron deferral).
     expect(laterRun).not.toHaveBeenCalled();
-    expect(ctx.configWriteBlockedByValidation).toBe(true);
+    expect(ctx.configWriteRefusal).toBe("validation");
     expect(ctx.configResultWriteCommitted).not.toBe(true);
     expect(ctx.cfgForPersistence).toEqual(cfg);
     // Never print "Doctor changes" for changes that were not persisted.
@@ -1225,7 +1225,7 @@ describe("doctor health contributions", () => {
     );
     await requireDoctorContribution("doctor:write-config").run(ctx);
 
-    expect(ctx.configWriteBlockedByValidation).toBe(true);
+    expect(ctx.configWriteRefusal).toBe("validation");
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("Earlier config fixes were already saved"),
       "Doctor warnings",
@@ -1302,7 +1302,7 @@ describe("doctor health contributions", () => {
     expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
     expect(laterRun).not.toHaveBeenCalled();
     expect(ctx.configResultWriteCommitted).not.toBe(true);
-    expect(ctx.configWriteDeferredByCronOwnership).toBe(true);
+    expect(ctx.configWriteRefusal).toBe("cron-owner-safety");
     expect(ctx.cfgForPersistence).toEqual(cfg);
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("preserving any retained legacy owner"),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -449,14 +449,9 @@ async function runDoctorHealthContributionList(
           contribution.run(ctx),
         );
       }
-      if (ctx.configWriteDeferredByCronOwnership === true) {
-        // Later repairs consume the candidate config. Stop before they persist state under an
-        // ownership topology that the config writer deliberately left non-durable.
-        return;
-      }
-      if (ctx.configWriteBlockedByValidation === true) {
-        // Same invariant for a validation-refused write: the candidate never reached
-        // disk, so later repairs must not persist state derived from it.
+      if (ctx.configWriteRefusal) {
+        // Later repairs consume the candidate. Stop before they persist state
+        // derived from config that the writer deliberately left non-durable.
         return;
       }
     } catch (error) {

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runDoctorHealthFlow } from "./doctor-health.js";
+
+const mocks = vi.hoisted(() => ({
+  outro: vi.fn(),
+  writeUpdatePostInstallDoctorResult: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: mocks.outro,
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveStateDir: () => "/tmp/openclaw-doctor-state-does-not-exist",
+}));
+
+vi.mock("../state/openclaw-database-preflight.js", () => ({
+  OpenClawDatabaseSchemaPreflightError: class extends Error {},
+  preflightOpenClawDatabaseSchemas: () => ({ incompatible: [] }),
+}));
+
+vi.mock("../state/openclaw-agent-db.js", () => ({
+  OPENCLAW_AGENT_SCHEMA_VERSION: 1,
+}));
+
+vi.mock("../state/openclaw-state-db.js", () => ({
+  OPENCLAW_STATE_SCHEMA_VERSION: 1,
+}));
+
+vi.mock("../commands/doctor-prompter.js", () => ({
+  createDoctorPrompter: () => ({}),
+}));
+
+vi.mock("../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: async () => undefined,
+}));
+
+vi.mock("../commands/doctor-update.js", () => ({
+  maybeOfferUpdateBeforeDoctor: async () => ({ handled: false }),
+}));
+
+vi.mock("../commands/doctor-ui.js", () => ({
+  maybeRepairUiProtocolFreshness: async () => undefined,
+}));
+
+vi.mock("../commands/doctor-install.js", () => ({
+  noteSourceInstallIssues: () => undefined,
+}));
+
+vi.mock("../commands/doctor/shared/plugin-runtime-symlinks.js", () => ({
+  noteStalePluginRuntimeSymlinks: async () => undefined,
+}));
+
+vi.mock("../commands/doctor-platform-notes.js", () => ({
+  noteStartupOptimizationHints: () => undefined,
+}));
+
+vi.mock("../commands/doctor-config-flow.js", () => ({
+  loadAndMaybeMigrateDoctorConfig: async () => ({ cfg: {}, shouldWriteConfig: true }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  CONFIG_PATH: "/tmp/openclaw.json",
+}));
+
+vi.mock("../infra/update-doctor-result.js", () => ({
+  UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE: 86,
+  UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV: "OPENCLAW_UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH",
+  writeUpdatePostInstallDoctorResult: mocks.writeUpdatePostInstallDoctorResult,
+}));
+
+vi.mock("./doctor-health-contributions.js", () => ({
+  runDoctorHealthContributions: async (ctx: {
+    configWriteRefusal?: "cron-owner-safety";
+    postInstallDoctorResult?: {
+      status: "advisory";
+      advisory: {
+        kind: "package-post-install-doctor";
+        message: string;
+        reason: "deferred-configured-plugin-repair";
+        details: string[];
+      };
+    };
+  }) => {
+    ctx.configWriteRefusal = "cron-owner-safety";
+    ctx.postInstallDoctorResult = {
+      status: "advisory",
+      advisory: {
+        kind: "package-post-install-doctor",
+        message: "recoverable plugin repair",
+        reason: "deferred-configured-plugin-repair",
+        details: ["plugin repair deferred"],
+      },
+    };
+  },
+}));
+
+describe("runDoctorHealthFlow", () => {
+  beforeEach(() => {
+    mocks.outro.mockClear();
+    mocks.writeUpdatePostInstallDoctorResult.mockClear();
+  });
+
+  it("reports a cron ownership refusal instead of a recoverable post-install advisory", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    vi.stubEnv(
+      "OPENCLAW_UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH",
+      "/tmp/openclaw-update-doctor-result.json",
+    );
+
+    try {
+      await runDoctorHealthFlow(runtime, {});
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(mocks.outro).toHaveBeenCalledWith("Doctor finished, but config fixes were not applied.");
+    expect(mocks.outro).not.toHaveBeenCalledWith("Doctor complete.");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.exit).not.toHaveBeenCalledWith(86);
+    expect(mocks.writeUpdatePostInstallDoctorResult).not.toHaveBeenCalled();
+  });
+});

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -114,6 +114,18 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
   };
   const { runDoctorHealthContributions } = await import("./doctor-health-contributions.js");
   await runDoctorHealthContributions(ctx);
+  if (ctx.configWriteRefusal) {
+    // Config fixes were computed but refused by the writer; the warning above
+    // already lists the manual work. This failure outranks a recoverable
+    // post-install advisory because the run did not converge.
+    outro(
+      ctx.configResultWriteCommitted === true
+        ? "Doctor finished, but some config fixes were not applied."
+        : "Doctor finished, but config fixes were not applied.",
+    );
+    effectiveRuntime.exit(1);
+    return;
+  }
   if (ctx.postInstallDoctorResult) {
     const {
       UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
@@ -129,20 +141,6 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
       effectiveRuntime.exit(UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE);
       return;
     }
-  }
-
-  if (ctx.configWriteBlockedByValidation) {
-    // Config fixes were computed but refused by write validation; the warning
-    // above already lists the manual work. When an earlier pass committed, only
-    // the later fixes are missing. Exit non-zero so --fix callers see that the
-    // run did not converge.
-    outro(
-      ctx.configResultWriteCommitted === true
-        ? "Doctor finished, but some config fixes were not applied."
-        : "Doctor finished, but config fixes were not applied.",
-    );
-    effectiveRuntime.exit(1);
-    return;
   }
   outro("Doctor complete.");
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix` (or accepting an interactive repair) could see `Doctor complete.` and receive exit code 0 after cron-ownership safety refused the requested config write. The refusal also stops remaining diagnostics, so automation could treat an unconverged and partially unchecked installation as healthy.

## Why This Change Was Made

Doctor now records every atomic config-write refusal in one closed outcome shared by validation and cron-ownership safety. Later contributions still stop rather than consuming an unpersisted candidate, while finalization reports the run as incomplete and exits 1. A config persistence failure also takes precedence over the updater's recoverable post-install advisory when both outcomes coexist; the unsafe write remains refused.

Production LOC: +21/-33 (net -12). The change replaces two parallel booleans with one discriminated outcome and removes duplicate terminal/short-circuit policy.

## User Impact

Operators and scripts now get a truthful nonzero result when Doctor could not apply accepted repairs. Existing actionable refusal guidance remains unchanged, and no unsafe cron-owner write is forced.

## Evidence

- `node scripts/run-vitest.mjs src/flows/doctor-health.test.ts src/flows/doctor-health-contributions.test.ts src/commands/doctor-config-flow.validation-refusal.test.ts src/infra/package-update-steps.test.ts` — 143 tests passed.
- The regression drives the real Doctor finalizer with both a cron-ownership refusal and a recoverable updater advisory, then proves exit 1 wins, `Doctor complete.` is absent, and no advisory result is published.
- Existing contribution tests prove the typed cron refusal leaves config uncommitted, prevents later contributions, and suppresses duplicate retries.
- `node scripts/check-changed.mjs` — all production checks and core production typecheck passed. The broad core-test typecheck is blocked by unrelated `ui/src/pages/chat/route-loader.ts(712,38): TS2339`; this branch does not touch that file, and the same baseline was independently reproduced at frozen exact `7810edca33f866df373b32e1779f7ecd51fbf78e`.
- Fresh structured autoreview: clean, correctness 0.99.