### PR TITLE
fix(slack): app mentions survive missing channel metadata

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -879,6 +879,34 @@ describe("registerSlackMessageEvents", () => {
     expect(inboundLogLines()).toEqual([]);
   });
 
+  it("fails closed when typeless app_mention channel resolution returns undefined", async () => {
+    const { ctx, handler, handleSlackMessage } = createHandlers("app_mention", {
+      dmPolicy: "open",
+    });
+    const resolveChannelName = vi.fn(() => undefined);
+    ctx.resolveChannelName = resolveChannelName as unknown as typeof ctx.resolveChannelName;
+    const turnAdoptionLifecycle = {
+      admission: "exclusive",
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(),
+    };
+
+    await expect(
+      requireMessageHandler(handler)({
+        event: { ...makeAppMentionEvent({ channel: "C123" }), channel_type: undefined },
+        body: {},
+        context: { [SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY]: turnAdoptionLifecycle },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(resolveChannelName).toHaveBeenCalledOnce();
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(noteConversationMessageMock).not.toHaveBeenCalled();
+    expect(inboundLogLines()).toEqual([]);
+  });
+
   it("routes app_mention events from channels to the message handler", async () => {
     const { handleSlackMessage } = await invokeRegisteredHandler({
       eventName: "app_mention",

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -78,9 +78,12 @@ async function resolveSlackAppMentionChannelType(params: {
   }
   // app_mention omits channel_type, and Slack ID prefixes are not a type contract.
   // Only an authoritative event/cache/API type may choose this event's owner.
-  const resolved = await params.ctx
-    .resolveChannelName(params.mention.channel, params.eventScope)
-    .catch(() => ({ type: undefined }));
+  const resolved = await Promise.resolve(
+    params.ctx.resolveChannelName(params.mention.channel, params.eventScope),
+  ).catch(() => undefined);
+  if (!resolved) {
+    return undefined;
+  }
   return resolved.type
     ? normalizeSlackChannelType(resolved.type, params.mention.channel)
     : undefined;


### PR DESCRIPTION
## What Problem This Solves\n\nFixes an issue where Slack users sending an app mention could terminate the gateway when channel metadata resolution returned no result instead of a promise. The failure occurred before message dispatch.\n\n## Why This Change Was Made\n\nThe app-mention channel lookup now accepts either a synchronous or promised result through Promise normalization. A missing or rejected result fails closed before receipt logging, conversation tracking, or message dispatch, so canonical Slack message events retain delivery ownership without duplication.\n\n## User Impact\n\nA malformed or unavailable Slack channel lookup no longer crashes the gateway. Valid app mentions continue through the existing channel-resolution and dispatch path.\n\n## Evidence\n\n- Behavioral RED on installed source commit 8f382a202f: 1 failed, 29 passed with TypeError reading catch from undefined at messages.ts:82.\n- Focused test on current upstream main: 33/33 passed.\n- Full Slack extension shard: 135 files and 2,414 tests passed.\n- pnpm tsgo passed.\n- oxfmt, oxlint, and git diff --check passed on the exact two-file fence.\n- Stable patch ID matches the Fable-approved incident fix: 2b7d177b0a3e1ade156020dbb9a7d717643edc04.\n- Fable verdict: FABLE_APPROVE.