### PR TITLE
fix(msteams): approval buttons time out in Teams

### DIFF
--- a/extensions/msteams/src/approval-control.ts
+++ b/extensions/msteams/src/approval-control.ts
@@ -1,0 +1,122 @@
+import { isImplicitSameChatApprovalAuthorization } from "openclaw/plugin-sdk/approval-auth-runtime";
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { msTeamsApprovalAuth } from "./approval-auth.js";
+import { formatUnknownError } from "./errors.js";
+import { stripMSTeamsMentionTags } from "./inbound.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
+import { getMSTeamsRuntime } from "./runtime.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+async function sendApprovalStatus(params: {
+  context: MSTeamsTurnContext;
+  deps: MSTeamsMessageHandlerDeps;
+  text: string;
+}): Promise<void> {
+  try {
+    await params.context.sendActivity(params.text);
+  } catch (error) {
+    params.deps.log.debug?.("failed to send approval control status", {
+      error: formatUnknownError(error),
+    });
+  }
+}
+
+export async function maybeHandleMSTeamsApprovalControl(params: {
+  context: MSTeamsTurnContext;
+  deps: MSTeamsMessageHandlerDeps;
+  text: string;
+}): Promise<boolean> {
+  const allowTextCommands = getMSTeamsRuntime().channel.commands.shouldHandleTextCommands({
+    cfg: params.deps.cfg,
+    surface: "msteams",
+  });
+  if (!allowTextCommands) {
+    return false;
+  }
+  const parsed = parseExecApprovalCommandText(stripMSTeamsMentionTags(params.text));
+  if (!parsed) {
+    return false;
+  }
+
+  const senderId = params.context.activity.from?.aadObjectId;
+  const approvalKind = parsed.approvalId.startsWith("plugin:") ? "plugin" : "exec";
+  const access = await resolveMSTeamsSenderAccess({
+    cfg: params.deps.cfg,
+    accountId: params.deps.accountId,
+    activity: params.context.activity,
+    hasControlCommand: true,
+  });
+  const senderAdmitted = access.isDirectMessage
+    ? !access.msteamsCfg || access.senderAccess.decision === "allow"
+    : (!access.msteamsCfg ||
+        !access.channelGate.allowlistConfigured ||
+        access.channelGate.allowed) &&
+      access.senderAccess.allowed;
+  const accountId = params.deps.accountId ?? access.pairing.accountId;
+  const authorization = msTeamsApprovalAuth.authorizeActorAction?.({
+    cfg: params.deps.cfg,
+    accountId,
+    senderId,
+    action: "approve",
+    approvalKind,
+  });
+  const explicitlyAuthorized = authorization
+    ? authorization.authorized && !isImplicitSameChatApprovalAuthorization(authorization)
+    : false;
+  const commandAuthorized = access.commandAccess.authorized;
+  if (!senderAdmitted || (!commandAuthorized && !explicitlyAuthorized)) {
+    params.deps.log.debug?.("dropping approval control from unauthorized sender", {
+      accountId,
+      sender: senderId ?? "unknown",
+      approvalKind,
+      senderAdmitted,
+      commandAuthorized,
+      explicitlyAuthorized,
+    });
+    return true;
+  }
+
+  try {
+    await resolveApprovalOverGateway({
+      cfg: params.deps.cfg,
+      approvalId: parsed.approvalId,
+      decision: parsed.decision,
+      channel: "msteams",
+      accountId,
+      senderId,
+      approvalKind,
+      ...(params.deps.approvalGatewayRuntime
+        ? { gatewayRuntime: params.deps.approvalGatewayRuntime }
+        : {}),
+      clientDisplayName: `Microsoft Teams approval (${senderId?.trim() || "unknown"})`,
+    });
+  } catch (error) {
+    params.deps.log.error("failed to resolve approval control", {
+      accountId,
+      approvalId: parsed.approvalId,
+      approvalKind,
+      sender: senderId ?? "unknown",
+      error: formatUnknownError(error),
+    });
+    await sendApprovalStatus({
+      context: params.context,
+      deps: params.deps,
+      text: "❌ Failed to submit approval.",
+    });
+    return true;
+  }
+  params.deps.log.info("resolved approval control", {
+    accountId,
+    approvalId: parsed.approvalId,
+    decision: parsed.decision,
+    sender: senderId ?? "unknown",
+  });
+  await sendApprovalStatus({
+    context: params.context,
+    deps: params.deps,
+    text: `✅ Approval ${parsed.decision} submitted for ${parsed.approvalId}.`,
+  });
+  return true;
+}

--- a/extensions/msteams/src/channel.startup.test.ts
+++ b/extensions/msteams/src/channel.startup.test.ts
@@ -1,0 +1,63 @@
+// Microsoft Teams gateway startup must preserve the active account identity.
+import { createStartAccountContext } from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedMSTeamsAccount } from "./channel-config.js";
+
+const monitorMSTeamsProvider = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("./index.js", () => ({ monitorMSTeamsProvider }));
+
+import { msteamsPlugin } from "./channel.js";
+
+function requireStartAccount() {
+  const startAccount = msteamsPlugin.gateway?.startAccount;
+  if (!startAccount) {
+    throw new Error("expected Microsoft Teams gateway startAccount");
+  }
+  return startAccount;
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      msteams: {
+        enabled: true,
+        appId: "app-id",
+        appPassword: "app-password", // pragma: allowlist secret
+        tenantId: "tenant-id",
+        webhook: { port: 0 },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("msteamsPlugin gateway.startAccount", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["jimmy", "david"])(
+    "passes active account %s into the provider monitor",
+    async (accountId) => {
+      const account: ResolvedMSTeamsAccount = {
+        accountId,
+        enabled: true,
+        configured: true,
+      };
+      const context = createStartAccountContext({ account, cfg: createConfig() });
+
+      await requireStartAccount()(context);
+
+      expect(monitorMSTeamsProvider).toHaveBeenCalledOnce();
+      expect(monitorMSTeamsProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: context.cfg,
+          accountId,
+          runtime: context.runtime,
+          abortSignal: context.abortSignal,
+        }),
+      );
+    },
+  );
+});

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1071,6 +1071,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           ctx.log?.info(`starting provider (port ${port})`);
           return monitorMSTeamsProvider({
             cfg: ctx.cfg,
+            accountId: ctx.accountId,
             runtime: ctx.runtime,
             abortSignal: ctx.abortSignal,
             statusSink,

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -1,4 +1,5 @@
 // Msteams tests cover monitor handler.adaptive card plugin behavior.
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
@@ -9,9 +10,11 @@ import {
   installMSTeamsTestRuntime,
 } from "./monitor-handler.test-helpers.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import { buildMSTeamsPresentationCard } from "./presentation.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 const runtimeApiMockState = getMSTeamsTestRuntimeState();
+const APPROVER_ID = "5e4b4b6f-c242-45de-b0de-bf44eb233145";
 
 vi.mock("./reply-dispatcher.js", () => ({
   createMSTeamsReplyDispatcher: () => ({
@@ -91,6 +94,7 @@ async function runMessageActivity(params: {
   value?: unknown;
   text?: string;
   deps?: MSTeamsMessageHandlerDeps;
+  senderId?: string;
 }) {
   const deps = params.deps ?? createDeps();
   let messageHandler: Parameters<MSTeamsActivityHandler["onMessage"]>[0] | undefined;
@@ -115,7 +119,7 @@ async function runMessageActivity(params: {
         serviceUrl: "https://service.example.test",
         from: {
           id: "user-bf",
-          aadObjectId: "user-aad",
+          aadObjectId: params.senderId ?? "user-aad",
           name: "User",
         },
         recipient: {
@@ -150,6 +154,98 @@ function lastDispatchedCtxPayload(): Record<string, unknown> {
 describe("msteams adaptive card action invoke", () => {
   beforeEach(() => {
     runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+  });
+
+  it("renders and resolves a typed approval before agent dispatch", async () => {
+    const card = buildMSTeamsPresentationCard({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Allow Once",
+                action: {
+                  type: "approval",
+                  approvalId: "plugin:approval-1",
+                  approvalKind: "plugin",
+                  decision: "allow-once",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const submittedData = (card.actions?.[0] as { data?: unknown } | undefined)?.data;
+    const gatewayRequest = vi.fn(
+      async (): Promise<ApprovalResolveResult> => ({
+        applied: true,
+        approval: {
+          id: "plugin:approval-1",
+          urlPath: "/approve/plugin%3Aapproval-1",
+          createdAtMs: 1,
+          expiresAtMs: 10_000,
+          resolvedAtMs: 2,
+          reason: "user",
+          presentation: {
+            kind: "plugin",
+            title: "Send Outlook message",
+            description: "Send this exact prepared Outlook message now.",
+            severity: "info",
+            allowedDecisions: ["allow-once", "deny"],
+          },
+          status: "allowed",
+          decision: "allow-once",
+        },
+      }),
+    );
+    const deps = createDeps();
+    deps.accountId = "jimmy";
+    deps.cfg = {
+      channels: { msteams: { allowFrom: [APPROVER_ID] } },
+    } as OpenClawConfig;
+    deps.approvalGatewayRuntime = { request: gatewayRequest };
+
+    await runMessageActivity({ value: submittedData, deps, senderId: APPROVER_ID });
+
+    expect(deps.log.debug).not.toHaveBeenCalled();
+    expect(deps.log.error).not.toHaveBeenCalled();
+    expect(deps.runtime.error).not.toHaveBeenCalled();
+    expect(gatewayRequest).toHaveBeenCalledWith(
+      "approval.resolve",
+      {
+        id: "plugin:approval-1",
+        kind: "plugin",
+        decision: "allow-once",
+        reviewer: {
+          channel: "msteams",
+          accountId: "jimmy",
+          senderId: APPROVER_ID,
+        },
+      },
+      { clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})` },
+    );
+    expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("consumes an unauthorized approval before gateway or agent dispatch", async () => {
+    const gatewayRequest = vi.fn();
+    const deps = createDeps();
+    deps.accountId = "jimmy";
+    deps.cfg = {
+      channels: { msteams: { allowFrom: [APPROVER_ID] } },
+    } as OpenClawConfig;
+    deps.approvalGatewayRuntime = { request: gatewayRequest };
+
+    await runMessageActivity({
+      text: "/approve plugin:approval-1 allow-once",
+      deps,
+      senderId: "6e4b4b6f-c242-45de-b0de-bf44eb233146",
+    });
+
+    expect(gatewayRequest).not.toHaveBeenCalled();
+    expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("forwards adaptive card submitted data to the agent as message text", async () => {

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,6 +1,7 @@
 // Msteams plugin module implements monitor handler behavior.
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { serializeMSTeamsAdaptiveCardActionValue } from "./adaptive-card-submit.js";
+import { maybeHandleMSTeamsApprovalControl } from "./approval-control.js";
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
@@ -155,6 +156,9 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "adaptiveCard/action") {
         const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
         if (text) {
+          if (await maybeHandleMSTeamsApprovalControl({ context: ctx, deps, text })) {
+            return;
+          }
           return await handleTeamsMessage(
             {
               ...ctx,
@@ -181,7 +185,13 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       await next();
     };
     try {
-      const result = await handleTeamsMessage(context as MSTeamsTurnContext, turnAdoptionLifecycle);
+      const ctx = context as MSTeamsTurnContext;
+      const text =
+        serializeMSTeamsAdaptiveCardActionValue(ctx.activity.value) ?? ctx.activity.text ?? "";
+      const handledApproval = await maybeHandleMSTeamsApprovalControl({ context: ctx, deps, text });
+      const result = handledApproval
+        ? undefined
+        : await handleTeamsMessage(ctx, turnAdoptionLifecycle);
       await runNext();
       return result;
     } catch (err) {

--- a/extensions/msteams/src/monitor-handler.types.ts
+++ b/extensions/msteams/src/monitor-handler.types.ts
@@ -1,12 +1,27 @@
 // Msteams type declarations define plugin contracts.
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import type { MSTeamsPollStore } from "./polls.js";
 import type { MSTeamsApp } from "./sdk.js";
 
+type MSTeamsApprovalGatewayRuntime = {
+  request: (
+    method: "approval.resolve",
+    params: {
+      id: string;
+      kind: "exec" | "plugin" | "system-agent";
+      decision: "allow-once" | "allow-always" | "deny";
+      reviewer?: { channel: string; accountId: string; senderId: string };
+    },
+    options?: { clientDisplayName?: string },
+  ) => Promise<ApprovalResolveResult>;
+};
+
 export type MSTeamsMessageHandlerDeps = {
   cfg: OpenClawConfig;
+  accountId?: string;
   runtime: RuntimeEnv;
   appId: string;
   app: MSTeamsApp;
@@ -18,4 +33,5 @@ export type MSTeamsMessageHandlerDeps = {
   conversationStore: MSTeamsConversationStore;
   pollStore: MSTeamsPollStore;
   log: MSTeamsMonitorLogger;
+  approvalGatewayRuntime?: MSTeamsApprovalGatewayRuntime;
 };

--- a/extensions/msteams/src/monitor-handler/access.ts
+++ b/extensions/msteams/src/monitor-handler/access.ts
@@ -113,12 +113,14 @@ function formatMSTeamsSenderReason(params: {
 
 export async function resolveMSTeamsSenderAccess(params: {
   cfg: OpenClawConfig;
+  accountId?: string;
   activity: MSTeamsTurnContext["activity"];
   hasControlCommand?: boolean;
   conversationThreadId?: string;
   contextBinding?: ChannelIngressContextBinding;
 }) {
   const activity = params.activity;
+  const accountId = params.accountId ?? DEFAULT_ACCOUNT_ID;
   const msteamsCfg = params.cfg.channels?.msteams;
   const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "unknown");
   const convType = normalizeOptionalLowercaseString(activity.conversation?.conversationType);
@@ -130,7 +132,7 @@ export async function resolveMSTeamsSenderAccess(params: {
   const pairing = createChannelPairingController({
     core,
     channel: "msteams",
-    accountId: DEFAULT_ACCOUNT_ID,
+    accountId,
   });
   const dmPolicy = msteamsCfg?.dmPolicy ?? "pairing";
   const configuredDmAllowFrom = msteamsCfg?.allowFrom ?? [];

--- a/extensions/msteams/src/monitor-ingress-mock.test-support.ts
+++ b/extensions/msteams/src/monitor-ingress-mock.test-support.ts
@@ -13,7 +13,7 @@ const ingressMockState = vi.hoisted(() => ({
     accept: Mock<(activity: unknown, context?: unknown) => Promise<void>>;
     start: ReturnType<typeof vi.fn>;
     stop: ReturnType<typeof vi.fn>;
-    options: { dispatch: IngressDispatch };
+    options: { accountId: string; dispatch: IngressDispatch };
   }>,
 }));
 
@@ -22,7 +22,7 @@ export function getMSTeamsIngressMockState() {
 }
 
 vi.mock("./msteams-ingress.js", () => ({
-  createMSTeamsIngress: (options: { dispatch: IngressDispatch }) => {
+  createMSTeamsIngress: (options: { accountId: string; dispatch: IngressDispatch }) => {
     const lifecycle = {
       abortSignal: new AbortController().signal,
       onAdopted: vi.fn(),

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -272,6 +272,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     const stores = createStores();
     const task = monitorMSTeamsProvider({
       cfg: createConfig(0),
+      accountId: "jimmy",
       runtime: createRuntime(),
       abortSignal: abort.signal,
       conversationStore: stores.conversationStore,
@@ -290,6 +291,8 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await waitForMSTeamsTestState(() => {
       expect(keepHttpServerTaskAliveMock).toHaveBeenCalledTimes(1);
     });
+    expect(registerMSTeamsHandlers.mock.calls[0]?.[1]?.accountId).toBe("jimmy");
+    expect(getMSTeamsIngressMockState().instances[0]?.options.accountId).toBe("jimmy");
     await Promise.resolve();
     expect(taskSettled).toBe(false);
 

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,6 +1,7 @@
 // Msteams plugin module implements monitor behavior.
 import type { Server } from "node:http";
 import type { Request, Response } from "express";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
   isDangerousNameMatchingEnabled,
@@ -67,6 +68,7 @@ import { applyMSTeamsWebhookTimeouts } from "./webhook-timeouts.js";
 
 type MonitorMSTeamsOpts = {
   cfg: OpenClawConfig;
+  accountId?: string;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   conversationStore?: MSTeamsConversationStore;
@@ -84,6 +86,7 @@ export async function monitorMSTeamsProvider(
 ): Promise<MonitorMSTeamsResult> {
   const core = getMSTeamsRuntime();
   const log = core.logging.getChildLogger({ name: "msteams" });
+  const accountId = opts.accountId?.trim() || DEFAULT_ACCOUNT_ID;
   let cfg = opts.cfg;
   let msteamsCfg = cfg.channels?.msteams;
   if (!msteamsCfg?.enabled) {
@@ -308,6 +311,7 @@ export async function monitorMSTeamsProvider(
   const handler = buildActivityHandler();
   const handlerDeps: MSTeamsMessageHandlerDeps = {
     cfg,
+    accountId,
     runtime,
     appId,
     app,
@@ -321,7 +325,7 @@ export async function monitorMSTeamsProvider(
   registerMSTeamsHandlers(handler, handlerDeps);
 
   const ingress = createMSTeamsIngress({
-    accountId: appId,
+    accountId,
     runtime,
     dispatch: async (activity, lifecycle, liveContext) => {
       // The journaled activity is the dispatch payload; the live context only

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -334,7 +334,7 @@ describe("msteamsOutbound cfg threading", () => {
     });
   });
 
-  it("renders typed URL actions and omits unresolved approval actions", async () => {
+  it("renders typed URL and approval actions", async () => {
     const presentation = {
       blocks: [
         {
@@ -394,9 +394,17 @@ describe("msteamsOutbound cfg threading", () => {
         title: "Open app",
         url: "https://example.com/app",
       },
+      {
+        type: "Action.Submit",
+        title: "Allow",
+        data: {
+          msteams: {
+            type: "imBack",
+            value: "/approve approval-1 allow-once",
+          },
+        },
+      },
     ]);
-    expect(JSON.stringify(card)).not.toContain("approval-1");
-    expect(JSON.stringify(card)).not.toContain("/approve");
   });
 
   it("falls back to text/media delivery when payload rendering did not produce a card", async () => {

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -88,6 +88,19 @@ export function buildMSTeamsPresentationCard(params: {
           });
           continue;
         }
+        if (action?.type === "approval") {
+          actions.push({
+            type: "Action.Submit",
+            title: button.label,
+            data: {
+              msteams: {
+                type: "imBack",
+                value: `/approve ${action.approvalId} ${action.decision}`,
+              },
+            },
+          });
+          continue;
+        }
         if (action?.type === "callback") {
           actions.push({
             type: "Action.Submit",


### PR DESCRIPTION
Related: #115301

## What Problem This Solves

Fixes an issue where Microsoft Teams users approving a guarded plugin action would see only a text command or a non-working approval card, while the submitted approval entered the normal agent queue and the original tool call timed out.

## Why This Change Was Made

Teams now renders OpenClaw's typed approval actions as native Adaptive Card submit buttons and resolves the submitted decision before agent dispatch through the existing Gateway approval API. The active Teams account and authenticated sender remain bound to the canonical reviewer identity, including multi-account startup paths.

This ports the pre-agent resolution pattern proposed in #115301 onto current `main`, while using current account-bound approval authorization rather than the older default-account assumption. Thanks to @EliasOpolski for the original resolver approach.

## User Impact

Users can select **Allow Once** or **Deny** directly in Teams and have that decision resume or cancel the same pending tool call before it expires. Approval commands from unauthorized users are consumed before they can reach the Gateway or the agent.

## Evidence

- Focused presentation, startup, account-custody, and pre-dispatch approval tests: 52 passed
- Full Microsoft Teams extension suite: 92 files, 1,433 tests passed
- Extension typecheck passed
- Targeted oxlint, oxfmt, and `git diff --check` passed
- Independent complete-diff security review passed on `72a26b1d061ba5ffd302d11ff41991465673c30e`
