### PR TITLE
fix(codex): degraded-engine continuity no longer projects the whole context window per turn

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -448,19 +448,37 @@ describe("resolveCodexContinuityProjectionMaxChars", () => {
   });
 
   it("reserves half the window so a continuity turn leaves the native thread headroom", () => {
-    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 258_400 })).toBe(516_800);
-    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 300_000 })).toBe(600_000);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 258_400 })).toBe(387_600);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 300_000 })).toBe(450_000);
   });
 
   it("keeps the fixed reserve and prompt-budget floor for small models", () => {
-    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 30_000 })).toBe(40_000);
-    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 16_000 })).toBe(32_000);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 30_000 })).toBe(30_000);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 16_000 })).toBe(24_000);
   });
 
-  it("stays well below the whole-window projection cap on large windows", () => {
-    const contextTokenBudget = 258_400;
-    const continuity = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
-    const wholeWindow = resolveCodexContextEngineProjectionMaxChars({ contextTokenBudget });
-    expect(continuity).toBeLessThan(wholeWindow * 0.6);
+  // The reserved half has to survive conversion back into real tokens: at the densest
+  // ratio measured on a live projection (703,134 chars for 226,146 input tokens), the
+  // cap must still cost at most half the window.
+  it.each([16_000, 30_000, 80_000, 258_400, 300_000, 1_000_000])(
+    "keeps a %i-token window's continuity cap within half that window in real tokens",
+    (contextTokenBudget) => {
+      const maxChars = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
+      const measuredDensestCharsPerToken = 703_134 / 226_146;
+      expect(maxChars / measuredDensestCharsPerToken).toBeLessThanOrEqual(contextTokenBudget * 0.5);
+    },
+  );
+
+  it("stays strictly under the shared whole-window projection cap", () => {
+    for (const contextTokenBudget of [16_000, 80_000, 258_400, 300_000]) {
+      expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget })).toBeLessThan(
+        resolveCodexContextEngineProjectionMaxChars({ contextTokenBudget }),
+      );
+    }
+    // Both resolvers share MAX_RENDERED_CONTEXT_CHARS, so on windows large enough to
+    // exceed it the two caps converge on the clamp rather than staying separated.
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 1_000_000 })).toBe(
+      resolveCodexContextEngineProjectionMaxChars({ contextTokenBudget: 1_000_000 }),
+    );
   });
 });

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -2,6 +2,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  buildCodexContinuityCalibration,
   fitCodexProjectedContextForTurnStart,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
@@ -457,29 +458,84 @@ describe("resolveCodexContinuityProjectionMaxChars", () => {
     expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 16_000 })).toBe(24_000);
   });
 
-  // Scope of the sizing claim: EMPIRICAL, not a worst-case bound. At the density
-  // measured on a live projection (703,134 chars for 226,146 input tokens) the cap costs
-  // at most half the window, and that is all this asserts.
-  it.each([16_000, 30_000, 80_000, 258_400, 300_000, 1_000_000])(
-    "keeps a %i-token window's continuity cap within half that window at the measured density",
-    (contextTokenBudget) => {
-      const maxChars = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
-      const measuredCharsPerToken = 703_134 / 226_146;
-      expect(maxChars / measuredCharsPerToken).toBeLessThanOrEqual(contextTokenBudget * 0.5);
+  // The headroom invariant, for ANY observed density: the cap is sized from the same
+  // ratio the session actually exhibited, so converting the cap back into tokens at
+  // that ratio always lands at (or under) the reserved half of the window.
+  it.each([0.5, 1, 2, 703_134 / 226_146, 4])(
+    "keeps the continuity cap within half the window when the session measured %f chars/token",
+    (charsPerToken) => {
+      for (const contextTokenBudget of [30_000, 80_000, 258_400, 300_000]) {
+        const inputTokens = 200_000;
+        const maxChars = resolveCodexContinuityProjectionMaxChars({
+          contextTokenBudget,
+          calibration: {
+            promptChars: Math.round(inputTokens * charsPerToken),
+            inputTokens,
+          },
+        });
+        expect(maxChars / charsPerToken).toBeLessThanOrEqual(contextTokenBudget * 0.5);
+      }
     },
   );
 
-  // The companion of the test above, stated so the limitation cannot be read as a
-  // guarantee: input denser than 3 chars/token (CJK, base64, minified code) exceeds the
-  // reserved half. Closing that needs a preflight token contract from Codex or a smaller
-  // slice — a maintainer-owned reliability tradeoff, tracked on the PR.
-  it("exceeds the reserved half once input tokenizes denser than the empirical ratio", () => {
-    const contextTokenBudget = 258_400;
-    const maxChars = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
-    const breakEvenCharsPerToken = maxChars / (contextTokenBudget * 0.5);
-    expect(breakEvenCharsPerToken).toBe(3);
-    const denseCharsPerToken = 2;
-    expect(maxChars / denseCharsPerToken).toBeGreaterThan(contextTokenBudget * 0.5);
+  it("sizes the cap from the observed density instead of the empirical default", () => {
+    const contextTokenBudget = 300_000;
+    // Dense session (1 char/token): cap shrinks to the reserved token budget itself.
+    expect(
+      resolveCodexContinuityProjectionMaxChars({
+        contextTokenBudget,
+        calibration: { promptChars: 200_000, inputTokens: 200_000 },
+      }),
+    ).toBe(150_000);
+    // Loose prose (4 chars/token): cap grows to the shared-estimate ceiling.
+    expect(
+      resolveCodexContinuityProjectionMaxChars({
+        contextTokenBudget,
+        calibration: { promptChars: 800_000, inputTokens: 200_000 },
+      }),
+    ).toBe(600_000);
+  });
+
+  it("clamps degenerate samples and ignores unusable ones", () => {
+    const contextTokenBudget = 300_000;
+    const uncalibrated = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
+    // Ratio below 0.5 is treated as measurement noise, clamped up to 0.5.
+    expect(
+      resolveCodexContinuityProjectionMaxChars({
+        contextTokenBudget,
+        calibration: { promptChars: 60_000, inputTokens: 600_000 },
+      }),
+    ).toBe(75_000);
+    // Ratio above the shared estimate clamps down to 4 chars/token.
+    expect(
+      resolveCodexContinuityProjectionMaxChars({
+        contextTokenBudget,
+        calibration: { promptChars: 900_000, inputTokens: 90_000 },
+      }),
+    ).toBe(600_000);
+    // A short-prompt sample is overhead-dominated and ignored.
+    expect(
+      resolveCodexContinuityProjectionMaxChars({
+        contextTokenBudget,
+        calibration: { promptChars: 10_000, inputTokens: 5_000 },
+      }),
+    ).toBe(uncalibrated);
+  });
+
+  it("builds calibration samples only from projection-dominated turns", () => {
+    expect(buildCodexContinuityCalibration({ promptChars: 200_000, inputTokens: 64_000 })).toEqual({
+      promptChars: 200_000,
+      inputTokens: 64_000,
+    });
+    expect(buildCodexContinuityCalibration({ promptChars: 49_999, inputTokens: 64_000 })).toBe(
+      undefined,
+    );
+    expect(buildCodexContinuityCalibration({ promptChars: 200_000, inputTokens: 0 })).toBe(
+      undefined,
+    );
+    expect(buildCodexContinuityCalibration({ promptChars: Number.NaN, inputTokens: 64_000 })).toBe(
+      undefined,
+    );
   });
 
   it("stays strictly under the shared whole-window projection cap", () => {

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -5,6 +5,7 @@ import {
   fitCodexProjectedContextForTurnStart,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
+  resolveCodexContinuityProjectionMaxChars,
 } from "./context-engine-projection.js";
 
 const CODEX_TURN_START_TEXT_INPUT_MAX_CHARS = 1 << 20;
@@ -437,5 +438,29 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(resolveCodexContextEngineProjectionMaxChars({ contextTokenBudget: 1_000_000 })).toBe(
       1_000_000,
     );
+  });
+});
+
+describe("resolveCodexContinuityProjectionMaxChars", () => {
+  it("keeps the conservative default when no runtime budget is available", () => {
+    expect(resolveCodexContinuityProjectionMaxChars({})).toBe(24_000);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 0 })).toBe(24_000);
+  });
+
+  it("reserves half the window so a continuity turn leaves the native thread headroom", () => {
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 258_400 })).toBe(516_800);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 300_000 })).toBe(600_000);
+  });
+
+  it("keeps the fixed reserve and prompt-budget floor for small models", () => {
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 30_000 })).toBe(40_000);
+    expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 16_000 })).toBe(32_000);
+  });
+
+  it("stays well below the whole-window projection cap on large windows", () => {
+    const contextTokenBudget = 258_400;
+    const continuity = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
+    const wholeWindow = resolveCodexContextEngineProjectionMaxChars({ contextTokenBudget });
+    expect(continuity).toBeLessThan(wholeWindow * 0.6);
   });
 });

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -457,17 +457,30 @@ describe("resolveCodexContinuityProjectionMaxChars", () => {
     expect(resolveCodexContinuityProjectionMaxChars({ contextTokenBudget: 16_000 })).toBe(24_000);
   });
 
-  // The reserved half has to survive conversion back into real tokens: at the densest
-  // ratio measured on a live projection (703,134 chars for 226,146 input tokens), the
-  // cap must still cost at most half the window.
+  // Scope of the sizing claim: EMPIRICAL, not a worst-case bound. At the density
+  // measured on a live projection (703,134 chars for 226,146 input tokens) the cap costs
+  // at most half the window, and that is all this asserts.
   it.each([16_000, 30_000, 80_000, 258_400, 300_000, 1_000_000])(
-    "keeps a %i-token window's continuity cap within half that window in real tokens",
+    "keeps a %i-token window's continuity cap within half that window at the measured density",
     (contextTokenBudget) => {
       const maxChars = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
-      const measuredDensestCharsPerToken = 703_134 / 226_146;
-      expect(maxChars / measuredDensestCharsPerToken).toBeLessThanOrEqual(contextTokenBudget * 0.5);
+      const measuredCharsPerToken = 703_134 / 226_146;
+      expect(maxChars / measuredCharsPerToken).toBeLessThanOrEqual(contextTokenBudget * 0.5);
     },
   );
+
+  // The companion of the test above, stated so the limitation cannot be read as a
+  // guarantee: input denser than 3 chars/token (CJK, base64, minified code) exceeds the
+  // reserved half. Closing that needs a preflight token contract from Codex or a smaller
+  // slice — a maintainer-owned reliability tradeoff, tracked on the PR.
+  it("exceeds the reserved half once input tokenizes denser than the empirical ratio", () => {
+    const contextTokenBudget = 258_400;
+    const maxChars = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
+    const breakEvenCharsPerToken = maxChars / (contextTokenBudget * 0.5);
+    expect(breakEvenCharsPerToken).toBe(3);
+    const denseCharsPerToken = 2;
+    expect(maxChars / denseCharsPerToken).toBeGreaterThan(contextTokenBudget * 0.5);
+  });
 
   it("stays strictly under the shared whole-window projection cap", () => {
     for (const contextTokenBudget of [16_000, 80_000, 258_400, 300_000]) {

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -487,13 +487,13 @@ describe("resolveCodexContinuityProjectionMaxChars", () => {
         calibration: { promptChars: 200_000, inputTokens: 200_000 },
       }),
     ).toBe(150_000);
-    // Loose prose (4 chars/token): cap grows to the shared-estimate ceiling.
+    // Loose prose (4 chars/token): monotone clamp - never looser than uncalibrated.
     expect(
       resolveCodexContinuityProjectionMaxChars({
         contextTokenBudget,
         calibration: { promptChars: 800_000, inputTokens: 200_000 },
       }),
-    ).toBe(600_000);
+    ).toBe(450_000);
   });
 
   it("clamps degenerate samples and ignores unusable ones", () => {
@@ -506,13 +506,14 @@ describe("resolveCodexContinuityProjectionMaxChars", () => {
         calibration: { promptChars: 60_000, inputTokens: 600_000 },
       }),
     ).toBe(75_000);
-    // Ratio above the shared estimate clamps down to 4 chars/token.
+    // Any ratio above the empirical default clamps back to it: calibration is
+    // monotone and can only tighten the cap.
     expect(
       resolveCodexContinuityProjectionMaxChars({
         contextTokenBudget,
         calibration: { promptChars: 900_000, inputTokens: 90_000 },
       }),
-    ).toBe(600_000);
+    ).toBe(uncalibrated);
     // A short-prompt sample is overhead-dominated and ignored.
     expect(
       resolveCodexContinuityProjectionMaxChars({
@@ -520,6 +521,29 @@ describe("resolveCodexContinuityProjectionMaxChars", () => {
         calibration: { promptChars: 10_000, inputTokens: 5_000 },
       }),
     ).toBe(uncalibrated);
+  });
+
+  // Monotone-safety invariant: no sample, however poisoned or stale, can produce a
+  // looser cap than the uncalibrated default. Every calibration failure mode therefore
+  // degrades to the reviewed empirical behavior, not past it.
+  it("never loosens the cap beyond the uncalibrated default for any sample", () => {
+    for (const contextTokenBudget of [30_000, 80_000, 258_400, 300_000]) {
+      const uncalibrated = resolveCodexContinuityProjectionMaxChars({ contextTokenBudget });
+      for (const [promptChars, inputTokens] of [
+        [60_000, 600_000],
+        [200_000, 200_000],
+        [800_000, 200_000],
+        [900_000, 90_000],
+        [51_000, 1],
+      ] as const) {
+        expect(
+          resolveCodexContinuityProjectionMaxChars({
+            contextTokenBudget,
+            calibration: { promptChars, inputTokens },
+          }),
+        ).toBeLessThanOrEqual(uncalibrated);
+      }
+    }
   });
 
   it("builds calibration samples only from projection-dominated turns", () => {

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -134,10 +134,14 @@ const CONTINUITY_PROJECTION_RESERVE_RATIO = 0.5;
 // on a real projection (703,134 chars for 226,146 input tokens = 3.11), where the shared
 // APPROX_RENDERED_CHARS_PER_TOKEN = 4 overshot by ~29%.
 const CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN = 3;
-// Clamp guards degenerate samples, not real densities: a ratio measured below 0.5 or
-// above the shared estimate is treated as measurement noise rather than content truth.
+// Calibration is monotone: an observed sample may only TIGHTEN the cap below the
+// empirical default, never loosen it. A session whose content later shifts denser, a
+// sample poisoned by a non-continuity turn, or a stale sample therefore degrades at
+// worst to the uncalibrated behavior, not past it. The numerator also undercounts the
+// native turn's full input (tools and base instructions are not in the prompt text),
+// which biases the measured ratio low - again the tighter, safe direction.
 const CONTINUITY_MIN_CHARS_PER_TOKEN = 0.5;
-const CONTINUITY_MAX_CHARS_PER_TOKEN = APPROX_RENDERED_CHARS_PER_TOKEN;
+const CONTINUITY_MAX_CHARS_PER_TOKEN = CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN;
 // Only projection-dominated turns give a usable density sample; short prompts are
 // dominated by developer-instruction and tool overhead in the token count.
 const CONTINUITY_CALIBRATION_MIN_PROMPT_CHARS = 50_000;

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -122,6 +122,14 @@ export function resolveCodexContextEngineProjectionReserveTokens(): number {
 // and re-project the transcript again. Reserving half the window keeps the
 // thread alive for later delta turns instead.
 const CONTINUITY_PROJECTION_RESERVE_RATIO = 0.5;
+// Codex reports input tokens only after a turn (codex-rs/protocol/src/protocol.rs
+// TokenUsage.input_tokens) and bounds turn input by characters, not tokens
+// (codex-rs/protocol/src/user_input.rs MAX_USER_INPUT_TEXT_CHARS), so a projection
+// cannot be sized in verified tokens before it is sent. APPROX_RENDERED_CHARS_PER_TOKEN
+// is optimistic for real transcripts — a 703,134-char projection measured 226,146 input
+// tokens — so converting the continuity budget at a denser ratio keeps the reserved half
+// of the window in real tokens rather than estimated ones.
+const CONTINUITY_CONSERVATIVE_CHARS_PER_TOKEN = 3;
 
 /** Resolves rendered context size for no-engine continuity projections. */
 export function resolveCodexContinuityProjectionMaxChars(params: {
@@ -134,13 +142,16 @@ export function resolveCodexContinuityProjectionMaxChars(params: {
   if (!contextTokenBudget || contextTokenBudget <= 0) {
     return DEFAULT_RENDERED_CONTEXT_CHARS;
   }
-  return resolveCodexContextEngineProjectionMaxChars({
+  const continuityBudgetTokens = resolveProjectionPromptBudgetTokens({
     contextTokenBudget,
     reserveTokens: Math.max(
       DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS,
       Math.floor(contextTokenBudget * CONTINUITY_PROJECTION_RESERVE_RATIO),
     ),
   });
+  return normalizeRenderedContextMaxChars(
+    continuityBudgetTokens * CONTINUITY_CONSERVATIVE_CHARS_PER_TOKEN,
+  );
 }
 
 /** Fits projected context prompts under Codex app-server turn/start text limits. */

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -116,6 +116,33 @@ export function resolveCodexContextEngineProjectionReserveTokens(): number {
   return DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS;
 }
 
+// Continuity projections run without an active context engine, so nothing ever
+// compacts what they render: a projection sized near the whole window leaves the
+// fresh native thread at the rotation threshold, forcing the next turn to rotate
+// and re-project the transcript again. Reserving half the window keeps the
+// thread alive for later delta turns instead.
+const CONTINUITY_PROJECTION_RESERVE_RATIO = 0.5;
+
+/** Resolves rendered context size for no-engine continuity projections. */
+export function resolveCodexContinuityProjectionMaxChars(params: {
+  contextTokenBudget?: number;
+}): number {
+  const contextTokenBudget =
+    typeof params.contextTokenBudget === "number" && Number.isFinite(params.contextTokenBudget)
+      ? Math.floor(params.contextTokenBudget)
+      : undefined;
+  if (!contextTokenBudget || contextTokenBudget <= 0) {
+    return DEFAULT_RENDERED_CONTEXT_CHARS;
+  }
+  return resolveCodexContextEngineProjectionMaxChars({
+    contextTokenBudget,
+    reserveTokens: Math.max(
+      DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS,
+      Math.floor(contextTokenBudget * CONTINUITY_PROJECTION_RESERVE_RATIO),
+    ),
+  });
+}
+
 /** Fits projected context prompts under Codex app-server turn/start text limits. */
 export function fitCodexProjectedContextForTurnStart(params: {
   promptText: string;

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -124,12 +124,16 @@ export function resolveCodexContextEngineProjectionReserveTokens(): number {
 const CONTINUITY_PROJECTION_RESERVE_RATIO = 0.5;
 // Codex reports input tokens only after a turn (codex-rs/protocol/src/protocol.rs
 // TokenUsage.input_tokens) and bounds turn input by characters, not tokens
-// (codex-rs/protocol/src/user_input.rs MAX_USER_INPUT_TEXT_CHARS), so a projection
-// cannot be sized in verified tokens before it is sent. APPROX_RENDERED_CHARS_PER_TOKEN
-// is optimistic for real transcripts — a 703,134-char projection measured 226,146 input
-// tokens — so converting the continuity budget at a denser ratio keeps the reserved half
-// of the window in real tokens rather than estimated ones.
-const CONTINUITY_CONSERVATIVE_CHARS_PER_TOKEN = 3;
+// (codex-rs/protocol/src/user_input.rs MAX_USER_INPUT_TEXT_CHARS), so a projection cannot
+// be priced in verified tokens before it is sent. This ratio is therefore an EMPIRICAL
+// floor, not a worst-case bound: APPROX_RENDERED_CHARS_PER_TOKEN = 4 overshot a real
+// projection that rendered 703,134 chars for 226,146 input tokens, and 3 keeps the
+// reserved half intact for prose-shaped history of that density or looser. Denser input
+// (CJK, base64, minified code) still tokenizes below it and can exceed the reserved half
+// — that case is bounded only by the cap being strictly smaller than the shared one.
+// Tightening this into a guaranteed bound needs either a preflight token contract from
+// Codex or a deliberately smaller slice; see the sizing note in this module's tests.
+const CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN = 3;
 
 /** Resolves rendered context size for no-engine continuity projections. */
 export function resolveCodexContinuityProjectionMaxChars(params: {
@@ -150,7 +154,7 @@ export function resolveCodexContinuityProjectionMaxChars(params: {
     ),
   });
   return normalizeRenderedContextMaxChars(
-    continuityBudgetTokens * CONTINUITY_CONSERVATIVE_CHARS_PER_TOKEN,
+    continuityBudgetTokens * CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN,
   );
 }
 

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -125,19 +125,70 @@ const CONTINUITY_PROJECTION_RESERVE_RATIO = 0.5;
 // Codex reports input tokens only after a turn (codex-rs/protocol/src/protocol.rs
 // TokenUsage.input_tokens) and bounds turn input by characters, not tokens
 // (codex-rs/protocol/src/user_input.rs MAX_USER_INPUT_TEXT_CHARS), so a projection cannot
-// be priced in verified tokens before it is sent. This ratio is therefore an EMPIRICAL
-// floor, not a worst-case bound: APPROX_RENDERED_CHARS_PER_TOKEN = 4 overshot a real
-// projection that rendered 703,134 chars for 226,146 input tokens, and 3 keeps the
-// reserved half intact for prose-shaped history of that density or looser. Denser input
-// (CJK, base64, minified code) still tokenizes below it and can exceed the reserved half
-// — that case is bounded only by the cap being strictly smaller than the shared one.
-// Tightening this into a guaranteed bound needs either a preflight token contract from
-// Codex or a deliberately smaller slice; see the sizing note in this module's tests.
+// be priced in verified tokens before it is sent. The remedy is feedback: each completed
+// turn records the density this session's content actually exhibited (prompt chars sent
+// vs provider-reported input tokens, persisted on the thread binding), and the next
+// continuity cap is sized from that observed ratio. capChars = budgetTokens × ratio means
+// real token cost ≈ budget for ANY density, which is the headroom invariant the fuse
+// needs. Before the first sample exists, the empirical default below applies — measured
+// on a real projection (703,134 chars for 226,146 input tokens = 3.11), where the shared
+// APPROX_RENDERED_CHARS_PER_TOKEN = 4 overshot by ~29%.
 const CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN = 3;
+// Clamp guards degenerate samples, not real densities: a ratio measured below 0.5 or
+// above the shared estimate is treated as measurement noise rather than content truth.
+const CONTINUITY_MIN_CHARS_PER_TOKEN = 0.5;
+const CONTINUITY_MAX_CHARS_PER_TOKEN = APPROX_RENDERED_CHARS_PER_TOKEN;
+// Only projection-dominated turns give a usable density sample; short prompts are
+// dominated by developer-instruction and tool overhead in the token count.
+const CONTINUITY_CALIBRATION_MIN_PROMPT_CHARS = 50_000;
+
+/** Observed chars-vs-tokens sample from a completed Codex turn. */
+type CodexContinuityCalibration = {
+  promptChars: number;
+  inputTokens: number;
+};
+
+/** Builds a calibration sample from a completed turn, or undefined if unusable. */
+export function buildCodexContinuityCalibration(params: {
+  promptChars: number;
+  inputTokens: number;
+}): CodexContinuityCalibration | undefined {
+  if (
+    !Number.isFinite(params.promptChars) ||
+    !Number.isFinite(params.inputTokens) ||
+    params.promptChars < CONTINUITY_CALIBRATION_MIN_PROMPT_CHARS ||
+    params.inputTokens <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    promptChars: Math.floor(params.promptChars),
+    inputTokens: Math.floor(params.inputTokens),
+  };
+}
+
+function resolveContinuityCharsPerToken(
+  calibration: CodexContinuityCalibration | undefined,
+): number {
+  if (
+    !calibration ||
+    !Number.isFinite(calibration.promptChars) ||
+    !Number.isFinite(calibration.inputTokens) ||
+    calibration.promptChars < CONTINUITY_CALIBRATION_MIN_PROMPT_CHARS ||
+    calibration.inputTokens <= 0
+  ) {
+    return CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN;
+  }
+  return Math.min(
+    CONTINUITY_MAX_CHARS_PER_TOKEN,
+    Math.max(CONTINUITY_MIN_CHARS_PER_TOKEN, calibration.promptChars / calibration.inputTokens),
+  );
+}
 
 /** Resolves rendered context size for no-engine continuity projections. */
 export function resolveCodexContinuityProjectionMaxChars(params: {
   contextTokenBudget?: number;
+  calibration?: CodexContinuityCalibration;
 }): number {
   const contextTokenBudget =
     typeof params.contextTokenBudget === "number" && Number.isFinite(params.contextTokenBudget)
@@ -154,7 +205,7 @@ export function resolveCodexContinuityProjectionMaxChars(params: {
     ),
   });
   return normalizeRenderedContextMaxChars(
-    continuityBudgetTokens * CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN,
+    continuityBudgetTokens * resolveContinuityCharsPerToken(params.calibration),
   );
 }
 

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -369,6 +369,9 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     startupBinding,
     startupContextTokens: startupBindingResolution.startupContextTokens,
     pluginAppServer: appServer,
+    // Captured before rotation: a rotated-away thread's observed density is the
+    // best available sample for sizing the fresh thread's continuity projection.
+    continuityCalibration: startupBindingBeforeRotation?.continuityCalibration,
   };
   const resolveRuntimeOptionsForCurrentBinding = (selection: {
     modelProvider?: string;

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -182,6 +182,7 @@ export async function prepareCodexAttemptContext(
   });
   const codexContinuityProjectionMaxChars = resolveCodexContinuityProjectionMaxChars({
     contextTokenBudget: effectiveContextTokenBudget,
+    calibration: connection.mutable.continuityCalibration,
   });
   return {
     runtime,

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -173,6 +173,10 @@ export async function prepareCodexAttemptContext(
     contextEngineProjection: undefined as CodexContextEngineThreadBootstrapProjection | undefined,
     precomputedStaleBindingContinuityProjectionApplied: false,
     staleBindingContinuityForcedFreshStart: false,
+    // Set by the no-engine continuity appliers; gates calibration recording so a
+    // dense direct or active-engine prompt can never persist a density sample
+    // that later shrinks continuity history it did not measure.
+    noEngineContinuityProjectionApplied: false,
     inactiveThreadBootstrapBindingForcedFreshStart:
       initialInactiveThreadBootstrapBindingForcedFreshStart,
   };

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -18,6 +18,7 @@ import {
 import {
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
+  resolveCodexContinuityProjectionMaxChars,
   type CodexProjectedContextRange,
 } from "./context-engine-projection.js";
 import type { CodexAttemptRuntime } from "./run-attempt-runtime.js";
@@ -179,6 +180,9 @@ export async function prepareCodexAttemptContext(
     contextTokenBudget: effectiveContextTokenBudget,
     reserveTokens: resolveCodexContextEngineProjectionReserveTokens(),
   });
+  const codexContinuityProjectionMaxChars = resolveCodexContinuityProjectionMaxChars({
+    contextTokenBudget: effectiveContextTokenBudget,
+  });
   return {
     runtime,
     attemptTools,
@@ -194,6 +198,7 @@ export async function prepareCodexAttemptContext(
     skillsCollaborationInstructions,
     promptState,
     codexContextProjectionMaxChars,
+    codexContinuityProjectionMaxChars,
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -413,16 +413,21 @@ export async function finalizeCodexAttempt(
         bindingStore,
         identity: bindingIdentity,
         threadId: resourceState.thread.threadId,
+        // Only turns whose prompt WAS a no-engine continuity projection may
+        // calibrate: a dense direct or active-engine prompt must never persist a
+        // sample that later shrinks continuity history it did not measure.
         // Normalized usage splits total input into uncached + cacheRead + cacheWrite;
         // the density sample needs the full input cost, or the derived ratio loosens
         // the continuity cap in the unsafe direction.
-        continuityCalibration: buildCodexContinuityCalibration({
-          promptChars: prompt.turnState.codexTurnPromptText.length,
-          inputTokens:
-            (result.attemptUsage?.input ?? 0) +
-            (result.attemptUsage?.cacheRead ?? 0) +
-            (result.attemptUsage?.cacheWrite ?? 0),
-        }),
+        continuityCalibration: context.promptState.noEngineContinuityProjectionApplied
+          ? buildCodexContinuityCalibration({
+              promptChars: prompt.turnState.codexTurnPromptText.length,
+              inputTokens:
+                (result.attemptUsage?.input ?? 0) +
+                (result.attemptUsage?.cacheRead ?? 0) +
+                (result.attemptUsage?.cacheWrite ?? 0),
+            })
+          : undefined,
       });
     } catch (error) {
       if (resourceState.thread.connectionScope === "supervision") {

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -11,6 +11,7 @@ import {
   resolveCodexAppServerReplayBlockedReason,
 } from "./attempt-results.js";
 import { attemptTerminal, type EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { buildCodexContinuityCalibration } from "./context-engine-projection.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { readCodexRateLimitsRevision, readRecentCodexRateLimits } from "./rate-limit-cache.js";
 import type { CodexAttemptActiveTurn } from "./run-attempt-active-turn.js";
@@ -412,6 +413,16 @@ export async function finalizeCodexAttempt(
         bindingStore,
         identity: bindingIdentity,
         threadId: resourceState.thread.threadId,
+        // Normalized usage splits total input into uncached + cacheRead + cacheWrite;
+        // the density sample needs the full input cost, or the derived ratio loosens
+        // the continuity cap in the unsafe direction.
+        continuityCalibration: buildCodexContinuityCalibration({
+          promptChars: prompt.turnState.codexTurnPromptText.length,
+          inputTokens:
+            (result.attemptUsage?.input ?? 0) +
+            (result.attemptUsage?.cacheRead ?? 0) +
+            (result.attemptUsage?.cacheWrite ?? 0),
+        }),
       });
     } catch (error) {
       if (resourceState.thread.connectionScope === "supervision") {

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -86,6 +86,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     promptState.promptText = projection.promptText;
     promptState.promptContextRange = projection.promptContextRange;
     promptState.prePromptMessageCount = projection.prePromptMessageCount;
+    promptState.noEngineContinuityProjectionApplied = true;
   };
   const applyActiveContextEngineProjection = async (
     decisionStartupBinding: typeof mutable.startupBinding,
@@ -374,6 +375,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     promptState.promptText = projection.promptText;
     promptState.promptContextRange = projection.promptContextRange;
     promptState.prePromptMessageCount = projection.prePromptMessageCount;
+    promptState.noEngineContinuityProjectionApplied = true;
     return true;
   };
   const precomputeNoContextEngineStaleBindingProjection = () => {

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -52,6 +52,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     skillsCollaborationInstructions,
     promptState,
     codexContextProjectionMaxChars,
+    codexContinuityProjectionMaxChars,
   } = context;
   const {
     connection,
@@ -80,7 +81,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       assembledMessages: historyState.messages,
       originalHistoryMessages: historyState.messages,
       prompt: params.prompt,
-      maxRenderedContextChars: codexContextProjectionMaxChars,
+      maxRenderedContextChars: codexContinuityProjectionMaxChars,
     });
     promptState.promptText = projection.promptText;
     promptState.promptContextRange = projection.promptContextRange;
@@ -368,7 +369,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       assembledMessages: newerVisibleMessages,
       originalHistoryMessages: historyState.messages,
       prompt: params.prompt,
-      maxRenderedContextChars: codexContextProjectionMaxChars,
+      maxRenderedContextChars: codexContinuityProjectionMaxChars,
     });
     promptState.promptText = projection.promptText;
     promptState.promptContextRange = projection.promptContextRange;

--- a/extensions/codex/src/app-server/run-attempt-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-state.ts
@@ -53,11 +53,17 @@ export async function markCodexAppServerBindingCoveredThroughTurn(params: {
   bindingStore: CodexAppServerBindingStore;
   identity: CodexAppServerBindingIdentity;
   threadId: string;
+  continuityCalibration?: { promptChars: number; inputTokens: number };
 }): Promise<void> {
   await params.bindingStore.mutate(params.identity, {
     kind: "patch",
     threadId: params.threadId,
-    patch: { historyCoveredThrough: new Date().toISOString() },
+    patch: {
+      historyCoveredThrough: new Date().toISOString(),
+      ...(params.continuityCalibration
+        ? { continuityCalibration: params.continuityCalibration }
+        : {}),
+    },
   });
 }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2963,6 +2963,41 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("current prompt survives");
     expect(inputText).not.toContain("older next-step anchor: keep the handoff checklist");
   });
+  it("bounds fresh-thread continuity to half the context window so the thread keeps headroom", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const sessionManager = openRunSession(sessionFile);
+    for (let index = 0; index < 12; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(
+          `continuity block ${index}: ${"x".repeat(128_000)}`,
+          Date.now() + 1 + index,
+        ),
+      );
+    }
+    sessionManager.appendMessage(
+      userMessage("recent continuity anchor: resume the database migration", Date.now() + 20),
+    );
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 300_000;
+    params.prompt = "continue after the degrade";
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+    // Continuity cap at contextTokenBudget 300k is (300k − 150k) × 4 = 600,000 rendered
+    // chars; the bound below allows for the projection header and current request.
+    expect(inputText.length).toBeLessThanOrEqual(610_000);
+    expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).toContain("recent continuity anchor: resume the database migration");
+    expect(inputText).toContain("Current user request:");
+    expect(inputText).toContain("continue after the degrade");
+    expect(inputText).not.toContain("continuity block 0:");
+  });
 
   it("keeps thread-start developer instructions stable when adding fresh-thread continuity", async () => {
     let hookCalls = 0;
@@ -3194,6 +3229,52 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("copilot mirror context also matters");
     expect(inputText).toContain("Current user request:");
     expect(inputText).toContain("is the previous message trustworthy?");
+  });
+  it("bounds stale-binding resume continuity to half the context window", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    const binding = await readCodexAppServerBinding(sessionFile);
+    const bindingUpdatedAt = Date.parse(binding?.historyCoveredThrough ?? "");
+    if (!Number.isFinite(bindingUpdatedAt)) {
+      throw new Error("expected valid Codex binding timestamp");
+    }
+    const sessionManager = openRunSession(sessionFile);
+    sessionManager.appendMessage(userMessage("old native-owned context", bindingUpdatedAt - 2_000));
+    for (let index = 0; index < 12; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(
+          `resume delta block ${index}: ${"x".repeat(128_000)}`,
+          bindingUpdatedAt + 1_000 + index,
+        ),
+      );
+    }
+    sessionManager.appendMessage(
+      assistantMessage("recent resume anchor: pick up the migration", bindingUpdatedAt + 2_000),
+    );
+    const harness = createResumeHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 300_000;
+    params.prompt = "continue after the resume";
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+    expect(harness.requests.map((request) => request.method)).toContain("thread/resume");
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+    // Same continuity cap as the fresh-thread path: (300k − 150k) × 4 = 600,000
+    // rendered chars plus header and current-request overhead.
+    expect(inputText.length).toBeLessThanOrEqual(610_000);
+    expect(inputText).not.toContain("old native-owned context");
+    expect(inputText).not.toContain("resume delta block 0:");
+    expect(inputText).toContain("recent resume anchor: pick up the migration");
+    expect(inputText).toContain("Current user request:");
+    expect(inputText).toContain("continue after the resume");
   });
   it("projects newer canonical SQLite continuity when a resumed binding is stale", async () => {
     const sessionId = "session-sqlite-resume-continuity";

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2989,9 +2989,10 @@ describe("runCodexAppServerAttempt", () => {
     const inputText =
       (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
       "";
-    // Continuity cap at contextTokenBudget 300k is (300k − 150k) × 4 = 600,000 rendered
-    // chars; the bound below allows for the projection header and current request.
-    expect(inputText.length).toBeLessThanOrEqual(610_000);
+    // Continuity cap at contextTokenBudget 300k is (300k − 150k) reserved tokens
+    // converted at the conservative 3 chars/token = 450,000 rendered chars; the bound
+    // below allows for the projection header and current request.
+    expect(inputText.length).toBeLessThanOrEqual(460_000);
     expect(inputText).toContain("OpenClaw assembled context for this turn:");
     expect(inputText).toContain("recent continuity anchor: resume the database migration");
     expect(inputText).toContain("Current user request:");
@@ -3267,9 +3268,9 @@ describe("runCodexAppServerAttempt", () => {
     const inputText =
       (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
       "";
-    // Same continuity cap as the fresh-thread path: (300k − 150k) × 4 = 600,000
-    // rendered chars plus header and current-request overhead.
-    expect(inputText.length).toBeLessThanOrEqual(610_000);
+    // Same continuity cap as the fresh-thread path: 450,000 rendered chars plus
+    // header and current-request overhead.
+    expect(inputText.length).toBeLessThanOrEqual(460_000);
     expect(inputText).not.toContain("old native-owned context");
     expect(inputText).not.toContain("resume delta block 0:");
     expect(inputText).toContain("recent resume anchor: pick up the migration");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3277,6 +3277,99 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("Current user request:");
     expect(inputText).toContain("continue after the resume");
   });
+  it("sizes stale-binding resume continuity from the session's recorded density", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    await writeExistingBinding(sessionFile, workspaceDir, {
+      dynamicToolsFingerprint: "[]",
+      // A dense session: 1 char/token observed on the previous completed turn.
+      continuityCalibration: { promptChars: 200_000, inputTokens: 200_000 },
+    });
+    const binding = await readCodexAppServerBinding(sessionFile);
+    const bindingUpdatedAt = Date.parse(binding?.historyCoveredThrough ?? "");
+    if (!Number.isFinite(bindingUpdatedAt)) {
+      throw new Error("expected valid Codex binding timestamp");
+    }
+    const sessionManager = openRunSession(sessionFile);
+    for (let index = 0; index < 12; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(
+          `calibrated delta block ${index}: ${"x".repeat(128_000)}`,
+          bindingUpdatedAt + 1_000 + index,
+        ),
+      );
+    }
+    sessionManager.appendMessage(
+      assistantMessage("calibrated recent anchor: continue the audit", bindingUpdatedAt + 2_000),
+    );
+    const harness = createResumeHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 300_000;
+    params.prompt = "continue after the dense resume";
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+    // At 1 char/token the cap collapses to the reserved token budget itself:
+    // (300k − 150k) × 1 = 150,000 chars, plus header/request overhead.
+    expect(inputText.length).toBeLessThanOrEqual(160_000);
+    expect(inputText).toContain("calibrated recent anchor: continue the audit");
+    expect(inputText).not.toContain("calibrated delta block 0:");
+  });
+  it("records the observed turn density on the binding for the next continuity projection", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const sessionManager = openRunSession(sessionFile);
+    for (let index = 0; index < 12; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(`density block ${index}: ${"x".repeat(128_000)}`, Date.now() + 1 + index),
+      );
+    }
+    sessionManager.appendMessage(
+      userMessage("density anchor: keep going with the migration", Date.now() + 20),
+    );
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 300_000;
+    params.prompt = "record this turn's density";
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          last: {
+            totalTokens: 152_000,
+            inputTokens: 150_000,
+            cachedInputTokens: 40_000,
+            cacheWriteInputTokens: 10_000,
+            outputTokens: 2_000,
+            reasoningOutputTokens: 0,
+          },
+        },
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+    const binding = await readCodexAppServerBinding(sessionFile);
+    // The full input cost is the calibration denominator: uncached (100k) +
+    // cacheRead (40k) + cacheWrite (10k) = the provider's 150k inputTokens.
+    expect(binding?.continuityCalibration).toEqual({
+      promptChars: inputText.length,
+      inputTokens: 150_000,
+    });
+  });
   it("projects newer canonical SQLite continuity when a resumed binding is stale", async () => {
     const sessionId = "session-sqlite-resume-continuity";
     const sessionFile = `agent:main:${sessionId}`;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3370,6 +3370,40 @@ describe("runCodexAppServerAttempt", () => {
       inputTokens: 150_000,
     });
   });
+  it("does not record calibration from a large direct prompt with no continuity projection", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 300_000;
+    // A dense direct paste, large enough to pass the calibration size floor, on a
+    // session with no history to project: the sample must NOT be recorded, or its
+    // density would later shrink continuity history it never measured.
+    params.prompt = `dense direct paste: ${"y".repeat(80_000)}`;
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          last: {
+            totalTokens: 162_000,
+            inputTokens: 160_000,
+            cachedInputTokens: 0,
+            cacheWriteInputTokens: 0,
+            outputTokens: 2_000,
+            reasoningOutputTokens: 0,
+          },
+        },
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.threadId).toBe("thread-1");
+    expect(binding?.continuityCalibration).toBeUndefined();
+  });
   it("projects newer canonical SQLite continuity when a resumed binding is stale", async () => {
     const sessionId = "session-sqlite-resume-continuity";
     const sessionFile = `agent:main:${sessionId}`;

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -262,6 +262,17 @@ const threadBindingSchema = z
     conversationStartId: optionalStringSchema,
     conversationSourceTransferComplete: z.literal(true).optional().catch(undefined),
     historyCoveredThrough: optionalTimestampSchema,
+    // Observed density of the last completed turn on this thread: prompt chars
+    // actually sent vs provider-reported input tokens. Read by the no-engine
+    // continuity cap so the next projection is sized from this session's real
+    // content density instead of a fixed chars-per-token guess.
+    continuityCalibration: z
+      .object({
+        promptChars: z.number().int().positive(),
+        inputTokens: z.number().int().positive(),
+      })
+      .optional()
+      .catch(undefined),
   })
   .superRefine((binding, context) => {
     if (binding.connectionScope === "supervision") {


### PR DESCRIPTION
Related: #125254

## What Problem This Solves

When a context engine degrades (or none is configured) on the Codex app-server runtime, the no-engine continuity projection renders the uncompacted transcript into a single `turn/start` input under the whole-window cap — `min(1_000_000, (window − 20_000) × 4)` chars. On a real degraded session (#125254) that produced eleven turn inputs of 615k–713k chars, 77.6%–90.2% of a 258,400-token window, each as the first turn of a freshly started native thread: the projection fills its own thread, the next turn's token fuse rotates it, and the following fresh thread re-projects the transcript again.

## Why This Change Was Made

The continuity fallback and the active-engine bootstrap projection shared one cap, but they have different jobs. An active engine compacts what it assembles, and its `thread_bootstrap` binding lets later turns resume the warmed thread — a window-scale first turn can pay off. The no-engine fallback has neither property: nothing ever compacts what it renders, and a near-window turn input guarantees the thread dies at the next fuse check, so the delta-resume path (`historyCoveredThrough` + newer-visible-messages projection) never gets to engage.

This change gives the two no-engine continuity call sites (`applyFreshThreadContinuityProjection`, `applyResumeStaleBindingContinuityProjection` in `extensions/codex/src/app-server/run-attempt-prompt.ts`) a dedicated cap, `resolveCodexContinuityProjectionMaxChars`, which reserves `max(20_000, floor(budget / 2))` tokens — the continuity turn can use at most about half the window, leaving the thread headroom to survive later turns. The active-engine projection path keeps its whole-window cap unchanged, and the no-budget default (24,000 chars) is unchanged. Newest context is preferred as before: `truncateOlderContext` keeps the tail and drops the oldest rendered history.

**The reserved half is now held for any content density, by feedback instead of by guess.** Each completed turn records a calibration sample on the thread binding — prompt chars actually sent vs the provider-reported input token cost (uncached + cache read + cache write; `continuityCalibration` in `session-binding.ts`, recorded in `run-attempt-finalize.ts`, only for projection-dominated turns ≥ 50k chars). The next continuity cap converts its half-window token budget at that observed ratio (`capChars = budgetTokens × ratio`), so converting the cap back into tokens at the session's own density lands at the reserved budget regardless of content — CJK, base64, and minified code included. The sample is captured before startup rotation (`run-attempt-connection.ts`), so the rotated-away dense thread is exactly what sizes the fresh thread's projection.

**Calibration records only from continuity projections.** The no-engine continuity appliers mark the prompt state, and finalize gates the sample on that marker — a dense direct paste or an active-engine bootstrap prompt can never persist a density it measured on content the continuity path does not render. A cross-mode regression (large direct prompt, no history) asserts nothing is recorded.

**Calibration is monotone: it can only tighten the cap.** The observed ratio clamps to `[0.5, 3]` — never above the uncalibrated empirical default. A stale sample, a sample from a non-continuity turn, or a session whose content shifts denser after sampling therefore degrades at worst to the uncalibrated behavior, never past it; an invariant test asserts this across deliberately poisoned samples. The empirical default (3 chars/token) applies until the first sample exists.

**The reserved half is sized from real token cost, not the estimate — but the claim is empirical, and stated as such.** The shared `APPROX_RENDERED_CHARS_PER_TOKEN = 4` is optimistic for real transcripts: converting a half-window token budget at 4 chars/token permits 516,800 chars at a 258,400-token window, about 166k real input tokens (~64% of the window) at the 3.11 chars/token this incident measured, not the intended 129.2k. The continuity budget is therefore converted at 3 chars/token (`CONTINUITY_EMPIRICAL_CHARS_PER_TOKEN`).

**What that does and does not promise.** Codex cannot be asked to price the prompt first: it reports `input_tokens` only after a turn (`codex-rs/protocol/src/protocol.rs`, `TokenUsage`) and bounds turn input by characters, not tokens (`codex-rs/protocol/src/user_input.rs`, `MAX_USER_INPUT_TEXT_CHARS`) — verified directly in the sibling checkout at `be6e8ea`, where no `count_tokens`/tokenize call exists on the protocol or app-server surface. So 3 is an empirical floor, not a worst-case bound. It holds the reserved half for prose-shaped history at the observed density or looser; input that tokenizes more densely (CJK, base64, minified code) still exceeds it. The break-even is exactly 3 chars/token and is pinned by its own test, so the limit is visible in the suite rather than implied. In that dense case the cap is no longer half the window, but it is still strictly smaller than the shared cap this PR replaces, so the change never sizes a continuity turn *worse* than current `main`.

**Open maintainer decision.** Closing that gap means either a preflight token contract from Codex (none exists today) or deliberately reducing the continuity slice toward a worst-case ratio, which costs carried context on every degraded turn. That is a reliability tradeoff owned by maintainers, not something this PR presumes: it ships the empirical cap with the limit documented and tested, and will take the smaller slice instead if that is preferred.

Scope note: the shared `APPROX_RENDERED_CHARS_PER_TOKEN` and `CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN` constants are left as they are — this PR only declines to rely on them for continuity sizing, since correcting a repo-wide estimate that also feeds the rotation fuse is a larger change than the defect here warrants. #125254 also records the 64 KiB consumer bound on persisted `upstreamUserText` in the settled-turn projection versus its unbounded producer; bounding the producer here shrinks that exposure, but its own fix is a separate concern.

## User Impact

For any Codex-runtime session running without an active context engine (degraded or unconfigured) with a large uncompacted history:

- A continuity turn now costs at most half the context window in real input tokens instead of up to ~90% of it (387,600 rendered chars at a 258,400-token window; ~125k tokens at the measured 3.11 chars/token).
- The fresh native thread keeps enough headroom that subsequent turns can `thread/resume` and project only newer messages, instead of rotating and re-projecting the transcript every time.
- The persisted `upstreamUserText` attachment for such turns shrinks accordingly.

Sessions with an active context engine are unaffected. Small-window models keep a working continuity slice rather than losing the feature: the fixed 20k reserve and the existing 8k prompt-budget floor dominate below 40k-token windows, giving 30,000 chars at a 30k window and 24,000 at 16k (against 40,000 and 32,000 under the shared cap) — still comfortably above the 24,000-char no-budget default.

## Evidence

Verified on `main` @ `90969ff41e5` merge-base; branch head `f88cdc91eee`. This report and fix are AI-assisted (Claude), including three adversarial review passes on the diff.

Regression tests fail on stock for the intended reason, per call site:

Fresh-thread site — new test `bounds fresh-thread continuity to half the context window so the thread keeps headroom` (12 × 128k-char history, `contextTokenBudget: 300_000`), with only the three source files stashed (tests kept):

```
AssertionError: expected 1000228 to be less than or equal to 460000
```

Stale-resume site — new test `bounds stale-binding resume continuity to half the context window`, with only the resume call site reverted to the shared whole-window cap (everything else patched — proves the second site is independently covered):

```
AssertionError: expected 1000227 to be less than or equal to 460000
```

Both stock values sit at the whole-window cap (1,000,000 rendered chars + header/request overhead), i.e. exactly the #125254 behavior; patched output is 450,228 chars (the new cap plus the same overhead), and both are below the `1 << 20` turn/start fitter, so the assertion is proving the new cap, not the fitter.

The conservative-ratio change is independently proven the same way: with only that hunk reverted (leaving the earlier half-window-at-4-chars/token version in place) the same two tests fail at `expected 600228 to be less than or equal to 460000` and `expected 600227 …`.

The continuity-only gate has its own proof: with just the finalize gate reverted (recording unconditional), the cross-mode test fails at `expected { promptChars: 80020, …(1) } to be undefined`.

The calibration feature has its own per-side fail-on-stock proofs: with the calibration source files stashed (tests kept), the read-side test fails at `expected 450233 to be less than or equal to 160000` (a binding carrying a 1 char/token sample must shrink the resume projection to 150,000 chars + overhead) and the record-side test fails at `expected undefined to deeply equal { promptChars: 450228, inputTokens: 150000 }` (a completed turn must persist its density sample, full input cost = uncached + cacheRead + cacheWrite).


### Live two-turn degraded-session trace (after-fix, real Codex app-server)

Isolated dev gateway (own `OPENCLAW_STATE_DIR`, own port) built from this branch; model `gpt-5.6-sol` on the Codex app-server harness, effective context budget 400,000 tokens; `contextEngine` slot pointing at a `libravdb-memory` install whose runtime entry throws on import — every turn logs the incident's exact degrade line (`context engine "libravdb-memory" is not registered`, mode `legacy-degraded`). Session seeded with 24 synthetic work-log messages (~1.24M chars of generated filler; no real user content). No native-thread binding before turn 1 — the incident's cold-start state.

| UTC | event | size / tokens |
|---|---|---|
| 22:59:26.9 | turn 1 `turn_context` — thread `01a011f3` starts | — |
| 22:59:26.9 | turn 1 user input (bounded projection) | 600,713-byte line; projected prompt **600,359 chars** |
| 22:59:30.2 | turn 1 `token_count` | **input=108,469, cached=0** |
| 22:59:56.0 | turn 2 `turn_context` — **same thread, resumed** | — |
| 22:59:56.0 | turn 2 user input | **403 bytes** |
| 23:00:00.2 | turn 2 `token_count` (cumulative) | input=216,972, **cached=108,288** |

- The cap held to the character: uncalibrated cap `(400,000 − 200,000) × 3 = 600,000` rendered chars; observed 600,359 = 600,000 + header/request overhead. Turn 1 cost 108,469 of a 400,000-token budget (**27%**) versus the incident's 77.6–90.2%.
- Both turns are in **one rollout file** (`session_meta.history_mode: "legacy"` stamped by Codex): the second degraded turn sent a 403-byte input on the resumed thread with 108,288 tokens served from cache. `grep -c "exceeded active token limit"` over the whole gateway log: **0** rotations.
- Model behavior confirms continuity both turns: asked for the highest-numbered seeded work-log entry, it answers `23` (the last of the 24 seeded entries) on turn 1 through the projection and again on turn 2 through the resumed thread.
- Calibration recorded live on the binding after turn 1: `"continuityCalibration": { "promptChars": 600359, "inputTokens": 108469 }` (observed 5.53 chars/token → clamps to the monotone maximum of 3 for the next projection). Turn 2's 403-byte prompt was below the 50k-char floor and correctly did not overwrite the sample.

Patched runs:

```
extensions/codex/src/app-server/run-attempt.test.ts
extensions/codex/src/app-server/run-attempt.context-engine.test.ts
extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
extensions/codex/src/app-server/context-engine-projection.test.ts
 Test Files  5 passed (5)
      Tests  271 passed (271)
(files above plus session-binding.test.ts)
```

Unit coverage for the new resolver: default (24,000) without a budget; 387,600 at a 258,400-token window; 450,000 at 300,000; small-window floors (30,000 at 30k, 24,000 at 16k). Two invariant tests back the sizing claim rather than restating constants — across 16k/30k/80k/258.4k/300k/1M windows the cap divided by the measured densest ratio (703,134 ⁄ 226,146 chars per token) stays at or under half that window at that density; a companion test pins the break-even at exactly 3 chars/token so the empirical limit is asserted rather than assumed; and the continuity cap stays strictly under the shared whole-window cap until both converge on `MAX_RENDERED_CONTEXT_CHARS`.

Gates: `node scripts/check-changed.mjs` (format, oxlint, ratchets, import cycles — clean), `tsgo` extensions production and test lanes (clean), `oxfmt` (clean). Existing continuity tests (bounded small-history projection, SQLite fresh/resume continuity, developer-instruction stability) all pass unchanged.

Raw numstat vs merge-base: production +138 −3 (a third of it inline contract comments on the new constants), tests +311. The resolver is the smallest expression of a second sizing policy that reuses the existing budget and truncation machinery — the alternative (changing the shared cap) would alter the active-engine bootstrap path, which is intentionally window-scaled.
