### PR TITLE
fix(ci): verify PR commits from local git

### DIFF
--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -28,7 +28,6 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
 // the existing 1,000-result search window through pagination.
 const WORKFLOW_RUNS_PAGE_SIZE = 30;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
-const COMPARE_COMMITS_PAGE_SIZE = 100;
 export const HOSTED_GATE_MAX_AGE_HOURS = 24;
 const HOSTED_GATE_MAX_AGE_MS = HOSTED_GATE_MAX_AGE_HOURS * 60 * 60 * 1_000;
 const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
@@ -972,55 +971,48 @@ function loadCiReuseCandidateRuns(repo: string, headBranch: string) {
   );
 }
 
-export function compareCommitPageCount(totalCommits: unknown) {
-  if (typeof totalCommits !== "number" || !Number.isSafeInteger(totalCommits) || totalCommits < 0) {
-    throw new Error("Expected comparison total_commits to be a non-negative integer.");
-  }
-  return Math.max(1, Math.ceil(totalCommits / COMPARE_COMMITS_PAGE_SIZE));
-}
-
-function loadPullRequestCommitShas(
+export function loadPullRequestCommitShas(
   repo: string,
+  pr: number,
   { baseSha, headSha }: { baseSha: string; headSha: string },
+  execGit: ExecGit = runGit,
 ) {
-  const loadPage = (page: number) => {
-    const comparison = JSON.parse(
-      execGhApiRead(
-        `repos/${repo}/compare/${baseSha}...${headSha}?per_page=${COMPARE_COMMITS_PAGE_SIZE}&page=${page}`,
-        {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      ),
-    ) as unknown;
-    if (!isRecord(comparison)) {
-      throw new Error(`Expected comparison commit page ${page} to be an object.`);
-    }
-    return comparison;
-  };
-
-  // The PR commits endpoint stops at 250. GitHub's paginated comparison is
-  // equivalent to git log BASE..HEAD and keeps the membership proof complete.
-  const firstPage = loadPage(1);
-  const pages = [firstPage];
-  for (let page = 2; page <= compareCommitPageCount(firstPage?.total_commits); page += 1) {
-    pages.push(loadPage(page));
+  const remote = execGit(["remote", "get-url", "origin"])
+    .trim()
+    .replace(/\.git$/u, "");
+  const remoteMatch = remote.match(
+    /^(?:https?:\/\/github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+\/[^/]+)$/u,
+  );
+  if (remoteMatch?.[1]?.toLowerCase() !== repo.toLowerCase()) {
+    throw new Error(`Current checkout does not match requested repository ${repo}.`);
   }
-  const shas = pages.flatMap((comparison, index) => {
-    if (!Array.isArray(comparison?.commits)) {
-      throw new Error(`Expected comparison commit page ${index + 1} to be an array.`);
+  if (execGit(["rev-parse", "--is-shallow-repository"]).trim() !== "false") {
+    throw new Error("Hosted gate verification requires a complete non-shallow checkout.");
+  }
+  if (!/^[0-9a-f]{40,64}$/u.test(baseSha) || !/^[0-9a-f]{40,64}$/u.test(headSha)) {
+    throw new Error("Expected full hexadecimal base and head commit object ids.");
+  }
+  if (!Number.isSafeInteger(pr) || pr <= 0) {
+    throw new Error("Expected a positive pull-request number.");
+  }
+  if (!ensureCommitAvailable(baseSha, execGit)) {
+    throw new Error(`Could not fetch pull-request base commit ${baseSha}.`);
+  }
+  if (!ensureCommitAvailable(headSha, execGit)) {
+    try {
+      execGit(["fetch", "--no-tags", "origin", `refs/pull/${pr}/head`]);
+      execGit(["cat-file", "-e", `${headSha}^{commit}`]);
+    } catch {
+      throw new Error(`Could not fetch pull-request head commit ${headSha}.`);
     }
-    if (!comparison.commits.every(isRecord)) {
-      throw new Error(`Expected comparison commit page ${index + 1} entries to be objects.`);
-    }
-    return comparison.commits
-      .map((commit) => commit.sha)
-      .filter((sha: unknown): sha is string => typeof sha === "string");
-  });
-  if (shas.length !== firstPage.total_commits) {
-    throw new Error(
-      `Expected ${firstPage.total_commits} comparison commits, received ${shas.length}.`,
-    );
+  }
+  const output = execGit(["rev-list", "--reverse", `${baseSha}..${headSha}`]).trim();
+  if (!output) {
+    return [];
+  }
+  const shas = output.split(/\r?\n/u);
+  if (!shas.every((sha) => /^[0-9a-f]{40,64}$/u.test(sha))) {
+    throw new Error("Expected git rev-list to return full commit object ids.");
   }
   return shas;
 }
@@ -1125,7 +1117,10 @@ function main(argv = process.argv.slice(2)) {
     sha: args.sha,
     pr: args.pr,
     recentSha: args.recentSha,
-    pullRequestCommitShas: loadPullRequestCommitShas(args.repo, { baseSha, headSha }),
+    pullRequestCommitShas: loadPullRequestCommitShas(args.repo, args.pr, {
+      baseSha,
+      headSha,
+    }),
     pullRequestHeadBranch: headBranch,
     pullRequestHeadRepository: headRepository,
     workflowRuns,

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -6,8 +6,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
   collectHostedGateEvidence as collectHostedGateEvidenceRaw,
-  compareCommitPageCount,
   HOSTED_GATE_MAX_AGE_HOURS,
+  loadPullRequestCommitShas,
   notApplicableScheduledHostedWorkflows,
   parseArgs,
   parseWorkflowRunPage,
@@ -735,11 +735,118 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(`Missing successful recent CI workflow for ${sha}`);
   });
 
-  it("paginates comparisons beyond the pull-request endpoint's 250-commit cap", () => {
-    expect(compareCommitPageCount(0)).toBe(1);
-    expect(compareCommitPageCount(250)).toBe(3);
-    expect(compareCommitPageCount(251)).toBe(3);
-    expect(compareCommitPageCount(301)).toBe(4);
+  it("loads complete pull-request commit membership from the local checkout", () => {
+    const execGit = (args: string[]) => {
+      switch (args[0]) {
+        case "remote":
+          return "git@github.com:openclaw/openclaw.git\n";
+        case "rev-parse":
+          return "false\n";
+        case "cat-file":
+          return "";
+        case "rev-list":
+          expect(args).toEqual(["rev-list", "--reverse", `${previousSha}..${sha}`]);
+          return `${previousSha}\n${sha}\n`;
+        default:
+          throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      }
+    };
+    expect(
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        execGit,
+      ),
+    ).toEqual([previousSha, sha]);
+  });
+
+  it("accepts an empty membership when the head is already contained by the base", () => {
+    const execGit = (args: string[]) => {
+      if (args[0] === "remote") {
+        return "https://github.com/openclaw/openclaw.git\n";
+      }
+      if (args[0] === "rev-parse") {
+        return "false\n";
+      }
+      if (args[0] === "cat-file") {
+        return "";
+      }
+      return "";
+    };
+    expect(
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        execGit,
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects the wrong repository or an incomplete checkout", () => {
+    const wrongRepository = (args: string[]) =>
+      args[0] === "remote" ? "https://github.com/acme/other.git\n" : "false\n";
+    expect(() =>
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        wrongRepository,
+      ),
+    ).toThrow("Current checkout does not match requested repository openclaw/openclaw.");
+
+    const shallowCheckout = (args: string[]) =>
+      args[0] === "remote" ? "https://github.com/openclaw/openclaw.git\n" : "true\n";
+    expect(() =>
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        shallowCheckout,
+      ),
+    ).toThrow("Hosted gate verification requires a complete non-shallow checkout.");
+  });
+
+  it("fetches a missing fork head through the pull-request ref", () => {
+    let headAvailable = false;
+    const commands: string[][] = [];
+    const execGit = (args: string[]) => {
+      commands.push(args);
+      if (args[0] === "remote") {
+        return "https://github.com/openclaw/openclaw.git\n";
+      }
+      if (args[0] === "rev-parse") {
+        return "false\n";
+      }
+      if (args[0] === "cat-file") {
+        if (args[2]?.startsWith(sha) && !headAvailable) {
+          throw new Error("missing head");
+        }
+        return "";
+      }
+      if (args[0] === "fetch") {
+        if (args.at(-1) === `refs/pull/${pr}/head`) {
+          headAvailable = true;
+          return "";
+        }
+        throw new Error("unadvertised object");
+      }
+      if (args[0] === "rev-list") {
+        return `${sha}\n`;
+      }
+      throw new Error(`Unexpected git command: ${args.join(" ")}`);
+    };
+
+    expect(
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        execGit,
+      ),
+    ).toEqual([sha]);
+    expect(commands).toContainEqual(["fetch", "--no-tags", "origin", `refs/pull/${pr}/head`]);
   });
 
   it("requires recent evidence for scheduled gates observed on the target head", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the native PR landing gate could not validate otherwise-green pull requests when GitHub's compare-commits REST endpoint returned 404. The failure blocked `scripts/pr prepare-run` after exact-head CI had completed successfully.

## Why This Change Was Made

PR commit membership now comes from the already-fetched local Git graph instead of the fragile compare endpoint. The verifier confirms that the checkout belongs to the requested GitHub repository, rejects shallow history, fetches the exact base object and `refs/pull/<n>/head` when needed, and then enumerates the complete full-SHA range locally.

## User Impact

Maintainers can complete the native prepare/merge workflow during a GitHub compare API outage without weakening commit-membership or fork-head validation.

## Evidence

- current canonical gate reproduction: full-SHA compare request returned GitHub 404 for PR #125281
- patched live gate: successfully validated PR #125281 exact-head CI run `32032411659` and Workflow Sanity run `32032411488`
- `node scripts/run-vitest.mjs run test/scripts/verify-pr-hosted-gates.test.ts` — 75/75
- targeted Oxfmt and Oxlint passed
- `git diff --check`
- Autoreview through P2: clean
