### PR TITLE
fix: Android Chat mic tap records a voice note when on-device dictation is unavailable

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt
@@ -361,6 +361,17 @@ internal fun dictationFailureForError(code: Int): ChatDictationFailure =
     else -> ChatDictationFailure.Generic
   }
 
+/** Tap starts on-device dictation; if that path cannot run, the same tap records a voice note. */
+internal fun shouldFallbackDictationToVoiceNote(
+  dictationAvailable: Boolean,
+  transcript: String?,
+  state: ChatDictationState,
+): Boolean {
+  if (transcript != null) return false
+  if (!dictationAvailable) return true
+  return (state as? ChatDictationState.Failure)?.reason == ChatDictationFailure.Unavailable
+}
+
 @Composable
 internal fun rememberChatDictationController(viewModel: MainViewModel): ChatDictationController {
   val context = LocalContext.current.applicationContext

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -815,6 +815,31 @@ fun ChatScreen(
 
     ChatSwarmProgress(groups = swarmGroups)
 
+    val startVoiceNote: () -> Unit = {
+      scope.launch {
+        val ownerSnapshot = composerOwner
+        val mediaAuthorizationId = composerState.beginMediaAcquisition(ownerSnapshot) ?: return@launch
+        val recordingId = UUID.randomUUID().toString()
+        if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
+          composerState.cancelMediaAcquisition(mediaAuthorizationId)
+          return@launch
+        }
+        if (voiceNoteRecorder.start(recordingId)) {
+          if (
+            viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
+            composerState.isMediaAcquisitionActive(mediaAuthorizationId)
+          ) {
+            voiceNoteCommitCheckpoint.begin(ownerSnapshot, mediaAuthorizationId, recordingId)
+          } else {
+            voiceNoteRecorder.cancel()
+            composerState.cancelMediaAcquisition(mediaAuthorizationId)
+          }
+        } else {
+          composerState.cancelMediaAcquisition(mediaAuthorizationId)
+        }
+      }
+    }
+
     ChatComposer(
       value = input,
       onValueChange = {
@@ -872,30 +897,7 @@ fun ChatScreen(
           !micCaptureActive &&
           !dictationActive &&
           !sendInFlight,
-      onStartVoiceNote = {
-        scope.launch {
-          val ownerSnapshot = composerOwner
-          val mediaAuthorizationId = composerState.beginMediaAcquisition(ownerSnapshot) ?: return@launch
-          val recordingId = UUID.randomUUID().toString()
-          if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
-            composerState.cancelMediaAcquisition(mediaAuthorizationId)
-            return@launch
-          }
-          if (voiceNoteRecorder.start(recordingId)) {
-            if (
-              viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
-              composerState.isMediaAcquisitionActive(mediaAuthorizationId)
-            ) {
-              voiceNoteCommitCheckpoint.begin(ownerSnapshot, mediaAuthorizationId, recordingId)
-            } else {
-              voiceNoteRecorder.cancel()
-              composerState.cancelMediaAcquisition(mediaAuthorizationId)
-            }
-          } else {
-            composerState.cancelMediaAcquisition(mediaAuthorizationId)
-          }
-        }
-      },
+      onStartVoiceNote = startVoiceNote,
       onCancelVoiceNote = {
         voiceNoteCommitCheckpoint.clear()?.let { lease ->
           composerState.cancelMediaAcquisition(lease.authorizationId)
@@ -913,6 +915,8 @@ fun ChatScreen(
       onToggleDictation = {
         if (dictationActive) {
           dictationController.finish()
+        } else if (!dictationController.isAvailable) {
+          startVoiceNote()
         } else {
           scope.launch {
             val ownerSnapshot = composerOwner
@@ -922,6 +926,18 @@ fun ChatScreen(
             if (transcript != null && viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
               inputDrafts[ownerSnapshot] =
                 appendChatDictationTranscript(inputDrafts[ownerSnapshot], transcript)
+              return@launch
+            }
+            if (
+              viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
+              shouldFallbackDictationToVoiceNote(
+                dictationAvailable = dictationController.isAvailable,
+                transcript = transcript,
+                state = dictationController.state.value,
+              )
+            ) {
+              dictationController.cancel()
+              startVoiceNote()
             }
           }
         }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatDictationControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatDictationControllerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -277,6 +278,38 @@ class ChatDictationControllerTest {
       assertEquals(ChatDictationState.Failure(ChatDictationFailure.Network), controller.state.value)
       assertEquals(1, released)
     }
+
+  @Test
+  fun unavailableRecognizerFallsBackToAVoiceNoteInsteadOfShowingTheError() {
+    assertTrue(
+      shouldFallbackDictationToVoiceNote(
+        dictationAvailable = false,
+        transcript = null,
+        state = ChatDictationState.Idle,
+      ),
+    )
+    assertTrue(
+      shouldFallbackDictationToVoiceNote(
+        dictationAvailable = true,
+        transcript = null,
+        state = ChatDictationState.Failure(ChatDictationFailure.Unavailable),
+      ),
+    )
+    assertFalse(
+      shouldFallbackDictationToVoiceNote(
+        dictationAvailable = true,
+        transcript = "hello",
+        state = ChatDictationState.Idle,
+      ),
+    )
+    assertFalse(
+      shouldFallbackDictationToVoiceNote(
+        dictationAvailable = true,
+        transcript = null,
+        state = ChatDictationState.Failure(ChatDictationFailure.NoSpeech),
+      ),
+    )
+  }
 
   @Test
   fun destroyCancelsCaptureAndDestroysThePlatformRecognizer() =

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -298,7 +298,9 @@ to waitlist-enabled Platform access.
 - Android's main navigation is **Home**, **Chat**, and **Settings**. Voice input
   lives in the Chat composer rather than a separate Voice tab.
 - Tap the composer microphone for on-device dictation. Long-press it to record
-  a voice-note attachment. Start continuous Talk from the Talk waveform.
+  a voice-note attachment. If on-device speech recognition is unavailable, tap
+  records a voice-note attachment instead of showing an error. Start continuous
+  Talk from the Talk waveform.
 - Dictation, voice-note recording, and Talk are mutually exclusive microphone
   paths; starting one stops or blocks the others.
 - Realtime Talk prefers a connected Bluetooth Classic or BLE headset


### PR DESCRIPTION
Related: #125322
Related: #125273

## What Problem This Solves

Fixes an issue where users tapping the Android Chat composer microphone would see “On-device speech recognition is unavailable.” (localized, e.g. German “Die Spracherkennung auf dem Gerät ist nicht verfügbar.”) and never send a voice message when on-device SpeechRecognizer cannot run.

## Why This Change Was Made

Android Chat tap is on-device dictation (`createOnDeviceSpeechRecognizer` + `EXTRA_PREFER_OFFLINE`). Long-press already records an m4a voice-note attachment for gateway STT. This keeps that split, but if dictation is unavailable or fails as `Unavailable`, the same tap starts the existing voice-note recorder instead of a dead-end error. It does not enable Talk Realtime / WebRTC.

## User Impact

On devices without on-device speech recognition (or without a language pack for the device locale), tapping the Chat mic records a voice note and uploads it through the media-understanding path. Long-press is unchanged. Continuous Talk is unchanged.

## Evidence

- Unit tests cover `shouldFallbackDictationToVoiceNote` for unavailable recognizer, `Unavailable` failure, successful transcript, and `NoSpeech` (no fallback).
- `ChatDictationController` already fails before requesting permission when `isAvailable` is false; Chat now routes that tap to the voice-note recorder.