### PR TITLE
fix(ai): derive Responses compact threshold from active context budget

### DIFF
--- a/packages/ai/src/transports/openai-responses-payload-policy.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { resolveOpenAIResponsesServerCompactionPlan } from "./openai-responses-payload-policy.js";
+
+describe("OpenAI Responses compact threshold", () => {
+  it.each([
+    {
+      name: "uses the active runtime cap for the direct Sol route",
+      model: { contextWindow: 1_050_000, contextTokens: 272_000 },
+      expected: 190_400,
+    },
+    {
+      name: "uses the active runtime cap for the Codex Sol budget",
+      model: { contextWindow: 372_000, contextTokens: 272_000 },
+      expected: 190_400,
+    },
+    {
+      name: "keeps window-only behavior",
+      model: { contextWindow: 400_000 },
+      expected: 280_000,
+    },
+    {
+      name: "honors an explicit threshold",
+      model: { contextWindow: 1_050_000, contextTokens: 272_000 },
+      extraParams: { responsesCompactThreshold: 123_456 },
+      expected: 123_456,
+    },
+    {
+      name: "uses the fallback without a known budget",
+      model: {},
+      expected: 80_000,
+    },
+  ])("$name", ({ model, extraParams, expected }) => {
+    expect(
+      resolveOpenAIResponsesServerCompactionPlan(
+        {
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          ...model,
+        },
+        extraParams,
+      ).threshold,
+    ).toBe(expected);
+  });
+});

--- a/packages/ai/src/transports/openai-responses-payload-policy.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.test.ts
@@ -9,7 +9,7 @@ describe("OpenAI Responses compact threshold", () => {
       expected: 190_400,
     },
     {
-      name: "uses the active runtime cap for the Codex Sol budget",
+      name: "uses the active runtime cap when the window is only modestly larger",
       model: { contextWindow: 372_000, contextTokens: 272_000 },
       expected: 190_400,
     },

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -17,6 +17,7 @@ type OpenAIResponsesPayloadModel = {
   baseUrl?: unknown;
   id?: unknown;
   provider?: unknown;
+  contextTokens?: unknown;
   contextWindow?: unknown;
   compat?: unknown;
 };
@@ -285,10 +286,18 @@ function parsePositiveInteger(value: unknown): number | undefined {
   return undefined;
 }
 
-function resolveOpenAIResponsesCompactThreshold(model: { contextWindow?: unknown }): number {
+function resolveOpenAIResponsesCompactThreshold(model: {
+  contextTokens?: unknown;
+  contextWindow?: unknown;
+}): number {
+  const contextTokens = parsePositiveInteger(model.contextTokens);
   const contextWindow = parsePositiveInteger(model.contextWindow);
-  if (contextWindow) {
-    return Math.max(1_000, Math.floor(contextWindow * 0.7));
+  const effectiveBudget =
+    contextTokens && contextWindow
+      ? Math.min(contextTokens, contextWindow)
+      : contextTokens || contextWindow;
+  if (effectiveBudget) {
+    return Math.max(1_000, Math.floor(effectiveBudget * 0.7));
   }
   return 80_000;
 }

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -12,7 +12,10 @@ const TEST_MODEL_ID = "gpt-5.4";
 const TEST_CONTEXT_WINDOW = 200_000;
 
 function buildModelConfig(
-  route: Pick<ModelDefinitionConfig, "api" | "baseUrl" | "compat">,
+  route: Pick<
+    ModelDefinitionConfig,
+    "api" | "baseUrl" | "compat" | "contextTokens" | "contextWindow"
+  >,
 ): ModelDefinitionConfig {
   return {
     id: TEST_MODEL_ID,
@@ -22,7 +25,8 @@ function buildModelConfig(
     reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: TEST_CONTEXT_WINDOW,
+    contextTokens: route.contextTokens,
+    contextWindow: route.contextWindow ?? TEST_CONTEXT_WINDOW,
     maxTokens: 8_192,
     compat: route.compat,
   };
@@ -33,6 +37,8 @@ function buildHostConfig(params: {
   api: ModelDefinitionConfig["api"];
   baseUrl?: string;
   compat?: ModelDefinitionConfig["compat"];
+  contextTokens?: number;
+  contextWindow?: number;
   extraParams?: Record<string, unknown>;
 }): OpenClawConfig {
   const modelEntry = {
@@ -44,7 +50,15 @@ function buildHostConfig(params: {
   const providerConfig: ModelProviderConfig = {
     api: params.api,
     baseUrl: params.baseUrl,
-    models: [buildModelConfig({ api: params.api, baseUrl: params.baseUrl, compat: params.compat })],
+    models: [
+      buildModelConfig({
+        api: params.api,
+        baseUrl: params.baseUrl,
+        compat: params.compat,
+        contextTokens: params.contextTokens,
+        contextWindow: params.contextWindow,
+      }),
+    ],
   };
   return {
     models: { providers: { [params.provider]: providerConfig } },
@@ -63,6 +77,17 @@ describe("Responses server compaction host/transport parity", () => {
       resolvedBaseUrl: "https://api.openai.com/v1",
       expectedEnabled: true,
       expectedThreshold: 140_000,
+    },
+    {
+      name: "OpenAI direct Sol route with an active runtime cap",
+      provider: "openai",
+      api: "openai-responses" as const,
+      baseUrl: "https://api.openai.com/v1",
+      resolvedBaseUrl: "https://api.openai.com/v1",
+      contextTokens: 272_000,
+      contextWindow: 1_050_000,
+      expectedEnabled: true,
+      expectedThreshold: 190_400,
     },
     {
       name: "OpenAI public route",
@@ -151,6 +176,8 @@ describe("Responses server compaction host/transport parity", () => {
       api: testCase.api,
       baseUrl: testCase.baseUrl,
       compat: testCase.compat,
+      contextTokens: testCase.contextTokens,
+      contextWindow: testCase.contextWindow,
       extraParams: testCase.extraParams,
     });
     const hostThreshold = resolveResponsesServerCompactionThreshold({
@@ -166,7 +193,8 @@ describe("Responses server compaction host/transport parity", () => {
         api: testCase.api,
         baseUrl: testCase.resolvedBaseUrl,
         compat: testCase.compat,
-        contextWindow: TEST_CONTEXT_WINDOW,
+        contextTokens: testCase.contextTokens,
+        contextWindow: testCase.contextWindow ?? TEST_CONTEXT_WINDOW,
       },
       {
         storeMode: "provider-policy",
@@ -178,6 +206,7 @@ describe("Responses server compaction host/transport parity", () => {
     const transportEnabled = payload.context_management !== undefined;
 
     expect(hostThreshold !== undefined).toBe(transportEnabled);
+    expect(policy.compactThreshold).toBe(hostThreshold);
     expect(transportEnabled).toBe(testCase.expectedEnabled);
     expect(hostThreshold).toBe(testCase.expectedThreshold);
   });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -81,6 +81,11 @@ export function resolveResponsesServerCompactionThreshold(params: {
   }
   const defaultOpenAIBaseUrl =
     normalizedProvider === "openai" ? "https://api.openai.com/v1" : undefined;
+  const activeContextTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    provider,
+    modelId,
+  });
   return resolveOpenAIResponsesServerCompactionPlan(
     {
       provider,
@@ -90,9 +95,8 @@ export function resolveResponsesServerCompactionThreshold(params: {
         (normalizedProvider === "openai" ? "openai-responses" : undefined),
       baseUrl: configuredModel?.baseUrl ?? providerConfig?.baseUrl ?? defaultOpenAIBaseUrl,
       compat: configuredModel?.compat,
-      contextWindow:
-        configuredModel?.contextWindow ??
-        resolveMemoryFlushContextWindowTokens({ cfg: params.cfg, provider, modelId }),
+      contextTokens: configuredModel?.contextTokens ?? activeContextTokens,
+      contextWindow: configuredModel?.contextWindow ?? activeContextTokens,
     },
     extraParams,
   ).threshold;


### PR DESCRIPTION
## Summary
- The default OpenAI Responses `context_management[].compact_threshold` was derived from `contextWindow` alone (70%). For `openai/gpt-5.6-sol` the direct-route descriptor carries `contextWindow: 1_050_000` while the runtime active budget is `contextTokens: 272_000`, so the default threshold resolved to 735,000 — far above the ~252k prompt budget the embedded runtime actually admits. Provider compaction never fired before local overflow handling. Any model whose descriptor window exceeds the active budget (e.g. a 372k window with the same 272k cap) mis-resolves the same way; the ChatGPT-auth route itself (`openai-chatgpt-responses`) remains excluded from in-request server compaction by the existing `allowsResponsesStore` gate and is not changed here.
- Default threshold now uses `0.7 × min(contextTokens, contextWindow)`; explicit `responsesCompactThreshold` still wins. `contextTokens` is threaded through the transport payload model and the host preflight (`resolveResponsesServerCompactionThreshold`), so host and payload thresholds resolve identically.

| Case | Before | After |
|---|---:|---:|
| Sol direct 1,050,000 / 272,000 | 735,000 | 190,400 |
| 372,000 window / 272,000 cap | 260,400 | 190,400 |
| Window-only 400,000 | 280,000 | 280,000 |
| Explicit param | param | param |
| Neither | 80,000 | 80,000 |

## Field report
Observed 2026-08-17 on four embedded direct-OpenAI deployments: `context-pressure-diagnostic route=compact_only estimatedPromptTokens=361k–984k promptBudgetBeforeReserve=252000`, local compaction `guard_blocked` / 180 s timeouts, while `context_management` was scheduled at 735k. Setting `responsesCompactThreshold=180000` per model worked around it; this PR fixes the default.

## Proof
`git diff --check`, format:check, oxlint, `tsgo`, `check:test-types`, and focused vitest on `packages/ai/src/transports/openai-responses-payload-policy.test.ts` + `src/auto-reply/reply/memory-flush.test.ts` (30 tests) pass locally. The threshold is asserted at 190,400 for the real Sol values on both the payload-policy and host-preflight paths; the Responses request body itself is not logged by the runtime, so a live redacted trace is not available without adding payload logging.

## Maintainer decision
Accepted on focused source proof (ClawSweeper local review `45af26e0`: patch correct, 0 findings, security cleared). The prior default (735,000) sat above the runtime's admitted prompt budget and could never fire, so no consumer depended on it; the runtime does not log Responses request bodies, so a live redacted trace would require new logging code and adds nothing over the exact-value parity tests. `responsesCompactThreshold` remains the explicit override.
