### PR TITLE
fix: surface skill and bootstrap load failures

### DIFF
--- a/src/agents/workspace.bootstrap-read-diagnostics.test.ts
+++ b/src/agents/workspace.bootstrap-read-diagnostics.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
+import { buildBootstrapContextFiles } from "./embedded-agent-helpers/bootstrap.js";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "./workspace-bootstrap-read.js";
+import { DEFAULT_AGENTS_FILENAME, loadWorkspaceBootstrapFiles } from "./workspace.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  setLoggerOverride(null);
+  loggingState.rawConsole = null;
+  resetLogger();
+});
+
+function captureWarningLogger() {
+  setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+  const warn = vi.fn();
+  loggingState.rawConsole = {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn,
+    error: vi.fn(),
+  };
+  return warn;
+}
+
+describe("workspace bootstrap read diagnostics", () => {
+  it("marks oversized bootstrap files unreadable and warns with the bounded-read reason", async () => {
+    const tempDir = tempDirs.make("openclaw-workspace-");
+    const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+    await fs.writeFile(agentsPath, "x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES + 1));
+    const warn = captureWarningLogger();
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+    const warningText = warn.mock.calls.flat().map(String).join("\n");
+
+    expect(agents?.missing).toBe(false);
+    expect(agents?.content).toBe(
+      `[UNREADABLE: File exceeds ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES} bytes]`,
+    );
+    if (!agents) {
+      throw new Error("expected AGENTS.md bootstrap record");
+    }
+    expect(buildBootstrapContextFiles([agents])).toEqual([
+      { path: agentsPath, content: agents.content },
+    ]);
+    expect(warningText).toContain(agentsPath);
+    expect(warningText).toContain(`File exceeds ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES} bytes`);
+  });
+});

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -990,7 +990,7 @@ describe("loadWorkspaceBootstrapFiles", () => {
     expect(getMemoryEntries(files)).toHaveLength(0);
   });
 
-  it("treats hardlinked bootstrap aliases as missing", async () => {
+  it("treats hardlinked bootstrap aliases as unreadable", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -1014,8 +1014,8 @@ describe("loadWorkspaceBootstrapFiles", () => {
 
       const files = await loadWorkspaceBootstrapFiles(workspaceDir);
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
-      expect(agents?.missing).toBe(true);
-      expect(agents?.content).toBeUndefined();
+      expect(agents?.missing).toBe(false);
+      expect(agents?.content).toBe("[UNREADABLE: path must not be hardlinked]");
     } finally {
       await fs.rm(rootDir, { recursive: true, force: true });
     }
@@ -1064,7 +1064,7 @@ describe("loadWorkspaceBootstrapFiles", () => {
     }
   });
 
-  it("marks a bootstrap file missing after transient read retries are exhausted", async () => {
+  it("marks a bootstrap file unreadable after transient read retries are exhausted", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await writeWorkspaceFile({
       dir: tempDir,
@@ -1083,12 +1083,10 @@ describe("loadWorkspaceBootstrapFiles", () => {
     }) as typeof syncFs.read);
 
     try {
-      // Unlike the template check, this reader returns an io failure (not a
-      // throw) when the budget is exhausted, so the file surfaces as missing.
       const files = await loadWorkspaceBootstrapFiles(tempDir);
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
-      expect(agents?.missing).toBe(true);
-      expect(agents?.content).toBeUndefined();
+      expect(agents?.missing).toBe(false);
+      expect(agents?.content).toBe("[UNREADABLE: Unknown system error -11: read]");
     } finally {
       readSpy.mockRestore();
     }
@@ -1102,7 +1100,7 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n\nboundary retry\n",
     });
 
-    const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+    const agentsPath = path.join(syncFs.realpathSync(tempDir), DEFAULT_AGENTS_FILENAME);
     const originalLstat = syncFs.promises.lstat.bind(syncFs.promises);
     let agentsLstatAttempts = 0;
     const lstatSpy = vi.spyOn(syncFs.promises, "lstat").mockImplementation((async (
@@ -1120,7 +1118,7 @@ describe("loadWorkspaceBootstrapFiles", () => {
 
     try {
       const files = await loadWorkspaceBootstrapFiles(tempDir);
-      expect(agentsLstatAttempts).toBe(2);
+      expect(agentsLstatAttempts).toBeGreaterThanOrEqual(2);
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
       expect(agents?.missing).toBe(false);
       expect(agents?.content).toContain("boundary retry");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -193,7 +193,7 @@ async function readWorkspaceFileWithGuards(params: {
   } catch (error) {
     // Non-transient read failure, or transient retries exhausted.
     workspaceFileCache.delete(params.filePath);
-    return { ok: false, reason: "io", error };
+    return { ok: false, reason: error instanceof RangeError ? "validation" : "io", error };
   }
 }
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -11,11 +11,15 @@ import { setTimeout as delay } from "node:timers/promises";
 import { Minimatch } from "minimatch";
 import { extractFrontmatterBlock } from "../../packages/markdown-core/src/frontmatter.js";
 import type { ChatType } from "../channels/chat-type.js";
-import { openRootFileFollowingParents } from "../infra/boundary-file-read.js";
+import {
+  isRootFileMissingFailure,
+  openRootFileFollowingParents,
+} from "../infra/boundary-file-read.js";
 import { sameFileIdentity, type FileIdentityStat } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, pathExists, root as fsSafeRoot } from "../infra/fs-safe.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { retryAsync } from "../infra/retry.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   CANONICAL_ROOT_MEMORY_FILENAME,
   exactWorkspaceEntryExists,
@@ -75,6 +79,7 @@ const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
 const TRANSIENT_WORKSPACE_READ_CODES = new Set(["EAGAIN", "EWOULDBLOCK", "EINTR"]);
 const TRANSIENT_WORKSPACE_READ_ERRNOS = new Set([-11, -4]);
 const TRANSIENT_WORKSPACE_READ_MESSAGE = /Unknown system error -(?:11|4)\b/i;
+const workspaceLogger = createSubsystemLogger("workspace");
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
 // Git availability is process-stable; cache the probe result, including failure, until restart.
@@ -147,7 +152,6 @@ async function readWorkspaceFileWithGuards(params: {
           absolutePath: params.filePath,
           rootPath: params.workspaceDir,
           boundaryLabel: "workspace root",
-          maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
         });
         if (!opened.ok) {
           // Boundary resolution can report transient IO as "validation", while
@@ -1191,8 +1195,24 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
       };
       setWorkspaceFileSourceIdentity(file, loaded.sourceIdentity);
       result.push(file);
-    } else {
+    } else if (isRootFileMissingFailure(loaded)) {
       result.push({ name: entry.name, path: entry.filePath, missing: true });
+    } else {
+      const fallbackReason = `workspace file could not be read (${loaded.reason})`;
+      const rawReason = loaded.error instanceof Error ? loaded.error.message : fallbackReason;
+      const reason = (rawReason.replaceAll(/\s+/gu, " ").trim() || fallbackReason).slice(0, 300);
+      workspaceLogger.warn("Workspace bootstrap file is unreadable.", {
+        fileName: entry.name,
+        filePath: entry.filePath,
+        reason,
+        consoleMessage: `Workspace bootstrap file is unreadable: file=${entry.filePath} reason=${reason}`,
+      });
+      result.push({
+        name: entry.name,
+        path: entry.filePath,
+        content: `[UNREADABLE: ${reason}]`,
+        missing: false,
+      });
     }
   }
   return result;

--- a/src/infra/boundary-file-read.ts
+++ b/src/infra/boundary-file-read.ts
@@ -52,6 +52,13 @@ function readFailureErrorCode(error: unknown): string | undefined {
   return typeof code === "string" && code ? code : undefined;
 }
 
+export function isRootFileMissingFailure(failure: RootFileOpenFailure): boolean {
+  return (
+    failure.reason === "path" &&
+    MISSING_PATH_ERROR_CODES.has(readFailureErrorCode(failure.error) ?? "")
+  );
+}
+
 /**
  * Describes a root-scoped open failure without collapsing every cause into a
  * containment violation. Only `validation` means the path failed the boundary or
@@ -70,9 +77,9 @@ export function describeRootFileOpenFailure(params: {
   return matchRootFileOpenFailureFsSafe(params.failure, {
     path: (failure) => {
       const code = readFailureErrorCode(failure.error);
-      return code && !MISSING_PATH_ERROR_CODES.has(code)
-        ? unreadable(code)
-        : `${params.subject} not found: ${params.filePath}`;
+      return isRootFileMissingFailure(failure)
+        ? `${params.subject} not found: ${params.filePath}`
+        : unreadable(code);
     },
     validation: () =>
       `${params.subject} escapes ${params.boundaryLabel} or fails alias checks: ${params.filePath}`,

--- a/src/node-host/skills.test.ts
+++ b/src/node-host/skills.test.ts
@@ -137,7 +137,7 @@ metadata:
     const skills = scanNodeHostedSkills({ skillsDir: root, warn });
 
     expect(skills.map((skill) => skill.name)).toEqual(["valid-skill"]);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("invalid or missing frontmatter"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("description is required"));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(malformedFile));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("BAD_INDENT"));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("exceeds 65536 bytes"));
@@ -157,7 +157,7 @@ metadata:
     expect(scanNodeHostedSkills({ skillsDir: root, warn })).toEqual([]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(nestedFile));
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining(`${candidateFile}): has invalid or missing frontmatter`),
+      expect.stringContaining(`${candidateFile}): description is required`),
     );
   });
 

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -1,7 +1,11 @@
 // Local skill loader reads skill definitions from local filesystem roots.
 import fs from "node:fs";
 import path from "node:path";
-import { openRootFileSync } from "../../infra/boundary-file-read.js";
+import {
+  isRootFileMissingFailure,
+  openRootFileSync,
+  readFileDescriptorBoundedSync,
+} from "../../infra/boundary-file-read.js";
 import type { ParsedSkillFrontmatter } from "../types.js";
 import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
 import {
@@ -26,6 +30,7 @@ function readSkillFileSync(params: {
   rootRealPath: string;
   filePath: string;
   maxBytes?: number;
+  onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
 }): string | null {
   const opened = openRootFileSync({
     absolutePath: params.filePath,
@@ -35,13 +40,25 @@ function readSkillFileSync(params: {
     // Operator skill roots are commonly symlinked; fs-safe still rejects hops
     // whose canonical target escapes the skill root.
     rejectSymlinks: false,
-    maxBytes: params.maxBytes,
   });
   if (!opened.ok) {
+    if (!isRootFileMissingFailure(opened)) {
+      const message =
+        opened.error instanceof Error
+          ? opened.error.message
+          : `failed to open skill file (${opened.reason})`;
+      params.onDiagnostic?.({ path: params.filePath, message });
+    }
     return null;
   }
   try {
-    return fs.readFileSync(opened.fd, "utf8");
+    return params.maxBytes === undefined
+      ? fs.readFileSync(opened.fd, "utf8")
+      : readFileDescriptorBoundedSync(opened.fd, params.maxBytes).toString("utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "failed to read skill file";
+    params.onDiagnostic?.({ path: params.filePath, message });
+    return null;
   } finally {
     fs.closeSync(opened.fd);
   }
@@ -59,8 +76,9 @@ function loadSingleSkillDirectory(params: {
     rootRealPath: params.rootRealPath,
     filePath: skillFilePath,
     maxBytes: params.maxBytes,
+    onDiagnostic: params.onDiagnostic,
   });
-  if (!raw) {
+  if (raw === null) {
     return null;
   }
 
@@ -77,6 +95,10 @@ function loadSingleSkillDirectory(params: {
   const name = frontmatter.name?.trim() || fallbackName;
   const description = frontmatter.description?.trim();
   if (!name || !description) {
+    params.onDiagnostic?.({
+      path: skillFilePath,
+      message: !name ? "name is required" : "description is required",
+    });
     return null;
   }
   const invocation = resolveSkillInvocationPolicy(frontmatter);
@@ -189,7 +211,7 @@ export function readSkillFrontmatterSafe(params: {
     filePath: path.resolve(params.filePath),
     maxBytes: params.maxBytes,
   });
-  if (!raw) {
+  if (raw === null) {
     return null;
   }
   try {

--- a/src/skills/loading/skill-root-discovery.ts
+++ b/src/skills/loading/skill-root-discovery.ts
@@ -6,7 +6,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { walkDirectorySync } from "../../infra/fs-safe.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { readSkillFrontmatterSafe } from "./local-loader.js";
 import { compactSkillPath } from "./skill-paths.js";
 import { findContainingAllowedSkillSymlinkTarget, tryRealpath } from "./symlink-targets.js";
 
@@ -38,6 +37,7 @@ export type CandidateSkillDir = {
 type DiscoveredSkillCandidates = {
   candidates: CandidateSkillDir[];
   rootIsSkill: boolean;
+  configuredRootCandidate?: CandidateSkillDir;
 };
 
 type ChildDirectoryScan = {
@@ -114,6 +114,16 @@ function createSkillDiscoveryBudget(maxCandidateDirs: number): SkillDiscoveryBud
   };
 }
 
+function hasSkillFileCandidate(skillDir: string): boolean {
+  try {
+    fs.lstatSync(path.join(skillDir, "SKILL.md"));
+    return true;
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    return code !== "ENOENT" && code !== "ENOTDIR";
+  }
+}
+
 function listBudgetedChildDirectories(
   dir: string,
   budget: SkillDiscoveryBudget,
@@ -143,7 +153,6 @@ function containsDiscoverableSkill(
   dir: string,
   opts: {
     maxCandidateDirs: number;
-    maxSkillFileBytes?: number;
     skipTopLevelDirName?: string;
   },
 ): boolean {
@@ -153,11 +162,8 @@ function containsDiscoverableSkill(
     if (!candidate) {
       continue;
     }
-    if (candidate.depth > 0 && fs.existsSync(path.join(candidate.dir, "SKILL.md"))) {
-      if (hasLoadableSkillFrontmatter(dir, candidate.dir, opts.maxSkillFileBytes)) {
-        return true;
-      }
-      continue;
+    if (candidate.depth > 0 && hasSkillFileCandidate(candidate.dir)) {
+      return true;
     }
     if (candidate.depth >= MAX_GROUPED_SKILL_SCAN_DEPTH) {
       continue;
@@ -215,21 +221,6 @@ function hasCandidateSymlinkChild(
     handle?.closeSync();
   }
   return false;
-}
-
-function hasLoadableSkillFrontmatter(
-  rootDir: string,
-  skillDir: string,
-  maxSkillFileBytes?: number,
-): boolean {
-  const frontmatter = readSkillFrontmatterSafe({
-    rootDir,
-    filePath: path.join(skillDir, "SKILL.md"),
-    maxBytes: maxSkillFileBytes ?? DEFAULT_MAX_SKILL_FILE_BYTES,
-  });
-  const fallbackName = path.basename(skillDir).trim();
-  const name = frontmatter?.name?.trim() || fallbackName;
-  return Boolean(name) && Boolean(frontmatter?.description?.trim());
 }
 
 function isSymlinkPath(filePath: string): boolean {
@@ -331,12 +322,9 @@ function resolveContainedSkillPath(params: {
 
 function resolveNestedSkillsRoot(
   dir: string,
-  opts?: { maxEntriesToScan?: number; maxSkillFileBytes?: number },
+  opts?: { maxEntriesToScan?: number },
 ): { baseDir: string; note?: string } {
-  if (hasLoadableSkillFrontmatter(dir, dir, opts?.maxSkillFileBytes)) {
-    return { baseDir: dir };
-  }
-  const rootSkillMdExists = fs.existsSync(path.join(dir, "SKILL.md"));
+  const rootSkillMdExists = hasSkillFileCandidate(dir);
   const nested = path.join(dir, "skills");
   try {
     if (!fs.existsSync(nested) || !fs.statSync(nested).isDirectory()) {
@@ -351,7 +339,6 @@ function resolveNestedSkillsRoot(
     !rootSkillMdExists &&
     containsDiscoverableSkill(dir, {
       maxCandidateDirs: scanLimit,
-      maxSkillFileBytes: opts?.maxSkillFileBytes,
       skipTopLevelDirName: "skills",
     })
   ) {
@@ -364,7 +351,7 @@ function resolveNestedSkillsRoot(
     if (!candidate) {
       continue;
     }
-    if (hasLoadableSkillFrontmatter(nested, candidate.dir, opts?.maxSkillFileBytes)) {
+    if (hasSkillFileCandidate(candidate.dir)) {
       return { baseDir: nested, note: `Detected nested skills root at ${nested}` };
     }
     if (candidate.depth >= MAX_GROUPED_SKILL_SCAN_DEPTH) {
@@ -427,12 +414,17 @@ function resolveSkillFilePath(params: {
   skillDirRealPath: string;
   candidatePath: string;
 }): string | null {
-  return resolveContainedSkillPath({
+  const resolved = resolveContainedSkillPath({
     source: params.source,
     rootDir: params.skillDir,
     rootRealPath: params.skillDirRealPath,
     candidatePath: params.candidatePath,
   });
+  if (resolved || tryRealpath(params.candidatePath)) {
+    return resolved;
+  }
+  // Let the root-scoped loader diagnose named paths that cannot be resolved.
+  return path.resolve(params.candidatePath);
 }
 
 /** Discover validated skill directory candidates below one configured source root. */
@@ -447,9 +439,9 @@ export function discoverSkillCandidates(params: {
     return { candidates: [], rootIsSkill: false };
   }
   const rootRealPath = tryRealpath(rootDir) ?? rootDir;
+  const configuredRootSkillMd = path.join(rootDir, "SKILL.md");
   const resolved = resolveNestedSkillsRoot(params.dir, {
     maxEntriesToScan: params.limits.maxCandidatesPerRoot,
-    maxSkillFileBytes: params.limits.maxSkillFileBytes,
   });
   const baseDir = resolved.baseDir;
   const baseDirRealPath = resolveSkillRootCandidatePath({
@@ -464,7 +456,7 @@ export function discoverSkillCandidates(params: {
   }
 
   const rootSkillMd = path.join(baseDir, "SKILL.md");
-  if (fs.existsSync(rootSkillMd)) {
+  if (hasSkillFileCandidate(baseDir)) {
     const rootSkillRealPath = resolveSkillFilePath({
       source: params.source,
       skillDir: baseDir,
@@ -527,12 +519,29 @@ export function discoverSkillCandidates(params: {
     });
   }
 
+  let configuredRootCandidate: CandidateSkillDir | undefined;
+  if (path.resolve(baseDir) !== rootDir && hasSkillFileCandidate(rootDir)) {
+    const configuredRootSkillRealPath = resolveSkillFilePath({
+      source: params.source,
+      skillDir: rootDir,
+      skillDirRealPath: rootRealPath,
+      candidatePath: configuredRootSkillMd,
+    });
+    if (configuredRootSkillRealPath) {
+      configuredRootCandidate = {
+        skillDir: rootDir,
+        skillDirRealPath: rootRealPath,
+        name: path.basename(rootDir),
+        skillMdRealPath: configuredRootSkillRealPath,
+      };
+    }
+  }
   const skillCandidates: CandidateSkillDir[] = [];
   const scanQueue: Array<{ skillDir: string; name: string; depth: number }> = limitedChildren.map(
     (name) => ({
       skillDir: path.join(baseDir, name),
       name,
-      depth: name === "skills" && !fs.existsSync(path.join(baseDir, name, "SKILL.md")) ? 0 : 1,
+      depth: name === "skills" && !hasSkillFileCandidate(path.join(baseDir, name)) ? 0 : 1,
     }),
   );
 
@@ -552,7 +561,7 @@ export function discoverSkillCandidates(params: {
     }
 
     const skillMd = path.join(candidate.skillDir, "SKILL.md");
-    if (fs.existsSync(skillMd)) {
+    if (hasSkillFileCandidate(candidate.skillDir)) {
       const skillMdRealPath = resolveSkillFilePath({
         source: params.source,
         skillDir: candidate.skillDir,
@@ -633,6 +642,7 @@ export function discoverSkillCandidates(params: {
   return {
     candidates: skillCandidates.toSorted((a, b) => a.name.localeCompare(b.name)),
     rootIsSkill: false,
+    ...(configuredRootCandidate ? { configuredRootCandidate } : {}),
   };
 }
 

--- a/src/skills/loading/workspace-precedence.test.ts
+++ b/src/skills/loading/workspace-precedence.test.ts
@@ -1,6 +1,8 @@
 // Workspace precedence tests cover precedence between workspace, plugin, and bundled skills.
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
+import { loggingState } from "../../logging/state.js";
 import { withEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
@@ -26,6 +28,24 @@ beforeAll(async () => {
 afterAll(async () => {
   await fixtureSuite.cleanup();
 });
+
+afterEach(() => {
+  setLoggerOverride(null);
+  loggingState.rawConsole = null;
+  resetLogger();
+});
+
+function captureWarningLogger() {
+  setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+  const warn = vi.fn();
+  loggingState.rawConsole = {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn,
+    error: vi.fn(),
+  };
+  return warn;
+}
 
 function createSkillEntry(params: {
   name: string;
@@ -87,6 +107,40 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(prompt.replaceAll("\\", "/")).toContain("demo-skill/SKILL.md");
     expect(prompt).not.toContain("Managed version");
     expect(prompt).not.toContain("Bundled version");
+  });
+
+  it("keeps extraDirs below bundled precedence and reports the collision", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("extra-bundled-collision");
+    const extraDir = path.join(workspaceDir, ".extra");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraSkillDir = path.join(extraDir, "demo-skill");
+    const bundledSkillDir = path.join(bundledDir, "demo-skill");
+    await writeSkill({
+      dir: extraSkillDir,
+      name: "demo-skill",
+      description: "Extra version",
+    });
+    await writeSkill({
+      dir: bundledSkillDir,
+      name: "demo-skill",
+      description: "Bundled version",
+    });
+    const warn = captureWarningLogger();
+
+    const prompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
+      buildWorkspaceSkillsPrompt(workspaceDir, {
+        bundledSkillsDir: bundledDir,
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        config: { skills: { load: { extraDirs: [extraDir] } } },
+      }),
+    );
+    const warningText = warn.mock.calls.flat().map(String).join("\n");
+
+    expect(prompt).toContain("Bundled version");
+    expect(prompt).not.toContain("Extra version");
+    expect(warningText).toContain('skill="demo-skill"');
+    expect(warningText).toContain("winner=openclaw-bundled:~/.bundled/demo-skill/SKILL.md");
+    expect(warningText).toContain("loser=openclaw-extra:~/.extra/demo-skill/SKILL.md");
   });
   it("gates by bins, config, and always", async () => {
     const workspaceDir = await fixtureSuite.createCaseDir("workspace");

--- a/src/skills/loading/workspace-skill-loader.test.ts
+++ b/src/skills/loading/workspace-skill-loader.test.ts
@@ -428,6 +428,38 @@ description: Broken skill
     );
   });
 
+  it("warns for invalid configured-root skills while loading nested siblings", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const configuredRoot = path.join(workspaceDir, "configured-skills");
+    const invalidFile = path.join(configuredRoot, "group", "descriptionless", "SKILL.md");
+    const unreadableFile = path.join(configuredRoot, "group", "unreadable", "SKILL.md");
+    await fs.mkdir(path.dirname(invalidFile), { recursive: true });
+    await fs.writeFile(invalidFile, "---\nname: descriptionless\n---\n", "utf8");
+    if (process.platform !== "win32") {
+      await fs.mkdir(path.dirname(unreadableFile), { recursive: true });
+      await fs.symlink("SKILL.md", unreadableFile);
+    }
+    await writeSkill({
+      dir: path.join(configuredRoot, "skills", "valid"),
+      name: "valid",
+      description: "Valid nested sibling",
+    });
+    const warn = captureWarningLogger();
+
+    const entries = loadTestWorkspaceSkills(workspaceDir, {
+      config: { skills: { load: { extraDirs: [configuredRoot] } } },
+    });
+    const warningText = warn.mock.calls.flat().map(String).join("\n");
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("valid");
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("descriptionless");
+    expect(warningText).toContain(invalidFile);
+    expect(warningText).toContain("description is required");
+    if (process.platform !== "win32") {
+      expect(warningText).toContain(unreadableFile);
+    }
+  });
+
   it("applies agent skill filters and replacement semantics", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     await writeWorkspaceSkills(workspaceDir, [

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -58,14 +58,14 @@ type LoadedSkillRecord = {
   syncDirName?: string;
 };
 
-function warnInvalidSkillFrontmatter(source: string, diagnostic: LocalSkillLoadDiagnostic): void {
-  skillsLogger.warn("Skipping skill with invalid frontmatter.", {
+function warnInvalidSkill(source: string, diagnostic: LocalSkillLoadDiagnostic): void {
+  skillsLogger.warn("Skipping invalid skill.", {
     source,
     filePath: diagnostic.path,
     error: diagnostic.message,
     consoleMessage:
-      `Skipping skill with invalid frontmatter: ` +
-      `file=${compactSkillPath(diagnostic.path)} error=${diagnostic.message}`,
+      `Skipping invalid skill: file=${compactSkillPath(diagnostic.path)} ` +
+      `error=${diagnostic.message}`,
   });
 }
 
@@ -111,7 +111,7 @@ function loadContainedSkillRecords(params: {
     dir: params.skillDir,
     source: params.source,
     maxBytes: params.maxSkillFileBytes,
-    onDiagnostic: (diagnostic) => warnInvalidSkillFrontmatter(params.source, diagnostic),
+    onDiagnostic: (diagnostic) => warnInvalidSkill(params.source, diagnostic),
   });
   const records = loaded.skills
     .map((skill) => ({
@@ -203,40 +203,6 @@ function setSyncSourceForPluginSkill(
   };
 }
 
-function isCandidateOversized(
-  candidate: CandidateSkillDir,
-  limits: ResolvedSkillDiscoveryLimits,
-  rootIsSkill: boolean,
-): boolean {
-  try {
-    const size = fs.statSync(candidate.skillMdRealPath).size;
-    if (size <= limits.maxSkillFileBytes) {
-      return false;
-    }
-    skillsLogger.warn(
-      rootIsSkill
-        ? "Skipping skills root due to oversized SKILL.md."
-        : "Skipping skill due to oversized SKILL.md.",
-      rootIsSkill
-        ? {
-            dir: candidate.skillDir,
-            filePath: path.join(candidate.skillDir, "SKILL.md"),
-            size,
-            maxSkillFileBytes: limits.maxSkillFileBytes,
-          }
-        : {
-            skill: candidate.name,
-            filePath: path.join(candidate.skillDir, "SKILL.md"),
-            size,
-            maxSkillFileBytes: limits.maxSkillFileBytes,
-          },
-    );
-    return true;
-  } catch {
-    return true;
-  }
-}
-
 function loadDiscoveredSkillRecords(params: {
   dir: string;
   source: string;
@@ -244,23 +210,27 @@ function loadDiscoveredSkillRecords(params: {
   allowedSymlinkTargetRealPaths: readonly string[];
 }): LoadedSkillRecord[] {
   const discovered = discoverSkillCandidates(params);
-  const loadedSkills: LoadedSkillRecord[] = [];
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
+  const loadCandidate = (candidate: CandidateSkillDir) =>
+    loadContainedSkillRecords({
+      skillDir: candidate.skillDir,
+      source: params.source,
+      maxSkillFileBytes: params.limits.maxSkillFileBytes,
+      canonicalSkillDir: canonicalSkillDirForSource(params.source, candidate.skillDirRealPath),
+    });
+  if (discovered.configuredRootCandidate) {
+    const rootRecords = loadCandidate(discovered.configuredRootCandidate);
+    if (rootRecords.length > 0) {
+      return rootRecords;
+    }
+  }
+
+  const loadedSkills: LoadedSkillRecord[] = [];
   for (const candidate of discovered.candidates) {
     if (!discovered.rootIsSkill && loadedSkills.length >= maxSkillsLoadedPerSource) {
       break;
     }
-    if (isCandidateOversized(candidate, params.limits, discovered.rootIsSkill)) {
-      continue;
-    }
-    loadedSkills.push(
-      ...loadContainedSkillRecords({
-        skillDir: candidate.skillDir,
-        source: params.source,
-        maxSkillFileBytes: params.limits.maxSkillFileBytes,
-        canonicalSkillDir: canonicalSkillDirForSource(params.source, candidate.skillDirRealPath),
-      }),
-    );
+    loadedSkills.push(...loadCandidate(candidate));
   }
   if (loadedSkills.length > maxSkillsLoadedPerSource && !discovered.rootIsSkill) {
     return loadedSkills
@@ -280,9 +250,6 @@ function loadGeneratedPluginSkillRecords(params: {
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
   const loadedSkills: LoadedSkillRecord[] = [];
   for (const candidate of candidates) {
-    if (isCandidateOversized(candidate, params.limits, false)) {
-      continue;
-    }
     const loadedRecords = loadContainedSkillRecords({
       skillDir: candidate.skillDir,
       source: params.source,
@@ -372,6 +339,24 @@ function loadSkillEntries(
   const mergeRecord = (record: LoadedSkillRecord) => {
     if (archivedSkillFiles?.has(canonicalizePath(record.skill.filePath))) {
       return;
+    }
+    const replaced = merged.get(record.skill.name);
+    if (
+      replaced &&
+      canonicalizePath(replaced.skill.filePath) !== canonicalizePath(record.skill.filePath)
+    ) {
+      const collisionName = record.skill.name.slice(0, 128);
+      skillsLogger.warn("Skill precedence collision resolved.", {
+        skill: collisionName,
+        winnerSource: record.skill.source,
+        loserSource: replaced.skill.source,
+        winnerPath: record.skill.filePath,
+        loserPath: replaced.skill.filePath,
+        consoleMessage:
+          `Skill precedence collision: skill="${collisionName}" ` +
+          `winner=${record.skill.source}:${compactSkillPath(record.skill.filePath)} ` +
+          `loser=${replaced.skill.source}:${compactSkillPath(replaced.skill.filePath)}`,
+      });
     }
     merged.set(record.skill.name, record);
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where invalid local skills could disappear without any diagnostic, workspace bootstrap files that existed but could not be read were presented to the model as missing, and same-named skills from different precedence levels were replaced without an operator-visible collision notice.

The most common skill-authoring mistake—a missing or empty `description` in `SKILL.md`—was invisible even to `openclaw skills check`. An oversized or otherwise unreadable `AGENTS.md` was injected as `[MISSING]`, which could incorrectly suggest recreating a file that already existed.

## Why This Change Was Made

Skill discovery now identifies `SKILL.md` candidates without pre-validating their frontmatter, leaving bounded reads and validation to the canonical skill loader so every dropped candidate can report its path and reason. Workspace bootstrap loading now distinguishes true absence from validation, size, permission, and I/O failures and records unreadable files with a bounded marker plus warning.

The documented precedence remains unchanged: `skills.load.extraDirs` is still the lowest-precedence source. The merge owner now reports distinct-file name collisions with the winning and losing sources and paths.

AI-assisted: yes. The implementation and tests were reviewed and verified by the maintainer.

## User Impact

- `openclaw skills check` now explains why descriptionless, unreadable, oversized, or malformed skill files were skipped while continuing to show valid siblings.
- Models receive `[UNREADABLE: <reason>]` for bootstrap files that exist but cannot be read, instead of the misleading `[MISSING] Expected at: ...` marker.
- Operators can see which skill won a same-name precedence collision and which lower-precedence file was ignored.
- Existing skill precedence does not change.

## Evidence

Pre-fix regression proof:

- Descriptionless configured-root skill: expected a warning containing its `SKILL.md` path; received no warning.
- Extra-directory versus bundled collision: expected winner/loser diagnostic output; received no warning.
- Oversized `AGENTS.md`: expected `missing === false` with an unreadable marker; received `missing === true`.
- Hardlink and exhausted read-retry bootstrap failures likewise surfaced as missing before the fix.

Post-fix proof:

- `node scripts/run-vitest.mjs src/skills/loading/workspace-skill-loader.test.ts src/skills/loading/workspace-precedence.test.ts src/skills/loading/skill-root-discovery.test.ts src/node-host/skills.test.ts src/agents/workspace.bootstrap-read-diagnostics.test.ts src/agents/workspace.test.ts src/infra/boundary-file-read.test.ts` — 115 tests passed across 3 shards.
- `node scripts/check-changed.mjs -- <10 changed files>` — core production/test typechecks, lint, formatting, dependency, architecture, dead-export, assertion-safety, and repository guards passed.
- `pnpm build` — passed.
- Black-box built-CLI validation with isolated state:
  - descriptionless and permission-denied `SKILL.md` fixtures produced exact path-and-reason warnings while a randomized valid sibling remained visible;
  - a bundled skill selected from live CLI JSON beat a same-named `extraDirs` fixture, and the collision output named both sources and paths;
  - production bootstrap composition injected `[UNREADABLE: File exceeds 2097152 bytes]` with `missing: false` for a real oversized `AGENTS.md` fixture.
- The installed `@openclaw/fs-safe` 0.5.5 bounded descriptor reader was exercised directly and returned `FsSafeError` code `too-large`; its installed source/types were inspected for the `path`/`validation`/`io` open-failure contract.
- Fresh post-CI structured autoreview completed clean with no accepted/actionable findings. An earlier proposed short-circuit issue was verified false because `loadContainedSkillRecords` filters records to the exact candidate base directory before the root-success check.

Production LOC: +143/-99 (net +44). Tests: +152/-13. The production growth is the new diagnostic/unreadable state handling and collision evidence; the patch deletes the duplicate discovery-time frontmatter/oversize filtering path so the canonical bounded loader owns these decisions.

<details>
<summary>Inspectable redacted real-behavior transcript</summary>

# OpenClaw PR #125348 real-behavior proof

Generated from the built CLI and production bootstrap composition on 2026-08-17.
Paths are redacted. No credentials or operator state were used.

## 1. Skill audit: invalid candidates remain visible as diagnostics

Commands:

    openclaw skills check --json
    openclaw skills info valid-proof --json
    openclaw skills info healthcheck --json

Relevant stderr (deduplicated):

[skills] Skipping invalid skill: file=<TMP>/skills/descriptionless-proof/SKILL.md error=description is required
[skills] Skipping invalid skill: file=<TMP>/skills/unreadable-proof/SKILL.md error=EACCES: permission denied, open '<TMP>/skills/unreadable-proof/SKILL.md'
[skills] Skill precedence collision: skill="healthcheck" winner=openclaw-bundled:<CHECKOUT>/skills/healthcheck/SKILL.md loser=openclaw-extra:<TMP>/skills/healthcheck/SKILL.md

Relevant JSON entries:

[
  {
    "name": "valid-proof",
    "description": "valid sibling proof",
    "source": "openclaw-extra",
    "bundled": false,
    "filePath": "<TMP>/skills/valid-proof/SKILL.md",
    "eligible": true,
    "modelVisible": true,
    "commandVisible": true
  },
  {
    "name": "healthcheck",
    "description": "Audit/harden OpenClaw hosts: SSH, firewall, updates, exposure, backups, disk encryption, gateway security.",
    "source": "openclaw-bundled",
    "bundled": true,
    "filePath": "<CHECKOUT>/skills/healthcheck/SKILL.md",
    "eligible": true,
    "modelVisible": true,
    "commandVisible": true
  }
]

Observed:
- descriptionless and permission-denied SKILL.md files report their exact redacted path and reason;
- the valid sibling remains eligible and model-visible;
- the bundled healthcheck skill wins over the same-named extraDirs fixture;
- collision output identifies winner and loser source/path.

## 2. Bootstrap context: existing oversized AGENTS.md is unreadable, not missing

Production bootstrap record and injected context:

{
  "bootstrapFile": {
    "name": "AGENTS.md",
    "path": "<TMP>/workspace/AGENTS.md",
    "missing": false,
    "content": "[UNREADABLE: File exceeds 2097152 bytes]"
  },
  "injectedContext": [
    {
      "path": "<TMP>/workspace/AGENTS.md",
      "content": "[UNREADABLE: File exceeds 2097152 bytes]"
    }
  ]
}

Observed:
- missing is false;
- the injected content is [UNREADABLE: File exceeds 2097152 bytes];
- no [MISSING] marker is emitted for the existing oversized file.

## 3. Dependency contract exercised directly

{
  "package": "@openclaw/fs-safe",
  "version": "0.5.5",
  "overflowError": {
    "name": "FsSafeError",
    "code": "too-large"
  }
}

The installed @openclaw/fs-safe bounded descriptor reader reports code=too-large.
OpenClaw preserves that overflow as a bounded RangeError message before classifying the bootstrap file as unreadable.


</details>
