### PR TITLE
fix(ci): parse Telegram QA launcher on macOS Bash

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1471,7 +1471,7 @@ jobs:
           if [[ "${1:-}" != "--root-run" ]]; then
             present=()
             for key in "${transport_keys[@]}" "${control_keys[@]}"; do
-              if [[ -v "$key" ]]; then
+              if declare -p "$key" >/dev/null 2>&1; then
                 present+=("$key")
               fi
             done
@@ -1492,7 +1492,7 @@ jobs:
             keep_env["$key"]=1
           done
           while IFS= read -r key; do
-            if [[ ! -v "keep_env[$key]" ]]; then
+            if [[ -z "${keep_env[$key]+x}" ]]; then
               unset "$key"
             fi
           done < <(compgen -e)
@@ -1557,7 +1557,7 @@ jobs:
 
           boundary_mode=false
           for key in "${control_keys[@]}"; do
-            if [[ -v "$key" ]]; then
+            if declare -p "$key" >/dev/null 2>&1; then
               boundary_mode=true
             fi
           done
@@ -1565,7 +1565,7 @@ jobs:
           sandbox_payload_b64=""
           if [[ "$boundary_mode" == "true" ]]; then
             for key in "${control_keys[@]}"; do
-              [[ -v "$key" ]]
+              declare -p "$key" >/dev/null 2>&1
             done
             command_file="$(realpath -e "$OPENCLAW_QA_SUT_BOUNDARY_COMMAND_FILE")"
             identity_file="$(realpath -m "$OPENCLAW_QA_SUT_BOUNDARY_IDENTITY_FILE")"


### PR DESCRIPTION
Closes #125293

## What Problem This Solves

The Telegram release-QA workflow test extracts and syntax-checks its embedded launcher. Four Bash 4.2-only `[[ -v ... ]]` probes made that test fail under stock macOS Bash 3.2.

## Change

- Use `declare -p` for dynamic variable-presence checks.
- Use `${keep_env[$key]+x}` for associative membership.

The trusted workflow still executes on Ubuntu; environment preservation and boundary-mode behavior are unchanged.

## Evidence

Exact head: `ef66a493ba8f324b6435424c61dcaf587e0d8133`

- Apple Bash `3.2.57(1)-release`
- `test/scripts/openclaw-release-telegram-qa-workflow.test.ts`: 13 passed, 2 existing platform skips
- Linux cross-check on the same head in `node:24-bookworm` (`linux/arm64`, Bash `5.2.15`): **15/15 passed**
- repository formatting and `git diff --check`: pass

AI-assisted: yes. Codex isolated the embedded-launcher syntax failure, implemented the compatibility substitutions, and ran the native macOS and Linux workflow suites.
