### PR TITLE
fix(ci): support macOS Bash in shared image helper

### DIFF
--- a/scripts/docker/shared-image-artifact.sh
+++ b/scripts/docker/shared-image-artifact.sh
@@ -206,15 +206,15 @@ require_common_inputs() {
     fail "at least one image ref is required."
   fi
   local image_ref
-  declare -A seen_refs=()
+  local seen_refs=" "
   for image_ref in "${image_refs[@]}"; do
     if [[ ! "$image_ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/@:-]*$ ]]; then
       fail "image ref contains unsupported characters: $image_ref"
     fi
-    if [[ -n "${seen_refs[$image_ref]:-}" ]]; then
+    if [[ "$seen_refs" == *" $image_ref "* ]]; then
       fail "duplicate image ref: $image_ref"
     fi
-    seen_refs["$image_ref"]=1
+    seen_refs+="$image_ref "
   done
 }
 
@@ -338,7 +338,7 @@ load_artifact() {
   [[ -f "$manifest_path" ]] || fail "shared Docker image artifact manifest is missing: $manifest_path"
   [[ -f "$archive_path" ]] || fail "shared Docker image archive is missing: $archive_path"
 
-  local validated_path
+  local validated_line validated_path
   validated_path="$(mktemp)"
   cleanup_load() {
     rm -f "$validated_path"
@@ -396,7 +396,10 @@ for (const image of value.images) {
 }
 NODE
 
-  mapfile -t validated < "$validated_path"
+  local -a validated=()
+  while IFS= read -r validated_line; do
+    validated+=("$validated_line")
+  done < "$validated_path"
   if [[ "${#validated[@]}" -ne $((2 + ${#image_refs[@]})) ]]; then
     fail "invalid shared Docker image artifact: validated manifest output length"
   fi


### PR DESCRIPTION
Closes #125289

## What Problem This Solves

Fixes an issue where contributors running the shared Docker image artifact tests on stock macOS would fail before the pack/load assertions because the helper used Bash 4-only associative arrays and `mapfile`.

## Why This Change Was Made

The helper now tracks validated image references in a delimiter-safe scalar and reads validated manifest output into a Bash 3-compatible indexed array. The accepted image-reference grammar excludes spaces and glob metacharacters, so the scalar membership check does not broaden accepted input.

Artifact identity, duplicate rejection, archive digest checks, and Docker load behavior are unchanged.

## User Impact

Contributors and CI jobs can run the shared image artifact helper on stock macOS Bash 3.2 without installing a newer Bash. Linux behavior is unchanged.

## Evidence

Exact head: `6e2f5c25e2c4552bedcd0c48cff4b7329a7c14b3`, rebased onto `cc56ea534f78b9494afcd0a6fbf7b7cafaf8a418`.

```text
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ /bin/bash -n scripts/docker/shared-image-artifact.sh

$ pnpm test test/scripts/shared-image-artifact.test.ts
Test Files  1 passed (1)
Tests  11 passed (11)

$ node scripts/check-changed.mjs -- scripts/docker/shared-image-artifact.sh
[check:changed] lanes=tooling
```

- `git range-diff` shows the refreshed commit is patch-equivalent to reviewed head `4179e6aaa9659c4132c6b19db8cd60f26ea44113`; intervening `main` changes did not touch the helper.
- Changed-file tooling checks and `git diff --check` pass.
- The patch-equivalent prior head passed exact-head CI and ClawSweeper found no actionable defect. Current-head hosted CI and review remain separate gates.
- Local Codex review was attempted but quota-blocked, so it is not counted as review coverage.

### Owner acceptance

- Assurance: Critical; the one-file helper is used by release and cross-OS automation, with no user runtime or public-contract change.
- Strongest evidence: stock-macOS Bash 3.2 syntax, 11/11 focused pack/load tests, full changed-file tooling checks, and patch equivalence to the previously reviewed head.
- Known gap/falsifier: a current-head hosted CI source failure, changed duplicate rejection, or changed artifact/image identity would invalidate readiness.
- Rollback: revert the single commit.
- Remaining decision: domain-competent maintainer acceptance of the Bash 3 compatibility form after current-head CI and review.

AI-assisted: yes. Codex isolated the Bash 4 dependencies, implemented the compatibility change, refreshed it onto current main without changing the patch, and reran the focused native macOS checks.
