### PR TITLE
fix(workers): propagate session permission context to worker placements

### DIFF
--- a/packages/gateway-protocol/src/schema/worker-admission.test.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.test.ts
@@ -444,11 +444,10 @@ describe("worker protocol schemas", () => {
     ).toBe(false);
   });
 
-  it("does not advertise legacy launch v2 after making execution context mandatory", () => {
-    // Older gateways adopt workers by the V2 feature alone. Omitting it forces
-    // them to reprovision instead of sending the legacy V2 assignment.
+  it("advertises only the current execution-context dialect", () => {
     expect(WORKER_PROTOCOL_FEATURES).not.toContain(WORKER_LAUNCH_V2_PROTOCOL_FEATURE);
-    expect(WORKER_PROTOCOL_FEATURES).toContain("worker-execution-context-v1");
+    expect(WORKER_PROTOCOL_FEATURES).not.toContain("worker-execution-context-v1");
+    expect(WORKER_PROTOCOL_FEATURES).toContain("worker-execution-context-v2");
   });
 
   it("validates the additive live-event protocol", () => {

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -41,7 +41,7 @@ export const WORKER_PROTOCOL_METHODS = [
 export const WORKER_TRANSCRIPT_COMMIT_PROTOCOL_FEATURE = "worker-transcript-commit-v1";
 export const WORKER_LIVE_EVENT_PROTOCOL_FEATURE = "worker-live-event-v1";
 export const WORKER_LAUNCH_V2_PROTOCOL_FEATURE = "worker-launch-v2";
-export const WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE = "worker-execution-context-v1";
+export const WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE = "worker-execution-context-v2";
 export const WORKER_SESSION_TOOLS_PROTOCOL_FEATURE = "worker-session-tools-v1";
 export const WORKER_PROTOCOL_FEATURES = [
   "worker-heartbeat-v1",

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -77,6 +77,7 @@ import {
   resolveScheduledToolCallerContext,
   type ScheduledToolPolicyContext,
 } from "./scheduled-tool-policy.js";
+import { resolveSessionPermissionCoreToolPolicy } from "./session-permission-exec-mode.js";
 import {
   createCodingTools,
   createEditTool,
@@ -84,7 +85,7 @@ import {
   createWriteTool,
 } from "./sessions/index.js";
 import type { TrustedSubagentCompletionHandoff } from "./subagents/announce/subagent-announce-handoff.js";
-import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
+import { resolveToolFsConfig } from "./tool-fs-policy.js";
 import type { PreparedSessionPermissionPolicy } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 import { buildDeclaredToolAllowlistContext } from "./tool-policy-declared-context.js";
@@ -503,19 +504,16 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const execConfig = resolveExecToolConfig({ cfg: options?.config, agentId });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
   const sessionPermissionPolicy = options?.sessionPermissionPolicy;
-  const fsPolicy = createToolFsPolicy({
-    workspaceOnly:
-      isMemoryFlushRun ||
-      (sessionPermissionPolicy ? sessionPermissionPolicy.mode !== "full" : fsConfig.workspaceOnly),
-    root: sessionPermissionPolicy?.root,
-  });
+  const sessionCoreToolPolicy = sessionPermissionPolicy
+    ? resolveSessionPermissionCoreToolPolicy(sessionPermissionPolicy)
+    : undefined;
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = capabilityProfile.workspace.workspaceRoot;
   const runtimeRoot = capabilityProfile.workspace.runtimeRoot;
   const codingRoot = sandboxRoot ?? runtimeRoot;
-  const containmentRoot = sandboxRoot ?? fsPolicy.root ?? codingRoot;
+  const containmentRoot = sandboxRoot ?? sessionPermissionPolicy?.root ?? codingRoot;
   const memoryFlushWriteRoot = sandboxRoot ?? workspaceRoot;
   // Flush exposes one append-only target; its fallback records inherited taint after success.
   const memoryWriteProvenance = isMemoryFlushRun
@@ -542,14 +540,19 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const includeOpenClawTools = includeCoreTools && toolConstructionPlan.includeOpenClawTools;
   const includeChannelTools = toolConstructionPlan.includeChannelTools;
   const includePluginTools = toolConstructionPlan.includePluginTools;
-  const workspaceOnly = fsPolicy.workspaceOnly;
-  const readOnly = sessionPermissionPolicy?.mode === "read-only";
+  const workspaceOnly =
+    isMemoryFlushRun || (sessionCoreToolPolicy?.workspaceOnly ?? fsConfig.workspaceOnly === true);
+  const fsPolicy = {
+    workspaceOnly,
+    ...(sessionPermissionPolicy ? { root: sessionPermissionPolicy.root } : {}),
+  };
+  const readOnly = sessionCoreToolPolicy?.readOnly ?? false;
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
-  const applyPatchWorkspaceOnly = sessionPermissionPolicy
-    ? sessionPermissionPolicy.mode !== "full"
-    : workspaceOnly || applyPatchConfig?.workspaceOnly !== false;
+  const applyPatchWorkspaceOnly =
+    sessionCoreToolPolicy?.applyPatchWorkspaceOnly ??
+    (workspaceOnly || applyPatchConfig?.workspaceOnly !== false);
   const applyPatchEnabled =
     !readOnly &&
     applyPatchConfig?.enabled !== false &&

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -710,6 +710,25 @@ export async function processGatewayAllowlist(
     requiresHeredocApproval ||
     requiresInlineEvalApproval ||
     requiresSecurityAuditSuppressionApproval;
+  const denyHeadlessApproval = (): ProcessGatewayAllowlistResult => {
+    const text = params.approvalFollowupText
+      ? `${params.approvalFollowupText}\nCommand: ${params.command}`
+      : `Exec denied (approval_required): ${params.command}`;
+    return {
+      deniedResult: {
+        content: [{ type: "text", text }],
+        details: {
+          status: "failed",
+          exitCode: null,
+          failureKind: "approval_required",
+          durationMs: 0,
+          aggregated: text,
+          timedOut: false,
+          cwd: params.workdir,
+        },
+      },
+    };
+  };
   if (requiresHeredocApproval) {
     params.warnings.push(
       "Warning: heredoc execution requires reviewer or explicit approval in allowlist mode.",
@@ -719,6 +738,9 @@ export async function processGatewayAllowlist(
     params.warnings.push(
       `Warning: allowlist auto-execution is unavailable on ${process.platform}; reviewer or explicit approval is required.`,
     );
+  }
+  if (policyRequiresAsk && params.nonInteractiveApproval) {
+    return denyHeadlessApproval();
   }
   const shouldDenyUnpromptedShellExpansion =
     requiresAllowlistPlanApproval &&
@@ -807,21 +829,7 @@ export async function processGatewayAllowlist(
   }
   if (requiresAsk) {
     if (params.nonInteractiveApproval) {
-      const text = `Exec denied (approval_required): ${params.command}`;
-      return {
-        deniedResult: {
-          content: [{ type: "text", text }],
-          details: {
-            status: "failed",
-            exitCode: null,
-            failureKind: "approval_required",
-            durationMs: 0,
-            aggregated: text,
-            timedOut: false,
-            cwd: params.workdir,
-          },
-        },
-      };
+      return denyHeadlessApproval();
     }
     if (!mutableFileBinding) {
       return {

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -748,9 +748,6 @@ vi.mock("../../tool-call-id.js", async (importOriginal) => {
 });
 
 vi.mock("../../tool-fs-policy.js", () => ({
-  createToolFsPolicy: (params: { workspaceOnly?: boolean }) => ({
-    workspaceOnly: params.workspaceOnly === true,
-  }),
   resolveSessionPermissionExecMode: (policy: { mode: string }) =>
     ({ "read-only": "deny", guarded: "ask", workspace: "auto", full: "full" })[policy.mode],
   resolveEffectiveToolFsWorkspaceOnly: () => false,

--- a/src/agents/session-permission-exec-mode.ts
+++ b/src/agents/session-permission-exec-mode.ts
@@ -1,18 +1,27 @@
 import type { ExecMode } from "../infra/exec-approvals.js";
 import type { PreparedSessionPermissionPolicy } from "./tool-fs-policy.types.js";
 
+const EXEC_MODE_BY_PERMISSION_MODE = {
+  "read-only": "deny",
+  guarded: "ask",
+  workspace: "auto",
+  full: "full",
+} as const satisfies Record<PreparedSessionPermissionPolicy["mode"], ExecMode>;
+
+export function resolveSessionPermissionCoreToolPolicy(
+  policy: Pick<PreparedSessionPermissionPolicy, "mode">,
+) {
+  const workspaceOnly = policy.mode !== "full";
+  return {
+    workspaceOnly,
+    readOnly: policy.mode === "read-only",
+    applyPatchWorkspaceOnly: workspaceOnly,
+    execMode: EXEC_MODE_BY_PERMISSION_MODE[policy.mode],
+  };
+}
+
 export function resolveSessionPermissionExecMode(
   policy: Pick<PreparedSessionPermissionPolicy, "mode">,
 ): ExecMode {
-  switch (policy.mode) {
-    case "read-only":
-      return "deny";
-    case "guarded":
-      return "ask";
-    case "workspace":
-      return "auto";
-    case "full":
-      return "full";
-  }
-  return policy.mode satisfies never;
+  return resolveSessionPermissionCoreToolPolicy(policy).execMode;
 }

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -6,22 +6,11 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
-import type { ToolFsPolicy } from "./tool-fs-policy.types.js";
 import { isToolAllowedByPolicies } from "./tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
 export type { PreparedSessionPermissionPolicy, ToolFsPolicy } from "./tool-fs-policy.types.js";
 export { resolveSessionPermissionExecMode } from "./session-permission-exec-mode.js";
-
-export function createToolFsPolicy(params: {
-  workspaceOnly?: boolean;
-  root?: string;
-}): ToolFsPolicy {
-  return {
-    workspaceOnly: params.workspaceOnly === true,
-    ...(params.root ? { root: params.root } : {}),
-  };
-}
 
 export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: string }): {
   workspaceOnly?: boolean;

--- a/src/gateway/node-runner-inventory-runtime.ts
+++ b/src/gateway/node-runner-inventory-runtime.ts
@@ -2,6 +2,7 @@ import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-i
 import {
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
   NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
+  NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
   type NodeRunnerInventoryIssue,
@@ -100,7 +101,9 @@ export function resolveNodeRunnerInventoryIssue(
     declaration.clientMode === "node" &&
     declaration.protocolFeatures.length === 1 &&
     (declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE)
+      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE ||
+      declaration.protocolFeatures[0] ===
+        NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE)
     ? NODE_RUNNER_UPDATE_REQUIRED_ISSUE
     : undefined;
 }

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -15,6 +15,7 @@ import {
   formatNodeRunnerUpdateRequired,
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
   NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
+  NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
   parseNodeRunnerInventoryDeclaration,
 } from "../../infra/node-runner-inventory.js";
@@ -426,7 +427,9 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
     }
     if (
       declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE
+      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE ||
+      declaration.protocolFeatures[0] ===
+        NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE
     ) {
       respond(
         false,

--- a/src/gateway/server-methods/nodes.runner-inventory.test.ts
+++ b/src/gateway/server-methods/nodes.runner-inventory.test.ts
@@ -5,6 +5,7 @@ import { NODE_WORKER_SUPERVISOR_STATUS_COMMAND } from "../../infra/node-commands
 import {
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
   NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
+  NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
 } from "../../infra/node-runner-inventory.js";
@@ -290,7 +291,7 @@ describe("nodeHandlers node.runnerInventory.update", () => {
     runtime.nodeRegistry.unregister("conn-1");
   });
 
-  it("keeps exact v1 inventory diagnostic-only until disconnect and v3 reconnect", async () => {
+  it("keeps exact v1 inventory diagnostic-only until disconnect and v4 reconnect", async () => {
     const inventoryChanged = vi.fn();
     const runtime = createNodeRegistryRuntime(() => new NodeRegistry());
     setNodeRunnerInventoryChangedListener(runtime.nodeRegistry, inventoryChanged);
@@ -370,7 +371,22 @@ describe("nodeHandlers node.runnerInventory.update", () => {
     runtime.nodeRegistry.unregister("conn-v2");
   });
 
-  it("routes the shipped v2 build-shaped inventory to update recovery", async () => {
+  it.each([
+    [
+      "v2 build-shaped",
+      {
+        protocolFeatures: [NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE],
+        workerRuns: { ...LEGACY_WORKER_RUNS, bundlePrewarm: 1 },
+      },
+    ],
+    [
+      "v3 execution-context",
+      {
+        protocolFeatures: [NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE],
+        workerHost: { enabled: true, capacity: "available", bundlePrewarm: 1 },
+      },
+    ],
+  ] as const)("routes the shipped %s inventory to update recovery", async (_name, declaration) => {
     const runtime = createNodeRegistryRuntime(() => new NodeRegistry());
     const client = createWorkerSupervisorNodeClient();
     runtime.nodeRegistry.register(client, {
@@ -380,10 +396,7 @@ describe("nodeHandlers node.runnerInventory.update", () => {
     const opts = runnerInventoryOptions({
       nodeRegistry: runtime.nodeRegistry,
       client,
-      declaration: {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE],
-        workerRuns: { ...LEGACY_WORKER_RUNS, bundlePrewarm: 1 },
-      },
+      declaration,
     });
 
     await runnerInventoryHandler(opts);

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -191,15 +191,6 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       respondInvalidWorkerSession(respond, "cannot dispatch an archived session");
       return;
     }
-    // Worker-authority doctrine fences facts the current execution-context dialect cannot carry.
-    // Follow-up: worker execution-context versioning requires an owner decision.
-    if (entry.permissionMode !== undefined) {
-      respondInvalidWorkerSession(
-        respond,
-        "cloud worker dispatch cannot preserve permissionMode/sessionRoot; run this session locally, or use operator.admin sessions.patch to clear permissionMode",
-      );
-      return;
-    }
     const sessionRuntime = resolveWorkerPlacementSessionRuntime({
       cfg,
       entry,

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -274,7 +274,7 @@ describe("sessions.dispatch", () => {
     );
   });
 
-  it("rejects explicit permission modes before cloud worker placement", async () => {
+  it("dispatches explicit permission modes through the worker capability gate", async () => {
     mocks.resolveTarget.mockReturnValue(
       targetWithEntry({
         sessionId,
@@ -288,7 +288,7 @@ describe("sessions.dispatch", () => {
       ownerKind: "session",
       ownerId: sessionKey,
     });
-    const dispatch = vi.fn();
+    const dispatch = vi.fn().mockResolvedValue(activePlacementRecord());
     const respond = await invoke(
       makeContext({
         workerPlacementDispatchService: { dispatch },
@@ -296,16 +296,14 @@ describe("sessions.dispatch", () => {
       }),
     );
 
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledOnce();
     expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
+      true,
       expect.objectContaining({
-        code: ErrorCodes.INVALID_REQUEST,
-        message: expect.stringMatching(
-          /permissionMode.*run this session locally.*operator\.admin/su,
-        ),
+        ok: true,
+        placement: expect.objectContaining({ state: "active" }),
       }),
+      undefined,
     );
   });
 
@@ -661,7 +659,7 @@ describe("sessions.dispatch", () => {
     );
   });
 
-  it("classifies workspace preflight operational failures as unavailable", async () => {
+  it("surfaces an execution-context feature mismatch as unavailable", async () => {
     mocks.resolveTarget.mockReturnValue(
       targetWithEntry({
         sessionId,
@@ -675,7 +673,11 @@ describe("sessions.dispatch", () => {
     });
     const dispatch = vi
       .fn()
-      .mockRejectedValue(Object.assign(new Error("spawn failed"), { code: "ENOENT" }));
+      .mockRejectedValue(
+        new Error(
+          "Worker environment is not dispatchable with the current execution-context contract: ready",
+        ),
+      );
 
     const respond = await invoke(
       makeContext({
@@ -685,7 +687,10 @@ describe("sessions.dispatch", () => {
     );
 
     const error = vi.mocked(respond).mock.calls[0]?.[2];
-    expect(error).toMatchObject({ code: ErrorCodes.UNAVAILABLE, message: "spawn failed" });
+    expect(error).toMatchObject({
+      code: ErrorCodes.UNAVAILABLE,
+      message: expect.stringContaining("current execution-context contract"),
+    });
   });
 
   it("dispatches an existing managed-worktree session and projects placement", async () => {

--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -51,7 +51,7 @@ function launchInput(): NodeWorkerLaunchInput {
     expectedBundleHash: WORKER_RUNS.bundleHash,
     placementGeneration: 4,
     descriptor: {
-      version: 3,
+      version: 4,
       admission: {
         environmentId: "environment-1",
         credential: "worker-fixture-value",

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -82,7 +82,7 @@ function environment(): WorkerEnvironmentRecord {
 
 function plan() {
   return parseWorkerLaunchPlan({
-    version: 3,
+    version: 4,
     admission: {
       environmentId: "environment-1",
       credential: "worker-credential-fixture",

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -653,7 +653,7 @@ describe("worker placement dispatch", () => {
 
   it("rejects and tears down a freshly provisioned bundle without execution context", async () => {
     const harness = createTestHarness();
-    harness.markEnvironmentProtocolFeatures([WORKER_LAUNCH_V2_PROTOCOL_FEATURE]);
+    harness.markEnvironmentProtocolFeatures(["worker-execution-context-v1"]);
 
     await expect(harness.service.dispatch(REQUEST)).rejects.toThrow(
       "current execution-context contract",

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -76,7 +76,7 @@ describe("worker tunnel manager", () => {
     expect(workspace?.argv.at(-1)).toContain("pwd");
     expect(fake.starts).toHaveLength(1);
     const plan = parseWorkerLaunchPlan({
-      version: 3,
+      version: 4,
       admission: {
         environmentId: "worker:one",
         credential: "worker-credential-fixture",

--- a/src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts
@@ -256,6 +256,11 @@ describe("worker turn launcher claim admission", () => {
     if (!launchRequest) {
       throw new Error("expected worker launch request");
     }
+    expect(launchRequest.plan.assignment).toMatchObject({
+      workspaceDir: "/worker/workspace",
+      permissionMode: "workspace",
+      workerContainmentRoot: "/worker/workspace",
+    });
     createWorkerSessionPlacementGate(placements).updateAckCursors({
       claim: launchRequest.turnClaim,
       transcriptSeq: 2,

--- a/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
@@ -276,7 +276,7 @@ describe("worker turn launcher remote handoff", () => {
     expect(descriptor?.assignment.prompt).toBe("Inspect this workspace");
     expect(descriptor?.assignment.suppressPromptTranscript).toBe(true);
     expect(descriptor?.assignment.agentId).toBe(sessionTarget.agentId);
-    expect(descriptor?.version).toBe(3);
+    expect(descriptor?.version).toBe(4);
     const verifiedRuntimeIdentity = await verifyAgentRuntimeIdentityToken(
       descriptor?.assignment.agentRuntimeIdentityToken,
     );

--- a/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
@@ -321,6 +321,8 @@ export function turn(runId = "run-worker-turn", executionIdentity = false) {
     sessionFile,
     sessionTarget,
     workspaceDir: root,
+    permissionMode: "workspace" as const,
+    sessionRoot: root,
     prompt: "Inspect this workspace",
     timeoutMs: 5_000,
     runId,

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -213,7 +213,7 @@ async function executeWorkerTurn(params: {
     messages: initialMessages,
     build: (agentRuntimeIdentityToken, windowedMessages) =>
       parseWorkerLaunchPlan({
-        version: 3,
+        version: 4,
         admission: {
           environmentId: placement.environmentId,
           credential: credential.credential,
@@ -231,6 +231,12 @@ async function executeWorkerTurn(params: {
           prompt: turn.prompt,
           suppressPromptTranscript: true,
           workspaceDir: placement.remoteWorkspaceDir,
+          ...(turn.permissionMode
+            ? {
+                permissionMode: turn.permissionMode,
+                workerContainmentRoot: placement.remoteWorkspaceDir,
+              }
+            : {}),
           modelRef,
           inferenceOptions: reasoning ? { reasoning } : {},
           ...(turn.extraSystemPrompt === undefined ? {} : { systemPrompt: turn.extraSystemPrompt }),

--- a/src/gateway/worker-environments/worker-turn-payload.test.ts
+++ b/src/gateway/worker-environments/worker-turn-payload.test.ts
@@ -82,7 +82,7 @@ function buildDescriptor(
   operationalRunInstance: OperationalRunInstanceRef,
 ): WorkerLaunchPlan {
   return {
-    version: 3,
+    version: 4,
     admission: {
       environmentId: "environment",
       credential: "worker-fixture-credential",

--- a/src/infra/node-runner-inventory.ts
+++ b/src/infra/node-runner-inventory.ts
@@ -3,7 +3,9 @@ import { validateWorkerAdmissionHandshake } from "../../packages/gateway-protoco
 import { WORKER_BUNDLE_PREWARM_VERSION } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 
 export const NODE_RUNNER_INVENTORY_UPDATE_METHOD = "node.runnerInventory.update";
-export const NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE = "node-worker-supervisor-v3";
+export const NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE = "node-worker-supervisor-v4";
+export const NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE =
+  "node-worker-supervisor-v3";
 export const NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE = "node-worker-supervisor-v2";
 export const NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE = "node-worker-supervisor-v1";
 export const NODE_WORKER_BUNDLE_RETENTION_VERSION = 1;
@@ -33,7 +35,8 @@ export type NodeRunnerInventoryDeclaration =
   | {
       protocolFeatures: readonly [
         | typeof NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE
-        | typeof NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
+        | typeof NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE
+        | typeof NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
       ];
     }
   | {
@@ -117,6 +120,11 @@ export function parseNodeRunnerInventoryDeclaration(
     // v1/v2 carried the node-local package build in inventory. Keep wire
     // validation only so shipped nodes receive the explicit update path.
     return { protocolFeatures: [feature] };
+  }
+  if (feature === NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE) {
+    return keys.length === 2 && parseWorkerHostDeclaration(value.workerHost)
+      ? { protocolFeatures: [feature] }
+      : null;
   }
   if (feature !== NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE || keys.length !== 2) {
     return null;

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -149,7 +149,7 @@ if (mode === "connection-failure") {
 
 export function testWorkerDescriptor(workspaceDir: string, prompt = "success"): WorkerLaunchPlan {
   return {
-    version: 3,
+    version: 4,
     admission: {
       environmentId: "environment-1",
       credential: TEST_WORKER_CREDENTIAL,

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -14,6 +14,7 @@ import { isApplyPatchAllowedForModel } from "../agents/apply-patch-model-policy.
 import { buildBootstrapContextForFiles } from "../agents/bootstrap-files.js";
 import { createCoreCodingTools } from "../agents/core-coding-tools.js";
 import { createNativeModelOwnedRuntimeModel } from "../agents/embedded-agent-runner/run/setup.js";
+import { resolveSessionPermissionCoreToolPolicy } from "../agents/session-permission-exec-mode.js";
 import { guardSessionManager } from "../agents/session-tool-result-guard-wrapper.js";
 import { AuthStorage } from "../agents/sessions/auth-storage.js";
 import { ModelRegistry } from "../agents/sessions/model-registry.js";
@@ -76,6 +77,7 @@ type RunWorkerEmbeddedTurnParams = {
   operationalRunInstance: OperationalRunInstanceRef;
   agentRuntimeIdentityToken: string;
   cwd: string;
+  workerContainmentRoot: string;
   stateDir: string;
   sessionId: string;
   sessionKey: string;
@@ -91,6 +93,7 @@ type RunWorkerEmbeddedTurnParams = {
   systemPrompt?: string;
   inferenceOptions?: WorkerInferenceOptions;
   allowedToolNames: readonly WorkerToolName[];
+  permissionMode?: import("../../packages/gateway-protocol/src/schema/sessions-row.js").SessionPermissionMode;
   browser?: WorkerBrowserLaunchDescriptor;
   browserRuntime?: WorkerBrowserRuntime;
   signal?: AbortSignal;
@@ -146,26 +149,46 @@ export async function runWorkerEmbeddedTurn(params: RunWorkerEmbeddedTurnParams)
   });
 
   const allowedToolNameSet = new Set<string>(params.allowedToolNames);
-  const activeToolNames = WORKER_TOOL_NAMES.filter((name) => allowedToolNameSet.has(name));
   const localToolNameSet = new Set<string>(WORKER_LOCAL_TOOL_NAMES);
+  const permissionToolPolicy = params.permissionMode
+    ? resolveSessionPermissionCoreToolPolicy({ mode: params.permissionMode })
+    : undefined;
+  const omittedToolNames = permissionToolPolicy?.readOnly
+    ? new Set<WorkerToolName>(["write", "edit", "apply_patch"])
+    : undefined;
+  const activeToolNames = WORKER_TOOL_NAMES.filter(
+    (name) => allowedToolNameSet.has(name) && !omittedToolNames?.has(name),
+  );
+  const headlessApprovalText = params.permissionMode
+    ? `Exec denied (approval_required) in worker ${params.permissionMode} permission mode. Run this command locally for interactive approval, or ask an administrator to clear the session permission mode.`
+    : undefined;
   const coreTools = createCoreCodingTools({
     codingRoot: params.cwd,
-    containmentRoot: params.cwd,
+    containmentRoot: params.workerContainmentRoot,
     includeBaseCodingTools: true,
     includeShellTools: true,
-    workspaceOnly: false,
-    readOnly: false,
+    workspaceOnly: permissionToolPolicy?.workspaceOnly ?? false,
+    readOnly: permissionToolPolicy?.readOnly ?? false,
     modelContextWindowTokens: model.contextWindow,
     imageSanitization: {},
-    applyPatchEnabled: isApplyPatchAllowedForModel({
-      modelProvider: params.modelRef.provider,
-      modelId: params.modelRef.model,
-    }),
-    applyPatchWorkspaceOnly: true,
+    applyPatchEnabled:
+      permissionToolPolicy?.readOnly !== true &&
+      isApplyPatchAllowedForModel({
+        modelProvider: params.modelRef.provider,
+        modelId: params.modelRef.model,
+      }),
+    applyPatchWorkspaceOnly: permissionToolPolicy?.applyPatchWorkspaceOnly ?? true,
     execDefaults: {
       host: "gateway",
+      mode: permissionToolPolicy?.execMode ?? "full",
       security: "full",
       ask: "off",
+      // Safe clamp v1 keeps allowlist hits local but denies misses before review.
+      // Worker LLM review and interactive approval RPC remain a named follow-up.
+      nonInteractiveApproval: Boolean(
+        permissionToolPolicy && permissionToolPolicy.execMode !== "full",
+      ),
+      approvalFollowupText: headlessApprovalText,
       config: WORKER_TOOL_CONFIG,
       commandHighlighting: false,
       agentId: params.agentId,
@@ -220,6 +243,9 @@ export async function runWorkerEmbeddedTurn(params: RunWorkerEmbeddedTurnParams)
       );
       const discoveredToolNames = new Set(localTools.map((tool) => tool.name));
       for (const toolName of WORKER_REQUIRED_LOCAL_TOOL_NAMES) {
+        if (omittedToolNames?.has(toolName)) {
+          continue;
+        }
         if (!discoveredToolNames.has(toolName)) {
           throw new Error(`Worker coding tool unavailable: ${toolName}`);
         }

--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -11,7 +11,7 @@ import { buildWorkerConnectParams, parseWorkerLaunchDescriptor } from "./launch-
 
 function launchDescriptor(): WorkerLaunchDescriptor {
   return {
-    version: 3,
+    version: 4,
     connectionEndpoint: { kind: "unix", socketPath: "/tmp/openclaw-worker/gateway.sock" },
     admission: {
       environmentId: "environment-1",
@@ -34,6 +34,8 @@ function launchDescriptor(): WorkerLaunchDescriptor {
       prompt: "Inspect the workspace.",
       suppressPromptTranscript: false,
       workspaceDir: "/tmp/openclaw-worker/workspace",
+      permissionMode: "workspace",
+      workerContainmentRoot: "/tmp/openclaw-worker/workspace",
       modelRef: { provider: "provider-1", model: "model-1" },
       inferenceOptions: { reasoning: "medium", maxTokens: 512 },
       initialMessages: [
@@ -60,6 +62,27 @@ describe("worker launch descriptor", () => {
       client: { id: "openclaw-worker", mode: "worker", version: "2026.7.12" },
       admission: { ...descriptor.admission, runId: descriptor.assignment.runId },
     });
+  });
+
+  it("accepts the permission context pair only when both fields are present", () => {
+    const descriptor = launchDescriptor();
+    const {
+      permissionMode: _permissionMode,
+      workerContainmentRoot: _root,
+      ...withoutContext
+    } = descriptor.assignment;
+    expect(
+      parseWorkerLaunchDescriptor({ ...descriptor, assignment: withoutContext }).assignment,
+    ).toEqual(withoutContext);
+
+    for (const assignment of [
+      { ...withoutContext, permissionMode: "workspace" },
+      { ...withoutContext, workerContainmentRoot: "/tmp/openclaw-worker/workspace" },
+    ]) {
+      expect(() => parseWorkerLaunchDescriptor({ ...descriptor, assignment })).toThrow(
+        "invalid worker launch descriptor",
+      );
+    }
   });
 
   it("accepts only closed Unix or public WebSocket connection endpoints", () => {
@@ -188,7 +211,7 @@ describe("worker launch descriptor", () => {
     const descriptor = launchDescriptor();
     const { toolAuthority: _missing, ...assignmentWithoutAuthority } = descriptor.assignment;
     const cases: unknown[] = [
-      { ...descriptor, version: 2 },
+      { ...descriptor, version: 3 },
       { ...descriptor, assignment: assignmentWithoutAuthority },
       {
         ...descriptor,
@@ -286,6 +309,10 @@ describe("worker launch descriptor", () => {
       {
         ...descriptor,
         assignment: { ...descriptor.assignment, workspaceDir: "workspace" },
+      },
+      {
+        ...descriptor,
+        assignment: { ...descriptor.assignment, workerContainmentRoot: "workspace" },
       },
       {
         ...descriptor,

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -6,6 +6,10 @@ import {
   GATEWAY_CLIENT_MODES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import {
+  type SessionPermissionMode,
+  SessionPermissionModeSchema,
+} from "../../packages/gateway-protocol/src/schema/sessions-row.js";
+import {
   type WorkerConnectParams,
   type WorkerConnectRequestFrame,
   WorkerConnectRequestFrameSchema,
@@ -32,14 +36,18 @@ import {
   type WorkerConnectionEndpoint,
 } from "./worker-connection-endpoint.js";
 
-const LAUNCH_VERSION = 3;
+const LAUNCH_VERSION = 4;
 
 export type WorkerBrowserLaunchDescriptor = {
   cdpUrl: string;
   launcherPath: string;
 };
 
-type WorkerLaunchAssignment = {
+type WorkerLaunchPermissionContext =
+  | { permissionMode: SessionPermissionMode; workerContainmentRoot: string }
+  | { permissionMode?: never; workerContainmentRoot?: never };
+
+type WorkerLaunchAssignment = WorkerLaunchPermissionContext & {
   /** Host placement namespace used for worker-local policy, hooks, and audit attribution. */
   agentId: string;
   operationalRunInstance: OperationalRunInstanceRef;
@@ -71,7 +79,7 @@ type WorkerLaunchAdmission = Omit<WorkerConnectParams["admission"], "runId"> & {
 };
 
 export type WorkerLaunchPlan = {
-  version: 3;
+  version: 4;
   admission: WorkerLaunchAdmission;
   assignment: WorkerLaunchAssignment;
 };
@@ -180,8 +188,20 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
         "liveEvents",
         "toolAuthority",
       ],
-      ["systemPrompt", "browser"],
+      ["systemPrompt", "browser", "permissionMode", "workerContainmentRoot"],
     )
+  ) {
+    return undefined;
+  }
+  const hasPermissionMode = Object.hasOwn(value, "permissionMode");
+  const hasContainmentRoot = Object.hasOwn(value, "workerContainmentRoot");
+  if (
+    hasPermissionMode !== hasContainmentRoot ||
+    (hasPermissionMode &&
+      (!Value.Check(SessionPermissionModeSchema, value.permissionMode) ||
+        typeof value.workerContainmentRoot !== "string" ||
+        !isIdentifier(value.workerContainmentRoot) ||
+        !isAbsoluteHostPath(value.workerContainmentRoot)))
   ) {
     return undefined;
   }
@@ -331,7 +351,7 @@ export function parseWorkerLaunchDescriptor(value: unknown): WorkerLaunchDescrip
   }
   return completeWorkerLaunchDescriptor(
     {
-      version: value.version as 3,
+      version: value.version as 4,
       admission: value.admission as WorkerLaunchAdmission,
       assignment: value.assignment as WorkerLaunchAssignment,
     },

--- a/src/worker/node-bundle-install-protocol.test.ts
+++ b/src/worker/node-bundle-install-protocol.test.ts
@@ -9,7 +9,7 @@ import {
 const build = {
   bundleHash: "a".repeat(64),
   openclawVersion: "2026.8.1",
-  protocolFeatures: ["worker-execution-context-v1"],
+  protocolFeatures: ["worker-execution-context-v2"],
 };
 const input = {
   gatewayNamespace: "gateway-test",

--- a/src/worker/worker-command.runtime.test.ts
+++ b/src/worker/worker-command.runtime.test.ts
@@ -14,7 +14,7 @@ vi.mock("./worker.runtime.js", () => ({
 }));
 
 const descriptor = {
-  version: 3,
+  version: 4,
   connectionEndpoint: { kind: "unix", socketPath: "/tmp/openclaw-worker/gateway.sock" },
   admission: {
     environmentId: "environment-1",

--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -294,7 +294,7 @@ export class ComposedGatewayHarness {
       throw new Error("fault descriptor epoch does not match its exact placement claim");
     }
     return {
-      version: 3,
+      version: 4,
       connectionEndpoint: { kind: "unix", socketPath: this.socketPath },
       admission: {
         environmentId: ENVIRONMENT_ID,

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -98,6 +98,7 @@ const CREDENTIAL = ["worker", "fixture", "admission"].join("-");
 type InferencePlan =
   | "text"
   | "tool"
+  | "safe-tool"
   | "background-tool"
   | "session-tool"
   | "hold"
@@ -494,8 +495,11 @@ class FakeWorkerGateway {
       });
       return;
     }
-    if (plan === "tool" || plan === "background-tool") {
-      this.sendToolTurn(socket, frame.params, plan === "background-tool");
+    if (plan === "tool" || plan === "safe-tool" || plan === "background-tool") {
+      this.sendToolTurn(socket, frame.params, {
+        background: plan === "background-tool",
+        safe: plan === "safe-tool",
+      });
       return;
     }
     if (plan === "session-tool") {
@@ -674,10 +678,10 @@ class FakeWorkerGateway {
   private sendToolTurn(
     socket: WebSocket,
     identity: WorkerInferenceStartParams,
-    background = false,
+    options: { background: boolean; safe: boolean },
   ): void {
     const toolCallId = "local-exec-call";
-    const args = background
+    const args = options.background
       ? {
           // POSIX sleep avoids Node startup; Windows keeps the portable Node fixture.
           command:
@@ -688,7 +692,9 @@ class FakeWorkerGateway {
               : "exec sleep 60",
           background: true,
         }
-      : { command: "printf worker-local > local-proof.txt" };
+      : {
+          command: options.safe ? "wc -c" : "printf worker-local > local-proof.txt",
+        };
     this.sendToolCallTurn(socket, identity, {
       args,
       toolCallId,
@@ -808,7 +814,7 @@ class FakeWorkerGateway {
 
 function descriptor(socketPath: string, workspaceDir: string): WorkerLaunchDescriptor {
   return {
-    version: 3,
+    version: 4,
     connectionEndpoint: { kind: "unix", socketPath },
     admission: {
       environmentId: "worker-environment",
@@ -1361,6 +1367,110 @@ describe("worker runtime", () => {
     expect(
       gateway.methods.every((method) => method.startsWith("worker.") || method === "connect"),
     ).toBe(true);
+  });
+
+  it.each([
+    {
+      mode: "read-only" as const,
+      omittedTools: ["write", "edit", "apply_patch"],
+      denial: /host=gateway security=deny/u,
+    },
+    {
+      mode: "guarded" as const,
+      omittedTools: [],
+      denial:
+        /approval_required.*worker guarded permission mode.*run this command locally.*interactive approval.*administrator.*clear the session permission mode/isu,
+    },
+    {
+      mode: "workspace" as const,
+      omittedTools: [],
+      denial:
+        /approval_required.*worker workspace permission mode.*run this command locally.*interactive approval.*administrator.*clear the session permission mode/isu,
+    },
+    { mode: "full" as const, omittedTools: [], denial: null },
+  ])("applies the $mode worker permission clamp", async ({ mode, omittedTools, denial }) => {
+    const { gateway, workspaceDir, launch } = await setup({ inferencePlans: ["tool", "text"] });
+    launch.assignment.permissionMode = mode;
+    launch.assignment.workerContainmentRoot = workspaceDir;
+
+    await expect(runWorkerDescriptor(launch)).resolves.toMatchObject({ status: "completed" });
+
+    const toolNames = gateway.inferenceRequests[0]?.context.tools?.map((tool) => tool.name) ?? [];
+    for (const toolName of omittedTools) {
+      expect(toolNames).not.toContain(toolName);
+    }
+    const toolResult = JSON.stringify(
+      gateway.inferenceRequests[1]?.context.messages.find(
+        (message) => message.role === "toolResult",
+      ),
+    );
+    if (denial) {
+      expect(toolResult).toMatch(denial);
+      await expect(
+        readFile(path.join(workspaceDir, "local-proof.txt"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } else {
+      await expect(readFile(path.join(workspaceDir, "local-proof.txt"), "utf8")).resolves.toBe(
+        "worker-local",
+      );
+    }
+  });
+
+  it.each(["guarded", "workspace"] as const)(
+    "keeps the %s worker allowlist fast path",
+    async (mode) => {
+      const { gateway, workspaceDir, launch } = await setup({
+        inferencePlans: ["safe-tool", "text"],
+      });
+      launch.assignment.permissionMode = mode;
+      launch.assignment.workerContainmentRoot = workspaceDir;
+
+      await expect(runWorkerDescriptor(launch)).resolves.toMatchObject({ status: "completed" });
+
+      const toolResult = JSON.stringify(
+        gateway.inferenceRequests[1]?.context.messages.find(
+          (message) => message.role === "toolResult",
+        ),
+      );
+      expect(toolResult).not.toContain("approval_required");
+      expect(toolResult).toMatch(/\b0\b/u);
+    },
+  );
+
+  it("canonicalizes an in-root worker workspace before enforcing containment", async () => {
+    const { workspaceDir, launch } = await setup();
+    const nested = path.join(workspaceDir, "nested");
+    await mkdir(nested);
+    launch.assignment.workspaceDir = path.join(nested, "..", "nested");
+    launch.assignment.permissionMode = "workspace";
+    launch.assignment.workerContainmentRoot = workspaceDir;
+
+    await expect(runWorkerDescriptor(launch)).resolves.toMatchObject({ status: "completed" });
+  });
+
+  it("rejects a worker workspace outside its canonical containment root", async () => {
+    const { workspaceDir, launch } = await setup();
+    const narrowerRoot = path.join(workspaceDir, "contained");
+    await mkdir(narrowerRoot);
+    launch.assignment.permissionMode = "workspace";
+    launch.assignment.workerContainmentRoot = narrowerRoot;
+
+    await expect(runWorkerDescriptor(launch)).rejects.toThrow(
+      "worker workspace path escapes its assigned containment root",
+    );
+  });
+
+  it("rejects a dot-dot workspace escape before worker connection", async () => {
+    const { workspaceDir, launch } = await setup();
+    const outside = await mkdtemp(path.join(tmpdir(), "openclaw-worker-outside-"));
+    tempDirs.push(outside);
+    launch.assignment.workspaceDir = path.join(workspaceDir, "..", path.basename(outside));
+    launch.assignment.permissionMode = "workspace";
+    launch.assignment.workerContainmentRoot = workspaceDir;
+
+    await expect(runWorkerDescriptor(launch)).rejects.toThrow(
+      "worker workspace path escapes its assigned containment root",
+    );
   });
 
   it("keeps a pinned replay anchor through repeated local tool-loop inference", async () => {

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdtemp, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { isPathInside } from "../infra/path-guards.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
@@ -39,11 +40,11 @@ function fencedResult(state: WorkerConnectionState): WorkerRuntimeResult | undef
   return undefined;
 }
 
-async function assertWorkspaceDirectory(workspaceDir: string): Promise<string> {
-  const resolved = await realpath(workspaceDir);
+async function assertWorkerDirectory(pathname: string, label: string): Promise<string> {
+  const resolved = await realpath(pathname);
   const workspaceStat = await stat(resolved);
   if (!workspaceStat.isDirectory()) {
-    throw new Error("worker workspace path must be a directory");
+    throw new Error(`worker ${label} path must be a directory`);
   }
   return resolved;
 }
@@ -63,7 +64,19 @@ export async function runWorkerDescriptor(
     registerSecretValueForRedaction(descriptor.connectionEndpoint.cloudflareAccess.clientId);
     registerSecretValueForRedaction(descriptor.connectionEndpoint.cloudflareAccess.clientSecret);
   }
-  const workspaceDir = await assertWorkspaceDirectory(descriptor.assignment.workspaceDir);
+  const workspaceDir = await assertWorkerDirectory(descriptor.assignment.workspaceDir, "workspace");
+  const workerContainmentRoot = descriptor.assignment.workerContainmentRoot
+    ? await assertWorkerDirectory(descriptor.assignment.workerContainmentRoot, "containment root")
+    : workspaceDir;
+  if (
+    descriptor.assignment.permissionMode &&
+    workspaceDir !== workerContainmentRoot &&
+    !isPathInside(workerContainmentRoot, workspaceDir)
+  ) {
+    throw new Error(
+      "worker workspace path escapes its assigned containment root; reprovision the worker workspace and retry",
+    );
+  }
   const stateDir = await mkdtemp(path.join(tmpdir(), "openclaw-worker-"));
   await chmod(stateDir, 0o700);
   const previousStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -142,6 +155,10 @@ export async function runWorkerDescriptor(
         operationalRunInstance: descriptor.assignment.operationalRunInstance,
         agentRuntimeIdentityToken: descriptor.assignment.agentRuntimeIdentityToken,
         cwd: workspaceDir,
+        workerContainmentRoot,
+        ...(descriptor.assignment.permissionMode
+          ? { permissionMode: descriptor.assignment.permissionMode }
+          : {}),
         stateDir,
         sessionId: descriptor.admission.sessionId,
         sessionKey: `worker:${descriptor.admission.sessionId}`,

--- a/test/e2e/qa-lab/runtime/cloud-worker-midturn-loss-fixture.ts
+++ b/test/e2e/qa-lab/runtime/cloud-worker-midturn-loss-fixture.ts
@@ -11,6 +11,9 @@ const execFileAsync = promisify(execFile);
 export const MODEL_REF = "mock-openai/gpt-5.6-luna";
 export const BASELINE_PROMPT = "Reply exactly: CLOUD-MIDTURN-BASELINE";
 export const BASELINE_REPLY = "CLOUD-MIDTURN-BASELINE";
+export const WORKER_PERMISSION_PROMPT =
+  "WORKER-PERMISSION-PROOF: run the requested workspace and exec checks.";
+export const WORKER_PERMISSION_REPLY = "WORKER-PERMISSION-PROOF-OK";
 export const MIDTURN_PROMPT =
   "CLOUD-MIDTURN-KILL: persist two checkpoints, then stream the final reply.";
 export const CONTEXT_PROMPT =
@@ -101,6 +104,66 @@ function toolCallItem(index: number, file: string) {
       arguments: args,
     },
   };
+}
+
+function writeFunctionCall(
+  response: ServerResponse,
+  params: { callId: string; name: string; arguments: Record<string, unknown> },
+): void {
+  const args = JSON.stringify(params.arguments);
+  const item = {
+    type: "function_call",
+    id: `fc_${params.callId}`,
+    call_id: params.callId,
+    name: params.name,
+    arguments: args,
+  };
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  writeSseEvent(response, {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...item, arguments: "" },
+  });
+  writeSseEvent(response, {
+    type: "response.function_call_arguments.delta",
+    item_id: item.id,
+    output_index: 0,
+    delta: args,
+  });
+  writeSseEvent(response, { type: "response.output_item.done", output_index: 0, item });
+  writeSseEvent(response, {
+    type: "response.completed",
+    response: {
+      id: `resp_${params.callId}`,
+      status: "completed",
+      output: [item],
+      usage: { input_tokens: 32, output_tokens: 12, total_tokens: 44 },
+    },
+  });
+  response.end("data: [DONE]\n\n");
+}
+
+function findFunctionCallOutput(raw: string, callId: string): string | undefined {
+  const body = JSON.parse(raw) as { input?: unknown[] };
+  const item = body.input?.find(
+    (candidate): candidate is { call_id: string; output: unknown; type: string } =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      "type" in candidate &&
+      candidate.type === "function_call_output" &&
+      "call_id" in candidate &&
+      candidate.call_id === callId &&
+      "output" in candidate,
+  );
+  return item
+    ? typeof item.output === "string"
+      ? item.output
+      : JSON.stringify(item.output)
+    : undefined;
 }
 
 function writeCompletedAssistant(response: ServerResponse, text: string, id: string): void {
@@ -209,6 +272,8 @@ export async function startMidturnProvider() {
   const partialStarted = createDeferred();
   const releasePartial = createDeferred();
   const requests: string[] = [];
+  let outsideWriteOutput = "";
+  let execOutput = "";
   const server = createServer((request, response) => {
     void (async () => {
       if (request.method === "GET" && request.url === "/v1/models") {
@@ -222,6 +287,59 @@ export async function startMidturnProvider() {
       }
       const raw = await readRequestBody(request);
       requests.push(raw);
+      if (raw.includes(WORKER_PERMISSION_PROMPT)) {
+        const insideOutput = findFunctionCallOutput(raw, "call_worker_permission_inside");
+        if (insideOutput === undefined) {
+          writeFunctionCall(response, {
+            callId: "call_worker_permission_inside",
+            name: "write",
+            arguments: {
+              path: "worker-permission-in-root.txt",
+              content: "worker permission proof\n",
+            },
+          });
+          return;
+        }
+        const outsideOutput = findFunctionCallOutput(raw, "call_worker_permission_outside");
+        if (outsideOutput === undefined) {
+          writeFunctionCall(response, {
+            callId: "call_worker_permission_outside",
+            name: "write",
+            arguments: { path: "../worker-permission-outside.txt", content: "escaped\n" },
+          });
+          return;
+        }
+        outsideWriteOutput = outsideOutput;
+        const deniedExecOutput = findFunctionCallOutput(raw, "call_worker_permission_exec");
+        if (deniedExecOutput === undefined) {
+          writeFunctionCall(response, {
+            callId: "call_worker_permission_exec",
+            name: "exec",
+            arguments: {
+              command: "printf WORKER_EXEC_ESCAPED > worker-exec-escaped.txt",
+            },
+          });
+          return;
+        }
+        execOutput = deniedExecOutput;
+        const visibleDenial = [
+          /workspace/iu,
+          /approval_required/iu,
+          /run this command locally/iu,
+          /interactive approval/iu,
+          /administrator/iu,
+          /clear the session permission mode/iu,
+        ].every((pattern) => pattern.test(execOutput));
+        const outsideRejected = /escape|outside|containment|workspace/iu.test(outsideWriteOutput);
+        writeCompletedAssistant(
+          response,
+          visibleDenial && outsideRejected
+            ? `${WORKER_PERMISSION_REPLY}\n${execOutput}`
+            : `WORKER-PERMISSION-PROOF-FAILED\noutside=${outsideWriteOutput}\nexec=${execOutput}`,
+          "msg_worker_permission_proof",
+        );
+        return;
+      }
       if (raw.includes(CONTEXT_PROMPT)) {
         contextRequest = raw;
         const missing = COMMITTED_MARKERS.filter((marker) => !raw.includes(marker));
@@ -307,6 +425,12 @@ export async function startMidturnProvider() {
     },
     get requestCount() {
       return requests.length;
+    },
+    get outsideWriteOutput() {
+      return outsideWriteOutput;
+    },
+    get execOutput() {
+      return execOutput;
     },
     async stop() {
       releasePartial.resolve();

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -16,6 +16,8 @@ import {
   BASELINE_PROMPT,
   BASELINE_REPLY,
   PROOF_TIMEOUT_MS,
+  WORKER_PERMISSION_PROMPT,
+  WORKER_PERMISSION_REPLY,
   startMidturnProvider,
 } from "./cloud-worker-midturn-loss-fixture.js";
 import {
@@ -214,6 +216,60 @@ describe("node worker launch wire", () => {
         expect(await fs.readFile(path.join(remoteWorkspaceDir, "node-result.txt"), "utf8")).toBe(
           "device result\n",
         );
+
+        const permissionRunId = `node-worker-permission-${Date.now()}`;
+        await expect(
+          operator.request<{ runId?: string; status?: string }>("chat.send", {
+            sessionKey: SESSION_KEY,
+            message: WORKER_PERMISSION_PROMPT,
+            deliver: false,
+            idempotencyKey: permissionRunId,
+          }),
+        ).resolves.toMatchObject({ runId: permissionRunId, status: "started" });
+        await expect(
+          operator.request<{ status?: string }>(
+            "agent.wait",
+            { runId: permissionRunId, timeoutMs: PROOF_TIMEOUT_MS },
+            { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+          ),
+        ).resolves.toMatchObject({ status: "ok" });
+        await workerNode.waitForInvokes();
+        expect(workerNode.invokeErrors).toEqual([]);
+
+        await expect(
+          fs.readFile(path.join(remoteWorkspaceDir, "worker-permission-in-root.txt"), "utf8"),
+        ).resolves.toBe("worker permission proof\n");
+        await expect(
+          fs.access(path.resolve(remoteWorkspaceDir, "..", "worker-permission-outside.txt")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(
+          fs.access(path.join(remoteWorkspaceDir, "worker-exec-escaped.txt")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+        expect(provider.outsideWriteOutput).toMatch(/escape|outside|containment|workspace/iu);
+        expect(provider.execOutput).toMatch(
+          /approval_required.*worker workspace permission mode.*run this command locally.*interactive approval.*administrator.*clear the session permission mode/isu,
+        );
+
+        const permissionHistory = await operator.request<{ messages?: unknown[] }>("chat.history", {
+          sessionKey: SESSION_KEY,
+          limit: 30,
+        });
+        const permissionReplies = permissionHistory.messages?.filter(
+          (message) =>
+            (message as { role?: unknown }).role === "assistant" &&
+            wireMessageText(message).includes(WORKER_PERMISSION_REPLY),
+        );
+        expect(permissionReplies).toHaveLength(1);
+        expect(wireMessageText(permissionReplies?.[0])).toContain(provider.execOutput);
+        const permissionDescribed = (await gateway.call("sessions.describe", {
+          key: SESSION_KEY,
+        })) as { session?: { execCwd?: string; spawnedCwd?: string } };
+        const permissionLocalDir =
+          permissionDescribed.session?.execCwd ?? permissionDescribed.session?.spawnedCwd;
+        expect(permissionLocalDir).toBeTruthy();
+        await expect(
+          fs.readFile(path.join(permissionLocalDir!, "worker-permission-in-root.txt"), "utf8"),
+        ).resolves.toBe("worker permission proof\n");
 
         legacyWorkerNode = await createPairedNodeWorkerHost({
           gateway,


### PR DESCRIPTION
## What Problem This Solves

PR #124909 introduced session permission modes and — lacking worker execution-context support — fenced mode-carrying sessions out of cloud/node worker placement entirely (`fix(worker): fence permission-mode cloud placements`). Since worktree sessions now default to `workspace` mode, the default worktree path could not dispatch to workers at all: the QA-lab node-worker e2e fails on `main` at that fence.

## Why This Change Was Made

Propagate the permission facts through the worker execution context, with the dialect bump the worker-authority doctrine requires (owner-approved):

- `worker-execution-context-v1` → `v2` (handshake feature string; only v2 advertised), `WorkerLaunchPlan` v3 → v4 with a closed co-present pair `{permissionMode, workerContainmentRoot}` (mixed presence rejected; absolute-path validated), `node-worker-supervisor-v3` → `v4` with v3 projected as update-required. Pre-v2 workers fence via the existing feature-set gating (admission mismatch → reprovision) — no compatibility payloads.
- The gateway fills `workerContainmentRoot` from `placement.remoteWorkspaceDir` — never the gateway-local `sessionRoot`; the worker canonicalizes and requires its workspace inside the containment root.
- The worker's tool construction now applies the **same** mode projection as the normal runner via a shared helper extracted from `agent-tools.ts` (one interpretation of the four modes; the previous hardcoded full/off defaults are gone).
- Worker exec uses the safe clamp v1: `read-only` denies; `guarded`/`workspace` keep the allowlist fast path and return a visible, actionable denial on approval miss (workers have no approval RPC or reviewer auth); `full` unchanged. Reviewer parity on workers (LLM review over the inference proxy, approval RPC) is the named follow-up.
- The unconditional dispatch fence is removed.

## User Impact

Worktree sessions (default `workspace` mode) can dispatch to node/cloud workers again, with the session's containment enforced worker-locally: contained reads/writes, mutating tools withheld in `read-only`, and exec misses ending in a visible denial that names the next step instead of silent full access. Outdated workers surface the standard update-required outcome.

## Evidence

- Deterministic real-worker proof: `test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts` — isolated gateway + paired local node host + sealed worker bundle; a worktree (`workspace`-mode) session dispatches, completes a real worker turn, writes inside the root, is rejected outside it, and receives the visible exec denial. **Fails on `main` at the old fence; passes here.**
- Focused suites: launch-descriptor v4 parse/reject (incl. mixed-pair), launcher fill, worker containment canonicalization, per-mode exec clamps, supervisor legacy projection, dispatch outcomes — 192 + 91 tests green; `check-changed` green; autoreview clean.
- Production LOC: +166/−83 (net **+83**, incl. all version plumbing, offset by fence + hardcoded-defaults deletion); tests +380/−42.
