### PR TITLE
fix(cli): report plugin policy refusals as expected conditions

### DIFF
--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -1,6 +1,6 @@
 // Failure output tests cover CLI error formatting and failure summaries.
 import { describe, expect, it } from "vitest";
-import { CliParseError, formatCliFailureLines, formatCliJsonFailure } from "./failure-output.js";
+import { ExpectedCliError, formatCliFailureLines, formatCliJsonFailure } from "./failure-output.js";
 
 describe("formatCliJsonFailure", () => {
   it("uses the canonical typed envelope and redacts the message", () => {
@@ -34,7 +34,7 @@ describe("formatCliJsonFailure", () => {
     { label: "debug output", env: { OPENCLAW_DEBUG: "1" } },
   ])("keeps the full parse guidance unchanged in $label", ({ env }) => {
     const error = Object.assign(
-      new CliParseError({
+      new ExpectedCliError({
         message: 'OpenClaw sessions has no command "lst".',
         humanOutput:
           '\u001B[31mOpenClaw sessions has no command "lst".\u001B[39m\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: \u001B]8;;https://docs.openclaw.ai/cli\u0007docs.openclaw.ai/cli\u001B]8;;\u0007\n',
@@ -55,19 +55,35 @@ describe("formatCliJsonFailure", () => {
     });
     expect(payload.error.message).not.toContain("internal parse cause");
   });
+
+  it("keeps plugin policy messages in the canonical JSON envelope", () => {
+    const message =
+      'The `openclaw workboard` command is provided by the "workboard" plugin, but that bundled plugin is disabled by default. Run `openclaw plugins enable workboard` to enable that CLI surface.';
+
+    const error = new ExpectedCliError({
+      message,
+      humanOutput: message,
+      machineOutput: message,
+    });
+
+    expect(formatCliJsonFailure(error)).toEqual({
+      ok: false,
+      error: { type: "cli_error", message },
+    });
+  });
 });
 
 describe("formatCliFailureLines", () => {
   it.each([
     { label: "default output", env: {} },
     { label: "debug output", env: { OPENCLAW_DEBUG: "1" } },
-  ])("emits parse guidance only when not already written in $label", ({ env }) => {
-    const pending = new CliParseError({
+  ])("emits expected guidance only when not already written in $label", ({ env }) => {
+    const pending = new ExpectedCliError({
       message: "bad input",
       humanOutput: "\u001B[31mfirst\u001B[39m\nsecond\n",
       machineOutput: "first\nsecond\n",
     });
-    const written = new CliParseError({
+    const written = new ExpectedCliError({
       message: "bad input",
       humanOutput: "\u001B[31mfirst\u001B[39m\nsecond\n",
       humanOutputWritten: true,

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -21,7 +21,7 @@ export type CliJsonFailure = {
   };
 };
 
-export class CliParseError extends Error {
+export class ExpectedCliError extends Error {
   readonly humanOutput: string;
   readonly humanOutputWritten: boolean;
   readonly machineOutput: string;
@@ -33,11 +33,15 @@ export class CliParseError extends Error {
     machineOutput: string;
   }) {
     super(params.message);
-    this.name = "CliParseError";
+    this.name = "ExpectedCliError";
     this.humanOutput = params.humanOutput;
     this.humanOutputWritten = params.humanOutputWritten ?? false;
     this.machineOutput = params.machineOutput;
   }
+}
+
+export function isExpectedCliError(error: unknown): error is ExpectedCliError {
+  return error instanceof ExpectedCliError;
 }
 
 /** Canonical machine-readable failure envelope for CLI-owned errors. */
@@ -45,10 +49,9 @@ export function formatCliJsonFailure(
   error: unknown,
   options: CliFailureDebugOptions = {},
 ): CliJsonFailure {
-  const message =
-    error instanceof CliParseError
-      ? formatErrorMessage(error.machineOutput.trimEnd())
-      : formatCliOperatorError(error, options);
+  const message = isExpectedCliError(error)
+    ? formatErrorMessage(error.machineOutput.trimEnd())
+    : formatCliOperatorError(error, options);
   return {
     ok: false,
     error: {
@@ -97,7 +100,7 @@ function pushPrefixed(out: string[], value: string): void {
 }
 
 export function formatCliFailureLines(options: FormatCliFailureOptions): string[] {
-  if (options.error instanceof CliParseError) {
+  if (isExpectedCliError(options.error)) {
     return options.error.humanOutputWritten ? [] : options.error.humanOutput.trimEnd().split("\n");
   }
 

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -4,7 +4,7 @@ import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { getCommandPathWithRootOptions } from "../argv.js";
 import { formatCliCommand } from "../command-format.js";
-import { CliParseError } from "../failure-output.js";
+import { ExpectedCliError } from "../failure-output.js";
 import { formatCliCommandSuggestions } from "./command-suggestions.js";
 
 type FormatCliParseErrorOptions = {
@@ -80,14 +80,14 @@ export function createCliParseError(
   raw: string,
   options: FormatCliParseErrorOptions = {},
   errorOptions: { humanOutputWritten?: boolean } = {},
-): CliParseError {
+): ExpectedCliError {
   const message = stripCommanderErrorPrefix(raw);
   const unknownCommand = message.match(/^unknown command ['"`](.+?)['"`]/i);
   if (unknownCommand) {
     const command = unknownCommand[1] ?? "";
     const commandPath = options.commandPath ?? [];
     const humanOutput = formatCliUnknownCommandOutput(command, options);
-    return new CliParseError({
+    return new ExpectedCliError({
       message: formatUnknownCommandMessage(command, commandPath),
       humanOutput,
       humanOutputWritten: errorOptions.humanOutputWritten,
@@ -95,7 +95,7 @@ export function createCliParseError(
     });
   }
   const humanOutput = formatCliParseErrorOutput(raw, options);
-  return new CliParseError({
+  return new ExpectedCliError({
     message,
     humanOutput,
     humanOutputWritten: errorOptions.humanOutputWritten,
@@ -106,10 +106,10 @@ export function createCliParseError(
 export function createCliUnknownCommandError(
   command: string,
   options: FormatCliParseErrorOptions = {},
-): CliParseError {
+): ExpectedCliError {
   const commandPath = options.commandPath ?? [];
   const humanOutput = formatCliUnknownCommandOutput(command, options);
-  return new CliParseError({
+  return new ExpectedCliError({
     message: formatUnknownCommandMessage(command, commandPath),
     humanOutput,
     machineOutput: formatCliMachineOutput(humanOutput),

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -12,7 +12,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
-import { CliParseError } from "./failure-output.js";
+import { ExpectedCliError } from "./failure-output.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 import { registerSignalExitBarrier } from "./signal-exit-barrier.js";
@@ -2935,8 +2935,8 @@ describe("runCli exit behavior", () => {
   it("suggests close known commands for unowned command roots before proxy startup", async () => {
     const error = await runCli(["node", "openclaw", "upate"]).catch((cause: unknown) => cause);
 
-    expect(error).toBeInstanceOf(CliParseError);
-    expect((error as CliParseError).humanOutput).toContain(
+    expect(error).toBeInstanceOf(ExpectedCliError);
+    expect((error as ExpectedCliError).humanOutput).toContain(
       "Did you mean this?\n  openclaw update\n",
     );
 
@@ -2982,28 +2982,109 @@ describe("runCli exit behavior", () => {
     expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
   });
 
-  it("keeps suggestions out of plugin-policy diagnostics", async () => {
-    resolveManifestCommandAliasOwnerMock.mockReturnValueOnce({
-      pluginId: "codex",
-      kind: "runtime-slash",
-      cliCommand: "plugins",
+  it.each([
+    {
+      label: "plugins.allow exclusion",
+      command: "workboard",
+      config: { plugins: { allow: ["browser"] } },
+      commandAlias: { pluginId: "workboard" },
+      expectedText: '`plugins.allow` excludes "workboard"',
+    },
+    {
+      label: "parent plugin allowlist guidance",
+      command: "voicecall",
+      config: { plugins: { allow: ["voicecall"] } },
+      commandAlias: { pluginId: "voice-call" },
+      expectedText: 'Add "voice-call" to `plugins.allow` instead of "voicecall"',
+    },
+    {
+      label: "explicit plugin disablement",
+      command: "browser",
+      config: { plugins: { entries: { browser: { enabled: false } } } },
+      commandAlias: { pluginId: "browser", enabledByDefault: true },
+      expectedText: "plugins.entries.browser.enabled=false",
+    },
+    {
+      label: "runtime slash command",
+      command: "dreaming",
+      config: {},
+      commandAlias: {
+        pluginId: "memory-core",
+        kind: "runtime-slash",
+        cliCommand: "memory",
+      },
+      expectedText: "runtime slash command (/dreaming)",
+    },
+    {
+      label: "loaded agent tool",
+      command: "lcm_recent",
+      config: {},
+      toolOwner: {
+        toolName: "lcm_recent",
+        pluginId: "lossless-claw",
+        availability: "loaded",
+      },
+      expectedText: "is an agent tool available",
+    },
+    {
+      label: "manifest-only agent tool",
+      command: "feishu_chat",
+      config: {},
+      toolOwner: {
+        toolName: "feishu_chat",
+        pluginId: "feishu",
+        availability: "manifest-only",
+      },
+      expectedText: "may be provided",
+    },
+  ])(
+    "reports $label as an expected condition before proxy startup",
+    async ({ command, config, commandAlias, toolOwner, expectedText }) => {
+      loadConfigMock.mockReturnValue(config);
+      resolveManifestCommandAliasOwnerMock.mockReturnValue(commandAlias);
+      resolveManifestToolOwnerMock.mockReturnValue(toolOwner);
+
+      const error = await runCli(["node", "openclaw", command]).catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(ExpectedCliError);
+      expect((error as ExpectedCliError).message).toContain(expectedText);
+      expect((error as ExpectedCliError).humanOutput).toBe((error as Error).message);
+      expect((error as ExpectedCliError).machineOutput).toBe((error as Error).message);
+      expect((error as Error).message).not.toContain("Did you mean this?");
+      expect(startProxyMock).not.toHaveBeenCalled();
+      expect(tryRouteCliMock).not.toHaveBeenCalled();
+      expect(buildProgramMock).not.toHaveBeenCalled();
+      expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports disabled-by-default plugin commands as expected after lazy registration", async () => {
+    const program = { commands: [], parseAsync: vi.fn() };
+    buildProgramMock.mockReturnValueOnce(program);
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    resolvePluginCliRootOwnerIdsMock.mockReturnValue(["workboard"]);
+    resolveManifestCommandAliasOwnerMock.mockReturnValue({
+      pluginId: "workboard",
+      enabledByDefault: false,
     });
 
-    let error: unknown;
-    try {
-      await runCli(["node", "openclaw", "codex"]);
-    } catch (caught) {
-      error = caught;
-    }
+    const error = await runCli(["node", "openclaw", "workboard", "list"]).catch(
+      (cause: unknown) => cause,
+    );
 
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("runtime slash command");
-    expect((error as Error).message).toContain("/codex");
-    expect((error as Error).message).not.toContain("Did you mean this?");
-    expect(startProxyMock).not.toHaveBeenCalled();
-    expect(tryRouteCliMock).not.toHaveBeenCalled();
-    expect(buildProgramMock).not.toHaveBeenCalled();
-    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+    expect(error).toBeInstanceOf(ExpectedCliError);
+    expect((error as ExpectedCliError).message).toContain(
+      'the "workboard" plugin, but that bundled plugin is disabled by default',
+    );
+    expect((error as ExpectedCliError).humanOutput).toBe((error as Error).message);
+    expect((error as ExpectedCliError).machineOutput).toBe((error as Error).message);
+    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
+      program,
+      undefined,
+      undefined,
+      { mode: "lazy", primary: "workboard", skipPluginValidation: false },
+    );
+    expect(program.parseAsync).not.toHaveBeenCalled();
   });
 
   it("rejects unowned command roots even when --help is appended (regression for #81077)", async () => {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -348,7 +348,9 @@ describe("resolveMissingPluginCommandMessage", () => {
         },
         { registry: browserCommandAliasRegistry },
       ),
-    ).toContain('`plugins.allow` excludes "browser"');
+    ).toBe(
+      'The `openclaw browser` command is unavailable because `plugins.allow` excludes "browser". Add "browser" to `plugins.allow` if you want that bundled plugin CLI surface.',
+    );
   });
 
   it("explains explicit bundled plugin disablement", () => {
@@ -362,7 +364,9 @@ describe("resolveMissingPluginCommandMessage", () => {
           },
         },
       }),
-    ).toContain("plugins.entries.browser.enabled=false");
+    ).toBe(
+      "The `openclaw browser` command is unavailable because `plugins.entries.browser.enabled=false`. Re-enable that entry if you want the bundled plugin CLI surface.",
+    );
   });
 
   it("returns null when the bundled plugin command is already allowed", () => {
@@ -394,10 +398,9 @@ describe("resolveMissingPluginCommandMessage", () => {
         registry: memoryCoreCommandAliasRegistry,
       },
     );
-    expect(message).toContain("runtime slash command");
-    expect(message).toContain("/dreaming");
-    expect(message).toContain("memory-core");
-    expect(message).toContain("openclaw memory");
+    expect(message).toBe(
+      '"dreaming" is a runtime slash command (/dreaming), not a CLI command. It is provided by the "memory-core" plugin. Use `openclaw memory` for related CLI operations, or `/dreaming` in a chat session.',
+    );
   });
 
   it("returns the runtime command message even when plugins.allow is set", () => {
@@ -428,9 +431,9 @@ describe("resolveMissingPluginCommandMessage", () => {
         registry: memoryCoreCommandAliasRegistry,
       },
     );
-    expect(message).toContain('"dreaming" is not a plugin');
-    expect(message).toContain('"memory-core"');
-    expect(message).toContain("plugins.allow");
+    expect(message).toBe(
+      '"dreaming" is not a plugin; it is a command provided by the "memory-core" plugin. Add "memory-core" to `plugins.allow` instead of "dreaming".',
+    );
   });
 
   it("explains disabled-by-default parent plugins for CLI command aliases", () => {
@@ -461,10 +464,9 @@ describe("resolveMissingPluginCommandMessage", () => {
       { registry: workboardCommandAliasRegistry },
     );
 
-    expect(message).toContain('"workboard" plugin');
-    expect(message).toContain("disabled by default");
-    expect(message).toContain("openclaw plugins enable workboard");
-    expect(message).not.toContain("runtime slash command");
+    expect(message).toBe(
+      'The `openclaw workboard` command is provided by the "workboard" plugin, but that bundled plugin is disabled by default. Run `openclaw plugins enable workboard` to enable that CLI surface.',
+    );
   });
 
   it("returns null for CLI command aliases when disabled-by-default parent plugins are enabled", () => {
@@ -554,10 +556,9 @@ describe("resolveMissingPluginCommandMessage", () => {
     if (message === null) {
       throw new Error("expected missing plugin command message");
     }
-    expect(message).toContain('"lcm_recent"');
-    expect(message).toContain('"lossless-claw"');
-    expect(message).toContain("agent tool");
-    expect(message).not.toContain("plugins.allow");
+    expect(message).toBe(
+      '"lcm_recent" is an agent tool available from the "lossless-claw" plugin, not a CLI subcommand. Use it from an agent turn (model tool-use), not the CLI. Run `openclaw --help` to see available CLI subcommands.',
+    );
   });
 
   it("matches agent tool names case-insensitively", () => {
@@ -653,8 +654,8 @@ describe("resolveMissingPluginCommandMessage", () => {
     if (message === null) {
       throw new Error("expected missing plugin command message");
     }
-    expect(message).toContain("may be provided by");
-    expect(message).toContain('"feishu"');
-    expect(message).not.toContain("registered by");
+    expect(message).toBe(
+      '"feishu_chat" may be provided by the "feishu" plugin as an agent tool, not a CLI subcommand. Run `openclaw --help` to see available CLI subcommands.',
+    );
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1009,7 +1009,7 @@ async function resolveUnownedCliPrimaryError(params: {
     resolveCliCommandSurfaceOwner: () => cliCommandSurfaceOwner,
   });
   if (pluginPolicyMessage) {
-    return new Error(pluginPolicyMessage);
+    return await createExpectedPluginPolicyError(pluginPolicyMessage);
   }
   const sanitizedPrimary = sanitizeTerminalText(params.primary);
   const displayPrimary =
@@ -1021,6 +1021,11 @@ async function resolveUnownedCliPrimaryError(params: {
     argv: params.argv,
     ...(displayPrimary === params.primary ? {} : { commandNames: [] }),
   });
+}
+
+async function createExpectedPluginPolicyError(message: string): Promise<Error> {
+  const { ExpectedCliError } = await import("./failure-output.js");
+  return new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
 }
 
 async function bootstrapCliProxyCaptureAndDispatcher(
@@ -1644,7 +1649,7 @@ async function runCliWithPreparedOutputMode(
               },
             );
             if (missingPluginCommandMessage) {
-              throw new Error(missingPluginCommandMessage);
+              throw await createExpectedPluginPolicyError(missingPluginCommandMessage);
             }
           }
         }

--- a/src/entry.run-main.test.ts
+++ b/src/entry.run-main.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ExpectedCliError } from "./cli/failure-output.js";
 import { runMainOrRootHelp } from "./entry.js";
 
 describe("entry run-main boundary", () => {
@@ -13,5 +14,37 @@ describe("entry run-main boundary", () => {
       additionalStartupTrace: expect.any(Object),
       retainConsoleRoutingUntilProcessExit: true,
     });
+  });
+
+  it("keeps expected conditions at exit 1 without crash framing", async () => {
+    const previousExitCode = process.exitCode;
+    const message =
+      'The `openclaw workboard` command is provided by the "workboard" plugin, but that bundled plugin is disabled by default. Run `openclaw plugins enable workboard` to enable that CLI surface.';
+    const error = new ExpectedCliError({
+      message,
+      humanOutput: message,
+      machineOutput: message,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = undefined;
+
+    try {
+      await runMainOrRootHelp(["node", "openclaw", "workboard", "list"], {
+        loadRunCli: async () => ({
+          runCli: vi.fn(async () => {
+            throw error;
+          }),
+        }),
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(errorSpy.mock.calls).toEqual([[message]]);
+      expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("OPENCLAW_DEBUG"));
+      expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("openclaw doctor"));
+      expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Could not start the CLI"));
+    } finally {
+      errorSpy.mockRestore();
+      process.exitCode = previousExitCode;
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import {
-  CliParseError,
   formatCliFailureLines,
   formatCliJsonFailure,
+  isExpectedCliError,
 } from "./cli/failure-output.js";
 import { isJsonOutputModeActive } from "./cli/json-output-mode.js";
 import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
@@ -155,7 +155,7 @@ if (isMain && !handledRootVersion) {
       })) {
         console.error(line);
       }
-      if (!(err instanceof CliParseError)) {
+      if (!isExpectedCliError(err)) {
         for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
           console.error("[openclaw]", message);
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin-policy refusals were rendered as CLI crashes. On a fresh profile, invoking a bundled plugin command that is disabled by default printed the correct enablement sentence inside a false crash title, stack-debug hint, Doctor recommendation, and generic help hint. The same framing affected `plugins.allow` exclusions, explicit plugin disablement, parent-plugin allowlist guidance, runtime slash commands used as CLI commands, and plugin agent tools used as CLI commands.

The impact is broad on the default path: an isolated `plugins list --json` run at the base SHA reported 65 disabled bundled plugins out of 149 total.

Related: #124892 established the pre-rendered expected-condition seam for parse guidance. #125007 is the open follow-up for missing Gateway credentials.

AI-assisted: Codex. The source, tests, built output, isolated profiles, and captured streams were inspected directly.

## Why This Change Was Made

The landed `CliParseError` carrier represented a broader contract than its name: canonical human output, canonical machine output, an already-written flag, and exemption from crash framing and fatal hooks. This change renames it to `ExpectedCliError`, keeps the parse-specific factories parse-specific, and adds `isExpectedCliError` as the one renderer predicate. Both plugin-policy producer sites now wrap their existing message in that carrier.

This leaves one expected-condition concept rather than reusing a misleading parse name or adding a parallel plugin-policy type. No compatibility alias remains: the type is an internal, unshipped CLI implementation detail introduced by #124892.

The design composes with #125007: after rebasing, that PR can extend `isExpectedCliError` with its structured `GatewayCredentialsRequiredError` classifier while preserving the Gateway error's `method` and `configPath` fields. Its command-local rethrow work is complementary; the expected textual conflicts are limited to the shared renderer, its tests, and the legacy executable entrypoint.

No policy message changed. The JSON envelope and message bytes did not change. Exit status remains 1.

### Docs-link verdict

No `Docs:` line was added. The seven policy/tool messages already state their exact remedy, while a generic `/plugins` link is not uniformly relevant to runtime slash commands and agent tools. Adding it would make the output noisier without improving the next action.

## User Impact

Operators now see the policy sentence by itself. For example, `openclaw workboard list` on a fresh profile says that Workboard is disabled by default and gives the exact enable command, without claiming the CLI crashed or suggesting stack inspection and Doctor.

Human and `--json` forms still exit 1. JSON stdout retains `{ ok: false, error: { type: "cli_error", message } }`, and stderr now contains only the same canonical message.

## Evidence

### Built CLI before/after

Every case used its own scratch `OPENCLAW_STATE_DIR`, an `openclaw.json` containing `gateway.mode=local` plus a free non-18789 port, `OPENCLAW_SKIP_CHANNELS=1`, and Discord/Twilio credential variables unset. Stdout and stderr were captured separately and inspected.

| Condition | Invocation | Before stderr | After stderr | Exit |
| --- | --- | --- | --- | ---: |
| Disabled by default | `workboard list` | Correct sentence inside crash/debug/Doctor/help framing | Exact existing sentence only | 1 |
| `plugins.allow` exclusion | `workboard list` with `allow=[browser]` | Correct sentence inside crash/debug/Doctor/help framing | Exact existing sentence only | 1 |
| Explicit `enabled=false` | `browser status` | Correct sentence inside crash/debug/Doctor/help framing | Exact existing sentence only | 1 |
| Parent plugin must be allowed | `voicecall status` with `allow=[voicecall]` | Correct sentence inside crash/debug/Doctor/help framing | Exact existing sentence only | 1 |
| Runtime slash used as CLI | `dreaming` | Correct sentence inside crash/debug/Doctor/help framing | Exact existing sentence only | 1 |

`reef status` independently proved a third disabled-by-default plugin. `dist/index.js workboard list` also exited 1 with the exact message only, covering the legacy `The CLI command failed` entrypoint.

For all six captured commands:

- human stdout stayed empty;
- after-fix stderr contained no crash title, `Reason:`, `OPENCLAW_DEBUG`, `Stack:`, Doctor hint, or generic help hint;
- JSON stdout was byte-for-byte identical before and after;
- JSON stderr exactly equaled `error.message`.

### Full message-surface sweep

| Producer condition | Result |
| --- | --- |
| Direct `plugins.allow` exclusion | Shared expected-condition carrier; text unchanged |
| Alias whose parent plugin must be allowed | Shared expected-condition carrier; text unchanged |
| Explicit `plugins.entries.<id>.enabled=false` | Shared expected-condition carrier; text unchanged |
| Disabled-by-default CLI plugin | Shared expected-condition carrier after lazy registration; text unchanged |
| Runtime slash command used as CLI | Shared expected-condition carrier; text unchanged |
| Loaded agent tool used as CLI | Shared expected-condition carrier; text unchanged |
| Manifest-only agent tool used as CLI | Shared expected-condition carrier; text unchanged |

The last two templates were an audit surprise: `canvas` is an enabled-by-default agent tool, not another disabled-plugin case. The renderer fix covers them because it wraps every non-null policy result.

Other CLI plain-error producers were left unchanged with evidence: container/profile argument validation is rendered directly by `src/entry.ts` and exits 2; container execution failures are genuine operational failures; unrelated command-local validation remains with its owner pending a concrete crash-framing reproduction. Missing Gateway credentials remain in #125007.

### Tests and gates

- Pre-fix regression run: seven new `run-main.exit` cases failed because every policy result was a plain `Error` rather than the expected-condition carrier.
- `node scripts/run-vitest.mjs src/cli/run-main.test.ts src/cli/run-main.exit.test.ts src/cli/failure-output.test.ts src/entry.run-main.test.ts src/cli/program/error-output.test.ts` — 309 passed across three routed shards.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — passed the complete local `core, coreTests` plan, including typechecks, type-aware lint, formatting, guards, dead exports, and import cycles.
- `pnpm build` — passed on the exact committed tree.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.

The first unqualified `node scripts/check-changed.mjs` attempt followed the configured Blacksmith Testbox route, but `tbx_01m081fmvdnx8zg6msx7hrhcgt` never allocated an IP or Actions run and was stopped. It produced no test verdict and is not counted as proof.

Production LOC: +25/-17 (net +8). Tests: +178/-47 (net +131).
