### PR TITLE
fix(hooks): honor explicit ingress targets and reject conflicts

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -575,7 +575,10 @@ Query-string tokens are rejected.
       `now` or `next-heartbeat`.
     </ParamField>
     <ParamField path="agentId" type="string">
-      Target agent. Required when the configured agent fleet has no implicit or retained legacy owner.
+      Target agent. When supplied, it must name a configured agent. It is required when the configured agent fleet has no implicit or retained legacy owner.
+    </ParamField>
+    <ParamField path="sessionKey" type="string">
+      Target session. Requires `hooks.allowRequestSessionKey: true` and must match `hooks.allowedSessionKeyPrefixes` when configured. Both wake modes can target an explicit session.
     </ParamField>
 
   </Accordion>
@@ -589,7 +592,7 @@ Query-string tokens are rejected.
       -d '{"message":"Summarize inbox","name":"Email","model":"openai/gpt-5.6-sol"}'
     ```
 
-    Fields: `message` (required), `name`, `agentId`, `sessionKey` (requires `hooks.allowRequestSessionKey=true`), `sessionMode` (`isolated` or `persistent`), `idempotencyKey`, `wakeMode`, `deliver`, `channel`, `to`, `accountId`, `model`, `thinking`, `timeoutSeconds`.
+    Fields: `message` (required), `name`, `agentId` (must name a configured agent when supplied), `sessionKey` (requires `hooks.allowRequestSessionKey=true`), `sessionMode` (`isolated` or `persistent`), `idempotencyKey`, `wakeMode`, `deliver`, `channel`, `to`, `accountId`, `model`, `thinking`, `timeoutSeconds`.
 
     Set `sessionMode: "persistent"` only when repeated deliveries should reuse prior context. Direct persistent hooks require an explicit `sessionKey`, `hooks.allowRequestSessionKey: true`, and a non-empty `hooks.allowedSessionKeyPrefixes` allowlist. Omit `sessionMode` or use `"isolated"` for a fresh run session.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1081,8 +1081,11 @@ Validation and safety notes:
 
 **Endpoints:**
 
-- `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
+- `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat", agentId?, sessionKey? }`
+  - `sessionKey` is accepted only when `hooks.allowRequestSessionKey=true` (default: `false`) and must match `hooks.allowedSessionKeyPrefixes` when configured.
+  - A supplied `agentId` must name a configured agent.
 - `POST /hooks/agent` → `{ message, name?, agentId?, sessionKey?, sessionMode?, wakeMode?, deliver?, channel?, to?, accountId?, model?, thinking?, timeoutSeconds? }`
+  - A supplied `agentId` must name a configured agent.
   - `sessionKey` from request payload is accepted only when `hooks.allowRequestSessionKey=true` (default: `false`).
   - `sessionMode` is `"isolated"` by default. `"persistent"` reuses the resolved session and requires an explicit request `sessionKey`, `hooks.allowRequestSessionKey=true`, and non-empty `hooks.allowedSessionKeyPrefixes`.
   - Direct announce delivery requires both a concrete `channel` and `to`; supplying only one fails before the run is scheduled.
@@ -1102,10 +1105,10 @@ Validation and safety notes:
 - `transform` can point to a JS/TS module returning a hook action.
   - `transform.module` must be a relative path and stays within `hooks.transformsDir` (absolute paths and traversal are rejected).
   - Keep `hooks.transformsDir` under `~/.openclaw/hooks/transforms`; workspace skill directories are rejected. If `openclaw doctor` reports this path as invalid, move the transform module into the hooks transforms directory or remove `hooks.transformsDir`.
-- `agentId` routes to a specific agent; unknown IDs fall back to the default agent.
+- Mapping `agentId` routes to a specific agent; unknown mapping IDs retain the legacy fallback to the default agent. Direct `/hooks/wake` and `/hooks/agent` request IDs must name a configured agent.
 - `allowedAgentIds`: restricts effective agent routing, including the default-agent path when `agentId` is omitted (`*` or omitted = allow all, `[]` = deny all).
 - `defaultSessionKey`: optional fixed session key for hook agent runs without explicit `sessionKey`.
-- `allowRequestSessionKey`: allow `/hooks/agent` callers and template-driven mapping session keys to set `sessionKey` (default: `false`).
+- `allowRequestSessionKey`: allow `/hooks/wake` and `/hooks/agent` callers, plus template-driven mappings, to set `sessionKey` (default: `false`).
 - `allowedSessionKeyPrefixes`: optional prefix allowlist for explicit `sessionKey` values (request + mapping), e.g. `["hook:"]`. It becomes required when any mapping or preset uses a templated `sessionKey`.
 - `sessionMode`: mapping session behavior (`"isolated"` by default or `"persistent"`). Persistent mappings must resolve a stable key from `sessionKey` or `hooks.defaultSessionKey`; template-derived keys retain the request-key and prefix checks.
 - `deliver: true` sends the final reply to a channel; mapped hooks may use `channel: "last"`.

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -104,7 +104,7 @@ export type HooksConfig = {
    */
   defaultSessionKey?: string;
   /**
-   * Allow `sessionKey` from external `/hooks/agent` request payloads.
+   * Allow `sessionKey` from external `/hooks/agent` and `/hooks/wake` request payloads.
    * Default: false.
    */
   allowRequestSessionKey?: boolean;

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -159,7 +159,11 @@ describe("gateway hooks helpers", () => {
     expect(normalizeWakePayload({ text: "  ", mode: "now" }).ok).toBe(false);
     expect(normalizeWakePayload({ text: "wake", agentId: 42 })).toEqual({
       ok: false,
-      error: "agentId must be a string",
+      error: "agentId must be a non-empty string",
+    });
+    expect(normalizeWakePayload({ text: "wake", agentId: "  " })).toEqual({
+      ok: false,
+      error: "agentId must be a non-empty string",
     });
   });
 
@@ -360,7 +364,11 @@ describe("gateway hooks helpers", () => {
 
     expect(normalizeAgentPayload({ message: "hello", agentId: 42 })).toEqual({
       ok: false,
-      error: "agentId must be a string",
+      error: "agentId must be a non-empty string",
+    });
+    expect(normalizeAgentPayload({ message: "hello", agentId: "  " })).toEqual({
+      ok: false,
+      error: "agentId must be a non-empty string",
     });
   });
 
@@ -406,10 +414,6 @@ describe("gateway hooks helpers", () => {
       error: 'unknown agentId "!!!"',
     });
     expect(resolveEffectiveHookTargetAgentId(resolved, undefined, "request")).toEqual({
-      ok: true,
-      effectiveAgentId: "main",
-    });
-    expect(resolveEffectiveHookTargetAgentId(resolved, " ", "request")).toEqual({
       ok: true,
       effectiveAgentId: "main",
     });

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -11,7 +11,6 @@ import {
   normalizeHookDispatchSessionKey,
   resolveEffectiveHookTargetAgentId,
   resolveHookSessionKey,
-  resolveHookTargetAgentId,
   normalizeAgentPayload,
   normalizeWakePayload,
   resolveHooksConfig,
@@ -143,7 +142,25 @@ describe("gateway hooks helpers", () => {
       ok: true,
       value: { text: "hi", mode: "now" },
     });
+    expect(
+      normalizeWakePayload({
+        text: "wake later",
+        mode: "next-heartbeat",
+        sessionKey: "hook:wake:later",
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        text: "wake later",
+        mode: "next-heartbeat",
+        sessionKey: "hook:wake:later",
+      },
+    });
     expect(normalizeWakePayload({ text: "  ", mode: "now" }).ok).toBe(false);
+    expect(normalizeWakePayload({ text: "wake", agentId: 42 })).toEqual({
+      ok: false,
+      error: "agentId must be a string",
+    });
   });
 
   test("normalizeAgentPayload defaults + validates channel", () => {
@@ -340,9 +357,14 @@ describe("gateway hooks helpers", () => {
     if (noAgent.ok) {
       expect(noAgent.value.agentId).toBeUndefined();
     }
+
+    expect(normalizeAgentPayload({ message: "hello", agentId: 42 })).toEqual({
+      ok: false,
+      error: "agentId must be a string",
+    });
   });
 
-  test("resolveHookTargetAgentId preserves omitted default target intent", () => {
+  test("hook target resolution keeps config fallback out of request payloads", () => {
     const cfg = {
       hooks: { enabled: true, token: "secret" },
       agents: {
@@ -350,12 +372,47 @@ describe("gateway hooks helpers", () => {
       },
     } as OpenClawConfig;
     const resolved = resolveHooksConfigOrThrow(cfg);
-    expect(resolveHookTargetAgentId(resolved, "hooks")).toBe("hooks");
-    expect(resolveHookTargetAgentId(resolved, "missing-agent")).toBe("main");
-    expect(resolveHookTargetAgentId(resolved, undefined)).toBeUndefined();
-    expect(resolveHookTargetAgentId(resolved, " ")).toBeUndefined();
-    expect(resolveEffectiveHookTargetAgentId(resolved, undefined)).toBe("main");
-    expect(resolveEffectiveHookTargetAgentId(resolved, " ")).toBe("main");
+    expect(resolveEffectiveHookTargetAgentId(resolved, "missing-agent", "mapping")).toEqual({
+      ok: true,
+      selectedAgentId: "main",
+      effectiveAgentId: "main",
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, "!!!", "mapping")).toEqual({
+      ok: true,
+      selectedAgentId: "main",
+      effectiveAgentId: "main",
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, "hooks", "request")).toEqual({
+      ok: true,
+      selectedAgentId: "hooks",
+      effectiveAgentId: "hooks",
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, "missing-agent", "request")).toEqual({
+      ok: false,
+      code: "unknown-agent",
+      agentId: "missing-agent",
+      error: 'unknown agentId "missing-agent"',
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, "Missing Agent", "request")).toEqual({
+      ok: false,
+      code: "unknown-agent",
+      agentId: "missing-agent",
+      error: 'unknown agentId "missing-agent"',
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, "!!!", "request")).toEqual({
+      ok: false,
+      code: "unknown-agent",
+      agentId: "!!!",
+      error: 'unknown agentId "!!!"',
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, undefined, "request")).toEqual({
+      ok: true,
+      effectiveAgentId: "main",
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, " ", "request")).toEqual({
+      ok: true,
+      effectiveAgentId: "main",
+    });
   });
 
   test("global hook dispatch honors the persisted fixed-store owner", () => {
@@ -369,42 +426,42 @@ describe("gateway hooks helpers", () => {
       },
     });
 
-    expect(resolveEffectiveHookTargetAgentId(resolved, undefined)).toBe("ops");
-    expect(resolveEffectiveHookTargetAgentId(resolved, "research")).toBeUndefined();
+    expect(resolveEffectiveHookTargetAgentId(resolved, undefined, "request")).toEqual({
+      ok: true,
+      effectiveAgentId: "ops",
+    });
+    expect(resolveEffectiveHookTargetAgentId(resolved, "research", "request")).toEqual({
+      ok: false,
+      code: "owner-conflict",
+      agentId: "research",
+      ownerAgentId: "ops",
+      error:
+        'agentId "research" conflicts with global session-store owner "ops"; use agentId "ops" or update agents.defaults.sessionStore.agentId',
+    });
   });
 
   test("isHookAgentAllowed honors hooks.allowedAgentIds for effective target routing", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["hooks"]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
-    expect(isHookAgentAllowed(resolved, "")).toBe(false);
-    expect(isHookAgentAllowed(resolved, "   ")).toBe(false);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
-    expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(false);
+    expect(isHookAgentAllowed(resolved, "main")).toBe(false);
   });
 
   test("isHookAgentAllowed treats empty allowlist as deny-all routing", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig([]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
-    expect(isHookAgentAllowed(resolved, "")).toBe(false);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
     expect(isHookAgentAllowed(resolved, "main")).toBe(false);
   });
 
-  test("isHookAgentAllowed allows omitted agentId when default agent is allowlisted", () => {
+  test("isHookAgentAllowed allows the resolved default agent when allowlisted", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["main"]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
-    expect(isHookAgentAllowed(resolved, "")).toBe(true);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
     expect(isHookAgentAllowed(resolved, "main")).toBe(true);
-    expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(true);
   });
 
   test("isHookAgentAllowed treats wildcard allowlist as allow-all", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["*"]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
-    expect(isHookAgentAllowed(resolved, "")).toBe(true);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
-    expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(true);
+    expect(isHookAgentAllowed(resolved, "main")).toBe(true);
   });
 
   test("resolveHookSessionKey disables request sessionKey by default", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -227,10 +227,13 @@ export function normalizeHookHeaders(req: IncomingMessage) {
 }
 
 function normalizeHookPayloadAgentId(raw: unknown): Result<string | undefined, string> {
-  if (raw !== undefined && typeof raw !== "string") {
-    return { ok: false, error: "agentId must be a string" };
+  if (raw === undefined) {
+    return { ok: true, value: undefined };
   }
-  return { ok: true, value: normalizeOptionalString(raw) };
+  const agentId = typeof raw === "string" ? normalizeOptionalString(raw) : undefined;
+  return agentId
+    ? { ok: true, value: agentId }
+    : { ok: false, error: "agentId must be a non-empty string" };
 }
 
 /** Validate a hook wake payload. */

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -16,7 +16,11 @@ import {
 import type { HookSessionMode } from "../config/types.hooks.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-body.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  normalizeAgentId,
+  normalizeAgentIdStrict,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
 import {
@@ -55,7 +59,7 @@ type HookSessionPolicyResolved = {
   allowedSessionKeyPrefixes?: string[];
 };
 
-type HookSessionKeySource = "request" | "mapping-static" | "mapping-templated";
+export type HookSessionKeySource = "request" | "mapping-static" | "mapping-templated";
 
 /** Resolve and validate hook config, returning null when hooks are disabled. */
 export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | null {
@@ -222,17 +226,42 @@ export function normalizeHookHeaders(req: IncomingMessage) {
   return headers;
 }
 
+function normalizeHookPayloadAgentId(raw: unknown): Result<string | undefined, string> {
+  if (raw !== undefined && typeof raw !== "string") {
+    return { ok: false, error: "agentId must be a string" };
+  }
+  return { ok: true, value: normalizeOptionalString(raw) };
+}
+
 /** Validate a hook wake payload. */
 export function normalizeWakePayload(
   payload: Record<string, unknown>,
-): Result<{ text: string; mode: "now" | "next-heartbeat"; agentId?: string }, string> {
+): Result<
+  { text: string; mode: "now" | "next-heartbeat"; agentId?: string; sessionKey?: string },
+  string
+> {
   const normalizedText = normalizeOptionalString(payload.text) ?? "";
   if (!normalizedText) {
     return { ok: false, error: "text required" };
   }
   const mode = payload.mode === "next-heartbeat" ? "next-heartbeat" : "now";
-  const agentId = normalizeOptionalString(payload.agentId);
-  return { ok: true, value: { text: normalizedText, mode, ...(agentId ? { agentId } : {}) } };
+  const agentId = normalizeHookPayloadAgentId(payload.agentId);
+  if (!agentId.ok) {
+    return agentId;
+  }
+  const sessionKey = normalizeOptionalString(payload.sessionKey);
+  if (payload.sessionKey !== undefined && !sessionKey) {
+    return { ok: false, error: "sessionKey must be a non-empty string" };
+  }
+  return {
+    ok: true,
+    value: {
+      text: normalizedText,
+      mode,
+      ...(agentId.value ? { agentId: agentId.value } : {}),
+      ...(sessionKey ? { sessionKey } : {}),
+    },
+  };
 }
 
 type HookAgentPayload = {
@@ -411,8 +440,21 @@ export function resolveHookIdempotencyKey(params: {
   );
 }
 
-/** Resolve an optional hook target agent id to a known configured agent. */
-export function resolveHookTargetAgentId(
+export type HookTargetAgentResolution =
+  | { ok: true; selectedAgentId?: string; effectiveAgentId: string }
+  | { ok: false; code: "unknown-agent"; agentId: string; error: string }
+  | { ok: false; code: "agent-required"; error: string }
+  | {
+      ok: false;
+      code: "owner-conflict";
+      agentId: string;
+      ownerAgentId: string;
+      error: string;
+    }
+  | { ok: false; code: "owner-retired"; ownerAgentId: string; error: string };
+
+/** Resolve an optional config-mapped target to a known agent or the configured default. */
+function resolveHookTargetAgentId(
   hooksConfig: HooksConfigResolved,
   agentId: string | undefined,
 ): string | undefined {
@@ -421,53 +463,92 @@ export function resolveHookTargetAgentId(
     return undefined;
   }
   const normalized = normalizeAgentId(raw);
-  if (hooksConfig.agentPolicy.knownAgentIds.has(normalized)) {
-    return normalized;
-  }
-  return hooksConfig.agentPolicy.defaultAgentId;
+  return hooksConfig.agentPolicy.knownAgentIds.has(normalized)
+    ? normalized
+    : hooksConfig.agentPolicy.defaultAgentId;
 }
 
-/** Resolve the effective hook target agent, falling back to the hook default. */
+/** Resolve request or config-mapped agent selection against durable session ownership. */
 export function resolveEffectiveHookTargetAgentId(
   hooksConfig: HooksConfigResolved,
   agentId: string | undefined,
-): string | undefined {
-  const resolvedAgentId =
-    resolveHookTargetAgentId(hooksConfig, agentId) ?? hooksConfig.agentPolicy.defaultAgentId;
+  source: "request" | "mapping",
+): HookTargetAgentResolution {
+  const raw = normalizeOptionalString(agentId);
+  let selectedAgentId =
+    source === "mapping" ? resolveHookTargetAgentId(hooksConfig, agentId) : undefined;
+  if (source === "request" && raw) {
+    const normalized = normalizeAgentIdStrict(raw);
+    if (!normalized.ok) {
+      return {
+        ok: false,
+        code: "unknown-agent",
+        agentId: raw,
+        error: `unknown agentId "${raw}"`,
+      };
+    }
+    if (hooksConfig.agentPolicy.knownAgentIds.has(normalized.value)) {
+      selectedAgentId = normalized.value;
+    } else {
+      return {
+        ok: false,
+        code: "unknown-agent",
+        agentId: normalized.value,
+        error: `unknown agentId "${normalized.value}"`,
+      };
+    }
+  }
+  const resolvedAgentId = selectedAgentId ?? hooksConfig.agentPolicy.defaultAgentId;
   const persistedOwner = hooksConfig.agentPolicy.globalSessionStoreOwner;
   if (persistedOwner.kind === "retired") {
-    return undefined;
+    return {
+      ok: false,
+      code: "owner-retired",
+      ownerAgentId: persistedOwner.agentId,
+      error: `global session-store owner "${persistedOwner.agentId}" is no longer configured; restore that agent or update agents.defaults.sessionStore.agentId`,
+    };
   }
   if (
     persistedOwner.kind === "configured" &&
     resolvedAgentId &&
     resolvedAgentId !== persistedOwner.agentId
   ) {
-    return undefined;
+    return {
+      ok: false,
+      code: "owner-conflict",
+      agentId: resolvedAgentId,
+      ownerAgentId: persistedOwner.agentId,
+      error: `agentId "${resolvedAgentId}" conflicts with global session-store owner "${persistedOwner.agentId}"; use agentId "${persistedOwner.agentId}" or update agents.defaults.sessionStore.agentId`,
+    };
   }
-  return persistedOwner.kind === "configured" ? persistedOwner.agentId : resolvedAgentId;
+  const effectiveAgentId =
+    persistedOwner.kind === "configured" ? persistedOwner.agentId : resolvedAgentId;
+  if (!effectiveAgentId) {
+    return { ok: false, code: "agent-required", error: getHookAgentSelectionError() };
+  }
+  return {
+    ok: true,
+    ...(selectedAgentId ? { selectedAgentId } : {}),
+    effectiveAgentId,
+  };
 }
 
 /** Check the hook agent allowlist against the effective target agent. */
 export function isHookAgentAllowed(
   hooksConfig: HooksConfigResolved,
-  agentId: string | undefined,
+  effectiveAgentId: string,
 ): boolean {
   const allowed = hooksConfig.agentPolicy.allowedAgentIds;
   if (allowed === undefined) {
     return true;
   }
-  // Omitted agentId still dispatches to the default agent downstream, so the
-  // allowlist must authorize that effective target before dispatch.
-  const effectiveAgentId = resolveEffectiveHookTargetAgentId(hooksConfig, agentId);
-  return effectiveAgentId !== undefined && allowed.has(effectiveAgentId);
+  return allowed.has(effectiveAgentId);
 }
 
 /** Error message for hook agent allowlist failures. */
 export const getHookAgentPolicyError = () => "agentId is not allowed by hooks.allowedAgentIds";
 
-export const getHookAgentSelectionError = () =>
-  "agentId is required when multiple agents are configured";
+const getHookAgentSelectionError = () => "agentId is required when multiple agents are configured";
 const getHookSessionKeyRequestPolicyError = () =>
   "sessionKey is disabled for externally supplied hook payload values; set hooks.allowRequestSessionKey=true to enable";
 /** Error message for hook session-key prefix allowlist failures. */
@@ -566,8 +647,10 @@ export function normalizeAgentPayload(
   }
   const nameRaw = payload.name;
   const name = normalizeOptionalString(nameRaw) ?? "Hook";
-  const agentIdRaw = payload.agentId;
-  const agentId = normalizeOptionalString(agentIdRaw);
+  const agentId = normalizeHookPayloadAgentId(payload.agentId);
+  if (!agentId.ok) {
+    return agentId;
+  }
   const idempotencyKey = resolveOptionalHookIdempotencyKey(payload.idempotencyKey);
   const wakeMode = payload.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const sessionKeyRaw = payload.sessionKey;
@@ -607,7 +690,7 @@ export function normalizeAgentPayload(
     value: {
       message,
       name,
-      agentId,
+      agentId: agentId.value,
       idempotencyKey,
       wakeMode,
       sessionKey,

--- a/src/gateway/server-http.hooks-delivery.test.ts
+++ b/src/gateway/server-http.hooks-delivery.test.ts
@@ -37,6 +37,7 @@ function createDeliveryHandler(params?: {
   mappings?: HookMappingResolved[];
   agentPolicy?: Partial<HooksConfigResolved["agentPolicy"]>;
 }) {
+  const dispatchWakeHook = vi.fn();
   const dispatchAgentHook = vi.fn((_value: HookAgentDispatchPayload) => ({
     ok: true as const,
     runId: "run-1",
@@ -57,10 +58,10 @@ function createDeliveryHandler(params?: {
       info: vi.fn(),
       error: vi.fn(),
     } as unknown as ReturnType<typeof createSubsystemLogger>,
-    dispatchWakeHook: vi.fn(),
+    dispatchWakeHook,
     dispatchAgentHook,
   });
-  return { handler, dispatchAgentHook };
+  return { handler, dispatchAgentHook, dispatchWakeHook };
 }
 
 async function dispatchPayload(params: {
@@ -234,6 +235,20 @@ describe("hook request delivery normalization", () => {
         delivery: { mode: "none" },
       }),
     );
+  });
+
+  test.each([
+    ["/hooks/agent", { message: "Direct", agentId: "  " }],
+    ["/hooks/wake", { text: "Wake", agentId: "  " }],
+  ])("rejects a blank direct agentId on %s without dispatch", async (path, payload) => {
+    const { handler, dispatchAgentHook, dispatchWakeHook } = createDeliveryHandler();
+
+    const response = await dispatchPayload({ handler, path, payload });
+
+    expect(response.res.statusCode).toBe(400);
+    expect(response.getBody()).toContain("agentId must be a non-empty string");
+    expect(dispatchAgentHook).not.toHaveBeenCalled();
+    expect(dispatchWakeHook).not.toHaveBeenCalled();
   });
 
   test("preserves config-mapping fallback for an unrepresentable agentId", async () => {

--- a/src/gateway/server-http.hooks-delivery.test.ts
+++ b/src/gateway/server-http.hooks-delivery.test.ts
@@ -5,7 +5,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import type { HookMappingResolved } from "./hooks-mapping.js";
 import { createHooksConfig } from "./hooks-test-helpers.js";
-import type { HookAgentDispatchPayload } from "./hooks.js";
+import type { HookAgentDispatchPayload, HooksConfigResolved } from "./hooks.js";
 import { createHookRequest, createResponse } from "./server-http.test-harness.js";
 import { createHooksRequestHandler } from "./server/hooks-request-handler.js";
 
@@ -33,14 +33,19 @@ vi.mock("./hooks.js", async () => {
   };
 });
 
-function createDeliveryHandler(params?: { mappings?: HookMappingResolved[] }) {
+function createDeliveryHandler(params?: {
+  mappings?: HookMappingResolved[];
+  agentPolicy?: Partial<HooksConfigResolved["agentPolicy"]>;
+}) {
   const dispatchAgentHook = vi.fn((_value: HookAgentDispatchPayload) => ({
     ok: true as const,
     runId: "run-1",
   }));
+  const canonicalConfig = createHooksConfig();
   const hooksConfig = {
-    ...createHooksConfig(),
+    ...canonicalConfig,
     mappings: params?.mappings ?? [],
+    agentPolicy: { ...canonicalConfig.agentPolicy, ...params?.agentPolicy },
   };
   const handler = createHooksRequestHandler({
     getHooksConfig: () => hooksConfig,
@@ -229,5 +234,57 @@ describe("hook request delivery normalization", () => {
         delivery: { mode: "none" },
       }),
     );
+  });
+
+  test("preserves config-mapping fallback for an unrepresentable agentId", async () => {
+    const { handler, dispatchAgentHook } = createDeliveryHandler({
+      mappings: [
+        {
+          id: "mapped-unknown-agent",
+          matchPath: "mapped-unknown-agent",
+          action: "agent",
+          agentId: "!!!",
+          messageTemplate: "Mapped fallback",
+        },
+      ],
+    });
+
+    const mapping = await dispatchPayload({
+      handler,
+      path: "/hooks/mapped-unknown-agent",
+      payload: {},
+    });
+    expect(mapping.res.statusCode).toBe(200);
+    expect(dispatchAgentHook).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", effectiveAgentId: "main" }),
+    );
+  });
+
+  test.each([
+    {
+      owner: { kind: "configured" as const, agentId: "ops" },
+      error: 'agentId \\"research\\" conflicts with global session-store owner \\"ops\\"',
+    },
+    {
+      owner: { kind: "retired" as const, agentId: "retired" },
+      error: 'global session-store owner \\"retired\\" is no longer configured',
+    },
+  ])("reports $owner.kind global session-store ownership", async ({ owner, error }) => {
+    const { handler, dispatchAgentHook } = createDeliveryHandler({
+      agentPolicy: {
+        globalSessionStoreOwner: owner,
+        knownAgentIds: new Set(["ops", "research"]),
+      },
+    });
+
+    const response = await dispatchPayload({
+      handler,
+      path: "/hooks/agent",
+      payload: { message: "Direct", agentId: "research" },
+    });
+    expect(response.res.statusCode).toBe(400);
+    expect(response.getBody()).toContain(error);
+    expect(response.getBody()).not.toContain("agentId is required");
+    expect(dispatchAgentHook).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -398,6 +398,8 @@ export function createGatewayHttpServer(opts: {
           Boolean(opts.handleMcpOAuthCallbackRequest),
         () => opts.handleMcpOAuthCallbackRequest?.(req, res) ?? false,
       );
+      // The hook owner claims only its configured base path before entering HTTP admission;
+      // this unconditional dispatcher must stay plain so unrelated routes can fall through.
       addRequestStage(true, () => handleHooksRequest(req, res));
       addAdmittedStage(
         Boolean(opts.handleWatchNodeRequest) && scopedRequestPath.startsWith("/api/nodes/watch/"),

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -949,7 +949,7 @@ describe("gateway server hooks", () => {
       });
       expect(resEmptyAgent.status).toBe(400);
       const emptyAgentBody = (await resEmptyAgent.json()) as { error?: string };
-      expect(emptyAgentBody.error).toContain("hooks.allowedAgentIds");
+      expect(emptyAgentBody.error).toBe("agentId must be a non-empty string");
       expect(cronIsolatedRun).not.toHaveBeenCalled();
 
       mockIsolatedRunOkOnce();
@@ -1008,17 +1008,6 @@ describe("gateway server hooks", () => {
       expect(noAgentCall?.job?.agentId).toBe("main");
       expect(noAgentCall?.sessionKey).toBe("agent:main:slack:channel:c123");
       expect(peekSystemEventEntries("agent:main:main")).toStrictEqual([]);
-      drainSystemEvents(resolveMainKey());
-
-      mockIsolatedRunOkOnce();
-      const resBlankAgent = await postHook(port, "/hooks/agent", {
-        message: "Blank target",
-        agentId: " ",
-      });
-      expect(resBlankAgent.status).toBe(200);
-      await waitForSystemEventTexts(resolveMainKey());
-      const blankAgentCall = cronRunCall();
-      expect(blankAgentCall?.job?.agentId).toBe("main");
       drainSystemEvents(resolveMainKey());
     });
   });

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -249,17 +249,16 @@ describe("gateway server hooks", () => {
       expect(routedCall?.job?.agentId).toBe("hooks");
       drainSystemEvents(HOOKS_MAIN_SESSION_KEY);
 
-      mockIsolatedRunOkOnce();
-      const resAgentUnknown = await postHook(port, "/hooks/agent", {
+      const unknownAgent = await postHook(port, "/hooks/agent", {
         message: "Do it",
-        name: "Email",
         agentId: "missing-agent",
       });
-      expect(resAgentUnknown.status).toBe(200);
-      await waitForSystemEvent();
-      const fallbackCall = cronRunCall();
-      expect(fallbackCall?.job?.agentId).toBe("main");
-      drainSystemEvents(resolveMainKey());
+      expect(unknownAgent.status).toBe(400);
+      await expect(unknownAgent.json()).resolves.toMatchObject({
+        error: 'unknown agentId "missing-agent"',
+      });
+      expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       const resQuery = await postHook(
         port,
@@ -504,6 +503,7 @@ describe("gateway server hooks", () => {
     testState.hooksConfig = {
       enabled: true,
       token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
       allowedAgentIds: ["main", "hooks"],
       allowedSessionKeyPrefixes: ["hook:"],
       mappings: [
@@ -519,13 +519,13 @@ describe("gateway server hooks", () => {
     setMainAndHooksAgents();
 
     await withGatewayServer(async ({ port }) => {
-      const direct = await postHook(port, "/hooks/wake", { text: "Direct wake" });
+      const direct = await postHook(port, "/hooks/wake", {
+        text: "Direct wake",
+        sessionKey: "hook:wake:direct",
+      });
       expect(direct.status).toBe(200);
-      await waitForSystemEvent(5_000);
-      const directEvents = peekSystemEventEntries(resolveMainKey());
-      expect(directEvents).toHaveLength(1);
-      expect(directEvents[0]?.text).toBe("Direct wake");
-      drainSystemEvents(resolveMainKey());
+      expect(await waitForSystemEventTexts("agent:main:hook:wake:direct")).toEqual(["Direct wake"]);
+      drainSystemEvents("agent:main:hook:wake:direct");
 
       const mapped = await postHook(port, "/hooks/mapped-wake", { subject: "Email" });
       expect(mapped.status).toBe(200);

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -14,10 +14,11 @@ import { applyHookMappings } from "../hooks-mapping.js";
 import {
   extractHookToken,
   getHookAgentPolicyError,
-  getHookAgentSelectionError,
   getHookChannelError,
   getHookSessionKeyPrefixError,
   type HookAgentDispatchPayload,
+  type HookSessionKeySource,
+  type HookTargetAgentResolution,
   type HooksConfigResolved,
   isHookAgentAllowed,
   isSessionKeyAllowedByPrefix,
@@ -31,7 +32,6 @@ import {
   resolveHookDeliver,
   resolveHookIdempotencyKey,
   resolveHookSessionKey,
-  resolveHookTargetAgentId,
 } from "../hooks.js";
 import { sendJson } from "../http-common.js";
 import { readPreparedGatewayIngressAttribution } from "../ingress-attribution.js";
@@ -322,6 +322,57 @@ export function createHooksRequestHandler(
       }
       return dispatchSessionKey;
     };
+    const resolveTargetAgentOrRespond = (
+      agentId: string | undefined,
+      source: "request" | "mapping",
+    ): Extract<HookTargetAgentResolution, { ok: true }> | null => {
+      const resolution = resolveEffectiveHookTargetAgentId(hooksConfig, agentId, source);
+      if (!resolution.ok) {
+        sendJson(res, 400, { ok: false, error: resolution.error });
+        return null;
+      }
+      if (!isHookAgentAllowed(hooksConfig, resolution.effectiveAgentId)) {
+        sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+        return null;
+      }
+      return resolution;
+    };
+    const dispatchWakeOrRespond = (
+      value: Parameters<HookDispatchers["dispatchWakeHook"]>[0],
+      targetAgentId: string,
+      source: HookSessionKeySource,
+    ): true => {
+      let dispatchSessionKey: string | undefined;
+      if (value.sessionKey) {
+        const sessionKey = resolveHookSessionKey({
+          hooksConfig,
+          source,
+          sessionKey: value.sessionKey,
+        });
+        if (!sessionKey.ok) {
+          sendJson(res, 400, { ok: false, error: sessionKey.error });
+          return true;
+        }
+        const resolvedSessionKey = resolveDispatchSessionKeyOrRespond(
+          sessionKey.value,
+          targetAgentId,
+        );
+        if (resolvedSessionKey === null) {
+          return true;
+        }
+        dispatchSessionKey = resolvedSessionKey;
+      }
+      dispatchWakeHook(
+        {
+          text: value.text,
+          mode: value.mode,
+          ...(dispatchSessionKey ? { sessionKey: dispatchSessionKey } : {}),
+        },
+        targetAgentId,
+      );
+      sendJson(res, 200, { ok: true, mode: value.mode });
+      return true;
+    };
 
     if (subPath === "wake") {
       const normalized = normalizeWakePayload(payload as Record<string, unknown>);
@@ -329,21 +380,11 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
       }
-      if (!isHookAgentAllowed(hooksConfig, normalized.value.agentId)) {
-        sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+      const target = resolveTargetAgentOrRespond(normalized.value.agentId, "request");
+      if (!target) {
         return true;
       }
-      const targetAgentId = resolveEffectiveHookTargetAgentId(
-        hooksConfig,
-        normalized.value.agentId,
-      );
-      if (!targetAgentId) {
-        sendJson(res, 400, { ok: false, error: getHookAgentSelectionError() });
-        return true;
-      }
-      dispatchWakeHook(normalized.value, targetAgentId);
-      sendJson(res, 200, { ok: true, mode: normalized.value.mode });
-      return true;
+      return dispatchWakeOrRespond(normalized.value, target.effectiveAgentId, "request");
     }
 
     if (subPath === "agent") {
@@ -352,8 +393,8 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
       }
-      if (!isHookAgentAllowed(hooksConfig, normalized.value.agentId)) {
-        sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+      const target = resolveTargetAgentOrRespond(normalized.value.agentId, "request");
+      if (!target) {
         return true;
       }
       if (normalized.value.sessionMode === "persistent" && !normalized.value.sessionKey) {
@@ -383,21 +424,12 @@ export function createHooksRequestHandler(
         });
         return true;
       }
-      const targetAgentId = resolveHookTargetAgentId(hooksConfig, normalized.value.agentId);
-      const effectiveTargetAgentId = resolveEffectiveHookTargetAgentId(
-        hooksConfig,
-        normalized.value.agentId,
-      );
-      if (!effectiveTargetAgentId) {
-        sendJson(res, 400, { ok: false, error: getHookAgentSelectionError() });
-        return true;
-      }
       const replayKey = buildHookReplayCacheKey({
         pathKey: "agent",
         token,
         idempotencyKey,
         dispatchScope: {
-          agentId: effectiveTargetAgentId,
+          agentId: target.effectiveAgentId,
           sessionKey:
             normalized.value.sessionKey ?? hooksConfig.sessionPolicy.defaultSessionKey ?? null,
           message: normalized.value.message,
@@ -420,7 +452,7 @@ export function createHooksRequestHandler(
       }
       const dispatchSessionKey = resolveDispatchSessionKeyOrRespond(
         sessionKey.value,
-        effectiveTargetAgentId,
+        target.effectiveAgentId,
       );
       if (dispatchSessionKey === null) {
         return true;
@@ -428,11 +460,11 @@ export function createHooksRequestHandler(
       const dispatched = await dispatchAgentHookWithReplay(replayKey, now, () =>
         dispatchAgentHook({
           ...normalized.value,
-          effectiveAgentId: effectiveTargetAgentId,
+          effectiveAgentId: target.effectiveAgentId,
           idempotencyKey,
           sessionKey: dispatchSessionKey,
           sourcePath: `${basePath}/agent`,
-          agentId: targetAgentId,
+          agentId: target.selectedAgentId,
           externalContentSource: "webhook",
         }),
       );
@@ -460,43 +492,19 @@ export function createHooksRequestHandler(
           }
           if (mapped.action.kind === "wake") {
             const action = mapped.action;
-            if (!isHookAgentAllowed(hooksConfig, action.agentId)) {
-              sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+            const target = resolveTargetAgentOrRespond(action.agentId, "mapping");
+            if (!target) {
               return true;
             }
-            const targetAgentId = resolveEffectiveHookTargetAgentId(hooksConfig, action.agentId);
-            if (!targetAgentId) {
-              sendJson(res, 400, { ok: false, error: getHookAgentSelectionError() });
-              return true;
-            }
-            let dispatchSessionKey: string | undefined;
-            if (action.sessionKey) {
-              const sessionKey = resolveHookSessionKey({
-                hooksConfig,
-                source:
-                  action.sessionKeySource === "static" ? "mapping-static" : "mapping-templated",
-                sessionKey: action.sessionKey,
-              });
-              if (!sessionKey.ok) {
-                sendJson(res, 400, { ok: false, error: sessionKey.error });
-                return true;
-              }
-              dispatchSessionKey =
-                resolveDispatchSessionKeyOrRespond(sessionKey.value, targetAgentId) ?? undefined;
-              if (!dispatchSessionKey) {
-                return true;
-              }
-            }
-            dispatchWakeHook(
+            return dispatchWakeOrRespond(
               {
                 text: action.text,
                 mode: action.mode,
-                ...(dispatchSessionKey ? { sessionKey: dispatchSessionKey } : {}),
+                sessionKey: action.sessionKey,
               },
-              targetAgentId,
+              target.effectiveAgentId,
+              action.sessionKeySource === "static" ? "mapping-static" : "mapping-templated",
             );
-            sendJson(res, 200, { ok: true, mode: action.mode });
-            return true;
           }
           const action = mapped.action;
           const channel = resolveHookChannel(action.channel);
@@ -512,8 +520,8 @@ export function createHooksRequestHandler(
                 to: action.to,
               }
             : { mode: "none" as const };
-          if (!isHookAgentAllowed(hooksConfig, action.agentId)) {
-            sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+          const target = resolveTargetAgentOrRespond(action.agentId, "mapping");
+          if (!target) {
             return true;
           }
           if (
@@ -537,18 +545,9 @@ export function createHooksRequestHandler(
             sendJson(res, 400, { ok: false, error: sessionKey.error });
             return true;
           }
-          const targetAgentId = resolveHookTargetAgentId(hooksConfig, action.agentId);
-          const effectiveTargetAgentId = resolveEffectiveHookTargetAgentId(
-            hooksConfig,
-            action.agentId,
-          );
-          if (!effectiveTargetAgentId) {
-            sendJson(res, 400, { ok: false, error: getHookAgentSelectionError() });
-            return true;
-          }
           const dispatchSessionKey = resolveDispatchSessionKeyOrRespond(
             sessionKey.value,
-            effectiveTargetAgentId,
+            target.effectiveAgentId,
           );
           if (dispatchSessionKey === null) {
             return true;
@@ -558,7 +557,7 @@ export function createHooksRequestHandler(
             token,
             idempotencyKey,
             dispatchScope: {
-              agentId: effectiveTargetAgentId,
+              agentId: target.effectiveAgentId,
               sessionKey: action.sessionKey ?? hooksConfig.sessionPolicy.defaultSessionKey ?? null,
               message: action.message,
               name: action.name ?? "Hook",
@@ -582,8 +581,8 @@ export function createHooksRequestHandler(
               message: action.message,
               name: action.name ?? "Hook",
               idempotencyKey,
-              agentId: targetAgentId,
-              effectiveAgentId: effectiveTargetAgentId,
+              agentId: target.selectedAgentId,
+              effectiveAgentId: target.effectiveAgentId,
               wakeMode: action.wakeMode,
               sessionKey: dispatchSessionKey,
               sessionMode: action.sessionMode,


### PR DESCRIPTION
Related: #64556
Related: #119808

## What Problem This Solves

Fixes three HTTP hook ingress failures that could silently route work somewhere other than the caller requested or return an unusable error:

- A supplied unknown `agentId` on `/hooks/agent` or `/hooks/wake` was normalized through the operator-config mapping fallback and could execute on the default agent while returning `200`.
- `/hooks/wake` accepted `sessionKey` in the JSON payload but dropped it, so the wake landed in the agent's main session instead of the requested session.
- A valid explicit agent conflicting with a persisted global fixed-store owner returned `agentId is required`, hiding the actual owner conflict and giving the caller no corrective path.

## Why This Change Was Made

Direct request payloads now resolve agent IDs strictly, while operator-authored hook mappings retain their documented unknown-ID fallback. Target resolution returns closed unknown/required/owner-conflict/owner-retired outcomes, and every direct or mapped wake/agent path uses the same resolved target before allowlist and session routing.

Direct wake session keys now use the existing request opt-in, prefix policy, and agent-prefix rebinding before dispatch. Hook HTTP admission is unchanged: the runtime hook owner matches the configured path and enters Gateway work admission before this router stage, while detached agent work reserves its own tracked continuation. A comment records why the unconditional router stage must not add a second admission wrapper.

## User Impact

- Typoed or invalid direct request agent IDs return `400` naming the rejected ID and schedule no work.
- A direct wake can target an explicit session when `hooks.allowRequestSessionKey=true` and the key matches `hooks.allowedSessionKeyPrefixes`.
- Global fixed-store owner conflicts and retired owners return truthful `400` errors naming the persisted owner state.
- Existing config mappings keep their legacy unknown-agent fallback to the configured default agent.
- The configuration reference and automation guide now describe the direct wake `sessionKey` contract and strict direct-agent behavior.

## Evidence

- Regression-only focused run against the pre-fix implementation: `6 failed, 53 passed` for the unknown-agent reroute, dropped wake session key, and owner-conflict error cases.
- ClawSweeper blank-ID follow-up regression-only run against the prior PR head: `4 failed, 57 passed`; both direct endpoints still routed whitespace IDs to the default before the parser repair.
- `node scripts/run-vitest.mjs src/gateway/hooks.test.ts src/gateway/server.hooks.test.ts src/gateway/server-http.hooks-delivery.test.ts` — 61 passed.
- `pnpm docs:check-mdx` — passed (775 files).
- `pnpm docs:check-links` — passed (6,503 internal links, 0 broken).
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- <changed files>` — passed, including format, core/test types, targeted lint, dead exports, import cycles, database-first and webhook boundary guards.
- Source-blind isolated Gateway validation — all original 5 contract clauses passed, plus the follow-up: both direct endpoints rejected whitespace-only IDs with `400` and zero state, omitted IDs still used the configured default, and whitespace mapping IDs retained default-agent fallback.
- Fresh structured autoreview — clean; no accepted/actionable findings.

Production LOC: +191/-104 (net +87) | Tests: +176/-54 (net +122) | Docs: +11/-5 (net +6). The production growth is the strict external-ID boundary, discriminated durable-owner failures, shared wake preparation, and recorded admission ownership; the request handler itself is net-negative.

AI-assisted: yes. The final diff and behavior were reviewed and verified by the maintainer.
