### PR TITLE
fix: cron jobs fail on Windows with "cannot acquire a durable fence without process start identity"

### DIFF
--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -223,10 +223,42 @@ describe("process start times", () => {
     });
   });
 
-  it("returns null on unsupported platforms", () => {
+  it("parses Windows file-lock owner start times as epoch seconds", () => {
+    const execSpy = vi
+      .spyOn(childProcess, "execFileSync")
+      .mockReturnValue("2026-08-17T07:00:00.0000000Z\n");
+
+    return withMockedPlatform("win32", async () => {
+      expect(getFileLockProcessStartTime(42)).toBe(Date.UTC(2026, 7, 17, 7, 0, 0) / 1000);
+      expect(execSpy).toHaveBeenCalledWith(
+        "powershell",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          '(Get-Process -Id 42).StartTime.ToUniversalTime().ToString("o")',
+        ],
+        expect.objectContaining({
+          encoding: "utf8",
+          timeout: 3000,
+        }),
+      );
+    });
+  });
+
+  it("fails conservatively when the Windows file-lock start-time probe fails", () => {
+    vi.spyOn(childProcess, "execFileSync").mockImplementation(() => {
+      throw new Error("powershell spawn failed");
+    });
+
+    return withMockedPlatform("win32", async () => {
+      expect(getFileLockProcessStartTime(42)).toBeNull();
+    });
+  });
+
+  it("keeps the Linux procfs start-time helper Linux-only on win32", () => {
     return withMockedPlatform("win32", async () => {
       expect(getProcessStartTime(process.pid)).toBeNull();
-      expect(getFileLockProcessStartTime(process.pid)).toBeNull();
     });
   });
 

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -3,6 +3,7 @@ import childProcess from "node:child_process";
 import fsSync from "node:fs";
 
 const DARWIN_PS_TIMEOUT_MS = 1000;
+const WINDOWS_PS_TIMEOUT_MS = 3000;
 
 function isValidPid(pid: number): boolean {
   return Number.isInteger(pid) && pid > 0;
@@ -78,6 +79,36 @@ function getDarwinProcessStartTime(pid: number): number | null {
   }
 }
 
+function getWindowsProcessStartTime(pid: number): number | null {
+  try {
+    const startedAt = childProcess
+      .execFileSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().ToString("o")`,
+        ],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: WINDOWS_PS_TIMEOUT_MS,
+        },
+      )
+      .trim();
+    if (!startedAt) {
+      return null;
+    }
+    // PowerShell's "o" round-trip format is a culture-invariant ISO 8601 UTC
+    // timestamp, so parsing stays independent of the host locale and timezone.
+    const startedAtMs = Date.parse(startedAt);
+    return Number.isFinite(startedAtMs) ? Math.floor(startedAtMs / 1000) : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Read the Linux procfs start identity used by Linux-owned runtime state. */
 export function getProcessStartTime(pid: number): number | null {
   if (!isValidPid(pid)) {
@@ -109,5 +140,11 @@ export function getFileLockProcessStartTime(pid: number): number | null {
   if (!isValidPid(pid)) {
     return null;
   }
-  return process.platform === "darwin" ? getDarwinProcessStartTime(pid) : getProcessStartTime(pid);
+  if (process.platform === "darwin") {
+    return getDarwinProcessStartTime(pid);
+  }
+  if (process.platform === "win32") {
+    return getWindowsProcessStartTime(pid);
+  }
+  return getProcessStartTime(pid);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw's cron scheduler cannot run any scheduled jobs on Windows. Every cron run fails immediately with `cron run cannot acquire a durable fence without process start identity`, which surfaces in the gateway log as a repeating `cron: timer tick failed` error storm (one failure roughly every 2 seconds while any job is due).

## Why This Change Was Made

`getFileLockProcessStartTime` — the cross-platform helper that returns the current process's start time for filesystem-lock ownership (used by the cron durable-fence / run-receipt claim) — only implemented Linux (`/proc/<pid>/stat`) and macOS (`/bin/ps`). On Windows it fell through to the Linux-only `getProcessStartTime`, which returns `null` for `process.platform !== "linux"`. The cron receipt claim then throws `cannot acquire a durable fence without process start identity` because the owner start time is `null`.

The fix adds a `getWindowsProcessStartTime` implementation that reads the process start time via PowerShell `(Get-Process -Id <pid>).StartTime.ToUniversalTime().ToString("o")` (ISO 8601 UTC, culture-invariant) and dispatches to it from `getFileLockProcessStartTime` when `process.platform === "win32"`. It fails closed (returns `null`) if the probe fails, matching the existing Linux/macOS behavior.

## User Impact

Cron jobs (heartbeats, scheduled automations, memory dreaming) now run on Windows instead of silently failing every tick. Operators no longer see the recurring `cron: timer tick failed` error storm.

## Evidence

- **Production log (before)**: on a Windows gateway, every cron tick failed with `Error: cron run cannot acquire a durable fence without process start identity` (945 failures over ~38 minutes, ~2.4s apart), nested under the `cron: timer tick failed` message.
- **Before**: `getProcessStartTime` returned `null` on `win32` — the function had a Linux-only guard `if (process.platform !== "linux") return null;`, and the pre-existing test `returns null on unsupported platforms` explicitly asserted `getFileLockProcessStartTime` was `null` on `win32`.
- **After**: `getFileLockProcessStartTime(process.pid)` on a real Windows host returns a valid epoch-seconds timestamp (e.g. `1786978438`), and the cron durable fence acquires normally.
- **Tests**: `pnpm test src/shared/pid-alive.test.ts` → 21 passed, including new cases `parses Windows file-lock owner start times as epoch seconds` and `fails conservatively when the Windows file-lock start-time probe fails`.
- **PowerShell output format verified**: `(Get-Process -Id <pid>).StartTime.ToUniversalTime().ToString("o")` returns `2026-08-17T15:23:10.3949896Z`, which `Date.parse` handles correctly (truncates to millisecond precision).
