### PR TITLE
fix(discord): keep stable nested DM config upgradeable

### DIFF
--- a/extensions/discord/src/config-schema.test.ts
+++ b/extensions/discord/src/config-schema.test.ts
@@ -75,12 +75,41 @@ describe("discord config schema", () => {
     expectInvalidDiscordConfig({ mentionAliases: { opslead: "not-a-user-id" } });
   });
 
-  it("rejects legacy nested DM access keys", () => {
-    const issues = expectInvalidDiscordConfig({
-      dm: { policy: "open", allowFrom: [] },
+  it("normalizes shipped nested DM access keys at root and account scope", () => {
+    const cfg = expectValidDiscordConfig({
+      dmPolicy: "pairing",
+      allowFrom: ["canonical-root"],
+      dm: { enabled: false, policy: "open", allowFrom: ["legacy-root"] },
+      accounts: {
+        work: {
+          dmPolicy: "allowlist",
+          allowFrom: ["canonical-account"],
+          dm: { groupEnabled: true, policy: "disabled", allowFrom: ["legacy-account"] },
+        },
+        personal: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+        },
+      },
     });
 
-    expect(issues[0]?.path.join(".")).toBe("dm");
+    expect(cfg).toMatchObject({
+      dmPolicy: "pairing",
+      allowFrom: ["canonical-root"],
+      dm: { enabled: false },
+      accounts: {
+        work: {
+          dmPolicy: "allowlist",
+          allowFrom: ["canonical-account"],
+          dm: { groupEnabled: true },
+        },
+        personal: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          dm: { enabled: true },
+        },
+      },
+    });
+    expectInvalidDiscordConfig({ dm: { enabled: false, unexpected: true } });
   });
 
   it("accepts textChunkLimit without reviving legacy message limits", () => {

--- a/extensions/discord/src/config-schema.ts
+++ b/extensions/discord/src/config-schema.ts
@@ -1,3 +1,4 @@
+import { normalizeLegacyDmAliases } from "openclaw/plugin-sdk/channel-config-helpers";
 // Discord helper module supports config schema behavior.
 import {
   buildChannelAllowBotsSchema,
@@ -15,6 +16,7 @@ import {
   requireOpenAllowFrom,
   TtsConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   buildSecretInputSchema,
   registerSensitiveConfigSchema,
@@ -196,7 +198,7 @@ const DiscordVoiceSchema = z
   .strict()
   .optional();
 
-const DiscordAccountSchema = z
+const DiscordAccountSchemaBase = z
   .object({
     ...buildCommonChannelAccountShape({
       omit: ["groupAllowFrom"],
@@ -372,7 +374,32 @@ const DiscordAccountSchema = z
     // can inherit top-level allowFrom via runtime shallow merge.
   });
 
-export const DiscordConfigSchema = DiscordAccountSchema.extend({
+function normalizeShippedDiscordDmAliases(value: unknown): unknown {
+  const entry = asObjectRecord(value);
+  if (!entry) {
+    return value;
+  }
+
+  const updated = normalizeLegacyDmAliases({
+    entry,
+    pathPrefix: "channels.discord",
+    changes: [],
+  }).entry;
+  const dm = asObjectRecord(updated.dm);
+  if (!dm || (dm.policy === undefined && dm.allowFrom === undefined)) {
+    return updated;
+  }
+  const { policy: _policy, allowFrom: _allowFrom, ...retainedDm } = dm;
+  const { dm: _dm, ...rest } = updated;
+  return Object.keys(retainedDm).length > 0 ? { ...rest, dm: retainedDm } : rest;
+}
+
+const DiscordAccountSchema = z.preprocess(
+  normalizeShippedDiscordDmAliases,
+  DiscordAccountSchemaBase,
+);
+
+const DiscordConfigSchemaBase = DiscordAccountSchemaBase.extend({
   accounts: z.record(z.string(), DiscordAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
@@ -421,6 +448,11 @@ export const DiscordConfigSchema = DiscordAccountSchema.extend({
     });
   }
 });
+
+export const DiscordConfigSchema = z.preprocess(
+  normalizeShippedDiscordDmAliases,
+  DiscordConfigSchemaBase,
+);
 
 export const DiscordChannelConfigSchema = buildChannelConfigSchema(DiscordConfigSchema, {
   uiHints: discordChannelConfigUiHints,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading from stable `2026.7.1-2` could not start the current package when their valid Discord configuration still used `channels.discord.dm.policy` or `channels.discord.dm.allowFrom`, including account-scoped values. Current strict plugin validation rejected those shipped fields before Doctor could migrate them.

## Why This Change Was Made

The Discord config schema now normalizes the two shipped nested aliases through the existing DM compatibility owner before strict validation, at both root and account scope. Canonical `dmPolicy` / `allowFrom` values keep precedence, unrelated nested keys remain rejected, and Doctor remains the persistence owner.

Production LOC: +34/-2 (net +32) | Tests: +33/-4. The production growth is the compatibility transform required at the pre-Doctor validation boundary; it reuses the existing migration helper instead of duplicating policy semantics.

## User Impact

Users can update directly from the latest stable package without manually rewriting valid Discord DM access configuration first. Runtime behavior and strict rejection of unknown Discord DM keys are unchanged.

## Evidence

- Exact pre-fix current-main probe rejected the stable shape with `dm: Unrecognized keys: "policy", "allowFrom"`.
- Focused Discord schema + Doctor suites: 66/66 passed.
- Changed-file gate passed all selected format, extension/test typecheck, Oxlint, plugin-boundary, bundled-channel metadata, dead-export, database-first, import-cycle, and ratchet checks.
- `git diff --check` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings; patch correct at 0.98 confidence.
- Node 24.15.0 with provider/channel requests disabled; no live provider or channel request was made.
