### PR TITLE
fix: large session migrations complete promptly

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2583,7 +2583,7 @@ src/commands/doctor-session-incognito-key-repair.ts	4
 src/commands/doctor-session-snapshots.ts	5
 src/commands/doctor-session-sqlite-compact.ts	1
 src/commands/doctor-session-sqlite-migration-run.ts	8
-src/commands/doctor-session-sqlite-readers.ts	12
+src/commands/doctor-session-sqlite-readers.ts	11
 src/commands/doctor-session-sqlite-recover-report.ts	3
 src/commands/doctor-session-sqlite.ts	3
 src/commands/doctor-session-state-providers.ts	3

--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -86,20 +86,16 @@ export function countTranscriptEventsForPath(
 export function createTranscriptEventReader(
   transcriptPath: string,
   sessionId: string,
+  allowMalformedPrefix = false,
+  sourceFingerprint = readTranscriptFingerprint(transcriptPath),
 ): (append: (event: TranscriptEvent) => void) => void {
   return (append) => {
-    for (const event of readTranscriptEventsForImport(transcriptPath, sessionId, false)) {
-      append(event as TranscriptEvent);
-    }
-  };
-}
-
-export function createTranscriptEventPrefixReader(
-  transcriptPath: string,
-  sessionId: string,
-): (append: (event: TranscriptEvent) => void) => void {
-  return (append) => {
-    for (const event of readTranscriptEventsForImport(transcriptPath, sessionId, true)) {
+    for (const event of readTranscriptEventsForImport(
+      transcriptPath,
+      sessionId,
+      allowMalformedPrefix,
+      sourceFingerprint,
+    )) {
       append(event as TranscriptEvent);
     }
   };
@@ -109,10 +105,10 @@ function readTranscriptEventsForImport(
   transcriptPath: string,
   sessionId: string,
   allowMalformedPrefix: boolean,
+  sourceFingerprint: TranscriptFileFingerprint,
 ): Iterable<FileEntry> {
   // Production import owns the process-wide Gateway/SQLite-maintenance lock
   // through commit and archive. Fingerprints catch non-cooperating external edits.
-  const sourceFingerprint = readTranscriptFileFingerprint(transcriptPath);
   const plan = planTranscriptImport(transcriptPath, allowMalformedPrefix);
   assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
   const classificationHeader = {
@@ -198,7 +194,7 @@ type TranscriptFileFingerprint = {
   size: bigint;
 };
 
-function readTranscriptFileFingerprint(transcriptPath: string): TranscriptFileFingerprint {
+export function readTranscriptFingerprint(transcriptPath: string): TranscriptFileFingerprint {
   const stat = fs.statSync(transcriptPath, { bigint: true });
   return {
     ctimeNs: stat.ctimeNs,
@@ -213,7 +209,7 @@ function assertTranscriptFileUnchanged(
   transcriptPath: string,
   expected: TranscriptFileFingerprint,
 ): void {
-  const current = readTranscriptFileFingerprint(transcriptPath);
+  const current = readTranscriptFingerprint(transcriptPath);
   if (
     current.ctimeNs !== expected.ctimeNs ||
     current.dev !== expected.dev ||

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -548,6 +548,33 @@ describe("runDoctorSessionSqlite", () => {
     }
   });
 
+  it("aborts a batch when a prepared transcript changes before import", async () => {
+    const store = createLegacyStore();
+    const realStatSync = fs.statSync.bind(fs);
+    let changed = false;
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation(((candidate, options) => {
+      const stat = realStatSync(candidate, options as never);
+      if (
+        !changed &&
+        path.resolve(String(candidate)) === path.resolve(store.transcriptPath) &&
+        !(options as { bigint?: boolean } | undefined)?.bigint
+      ) {
+        changed = true;
+        fs.appendFileSync(store.transcriptPath, '{"type":"custom","customType":"late"}\n');
+      }
+      return stat;
+    }) as typeof fs.statSync);
+
+    try {
+      await expect(
+        runDoctorSessionSqlite({ env: store.env, mode: "import", store: store.storePath }),
+      ).rejects.toThrow(/stop active session writers and rerun `openclaw doctor --fix`/);
+      expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
   it("preserves the legacy transcript mtime as the SQLite mutation watermark", async () => {
     const store = createLegacyStore();
     const transcriptMtimeMs = 1_700_000_000_000;

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -7,7 +7,7 @@ import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-a
 import { resolveStateDir } from "../config/paths.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { resolveSessionFilePathCore } from "../config/sessions/paths.js";
-import { importSqliteSessionRows } from "../config/sessions/session-accessor.sqlite-import.js";
+import { importSqliteSessionRowsBatch } from "../config/sessions/session-accessor.sqlite-import.js";
 import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { normalizeStoreSessionKey } from "../config/sessions/store-entry.js";
 import {
@@ -51,11 +51,11 @@ import {
 import {
   countTranscriptEventsForPath,
   createTranscriptEventReader,
-  createTranscriptEventPrefixReader,
   readOnlySqliteDbStats,
   readOnlySqliteExactSessionEntry,
   readOnlySqliteSessionEntries,
   readOnlySqliteTranscriptEventCount,
+  readTranscriptFingerprint,
   readSqliteEntryCount,
   resolveTargetSqlitePath,
 } from "./doctor-session-sqlite-readers.js";
@@ -97,6 +97,8 @@ type LegacySessionRecord = {
   sessionKey: string;
   transcriptPath?: string;
 };
+
+const SESSION_IMPORT_BATCH_SIZE = 256;
 
 /**
  * Runs the targeted doctor SQLite session migration/inspection submode.
@@ -345,17 +347,16 @@ async function inspectOrMigrateTarget(params: {
     appendSqliteDbStats(params.target, report);
     return report;
   }
-  const importedTranscriptSources = new Set<string>();
-  for (const record of records) {
-    if (params.mode === "dry-run") {
-      countLegacyTranscript(record, report);
-      continue;
+  if (params.mode === "import") {
+    await importLegacySessionRecords(params.target, records, report);
+  } else {
+    for (const record of records) {
+      if (params.mode === "dry-run") {
+        countLegacyTranscript(record, report);
+      } else {
+        validateLegacySessionRecord(params.target, record, report);
+      }
     }
-    if (params.mode === "import") {
-      await importLegacySessionRecord(params.target, record, report, importedTranscriptSources);
-      continue;
-    }
-    validateLegacySessionRecord(params.target, record, report);
   }
   if (params.mode === "import" && blockingIssueCount(report) === 0) {
     const validationPassed = validateImportedTargetBeforeArchive(params.target, records, report);
@@ -617,91 +618,99 @@ function blockingIssueCount(report: DoctorSessionSqliteTargetReport): number {
   return report.issues.filter((issue) => !isSessionSqliteMigrationWarning(issue)).length;
 }
 
-async function importLegacySessionRecord(
+async function importLegacySessionRecords(
+  target: SessionStoreTarget,
+  records: readonly LegacySessionRecord[],
+  report: DoctorSessionSqliteTargetReport,
+): Promise<void> {
+  const importedTranscriptSources = new Set<string>();
+  for (let offset = 0; offset < records.length; offset += SESSION_IMPORT_BATCH_SIZE) {
+    const pending = records.slice(offset, offset + SESSION_IMPORT_BATCH_SIZE).flatMap((record) => {
+      const prepared = prepareLegacySessionImport(
+        target,
+        record,
+        report,
+        importedTranscriptSources,
+      );
+      return prepared ? [prepared] : [];
+    });
+    const imported = await importSqliteSessionRowsBatch(pending.map((entry) => entry.params));
+    report.importedEntries += imported.length;
+    report.importedTranscriptEvents += imported.reduce(
+      (total, result) => total + result.transcriptEvents,
+      0,
+    );
+    report.issues.push(...pending.flatMap((entry) => (entry.issue ? [entry.issue] : [])));
+  }
+}
+
+function prepareLegacySessionImport(
   target: SessionStoreTarget,
   record: LegacySessionRecord,
   report: DoctorSessionSqliteTargetReport,
   importedTranscriptSources: Set<string>,
-): Promise<void> {
-  const result = countTranscriptEvents(record);
-  const transcriptMtimeMs = readLegacyTranscriptMtimeMs(record);
+) {
   const transcriptSourceKey = record.transcriptPath
     ? `${record.entry.sessionId}\0${record.transcriptPath}`
     : undefined;
-  const shouldImportTranscript =
-    transcriptSourceKey !== undefined && !importedTranscriptSources.has(transcriptSourceKey);
-  if (result.status === "missing") {
-    if (markAlreadyMigratedTranscript(target, record, report)) {
-      return;
-    }
-    const imported = await importSqliteSessionRows({
-      allowMalformedRowRepair: true,
-      agentId: target.agentId,
-      entry: record.entry,
-      preserveExactStoredKey: true,
-      sessionKey: record.sessionKey,
-      storePath: target.sqlitePath ?? target.storePath,
-    });
-    report.importedEntries += 1;
-    report.importedTranscriptEvents += imported.transcriptEvents;
-    report.issues.push({
-      code: "transcript_missing",
-      message: `Transcript file is missing: ${record.transcriptPath}`,
-      sessionKey: record.sessionKey,
-    });
-    return;
-  } else if (result.status === "malformed") {
-    const imported = await importSqliteSessionRows({
-      allowMalformedRowRepair: true,
-      agentId: target.agentId,
-      entry: record.entry,
-      preserveExactStoredKey: true,
-      sessionKey: record.sessionKey,
-      storePath: target.sqlitePath ?? target.storePath,
-      ...(record.transcriptPath && shouldImportTranscript
-        ? {
-            readTranscriptEvents: createTranscriptEventPrefixReader(
-              record.transcriptPath,
-              record.entry.sessionId,
-            ),
-          }
-        : {}),
-      ...(transcriptMtimeMs !== undefined ? { transcriptMtimeMs } : {}),
-    });
-    if (transcriptSourceKey) {
-      importedTranscriptSources.add(transcriptSourceKey);
-    }
-    report.importedEntries += 1;
-    report.importedTranscriptEvents += imported.transcriptEvents;
-    report.issues.push({
-      code: "transcript_malformed",
-      message: result.message,
-      sessionKey: record.sessionKey,
-    });
-    return;
-  }
-  const imported = await importSqliteSessionRows({
+  const transcriptFingerprint =
+    transcriptSourceKey !== undefined &&
+    !importedTranscriptSources.has(transcriptSourceKey) &&
+    record.transcriptPath &&
+    fs.existsSync(record.transcriptPath)
+      ? readTranscriptFingerprint(record.transcriptPath)
+      : undefined;
+  const result = countTranscriptEvents(record);
+  const transcriptMtimeMs = readLegacyTranscriptMtimeMs(record);
+  const params = {
     allowMalformedRowRepair: true,
     agentId: target.agentId,
     entry: record.entry,
     preserveExactStoredKey: true,
     sessionKey: record.sessionKey,
     storePath: target.sqlitePath ?? target.storePath,
-    ...(record.transcriptPath && result.status === "ok" && shouldImportTranscript
-      ? {
-          readTranscriptEvents: createTranscriptEventReader(
-            record.transcriptPath,
-            record.entry.sessionId,
-          ),
-        }
-      : {}),
-    ...(transcriptMtimeMs !== undefined ? { transcriptMtimeMs } : {}),
-  });
+  };
+  if (result.status === "missing") {
+    if (markAlreadyMigratedTranscript(target, record, report)) {
+      return undefined;
+    }
+    return {
+      issue: {
+        code: "transcript_missing",
+        message: `Transcript file is missing: ${record.transcriptPath}`,
+        sessionKey: record.sessionKey,
+      },
+      params,
+    };
+  }
   if (transcriptSourceKey) {
     importedTranscriptSources.add(transcriptSourceKey);
   }
-  report.importedEntries += 1;
-  report.importedTranscriptEvents += imported.transcriptEvents;
+  return {
+    ...(result.status === "malformed"
+      ? {
+          issue: {
+            code: "transcript_malformed" as const,
+            message: result.message,
+            sessionKey: record.sessionKey,
+          },
+        }
+      : {}),
+    params: {
+      ...params,
+      ...(record.transcriptPath && transcriptFingerprint
+        ? {
+            readTranscriptEvents: createTranscriptEventReader(
+              record.transcriptPath,
+              record.entry.sessionId,
+              result.status === "malformed",
+              transcriptFingerprint,
+            ),
+          }
+        : {}),
+      ...(transcriptMtimeMs !== undefined ? { transcriptMtimeMs } : {}),
+    },
+  };
 }
 
 function markAlreadyMigratedTranscript(

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -2,7 +2,10 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
-import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
+import {
+  runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import { readExactSessionEntryRowForCanonicalRepair } from "./session-accessor.sqlite-canonical-repair.js";
 import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
 import { publishSessionEntryCacheInvalidation } from "./session-accessor.sqlite-entry-cache.js";
@@ -50,10 +53,7 @@ type SqliteSessionImportRowsResult = {
   transcriptEvents: number;
 };
 
-/** Imports one legacy session entry and its transcript rows for doctor migration. */
-export async function importSqliteSessionRows(
-  params: SqliteSessionImportRowsParams,
-): Promise<SqliteSessionImportRowsResult> {
+function prepareSqliteSessionImport(params: SqliteSessionImportRowsParams) {
   if (params.readExactTranscriptRows && params.readTranscriptEvents) {
     throw new Error("SQLite session import accepts only one transcript row source");
   }
@@ -67,127 +67,159 @@ export async function importSqliteSessionRows(
   const resolved = params.preserveExactStoredKey
     ? { ...resolvedScope, sessionKey: params.sessionKey }
     : resolvedScope;
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
-    let transcriptEvents = 0;
-    let skippedExisting = false;
-    runOpenClawAgentWriteTransaction((database) => {
-      // Doctor may have staged another legacy alias in this database already. Inspect only this
-      // exact import target; runtime-wide canonical validation runs after the import phase.
-      const currentEntry = readExactSessionEntryRowForCanonicalRepair(
-        database,
-        resolved.sessionKey,
-        {
-          allowMalformedRowRepair: params.allowMalformedRowRepair === true,
-        },
-      )?.entry;
-      if (params.skipIfExists === true && currentEntry) {
-        skippedExisting = true;
-        return;
-      }
-      const preservedHarnessId =
-        params.entry.agentHarnessId === undefined &&
-        currentEntry?.sessionId === params.entry.sessionId &&
-        currentEntry.lifecycleRevision === params.entry.lifecycleRevision
-          ? currentEntry.agentHarnessId?.trim()
-          : undefined;
-      // Plugin doctor migrations can claim a legacy session before the full
-      // session import runs. Preserve that same-generation canonical owner.
-      const importedEntry = {
-        ...params.entry,
-        ...(preservedHarnessId ? { agentHarnessId: preservedHarnessId } : {}),
-        sessionFile: formatSqliteSessionReferenceForScope({
-          ...resolved,
-          sessionId: params.entry.sessionId,
-        }),
-      };
-      // Doctor imports legacy aliases verbatim; canonical-key repair owns their normalization.
-      writeSessionEntry(database, resolved.sessionKey, importedEntry, {
-        allowStoredAliases: true,
-        previousEntry: currentEntry ?? null,
-      });
-      // The legacy-main handoff hashes raw ordered rows. Parsing or deduping here would make the
-      // destination proof differ and strand a partially imported canonical claim.
-      if (params.readExactTranscriptRows) {
-        const transcriptScope = {
-          ...resolved,
-          sessionId: params.entry.sessionId,
-        };
-        const db = getSessionKysely(database.db);
-        const existing = executeSqliteQueryTakeFirstSync(
-          database.db,
-          db
-            .selectFrom("transcript_events")
-            .select("seq")
-            .where("session_id", "=", params.entry.sessionId)
-            .limit(1),
-        );
-        if (!existing) {
-          const rows: Array<{ createdAt: number; eventJson: string }> = [];
-          params.readExactTranscriptRows((row) => rows.push(row));
-          if (rows.length > 0) {
-            ensureTranscriptSessionRoot(database, transcriptScope, rows[0]!.createdAt, {
-              allowStoredAlias: true,
-            });
-            ensureTranscriptGenerationInTransaction(database, params.entry.sessionId);
-            for (const [seq, row] of rows.entries()) {
-              executeSqliteQuerySync(
-                database.db,
-                db.insertInto("transcript_events").values({
-                  session_id: params.entry.sessionId,
-                  seq,
-                  event_json: row.eventJson,
-                  created_at: row.createdAt,
-                }),
-              );
-            }
-            transcriptEvents = rows.length;
-            reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
-            publishSessionEntryCacheInvalidation(database);
-          }
-        }
-      } else if (params.readTranscriptEvents) {
-        const transcriptScope = {
-          ...resolved,
-          sessionId: params.entry.sessionId,
-        };
-        const existingEventJson = readTranscriptEventJsonSetInTransaction(
-          database,
-          params.entry.sessionId,
-        );
-        params.readTranscriptEvents((event) => {
-          const eventJson = JSON.stringify(event);
-          if (existingEventJson.has(eventJson)) {
-            return;
-          }
-          if (
-            appendTranscriptEventInTransaction(database, transcriptScope, event, {
-              allowStoredAlias: true,
-              scheduleProjectionReconcile: false,
-              touchMutation: false,
-            })
-          ) {
-            existingEventJson.add(eventJson);
-            transcriptEvents += 1;
-          }
-        });
-        reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
-        publishSessionEntryCacheInvalidation(database);
-      }
-      if (params.transcriptMtimeMs !== undefined) {
-        advanceTranscriptMutationAtInTransaction(
-          database,
-          params.entry.sessionId,
-          params.transcriptMtimeMs,
-        );
-      } else if (transcriptEvents > 0) {
-        touchTranscriptMutationInTransaction(database, params.entry.sessionId);
-      }
-    }, toDatabaseOptions(resolved));
+  const exactTranscriptRows = params.readExactTranscriptRows
+    ? new Array<{ createdAt: number; eventJson: string }>()
+    : undefined;
+  params.readExactTranscriptRows?.((row) => exactTranscriptRows?.push(row));
+  const transcriptEvents = params.readTranscriptEvents ? new Array<TranscriptEvent>() : undefined;
+  params.readTranscriptEvents?.((event) => transcriptEvents?.push(event));
+  return { exactTranscriptRows, params, resolved, transcriptEvents };
+}
+
+function importSqliteSessionRowsInTransaction(
+  database: OpenClawAgentDatabase,
+  prepared: ReturnType<typeof prepareSqliteSessionImport>,
+): SqliteSessionImportRowsResult {
+  const { params, resolved } = prepared;
+  let transcriptEvents = 0;
+  // Doctor may have staged another legacy alias in this database already. Inspect only this
+  // exact import target; runtime-wide canonical validation runs after the import phase.
+  const currentEntry = readExactSessionEntryRowForCanonicalRepair(database, resolved.sessionKey, {
+    allowMalformedRowRepair: params.allowMalformedRowRepair === true,
+  })?.entry;
+  if (params.skipIfExists === true && currentEntry) {
     return {
       sessionId: params.entry.sessionId,
       sessionKey: resolved.sessionKey,
-      ...(skippedExisting ? { skippedExisting: true as const } : {}),
+      skippedExisting: true,
       transcriptEvents,
     };
+  }
+  const preservedHarnessId =
+    params.entry.agentHarnessId === undefined &&
+    currentEntry?.sessionId === params.entry.sessionId &&
+    currentEntry.lifecycleRevision === params.entry.lifecycleRevision
+      ? currentEntry.agentHarnessId?.trim()
+      : undefined;
+  // Plugin doctor migrations can claim a legacy session before the full
+  // session import runs. Preserve that same-generation canonical owner.
+  const importedEntry = {
+    ...params.entry,
+    ...(preservedHarnessId ? { agentHarnessId: preservedHarnessId } : {}),
+    sessionFile: formatSqliteSessionReferenceForScope({
+      ...resolved,
+      sessionId: params.entry.sessionId,
+    }),
+  };
+  // Doctor imports legacy aliases verbatim; canonical-key repair owns their normalization.
+  writeSessionEntry(database, resolved.sessionKey, importedEntry, {
+    allowStoredAliases: true,
+    previousEntry: currentEntry ?? null,
   });
+  // The legacy-main handoff hashes raw ordered rows. Parsing or deduping here would make the
+  // destination proof differ and strand a partially imported canonical claim.
+  const exactTranscriptRows = prepared.exactTranscriptRows;
+  if (exactTranscriptRows) {
+    const transcriptScope = {
+      ...resolved,
+      sessionId: params.entry.sessionId,
+    };
+    const db = getSessionKysely(database.db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("transcript_events")
+        .select("seq")
+        .where("session_id", "=", params.entry.sessionId)
+        .limit(1),
+    );
+    if (!existing && exactTranscriptRows.length > 0) {
+      ensureTranscriptSessionRoot(database, transcriptScope, exactTranscriptRows[0]!.createdAt, {
+        allowStoredAlias: true,
+      });
+      ensureTranscriptGenerationInTransaction(database, params.entry.sessionId);
+      for (const [seq, row] of exactTranscriptRows.entries()) {
+        executeSqliteQuerySync(
+          database.db,
+          db.insertInto("transcript_events").values({
+            session_id: params.entry.sessionId,
+            seq,
+            event_json: row.eventJson,
+            created_at: row.createdAt,
+          }),
+        );
+      }
+      transcriptEvents = exactTranscriptRows.length;
+      reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
+      publishSessionEntryCacheInvalidation(database);
+    }
+  } else if (prepared.transcriptEvents) {
+    const transcriptScope = {
+      ...resolved,
+      sessionId: params.entry.sessionId,
+    };
+    const existingEventJson = readTranscriptEventJsonSetInTransaction(
+      database,
+      params.entry.sessionId,
+    );
+    for (const event of prepared.transcriptEvents) {
+      const eventJson = JSON.stringify(event);
+      if (existingEventJson.has(eventJson)) {
+        continue;
+      }
+      if (
+        appendTranscriptEventInTransaction(database, transcriptScope, event, {
+          allowStoredAlias: true,
+          scheduleProjectionReconcile: false,
+          touchMutation: false,
+        })
+      ) {
+        existingEventJson.add(eventJson);
+        transcriptEvents += 1;
+      }
+    }
+    reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
+    publishSessionEntryCacheInvalidation(database);
+  }
+  if (params.transcriptMtimeMs !== undefined) {
+    advanceTranscriptMutationAtInTransaction(
+      database,
+      params.entry.sessionId,
+      params.transcriptMtimeMs,
+    );
+  } else if (transcriptEvents > 0) {
+    touchTranscriptMutationInTransaction(database, params.entry.sessionId);
+  }
+  return {
+    sessionId: params.entry.sessionId,
+    sessionKey: resolved.sessionKey,
+    transcriptEvents,
+  };
+}
+
+/** Imports legacy session rows that share one SQLite store in one durable transaction. */
+export async function importSqliteSessionRowsBatch(
+  params: readonly SqliteSessionImportRowsParams[],
+): Promise<SqliteSessionImportRowsResult[]> {
+  if (params.length === 0) {
+    return [];
+  }
+  const prepared = params.map(prepareSqliteSessionImport);
+  const resolved = prepared[0]!.resolved;
+  if (prepared.some((row) => row.resolved.path !== resolved.path)) {
+    throw new Error("SQLite session import batch spans multiple stores");
+  }
+  return await runExclusiveSqliteSessionWrite(resolved, async () =>
+    runOpenClawAgentWriteTransaction(
+      (database) => prepared.map((row) => importSqliteSessionRowsInTransaction(database, row)),
+      toDatabaseOptions(resolved),
+    ),
+  );
+}
+
+/** Imports one legacy session entry and its transcript rows for doctor migration. */
+export async function importSqliteSessionRows(
+  params: SqliteSessionImportRowsParams,
+): Promise<SqliteSessionImportRowsResult> {
+  return (await importSqliteSessionRowsBatch([params]))[0]!;
 }

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -4242,6 +4242,32 @@ describe("session accessor seam", () => {
     ).not.toHaveProperty("sessionFile");
   });
 
+  it("reads imported transcripts before opening the SQLite transaction", async () => {
+    const agentId = "main";
+    const sessionId = "session-1";
+    const database = openOpenClawAgentDatabase({
+      agentId,
+      path: expectDefined(
+        resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path,
+        "session database path",
+      ),
+    });
+    let readInsideTransaction: boolean | undefined;
+
+    await importSqliteSessionRows({
+      agentId,
+      entry: { sessionId, updatedAt: 10 },
+      readTranscriptEvents: (append) => {
+        readInsideTransaction = database.db.isTransaction;
+        append({ sessionId, type: "session" });
+      },
+      sessionKey: "agent:main:main",
+      storePath,
+    });
+
+    expect(readInsideTransaction).toBe(false);
+  });
+
   it("tracks replacement and deletion transcript mutations", async () => {
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     const scope = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading a large legacy installation could wait indefinitely while Doctor migrated JSONL session history to SQLite. A 4,800-session reproduction did not complete within 15 minutes because every session opened and committed a separate durable SQLite transaction, repeatedly maintaining transcript projections and FTS state.

## Why This Change Was Made

Doctor now prepares legacy session imports in bounded groups of 256 and writes each group through one SQLite transaction. Callback-backed transcript rows are fully materialized before `BEGIN IMMEDIATE`, while authoritative SQLite rows are reread inside the transaction. Source fingerprints are captured before counting and carried into deferred readers so an externally changed JSONL file aborts migration instead of being imported and archived.

The existing single-session import API delegates to the same implementation, so malformed-prefix handling, canonical-key repair, deduplication, projection/FTS maintenance, validation-before-archive, and idempotence retain one path.

Production LOC: +254/-217 (net +37). Tests: +53/-0. Ratchet metadata: +1/-1.

## User Impact

Large upgrades finish the session migration promptly without losing transcripts or configuration. The bounded transaction size avoids both per-session commit amplification and one unbounded all-history transaction; parsing outside the transaction prevents slow filesystems from extending SQLite write-lock holds.

## Evidence

- Packaged Docker upgrade from published `openclaw@2026.7.1-2` to the batched candidate tarball (`fd1faca9e8a1f7d68b4db073f8a9aaa72e4c48de3782e59045715b78eb0dabc6`) passed with 4,800 sessions, 23,890 transcript events, and 2,200 cron jobs.
- Doctor migration: 9s (300s budget); idempotence rerun: 9s (60s budget); Gateway startup: 7s. The update phase itself took 17m26s in the already-running 2026.7.1-2 CLI before candidate installation; that shipped startup work is separate from this Doctor fix.
- The survivor assertions covered session/archive counts, malformed valid-prefix import, duplicate transcript sources, SQLite search/projections, cron normalization, and configured Discord, Telegram, Matrix, WhatsApp, Brave, and plugin state. No provider or channel requests were made.
- The source-change regression fails on pre-fix `4f6611b9`: Doctor resolves, imports 3 events, and archives the changed source. Current head aborts the batch and leaves the source intact.
- The transaction-boundary regression fails on pre-fix `cfef0a99`: transcript input observes `db.isTransaction === true`. Current head observes `false`.
- Full owner suites: session accessor 107/107; Doctor 83 passed, 2 skipped; legacy-main migration/race 22/22.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.98 confidence.
- The full changed-file gate passed on the prior reviewed head and is rerunning after the final transaction-boundary repair.
