### PR TITLE
chore(macos): update Peekaboo revision

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "07a0ad2130048d602c404224b9c6b7a17ce9751536369cfec603701121bf93df",
+  "originHash" : "3d772c15878cee29346b54b6cb85f5a08bff6570cfbee044b340bc8d1b2e57fa",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "a48c462c757acbf320b22a6c9b34852e26bcb763"
+        "revision" : "6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "a48c462c757acbf320b22a6c9b34852e26bcb763"),
+            revision: "6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's macOS elevation host still embeds the earlier Peekaboo 4.2.1 candidate and therefore misses the landed fail-closed background-keyboard target planner.

## Why This Change Was Made

Pins the macOS package to landed Peekaboo `6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605` and lets SwiftPM regenerate the lockfile origin hash. The change is deliberately limited to the manifest and resolved file; every transitive dependency remains byte-identical.

## User Impact

OpenClaw's next macOS elevation build will use the final background-first Peekaboo planner, so fuzzy application selectors and incomplete window inventories refuse before type, paste, or keypress dispatch instead of risking input to an unproven target. No configuration or migration is required.

## Evidence

- Base `5fe5d26007cc53ccd4818d9bc2b36c8c2da7a5f2` contains codesign merge `49af98c12bb4748637353c575a9416df33549439` and the final native-locale merge.
- SwiftPM `resolve` and `dump-package` select exactly `6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605`; a second resolve is byte-stable.
- All non-Peekaboo pins are unchanged; `git diff --check` passes.
- Focused package/elevation proof: 142/142 tests passed.
- `pnpm check:changed` passed, including dependency/format guards, SwiftLint with zero violations, and 462 macOS CI tests across seven Vitest shards.
- Unsigned release build passed: `swift build --package-path apps/macos --product OpenClaw --configuration release`.
- Fresh P2 autoreview reported no actionable finding at 0.97 confidence.

Local direct `swift test --package-path apps/macos` compiled the full package but SwiftPM's Xcode 27 test helper did not stage `Sparkle.framework` on the test-bundle rpath. Exact-head `macos-swift` CI on the repository's supported Xcode 26 runner remains the authoritative package-test proof.
