### PR TITLE
fix(voice-call): status exits after offline lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Voice Call status fallback:** read retained call state directly when the Gateway is unavailable instead of starting a standalone telephony runtime that keeps the CLI alive and occupies the webhook port.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Voice Call status fallback:** read retained call state directly when the Gateway is unavailable instead of starting a standalone telephony runtime that keeps the CLI alive and occupies the webhook port.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -1227,7 +1227,7 @@ describe("voice-call plugin", () => {
     }
   });
 
-  it("CLI status lists active calls without a call id", async () => {
+  it("CLI status stays read-only when the gateway is unavailable", async () => {
     const program = new Command();
     const stdout = captureStdout();
     await registerVoiceCallCli(program);
@@ -1237,8 +1237,8 @@ describe("voice-call plugin", () => {
       const parsed = JSON.parse(stdout.output()) as {
         calls?: Array<{ callId?: string }>;
       };
-      expect(parsed.calls).toHaveLength(1);
-      expect(parsed.calls?.[0]?.callId).toBe("call-1");
+      expect(parsed.calls).toEqual([]);
+      expect(createVoiceCallRuntime).not.toHaveBeenCalled();
     } finally {
       stdout.restore();
     }

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -6,6 +6,8 @@ import { Command } from "commander";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 const callGatewayFromCliMock = vi.hoisted(() => vi.fn());
+const findCallMatchesInStoreMock = vi.hoisted(() => vi.fn());
+const loadActiveCallsFromStoreMock = vi.hoisted(() => vi.fn());
 const sleepMock = vi.hoisted(() =>
   vi.fn(
     async (ms: number) =>
@@ -22,6 +24,11 @@ vi.mock("openclaw/plugin-sdk/gateway-runtime", async (importOriginal) => ({
 vi.mock("../api.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api.js")>()),
   sleep: sleepMock,
+}));
+vi.mock("./manager/store.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./manager/store.js")>()),
+  findCallMatchesInStore: findCallMatchesInStoreMock,
+  loadActiveCallsFromStore: loadActiveCallsFromStoreMock,
 }));
 
 import { registerVoiceCallCli } from "./cli.js";
@@ -41,6 +48,8 @@ function captureStdout() {
 describe("voice-call CLI status fallback", () => {
   afterEach(() => {
     callGatewayFromCliMock.mockReset();
+    findCallMatchesInStoreMock.mockReset();
+    loadActiveCallsFromStoreMock.mockReset();
     sleepMock.mockReset();
     sleepMock.mockImplementation(
       async (ms: number) =>
@@ -67,11 +76,22 @@ describe("voice-call CLI status fallback", () => {
   }
 
   async function runStatusWithUnavailableGateway(
-    manager: Record<string, unknown>,
+    persisted: unknown,
     error = new Error("connect ECONNREFUSED 127.0.0.1:18789"),
   ): Promise<unknown> {
     callGatewayFromCliMock.mockRejectedValue(error);
-    const program = buildProgram(manager);
+    findCallMatchesInStoreMock.mockResolvedValue({ byCallId: persisted });
+    const ensureRuntime = vi.fn(async () => {
+      throw new Error("status fallback must not initialize the telephony runtime");
+    });
+    const program = new Command();
+    registerVoiceCallCli({
+      program,
+      config: {} as never,
+      ensureRuntime,
+      stateRuntime: {} as never,
+      logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
+    });
     const capturer = captureStdout();
     try {
       await program.parseAsync(["voicecall", "status", "--call-id", "call-1", "--json"], {
@@ -80,37 +100,59 @@ describe("voice-call CLI status fallback", () => {
     } finally {
       capturer.restore();
     }
+    expect(ensureRuntime).not.toHaveBeenCalled();
     return JSON.parse(capturer.output().trim());
   }
 
   it("uses the manager's persisted fallback when the gateway is unavailable", async () => {
     const result = await runStatusWithUnavailableGateway({
-      getActiveCalls: () => [],
-      getCallFromMemoryOrStore: async () => ({
-        callId: "call-1",
-        providerCallId: "CA123",
-        state: "completed",
-        endReason: "completed",
-        endedAt: 1,
-      }),
+      callId: "call-1",
+      providerCallId: "CA123",
+      state: "completed",
+      endReason: "completed",
+      endedAt: 1,
     });
     expect(result).toMatchObject({ callId: "call-1", state: "completed" });
   });
 
   it("reports found:false when the call is neither active nor persisted", async () => {
-    const result = await runStatusWithUnavailableGateway({
-      getActiveCalls: () => [],
-      getCallFromMemoryOrStore: async () => undefined,
-    });
+    const result = await runStatusWithUnavailableGateway(undefined);
     expect(result).toEqual({ found: false });
+  });
+
+  it("lists persisted active calls without initializing the telephony runtime", async () => {
+    callGatewayFromCliMock.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:18789"));
+    loadActiveCallsFromStoreMock.mockReturnValue({
+      activeCalls: new Map([["call-1", { callId: "call-1", state: "ringing" }]]),
+    });
+    const ensureRuntime = vi.fn(async () => {
+      throw new Error("status fallback must not initialize the telephony runtime");
+    });
+    const program = new Command();
+    registerVoiceCallCli({
+      program,
+      config: {} as never,
+      ensureRuntime,
+      stateRuntime: {} as never,
+      logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
+    });
+    const capturer = captureStdout();
+    try {
+      await program.parseAsync(["voicecall", "status", "--json"], { from: "user" });
+    } finally {
+      capturer.restore();
+    }
+
+    expect(ensureRuntime).not.toHaveBeenCalled();
+    expect(JSON.parse(capturer.output().trim())).toEqual({
+      found: true,
+      calls: [{ callId: "call-1", state: "ringing" }],
+    });
   });
 
   it("falls back after an abnormal local gateway close", async () => {
     const result = await runStatusWithUnavailableGateway(
-      {
-        getActiveCalls: () => [],
-        getCallFromMemoryOrStore: async () => ({ callId: "call-1", state: "completed" }),
-      },
+      { callId: "call-1", state: "completed" },
       new Error("gateway closed (1006 abnormal closure (no close frame)): no close reason"),
     );
     expect(result).toMatchObject({ callId: "call-1", state: "completed" });

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -75,12 +75,15 @@ describe("voice-call CLI status fallback", () => {
     return program;
   }
 
-  async function runStatusWithUnavailableGateway(
-    persisted: unknown,
-    error = new Error("connect ECONNREFUSED 127.0.0.1:18789"),
-  ): Promise<unknown> {
-    callGatewayFromCliMock.mockRejectedValue(error);
-    findCallMatchesInStoreMock.mockResolvedValue({ byCallId: persisted });
+  async function runStatusWithUnavailableGateway(params: {
+    persisted?: unknown;
+    error?: Error;
+    args?: string[];
+  }): Promise<unknown> {
+    callGatewayFromCliMock.mockRejectedValue(
+      params.error ?? new Error("connect ECONNREFUSED 127.0.0.1:18789"),
+    );
+    findCallMatchesInStoreMock.mockResolvedValue({ byCallId: params.persisted });
     const ensureRuntime = vi.fn(async () => {
       throw new Error("status fallback must not initialize the telephony runtime");
     });
@@ -94,9 +97,10 @@ describe("voice-call CLI status fallback", () => {
     });
     const capturer = captureStdout();
     try {
-      await program.parseAsync(["voicecall", "status", "--call-id", "call-1", "--json"], {
-        from: "user",
-      });
+      await program.parseAsync(
+        ["voicecall", "status", ...(params.args ?? ["--call-id", "call-1"]), "--json"],
+        { from: "user" },
+      );
     } finally {
       capturer.restore();
     }
@@ -106,55 +110,37 @@ describe("voice-call CLI status fallback", () => {
 
   it("uses the manager's persisted fallback when the gateway is unavailable", async () => {
     const result = await runStatusWithUnavailableGateway({
-      callId: "call-1",
-      providerCallId: "CA123",
-      state: "completed",
-      endReason: "completed",
-      endedAt: 1,
+      persisted: {
+        callId: "call-1",
+        providerCallId: "CA123",
+        state: "completed",
+        endReason: "completed",
+        endedAt: 1,
+      },
     });
     expect(result).toMatchObject({ callId: "call-1", state: "completed" });
   });
 
   it("reports found:false when the call is neither active nor persisted", async () => {
-    const result = await runStatusWithUnavailableGateway(undefined);
+    const result = await runStatusWithUnavailableGateway({});
     expect(result).toEqual({ found: false });
   });
 
   it("lists persisted active calls without initializing the telephony runtime", async () => {
-    callGatewayFromCliMock.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:18789"));
     loadActiveCallsFromStoreMock.mockReturnValue({
       activeCalls: new Map([["call-1", { callId: "call-1", state: "ringing" }]]),
     });
-    const ensureRuntime = vi.fn(async () => {
-      throw new Error("status fallback must not initialize the telephony runtime");
-    });
-    const program = new Command();
-    registerVoiceCallCli({
-      program,
-      config: {} as never,
-      ensureRuntime,
-      stateRuntime: {} as never,
-      logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
-    });
-    const capturer = captureStdout();
-    try {
-      await program.parseAsync(["voicecall", "status", "--json"], { from: "user" });
-    } finally {
-      capturer.restore();
-    }
-
-    expect(ensureRuntime).not.toHaveBeenCalled();
-    expect(JSON.parse(capturer.output().trim())).toEqual({
+    expect(await runStatusWithUnavailableGateway({ args: [] })).toEqual({
       found: true,
       calls: [{ callId: "call-1", state: "ringing" }],
     });
   });
 
   it("falls back after an abnormal local gateway close", async () => {
-    const result = await runStatusWithUnavailableGateway(
-      { callId: "call-1", state: "completed" },
-      new Error("gateway closed (1006 abnormal closure (no close frame)): no close reason"),
-    );
+    const result = await runStatusWithUnavailableGateway({
+      persisted: { callId: "call-1", state: "completed" },
+      error: new Error("gateway closed (1006 abnormal closure (no close frame)): no close reason"),
+    });
     expect(result).toMatchObject({ callId: "call-1", state: "completed" });
   });
 

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -19,7 +19,11 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sleep } from "../api.js";
 import { validateProviderConfig, type VoiceCallConfig } from "./config.js";
-import { getCallHistoryFromStore } from "./manager/store.js";
+import {
+  findCallMatchesInStore,
+  getCallHistoryFromStore,
+  loadActiveCallsFromStore,
+} from "./manager/store.js";
 import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "./runtime-state.js";
 import type { VoiceCallRuntime } from "./runtime.js";
 import { resolveDefaultVoiceCallStoreDir } from "./store-path.js";
@@ -716,15 +720,19 @@ export function registerVoiceCallCli(params: {
         writeStdoutJson(gateway.payload);
         return;
       }
-      const rt = await ensureRuntime();
+      // Status is a read-only command. Starting the telephony runtime here would
+      // bind the webhook port and keep this one-shot CLI process alive.
+      ensureHistoryStateRuntime();
+      const storePath = path.dirname(resolveDefaultStorePath(config));
       if (options.callId) {
-        const call = await rt.manager.getCallFromMemoryOrStore(options.callId);
+        const persisted = await findCallMatchesInStore(storePath, options.callId);
+        const call = persisted.byCallId ?? persisted.byProviderCallId;
         writeStdoutJson(call ?? { found: false });
         return;
       }
       writeStdoutJson({
         found: true,
-        calls: rt.manager.getActiveCalls(),
+        calls: Array.from(loadActiveCallsFromStore(storePath).activeCalls.values()),
       });
     });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw voicecall status` could remain alive and occupy the configured webhook port when the Gateway was unavailable. A later Gateway start then failed to initialize Voice Call with `EADDRINUSE` even though the status command had already printed its result.

## Why This Change Was Made

The offline status path now reads retained Voice Call state directly through the plugin state store, matching the existing history commands. It no longer initializes the telephony runtime, webhook listener, provider, or tunnel for a read-only query; live and mutating standalone fallbacks remain unchanged.

## User Impact

Offline Voice Call status queries exit normally after printing retained state and cannot steal the webhook port from the managed Gateway.

## Evidence

- Pre-fix focused regression: `extensions/voice-call/src/cli.test.ts` failed 4 of 15 tests because the offline status path invoked the injected telephony runtime.
- Post-fix focused regression: the CLI and plugin-index shards passed 63 of 63 tests.
- `git diff --check` passed.
- `autoreview --mode local` reported no accepted or actionable findings.

The full changed gate completed formatting, dependency and architecture guards, doctor contract tests, dead-export checks, and extension production/test typechecks before host saturation stalled the extension lint boundary-artifact step. Exact-head CI is the remaining broad proof.
