### PR TITLE
perf(test): replace Nostr startup drain wait with completion gate

### DIFF
--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -480,24 +480,56 @@ describe("startNostrBus inbound guards", () => {
     await bus.close();
   });
 
-  it("stops the ingress drain when startup state persistence fails", async () => {
+  it("awaits ingress drain shutdown when startup state persistence fails", async () => {
     const startupError = new Error("state unavailable");
     const claimNext = vi.spyOn(ingressQueue, "claimNext");
+    let notifyPruneStarted = () => {};
+    const pruneStarted = new Promise<void>((resolve) => {
+      notifyPruneStarted = resolve;
+    });
+    let releasePrune = () => {};
+    const pruneGate = new Promise<void>((resolve) => {
+      releasePrune = resolve;
+    });
+    let pruneActive = false;
+    const prune = vi.fn(async (...args: Parameters<typeof ingressQueue.prune>) => {
+      pruneActive = true;
+      notifyPruneStarted();
+      try {
+        await pruneGate;
+        return await ingressQueue.prune(...args);
+      } finally {
+        pruneActive = false;
+      }
+    });
+    setNostrRuntime({
+      state: {
+        openChannelIngressQueue: () => ({ ...ingressQueue, prune }),
+      },
+    } as unknown as PluginRuntime);
     mockState.writeNostrBusState.mockRejectedValueOnce(startupError);
 
-    await expect(
-      startTestNostrBus({
-        ...buildResolvedNostrAccount(),
-        onMessage: vi.fn(async () => {}),
-        onMetric: () => {},
-      }),
-    ).rejects.toThrow("state unavailable");
-
-    const callsAfterCleanup = claimNext.mock.calls.length;
-    await new Promise((resolve) => {
-      setTimeout(resolve, 600);
+    const startup = startTestNostrBus({
+      ...buildResolvedNostrAccount(),
+      onMessage: vi.fn(async () => {}),
+      onMetric: () => {},
     });
-    expect(claimNext).toHaveBeenCalledTimes(callsAfterCleanup);
+    const settled = vi.fn();
+    void startup.then(settled, settled);
+
+    await pruneStarted;
+    await Promise.resolve();
+    try {
+      expect(pruneActive).toBe(true);
+      expect(settled).not.toHaveBeenCalled();
+    } finally {
+      releasePrune();
+    }
+
+    await expect(startup).rejects.toThrow("state unavailable");
+    expect(pruneActive).toBe(false);
+    expect(prune).toHaveBeenCalledOnce();
+    expect(claimNext).not.toHaveBeenCalled();
   });
 
   it("links authorization replies to the inbound NIP-04 event", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Nostr inbound startup-cleanup test used a fixed 600 ms sleep after startup rejection to infer that the ingress drain had stopped. That made the focused test and its full files pay wall-clock time without directly proving the cleanup ordering.

## Why This Change Was Made

The startup rejection path already awaits `ingress.stop()`. The test now gates the queue prune performed by ingress startup, proves the startup promise remains pending while that pump work is active, releases the gate, observes the original state-persistence rejection, and verifies that no `claimNext` polling occurs. This preserves the ownership boundary while replacing elapsed-time inference with a completion gate.

## User Impact

There is no runtime or user-visible behavior change. The Nostr startup-cleanup regression remains protected while the test completes substantially faster. No changelog entry is needed for this test-only change.

## Evidence

- Controlled comparison: https://github.com/openclaw/openclaw/actions/runs/32047636790
  - Target test: 765 ms -> 121 ms (-84.2%).
  - Full wall time: 9.93 s -> 8.33 s (-1.60 s / -16.1%); test body improved by 0.75 s.
- Fault check: removing `ingress.stop()` from the startup cleanup path makes the new test observe `claimNext`, proving the test fails on the intended regression.
- Fresh exact-head Testbox proof: `tbx_01m08bkjet31yx486zz94p9m9w`, https://github.com/openclaw/openclaw/actions/runs/32049616401
  - Target x5 mean: 119 ms.
  - Full inbound: 29/29.
  - Full Nostr: 269/269.
  - Admission: 13/13.
  - Shared monitor: 22/22.
  - Changed gate: green.
- Fresh autoreview of `7a4802efa3eaeac9b2e1ef0f6388c2838c9809d6`: clean, 0.99, zero accepted/actionable findings.
