### PR TITLE
fix: keep model skill catalogs bounded and available

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -22,6 +22,8 @@ import {
 import { createPluginRegistry } from "../../plugins/registry.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
+import { buildSkillSnapshot } from "../../skills/loading/workspace-skill-prompt.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
@@ -398,6 +400,7 @@ describe("prepareCliRunContext", () => {
     resetContextWindowCacheForTest();
     clearMemoryPluginState();
     setActivePluginRegistry(createTestRegistry());
+    setActiveDegradedSecretOwners([]);
     vi.unstubAllEnvs();
     fixture.cleanup();
   });
@@ -4515,6 +4518,43 @@ describe("prepareCliRunContext", () => {
     expect(context.systemPromptReport.skills.entries).toEqual([
       { name: "gog", blockChars: expect.any(Number) },
     ]);
+  });
+
+  it("lazily rebuilds an unsafe modern skills snapshot for a non-sandbox CLI run", async () => {
+    const { dir } = fixture.session;
+    for (const name of ["cold-skill", "healthy-skill"]) {
+      const skillDir = path.join(dir, "skills", name);
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        `---\nname: ${name}\ndescription: ${name}\n---\n`,
+        "utf-8",
+      );
+    }
+    const snapshot = buildSkillSnapshot(dir, {
+      bundledSkillsDir: path.join(dir, "missing-bundled-skills"),
+      managedSkillsDir: path.join(dir, "missing-managed-skills"),
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    const context = await fixture.prepare({
+      skillsSnapshot: {
+        ...snapshot,
+        prompt: `${snapshot.prompt}\n<available_skills></available_skills>`,
+      },
+    });
+
+    expect(context.systemPrompt).not.toContain("cold-skill/SKILL.md");
+    expect(context.systemPrompt).toContain("healthy-skill/SKILL.md");
   });
 
   it.each([

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -260,8 +260,17 @@ async function resolveCliSkillsPrompt(params: {
     workspaceDir: params.workspaceDir,
   });
   if (!sandboxWorkspace) {
+    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries } =
+      resolveEmbeddedRunSkillEntries({
+        workspaceDir: params.workspaceDir,
+        config: params.config,
+        agentId: params.agentId,
+        skillsSnapshot: params.skillsSnapshot,
+      });
     return resolveSkillsPrompt({
       skillsSnapshot: params.skillsSnapshot,
+      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      loadEntries: loadSkillEntries,
       workspaceDir: params.workspaceDir,
       config: params.config,
       agentId: params.agentId,

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -70,6 +70,7 @@ import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-disco
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt-thread-helpers.js";
 import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
 import {
+  createSandboxPromptEntryLoader,
   mapSandboxSkillEntriesForPrompt,
   mapSandboxSkillUsagePaths,
   resolveSandboxSkillRuntimeInputs,
@@ -144,14 +145,15 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       effectiveWorkspace,
       skillsSnapshot: params.skillsSnapshot,
     });
-    const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-      workspaceDir: effectiveSkillsWorkspace,
-      config: params.config,
-      agentId: effectiveSkillAgentId,
-      eligibility: skillsEligibility,
-      skillsSnapshot: skillsSnapshotForRun,
-      workspaceOnly: loadSkillsWorkspaceOnly,
-    });
+    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries } =
+      resolveEmbeddedRunSkillEntries({
+        workspaceDir: effectiveSkillsWorkspace,
+        config: params.config,
+        agentId: effectiveSkillAgentId,
+        eligibility: skillsEligibility,
+        skillsSnapshot: skillsSnapshotForRun,
+        workspaceOnly: loadSkillsWorkspaceOnly,
+      });
     restoreSkillEnv = skillsSnapshotForRun
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: skillsSnapshotForRun,
@@ -174,6 +176,11 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const skillsPrompt = resolveSkillsPrompt({
       skillsSnapshot: skillsSnapshotForRun,
       entries: promptSkillEntries,
+      loadEntries: createSandboxPromptEntryLoader({
+        loadEntries: loadSkillEntries,
+        skillsWorkspaceDir: effectiveSkillsWorkspace,
+        skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
+      }),
       config: params.config,
       workspaceDir: effectiveSkillsPromptWorkspace,
       agentId: effectiveSkillAgentId,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -51,6 +51,7 @@ import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { log } from "../logger.js";
 import {
+  createSandboxPromptEntryLoader,
   mapSandboxSkillEntriesForPrompt,
   mapSandboxSkillUsagePaths,
   resolveSandboxSkillRuntimeInputs,
@@ -510,14 +511,16 @@ export function prepareEmbeddedAttemptSkills(params: {
     effectiveWorkspace: params.effectiveWorkspace,
     skillsSnapshot: params.attempt.skillsSnapshot,
   });
-  const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-    workspaceDir: skillsWorkspaceDir,
-    config: params.attempt.config,
-    agentId: params.sessionAgentId,
-    eligibility: skillsEligibility,
-    skillsSnapshot,
-    workspaceOnly,
-  });
+  const { shouldLoadSkillEntries, skillEntries, loadSkillEntries } = resolveEmbeddedRunSkillEntries(
+    {
+      workspaceDir: skillsWorkspaceDir,
+      config: params.attempt.config,
+      agentId: params.sessionAgentId,
+      eligibility: skillsEligibility,
+      skillsSnapshot,
+      workspaceOnly,
+    },
+  );
   const restoreSkillEnv = skillsSnapshot
     ? applySkillEnvOverridesFromSnapshot({
         snapshot: skillsSnapshot,
@@ -541,6 +544,11 @@ export function prepareEmbeddedAttemptSkills(params: {
     const skillsPrompt = resolveSkillsPrompt({
       skillsSnapshot,
       entries: promptSkillEntries,
+      loadEntries: createSandboxPromptEntryLoader({
+        loadEntries: loadSkillEntries,
+        skillsWorkspaceDir,
+        skillsPromptWorkspaceDir,
+      }),
       config: params.attempt.config,
       workspaceDir: skillsPromptWorkspaceDir,
       agentId: params.sessionAgentId,

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -207,6 +207,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const resolveEmbeddedRunSkillEntriesMock = vi.fn(() => ({
     shouldLoadSkillEntries: false,
     skillEntries: [],
+    loadSkillEntries: vi.fn(() => []),
   }));
   const resolveSkillsPromptForRunMock = vi.fn(() => "");
   const supportsModelToolsMock = vi.fn<(model?: unknown) => boolean>(() => true);
@@ -1078,6 +1079,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.resolveEmbeddedRunSkillEntriesMock.mockReset().mockReturnValue({
     shouldLoadSkillEntries: false,
     skillEntries: [],
+    loadSkillEntries: vi.fn(() => []),
   });
   hoisted.resolveSkillsPromptForRunMock.mockReset().mockReturnValue("");
   hoisted.supportsModelToolsMock.mockReset().mockReturnValue(true);

--- a/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../../skills/runtime/embedded-run-entries.js", () => ({
   resolveEmbeddedRunSkillEntries: vi.fn(() => ({
     shouldLoadSkillEntries: true,
     skillEntries: [],
+    loadSkillEntries: vi.fn(() => []),
   })),
 }));
 
@@ -23,6 +24,9 @@ vi.mock("../../../skills/loading/workspace-skill-prompt.js", () => ({
 }));
 
 vi.mock("../sandbox-skills.js", () => ({
+  createSandboxPromptEntryLoader: vi.fn(
+    ({ loadEntries }: { loadEntries: () => unknown[] }) => loadEntries,
+  ),
   resolveSandboxSkillRuntimeInputs: vi.fn(() => ({
     skillsEligibility: undefined,
     skillsPromptWorkspaceDir: "/tmp/workspace",

--- a/src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts
@@ -53,6 +53,7 @@ describe("runEmbeddedAttempt skill policy projections", () => {
       hoisted.resolveEmbeddedRunSkillEntriesMock.mockReturnValue({
         shouldLoadSkillEntries: true,
         skillEntries: [createFixtureSkillEntry("demo")],
+        loadSkillEntries: vi.fn(() => [createFixtureSkillEntry("demo")]),
       });
       hoisted.resolveSkillsPromptForRunMock.mockReturnValue(skillsPrompt);
 

--- a/src/agents/embedded-agent-runner/sandbox-skills.ts
+++ b/src/agents/embedded-agent-runner/sandbox-skills.ts
@@ -108,6 +108,19 @@ export function mapSandboxSkillEntriesForPrompt(params: {
   });
 }
 
+export function createSandboxPromptEntryLoader(params: {
+  loadEntries: () => SkillEntry[];
+  skillsWorkspaceDir: string;
+  skillsPromptWorkspaceDir: string;
+}): () => SkillEntry[] {
+  return () =>
+    mapSandboxSkillEntriesForPrompt({
+      entries: params.loadEntries(),
+      skillsWorkspaceDir: params.skillsWorkspaceDir,
+      skillsPromptWorkspaceDir: params.skillsPromptWorkspaceDir,
+    }) ?? [];
+}
+
 export function mapSandboxSkillUsagePaths(params: {
   paths?: SkillUsagePath[];
   skillsWorkspaceDir: string;

--- a/src/agents/sessions/system-prompt.test.ts
+++ b/src/agents/sessions/system-prompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 
 describe("buildSystemPrompt", () => {
@@ -15,5 +16,41 @@ describe("buildSystemPrompt", () => {
         customPrompt: "Custom replacement prompt",
       }),
     ).not.toContain("## Promised Work");
+  });
+
+  it("bounds and deterministically orders the embedded skills catalog", () => {
+    const skills = Array.from({ length: 200 }, (_, index) => {
+      const name = `skill-${String(199 - index).padStart(3, "0")}`;
+      return createCanonicalFixtureSkill({
+        name,
+        description: "x".repeat(1_024),
+        filePath: `/skills/${name}/SKILL.md`,
+        baseDir: `/skills/${name}`,
+        source: "test",
+      });
+    });
+
+    const prompt = buildSystemPrompt({
+      cwd: "/tmp/workspace",
+      customPrompt: "Custom replacement prompt",
+      skills,
+    });
+    const skillsPrompt = prompt.slice(
+      "Custom replacement prompt".length,
+      prompt.indexOf("\nCurrent date:"),
+    );
+    const renderedNames = [...skillsPrompt.matchAll(/<name>([^<]+)<\/name>/g)].map((match) => {
+      const name = match[1];
+      if (!name) {
+        throw new Error("expected a rendered skill name");
+      }
+      return name;
+    });
+
+    expect(skillsPrompt.length).toBeLessThanOrEqual(18_000);
+    expect(renderedNames.length).toBeLessThanOrEqual(150);
+    expect(renderedNames.length).toBeGreaterThan(0);
+    expect(renderedNames).toEqual(renderedNames.toSorted((a, b) => a.localeCompare(b, "en")));
+    expect(skillsPrompt).toContain("⚠️ Skills truncated:");
   });
 });

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -13,7 +13,8 @@ import {
 import { expandTildePath } from "../../shared/tilde-path.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import { formatSkillsForPromptCore, resolveSkillDisplayName } from "./skill-contract.js";
+import { resolveSkillDisplayName } from "./skill-contract.js";
+import { formatSkillsForPromptBounded } from "./skill-prompt-limits.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
 
 /** Max name length per spec */
@@ -277,7 +278,7 @@ function loadSkillFromFile(
  */
 export function formatSkillsForPrompt(skills: Skill[]): string {
   const visibleSkills = skills.filter((s) => !s.disableModelInvocation);
-  return formatSkillsForPromptCore(visibleSkills);
+  return formatSkillsForPromptBounded({ skills: visibleSkills });
 }
 
 interface LoadSkillsOptions {

--- a/src/skills/loading/skill-contract.test.ts
+++ b/src/skills/loading/skill-contract.test.ts
@@ -39,8 +39,8 @@ describe("resolveSkillDisplayName", () => {
 describe("formatSkillsCompact", () => {
   it("keeps the full-format XML output aligned with the upstream formatter for visible skills", () => {
     const skills = [
-      { ...makeSkill("weather", "Get weather <data> & forecasts"), promptVersion: "sha256:abc123" },
       makeSkill("notes", "Summarize notes", "/tmp/notes/SKILL.md"),
+      { ...makeSkill("weather", "Get weather <data> & forecasts"), promptVersion: "sha256:abc123" },
     ];
     expect(formatSkillsForPromptCore(skills)).toBe(upstreamFormatSkillsForPrompt(skills));
   });

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -32,7 +32,7 @@ export function escapeSkillXml(str: string): string {
     .replace(/'/g, "&apos;");
 }
 
-const COMPACT_DESCRIPTION_MAX_CHARS = 220;
+export const COMPACT_DESCRIPTION_MAX_CHARS = 220;
 const SKILL_FRONTMATTER_BLOCK = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u;
 const SKILL_TITLE_HEADING = /^#\s+(.+?)\s*#*\s*$/mu;
 

--- a/src/skills/loading/skill-prompt-limits.ts
+++ b/src/skills/loading/skill-prompt-limits.ts
@@ -1,0 +1,172 @@
+// Skill prompt limits keep every catalog producer within one shared model-context budget.
+import {
+  COMPACT_DESCRIPTION_MAX_CHARS,
+  formatSkillsCompactForPrompt,
+  formatSkillsForPromptCore,
+  type Skill,
+} from "./skill-contract.js";
+
+const COMPACT_DESCRIPTION_MIN_CHARS = 4;
+const DEFAULT_MAX_SKILLS_IN_PROMPT = 150;
+const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 18_000;
+
+type SkillsPromptFormat = { kind: "full" } | { kind: "compact"; descriptionMaxChars: number };
+
+function buildSkillsLimitNote(params: {
+  truncated: boolean;
+  format: SkillsPromptFormat;
+  included: number;
+  total: number;
+}): string {
+  if (params.truncated) {
+    const compactDetails =
+      params.format.kind === "compact"
+        ? ` (compact format, ${params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted"})`
+        : "";
+    return `⚠️ Skills truncated: included ${params.included} of ${params.total}${compactDetails}. Run \`openclaw skills check\` to audit.`;
+  }
+  if (params.format.kind === "compact") {
+    const compactDetails =
+      params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted";
+    return `⚠️ Skills catalog using compact format (${compactDetails}). Run \`openclaw skills check\` to audit.`;
+  }
+  return "";
+}
+
+function buildRenderedSkillsPrompt(params: {
+  remoteNote?: string;
+  skills: Skill[];
+  total: number;
+  format: SkillsPromptFormat;
+  includeLimitNote?: boolean;
+}): string {
+  // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
+  // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
+  const truncated = params.skills.length < params.total;
+  const limitNote =
+    params.includeLimitNote === false
+      ? ""
+      : buildSkillsLimitNote({
+          truncated,
+          format: params.format,
+          included: params.skills.length,
+          total: params.total,
+        });
+  const catalog =
+    params.format.kind === "compact"
+      ? formatSkillsCompactForPrompt(params.skills, {
+          descriptionMaxChars: params.format.descriptionMaxChars,
+        })
+      : formatSkillsForPromptCore(params.skills);
+  return [params.remoteNote, limitNote, catalog].filter(Boolean).join("\n");
+}
+
+/** Render a deterministic skills catalog within the shared model-context budget. */
+export function formatSkillsForPromptBounded(params: {
+  skills: Skill[];
+  maxSkillsInPrompt?: number;
+  maxSkillsPromptChars?: number;
+  remoteNote?: string;
+}): string {
+  const maxSkillsInPrompt = params.maxSkillsInPrompt ?? DEFAULT_MAX_SKILLS_IN_PROMPT;
+  const maxSkillsPromptChars = params.maxSkillsPromptChars ?? DEFAULT_MAX_SKILLS_PROMPT_CHARS;
+  const orderedSkills = params.skills.toSorted((a, b) => a.name.localeCompare(b.name, "en"));
+  const total = orderedSkills.length;
+  const byCount = orderedSkills.slice(0, Math.max(0, maxSkillsInPrompt));
+  let skillsForPrompt = byCount;
+
+  const renderWithinLimit = (
+    skills: Skill[],
+    format: SkillsPromptFormat,
+    includeLimitNote = true,
+  ): string | undefined => {
+    const remoteNotes = params.remoteNote ? [params.remoteNote, undefined] : [undefined];
+    for (const remoteNote of remoteNotes) {
+      const prompt = buildRenderedSkillsPrompt({
+        remoteNote,
+        skills,
+        total,
+        format,
+        includeLimitNote,
+      });
+      if (prompt.length <= maxSkillsPromptChars) {
+        return prompt;
+      }
+    }
+    return undefined;
+  };
+
+  const fitsFull = (skills: Skill[], includeLimitNote = true): boolean =>
+    renderWithinLimit(skills, { kind: "full" }, includeLimitNote) !== undefined;
+  const fitsCompact = (
+    skills: Skill[],
+    descriptionMaxChars: number,
+    includeLimitNote = true,
+  ): boolean =>
+    renderWithinLimit(skills, { kind: "compact", descriptionMaxChars }, includeLimitNote) !==
+    undefined;
+
+  if (fitsFull(skillsForPrompt)) {
+    return renderWithinLimit(skillsForPrompt, { kind: "full" }) ?? "";
+  }
+
+  if (!fitsCompact(skillsForPrompt, 0)) {
+    let lo = 0;
+    let hi = skillsForPrompt.length;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (fitsCompact(skillsForPrompt.slice(0, mid), 0)) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    skillsForPrompt = skillsForPrompt.slice(0, lo);
+  }
+
+  if (skillsForPrompt.length === 0 && byCount.length > 0) {
+    const fullWithoutNotice = renderWithinLimit(byCount, { kind: "full" }, false);
+    if (fullWithoutNotice !== undefined) {
+      return fullWithoutNotice;
+    }
+    let lo = 0;
+    let hi = byCount.length;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (fitsCompact(byCount.slice(0, mid), 0, false)) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    if (lo > 0) {
+      skillsForPrompt = byCount.slice(0, lo);
+    }
+  }
+
+  const includeLimitNote = fitsCompact(skillsForPrompt, 0);
+  let descriptionMaxChars = 0;
+  if (
+    skillsForPrompt.length > 0 &&
+    fitsCompact(skillsForPrompt, COMPACT_DESCRIPTION_MIN_CHARS, includeLimitNote)
+  ) {
+    let lo = COMPACT_DESCRIPTION_MIN_CHARS;
+    let hi = COMPACT_DESCRIPTION_MAX_CHARS;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (fitsCompact(skillsForPrompt, mid, includeLimitNote)) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    descriptionMaxChars = lo;
+  }
+  return (
+    renderWithinLimit(
+      skillsForPrompt,
+      { kind: "compact", descriptionMaxChars },
+      includeLimitNote,
+    ) ?? ""
+  );
+}

--- a/src/skills/loading/workspace-skill-prompt-resolution.test.ts
+++ b/src/skills/loading/workspace-skill-prompt-resolution.test.ts
@@ -2,16 +2,47 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION, type SkillEntry } from "../types.js";
 import { buildSkillSnapshot, resolveSkillsPrompt } from "./workspace-skill-prompt.js";
 
+const loggingMocks = vi.hoisted(() => ({ warn: vi.fn() }));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    subsystem: "skills",
+    isEnabled: () => false,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: loggingMocks.warn,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
 afterEach(() => {
   setActiveDegradedSecretOwners([]);
+  loggingMocks.warn.mockClear();
 });
+
+function createEntry(name: string): SkillEntry {
+  return {
+    skill: createCanonicalFixtureSkill({
+      name,
+      description: name,
+      filePath: `/app/skills/${name}/SKILL.md`,
+      baseDir: `/app/skills/${name}`,
+      source: "openclaw-workspace",
+    }),
+    frontmatter: {},
+  };
+}
 
 describe("resolveSkillsPrompt", () => {
   it("prefers snapshot prompt when available", () => {
@@ -109,6 +140,71 @@ describe("resolveSkillsPrompt", () => {
     expect(prompt).toBe("");
   });
 
+  it.each([
+    {
+      name: "legacy owner identity",
+      reason: "legacy-skill-identity",
+      mutate: (snapshot: ReturnType<typeof buildSkillSnapshot>) => ({
+        ...snapshot,
+        skills: snapshot.skills.map(({ name }) => ({ name })),
+      }),
+    },
+    {
+      name: "structurally anomalous catalog",
+      reason: "invalid-catalog-structure",
+      mutate: (snapshot: ReturnType<typeof buildSkillSnapshot>) => ({
+        ...snapshot,
+        prompt: `${snapshot.prompt}\n<available_skills></available_skills>`,
+      }),
+    },
+  ])(
+    "lazily rebuilds healthy entries for a degraded modern $name snapshot",
+    ({ reason, mutate }) => {
+      const entries = [createEntry("cold-skill"), createEntry("healthy-skill")];
+      const snapshot = mutate(buildSkillSnapshot("/tmp/openclaw", { entries }));
+      const loadEntries = vi.fn(() => entries);
+      setActiveDegradedSecretOwners([
+        {
+          ownerKind: "capability",
+          ownerId: "skill:cold-skill",
+          state: "unavailable",
+          paths: ["skills.entries.cold-skill.apiKey"],
+          refKeys: ["env:default:MISSING_SKILL_KEY"],
+          reason: "secret provider failed",
+        },
+      ]);
+
+      const prompt = resolveSkillsPrompt({
+        skillsSnapshot: snapshot,
+        loadEntries,
+        workspaceDir: "/tmp/openclaw",
+      });
+
+      expect(loadEntries).toHaveBeenCalledOnce();
+      expect(prompt).not.toContain("cold-skill/SKILL.md");
+      expect(prompt).toContain("healthy-skill/SKILL.md");
+      expect(loggingMocks.warn).toHaveBeenCalledWith(
+        "Cached skills prompt could not be safely filtered; rebuilding from current skill entries.",
+        { reason },
+      );
+    },
+  );
+
+  it("does not load entries while reusing a valid modern snapshot", () => {
+    const entries = [createEntry("healthy-skill")];
+    const snapshot = buildSkillSnapshot("/tmp/openclaw", { entries });
+    const loadEntries = vi.fn(() => entries);
+
+    expect(
+      resolveSkillsPrompt({
+        skillsSnapshot: snapshot,
+        loadEntries,
+        workspaceDir: "/tmp/openclaw",
+      }),
+    ).toBe(snapshot.prompt.trim());
+    expect(loadEntries).not.toHaveBeenCalled();
+  });
+
   it("matches unavailable owners against a snapshot skill's config key", () => {
     const cold: SkillEntry = {
       skill: createCanonicalFixtureSkill({
@@ -156,16 +252,6 @@ describe("resolveSkillsPrompt", () => {
   });
 
   it("does not add supplied skills outside the saved snapshot during a degraded rebuild", () => {
-    const createEntry = (name: string): SkillEntry => ({
-      skill: createCanonicalFixtureSkill({
-        name,
-        description: name,
-        filePath: `/app/skills/${name}/SKILL.md`,
-        baseDir: `/app/skills/${name}`,
-        source: "openclaw-workspace",
-      }),
-      frontmatter: {},
-    });
     const capturedEntries = [createEntry("cold-skill"), createEntry("healthy-skill")];
     const snapshot = buildSkillSnapshot("/tmp/openclaw", {
       entries: capturedEntries,

--- a/src/skills/loading/workspace-skill-prompt.test.ts
+++ b/src/skills/loading/workspace-skill-prompt.test.ts
@@ -231,6 +231,30 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).not.toContain("REMOTE_NOTE_");
   });
 
+  it("preserves the exact full-catalog bytes when a remote note fits", () => {
+    const skill = makeSkill("weather", "Get weather data");
+    const remoteNote = "Remote node skills are available.";
+    const catalog = formatSkillsForPromptCore([skill]);
+    const expected = [remoteNote, catalog].join("\n");
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+      config: {
+        skills: { limits: { maxSkillsPromptChars: expected.length } },
+      } satisfies OpenClawConfig,
+      eligibility: {
+        remote: {
+          platforms: ["linux"],
+          hasBin: () => false,
+          hasAnyBin: () => false,
+          note: remoteNote,
+        },
+      },
+    });
+
+    expect(prompt).toBe(expected);
+    expect(prompt.length).toBeLessThanOrEqual(expected.length);
+  });
+
   it("budgets the final rendered prompt including versions and limit notices", () => {
     const skills = Array.from({ length: 24 }, (_, i) => ({
       ...makeSkill(`skill-${i}`, "A".repeat(160)),

--- a/src/skills/loading/workspace-skill-prompt.ts
+++ b/src/skills/loading/workspace-skill-prompt.ts
@@ -1,202 +1,18 @@
 // Workspace skill prompt helpers render bounded catalogs and reusable snapshots.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveEffectiveAgentSkillsLimits } from "../discovery/agent-filter.js";
 import { filterPromptVisibleSkillEntries } from "../discovery/skill-index.js";
 import type { SkillEligibilityContext, SkillEntry, SkillSnapshot } from "../types.js";
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import { hasUnavailableSkillSecretOwners, isSkillSecretOwnerUnavailable } from "./config.js";
 import { resolveSkillKey } from "./frontmatter.js";
-import {
-  escapeSkillXml,
-  formatSkillsCompactForPrompt,
-  formatSkillsForPromptCore,
-  type Skill,
-} from "./skill-contract.js";
+import { escapeSkillXml, type Skill } from "./skill-contract.js";
 import { compactPromptSkills } from "./skill-paths.js";
+import { formatSkillsForPromptBounded } from "./skill-prompt-limits.js";
 import { resolveWorkspaceSkillPromptEntries } from "./workspace-skill-loader.js";
 
-const COMPACT_DESCRIPTION_MAX_CHARS = 220;
-const COMPACT_DESCRIPTION_MIN_CHARS = 4;
-const DEFAULT_MAX_SKILLS_IN_PROMPT = 150;
-const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 18_000;
-
-type ResolvedSkillsPromptLimits = {
-  maxSkillsInPrompt: number;
-  maxSkillsPromptChars: number;
-};
-
-function resolveSkillsPromptLimits(
-  config?: OpenClawConfig,
-  agentId?: string,
-): ResolvedSkillsPromptLimits {
-  const limits = config?.skills?.limits;
-  const agentLimits = resolveEffectiveAgentSkillsLimits(config, agentId);
-  return {
-    maxSkillsInPrompt: limits?.maxSkillsInPrompt ?? DEFAULT_MAX_SKILLS_IN_PROMPT,
-    maxSkillsPromptChars:
-      agentLimits?.maxSkillsPromptChars ??
-      limits?.maxSkillsPromptChars ??
-      DEFAULT_MAX_SKILLS_PROMPT_CHARS,
-  };
-}
-
-type SkillsPromptFormat = { kind: "full" } | { kind: "compact"; descriptionMaxChars: number };
-
-function buildSkillsLimitNote(params: {
-  truncated: boolean;
-  format: SkillsPromptFormat;
-  included: number;
-  total: number;
-}): string {
-  if (params.truncated) {
-    const compactDetails =
-      params.format.kind === "compact"
-        ? ` (compact format, ${params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted"})`
-        : "";
-    return `⚠️ Skills truncated: included ${params.included} of ${params.total}${compactDetails}. Run \`openclaw skills check\` to audit.`;
-  }
-  if (params.format.kind === "compact") {
-    const compactDetails =
-      params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted";
-    return `⚠️ Skills catalog using compact format (${compactDetails}). Run \`openclaw skills check\` to audit.`;
-  }
-  return "";
-}
-
-function buildRenderedSkillsPrompt(params: {
-  remoteNote?: string;
-  skills: Skill[];
-  total: number;
-  format: SkillsPromptFormat;
-  includeLimitNote?: boolean;
-}): string {
-  // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
-  // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
-  const truncated = params.skills.length < params.total;
-  const limitNote =
-    params.includeLimitNote === false
-      ? ""
-      : buildSkillsLimitNote({
-          truncated,
-          format: params.format,
-          included: params.skills.length,
-          total: params.total,
-        });
-  const catalog =
-    params.format.kind === "compact"
-      ? formatSkillsCompactForPrompt(params.skills, {
-          descriptionMaxChars: params.format.descriptionMaxChars,
-        })
-      : formatSkillsForPromptCore(params.skills);
-  return [params.remoteNote, limitNote, catalog].filter(Boolean).join("\n");
-}
-
-function applySkillsPromptLimits(params: {
-  skills: Skill[];
-  config?: OpenClawConfig;
-  agentId?: string;
-  remoteNote?: string;
-}): string {
-  const limits = resolveSkillsPromptLimits(params.config, params.agentId);
-  const total = params.skills.length;
-  const byCount = params.skills.slice(0, Math.max(0, limits.maxSkillsInPrompt));
-  let skillsForPrompt = byCount;
-
-  const renderWithinLimit = (
-    skills: Skill[],
-    format: SkillsPromptFormat,
-    includeLimitNote = true,
-  ): string | undefined => {
-    const remoteNotes = params.remoteNote ? [params.remoteNote, undefined] : [undefined];
-    for (const remoteNote of remoteNotes) {
-      const prompt = buildRenderedSkillsPrompt({
-        remoteNote,
-        skills,
-        total,
-        format,
-        includeLimitNote,
-      });
-      if (prompt.length <= limits.maxSkillsPromptChars) {
-        return prompt;
-      }
-    }
-    return undefined;
-  };
-
-  const fitsFull = (skills: Skill[], includeLimitNote = true): boolean =>
-    renderWithinLimit(skills, { kind: "full" }, includeLimitNote) !== undefined;
-  const fitsCompact = (
-    skills: Skill[],
-    descriptionMaxChars: number,
-    includeLimitNote = true,
-  ): boolean =>
-    renderWithinLimit(skills, { kind: "compact", descriptionMaxChars }, includeLimitNote) !==
-    undefined;
-
-  if (!fitsFull(skillsForPrompt)) {
-    if (!fitsCompact(skillsForPrompt, 0)) {
-      let lo = 0;
-      let hi = skillsForPrompt.length;
-      while (lo < hi) {
-        const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(skillsForPrompt.slice(0, mid), 0)) {
-          lo = mid;
-        } else {
-          hi = mid - 1;
-        }
-      }
-      skillsForPrompt = skillsForPrompt.slice(0, lo);
-    }
-
-    if (skillsForPrompt.length === 0 && byCount.length > 0) {
-      const fullWithoutNotice = renderWithinLimit(byCount, { kind: "full" }, false);
-      if (fullWithoutNotice !== undefined) {
-        return fullWithoutNotice;
-      }
-      let lo = 0;
-      let hi = byCount.length;
-      while (lo < hi) {
-        const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(byCount.slice(0, mid), 0, false)) {
-          lo = mid;
-        } else {
-          hi = mid - 1;
-        }
-      }
-      if (lo > 0) {
-        skillsForPrompt = byCount.slice(0, lo);
-      }
-    }
-
-    const includeLimitNote = fitsCompact(skillsForPrompt, 0);
-    let descriptionMaxChars = 0;
-    if (
-      skillsForPrompt.length > 0 &&
-      fitsCompact(skillsForPrompt, COMPACT_DESCRIPTION_MIN_CHARS, includeLimitNote)
-    ) {
-      let lo = COMPACT_DESCRIPTION_MIN_CHARS;
-      let hi = COMPACT_DESCRIPTION_MAX_CHARS;
-      while (lo < hi) {
-        const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(skillsForPrompt, mid, includeLimitNote)) {
-          lo = mid;
-        } else {
-          hi = mid - 1;
-        }
-      }
-      descriptionMaxChars = lo;
-    }
-    return (
-      renderWithinLimit(
-        skillsForPrompt,
-        { kind: "compact", descriptionMaxChars },
-        includeLimitNote,
-      ) ?? ""
-    );
-  }
-
-  return renderWithinLimit(skillsForPrompt, { kind: "full" }) ?? "";
-}
+const skillsLogger = createSubsystemLogger("skills");
 
 type WorkspaceSkillBuildOptions = {
   config?: OpenClawConfig;
@@ -217,13 +33,12 @@ function resolveWorkspaceSkillPromptState(
   const promptEntries = filterPromptVisibleSkillEntries(eligible);
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
-  const promptSkills = compactPromptSkills(resolvedSkills).toSorted((a, b) =>
-    a.name.localeCompare(b.name, "en"),
-  );
-  const prompt = applySkillsPromptLimits({
-    skills: promptSkills,
-    config: opts?.config,
-    agentId: opts?.agentId,
+  const limits = opts?.config?.skills?.limits;
+  const agentLimits = resolveEffectiveAgentSkillsLimits(opts?.config, opts?.agentId);
+  const prompt = formatSkillsForPromptBounded({
+    skills: compactPromptSkills(resolvedSkills),
+    maxSkillsInPrompt: limits?.maxSkillsInPrompt,
+    maxSkillsPromptChars: agentLimits?.maxSkillsPromptChars ?? limits?.maxSkillsPromptChars,
     remoteNote,
   });
   return { eligible, prompt, resolvedSkills, skillFilter };
@@ -256,14 +71,48 @@ export function buildSkillSnapshot(
   };
 }
 
-export function resolveSkillsPrompt(params: {
+type ResolveSkillsPromptParams = {
   skillsSnapshot?: SkillSnapshot;
   entries?: SkillEntry[];
   config?: OpenClawConfig;
   workspaceDir: string;
   agentId?: string;
   eligibility?: SkillEligibilityContext;
-}): string {
+  loadEntries?: () => SkillEntry[];
+};
+
+function buildSkillsPromptFromEntries(
+  params: ResolveSkillsPromptParams,
+  entries: SkillEntry[] | undefined,
+): string {
+  if (!entries || entries.length === 0) {
+    return "";
+  }
+  const prompt = buildSkillSnapshot(params.workspaceDir, {
+    entries,
+    config: params.config,
+    agentId: params.agentId,
+    eligibility: params.eligibility,
+  }).prompt;
+  return prompt.trim() ? prompt : "";
+}
+
+function rebuildAfterUnsafeSnapshot(
+  params: ResolveSkillsPromptParams,
+  reason: "unsupported-prompt-format" | "legacy-skill-identity" | "invalid-catalog-structure",
+): string {
+  skillsLogger.warn(
+    "Cached skills prompt could not be safely filtered; rebuilding from current skill entries.",
+    { reason },
+  );
+  const sourceEntries = params.entries ?? params.loadEntries?.();
+  const entries = sourceEntries?.filter(
+    (entry) => !isSkillSecretOwnerUnavailable(resolveSkillKey(entry.skill, entry)),
+  );
+  return buildSkillsPromptFromEntries(params, entries);
+}
+
+export function resolveSkillsPrompt(params: ResolveSkillsPromptParams): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (params.skillsSnapshot && !snapshotPrompt) {
     return "";
@@ -281,10 +130,10 @@ export function resolveSkillsPrompt(params: {
       snapshotHasUnavailableSkill &&
       params.skillsSnapshot?.promptFormatVersion !== WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION
     ) {
-      return "";
+      return rebuildAfterUnsafeSnapshot(params, "unsupported-prompt-format");
     }
     if (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners()) {
-      return "";
+      return rebuildAfterUnsafeSnapshot(params, "legacy-skill-identity");
     }
     const unavailableNames = new Set(
       params.skillsSnapshot?.skills
@@ -306,7 +155,7 @@ export function resolveSkillsPrompt(params: {
       snapshotPrompt.includes(catalogOpen, catalogStart + catalogOpen.length) ||
       snapshotPrompt.includes(catalogClose, catalogEnd + catalogClose.length)
     ) {
-      return "";
+      return rebuildAfterUnsafeSnapshot(params, "invalid-catalog-structure");
     }
     const bodyStart = catalogStart + catalogOpen.length;
     const catalogBody = snapshotPrompt.slice(bodyStart, catalogEnd);
@@ -318,7 +167,7 @@ export function resolveSkillsPrompt(params: {
       const block = match[0];
       const name = /^[ ]{4}<name>(.*)<\/name>$/m.exec(block)?.[1];
       if (gap.trim() || !name) {
-        return "";
+        return rebuildAfterUnsafeSnapshot(params, "invalid-catalog-structure");
       }
       filteredBody += gap;
       if (!unavailableNames.has(name)) {
@@ -328,18 +177,9 @@ export function resolveSkillsPrompt(params: {
     }
     const tail = catalogBody.slice(cursor);
     if (tail.trim()) {
-      return "";
+      return rebuildAfterUnsafeSnapshot(params, "invalid-catalog-structure");
     }
     return `${snapshotPrompt.slice(0, bodyStart)}${filteredBody}${tail}${snapshotPrompt.slice(catalogEnd)}`.trim();
   }
-  if (params.entries && params.entries.length > 0) {
-    const prompt = buildSkillSnapshot(params.workspaceDir, {
-      entries: params.entries,
-      config: params.config,
-      agentId: params.agentId,
-      eligibility: params.eligibility,
-    }).prompt;
-    return prompt.trim() ? prompt : "";
-  }
-  return "";
+  return buildSkillsPromptFromEntries(params, params.entries);
 }

--- a/src/skills/runtime/embedded-run-entries.test.ts
+++ b/src/skills/runtime/embedded-run-entries.test.ts
@@ -6,7 +6,8 @@ import {
   type OpenClawConfig,
 } from "../../config/config.js";
 import * as skillsLoaderModule from "../loading/workspace-skill-loader.js";
-import type { SkillSnapshot } from "../types.js";
+import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
+import type { SkillEntry, SkillSnapshot } from "../types.js";
 import { resolveEmbeddedRunSkillEntries } from "./embedded-run-entries.js";
 
 describe("resolveEmbeddedRunSkillEntries", () => {
@@ -178,10 +179,38 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       skillsSnapshot: snapshot,
     });
 
-    expect(result).toEqual({
-      shouldLoadSkillEntries: false,
-      skillEntries: [],
-    });
+    expect(result.shouldLoadSkillEntries).toBe(false);
+    expect(result.skillEntries).toEqual([]);
     expect(loadWorkspaceSkillsSpy).not.toHaveBeenCalled();
+  });
+
+  it("exposes a cached lazy loader without eagerly loading a modern snapshot", () => {
+    const loadedEntries: SkillEntry[] = [
+      {
+        skill: createCanonicalFixtureSkill({
+          name: "healthy",
+          description: "healthy",
+          filePath: "/tmp/workspace/skills/healthy/SKILL.md",
+          baseDir: "/tmp/workspace/skills/healthy",
+          source: "test",
+        }),
+        frontmatter: {},
+      },
+    ];
+    loadWorkspaceSkillsSpy.mockReturnValue(loadedEntries);
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+      skillsSnapshot: {
+        prompt: "skills prompt",
+        skills: [{ name: "healthy", skillKey: "healthy" }],
+        resolvedSkills: [],
+      },
+    });
+
+    expect(loadWorkspaceSkillsSpy).not.toHaveBeenCalled();
+    expect(result.loadSkillEntries()).toBe(loadedEntries);
+    expect(result.loadSkillEntries()).toBe(loadedEntries);
+    expect(loadWorkspaceSkillsSpy).toHaveBeenCalledOnce();
   });
 });

--- a/src/skills/runtime/embedded-run-entries.ts
+++ b/src/skills/runtime/embedded-run-entries.ts
@@ -15,18 +15,26 @@ export function resolveEmbeddedRunSkillEntries(params: {
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
+  loadSkillEntries: () => SkillEntry[];
 } {
   const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
   const config = resolveSkillRuntimeConfig(params.config);
+  let cachedSkillEntries: SkillEntry[] | undefined;
+  const loadSkillEntries = (): SkillEntry[] => {
+    if (cachedSkillEntries) {
+      return cachedSkillEntries;
+    }
+    cachedSkillEntries = loadWorkspaceSkills(params.workspaceDir, {
+      config,
+      agentId: params.agentId,
+      ...(params.eligibility ? { eligibility: params.eligibility } : {}),
+      ...(params.workspaceOnly === true ? { workspaceOnly: true } : {}),
+    });
+    return cachedSkillEntries;
+  };
   return {
     shouldLoadSkillEntries,
-    skillEntries: shouldLoadSkillEntries
-      ? loadWorkspaceSkills(params.workspaceDir, {
-          config,
-          agentId: params.agentId,
-          ...(params.eligibility ? { eligibility: params.eligibility } : {}),
-          ...(params.workspaceOnly === true ? { workspaceOnly: true } : {}),
-        })
-      : [],
+    skillEntries: shouldLoadSkillEntries ? loadSkillEntries() : [],
+    loadSkillEntries,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where embedded and Plugin SDK sessions could inject an unbounded skills catalog into the model prompt. It also fixes a degraded-secret failure where one unavailable skill secret combined with a legacy or structurally anomalous cached snapshot could silently remove every skill from the model-visible catalog.

## Why This Change Was Made

The existing workspace prompt budget is now the single lightweight renderer for workspace, embedded, and SDK skill catalogs: deterministic ordering, a 150-skill ceiling, an 18,000-character ceiling, binary-search compaction, and an explicit truncation notice. When cached-snapshot filtering is unsafe, the resolver records a bounded warning and lazily rebuilds from current skill entries while excluding degraded owners; valid modern snapshots retain the cache-friendly no-discovery path.

This keeps prompt policy in one owner rather than adding separate limits at each caller, and preserves the existing workspace prompt bytes for remote-skill notes.

## User Impact

Models now receive a deterministic, hard-bounded skills catalog in embedded and SDK sessions. During partial secret-provider degradation, healthy skills remain available instead of disappearing with the unavailable skill.

## Evidence

Pre-fix regressions failed at the owning boundaries:

- Embedded/SDK catalog: 200 skills rendered 231,659 characters instead of staying within 18,000.
- Degraded legacy/anomalous snapshots: the resolver returned an empty string instead of retaining the healthy skill.
- Modern cached snapshots initially exposed a caller gap where recovery had no entries; the final regression covers lazy non-sandbox CLI recovery and proves valid snapshots do not trigger discovery.

Passing local proof:

- `node scripts/run-vitest.mjs src/agents/sessions/system-prompt.test.ts src/skills/loading/skill-contract.test.ts src/skills/loading/workspace-skill-prompt.test.ts src/skills/loading/workspace-skill-prompt-resolution.test.ts src/skills/runtime/embedded-run-entries.test.ts --reporter=verbose` — 62 tests passed.
- `node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts src/skills/runtime/embedded-run-entries.integration.test.ts --reporter=verbose` — 107 tests passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-startup.test.ts src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts --reporter=verbose` — 3 tests passed.
- `node scripts/check-changed.mjs -- <changed files>` — core production/test typechecks, lint, format, dead-export, import-cycle, boundary, and repository guards passed.
- Fresh Codex autoreview: no accepted/actionable findings.

Source-blind real-flow proof used `agent exec` with 200 reverse-ordered 1,024-character skills and a localhost mock OpenAI-compatible endpoint that captured the actual model system prompt. The model-visible catalog contained 74 skills, was alphabetically ordered, measured 17,428 characters (17,960 for the full injected skills block), and included the explicit `Skills truncated` notice. No external provider credentials were used.

Production LOC: +297/-239 (net +58) | Tests/test support: +239/-16.

AI-assisted: implementation and review used coding agents; the final diff and behavior were independently inspected and validated.
