### PR TITLE
fix(ui): balance side panel tab pill padding

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -320,19 +320,25 @@ suite.define(() => {
           trailing: rtl
             ? trailingBounds.left - closeBounds.left
             : closeBounds.right - trailingBounds.right,
-          tabOuterRadius: rtl ? tabStyle.borderTopRightRadius : tabStyle.borderTopLeftRadius,
-          tabJoinRadius: rtl ? tabStyle.borderTopLeftRadius : tabStyle.borderTopRightRadius,
-          closeJoinRadius: rtl ? closeStyle.borderTopRightRadius : closeStyle.borderTopLeftRadius,
-          closeOuterRadius: rtl ? closeStyle.borderTopLeftRadius : closeStyle.borderTopRightRadius,
+          tabOuterRadius: Number.parseFloat(
+            rtl ? tabStyle.borderTopRightRadius : tabStyle.borderTopLeftRadius,
+          ),
+          tabJoinRadius: Number.parseFloat(
+            rtl ? tabStyle.borderTopLeftRadius : tabStyle.borderTopRightRadius,
+          ),
+          closeJoinRadius: Number.parseFloat(
+            rtl ? closeStyle.borderTopRightRadius : closeStyle.borderTopLeftRadius,
+          ),
+          closeOuterRadius: Number.parseFloat(
+            rtl ? closeStyle.borderTopLeftRadius : closeStyle.borderTopRightRadius,
+          ),
         };
       }, direction);
       expect(tabPadding.trailing, `${direction} glyph insets`).toBeCloseTo(tabPadding.leading, 0);
-      expect(parseFloat(tabPadding.tabJoinRadius), `${direction} tab join`).toBe(0);
-      expect(parseFloat(tabPadding.closeJoinRadius), `${direction} close join`).toBe(0);
-      expect(parseFloat(tabPadding.tabOuterRadius), `${direction} tab outer`).toBeGreaterThan(0);
-      expect(parseFloat(tabPadding.closeOuterRadius), `${direction} close outer`).toBeGreaterThan(
-        0,
-      );
+      expect(tabPadding.tabJoinRadius, `${direction} tab join`).toBe(0);
+      expect(tabPadding.closeJoinRadius, `${direction} close join`).toBe(0);
+      expect(tabPadding.tabOuterRadius, `${direction} tab outer`).toBeGreaterThan(0);
+      expect(tabPadding.closeOuterRadius, `${direction} close outer`).toBeGreaterThan(0);
     }
     await tab.evaluate((node) => {
       const panel = node.closest(".side-panel");

--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -291,6 +291,27 @@ suite.define(() => {
     expect(await companionMenu.count()).toBe(1);
     expect(await contentActions.locator(":scope > button").count()).toBe(0);
 
+    const tabPadding = await page
+      .locator(".side-panel__header .tabstrip-tab[active]")
+      .evaluate((tab) => {
+        const tabBase = tab.shadowRoot?.querySelector<HTMLElement>("[part~='base']");
+        const leadingGlyph = tab.querySelector<HTMLElement>(".tabstrip-tab__icon svg");
+        const close = tab.nextElementSibling;
+        const trailingGlyph = close?.querySelector<HTMLElement>("svg");
+        if (!(close instanceof HTMLElement) || !tabBase || !leadingGlyph || !trailingGlyph) {
+          throw new Error("Active side-panel tab must render both edge glyphs");
+        }
+        const tabBounds = tabBase.getBoundingClientRect();
+        const closeBounds = close.getBoundingClientRect();
+        const leadingBounds = leadingGlyph.getBoundingClientRect();
+        const trailingBounds = trailingGlyph.getBoundingClientRect();
+        return {
+          leading: leadingBounds.left - tabBounds.left,
+          trailing: closeBounds.right - trailingBounds.right,
+        };
+      });
+    expect(tabPadding.trailing).toBeCloseTo(tabPadding.leading, 0);
+
     await page.locator(".side-panel-type-menu__trigger").click();
     await page.locator(".side-panel-type-menu__item").filter({ hasText: "Discussion" }).click();
     const discussionAction = contentActions.locator(

--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -291,12 +291,17 @@ suite.define(() => {
     expect(await companionMenu.count()).toBe(1);
     expect(await contentActions.locator(":scope > button").count()).toBe(0);
 
-    const tabPadding = await page
-      .locator(".side-panel__header .tabstrip-tab[active]")
-      .evaluate((tab) => {
-        const tabBase = tab.shadowRoot?.querySelector<HTMLElement>("[part~='base']");
-        const leadingGlyph = tab.querySelector<HTMLElement>(".tabstrip-tab__icon svg");
-        const close = tab.nextElementSibling;
+    const tab = page.locator(".side-panel__header .tabstrip-tab[active]");
+    for (const direction of ["ltr", "rtl"] as const) {
+      const tabPadding = await tab.evaluate((node, dir) => {
+        const panel = node.closest(".side-panel");
+        if (!(panel instanceof HTMLElement)) {
+          throw new Error("Active side-panel tab must render inside the side panel");
+        }
+        panel.dir = dir;
+        const tabBase = node.shadowRoot?.querySelector<HTMLElement>("[part~='base']");
+        const leadingGlyph = node.querySelector<HTMLElement>(".tabstrip-tab__icon svg");
+        const close = node.nextElementSibling;
         const trailingGlyph = close?.querySelector<HTMLElement>("svg");
         if (!(close instanceof HTMLElement) || !tabBase || !leadingGlyph || !trailingGlyph) {
           throw new Error("Active side-panel tab must render both edge glyphs");
@@ -305,12 +310,24 @@ suite.define(() => {
         const closeBounds = close.getBoundingClientRect();
         const leadingBounds = leadingGlyph.getBoundingClientRect();
         const trailingBounds = trailingGlyph.getBoundingClientRect();
+        const rtl = dir === "rtl";
         return {
-          leading: leadingBounds.left - tabBounds.left,
-          trailing: closeBounds.right - trailingBounds.right,
+          leading: rtl
+            ? tabBounds.right - leadingBounds.right
+            : leadingBounds.left - tabBounds.left,
+          trailing: rtl
+            ? trailingBounds.left - closeBounds.left
+            : closeBounds.right - trailingBounds.right,
         };
-      });
-    expect(tabPadding.trailing).toBeCloseTo(tabPadding.leading, 0);
+      }, direction);
+      expect(tabPadding.trailing, `${direction} glyph insets`).toBeCloseTo(tabPadding.leading, 0);
+    }
+    await tab.evaluate((node) => {
+      const panel = node.closest(".side-panel");
+      if (panel instanceof HTMLElement) {
+        panel.removeAttribute("dir");
+      }
+    });
 
     await page.locator(".side-panel-type-menu__trigger").click();
     await page.locator(".side-panel-type-menu__item").filter({ hasText: "Discussion" }).click();

--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -311,6 +311,8 @@ suite.define(() => {
         const leadingBounds = leadingGlyph.getBoundingClientRect();
         const trailingBounds = trailingGlyph.getBoundingClientRect();
         const rtl = dir === "rtl";
+        const tabStyle = getComputedStyle(tabBase);
+        const closeStyle = getComputedStyle(close);
         return {
           leading: rtl
             ? tabBounds.right - leadingBounds.right
@@ -318,9 +320,19 @@ suite.define(() => {
           trailing: rtl
             ? trailingBounds.left - closeBounds.left
             : closeBounds.right - trailingBounds.right,
+          tabOuterRadius: rtl ? tabStyle.borderTopRightRadius : tabStyle.borderTopLeftRadius,
+          tabJoinRadius: rtl ? tabStyle.borderTopLeftRadius : tabStyle.borderTopRightRadius,
+          closeJoinRadius: rtl ? closeStyle.borderTopRightRadius : closeStyle.borderTopLeftRadius,
+          closeOuterRadius: rtl ? closeStyle.borderTopLeftRadius : closeStyle.borderTopRightRadius,
         };
       }, direction);
       expect(tabPadding.trailing, `${direction} glyph insets`).toBeCloseTo(tabPadding.leading, 0);
+      expect(parseFloat(tabPadding.tabJoinRadius), `${direction} tab join`).toBe(0);
+      expect(parseFloat(tabPadding.closeJoinRadius), `${direction} close join`).toBe(0);
+      expect(parseFloat(tabPadding.tabOuterRadius), `${direction} tab outer`).toBeGreaterThan(0);
+      expect(parseFloat(tabPadding.closeOuterRadius), `${direction} close outer`).toBeGreaterThan(
+        0,
+      );
     }
     await tab.evaluate((node) => {
       const panel = node.closest(".side-panel");

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -440,14 +440,21 @@ openclaw-chat-sidebar-region,
 }
 
 .side-panel__header
+  .tabstrip-tab:not([active]):is(:hover, :has(+ .tabstrip-tab__close:hover))::part(base),
+.side-panel__header .tabstrip-tab[active]::part(base) {
+  border-start-start-radius: var(--radius-md);
+  border-end-start-radius: var(--radius-md);
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+
+.side-panel__header
   .tabstrip-tab:not([active]):is(:hover, :has(+ .tabstrip-tab__close:hover))::part(base) {
-  border-radius: var(--radius-md) 0 0 var(--radius-md);
   background: color-mix(in srgb, var(--text) 5%, transparent);
   color: var(--text);
 }
 
 .side-panel__header .tabstrip-tab[active]::part(base) {
-  border-radius: var(--radius-md) 0 0 var(--radius-md);
   background: var(--bg-hover);
   color: var(--text);
 }
@@ -516,7 +523,10 @@ openclaw-chat-sidebar-region,
   flex: 0 0 28px;
   align-self: center;
   margin: 0;
-  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  border-start-end-radius: var(--radius-md);
+  border-end-end-radius: var(--radius-md);
   opacity: 0;
   transition:
     background-color 120ms ease,

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -427,7 +427,7 @@ openclaw-chat-sidebar-region,
   align-items: center;
   justify-content: flex-start;
   gap: 7px;
-  padding: 0 8px;
+  padding: 0 0 0 8px;
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;
@@ -510,10 +510,10 @@ openclaw-chat-sidebar-region,
 }
 
 .side-panel__header .tabstrip-tab__close {
-  width: 16px;
-  min-width: 16px;
+  width: 28px;
+  min-width: 28px;
   height: 28px;
-  flex: 0 0 16px;
+  flex: 0 0 28px;
   align-self: center;
   margin: 0;
   border-radius: 0 var(--radius-md) var(--radius-md) 0;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -427,7 +427,7 @@ openclaw-chat-sidebar-region,
   align-items: center;
   justify-content: flex-start;
   gap: 7px;
-  padding: 0 0 0 8px;
+  padding-inline: 8px 0;
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing the unified chat side panel would see the tab close action crowded against the pill's right edge.

## Why This Change Was Made

The side-panel tab and its sibling close action now form one balanced surface: the base keeps its leading inset, while the close action supplies an equal trailing inset without an extra gap between the label and X.

The existing Side chat browser contract now measures the actual SVG glyph edges, so nested action-box padding cannot hide a visual regression.

## User Impact

Unified side-panel tabs have visually balanced pill padding in Safari and other browsers while retaining the same controls and header layout.

## Evidence

### Before

![Side chat tab before: the X is crowded against the right edge](https://github.com/user-attachments/assets/6139e594-bcfc-4aef-bcc5-8f51293ae08f)

### After

![Side chat tab after: the leading bot and trailing X have matching visual insets](https://github.com/user-attachments/assets/594e5aaa-b075-47dc-a249-717f474394b3)

- Pre-fix browser measurement: 8.5px leading glyph inset, 2.5px trailing glyph inset (regression assertion failed as expected).
- Post-fix browser measurement: 8.5px leading glyph inset, 8.5px trailing glyph inset.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts` — 2 passed.
- Current-main focused rerun including the previously failing `cloud-workers-settings.e2e.test.ts` — 6 passed.
- Focused oxlint, stylelint, formatting, and `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.
- Exact-head CI on `cc7b579e7ea`: 68 successful, 0 failing, 0 pending; required `openclaw/ci-gate` passed.
