### PR TITLE
fix: surface swallowed failures on action paths

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1621,7 +1621,6 @@ packages/memory-host-sdk/src/host/batch-http.ts	2
 packages/memory-host-sdk/src/host/batch-output.ts	2
 packages/memory-host-sdk/src/host/batch-upload.ts	1
 packages/memory-host-sdk/src/host/config-utils.ts	2
-packages/memory-host-sdk/src/host/fs-utils.ts	3
 packages/memory-host-sdk/src/host/internal.ts	1
 packages/memory-host-sdk/src/host/memory-schema-fts.ts	2
 packages/memory-host-sdk/src/host/memory-schema-migration.ts	1

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -549,6 +549,41 @@ describe("memory index", () => {
     }
   });
 
+  it("keeps indexed memory searchable when source discovery fails", async () => {
+    const memoryPath = path.join(fixture.paths.workspace, "MEMORY.md");
+    const query = "harbor seal migration ritual";
+    await fs.writeFile(memoryPath, `Remember the ${query}.\n`);
+    const manager = await getFreshManager(createCfg({}));
+    try {
+      await manager.sync({ reason: "test", force: true });
+      await expect(manager.search(query)).resolves.toEqual([
+        expect.objectContaining({ path: "MEMORY.md" }),
+      ]);
+
+      const scanError = Object.assign(new Error("workspace scan failed"), { code: "EIO" });
+      const realReaddir = fs.readdir;
+      const readdirSpy = vi
+        .spyOn(fs, "readdir")
+        .mockImplementation(async (...args: Parameters<typeof fs.readdir>) => {
+          if (path.resolve(String(args[0])) === fixture.paths.workspace) {
+            throw scanError;
+          }
+          return await realReaddir(...args);
+        });
+      try {
+        await expect(manager.sync({ reason: "cli", force: true })).rejects.toBe(scanError);
+      } finally {
+        readdirSpy.mockRestore();
+      }
+
+      await expect(manager.search(query)).resolves.toEqual([
+        expect.objectContaining({ path: "MEMORY.md" }),
+      ]);
+    } finally {
+      await manager.close?.();
+    }
+  });
+
   it("reindexes memory tables in place without deleting unrelated agent rows", async () => {
     const stateDir = path.join(fixture.paths.workspace, "managed-memory-state");
     fixture.setStateDir(stateDir);

--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -112,6 +112,22 @@ describe("qa-bus server", () => {
     await Promise.all(stops.splice(0).map((stop) => stop()));
   });
 
+  it("returns a 500 JSON response when request handling rejects", async () => {
+    const state = createQaBusState();
+    const requestError = new Error("snapshot unavailable");
+    state.getSnapshot = () => {
+      throw requestError;
+    };
+    const bus = await startQaBusServer({ state });
+    stops.push(async () => await bus.stop());
+
+    const response = await fetch(`${bus.baseUrl}/v1/state`, {
+      signal: AbortSignal.timeout(1_000),
+    });
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: requestError.message });
+  });
+
   it("wakes matching polls and fences late polls and writes during shutdown", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -211,6 +211,18 @@ export function writeError(res: ServerResponse, statusCode: number, error: unkno
   });
 }
 
+export function dispatchQaHttpRequest(res: ServerResponse, task: () => Promise<void>): void {
+  // Node does not observe promises returned by request listeners. Own rejection here so
+  // every admitted request receives an HTTP failure or an explicit connection close.
+  void task().catch((error: unknown) => {
+    if (res.headersSent) {
+      res.destroy(error instanceof Error ? error : new Error(formatErrorMessage(error)));
+      return;
+    }
+    writeError(res, 500, error);
+  });
+}
+
 export function writeQaRequestBodyLimitError(res: ServerResponse, error: unknown): boolean {
   if (!isRequestBodyLimitError(error)) {
     return false;
@@ -448,12 +460,12 @@ export async function handleQaBusRequest(params: {
 
 export function createQaBusServer(state: QaBusState): Server {
   return createServer((req, res) => {
-    void (async () => {
+    dispatchQaHttpRequest(res, async () => {
       const handled = await handleQaBusRequest({ req, res, state });
       if (!handled) {
         writeError(res, 404, "not found");
       }
-    })();
+    });
   });
 }
 

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -402,6 +402,21 @@ async function createQaLabSuiteResultFixture(params?: {
 }
 
 describe("qa-lab server", () => {
+  it("returns a 500 JSON response when a shared bus route rejects", async () => {
+    const lab = await startQaLabServerForTest();
+    cleanups.push(async () => await lab.stop());
+    const requestError = new Error("combined snapshot unavailable");
+    lab.state.getSnapshot = () => {
+      throw requestError;
+    };
+
+    const response = await fetch(`${lab.baseUrl}/v1/state`, {
+      signal: AbortSignal.timeout(1_000),
+    });
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: requestError.message });
+  });
+
   it("dispatches explicit mixed-kind selections through the suite planner", async () => {
     const lab = await startQaLabServerForTest();
     cleanups.push(async () => {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/proxy-capture";
 import {
   closeQaHttpServer,
+  dispatchQaHttpRequest,
   handleQaBusRequest,
   isQaMalformedJsonBodyError,
   readQaJsonBody,
@@ -449,7 +450,7 @@ export async function startQaLabServer(
   }
 
   const server = createServer((req, res) => {
-    void (async () => {
+    dispatchQaHttpRequest(res, async () => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
 
       if (await handleQaBusRequest({ req, res, state })) {
@@ -933,7 +934,7 @@ export async function startQaLabServer(
       } catch (error) {
         writeQaLabServerError(res, error);
       }
-    })();
+    });
   });
 
   const releaseCaptureStore = () => {

--- a/packages/memory-host-sdk/src/host/fs-utils.ts
+++ b/packages/memory-host-sdk/src/host/fs-utils.ts
@@ -28,12 +28,13 @@ if (!hasModeOverride) {
 export function isFileMissingError(
   err: unknown,
 ): err is NodeJS.ErrnoException & { code: "ENOENT" | "ENOTDIR" | "not-file" | "not-found" } {
-  return Boolean(
-    err &&
-    typeof err === "object" &&
-    "code" in err &&
-    ((err as Partial<NodeJS.ErrnoException>).code === "ENOENT" ||
-      (err as Partial<NodeJS.ErrnoException>).code === "ENOTDIR" ||
-      (err as { code?: unknown }).code === "not-found"),
+  if (!err || typeof err !== "object" || !("code" in err)) {
+    return false;
+  }
+  return (
+    err.code === "ENOENT" ||
+    err.code === "ENOTDIR" ||
+    err.code === "not-file" ||
+    err.code === "not-found"
   );
 }

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -270,6 +270,22 @@ describe("memory host SDK package internals", () => {
     await expect(listMemoryFiles(workspaceDir)).rejects.toBe(scanError);
   });
 
+  it("propagates operational failures while traversing a memory directory", async () => {
+    const workspaceDir = getTmpDir();
+    const memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir);
+    const scanError = Object.assign(new Error(`I/O failure: ${memoryDir}`), { code: "EIO" });
+    const realReaddir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args: Parameters<typeof fs.readdir>) => {
+      if (path.resolve(String(args[0])) === memoryDir) {
+        throw scanError;
+      }
+      return await realReaddir(...args);
+    });
+
+    await expect(listMemoryFiles(workspaceDir)).rejects.toBe(scanError);
+  });
+
   it("filters extra directories by glob while preserving symlink skips", async () => {
     const tmpDir = getTmpDir();
     const extraDir = path.join(tmpDir, "extra");

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -223,6 +223,53 @@ describe("memory host SDK package internals", () => {
     ]);
   });
 
+  it.each([
+    {
+      label: "primary memory file",
+      target: (workspaceDir: string) => path.join(workspaceDir, "USER.md"),
+      extraPaths: (_workspaceDir: string) => undefined,
+    },
+    {
+      label: "workspace memory directory",
+      target: (workspaceDir: string) => path.join(workspaceDir, "memory"),
+      extraPaths: (_workspaceDir: string) => undefined,
+    },
+    {
+      label: "configured extra path",
+      target: (workspaceDir: string) => path.join(workspaceDir, "extra"),
+      extraPaths: (workspaceDir: string) => [path.join(workspaceDir, "extra")],
+    },
+  ])("propagates operational scan failures for $label", async ({ target, extraPaths }) => {
+    const workspaceDir = getTmpDir();
+    const failedPath = target(workspaceDir);
+    const scanError = Object.assign(new Error(`I/O failure: ${failedPath}`), { code: "EIO" });
+    const realLstat = fs.lstat;
+    vi.spyOn(fs, "lstat").mockImplementation(
+      async (...args: Parameters<typeof fs.lstat>): ReturnType<typeof fs.lstat> => {
+        if (path.resolve(String(args[0])) === failedPath) {
+          throw scanError;
+        }
+        return await realLstat(...args);
+      },
+    );
+
+    await expect(listMemoryFiles(workspaceDir, extraPaths(workspaceDir))).rejects.toBe(scanError);
+  });
+
+  it("propagates operational failures while discovering the canonical memory file", async () => {
+    const workspaceDir = getTmpDir();
+    const scanError = Object.assign(new Error(`I/O failure: ${workspaceDir}`), { code: "EIO" });
+    const realReaddir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args: Parameters<typeof fs.readdir>) => {
+      if (path.resolve(String(args[0])) === workspaceDir) {
+        throw scanError;
+      }
+      return await realReaddir(...args);
+    });
+
+    await expect(listMemoryFiles(workspaceDir)).rejects.toBe(scanError);
+  });
+
   it("filters extra directories by glob while preserving symlink skips", async () => {
     const tmpDir = getTmpDir();
     const extraDir = path.join(tmpDir, "extra");

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -220,7 +220,11 @@ export async function listMemoryFiles(
         return;
       }
       result.push(absPath);
-    } catch {}
+    } catch (error) {
+      if (!isFileMissingError(error)) {
+        throw error;
+      }
+    }
   };
 
   const memoryFile = await resolveCanonicalRootMemoryFile(workspaceDir);
@@ -234,7 +238,11 @@ export async function listMemoryFiles(
       // Default memory roots stay Markdown-only; multimodal discovery is an extraPaths opt-in.
       await collectMemoryFilesFromDir(memoryDir, result, undefined, shouldSkipWorkspaceMemoryPath);
     }
-  } catch {}
+  } catch (error) {
+    if (!isFileMissingError(error)) {
+      throw error;
+    }
+  }
 
   const normalizedExtraPaths = normalizeExtraMemoryPathEntries(workspaceDir, extraPaths);
   if (normalizedExtraPaths.length > 0) {
@@ -265,7 +273,11 @@ export async function listMemoryFiles(
         ) {
           result.push(inputPath);
         }
-      } catch {}
+      } catch (error) {
+        if (!isFileMissingError(error)) {
+          throw error;
+        }
+      }
     }
   }
   if (result.length <= 1) {

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -196,6 +196,10 @@ async function collectMemoryFilesFromDir(
       isAllowedMemoryFilePath(entry.path, multimodal) &&
       (!extraPathEntry || matchesExtraMemoryPathEntry(extraPathEntry, entry.path)),
   });
+  const operationalFailure = scan.failedDirs.find((failure) => !isFileMissingError(failure.error));
+  if (operationalFailure) {
+    throw operationalFailure.error;
+  }
   files.push(...scan.entries.map((entry) => entry.path));
 }
 

--- a/src/memory/root-memory-files.ts
+++ b/src/memory/root-memory-files.ts
@@ -1,6 +1,7 @@
 // Locates root memory files that seed agent context.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isMissingPathError } from "../infra/errno.js";
 
 /** Canonical root memory file name used by current workspaces. */
 export const CANONICAL_ROOT_MEMORY_FILENAME = "MEMORY.md";
@@ -50,7 +51,11 @@ export async function resolveCanonicalRootMemoryFile(workspaceDir: string): Prom
         return path.join(workspaceDir, entry.name);
       }
     }
-  } catch {}
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+  }
   return null;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where memory indexing could silently treat operational filesystem failures as missing sources, then delete the last-known-good searchable rows. It also fixes QA Lab HTTP requests that could remain unanswered when detached async request handling rejected.

## Why This Change Was Made

The repair keeps absence and operational failure distinct at their owning boundaries. Memory discovery now ignores only genuine missing/non-file states and propagates I/O failures before stale-row reconciliation. Both QA HTTP listeners use one terminal-outcome owner that returns JSON 500 before headers, or explicitly closes an already-started response.

The memory change also preserves the historical symlink/non-file skip contract and removes three grandfathered type assertions from the filesystem error classifier. No protocol, config, storage schema, dependency, or public plugin API changes are involved.

## User Impact

Operators no longer lose healthy memory index entries when a memory path is temporarily unreadable. Programmatic QA Lab clients receive a concrete HTTP failure instead of timing out on a rejected request task.

## Evidence

### Scan

AST inventory at head `ca10b4f5a626e5d1ed82346848330a2ce675fdc4`:

| Surface | Executable handlers |
| --- | ---: |
| Core `src/` | 8,050 |
| `packages/` | 253 |
| Plugins | 5,110 |
| `ui/src/` | 913 |
| **Total** | **14,326** |

The separate ownership census contains 2,568 production `void` expressions, including 2,470 direct calls. The top 30 suspicion sites were caller-traced; tail classification remains explicitly heuristic because lexical R/L/S/D totals misclassify typed degraded results and promises observed by another owner.

### Repaired outcomes

| Surface | Before | After |
| --- | --- | --- |
| Canonical `MEMORY.md`, `USER.md`, workspace `memory/`, configured extra paths, traversal reports | EIO/EACCES became absence; forced sync could delete healthy indexed sources | Operational failure rejects sync before reconciliation; last-known-good memory remains searchable |
| QA bus and combined QA Lab listeners | Rejected detached request timed out with an unhandled rejection | Client receives JSON 500, or an explicit connection close after headers |

### Pre-fix regressions

- Memory SDK fault matrix: 3 failures; each promise resolved `[]` instead of rejecting on EIO.
- Canonical memory discovery: resolved `[]` instead of rejecting.
- Memory manager boundary: forced sync resolved instead of rejecting, admitting an incomplete authoritative source set.
- QA bus: request timed out; Vitest reported unhandled `snapshot unavailable`.
- Combined QA Lab: request timed out; Vitest reported unhandled `combined snapshot unavailable`.

### Post-fix proof

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/internal.test.ts` — 21 passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts` — 56 passed.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts` — 15 passed.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/lab-server.test.ts` — 30 passed.
- `pnpm lint` — passed.
- `node scripts/check-changed.mjs` — passed on the rebased head.
- `pnpm build` — passed on the exact proof head.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings, 0.97 confidence.

Production LOC: +50/-15 (net +35) | Tests: +129/-0 | Tooling ratchet: +0/-1. The production growth owns two concrete terminal-outcome boundaries and the missing-path/operational-error distinction across source producers plus `fs-safe` traversal reports; no parallel fallback or compatibility path was added.

### Real behavior proof

Built exact-head CLI with an isolated state directory, a loopback OpenAI-compatible embedding server, and a real mode-`000` workspace `memory/` directory:

```text
initial index: exit 0 — Memory index updated (main): 2 files indexed.
search before: exit 0 — MEMORY.md contains "harbor seal migration ritual"
forced index with memory/ mode 000: exit 1
  Memory index failed (main): EACCES: permission denied, scandir '<isolated>/workspace/memory'
search after: exit 0 — the same MEMORY.md result remains searchable
```

Standalone production QA servers over real loopback HTTP:

```text
qa-bus  GET http://127.0.0.1:<port>/v1/state → 500 {"error":"standalone snapshot failure"}
qa-lab  GET http://127.0.0.1:<port>/v1/state → 500 {"error":"standalone combined snapshot failure"}
```

### Intentional accounting and follow-ups

Reviewed intentional swallows retain a separate outcome owner: gateway subscription readiness is awaited by its acquirer; transport cancellation follows an already-fixed primary outcome; conversation-binding queue rejection only admits the next awaited write; Telegram ingress acknowledges only after a durable queue write; terminal upload catches render `failBatch`; clipboard rejection falls through to the legacy copy path.

Named follow-ups from confirmed but separate owner surfaces: Doctor/security false-success reporting, session compaction read failures, Discord approval receipts, terminal request rejection, cloud recovery and outbox storage degradation, Realtime Talk queue-full result submission, Signal install mode, and Zalo credential revocation. The rejected-config recovery artifact was deliberately removed from this patch because the overall config action already logs, audits, and throws; only its diagnostic wording is dishonest.

AI-assisted: yes. The maintainer reviewed the complete diff and understands the ownership changes.
