### PR TITLE
fix(pr): verify hosted commit membership locally

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -50,6 +50,8 @@ pr_wrapper_components=(
   scripts/lib/plain-gh.mjs
   scripts/lib/direct-run.mjs
   scripts/lib/tsx-cli-shim.mjs
+  scripts/verify-pr-hosted-gates.mjs
+  scripts/verify-pr-hosted-gates.mts
   scripts/watch-pr-ci.mjs
   scripts/watch-pr-ci.mts
 )

--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -28,7 +28,6 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
 // the existing 1,000-result search window through pagination.
 const WORKFLOW_RUNS_PAGE_SIZE = 30;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
-const COMPARE_COMMITS_PAGE_SIZE = 100;
 export const HOSTED_GATE_MAX_AGE_HOURS = 24;
 const HOSTED_GATE_MAX_AGE_MS = HOSTED_GATE_MAX_AGE_HOURS * 60 * 60 * 1_000;
 const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
@@ -972,55 +971,17 @@ function loadCiReuseCandidateRuns(repo: string, headBranch: string) {
   );
 }
 
-export function compareCommitPageCount(totalCommits: unknown) {
-  if (typeof totalCommits !== "number" || !Number.isSafeInteger(totalCommits) || totalCommits < 0) {
-    throw new Error("Expected comparison total_commits to be a non-negative integer.");
-  }
-  return Math.max(1, Math.ceil(totalCommits / COMPARE_COMMITS_PAGE_SIZE));
-}
-
-function loadPullRequestCommitShas(
-  repo: string,
+export function loadPullRequestCommitShas(
   { baseSha, headSha }: { baseSha: string; headSha: string },
+  execGit: ExecGit = runGit,
 ) {
-  const loadPage = (page: number) => {
-    const comparison = JSON.parse(
-      execGhApiRead(
-        `repos/${repo}/compare/${baseSha}...${headSha}?per_page=${COMPARE_COMMITS_PAGE_SIZE}&page=${page}`,
-        {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      ),
-    ) as unknown;
-    if (!isRecord(comparison)) {
-      throw new Error(`Expected comparison commit page ${page} to be an object.`);
-    }
-    return comparison;
-  };
-
-  // The PR commits endpoint stops at 250. GitHub's paginated comparison is
-  // equivalent to git log BASE..HEAD and keeps the membership proof complete.
-  const firstPage = loadPage(1);
-  const pages = [firstPage];
-  for (let page = 2; page <= compareCommitPageCount(firstPage?.total_commits); page += 1) {
-    pages.push(loadPage(page));
+  const output = execGit(["rev-list", "--reverse", `${baseSha}..${headSha}`]);
+  const shas = output.replace(/\r?\n$/u, "").split(/\r?\n/u);
+  if (shas.length === 0 || shas.some((sha) => !/^[0-9a-f]{40,64}$/u.test(sha))) {
+    throw new Error("Expected pull request commit object ids from git rev-list.");
   }
-  const shas = pages.flatMap((comparison, index) => {
-    if (!Array.isArray(comparison?.commits)) {
-      throw new Error(`Expected comparison commit page ${index + 1} to be an array.`);
-    }
-    if (!comparison.commits.every(isRecord)) {
-      throw new Error(`Expected comparison commit page ${index + 1} entries to be objects.`);
-    }
-    return comparison.commits
-      .map((commit) => commit.sha)
-      .filter((sha: unknown): sha is string => typeof sha === "string");
-  });
-  if (shas.length !== firstPage.total_commits) {
-    throw new Error(
-      `Expected ${firstPage.total_commits} comparison commits, received ${shas.length}.`,
-    );
+  if (!shas.includes(headSha)) {
+    throw new Error(`Expected pull request commit list to contain head ${headSha}.`);
   }
   return shas;
 }
@@ -1125,7 +1086,7 @@ function main(argv = process.argv.slice(2)) {
     sha: args.sha,
     pr: args.pr,
     recentSha: args.recentSha,
-    pullRequestCommitShas: loadPullRequestCommitShas(args.repo, { baseSha, headSha }),
+    pullRequestCommitShas: loadPullRequestCommitShas({ baseSha, headSha }),
     pullRequestHeadBranch: headBranch,
     pullRequestHeadRepository: headRepository,
     workflowRuns,

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -76,6 +76,14 @@ function makeMismatchedWrapperRepo() {
   writeFileSync(join(canonical, "scripts", "pr"), readScript("scripts/pr"));
   cpSync("scripts/watch-pr-ci.mjs", join(canonical, "scripts", "watch-pr-ci.mjs"));
   cpSync("scripts/watch-pr-ci.mts", join(canonical, "scripts", "watch-pr-ci.mts"));
+  cpSync(
+    "scripts/verify-pr-hosted-gates.mjs",
+    join(canonical, "scripts", "verify-pr-hosted-gates.mjs"),
+  );
+  cpSync(
+    "scripts/verify-pr-hosted-gates.mts",
+    join(canonical, "scripts", "verify-pr-hosted-gates.mts"),
+  );
   cpSync("scripts/lib/plain-gh.mjs", join(canonical, "scripts", "lib", "plain-gh.mjs"));
   cpSync("scripts/lib/direct-run.mjs", join(canonical, "scripts", "lib", "direct-run.mjs"));
   cpSync("scripts/lib/tsx-cli-shim.mjs", join(canonical, "scripts", "lib", "tsx-cli-shim.mjs"));
@@ -190,6 +198,8 @@ describe("scripts/pr wrappers", () => {
     expect(script).not.toContain("gh() {");
     expect(script).toContain("scripts/watch-pr-ci.mjs");
     expect(script).toContain("scripts/watch-pr-ci.mts");
+    expect(script).toContain("scripts/verify-pr-hosted-gates.mjs");
+    expect(script).toContain("scripts/verify-pr-hosted-gates.mts");
     expect(script).toContain("scripts/lib/tsx-cli-shim.mjs");
     expect(script).toContain("scripts/lib/plain-gh.mjs");
     expect(script).toContain("scripts/lib/direct-run.mjs");
@@ -428,6 +438,8 @@ describe("scripts/pr wrappers", () => {
     writeFileSync(join(repo, "scripts", "lib", "tsx-cli-shim.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mts"), "// canonical\n");
+    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mjs"), "// canonical\n");
+    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mts"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# canonical\n");
     chmodSync(join(repo, "scripts", "pr"), 0o755);
 
@@ -459,6 +471,17 @@ describe("scripts/pr wrappers", () => {
       "scripts/pr wrapper files have uncommitted changes",
     );
     expect(git(linked, ["restore", "scripts/watch-pr-ci.mts"]).status).toBe(0);
+
+    writeFileSync(join(linked, "scripts", "verify-pr-hosted-gates.mts"), "// dirty verifier\n");
+    const dirtyVerifierResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
+      cwd: linked,
+      encoding: "utf8",
+    });
+    expect(dirtyVerifierResult.status).toBe(1);
+    expect(dirtyVerifierResult.stderr).toContain(
+      "scripts/pr wrapper files have uncommitted changes",
+    );
+    expect(git(linked, ["restore", "scripts/verify-pr-hosted-gates.mts"]).status).toBe(0);
 
     // A dirty canonical checkout no longer blocks a linked worktree whose
     // committed wrapper matches the origin/main trust anchor; without that
@@ -503,6 +526,8 @@ describe("scripts/pr wrappers", () => {
     writeFileSync(join(repo, "scripts", "lib", "tsx-cli-shim.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mts"), "// canonical\n");
+    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mjs"), "// canonical\n");
+    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mts"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# canonical\n");
     chmodSync(join(repo, "scripts", "pr"), 0o755);
 

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -1,13 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
   collectHostedGateEvidence as collectHostedGateEvidenceRaw,
-  compareCommitPageCount,
   HOSTED_GATE_MAX_AGE_HOURS,
+  loadPullRequestCommitShas,
   notApplicableScheduledHostedWorkflows,
   parseArgs,
   parseWorkflowRunPage,
@@ -735,11 +735,89 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(`Missing successful recent CI workflow for ${sha}`);
   });
 
-  it("paginates comparisons beyond the pull-request endpoint's 250-commit cap", () => {
-    expect(compareCommitPageCount(0)).toBe(1);
-    expect(compareCommitPageCount(250)).toBe(3);
-    expect(compareCommitPageCount(251)).toBe(3);
-    expect(compareCommitPageCount(301)).toBe(4);
+  it("loads the complete PR commit set with one local rev-list command", () => {
+    const baseSha = "a".repeat(40);
+    const shas = Array.from({ length: 301 }, (_, index) =>
+      (index + 1).toString(16).padStart(40, "0"),
+    );
+    const headSha = expectDefined(shas.at(-1), "generated head sha");
+    const calls: string[][] = [];
+
+    expect(
+      loadPullRequestCommitShas({ baseSha, headSha }, (args) => {
+        calls.push(args);
+        return `${shas.join("\n")}\n`;
+      }),
+    ).toEqual(shas);
+    expect(calls).toEqual([["rev-list", "--reverse", `${baseSha}..${headSha}`]]);
+  });
+
+  it.each([
+    ["uppercase", "A".repeat(40)],
+    ["too short", "a".repeat(39)],
+    ["too long", "a".repeat(65)],
+    ["leading whitespace", ` ${"a".repeat(40)}`],
+    ["multiple fields", `${"a".repeat(40)} ${"b".repeat(40)}`],
+    ["blank line", `${"a".repeat(40)}\n\n${"b".repeat(40)}`],
+  ])("rejects malformed rev-list object ids: %s", (_case, output) => {
+    expect(() =>
+      loadPullRequestCommitShas(
+        { baseSha: "c".repeat(40), headSha: "b".repeat(40) },
+        () => `${output}\n`,
+      ),
+    ).toThrow("Expected pull request commit object ids from git rev-list.");
+  });
+
+  it("rejects empty rev-list output and output missing the requested head", () => {
+    const baseSha = "a".repeat(40);
+    const headSha = "b".repeat(40);
+    expect(() => loadPullRequestCommitShas({ baseSha, headSha }, () => "")).toThrow(
+      "Expected pull request commit object ids from git rev-list.",
+    );
+    expect(() =>
+      loadPullRequestCommitShas({ baseSha, headSha }, () => `${"c".repeat(40)}\n`),
+    ).toThrow(`Expected pull request commit list to contain head ${headSha}.`);
+  });
+
+  it("propagates rev-list command failures", () => {
+    const commandError = new Error("git rev-list failed");
+    expect(() =>
+      loadPullRequestCommitShas({ baseSha: "a".repeat(40), headSha: "b".repeat(40) }, () => {
+        throw commandError;
+      }),
+    ).toThrow(commandError);
+  });
+
+  it("keeps complete membership when the PR head is behind the current base", () => {
+    const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "openclaw-pr-commit-set-")));
+    const git = (args: string[]) => {
+      const result = spawnSync("git", args, { cwd: fixtureRoot, encoding: "utf8" });
+      expect(result.status, `git ${args.join(" ")}\n${result.stderr}`).toBe(0);
+      return result.stdout;
+    };
+    try {
+      git(["init", "-q", "-b", "main"]);
+      git(["config", "user.name", "OpenClaw Test"]);
+      git(["config", "user.email", "test@example.invalid"]);
+      git(["commit", "-q", "--allow-empty", "-m", "root"]);
+      git(["branch", "feature"]);
+      git(["commit", "-q", "--allow-empty", "-m", "main one"]);
+      git(["commit", "-q", "--allow-empty", "-m", "main two"]);
+      const baseSha = git(["rev-parse", "HEAD"]).trim();
+      git(["switch", "-q", "feature"]);
+      git(["commit", "-q", "--allow-empty", "-m", "feature one"]);
+      const firstFeatureSha = git(["rev-parse", "HEAD"]).trim();
+      git(["commit", "-q", "--allow-empty", "-m", "feature two"]);
+      const headSha = git(["rev-parse", "HEAD"]).trim();
+
+      expect(loadPullRequestCommitShas({ baseSha, headSha }, (args) => git(args))).toEqual([
+        firstFeatureSha,
+        headSha,
+      ]);
+      expect(Number(git(["rev-list", "--count", `${headSha}..${baseSha}`]).trim())).toBe(2);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it("requires recent evidence for scheduled gates observed on the target head", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running the native PR prepare flow could not validate otherwise-green hosted gates when GitHub's compare endpoint returned HTTP 404. The blocker affected `OPENCLAW_TESTBOX=1 scripts/pr prepare-run`, including exact-head-green PR #125318.

## Why This Change Was Made

The hosted verifier now derives the complete PR commit membership set from the authoritative base and head objects already fetched into its Git worktree with `git rev-list --reverse BASE..HEAD`. It validates every returned object ID, rejects empty or malformed output, requires the requested head, and propagates Git failures. This removes the unavailable compare API and its pagination helper without introducing the PR-commits endpoint's 250-commit cap.

The verifier's JavaScript entrypoint and TypeScript implementation are also part of `scripts/pr`'s canonical wrapper component set, so landing-critical verification remains anchored to trusted `origin/main` code.

## User Impact

Maintainers can validate hosted CI/Testbox evidence without depending on GitHub's compare route. Commit membership remains complete for branches with more than 250 commits and for feature heads whose base branch has advanced, while malformed, empty, or incomplete local graph output fails closed.

This is a bootstrap repair for a self-blocking native prepare gate. Native review artifacts will be initialized and validated, but `prepare-run` and merge are intentionally deferred for an explicit bootstrap/break-glass landing decision because trusted `origin/main` contains the verifier being repaired.

## Evidence

Before the fix, the direct verifier command for #125318 failed on `repos/openclaw/openclaw/compare/793669c8f6ddfad07b40009068f532832685b7d6...fb8c17c6f4e09b404d0f7f775bcd8d916d0ae340?per_page=100&page=1` with HTTP 404.

After the fix, the same direct verifier command passed and wrote `/tmp/verify-pr-hosted-gates-after-125318.json`, selecting exact-head CI run 32040840945 and Workflow Sanity run 32040824975 for `fb8c17c6f4e09b404d0f7f775bcd8d916d0ae340`. The three Testbox workflows were correctly recorded as path-inapplicable.

- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts` — 81 passed.
- `node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts` — 16 passed.
- `node scripts/check-changed.mjs -- scripts/pr scripts/verify-pr-hosted-gates.mts test/scripts/pr-wrappers.test.ts test/scripts/verify-pr-hosted-gates.test.ts` — passed.
- Targeted `oxfmt` and `git diff --check` — passed.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
- Tooling LOC: +11/-48 (net -37); tests: +110/-7 (net +103).

No production hosts, dependencies, lockfiles, baselines, release surfaces, SQLite/protocol versions, or unrelated files were touched.

AI-assisted; the implementation and evidence were reviewed before submission.
