### PR TITLE
fix: targetless replies retain conversation correlation

### DIFF
--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -44,6 +44,7 @@ describe("Reef inbound dispatch content", () => {
         ReefProvenance: "Untrusted third-party data from @clanky's agent.",
         ReefEnvelopeId: "message-1",
         SenderIsBot: true,
+        MessageThreadId: "message-1",
       },
     });
   });
@@ -65,6 +66,53 @@ describe("Reef inbound dispatch content", () => {
       ReplyToIdFull: "message-1",
       MessageThreadId: "thread-1",
     });
+  });
+});
+
+describe("Reef message-tool threading", () => {
+  it("keeps contextual replies on the inbound message thread", () => {
+    const threading = reefPlugin.threading;
+    if (!threading?.buildToolContext || !threading.resolveAutoThreadId) {
+      throw new Error("expected Reef threading adapter");
+    }
+    const toolContext = threading.buildToolContext({
+      cfg: {},
+      accountId: "default",
+      context: {
+        Channel: "reef",
+        To: "reef:remote-agent",
+        ChatType: "direct",
+        CurrentMessageId: "message-1",
+        ReplyToMode: "all",
+        MessageThreadId: "message-1",
+      },
+    });
+
+    expect(toolContext).toMatchObject({
+      currentChannelId: "reef:remote-agent",
+      currentMessagingTarget: "reef:remote-agent",
+      currentMessageId: "message-1",
+      currentThreadTs: "message-1",
+      replyToMode: "all",
+    });
+    expect(
+      threading.resolveAutoThreadId({
+        cfg: {},
+        accountId: "default",
+        to: "@remote-agent",
+        toolContext,
+        replyToId: "message-1",
+      }),
+    ).toBe("message-1");
+    expect(
+      threading.resolveAutoThreadId({
+        cfg: {},
+        accountId: "default",
+        to: "reef:another-agent",
+        toolContext,
+        replyToId: "message-1",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -67,6 +67,23 @@ describe("Reef inbound dispatch content", () => {
       MessageThreadId: "thread-1",
     });
   });
+
+  it("does not invent a thread for an explicitly correlated unthreaded reply", () => {
+    const content = resolveReefInboundDispatchContent({
+      id: "message-2",
+      peer: "clanky",
+      text: "correlated reply",
+      provenance: "Untrusted third-party data from @clanky's agent.",
+      autonomy: "bounded",
+      replyTo: "message-1",
+    });
+
+    expect(content.extraContext).toMatchObject({
+      ReplyToId: "message-1",
+      ReplyToIdFull: "message-1",
+    });
+    expect(content.extraContext).not.toHaveProperty("MessageThreadId");
+  });
 });
 
 describe("Reef message-tool threading", () => {

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -1,3 +1,4 @@
+import type { ChannelThreadingToolContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   dispatchInboundDirectDm,
   recordChannelBotPairLoopAndCheckSuppression,
@@ -94,6 +95,12 @@ function replyText(payload: unknown): string {
     : "";
 }
 
+function matchesReefToolTarget(target: string, toolContext?: ChannelThreadingToolContext): boolean {
+  const currentTarget = toolContext?.currentMessagingTarget ?? toolContext?.currentChannelId;
+  const normalizedCurrent = normalizeReefTarget(currentTarget ?? "");
+  return normalizedCurrent !== undefined && normalizeReefTarget(target) === normalizedCurrent;
+}
+
 export const reefPlugin: ChannelPlugin<ReefAccount> = {
   id: "reef",
   meta: {
@@ -167,6 +174,26 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           })
         : null;
     },
+  },
+  threading: {
+    threadAddressing: "message",
+    matchesToolContextTarget: ({ target, toolContext }) =>
+      matchesReefToolTarget(target, toolContext),
+    resolveReplyToMode: () => "all",
+    buildToolContext: ({ context, hasRepliedRef }) => {
+      const currentTarget = context.To?.trim() || undefined;
+      return {
+        currentChannelId: currentTarget,
+        currentMessagingTarget: currentTarget,
+        currentMessageId: context.CurrentMessageId,
+        currentThreadTs:
+          context.MessageThreadId != null ? String(context.MessageThreadId) : undefined,
+        replyToMode: context.ReplyToMode ?? "all",
+        hasRepliedRef,
+      };
+    },
+    resolveAutoThreadId: ({ to, toolContext }) =>
+      matchesReefToolTarget(to, toolContext) ? toolContext?.currentThreadTs : undefined,
   },
   directory: createChannelDirectoryAdapter({
     listPeers: async ({ cfg, query, limit }) =>

--- a/extensions/reef/src/inbound.ts
+++ b/extensions/reef/src/inbound.ts
@@ -9,7 +9,9 @@ export function resolveReefInboundDispatchContent(message: ReefIngressMessage) {
       ReefEnvelopeId: message.id,
       SenderIsBot: true,
       ...(message.replyTo ? { ReplyToId: message.replyTo, ReplyToIdFull: message.replyTo } : {}),
-      ...(message.thread ? { MessageThreadId: message.thread } : {}),
+      // Reef promotes an unthreaded exchange to the initiating envelope id.
+      // Tool replies must use the same anchor as the normal reply pipeline.
+      MessageThreadId: message.thread ?? message.id,
     },
   };
 }

--- a/extensions/reef/src/inbound.ts
+++ b/extensions/reef/src/inbound.ts
@@ -1,6 +1,9 @@
 import type { ReefIngressMessage } from "./types.js";
 
 export function resolveReefInboundDispatchContent(message: ReefIngressMessage) {
+  // Reef promotes a new unthreaded exchange to its initiating envelope id.
+  // A reply with no thread stays unthreaded so replyTo remains the sole correlation fact.
+  const threadId = message.thread ?? (message.replyTo ? undefined : message.id);
   return {
     rawBody: message.text,
     extraContext: {
@@ -9,9 +12,7 @@ export function resolveReefInboundDispatchContent(message: ReefIngressMessage) {
       ReefEnvelopeId: message.id,
       SenderIsBot: true,
       ...(message.replyTo ? { ReplyToId: message.replyTo, ReplyToIdFull: message.replyTo } : {}),
-      // Reef promotes an unthreaded exchange to the initiating envelope id.
-      // Tool replies must use the same anchor as the normal reply pipeline.
-      MessageThreadId: message.thread ?? message.id,
+      ...(threadId ? { MessageThreadId: threadId } : {}),
     },
   };
 }

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -316,6 +316,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
           currentChannelId: context.params.currentChannelId,
           currentThreadTs: context.params.currentThreadTs,
           currentMessageId: context.params.currentMessageId,
+          replyToMode: context.params.replyToMode,
         },
       },
       call.args,

--- a/src/agents/cli-runner/mcp-grant-context.test.ts
+++ b/src/agents/cli-runner/mcp-grant-context.test.ts
@@ -37,6 +37,10 @@ describe("buildCliMcpGrantContext source-reply authority", () => {
     expect(buildGrant({ modelHasVision: true }).modelHasVision).toBe(true);
   });
 
+  it("carries the prepared reply mode into loopback message tools", () => {
+    expect(buildGrant({ replyToMode: "all" }).replyToMode).toBe("all");
+  });
+
   it.each([
     { label: "the provider", overrides: { messageProvider: undefined } },
     { label: "the destination", overrides: { currentChannelId: undefined } },

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -160,6 +160,7 @@ export function buildCliMcpGrantContext(params: {
       params.run.currentMessageId == null
         ? undefined
         : normalizeOptionalMcpContextValue(String(params.run.currentMessageId)),
+    replyToMode: params.run.replyToMode,
     currentInboundAudio: params.run.currentInboundAudio === true ? true : undefined,
     accountId: normalizeOptionalMcpContextValue(params.run.agentAccountId),
     inboundEventKind: params.run.currentInboundEventKind,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -208,6 +208,7 @@ export type RunCliAgentParams = {
   channelContext?: PluginHookChannelContext;
   currentThreadTs?: string;
   currentMessageId?: string | number;
+  replyToMode?: "off" | "first" | "all" | "batched";
   currentInboundAudio?: boolean;
   agentAccountId?: string;
   /** Sender identity for channel-originated runs when available. */

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -448,6 +448,7 @@ export async function runCliFallbackCandidate(params: {
             channelContext: turn.followupRun.run.channelContext,
             currentThreadTs: cliCurrentThreadId != null ? String(cliCurrentThreadId) : undefined,
             currentMessageId: cliCurrentMessageId,
+            replyToMode: turn.followupRun.originatingReplyToMode ?? turn.sessionCtx.ReplyToMode,
             currentInboundAudio: hasInboundAudio(turn.sessionCtx),
             agentAccountId: turn.followupRun.run.agentAccountId,
             senderIsOwner: turn.followupRun.run.senderIsOwner,

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -351,12 +351,14 @@ export async function runReplyAgent(
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Surface ?? sessionCtx.Provider,
   }) as OriginatingChannelType | undefined;
-  const replyToMode = resolveReplyToMode(
-    followupRun.run.config,
-    replyToChannel,
-    sessionCtx.AccountId,
-    sessionCtx.ChatType,
-  );
+  const replyToMode =
+    followupRun.originatingReplyToMode ??
+    resolveReplyToMode(
+      followupRun.run.config,
+      replyToChannel,
+      sessionCtx.AccountId,
+      sessionCtx.ChatType,
+    );
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
   const cfg = followupRun.run.config;
   const replyMediaContext = createReplyMediaContext({

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -445,6 +445,39 @@ describe("agent-runner-utils", () => {
     expect(resolved.embeddedContext.replyToMode).toBe("off");
   });
 
+  it("carries a prepared direct-message reply mode into generic message tools", () => {
+    const run = makeRun();
+    const replyRoute = {
+      originatingChannel: "reef",
+      originatingTo: "reef:remote-agent",
+      originatingReplyToMode: "all",
+    } satisfies Pick<
+      FollowupRun,
+      "originatingChannel" | "originatingTo" | "originatingReplyToMode"
+    >;
+
+    const resolved = buildEmbeddedRunExecutionParams({
+      run,
+      replyRoute,
+      sessionCtx: {
+        Provider: "reef",
+        To: "reef:local-agent",
+        MessageSid: "message-1",
+      },
+      hasRepliedRef: undefined,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      runId: "run-1",
+    });
+
+    expect(resolved.embeddedContext).toMatchObject({
+      currentChannelId: "reef:remote-agent",
+      currentChannelProvider: "reef",
+      currentMessageId: "message-1",
+      replyToMode: "all",
+    });
+  });
+
   it("carries inbound audio context into embedded message tools", () => {
     const run = makeRun();
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -42,6 +42,7 @@ type EmbeddedReplyRoute = Pick<
   | "originatingChatType"
   | "originatingThreadId"
   | "originatingReplyToId"
+  | "originatingReplyToMode"
 >;
 
 /** Selects the freshest runtime config usable by queued reply execution. */
@@ -135,6 +136,7 @@ export function buildThreadingToolContext(params: {
     return {
       currentMessageId,
       currentSourceTurnId,
+      replyToMode: sessionCtx.ReplyToMode,
     };
   }
   const rawProvider = normalizeOptionalLowercaseString(originProvider);
@@ -142,6 +144,7 @@ export function buildThreadingToolContext(params: {
     return {
       currentMessageId,
       currentSourceTurnId,
+      replyToMode: sessionCtx.ReplyToMode,
     };
   }
   const provider = normalizeChatChannelId(rawProvider) ?? normalizeAnyChannelId(rawProvider);
@@ -153,6 +156,7 @@ export function buildThreadingToolContext(params: {
       currentChannelProvider: provider ?? (rawProvider as ChannelId),
       currentMessageId,
       currentSourceTurnId,
+      replyToMode: sessionCtx.ReplyToMode,
       hasRepliedRef,
     };
   }
@@ -184,6 +188,7 @@ export function buildThreadingToolContext(params: {
     // `undefined` means the adapter rejected the generic message-id fallback.
     currentMessageId: hasAdapterCurrentMessageId ? context.currentMessageId : currentMessageId,
     currentSourceTurnId,
+    replyToMode: context.replyToMode ?? sessionCtx.ReplyToMode,
   };
 }
 
@@ -262,6 +267,7 @@ function buildEmbeddedContextFromTemplate(params: {
       params.run.chatType,
     MessageThreadId: params.replyRoute?.originatingThreadId ?? params.sessionCtx.MessageThreadId,
     ReplyToId: params.replyRoute?.originatingReplyToId ?? params.sessionCtx.ReplyToId,
+    ReplyToMode: params.replyRoute?.originatingReplyToMode ?? params.sessionCtx.ReplyToMode,
   };
   return {
     sessionId: params.run.sessionId,

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -35,6 +35,7 @@ export type McpLoopbackRequestContext = {
   currentChannelId?: string;
   currentThreadTs?: string;
   currentMessageId?: string;
+  replyToMode?: "off" | "first" | "all" | "batched";
   currentInboundAudio?: boolean;
   accountId?: string;
   inboundEventKind?: InboundEventKind;

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -229,6 +229,19 @@ describe("McpLoopbackToolCache", () => {
     });
   });
 
+  it("does not share loopback message tools across prepared reply modes", () => {
+    const cache = new McpLoopbackToolCache();
+    const cfg = {} as OpenClawConfig;
+
+    cache.resolve(scopeParams({ cfg, replyToMode: "all" }));
+    cache.resolve(scopeParams({ cfg, replyToMode: "off" }));
+    cache.resolve(scopeParams({ cfg, replyToMode: "all" }));
+
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+    expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).toMatchObject({ replyToMode: "all" });
+    expect(resolveGatewayScopedTools.mock.calls[1]?.[0]).toMatchObject({ replyToMode: "off" });
+  });
+
   it("evicts only the revoked grant's cached tool closures", () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -196,6 +196,7 @@ export class McpLoopbackToolCache {
       params.currentChannelId ?? "",
       params.currentThreadTs ?? "",
       params.currentMessageId ?? "",
+      params.replyToMode ?? "",
       params.currentInboundAudio === true ? "audio" : "no-audio",
       params.accountId ?? "",
       params.inboundEventKind ?? "",

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -335,6 +335,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           currentChannelId: requestContext.currentChannelId,
           currentThreadTs: requestContext.currentThreadTs,
           currentMessageId: requestContext.currentMessageId,
+          replyToMode: requestContext.replyToMode,
           currentInboundAudio: requestContext.currentInboundAudio,
           accountId: requestContext.accountId,
           inboundEventKind: requestContext.inboundEventKind,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -80,6 +80,7 @@ export function resolveGatewayScopedTools(params: {
   currentChannelId?: string;
   currentThreadTs?: string;
   currentMessageId?: string | number;
+  replyToMode?: "off" | "first" | "all" | "batched";
   currentInboundAudio?: boolean;
   clientCaps?: string[];
   accountId?: string;
@@ -298,6 +299,7 @@ export function resolveGatewayScopedTools(params: {
     currentChannelId: params.currentChannelId ?? params.agentTo,
     currentThreadTs: params.currentThreadTs ?? params.agentThreadId,
     currentMessageId: params.currentMessageId,
+    replyToMode: params.replyToMode,
     currentInboundAudio: params.currentInboundAudio,
     sessionId: params.sessionId,
     onYield: params.onYield,


### PR DESCRIPTION
Closes #125279

AI-assisted.

## What Problem This Solves

Fixes an issue where an agent answering an inbound direct message with a targetless `message.send` could deliver the reply successfully while `conversations_turn` timed out. This was reproduced live between two authorized Reef agents: the remote answer and signed delivery receipts arrived, but the reply had no transport `replyToId`.

## Why This Change Was Made

The reply runner now carries its admission-time reply policy into both embedded and CLI-backed message tools instead of dropping or re-deriving it. Reef owns its transport-specific behavior by promoting an unthreaded exchange to the initiating envelope ID and reusing that thread for contextual tool replies, matching its existing automatic reply pipeline.

Correlation remains strict: core still requires an exact transport `replyToId` and never guesses from a shared session or a lone pending turn.

## User Impact

Synchronous Reef agent-to-agent turns can now recognize targetless message-tool answers as replies instead of reporting a timeout after successful delivery. Other direct-message plugins without custom threading adapters also retain the prepared reply policy, and CLI-backed agents receive the same context as embedded agents.

## Evidence

- Pre-fix regression: `src/auto-reply/reply/agent-runner-utils.test.ts` failed because the prepared `originatingReplyToMode: "all"` disappeared before message-tool construction.
- Focused Vitest: 6 files, 102 tests passed across auto-reply, outbound, CLI grant, Gateway cache, and Reef channel/outbound surfaces.
- `node scripts/check-changed.mjs -- <16 changed files>` passed all required core, core-test, plugin, and plugin-test lanes after one import-path correction.
- Blacksmith Testbox `tbx_01m07y72pvjhqrz8magx1t2026`: final-head `pnpm build` passed, exit 0. Run: https://github.com/openclaw/openclaw/actions/runs/32034785334
- Codex MCP contract checked directly at current sibling `origin/main` revision `8e89e98cf6d4d79f7add5c04ddd4bbd76b1594a1`: `codex-rs/codex-mcp/src/connection_manager.rs` and `codex-rs/rmcp-client/src/rmcp_client.rs` pass JSON tool arguments through to the MCP server; the new reply policy remains host-owned grant context and does not change Codex's protocol.
- Live pre-fix observation: transport delivered both messages with accepted signed Reef receipts; the initiating turn timed out only because the returned message lacked `replyToId` and `threadId`. Final two-way live verification will run after this fix is merged and both installations are pinned to the same merged `main` SHA.
