### PR TITLE
fix(cron): report missing automations in run history

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3014,7 +3014,7 @@ src/gateway/server-methods/chat.ts	2
 src/gateway/server-methods/config-write-flow.ts	1
 src/gateway/server-methods/config.ts	7
 src/gateway/server-methods/conversations.ts	4
-src/gateway/server-methods/cron.ts	20
+src/gateway/server-methods/cron.ts	17
 src/gateway/server-methods/device-scope-upgrade.ts	2
 src/gateway/server-methods/devices.ts	6
 src/gateway/server-methods/doctor.ts	5

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -397,6 +397,59 @@ describe("cron cli", () => {
   );
 
   it.each([
+    { name: "rm", args: ["cron", "rm", "missing"], method: "cron.remove" },
+    { name: "enable", args: ["cron", "enable", "missing"], method: "cron.update" },
+    { name: "disable", args: ["cron", "disable", "missing"], method: "cron.update" },
+    { name: "run", args: ["cron", "run", "missing"], method: "cron.run" },
+    { name: "scratch", args: ["cron", "scratch", "missing"], method: "cron.scratch.get" },
+    { name: "runs", args: ["cron", "runs", "--id", "missing"], method: "cron.runs" },
+  ])("keeps the canonical lookup miss for cron $name", async ({ args, method }) => {
+    resetGatewayMock();
+    callGatewayFromCli.mockImplementation(
+      async (calledMethod: string, opts: unknown, params?: unknown, timeoutMs?: number) => {
+        if (calledMethod === method) {
+          throw Object.assign(new Error("gateway cron lookup failed"), {
+            details: { code: "CRON_JOB_NOT_FOUND", jobId: "missing" },
+          });
+        }
+        return await defaultGatewayMock(calledMethod, opts, params, timeoutMs);
+      },
+    );
+
+    const program = buildProgram();
+    await expect(program.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
+
+    expectRuntimeErrorContaining(
+      "Automation not found: missing. Run `openclaw cron list` to see recent automation ids.",
+    );
+  });
+
+  it("keeps real empty cron history as an exact stdout success payload", async () => {
+    const emptyPage = {
+      entries: [],
+      total: 0,
+      offset: 0,
+      limit: 50,
+      hasMore: false,
+      nextOffset: null,
+    };
+    resetGatewayMock();
+    callGatewayFromCli.mockImplementation(
+      async (method: string, opts: unknown, params?: unknown, timeoutMs?: number) =>
+        method === "cron.runs"
+          ? emptyPage
+          : await defaultGatewayMock(method, opts, params, timeoutMs),
+    );
+
+    const program = buildProgram();
+    await program.parseAsync(["cron", "runs", "--id", "empty-cron"], { from: "user" });
+
+    expect(stdoutText()).toBe(JSON.stringify(emptyPage, null, 2));
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
+  it.each([
     {
       name: "bounds the default history RPC by the wait deadline",
       waitTimeout: "1s",

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -207,7 +207,7 @@ describe("cron show pagination guard (regression for #83856)", () => {
     );
   });
 
-  it("returns empty result when pagination terminates without a match", async () => {
+  it("uses the canonical lookup miss when pagination terminates without a match", async () => {
     mockCronShowPages(() => ({
       jobs: [],
       snapshotRevision: "test-empty-cron-inventory",
@@ -219,7 +219,9 @@ describe("cron show pagination guard (regression for #83856)", () => {
     }));
     await expect(runCronShow("missing")).rejects.toThrow("exit 1");
     expect(defaultRuntime.error).toHaveBeenCalledWith(
-      expect.stringContaining("automation not found: missing"),
+      expect.stringContaining(
+        "Automation not found: missing. Run `openclaw cron list` to see recent automation ids.",
+      ),
     );
   });
 });

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -15,6 +15,7 @@ import { findCronJobByIdOrName } from "./list-jobs.js";
 import { createCronOutputCommand } from "./output-mode.js";
 import {
   enrichCronJsonWithStatus,
+  formatCronLookupMiss,
   handleCronCliError,
   printCronJson,
   printCronShow,
@@ -179,7 +180,7 @@ export function registerCronSimpleCommands(cron: Command) {
             includeDeliveryPreview: !opts.json,
           });
           if (!job) {
-            throw new Error(`automation not found: ${String(id)}`);
+            throw new Error(formatCronLookupMiss(String(id)));
           }
           if (opts.json) {
             printCronJson(enrichCronJsonWithStatus(job));

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -206,20 +206,21 @@ function formatCronStatusForDisplay(job: CronJob): string {
 
 export function handleCronCliError(err: unknown) {
   const missingJob = readCronJobNotFoundError(err);
-  const message = missingJob
-    ? formatLookupMiss({
-        noun: "Automation",
-        value: sanitizeTerminalText(missingJob.jobId),
-        listCommand: "openclaw cron list",
-        valueLabel: "automation id",
-      })
-    : formatErrorMessage(err);
+  const message = missingJob ? formatCronLookupMiss(missingJob.jobId) : formatErrorMessage(err);
   if (isJsonOutputModeActive(process.argv)) {
     throw new Error(message);
   }
   defaultRuntime.error(danger(message));
   defaultRuntime.exit(1);
 }
+
+export const formatCronLookupMiss = (jobId: string) =>
+  formatLookupMiss({
+    noun: "Automation",
+    value: sanitizeTerminalText(jobId),
+    listCommand: "openclaw cron list",
+    valueLabel: "automation id",
+  });
 
 export async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
   // Old/offline gateways should not make successful cron mutations fail after the fact.

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1196,10 +1196,6 @@ export const cronHandlers: GatewayRequestHandlers = {
     const hasJobSelector = p.id !== undefined || p.jobId !== undefined;
     const jobId = resolveCronJobId(p);
     const scope: "job" | "all" = explicitScope ?? (hasJobSelector ? "job" : "all");
-    if (scope === "job" && !jobId) {
-      respondMissingCronJobId(respond, "cron.runs");
-      return;
-    }
     if (scope === "all") {
       if (callerScope) {
         respondInvalidCronParams(respond, "cron.runs", "scope all is not allowed by caller scope");
@@ -1224,8 +1220,12 @@ export const cronHandlers: GatewayRequestHandlers = {
       respond(true, page, undefined);
       return;
     }
+    if (!jobId) {
+      respondMissingCronJobId(respond, "cron.runs");
+      return;
+    }
     try {
-      const job = await context.cron.readJob(jobId as string);
+      const job = await context.cron.readJob(jobId);
       const defaultAgentId = context.cron.getDefaultAgentId();
       const matchedJob =
         job &&
@@ -1239,21 +1239,21 @@ export const cronHandlers: GatewayRequestHandlers = {
           ? job
           : undefined;
       // Operator history survives job deletion; scoped reads still need a live, matching owner.
-      if ((callerScope || p.agentId) && !matchedJob) {
-        if (!jobId) {
-          respondMissingCronJobId(respond, "cron.runs");
-          return;
-        }
+      const storeKey = cronStoreKey(context.cronStorePath);
+      if (
+        ((callerScope || p.agentId) && !matchedJob) ||
+        (!job && readCronTaskRunHistoryPage({ storeKey, jobId, limit: 1 }).total === 0)
+      ) {
         respondCronJobNotFound(respond, jobId);
         return;
       }
       const jobNameById =
         matchedJob && typeof matchedJob.name === "string"
-          ? { [jobId as string]: matchedJob.name }
+          ? { [jobId]: matchedJob.name }
           : undefined;
       const page = readCronTaskRunHistoryPage({
-        storeKey: cronStoreKey(context.cronStorePath),
-        jobId: jobId as string,
+        storeKey,
+        jobId,
         ...cronRunLogPageFilters(p),
         jobNameById,
       });

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -40,6 +40,18 @@ const loadGatewaySessionEntry = vi.hoisted(() =>
     } => ({ canonicalKey: sessionKey, entry: undefined }),
   ),
 );
+const cronTaskRunHistoryPageOverride = vi.hoisted(() => vi.fn());
+
+vi.mock("../../cron/task-run-history.js", async () => {
+  const actual = await vi.importActual<typeof import("../../cron/task-run-history.js")>(
+    "../../cron/task-run-history.js",
+  );
+  return {
+    ...actual,
+    readCronTaskRunHistoryPage: (...args: Parameters<typeof actual.readCronTaskRunHistoryPage>) =>
+      cronTaskRunHistoryPageOverride(...args) ?? actual.readCronTaskRunHistoryPage(...args),
+  };
+});
 
 vi.mock("../../config/config.js", async () => {
   const actual =
@@ -579,6 +591,7 @@ function expectInvalidCronPatternError(respond: ReturnType<typeof vi.fn>): void 
 describe("cron method validation", () => {
   beforeEach(() => {
     getRuntimeConfig.mockReset().mockReturnValue({} as OpenClawConfig);
+    cronTaskRunHistoryPageOverride.mockReset().mockReturnValue(undefined);
     loadGatewaySessionEntry
       .mockReset()
       .mockImplementation((sessionKey: string) => ({ canonicalKey: sessionKey, entry: undefined }));
@@ -3825,6 +3838,14 @@ describe("cron method validation", () => {
   });
 
   it("preserves deleted-job history without listing unrelated cron jobs", async () => {
+    cronTaskRunHistoryPageOverride.mockReturnValue({
+      entries: [{ jobId: "deleted-cron", action: "finished", status: "ok", ts: 1 }],
+      total: 1,
+      offset: 0,
+      limit: 50,
+      hasMore: false,
+      nextOffset: null,
+    });
     const context = createCronContext();
 
     const { respond } = await invokeCron("cron.runs", { id: "deleted-cron" }, { context });
@@ -3834,6 +3855,39 @@ describe("cron method validation", () => {
     expect(respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({ entries: expect.any(Array) }),
+      undefined,
+    );
+  });
+
+  it("returns a typed lookup miss when cron.runs has no live job or retained history", async () => {
+    const context = createCronContext();
+
+    const { respond } = await invokeCron("cron.runs", { id: "missing-cron" }, { context });
+
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("missing-cron");
+    expect(context.cron.list).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "Automation not found: missing-cron",
+      details: { code: "CRON_JOB_NOT_FOUND", jobId: "missing-cron" },
+    });
+  });
+
+  it("keeps the exact empty cron.runs page for a live job with no history", async () => {
+    const context = createCronContext(createCronJob({ id: "empty-cron" }));
+
+    const { respond } = await invokeCron("cron.runs", { id: "empty-cron" }, { context });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        entries: [],
+        total: 0,
+        offset: 0,
+        limit: 50,
+        hasMore: false,
+        nextOffset: null,
+      },
       undefined,
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw cron runs --id <missing>` returned the same successful empty-history payload as a real automation that had never run, so operators and scripts could not distinguish a typo from valid empty history. It also fixes `cron show <missing>` being the lone lookup command that returned lowercase gateway prose without the canonical recovery step.

AI-assisted implementation; the behavior, ownership boundary, tests, and live proof were reviewed directly.

Before, the same nonexistent id produced inconsistent results:

| command | exit | operator-visible result |
| --- | ---: | --- |
| `cron rm BOGUS` | 1 | canonical `Automation not found` message |
| `cron enable BOGUS` | 1 | canonical message |
| `cron disable BOGUS` | 1 | canonical message |
| `cron run BOGUS` | 1 | canonical message |
| `cron scratch BOGUS` | 1 | canonical message |
| `cron show BOGUS` | 1 | `automation not found: BOGUS` |
| `cron runs --id BOGUS` | 0 | empty success payload |

The missing-id and real-empty stdout captures were byte-identical:

```json
{"entries":[],"total":0,"offset":0,"limit":50,"hasMore":false,"nextOffset":null}
```

## Why This Change Was Made

The ambiguity belonged to the Gateway RPC, not the CLI: `cron.runs` read the live job but intentionally allowed operator history reads to continue when the job was deleted, preserving retained task-ledger history. The handler now performs an unfiltered, one-row history existence probe when the live job is absent and returns the existing typed `CRON_JOB_NOT_FOUND` error only when neither a live job nor readable retained history exists. This stays within one Gateway RPC, preserves filtered history for deleted jobs, and does not change the successful result schema.

`cron show` resolves ids and exact names through `cron.get` plus paginated `cron.list`. When both miss, it synthesized a plain lowercase `Error`, so `handleCronCliError` could not read typed Gateway details. The local fallback now uses the same shared `formatLookupMiss` path as the typed errors; no new wording was introduced.

Alternatives rejected:

- A CLI-side `cron.list` preflight would add a second Gateway round trip and leave HTTP/other RPC clients ambiguous.
- Extending the success payload would break the empty-history machine contract.
- Treating every missing live job as not found would regress intentional access to retained history for deleted jobs.

## User Impact

`cron runs --id <missing>` now exits 1 with the same canonical message as the other cron lookup commands. A real automation with no runs still exits 0 with the exact existing payload and empty stderr. Deleted automations with retained run history remain queryable.

After live verification:

| command | exit | result |
| --- | ---: | --- |
| `cron rm BOGUS` | 1 | canonical message |
| `cron enable BOGUS` | 1 | canonical message |
| `cron disable BOGUS` | 1 | canonical message |
| `cron run BOGUS` | 1 | canonical message |
| `cron scratch BOGUS` | 1 | canonical message |
| `cron show BOGUS` | 1 | canonical message |
| `cron runs --id BOGUS` | 1 | canonical message |

The raw Gateway call now returns `INVALID_REQUEST` with `details.code = "CRON_JOB_NOT_FOUND"` and `details.jobId = "BOGUS"`.

## Evidence

Focused regressions were written first and failed on the original code for the intended reasons: the Gateway test received success instead of a typed miss, and the `show` test received lowercase prose instead of the canonical message.

Final validation:

- `node scripts/run-vitest.mjs src/gateway/server-methods/cron.validation.test.ts src/cli/cron-cli.test.ts src/cli/cron-cli/register.cron-simple.test.ts` — 382 tests passed after the final rebase.
- `env -u OPENCLAW_TESTBOX OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — passed core, core-test, and tooling gates. The initial default route was cancelled after remaining queued without executing; the local gate then ran to completion.
- `pnpm build` — passed on the final source.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings (final run confidence 0.99).
- Live built-dist proof used a scratch state directory, isolated token config, `OPENCLAW_SKIP_CHANNELS=1`, unset Discord/Twilio variables, and loopback port 60374 (never 18789). The owned Gateway was stopped and the port was verified closed.
- Missing history: exit 1; canonical error; distinct from empty history.
- Real automation with no runs: exit 0; stdout is the exact existing seven-field empty page (106 bytes, pretty-printed by the CLI); stderr empty.
- Real command automation with a completed run: exit 0; one `ok` entry with summary `live-run-proof`.

Sibling `--id`/lookup sweep (left unchanged):

- `tasks`: `show`/mutation lookups already emit canonical `Task not found` failures; no history endpoint returns an indistinguishable empty page.
- `nodes`: `describe --node` resolves against `node.list` and throws `unknown node` when absent.
- `devices`: id-bearing commands are mutations whose Gateway methods fail for missing targets; there is no analogous history lookup.
- `sessions`: lifecycle commands preflight paginated `sessions.list` and return explicit `not_found`; tail/export selectors are not id-history lookups.
- Workboard: `workboard.cards.runs` calls the owning store, which throws `card not found` before returning attempts; a real card with zero attempts remains a valid success.

Surface/contract checks:

- Admin HTTP exposes the same `cron.runs` Gateway handler, so the RPC fix removes its ambiguity too.
- Control UI requests job history only for a job selected from `cron.list` and already renders RPC errors; the normal UI did not expose a free-form missing-id path.
- `docs/cli/cron.md` documents the successful run-history payload and polling contract but does not promise empty success for unknown ids, so this is not a documented compatibility choice.
- Production LOC: +24/-22 (net +2). Tests: +111/-2. Tooling ratchet: +1/-1, shrinking the cron assertion baseline from 20 to 17 after the owner refactor removed three old assertions.

CI note: current repository Actions runs are broadly failing before tests while downloading third-party Actions with 429/503 responses. No reruns were spent on that known infrastructure failure; the touched suites and required gates passed locally.
