### PR TITLE
fix(plugins): expose background service failures in health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Plugin service health:** retain generation-scoped background service failures in verbose Gateway health and clear them on recovery, stop, or replacement so loaded plugins cannot mask broken runtimes.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plugin service health:** retain generation-scoped background service failures in verbose Gateway health and clear them on recovery, stop, or replacement so loaded plugins cannot mask broken runtimes.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -968,6 +968,30 @@ returned unsubscribe function and call it during service cleanup. The payload is
 change notice; use `api.runtime.agent.session.getSessionEntry(...)` when the plugin needs the full
 current session entry.
 
+Service startup failures from a returned or awaited promise are recorded automatically. A service
+that intentionally starts required work in the background must report later failure and recovery
+through its generation-bound health reporter:
+
+```typescript
+api.registerService({
+  id: "index-worker",
+  start(ctx) {
+    void startIndexWorker().then(
+      () => ctx.serviceHealth?.clearFailure(),
+      (error) => ctx.serviceHealth?.reportFailure(error),
+    );
+  },
+  stop() {
+    stopIndexWorker();
+  },
+});
+```
+
+The reporter is revoked when the service stops or its plugin registry generation is replaced, so a
+late callback from an old generation cannot overwrite current health. Prefer returning the startup
+promise when the service is not usable until that promise settles; use the reporter only for
+deliberately nonblocking work that owns its own stop path.
+
 ## Storing runtime references
 
 Use `createPluginRuntimeStore` to store the runtime reference for use outside the `register` callback:

--- a/extensions/voice-call/index.lifecycle.test.ts
+++ b/extensions/voice-call/index.lifecycle.test.ts
@@ -28,10 +28,15 @@ type RuntimeFixture = {
   stop: ReturnType<typeof vi.fn>;
 };
 
+const serviceHealth = {
+  reportFailure: vi.fn(),
+  clearFailure: vi.fn(),
+};
 const serviceContext = {
   config: {},
   stateDir: os.tmpdir(),
   logger: { info() {}, warn() {}, error() {}, debug() {} },
+  serviceHealth,
 } as Parameters<VoiceCallService["start"]>[0];
 
 function createLogger(onError?: (message: string) => void) {
@@ -107,6 +112,8 @@ function expectLifecycleError(result: VoiceCallToolResult, text: string): void {
 describe("voice-call runtime lifecycle", () => {
   beforeEach(() => {
     vi.mocked(createVoiceCallRuntime).mockReset();
+    serviceHealth.reportFailure.mockReset();
+    serviceHealth.clearFailure.mockReset();
   });
 
   afterEach(() => {
@@ -274,9 +281,13 @@ describe("voice-call runtime lifecycle", () => {
 
     expect(generationA.service.start(serviceContext)).toBeUndefined();
     await expect(logged.promise).resolves.toContain("Failed to start runtime: provider boom");
+    expect(serviceHealth.reportFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "provider boom" }),
+    );
 
     await executeCall(generationA.tool());
     expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
     expect(runtimeA.initiateCall).toHaveBeenCalledTimes(1);
+    expect(serviceHealth.clearFailure).toHaveBeenCalled();
   });
 });

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -97,6 +97,9 @@ const VOICE_CALL_RUNTIME_COORDINATOR_KEY = Symbol.for("openclaw.voice-call.runti
 type VoiceCallRuntimeGeneration = {
   epoch: number;
   retired: boolean;
+  serviceHealth?: Parameters<
+    Parameters<OpenClawPluginApi["registerService"]>[0]["start"]
+  >[0]["serviceHealth"];
   stopPromise?: Promise<void>;
 };
 
@@ -179,7 +182,7 @@ export default definePluginEntry({
       coreConfig: api.config as OpenClawConfig,
     });
 
-    const ensureRuntime = async (): Promise<VoiceCallRuntime> => {
+    const ensureRuntimeForGeneration = async (): Promise<VoiceCallRuntime> => {
       activateVoiceCallRuntimeGeneration(runtimeCoordinator, runtimeGeneration);
       if (!config.enabled) {
         throw new Error("Voice call disabled in plugin config");
@@ -246,6 +249,20 @@ export default definePluginEntry({
           promise: runtimePromise,
         };
         runtimeCoordinator.slot = startingSlot;
+      }
+    };
+    const ensureRuntime = async (): Promise<VoiceCallRuntime> => {
+      try {
+        const runtime = await ensureRuntimeForGeneration();
+        runtimeGeneration.serviceHealth?.clearFailure();
+        return runtime;
+      } catch (err) {
+        const staleGeneration =
+          runtimeGeneration.retired || runtimeGeneration.epoch < runtimeCoordinator.registeredEpoch;
+        if (!(err instanceof VoiceCallRuntimeLifecycleError && staleGeneration)) {
+          runtimeGeneration.serviceHealth?.reportFailure(err);
+        }
+        throw err;
       }
     };
 
@@ -513,7 +530,8 @@ export default definePluginEntry({
 
     api.registerService({
       id: "voicecall",
-      start: () => {
+      start: (ctx) => {
+        runtimeGeneration.serviceHealth = ctx.serviceHealth;
         if (isCliOnlyProcess()) {
           return;
         }
@@ -587,6 +605,7 @@ export default definePluginEntry({
           if (runtimeCoordinator.current === runtimeGeneration) {
             runtimeCoordinator.current = undefined;
           }
+          runtimeGeneration.serviceHealth = undefined;
         }
       },
     });

--- a/src/commands/health.plugins.test.ts
+++ b/src/commands/health.plugins.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { SnapshotSchema } from "../../packages/gateway-protocol/src/schema/snapshot.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
 import { createPluginRecord } from "../plugins/status.test-fixtures.js";
 
 const testConfig = { session: { store: "/tmp/x" } };
@@ -13,6 +14,8 @@ let setActivePluginRegistry: typeof import("../plugins/runtime.js").setActivePlu
 let setActiveDegradedPlugins: typeof import("../plugins/runtime-degraded-state.js").setActiveDegradedPlugins;
 let createTestRegistry: typeof import("../test-utils/channel-plugins.js").createTestRegistry;
 let collectGatewayHealthSnapshot: typeof import("../gateway/health/collector.js").collectGatewayHealthSnapshot;
+let startPluginServices: typeof import("../plugins/services.js").startPluginServices;
+let pluginServicesHandle: PluginServicesHandle | undefined;
 
 describe("collectGatewayHealthSnapshot plugin state", () => {
   beforeAll(async () => {
@@ -31,19 +34,24 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       listReadOnlyChannelPluginsForConfig: () => [],
     }));
 
-    const [pluginsRuntime, degradedState, channelTestUtils, health] = await Promise.all([
-      import("../plugins/runtime.js"),
-      import("../plugins/runtime-degraded-state.js"),
-      import("../test-utils/channel-plugins.js"),
-      import("../gateway/health/collector.js"),
-    ]);
+    const [pluginsRuntime, degradedState, channelTestUtils, health, pluginServices] =
+      await Promise.all([
+        import("../plugins/runtime.js"),
+        import("../plugins/runtime-degraded-state.js"),
+        import("../test-utils/channel-plugins.js"),
+        import("../gateway/health/collector.js"),
+        import("../plugins/services.js"),
+      ]);
     setActivePluginRegistry = pluginsRuntime.setActivePluginRegistry;
     setActiveDegradedPlugins = degradedState.setActiveDegradedPlugins;
     createTestRegistry = channelTestUtils.createTestRegistry;
     collectGatewayHealthSnapshot = health.collectGatewayHealthSnapshot;
+    startPluginServices = pluginServices.startPluginServices;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await pluginServicesHandle?.stop();
+    pluginServicesHandle = undefined;
     setActiveDegradedPlugins([]);
     setActivePluginRegistry(createTestRegistry([]));
     for (const tempPath of tempPaths.splice(0)) {
@@ -122,5 +130,70 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
         error: "healthy override has an unrelated import error",
       },
     ]);
+  });
+
+  it("surfaces a failed service while continuing healthy siblings", async () => {
+    const siblingStart = vi.fn();
+    const registry = {
+      ...createTestRegistry([]),
+      plugins: [
+        createPluginRecord({
+          id: "service-plugin",
+          origin: "workspace",
+          status: "loaded",
+          services: ["broken", "healthy-sibling"],
+        }),
+      ],
+      services: [
+        {
+          pluginId: "service-plugin",
+          pluginName: "Service Plugin",
+          service: {
+            id: "broken",
+            start: () => {
+              throw new Error("listen EADDRINUSE: address already in use");
+            },
+          },
+          source: "test",
+          origin: "workspace" as const,
+        },
+        {
+          pluginId: "service-plugin",
+          pluginName: "Service Plugin",
+          service: { id: "healthy-sibling", start: siblingStart },
+          source: "test",
+          origin: "workspace" as const,
+        },
+      ],
+    };
+    setActivePluginRegistry(registry);
+
+    pluginServicesHandle = await startPluginServices({ registry, config: {} });
+    const failed = await collectGatewayHealthSnapshot({
+      audience: "admin",
+      timeoutMs: 10,
+      probe: false,
+    });
+
+    expect(Value.Check(SnapshotSchema.properties.health, failed)).toBe(true);
+    expect(siblingStart).toHaveBeenCalledOnce();
+    expect(failed.plugins?.loaded).toContain("service-plugin");
+    expect(failed.plugins?.errors).toContainEqual({
+      id: "service-plugin",
+      origin: "workspace",
+      activated: true,
+      activationSource: "explicit",
+      failurePhase: "service",
+      error: "service broken: listen EADDRINUSE: address already in use",
+    });
+
+    await pluginServicesHandle.stop();
+    pluginServicesHandle = undefined;
+    const stopped = await collectGatewayHealthSnapshot({
+      audience: "admin",
+      timeoutMs: 10,
+      probe: false,
+    });
+    expect(stopped.plugins?.errors).toEqual([]);
   });
 });

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -21,6 +21,7 @@ import {
   toPublicPluginVerificationDiagnostic,
 } from "../../plugins/runtime-degraded-state.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { listPluginServiceHealthFailures } from "../../plugins/service-health.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import {
@@ -59,6 +60,19 @@ const debugHealth = (
 
 const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
   resolveHeartbeatSummaryForAgent(cfg, agentId);
+
+function attachPluginActivation(
+  plugin: NonNullable<ReturnType<typeof getActivePluginRegistry>>["plugins"][number] | undefined,
+  error: PluginHealthErrorSummary,
+): PluginHealthErrorSummary {
+  if (plugin?.activationSource) {
+    error.activationSource = plugin.activationSource;
+  }
+  if (plugin?.activationReason) {
+    error.activationReason = plugin.activationReason;
+  }
+  return error;
+}
 
 export function resolveHealthAgentOrder(cfg: OpenClawConfig) {
   const defaultAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
@@ -138,7 +152,7 @@ function buildPluginHealthSummary(): PluginHealthSummary | undefined {
     .filter((plugin) => plugin.status === "loaded")
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));
-  const errors = (registry?.plugins ?? [])
+  const loadErrors = (registry?.plugins ?? [])
     .filter(
       (plugin) =>
         plugin.status === "error" &&
@@ -151,25 +165,33 @@ function buildPluginHealthSummary(): PluginHealthSummary | undefined {
             degradedPluginMatchesRoot(degraded, plugin.rootDir ?? ""),
         ),
     )
-    .map((plugin) => {
-      const error: PluginHealthErrorSummary = {
+    .map((plugin) =>
+      attachPluginActivation(plugin, {
         id: plugin.id,
         origin: plugin.origin,
         activated: plugin.activated === true,
         error: plugin.error ?? "unknown plugin load error",
-      };
-      if (plugin.activationSource) {
-        error.activationSource = plugin.activationSource;
-      }
-      if (plugin.activationReason) {
-        error.activationReason = plugin.activationReason;
-      }
-      if (plugin.failurePhase) {
-        error.failurePhase = plugin.failurePhase;
-      }
-      return error;
-    })
-    .toSorted((left, right) => left.id.localeCompare(right.id));
+        ...(plugin.failurePhase ? { failurePhase: plugin.failurePhase } : {}),
+      }),
+    );
+  const serviceErrors = registry
+    ? listPluginServiceHealthFailures(registry).map((failure) =>
+        attachPluginActivation(
+          registry.plugins.find((entry) => entry.id === failure.pluginId),
+          {
+            id: failure.pluginId,
+            origin: failure.origin,
+            // Starting the registered service is the authoritative activation fact.
+            activated: true,
+            failurePhase: "service",
+            error: `service ${failure.serviceId}: ${failure.error}`,
+          },
+        ),
+      )
+    : [];
+  const errors = [...loadErrors, ...serviceErrors].toSorted(
+    (left, right) => left.id.localeCompare(right.id) || left.error.localeCompare(right.error),
+  );
   if (loaded.length === 0 && errors.length === 0 && unavailable.length === 0) {
     return undefined;
   }

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -283,11 +283,17 @@ export type OpenClawGatewayDiscoveryService = {
 };
 
 /** Context passed to long-lived plugin services. */
+export type OpenClawPluginServiceHealth = {
+  reportFailure: (error: unknown) => void;
+  clearFailure: () => void;
+};
+
 export type OpenClawPluginServiceContext = {
   config: OpenClawConfig;
   workspaceDir?: string;
   stateDir: string;
   logger: PluginLogger;
+  serviceHealth?: OpenClawPluginServiceHealth;
   gatewayEvents?: import("./gateway-events.js").OpenClawPluginGatewayEvents;
   startupTrace?: {
     detail?: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;

--- a/src/plugins/service-health.ts
+++ b/src/plugins/service-health.ts
@@ -1,0 +1,71 @@
+/** Keeps plugin service failures scoped to the registry generation that owns them. */
+import { formatErrorMessage } from "../infra/errors.js";
+import type { OpenClawPluginServiceHealth } from "./plugin-registration.types.js";
+import type { PluginServiceRegistration } from "./registry-types.js";
+import type { PluginRegistry } from "./registry.js";
+
+type PluginServiceHealthFailure = {
+  pluginId: string;
+  serviceId: string;
+  origin: PluginServiceRegistration["origin"];
+  error: string;
+};
+
+const states = new WeakMap<
+  PluginRegistry,
+  { generation: symbol; failures: Map<string, PluginServiceHealthFailure> }
+>();
+
+export function createPluginServiceHealthGeneration(registry: PluginRegistry) {
+  const generation = Symbol("plugin-service-health-generation");
+  const state = { generation, failures: new Map<string, PluginServiceHealthFailure>() };
+  states.set(registry, state);
+  const ownsGeneration = () => states.get(registry)?.generation === generation;
+
+  return {
+    createReporter(service: PluginServiceRegistration): {
+      health: OpenClawPluginServiceHealth;
+      revoke: () => void;
+    } {
+      let active = true;
+      const canReport = () => active && ownsGeneration();
+      return {
+        health: {
+          reportFailure: (error) => {
+            if (!canReport()) {
+              return;
+            }
+            state.failures.set(service.service.id, {
+              pluginId: service.pluginId,
+              serviceId: service.service.id,
+              origin: service.origin,
+              error: formatErrorMessage(error),
+            });
+          },
+          clearFailure: () => {
+            if (canReport()) {
+              state.failures.delete(service.service.id);
+            }
+          },
+        },
+        revoke: () => {
+          active = false;
+        },
+      };
+    },
+    retire: () => {
+      if (ownsGeneration()) {
+        states.delete(registry);
+      }
+    },
+  };
+}
+
+export function listPluginServiceHealthFailures(
+  registry: PluginRegistry,
+): PluginServiceHealthFailure[] {
+  return [...(states.get(registry)?.failures.values() ?? [])].toSorted(
+    (left, right) =>
+      left.pluginId.localeCompare(right.pluginId) || left.serviceId.localeCompare(right.serviceId),
+  );
+}

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -31,6 +31,7 @@ import {
 import { queuePluginSessionsChanged, subscribePluginSessionsChanged } from "./gateway-events.js";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+import { listPluginServiceHealthFailures } from "./service-health.js";
 import { startPluginServices, type PluginServicesHandle } from "./services.js";
 
 type TrustedExporterInternalDiagnostics = NonNullable<
@@ -219,6 +220,38 @@ describe("startPluginServices", () => {
 
     expect(stopService).toHaveBeenCalledOnce();
     expect(siblingStart).not.toHaveBeenCalled();
+  });
+
+  it("fences service health reporters to their owning generation", async () => {
+    const contexts: OpenClawPluginServiceContext[] = [];
+    const registry = createRegistry([
+      {
+        id: "service",
+        start: (ctx) => {
+          contexts.push(ctx);
+        },
+      },
+    ]);
+    const generationA = await startPluginServices({ registry, config: createServiceConfig() });
+    const generationB = await startPluginServices({ registry, config: createServiceConfig() });
+
+    contexts[0]?.serviceHealth?.reportFailure(new Error("stale failure"));
+    expect(listPluginServiceHealthFailures(registry)).toEqual([]);
+    contexts[1]?.serviceHealth?.reportFailure(new Error("current failure"));
+    expect(listPluginServiceHealthFailures(registry)).toEqual([
+      {
+        pluginId: "plugin:test",
+        serviceId: "service",
+        origin: "workspace",
+        error: "current failure",
+      },
+    ]);
+
+    await generationA.stop();
+    expect(listPluginServiceHealthFailures(registry)).toHaveLength(1);
+    contexts[1]?.serviceHealth?.clearFailure();
+    expect(listPluginServiceHealthFailures(registry)).toEqual([]);
+    await generationB.stop();
   });
 
   it("drains producer diagnostics before exporters stop and propagates exporter failures", async () => {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -20,6 +20,7 @@ import { isPluginJsonValue, type PluginJsonValue } from "./host-hook-json.js";
 import { withPluginHttpRouteRegistry } from "./http-registry.js";
 import type { PluginServiceRegistration } from "./registry-types.js";
 import type { PluginRegistry } from "./registry.js";
+import { createPluginServiceHealthGeneration } from "./service-health.js";
 import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
 import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 
@@ -44,6 +45,7 @@ function createServiceContext(params: {
   startupTrace?: PluginServiceStartupTrace;
   workspaceDir?: string;
   service: PluginServiceRegistration;
+  serviceHealth: NonNullable<OpenClawPluginServiceContext["serviceHealth"]>;
   gatewayEvents?: OpenClawPluginServiceContext["gatewayEvents"];
 }): OpenClawPluginServiceContext {
   const isDiagnosticsExporter =
@@ -73,6 +75,7 @@ function createServiceContext(params: {
     workspaceDir: params.workspaceDir,
     stateDir: STATE_DIR,
     logger: createPluginLogger(),
+    serviceHealth: params.serviceHealth,
     ...(params.gatewayEvents ? { gatewayEvents: params.gatewayEvents } : {}),
     ...(params.startupTrace
       ? {
@@ -191,11 +194,13 @@ export async function startPluginServices(params: {
   broadcastPluginEvent?: GatewayPluginEventBroadcastFn;
   onHandle?: (handle: PluginServicesHandle) => void;
 }): Promise<PluginServicesHandle> {
+  const healthGeneration = createPluginServiceHealthGeneration(params.registry);
   const running: Array<{
     id: string;
     diagnosticsExporter: boolean;
     stop?: () => void | Promise<void>;
     revokeGatewayEvents: () => void;
+    revokeServiceHealth: () => void;
   }> = [];
   const stopService = async (entry: (typeof running)[number], failures?: unknown[]) => {
     try {
@@ -207,6 +212,7 @@ export async function startPluginServices(params: {
       failures?.push(err);
     } finally {
       entry.revokeGatewayEvents();
+      entry.revokeServiceHealth();
     }
   };
   const startupSettled = createDeferredCore();
@@ -217,34 +223,38 @@ export async function startPluginServices(params: {
     stop: () => {
       stopRequested = true;
       // Store the shared promise before plugin cleanup runs so shutdown cannot start twice.
-      return (stopPromise ??= Promise.resolve().then(async () => {
-        await startupSettled.promise.catch(() => {});
-        const reversed = running.toReversed();
-        const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
-        const exporterFailures: unknown[] = [];
-        const stopServices = async (services: typeof reversed, failures?: unknown[]) => {
-          for (const entry of services) {
-            await stopService(entry, failures);
+      if (!stopPromise) {
+        stopPromise = Promise.resolve().then(async () => {
+          await startupSettled.promise.catch(() => {});
+          const reversed = running.toReversed();
+          const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
+          const exporterFailures: unknown[] = [];
+          const stopServices = async (services: typeof reversed, failures?: unknown[]) => {
+            for (const entry of services) {
+              await stopService(entry, failures);
+            }
+          };
+          await stopServices(reversed.filter((entry) => !entry.diagnosticsExporter));
+          if (diagnosticsExporters.length > 0) {
+            // Producers stop first; this barrier preserves their queued tail before exporters detach.
+            await waitForDiagnosticEventsDrained();
           }
-        };
-        await stopServices(reversed.filter((entry) => !entry.diagnosticsExporter));
-        if (diagnosticsExporters.length > 0) {
-          // Producers stop first; this barrier preserves their queued tail before exporters detach.
-          await waitForDiagnosticEventsDrained();
-        }
-        // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
-        // exporter failures propagate because they can mean telemetry was lost.
-        await stopServices(diagnosticsExporters, exporterFailures);
-        if (exporterFailures.length === 1) {
-          throw exporterFailures[0];
-        }
-        if (exporterFailures.length > 1) {
-          throw new AggregateError(
-            exporterFailures,
-            "multiple diagnostics exporters failed to stop",
-          );
-        }
-      }));
+          // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
+          // exporter failures propagate because they can mean telemetry was lost.
+          await stopServices(diagnosticsExporters, exporterFailures);
+          if (exporterFailures.length === 1) {
+            throw exporterFailures[0];
+          }
+          if (exporterFailures.length > 1) {
+            throw new AggregateError(
+              exporterFailures,
+              "multiple diagnostics exporters failed to stop",
+            );
+          }
+        });
+        void stopPromise.then(healthGeneration.retire, healthGeneration.retire);
+      }
+      return stopPromise;
     },
   };
   params.onHandle?.(handle);
@@ -261,11 +271,13 @@ export async function startPluginServices(params: {
         pluginId: entry.pluginId,
         broadcast: params.broadcastPluginEvent,
       });
+      const serviceHealth = healthGeneration.createReporter(entry);
       const serviceContext = createServiceContext({
         config: params.config,
         startupTrace: params.startupTrace,
         workspaceDir: params.workspaceDir,
         service: entry,
+        serviceHealth: serviceHealth.health,
         gatewayEvents: scopedGatewayEvents.gatewayEvents,
       });
       const runningService = {
@@ -273,6 +285,7 @@ export async function startPluginServices(params: {
         diagnosticsExporter: serviceContext.internalDiagnostics !== undefined,
         stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
         revokeGatewayEvents: scopedGatewayEvents.revoke,
+        revokeServiceHealth: serviceHealth.revoke,
       };
       try {
         const startService = () =>
@@ -285,6 +298,7 @@ export async function startPluginServices(params: {
         running.push(runningService);
       } catch (err) {
         failedCount += 1;
+        serviceContext.serviceHealth?.reportFailure(err);
         const error = err as Error;
         log.error(
           `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,


### PR DESCRIPTION
Related: #125354

## What Problem This Solves

Fixes an issue where an activated plugin could remain clean and loaded in `openclaw health --verbose --json` after its background service failed to start. Voice Call exposed this when its webhook listener hit `EADDRINUSE`: the failure was logged, but managed health still passed.

## Why This Change Was Made

Plugin service health is now owned by the exact active registry generation. Returned startup failures are recorded automatically; intentionally nonblocking services can report failure and recovery through a scoped service-context reporter. Stop, replacement, and stale callbacks cannot leak state across generations.

Voice Call uses that generic contract around its nonblocking runtime startup and same-generation retry. This remains separate from #125354, which prevents offline status queries from creating an orphan listener.

Production LOC is +177/-45 (net +132); tests are +124/-7. The production growth establishes the missing public service-health capability and its host-owned generation boundary without mutating loader status or adding a protocol field.

## User Impact

Operators and deployment managers now see activated plugin service failures in verbose Gateway health. A successful retry clears the failure, while stale or stopped plugin generations cannot overwrite current health.

## Evidence

- Pre-fix regression: `src/commands/health.plugins.test.ts` failed because `plugins.errors` stayed empty after an awaited service start threw `EADDRINUSE`.
- Focused post-fix tests: 84/84 passed across health projection/schema validation, plugin service lifecycle, Voice Call lifecycle/index behavior, and the public service-context type contract.
- `node scripts/check-changed.mjs -- <changed paths>` passed formatting, dead-export scans, core/extension production and test typechecks, lint, architecture guards, and database/runtime-sidecar boundaries.
- Blacksmith Testbox full build passed: https://github.com/openclaw/openclaw/actions/runs/32053495118
- Final autoreview reported no accepted or actionable findings (confidence 0.98).

Live production deployment was not used as proof; exact-head CI remains pending.
