### PR TITLE
fix(release): bound ClawHub publish without GNU timeout

### DIFF
--- a/scripts/lib/bounded-command.mjs
+++ b/scripts/lib/bounded-command.mjs
@@ -1,5 +1,8 @@
 import { runTsxCliShim } from "./tsx-cli-shim.mjs";
 
 await runTsxCliShim(import.meta.url, {
+  // The managed child owner may spend 5s on TERM grace and another 5s
+  // verifying tree exit. Keep the launcher alive beyond that cleanup window.
+  forceKillDelayMs: 15_000,
   implementation: "./bounded-command.mts",
 });

--- a/scripts/lib/bounded-command.mjs
+++ b/scripts/lib/bounded-command.mjs
@@ -1,0 +1,5 @@
+import { runTsxCliShim } from "./tsx-cli-shim.mjs";
+
+await runTsxCliShim(import.meta.url, {
+  implementation: "./bounded-command.mts",
+});

--- a/scripts/lib/bounded-command.mts
+++ b/scripts/lib/bounded-command.mts
@@ -1,5 +1,7 @@
 import { runManagedCommand } from "./managed-child-process.mjs";
 
+const NODE_TIMEOUT_MAX_MS = 2 ** 31 - 1;
+
 function usage(message?: string): never {
   if (message) {
     console.error(message);
@@ -21,12 +23,16 @@ const timeoutMs = Number(timeoutMsRaw);
 if (!Number.isSafeInteger(timeoutMs)) {
   usage("timeout-ms must be a safe integer");
 }
+if (timeoutMs > NODE_TIMEOUT_MAX_MS) {
+  usage(`timeout-ms must be at most ${NODE_TIMEOUT_MAX_MS}`);
+}
 
 try {
   process.exitCode = await runManagedCommand({
     args,
     bin: command,
     requireProcessTreeExit: true,
+    timeoutForceKillOnLeaderExit: true,
     timeoutKillGraceMs: 10_000,
     timeoutMs,
   });

--- a/scripts/lib/bounded-command.mts
+++ b/scripts/lib/bounded-command.mts
@@ -1,0 +1,39 @@
+import { runManagedCommand } from "./managed-child-process.mjs";
+
+function usage(message?: string): never {
+  if (message) {
+    console.error(message);
+  }
+  console.error(
+    "usage: node --import tsx scripts/lib/bounded-command.mts <timeout-ms> -- <command> [args...]",
+  );
+  process.exit(2);
+}
+
+const [timeoutMsRaw, separator, command, ...args] = process.argv.slice(2);
+if (separator !== "--" || !command) {
+  usage();
+}
+if (!timeoutMsRaw || !/^[1-9][0-9]*$/u.test(timeoutMsRaw)) {
+  usage("timeout-ms must be a positive integer");
+}
+const timeoutMs = Number(timeoutMsRaw);
+if (!Number.isSafeInteger(timeoutMs)) {
+  usage("timeout-ms must be a safe integer");
+}
+
+try {
+  process.exitCode = await runManagedCommand({
+    args,
+    bin: command,
+    requireProcessTreeExit: true,
+    timeoutKillGraceMs: 10_000,
+    timeoutMs,
+  });
+} catch (error) {
+  if (error instanceof Error && "code" in error && error.code === "ETIMEDOUT") {
+    process.exitCode = 124;
+  } else {
+    throw error;
+  }
+}

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -56,6 +56,7 @@ type ManagedCommandOptions = {
 type RunManagedCommandOptions = ManagedCommandOptions & {
   timeoutMs?: number;
   timeoutKillGraceMs?: number;
+  timeoutForceKillOnLeaderExit?: boolean;
   requireProcessTreeExit?: boolean;
   runTaskkill?: TaskkillRunner;
   onReady?: (child: ChildProcess) => void;
@@ -280,6 +281,7 @@ export async function runManagedCommand({
   comSpec,
   timeoutMs,
   timeoutKillGraceMs,
+  timeoutForceKillOnLeaderExit = false,
   requireProcessTreeExit = false,
   runTaskkill = spawnSync,
   onReady,
@@ -342,6 +344,7 @@ export async function runManagedCommand({
     outcome: ManagedCommandOutcome,
     stopSignal: NodeJS.Signals,
     forceKillDelayMs?: number,
+    forceKillOnLeaderExit = false,
   ) => {
     if (cancellation) {
       return cancellation;
@@ -351,6 +354,7 @@ export async function runManagedCommand({
       platform,
       runTaskkill,
       forceKillDelayMs,
+      forceKillOnLeaderExit,
     });
     cancellation = finalization.then(
       () => outcome,
@@ -386,7 +390,7 @@ export async function runManagedCommand({
     });
     if (timeoutMs !== undefined) {
       timeoutTimer = setTimeout(() => {
-        void stop({ type: "timeout" }, "SIGTERM", timeoutKillGraceMs);
+        void stop({ type: "timeout" }, "SIGTERM", timeoutKillGraceMs, timeoutForceKillOnLeaderExit);
       }, timeoutMs);
     }
     signal?.addEventListener("abort", abort, { once: true });
@@ -456,10 +460,12 @@ async function finalizeManagedChild(
     platform,
     runTaskkill,
     forceKillDelayMs = FORCE_KILL_DELAY_MS,
+    forceKillOnLeaderExit = false,
   }: {
     platform: NodeJS.Platform;
     runTaskkill: TaskkillRunner;
     forceKillDelayMs?: number;
+    forceKillOnLeaderExit?: boolean;
   },
 ) {
   // Nested wrappers own detached groups. Let them forward the signal before
@@ -502,7 +508,9 @@ async function finalizeManagedChild(
       return;
     }
     const now = Date.now();
-    if (!forced && now >= forceAt) {
+    // Bounded timeout callers can retire remaining descendants as soon as the
+    // leader exits. Other owners retain their configured graceful-drain window.
+    if (!forced && (now >= forceAt || (forceKillOnLeaderExit && exited))) {
       forced = true;
       if (groupState !== "dead") {
         terminateManagedChild(child, "SIGKILL", { platform, runTaskkill });

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -55,6 +55,7 @@ type ManagedCommandOptions = {
 
 type RunManagedCommandOptions = ManagedCommandOptions & {
   timeoutMs?: number;
+  timeoutKillGraceMs?: number;
   requireProcessTreeExit?: boolean;
   runTaskkill?: TaskkillRunner;
   onReady?: (child: ChildProcess) => void;
@@ -278,6 +279,7 @@ export async function runManagedCommand({
   windowsVerbatimArguments,
   comSpec,
   timeoutMs,
+  timeoutKillGraceMs,
   requireProcessTreeExit = false,
   runTaskkill = spawnSync,
   onReady,
@@ -384,7 +386,7 @@ export async function runManagedCommand({
     });
     if (timeoutMs !== undefined) {
       timeoutTimer = setTimeout(() => {
-        void stop({ type: "timeout" }, "SIGTERM");
+        void stop({ type: "timeout" }, "SIGTERM", timeoutKillGraceMs);
       }, timeoutMs);
     }
     signal?.addEventListener("abort", abort, { once: true });

--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -85,6 +85,7 @@ const CLAWHUB_RELEASE_AUTHORITY_PATHS = [
   "scripts/lib/bounded-command.mjs",
   "scripts/lib/bounded-command.mts",
   "scripts/lib/managed-child-process.mts",
+  "scripts/lib/tsx-cli-shim.mjs",
   "scripts/lib/bounded-response.mjs",
   "scripts/lib/plugin-npm-release.ts",
   "scripts/lib/plugin-clawhub-release.ts",

--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -82,6 +82,9 @@ const OPENCLAW_PLUGIN_CLAWHUB_WORKFLOW_FILENAME = "plugin-clawhub-release.yml";
 const CLAWHUB_RELEASE_AUTHORITY_PATHS = [
   ".github/workflows/plugin-clawhub-release.yml",
   ".github/actions/setup-node-env",
+  "scripts/lib/bounded-command.mjs",
+  "scripts/lib/bounded-command.mts",
+  "scripts/lib/managed-child-process.mts",
   "scripts/lib/bounded-response.mjs",
   "scripts/lib/plugin-npm-release.ts",
   "scripts/lib/plugin-clawhub-release.ts",

--- a/scripts/plugin-clawhub-publish.sh
+++ b/scripts/plugin-clawhub-publish.sh
@@ -261,16 +261,21 @@ for timeout_candidate in timeout gtimeout; do
     break
   fi
 done
-if [[ -z "${timeout_bin}" ]]; then
-  echo "GNU timeout or gtimeout with --signal and --kill-after support is required for bounded ClawHub CLI calls." >&2
-  exit 1
+if [[ -n "${timeout_bin}" ]]; then
+  clawhub_timeout=(
+    "${timeout_bin}"
+    --signal=TERM
+    --kill-after=10s
+    "${clawhub_timeout_seconds}s"
+  )
+else
+  clawhub_timeout=(
+    node
+    "${repo_root}/scripts/lib/bounded-command.mjs"
+    "$((clawhub_timeout_seconds * 1000))"
+    --
+  )
 fi
-clawhub_timeout=(
-  "${timeout_bin}"
-  --signal=TERM
-  --kill-after=10s
-  "${clawhub_timeout_seconds}s"
-)
 
 validate_packed_publish() {
   local dry_run_json

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -1698,14 +1698,17 @@ describe("plugin-clawhub-publish.sh", () => {
     expect(localIdentityIndex).toBeLessThan(clawHubDryRunIndex);
   });
 
-  it("probes GNU timeout capabilities and leaves pack-only mode portable", () => {
+  it("prefers GNU timeout and keeps a portable bounded fallback", () => {
     const source = readFileSync("scripts/plugin-clawhub-publish.sh", "utf8");
     const packExitIndex = source.indexOf('if [[ "${mode}" == "--pack" ]]');
     const timeoutProbeIndex = source.indexOf("for timeout_candidate in timeout gtimeout");
 
     expect(timeoutProbeIndex).toBeGreaterThan(packExitIndex);
     expect(source).toContain("--signal=TERM --kill-after=1s 1s true");
-    expect(source).toContain("with --signal and --kill-after support is required");
+    expect(source).toContain('"${repo_root}/scripts/lib/bounded-command.mjs"');
+    expect(readFileSync("scripts/lib/bounded-command.mts", "utf8")).toContain(
+      "timeoutKillGraceMs: 10_000",
+    );
   });
 
   it("prints help before package or ClawHub checks", () => {

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -1713,6 +1713,9 @@ describe("plugin-clawhub-publish.sh", () => {
     expect(readFileSync("scripts/lib/bounded-command.mts", "utf8")).toContain(
       "timeoutKillGraceMs: 10_000",
     );
+    expect(readFileSync("scripts/lib/bounded-command.mjs", "utf8")).toContain(
+      "forceKillDelayMs: 15_000",
+    );
   });
 
   it("prints help before package or ClawHub checks", () => {

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -429,6 +429,7 @@ describe("resolveSelectedClawHubPublishablePluginPackages", () => {
     "scripts/lib/bounded-command.mjs",
     "scripts/lib/bounded-command.mts",
     "scripts/lib/managed-child-process.mts",
+    "scripts/lib/tsx-cli-shim.mjs",
     "scripts/lib/plugin-publication-candidates.ts",
     "scripts/lib/plugin-publication-collector.ts",
   ])("selects all publishable plugins when %s changes", (changedPath) => {

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -426,6 +426,9 @@ describe("resolveSelectedClawHubPublishablePluginPackages", () => {
   it.each([
     "packages/normalization-core/src/record-coerce.ts",
     "packages/plugin-package-contract/src/schema.ts",
+    "scripts/lib/bounded-command.mjs",
+    "scripts/lib/bounded-command.mts",
+    "scripts/lib/managed-child-process.mts",
     "scripts/lib/plugin-publication-candidates.ts",
     "scripts/lib/plugin-publication-collector.ts",
   ])("selects all publishable plugins when %s changes", (changedPath) => {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -1,5 +1,5 @@
 // Managed Child Process tests cover managed child process script behavior.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -252,6 +252,65 @@ ${publish(2)}
       );
     },
     20_000,
+  );
+
+  it("rejects timeout values beyond Node's timer range", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/lib/bounded-command.mjs",
+        "2147483648",
+        "--",
+        process.execPath,
+        "-e",
+        "process.exit(0)",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("timeout-ms must be at most 2147483647");
+    expect(result.stderr).not.toContain("TimeoutOverflowWarning");
+  });
+
+  posixIt(
+    "keeps the bounded launcher alive until nested signal cleanup finishes",
+    async () => {
+      const dir = createTempDir("openclaw-bounded-launcher-cleanup-");
+      const leafPath = path.join(dir, "leaf.mjs");
+      const leafPidPath = path.join(dir, "leaf.pid");
+      fs.writeFileSync(
+        leafPath,
+        `
+import fs from "node:fs";
+fs.writeFileSync(process.argv[2], String(process.pid));
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1_000);
+`,
+        "utf8",
+      );
+      const launcher = spawn(
+        process.execPath,
+        ["scripts/lib/bounded-command.mjs", "60000", "--", process.execPath, leafPath, leafPidPath],
+        { detached: true, stdio: "ignore" },
+      );
+      const closed = waitForChildClose(launcher, 12_000);
+      let leafPid = 0;
+      try {
+        leafPid = await waitForPidFile(leafPidPath, 5_000);
+        process.kill(-launcher.pid!, "SIGTERM");
+        await expect(closed).resolves.toEqual({ code: 143, signal: null });
+        await waitForDead(leafPid, 2_000);
+      } finally {
+        if (launcher.pid && isProcessAlive(launcher.pid)) {
+          process.kill(-launcher.pid, "SIGKILL");
+        }
+        if (leafPid && isProcessAlive(leafPid)) {
+          process.kill(leafPid, "SIGKILL");
+        }
+      }
+    },
+    15_000,
   );
 
   it("maps forwarded signals to shell-compatible exit codes", () => {
@@ -807,13 +866,15 @@ setInterval(() => {}, 1_000);
 
     let descendantPid = 0;
     try {
+      const startedAt = Date.now();
       await expect(
         runManagedCommand({
           args: [childPath, descendantPidPath, signalPath],
           bin: process.execPath,
           shell: false,
           stdio: "ignore",
-          timeoutKillGraceMs: 100,
+          timeoutForceKillOnLeaderExit: true,
+          timeoutKillGraceMs: 10_000,
           timeoutMs: 500,
         }),
       ).rejects.toMatchObject({ code: "ETIMEDOUT" });
@@ -821,6 +882,7 @@ setInterval(() => {}, 1_000);
       descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
       expect(fs.readFileSync(signalPath, "utf8")).toBe("SIGTERM\n");
       expect(isProcessAlive(descendantPid)).toBe(false);
+      expect(Date.now() - startedAt).toBeLessThan(3_000);
     } finally {
       if (descendantPid && isProcessAlive(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -679,13 +679,14 @@ ${publish(2)}
     const childPath = path.join(dir, "child.mjs");
     const childPidPath = path.join(dir, "child.pid");
     const descendantPidPath = path.join(dir, "descendant.pid");
+    const signalPath = path.join(dir, "signal.txt");
     fs.writeFileSync(
       childPath,
       `
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 
-process.on("SIGTERM", () => {});
+process.on("SIGTERM", () => fs.writeFileSync(process.argv[4], "SIGTERM\\n"));
 setInterval(() => {}, 1_000);
 spawn(process.execPath, [
   "-e",
@@ -706,9 +707,10 @@ ${publishReadyPidScript(2)}
       expect(
         runManagedCommand({
           bin: process.execPath,
-          args: [childPath, childPidPath, descendantPidPath],
+          args: [childPath, childPidPath, descendantPidPath, signalPath],
           shell: false,
           stdio: "ignore",
+          timeoutKillGraceMs: 100,
           timeoutMs: 500,
         }),
       ).rejects.toMatchObject({ code: "ETIMEDOUT" }),
@@ -723,6 +725,7 @@ ${publishReadyPidScript(2)}
       expect(isProcessAlive(descendantPid)).toBe(true);
       await releaseAndWait();
       if (process.platform !== "win32") {
+        expect(fs.readFileSync(signalPath, "utf8")).toBe("SIGTERM\n");
         expect(killSpy).toHaveBeenCalledWith(-childPid, "SIGKILL");
       }
       expect(isProcessAlive(childPid)).toBe(false);
@@ -743,6 +746,84 @@ ${publishReadyPidScript(2)}
             await waitForDead(descendantPid, 2_000);
           }
         }
+      }
+    }
+  });
+
+  posixIt("lets a timed-out command handle SIGTERM before forced cleanup", async () => {
+    const dir = createTempDir("openclaw-managed-timeout-grace-");
+    const childPath = path.join(dir, "child.mjs");
+    const signalPath = path.join(dir, "signal.txt");
+    fs.writeFileSync(
+      childPath,
+      `
+import fs from "node:fs";
+process.on("SIGTERM", () => {
+  fs.writeFileSync(process.argv[2], "SIGTERM\\n");
+  process.exit(0);
+});
+setInterval(() => {}, 1_000);
+`,
+      "utf8",
+    );
+
+    await expect(
+      runManagedCommand({
+        args: [childPath, signalPath],
+        bin: process.execPath,
+        shell: false,
+        stdio: "ignore",
+        timeoutKillGraceMs: 10_000,
+        timeoutMs: 500,
+      }),
+    ).rejects.toMatchObject({ code: "ETIMEDOUT" });
+    expect(fs.readFileSync(signalPath, "utf8")).toBe("SIGTERM\n");
+  });
+
+  posixIt("force-kills descendants after the timed-out leader exits during grace", async () => {
+    const dir = createTempDir("openclaw-managed-timeout-leader-exit-");
+    const childPath = path.join(dir, "child.mjs");
+    const descendantPidPath = path.join(dir, "descendant.pid");
+    const signalPath = path.join(dir, "signal.txt");
+    fs.writeFileSync(
+      childPath,
+      `
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const descendant = spawn(process.execPath, [
+  "-e",
+  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1_000);",
+], { stdio: "ignore" });
+fs.writeFileSync(process.argv[2], String(descendant.pid));
+process.on("SIGTERM", () => {
+  fs.writeFileSync(process.argv[3], "SIGTERM\\n");
+  process.exit(0);
+});
+setInterval(() => {}, 1_000);
+`,
+      "utf8",
+    );
+
+    let descendantPid = 0;
+    try {
+      await expect(
+        runManagedCommand({
+          args: [childPath, descendantPidPath, signalPath],
+          bin: process.execPath,
+          shell: false,
+          stdio: "ignore",
+          timeoutKillGraceMs: 100,
+          timeoutMs: 500,
+        }),
+      ).rejects.toMatchObject({ code: "ETIMEDOUT" });
+
+      descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+      expect(fs.readFileSync(signalPath, "utf8")).toBe("SIGTERM\n");
+      expect(isProcessAlive(descendantPid)).toBe(false);
+    } finally {
+      if (descendantPid && isProcessAlive(descendantPid)) {
+        process.kill(descendantPid, "SIGKILL");
       }
     }
   });


### PR DESCRIPTION
Closes #125295

## What Problem This Solves

Fixes an issue where ClawHub publish validation and retry calls could not run on stock macOS because the release script hard-required GNU `timeout`/`gtimeout`, neither of which ships with macOS.

## Why This Change Was Made

The release script continues to prefer GNU `timeout` where available and otherwise uses a small Node entrypoint backed by OpenClaw's existing managed child-process owner. The fallback preserves status 124 and the existing retry policy, sends TERM before KILL, bounds Node timer inputs to Node's supported range, and immediately cleans up remaining descendants if the process-group leader exits during the grace interval.

The current-head refresh integrates with the immutable release-plan authority and unified managed-process cleanup now on `main`: timeout helpers are tracked as ClawHub release authorities, and grace-period liveness uses the shared `inspectManagedProcessGroup` owner.

The immediate leader-exit escalation is opt-in for the ClawHub timeout path, so existing abort and signal callers retain their graceful-drain windows. The JavaScript launcher also remains alive beyond the inner manager's complete TERM, force-kill, and verification budget, preventing cancellation from orphaning a resistant publish descendant.

Pack-only mode and the Linux release path are unchanged.

## User Impact

Release maintainers can run the bounded ClawHub publish path on stock macOS without installing GNU coreutils, while Linux hosts retain the existing GNU timeout path.

## Evidence

Exact head: `9e4abb24f5dcf4403aac6da0b6dc9fee29c5c327`, rebased onto `16367468a7edce977360becc72443943d805593d`.

```text
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ command -v timeout || true; command -v gtimeout || true

$ node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/plugin-clawhub-release.test.ts
Test Files  3 passed (3)
Tests  130 passed | 1 skipped (131)

$ node scripts/lib/bounded-command.mjs 250 -- node -e 'process.on("SIGTERM",()=>{console.log("signal=SIGTERM");process.exit(0)});setInterval(()=>{},1000)'
signal=SIGTERM
exit=124

$ node scripts/lib/bounded-command.mjs 2147483648 -- node -e 'process.exit(0)'
timeout-ms must be at most 2147483647
overflow_exit=2
```

### Stock-macOS release-script proof

- The macOS host had neither `timeout` nor `gtimeout`, so `scripts/plugin-clawhub-publish.sh` selected `scripts/lib/bounded-command.mjs` for every bounded ClawHub call.
- The exact-head test `bounds each packed publish attempt and retries a timed-out CLI` ran the full `--publish-packed` script. Its first fixture attempt slept for 60 seconds, the one-second fallback returned timeout status 124, and the script completed its second attempt in under five seconds.
- The same macOS run passed the launcher cleanup regression. That test sends SIGTERM to the launcher group, expects wrapper status 143, and waits until the resistant leaf PID is dead before it can pass.
- The managed-process regressions also passed TERM-before-KILL and leader-exit descendant cleanup, so no child remained after the bounded command returned.

- A 2026-08-30 current-main check used `46c1eef6e6d4118dba29cf11285601e8b5e35a5b`. No touched owner file changed after the PR merge base, and `git merge-tree --write-tree origin/main HEAD` produced clean tree `7a012ae367772faf6f4c8aa06faf5b72293693d1`.
- The focused exact-head suite was rerun on 2026-08-30: 3 files and 131 tests passed.
- `node scripts/check-changed.mjs --timed`, focused formatting, `/bin/bash -n scripts/plugin-clawhub-publish.sh`, and `git diff --check` pass.
- The exact launcher-level cancellation regression returns 143 and proves its SIGTERM-resistant target is dead before wrapper completion.
- Process-tree regressions cover TERM-before-KILL, leader-exit cleanup, graceful sibling drainage, timer overflow, and process-group reuse exposure.
- The exact seven-file diff is 241 additions and 16 deletions. TruffleHog found zero verified or unverified secrets in the exact patch.
- A fresh independent reviewer found the competing outer/inner kill-timer race; the final head fixes it, and the same reviewer verified the P1 closed with no remaining actionable findings.
- Hosted exact-head CI completed successfully on this head: 120 jobs passed, 18 skipped, and 0 failed (run 33253290140).
- Workflow Sanity run 33253290110 initially failed before branch linting because all trusted-base fetch attempts timed out with status 124. Its exact-head attempt 2 passed on 2026-08-30.

### Owner acceptance

- Assurance: Critical; release machinery and process-tree cleanup, with no user runtime or public API change.
- Strongest evidence: exact-head focused tests, stock-macOS fallback execution, actual-launcher cancellation cleanup, current-main integration proof, and the full changed-file gate.
- Known gap/falsifier: a current-head hosted Linux release failure, leaked descendant, or maintainer finding at the process-tree boundary would invalidate readiness.
- Rollback: revert the four PR commits; GNU-timeout hosts then return to the previous path and stock macOS again fails closed.
- Reviewability: seven focused files; current `main` owners are reused instead of duplicating release-plan selection or process-group inspection.
- Maintainer decision: the repository owner approved landing this repair when the exact-head CI, current-main integration, and local review gates pass.

AI-assisted: yes. Codex isolated the missing-host-tool failure, implemented the managed-process fallback, rebased it onto current main, adapted it to the merged release-plan and process-group owners, and addressed clean-context findings at the timer, launcher, and process-group boundaries.
