### PR TITLE
fix: reject unusable worktrees before agent runs

### DIFF
--- a/src/agents/worktrees/run-lease.test.ts
+++ b/src/agents/worktrees/run-lease.test.ts
@@ -103,6 +103,30 @@ describe("worktree run lease", () => {
     expect(hasLiveWorktreeRunLease(env, created.id)).toBe(false);
   });
 
+  it("rejects admission when the linked Git admin directory is missing", async () => {
+    const created = await createSessionWorktree();
+    const knownFile = path.join(created.path, "README.md");
+    const gitAdminDir = await git(created.path, "rev-parse", "--absolute-git-dir");
+    const displacedGitAdminDir = path.join(root, "git-admin-aside");
+    await fs.rename(gitAdminDir, displacedGitAdminDir);
+
+    try {
+      const acquisition = acquireWorktreeRunLease(created.id, { env });
+      await expect(acquisition).rejects.toThrow(
+        `managed worktree is unusable because its Git removal guard could not be acquired: ${created.path}`,
+      );
+      await expect(acquisition).rejects.toMatchObject({ cause: expect.any(Error) });
+      expect(hasLiveWorktreeRunLease(env, created.id)).toBe(false);
+      expect(await fs.readFile(knownFile, "utf8")).toBe("base\n");
+    } finally {
+      await fs.rename(displacedGitAdminDir, gitAdminDir);
+    }
+
+    const lease = await acquireWorktreeRunLease(created.id, { env });
+    await lease.release();
+    expect(hasLiveWorktreeRunLease(env, created.id)).toBe(false);
+  });
+
   it("resolves the worktree id for a nested workspace path with no session binding", async () => {
     const created = await createSessionWorktree();
     const nested = path.join(created.path, "workspace");

--- a/src/agents/worktrees/run-lease.ts
+++ b/src/agents/worktrees/run-lease.ts
@@ -89,7 +89,11 @@ async function retainGitLock(env: NodeJS.ProcessEnv, id: string): Promise<void> 
       await lockWorktreeForProcess(record);
       held.gitLocked = true;
     } catch (error) {
-      log.warn(`worktree git lock unavailable for ${id}: ${errorMessage(error)}`);
+      heldGitLocks.delete(id);
+      throw new Error(
+        `managed worktree is unusable because its Git removal guard could not be acquired: ${record.path}; repair the checkout or create a new worktree before retrying: ${errorMessage(error)}`,
+        { cause: error },
+      );
     }
   });
 }
@@ -261,9 +265,6 @@ export async function acquireWorktreeRunLease(
     now: Date.now(),
     checks: ownerChecks,
   });
-  // Serialize refcount and Git transitions so a cleanup retry cannot unlock a
-  // newer same-process holder after a prior generation's unlock failed.
-  await retainGitLock(env, id);
   const cleanup: LeaseCleanup = {
     env,
     id,
@@ -272,6 +273,19 @@ export async function acquireWorktreeRunLease(
     refcountReleased: false,
     gitUnlockPending: false,
   };
+  // Serialize refcount and Git transitions so a cleanup retry cannot unlock a
+  // newer same-process holder after a prior generation's unlock failed.
+  try {
+    await retainGitLock(env, id);
+  } catch (error) {
+    // The failed retain already discarded its in-memory holder; cleanup owns only
+    // the durable row and keeps it fenced if deletion cannot complete yet.
+    cleanup.refcountReleased = true;
+    if (!(await runLeaseCleanup(cleanup))) {
+      pendingLeaseCleanups.add(cleanup);
+    }
+    throw error;
+  }
   let released = false;
   return {
     id,


### PR DESCRIPTION
Related: #114129

AI-assisted: Yes. The maintainer reviewed and understands the change. No agent transcript is included.

## What Problem This Solves

Fixes an issue where an agent run could start in a managed worktree even when Git could no longer acquire the checkout's removal guard, such as after linked Git administration metadata became unavailable. Cleanup correctly retained the checkout bytes, but run admission swallowed the guard error and continued with a worktree that Git could not safely manage.

## Why This Change Was Made

Run admission now treats the durable SQLite lease and the Git worktree guard as one authority boundary. If Git guard acquisition fails, OpenClaw removes the in-process holder, unwinds or safely retains the durable lease cleanup, and returns an actionable error with the preserved path. Idle cleanup and nested-repository fail-closed retention are intentionally unchanged.

## User Impact

Broken or externally relocated managed worktrees no longer accept new agent work and fail later in confusing Git operations. Operators receive a clear repair-or-create-new-worktree outcome, while healthy worktree runs keep their existing concurrency and cleanup behavior.

## Evidence

- Pre-fix focused regression: `AssertionError: promise resolved instead of rejecting`.
- Focused regression: `node scripts/run-vitest.mjs src/agents/worktrees/run-lease.test.ts` — 16/16 passed.
- Sibling coverage: `node scripts/run-vitest.mjs src/agents/worktrees/service.remove-lease.test.ts src/commands/agent.worktree-race.test.ts` — 5/5 passed.
- Clean replay coverage: all three focused files passed together — 21/21 passed.
- Changed gate: `node scripts/check-changed.mjs -- src/agents/worktrees/run-lease.ts src/agents/worktrees/run-lease.test.ts` passed every selected core/coreTests gate.
- Patch hygiene: `git diff --check origin/main...HEAD` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings; correctness 0.98.
- LOC: production +18/-4 (net +14); tests +24/-0. The production growth makes the SQLite lease and Git removal guard a fail-closed authority boundary and unwinds both owners on admission failure.
