### PR TITLE
fix(gateway): stop verified isolated gateways

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -542,6 +542,30 @@ describe("runServiceRestart token drift", () => {
     expect(onNotLoaded).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { loaded: true, stopWhenNotLoaded: false },
+    { loaded: false, stopWhenNotLoaded: true },
+  ])(
+    "runs the service mutation guard before managed stop (loaded=$loaded)",
+    async ({ loaded, stopWhenNotLoaded }) => {
+      service.isLoaded.mockResolvedValue(loaded);
+      const beforeServiceMutation = vi.fn();
+
+      await runServiceStop({
+        serviceNoun: "Gateway",
+        service,
+        opts: { json: true, disable: stopWhenNotLoaded },
+        stopWhenNotLoaded,
+        beforeServiceMutation,
+      });
+
+      expect(beforeServiceMutation).toHaveBeenCalledTimes(1);
+      expect(beforeServiceMutation.mock.invocationCallOrder[0]).toBeLessThan(
+        service.stop.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      );
+    },
+  );
+
   it("emits started when a not-loaded start path repairs the service", async () => {
     service.isLoaded.mockResolvedValue(false);
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -350,6 +350,7 @@ export async function runServiceStop(params: {
   serviceNoun: string;
   service: GatewayService;
   opts?: DaemonLifecycleOptions;
+  beforeServiceMutation?: () => void;
   onNotLoaded?: (ctx: ServiceRecoveryContext) => Promise<ServiceRecoveryResult<"stopped"> | null>;
   stopWhenNotLoaded?: boolean;
 }) {
@@ -377,6 +378,7 @@ export async function runServiceStop(params: {
   }
   if (!loaded) {
     if (params.stopWhenNotLoaded) {
+      params.beforeServiceMutation?.();
       try {
         await params.service.stop({
           env: process.env,
@@ -425,6 +427,7 @@ export async function runServiceStop(params: {
     }
     return;
   }
+  params.beforeServiceMutation?.();
   try {
     await params.service.stop({
       env: process.env,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -1118,6 +1118,22 @@ describe("runDaemonRestart health checks", () => {
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
   });
 
+  it("rejects a system-scope stop for a non-default install identity before mutation", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    isDefaultInstallIdentity.mockReturnValue(false);
+    findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "system",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/etc/systemd/system/openclaw-gateway.service",
+    });
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+
+    await expect(runUnmanagedStop()).rejects.toThrow(/non-default state dir/);
+
+    expect(stopSystemdService).not.toHaveBeenCalled();
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+  });
+
   it("surfaces systemd sudo guidance and never signals when stopping a system-scope unit as non-root (openclaw#87577)", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     findInstalledSystemdGatewayScope.mockResolvedValue({

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -741,6 +741,27 @@ describe("runDaemonRestart health checks", () => {
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
   });
 
+  it("stops a verified unmanaged gateway for a non-default install identity", async () => {
+    isDefaultInstallIdentity.mockReturnValue(false);
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+
+    await runUnmanagedStop();
+
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
+    expect(service.stop).not.toHaveBeenCalled();
+  });
+
+  it("retains the service guard when a non-default identity has no unmanaged gateway", async () => {
+    isDefaultInstallIdentity.mockReturnValue(false);
+    readActiveGatewayLockIdentity.mockResolvedValue(undefined);
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+
+    await expect(runUnmanagedStop()).rejects.toThrow(/non-default state dir/);
+
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(service.stop).not.toHaveBeenCalled();
+  });
+
   it("routes macOS disable stops through the service manager when not loaded", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 
@@ -763,6 +784,17 @@ describe("runDaemonRestart health checks", () => {
     expect(service.stop).toHaveBeenCalledWith(
       expect.objectContaining({ env: process.env, stdout: process.stdout }),
     );
+    expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+  });
+
+  it("guards a disabled running systemd service before stopping it", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    isDefaultInstallIdentity.mockReturnValue(false);
+    service.readRuntime.mockResolvedValue({ status: "running" });
+
+    await expect(runUnmanagedStop()).rejects.toThrow(/non-default state dir/);
+
+    expect(service.stop).not.toHaveBeenCalled();
     expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
   });
 

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -520,12 +520,15 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
     fail(NON_INTERACTIVE_GATEWAY_STOP_MESSAGE);
     return;
   }
-  assertGatewayServiceMutationAllowed("stop the gateway");
+  if (isGatewayExternallySupervised()) {
+    assertGatewayServiceMutationAllowed("stop the gateway");
+  }
   const service = resolveGatewayService();
   return await runServiceStop({
     serviceNoun: "Gateway",
     service,
     opts,
+    beforeServiceMutation: () => assertGatewayServiceMutationAllowed("stop the gateway"),
     stopWhenNotLoaded: process.platform === "darwin" && Boolean(opts.disable),
     onNotLoaded: async ({ stdout }) => {
       if (process.platform === "linux") {
@@ -533,6 +536,7 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
         if (runtime?.status === "running") {
           // systemd can run a disabled unit with Restart=always. Stop it through
           // systemctl so a process-level SIGTERM cannot trigger a respawn.
+          assertGatewayServiceMutationAllowed("stop the gateway");
           await service.stop({
             env: process.env,
             stdout,
@@ -548,7 +552,11 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
       const port =
         lockIdentity?.port ??
         (await resolveGatewayLifecyclePort(service).catch(() => resolveGatewayPortFallback()));
-      return await stopGatewayWithoutServiceManager(port, lockIdentity?.pid);
+      const handled = await stopGatewayWithoutServiceManager(port, lockIdentity?.pid);
+      if (!handled) {
+        assertGatewayServiceMutationAllowed("stop the gateway");
+      }
+      return handled;
     },
   });
 }

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -186,6 +186,7 @@ async function handleSystemScopeSystemdGateway(
   }
   const stdout = createNullWriter();
   if (action === "stop") {
+    assertGatewayServiceMutationAllowed("stop the gateway");
     await stopSystemdService({
       stdout,
       env: process.env,
@@ -196,6 +197,7 @@ async function handleSystemScopeSystemdGateway(
       message: `Gateway stopped via system-scope systemd unit ${installed.unitName}.`,
     };
   }
+  assertGatewayServiceMutationAllowed("restart the gateway");
   await restartSystemdService({
     stdout,
     env: process.env,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running an isolated, non-default Gateway without a native service could not stop that Gateway with `openclaw gateway stop`. The native-service identity guard rejected the command before the existing verified-PID unmanaged fallback could run.

## Why This Change Was Made

The stop lifecycle now applies service-identity policy only at the native service mutation boundary. Verified unmanaged listener/lock ownership remains eligible for the existing process stop path, while external supervisors, loaded native services, disabled-but-running systemd units, macOS disable operations, and not-loaded calls with no verified unmanaged process retain the original service guard.

AI-assisted: implementation and review were performed with Amp/Codex; the resulting code and tests were inspected and verified locally.

## User Impact

Operators can stop an isolated unmanaged Gateway by verified process identity even when its state directory is non-default. The command still refuses to mutate a mismatched native service installation.

## Evidence

- Before: `runDaemonStop` called `assertGatewayServiceMutationAllowed` before service discovery, so non-default state prevented `stopGatewayWithoutServiceManager` from examining the verified listener or lock owner.
- Regression coverage proves a non-default identity can stop a verified unmanaged process, but still rejects loaded native services, disabled running systemd services, macOS disable mutation, and the no-process fallback.
- `node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/lifecycle.external-supervision.test.ts` — 95/95 passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo` — passed from a fresh direct test-root cache.
- Full fresh core-test type shards remain blocked by the untouched frozen-main error `ui/src/pages/chat/route-loader.ts(712,38): Property 'literalSessionKey' does not exist`; this PR changes only four `src/cli/daemon-cli` files and the direct affected type root is green.
- Focused formatting, `git diff --check`, and fresh autoreview passed with no accepted/actionable findings.

### After-fix live CLI proof

Built exact head `d374b57eac793d88527a6dbf10f6a0be01a31474`, started a real plugin-disabled Gateway with `HOME=/tmp/.../home`, non-canonical `OPENCLAW_STATE_DIR=/tmp/.../state`, and port `39473`, then invoked the built CLI's `gateway stop --force --json` from the same isolated identity:

```text
state_dir=/tmp/.../state
canonical_for_home=/tmp/.../home/.openclaw
LISTEN 127.0.0.1:39473 users:(("openclaw-gateway",pid=1605609,...))
{
  "action": "stop",
  "ok": true,
  "result": "stopped",
  "message": "Gateway stop signal sent to unmanaged process on port 39473: 1605609.",
  "service": { "label": "systemd user", "loaded": false }
}
listener_stopped_after_ms=400
[gateway] received SIGTERM; shutting down
[shutdown] completed cleanly in 29ms
```

The complementary non-default/system-scope regression rejects before `stopSystemdService` and before unmanaged PID signaling. `node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle.test.ts src/infra/gateway-supervision.test.ts` passed 62/62 on the final patch, and final P1 autoreview was clean (0.97).
