### PR TITLE
fix(agents): honor system owner for unscoped reads

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -576,7 +576,7 @@ Periodic heartbeat runs.
 
 ### `agents.defaults.systemAgent`
 
-Selects the agent whose model and credentials own ambient OpenClaw system-agent and Custodian consults:
+Selects the agent whose model and credentials own ambient OpenClaw system-agent and Custodian consults. It is also the fallback owner when `models.list`, `models.authStatus`, `skills.status`, or `doctor.memory.status` omits `agentId`:
 
 ```json5
 {
@@ -588,7 +588,7 @@ Selects the agent whose model and credentials own ambient OpenClaw system-agent 
 }
 ```
 
-Delegated consults with a requesting agent keep that requester as their owner. When `agentId` is absent, a sole configured agent resolves implicitly; ambient consults in a multi-agent fleet fail with an actionable error. Upgrade-only ownership lives at `agents.defaults.authInheritance.agentId` for inherited credentials and `agents.defaults.sessionStore.agentId` for retired `main` session rows or unscoped rows in a fixed `session.store`.
+An explicit request `agentId` always wins. Other agent-scoped methods do not use this setting as a general default. Delegated consults with a requesting agent keep that requester as their owner. When `systemAgent.agentId` is absent, a sole configured agent resolves implicitly; the four reads above and ambient consults in a multi-agent fleet fail with an actionable error. Upgrade-only ownership lives at `agents.defaults.authInheritance.agentId` for inherited credentials and `agents.defaults.sessionStore.agentId` for retired `main` session rows or unscoped rows in a fixed `session.store`.
 
 ### `agents.defaults.compaction`
 

--- a/src/commands/models/auth-logout.test.ts
+++ b/src/commands/models/auth-logout.test.ts
@@ -126,7 +126,7 @@ describe("models auth logout", () => {
       agentDir: "/tmp/agent-poe",
       profileIds: ["openai:manual"],
     });
-    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledWith("poe");
     expect(runtime.logs).toContain("Removed auth profile: openai:manual (openai/oauth)");
     expect(runtime.logs.some((line) => line.includes("No auth profiles remain for openai"))).toBe(
       true,

--- a/src/commands/models/auth-logout.ts
+++ b/src/commands/models/auth-logout.ts
@@ -107,7 +107,7 @@ export async function modelsAuthLogoutCommand(
     );
   }
 
-  await refreshRunningGatewayAuthState();
+  await refreshRunningGatewayAuthState(agentId);
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Removed auth profile: ${description}`);

--- a/src/commands/models/auth-order.test.ts
+++ b/src/commands/models/auth-order.test.ts
@@ -78,16 +78,16 @@ describe("models auth order", () => {
   it("set writes the store order and refreshes a running gateway", async () => {
     const runtime = createRuntime();
     await modelsAuthOrderSetCommand(
-      { provider: "anthropic", order: ["anthropic:b", "anthropic:a"] },
+      { provider: "anthropic", agent: "ops", order: ["anthropic:b", "anthropic:a"] },
       runtime,
     );
 
     expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
-      agentDir: "/tmp/agent-main",
+      agentDir: "/tmp/agent-ops",
       provider: "anthropic",
       order: ["anthropic:b", "anthropic:a"],
     });
-    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledWith("ops");
     expect(runtime.logs).toContain("Auth profile order override: anthropic:b, anthropic:a");
   });
 
@@ -124,7 +124,7 @@ describe("models auth order", () => {
       provider: "anthropic",
       order: null,
     });
-    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledWith("main");
     expect(runtime.logs.some((line) => line.includes("Auth profile order override cleared"))).toBe(
       true,
     );

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -111,7 +111,7 @@ export async function modelsAuthOrderClearCommand(
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
   runtime.log(`Auth profile order override cleared; ${describeOrderFallback(cfg, provider)}.`);
-  await refreshRunningGatewayAuthState();
+  await refreshRunningGatewayAuthState(agentId);
 }
 
 /** Sets the provider auth profile priority order after validating each profile id. */
@@ -158,5 +158,5 @@ export async function modelsAuthOrderSetCommand(
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
   runtime.log(`Auth profile order override: ${describeOrder(updated, provider, cfg).join(", ")}`);
-  await refreshRunningGatewayAuthState();
+  await refreshRunningGatewayAuthState(agentId);
 }

--- a/src/commands/models/auth-refresh.ts
+++ b/src/commands/models/auth-refresh.ts
@@ -1,13 +1,12 @@
 /** Shared gateway refresh for CLI auth writes made outside the gateway process. */
 import { callGateway } from "../../gateway/call.js";
 
-// CLI auth writes occur outside the gateway process, which may retain an older
-// runtime snapshot. Best-effort: auth writes must still succeed with no gateway.
-export async function refreshRunningGatewayAuthState(): Promise<void> {
+// Best-effort refresh: auth writes must still succeed when the gateway is absent or stale.
+export async function refreshRunningGatewayAuthState(agentId?: string): Promise<void> {
   try {
     await callGateway({
       method: "models.authStatus",
-      params: { refresh: true },
+      params: { refresh: true, ...(agentId ? { agentId } : {}) },
       timeoutMs: 3000,
     });
   } catch {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -518,7 +518,7 @@ describe("modelsAuthLoginCommand", () => {
     );
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",
-      params: { refresh: true },
+      params: { refresh: true, agentId: "main" },
       timeoutMs: 3000,
     });
   });
@@ -532,7 +532,7 @@ describe("modelsAuthLoginCommand", () => {
     expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledOnce();
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",
-      params: { refresh: true },
+      params: { refresh: true, agentId: "main" },
       timeoutMs: 3000,
     });
   });
@@ -857,6 +857,11 @@ describe("modelsAuthLoginCommand", () => {
     expect(
       (readMockCallArg(mocks.upsertAuthProfileWithLock) as UpsertAuthProfileCall).agentDir,
     ).toBe("/tmp/openclaw/agents/coder");
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true, agentId: "coder" },
+      timeoutMs: 3000,
+    });
   });
 
   it("forwards an app-owned cancellation signal to provider auth", async () => {
@@ -1420,7 +1425,7 @@ describe("modelsAuthLoginCommand", () => {
     );
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",
-      params: { refresh: true },
+      params: { refresh: true, agentId: "main" },
       timeoutMs: 3000,
     });
   });
@@ -1467,6 +1472,11 @@ describe("modelsAuthLoginCommand", () => {
         token: "openai-token",
       },
       agentDir: "/tmp/openclaw/agents/coder",
+    });
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true, agentId: "coder" },
+      timeoutMs: 3000,
     });
   });
 
@@ -1578,7 +1588,7 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith("Auth profile: openai:manual (openai/api_key)");
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",
-      params: { refresh: true },
+      params: { refresh: true, agentId: "coder" },
       timeoutMs: 3000,
     });
   });

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -16,11 +16,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { styleSelectParams } from "../../../packages/terminal-core/src/prompt-select-styled-params.js";
 import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
-import {
-  resolveAgentDir,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-} from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   externalCliDiscoveryForProviderAuth,
   removeProviderAuthProfilesWithLock,
@@ -69,7 +65,7 @@ import { validateAnthropicSetupToken } from "../auth-token.js";
 import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runtime-plugin-install.js";
 import { repairCopilotRuntimePluginInstallForModelSelection } from "../copilot-runtime-plugin-install.js";
 import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
-import { loadValidConfigOrThrow, resolveKnownAgentId, updateConfig } from "./shared.js";
+import { loadValidConfigOrThrow, resolveModelsTargetAgent, updateConfig } from "./shared.js";
 
 function resolveManualTokenExpiryMs(expiresIn: string | undefined): number | undefined {
   const normalizedExpiresIn = normalizeStringifiedOptionalString(expiresIn);
@@ -199,6 +195,7 @@ function validateOpenAICodexApiKeyInput(value: string): string | undefined {
 
 type ResolvedModelsAuthContext = {
   config: OpenClawConfig;
+  agentId: string;
   agentDir: string;
   workspaceDir: string;
   providers: ProviderPlugin[];
@@ -269,10 +266,7 @@ async function resolveModelsAuthContext(params?: {
   config?: OpenClawConfig;
 }): Promise<ResolvedModelsAuthContext> {
   const config = params?.config ?? (await loadValidConfigOrThrow());
-  const agentId =
-    resolveKnownAgentId({ cfg: config, rawAgentId: params?.rawAgentId }) ??
-    resolveDefaultAgentId(config);
-  const agentDir = resolveAgentDir(config, agentId);
+  const { agentId, agentDir } = await resolveModelsAuthAgent(params?.rawAgentId, config);
   const workspaceDir =
     resolveAgentWorkspaceDir(config, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const requestedProvider = params?.requestedProvider?.trim();
@@ -299,16 +293,16 @@ async function resolveModelsAuthContext(params?: {
   });
   return {
     config,
+    agentId,
     agentDir,
     workspaceDir,
     providers: authProviders,
   };
 }
 
-async function resolveModelsAuthAgentDir(rawAgentId?: string | null): Promise<string> {
-  const config = await loadValidConfigOrThrow();
-  const agentId = resolveKnownAgentId({ cfg: config, rawAgentId }) ?? resolveDefaultAgentId(config);
-  return resolveAgentDir(config, agentId);
+async function resolveModelsAuthAgent(rawAgentId?: string | null, config?: OpenClawConfig) {
+  const cfg = config ?? (await loadValidConfigOrThrow());
+  return resolveModelsTargetAgent(cfg, rawAgentId ?? undefined);
 }
 
 function resolveRequestedProviderOrThrow(
@@ -415,6 +409,7 @@ async function persistProviderAuthResult(params: {
   result: ProviderAuthResult;
   profiles?: ProviderAuthResult["profiles"];
   config: OpenClawConfig;
+  agentId: string;
   agentDir: string;
   runtime: RuntimeEnv;
   prompter: WizardPrompter;
@@ -485,7 +480,7 @@ async function persistProviderAuthResult(params: {
     logConfigUpdated(params.runtime);
   }
 
-  await refreshRunningGatewayAuthState();
+  await refreshRunningGatewayAuthState(params.agentId);
 
   for (const profile of profiles) {
     params.runtime.log(
@@ -530,6 +525,7 @@ function resolveConfiguredAuthSelectionForProvider(
 
 async function runProviderAuthMethod(params: {
   config: OpenClawConfig;
+  agentId: string;
   agentDir: string;
   workspaceDir: string;
   provider: ProviderPlugin;
@@ -586,6 +582,7 @@ async function runProviderAuthMethod(params: {
     result,
     profiles,
     config: params.config,
+    agentId: params.agentId,
     agentDir: params.agentDir,
     runtime: params.runtime,
     prompter: params.prompter,
@@ -606,7 +603,7 @@ export async function modelsAuthSetupTokenCommand(
     );
   }
 
-  const { config, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
+  const { config, agentId, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
     requestedProvider: opts.provider,
     rawAgentId: opts.agent,
   });
@@ -643,6 +640,7 @@ export async function modelsAuthSetupTokenCommand(
 
   await runProviderAuthMethod({
     config,
+    agentId,
     agentDir,
     workspaceDir,
     provider,
@@ -662,7 +660,7 @@ export async function modelsAuthPasteTokenCommand(
   },
   runtime: RuntimeEnv,
 ) {
-  const agentDir = await resolveModelsAuthAgentDir(opts.agent);
+  const { agentId, agentDir } = await resolveModelsAuthAgent(opts.agent);
   const rawProvider = normalizeOptionalString(opts.provider);
   if (!rawProvider) {
     throw new Error(
@@ -711,7 +709,7 @@ export async function modelsAuthPasteTokenCommand(
 
   await updateConfig((cfg) => applyAuthProfileConfig(cfg, { profileId, provider, mode: "token" }));
 
-  await refreshRunningGatewayAuthState();
+  await refreshRunningGatewayAuthState(agentId);
 
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (${provider}/token)`);
@@ -731,7 +729,7 @@ export async function modelsAuthPasteApiKeyCommand(
   },
   runtime: RuntimeEnv,
 ) {
-  const agentDir = await resolveModelsAuthAgentDir(opts.agent);
+  const { agentId, agentDir } = await resolveModelsAuthAgent(opts.agent);
   const rawProvider = normalizeOptionalString(opts.provider);
   if (!rawProvider) {
     throw new Error(
@@ -771,7 +769,7 @@ export async function modelsAuthPasteApiKeyCommand(
     applyAuthProfileConfig(cfg, { profileId, provider, mode: "api_key" }),
   );
 
-  await refreshRunningGatewayAuthState();
+  await refreshRunningGatewayAuthState(agentId);
 
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (${provider}/api_key)`);
@@ -779,7 +777,7 @@ export async function modelsAuthPasteApiKeyCommand(
 
 /** Interactive helper for adding token auth profiles, with provider/method prompts. */
 export async function modelsAuthAddCommand(opts: { agent?: string }, runtime: RuntimeEnv) {
-  const { config, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
+  const { config, agentId, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
     rawAgentId: opts.agent,
   });
   const tokenProviders = listProvidersWithTokenMethods(providers);
@@ -834,6 +832,7 @@ export async function modelsAuthAddCommand(opts: { agent?: string }, runtime: Ru
       }
       await runProviderAuthMethod({
         config,
+        agentId,
         agentDir,
         workspaceDir,
         provider: providerPlugin,
@@ -988,7 +987,7 @@ function maybeLogOpenAICodexNativeSearchTip(runtime: RuntimeEnv, providerId: str
 export async function runModelsAuthLoginFlowCore(
   opts: ModelsAuthLoginFlowOptions,
 ): Promise<ModelsAuthLoginFlowResult> {
-  const { config, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
+  const { config, agentId, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
     requestedProvider: opts.provider,
     rawAgentId: opts.agent,
     config: opts.config,
@@ -1067,6 +1066,7 @@ export async function runModelsAuthLoginFlowCore(
 
   const { result, profiles } = await runProviderAuthMethod({
     config,
+    agentId,
     agentDir,
     workspaceDir,
     provider: selectedProvider,

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -326,9 +326,9 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "agents.entries.*.heartbeat.timeoutSeconds":
     "Per-agent maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to inherit the merged heartbeat timeout, then agents.defaults.timeoutSeconds when set, otherwise the heartbeat cadence capped at 600 seconds.",
   "agents.defaults.systemAgent":
-    "Target settings for ambient OpenClaw system-agent and Custodian inference.",
+    "Target settings for ambient OpenClaw system-agent and Custodian inference plus selected unscoped operator reads.",
   "agents.defaults.systemAgent.agentId":
-    "Agent whose model and credentials own ambient system-agent and Custodian consults. Delegated consults still use their requesting agent.",
+    "Agent whose model and credentials own ambient system-agent and Custodian consults. Also used when models.list, models.authStatus, skills.status, or doctor.memory.status omits agentId; explicit request agentId always wins.",
   "agents.defaults.authInheritance":
     "Upgrade compatibility owner for the inherited credential store until credentials are relocated per agent.",
   "agents.defaults.authInheritance.agentId":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -318,7 +318,7 @@ export type AgentDefaultsConfig = {
      */
     isolatedSession?: boolean;
   };
-  /** Owner for ambient OpenClaw system-agent/Custodian inference. */
+  /** Owner for ambient system-agent/Custodian inference and unscoped operator-read fallbacks. */
   systemAgent?: {
     agentId?: string;
   };

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -240,6 +240,7 @@ const expectEmbeddingErrorResponse = (respond: ReturnType<typeof vi.fn>, error: 
 
 describe("doctor.memory agent targeting", () => {
   beforeEach(() => {
+    getRuntimeConfig.mockReset().mockReturnValue({});
     listAgentIds.mockClear();
     resolveDefaultAgentId.mockReset().mockReturnValue("main");
     resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw");
@@ -262,6 +263,9 @@ describe("doctor.memory agent targeting", () => {
   it.each(DOCTOR_MEMORY_TARGET_METHODS)(
     "%s returns typed selection-required when agentId is omitted",
     async (method) => {
+      getRuntimeConfig.mockReturnValue({
+        agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+      });
       resolveDefaultAgentId.mockImplementationOnce(() => {
         throw new AgentSelectionRequiredError(["ops", "research"], {
           surface: "doctor memory",
@@ -327,7 +331,7 @@ describe("doctor.memory agent targeting", () => {
 
 describe("doctor.memory.status", () => {
   beforeEach(() => {
-    getRuntimeConfig.mockClear();
+    getRuntimeConfig.mockReset().mockReturnValue({});
     resolveDefaultAgentId.mockClear();
     resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw");
     resolveMemorySearchConfig.mockReset().mockReturnValue({ enabled: true });
@@ -701,9 +705,13 @@ describe("doctor.memory.status", () => {
 
       agents: {
         defaults: {
+          systemAgent: { agentId: "main" },
           userTimezone: "America/Los_Angeles",
         },
-        list: [{ id: "alpha", workspace: alphaWorkspaceDir }],
+        list: [
+          { id: "main", workspace: mainWorkspaceDir },
+          { id: "alpha", workspace: alphaWorkspaceDir },
+        ],
       },
       plugins: {
         entries: {
@@ -1116,7 +1124,7 @@ describe("doctor.memory.status", () => {
       },
 
       agents: {
-        defaults: {},
+        defaults: { systemAgent: { agentId: "main" } },
         list: [
           { id: "main", workspace: mainWorkspaceDir },
           { id: "alpha", workspace: alphaWorkspaceDir },

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -6,7 +6,10 @@ import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
-import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
+import {
+  AgentSelectionRequiredError,
+  tryResolveSystemAgentTargetAgentId,
+} from "../../agents/agent-scope-config.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
@@ -636,6 +639,7 @@ function resolveDoctorMemoryAgent(
   context: GatewayRequestContext,
   params: unknown,
   respond: RespondFn,
+  omittedAgentId?: string,
 ): {
   cfg: OpenClawConfig;
   agentId: string;
@@ -651,7 +655,7 @@ function resolveDoctorMemoryAgent(
   }
   const requestedAgentId =
     typeof rawAgentId === "string" ? normalizeAgentId(rawAgentId) : undefined;
-  let agentId = requestedAgentId;
+  let agentId = requestedAgentId ?? omittedAgentId;
   if (!agentId) {
     try {
       agentId = resolveDefaultAgentId(cfg, {
@@ -707,7 +711,8 @@ export const createDoctorHandlers = (
   memoryCoreRuntime: DoctorMemoryCoreRuntime = defaultMemoryCoreRuntime,
 ): GatewayRequestHandlers => ({
   "doctor.memory.status": async ({ respond, context, params }) => {
-    const resolved = resolveDoctorMemoryAgent(context, params, respond);
+    const omittedAgentId = tryResolveSystemAgentTargetAgentId(context.getRuntimeConfig());
+    const resolved = resolveDoctorMemoryAgent(context, params, respond, omittedAgentId);
     if (!resolved) {
       return;
     }

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -389,7 +389,12 @@ describe("models.authStatus", () => {
   ])(
     "resolves an $name agentId against the configured roster",
     async ({ params, expectedAgentId }) => {
-      const cfg = { agents: { list: [{ id: "main", default: true }, { id: "writer" }] } };
+      const cfg = {
+        agents: {
+          defaults: { systemAgent: { agentId: "main" } },
+          list: [{ id: "main" }, { id: "writer" }],
+        },
+      };
       mocks.getRuntimeConfig.mockReturnValue(cfg);
       mocks.listAgentIds.mockReturnValue(["main", "writer"]);
 

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -608,7 +608,12 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
     const now = Date.now();
     const refreshRequested = Boolean(params.refresh);
     const resolveScope = (cfg: OpenClawConfig) =>
-      resolveModelAuthAgentScope(cfg, params.agentId ?? tryResolveSystemAgentTargetAgentId(cfg));
+      resolveModelAuthAgentScope(
+        cfg,
+        params.agentId === undefined || params.agentId === ""
+          ? tryResolveSystemAgentTargetAgentId(cfg)
+          : params.agentId,
+      );
     try {
       let cfg = context.getRuntimeConfig();
       let scope = resolveScope(cfg);

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/model-catalog-core/provider-id";
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { tryResolveSystemAgentTargetAgentId } from "../../agents/agent-scope-config.js";
 import {
   type AuthHealthSummary,
   type AuthProfileHealthStatus,
@@ -606,9 +607,11 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
   "models.authStatus": async ({ params, respond, context }) => {
     const now = Date.now();
     const refreshRequested = Boolean(params.refresh);
+    const resolveScope = (cfg: OpenClawConfig) =>
+      resolveModelAuthAgentScope(cfg, params.agentId ?? tryResolveSystemAgentTargetAgentId(cfg));
     try {
       let cfg = context.getRuntimeConfig();
-      let scope = resolveModelAuthAgentScope(cfg, params.agentId);
+      let scope = resolveScope(cfg);
       if (!scope.ok) {
         respond(false, undefined, modelAuthAgentScopeError(scope));
         return;
@@ -616,7 +619,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       if (refreshRequested) {
         await refreshModelAuthStatusRuntimeState();
         cfg = context.getRuntimeConfig();
-        scope = resolveModelAuthAgentScope(cfg, params.agentId);
+        scope = resolveScope(cfg);
         if (!scope.ok) {
           respond(false, undefined, modelAuthAgentScopeError(scope));
           return;

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,6 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 // Models gateway methods expose prepared, cached, and explicitly refreshed catalog views.
 import { validateModelsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import { tryResolveSystemAgentTargetAgentId } from "../../agents/agent-scope-config.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import { buildModelsListResult } from "./models-list-result.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -14,10 +15,11 @@ export const modelsHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateModelsListParams, "models.list", respond)) {
       return;
     }
+    const cfg = context.getRuntimeConfig();
     const resolved = resolveAgentIdOrRespondError({
-      rawAgentId: params.agentId,
+      rawAgentId: params.agentId ?? tryResolveSystemAgentTargetAgentId(cfg),
       respond,
-      cfg: context.getRuntimeConfig(),
+      cfg,
       normalize: normalizeOptionalString,
     });
     if (!resolved) {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -24,6 +24,7 @@ import {
   validateSkillsStatusParams,
   validateSkillsUpdateParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { tryResolveSystemAgentTargetAgentId } from "../../agents/agent-scope-config.js";
 import { resolveNodeExecEligibility } from "../../agents/exec-defaults.js";
 import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import { redactConfigObject } from "../../config/redact-snapshot.js";
@@ -185,7 +186,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateSkillsStatusParams, "skills.status", respond)) {
       return;
     }
-    const resolved = resolveSkillsAgentWorkspace(params, context);
+    const agentId =
+      params.agentId ?? tryResolveSystemAgentTargetAgentId(context.getRuntimeConfig());
+    const resolved = resolveSkillsAgentWorkspace({ ...params, agentId }, context);
     if (!resolved.ok) {
       respond(false, undefined, resolved.error);
       return;

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -545,7 +545,16 @@ describe("gateway server models + voicewake", () => {
     );
   });
 
-  test("prepared model RPCs reuse both explicit startup owners without live fallback", async () => {
+  test("prepared agent read RPCs preserve explicit and system owners without live fallback", async () => {
+    const configPath = process.env.OPENCLAW_CONFIG_PATH;
+    if (!configPath) {
+      throw new Error("Missing OPENCLAW_CONFIG_PATH");
+    }
+    const workspaceRoot = path.dirname(configPath);
+    const startupModels = [
+      { id: "ops-model", name: "Ops Model", provider: "fixture" },
+      { id: "research-model", name: "Research Model", provider: "fixture" },
+    ];
     const modelConfig = {
       models: {
         providers: {
@@ -554,40 +563,48 @@ describe("gateway server models + voicewake", () => {
             apiKey: "test-fixture-key",
             baseUrl: "https://fixture.example.com/v1",
             models: [
-              { id: "alpha-model", name: "Alpha Model" },
-              { id: "beta-model", name: "Beta Model" },
+              { id: "ops-model", name: "Ops Model" },
+              { id: "research-model", name: "Research Model" },
             ],
           },
         },
       },
       agents: {
         ownership: "explicit",
+        defaults: { systemAgent: { agentId: "ops" } },
         entries: {
-          alpha: {
-            model: { primary: "fixture/alpha-model" },
-            modelPolicy: { allow: ["fixture/alpha-model"] },
+          ops: {
+            workspace: path.join(workspaceRoot, "ops-workspace"),
+            model: { primary: "fixture/ops-model" },
+            modelPolicy: { allow: ["fixture/ops-model"] },
           },
-          beta: {
-            model: { primary: "fixture/beta-model" },
-            modelPolicy: { allow: ["fixture/beta-model"] },
+          research: {
+            workspace: path.join(workspaceRoot, "research-workspace"),
+            model: { primary: "fixture/research-model" },
+            modelPolicy: { allow: ["fixture/research-model"] },
           },
         },
       },
     };
-
-    await withModelsConfig(modelConfig, async () => {
+    const publishPreparedOwners = async () => {
       await resetPreparedModelCatalogStateForTest();
       agentDiscoveryMock.enabled = true;
-      const startupModels = [
-        { id: "alpha-model", name: "Alpha Model", provider: "fixture" },
-        { id: "beta-model", name: "Beta Model", provider: "fixture" },
-      ];
       agentDiscoveryMock.models = startupModels;
       const { getRuntimeConfig } = await import("../config/io.js");
       await startupTesting.publishStartupModelRuntime({
         cfg: getRuntimeConfig(),
         log: { warn: () => {} },
       });
+    };
+    const readMethods = [
+      "models.list",
+      "models.authStatus",
+      "skills.status",
+      "doctor.memory.status",
+    ] as const;
+
+    await withModelsConfig(modelConfig, async () => {
+      await publishPreparedOwners();
       const discoveryCallsAfterStartup = agentDiscoveryMock.discoverCalls;
 
       let blockedRequestFallback = false;
@@ -607,42 +624,68 @@ describe("gateway server models + voicewake", () => {
         },
       ];
       try {
-        const [alphaModels, betaModels, alphaAuth, betaAuth, health] = await Promise.all([
+        const [
+          opsModels,
+          researchModels,
+          opsAuth,
+          researchAuth,
+          models,
+          auth,
+          skills,
+          memory,
+          health,
+        ] = await Promise.all([
           rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list", {
-            agentId: "alpha",
+            agentId: "ops",
             view: "configured",
             preparedOnly: true,
           }),
           rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list", {
-            agentId: "beta",
+            agentId: "research",
             view: "configured",
             preparedOnly: true,
           }),
           rpcReq<{ providers: Array<{ provider: string }> }>(ws, "models.authStatus", {
-            agentId: "alpha",
+            agentId: "ops",
           }),
           rpcReq<{ providers: Array<{ provider: string }> }>(ws, "models.authStatus", {
-            agentId: "beta",
+            agentId: "research",
           }),
+          rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list", {
+            view: "configured",
+            preparedOnly: true,
+          }),
+          rpcReq(ws, "models.authStatus", {}),
+          rpcReq<{ agentId: string; workspaceDir: string }>(ws, "skills.status", {}),
+          rpcReq<{ agentId: string }>(ws, "doctor.memory.status", {}),
           rpcReq<Record<string, unknown>>(ws, "health", { probe: true }),
         ]);
 
-        expect(alphaModels.ok, JSON.stringify(alphaModels)).toBe(true);
-        expect(betaModels.ok, JSON.stringify(betaModels)).toBe(true);
-        expect(alphaModels.payload?.models).toContainEqual(
-          expect.objectContaining({ id: "alpha-model", provider: "fixture" }),
+        expect(opsModels.ok, JSON.stringify(opsModels)).toBe(true);
+        expect(researchModels.ok, JSON.stringify(researchModels)).toBe(true);
+        expect(opsModels.payload?.models).toContainEqual(
+          expect.objectContaining({ id: "ops-model", provider: "fixture" }),
         );
-        expect(betaModels.payload?.models).toContainEqual(
-          expect.objectContaining({ id: "beta-model", provider: "fixture" }),
+        expect(researchModels.payload?.models).toContainEqual(
+          expect.objectContaining({ id: "research-model", provider: "fixture" }),
         );
-        expect(alphaAuth.ok, JSON.stringify(alphaAuth)).toBe(true);
-        expect(betaAuth.ok, JSON.stringify(betaAuth)).toBe(true);
-        expect(alphaAuth.payload?.providers).toContainEqual(
+        expect(opsAuth.ok, JSON.stringify(opsAuth)).toBe(true);
+        expect(researchAuth.ok, JSON.stringify(researchAuth)).toBe(true);
+        expect(opsAuth.payload?.providers).toContainEqual(
           expect.objectContaining({ provider: "fixture" }),
         );
-        expect(betaAuth.payload?.providers).toContainEqual(
+        expect(researchAuth.payload?.providers).toContainEqual(
           expect.objectContaining({ provider: "fixture" }),
         );
+        expect(models.payload?.models).toEqual([
+          expect.objectContaining({ id: "ops-model", provider: "fixture" }),
+        ]);
+        expect(auth.ok, JSON.stringify(auth)).toBe(true);
+        expect(skills.payload).toMatchObject({
+          agentId: "ops",
+          workspaceDir: path.join(workspaceRoot, "ops-workspace"),
+        });
+        expect(memory.payload).toMatchObject({ agentId: "ops" });
         expect(health.ok, JSON.stringify(health)).toBe(true);
       } finally {
         agentDiscoveryMock.models = startupModels;
@@ -650,6 +693,25 @@ describe("gateway server models + voicewake", () => {
 
       expect(agentDiscoveryMock.discoverCalls).toBe(discoveryCallsAfterStartup);
       expect(blockedRequestFallback).toBe(false);
+      for (const method of readMethods) {
+        const response = await rpcReq(ws, method, { agentId: "missing" });
+        expect(response.ok, method).toBe(false);
+        expect(response.error).toMatchObject({ code: "INVALID_REQUEST" });
+      }
+    });
+
+    const noSystemAgentConfig = {
+      ...modelConfig,
+      agents: { ownership: modelConfig.agents.ownership, entries: modelConfig.agents.entries },
+    };
+    await withModelsConfig(noSystemAgentConfig, async () => {
+      await publishPreparedOwners();
+
+      for (const method of readMethods) {
+        const response = await rpcReq(ws, method, {});
+        expect(response.ok, method).toBe(false);
+        expect(response.error).toMatchObject({ code: "INVALID_REQUEST" });
+      }
     });
   });
 

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -631,6 +631,7 @@ describe("gateway server models + voicewake", () => {
           researchAuth,
           models,
           auth,
+          emptyAuth,
           skills,
           memory,
           health,
@@ -656,6 +657,7 @@ describe("gateway server models + voicewake", () => {
             preparedOnly: true,
           }),
           rpcReq(ws, "models.authStatus", {}),
+          rpcReq(ws, "models.authStatus", { agentId: "" }),
           rpcReq<{ agentId: string; workspaceDir: string }>(ws, "skills.status", {}),
           rpcReq<{ agentId: string }>(ws, "doctor.memory.status", {}),
           rpcReq<Record<string, unknown>>(ws, "health", { probe: true }),
@@ -681,6 +683,7 @@ describe("gateway server models + voicewake", () => {
           expect.objectContaining({ id: "ops-model", provider: "fixture" }),
         ]);
         expect(auth.ok, JSON.stringify(auth)).toBe(true);
+        expect(emptyAuth.ok, JSON.stringify(emptyAuth)).toBe(true);
         expect(skills.payload).toMatchObject({
           agentId: "ops",
           workspaceDir: path.join(workspaceRoot, "ops-workspace"),

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -61,6 +61,9 @@ const getRuntimeConfigMock = vi.fn(() => ({}));
 const loadGatewayModelCatalogMock = vi.fn(
   (_params?: unknown): Array<{ id: string; name: string; provider: string }> => [],
 );
+const buildAllowedModelSetMock = vi.fn(({ catalog }: { catalog: unknown[] }) => ({
+  allowedCatalog: catalog,
+}));
 const readChatHistoryPageMock = vi.fn(
   async (_params?: unknown): Promise<{ messages: unknown[] }> => ({
     messages: [],
@@ -170,7 +173,8 @@ vi.mock("../agents/defaults.js", () => ({
 }));
 
 vi.mock("../agents/model-selection.js", () => ({
-  buildAllowedModelSet: ({ catalog }: { catalog: unknown[] }) => ({ allowedCatalog: catalog }),
+  buildAllowedModelSet: (params: { catalog: unknown[]; agentId?: string }) =>
+    buildAllowedModelSetMock(params),
   buildConfiguredModelCatalog: ({ cfg }: { cfg: { models?: { providers?: unknown } } }) =>
     Object.entries(
       (cfg.models?.providers as Record<string, { models?: Array<{ id: string }> }>) ?? {},
@@ -385,6 +389,7 @@ describe("EmbeddedTuiBackend", () => {
     getRuntimeConfigMock.mockReturnValue({});
     loadGatewayModelCatalogMock.mockReset();
     loadGatewayModelCatalogMock.mockReturnValue([]);
+    buildAllowedModelSetMock.mockClear();
     readChatHistoryPageMock.mockReset();
     readChatHistoryPageMock.mockResolvedValue({ messages: [] });
     loadSessionEntryMock.mockReset();
@@ -714,6 +719,35 @@ describe("EmbeddedTuiBackend", () => {
       },
     ]);
     expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+  });
+
+  it("passes the selected agent into model filtering", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { modelPolicy: { allow: ["fixture/main-model"] } },
+          work: { modelPolicy: { allow: ["fixture/work-model"] } },
+        },
+      },
+      models: {
+        mode: "replace",
+        providers: {
+          fixture: {
+            models: [{ id: "main-model" }, { id: "work-model" }],
+          },
+        },
+      },
+    });
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await backend.listModels({ agentId: "work" });
+
+    expect(buildAllowedModelSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "work" }),
+    );
   });
 
   it("patches wildcard replace-mode sessions against the same full catalog as model listing", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -917,13 +917,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
     return { ok: this.pluginApprovalBroker.resolve(id, decision) };
   }
 
-  async listModels(): Promise<TuiModelChoice[]> {
+  async listModels(opts?: { agentId?: string }): Promise<TuiModelChoice[]> {
     const cfg = getRuntimeConfig();
     const catalog = await this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg));
     const { allowedCatalog } = buildAllowedModelSet({
       cfg,
       catalog,
       defaultProvider: DEFAULT_PROVIDER,
+      agentId: opts?.agentId,
     });
     const entries = allowedCatalog.length > 0 ? allowedCatalog : catalog;
     return entries.map((entry) => ({

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -226,6 +226,7 @@ describe("GatewayChatClient", () => {
     });
     await client.loadHistory({ sessionKey: "global", agentId: "work", limit: 50 });
     await client.abortChat({ sessionKey: "global", agentId: "work", runId: "run-global-work" });
+    await client.listModels({ agentId: "work" });
 
     expect(request).toHaveBeenNthCalledWith(1, "chat.send", {
       sessionKey: "global",
@@ -246,6 +247,7 @@ describe("GatewayChatClient", () => {
       agentId: "work",
       runId: "run-global-work",
     });
+    expect(request).toHaveBeenNthCalledWith(4, "models.list", { agentId: "work" });
   });
 
   it("resolves a handoff key through the exact sessions.resolve wire contract", async () => {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -447,8 +447,8 @@ export class GatewayChatClient implements TuiBackend {
     return await this.client.request("status");
   }
 
-  async listModels(): Promise<GatewayModelChoice[]> {
-    const res = await this.client.request("models.list");
+  async listModels(opts?: { agentId?: string }): Promise<GatewayModelChoice[]> {
+    const res = await this.client.request("models.list", opts ?? {});
     return Array.isArray(res?.models) ? res.models : [];
   }
 

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -210,7 +210,7 @@ export type TuiBackend = {
     opts?: { agentId?: string },
   ) => Promise<TuiSessionMutationResult>;
   getGatewayStatus: () => Promise<unknown>;
-  listModels: () => Promise<TuiModelChoice[]>;
+  listModels: (opts?: { agentId?: string }) => Promise<TuiModelChoice[]>;
   listCommands?: (opts?: CommandsListParams) => Promise<CommandEntry[]>;
   listPluginApprovals?: () => Promise<unknown>;
   resolvePluginApproval?: (id: string, decision: TuiApprovalDecision) => Promise<{ ok?: boolean }>;

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -2517,6 +2517,7 @@ describe("tui command handlers", () => {
 
     await handleCommand("/model");
 
+    expect(listModels).toHaveBeenCalledWith({ agentId: "main" });
     const selector = firstMockArg(openOverlay, "openOverlay") as SelectableOverlay;
     expect(selector?.items?.[0]?.value).toBe("openrouter/auto");
     expect(selector?.items?.[0]?.label).toBe("openrouter/auto");

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -324,7 +324,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     try {
       chatLog.addSystem("loading models...");
       tui.requestRender();
-      const models = await client.listModels();
+      const models = await client.listModels({ agentId: selection.agentId });
       if (!isCurrentSessionSelection(selection)) {
         return;
       }


### PR DESCRIPTION
Related: #114388

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where agent-scoped operator reads without an explicit `agentId` failed in explicitly owned multi-agent setups even when `agents.defaults.systemAgent.agentId` configured the intended ambient owner. The affected reads were `models.list`, `models.authStatus`, `skills.status`, and `doctor.memory.status`; the TUI model picker and post-write model-auth refresh also dropped owner IDs they already knew.

## Why This Change Was Made

The four affected Gateway reads now use the configured system agent only when the request omits `agentId`. An explicit request ID always wins and is still validated, unknown IDs still fail, and an explicit multi-agent roster without a configured system agent still returns `INVALID_REQUEST`; this is deliberately not a universal agent fallback.

Current Control UI model calls and the skills CLI already pass their selected owner. This change repairs TUI model listing and model-auth refresh so they also carry the exact selected agent, while ambient, SDK, and native callers that legitimately omit an owner resolve through the configured system agent for these four reads.

The regression was made visible by #114388 in commit [1ca60fbc3a3f](https://github.com/openclaw/openclaw/commit/1ca60fbc3a3f), which made omitted agent ownership fail closed without teaching these four read paths about the existing system-agent owner. That change was authored and merged by @steipete on 2026-08-12.

The production delta is +58/-45 (net +13). The small positive growth is the narrow owner-boundary capability and caller propagation needed to preserve explicit ownership without creating a general fallback. Tests are +166/-44; docs are +2/-2 (net 0).

## User Impact

Operators with explicitly owned multi-agent configurations can once again use model listing, auth status, skill status, and memory doctor status through ambient or owner-omitting clients when a system agent is configured. Explicitly targeted requests remain isolated to their selected agent, and ambiguous fleets still fail with an actionable request for an owner.

Release-note context: restores system-agent ownership for the four unscoped operator reads and preserves selected-agent ownership in TUI model listing and CLI model-auth refresh.

## Evidence

Local proof on the frozen diff:

- Gateway: 183 tests passed.
- TUI: 258 tests passed.
- Model auth: 58 tests passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- <27 changed paths>` passed.
- `git diff --check` passed.
- Fresh Codex autoreview with `.claude/skills/autoreview/scripts/autoreview --mode uncommitted --max-priority P1 ...` exited clean with no accepted or actionable findings.
- Production LOC: +58/-45 (net +13); tests: +166/-44; docs: +2/-2 (net 0).

The Gateway coverage exercises explicit owners, configured system-owner omission, unknown IDs, and the no-system-agent ambiguous roster for all four reads. TUI and auth tests assert that the exact selected owner reaches their downstream calls. No production host was used for testing, and there is no visual UI change requiring screenshots.

AI-assisted; the implementation and evidence were reviewed before submission.
