### PR TITLE
fix(agents): stop silent compaction failures

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1913,7 +1913,6 @@ src/agents/embedded-agent-runner/tool-result-context-guard.ts	13
 src/agents/embedded-agent-runner/tool-result-truncation.ts	23
 src/agents/embedded-agent-runner/tool-schema-runtime.ts	1
 src/agents/embedded-agent-runner/transcript-rewrite.ts	2
-src/agents/embedded-agent-subscribe.handlers.compaction.ts	1
 src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts	6
 src/agents/embedded-agent-subscribe.handlers.messages.stream.ts	6
 src/agents/embedded-agent-subscribe.handlers.messages.update.ts	6

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -10,6 +10,7 @@ import {
   CHARS_PER_TOKEN_ESTIMATE,
   estimateStringChars,
 } from "@openclaw/normalization-core/cjk-chars";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentReasoningOption } from "../../reasoning.js";
 import {
   type AgentCoreCompletionRuntimeDeps,
@@ -83,6 +84,22 @@ export interface CompactionResult<T = unknown> {
   tokensBefore: number;
   /** Optional implementation-specific details stored with the compaction entry. */
   details?: T;
+}
+
+// Persisted summaries replay on every later request, so their owner enforces
+// this provider-independent 16K hard bound.
+export const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
+export const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
+
+export function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY_CHARS) {
+  if (maxChars <= 0 || summary.length <= maxChars) {
+    return summary;
+  }
+  if (maxChars < SUMMARY_TRUNCATED_MARKER.length) {
+    return truncateUtf16Safe(summary, maxChars);
+  }
+  const budget = maxChars - SUMMARY_TRUNCATED_MARKER.length;
+  return `${truncateUtf16Safe(summary, budget)}${SUMMARY_TRUNCATED_MARKER}`;
 }
 
 /** Compaction thresholds and retention settings. */

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -7,6 +7,11 @@ import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-c
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
+  capCompactionSummary,
+  MAX_COMPACTION_SUMMARY_CHARS,
+  SUMMARY_TRUNCATED_MARKER,
+} from "../../../packages/agent-core/src/harness/compaction/compaction.js";
+import {
   computeFileLists,
   formatFileOperations,
   MAX_FILE_OPS_LIST_CHARS,
@@ -74,8 +79,6 @@ const TURN_PREFIX_INSTRUCTIONS =
   " early progress, and any details needed to understand the retained suffix.";
 const MAX_TOOL_FAILURES = 8;
 const MAX_TOOL_FAILURE_CHARS = 240;
-const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
-const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
 const CONTEXT_TRUNCATED_MARKER = "\n\n[Earlier compaction context truncated to fit budget]\n\n";
 // Split-turn context supplements the generated summary and must not claim its
 // guaranteed half of the final artifact before common finalization runs.
@@ -559,19 +562,6 @@ function formatToolFailuresSection(failures: ToolFailure[]): string {
     lines.push(`- ...and ${failures.length - MAX_TOOL_FAILURES} more`);
   }
   return `\n\n## Tool Failures\n${lines.join("\n")}`;
-}
-
-function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY_CHARS): string {
-  if (maxChars <= 0 || summary.length <= maxChars) {
-    return summary;
-  }
-  const marker = SUMMARY_TRUNCATED_MARKER;
-  if (maxChars < marker.length) {
-    // Marker cannot fit; keep body prefix instead of a partial marker fragment.
-    return truncateUtf16Safe(summary, maxChars);
-  }
-  const budget = maxChars - marker.length;
-  return `${truncateUtf16Safe(summary, budget)}${marker}`;
 }
 
 function normalizeCompactionSuffix(suffix: string | CompactionSuffix): CompactionSuffix {

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -33,6 +33,13 @@ describe("resolveCompactionFailureReason", () => {
 });
 
 describe("classifyCompactionReason", () => {
+  it.each([
+    'No API key found for "anthropic".',
+    "Authentication failed for \"anthropic\". Credentials may have expired or network is unavailable. Run '/login anthropic' to re-authenticate.",
+  ])("classifies known authentication guidance as auth_failed: %s", (reason) => {
+    expect(classifyCompactionReason(reason)).toBe("auth_failed");
+  });
+
   it('classifies "nothing to compact" as a skip-like reason', () => {
     expect(classifyCompactionReason("Nothing to compact (session too small)")).toBe(
       "no_compactable_entries",

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -34,6 +34,12 @@ export function classifyCompactionReason(reason?: string): string {
   if (!text) {
     return "unknown";
   }
+  if (
+    text.startsWith("no api key found") ||
+    (text.startsWith("authentication failed for ") && text.includes("credentials may have expired"))
+  ) {
+    return "auth_failed";
+  }
   if (text.includes("nothing to compact") || text.includes("no real conversation messages")) {
     return "no_compactable_entries";
   }

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
@@ -24,6 +24,7 @@ function createCompactionContext(params: {
   agentId?: string;
   initialCount: number;
   info?: (message: string, meta?: Record<string, unknown>) => void;
+  warn?: (message: string, meta?: Record<string, unknown>) => void;
   messages?: AgentMessage[];
 }): EmbeddedAgentSubscribeContext {
   // Minimal context preserves only the compaction counters and callbacks the
@@ -46,7 +47,7 @@ function createCompactionContext(params: {
     log: {
       debug: vi.fn(),
       info: params.info ?? vi.fn(),
-      warn: vi.fn(),
+      warn: params.warn ?? vi.fn(),
     },
     ensureCompactionPromise: vi.fn(),
     noteCompactionRetry: vi.fn(),
@@ -102,14 +103,15 @@ function makeCompactionSummaryMessage(timestamp?: number): AgentMessage {
   } as AgentMessage;
 }
 
-function finishCompaction(ctx: EmbeddedAgentSubscribeContext): void {
-  handleCompactionEnd(ctx, {
+const completedCompactionEnd = () =>
+  ({
     type: "compaction_end",
     reason: "threshold",
-    result: { kept: 12 },
-    willRetry: false,
-    aborted: false,
-  });
+    outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: false },
+  }) as const;
+
+function finishCompaction(ctx: EmbeddedAgentSubscribeContext): void {
+  handleCompactionEnd(ctx, completedCompactionEnd());
 }
 
 function loggedInfoMetaAt(info: ReturnType<typeof vi.fn>, index: number): Record<string, unknown> {
@@ -199,13 +201,7 @@ describe("compaction lifecycle logging", () => {
       type: "compaction_start",
       reason: "threshold",
     });
-    handleCompactionEnd(ctx, {
-      type: "compaction_end",
-      reason: "threshold",
-      result: { kept: 12 },
-      willRetry: false,
-      aborted: false,
-    });
+    handleCompactionEnd(ctx, completedCompactionEnd());
 
     expect(loggedInfoMessageAt(info, 0)).toBe("embedded run auto-compaction start");
     const startMeta = loggedInfoMetaAt(info, 0);
@@ -228,7 +224,7 @@ describe("compaction lifecycle logging", () => {
     );
   });
 
-  it("logs manual compaction as incomplete when no result is produced", async () => {
+  it("logs a benign manual skip at info", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-incomplete-log-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
@@ -252,9 +248,7 @@ describe("compaction lifecycle logging", () => {
     handleCompactionEnd(ctx, {
       type: "compaction_end",
       reason: "manual",
-      result: undefined,
-      willRetry: false,
-      aborted: false,
+      outcome: { status: "skipped", reason: "Nothing to compact (session too small)" },
     });
 
     expect(loggedInfoMessageAt(info, 0)).toBe("embedded run manual compaction start");
@@ -266,19 +260,49 @@ describe("compaction lifecycle logging", () => {
       "embedded run manual compaction start: runId=run-test reason=manual",
     );
 
-    expect(loggedInfoMessageAt(info, 1)).toBe("embedded run manual compaction incomplete");
+    expect(loggedInfoMessageAt(info, 1)).toBe("embedded run manual compaction skipped");
     const endMeta = loggedInfoMetaAt(info, 1);
     expect(endMeta.event).toBe("embedded_run_compaction_end");
     expect(endMeta.reason).toBe("manual");
+    expect(endMeta.outcome).toBe("skipped");
     expect(endMeta.runId).toBe("run-test");
     expect(endMeta.completed).toBe(false);
-    expect(endMeta.aborted).toBe(false);
+    expect(endMeta.reasonClass).toBe("no_compactable_entries");
     expect(endMeta.consoleMessage).toBe(
-      "embedded run manual compaction incomplete: runId=run-test reason=manual aborted=false willRetry=false",
+      "embedded run manual compaction skipped: runId=run-test reason=no_compactable_entries",
     );
   });
 
-  it("defaults legacy synthetic compaction events to threshold logs", async () => {
+  it("warns with classified, bounded metadata for failed compaction", () => {
+    const warn = vi.fn();
+    const ctx = createCompactionContext({
+      storePath: path.join(os.tmpdir(), "openclaw-compaction-failed-log", "sessions.json"),
+      sessionKey: "main",
+      initialCount: 0,
+      warn,
+    });
+    const reason = `Provider unavailable: ${"provider detail ".repeat(100)}`;
+
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
+      reason: "overflow",
+      outcome: { status: "failed", reason },
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    const metadata = loggedInfoMetaAt(warn, 0);
+    expect(metadata).toMatchObject({
+      event: "embedded_run_compaction_end",
+      reason: "overflow",
+      outcome: "failed",
+      reasonClass: "unknown",
+      outcomeReason: reason,
+    });
+    expect(String(metadata.reasonDetail)).toHaveLength(100);
+    expect(String(metadata.consoleMessage)).not.toContain("provider detail provider detail");
+  });
+
+  it("defaults an unknown synthetic compaction start to threshold logs", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-legacy-log-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
@@ -298,12 +322,7 @@ describe("compaction lifecycle logging", () => {
     handleCompactionStart(ctx, {
       type: "compaction_start",
     });
-    handleCompactionEnd(ctx, {
-      type: "compaction_end",
-      result: { kept: 12 },
-      willRetry: false,
-      aborted: false,
-    });
+    handleCompactionEnd(ctx, completedCompactionEnd());
 
     expect(loggedInfoMessageAt(info, 0)).toBe("embedded run auto-compaction start");
     const startMeta = loggedInfoMetaAt(info, 0);
@@ -344,13 +363,7 @@ describe("handleCompactionEnd", () => {
       initialCount: 1,
     });
 
-    handleCompactionEnd(ctx, {
-      type: "compaction_end",
-      reason: "threshold",
-      result: { kept: 12 },
-      willRetry: false,
-      aborted: false,
-    });
+    handleCompactionEnd(ctx, completedCompactionEnd());
 
     await waitForCompactionCount({
       storePath,
@@ -359,7 +372,7 @@ describe("handleCompactionEnd", () => {
     });
 
     expect(await readCompactionCount(storePath, sessionKey)).toBe(2);
-    expect(ctx.noteCompactionTokensAfter).toHaveBeenCalledWith(undefined);
+    expect(ctx.noteCompactionTokensAfter).toHaveBeenCalledWith(50);
   });
 
   it("clears stale assistant usage before compaction and preserves fresh usage after it", async () => {
@@ -401,8 +414,8 @@ describe("handleCompactionEnd", () => {
     // A failed/aborted end never rewrote history; zeroing usage here would
     // disable the persistent-error compaction trigger for degraded sessions.
     const failureEnds = [
-      { name: "failed", result: undefined, aborted: false },
-      { name: "aborted", result: { kept: 12 }, aborted: true },
+      { name: "failed", outcome: { status: "failed", reason: "summary failed" } },
+      { name: "aborted", outcome: { status: "aborted" } },
     ] as const;
     for (const failure of failureEnds) {
       const liveUsage = makeUsageSnapshot(123_000);
@@ -425,9 +438,7 @@ describe("handleCompactionEnd", () => {
       handleCompactionEnd(ctx, {
         type: "compaction_end",
         reason: "threshold",
-        result: failure.result,
-        willRetry: false,
-        aborted: failure.aborted,
+        outcome: failure.outcome,
       });
 
       const liveAssistant = messages[0] as Extract<AgentMessage, { role: "assistant" }>;

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -7,6 +7,10 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { recordSessionCompacted } from "../sessions/session-state-events.js";
 import { stripStaleAssistantUsageBeforeLatestCompaction } from "./compaction-usage.js";
+import {
+  classifyCompactionReason,
+  formatUnknownCompactionReasonDetail,
+} from "./embedded-agent-runner/compact-reasons.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
@@ -22,16 +26,6 @@ type CompactionStartEvent =
       reason?: unknown;
     };
 
-type CompactionEndEvent =
-  | SessionCompactionEndEvent
-  | {
-      type: "compaction_end";
-      reason?: unknown;
-      willRetry?: unknown;
-      result?: unknown;
-      aborted?: unknown;
-    };
-
 // Unknown reasons come from external runtimes or older sessions. Treat them as
 // threshold compaction so logs and event payloads stay on the closed reason set.
 function normalizeCompactionReason(reason: unknown): CompactionReason {
@@ -40,13 +34,17 @@ function normalizeCompactionReason(reason: unknown): CompactionReason {
     : "threshold";
 }
 
-function compactionLogKind(reason: CompactionReason): string {
-  return reason === "manual" ? "manual compaction" : "auto-compaction";
-}
-
 function emitCompactionAgentEvent(
   ctx: EmbeddedAgentSubscribeContext,
-  data: { phase: "start" } | { phase: "end"; willRetry: boolean; completed: boolean },
+  data:
+    | { phase: "start" }
+    | {
+        phase: "end";
+        completed: boolean;
+        willRetry: boolean;
+        outcome: SessionCompactionEndEvent["outcome"]["status"];
+        reason?: string;
+      },
 ): void {
   const event = { stream: "compaction" as const, data };
   emitAgentEvent({ runId: ctx.params.runId, ...event });
@@ -92,7 +90,7 @@ export function handleCompactionStart(
   evt: CompactionStartEvent,
 ) {
   const reason = normalizeCompactionReason(evt.reason);
-  const kind = compactionLogKind(reason);
+  const kind = reason === "manual" ? "manual compaction" : "auto-compaction";
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
   ctx.ensureCompactionPromise();
@@ -110,24 +108,19 @@ export function handleCompactionStart(
 }
 
 /** Handles compaction completion, retry, and incomplete events. */
-export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: CompactionEndEvent) {
-  const reason = normalizeCompactionReason(evt.reason);
-  const kind = compactionLogKind(reason);
+export function handleCompactionEnd(
+  ctx: EmbeddedAgentSubscribeContext,
+  evt: SessionCompactionEndEvent,
+) {
+  const reason = evt.reason;
+  const kind = reason === "manual" ? "manual compaction" : "auto-compaction";
+  const outcome = evt.outcome;
   ctx.state.compactionInFlight = false;
-  const willRetry = Boolean(evt.willRetry);
-  // Increment counter whenever compaction actually produced a result, regardless
-  // of willRetry. Overflow-triggered compaction retries the LLM request after
-  // trimming context, and the persisted count must reflect that successful trim.
-  const hasResult = evt.result != null;
-  const wasAborted = Boolean(evt.aborted);
-  const completed = hasResult && !wasAborted;
+  const completed = outcome.status === "completed";
+  const willRetry = completed && outcome.willRetry;
   if (completed) {
     ctx.incrementCompactionCount();
-    const tokensAfter =
-      typeof evt.result === "object" && evt.result
-        ? (evt.result as { tokensAfter?: unknown }).tokensAfter
-        : undefined;
-    ctx.noteCompactionTokensAfter(tokensAfter);
+    ctx.noteCompactionTokensAfter(outcome.tokensAfter);
     const observedCompactionCount = ctx.getCompactionCount();
     recordSessionCompacted({
       sessionKey: ctx.params.sessionKey,
@@ -162,7 +155,7 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
     ctx.resetForCompactionRetry();
     ctx.log.debug(`embedded run compaction retry: runId=${ctx.params.runId}`);
   } else {
-    if (!wasAborted) {
+    if (outcome.status !== "aborted") {
       ctx.state.livenessState = "working";
     }
     ctx.maybeResolveCompactionWait();
@@ -180,18 +173,43 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
       });
     }
   }
+  const outcomeReason =
+    outcome.status === "skipped" || outcome.status === "failed" ? outcome.reason : undefined;
   if (!completed) {
-    ctx.log.info(`embedded run ${kind} incomplete`, {
+    const reasonClass = outcomeReason ? classifyCompactionReason(outcomeReason) : "aborted";
+    const reasonDetail =
+      reasonClass === "unknown" ? formatUnknownCompactionReasonDetail(outcomeReason) : undefined;
+    const metadata = {
       event: "embedded_run_compaction_end",
       runId: ctx.params.runId,
       reason,
+      outcome: outcome.status,
       completed: false,
-      willRetry,
-      aborted: wasAborted,
-      consoleMessage: `embedded run ${kind} incomplete: runId=${ctx.params.runId} reason=${reason} aborted=${wasAborted} willRetry=${willRetry}`,
-    });
+      willRetry: false,
+      reasonClass,
+      ...(outcomeReason ? { outcomeReason } : {}),
+      ...(reasonDetail ? { reasonDetail } : {}),
+      consoleMessage: `embedded run ${kind} ${outcome.status}: runId=${ctx.params.runId} reason=${reasonClass}${reasonDetail ? ` detail=${reasonDetail}` : ""}`,
+    };
+    const benign =
+      outcome.status === "aborted" ||
+      (outcome.status === "skipped" &&
+        (reasonClass === "no_compactable_entries" ||
+          reasonClass === "below_threshold" ||
+          reasonClass === "already_compacted"));
+    if (benign) {
+      ctx.log.info(`embedded run ${kind} ${outcome.status}`, metadata);
+    } else {
+      ctx.log.warn(`embedded run ${kind} ${outcome.status}`, metadata);
+    }
   }
-  emitCompactionAgentEvent(ctx, { phase: "end", willRetry, completed });
+  emitCompactionAgentEvent(ctx, {
+    phase: "end",
+    completed,
+    willRetry,
+    outcome: outcome.status,
+    ...(outcomeReason ? { reason: outcomeReason } : {}),
+  });
 
   // after_compaction runs only once the run will not retry, matching the visible
   // post-compaction session state plugin authors observe.

--- a/src/agents/embedded-agent-subscribe.handlers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.ts
@@ -21,16 +21,14 @@ import {
   handleToolExecutionStart,
   handleToolExecutionUpdate,
 } from "./embedded-agent-subscribe.handlers.tools.js";
-import type {
-  EmbeddedAgentSubscribeContext,
-  EmbeddedAgentSubscribeEvent,
-} from "./embedded-agent-subscribe.handlers.types.js";
+import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import type { AgentMessage } from "./runtime/index.js";
+import type { AgentSessionEvent } from "./sessions/index.js";
 
 /** Create the serialized event dispatcher for subscribed embedded-agent sessions. */
 export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscribeContext) {
   const scheduleEvent = (
-    evt: EmbeddedAgentSubscribeEvent,
+    evt: AgentSessionEvent,
     handler: () => void | Promise<void>,
     options?: { detach?: boolean },
   ): void | Promise<void> => {
@@ -81,7 +79,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
     }
   };
 
-  return (evt: EmbeddedAgentSubscribeEvent) => {
+  return (evt: AgentSessionEvent) => {
     switch (evt.type) {
       case "message_start":
         // Delivery from the previous message may still be queued, but usage is
@@ -146,13 +144,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         return;
       case "compaction_end":
         void scheduleEvent(evt, () => {
-          handleCompactionEnd(ctx, {
-            type: "compaction_end",
-            reason: evt.reason,
-            willRetry: evt.willRetry,
-            result: evt.result,
-            aborted: evt.aborted,
-          });
+          handleCompactionEnd(ctx, evt);
         });
         return;
       case "agent_end":

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -29,7 +29,6 @@ import type { McpConnectAction } from "./mcp-connect-action.js";
 import type { McpAppChannelView } from "./mcp-ui-resource.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
-import type { AgentSessionEvent } from "./sessions/index.js";
 import type { ToolErrorSummary, ToolRecoverySummary } from "./tool-error-summary.js";
 import type { NormalizedUsage } from "./usage.js";
 
@@ -397,8 +396,3 @@ export type ToolHandlerContext = {
   trimMessagingToolSent: () => void;
   consumeToolSendReceipt?: (toolCallId: string) => unknown;
 };
-
-export type EmbeddedAgentSubscribeEvent =
-  | AgentSessionEvent
-  | { type: string; [k: string]: unknown }
-  | { type: "message_start"; message: AgentMessage };

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts
@@ -8,6 +8,26 @@ import { makeZeroUsageSnapshot } from "./usage.js";
 
 type SessionEventHandler = (evt: unknown) => void;
 
+function completedCompactionEnd(willRetry = true, tokensBefore = 100, tokensAfter = 50) {
+  return {
+    type: "compaction_end",
+    reason: willRetry ? "overflow" : "threshold",
+    outcome: {
+      status: "completed",
+      tokensBefore,
+      tokensAfter,
+      willRetry,
+    },
+  } as const;
+}
+
+const skippedCompactionEnd = () =>
+  ({
+    type: "compaction_end",
+    reason: "threshold",
+    outcome: { status: "skipped", reason: "Nothing to compact (session too small)" },
+  }) as const;
+
 describe("fenced output and compaction retries", () => {
   it("waits for auto-compaction retry and clears buffered text", async () => {
     // A retrying compaction invalidates any assistant text buffered from the
@@ -42,10 +62,7 @@ describe("fenced output and compaction retries", () => {
     expect(subscription.assistantTexts.length).toBe(1);
 
     for (const listener of listeners) {
-      listener({
-        type: "compaction_end",
-        willRetry: true,
-      });
+      listener(completedCompactionEnd());
     }
 
     expect(subscription.isCompacting()).toBe(true);
@@ -100,7 +117,7 @@ describe("fenced output and compaction retries", () => {
     });
 
     for (const listener of listeners) {
-      listener({ type: "compaction_end", willRetry: true });
+      listener(completedCompactionEnd());
     }
     expect(subscription.getLastAssistantUsage()).toBeUndefined();
   });
@@ -133,7 +150,7 @@ describe("fenced output and compaction retries", () => {
     expect(resolved).toBe(false);
 
     for (const listener of listeners) {
-      listener({ type: "compaction_end", willRetry: false });
+      listener(skippedCompactionEnd());
     }
 
     await waitPromise;
@@ -173,7 +190,7 @@ describe("fenced output and compaction retries", () => {
     });
 
     for (const listener of listeners) {
-      listener({ type: "compaction_end", result: { kept: 1 }, aborted: false, willRetry: false });
+      listener(completedCompactionEnd(false));
     }
 
     const usage = (session.messages?.[0] as { usage?: unknown } | undefined)?.usage;
@@ -266,6 +283,27 @@ function toolResultPayloadAt(
 }
 
 describe("subscribeEmbeddedAgentSession", () => {
+  it("forwards max-attempt failure text to the observable compaction event", () => {
+    const onCompactionEvent = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-compaction-failure",
+      onAgentEvent: onCompactionEvent,
+    });
+    const failure =
+      "Context overflow recovery failed after 3 compact-and-retry attempts. Try reducing context or switching to a larger-context model.";
+
+    emit({
+      type: "compaction_end",
+      reason: "overflow",
+      outcome: { status: "failed", reason: failure },
+    });
+
+    expect(onCompactionEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: expect.objectContaining({ phase: "end", completed: false, reason: failure }),
+    });
+  });
+
   it("waits for multiple compaction retries before resolving", async () => {
     // Each retrying compaction requires a matching agent_end before waiters are
     // released, preventing early continuation during repeated overflow repairs.
@@ -273,8 +311,8 @@ describe("subscribeEmbeddedAgentSession", () => {
       runId: "run-3",
     });
 
-    emit({ type: "compaction_end", willRetry: true });
-    emit({ type: "compaction_end", willRetry: true });
+    emit(completedCompactionEnd());
+    emit(completedCompactionEnd());
 
     let resolved = false;
     const waitPromise = subscription.waitForCompactionRetry().then(() => {
@@ -304,20 +342,12 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(subscription.getCompactionCount()).toBe(0);
 
     // willRetry with result — counter IS incremented (overflow compaction succeeded)
-    emit({
-      type: "compaction_end",
-      willRetry: true,
-      result: { summary: "s", tokensAfter: 12_345 },
-    });
+    emit(completedCompactionEnd(true, 20_000, 12_345));
     expect(subscription.getCompactionCount()).toBe(1);
     expect(subscription.getLastCompactionTokensAfter()).toBe(12_345);
 
     // willRetry=false with result — counter incremented again
-    emit({
-      type: "compaction_end",
-      willRetry: false,
-      result: { summary: "s2", tokensAfter: 6_789 },
-    });
+    emit(completedCompactionEnd(false, 12_345, 6_789));
     expect(subscription.getCompactionCount()).toBe(2);
     expect(subscription.getLastCompactionTokensAfter()).toBe(6_789);
   });
@@ -335,7 +365,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(subscription.getCurrentAttemptAssistant()).toEqual(assistant);
     expect(subscription.assistantTexts).toEqual(["Reply before compaction"]);
 
-    emit({ type: "compaction_end", willRetry: true });
+    emit(completedCompactionEnd());
     expect(subscription.getCurrentAttemptAssistant()).toBeUndefined();
     expect(subscription.assistantTexts).toEqual([]);
   });
@@ -346,10 +376,14 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
 
     // No result (e.g. aborted or cancelled) — counter stays at 0
-    emit({ type: "compaction_end", willRetry: false, result: undefined });
+    emit(skippedCompactionEnd());
     expect(subscription.getCompactionCount()).toBe(0);
 
-    emit({ type: "compaction_end", willRetry: false, aborted: true });
+    emit({
+      type: "compaction_end",
+      reason: "threshold",
+      outcome: { status: "aborted" },
+    });
     expect(subscription.getCompactionCount()).toBe(0);
   });
 
@@ -373,8 +407,8 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
 
     emit({ type: "compaction_start" });
-    emit({ type: "compaction_end", willRetry: true });
-    emit({ type: "compaction_end", willRetry: false });
+    emit(completedCompactionEnd());
+    emit(skippedCompactionEnd());
 
     stop();
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
@@ -9,6 +9,13 @@ import {
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
 
+const retryingCompactionEnd = () =>
+  ({
+    type: "compaction_end",
+    reason: "overflow",
+    outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: true },
+  }) as const;
+
 function createBlockReplyHarness(
   blockReplyBreak: "message_end" | "text_end",
   options: {
@@ -221,7 +228,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       to: null,
       result: { details: { deliveryStatus: "sent" } },
     });
-    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit(retryingCompactionEnd());
     await Promise.resolve();
     emitAssistantMessageEnd(emit, "Done after compaction.");
     await Promise.resolve();
@@ -247,7 +254,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         },
       },
     });
-    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit(retryingCompactionEnd());
     await Promise.resolve();
 
     expect(subscription.getMessagingToolSourceReplyPayloads()).toEqual([

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -22,6 +22,13 @@ import {
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
+const retryingCompactionEnd = () =>
+  ({
+    type: "compaction_end",
+    reason: "overflow",
+    outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: true },
+  }) as const;
+
 describe("subscribeEmbeddedAgentSession", () => {
   async function flushBlockReplyCallbacks(): Promise<void> {
     // Block replies can schedule nested microtasks; drain twice before checking
@@ -1437,7 +1444,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       });
     }
 
-    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit(retryingCompactionEnd());
     emitToolRun({
       emit,
       toolName: "write",
@@ -1591,7 +1598,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       isError: false,
       result: { ok: true },
     });
-    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit(retryingCompactionEnd());
     emit({ type: "agent_end" });
 
     expect(subscription.getReplayState()).toEqual({
@@ -1625,7 +1632,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       isError: false,
       result: { details: { status: "ok" } },
     });
-    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit(retryingCompactionEnd());
     emit({ type: "agent_end" });
 
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
@@ -1660,7 +1667,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         },
       },
     });
-    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit(retryingCompactionEnd());
 
     expect(subscription.getAcceptedSessionSpawns()).toEqual([
       {

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -1,4 +1,5 @@
 import { cleanupSessionResources } from "@openclaw/ai/internal/runtime";
+import { getStreamLlmRuntime } from "../../llm/model-runtime-binding.js";
 import type { AssistantMessage, Model } from "../../llm/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
@@ -197,8 +198,8 @@ export abstract class AgentSessionBase {
     headers?: Record<string, string>;
   }> {
     if (
-      this.agent.streamFn ===
-      getModelRegistryRuntime(this.sessionModelRegistry).llmRuntime.streamSimple
+      getStreamLlmRuntime(this.agent.streamFn) ===
+      getModelRegistryRuntime(this.sessionModelRegistry).llmRuntime
     ) {
       return this.getRequiredRequestAuth(model);
     }

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
+import { subscribeEmbeddedAgentSession } from "../embedded-agent-subscribe.js";
 import {
   createAssistant,
   createAssistantResultStream,
@@ -31,7 +32,113 @@ function createStaleThinkingContent(): AssistantMessage["content"] {
   ] as unknown as AssistantMessage["content"];
 }
 
+function createResultHandlers(summary: string, firstKeptEntryId?: string) {
+  const handlers = createCompactionHandlers();
+  handlers.set("session_before_compact", [
+    async (event: unknown) => {
+      const preparation = (
+        event as { preparation: { firstKeptEntryId: string; tokensBefore: number } }
+      ).preparation;
+      return {
+        compaction: {
+          summary,
+          firstKeptEntryId: firstKeptEntryId ?? preparation.firstKeptEntryId,
+          tokensBefore: preparation.tokensBefore,
+        },
+      };
+    },
+  ]);
+  return handlers;
+}
+
+function collectCompactionEnds(session: Awaited<ReturnType<typeof createTestSession>>["session"]) {
+  const events: Array<Extract<AgentSessionEvent, { type: "compaction_end" }>> = [];
+  session.subscribe((event) => {
+    if (event.type === "compaction_end") {
+      events.push(event);
+    }
+  });
+  return events;
+}
+
 describe("AgentSession compaction", () => {
+  it("preserves the automatic authentication failure as a reasoned skip", async () => {
+    const { session, modelRegistry } = await createTestSession({
+      settingsManager: createAutoCompactionSettings(),
+    });
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) => {
+      vi.spyOn(modelRegistry, "getApiKeyAndHeaders").mockResolvedValue({
+        ok: false,
+        error: `No API key found for ${activeModel.provider}`,
+      });
+      return createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "complete answer" }], "stop", 100),
+      );
+    });
+    const compactionEvents = collectCompactionEnds(session);
+
+    await session.prompt("continue");
+
+    expect(compactionEvents.at(0)).toMatchObject({
+      type: "compaction_end",
+      reason: "threshold",
+      outcome: { status: "skipped", reason: expect.stringContaining("No API key found") },
+    });
+  });
+
+  it("records post-compaction live-message tokens through the subscriber", async () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+    const firstKeptEntryId = sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "retained answer" }]),
+      timestamp: 2,
+    });
+    let requests = 0;
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        ++requests === 1
+          ? createOverflowAssistant(activeModel)
+          : createAssistant(activeModel, [{ type: "text", text: "complete retry" }]),
+      ),
+    );
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager: createAutoCompactionSettings(),
+      resourceLoader: createResourceLoader(
+        createResultHandlers("condensed history", firstKeptEntryId),
+      ),
+    });
+    const subscription = subscribeEmbeddedAgentSession({ session, runId: "run-tokens-after" });
+
+    await session.prompt("long request");
+
+    expect(subscription.getCompactionCount()).toBe(1);
+    expect(subscription.getLastCompactionTokensAfter()).toEqual(expect.any(Number));
+    expect(subscription.getLastCompactionTokensAfter()).toBeGreaterThan(0);
+    subscription.unsubscribe();
+  });
+
+  it("caps extension summaries before persistence and manual return", async () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "old answer" }]),
+      timestamp: 2,
+    });
+    const oversizedSummary = "summary detail ".repeat(2_000);
+    const { session } = await createTestSession({
+      sessionManager,
+      resourceLoader: createResourceLoader(createResultHandlers(oversizedSummary)),
+    });
+
+    const result = await session.compact();
+    const persisted = sessionManager.getBranch().findLast((entry) => entry.type === "compaction");
+
+    expect(result.summary.length).toBeLessThanOrEqual(16_000);
+    expect(result.summary).toContain("[Compaction summary truncated to fit budget]");
+    expect(persisted).toMatchObject({ type: "compaction", summary: result.summary });
+  });
+
   it.each(Array.from({ length: MAX_OVERFLOW_COMPACTION_ATTEMPTS }, (_, index) => index + 1))(
     "recovers when the provider accepts overflow compaction attempt %i",
     async (overflowCount) => {
@@ -48,18 +155,18 @@ describe("AgentSession compaction", () => {
         settingsManager: createAutoCompactionSettings(),
         resourceLoader: createResourceLoader(createCompactionHandlers()),
       });
-      const compactionEvents: AgentSessionEvent[] = [];
-      session.subscribe((event) => {
-        if (event.type === "compaction_end") {
-          compactionEvents.push(event);
-        }
-      });
+      const compactionEvents = collectCompactionEnds(session);
 
       await session.prompt("long request");
 
       expect(agentRequests).toBe(overflowCount + 1);
       expect(
-        compactionEvents.filter((event) => event.type === "compaction_end" && event.willRetry),
+        compactionEvents.filter(
+          (event) =>
+            event.type === "compaction_end" &&
+            event.outcome.status === "completed" &&
+            event.outcome.willRetry,
+        ),
       ).toHaveLength(overflowCount);
       expect(session.getLastAssistantText()).toBe("complete retry");
     },
@@ -78,12 +185,7 @@ describe("AgentSession compaction", () => {
       settingsManager: createAutoCompactionSettings(),
       resourceLoader: createResourceLoader(createCompactionHandlers()),
     });
-    const compactionEvents: AgentSessionEvent[] = [];
-    session.subscribe((event) => {
-      if (event.type === "compaction_end") {
-        compactionEvents.push(event);
-      }
-    });
+    const compactionEvents = collectCompactionEnds(session);
 
     await session.prompt("long request");
 
@@ -91,8 +193,10 @@ describe("AgentSession compaction", () => {
     expect(compactionEvents.at(-1)).toMatchObject({
       type: "compaction_end",
       reason: "overflow",
-      willRetry: false,
-      errorMessage: `Context overflow recovery failed after ${MAX_OVERFLOW_COMPACTION_ATTEMPTS} compact-and-retry attempts. Try reducing context or switching to a larger-context model.`,
+      outcome: {
+        status: "failed",
+        reason: `Context overflow recovery failed after ${MAX_OVERFLOW_COMPACTION_ATTEMPTS} compact-and-retry attempts. Try reducing context or switching to a larger-context model.`,
+      },
     });
   });
 

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,4 +1,9 @@
-import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
+import type {
+  AssistantMessage,
+  Context,
+  Model,
+  SimpleStreamOptions,
+} from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
 import { subscribeEmbeddedAgentSession } from "../embedded-agent-subscribe.js";
@@ -115,6 +120,60 @@ describe("AgentSession compaction", () => {
     expect(subscription.getCompactionCount()).toBe(1);
     expect(subscription.getLastCompactionTokensAfter()).toEqual(expect.any(Number));
     expect(subscription.getLastCompactionTokensAfter()).toBeGreaterThan(0);
+    subscription.unsubscribe();
+  });
+
+  it("projects a rejected automatic cancellation as aborted without recording compaction", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const handlers = createCompactionHandlers();
+    const syntheticError = new Error("synthetic cancellation rejection");
+    const abortActiveCompaction = () => session.abortCompaction();
+    handlers.set("session_before_compact", [
+      async () => {
+        abortActiveCompaction();
+        throw syntheticError;
+      },
+    ]);
+    streamMocks.streamSimple.mockImplementation(
+      (activeModel: Model, _context: Context, options?: SimpleStreamOptions) => {
+        if (options?.signal?.aborted) {
+          throw syntheticError;
+        }
+        return createAssistantResultStream(
+          createAssistant(activeModel, [{ type: "text", text: "complete answer" }], "stop", 100),
+        );
+      },
+    );
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager: createAutoCompactionSettings(),
+      resourceLoader: createResourceLoader(handlers),
+    });
+    const onAgentEvent = vi.fn();
+    const subscription = subscribeEmbeddedAgentSession({
+      session,
+      runId: "run-rejected-cancellation",
+      onAgentEvent,
+    });
+
+    await session.prompt("continue");
+
+    const compactionEvents = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "compaction");
+    expect(compactionEvents).toHaveLength(2);
+    expect(compactionEvents.at(-1)).toEqual({
+      stream: "compaction",
+      data: {
+        phase: "end",
+        outcome: "aborted",
+        completed: false,
+        willRetry: false,
+      },
+    });
+    expect(subscription.getCompactionCount()).toBe(0);
+    expect(subscription.getLastCompactionTokensAfter()).toBeUndefined();
+    expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
     subscription.unsubscribe();
   });
 

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -177,6 +177,64 @@ describe("AgentSession compaction", () => {
     subscription.unsubscribe();
   });
 
+  it("projects a rejected manual cancellation as aborted without recording compaction", async () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "old answer" }]),
+      timestamp: 2,
+    });
+    const handlers = createCompactionHandlers();
+    const syntheticError = new Error("synthetic manual cancellation rejection");
+    const abortActiveCompaction = () => session.abortCompaction();
+    handlers.set("session_before_compact", [
+      async () => {
+        abortActiveCompaction();
+        throw syntheticError;
+      },
+    ]);
+    streamMocks.streamSimple.mockImplementation(
+      (_activeModel: Model, _context: Context, options?: SimpleStreamOptions) => {
+        if (options?.signal?.aborted) {
+          throw syntheticError;
+        }
+        return createAssistantResultStream(
+          createAssistant(testModel, [{ type: "text", text: "unexpected compaction" }]),
+        );
+      },
+    );
+    const { session } = await createTestSession({
+      sessionManager,
+      resourceLoader: createResourceLoader(handlers),
+    });
+    const onAgentEvent = vi.fn();
+    const subscription = subscribeEmbeddedAgentSession({
+      session,
+      runId: "run-rejected-manual-cancellation",
+      onAgentEvent,
+    });
+
+    await expect(session.compact()).rejects.toBe(syntheticError);
+
+    const compactionEvents = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "compaction");
+    expect(compactionEvents).toHaveLength(2);
+    expect(compactionEvents.at(-1)).toEqual({
+      stream: "compaction",
+      data: {
+        phase: "end",
+        outcome: "aborted",
+        completed: false,
+        willRetry: false,
+      },
+    });
+    expect(subscription.getCompactionCount()).toBe(0);
+    expect(subscription.getLastCompactionTokensAfter()).toBeUndefined();
+    expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+    subscription.unsubscribe();
+  });
+
   it("caps extension summaries before persistence and manual return", async () => {
     const sessionManager = SessionManager.inMemory();
     sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -66,7 +66,8 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
   ): Promise<CompactionResult> {
     this.disconnectFromAgent();
     await this.abort();
-    this.compactionAbortController = new AbortController();
+    const abortController = new AbortController();
+    this.compactionAbortController = abortController;
     this.emit({ type: "compaction_start", reason: "manual" });
 
     try {
@@ -78,11 +79,12 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
           mode: "manual",
           summaryOutputPolicy,
           settings,
-          signal: this.compactionAbortController.signal,
+          signal: abortController.signal,
         });
       } catch (error) {
         const message = compactionErrorMessage(error, "Compaction failed");
-        const aborted = error instanceof Error && error.name === "AbortError";
+        const aborted =
+          abortController.signal.aborted || (error instanceof Error && error.name === "AbortError");
         this.emit({
           type: "compaction_end",
           reason: "manual",
@@ -113,7 +115,9 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       });
       return outcome.result;
     } finally {
-      this.compactionAbortController = undefined;
+      if (this.compactionAbortController === abortController) {
+        this.compactionAbortController = undefined;
+      }
       this.reconnectToAgent();
     }
   }

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -1,6 +1,7 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
+import { capCompactionSummary } from "../../../packages/agent-core/src/harness/compaction/compaction.js";
 import { InvalidSummaryOutputError } from "../../../packages/agent-core/src/harness/types.js";
-import type { AssistantMessage, Model } from "../../llm/types.js";
+import type { AssistantMessage } from "../../llm/types.js";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
 import { sanitizeCompactionReplayMessages } from "../compaction-replay.js";
 import {
@@ -16,16 +17,20 @@ import { AgentSessionInspection } from "./agent-session-inspection.js";
 import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
 import { preflightManualSessionCompaction } from "./manual-compaction-preflight.js";
-import { getModelRegistryRuntime } from "./model-registry-runtime.js";
 import { getLatestCompactionEntry, type CompactionEntry } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 
 type CompactionReason = "manual" | "threshold" | "overflow";
 type SummaryOutputPolicy = "none" | "retry-invalid-once";
 type CompactionWorkOutcome =
-  | { status: "compacted"; result: CompactionResult }
+  | { status: "completed"; result: CompactionResult; tokensAfter: number }
   | { status: "aborted" }
-  | { status: "skipped" };
+  | { status: "skipped"; reason: string };
+
+function compactionErrorMessage(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.trim() ? message : fallback;
+}
 
 /** @internal */
 export const agentSessionAutomaticCompaction: unique symbol = Symbol.for(
@@ -66,39 +71,47 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
 
     try {
       const settings = this.settingsManager.getCompactionSettings();
-      const outcome = await this.runCompactionWork({
-        customInstructions,
-        mode: "manual",
-        summaryOutputPolicy,
-        settings,
-        signal: this.compactionAbortController.signal,
-      });
-      if (outcome.status !== "compacted") {
+      let outcome: CompactionWorkOutcome;
+      try {
+        outcome = await this.runCompactionWork({
+          customInstructions,
+          mode: "manual",
+          summaryOutputPolicy,
+          settings,
+          signal: this.compactionAbortController.signal,
+        });
+      } catch (error) {
+        const message = compactionErrorMessage(error, "Compaction failed");
+        const aborted = error instanceof Error && error.name === "AbortError";
+        this.emit({
+          type: "compaction_end",
+          reason: "manual",
+          outcome: aborted
+            ? { status: "aborted" }
+            : { status: "failed", reason: `Compaction failed: ${message}` },
+        });
+        throw error;
+      }
+      if (outcome.status === "skipped") {
+        this.emit({ type: "compaction_end", reason: "manual", outcome });
+        throw new Error(outcome.reason);
+      }
+      if (outcome.status === "aborted") {
+        this.emit({ type: "compaction_end", reason: "manual", outcome });
         throw new Error("Compaction cancelled");
       }
 
       this.emit({
         type: "compaction_end",
         reason: "manual",
-        result: outcome.result,
-        aborted: false,
-        willRetry: false,
+        outcome: {
+          status: "completed",
+          tokensBefore: outcome.result.tokensBefore,
+          tokensAfter: outcome.tokensAfter,
+          willRetry: false,
+        },
       });
       return outcome.result;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const aborted =
-        message === "Compaction cancelled" ||
-        (error instanceof Error && error.name === "AbortError");
-      this.emit({
-        type: "compaction_end",
-        reason: "manual",
-        result: undefined,
-        aborted,
-        willRetry: false,
-        errorMessage: aborted ? undefined : `Compaction failed: ${message}`,
-      });
-      throw error;
     } finally {
       this.compactionAbortController = undefined;
       this.reconnectToAgent();
@@ -120,28 +133,6 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     this.branchSummaryAbortController?.abort();
   }
 
-  private async getAutoCompactionRequestAuth(model: Model): Promise<
-    | {
-        apiKey?: string;
-        headers?: Record<string, string>;
-      }
-    | undefined
-  > {
-    if (
-      this.agent.streamFn !==
-      getModelRegistryRuntime(this.sessionModelRegistry).llmRuntime.streamSimple
-    ) {
-      return this.getCompactionRequestAuth(model);
-    }
-
-    const authResult = await this.sessionModelRegistry.getApiKeyAndHeaders(model);
-    if (!authResult.ok || !authResult.apiKey) {
-      return undefined;
-    }
-    const { apiKey, headers } = authResult;
-    return { apiKey, headers };
-  }
-
   private async runCompactionWork(options: {
     settings: ReturnType<SettingsManager["getCompactionSettings"]>;
     signal: AbortSignal;
@@ -154,15 +145,21 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       if (isManual) {
         throw new Error(formatNoModelSelectedMessage());
       }
-      return { status: "skipped" };
+      return { status: "skipped", reason: formatNoModelSelectedMessage() };
     }
     const model = this.model;
 
-    const auth = isManual
-      ? await this.getCompactionRequestAuth(model)
-      : await this.getAutoCompactionRequestAuth(model);
-    if (!auth) {
-      return { status: "skipped" };
+    let auth: Awaited<ReturnType<typeof this.getCompactionRequestAuth>>;
+    try {
+      auth = await this.getCompactionRequestAuth(model);
+    } catch (error) {
+      if (isManual) {
+        throw error;
+      }
+      return {
+        status: "skipped",
+        reason: compactionErrorMessage(error, "Compaction authentication failed"),
+      };
     }
 
     const pathEntries = this.sessionManager.getBranch();
@@ -177,7 +174,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       preparation = unwrapCoreResult(prepareCompaction(pathEntries, options.settings));
     }
     if (!preparation) {
-      return { status: "skipped" };
+      return { status: "skipped", reason: "Nothing to compact (session too small)" };
     }
 
     let compactionResult: CompactionResult | undefined;
@@ -240,6 +237,11 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       return { status: "aborted" };
     }
 
+    compactionResult = {
+      ...compactionResult,
+      summary: capCompactionSummary(compactionResult.summary),
+    };
+
     this.sessionManager.appendCompaction(
       compactionResult.summary,
       compactionResult.firstKeptEntryId,
@@ -265,7 +267,8 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       });
     }
 
-    return { status: "compacted", result: compactionResult };
+    const tokensAfter = estimateContextTokens(this.agent.state.messages).tokens;
+    return { status: "completed", result: compactionResult, tokensAfter };
   }
 
   /**
@@ -329,10 +332,10 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         this.emit({
           type: "compaction_end",
           reason: "overflow",
-          result: undefined,
-          aborted: false,
-          willRetry: false,
-          errorMessage: `Context overflow recovery failed after ${MAX_OVERFLOW_COMPACTION_ATTEMPTS} compact-and-retry attempts. Try reducing context or switching to a larger-context model.`,
+          outcome: {
+            status: "failed",
+            reason: `Context overflow recovery failed after ${MAX_OVERFLOW_COMPACTION_ATTEMPTS} compact-and-retry attempts. Try reducing context or switching to a larger-context model.`,
+          },
         });
         return false;
       }
@@ -392,31 +395,22 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         signal: this.autoCompactionAbortController.signal,
       });
       if (outcome.status === "skipped") {
-        this.emit({
-          type: "compaction_end",
-          reason,
-          result: undefined,
-          aborted: false,
-          willRetry: false,
-        });
+        this.emit({ type: "compaction_end", reason, outcome });
         return false;
       }
       if (outcome.status === "aborted") {
-        this.emit({
-          type: "compaction_end",
-          reason,
-          result: undefined,
-          aborted: true,
-          willRetry: false,
-        });
+        this.emit({ type: "compaction_end", reason, outcome });
         return false;
       }
       this.emit({
         type: "compaction_end",
         reason,
-        result: outcome.result,
-        aborted: false,
-        willRetry,
+        outcome: {
+          status: "completed",
+          tokensBefore: outcome.result.tokensBefore,
+          tokensAfter: outcome.tokensAfter,
+          willRetry,
+        },
       });
 
       if (willRetry) {
@@ -435,17 +429,17 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       // Continue once so queued messages are delivered.
       return this.agent.hasQueuedMessages();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "compaction failed";
+      const errorMessage = compactionErrorMessage(error, "compaction failed");
       this.emit({
         type: "compaction_end",
         reason,
-        result: undefined,
-        aborted: false,
-        willRetry: false,
-        errorMessage:
-          reason === "overflow"
-            ? `Context overflow recovery failed: ${errorMessage}`
-            : `Auto-compaction failed: ${errorMessage}`,
+        outcome: {
+          status: "failed",
+          reason:
+            reason === "overflow"
+              ? `Context overflow recovery failed: ${errorMessage}`
+              : `Auto-compaction failed: ${errorMessage}`,
+        },
       });
       return false;
     } finally {

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -385,14 +385,15 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     const settings = this.settingsManager.getCompactionSettings();
 
     this.emit({ type: "compaction_start", reason });
-    this.autoCompactionAbortController = new AbortController();
+    const abortController = new AbortController();
+    this.autoCompactionAbortController = abortController;
 
     try {
       const outcome = await this.runCompactionWork({
         mode: "auto",
         summaryOutputPolicy: "retry-invalid-once",
         settings,
-        signal: this.autoCompactionAbortController.signal,
+        signal: abortController.signal,
       });
       if (outcome.status === "skipped") {
         this.emit({ type: "compaction_end", reason, outcome });
@@ -429,6 +430,10 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       // Continue once so queued messages are delivered.
       return this.agent.hasQueuedMessages();
     } catch (error) {
+      if (abortController.signal.aborted) {
+        this.emit({ type: "compaction_end", reason, outcome: { status: "aborted" } });
+        return false;
+      }
       const errorMessage = compactionErrorMessage(error, "compaction failed");
       this.emit({
         type: "compaction_end",
@@ -443,7 +448,9 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       });
       return false;
     } finally {
-      this.autoCompactionAbortController = undefined;
+      if (this.autoCompactionAbortController === abortController) {
+        this.autoCompactionAbortController = undefined;
+      }
     }
   }
 

--- a/src/agents/sessions/agent-session-loop-correctness.test-support.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test-support.ts
@@ -148,7 +148,7 @@ export async function createTestSession(
       })
     : await createAgentSession(sessionOptions);
   sessions.push(result.session);
-  return { ...result, settingsManager, sessionManager };
+  return { ...result, modelRegistry, settingsManager, sessionManager };
 }
 
 export function appendHistory(sessionManager: SessionManager, assistant: AssistantMessage): void {

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -40,6 +40,12 @@ import { getSteeringMessageIdentity } from "./steering-message-identity.js";
 
 registerAgentSessionLoopTestLifecycle();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const completedCompactionEvent = (reason: "threshold" | "overflow", willRetry: boolean) =>
+  expect.objectContaining({
+    type: "compaction_end",
+    reason,
+    outcome: expect.objectContaining({ status: "completed", willRetry }),
+  });
 
 describe("AgentSession loop correctness", () => {
   it("publishes a queued user message only after its transcript entry is committed", async () => {
@@ -454,9 +460,7 @@ describe("AgentSession loop correctness", () => {
         content: [{ type: "text", text: "complete answer" }],
       }),
     );
-    expect(compactionEvents).toContainEqual(
-      expect.objectContaining({ type: "compaction_end", reason: "threshold", willRetry: false }),
-    );
+    expect(compactionEvents).toContainEqual(completedCompactionEvent("threshold", false));
   });
 
   it("surfaces threshold safeguard rejection without appending compaction state", async () => {
@@ -486,8 +490,7 @@ describe("AgentSession loop correctness", () => {
       expect.objectContaining({
         type: "compaction_end",
         reason: "threshold",
-        aborted: true,
-        willRetry: false,
+        outcome: { status: "aborted" },
       }),
     );
     expect(sessionManager.getBranch().some((entry) => entry.type === "compaction")).toBe(false);
@@ -612,9 +615,7 @@ describe("AgentSession loop correctness", () => {
     await session.prompt("finish now");
 
     expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
-    expect(compactionEvents).toContainEqual(
-      expect.objectContaining({ type: "compaction_end", reason: "threshold", willRetry: false }),
-    );
+    expect(compactionEvents).toContainEqual(completedCompactionEvent("threshold", false));
   });
 
   it("compacts and retries a high-usage length-truncated response", async () => {
@@ -642,9 +643,7 @@ describe("AgentSession loop correctness", () => {
     await session.prompt("long request");
 
     expect(streamMocks.streamSimple).toHaveBeenCalledTimes(2);
-    expect(compactionEvents).toContainEqual(
-      expect.objectContaining({ type: "compaction_end", reason: "overflow", willRetry: true }),
-    );
+    expect(compactionEvents).toContainEqual(completedCompactionEvent("overflow", true));
     expect(session.getLastAssistantText()).toBe("complete retry");
   });
 
@@ -686,9 +685,7 @@ describe("AgentSession loop correctness", () => {
     await session.prompt("long request");
 
     expect({ agentRequests, summaryRequests }).toEqual({ agentRequests: 2, summaryRequests: 2 });
-    expect(compactionEvents).toContainEqual(
-      expect.objectContaining({ type: "compaction_end", reason: "overflow", willRetry: true }),
-    );
+    expect(compactionEvents).toContainEqual(completedCompactionEvent("overflow", true));
     const compactionEntry = sessionManager.getBranch().find((entry) => entry.type === "compaction");
     expect(compactionEntry).toMatchObject({ type: "compaction", fromHook: false });
     expect(compactionEntry?.summary).toContain("recovered default summary");
@@ -773,9 +770,11 @@ describe("AgentSession loop correctness", () => {
       expect.objectContaining({
         type: "compaction_end",
         reason: "overflow",
-        willRetry: false,
-        errorMessage:
-          "Context overflow recovery failed: Turn prefix summarization failed: model returned no summary text",
+        outcome: {
+          status: "failed",
+          reason:
+            "Context overflow recovery failed: Turn prefix summarization failed: model returned no summary text",
+        },
       }),
     );
     expect(sessionManager.getBranch().some((entry) => entry.type === "compaction")).toBe(false);
@@ -831,10 +830,8 @@ describe("AgentSession loop correctness", () => {
       expect(compactionEvents[0]).toMatchObject({
         type: "compaction_end",
         reason: "overflow",
-        aborted: true,
-        willRetry: false,
+        outcome: { status: "aborted" },
       });
-      expect(compactionEvents[0]?.errorMessage).toBeUndefined();
       expect(created.sessionManager.getBranch().some((entry) => entry.type === "compaction")).toBe(
         false,
       );
@@ -874,9 +871,11 @@ describe("AgentSession loop correctness", () => {
       expect.objectContaining({
         type: "compaction_end",
         reason: "overflow",
-        willRetry: false,
-        errorMessage:
-          "Context overflow recovery failed: Turn prefix summarization failed: provider unavailable",
+        outcome: {
+          status: "failed",
+          reason:
+            "Context overflow recovery failed: Turn prefix summarization failed: provider unavailable",
+        },
       }),
     );
     expect(sessionManager.getBranch().some((entry) => entry.type === "compaction")).toBe(false);
@@ -935,9 +934,7 @@ describe("AgentSession loop correctness", () => {
     await session.prompt("long request");
 
     expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
-    expect(compactionEvents).toContainEqual(
-      expect.objectContaining({ type: "compaction_end", reason: "threshold", willRetry: false }),
-    );
+    expect(compactionEvents).toContainEqual(completedCompactionEvent("threshold", false));
   });
 
   it("delivers a pending prompt immediately after pre-prompt compaction", async () => {

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -4,7 +4,6 @@ import type {
   AgentEvent,
   AgentMessage,
   AgentTool,
-  CompactionResult,
   ThinkingLevel,
 } from "../runtime/index.js";
 import type {
@@ -23,6 +22,18 @@ import type { ResourceLoader } from "./resource-loader.js";
 import type { SessionManager } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 
+type AgentSessionCompactionOutcome =
+  | { status: "completed"; tokensBefore: number; tokensAfter: number; willRetry: boolean }
+  | { status: "skipped"; reason: string }
+  | { status: "failed"; reason: string }
+  | { status: "aborted" };
+
+type AgentSessionCompactionEndEvent = {
+  type: "compaction_end";
+  reason: "manual" | "threshold" | "overflow";
+  outcome: AgentSessionCompactionOutcome;
+};
+
 export type AgentSessionEvent =
   | Exclude<AgentEvent, { type: "agent_end" }>
   | {
@@ -35,14 +46,7 @@ export type AgentSessionEvent =
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | { type: "session_info_changed"; name: string | undefined }
   | { type: "thinking_level_changed"; level: ThinkingLevel }
-  | {
-      type: "compaction_end";
-      reason: "manual" | "threshold" | "overflow";
-      result: CompactionResult | undefined;
-      aborted: boolean;
-      willRetry: boolean;
-      errorMessage?: string;
-    }
+  | AgentSessionCompactionEndEvent
   | {
       type: "auto_retry_start";
       attempt: number;

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -243,7 +243,7 @@ type EmbeddedAgentParams = {
   isFinalFallbackAttempt?: boolean;
   onAgentEvent?: (evt: {
     stream: string;
-    data: { isError?: boolean; name?: string; phase?: string };
+    data: { completed?: boolean; isError?: boolean; name?: string; phase?: string };
   }) => void;
 };
 
@@ -305,6 +305,43 @@ function requireCompactEmbeddedAgentSessionCall(index = 0) {
 
 describe("runMemoryFlushIfNeeded", () => {
   let rootDir = "";
+
+  async function runProjectedCompaction(completed: boolean, followupRun = createTestFollowupRun()) {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      totalTokensFresh: true,
+      totalTokensVersion: 1,
+      compactionCount: 1,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+    runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onAgentEvent?.({ stream: "compaction", data: { phase: "end", completed } });
+      return {
+        payloads: [],
+        meta: { agentMeta: { sessionId: "session-rotated" } },
+      };
+    });
+    const result = await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun,
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      modelContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+    return { followupRun, result, sessionKey, storePath };
+  }
 
   beforeEach(async () => {
     rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-unit-"));
@@ -433,57 +470,11 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("runs exactly one auto-reply memory flush turn, rotates, and persists metadata", async () => {
-    const storePath = path.join(rootDir, "sessions.json");
-    const sessionKey = "main";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
-    const sessionStore = { [sessionKey]: sessionEntry };
-    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
-
-    runEmbeddedAgentMock.mockImplementationOnce(
-      async (params: {
-        onAgentEvent?: (evt: { stream: string; data: { phase: string } }) => void;
-      }) => {
-        params.onAgentEvent?.({ stream: "compaction", data: { phase: "end" } });
-        return {
-          payloads: [],
-          meta: { agentMeta: { sessionId: "session-rotated" } },
-        };
-      },
-    );
-
     const followupRun = createTestFollowupRun({
       authProfileId: "anthropic:work",
       authProfileIdSource: "user",
     });
-    const result = await runMemoryFlushIfNeeded({
-      cfg: {
-        agents: {
-          defaults: {
-            compaction: {
-              memoryFlush: {},
-            },
-          },
-        },
-      },
-      followupRun,
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore,
-      sessionKey,
-      storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
-    });
+    const { result, sessionKey, storePath } = await runProjectedCompaction(true, followupRun);
 
     expect(result.outcome).toBe("completed");
     expect(result.sessionEntry?.sessionId).toBe("session-rotated");
@@ -533,6 +524,16 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(persisted.sessionId).toBe("session-rotated");
     expect(persisted.compactionCount).toBe(2);
     expect(persisted.memoryFlush).toEqual({ kind: "succeeded", compactionCount: 1 });
+  });
+
+  it("does not rotate or increment for an incomplete projected compaction end", async () => {
+    const { followupRun, result, storePath } = await runProjectedCompaction(false);
+
+    expect(result.sessionEntry?.sessionId).toBe("session");
+    expect(followupRun.run.sessionId).toBe("session");
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
+    expect(loadMainSessionEntry(storePath).compactionCount).toBe(1);
   });
 
   it("records the least-trusted provenance across a multi-write flush", async () => {
@@ -853,9 +854,15 @@ describe("runMemoryFlushIfNeeded", () => {
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
     runEmbeddedAgentMock.mockImplementationOnce(
       async (params: {
-        onAgentEvent?: (event: { stream: string; data: { phase: string } }) => void;
+        onAgentEvent?: (event: {
+          stream: string;
+          data: { phase: string; completed?: boolean };
+        }) => void;
       }) => {
-        params.onAgentEvent?.({ stream: "compaction", data: { phase: "end" } });
+        params.onAgentEvent?.({
+          stream: "compaction",
+          data: { phase: "end", completed: true },
+        });
         return {
           payloads: [
             { text: "normal silent maintenance reply" },

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1507,7 +1507,7 @@ export async function runMemoryFlushIfNeeded(params: {
             }
             if (evt.stream === "compaction") {
               const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-              if (phase === "end") {
+              if (phase === "end" && evt.data.completed === true) {
                 memoryCompactionCompleted = true;
               }
             }

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -114,15 +114,17 @@ describe("compaction hook wiring", () => {
   function runCompactionEnd(
     ctx: ReturnType<typeof createCompactionEndCtx> | Record<string, unknown>,
     event: {
-      willRetry: boolean;
-      result?: { summary: string; tokensAfter?: number };
-      aborted?: boolean;
+      outcome:
+        | { status: "completed"; tokensBefore: number; tokensAfter: number; willRetry: boolean }
+        | { status: "skipped" | "failed"; reason: string }
+        | { status: "aborted" };
     },
   ) {
     handleCompactionEnd(
       ctx as never,
       {
         type: "compaction_end",
+        reason: "threshold",
         ...event,
       } as never,
     );
@@ -179,7 +181,9 @@ describe("compaction hook wiring", () => {
       compactionCount: 1,
     });
 
-    runCompactionEnd(ctx, { willRetry: false, result: { summary: "compacted" } });
+    runCompactionEnd(ctx, {
+      outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: false },
+    });
 
     expect(hookMocks.runner.runAfterCompaction).toHaveBeenCalledTimes(1);
     expectCompactionEvent({
@@ -192,12 +196,17 @@ describe("compaction hook wiring", () => {
       expectedSessionKey: "agent:main:web-xyz",
     });
     expect(ctx.incrementCompactionCount).toHaveBeenCalledTimes(1);
-    expect(ctx.noteCompactionTokensAfter).toHaveBeenCalledWith(undefined);
+    expect(ctx.noteCompactionTokensAfter).toHaveBeenCalledWith(50);
     expect(ctx.maybeResolveCompactionWait).toHaveBeenCalledTimes(1);
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r2",
       stream: "compaction",
-      data: { phase: "end", willRetry: false, completed: true },
+      data: {
+        phase: "end",
+        outcome: "completed",
+        willRetry: false,
+        completed: true,
+      },
     });
   });
 
@@ -210,7 +219,9 @@ describe("compaction hook wiring", () => {
       withRetryHooks: true,
     });
 
-    runCompactionEnd(ctx, { willRetry: true, result: { summary: "compacted" } });
+    runCompactionEnd(ctx, {
+      outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: true },
+    });
 
     expect(hookMocks.runner.runAfterCompaction).not.toHaveBeenCalled();
     // Counter is incremented even with willRetry — compaction succeeded (#38905)
@@ -221,17 +232,23 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r3",
       stream: "compaction",
-      data: { phase: "end", willRetry: true, completed: true },
+      data: {
+        phase: "end",
+        outcome: "completed",
+        willRetry: true,
+        completed: true,
+      },
     });
   });
 
   it.each([
-    ["does not increment counter when compaction was aborted", { willRetry: false, aborted: true }],
+    ["does not increment counter when compaction was aborted", { outcome: { status: "aborted" } }],
     [
-      "does not increment counter when compaction has result but was aborted",
-      { willRetry: false, result: { summary: "compacted" }, aborted: true },
+      "does not increment counter when compaction was skipped",
+      {
+        outcome: { status: "skipped", reason: "Nothing to compact (session too small)" },
+      },
     ],
-    ["does not increment counter when result is undefined", { willRetry: false }],
   ] as const)("%s", (_name, event) => {
     const ctx = createCompactionEndCtx({ runId: "r3c" });
     runCompactionEnd(ctx, event);
@@ -264,7 +281,9 @@ describe("compaction hook wiring", () => {
       getLastCompactionTokensAfter: vi.fn(() => undefined),
     };
 
-    runCompactionEnd(ctx, { willRetry: false, result: { summary: "compacted" } });
+    runCompactionEnd(ctx, {
+      outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: false },
+    });
 
     const assistantOne = messages[1] as { usage?: unknown };
     const assistantTwo = messages[2] as { usage?: unknown };
@@ -287,10 +306,14 @@ describe("compaction hook wiring", () => {
       log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
       noteCompactionRetry: vi.fn(),
       resetForCompactionRetry: vi.fn(),
+      incrementCompactionCount: vi.fn(),
       getCompactionCount: () => 0,
+      noteCompactionTokensAfter: vi.fn(),
     };
 
-    runCompactionEnd(ctx, { willRetry: true });
+    runCompactionEnd(ctx, {
+      outcome: { status: "completed", tokensBefore: 100, tokensAfter: 50, willRetry: true },
+    });
 
     const assistant = messages[0] as { usage?: unknown };
     expect(assistant.usage).toEqual({ totalTokens: 184_297, input: 130_000, output: 2_000 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where automatic session compaction could fail without any recorded reason, causing sessions to keep growing until hard context overflow. Expired or missing model credentials were also collapsed into indistinguishable skips, and successful session-loop compaction never supplied the post-compaction token snapshot that session persistence expects.

## Why This Change Was Made

Replace the parallel optional compaction-end fields with one closed completed/skipped/failed/aborted outcome owned by the session producer. Completed outcomes carry tokens before and after; skipped and failed outcomes carry actionable reasons; retry state exists only on completed outcomes. The embedded subscriber forwards the complete event, records the token snapshot, and projects failure reasons without changing the existing public completed/willRetry fields, so no Gateway protocol version or coordinated UI migration is required.

Automatic and manual compaction now capture the exact operation's abort controller, use that controller's signal to classify rejected work as aborted, and clear the shared controller only when it still owns that exact operation. This preserves cancellation through provider or extension rejection instead of misreporting it as failure.

Compaction summaries are now capped at 16,000 UTF-16 code units at the persistence boundary, using the same helper as the safeguard path. This is an intentional model-context bound: the summary is replayed on every subsequent request, so provider token limits alone are not a durable size guarantee. Memory-flush rotation now also requires completed === true instead of treating every compaction end as success.

Provenance: the reasonless automatic-auth/result shape was carried forward by #107948; the impossible tokensAfter read was introduced by f3e8a8a3195; the max-attempt guidance added in #123484 was produced but never forwarded.

## User Impact

Operators now get a recorded reason when automatic compaction fails or cannot authenticate, cancelled automatic or manual compactions remain visible as benign aborts even when work rejects, overflow exhaustion is observable, and successful compaction immediately refreshes persisted context totals. Oversized summaries cannot silently consume unbounded context on every later turn.

## Evidence

Final local proof on head `883a9981d9baa611622a459163343665d2c37dc0`:

- Rejected manual-cancellation regression: before the producer fix, `src/agents/sessions/agent-session-compaction.test.ts` failed because the observable compaction end was `outcome: "failed"` with `reason: "Compaction failed: synthetic manual cancellation rejection"`; after the fix the original promise still rejects with the synthetic error while the observable end is a reasonless `outcome: "aborted"`, `completed: false`, `willRetry: false`, with no compaction entry/count/token snapshot.
- Rejected automatic-cancellation coverage remains reasonless `outcome: "aborted"`, `completed: false`, `willRetry: false`, with no compaction entry/count/token snapshot.
- `node scripts/run-vitest.mjs src/agents/sessions/agent-session-compaction.test.ts` — 1 file, 11 tests passed.
- `node scripts/run-vitest.mjs src/agents/sessions/agent-session-loop-correctness.test.ts -t 'preserves cancellation'` — 2 tests passed; 24 unrelated tests skipped by the filter.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.compaction.test.ts` — 1 file, 13 tests passed.
- `node_modules/.bin/oxfmt src/agents/sessions/agent-session-compaction.ts src/agents/sessions/agent-session-compaction.test.ts` — clean.
- `git diff --check` — clean.
- `node scripts/check-changed.mjs --dry-run -- src/agents/sessions/agent-session-compaction.ts src/agents/sessions/agent-session-compaction.test.ts` — selected only `core` and `coreTests`.
- `node scripts/check-changed.mjs -- src/agents/sessions/agent-session-compaction.ts src/agents/sessions/agent-session-compaction.test.ts` — green, including core/core-test typecheck, lint, formatting, architecture, database, schema-version, dead-export, and import-cycle guards.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` — clean one-pass review, TruffleHog clean, no accepted/actionable findings, overall correctness 0.99.
- Exact-head `pull_request` CI — [run 32080848415](https://github.com/openclaw/openclaw/actions/runs/32080848415) green; [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/32080848415/job/95544858213) green for `883a9981d9baa611622a459163343665d2c37dc0`.
- No separate Testbox lease was launched; the focused owner-boundary proof, exact local changed gate, and exact-head hosted CI are the current check path.

Changed LOC: production +204/-177 (net +27); tests/support +493/-179 (net +314); tooling +0/-1. The manual-abort follow-up itself is production +8/-4 (net +4) and test +58/-0. The tooling change is the required shrink-only deletion from `config/assertion-safety-baseline.txt`. There are no unrelated paths, changelog, release/version, generated API/protocol, lockfile, dependency, or other config changes.

Pre-fix evidence covered the missing automatic-auth reason, missing `tokensAfter`, an uncapped 30K summary, a dropped max-attempt reason, false memory-flush rotation on incomplete compaction, unclassified auth guidance, and rejected automatic and manual cancellation being projected as failure.

Live-proof gap: live-provider injection was not used because deterministically forcing provider 5xx, expired credentials, repeated hard overflow, rejected cancellation, and an oversized summary in one real account would require intentionally invalid credentials and costly context growth; owner-boundary regressions exercise those exact real AgentSession/subscriber/store paths.

AI-assisted: yes. The maintainer reviewed the complete diff and understands the ownership changes.
