### PR TITLE
fix(matrix): recover providers after disconnected sync stop

### DIFF
--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -393,6 +393,10 @@ describe("shared Matrix client generations", () => {
     expect(transient.abortSignal.aborted).toBe(true);
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     expect(client.stopAndPersist).not.toHaveBeenCalled();
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
 
     const firstLateRelease = transient.release({ mode: "persist" });
     const secondLateRelease = transient.release({ mode: "persist" });
@@ -602,6 +606,26 @@ describe("shared Matrix client generations", () => {
     expect(replacement.client).toBe(replacementClient);
     expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
     await replacement.release({ mode: "discard" });
+  });
+
+  it("keeps monitor cleanup failures poisoned", async () => {
+    const cause = new Error("monitor cleanup failed");
+    const client = createMockClient("main");
+    createMatrixClientMock.mockResolvedValue(client);
+    const auth = authFor("main");
+    const monitor = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    const retirement = createMonitorRetirement([]);
+    retirement.cleanup.mockRejectedValue(cause);
+
+    monitor.registerMonitorRetirement(retirement);
+    await expect(monitor.release({ mode: "persist" })).rejects.toBe(cause);
+    expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
   });
 
   it("preserves an earlier stop requirement when the final lease requests discard", async () => {

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -558,15 +558,18 @@ describe("shared Matrix client generations", () => {
     await replacement.release();
   });
 
-  it("poisons a timed-out generation, discards final state, and never reopens it automatically", async () => {
+  it("discards a timed-out generation and lets a later acquisition create a fresh client", async () => {
     const cause = new Error("Matrix classic sync did not reach STOPPED within 5000ms");
     const callOrder: string[] = [];
-    const client = createMockClient("main", callOrder);
-    client.quiesceSync.mockImplementation(async () => {
+    const timedOutClient = createMockClient("timed-out", callOrder);
+    const replacementClient = createMockClient("replacement");
+    timedOutClient.quiesceSync.mockImplementation(async () => {
       callOrder.push("quiesce");
       throw cause;
     });
-    createMatrixClientMock.mockResolvedValue(client);
+    createMatrixClientMock
+      .mockResolvedValueOnce(timedOutClient)
+      .mockResolvedValueOnce(replacementClient);
     const auth = authFor("main");
     const monitor = await acquireSharedMatrixClient({
       auth,
@@ -592,10 +595,13 @@ describe("shared Matrix client generations", () => {
 
     await expect(transient.release()).rejects.toBe(cause);
     expect(await releaseError).toBe(cause);
-    expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
-    expect(client.stopAndPersist).not.toHaveBeenCalled();
-    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
-    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+    expect(timedOutClient.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    expect(timedOutClient.stopAndPersist).not.toHaveBeenCalled();
+
+    const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
+    expect(replacement.client).toBe(replacementClient);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
+    await replacement.release({ mode: "discard" });
   });
 
   it("preserves an earlier stop requirement when the final lease requests discard", async () => {

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -345,18 +345,21 @@ function beginGenerationRetirement(params: {
   }
   state.phase = "quiescing";
   state.retirementPromise = Promise.resolve().then(async () => {
+    let canReplacePoisonedGeneration = false;
     try {
       await state.client.quiesceSync();
       state.started = false;
       await state.client.drainPendingDecryptions("matrix monitor sync quiesce");
     } catch (error) {
       state.poisonError = toRetirementError(error);
+      canReplacePoisonedGeneration = true;
     }
 
     try {
       await retireMonitorLeases(state, params.monitorLeases ?? []);
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
+      canReplacePoisonedGeneration = false;
     }
 
     state.phase = "closing";
@@ -364,16 +367,21 @@ function beginGenerationRetirement(params: {
       await waitForLeaseDrain(state);
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
+      canReplacePoisonedGeneration = false;
       forceReleaseLeases(state);
     }
 
     if (state.poisonError) {
-      try {
-        await state.client
-          .drainPendingDecryptions("matrix poisoned client shutdown")
-          .catch(() => undefined);
-        state.client.stopWithoutPersist();
-      } finally {
+      const decryptionsDrained = await state.client
+        .drainPendingDecryptions("matrix poisoned client shutdown")
+        .then(
+          () => true,
+          () => false,
+        );
+      state.client.stopWithoutPersist();
+      // Only sync/decryption poison is replaceable, after every other owner retired
+      // and the discarded client conclusively drained and stopped.
+      if (canReplacePoisonedGeneration && decryptionsDrained) {
         deleteSharedClientState(state);
       }
       throw state.poisonError;

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -368,10 +368,14 @@ function beginGenerationRetirement(params: {
     }
 
     if (state.poisonError) {
-      await state.client
-        .drainPendingDecryptions("matrix poisoned client shutdown")
-        .catch(() => undefined);
-      state.client.stopWithoutPersist();
+      try {
+        await state.client
+          .drainPendingDecryptions("matrix poisoned client shutdown")
+          .catch(() => undefined);
+        state.client.stopWithoutPersist();
+      } finally {
+        deleteSharedClientState(state);
+      }
       throw state.poisonError;
     }
 

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -10,6 +10,7 @@ import { MatrixError } from "matrix-js-sdk/lib/http-api/errors.js";
 import { type MatrixEvent, MsgType } from "matrix-js-sdk/lib/matrix.js";
 import { EventStatus } from "matrix-js-sdk/lib/models/event-status.js";
 import { SyncApi, SyncState } from "matrix-js-sdk/lib/sync.js";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 // Matrix tests cover sdk plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -19,6 +20,15 @@ import { readMatrixRecoveryKeyStateForPath } from "./crypto-state-store.js";
 import { MatrixDecryptBridge } from "./sdk/decrypt-bridge.js";
 
 const requireMatrixJsSdkPackage = createRequire(import.meta.url);
+
+type MatrixSyncApiTestInternals = {
+  connectionReturnedResolvers?: ReturnType<typeof createDeferred<boolean>>;
+};
+
+function requireMatrixSyncApiTestInternals(syncApi: unknown): MatrixSyncApiTestInternals {
+  // SAFETY: the test stub intentionally models the pinned SDK's private resolver field.
+  return syncApi as MatrixSyncApiTestInternals;
+}
 
 function requestUrl(input: RequestInfo | URL | undefined): string {
   if (!input) {
@@ -1539,11 +1549,9 @@ describe("MatrixClient request hardening", () => {
       const client = new MatrixClient("https://matrix.example.org", "token");
       await client.start();
       vi.spyOn(matrixJsClient.syncApi, "getSyncState").mockReturnValue(syncState);
-      const keepalive = Promise.withResolvers<boolean>();
+      const keepalive = createDeferred<boolean>();
       const keepaliveRejection = keepalive.promise.catch((error: unknown) => error);
-      const syncInternals = matrixJsClient.syncApi as SyncApi & {
-        connectionReturnedResolvers?: typeof keepalive;
-      };
+      const syncInternals = requireMatrixSyncApiTestInternals(matrixJsClient.syncApi);
       syncInternals.connectionReturnedResolvers = keepalive;
       matrixJsClient.classicSyncStop.mockImplementation(() => {});
 
@@ -1571,11 +1579,9 @@ describe("MatrixClient request hardening", () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
     await client.start();
     vi.spyOn(matrixJsClient.syncApi, "getSyncState").mockReturnValue(SyncState.Error);
-    const captured = Promise.withResolvers<boolean>();
-    const replacement = Promise.withResolvers<boolean>();
-    const syncInternals = matrixJsClient.syncApi as SyncApi & {
-      connectionReturnedResolvers?: typeof captured;
-    };
+    const captured = createDeferred<boolean>();
+    const replacement = createDeferred<boolean>();
+    const syncInternals = requireMatrixSyncApiTestInternals(matrixJsClient.syncApi);
     syncInternals.connectionReturnedResolvers = captured;
     matrixJsClient.classicSyncStop.mockImplementation(() => {
       syncInternals.connectionReturnedResolvers = replacement;
@@ -1622,9 +1628,7 @@ describe("MatrixClient request hardening", () => {
       });
       await client.start();
       vi.spyOn(matrixJsClient.syncApi, "getSyncState").mockReturnValue(state);
-      const syncInternals = matrixJsClient.syncApi as SyncApi & {
-        connectionReturnedResolvers?: unknown;
-      };
+      const syncInternals = requireMatrixSyncApiTestInternals(matrixJsClient.syncApi);
       expect(syncInternals.connectionReturnedResolvers).toBeUndefined();
       const emitter = (
         client as unknown as {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1651,8 +1651,13 @@ describe("MatrixClient request hardening", () => {
       );
       await vi.advanceTimersByTimeAsync(5_000);
       await rejection;
-      await expect(client.quiesceSync()).rejects.toThrow(
-        "Matrix classic sync did not reach STOPPED within 5000ms",
+      const repeatedOutcome = client.quiesceSync().then(
+        () => "resolved",
+        () => "rejected",
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(Promise.race([repeatedOutcome, Promise.resolve("pending")])).resolves.toBe(
+        "rejected",
       );
 
       expect(syncInternals.connectionReturnedResolvers).toBeUndefined();

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1532,6 +1532,66 @@ describe("MatrixClient request hardening", () => {
     expect(emitter.listenerCount("sync.state")).toBe(listenerCountBefore);
   });
 
+  it.each([SyncState.Error, SyncState.Reconnecting])(
+    "accepts protected sync stop from the SDK %s keepalive path without a STOPPED event",
+    async (syncState) => {
+      vi.useFakeTimers();
+      const client = new MatrixClient("https://matrix.example.org", "token");
+      await client.start();
+      vi.spyOn(matrixJsClient.syncApi, "getSyncState").mockReturnValue(syncState);
+      const keepalive = Promise.withResolvers<boolean>();
+      const keepaliveRejection = keepalive.promise.catch((error: unknown) => error);
+      const syncInternals = matrixJsClient.syncApi as SyncApi & {
+        connectionReturnedResolvers?: typeof keepalive;
+      };
+      syncInternals.connectionReturnedResolvers = keepalive;
+      matrixJsClient.classicSyncStop.mockImplementation(() => {});
+
+      const outcome = client.quiesceSync().then(
+        () => "resolved",
+        () => "rejected",
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      await expect(Promise.race([outcome, Promise.resolve("pending")])).resolves.toBe("resolved");
+      expect(matrixJsClient.classicSyncStop).toHaveBeenCalledTimes(1);
+      await expect(keepaliveRejection).resolves.toBe("SyncApi.stop() was called");
+      expect(syncInternals.connectionReturnedResolvers).toBeUndefined();
+      expect(matrixJsClient.stopClient).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+
+      await client.stopAndPersist();
+      expect(matrixJsClient.classicSyncStop).toHaveBeenCalledTimes(1);
+      expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("does not clear a keepalive resolver replaced during protected sync stop", async () => {
+    const client = new MatrixClient("https://matrix.example.org", "token");
+    await client.start();
+    vi.spyOn(matrixJsClient.syncApi, "getSyncState").mockReturnValue(SyncState.Error);
+    const captured = Promise.withResolvers<boolean>();
+    const replacement = Promise.withResolvers<boolean>();
+    const syncInternals = matrixJsClient.syncApi as SyncApi & {
+      connectionReturnedResolvers?: typeof captured;
+    };
+    syncInternals.connectionReturnedResolvers = captured;
+    matrixJsClient.classicSyncStop.mockImplementation(() => {
+      syncInternals.connectionReturnedResolvers = replacement;
+      queueMicrotask(() => {
+        matrixJsClient.emit("sync", SyncState.Stopped, SyncState.Error, undefined);
+      });
+    });
+
+    await client.quiesceSync();
+
+    expect(syncInternals.connectionReturnedResolvers).toBe(replacement);
+    captured.resolve(false);
+    replacement.resolve(false);
+    syncInternals.connectionReturnedResolvers = undefined;
+  });
+
   it("stops classic sync created by a partial startup before readiness", async () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
     const abortController = new AbortController();
@@ -1550,7 +1610,10 @@ describe("MatrixClient request hardening", () => {
     expect(matrixJsClient.stopClient).not.toHaveBeenCalled();
   });
 
-  it("times out classic sync quiesce without public stop and removes its waiter", async () => {
+  it.each([
+    { label: "active SYNCING", state: SyncState.Syncing },
+    { label: "stale ERROR", state: SyncState.Error },
+  ])("times out $label quiesce without public stop and discards its cursor", async ({ state }) => {
     vi.useFakeTimers();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sync-timeout-"));
     try {
@@ -1558,11 +1621,23 @@ describe("MatrixClient request hardening", () => {
         storageRootDir: tempDir,
       });
       await client.start();
+      vi.spyOn(matrixJsClient.syncApi, "getSyncState").mockReturnValue(state);
+      const syncInternals = matrixJsClient.syncApi as SyncApi & {
+        connectionReturnedResolvers?: unknown;
+      };
+      expect(syncInternals.connectionReturnedResolvers).toBeUndefined();
       const emitter = (
         client as unknown as {
           emitter: EventEmitter;
         }
       ).emitter;
+      const store = lastCreateClientOpts?.store as
+        | { discardPendingSyncCursorPersistence: () => void }
+        | undefined;
+      if (!store) {
+        throw new Error("expected Matrix sync store");
+      }
+      const discardSpy = vi.spyOn(store, "discardPendingSyncCursorPersistence");
       const listenerCountBefore = emitter.listenerCount("sync.state");
       matrixJsClient.classicSyncStop.mockImplementation(() => {});
 
@@ -1572,8 +1647,14 @@ describe("MatrixClient request hardening", () => {
       );
       await vi.advanceTimersByTimeAsync(5_000);
       await rejection;
+      await expect(client.quiesceSync()).rejects.toThrow(
+        "Matrix classic sync did not reach STOPPED within 5000ms",
+      );
 
+      expect(syncInternals.connectionReturnedResolvers).toBeUndefined();
+      expect(matrixJsClient.classicSyncStop).toHaveBeenCalledTimes(1);
       expect(matrixJsClient.stopClient).not.toHaveBeenCalled();
+      expect(discardSpy).toHaveBeenCalledTimes(1);
       expect(emitter.listenerCount("sync.state")).toBe(listenerCountBefore);
       expect(vi.getTimerCount()).toBe(0);
     } finally {

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -136,6 +136,7 @@ export abstract class MatrixClientBase {
     | import("./crypto-bootstrap.js").MatrixCryptoBootstrapper<MatrixRawEvent>
     | undefined;
   protected readonly autoBootstrapCrypto: boolean;
+  protected syncQuiescePromise: Promise<void> | null = null;
   protected stopPersistPromise: Promise<void> | null = null;
   protected verificationSummaryListenerBound = false;
   protected currentSyncState: MatrixSyncState | null = null;
@@ -558,7 +559,9 @@ export abstract class MatrixClientBase {
   }
 
   async quiesceSync(): Promise<void> {
-    await quiesceMatrixClientSync({
+    // Quiescence is terminal for a client generation. Memoize both success and
+    // failure so an untrusted cursor can never be persisted by a later retry.
+    this.syncQuiescePromise ??= quiesceMatrixClientSync({
       client: this.client,
       emitter: this.emitter,
       markStopped: () => {
@@ -567,6 +570,7 @@ export abstract class MatrixClientBase {
       started: this.started,
       syncStore: this.syncStore,
     });
+    await this.syncQuiescePromise;
   }
 
   async drainPendingDecryptions(reason = "matrix client shutdown"): Promise<void> {

--- a/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts
+++ b/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts
@@ -10,9 +10,14 @@ const MATRIX_JS_SDK_SYNC_VERSION = "41.9.0";
 const matrixJsSdkPackage = createRequire(import.meta.url)("matrix-js-sdk/package.json") as {
   version?: unknown;
 };
-type MatrixClassicSyncInternals = SyncApi & {
+type MatrixClassicSyncInternals = {
   connectionReturnedResolvers?: { reject: (reason?: unknown) => void };
 };
+
+function requireMatrixClassicSyncInternals(syncApi: unknown): MatrixClassicSyncInternals {
+  // SAFETY: the caller asserts the exact matrix-js-sdk version before using this private shape.
+  return syncApi as MatrixClassicSyncInternals;
+}
 
 function assertMatrixJsSdkSyncVersion(): void {
   const version = matrixJsSdkPackage.version;
@@ -61,9 +66,7 @@ export async function quiesceMatrixClientSync(params: {
   }
   const disconnectedBeforeStop =
     syncState === SyncState.Error || syncState === SyncState.Reconnecting;
-  // SAFETY: the exact matrix-js-sdk version is asserted above before accessing
-  // the pinned classic-sync keepalive resolver used by SyncApi.stop().
-  const syncInternals = syncApi as MatrixClassicSyncInternals;
+  const syncInternals = requireMatrixClassicSyncInternals(syncApi);
   const keepaliveResolvers = disconnectedBeforeStop
     ? syncInternals.connectionReturnedResolvers
     : undefined;

--- a/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts
+++ b/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts
@@ -10,6 +10,9 @@ const MATRIX_JS_SDK_SYNC_VERSION = "41.9.0";
 const matrixJsSdkPackage = createRequire(import.meta.url)("matrix-js-sdk/package.json") as {
   version?: unknown;
 };
+type MatrixClassicSyncInternals = SyncApi & {
+  connectionReturnedResolvers?: { reject: (reason?: unknown) => void };
+};
 
 function assertMatrixJsSdkSyncVersion(): void {
   const version = matrixJsSdkPackage.version;
@@ -51,10 +54,19 @@ export async function quiesceMatrixClientSync(params: {
         : "Matrix sync quiesce rejected a sliding or unknown matrix-js-sdk sync implementation",
     );
   }
-  if (syncApi.getSyncState() === SyncState.Stopped) {
+  const syncState = syncApi.getSyncState();
+  if (syncState === SyncState.Stopped) {
     params.markStopped();
     return;
   }
+  const disconnectedBeforeStop =
+    syncState === SyncState.Error || syncState === SyncState.Reconnecting;
+  // SAFETY: the exact matrix-js-sdk version is asserted above before accessing
+  // the pinned classic-sync keepalive resolver used by SyncApi.stop().
+  const syncInternals = syncApi as MatrixClassicSyncInternals;
+  const keepaliveResolvers = disconnectedBeforeStop
+    ? syncInternals.connectionReturnedResolvers
+    : undefined;
 
   await new Promise<void>((resolve, reject) => {
     let settled = false;
@@ -86,6 +98,13 @@ export async function quiesceMatrixClientSync(params: {
     params.emitter.on("sync.state", onSyncState);
     try {
       syncApi.stop();
+      // Exact-version internals: a parked keepalive emits no STOPPED. Rejecting its
+      // captured resolver unwinds it without retryImmediately() allocating a new one.
+      if (keepaliveResolvers && syncInternals.connectionReturnedResolvers === keepaliveResolvers) {
+        syncInternals.connectionReturnedResolvers = undefined;
+        keepaliveResolvers.reject("SyncApi.stop() was called");
+        settle();
+      }
     } catch (error) {
       params.syncStore?.discardPendingSyncCursorPersistence();
       settle(error instanceof Error ? error : new Error(String(error)));


### PR DESCRIPTION
## What Problem This Solves

A Matrix provider that is restarted while `matrix-js-sdk` classic sync is parked in its disconnected keepalive path can become permanently unrecoverable inside the gateway process.

The SDK's `SyncApi.stop()` fences that path, but version 41.9.0 does not emit a later `STOPPED` event there. OpenClaw waited only for `STOPPED`, timed out after five seconds, and retained the resulting `poisonError` in the keyed shared-client state. Every provider auto-restart then synchronously rethrew the old error instead of creating a new Matrix client.

On a real six-account deployment, Synapse and nginx recovered, but every OpenClaw Matrix account remained stopped and disconnected until the gateway process was replaced.

## Why This Change Was Made

This patch makes shutdown match the exact pinned SDK contract while preserving fail-closed cursor handling:

1. Freeze sync-cursor persistence before stopping classic sync, as before.
2. For SDK `ERROR`/`RECONNECTING`, capture the actual parked keepalive resolver.
3. Call protected `SyncApi.stop()`.
4. Settle without waiting for `STOPPED` only when the exact captured resolver is still installed; clear and reject it with the SDK's own `SyncApi.stop() was called` reason so the parked SDK task unwinds.
5. If no resolver exists, or it was replaced during stop, retain the existing real-`STOPPED` wait and five-second fail-closed timeout.
6. Memoize both successful and failed quiescence for the client generation, making the production `quiesceSync()` -> `stopAndPersist()` double call idempotent and preventing a timed-out generation from later persisting an untrusted cursor.
7. After a poisoned generation has drained leases and called `stopWithoutPersist()`, evict it from the shared-client registry in `finally`. The current caller still receives the original error, but a later provider retry creates a genuinely fresh client instead of reusing cached poison.

The exact SDK version assertion remains in place. This does not change Matrix dependencies or relax the timeout for active sync work.

## User Impact

Before this change, one disconnected health-monitor restart could strand a Matrix account for the lifetime of the gateway process. Provider auto-restart exhausted all attempts while replaying a stale five-second error in milliseconds.

After this change, the pinned SDK's parked keepalive path quiesces deterministically. Genuine uncertainty still discards the pending cursor and fails closed, but the discarded generation no longer poisons every future provider acquisition.

## Evidence

Production account labels below are anonymized consistently as `agent1` through `agent6`; timestamps, durations, versions, state transitions, and account cardinality are unchanged.

### Pinned `matrix-js-sdk` source contract

This source proof is independent of a live deployment: both sides of the comparison are commit-pinned. The Matrix extension pins `matrix-js-sdk` to exactly `41.9.0`, whose `v41.9.0` tag resolves to upstream commit [`ab387673152848cf676d264003b17f2e7e780370`](https://github.com/matrix-org/matrix-js-sdk/tree/ab387673152848cf676d264003b17f2e7e780370). The PR head is [`77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc`](https://github.com/openclaw/openclaw/commit/77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc).

The pinned SDK establishes the failure contract directly:

1. `SyncApi` owns the private [`connectionReturnedResolvers`](https://github.com/matrix-org/matrix-js-sdk/blob/ab387673152848cf676d264003b17f2e7e780370/src/sync.ts#L205-L218) used by disconnected keepalive.
2. [`SyncApi.stop()`](https://github.com/matrix-org/matrix-js-sdk/blob/ab387673152848cf676d264003b17f2e7e780370/src/sync.ts#L786-L802) sets `running = false`, aborts the current request, and clears `keepAliveTimer`, but it neither settles nor clears `connectionReturnedResolvers`.
3. After a sync error, [`onSyncError()`](https://github.com/matrix-org/matrix-js-sdk/blob/ab387673152848cf676d264003b17f2e7e780370/src/sync.ts#L1014-L1052) starts keepalive, publishes `RECONNECTING` or `ERROR`, and awaits that resolver-backed promise. [`startKeepAlives()`](https://github.com/matrix-org/matrix-js-sdk/blob/ab387673152848cf676d264003b17f2e7e780370/src/sync.ts#L1590-L1613) schedules the timer and creates the resolver. Clearing the timer in `stop()` can therefore leave the awaited promise unsettled, so execution does not reach the SDK's normal [`STOPPED` emission](https://github.com/matrix-org/matrix-js-sdk/blob/ab387673152848cf676d264003b17f2e7e780370/src/sync.ts#L925-L939).
4. The SDK's own stopped-keepalive branch defines the missing terminal action: [`pokeKeepAlive()`](https://github.com/matrix-org/matrix-js-sdk/blob/ab387673152848cf676d264003b17f2e7e780370/src/sync.ts#L1625-L1642) rejects the resolver with exactly `SyncApi.stop() was called`, clears it, and returns without emitting `STOPPED`.

The PR mirrors only that exact terminal action. It [asserts SDK version `41.9.0` before crossing the private boundary](https://github.com/openclaw/openclaw/blob/77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts#L8-L29), verifies the object is the classic `SyncApi`, captures a resolver only from pre-stop `ERROR`/`RECONNECTING`, calls `stop()`, then [clears and rejects only if the same resolver identity is still installed](https://github.com/openclaw/openclaw/blob/77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts#L49-L115). If the state is active, no resolver exists, or the resolver was replaced, the existing real-`STOPPED` wait and fail-closed cursor discard remain in force. The patch deliberately does not call `retryImmediately()`, which routes through `startKeepAlives(0)` and can create a replacement resolver.

This is intentionally narrow reliance on one private field in one exact SDK version, guarded by both a version assertion and resolver-identity check. A future SDK change fails closed rather than silently using a changed private contract. Whether OpenClaw should carry that bounded private-field dependency remains an explicit maintainer decision.

### Evidence scope

The commit-pinned SDK comparison remains independent of deployment state. The first production-after trace below is retained as evidence for built behavior commit `c17e4ff4`. A second production-after trace now covers the final PR head `77f4df4e` applied to exact integration head `e8a5035`, which was 299 commits ahead of the cut used for the original PR submission. That newer trace exercises all six production accounts through the disconnected health-restart path and proves recovery without replacing the gateway process.

### Production before: six accounts remained poisoned after the server recovered

Incident runtime:

- OpenClaw `2026.8.1`, gateway source `793669c8f6dd`
- Current PR base `1ea18c8cd8c`; the relevant Matrix files were byte-identical between those revisions
- Bundled Matrix plugin `2026.8.1`
- `matrix-js-sdk` `41.9.0`
- Synapse `1.150.0`; nginx `1.29.8`

Initial failure chain on 2026-08-17 (UTC+03:00):

```text
18:57:04.519 [matrix:agent1] health-monitor: restarting (reason: disconnected)
18:57:09.653 [matrix:agent2] health-monitor: restarting (reason: disconnected)
18:57:12.631 Sync startup aborted with an error: SyncApi.stop() was called
18:57:14.659 [matrix:agent3] health-monitor: restarting (reason: disconnected)
18:57:19.665 [matrix:agent4] health-monitor: restarting (reason: disconnected)
18:57:24.672 [matrix:agent5] health-monitor: restarting (reason: disconnected)
18:57:30.363 [matrix:agent6] health-monitor: restarting (reason: disconnected)
```

Before the final failed retry cycle, the homeserver path was independently healthy:

```text
20:46:45 GET :8008/_matrix/client/versions -> HTTP 200 (1.722 ms)
20:46:45 GET :8010/_matrix/client/versions -> HTTP 200 (1.940 ms)
20:46:45 GET :8086/health -> HTTP 200
20:46:45 GET :8087/health -> HTTP 200
20:46:45 GET :9088/health -> HTTP 200
20:46:45 GET :9089/health -> HTTP 200
```

Nevertheless, attempt 10/10 for every account replayed the nominal `5000ms` error in only 2-5 ms:

| Account | Provider start | Same cached error | Elapsed |
|---|---:|---:|---:|
| agent4 | 20:48:20.242 | 20:48:20.247 | 5 ms |
| agent3 | 20:48:20.249 | 20:48:20.252 | 3 ms |
| agent5 | 20:48:23.679 | 20:48:23.681 | 2 ms |
| agent1 | 20:48:27.177 | 20:48:27.180 | 3 ms |
| agent2 | 20:48:27.257 | 20:48:27.259 | 2 ms |
| agent6 | 20:48:29.984 | 20:48:29.986 | 2 ms |

At 20:49:19, the reachable gateway reported all six configured accounts as enabled/configured but stopped, disconnected, and in health error with `Matrix classic sync did not reach STOPPED within 5000ms`. The 2-5 ms rethrows prove cached poison rather than a fresh five-second server timeout.

### Regression proof

On unmodified `main`, the new tests failed at both causal boundaries while the prior 158 owner-suite tests passed:

- disconnected keepalive quiescence remained pending waiting for an event the pinned SDK never emits;
- acquisition after poisoned retirement rethrew the cached timeout and created no replacement client.

On this branch:

```text
pnpm test extensions/matrix/src/matrix/sdk.test.ts extensions/matrix/src/matrix/client/shared.test.ts
Test Files  2 passed (2)
Tests       163 passed (163)

pnpm test:extension matrix
Test Files  122 passed (122)
Tests       1931 passed (1931)

pnpm build
exit 0
```

Coverage includes parked `ERROR` and `RECONNECTING`, stale `ERROR` without a resolver, active `SYNCING`, resolver replacement during stop, double quiescence through `stopAndPersist()`, permanent rejection memoization after cursor discard, and fresh acquisition after poisoned retirement.

### Production after

The exact built head `c17e4ff4e41958327d336e83846f6003a959bbb6` was applied to the incident installation with one ordinary managed-gateway restart at 21:04:50. No force restart or repeated restart was used. The old process completed shutdown cleanly in 1.749 seconds. The replacement process then completed the installation's known slow SQLite startup and reported:

```text
21:09:26.683 http server listening (...; 168.5s)
21:09:45.982 [agent1] starting provider
21:09:45.982 [agent2] starting provider
21:09:45.983 [agent3] starting provider
21:09:45.983 [agent4] starting provider
21:09:45.983 [agent5] starting provider
21:09:45.983 [agent6] starting provider
21:09:46.054 gateway ready
21:09:47.799 matrix: logged in as agent5
21:09:47.829 matrix: logged in as agent6
21:09:47.837 matrix: logged in as agent1
21:09:47.850 matrix: logged in as agent2
21:09:47.858 matrix: logged in as agent4
21:09:47.874 matrix: logged in as agent3
```

At 21:10:04, a live gateway status query reported each of the six configured accounts with:

```text
running=true
connected=true
healthState=healthy
lifecycle=ready
restartPending=false
reconnectAttempts=0
lastError=null
```

The first post-start syncs included transient nginx 502s, then recovered in-process: all six clients logged `Resuming queue after resumed sync` instead of entering the old cached-poison loop. The gateway also recovered four real pending Matrix deliveries between 21:09:50.337 and 21:09:51.085; the delivery summary was `4 recovered, 0 failed, 0 skipped, 0 deferred`.

Finally, a unique live probe traversed the complete path through an existing two-member room: Matrix user -> homeserver -> recovered OpenClaw `agent5` provider -> agent -> Matrix reply. The reply matched the requested probe exactly. The homeserver recorded inbound at 21:14:05.629 and outbound at 21:14:16.162, a 10.533-second round trip (10.652 seconds client-observed). Sanitized correlation hashes: room `c98e15387b9d`, inbound event `9d3a5bdbcf2c`, outbound event `d207b143fabb`. The ephemeral client login used for the probe was revoked afterward.

No `Matrix classic sync did not reach STOPPED within 5000ms` error occurred after the patched process started.


### Production after: final PR head on exact integration head `e8a5035`

The final PR head [`77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc`](https://github.com/openclaw/openclaw/commit/77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc) was applied to exact integration head [`e8a5035ca6bf2604665aad6c54d2c346221bc3a6`](https://github.com/openclaw/openclaw/commit/e8a5035ca6bf2604665aad6c54d2c346221bc3a6), which was 299 commits ahead of the cut used for the original PR submission. The running composite revision was `d5f8d87ec72b383b6318d5183c6c33f38bce5316`; its two parents are exactly `e8a5035` and `77f4df4e`, and both are ancestors of the clean installed worktree.

The gateway process started from that composite build at 23:44:36 UTC+03:00 on 2026-08-18. At 01:34 on 2026-08-19, all six production Matrix accounts entered a real disconnected health-monitor restart inside that same gateway process:

```text
01:34:25.642 [matrix:agent1] health-monitor: restarting (reason: disconnected)
01:34:25.823 Sync startup aborted with an error: SyncApi.stop() was called
01:34:26.049 [matrix:agent2] health-monitor: restarting (reason: disconnected)
01:34:26.072 Sync startup aborted with an error: SyncApi.stop() was called
01:34:26.310 [matrix:agent3] health-monitor: restarting (reason: disconnected)
01:34:26.330 Sync startup aborted with an error: SyncApi.stop() was called
01:34:26.600 [matrix:agent4] health-monitor: restarting (reason: disconnected)
01:34:26.604 Sync startup aborted with an error: SyncApi.stop() was called
01:34:26.772 [matrix:agent5] health-monitor: restarting (reason: disconnected)
01:34:26.777 Sync startup aborted with an error: SyncApi.stop() was called
01:34:26.958 [matrix:agent6] health-monitor: restarting (reason: disconnected)
01:34:26.961 Sync startup aborted with an error: SyncApi.stop() was called
```

This is the exact pinned-SDK terminal branch addressed by the PR: each stopped disconnected generation reached the SDK's own `SyncApi.stop() was called` rejection. Instead of waiting five seconds for a `STOPPED` event that this branch does not emit, every account acquired a fresh provider generation in 149-445 ms:

| Account | Restart requested | Fresh provider start | Elapsed |
|---|---:|---:|---:|
| agent1 | 01:34:25.642 | 01:34:26.087 | 445 ms |
| agent2 | 01:34:26.049 | 01:34:26.339 | 290 ms |
| agent3 | 01:34:26.310 | 01:34:26.605 | 295 ms |
| agent4 | 01:34:26.600 | 01:34:26.788 | 188 ms |
| agent5 | 01:34:26.772 | 01:34:26.963 | 191 ms |
| agent6 | 01:34:26.958 | 01:34:27.107 | 149 ms |

All six replacement clients then completed fresh Matrix login in-process:

```text
01:34:36.685 matrix: logged in as agent5
01:34:39.830 matrix: logged in as agent6
01:34:40.097 matrix: logged in as agent4
01:34:40.338 matrix: logged in as agent3
01:34:40.524 matrix: logged in as agent1
01:34:40.656 matrix: logged in as agent2
```

No gateway restart or process replacement occurred during this recovery. From the composite gateway's 23:44:36 start through the post-recovery check, the log contains zero `Matrix classic sync did not reach STOPPED within 5000ms` errors and zero Matrix `channel exited` events.

At 02:08:22 UTC+03:00, a fresh live `channels status` query reported all six configured production accounts with the same healthy terminal state:

```text
enabled=true
configured=true
running=true
connected=true
healthState=healthy
lifecycle=ready
restartPending=false
reconnectAttempts=0
lastError=null
```

This newer-base run directly covers both causal boundaries requested in review: parked disconnected sync shutdown completed without the impossible `STOPPED` wait, and each retired generation was followed by fresh client acquisition and a healthy provider rather than a cached-poison rethrow.
## Safety and Scope

- No dependency or lockfile changes.
- No Synapse, nginx, Matrix worker, credential, room, or schema changes.
- Active or ambiguous sync states still require a real `STOPPED` event or fail closed after five seconds.
- Timeout still discards pending cursor persistence.
- A failed quiescence remains permanently failed for that client generation.
- A poisoned generation is evicted only after monitor retirement, lease draining, decryption draining, and `stopWithoutPersist()`.

