### PR TITLE
fix(doctor): report unavailable plugin manifests

### DIFF
--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -34,6 +34,9 @@ async function writePluginFixture(
     includePackageJsonRecord?: boolean;
     manifest?: Record<string, unknown> | false;
     manifestHash?: string;
+    includeManifestPath?: boolean;
+    format?: "openclaw" | "bundle";
+    bundleFormat?: "agent" | "codex" | "claude" | "cursor";
   },
 ) {
   const pluginDir = path.join(root, params.location ?? "user-plugins", params.id);
@@ -71,8 +74,12 @@ async function writePluginFixture(
           ...(hasPackageJson && params.includePackageJsonRecord !== false
             ? { packageJson: { path: "package.json" } }
             : {}),
-          ...(params.manifest === false ? {} : { manifestPath }),
+          ...(params.manifest !== false || params.includeManifestPath === true
+            ? { manifestPath }
+            : {}),
           ...(params.manifestHash ? { manifestHash: params.manifestHash } : {}),
+          ...(params.format ? { format: params.format } : {}),
+          ...(params.bundleFormat ? { bundleFormat: params.bundleFormat } : {}),
         },
       ],
     }),
@@ -615,6 +622,50 @@ describe("runPostUpgradeProbes — plugin.manifest_drift", () => {
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("warn");
       expect(finding?.plugin).toBe("drifted");
+    });
+  });
+
+  it("returns an error when an indexed manifest is no longer readable", async () => {
+    await withFixtureRoot("manifest-missing", async (root) => {
+      const { installsPath, manifestPath } = await writePluginFixture(root, {
+        id: "missing-manifest",
+        packageJson: {
+          name: "missing-manifest",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./dist/index.js"] },
+        },
+        files: { "dist/index.js": "export default {};" },
+        manifestHash: "indexed-manifest-hash",
+      });
+      await fs.rm(manifestPath);
+
+      const report = await runPostUpgradeProbes({ installsPath });
+
+      expect(report.findings).toEqual([
+        expect.objectContaining({
+          level: "error",
+          code: "plugin.manifest_unavailable",
+          plugin: "missing-manifest",
+        }),
+      ]);
+    });
+  });
+
+  it("keeps manifestless Claude bundles healthy", async () => {
+    await withFixtureRoot("manifestless-claude", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "claude-bundle",
+        manifest: false,
+        includeManifestPath: true,
+        manifestHash: "derived-bundle-hash",
+        format: "bundle",
+        bundleFormat: "claude",
+      });
+
+      const report = await runPostUpgradeProbes({ installsPath });
+
+      expect(report.findings).toEqual([]);
     });
   });
 });

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
+import { hasOptionalMissingPluginManifestFile } from "../plugins/installed-plugin-index-manifest.js";
 import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../plugins/package-entry-resolution.js";
@@ -22,6 +23,8 @@ type InstalledPluginRecord = {
   packageJson?: { path: string };
   manifestPath?: string;
   manifestHash?: string;
+  format?: string;
+  bundleFormat?: string;
 };
 
 type InstallsJson = { plugins: InstalledPluginRecord[] };
@@ -91,7 +94,9 @@ function isInstalledPluginRecord(value: unknown): value is InstalledPluginRecord
     isOptionalString(record.origin) &&
     isPackageJsonRef(record.packageJson) &&
     isOptionalString(record.manifestPath) &&
-    isOptionalString(record.manifestHash)
+    isOptionalString(record.manifestHash) &&
+    isOptionalString(record.format) &&
+    isOptionalString(record.bundleFormat)
   );
 }
 
@@ -142,15 +147,6 @@ async function resolvePackageJsonRelPath(
     return "package.json";
   } catch {
     return undefined;
-  }
-}
-
-async function sha256OfFile(absPath: string): Promise<string | null> {
-  try {
-    const raw = await fs.readFile(absPath);
-    return crypto.createHash("sha256").update(raw).digest("hex");
-  } catch {
-    return null;
   }
 }
 
@@ -229,8 +225,32 @@ export async function runPostUpgradeProbes(params: {
     }
 
     if (record.manifestPath && record.manifestHash) {
-      const currentHash = await sha256OfFile(record.manifestPath);
-      if (currentHash && currentHash !== record.manifestHash) {
+      let currentHash: string;
+      try {
+        const raw = await fs.readFile(record.manifestPath);
+        currentHash = crypto.createHash("sha256").update(raw).digest("hex");
+      } catch (err) {
+        if (
+          record.format === "bundle" &&
+          record.bundleFormat === "claude" &&
+          hasOptionalMissingPluginManifestFile({
+            format: record.format,
+            bundleFormat: record.bundleFormat,
+            manifestPath: record.manifestPath,
+          })
+        ) {
+          continue;
+        }
+        const reason = err instanceof Error ? err.message : String(err);
+        findings.push({
+          level: "error",
+          code: "plugin.manifest_unavailable",
+          message: `Plugin ${record.pluginId}: could not read indexed manifest (${record.manifestPath}): ${reason}. Reinstall the plugin or run \`openclaw plugins registry --refresh\`.`,
+          plugin: record.pluginId,
+        });
+        continue;
+      }
+      if (currentHash !== record.manifestHash) {
         findings.push({
           level: "warn",
           code: "plugin.manifest_drift",

--- a/src/commands/doctor-post-upgrade.types.ts
+++ b/src/commands/doctor-post-upgrade.types.ts
@@ -20,5 +20,6 @@ export type PostUpgradeReport = {
 export const POST_UPGRADE_PROBE_CODES = [
   "plugin.index_unavailable",
   "plugin.entry_unresolved",
+  "plugin.manifest_unavailable",
   "plugin.manifest_drift",
 ] as const;


### PR DESCRIPTION
## Problem

Post-upgrade Doctor could report an enabled plugin healthy when its indexed required manifest was missing or unreadable. This also occurred when the index builder recorded an empty hash after a read failure.

## Change

Read required indexed manifests regardless of whether a stored hash exists. Report `plugin.manifest_unavailable` as an actionable error; preserve `plugin.manifest_drift` as a warning only when a stored hash exists. The installed-index owner continues to define optional Claude manifests: only an actual `ENOENT` is optional, not permission or directory-read errors. Preserve current SQLite index ownership, disabled-plugin behavior, JSON output and exit status.

## Verification

- Prior canonical repair: 83 focused Doctor/plugin-index tests, eight isolated real CLI cases, full build and selected native checks passed. This evidence is retained; no standalone replay was run for credit. Mandatory native gate results are recorded separately.
- Independent API source review identified the empty-hash gap. The original source failed four of eight new real-filesystem cases; the corrected source passed all eight. Follow-up review of the resulting source was scoped-clean through P2.
- Repository-pinned pnpm 12.4.0 product graph: all eight new empty-hash Vitest rows passed (38 unchanged rows skipped), including actual non-root macOS permission denial. Covered missing/directory/unreadable required manifests, readable required manifests, disabled plugins, and optional/malformed/readable Claude manifests. The persisted index stays unchanged.
- Native staged checks, isolated full build, and full `pnpm check` passed. The broad local test attempt hit seven failures outside the changed files and was stopped: six pass when rerun with a clean test environment; the remaining execution-policy fixture reproduces on exact current main `3afeee6200ffdefc8c808554610d35d78eb1bdd3` (this macOS host lacks `timeout`). No full local-suite pass is claimed.
- Exact-head hosted CI remains required for final acceptance and is tracked in the PR checks. No live Gateway update or restart is part of this change.

## Compatibility decision

Retain the existing, documented error-exit contract for explicitly requested `doctor --post-upgrade` checks: an unavailable required manifest for an enabled plugin is an error and returns exit 1. Reporting success for that condition was the false-healthy behavior this repair is intended to fix. Scripts that opt into this validation should handle its existing nonzero-error contract. The normal updater remains advisory; this read-only probe does not mutate the installed index or introduce a persisted-state migration.

## Attribution and release note

Retains the original contributor branch and Peter Steinberger’s PR. Doctor now reports unavailable required plugin manifests after an upgrade instead of silently treating them as healthy. AI-assisted implementation and independent review.
