### PR TITLE
fix(ci): verify PR commits from local git

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -35,7 +35,27 @@ ensure_full_pr_worktree_checkout() {
   if [ "$sparse_checkout" = "true" ]; then
     # Prepare gates build the whole repository. Inherited sparse settings can
     # omit tracked transitive inputs and turn healthy PRs into false failures.
-    git sparse-checkout disable
+    if ! git sparse-checkout disable; then
+      echo "Unable to materialize the complete PR worktree." >&2
+      return 1
+    fi
+  fi
+
+  local shallow_checkout
+  shallow_checkout=$(git rev-parse --is-shallow-repository 2>/dev/null || true)
+  if [ "$shallow_checkout" = "true" ]; then
+    # Hosted-gate commit membership is derived from immutable local objects.
+    # Materialize history at the checkout owner instead of letting a verifier
+    # mutate its repository while deciding whether evidence is trustworthy.
+    if ! git fetch --no-tags --unshallow origin; then
+      echo "Unable to fetch complete history for the PR worktree." >&2
+      return 1
+    fi
+    shallow_checkout=$(git rev-parse --is-shallow-repository 2>/dev/null || true)
+  fi
+  if [ "$shallow_checkout" != "false" ]; then
+    echo "Unable to materialize complete history for the PR worktree." >&2
+    return 1
   fi
 }
 
@@ -91,7 +111,7 @@ enter_worktree() {
     return 1
   fi
 
-  ensure_full_pr_worktree_checkout
+  ensure_full_pr_worktree_checkout || return 1
   git fetch origin main
   if [ "$reset_to_main" = "true" ]; then
     git checkout -B "temp/pr-$pr" origin/main

--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -28,7 +28,6 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
 // the existing 1,000-result search window through pagination.
 const WORKFLOW_RUNS_PAGE_SIZE = 30;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
-const COMPARE_COMMITS_PAGE_SIZE = 100;
 export const HOSTED_GATE_MAX_AGE_HOURS = 24;
 const HOSTED_GATE_MAX_AGE_MS = HOSTED_GATE_MAX_AGE_HOURS * 60 * 60 * 1_000;
 const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
@@ -972,55 +971,48 @@ function loadCiReuseCandidateRuns(repo: string, headBranch: string) {
   );
 }
 
-export function compareCommitPageCount(totalCommits: unknown) {
-  if (typeof totalCommits !== "number" || !Number.isSafeInteger(totalCommits) || totalCommits < 0) {
-    throw new Error("Expected comparison total_commits to be a non-negative integer.");
-  }
-  return Math.max(1, Math.ceil(totalCommits / COMPARE_COMMITS_PAGE_SIZE));
-}
-
-function loadPullRequestCommitShas(
+export function loadPullRequestCommitShas(
   repo: string,
+  pr: number,
   { baseSha, headSha }: { baseSha: string; headSha: string },
+  execGit: ExecGit = runGit,
 ) {
-  const loadPage = (page: number) => {
-    const comparison = JSON.parse(
-      execGhApiRead(
-        `repos/${repo}/compare/${baseSha}...${headSha}?per_page=${COMPARE_COMMITS_PAGE_SIZE}&page=${page}`,
-        {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      ),
-    ) as unknown;
-    if (!isRecord(comparison)) {
-      throw new Error(`Expected comparison commit page ${page} to be an object.`);
-    }
-    return comparison;
-  };
-
-  // The PR commits endpoint stops at 250. GitHub's paginated comparison is
-  // equivalent to git log BASE..HEAD and keeps the membership proof complete.
-  const firstPage = loadPage(1);
-  const pages = [firstPage];
-  for (let page = 2; page <= compareCommitPageCount(firstPage?.total_commits); page += 1) {
-    pages.push(loadPage(page));
+  const remote = execGit(["remote", "get-url", "origin"])
+    .trim()
+    .replace(/\.git$/u, "");
+  const remoteMatch = remote.match(
+    /^(?:https?:\/\/github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+\/[^/]+)$/u,
+  );
+  if (remoteMatch?.[1]?.toLowerCase() !== repo.toLowerCase()) {
+    throw new Error(`Current checkout does not match requested repository ${repo}.`);
   }
-  const shas = pages.flatMap((comparison, index) => {
-    if (!Array.isArray(comparison?.commits)) {
-      throw new Error(`Expected comparison commit page ${index + 1} to be an array.`);
+  if (execGit(["rev-parse", "--is-shallow-repository"]).trim() !== "false") {
+    throw new Error("Hosted gate verification requires a complete non-shallow checkout.");
+  }
+  if (!/^[0-9a-f]{40,64}$/u.test(baseSha) || !/^[0-9a-f]{40,64}$/u.test(headSha)) {
+    throw new Error("Expected full hexadecimal base and head commit object ids.");
+  }
+  if (!Number.isSafeInteger(pr) || pr <= 0) {
+    throw new Error("Expected a positive pull-request number.");
+  }
+  if (!ensureCommitAvailable(baseSha, execGit)) {
+    throw new Error(`Could not fetch pull-request base commit ${baseSha}.`);
+  }
+  if (!ensureCommitAvailable(headSha, execGit)) {
+    try {
+      execGit(["fetch", "--no-tags", "origin", `refs/pull/${pr}/head`]);
+      execGit(["cat-file", "-e", `${headSha}^{commit}`]);
+    } catch {
+      throw new Error(`Could not fetch pull-request head commit ${headSha}.`);
     }
-    if (!comparison.commits.every(isRecord)) {
-      throw new Error(`Expected comparison commit page ${index + 1} entries to be objects.`);
-    }
-    return comparison.commits
-      .map((commit) => commit.sha)
-      .filter((sha: unknown): sha is string => typeof sha === "string");
-  });
-  if (shas.length !== firstPage.total_commits) {
-    throw new Error(
-      `Expected ${firstPage.total_commits} comparison commits, received ${shas.length}.`,
-    );
+  }
+  const output = execGit(["rev-list", "--reverse", `${baseSha}..${headSha}`]).trim();
+  if (!output) {
+    return [];
+  }
+  const shas = output.split(/\r?\n/u);
+  if (!shas.every((sha) => /^[0-9a-f]{40,64}$/u.test(sha))) {
+    throw new Error("Expected git rev-list to return full commit object ids.");
   }
   return shas;
 }
@@ -1125,7 +1117,10 @@ function main(argv = process.argv.slice(2)) {
     sha: args.sha,
     pr: args.pr,
     recentSha: args.recentSha,
-    pullRequestCommitShas: loadPullRequestCommitShas(args.repo, { baseSha, headSha }),
+    pullRequestCommitShas: loadPullRequestCommitShas(args.repo, args.pr, {
+      baseSha,
+      headSha,
+    }),
     pullRequestHeadBranch: headBranch,
     pullRequestHeadRepository: headRepository,
     workflowRuns,

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -46,6 +46,35 @@ function createFixture(): Fixture {
   };
 }
 
+function createShallowFixture(): Fixture & { commitCount: number } {
+  const origin = tempDirs.make("openclaw-pr-worktree-origin-");
+  git(origin, "init", "--initial-branch=main");
+  git(origin, "config", "user.name", "OpenClaw Test");
+  git(origin, "config", "user.email", "test@openclaw.invalid");
+  const commitCount = 3;
+  for (let index = 1; index <= commitCount; index += 1) {
+    writeFileSync(join(origin, "fixture.txt"), `main ${index}\n`);
+    git(origin, "add", "fixture.txt");
+    git(origin, "commit", "-m", `main fixture ${index}`);
+  }
+
+  const root = tempDirs.make("openclaw-pr-worktree-shallow-");
+  git(root, "clone", "--depth=1", "--branch=main", `file://${origin}`, ".");
+  git(root, "config", "user.name", "OpenClaw Test");
+  git(root, "config", "user.email", "test@openclaw.invalid");
+  const mainSha = git(root, "rev-parse", "HEAD");
+  git(root, "checkout", "-b", "sibling/work");
+  writeFileSync(join(root, "fixture.txt"), "sibling\n");
+  git(root, "commit", "-am", "sibling fixture");
+  return {
+    root,
+    mainSha,
+    siblingBranch: git(root, "branch", "--show-current"),
+    siblingSha: git(root, "rev-parse", "HEAD"),
+    commitCount,
+  };
+}
+
 function makeStaleWorktreeDir(fixture: Fixture) {
   mkdirSync(join(fixture.root, ".worktrees", "pr-42"), { recursive: true });
 }
@@ -159,6 +188,50 @@ describePosix("scripts/pr worktree containment", () => {
     expect(result.stdout).toContain(`cwd=${realpathSync(expectedWorktree)}`);
     expect(result.stdout).toContain("branch=temp/pr-42");
     expect(result.stdout).toContain(`head=${fixture.mainSha}`);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("materializes complete history for a PR worktree from a shallow clone", () => {
+    const fixture = createShallowFixture();
+    const expectedWorktree = join(fixture.root, ".worktrees", "pr-42");
+    expect(git(fixture.root, "rev-parse", "--is-shallow-repository")).toBe("true");
+
+    const result = runShell(fixture, ["enter_worktree 42 false"]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(git(expectedWorktree, "rev-parse", "--is-shallow-repository")).toBe("false");
+    expect(Number(git(expectedWorktree, "rev-list", "--count", "HEAD"))).toBe(fixture.commitCount);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("propagates shallow-history materialization failure from a conditional caller", () => {
+    const fixture = createShallowFixture();
+    const expectedWorktree = join(fixture.root, ".worktrees", "pr-42");
+
+    const result = runShell(fixture, [
+      'git() { local arg; for arg in "$@"; do [ "$arg" != "--unshallow" ] || return 1; done; command git "$@"; }',
+      'if enter_worktree 42 false; then echo "unexpected worktree success"; exit 0; fi',
+      "exit 42",
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(42);
+    expect(result.stdout).not.toContain("unexpected worktree success");
+    expect(git(expectedWorktree, "rev-parse", "--is-shallow-repository")).toBe("true");
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("propagates sparse-checkout materialization failure from a conditional caller", () => {
+    const fixture = createFixture();
+
+    const result = runShell(fixture, [
+      'git() { if [ "${1-}" = "config" ] && [ "${2-}" = "--bool" ] && [ "${3-}" = "core.sparseCheckout" ]; then printf "true\\n"; return 0; fi; if [ "${1-}" = "sparse-checkout" ]; then return 1; fi; command git "$@"; }',
+      'if enter_worktree 42 false; then echo "unexpected worktree success"; exit 0; fi',
+      "exit 43",
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(43);
+    expect(result.stdout).not.toContain("unexpected worktree success");
+    expect(result.stderr).toContain("Unable to materialize the complete PR worktree.");
     expectCanonicalCheckoutUnchanged(fixture);
   });
 });

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -6,8 +6,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
   collectHostedGateEvidence as collectHostedGateEvidenceRaw,
-  compareCommitPageCount,
   HOSTED_GATE_MAX_AGE_HOURS,
+  loadPullRequestCommitShas,
   notApplicableScheduledHostedWorkflows,
   parseArgs,
   parseWorkflowRunPage,
@@ -735,11 +735,118 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(`Missing successful recent CI workflow for ${sha}`);
   });
 
-  it("paginates comparisons beyond the pull-request endpoint's 250-commit cap", () => {
-    expect(compareCommitPageCount(0)).toBe(1);
-    expect(compareCommitPageCount(250)).toBe(3);
-    expect(compareCommitPageCount(251)).toBe(3);
-    expect(compareCommitPageCount(301)).toBe(4);
+  it("loads complete pull-request commit membership from the local checkout", () => {
+    const execGit = (args: string[]) => {
+      switch (args[0]) {
+        case "remote":
+          return "git@github.com:openclaw/openclaw.git\n";
+        case "rev-parse":
+          return "false\n";
+        case "cat-file":
+          return "";
+        case "rev-list":
+          expect(args).toEqual(["rev-list", "--reverse", `${previousSha}..${sha}`]);
+          return `${previousSha}\n${sha}\n`;
+        default:
+          throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      }
+    };
+    expect(
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        execGit,
+      ),
+    ).toEqual([previousSha, sha]);
+  });
+
+  it("accepts an empty membership when the head is already contained by the base", () => {
+    const execGit = (args: string[]) => {
+      if (args[0] === "remote") {
+        return "https://github.com/openclaw/openclaw.git\n";
+      }
+      if (args[0] === "rev-parse") {
+        return "false\n";
+      }
+      if (args[0] === "cat-file") {
+        return "";
+      }
+      return "";
+    };
+    expect(
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        execGit,
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects the wrong repository or an incomplete checkout", () => {
+    const wrongRepository = (args: string[]) =>
+      args[0] === "remote" ? "https://github.com/acme/other.git\n" : "false\n";
+    expect(() =>
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        wrongRepository,
+      ),
+    ).toThrow("Current checkout does not match requested repository openclaw/openclaw.");
+
+    const shallowCheckout = (args: string[]) =>
+      args[0] === "remote" ? "https://github.com/openclaw/openclaw.git\n" : "true\n";
+    expect(() =>
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        shallowCheckout,
+      ),
+    ).toThrow("Hosted gate verification requires a complete non-shallow checkout.");
+  });
+
+  it("fetches a missing fork head through the pull-request ref", () => {
+    let headAvailable = false;
+    const commands: string[][] = [];
+    const execGit = (args: string[]) => {
+      commands.push(args);
+      if (args[0] === "remote") {
+        return "https://github.com/openclaw/openclaw.git\n";
+      }
+      if (args[0] === "rev-parse") {
+        return "false\n";
+      }
+      if (args[0] === "cat-file") {
+        if (args[2]?.startsWith(sha) && !headAvailable) {
+          throw new Error("missing head");
+        }
+        return "";
+      }
+      if (args[0] === "fetch") {
+        if (args.at(-1) === `refs/pull/${pr}/head`) {
+          headAvailable = true;
+          return "";
+        }
+        throw new Error("unadvertised object");
+      }
+      if (args[0] === "rev-list") {
+        return `${sha}\n`;
+      }
+      throw new Error(`Unexpected git command: ${args.join(" ")}`);
+    };
+
+    expect(
+      loadPullRequestCommitShas(
+        "openclaw/openclaw",
+        pr,
+        { baseSha: previousSha, headSha: sha },
+        execGit,
+      ),
+    ).toEqual([sha]);
+    expect(commands).toContainEqual(["fetch", "--no-tags", "origin", `refs/pull/${pr}/head`]);
   });
 
   it("requires recent evidence for scheduled gates observed on the target head", () => {

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -735,7 +735,10 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(`Missing successful recent CI workflow for ${sha}`);
   });
 
-  it("loads complete pull-request commit membership from the local checkout", () => {
+  it("loads more than 250 pull-request commits from the local checkout", () => {
+    const commitShas = Array.from({ length: 300 }, (_, index) =>
+      (index + 1).toString(16).padStart(40, "0"),
+    ).concat(sha);
     const execGit = (args: string[]) => {
       switch (args[0]) {
         case "remote":
@@ -746,7 +749,7 @@ describe("verify-pr-hosted-gates", () => {
           return "";
         case "rev-list":
           expect(args).toEqual(["rev-list", "--reverse", `${previousSha}..${sha}`]);
-          return `${previousSha}\n${sha}\n`;
+          return `${commitShas.join("\n")}\n`;
         default:
           throw new Error(`Unexpected git command: ${args.join(" ")}`);
       }
@@ -758,7 +761,7 @@ describe("verify-pr-hosted-gates", () => {
         { baseSha: previousSha, headSha: sha },
         execGit,
       ),
-    ).toEqual([previousSha, sha]);
+    ).toEqual(commitShas);
   });
 
   it("accepts an empty membership when the head is already contained by the base", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the native PR landing gate could not validate otherwise-green pull requests when GitHub's compare-commits REST endpoint returned 404. The failure blocked `scripts/pr prepare-run` after exact-head CI had completed successfully.

## Why This Change Was Made

PR commit membership now comes from the already-fetched local Git graph instead of the fragile compare endpoint. The verifier confirms that the checkout belongs to the requested GitHub repository, rejects shallow history, fetches the exact base object and `refs/pull/<n>/head` when needed, and then enumerates the complete full-SHA range locally.

## User Impact

Maintainers can complete the native prepare/merge workflow during a GitHub compare API outage without weakening commit-membership or fork-head validation.

## Evidence

- current canonical gate reproduction: full-SHA compare request returned GitHub 404 for PR #125281
- patched live gate: successfully validated PR #125281 exact-head CI run `32032411659` and Workflow Sanity run `32032411488`
- `node scripts/run-vitest.mjs run test/scripts/verify-pr-hosted-gates.test.ts` — 75/75
- targeted Oxfmt and Oxlint passed
- `git diff --check`
- Autoreview through P2: clean
