### PR TITLE
fix(ui): generic mock chat sends show a visible outcome

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -75,6 +75,7 @@ const OBSERVER_DEMO_SESSION_KEY = "agent:main:session-observer-demo";
 const OBSERVER_DEMO_RUN_ID = "mock-session-observer-run";
 const PLAN_DEMO_RUN_ID = "mock-plan-run";
 const CUSTODIAN_CHAT_REPLY_DELAY_MS = 600;
+const CHAT_SEND_REPLY_DELAY_MS = 200;
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const uiRoot = path.join(repoRoot, "ui");
@@ -1515,6 +1516,33 @@ async function createChatPickerScenario(
     swarmEnabled: fixture === "swarm",
     workboardEnabled: fixture === "workboard",
   });
+  const historyMessages = buildScrollableChatHistory(baseTime);
+  const planSessionInfo = {
+    activeRunIds: [PLAN_DEMO_RUN_ID],
+    hasActiveRun: true,
+    key: "agent:main:main",
+  };
+  const planInFlightRun = {
+    runId: PLAN_DEMO_RUN_ID,
+    text: "",
+    plan: {
+      explanation: "Keep the Control UI change focused",
+      steps: [
+        { step: "Inspect the transcript renderer", status: "completed" },
+        { step: "Confirm the plan event contract", status: "completed" },
+        { step: "Remove the duplicate card summary", status: "in_progress" },
+        { step: "Run focused UI tests", status: "pending" },
+        { step: "Capture browser proof", status: "pending" },
+      ],
+    },
+  };
+  const planChatHistory = {
+    messages: historyMessages,
+    sessionId: "control-ui-e2e-session",
+    sessionInfo: planSessionInfo,
+    inFlightRun: planInFlightRun,
+    thinkingLevel: null,
+  };
   const custodianHistory = {
     turns: [
       {
@@ -1617,21 +1645,7 @@ async function createChatPickerScenario(
     // Terminal has a second gate beyond the advertised method (see
     // ui/src/lib/terminal-availability.ts).
     terminalEnabled: true,
-    historyMessages: buildScrollableChatHistory(baseTime),
-    inFlightRun: {
-      runId: PLAN_DEMO_RUN_ID,
-      text: "",
-      plan: {
-        explanation: "Keep the Control UI change focused",
-        steps: [
-          { step: "Inspect the transcript renderer", status: "completed" },
-          { step: "Confirm the plan event contract", status: "completed" },
-          { step: "Remove the duplicate card summary", status: "in_progress" },
-          { step: "Run focused UI tests", status: "pending" },
-          { step: "Capture browser proof", status: "pending" },
-        ],
-      },
-    },
+    historyMessages,
     // Lights up the footer facepile and who's-online roster; the email-only
     // entry keeps the roster's no-display-name row exercised.
     presenceUsers: [
@@ -1647,6 +1661,34 @@ async function createChatPickerScenario(
     methodResponses: {
       ...buildBackgroundTasksMock(baseTime),
       ...cronMocks,
+      "chat.history": {
+        cases: [{ match: { sessionKey: "agent:main:main" }, response: planChatHistory }],
+      },
+      "chat.startup": {
+        cases: [
+          {
+            match: { sessionKey: "agent:main:main" },
+            response: {
+              ...planChatHistory,
+              agentsList: {
+                agents: [
+                  {
+                    id: "main",
+                    identity: { name: "Molty" },
+                    name: "Molty",
+                    workspace: "/Users/peter/Projects/openclaw",
+                    workspaceGit: true,
+                  },
+                ],
+                defaultId: "main",
+                mainKey: "main",
+                scope: "agent",
+              },
+              metadata: { models: modelProviders.models },
+            },
+          },
+        ],
+      },
       "users.self": { profile: selfProfile },
       // Talk settings page pickers: realtime catalog with the model/voice
       // suggestion lists the gateway emits for provider entries.
@@ -2446,11 +2488,6 @@ async function createChatPickerScenario(
       ],
     },
     sessionArchiveFiltering: true,
-    sessionInfo: {
-      activeRunIds: [PLAN_DEMO_RUN_ID],
-      hasActiveRun: true,
-      key: "agent:main:main",
-    },
     sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,
@@ -2461,10 +2498,14 @@ function escapeScriptContent(script: string): string {
   return script.replaceAll("</script", "<\\/script");
 }
 
-/** Adds the one stateful mock surface the generic scenario fixture cannot express. */
-function installControlUiCustodianMock(replyDelayMs: number): void {
+/** Adds the stateful mock surfaces the generic scenario fixture cannot express. */
+function installControlUiStatefulMocks(
+  custodianReplyDelayMs: number,
+  chatReplyDelayMs: number,
+): void {
   type MockGatewayControls = {
     deferNext: (method: string) => void;
+    emit: (event: string, payload: unknown) => void;
     resolveDeferred: (method: string, payload: unknown) => void;
   };
   type MockWindow = Window & {
@@ -2494,7 +2535,53 @@ function installControlUiCustodianMock(replyDelayMs: number): void {
         frame = null;
       }
     }
-    if (frame?.type !== "req" || frame.method !== "openclaw.chat") {
+    if (frame?.type !== "req") {
+      sendOriginal(this, data);
+      return;
+    }
+
+    if (frame.method === "chat.send") {
+      const params =
+        frame.params && typeof frame.params === "object"
+          ? (frame.params as {
+              idempotencyKey?: unknown;
+              message?: unknown;
+              sessionKey?: unknown;
+            })
+          : {};
+      const runId =
+        typeof params.idempotencyKey === "string" && params.idempotencyKey.trim()
+          ? params.idempotencyKey
+          : "control-ui-mock-run";
+      const sessionKey =
+        typeof params.sessionKey === "string" && params.sessionKey.trim()
+          ? params.sessionKey
+          : "agent:main:main";
+      const message = typeof params.message === "string" ? params.message.trim() : "";
+      gateway.deferNext("chat.send");
+      sendOriginal(this, data);
+      window.setTimeout(() => {
+        gateway.resolveDeferred("chat.send", { runId, status: "started" });
+        window.setTimeout(
+          () =>
+            gateway.emit("chat", {
+              message: {
+                content: [{ text: `Mock reply: ${message || "message received"}`, type: "text" }],
+                role: "assistant",
+                timestamp: Date.now(),
+              },
+              runId,
+              seq: 1,
+              sessionKey,
+              state: "final",
+            }),
+          0,
+        );
+      }, chatReplyDelayMs);
+      return;
+    }
+
+    if (frame.method !== "openclaw.chat") {
       sendOriginal(this, data);
       return;
     }
@@ -2560,18 +2647,18 @@ function installControlUiCustodianMock(replyDelayMs: number): void {
     sendOriginal(this, data);
     window.setTimeout(
       () => gateway.resolveDeferred("openclaw.chat", response),
-      message === undefined ? 0 : replyDelayMs,
+      message === undefined ? 0 : custodianReplyDelayMs,
     );
   };
 }
 
-function createCustodianMockInitScript(): string {
-  return `(() => { const __name = (target) => target; (${installControlUiCustodianMock.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}); })();`;
+function createStatefulMockInitScript(): string {
+  return `(() => { const __name = (target) => target; (${installControlUiStatefulMocks.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}, ${CHAT_SEND_REPLY_DELAY_MS}); })();`;
 }
 
 function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin {
   const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
-  const custodianInitScript = escapeScriptContent(createCustodianMockInitScript());
+  const statefulInitScript = escapeScriptContent(createStatefulMockInitScript());
   const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
   return {
     configureServer(server) {
@@ -2589,7 +2676,7 @@ function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin
     transformIndexHtml(html) {
       return html.replace(
         "</head>",
-        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${custodianInitScript}\n    </script>\n  </head>`,
+        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n    </script>\n  </head>`,
       );
     },
   };

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -279,13 +279,14 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     try {
       await page.goto(new URL("/chat", fixtureServer.url).toString(), { waitUntil: "networkidle" });
       await page.getByText("OpenClaw work checkout", { exact: true }).click();
+      await page.getByRole("button", { name: "Write a message to send." }).waitFor();
 
       const prompt = "generic mock send probe";
       const composer = page.locator(
         ".chat-pane-cache__pane--active .agent-chat__composer-combobox textarea",
       );
       await composer.fill(prompt);
-      await composer.press("Enter");
+      await page.getByRole("button", { name: "Send message" }).click();
 
       await page
         .locator(".chat-thread-inner")

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -260,4 +260,40 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
       await page.close();
     }
   });
+
+  it("opens an idle generic session for ordinary sends", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString(), { waitUntil: "networkidle" });
+      await page.getByText("OpenClaw work checkout", { exact: true }).click();
+
+      await page.getByRole("button", { name: "Write a message to send." }).waitFor();
+      expect(await page.getByRole("button", { name: "Stop" }).count()).toBe(0);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("renders a deterministic reply after generic chat.send", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString(), { waitUntil: "networkidle" });
+      await page.getByText("OpenClaw work checkout", { exact: true }).click();
+
+      const prompt = "generic mock send probe";
+      const composer = page.locator(
+        ".chat-pane-cache__pane--active .agent-chat__composer-combobox textarea",
+      );
+      await composer.fill(prompt);
+      await composer.press("Enter");
+
+      await page
+        .locator(".chat-thread-inner")
+        .getByText(`Mock reply: ${prompt}`, { exact: true })
+        .waitFor();
+      expect(await composer.inputValue()).toBe("");
+    } finally {
+      await page.close();
+    }
+  });
 });

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -31,6 +31,15 @@ async function newContext(options: Parameters<Browser["newContext"]>[0]) {
 async function closeContext(context: BrowserContext) {
   openContexts.delete(context);
   await context.close().catch(() => {});
+}
+
+async function waitForLightboxAnimations(page: Page): Promise<void> {
+  await page.locator("openclaw-image-lightbox wa-dialog").evaluate(async (dialogAdapter) => {
+    const nativeDialog = dialogAdapter.shadowRoot?.querySelector("dialog");
+    await Promise.all(
+      (nativeDialog?.getAnimations({ subtree: true }) ?? []).map((animation) => animation.finished),
+    );
+  });
 }
 
 describeControlUiE2e("Control UI image lightbox", () => {
@@ -156,6 +165,7 @@ describeControlUiE2e("Control UI image lightbox", () => {
           ),
         )
         .toBeGreaterThan(0);
+      await waitForLightboxAnimations(page);
       const desktopBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
       expect(desktopBox?.width ?? 0).toBeGreaterThan(1000);
       expect(desktopBox?.height ?? 0).toBeGreaterThan(700);
@@ -213,14 +223,7 @@ describeControlUiE2e("Control UI image lightbox", () => {
       await page.setViewportSize({ height: 844, width: 390 });
       await sidebarTrigger.click();
       await sidebarDialog.waitFor({ state: "visible" });
-      await page.locator("openclaw-image-lightbox wa-dialog").evaluate(async (dialogAdapter) => {
-        const nativeDialog = dialogAdapter.shadowRoot?.querySelector("dialog");
-        await Promise.all(
-          (nativeDialog?.getAnimations({ subtree: true }) ?? []).map(
-            (animation) => animation.finished,
-          ),
-        );
-      });
+      await waitForLightboxAnimations(page);
       const mobileBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
       const mobileImageLayout = await page
         .locator("openclaw-image-lightbox .stage")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers validating the generic Control UI mock could not exercise an ordinary send outcome: every available demo session appeared active, and `chat.send` cleared the composer without any visible acknowledgement.

## Why This Change Was Made

Scope the existing plan/in-flight fixture to its owning main demo session, leaving another generic session idle. The stateful mock now acknowledges `chat.send` and emits the standard deterministic final chat event. Persistent composer draft storage is explicitly unchanged.

## User Impact

Developers and source-blind behavior validators can now select an idle demo session, send a message, and observe both the submitted user message and a deterministic final reply instead of a silent composer clear. This changes only the developer mock harness, not production chat behavior.

## Evidence

- Before the fix, the focused E2E file failed 2 of 6 tests: the chosen generic session never exposed an idle send state, and no reply appeared after submission.
- After the fix, focused E2E passes 6/6 and changed-file gates pass.
- Hosted shard validation exposed two timing races: the PR now waits for selected-session composer readiness and settled lightbox animations; the exact shard passes 20/20 files and 62/62 tests.
- Initial idle state:
  ![Generic mock idle session](https://github.com/user-attachments/assets/c66bdd32-349c-4bfd-89fe-2e55d98763b3)
- After send:
  ![Generic mock visible reply](https://github.com/user-attachments/assets/9095c2f2-d72e-4475-856a-33276e1cdaf2)
- Recorded flow (bare URL on its own line):
  https://github.com/user-attachments/assets/06a080e0-d91d-4b65-b0d4-6b7e086b3610
- Commands:
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-fixture.e2e.test.ts`
  `node scripts/check-changed.mjs -- scripts/control-ui-mock-dev.ts ui/src/e2e/board-fixture.e2e.test.ts`
  `git diff --check`
- AI-assisted; the author inspected the implementation and proof. Fresh autoreview found no accepted/actionable findings.
