### PR TITLE
perf(test): await 1Password descendant cleanup

### DIFF
--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -115,6 +115,15 @@ async function waitForPath(filePath: string, timeoutMs: number): Promise<void> {
   }
 }
 
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function runResolver(params: {
   request: unknown;
   cwd?: string;
@@ -707,35 +716,51 @@ process.exitCode = 1;
     async () => {
       const tempDir = fixtureWorkspace.dir;
       const opPath = path.join(tempDir, "op");
-      const descendantMarker = path.join(tempDir, "descendant-survived");
+      const descendantPidPath = path.join(tempDir, "descendant.pid");
       fs.writeFileSync(
         opPath,
         `#!${getTrustedNodePath()}
+const fs = require("node:fs");
 const { spawn } = require("node:child_process");
-spawn(process.execPath, ["-e", ${JSON.stringify(`process.on("SIGTERM", () => {}); setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(descendantMarker)}, "survived"), 800); setInterval(() => {}, 1000);`)}], { stdio: "ignore" });
-process.stdout.write("x".repeat(70 * 1024));
+const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(`process.on("SIGTERM", () => {}); setInterval(() => {}, 1000);`)}], { stdio: "ignore" });
+descendant.once("spawn", () => {
+  fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));
+  process.stdout.write("x".repeat(70 * 1024));
+});
 setInterval(() => {}, 1000);
 `,
         { mode: 0o755 },
       );
 
-      const result = await runResolver({
-        request: {
-          protocolVersion: 1,
-          provider: "onepassword",
-          ids: ["op://Engineering/OpenRouter/apiKey"],
-        },
-        env: { CLAW_1PASSWORD_OP: opPath },
-      });
-      expect(JSON.parse(result.stdout).errors).toEqual({
-        "op://Engineering/OpenRouter/apiKey": {
-          message: "op read output exceeded the secret value limit.",
-        },
-      });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 650);
-      });
-      expect(fs.existsSync(descendantMarker)).toBe(false);
+      let descendantPid: number | undefined;
+      try {
+        const result = await runResolver({
+          request: {
+            protocolVersion: 1,
+            provider: "onepassword",
+            ids: ["op://Engineering/OpenRouter/apiKey"],
+          },
+          env: { CLAW_1PASSWORD_OP: opPath },
+        });
+        expect(JSON.parse(result.stdout).errors).toEqual({
+          "op://Engineering/OpenRouter/apiKey": {
+            message: "op read output exceeded the secret value limit.",
+          },
+        });
+        const pid = Number.parseInt(fs.readFileSync(descendantPidPath, "utf8"), 10);
+        descendantPid = pid;
+        expect(pid).toBeGreaterThan(0);
+        await expect
+          .poll(
+            () => (isProcessAlive(pid) ? `descendant ${String(pid)} is still alive` : "exited"),
+            { timeout: 2_000, interval: 10 },
+          )
+          .toBe("exited");
+      } finally {
+        if (descendantPid && isProcessAlive(descendantPid)) {
+          process.kill(descendantPid, "SIGKILL");
+        }
+      }
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

The 1Password plugin cleanup regression test always waited 650 ms after the Execa child returned, even when descendant cleanup had already completed. That fixed delay unnecessarily stretched both the focused plugin run and the full suite.

## Why This Change Was Made

The test now waits for the captured descendant PID to become observable, then uses bounded OS liveness polling for cleanup instead of an unconditional sleep. It preserves the original oversized-output error assertion and exercises real Execa descendant cleanup rather than replacing the behavior with a mock.

## User Impact

There is no product or runtime behavior change. Maintainers get faster, more deterministic feedback from the 1Password plugin test. This test-only change does not require a changelog entry.

## Evidence

Performance measurements on exact base `793669c8f6ddfad07b40009068f532832685b7d6`, with the patch unchanged:

- Full wall time: 20.235 s -> 19.300 s (-0.935 s, -4.62%).
- Target wall time: 6.235 s -> 5.150 s (-1.085 s, -17.4%).
- Target test body: -0.692 s.
- Before/after Testbox runs: https://github.com/openclaw/openclaw/actions/runs/32008323485 and https://github.com/openclaw/openclaw/actions/runs/32008803140.

Fault injections preserved the behavior boundary:

- Disabling process-tree cleanup leaves the real captured PID alive.
- Changing output-limit classification fails the original error assertion.

Current-base local proof after rebase:

- Focused target: 10/10 independent passes.
- Full 1Password plugin: 109 passed, 1 skipped.
- Process siblings: 64 passed, 1 skipped.
- Complete changed gate, including the 501/501 environment-variable ratchet, plus format, lint, typecheck, and diff checks: green.
- Fresh post-rebase autoreview: clean, confidence 0.99.

A fresh exact-base Testbox (`tbx_01m07zz4mxhfytx6j1e2c6hvpf`) remained queued for 60 minutes without allocation, IP, or Actions run and was stopped. Per repository policy for trusted source, validation fell back to the suitable local host. This is not claimed as current-base Testbox proof; exact-head pull-request CI is the required hosted proof before merge.
