### PR TITLE
fix(mattermost): react action rejects raw emoji glyphs

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -1231,6 +1231,25 @@ describe("mattermostPlugin", () => {
       expect(result?.details).toStrictEqual({});
     });
 
+    it("normalizes a raw emoji glyph through the react action boundary", async () => {
+      const result = await runReactAction({ messageId: "POST1", emoji: "👍" }, "add");
+
+      expect(result?.content).toEqual([{ type: "text", text: "Reacted with :thumbsup: on POST1" }]);
+      expect(result?.details).toStrictEqual({});
+    });
+
+    it("normalizes a raw emoji glyph when removing a reaction", async () => {
+      const result = await runReactAction(
+        { messageId: "POST1", emoji: "👍", remove: true },
+        "remove",
+      );
+
+      expect(result?.content).toEqual([
+        { type: "text", text: "Removed reaction :thumbsup: from POST1" },
+      ]);
+      expect(result?.details).toStrictEqual({});
+    });
+
     it("maps replyTo to replyToId for send actions", async () => {
       const cfg = createMattermostTestConfig();
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -653,12 +653,16 @@ describe("mattermostPlugin", () => {
   describe("messageActions", () => {
     let reactionActionSequence = 0;
 
-    const runReactAction = async (params: Record<string, unknown>, fetchMode: "add" | "remove") => {
+    const runReactAction = async (
+      params: Record<string, unknown>,
+      fetchMode: "add" | "remove",
+      emojiName = "thumbsup",
+    ) => {
       const cfg = createMattermostTestConfig(`message-action-${++reactionActionSequence}`);
       const fetchImpl = createMattermostReactionFetchMock({
         mode: fetchMode,
         postId: "POST1",
-        emojiName: "thumbsup",
+        emojiName,
       });
 
       return await withMockedGlobalFetch(fetchImpl, async () => {
@@ -1246,6 +1250,32 @@ describe("mattermostPlugin", () => {
 
       expect(result?.content).toEqual([
         { type: "text", text: "Removed reaction :thumbsup: from POST1" },
+      ]);
+      expect(result?.details).toStrictEqual({});
+    });
+
+    it("preserves the skin tone when adding a toned glyph reaction", async () => {
+      const result = await runReactAction(
+        { messageId: "POST1", emoji: "👍🏽" },
+        "add",
+        "thumbsup_medium_skin_tone",
+      );
+
+      expect(result?.content).toEqual([
+        { type: "text", text: "Reacted with :thumbsup_medium_skin_tone: on POST1" },
+      ]);
+      expect(result?.details).toStrictEqual({});
+    });
+
+    it("preserves the skin tone when removing a toned glyph reaction", async () => {
+      const result = await runReactAction(
+        { messageId: "POST1", emoji: "👍🏽", remove: true },
+        "remove",
+        "thumbsup_medium_skin_tone",
+      );
+
+      expect(result?.content).toEqual([
+        { type: "text", text: "Removed reaction :thumbsup_medium_skin_tone: from POST1" },
       ]);
       expect(result?.details).toStrictEqual({});
     });

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -68,6 +68,7 @@ import {
   resolveMattermostReplyToMode,
   type ResolvedMattermostAccount,
 } from "./mattermost/accounts.js";
+import { normalizeMattermostEmojiName } from "./mattermost/emoji.js";
 import type { MattermostSendResult } from "./mattermost/send.js";
 import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
@@ -636,7 +637,7 @@ function parseMattermostReactActionParams(params: Record<string, unknown>): {
     throw new Error("Mattermost react requires messageId (post id)");
   }
 
-  const emojiName = normalizeOptionalString(params.emoji)?.replace(/^:+|:+$/g, "");
+  const emojiName = normalizeMattermostEmojiName(normalizeOptionalString(params.emoji));
   if (!emojiName) {
     throw new Error("Mattermost react requires emoji");
   }

--- a/extensions/mattermost/src/mattermost/emoji.test.ts
+++ b/extensions/mattermost/src/mattermost/emoji.test.ts
@@ -9,8 +9,15 @@ describe("normalizeMattermostEmojiName", () => {
     expect(normalizeMattermostEmojiName("🎉")).toBe("tada");
   });
 
-  it("strips skin-tone modifiers and variation selectors before lookup", () => {
-    expect(normalizeMattermostEmojiName("👍🏽")).toBe("thumbsup");
+  it("preserves the skin tone as Mattermost's toned short name", () => {
+    expect(normalizeMattermostEmojiName("👍🏽")).toBe("thumbsup_medium_skin_tone");
+    expect(normalizeMattermostEmojiName("🙌🏿")).toBe("raised_hands_dark_skin_tone");
+    // Accepted tradeoff: a modifier on a non-modifier base is not a real emoji
+    // sequence, so the stray tone is dropped instead of composing an unknown name.
+    expect(normalizeMattermostEmojiName("🔥\u{1F3FD}")).toBe("fire");
+  });
+
+  it("strips variation selectors before lookup", () => {
     expect(normalizeMattermostEmojiName("⚠️")).toBe("warning");
   });
 

--- a/extensions/mattermost/src/mattermost/emoji.test.ts
+++ b/extensions/mattermost/src/mattermost/emoji.test.ts
@@ -23,6 +23,9 @@ describe("normalizeMattermostEmojiName", () => {
   it("passes through an unknown glyph or short name unchanged (no regression)", () => {
     expect(normalizeMattermostEmojiName("custom_emoji")).toBe("custom_emoji");
     expect(normalizeMattermostEmojiName("🫶")).toBe("🫶");
+    expect(normalizeMattermostEmojiName("constructor")).toBe("constructor");
+    expect(normalizeMattermostEmojiName("toString")).toBe("toString");
+    expect(normalizeMattermostEmojiName("__proto__")).toBe("__proto__");
   });
 
   it("returns undefined for blank input", () => {

--- a/extensions/mattermost/src/mattermost/emoji.test.ts
+++ b/extensions/mattermost/src/mattermost/emoji.test.ts
@@ -1,0 +1,33 @@
+// Mattermost tests cover emoji reaction name normalization.
+import { describe, expect, it } from "vitest";
+import { normalizeMattermostEmojiName } from "./emoji.js";
+
+describe("normalizeMattermostEmojiName", () => {
+  it("maps a raw Unicode glyph to a Mattermost short name (the server rejects raw glyphs)", () => {
+    expect(normalizeMattermostEmojiName("👍")).toBe("thumbsup");
+    expect(normalizeMattermostEmojiName("✅")).toBe("white_check_mark");
+    expect(normalizeMattermostEmojiName("🎉")).toBe("tada");
+  });
+
+  it("strips skin-tone modifiers and variation selectors before lookup", () => {
+    expect(normalizeMattermostEmojiName("👍🏽")).toBe("thumbsup");
+    expect(normalizeMattermostEmojiName("⚠️")).toBe("warning");
+  });
+
+  it("accepts an existing short name with or without wrapping colons", () => {
+    expect(normalizeMattermostEmojiName("thumbsup")).toBe("thumbsup");
+    expect(normalizeMattermostEmojiName(":thumbsup:")).toBe("thumbsup");
+    expect(normalizeMattermostEmojiName(":+1:")).toBe("+1");
+  });
+
+  it("passes through an unknown glyph or short name unchanged (no regression)", () => {
+    expect(normalizeMattermostEmojiName("custom_emoji")).toBe("custom_emoji");
+    expect(normalizeMattermostEmojiName("🫶")).toBe("🫶");
+  });
+
+  it("returns undefined for blank input", () => {
+    expect(normalizeMattermostEmojiName(undefined)).toBeUndefined();
+    expect(normalizeMattermostEmojiName("   ")).toBeUndefined();
+    expect(normalizeMattermostEmojiName("::")).toBeUndefined();
+  });
+});

--- a/extensions/mattermost/src/mattermost/emoji.ts
+++ b/extensions/mattermost/src/mattermost/emoji.ts
@@ -1,10 +1,7 @@
 // Mattermost helper module supports emoji reaction name normalization.
 
-// Mattermost's reaction API accepts only emoji short names, not a raw Unicode
-// glyph, so the server rejects a glyph and the reaction never appears. Models
-// routinely pass the glyph because the `emoji` param reads as "an emoji", so
-// map the common ones to their short name to avoid that failure. Unknown values
-// pass through unchanged (no regression). Mirrors the Slack plugin's handling.
+// Mattermost rejects raw reaction glyphs; preserve unknown names while mapping
+// common model-supplied emoji to the short names its API accepts.
 const MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
   "✅": "white_check_mark",
   "❌": "x",
@@ -32,28 +29,16 @@ const MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
   "🙌": "raised_hands",
 };
 
-// Strip skin-tone modifiers and variation selectors before lookup so a glyph
-// like "👍🏽" resolves to the same base short name as "👍".
-const EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/gu;
-const EMOJI_VARIATION_SELECTOR_RE = /[\u{FE00}-\u{FE0F}]/gu;
+// Skin tones and variation selectors must not prevent their base glyph lookup.
+const EMOJI_DECORATION_RE = /[\u{1F3FB}-\u{1F3FF}\u{FE00}-\u{FE0F}]/gu;
 
-/**
- * Normalizes a caller-supplied emoji into a Mattermost short name. Accepts a
- * short name (with or without wrapping colons) or a raw Unicode glyph. Returns
- * `undefined` for blank input; unknown glyphs and short names are returned
- * unchanged so callers keep working for emoji outside the common map.
- */
 export function normalizeMattermostEmojiName(raw: string | undefined): string | undefined {
-  const trimmed = raw?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const withoutColons = trimmed.replace(/^:+|:+$/g, "");
+  const withoutColons = raw?.trim().replace(/^:+|:+$/g, "");
   if (!withoutColons) {
     return undefined;
   }
-  const glyphKey = withoutColons
-    .replace(EMOJI_SKIN_TONE_MODIFIER_RE, "")
-    .replace(EMOJI_VARIATION_SELECTOR_RE, "");
-  return MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH[glyphKey] ?? withoutColons;
+  const glyphKey = withoutColons.replace(EMOJI_DECORATION_RE, "");
+  return Object.hasOwn(MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH, glyphKey)
+    ? MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH[glyphKey]
+    : withoutColons;
 }

--- a/extensions/mattermost/src/mattermost/emoji.ts
+++ b/extensions/mattermost/src/mattermost/emoji.ts
@@ -1,0 +1,59 @@
+// Mattermost helper module supports emoji reaction name normalization.
+
+// Mattermost's reaction API accepts only emoji short names, not a raw Unicode
+// glyph, so the server rejects a glyph and the reaction never appears. Models
+// routinely pass the glyph because the `emoji` param reads as "an emoji", so
+// map the common ones to their short name to avoid that failure. Unknown values
+// pass through unchanged (no regression). Mirrors the Slack plugin's handling.
+const MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
+  "✅": "white_check_mark",
+  "❌": "x",
+  "👍": "thumbsup",
+  "👎": "thumbsdown",
+  "🎉": "tada",
+  "❤": "heart",
+  "😄": "smile",
+  "😂": "joy",
+  "🚀": "rocket",
+  "👀": "eyes",
+  "🙏": "pray",
+  "🔥": "fire",
+  "💯": "100",
+  "⚠": "warning",
+  "➕": "heavy_plus_sign",
+  "➖": "heavy_minus_sign",
+  "🤔": "thinking_face",
+  "⚡": "zap",
+  "🌐": "globe_with_meridians",
+  "😱": "scream",
+  "🧠": "brain",
+  "💻": "computer",
+  "👋": "wave",
+  "🙌": "raised_hands",
+};
+
+// Strip skin-tone modifiers and variation selectors before lookup so a glyph
+// like "👍🏽" resolves to the same base short name as "👍".
+const EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/gu;
+const EMOJI_VARIATION_SELECTOR_RE = /[\u{FE00}-\u{FE0F}]/gu;
+
+/**
+ * Normalizes a caller-supplied emoji into a Mattermost short name. Accepts a
+ * short name (with or without wrapping colons) or a raw Unicode glyph. Returns
+ * `undefined` for blank input; unknown glyphs and short names are returned
+ * unchanged so callers keep working for emoji outside the common map.
+ */
+export function normalizeMattermostEmojiName(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const withoutColons = trimmed.replace(/^:+|:+$/g, "");
+  if (!withoutColons) {
+    return undefined;
+  }
+  const glyphKey = withoutColons
+    .replace(EMOJI_SKIN_TONE_MODIFIER_RE, "")
+    .replace(EMOJI_VARIATION_SELECTOR_RE, "");
+  return MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH[glyphKey] ?? withoutColons;
+}

--- a/extensions/mattermost/src/mattermost/emoji.ts
+++ b/extensions/mattermost/src/mattermost/emoji.ts
@@ -30,14 +30,17 @@ const MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
 };
 
 // Skin tones and variation selectors must not prevent their base glyph lookup.
-const EMOJI_DECORATION_RE = /[\u{1F3FB}-\u{1F3FF}\u{FE00}-\u{FE0F}]/gu;
+const EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/gu;
+const EMOJI_VARIATION_SELECTOR_RE = /[\u{FE00}-\u{FE0F}]/gu;
 
 export function normalizeMattermostEmojiName(raw: string | undefined): string | undefined {
   const withoutColons = raw?.trim().replace(/^:+|:+$/g, "");
   if (!withoutColons) {
     return undefined;
   }
-  const glyphKey = withoutColons.replace(EMOJI_DECORATION_RE, "");
+  const glyphKey = withoutColons
+    .replace(EMOJI_SKIN_TONE_MODIFIER_RE, "")
+    .replace(EMOJI_VARIATION_SELECTOR_RE, "");
   return Object.hasOwn(MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH, glyphKey)
     ? MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH[glyphKey]
     : withoutColons;

--- a/extensions/mattermost/src/mattermost/emoji.ts
+++ b/extensions/mattermost/src/mattermost/emoji.ts
@@ -29,6 +29,25 @@ const MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
   "🙌": "raised_hands",
 };
 
+// Mattermost names toned system emoji `<base>_<suffix>`; these five bases are
+// the only Unicode emoji-modifier bases in the map above, so composing outside
+// this set would emit a name the server does not have.
+const MATTERMOST_EMOJI_TONE_CAPABLE_NAMES = new Set([
+  "thumbsup",
+  "thumbsdown",
+  "pray",
+  "wave",
+  "raised_hands",
+]);
+
+const MATTERMOST_EMOJI_TONE_SUFFIX_BY_MODIFIER = new Map<string, string>([
+  ["\u{1F3FB}", "light_skin_tone"],
+  ["\u{1F3FC}", "medium_light_skin_tone"],
+  ["\u{1F3FD}", "medium_skin_tone"],
+  ["\u{1F3FE}", "medium_dark_skin_tone"],
+  ["\u{1F3FF}", "dark_skin_tone"],
+]);
+
 // Skin tones and variation selectors must not prevent their base glyph lookup.
 const EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/gu;
 const EMOJI_VARIATION_SELECTOR_RE = /[\u{FE00}-\u{FE0F}]/gu;
@@ -38,10 +57,21 @@ export function normalizeMattermostEmojiName(raw: string | undefined): string | 
   if (!withoutColons) {
     return undefined;
   }
+  const toneModifier = withoutColons.match(EMOJI_SKIN_TONE_MODIFIER_RE)?.[0];
   const glyphKey = withoutColons
     .replace(EMOJI_SKIN_TONE_MODIFIER_RE, "")
     .replace(EMOJI_VARIATION_SELECTOR_RE, "");
-  return Object.hasOwn(MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH, glyphKey)
+  const shortname = Object.hasOwn(MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH, glyphKey)
     ? MATTERMOST_EMOJI_SHORTNAME_BY_GLYPH[glyphKey]
-    : withoutColons;
+    : undefined;
+  if (shortname === undefined) {
+    return withoutColons;
+  }
+  const toneSuffix = toneModifier
+    ? MATTERMOST_EMOJI_TONE_SUFFIX_BY_MODIFIER.get(toneModifier)
+    : undefined;
+  if (!toneSuffix || !MATTERMOST_EMOJI_TONE_CAPABLE_NAMES.has(shortname)) {
+    return shortname;
+  }
+  return `${shortname}_${toneSuffix}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent reacting to a Mattermost message with a raw Unicode emoji glyph (for example reacting with a 👍 character) fails and the reaction never appears. Mattermost's reaction API accepts only emoji short names, not glyphs, so every glyph reaction was rejected by the server.

## Why This Change Was Made

The react message action forwarded the caller's emoji verbatim after only stripping wrapping colons, so a raw glyph was sent as the `emoji_name`. This change adds a Mattermost-local normalizer that maps the 24 common glyphs to their platform-specific short names, strips `FE00-FE0F` variation selectors before lookup, and preserves unknown glyphs or custom short names unchanged. Skin-tone modifiers are preserved, not dropped: a toned glyph such as 👍🏽 resolves to Mattermost's toned short name (`thumbsup_medium_skin_tone`) for the five modifier-capable mapped bases, mirroring the Slack plugin's modifier handling; a stray modifier on a non-modifier base falls back to the base name so the emitted vocabulary stays within the server's verified table.

An owner review also found that an ordinary object lookup incorrectly resolves valid custom names such as `constructor`, `toString`, and `__proto__` to inherited JavaScript values. An explicit own-property check keeps those existing custom shortcodes as strings; focused regressions cover all three. Delegated conversation authorization, resource binding, account configuration, add/remove permissions, and the public message-tool contract are unchanged.

## User Impact

Agent reactions that pass an emoji glyph now succeed instead of silently failing, and toned glyphs keep their skin tone as the visible reaction. Existing short names, wrapped short names, unknown emoji, and valid custom names that collide with JavaScript prototype properties pass through unchanged for both add and remove actions.

## Evidence

Reviewed current head: `9a6eee10b31791a0d42c7b61988897701c5d0c23` — the skin-tone preservation repair on top of `6a2f42fb4c` (itself a rebase onto current main of the signed `303bae1174c9f14bcfa5c97e15fca6a553697d95`; per-file contents byte-identical, both maintainer commits keep their original authorship).

Production LOC: `+79/-1` (net `+78`). Test LOC: `+94/-2`. The production capability is the Mattermost-owned platform vocabulary required by the upstream reaction contract: the 24-entry glyph map plus the tone-suffix and tone-capable tables that keep toned reactions within the server's verified names; the maintainer owner repair removed 12 production lines from the incoming helper while fixing inherited-name passthrough.

**Original contributor live-behavior proof against a real Mattermost server** (throwaway `mattermost/mattermost-preview`), calling the real `addMattermostReaction` before and after normalization:

```text
[BEFORE glyph="👍"]             ok=false  error=Mattermost API 404 Not Found: We couldn't find the emoji.
[AFTER normalized="thumbsup"]  ok=true   serverReactions=["thumbsup"]
 Test Files  2 passed (2)
      Tests  7 passed (7)
```

- BEFORE: reacting with the raw glyph is rejected by the real server and no reaction is created.
- AFTER: the normalized short name is accepted and the reaction is created on the post.
- Both real channel action boundaries are covered: add resolves 👍 to `thumbsup` and remove resolves 👍 to `thumbsup`.
- Existing emoji owner tests cover glyph mapping, explicit skin-tone/variation-selector stripping, colon-wrapped short names, pass-through of unknown emoji, and blank input.
- Added owner regressions confirm `constructor`, `toString`, and `__proto__` remain their original custom-shortcode strings instead of resolving inherited functions or objects.
- A trusted standalone JavaScript reproduction confirmed the incoming lookup returned `function`, `function`, and `object` respectively, while the own-property repair returns the exact original strings.

The original real Mattermost-server proof was obtained by the contributor before the owner simplification. The current head preserves identical upstream glyph mappings and add/remove behavior; current-head normal hosted CI executes the expanded owner and action regressions. Untrusted contributor code was not executed on the credentialed maintainer host.

**Provider-contract verification of the full 24-entry map** (addresses the open review item that only `thumbsup` had live-server confirmation):

Mattermost validates reaction names server-side in `SaveReactionForPost`: the name is lowercased, checked against the generated `SystemEmojis` table, and otherwise falls through to a custom-emoji lookup whose failure is the visible 404 in the live proof above ([reaction.go L36-L40](https://github.com/mattermost/mattermost/blob/v11.10.0/server/channels/app/reaction.go#L36-L40) via [`GetSystemEmojiId`, emoji.go L45](https://github.com/mattermost/mattermost/blob/v11.10.0/server/public/model/emoji.go#L45)).

All 24 mapped short names were checked directly against that table, [`server/public/model/emoji_data.go`](https://github.com/mattermost/mattermost/blob/v11.10.0/server/public/model/emoji_data.go):

- **Presence: 24/24** in `SystemEmojis` at `v11.10.0` (current stable, 2026-08-04) and at `v10.11.23` (current ESR patch line).
- **Codepoint match: 24/24.** For every entry the table's unified codepoint equals the mapped glyph key's codepoint (e.g. `"thumbsup": "1f44d"` = U+1F44D 👍), so each alias denotes the same emoji rather than merely an existing name. `heart` (`2764-fe0f`) and `warning` (`26a0-fe0f`) differ only by the `FE0F` variation selector, which the normalizer already strips from input before lookup.
- All mapped values are lowercase, so the server's `strings.ToLower` normalization is a no-op for them.
- **Toned vocabulary: 25/25.** Skin-tone preservation composes `<base>_<tone>_skin_tone`; every combination of the five modifier-capable mapped bases (`thumbsup`, `thumbsdown`, `pray`, `wave`, `raised_hands`) with the five Fitzpatrick suffixes (`light`/`medium_light`/`medium`/`medium_dark`/`dark_skin_tone`) exists in `SystemEmojis` at both checked versions, with the expected `{base}-{1f3fb..1f3ff}` unified codepoints (e.g. `"thumbsup_medium_skin_tone": "1f44d-1f3fd"`). The tone-capable set in code is exactly this verified list, so a stray modifier on any other base cannot compose a name outside the table.

<details>
<summary>Per-entry verification (name → emoji_data.go line, unified codepoint, glyph codepoint)</summary>

```text
white_check_mark      L1717  2705       ✅ 2705
x                     L1720  274c       ❌ 274c
thumbsup              L208   1f44d      👍 1f44d
thumbsdown            L210   1f44e      👎 1f44e
tada                  L1221  1f389      🎉 1f389
heart                 L157   2764-fe0f  ❤ 2764 (FE0F stripped on input)
smile                 L11    1f604      😄 1f604
joy                   L18    1f602      😂 1f602
rocket                L1116  1f680      🚀 1f680
eyes                  L242   1f440      👀 1f440
pray                  L225   1f64f      🙏 1f64f
fire                  L1211  1f525      🔥 1f525
100                   L166   1f4af      💯 1f4af
warning               L1598  26a0-fe0f  ⚠ 26a0 (FE0F stripped on input)
heavy_plus_sign       L1695  2795       ➕ 2795
heavy_minus_sign      L1696  2796       ➖ 2796
thinking_face         L47    1f914      🤔 1f914
zap                   L1205  26a1       ⚡ 26a1
globe_with_meridians  L974   1f310      🌐 1f310
scream                L103   1f631      😱 1f631
brain                 L237   1f9e0      🧠 1f9e0
computer              L1395  1f4bb      💻 1f4bb
wave                  L181   1f44b      👋 1f44b
raised_hands          L221   1f64c      🙌 1f64c
```

Line numbers refer to `server/public/model/emoji_data.go` at tag `v11.10.0`; the same 24 names are present at `v10.11.23`.

</details>
