### PR TITLE
fix(mattermost): agent media replies silently drop the attachment when upload fails

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -69,7 +69,11 @@ import {
   type ResolvedMattermostAccount,
 } from "./mattermost/accounts.js";
 import type { MattermostSendResult } from "./mattermost/send.js";
-import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
+import {
+  looksLikeMattermostTargetId,
+  normalizeMattermostMessagingTarget,
+  requiresMattermostMediaUpload,
+} from "./normalize.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMattermostOutboundSessionRoute } from "./session-route.js";
 import { mattermostSetupContract } from "./setup-core.js";
@@ -699,11 +703,6 @@ function readMattermostStringArrayParam(params: Record<string, unknown>, key: st
     return normalized ? [normalized] : [];
   }
   return [];
-}
-
-function requiresMattermostMediaUpload(mediaUrl: string | undefined): boolean {
-  const normalized = normalizeOptionalString(mediaUrl);
-  return Boolean(normalized && !/^https?:\/\//i.test(normalized));
 }
 
 function collectMattermostAttachmentMedia(params: Record<string, unknown>): {

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -10,6 +10,9 @@ import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import type { MattermostSendResult } from "./send.js";
 
 type DeliverMattermostReplyPayloadParams = Parameters<typeof deliverMattermostReplyPayload>[0];
+type SendMattermostMessageOptions = Parameters<
+  DeliverMattermostReplyPayloadParams["sendMessage"]
+>[2];
 type ReplyDeliveryMarkdownTableMode = Parameters<
   DeliverMattermostReplyPayloadParams["core"]["channel"]["text"]["convertMarkdownTables"]
 >[1];
@@ -42,18 +45,24 @@ function createReplyDeliveryCore(): DeliverMattermostReplyPayloadParams["core"] 
 
 function createSendMessageMock() {
   let sendCount = 0;
-  return vi.fn(async (_to: string, content: string): Promise<MattermostSendResult> => {
-    const messageId = `post-${++sendCount}`;
-    return {
-      messageId,
-      channelId: "channel-1",
-      content: content.trim(),
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "mattermost", messageId, channelId: "channel-1" }],
-        kind: "text",
-      }),
-    };
-  });
+  return vi.fn(
+    async (
+      _to: string,
+      content: string,
+      _opts: SendMattermostMessageOptions,
+    ): Promise<MattermostSendResult> => {
+      const messageId = `post-${++sendCount}`;
+      return {
+        messageId,
+        channelId: "channel-1",
+        content: content.trim(),
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "mattermost", messageId, channelId: "channel-1" }],
+          kind: "text",
+        }),
+      };
+    },
+  );
 }
 
 describe("deliverMattermostReplyPayload", () => {
@@ -221,6 +230,9 @@ describe("deliverMattermostReplyPayload", () => {
           cfg,
           accountId: "default",
           mediaUrl,
+          // Local (non-http) media must require a successful upload so a
+          // failure surfaces instead of silently posting the caption alone.
+          requireMediaUpload: true,
           replyToId: "root-post",
           mediaLocalRoots: expect.arrayContaining([
             path.join(stateDir, "media"),
@@ -234,6 +246,29 @@ describe("deliverMattermostReplyPayload", () => {
     } finally {
       await openClawState.cleanup();
     }
+  });
+
+  it("does not require upload for remote (http) media captions", async () => {
+    const sendMessage = createSendMessageMock();
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg,
+      payload: { text: "caption", mediaUrl: "https://example.com/photo.png" },
+      channelId: "town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const options = sendMessage.mock.calls[0]?.[2] as { requireMediaUpload?: boolean };
+    expect(options.requireMediaUpload).toBeUndefined();
   });
 
   it("forwards replyToId for text-only chunked replies", async () => {

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -16,6 +16,7 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { requiresMattermostMediaUpload } from "../normalize.js";
 import type { MattermostSendResult } from "./send.js";
 
 type MarkdownTableMode = Parameters<PluginRuntime["channel"]["text"]["convertMarkdownTables"]>[1];
@@ -28,6 +29,7 @@ type SendMattermostMessage = (
     accountId?: string;
     mediaUrl?: string;
     mediaLocalRoots?: readonly string[];
+    requireMediaUpload?: boolean;
     replyToId?: string;
   },
 ) => Promise<MattermostSendResult>;
@@ -105,11 +107,14 @@ export async function deliverMattermostReplyPayload(params: {
         acceptedContents.push(result.content);
       },
       sendMedia: async ({ mediaUrl, caption }) => {
+        // Require upload for local media so a failure surfaces instead of
+        // silently posting the caption alone (mirrors channel.ts send paths).
         const result = await params.sendMessage(deliveryTarget, caption ?? "", {
           cfg: params.cfg,
           accountId: params.accountId,
           mediaUrl,
           mediaLocalRoots,
+          ...(requiresMattermostMediaUpload(mediaUrl) ? { requireMediaUpload: true } : {}),
           replyToId: params.replyToId,
         });
         results.push(result);

--- a/extensions/mattermost/src/normalize.ts
+++ b/extensions/mattermost/src/normalize.ts
@@ -37,6 +37,16 @@ export function normalizeMattermostMessagingTarget(raw: string): string | undefi
   return undefined;
 }
 
+/**
+ * True when media must be uploaded as a file: any non-empty, non-http(s) value
+ * (e.g. a local workspace path) has no address the server can fetch, so the
+ * send must require a successful upload rather than degrade to caption text.
+ */
+export function requiresMattermostMediaUpload(mediaUrl: string | undefined): boolean {
+  const trimmed = mediaUrl?.trim();
+  return Boolean(trimmed && !/^https?:\/\//i.test(trimmed));
+}
+
 export function looksLikeMattermostTargetId(raw: string, _normalized?: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent replying in a monitored Mattermost channel with a locally-generated attachment (a workspace file such as a chart, export, or screenshot) plus caption text would silently lose the attachment if the upload failed. The bot posted the caption alone, and the delivery was recorded as a successful media send, so nothing indicated the file was missing except a verbose-only debug line. The user simply never received the file.

## Why This Change Was Made

The message-tool send paths in `channel.ts` already pass `requireMediaUpload` for non-http media, so a failed upload fails loudly instead of falling back to caption-only text. The monitor reply path in `reply-delivery.ts` did not, leaving one path that silently degraded. This change aligns the reply path with the existing policy. The shared `requiresMattermostMediaUpload` predicate is extracted into the lightweight `normalize` module and reused from both `channel.ts` (removing a duplicate definition) and the reply path, so the two stay in sync.

Non-goal: this PR does not change behavior for remote (http/https) media, which has a URL the server can fetch and is left untouched.

## User Impact

An upload failure on the agent reply path now surfaces as a visible error instead of a silent partial delivery that falsely reports success. Operators get an actionable failure rather than a missing attachment with no signal. No change for successful sends or for remote-URL media.

## Evidence

**Live-behavior proof against a real Mattermost server.** Ran the real Mattermost client and real media loader (only ambient logging stubbed) against a throwaway `mattermost/mattermost-preview` server, exercising both the pre-fix symptom and the fixed reply path:

- **BEFORE (reproduce the bug):** calling the sender the way the pre-fix reply path did (no `requireMediaUpload`) with a local attachment whose upload fails → a caption-only message is posted to the channel with an empty `file_ids` (the attachment is silently dropped).
- **AFTER (the fix):** `deliverMattermostReplyPayload` with the same failing local attachment → throws `Mattermost media upload failed` and posts **nothing** (channel post count unchanged), so the failure is surfaced instead of degrading to a caption-only post.

```
[BEFORE] posted messageId=wh9yiis6h7dsfqxz4k1ibzu6ch leakedPosts=1 fileIds=[]
[AFTER]  postsBefore=2 postsAfter=2 leaked=0
 ✓ extension-mattermost  reply-media-upload.live-proof.test.ts (2 tests)
 Test Files  1 passed (1)
      Tests  2 passed (2)

# raw Mattermost post left by the pre-fix path (caption present, attachment gone):
{"message":"PROOF-BEFORE-FIX-caption-only-leak","file_ids":[]}
```

The committed unit tests in `reply-delivery.test.ts` pin the wiring: the local (non-http) media reply asserts `requireMediaUpload: true` is forwarded (fails on the base revision, where the option is absent), and a companion test asserts remote (http) media does not set the flag.

## Notes for reviewers

Related but out of scope for this PR (left as a follow-up): on the same reply path, a media caption longer than the Mattermost post cap (16383 chars) is sent unchunked and can be rejected wholesale. That is a separate mechanism from the upload-failure drop fixed here and is better handled in its own change.
