### PR TITLE
fix(android): make realtime Talk interruptible during playback

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -9,6 +9,8 @@ import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.AudioRouting
 import android.media.MediaRecorder
+import android.media.audiofx.AcousticEchoCanceler
+import android.media.audiofx.AudioEffect
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -21,10 +23,22 @@ internal data class AudioInputDeviceOption(
   val type: Int,
 )
 
+/** Selects the Android capture semantics for one [AndroidAudioInputSession]. */
+internal enum class AndroidAudioInputProfile(
+  internal val audioSource: Int,
+) {
+  /** Manual Mic/STT: unchanged recognition-oriented capture. */
+  VoiceRecognition(MediaRecorder.AudioSource.VOICE_RECOGNITION),
+
+  /** Realtime Talk: communication-oriented capture, paired with platform AEC ownership. */
+  VoiceCommunication(MediaRecorder.AudioSource.VOICE_COMMUNICATION),
+}
+
 /** Owns one recorder and its Bluetooth route for the full capture lifecycle. */
 internal class AndroidAudioInputSession private constructor(
   private val audioManager: AudioManager,
   private val audioRecord: AudioRecord,
+  private val acousticEchoCanceler: AcousticEchoCanceler?,
   private val preferredInputKey: String?,
   private val onAppliedPreferredDeviceChanged: (String?) -> Unit,
   private val setPreferredDevice: (AudioDeviceInfo?) -> Boolean,
@@ -40,6 +54,7 @@ internal class AndroidAudioInputSession private constructor(
       preferredDeviceKey: String? = null,
       onAppliedPreferredDeviceChanged: (String?) -> Unit = {},
       setPreferredDevice: ((AudioDeviceInfo?) -> Boolean)? = null,
+      profile: AndroidAudioInputProfile = AndroidAudioInputProfile.VoiceRecognition,
     ): AndroidAudioInputSession {
       val minBuffer =
         AudioRecord.getMinBufferSize(
@@ -53,7 +68,7 @@ internal class AndroidAudioInputSession private constructor(
       val audioRecord =
         AudioRecord
           .Builder()
-          .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+          .setAudioSource(profile.audioSource)
           .setAudioFormat(
             AudioFormat
               .Builder()
@@ -63,10 +78,21 @@ internal class AndroidAudioInputSession private constructor(
               .build(),
           ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
           .build()
+      // AEC is optional. The caller's forwarding policy already falls back to safe
+      // half-duplex capture when it is absent, so an effect that cannot be set up
+      // must never cost the session its microphone.
+      val acousticEchoCanceler =
+        try {
+          openAcousticEchoCanceler(profile, audioRecord.audioSessionId)
+        } catch (err: RuntimeException) {
+          Log.w(tag, "AcousticEchoCanceler setup failed: ${err.message ?: err::class.simpleName}")
+          null
+        }
       val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
       return AndroidAudioInputSession(
         audioManager = audioManager,
         audioRecord = audioRecord,
+        acousticEchoCanceler = acousticEchoCanceler,
         preferredInputKey = preferredDeviceKey,
         onAppliedPreferredDeviceChanged = onAppliedPreferredDeviceChanged,
         setPreferredDevice = setPreferredDevice ?: audioRecord::setPreferredDevice,
@@ -78,6 +104,33 @@ internal class AndroidAudioInputSession private constructor(
           throw err
         }
       }
+    }
+
+    /**
+     * Communication-profile capture only: attaches platform AEC to the just-built
+     * [AudioRecord] and reads back the enabled state Android actually applied — a
+     * successful [AcousticEchoCanceler.create] does not itself mean AEC is active.
+     */
+    private fun openAcousticEchoCanceler(
+      profile: AndroidAudioInputProfile,
+      audioSessionId: Int,
+    ): AcousticEchoCanceler? {
+      if (profile != AndroidAudioInputProfile.VoiceCommunication) return null
+      if (!AcousticEchoCanceler.isAvailable()) return null
+      val canceler = AcousticEchoCanceler.create(audioSessionId) ?: return null
+      val enableResult = runCatching { if (canceler.enabled) AudioEffect.SUCCESS else canceler.setEnabled(true) }
+      val result = enableResult.getOrNull()
+      if (result == null) {
+        // Release the half-configured effect rather than leaking it, and report
+        // no AEC so the caller keeps its half-duplex fallback.
+        Log.w(tag, "AcousticEchoCanceler enable threw: ${enableResult.exceptionOrNull()?.message ?: "unknown"}")
+        runCatching { canceler.release() }
+        return null
+      }
+      if (result != AudioEffect.SUCCESS) {
+        Log.w(tag, "AcousticEchoCanceler enable failed result=$result")
+      }
+      return canceler
     }
 
     fun listAvailableDevices(context: Context): List<AudioInputDeviceOption> {
@@ -145,6 +198,17 @@ internal class AndroidAudioInputSession private constructor(
 
   internal val appliedPreferredDeviceKey: String?
     get() = synchronized(lock) { appliedPreferredInputKey }
+
+  /** The rate AudioRecord actually negotiated, which need not be the requested one;
+   * callers converting capture to a wire rate must build that conversion from this. */
+  internal val actualSampleRateHz: Int
+    get() = audioRecord.sampleRate
+
+  /** Whether platform AEC was created for this session and Android accepted enabling it,
+   * read back from the effect rather than inferred from
+   * [AndroidAudioInputProfile.VoiceCommunication] alone. Snapshotted at open time on
+   * purpose: the effect is released in [close], so a live read could outlive it. */
+  internal val communicationEchoCancellationEnabled: Boolean = acousticEchoCanceler?.enabled == true
 
   fun startRecording() {
     synchronized(lock) {
@@ -270,6 +334,9 @@ internal class AndroidAudioInputSession private constructor(
       requestedInput = null
       selectedInput = null
       setAppliedPreferredInputKey(null)
+      // The effect is attached to the recorder's audio session, so it is released
+      // first — releasing the recorder destroys the session it is bound to.
+      runCatching { acousticEchoCanceler?.release() }
       if (audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
         runCatching { audioRecord.stop() }
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -39,6 +39,7 @@ internal class AndroidAudioInputSession private constructor(
   private val audioManager: AudioManager,
   private val audioRecord: AudioRecord,
   private val acousticEchoCanceler: AcousticEchoCanceler?,
+  private val profile: AndroidAudioInputProfile,
   private val preferredInputKey: String?,
   private val onAppliedPreferredDeviceChanged: (String?) -> Unit,
   private val setPreferredDevice: (AudioDeviceInfo?) -> Boolean,
@@ -93,6 +94,7 @@ internal class AndroidAudioInputSession private constructor(
         audioManager = audioManager,
         audioRecord = audioRecord,
         acousticEchoCanceler = acousticEchoCanceler,
+        profile = profile,
         preferredInputKey = preferredDeviceKey,
         onAppliedPreferredDeviceChanged = onAppliedPreferredDeviceChanged,
         setPreferredDevice = setPreferredDevice ?: audioRecord::setPreferredDevice,
@@ -178,6 +180,7 @@ internal class AndroidAudioInputSession private constructor(
   private var requestedCommunicationDevice: AudioDeviceInfo? = null
   private var selectedInput: AudioDeviceInfo? = null
   private var appliedPreferredInputKey: String? = null
+  private var appliedCommunicationType: Int? = null
 
   private val deviceCallback =
     object : AudioDeviceCallback() {
@@ -198,6 +201,36 @@ internal class AndroidAudioInputSession private constructor(
 
   internal val appliedPreferredDeviceKey: String?
     get() = synchronized(lock) { appliedPreferredInputKey }
+
+  /** Type of the communication output device this session actually holds, or null when it
+   * holds none — either because it is a recognition-profile session, or because the
+   * platform rejected the selection. Never inferred from what was requested. */
+  internal val appliedCommunicationDeviceType: Int?
+    get() = synchronized(lock) { appliedCommunicationType }
+
+  /**
+   * The built-in speaker, but only when selecting it is the difference between the
+   * loudspeaker and the earpiece.
+   *
+   * Any external communication output — wired or USB headset, hearing aid, dock —
+   * already outranks the earpiece in Android's own routing, so forcing the speaker
+   * there would blast audio out of the phone while a headset is plugged in. The only
+   * case that needs an explicit choice is a device whose communication outputs are
+   * just the built-in pair, where the default lands on the earpiece.
+   */
+  private fun builtInSpeakerForCommunicationCapture(available: List<AudioDeviceInfo>): AudioDeviceInfo? {
+    if (profile != AndroidAudioInputProfile.VoiceCommunication) return null
+    val hasExternalOutput =
+      available.any {
+        it.type != AudioDeviceInfo.TYPE_BUILTIN_SPEAKER && it.type != AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
+      }
+    if (hasExternalOutput) return null
+    return available.firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }
+  }
+
+  private fun setAppliedCommunicationDeviceType(value: Int?) {
+    appliedCommunicationType = value
+  }
 
   /** The rate AudioRecord actually negotiated, which need not be the requested one;
    * callers converting capture to a wire rate must build that conversion from this. */
@@ -263,14 +296,27 @@ internal class AndroidAudioInputSession private constructor(
     inputs: List<AudioDeviceInfo>,
     preferredInput: AudioDeviceInfo?,
   ): Boolean {
-    val communicationDevice =
+    val available = audioManager.availableCommunicationDevices
+    val bluetoothDevice =
       if (preferredInput == null) {
-        selectBluetoothDevice(audioManager.availableCommunicationDevices, requestedCommunicationDevice)
+        selectBluetoothDevice(available, requestedCommunicationDevice)
       } else {
-        selectCommunicationDevice(audioManager.availableCommunicationDevices, preferredInput)
+        selectCommunicationDevice(available, preferredInput)
       }
-    val communicationSelected = bluetoothCommunicationRoute.update(audioManager, communicationRouteOwner, communicationDevice)
-    requestedCommunicationDevice = communicationDevice.takeIf { communicationSelected }
+    // Communication-profile capture owns the output route too. Without an explicit
+    // selection Android's phone strategy sends STREAM_VOICE_CALL to the earpiece,
+    // which turns hands-free Talk into hold-to-your-ear Talk; the recognition
+    // profile (manual Mic/STT) must keep its existing no-ownership behaviour.
+    val communicationDevice = bluetoothDevice ?: builtInSpeakerForCommunicationCapture(available)
+    val outcome = bluetoothCommunicationRoute.update(audioManager, communicationRouteOwner, communicationDevice)
+    if (outcome == CommunicationRouteOutcome.Rejected) {
+      Log.w(tag, "communication device rejected type=${communicationDevice?.type}")
+    }
+    val selectedCommunicationDevice = communicationDevice.takeIf { outcome == CommunicationRouteOutcome.Selected }
+    setAppliedCommunicationDeviceType(selectedCommunicationDevice?.type)
+    // Input following stays Bluetooth-only: the built-in speaker is an output device
+    // and must never be fed to the input selector as if it were a headset.
+    requestedCommunicationDevice = bluetoothDevice.takeIf { outcome == CommunicationRouteOutcome.Selected }
     val input = preferredInput ?: selectBluetoothInput(inputs, requestedInput, requestedCommunicationDevice)
     if (sameDevice(requestedInput, input) && sameDevice(selectedInput, input)) return true
     requestedInput = input
@@ -341,10 +387,29 @@ internal class AndroidAudioInputSession private constructor(
         runCatching { audioRecord.stop() }
       }
       runCatching { audioRecord.release() }
+      // Releases the process communication route this session held, so Talk-owned
+      // routing does not leak into unrelated app audio after Talk stops.
       bluetoothCommunicationRoute.close(audioManager, communicationRouteOwner)
       requestedCommunicationDevice = null
+      appliedCommunicationType = null
     }
   }
+}
+
+/**
+ * Result of one communication-route update. Distinguishing a rejection from "nothing was
+ * wanted" is the point: a Boolean cannot say whether the platform refused a device we asked
+ * for, and callers must never report speaker routing as achieved when it was refused.
+ */
+private enum class CommunicationRouteOutcome {
+  /** The requested device is now the active communication device. */
+  Selected,
+
+  /** No device was requested; any previously held route was released. */
+  Cleared,
+
+  /** A device was requested and the platform refused it. */
+  Rejected,
 }
 
 /** Serializes Android's process-wide communication route across overlapping capture cleanup. */
@@ -366,21 +431,23 @@ private class BluetoothCommunicationRoute {
     audioManager: AudioManager,
     owner: Long,
     device: AudioDeviceInfo?,
-  ): Boolean {
-    if (owner < latestOwner) return false
+  ): CommunicationRouteOutcome {
+    // A superseded owner must not disturb a newer session's route, and it has not
+    // requested anything of its own, so this is Cleared rather than Rejected.
+    if (owner < latestOwner) return CommunicationRouteOutcome.Cleared
     latestOwner = owner
     if (device == null) {
       if (activeOwner != null) audioManager.clearCommunicationDevice()
       activeOwner = null
-      return false
+      return CommunicationRouteOutcome.Cleared
     }
     if (!audioManager.setCommunicationDevice(device)) {
       if (activeOwner != null) audioManager.clearCommunicationDevice()
       activeOwner = null
-      return false
+      return CommunicationRouteOutcome.Rejected
     }
     activeOwner = owner
-    return true
+    return CommunicationRouteOutcome.Selected
   }
 
   @Synchronized

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCaptureResampler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCaptureResampler.kt
@@ -1,0 +1,126 @@
+package ai.openclaw.app.voice
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/**
+ * Converts little-endian PCM16 mono audio from a device-portable hardware
+ * capture rate to the realtime wire rate the Gateway declared in
+ * talk.session.create's audio contract. Android hardware capture and the
+ * realtime wire format are separate invariants (Android 14 CDD only
+ * guarantees 16k/44.1k/48k raw PCM capture; the wire rate is whatever the
+ * Gateway configured for the provider) and must never be conflated by
+ * sending unconverted PCM at the wrong clock.
+ *
+ * Only exact integer downsample ratios are supported (anti-alias FIR
+ * lowpass + decimate-by-M, or a passthrough when the rates already match).
+ * [resolveRealtimeCaptureResampler] returns null for any other ratio so the
+ * caller fails closed instead of shipping mis-clocked audio.
+ */
+internal class RealtimeCaptureResampler private constructor(
+  private val decimationFactor: Int,
+  private val taps: DoubleArray,
+) {
+  companion object {
+    fun create(decimationFactor: Int): RealtimeCaptureResampler {
+      if (decimationFactor <= 1) return RealtimeCaptureResampler(1, DoubleArray(0))
+      val numTaps = 8 * decimationFactor + 1
+      val center = (numTaps - 1) / 2.0
+      val cutoff = 1.0 / (2.0 * decimationFactor)
+      val raw =
+        DoubleArray(numTaps) { n ->
+          val x = n - center
+          val ideal = if (x == 0.0) 2.0 * cutoff else sin(2.0 * PI * cutoff * x) / (PI * x)
+          val window = 0.54 - 0.46 * cos(2.0 * PI * n / (numTaps - 1))
+          ideal * window
+        }
+      val gain = raw.sum()
+      return RealtimeCaptureResampler(decimationFactor, DoubleArray(numTaps) { raw[it] / gain })
+    }
+  }
+
+  private val historyLen = (taps.size - 1).coerceAtLeast(0)
+  private val history = DoubleArray(historyLen)
+  private var phase = 0
+  private var pendingByte: Byte? = null
+
+  /** Consumes one capture-rate PCM16 chunk (first [length] bytes of [input]) and returns wire-rate PCM16 bytes. */
+  fun process(
+    input: ByteArray,
+    length: Int,
+  ): ByteArray {
+    val samples = consumeBytes(input, length)
+    if (decimationFactor == 1) return samplesToBytes(samples)
+    if (samples.isEmpty()) return ByteArray(0)
+    val combined = DoubleArray(historyLen + samples.size)
+    history.copyInto(combined)
+    samples.copyInto(combined, historyLen)
+    val outputs = ArrayList<Double>(samples.size / decimationFactor + 1)
+    for (i in samples.indices) {
+      if ((phase + i) % decimationFactor == decimationFactor - 1) {
+        val windowEnd = historyLen + i
+        var acc = 0.0
+        for (k in taps.indices) acc += taps[k] * combined[windowEnd - k]
+        outputs.add(acc)
+      }
+    }
+    phase = (phase + samples.size) % decimationFactor
+    combined.copyInto(history, destinationOffset = 0, startIndex = samples.size, endIndex = samples.size + historyLen)
+    return samplesToBytes(outputs.toDoubleArray())
+  }
+
+  /** Merges a carried-over odd trailing byte with [input] and decodes little-endian PCM16 samples. */
+  private fun consumeBytes(
+    input: ByteArray,
+    length: Int,
+  ): DoubleArray {
+    val usableLength = length.coerceIn(0, input.size)
+    val prefix = pendingByte
+    pendingByte = null
+    val merged =
+      if (prefix == null) {
+        input
+      } else {
+        ByteArray(usableLength + 1).also { buf ->
+          buf[0] = prefix
+          System.arraycopy(input, 0, buf, 1, usableLength)
+        }
+      }
+    val mergedLength = usableLength + if (prefix == null) 0 else 1
+    val sampleCount = mergedLength / 2
+    val samples = DoubleArray(sampleCount)
+    for (i in 0 until sampleCount) {
+      val base = i * 2
+      val lo = merged[base].toInt() and 0xff
+      val hi = merged[base + 1].toInt()
+      samples[i] = ((lo) or (hi shl 8)).toShort().toInt().toDouble()
+    }
+    if (mergedLength % 2 == 1) pendingByte = merged[mergedLength - 1]
+    return samples
+  }
+
+  private fun samplesToBytes(samples: DoubleArray): ByteArray {
+    val out = ByteArray(samples.size * 2)
+    for (i in samples.indices) {
+      val clamped = samples[i].roundToInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+      out[i * 2] = (clamped and 0xff).toByte()
+      out[i * 2 + 1] = ((clamped shr 8) and 0xff).toByte()
+    }
+    return out
+  }
+}
+
+/**
+ * Resolves the capture-to-wire converter for [captureRateHz] -> [wireRateHz], or null when the
+ * ratio isn't an exact integer downsample (caller must fail closed rather than guess a conversion).
+ */
+internal fun resolveRealtimeCaptureResampler(
+  captureRateHz: Int,
+  wireRateHz: Int,
+): RealtimeCaptureResampler? {
+  if (captureRateHz <= 0 || wireRateHz <= 0 || captureRateHz < wireRateHz) return null
+  if (captureRateHz % wireRateHz != 0) return null
+  return RealtimeCaptureResampler.create(captureRateHz / wireRateHz)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -125,6 +125,27 @@ internal suspend fun requestPhoneRealtimeSessionWithLanguageFallback(
     request(null)
   }
 
+internal data class RealtimeWireAudioContract(
+  val encoding: String?,
+  val sampleRateHz: Int?,
+)
+
+/**
+ * TalkSessionCreateResultSchema.audio is optional (older/simpler Gateway peers omit it
+ * entirely); an absent field is the established legacy PCM16/24kHz relay format iOS also
+ * still defaults to (RealtimeTalkRelaySession.configureAudioContract), not an unsupported
+ * contract. A field that IS present but doesn't parse as a usable pcm16 rate stays
+ * fail-closed via the caller's existing null checks.
+ */
+internal fun parseRealtimeWireAudioContract(root: JsonObject?): RealtimeWireAudioContract {
+  val rawAudioContract = root?.get("audio") ?: return RealtimeWireAudioContract("pcm16", 24_000)
+  val audioContract = rawAudioContract.asObjectOrNull()
+  return RealtimeWireAudioContract(
+    encoding = audioContract?.get("inputEncoding").asStringOrNull(),
+    sampleRateHz = audioContract?.get("inputSampleRateHz").asIntOrNull(),
+  )
+}
+
 private enum class TalkStatusState {
   Off,
   Active,
@@ -137,21 +158,76 @@ private data class TalkStatus(
   val awaitingAgent: Boolean = false,
 )
 
-private sealed interface RealtimePlaybackItem {
+/**
+ * Commands the Gateway message pump enqueues (trySend only, never blocking)
+ * for the single realtime playout owner coroutine to process. Audio/Mark
+ * carry the epoch that was current when the Gateway event arrived, so the
+ * owner can discard a command superseded by a later Clear/Stop without
+ * needing to touch AudioTrack or any owner-exclusive state from the pump.
+ */
+private sealed interface RealtimePlaybackCommand {
   data class Audio(
+    val epoch: Long,
     val bytes: ByteArray,
-  ) : RealtimePlaybackItem
+  ) : RealtimePlaybackCommand
 
   data class Mark(
-    val name: String,
-  ) : RealtimePlaybackItem
+    val sessionId: String,
+    val markName: String,
+  ) : RealtimePlaybackCommand
+
+  data class Clear(
+    val epoch: Long,
+    val completion: CompletableDeferred<Unit>?,
+  ) : RealtimePlaybackCommand
+
+  data class Stop(
+    /**
+     * True only for real relay teardown, which drops pending marks unacknowledged.
+     * A plain playback stop (PTT pause, TTS stop, playback disabled) keeps them: the
+     * provider's own `clear` for that cancelled turn arrives afterwards and is what
+     * acknowledges them.
+     */
+    val discardMarks: Boolean,
+  ) : RealtimePlaybackCommand
+
+  data object PollIdle : RealtimePlaybackCommand
 }
+
+/** One opened realtime capture session together with the converter its negotiated rate resolved to. */
+private class RealtimeCaptureOpen(
+  val session: AndroidAudioInputSession,
+  val resampler: RealtimeCaptureResampler,
+  val captureSampleRateHz: Int,
+)
 
 private data class PendingRealtimePlaybackMark(
   val sessionId: String,
   val name: String,
   var targetFrame: Long? = null,
 )
+
+/**
+ * Testable seam for the one hardware call realtime playout depends on.
+ * Default writes non-blocking so the playout owner never does a blocking
+ * data-transfer call; production behavior is otherwise identical to a plain
+ * AudioTrack.write call.
+ */
+internal fun interface RealtimeAudioTrackWriter {
+  fun write(
+    track: AudioTrack,
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int
+
+  companion object {
+    val Default =
+      RealtimeAudioTrackWriter { track, bytes, offset, length ->
+        track.write(bytes, offset, length, AudioTrack.WRITE_NON_BLOCKING)
+      }
+  }
+}
 
 private class PushToTalkAudioSource(
   val readDescriptor: ParcelFileDescriptor,
@@ -220,15 +296,42 @@ class TalkModeManager internal constructor(
   private val realtimeCaptureDispatcher: CoroutineDispatcher = Dispatchers.IO,
   private val realtimePlaybackDispatcher: CoroutineDispatcher = Dispatchers.IO,
   private val realtimeMarkAcknowledger: (suspend (sessionId: String, markName: String) -> Unit)? = null,
+  private val realtimeAudioTrackWriter: RealtimeAudioTrackWriter = RealtimeAudioTrackWriter.Default,
+  // Separate from `scope` only so tests can exempt this specific
+  // intentionally-infinite coroutine (and its idle-poll ticker) from
+  // kotlinx-coroutines-test's "all child jobs of the test scope must
+  // complete" check, without also exempting gatewayWorkScope (which is
+  // built from `scope`'s CoroutineContext and must stay normally tracked).
+  // Production always defaults this to `scope` — same lifetime either way.
+  private val realtimePlaybackOwnerScope: CoroutineScope = scope,
 ) {
   companion object {
     private const val tag = "TalkMode"
-    private const val realtimeSampleRateHz = 24_000
+
+    // Realtime playback (provider -> device) is Gateway-declared PCM16 wire
+    // audio, played back verbatim; realtime capture (device -> provider) uses
+    // a device-portable hardware rate and is resampled to the Gateway's
+    // declared wire rate before appendAudio (see startRealtimeCaptureLocked).
+    // These are deliberately separate constants: Android 14 CDD only
+    // guarantees 16k/44.1k/48k raw PCM capture, so capture cannot assume the
+    // wire rate is a usable AudioRecord rate on every device.
+    private const val realtimeOutputSampleRateHz = 24_000
+    private const val realtimeCapturePortableSampleRateHz = 48_000
     private const val realtimeAudioFrameMs = 100
     private const val chatFinalWaitMs = 45_000L
     private const val maxCachedRunCompletions = 128
     private const val maxConversationEntries = 40
     private const val realtimePlaybackBufferMs = 240
+    private const val realtimePlaybackIdlePollMs = 20L
+
+    // Retry backoff after AudioTrack.write(..., WRITE_NON_BLOCKING) reports 0
+    // bytes accepted (hardware buffer momentarily full). This delay runs
+    // inside the single playout owner coroutine only — never under a lock
+    // the Gateway message pump needs — so it cannot reproduce the receive
+    // head-of-line blocking this design replaces (see
+    // processRealtimeAudioCommandOwnerOnly). Bounded and short relative to
+    // realtimeAudioFrameMs (100ms provider cadence).
+    private const val realtimePlaybackWriteRetryDelayMs = 5L
     private const val realtimeUserFinalRewriteGraceMs = 1_500L
     private const val pushToTalkSampleRateHz = 16_000
     private const val pushToTalkReleaseGraceMs = 5_000L
@@ -342,10 +445,18 @@ class TalkModeManager internal constructor(
   private val audioInputGeneration = AtomicLong(0L)
 
   @Volatile private var realtimeSessionId: String? = null
+  private var realtimeWireAudioSampleRateHz: Int? = null
+  private var realtimeWireAudioEncoding: String? = null
   private var realtimeCaptureJob: Job? = null
   private var realtimeAppendJob: Job? = null
   private val realtimeCapturePauseLock = Any()
   private var realtimeCapturePause: RealtimeCapturePause? = null
+
+  // True only while communication-profile capture reports platform AEC actually
+  // enabled; drives the full-duplex forwarding policy in
+  // shouldSuppressRealtimeCaptureForPlayback. Cleared whenever the capture job
+  // that set it ends, so a later session/profile never inherits a stale true.
+  @Volatile private var realtimeAecEnabled = false
 
   private val finishingPttLock = Any()
 
@@ -376,13 +487,58 @@ class TalkModeManager internal constructor(
   private var realtimeUserEntryAwaitingFinal = false
   private var realtimeUserEntryAwaitingFinalStartedAtMs: Long? = null
   private var realtimeAssistantEntryId: String? = null
-  private val realtimePlaybackLock = Any()
+
+  // Single logical owner of AudioTrack create/write/pause/flush/stop/release
+  // and every field below it in this group: the Gateway message pump only
+  // ever enqueues commands here (trySend, never blocking, never touches
+  // AudioTrack or these fields directly) — see realtimeAudioWriterJob and
+  // RealtimePlaybackCommand. Long-lived for this TalkModeManager's full
+  // lifetime rather than recreated per session, so there is no per-session
+  // channel-close/recreate race to guard against.
+  private val realtimePlaybackCommands = Channel<RealtimePlaybackCommand>(Channel.UNLIMITED)
+  private val realtimePlaybackEpoch = AtomicLong(0L)
   private var realtimeAudioTrack: AudioTrack? = null
-  private var realtimeAudioQueue: Channel<RealtimePlaybackItem>? = null
-  private var realtimeAudioWriterJob: Job? = null
-  private var realtimePlaybackIdleJob: Job? = null
   private var realtimeWrittenFrames = 0L
   private val pendingRealtimePlaybackMarks = LinkedHashMap<String, PendingRealtimePlaybackMark>()
+  private var realtimePlaybackIdleJob: Job? = null
+
+  // Declared above the launch below: the coroutine body mutates them, and a
+  // field initializer that starts a coroutine must not depend on fields the
+  // constructor has not reached yet.
+  private val realtimeAudioWriterJob: Job =
+    realtimePlaybackOwnerScope.launch(realtimePlaybackDispatcher) {
+      for (command in realtimePlaybackCommands) {
+        // Per-command boundary: an uncaught throw here (e.g. AudioTrack
+        // creation/write failing on a route/dead-object error) would
+        // otherwise end this for-loop and terminate the owner job for the
+        // rest of the manager's lifetime — the channel is long-lived and
+        // never recreated, so every later command would enqueue into a
+        // consumer that no longer exists. Retire the track so the next
+        // Audio command starts clean instead of reusing a track that may be
+        // in whatever state the failure left it.
+        try {
+          when (command) {
+            is RealtimePlaybackCommand.Audio -> processRealtimeAudioCommandOwnerOnly(command)
+            is RealtimePlaybackCommand.Mark -> processRealtimeMarkCommandOwnerOnly(command)
+            is RealtimePlaybackCommand.Clear -> processRealtimeClearCommandOwnerOnly(command)
+            is RealtimePlaybackCommand.Stop -> processRealtimeStopCommandOwnerOnly(command)
+            RealtimePlaybackCommand.PollIdle -> processRealtimePollIdleCommandOwnerOnly()
+          }
+        } catch (err: Throwable) {
+          if (err is CancellationException) throw err
+          Log.w(tag, "realtime playback command failed: ${err.message ?: err::class.simpleName}")
+          // Treat a failure like Clear for any mark still pending against the
+          // track being retired: retireRealtimeAudioTrackOwnerOnly() resets
+          // realtimeWrittenFrames to 0, so a stale positive targetFrame would
+          // otherwise never be satisfied again — takeCompletedRealtimePlaybackMarksOwnerOnly()
+          // would poll it forever and the provider would never get its ack.
+          val strandedMarks = pendingRealtimePlaybackMarks.values.toList()
+          pendingRealtimePlaybackMarks.clear()
+          retireRealtimeAudioTrackOwnerOnly()
+          acknowledgeRealtimePlaybackMarks(strandedMarks)
+        }
+      }
+    }
 
   @Volatile private var pendingRealtimeOutputClear: CompletableDeferred<Unit>? = null
   private val realtimeOutputCancellationMutex = Mutex()
@@ -1137,6 +1293,13 @@ class TalkModeManager internal constructor(
       throw CancellationException("realtime talk stopped while connecting")
     }
 
+    // Capture must resample to whatever wire rate the Gateway declares here,
+    // never a rate Android assumes on its own (see realtimeCapturePortableSampleRateHz).
+    val wireAudioContract = parseRealtimeWireAudioContract(root)
+    realtimeWireAudioEncoding = wireAudioContract.encoding
+    realtimeWireAudioSampleRateHz = wireAudioContract.sampleRateHz
+
+    var captureInstalled = false
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {
         // Session publication and capture installation are one transition. PTT
@@ -1157,7 +1320,7 @@ class TalkModeManager internal constructor(
           realtimeOutputSuppressed = false
           _isListening.value = true
           setStatus(nativeText("Listening"))
-          startRealtimeCaptureLocked(sessionId)
+          captureInstalled = startRealtimeCaptureLocked(sessionId)
           false
         }
       }
@@ -1165,6 +1328,7 @@ class TalkModeManager internal constructor(
       Log.d(tag, "realtime session ready; capture paused for PTT relaySessionId=$sessionId")
       return
     }
+    if (!captureInstalled) return
     Log.d(tag, "realtime session started relaySessionId=$sessionId")
   }
 
@@ -1228,9 +1392,28 @@ class TalkModeManager internal constructor(
         )
     }
 
-  /** Caller holds [realtimeCapturePauseLock] so PTT cannot miss newly installed jobs. */
+  /**
+   * Caller holds [realtimeCapturePauseLock] so PTT cannot miss newly installed jobs.
+   * Returns false when the session was failed instead of capture being installed, so
+   * callers do not report a session that is already being torn down as started.
+   */
   @SuppressLint("MissingPermission")
-  private fun startRealtimeCaptureLocked(sessionId: String) {
+  private fun startRealtimeCaptureLocked(sessionId: String): Boolean {
+    val wireSampleRateHz = realtimeWireAudioSampleRateHz
+    val wireEncoding = realtimeWireAudioEncoding
+    // Only the wire half of the contract can be judged before the microphone is
+    // open: whether a converter exists depends on the rate AudioRecord actually
+    // negotiates, which is checked once below. Rejecting a declared wire rate
+    // here against the merely requested capture rate would fail sessions this
+    // device can still serve.
+    if (wireEncoding != "pcm16" || wireSampleRateHz == null) {
+      Log.w(
+        tag,
+        "realtime capture rejected: unsupported wire audio format encoding=$wireEncoding sampleRateHz=$wireSampleRateHz",
+      )
+      failRealtimeRelay(sessionId, "unsupported realtime audio format")
+      return false
+    }
     realtimeCaptureJob?.cancel()
     realtimeAppendJob?.cancel()
     val inputGeneration = audioInputGeneration.incrementAndGet()
@@ -1244,7 +1427,7 @@ class TalkModeManager internal constructor(
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
           if (realtimeSessionId != sessionId) continue
-          if (isRealtimePlaybackActive()) continue
+          if (shouldSuppressRealtimeCaptureForPlayback()) continue
           val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
           val params =
             buildJsonObject {
@@ -1272,26 +1455,43 @@ class TalkModeManager internal constructor(
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         var audioInput: AndroidAudioInputSession? = null
         try {
-          val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000
-          val openedAudioInput =
-            AndroidAudioInputSession.open(
-              context,
-              realtimeSampleRateHz,
-              frameBytes,
-              preferredAudioInputDevice(),
-              { key ->
-                if (audioInputGeneration.get() == inputGeneration) onAppliedAudioInputChanged(key)
-              },
+          val frameBytes = realtimeCapturePortableSampleRateHz * 2 * realtimeAudioFrameMs / 1000
+          val opened =
+            openRealtimeCaptureSession(
+              // The portable rate is a preference, not a requirement: a device that
+              // cannot open it, or whose negotiated rate cannot reach the wire rate,
+              // must not lose Talk entirely — capturing straight at the wire rate is
+              // what this endpoint did before and needs no conversion at all.
+              candidateSampleRatesHz = listOf(realtimeCapturePortableSampleRateHz, wireSampleRateHz),
+              wireSampleRateHz = wireSampleRateHz,
+              frameBytes = frameBytes,
+              inputGeneration = inputGeneration,
             )
+          val openedAudioInput = opened.session
           audioInput = openedAudioInput
-          val buffer = ByteArray(frameBytes)
+          val captureSampleRateHz = opened.captureSampleRateHz
+          val resampler = opened.resampler
+          val aecEnabled = openedAudioInput.communicationEchoCancellationEnabled
+          // Generation-guarded: this coroutine's own cancellation is not
+          // synchronous with the caller that requested it (realtimeCaptureJob?.cancel()
+          // above returns immediately), so a superseded job can still be
+          // between its cancellation check and here when a newer one starts.
+          if (audioInputGeneration.get() == inputGeneration) {
+            realtimeAecEnabled = aecEnabled
+          }
+          Log.d(tag, "realtime capture opened rateHz=$captureSampleRateHz aecEnabled=$aecEnabled")
+          // One read stays realtimeAudioFrameMs of audio at the negotiated rate,
+          // so uplink pacing does not stretch when that rate is below the
+          // requested one. Never larger than the buffer the recorder was sized for.
+          val buffer = ByteArray(minOf(captureSampleRateHz * 2 * realtimeAudioFrameMs / 1000, frameBytes))
           audioInput.startRecording()
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
             _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.pcm16Level(buffer, read))
-            if (!shouldAppendRealtimeCapturedFrame(read)) continue
-            audioFrames.trySend(buffer.copyOf(read))
+            val resampled = resampler.process(buffer, read)
+            if (!shouldAppendRealtimeCapturedFrame(resampled.size)) continue
+            audioFrames.trySend(resampled)
           }
         } catch (err: Throwable) {
           if (err is CancellationException) throw err
@@ -1301,11 +1501,72 @@ class TalkModeManager internal constructor(
           audioFrames.close()
           audioInput?.close()
           _inputLevel.value = 0f
+          // Same generation guard as the assignment above: a newer capture
+          // job may already have set realtimeAecEnabled for its own session
+          // by the time this superseded job's finally runs.
+          if (audioInputGeneration.get() == inputGeneration) {
+            realtimeAecEnabled = false
+          }
         }
       }
+    return true
   }
 
-  private fun shouldAppendRealtimeCapturedFrame(length: Int): Boolean = !isRealtimePlaybackActive() && length > 0
+  /**
+   * Opens realtime capture at the first of [candidateSampleRatesHz] the device both accepts
+   * and can be converted to [wireSampleRateHz] from. `AudioRecord` rejects a rate it cannot
+   * deliver by throwing from its builder, and the rate it actually negotiates is only
+   * readable once open, so both halves have to be decided per candidate: a rate that opens
+   * but yields no converter is closed again and the next candidate tried. A device that has
+   * no usable candidate fails the session closed.
+   */
+  @SuppressLint("MissingPermission")
+  private fun openRealtimeCaptureSession(
+    candidateSampleRatesHz: List<Int>,
+    wireSampleRateHz: Int,
+    frameBytes: Int,
+    inputGeneration: Long,
+  ): RealtimeCaptureOpen {
+    var lastFailure: Throwable? = null
+    for (sampleRateHz in candidateSampleRatesHz.distinct()) {
+      val session =
+        try {
+          AndroidAudioInputSession.open(
+            context,
+            sampleRateHz,
+            frameBytes,
+            preferredAudioInputDevice(),
+            { key ->
+              if (audioInputGeneration.get() == inputGeneration) onAppliedAudioInputChanged(key)
+            },
+            profile = AndroidAudioInputProfile.VoiceCommunication,
+          )
+        } catch (err: RuntimeException) {
+          Log.w(tag, "realtime capture could not open at ${sampleRateHz}Hz: ${err.message ?: err::class.simpleName}")
+          lastFailure = err
+          continue
+        }
+      // The recorder, not the request, owns the capture clock.
+      val captureSampleRateHz = session.actualSampleRateHz
+      val resampler = resolveRealtimeCaptureResampler(captureSampleRateHz, wireSampleRateHz)
+      if (resampler != null) {
+        return RealtimeCaptureOpen(session = session, resampler = resampler, captureSampleRateHz = captureSampleRateHz)
+      }
+      Log.w(tag, "realtime capture negotiated ${captureSampleRateHz}Hz, which cannot convert to the ${wireSampleRateHz}Hz wire rate")
+      session.close()
+      lastFailure = IllegalStateException("microphone audio cannot be converted to this session's format")
+    }
+    throw lastFailure ?: IllegalStateException("no usable microphone capture rate")
+  }
+
+  // Centralizes the full-duplex forwarding policy so the append-loop and
+  // capture-loop suppression checks cannot drift: communication-profile capture
+  // with platform AEC actually enabled keeps forwarding through assistant
+  // playback; otherwise the pre-existing playback-time suppression is the safe
+  // fallback (route-independent — no Bluetooth/wired/USB heuristic).
+  private fun shouldSuppressRealtimeCaptureForPlayback(): Boolean = isRealtimePlaybackActive() && !realtimeAecEnabled
+
+  private fun shouldAppendRealtimeCapturedFrame(length: Int): Boolean = !shouldSuppressRealtimeCaptureForPlayback() && length > 0
 
   private fun isRealtimePlaybackActive(): Boolean = _isSpeaking.value || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
 
@@ -1349,12 +1610,7 @@ class TalkModeManager internal constructor(
           }
         playRealtimeAudio(bytes)
       }
-      "clear" -> {
-        val marks = takePendingRealtimePlaybackMarks()
-        stopRealtimePlayback()
-        acknowledgeRealtimePlaybackMarks(marks)
-        pendingRealtimeOutputClear?.complete(Unit)
-      }
+      "clear" -> requestRealtimePlaybackClear()
       "mark" -> {
         val markName = obj["markName"].asStringOrNull()?.trim()?.takeIf(String::isNotEmpty) ?: return
         queueRealtimePlaybackMark(sessionId, markName)
@@ -1384,7 +1640,7 @@ class TalkModeManager internal constructor(
         if (isFinal && role == "user") {
           setStatus(nativeText("Thinking…"), awaitingAgent = true)
         } else if (isFinal && role == "assistant") {
-          scheduleRealtimePlaybackIdle()
+          requestRealtimePlaybackIdleCheck()
         }
       }
       "toolCall" -> {
@@ -1434,135 +1690,243 @@ class TalkModeManager internal constructor(
       put("final", JsonPrimitive(true))
     }.toString()
 
+  // --- Gateway message pump side: enqueue only, never touch AudioTrack, a
+  // playback-owned lock, or owner-exclusive state (see realtimeAudioWriterJob
+  // above and the *OwnerOnly functions below). ---
+
   private fun playRealtimeAudio(bytes: ByteArray) {
     if (!playbackEnabled || realtimeOutputSuppressed || bytes.isEmpty()) return
-    val queue = ensureRealtimeAudioQueue()
-    if (!queue.trySend(RealtimePlaybackItem.Audio(bytes)).isSuccess) {
-      Log.w(tag, "realtime audio queue full")
-    }
+    val enqueued =
+      synchronized(realtimePlaybackCommandLock) {
+        val epoch = realtimePlaybackEpoch.get()
+        realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Audio(epoch, bytes)).isSuccess
+      }
+    if (!enqueued) Log.w(tag, "realtime audio queue full")
   }
 
   private fun queueRealtimePlaybackMark(
     sessionId: String,
     markName: String,
   ) {
-    synchronized(realtimePlaybackLock) {
-      pendingRealtimePlaybackMarks[markName] =
-        PendingRealtimePlaybackMark(
-          sessionId = sessionId,
-          name = markName,
-        )
-    }
-    if (!ensureRealtimeAudioQueue().trySend(RealtimePlaybackItem.Mark(markName)).isSuccess) {
-      val mark = synchronized(realtimePlaybackLock) { pendingRealtimePlaybackMarks.remove(markName) }
-      acknowledgeRealtimePlaybackMarks(listOfNotNull(mark))
+    // Enqueued under the same lock as every other producer. A mark carries no
+    // epoch of its own and relies purely on arriving before the Clear or Stop
+    // that owes it an acknowledgement, so it must not be able to slip between
+    // another producer's epoch bump and that producer's own enqueue.
+    val enqueued =
+      synchronized(realtimePlaybackCommandLock) {
+        realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Mark(sessionId, markName)).isSuccess
+      }
+    if (!enqueued) {
+      // Channel is unlimited and lives for this TalkModeManager's whole
+      // lifetime, so this is not expected to happen — but a lost mark must
+      // not leave the provider waiting forever for an acknowledgement.
+      acknowledgeRealtimePlaybackMarks(listOf(PendingRealtimePlaybackMark(sessionId = sessionId, name = markName)))
     }
   }
 
-  private fun ensureRealtimeAudioQueue(): Channel<RealtimePlaybackItem> =
-    synchronized(realtimePlaybackLock) {
-      realtimeAudioQueue
-        ?: Channel<RealtimePlaybackItem>(Channel.UNLIMITED).also { queue ->
-          realtimeAudioQueue = queue
-          realtimeAudioWriterJob =
-            gatewayWorkScope.launch(realtimePlaybackDispatcher) {
-              for (item in queue) {
-                when (item) {
-                  is RealtimePlaybackItem.Audio -> {
-                    if (!playbackEnabled || realtimeOutputSuppressed || realtimeSessionId == null) continue
-                    try {
-                      writeRealtimeAudio(item.bytes)
-                    } catch (err: CancellationException) {
-                      throw err
-                    } catch (err: Throwable) {
-                      Log.w(tag, "realtime audio playback failed: ${err.message ?: err::class.java.simpleName}")
-                    }
-                  }
-                  is RealtimePlaybackItem.Mark -> prepareRealtimePlaybackMark(item.name)
-                }
-              }
-            }
-        }
-    }
+  // Stamping a command with the playback epoch and enqueueing it is one step,
+  // for every producer. The epoch is what the owner uses to decide whether a
+  // command is still current, so a read/bump that is not atomic with its own
+  // trySend lets commands reach the owner in a different order than their
+  // epochs imply: a Stop could overtake an earlier Clear and swallow the marks
+  // that Clear still owed the provider, or a new turn's first audio chunk could
+  // land ahead of a pending Stop and be retired away unplayed. The section is
+  // an atomic read/increment plus a trySend on an unlimited channel, so it can
+  // never block the Gateway message pump.
+  private val realtimePlaybackCommandLock = Any()
 
-  private fun writeRealtimeAudio(bytes: ByteArray) {
-    synchronized(realtimePlaybackLock) {
-      val track =
-        realtimeAudioTrack ?: run {
-          val minBuffer =
-            AudioTrack.getMinBufferSize(
-              realtimeSampleRateHz,
-              AudioFormat.CHANNEL_OUT_MONO,
-              AudioFormat.ENCODING_PCM_16BIT,
-            )
-          val bufferSizeBytes =
-            maxOf(
-              minBuffer * 2,
-              realtimeSampleRateHz * 2 * realtimePlaybackBufferMs / 1000,
-              bytes.size * 4,
-            )
-          val created =
-            AudioTrack
-              .Builder()
-              .setAudioAttributes(
-                AudioAttributes
-                  .Builder()
-                  .setUsage(AudioAttributes.USAGE_MEDIA)
-                  .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                  .build(),
-              ).setAudioFormat(
-                AudioFormat
-                  .Builder()
-                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                  .setSampleRate(realtimeSampleRateHz)
-                  .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
-                  .build(),
-              ).setTransferMode(AudioTrack.MODE_STREAM)
-              .setBufferSizeInBytes(bufferSizeBytes)
-              .build()
-          realtimeAudioTrack = created
-          realtimeWrittenFrames = 0L
-          created
-        }
-      var writtenBytes = 0
-      while (writtenBytes < bytes.size) {
-        val written = track.write(bytes, writtenBytes, bytes.size - writtenBytes)
-        if (written <= 0) {
-          Log.w(tag, "realtime audio write failed: $written")
-          break
-        }
-        writtenBytes += written
+  /**
+   * Barge-in clear: bump the epoch immediately (cheap, no AudioTrack touch)
+   * so any audio the owner is mid-write on is preempted at its next retry
+   * check, then hand the actual hardware pause/flush to the owner. Captures
+   * the currently pending cancelRealtimeOutput() deferred, if any, so the
+   * owner completes exactly this generation's confirmation — never a later
+   * caller's — once hardware-side clear has actually finished.
+   */
+  private fun requestRealtimePlaybackClear() {
+    val completion = pendingRealtimeOutputClear
+    val enqueued =
+      synchronized(realtimePlaybackCommandLock) {
+        val epoch = realtimePlaybackEpoch.incrementAndGet()
+        realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Clear(epoch, completion)).isSuccess
       }
-      if (writtenBytes <= 0) return
-      if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
-        track.play()
+    if (!enqueued) completion?.complete(Unit)
+  }
+
+  private fun requestRealtimePlaybackIdleCheck() {
+    realtimePlaybackCommands.trySend(RealtimePlaybackCommand.PollIdle)
+  }
+
+  private fun stopRealtimePlayback(discardMarks: Boolean = false) {
+    // Bump, enqueue and clear under one lock: the playout owner publishes the
+    // speaking state under the same lock, so it can neither observe a stale
+    // epoch nor reinstate this state afterwards.
+    // Status and speaking state stay synchronous here (not deferred to the
+    // owner) so callers like stopRealtimeRelay's preserveStatus re-application —
+    // which runs immediately after this returns — can still override them,
+    // matching the pre-single-owner ordering.
+    // realtimePlaybackEndsAtMs deliberately is NOT cleared here. The speaker is
+    // still emitting until the owner actually pauses and flushes the track, and
+    // isRealtimePlaybackActive() reads that deadline: clearing it early would
+    // lift microphone suppression on the half-duplex path while assistant audio
+    // is still audible. retireRealtimeAudioTrackOwnerOnly() clears it once the
+    // hardware really has stopped.
+    synchronized(realtimePlaybackCommandLock) {
+      realtimePlaybackEpoch.incrementAndGet()
+      realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Stop(discardMarks = discardMarks))
+      _isSpeaking.value = false
+      _outputLevel.value = null
+      if (_isEnabled.value) {
+        setStatus(nativeText("Listening"))
       }
-      // Blocking MODE_STREAM writes are playback-paced once the track buffer
-      // fills, so per-write metering tracks what the speaker actually plays.
-      _outputLevel.value =
-        TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
+    }
+  }
+
+  // --- Playout owner side: the only code below this point that may touch
+  // AudioTrack, realtimeAudioTrack, realtimeWrittenFrames,
+  // pendingRealtimePlaybackMarks, or realtimePlaybackIdleJob. All of it runs
+  // sequentially inside realtimeAudioWriterJob, so none of it needs a lock. ---
+
+  private suspend fun processRealtimeAudioCommandOwnerOnly(command: RealtimePlaybackCommand.Audio) {
+    if (realtimePlaybackEpoch.get() != command.epoch) return
+    // playbackEnabled/realtimeSessionId are @Volatile and safe to read here;
+    // toggling either already bumps the epoch via stopRealtimePlayback(), but
+    // this direct check preserves the dequeue-time guard the previous
+    // single-queue design also had, in case a future caller changes either
+    // without routing through a Stop/Clear command.
+    if (!playbackEnabled || realtimeOutputSuppressed || realtimeSessionId == null) return
+    val track = obtainRealtimeAudioTrackOwnerOnly(command.bytes.size)
+    val bytes = command.bytes
+    var writtenBytes = 0
+    // A non-blocking write returning 0 normally means "buffer full, retry"; on
+    // some devices it also means the OS stopped draining this track for good.
+    // Retrying forever would wedge the single playout owner, so allow only as
+    // many consecutive empty writes as it takes to drain one buffer plus this
+    // frame. Counted rather than timed so the bound does not depend on how
+    // promptly the dispatcher resumes each retry.
+    // Sized from the track's real buffer, not just the requested one: AudioTrack
+    // may allocate more than realtimePlaybackBufferMs asked for, and draining a
+    // bigger buffer legitimately takes longer than the constant would allow.
+    val trackBufferMs =
+      maxOf(
+        realtimePlaybackBufferMs.toLong(),
+        track.bufferSizeInFrames.toLong() * 1000L / realtimeOutputSampleRateHz,
+      )
+    val maxConsecutiveEmptyWrites =
+      (
+        (trackBufferMs + (bytes.size / 2L) * 1000L / realtimeOutputSampleRateHz) /
+          realtimePlaybackWriteRetryDelayMs
+      ).toInt()
+    var consecutiveEmptyWrites = 0
+    while (writtenBytes < bytes.size) {
+      // Re-checked on every retry (not just once per command) so a clear/stop
+      // that lands mid-frame discards the remaining bytes immediately rather
+      // than waiting for this frame to finish writing.
+      if (realtimePlaybackEpoch.get() != command.epoch) return
+      val result = realtimeAudioTrackWriter.write(track, bytes, writtenBytes, bytes.size - writtenBytes)
+      when {
+        result > 0 -> {
+          writtenBytes += result
+          // Any progress means the track is draining after all.
+          consecutiveEmptyWrites = 0
+        }
+        result == 0 -> {
+          if (++consecutiveEmptyWrites > maxConsecutiveEmptyWrites) {
+            // Stuck, not merely backpressured. Fail this command so the shared
+            // recovery path retires the dead track and acknowledges any mark
+            // stranded against it, instead of playing on silently forever.
+            throw IllegalStateException("realtime audio write stalled after $writtenBytes/${bytes.size} bytes")
+          }
+          delay(realtimePlaybackWriteRetryDelayMs)
+        }
+        // A negative result is terminal for this track (e.g. ERROR_DEAD_OBJECT
+        // after the audio server died). Same recovery path: without it the dead
+        // track stays installed and every later command is silently discarded.
+        else -> throw IllegalStateException("realtime audio write failed: $result")
+      }
+    }
+    if (writtenBytes <= 0) return
+    if (realtimePlaybackEpoch.get() != command.epoch) return
+    if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
+      track.play()
+    }
+    // Publishing the speaking state and re-checking the epoch are one step,
+    // under the same lock stopRealtimePlayback()/requestRealtimePlaybackClear()
+    // use to bump that epoch and clear this state. Without it a stop landing
+    // between the check above and these assignments would be overwritten, and
+    // the UI would stay on "Speaking…" with a future playback deadline after
+    // Talk was already stopped — which also keeps the microphone suppressed on
+    // the half-duplex path. Nothing in here blocks.
+    synchronized(realtimePlaybackCommandLock) {
+      if (realtimePlaybackEpoch.get() != command.epoch) return
+      _outputLevel.value = TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
       _isSpeaking.value = true
       setStatus(nativeText("Speaking…"))
-      val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
+      val durationMs = ((writtenBytes / 2.0) / realtimeOutputSampleRateHz * 1000.0).toLong()
       realtimeWrittenFrames += writtenBytes / 2L
       val now = SystemClock.elapsedRealtime()
       realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
-      scheduleRealtimePlaybackIdle()
     }
+    ensureRealtimePlaybackIdlePollingOwnerOnly()
   }
 
-  private fun prepareRealtimePlaybackMark(markName: String) {
-    val completed =
-      synchronized(realtimePlaybackLock) {
-        val mark = pendingRealtimePlaybackMarks[markName] ?: return
-        mark.targetFrame = realtimeWrittenFrames
-        takeCompletedRealtimePlaybackMarksLocked()
-      }
+  private fun obtainRealtimeAudioTrackOwnerOnly(pendingBytes: Int): AudioTrack {
+    realtimeAudioTrack?.let { return it }
+    val minBuffer =
+      AudioTrack.getMinBufferSize(
+        realtimeOutputSampleRateHz,
+        AudioFormat.CHANNEL_OUT_MONO,
+        AudioFormat.ENCODING_PCM_16BIT,
+      )
+    val bufferSizeBytes =
+      maxOf(
+        minBuffer * 2,
+        realtimeOutputSampleRateHz * 2 * realtimePlaybackBufferMs / 1000,
+        pendingBytes * 4,
+      )
+    val created =
+      AudioTrack
+        .Builder()
+        .setAudioAttributes(
+          AudioAttributes
+            .Builder()
+            .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build(),
+        ).setAudioFormat(
+          AudioFormat
+            .Builder()
+            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+            .setSampleRate(realtimeOutputSampleRateHz)
+            .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+            .build(),
+        ).setTransferMode(AudioTrack.MODE_STREAM)
+        .setBufferSizeInBytes(bufferSizeBytes)
+        .build()
+    realtimeAudioTrack = created
+    realtimeWrittenFrames = 0L
+    return created
+  }
+
+  private fun processRealtimeMarkCommandOwnerOnly(command: RealtimePlaybackCommand.Mark) {
+    // Not epoch-gated: registration must be unconditional so a Mark made
+    // stale by a Clear/Stop enqueued right after it is still visible to that
+    // Clear/Stop's own mark handling once dequeued (single sequential owner
+    // guarantees this Mark is always processed first) — an epoch check here
+    // would instead drop the mark before either handler ever sees it,
+    // silently losing its acknowledgement.
+    val mark = PendingRealtimePlaybackMark(sessionId = command.sessionId, name = command.markName)
+    // Every Audio command enqueued before this Mark has already been
+    // processed in order by the time this runs (single sequential owner), so
+    // realtimeWrittenFrames already reflects the correct target.
+    mark.targetFrame = realtimeWrittenFrames
+    pendingRealtimePlaybackMarks[command.markName] = mark
+    val completed = takeCompletedRealtimePlaybackMarksOwnerOnly()
     acknowledgeRealtimePlaybackMarks(completed)
-    scheduleRealtimePlaybackIdle()
+    ensureRealtimePlaybackIdlePollingOwnerOnly()
   }
 
-  private fun takeCompletedRealtimePlaybackMarksLocked(): List<PendingRealtimePlaybackMark> {
+  private fun takeCompletedRealtimePlaybackMarksOwnerOnly(): List<PendingRealtimePlaybackMark> {
     val playedFrames = realtimeAudioTrack?.playbackHeadPosition?.toLong()?.and(0xffff_ffffL) ?: realtimeWrittenFrames
     val completed =
       pendingRealtimePlaybackMarks.values.filter { mark ->
@@ -1573,12 +1937,119 @@ class TalkModeManager internal constructor(
     return completed
   }
 
-  private fun takePendingRealtimePlaybackMarks(): List<PendingRealtimePlaybackMark> =
-    synchronized(realtimePlaybackLock) {
-      val marks = pendingRealtimePlaybackMarks.values.toList()
-      pendingRealtimePlaybackMarks.clear()
-      marks
+  /**
+   * Barge-in clear: retires the current track (pause/flush/stop/release) and
+   * acknowledges every still-pending mark as cleared — existing semantics
+   * already treated a clear as "these marks will never complete normally" —
+   * then completes exactly the deferred captured when this Clear was
+   * created. Runs unconditionally (not epoch-gated): a Clear is itself an
+   * invalidating event, so retiring an already-retired track is a safe
+   * no-op, and completing an already-superseded completion reference is
+   * harmless because nothing still awaits it.
+   */
+  private fun processRealtimeClearCommandOwnerOnly(command: RealtimePlaybackCommand.Clear) {
+    // Completed in a finally: a throw anywhere below would otherwise leave
+    // cancelRealtimeOutput() waiting out its whole timeout and escalate a PTT
+    // turn into a full relay restart.
+    try {
+      processRealtimeClearCommandBodyOwnerOnly()
+    } finally {
+      command.completion?.complete(Unit)
     }
+  }
+
+  private fun processRealtimeClearCommandBodyOwnerOnly() {
+    val marks = pendingRealtimePlaybackMarks.values.toList()
+    pendingRealtimePlaybackMarks.clear()
+    retireRealtimeAudioTrackOwnerOnly()
+    cancelRealtimePlaybackIdlePollingOwnerOnly()
+    _isSpeaking.value = false
+    _outputLevel.value = null
+    // Same guard the idle path uses: a Clear dequeued after the relay was torn
+    // down must not overwrite a failure status stopRealtimeRelay preserved.
+    if (_isEnabled.value && realtimeSessionId != null) {
+      setStatus(nativeText("Listening"))
+    }
+    acknowledgeRealtimePlaybackMarks(marks)
+  }
+
+  /** Teardown paths (stopRealtimeRelay, PTT pause, gateway scope change,
+   * relay close): unlike Clear, pending marks are dropped without
+   * acknowledgement — matches the marks discard stopRealtimeRelay already
+   * did directly before this command queue existed. */
+  private fun processRealtimeStopCommandOwnerOnly(command: RealtimePlaybackCommand.Stop) {
+    // Status/_isSpeaking/_outputLevel are already handled synchronously by
+    // stopRealtimePlayback() at enqueue time; this only tears down the
+    // hardware-owned track/marks/ticker, which is safe to do asynchronously.
+    // Marks survive a plain playback stop: PTT pause and stopTts are followed by
+    // the provider's own clear for the cancelled turn, and that clear is what
+    // acknowledges them. Only real relay teardown drops them unacknowledged.
+    if (command.discardMarks) pendingRealtimePlaybackMarks.clear()
+    retireRealtimeAudioTrackOwnerOnly()
+    cancelRealtimePlaybackIdlePollingOwnerOnly()
+    // Re-cleared here even though stopRealtimePlayback() already did it on the
+    // Gateway thread: an Audio command that had passed its epoch check just
+    // before the stop can still set these afterwards, and a stuck _isSpeaking
+    // keeps isRealtimePlaybackActive() true, which suppresses the microphone on
+    // the half-duplex path. The owner is sequential, so its own clear is last.
+    // Status is deliberately not touched — stopRealtimeRelay(preserveStatus)
+    // owns that, and Clear has its own guarded re-set.
+    _isSpeaking.value = false
+    _outputLevel.value = null
+  }
+
+  private fun retireRealtimeAudioTrackOwnerOnly() {
+    realtimeAudioTrack?.let { track ->
+      try {
+        track.pause()
+        track.flush()
+        track.stop()
+      } catch (_: Throwable) {
+      }
+      track.release()
+    }
+    realtimeAudioTrack = null
+    realtimeWrittenFrames = 0L
+    realtimePlaybackEndsAtMs = 0L
+  }
+
+  private fun processRealtimePollIdleCommandOwnerOnly() {
+    val playbackTimeElapsed = SystemClock.elapsedRealtime() >= realtimePlaybackEndsAtMs
+    val completed = takeCompletedRealtimePlaybackMarksOwnerOnly()
+    // AudioTrack may lag the duration estimate by its device buffer. Keep
+    // polling until queued marks prove the speaker reached the barrier.
+    val awaitingPlaybackMark = pendingRealtimePlaybackMarks.values.any { it.targetFrame != null }
+    val playbackIdle = playbackTimeElapsed && !awaitingPlaybackMark
+    if (playbackIdle) {
+      _isSpeaking.value = false
+      _outputLevel.value = null
+      cancelRealtimePlaybackIdlePollingOwnerOnly()
+      if (_isEnabled.value && realtimeSessionId != null) {
+        setStatus(nativeText("Listening"))
+      }
+    } else {
+      ensureRealtimePlaybackIdlePollingOwnerOnly()
+    }
+    acknowledgeRealtimePlaybackMarks(completed)
+  }
+
+  /** Ticker only pings the owner (trySend) on a timer — it never reads
+   * AudioTrack or owner-exclusive state itself; see PollIdle handling above. */
+  private fun ensureRealtimePlaybackIdlePollingOwnerOnly() {
+    if (realtimePlaybackIdleJob?.isActive == true) return
+    realtimePlaybackIdleJob =
+      realtimePlaybackOwnerScope.launch(realtimePlaybackDispatcher) {
+        while (isActive) {
+          delay(realtimePlaybackIdlePollMs)
+          if (!realtimePlaybackCommands.trySend(RealtimePlaybackCommand.PollIdle).isSuccess) break
+        }
+      }
+  }
+
+  private fun cancelRealtimePlaybackIdlePollingOwnerOnly() {
+    realtimePlaybackIdleJob?.cancel()
+    realtimePlaybackIdleJob = null
+  }
 
   private fun acknowledgeRealtimePlaybackMarks(marks: List<PendingRealtimePlaybackMark>) {
     for (mark in marks) {
@@ -1603,67 +2074,6 @@ class TalkModeManager internal constructor(
     }
   }
 
-  private fun scheduleRealtimePlaybackIdle() {
-    realtimePlaybackIdleJob?.cancel()
-    realtimePlaybackIdleJob =
-      gatewayWorkScope.launch {
-        while (true) {
-          delay(20)
-          val (completed, idle) =
-            synchronized(realtimePlaybackLock) {
-              val playbackTimeElapsed = SystemClock.elapsedRealtime() >= realtimePlaybackEndsAtMs
-              val completed = takeCompletedRealtimePlaybackMarksLocked()
-              // AudioTrack may lag the duration estimate by its device buffer. Keep
-              // polling until queued marks prove the speaker reached the barrier.
-              val awaitingPlaybackMark = pendingRealtimePlaybackMarks.values.any { it.targetFrame != null }
-              val playbackIdle = playbackTimeElapsed && !awaitingPlaybackMark
-              if (playbackIdle) {
-                _isSpeaking.value = false
-                _outputLevel.value = null
-              }
-              completed to playbackIdle
-            }
-          acknowledgeRealtimePlaybackMarks(completed)
-          if (idle) {
-            if (_isEnabled.value && realtimeSessionId != null) {
-              setStatus(nativeText("Listening"))
-            }
-            return@launch
-          }
-        }
-      }
-  }
-
-  private fun stopRealtimePlayback() {
-    val audioQueue = realtimeAudioQueue
-    val audioWriterJob = realtimeAudioWriterJob
-    realtimeAudioQueue = null
-    realtimeAudioWriterJob = null
-    audioQueue?.close()
-    audioWriterJob?.cancel()
-    realtimePlaybackIdleJob?.cancel()
-    realtimePlaybackIdleJob = null
-    realtimePlaybackEndsAtMs = 0L
-    synchronized(realtimePlaybackLock) {
-      realtimeAudioTrack?.let { track ->
-        try {
-          track.pause()
-          track.flush()
-          track.stop()
-        } catch (_: Throwable) {
-        }
-        track.release()
-      }
-      realtimeAudioTrack = null
-      realtimeWrittenFrames = 0L
-    }
-    _isSpeaking.value = false
-    _outputLevel.value = null
-    if (_isEnabled.value) {
-      setStatus(nativeText("Listening"))
-    }
-  }
-
   private fun stopRealtimeRelay(
     closeSession: Boolean = true,
     cancelCapture: Boolean = true,
@@ -1678,6 +2088,8 @@ class TalkModeManager internal constructor(
         val currentSessionId = realtimeSessionId
         val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
         realtimeSessionId = null
+        realtimeWireAudioSampleRateHz = null
+        realtimeWireAudioEncoding = null
         realtimeCaptureJob = null
         realtimeAppendJob = null
         realtimeCapturePause = null
@@ -1697,10 +2109,13 @@ class TalkModeManager internal constructor(
     realtimeUserEntryAwaitingFinal = false
     realtimeUserEntryAwaitingFinalStartedAtMs = null
     realtimeAssistantEntryId = null
-    takePendingRealtimePlaybackMarks()
+    // Relay teardown is the one path that drops pending marks unacknowledged,
+    // matching what this function did directly before mark ownership moved to
+    // the playout owner. Every other stopRealtimePlayback() caller keeps them
+    // for the provider's own clear to acknowledge.
     _speechActive.value = false
     _inputLevel.value = 0f
-    stopRealtimePlayback()
+    stopRealtimePlayback(discardMarks = true)
     if (preserveStatus) {
       setStatus(status)
     }
@@ -1772,9 +2187,14 @@ class TalkModeManager internal constructor(
           return@synchronized RealtimeCaptureResume.Skipped
         }
         realtimeCapturePause = null
+        // Honour the install result: on the unsupported-contract path
+        // startRealtimeCaptureLocked() already failed the relay, so reporting
+        // "Listening" here would advertise a session that is being torn down.
+        if (!startRealtimeCaptureLocked(sessionId)) {
+          return@synchronized RealtimeCaptureResume.Skipped
+        }
         _isListening.value = true
         setStatus(nativeText("Listening"))
-        startRealtimeCaptureLocked(sessionId)
         RealtimeCaptureResume.Resumed
       }
     when (outcome) {
@@ -3327,6 +3747,11 @@ private fun JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.t
 private fun JsonElement?.asDoubleOrNull(): Double? {
   val primitive = this as? JsonPrimitive ?: return null
   return primitive.content.toDoubleOrNull()
+}
+
+private fun JsonElement?.asIntOrNull(): Int? {
+  val primitive = this as? JsonPrimitive ?: return null
+  return primitive.content.toIntOrNull()
 }
 
 private fun JsonElement?.asBooleanOrNull(): Boolean? {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -454,8 +454,9 @@ class TalkModeManager internal constructor(
 
   // True only while communication-profile capture reports platform AEC actually
   // enabled; drives the full-duplex forwarding policy in
-  // shouldSuppressRealtimeCaptureForPlayback. Cleared whenever the capture job
-  // that set it ends, so a later session/profile never inherits a stale true.
+  // shouldSuppressRealtimeCaptureForPlayback. Cleared at the start of every
+  // capture generation and again when the job that set it ends, so it only ever
+  // describes the capture session currently running - never the previous one.
   @Volatile private var realtimeAecEnabled = false
 
   private val finishingPttLock = Any()
@@ -1417,6 +1418,12 @@ class TalkModeManager internal constructor(
     realtimeCaptureJob?.cancel()
     realtimeAppendJob?.cancel()
     val inputGeneration = audioInputGeneration.incrementAndGet()
+    // The superseded job's finally is generation-guarded, so it will decline to
+    // clear this - by then the generation is already this one's. Clearing here,
+    // at the boundary itself, is what keeps the flag from describing the session
+    // that just ended: until the new capture reports its own AEC state, no
+    // session has reported one, and the safe answer is "not enabled".
+    realtimeAecEnabled = false
     onAppliedAudioInputChanged(null)
     val audioFrames =
       Channel<ByteArray>(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
@@ -83,6 +83,194 @@ class AndroidAudioInputSessionTest {
   }
 
   @Test
+  fun communicationCaptureSelectsBuiltInSpeakerWhenNoBluetoothIsAvailable() {
+    // Without an explicit selection Android's phone strategy routes
+    // STREAM_VOICE_CALL to the earpiece, which is what made hands-free Talk
+    // unusable. Talk must claim the loudspeaker instead.
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    val earpiece = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(earpiece, speaker))
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, audioManager.communicationDevice?.type)
+    assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, session.appliedCommunicationDeviceType)
+    session.close()
+  }
+
+  @Test
+  fun communicationCaptureNeverFallsThroughToTheEarpiece() {
+    // Even when the earpiece is the first available communication device, it must
+    // never be the one Talk ends up on.
+    val earpiece = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(earpiece, speaker))
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertFalse(audioManager.communicationDevice?.type == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    assertFalse(session.appliedCommunicationDeviceType == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    session.close()
+  }
+
+  @Test
+  fun communicationCaptureLeavesWiredHeadsetRoutingAlone() {
+    // A wired headset already outranks the earpiece in Android's own routing, so
+    // forcing the speaker here would play out of the phone while headphones are
+    // plugged in. Only the built-in-only case needs an explicit choice.
+    val wired = audioDevice(AudioDeviceInfo.TYPE_WIRED_HEADSET)
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    val earpiece = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(earpiece, speaker, wired))
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertNull(audioManager.communicationDevice)
+    assertNull(session.appliedCommunicationDeviceType)
+    session.close()
+  }
+
+  @Test
+  fun communicationCaptureLeavesUsbHeadsetRoutingAlone() {
+    val usb = audioDevice(AudioDeviceInfo.TYPE_USB_HEADSET)
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    val earpiece = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(earpiece, speaker, usb))
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertNull(audioManager.communicationDevice)
+    assertNull(session.appliedCommunicationDeviceType)
+    session.close()
+  }
+
+  @Test
+  fun communicationCapturePrefersBluetoothOverTheBuiltInSpeaker() {
+    val sco = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val scoOutput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    shadowAudioManager.setInputDevices(listOf(sco))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput, speaker))
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, audioManager.communicationDevice?.type)
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, session.appliedCommunicationDeviceType)
+    session.close()
+  }
+
+  @Test
+  fun bluetoothDisconnectDuringCommunicationCaptureFallsBackToTheBuiltInSpeaker() {
+    val sco = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val scoOutput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    shadowAudioManager.setInputDevices(listOf(sco))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput, speaker))
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, session.appliedCommunicationDeviceType)
+
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(speaker))
+    shadowAudioManager.removeInputDevice(sco, true)
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, audioManager.communicationDevice?.type)
+    assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, session.appliedCommunicationDeviceType)
+    session.close()
+  }
+
+  @Test
+  fun closingCommunicationCaptureReleasesTheRouteItHeld() {
+    // Talk-owned routing must not leak into unrelated app audio after Talk stops.
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(speaker))
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+    assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, audioManager.communicationDevice?.type)
+
+    session.close()
+
+    assertNull(audioManager.communicationDevice)
+    assertNull(session.appliedCommunicationDeviceType)
+  }
+
+  @Test
+  fun rejectedSpeakerSelectionIsReportedAsUnheldRatherThanAssumedSuccessful() {
+    // setCommunicationDevice() returning false is a routing failure, not a
+    // silent success: the session must not claim it holds the speaker.
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(speaker))
+    shadowAudioManager.lockCommunicationDevice(true)
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertNull(session.appliedCommunicationDeviceType)
+    session.close()
+    shadowAudioManager.lockCommunicationDevice(false)
+  }
+
+  @Test
+  fun recognitionCaptureDoesNotClaimAnyCommunicationRoute() {
+    // Manual Mic/STT semantics are unchanged: it never took ownership of the
+    // process communication route and must not start now.
+    val speaker = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+    val earpiece = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(speaker, earpiece))
+
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    assertNull(audioManager.communicationDevice)
+    assertNull(session.appliedCommunicationDeviceType)
+    session.close()
+  }
+
+  @Test
   fun presentPreferredInputResolvesByStableKey() {
     val sco = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
     val ble = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
@@ -5,9 +5,12 @@ import android.content.Context
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.media.audiofx.AudioEffect
 import android.os.Looper
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -18,8 +21,10 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.AudioDeviceInfoBuilder
+import org.robolectric.shadows.ShadowAudioEffect
 import org.robolectric.shadows.ShadowAudioManager
 import org.robolectric.util.ReflectionHelpers
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -39,6 +44,7 @@ class AndroidAudioInputSessionTest {
     shadowAudioManager.setInputDevices(emptyList())
     shadowAudioManager.setAvailableCommunicationDevices(emptyList())
     audioManager.clearCommunicationDevice()
+    ShadowAudioEffect.reset()
   }
 
   @Test
@@ -230,6 +236,97 @@ class AndroidAudioInputSessionTest {
     val unknown = runCatching { checkAudioRecordReadResult(-99) }.exceptionOrNull()
     assertTrue(unknown is IllegalStateException)
     assertEquals("microphone read failed: code=-99", unknown?.message)
+  }
+
+  @Test
+  fun defaultProfileOpensVoiceRecognitionAudioSource() {
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    assertEquals(MediaRecorder.AudioSource.VOICE_RECOGNITION, capturedAudioSource(session))
+    session.close()
+  }
+
+  @Test
+  fun communicationProfileOpensVoiceCommunicationAudioSource() {
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertEquals(MediaRecorder.AudioSource.VOICE_COMMUNICATION, capturedAudioSource(session))
+    session.close()
+  }
+
+  @Test
+  fun recognitionProfileNeverCreatesAcousticEchoCanceler() {
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    assertFalse(session.communicationEchoCancellationEnabled)
+    session.close()
+  }
+
+  @Test
+  fun communicationProfileWithoutPlatformAecReportsDisabled() {
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    // No AudioEffect.Descriptor registered in this Robolectric environment, so
+    // platform AEC is unavailable — the safe-fallback surface (no crash, no
+    // false "enabled") that a device without AEC hardware also exercises.
+    assertFalse(session.communicationEchoCancellationEnabled)
+    session.close()
+  }
+
+  @Test
+  fun communicationProfileWithPlatformAecReportsEnabled() {
+    registerFakeAcousticEchoCancelerEffect()
+
+    val session =
+      AndroidAudioInputSession.open(
+        context,
+        sampleRateHz = 24_000,
+        frameBytes = 4_800,
+        profile = AndroidAudioInputProfile.VoiceCommunication,
+      )
+
+    assertTrue(session.communicationEchoCancellationEnabled)
+    session.close()
+  }
+
+  @Test
+  fun recognitionProfileIgnoresAvailablePlatformAec() {
+    registerFakeAcousticEchoCancelerEffect()
+
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    // Manual Mic/STT never requests communication-profile AEC ownership, even
+    // when the platform effect is available for other capture sessions.
+    assertFalse(session.communicationEchoCancellationEnabled)
+    session.close()
+  }
+
+  private fun registerFakeAcousticEchoCancelerEffect() {
+    val descriptor = AudioEffect.Descriptor()
+    descriptor.type = AudioEffect.EFFECT_TYPE_AEC
+    descriptor.uuid = UUID.randomUUID()
+    descriptor.connectMode = AudioEffect.EFFECT_PRE_PROCESSING
+    descriptor.name = "Test AEC"
+    descriptor.implementor = "Test"
+    ShadowAudioEffect.addEffect(descriptor)
+  }
+
+  private fun capturedAudioSource(session: AndroidAudioInputSession): Int {
+    val field = session.javaClass.getDeclaredField("audioRecord")
+    field.isAccessible = true
+    return (field.get(session) as AudioRecord).audioSource
   }
 
   private fun audioDevice(type: Int): AudioDeviceInfo {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureResamplerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureResamplerTest.kt
@@ -1,0 +1,190 @@
+package ai.openclaw.app.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+class RealtimeCaptureResamplerTest {
+  @Test
+  fun rejectsRatiosThatArentAnExactIntegerDownsample() {
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 48_000, wireRateHz = 22_050))
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 16_000, wireRateHz = 24_000))
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 48_000, wireRateHz = 0))
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 0, wireRateHz = 24_000))
+  }
+
+  @Test
+  fun anyNegotiatedCaptureRateWithAnExactRatioResolves() {
+    // The converter is keyed on the rate AudioRecord actually negotiated, not on
+    // the rate the caller requested, so every exact ratio has to resolve -- not
+    // just the requested portable rate's own ones.
+    assertTrue(resolveRealtimeCaptureResampler(captureRateHz = 16_000, wireRateHz = 16_000) != null)
+    assertTrue(resolveRealtimeCaptureResampler(captureRateHz = 44_100, wireRateHz = 22_050) != null)
+    assertTrue(resolveRealtimeCaptureResampler(captureRateHz = 96_000, wireRateHz = 24_000) != null)
+  }
+
+  @Test
+  fun equalRatePassesThroughUnchanged() {
+    val resampler = resolveRealtimeCaptureResampler(captureRateHz = 24_000, wireRateHz = 24_000)!!
+    val input = sineSamples(freqHz = 440.0, sampleRateHz = 24_000, count = 480)
+    val bytes = pcm16Bytes(input)
+
+    val output = resampler.process(bytes, bytes.size)
+
+    assertEquals(bytes.size, output.size)
+    assertTrue(bytes.contentEquals(output))
+  }
+
+  @Test
+  fun downsample48kTo24kHalvesTheSampleCount() {
+    val resampler = resolveRealtimeCaptureResampler(captureRateHz = 48_000, wireRateHz = 24_000)!!
+    val chunk = pcm16Bytes(sineSamples(freqHz = 1_000.0, sampleRateHz = 48_000, count = 4_800))
+
+    val output = resampler.process(chunk, chunk.size)
+
+    // 100ms of 48kHz capture (4,800 samples) must become 100ms of 24kHz wire
+    // audio (2,400 samples) -- the frame represents the Gateway-advertised
+    // rate, not the capture rate.
+    assertEquals(2_400 * 2, output.size)
+  }
+
+  @Test
+  fun chunkBoundariesProduceNoGapsOrDuplicationVersusOneShotProcessing() {
+    val signal = sineSamples(freqHz = 300.0, sampleRateHz = 48_000, count = 9_600)
+    val bytes = pcm16Bytes(signal)
+
+    val wholeChunk = resolveRealtimeCaptureResampler(48_000, 24_000)!!.process(bytes, bytes.size)
+
+    val piecemeal = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val out = java.io.ByteArrayOutputStream()
+    var offset = 0
+    // Odd, uneven chunk sizes -- not a clean divisor of the frame or the
+    // decimation factor -- exercise both chunk-boundary continuity and
+    // odd-sized input handling in one pass.
+    val chunkSizesBytes = intArrayOf(37, 501, 2, 1200, 4001, 999)
+    var chunkIndex = 0
+    while (offset < bytes.size) {
+      val size = minOf(chunkSizesBytes[chunkIndex % chunkSizesBytes.size], bytes.size - offset)
+      chunkIndex += 1
+      val piece = bytes.copyOfRange(offset, offset + size)
+      out.write(piecemeal.process(piece, piece.size))
+      offset += size
+    }
+
+    assertTrue(wholeChunk.contentEquals(out.toByteArray()))
+  }
+
+  @Test
+  fun constantSignalReachesASteadyStateConstantOutput() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val level = 5_000
+    val bytes = pcm16Bytes(IntArray(9_600) { level })
+
+    val output = pcm16Samples(resampler.process(bytes, bytes.size))
+
+    // Skip the filter's warm-up transient (zero-initialized history); the
+    // rest of a sustained DC input must settle back to the input level.
+    for (sample in output.drop(64)) {
+      assertEquals(level.toDouble(), sample.toDouble(), 3.0)
+    }
+  }
+
+  @Test
+  fun belowNyquistToneKeepsItsFrequencyAfterDecimation() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val freqHz = 1_000.0
+    val durationSamples = 48_000 // 1 second, safely below the 12kHz output Nyquist
+    val bytes = pcm16Bytes(sineSamples(freqHz, 48_000, durationSamples))
+
+    val output = pcm16Samples(resampler.process(bytes, bytes.size))
+
+    val steadyState = output.drop(64)
+    val crossings = zeroCrossings(steadyState)
+    val steadySeconds = steadyState.size / 24_000.0
+    val estimatedHz = crossings / 2.0 / steadySeconds
+
+    assertEquals(freqHz, estimatedHz, 25.0)
+  }
+
+  @Test
+  fun aliasSensitiveHighFrequencyIsAttenuatedNotAliasedThrough() {
+    // 20kHz at 48kHz capture is above the 12kHz output Nyquist; naive
+    // drop-every-other-sample decimation aliases it into the 4kHz audible
+    // band. The anti-alias filter must suppress it instead.
+    val freqHz = 20_000.0
+    val captureCount = 9_600
+    val samples = sineSamples(freqHz, 48_000, captureCount)
+    val bytes = pcm16Bytes(samples)
+
+    val filtered = pcm16Samples(resolveRealtimeCaptureResampler(48_000, 24_000)!!.process(bytes, bytes.size))
+    val naive = DoubleArray(samples.size / 2) { samples[it * 2].toDouble() }
+
+    assertTrue(rms(filtered.map { it.toDouble() }) < rms(naive.toList()) * 0.25)
+  }
+
+  @Test
+  fun fullScaleSquareEdgesStayWithinPcm16Bounds() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val samples = IntArray(4_800) { if (it % 2 == 0) Short.MAX_VALUE.toInt() else Short.MIN_VALUE.toInt() }
+    val bytes = pcm16Bytes(samples)
+
+    val output = pcm16Samples(resampler.process(bytes, bytes.size))
+
+    for (sample in output) {
+      assertTrue(sample >= Short.MIN_VALUE.toInt() && sample <= Short.MAX_VALUE.toInt())
+    }
+  }
+
+  @Test
+  fun freshInstancesDoNotShareStateAcrossSessions() {
+    val leftoverOddByte = byteArrayOf(0x11, 0x22, 0x33)
+    resolveRealtimeCaptureResampler(48_000, 24_000)!!.process(leftoverOddByte, leftoverOddByte.size)
+
+    // A brand new instance for a new capture session (as startRealtimeCaptureLocked
+    // creates on every start/PTT-resume) must behave identically to the very
+    // first instance ever created, regardless of what a prior session did.
+    val a = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val b = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val bytes = pcm16Bytes(sineSamples(500.0, 48_000, 4_800))
+
+    assertTrue(a.process(bytes, bytes.size).contentEquals(b.process(bytes, bytes.size)))
+  }
+
+  private fun sineSamples(
+    freqHz: Double,
+    sampleRateHz: Int,
+    count: Int,
+    amplitude: Int = 16_000,
+  ): IntArray = IntArray(count) { n -> (amplitude * sin(2.0 * PI * freqHz * n / sampleRateHz)).roundToInt() }
+
+  private fun pcm16Bytes(samples: IntArray): ByteArray {
+    val bytes = ByteArray(samples.size * 2)
+    for (i in samples.indices) {
+      bytes[i * 2] = (samples[i] and 0xff).toByte()
+      bytes[i * 2 + 1] = ((samples[i] shr 8) and 0xff).toByte()
+    }
+    return bytes
+  }
+
+  private fun pcm16Samples(bytes: ByteArray): IntArray =
+    IntArray(bytes.size / 2) { i ->
+      val lo = bytes[i * 2].toInt() and 0xff
+      val hi = bytes[i * 2 + 1].toInt()
+      ((lo) or (hi shl 8)).toShort().toInt()
+    }
+
+  private fun zeroCrossings(samples: List<Int>): Int {
+    var count = 0
+    for (i in 1 until samples.size) {
+      if ((samples[i - 1] < 0) != (samples[i] < 0)) count += 1
+    }
+    return count
+  }
+
+  private fun rms(samples: List<Double>): Double = sqrt(samples.sumOf { it * it } / samples.size)
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -11,6 +11,8 @@ import ai.openclaw.app.i18n.verbatimText
 import android.Manifest
 import android.content.ComponentName
 import android.content.IntentFilter
+import android.media.AudioAttributes
+import android.media.AudioTrack
 import android.os.Bundle
 import android.os.SystemClock
 import android.speech.RecognitionListener
@@ -37,6 +39,9 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -48,12 +53,33 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class TalkModeManagerTest {
+  // realtimeAudioWriterJob (playout owner) and its idle-poll ticker are
+  // intentionally infinite for TalkModeManager's real lifetime, unlike every
+  // other coroutine this class launches (which complete naturally and so
+  // stay properly tracked by runTest/advanceUntilIdle on scope = this, realtimePlaybackOwnerScope = backgroundScope).
+  // Every createManager() call registers here so this teardown can cancel
+  // just those two jobs after each test, without changing scope for
+  // anything else — using TestScope.backgroundScope for the whole manager
+  // instead was tried and rejected: it also silently exempts gatewayWorkScope
+  // (built from the same scope's CoroutineContext) from advanceUntilIdle()
+  // draining, which broke unrelated pre-existing tests.
+  private val createdManagers = mutableListOf<TalkModeManager>()
+
+  @After
+  fun cancelRealtimePlaybackOwners() {
+    for (manager in createdManagers) {
+      runCatching { cancelRealtimeAudioWriterJob(manager) }
+    }
+    createdManagers.clear()
+  }
+
   @Test
   fun phoneRealtimeRetriesWithoutLanguageWhenOlderGatewayRejectsCreateParams() =
     runTest {
@@ -453,7 +479,7 @@ class TalkModeManagerTest {
   @Test
   fun localizedOffStatusDoesNotBecomeRealtimeStartFailure() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
       val turn =
         async(start = CoroutineStart.UNDISPATCHED) {
           runCatching {
@@ -480,6 +506,7 @@ class TalkModeManagerTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
           realtimePlaybackDispatcher = StandardTestDispatcher(testScheduler),
           realtimeMarkAcknowledger = { sessionId, markName ->
             acknowledgements += sessionId to markName
@@ -693,7 +720,7 @@ class TalkModeManagerTest {
   @Test
   fun e2eRealtimeTurnUsesRelayTranscriptPath() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
 
       setPrivateField(manager, "realtimeSessionId", "relay-1")
       setMutableStateFlow(manager, "_isEnabled", true)
@@ -719,6 +746,7 @@ class TalkModeManagerTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
           isConnected = { false },
           onStoppedByRelay = { stoppedByRelay.set(true) },
         )
@@ -740,6 +768,7 @@ class TalkModeManagerTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
         )
       withMain(cleanup = { manager.setEnabled(false) }) {
         setPrivateField(manager, "configLoaded", true)
@@ -806,6 +835,560 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun aecEnabledCommunicationCaptureForwardsThroughPlayback() {
+    val manager = createManager()
+    setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 1_000)
+
+    setPrivateField(manager, "realtimeAecEnabled", true)
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+    // AEC unavailable/disabled is the safe fallback: playback-time suppression returns.
+    setPrivateField(manager, "realtimeAecEnabled", false)
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+  }
+
+  @Test
+  fun realtimePlaybackUsesVoiceCommunicationAudioAttributes() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, byteArrayOf(1, 2, 3, 4))
+      runCurrent()
+      val track = readPrivateField(manager, "realtimeAudioTrack") as AudioTrack
+
+      assertEquals(AudioAttributes.USAGE_VOICE_COMMUNICATION, track.audioAttributes.usage)
+      assertEquals(AudioAttributes.CONTENT_TYPE_SPEECH, track.audioAttributes.contentType)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  // --- Root-cause regression suite for the Gateway receive head-of-line
+  // blocking fix. The prior design (c8d45) held realtimePlaybackLock across
+  // one bounded-but-still-blocking AudioTrack.write() chunk; physical retest
+  // showed contention still ran 767-850ms because AudioTrack hardware
+  // backpressure itself, not chunk size, is what stalled the lock holder.
+  // This design removes the shared lock and blocking write entirely: the
+  // Gateway message pump only ever enqueues commands (trySend, never
+  // suspends, never touches AudioTrack), and a single playout owner
+  // coroutine processes them with WRITE_NON_BLOCKING, retrying zero-accept
+  // writes via delay() instead of blocking.
+  //
+  // These tests drive that owner coroutine deterministically via
+  // StandardTestDispatcher, using runCurrent()/bounded advanceTimeBy() rather
+  // than advanceUntilIdle(). The owner's idle-poll ticker compares
+  // SystemClock.elapsedRealtime() (a real/Robolectric-shadow clock) against a
+  // deadline computed the same way; that clock does not advance in lockstep
+  // with the coroutine test scheduler's virtual time, so it never naturally
+  // crosses the deadline under advanceUntilIdle() alone, which would keep
+  // rearming the ticker forever. Staying below one full
+  // realtimePlaybackIdlePollMs tick avoids ever exercising that mismatch.
+  // Because every retry path suspends on delay() (never a tight spin), each
+  // step below is still fully deterministic. scope = this, realtimePlaybackOwnerScope = backgroundScope (not
+  // backgroundScope) is required so runCurrent()/advanceTimeBy() actually
+  // dispatch the owner; each test cancels it at the end since it is
+  // intentionally infinite for TalkModeManager's real lifetime. ---
+
+  @Test
+  fun gatewayIngressNeverSuspendsRegardlessOfPlayoutOwnerState() =
+    runTest {
+      // No runCurrent/advanceTimeBy call anywhere in this test: the playout
+      // owner never actually runs. Every ingress call below is a trySend and
+      // must still return immediately without consuming any virtual time —
+      // proof that the Gateway message pump cannot be made to wait on the
+      // playout owner or any playback-owned monitor.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+      val startTime = testScheduler.currentTime
+
+      repeat(50) { playRealtimeAudio(manager, ByteArray(960)) }
+      queueRealtimePlaybackMark(manager, "relay-1", "mark-1")
+      requestRealtimePlaybackClear(manager)
+      stopRealtimePlayback(manager)
+
+      assertEquals(startTime, testScheduler.currentTime)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun partialWritesAccumulateCorrectTotalsAndMarkTarget() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      // First two write() calls only accept 320 of what's offered; the third
+      // (fallback) accepts the rest — exercises the partial-write accounting
+      // path without assuming a whole frame is written in one call. Neither
+      // partial result is 0, so no delay() retry is involved.
+      val writer = ScriptedRealtimeAudioTrackWriter(scripted = listOf(320, 320))
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+      val bytes = ByteArray(960) { (it % 128).toByte() }
+
+      playRealtimeAudio(manager, bytes)
+      queueRealtimePlaybackMark(manager, "relay-1", "mark-1")
+      runCurrent()
+
+      assertEquals(listOf(0, 320, 640), writer.calls.map { it[0] })
+      assertEquals((bytes.size / 2).toLong(), readPrivateField(manager, "realtimeWrittenFrames") as Long)
+      assertTrue(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun zeroWriteRetriesWithBoundedDelayInsteadOfBusySpinning() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      // Buffer momentarily full for 3 attempts, then accepts the rest.
+      val writer = ScriptedRealtimeAudioTrackWriter(scripted = listOf(0, 0, 0))
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      // Runs only what's schedulable at the CURRENT virtual time, without
+      // advancing it. A busy-spinning retry loop has no suspension point, so
+      // it would run every retry synchronously right here; the real
+      // (delay()-based) implementation instead suspends after exactly one
+      // write attempt, leaving the rest for later virtual-time ticks.
+      runCurrent()
+      assertEquals(1, writer.calls.size)
+
+      // Exactly enough virtual time for the 3 scripted retries
+      // (realtimePlaybackWriteRetryDelayMs each), and comfortably under one
+      // realtimePlaybackIdlePollMs tick so the idle-poll ticker (armed only
+      // after the 4th, successful write) never actually fires here.
+      advanceTimeBy(3 * REALTIME_PLAYBACK_WRITE_RETRY_DELAY_MS)
+      runCurrent()
+      assertEquals(4, writer.calls.size)
+      assertTrue(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun permanentlyStalledWriteGivesUpAndRetiresTheTrackInsteadOfSpinningForever() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      // Never drains. A non-blocking write returning 0 usually means "buffer
+      // full, retry", but on some devices the OS stops draining a track for
+      // good; the single playout owner must not be wedged by that.
+      val writer = ScriptedRealtimeAudioTrackWriter().apply { stalled = true }
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      // Comfortably past realtimePlaybackBufferMs + this frame's own duration.
+      advanceTimeBy(2_000)
+      runCurrent()
+      val callsAfterGivingUp = writer.calls.size
+
+      advanceTimeBy(2_000)
+      runCurrent()
+
+      // Bounded: it stopped calling write, retired the dead track, and left no
+      // stale speaking state behind (which would keep the mic suppressed on the
+      // half-duplex fallback path for the rest of the session).
+      assertEquals(callsAfterGivingUp, writer.calls.size)
+      assertNull(readPrivateField(manager, "realtimeAudioTrack"))
+      assertFalse(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun negativeWriteResultRetiresTheTrackInsteadOfLeavingItInstalled() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      // ERROR_DEAD_OBJECT is terminal for this handle: keeping it installed
+      // would make every later Audio command fail the same way in silence.
+      val writer = ScriptedRealtimeAudioTrackWriter(scripted = listOf(AudioTrack.ERROR_DEAD_OBJECT))
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent()
+
+      assertNull(readPrivateField(manager, "realtimeAudioTrack"))
+      assertFalse(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun clearPreemptsInProgressWriteAndDoesNotResumeStaleAudio() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      // Accepts 320 bytes, then stalls (0) until told otherwise.
+      val writer = ScriptedRealtimeAudioTrackWriter(scripted = listOf(320)).apply { stalled = true }
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent() // owner accepts 320 bytes, then a zero-write, and suspends in delay()
+      assertEquals(2, writer.calls.size)
+
+      // Bumps the epoch immediately (no AudioTrack touch); the owner's next
+      // retry check (after its current delay() resolves) must see it and
+      // discard the remaining 640 bytes of this frame rather than resuming.
+      requestRealtimePlaybackClear(manager)
+      advanceTimeBy(REALTIME_PLAYBACK_WRITE_RETRY_DELAY_MS)
+      runCurrent()
+
+      assertEquals(2, writer.calls.size)
+      assertNull(readPrivateField(manager, "realtimeAudioTrack"))
+      assertFalse(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun ownerSideStopClearsSpeakingStateSetAfterTheSynchronousStop() =
+    runTest {
+      // An Audio command that passed its epoch check just before a stop can set
+      // _isSpeaking after stopRealtimePlayback() already cleared it on the
+      // Gateway thread. The owner is sequential, so its own Stop handling has to
+      // be what leaves the state clean; a stuck _isSpeaking keeps
+      // isRealtimePlaybackActive() true and suppresses the mic on the
+      // half-duplex path. Setting the flag directly here stands in for that
+      // interleaving, which a single test dispatcher cannot produce.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent()
+      stopRealtimePlayback(manager)
+      setMutableStateFlow(manager, "_isSpeaking", true)
+      runCurrent()
+
+      assertFalse(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun playbackStopKeepsPendingMarksForTheProviderClearThatFollowsIt() =
+    runTest {
+      // PTT pause and stopTts stop playback and then ask the relay to cancel the
+      // turn; the provider's own "clear" arrives afterwards and is what
+      // acknowledges the marks. Discarding them on the stop would leave the
+      // cancelled turn unacknowledged forever.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val acknowledged = mutableListOf<Pair<String, String>>()
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimePlaybackDispatcher = dispatcher,
+          realtimeAudioTrackWriter = writer,
+          realtimeMarkAcknowledger = { sessionId, markName -> acknowledged += sessionId to markName },
+        ).also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      queueRealtimePlaybackMark(manager, "relay-1", "cancelled-turn-mark")
+      runCurrent()
+
+      stopRealtimePlayback(manager)
+      runCurrent()
+      assertEquals(emptyList<Pair<String, String>>(), acknowledged)
+
+      requestRealtimePlaybackClear(manager)
+      runCurrent()
+
+      assertEquals(listOf("relay-1" to "cancelled-turn-mark"), acknowledged)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun clearAcknowledgesStillPendingMarkExactlyOnce() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      // ScriptedRealtimeAudioTrackWriter never calls the real AudioTrack.write,
+      // so Robolectric's shadow playbackHeadPosition stays at 0 — the mark
+      // set against realtimeWrittenFrames (> 0) never auto-completes via
+      // PollIdle, keeping it genuinely pending until clear runs.
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val acknowledged = mutableListOf<Pair<String, String>>()
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimePlaybackDispatcher = dispatcher,
+          realtimeAudioTrackWriter = writer,
+          realtimeMarkAcknowledger = { sessionId, markName -> acknowledged += sessionId to markName },
+        ).also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      queueRealtimePlaybackMark(manager, "relay-1", "old-mark")
+      runCurrent()
+      assertEquals(emptyList<Pair<String, String>>(), acknowledged)
+
+      requestRealtimePlaybackClear(manager)
+      runCurrent()
+
+      assertEquals(listOf("relay-1" to "old-mark"), acknowledged)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun markEnqueuedJustBeforeClearIsStillAcknowledgedNotLost() =
+    runTest {
+      // Regression for a race the epoch design can hit: the Gateway thread
+      // can bump the epoch (via requestRealtimePlaybackClear) before the
+      // owner ever dequeues a Mark command sent moments earlier on the same
+      // thread. If Mark processing were epoch-gated, it would drop the mark
+      // before either it or the following Clear ever acknowledged it.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val acknowledged = mutableListOf<Pair<String, String>>()
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimePlaybackDispatcher = dispatcher,
+          realtimeMarkAcknowledger = { sessionId, markName -> acknowledged += sessionId to markName },
+        ).also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      // Both enqueued before the owner coroutine gets a chance to run, so the
+      // epoch bump from requestRealtimePlaybackClear lands before the owner
+      // ever dequeues the Mark command sent just before it.
+      queueRealtimePlaybackMark(manager, "relay-1", "raced-mark")
+      requestRealtimePlaybackClear(manager)
+      runCurrent()
+
+      assertEquals(listOf("relay-1" to "raced-mark"), acknowledged)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun stopDuringInProgressAudioDoesNotLeakIntoNextSession() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter(scripted = listOf(320)).apply { stalled = true }
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent() // old session: partial write in flight, then stalled
+
+      val oldTrack = readPrivateField(manager, "realtimeAudioTrack")
+      stopRealtimePlayback(manager)
+      advanceTimeBy(REALTIME_PLAYBACK_WRITE_RETRY_DELAY_MS)
+      runCurrent()
+      assertNull(readPrivateField(manager, "realtimeAudioTrack"))
+      assertFalse(manager.isSpeaking.value)
+
+      // New session's audio must create a fresh track and play normally —
+      // the old session's stalled write must not resume or leak state in.
+      writer.stalled = false
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent()
+
+      val newTrack = readPrivateField(manager, "realtimeAudioTrack")
+      assertTrue(newTrack != null && newTrack !== oldTrack)
+      assertTrue(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun normalTransitionDoesNotTruncateActivePlayback() =
+    runTest {
+      // Root-cause regression for a one-time Bluetooth truncation seen in
+      // physical proof: confirms ordinary next-turn audio (no Clear, no
+      // Stop) never retires the still-playing track. ScriptedRealtimeAudioTrackWriter
+      // never calls the real AudioTrack.write, so Robolectric's shadow
+      // playbackHeadPosition stays at 0 even after A is "accepted" —
+      // exactly the "unplayed audio still behind writtenFrames" shape a
+      // slow (e.g. Bluetooth) drain produces, without needing real time.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent()
+      val trackDuringA = readPrivateField(manager, "realtimeAudioTrack")
+      assertTrue(trackDuringA != null)
+
+      // Same session, no Clear/Stop in between: a normal next turn's audio.
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent()
+
+      assertTrue(trackDuringA === readPrivateField(manager, "realtimeAudioTrack"))
+      assertEquals(listOf(960, 960), writer.calls.map { it[1] })
+      assertTrue(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun normalTransitionPreservesQueuedAudioOrdering() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      playRealtimeAudio(manager, ByteArray(320))
+      runCurrent()
+
+      // B is neither dropped nor written ahead of A, and metering accumulates
+      // across the transition instead of resetting mid-turn (§13): the single
+      // sequential owner already guarantees order, this pins it as a contract.
+      assertEquals(listOf(960, 320), writer.calls.map { it[1] })
+      assertEquals(((960 + 320) / 2).toLong(), readPrivateField(manager, "realtimeWrittenFrames") as Long)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun normalTransitionReusesCompatibleTrackAcrossSeveralTurns() =
+    runTest {
+      // Sustained reuse, not a one-shot coincidence: the same track must
+      // survive several consecutive normal turns, matching the "AudioTrack
+      // hardware lifetime is not tied to Talk turn lifetime" invariant.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(320))
+      runCurrent()
+      val firstTrack = readPrivateField(manager, "realtimeAudioTrack")
+
+      repeat(4) {
+        playRealtimeAudio(manager, ByteArray(320))
+        runCurrent()
+        assertTrue(firstTrack === readPrivateField(manager, "realtimeAudioTrack"))
+      }
+      assertEquals(5, writer.calls.size)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun marksRemainOrderedAcrossNormalTransition() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ScriptedRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      queueRealtimePlaybackMark(manager, "relay-1", "mark-after-a")
+      runCurrent()
+
+      // Normal transition: track reused, no Clear/Stop, second turn's audio
+      // and mark queued after the first mark.
+      playRealtimeAudio(manager, ByteArray(320))
+      queueRealtimePlaybackMark(manager, "relay-1", "mark-after-b")
+      runCurrent()
+
+      @Suppress("UNCHECKED_CAST")
+      val marks = readPrivateField(manager, "pendingRealtimePlaybackMarks") as Map<String, Any>
+      val targetFrameOf = { name: String ->
+        val mark = marks.getValue(name)
+        readPrivateField(mark, "targetFrame") as Long?
+      }
+      // mark-after-a's target predates mark-after-b's by exactly B's frames —
+      // the transition did not renumber or drop either registration.
+      assertEquals(960L / 2, targetFrameOf("mark-after-a"))
+      assertEquals((960 + 320).toLong() / 2, targetFrameOf("mark-after-b"))
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun ownerJobSurvivesACommandExceptionAndKeepsProcessingLaterAudio() =
+    runTest {
+      // Structured-review regression: an uncaught throw while processing one
+      // command (e.g. AudioTrack.write failing on a route/dead-object error)
+      // must not end realtimeAudioWriterJob's for-loop. The channel is
+      // long-lived and never recreated, so a dead owner would silently
+      // swallow every later command for the rest of the manager's lifetime.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ThrowingOnceRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent() // write() throws; the owner must survive and keep looping.
+
+      val job = readPrivateField(manager, "realtimeAudioWriterJob") as Job
+      assertTrue(job.isActive)
+      // The failed track is retired rather than reused in whatever state the
+      // throw left it.
+      assertNull(readPrivateField(manager, "realtimeAudioTrack"))
+
+      // A later, ordinary Audio command must still reach a (fresh) track —
+      // proof the owner is still consuming the channel, not just alive.
+      playRealtimeAudio(manager, ByteArray(960))
+      runCurrent()
+
+      assertEquals(2, writer.calls.size)
+      assertTrue(manager.isSpeaking.value)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun aCommandFailureAcknowledgesStrandedMarksInsteadOfPollingForever() =
+    runTest {
+      // Structured-review regression: retiring the track on a command
+      // failure resets realtimeWrittenFrames to 0, so a mark registered
+      // against the pre-failure (positive) frame count would otherwise never
+      // be satisfied again -- the idle poll would compare against it forever
+      // with no ack ever reaching the provider.
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ThrowingOnceRealtimeAudioTrackWriter(throwOnCallIndex = 1)
+      val acknowledged = mutableListOf<Pair<String, String>>()
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimePlaybackDispatcher = dispatcher,
+          realtimeAudioTrackWriter = writer,
+          realtimeMarkAcknowledger = { sessionId, markName -> acknowledged += sessionId to markName },
+        ).also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      playRealtimeAudio(manager, ByteArray(960)) // call 0: succeeds, writtenFrames > 0
+      runCurrent()
+      queueRealtimePlaybackMark(manager, "relay-1", "pending-mark")
+      runCurrent()
+      assertEquals(emptyList<Pair<String, String>>(), acknowledged) // not yet satisfied
+
+      playRealtimeAudio(manager, ByteArray(960)) // call 1: throws
+      runCurrent()
+
+      assertEquals(listOf("relay-1" to "pending-mark"), acknowledged)
+      @Suppress("UNCHECKED_CAST")
+      val marks = readPrivateField(manager, "pendingRealtimePlaybackMarks") as Map<String, Any>
+      assertTrue(marks.isEmpty())
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
+  fun audioTrackWritesAreSerializedThroughTheSinglePlayoutOwner() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val writer = ConcurrencyTrackingRealtimeAudioTrackWriter()
+      val manager =
+        createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope, realtimePlaybackDispatcher = dispatcher, realtimeAudioTrackWriter = writer)
+          .also { setPrivateField(it, "realtimeSessionId", "relay-1") }
+
+      repeat(5) { playRealtimeAudio(manager, ByteArray(960)) }
+      runCurrent()
+
+      assertEquals(1, writer.maxConcurrentCalls)
+      cancelRealtimeAudioWriterJob(manager)
+    }
+
+  @Test
   fun pushToTalkPauseWaitsForRealtimeCaptureJobs() =
     runTest {
       val manager = createManager()
@@ -831,6 +1414,7 @@ class TalkModeManagerTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
           onStoppedByRelay = { stoppedByRelay = true },
         )
       setPrivateField(manager, "realtimeSessionId", "relay-1")
@@ -884,6 +1468,7 @@ class TalkModeManagerTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
           realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
         )
       setMutableStateFlow(manager, "_isEnabled", true)
@@ -891,6 +1476,8 @@ class TalkModeManagerTest {
       val pause = readPrivateField(manager, "realtimeCapturePause")!!
       setPrivateField(pause, "sessionId", "relay-1")
       setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeWireAudioSampleRateHz", 24_000)
+      setPrivateField(manager, "realtimeWireAudioEncoding", "pcm16")
       setMutableStateFlow(manager, "_isListening", false)
       setMutableStateFlow(manager, "_statusText", nativeText("Thinking…"))
 
@@ -911,11 +1498,125 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun resumingRealtimeCaptureFailsClosedWhenWireAudioContractNeverResolved() =
+    runTest {
+      // Distinct from an absent talk.session.create `audio` field (which now resolves to
+      // the legacy pcm16/24kHz contract, see parseRealtimeWireAudioContract tests below):
+      // this is the fields simply never having been populated at all, which must still
+      // fail closed rather than silently guess a rate.
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setMutableStateFlow(manager, "_isListening", false)
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertFalse(manager.isListening.value)
+      assertFalse(manager.isEnabled.value)
+      assertNull(readPrivateField(manager, "realtimeCaptureJob"))
+    }
+
+  @Test
+  fun declaredWireRateUnreachableFromTheRequestedRateIsNotRejectedBeforeOpening() =
+    runTest {
+      // The requested capture rate is only a preference; whether a conversion
+      // exists is decided by the rate AudioRecord actually negotiates, which is
+      // not known until it is open. Rejecting a declared wire rate up front
+      // against the requested rate (22.05kHz is no integer divisor of 48kHz)
+      // would kill sessions on devices whose recorder negotiates a rate that
+      // does reach it. This asserts the gate location only -- capture is
+      // installed rather than refused before the microphone is touched.
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeWireAudioEncoding", "pcm16")
+      setPrivateField(manager, "realtimeWireAudioSampleRateHz", 22_050)
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertTrue(manager.isEnabled.value)
+      assertTrue(readPrivateField(manager, "realtimeCaptureJob") != null)
+      manager.stopAllCapture()
+    }
+
+  @Test
+  fun absentAudioContractParsesToTheLegacyPcm16TwentyFourKhzWireFormat() {
+    // talk.session.create's `audio` field is optional (TalkSessionCreateResultSchema);
+    // older/simpler Gateway peers omit it, and iOS's RealtimeTalkRelaySession still
+    // defaults to this exact pcm16/24kHz contract in that case. Android must match, not
+    // treat an absent field as an unsupported contract.
+    val root = Json.parseToJsonElement("""{"relaySessionId":"relay-1"}""").jsonObject
+
+    val contract = parseRealtimeWireAudioContract(root)
+
+    assertEquals("pcm16", contract.encoding)
+    assertEquals(24_000, contract.sampleRateHz)
+  }
+
+  @Test
+  fun presentAudioContractIsParsedAsDeclared() {
+    val root =
+      Json
+        .parseToJsonElement(
+          """{"relaySessionId":"relay-1","audio":{"inputEncoding":"pcm16","inputSampleRateHz":48000}}""",
+        ).jsonObject
+
+    val contract = parseRealtimeWireAudioContract(root)
+
+    assertEquals("pcm16", contract.encoding)
+    assertEquals(48_000, contract.sampleRateHz)
+  }
+
+  @Test
+  fun malformedAudioContractStaysUnresolvedForFailClosed() {
+    // Present but not an object at all -- an explicitly unsupported shape, not an
+    // omission, so it must not fall back to the legacy contract.
+    val notAnObject = Json.parseToJsonElement("""{"relaySessionId":"relay-1","audio":"unsupported"}""").jsonObject
+    // Present as an object but missing the fields this client understands.
+    val emptyObject = Json.parseToJsonElement("""{"relaySessionId":"relay-1","audio":{}}""").jsonObject
+
+    for (root in listOf(notAnObject, emptyObject)) {
+      val contract = parseRealtimeWireAudioContract(root)
+      assertNull(contract.encoding)
+      assertNull(contract.sampleRateHz)
+    }
+  }
+
+  @Test
+  fun legacyFallbackWireRateResolvesToTheSame48kTo24kResamplerPath() {
+    // Locks the composition end to end: an absent audio contract must land on exactly
+    // the same capture-portable-rate -> wire-rate conversion already proven correct by
+    // RealtimeCaptureResamplerTest, not a rate the resampler rejects.
+    val contract = parseRealtimeWireAudioContract(Json.parseToJsonElement("""{"relaySessionId":"relay-1"}""").jsonObject)
+
+    val resampler = resolveRealtimeCaptureResampler(48_000, contract.sampleRateHz!!)
+
+    assertTrue(resampler != null)
+  }
+
+  @Test
   fun replacementRelayPublishedDuringPushToTalkResumesCapture() =
     runTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
           realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
         )
       setMutableStateFlow(manager, "_isEnabled", true)
@@ -924,6 +1625,8 @@ class TalkModeManagerTest {
       setPrivateField(pause, "sessionId", "relay-replacement")
       setPrivateField(pause, "restartRelay", true)
       setPrivateField(manager, "realtimeSessionId", "relay-replacement")
+      setPrivateField(manager, "realtimeWireAudioSampleRateHz", 24_000)
+      setPrivateField(manager, "realtimeWireAudioEncoding", "pcm16")
 
       manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
 
@@ -937,7 +1640,7 @@ class TalkModeManagerTest {
   @Test
   fun stoppedTalkModeDoesNotRestartRelayAfterPushToTalk() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
       val pause = readPrivateField(manager, "realtimeCapturePause")!!
       setPrivateField(pause, "restartRelay", true)
@@ -955,7 +1658,7 @@ class TalkModeManagerTest {
   @Test
   fun pausedPushToTalkTurnSuppressesSpeechInterruptListener() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
       assertTrue(manager.shouldAllowSpeechInterrupt())
 
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
@@ -968,7 +1671,7 @@ class TalkModeManagerTest {
   @Test
   fun finishingPushToTalkTurnRejectsReplacementCapture() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
       setPrivateField(manager, "finishingPttCaptureId", "capture-1")
 
       val error =
@@ -1016,7 +1719,7 @@ class TalkModeManagerTest {
   @Test
   fun relayClosePreservesFinishingPushToTalkOwnership() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
       setPrivateField(manager, "realtimeSessionId", "relay-1")
       setPrivateField(manager, "finishingPttCaptureId", "capture-1")
@@ -1034,6 +1737,7 @@ class TalkModeManagerTest {
       val manager =
         createManager(
           scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
           isConnected = { false },
           onStoppedByRelay = { stoppedByRelay = true },
         )
@@ -1059,7 +1763,7 @@ class TalkModeManagerTest {
   @Test
   fun chatFinalWaitUsesGatewayEventTimeout() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager = createManager(scope = this, realtimePlaybackOwnerScope = backgroundScope)
 
       setPrivateField(manager, "pendingRunId", "run-missing-final")
       setPrivateField(manager, "pendingFinal", CompletableDeferred<Boolean>())
@@ -1077,6 +1781,11 @@ class TalkModeManagerTest {
     realtimeCaptureDispatcher: CoroutineDispatcher = Dispatchers.IO,
     realtimePlaybackDispatcher: CoroutineDispatcher = Dispatchers.IO,
     realtimeMarkAcknowledger: (suspend (String, String) -> Unit)? = null,
+    realtimeAudioTrackWriter: RealtimeAudioTrackWriter = RealtimeAudioTrackWriter.Default,
+    // Defaults to `scope` (TalkModeManager's own default) unless a test
+    // explicitly exempts the playout owner from runTest's child-job
+    // completion check — see the constructor parameter's doc comment.
+    realtimePlaybackOwnerScope: CoroutineScope? = null,
   ): TalkModeManager {
     val app = RuntimeEnvironment.getApplication()
     val session =
@@ -1099,7 +1808,9 @@ class TalkModeManagerTest {
       realtimeCaptureDispatcher = realtimeCaptureDispatcher,
       realtimePlaybackDispatcher = realtimePlaybackDispatcher,
       realtimeMarkAcknowledger = realtimeMarkAcknowledger,
-    )
+      realtimeAudioTrackWriter = realtimeAudioTrackWriter,
+      realtimePlaybackOwnerScope = realtimePlaybackOwnerScope ?: scope,
+    ).also { createdManagers += it }
   }
 
   private fun createRealtimeManager(): TalkModeManager = createManager().also { setPrivateField(it, "realtimeSessionId", "relay-1") }
@@ -1189,6 +1900,66 @@ class TalkModeManagerTest {
     return method.invoke(manager, length) as Boolean
   }
 
+  private fun playRealtimeAudio(
+    manager: TalkModeManager,
+    bytes: ByteArray,
+  ) {
+    val method = manager.javaClass.getDeclaredMethod("playRealtimeAudio", ByteArray::class.java)
+    method.isAccessible = true
+    method.invoke(manager, bytes)
+  }
+
+  private fun queueRealtimePlaybackMark(
+    manager: TalkModeManager,
+    sessionId: String,
+    markName: String,
+  ) {
+    val method = manager.javaClass.getDeclaredMethod("queueRealtimePlaybackMark", String::class.java, String::class.java)
+    method.isAccessible = true
+    method.invoke(manager, sessionId, markName)
+  }
+
+  private fun requestRealtimePlaybackClear(manager: TalkModeManager) {
+    val method = manager.javaClass.getDeclaredMethod("requestRealtimePlaybackClear")
+    method.isAccessible = true
+    method.invoke(manager)
+  }
+
+  private fun stopRealtimePlayback(
+    manager: TalkModeManager,
+    discardMarks: Boolean = false,
+  ) {
+    val method = manager.javaClass.getDeclaredMethod("stopRealtimePlayback", Boolean::class.javaPrimitiveType)
+    method.isAccessible = true
+    method.invoke(manager, discardMarks)
+  }
+
+  /** realtimeAudioWriterJob (the playout owner) and realtimePlaybackIdleJob
+   * (its idle-poll ticker, armed by any successful write/mark) are both
+   * intentionally infinite for TalkModeManager's real lifetime (see
+   * production comments); tests that drive them via scope = this, realtimePlaybackOwnerScope = backgroundScope must
+   * cancel both explicitly or runTest fails waiting for them. */
+  private fun cancelRealtimeAudioWriterJob(manager: TalkModeManager) {
+    (readPrivateField(manager, "realtimeAudioWriterJob") as Job).cancel()
+    (readPrivateField(manager, "realtimePlaybackIdleJob") as Job?)?.cancel()
+  }
+
+  private fun invokeStopRealtimeRelay(
+    manager: TalkModeManager,
+    closeSession: Boolean,
+  ) {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "stopRealtimeRelay",
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    method.invoke(manager, closeSession, true, true, false)
+  }
+
   private fun recognitionListener(
     manager: TalkModeManager,
     captureId: String,
@@ -1241,5 +2012,82 @@ private class FakeTalkAudioPlayer : TalkAudioPlaying {
 
   override fun stop() {
     stopped = true
+  }
+}
+
+// Mirrors TalkModeManager's private realtimePlaybackWriteRetryDelayMs (5L).
+// Kept as a separate constant because that value is a private companion
+// const not reachable via reflection on a compiled Int/Long constant.
+private const val REALTIME_PLAYBACK_WRITE_RETRY_DELAY_MS = 5L
+
+/**
+ * Deterministic [RealtimeAudioTrackWriter] fake: never touches the real
+ * AudioTrack, so tests control exactly what each write() call reports
+ * (partial/zero accept) without depending on Robolectric's shadow to
+ * simulate hardware pacing it doesn't actually model.
+ */
+private class ScriptedRealtimeAudioTrackWriter(
+  scripted: List<Int> = emptyList(),
+) : RealtimeAudioTrackWriter {
+  private val queue = ArrayDeque(scripted)
+
+  /** Once [queue] is drained: true keeps returning 0 (stalled); false accepts the full request. */
+  @Volatile var stalled = false
+  val calls = mutableListOf<IntArray>()
+
+  override fun write(
+    track: AudioTrack,
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int {
+    calls += intArrayOf(offset, length)
+    if (queue.isNotEmpty()) return queue.removeFirst()
+    return if (stalled) 0 else length
+  }
+}
+
+/** Throws once (simulating a hardware/route failure), then writes normally. */
+private class ThrowingOnceRealtimeAudioTrackWriter(
+  private val throwOnCallIndex: Int = 0,
+) : RealtimeAudioTrackWriter {
+  private var thrown = false
+  val calls = mutableListOf<IntArray>()
+
+  override fun write(
+    track: AudioTrack,
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int {
+    val callIndex = calls.size
+    calls += intArrayOf(offset, length)
+    if (!thrown && callIndex == throwOnCallIndex) {
+      thrown = true
+      throw RuntimeException("simulated hardware failure")
+    }
+    return length
+  }
+}
+
+/** Records the peak number of concurrent write() calls to prove AudioTrack access is serialized. */
+private class ConcurrencyTrackingRealtimeAudioTrackWriter : RealtimeAudioTrackWriter {
+  private val concurrentCalls = AtomicInteger(0)
+
+  @Volatile var maxConcurrentCalls = 0
+
+  override fun write(
+    track: AudioTrack,
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int {
+    val current = concurrentCalls.incrementAndGet()
+    synchronized(this) { maxConcurrentCalls = maxOf(maxConcurrentCalls, current) }
+    try {
+      return length
+    } finally {
+      concurrentCalls.decrementAndGet()
+    }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1556,6 +1556,45 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun replacingCaptureClearsTheAecFlagBeforeTheNewSessionReportsItsOwn() =
+    runTest {
+      // realtimeAecEnabled is the gate that lets the microphone stay live during
+      // playback, so it must never describe a capture session that has ended. The
+      // superseded job's finally is generation-guarded and therefore declines to
+      // clear it -- by the time it runs, the generation already belongs to the new
+      // job. Without a reset at the generation boundary the flag stays true from the
+      // previous session until the new capture finishes opening and reports its own
+      // state, and suppression is lifted for that whole window even if the new
+      // session has no AEC at all.
+      val manager =
+        createManager(
+          scope = this,
+          realtimePlaybackOwnerScope = backgroundScope,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeWireAudioEncoding", "pcm16")
+      setPrivateField(manager, "realtimeWireAudioSampleRateHz", 24_000)
+      // The session being replaced had platform AEC enabled.
+      setPrivateField(manager, "realtimeAecEnabled", true)
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      // The new capture job has not reported yet (its dispatcher has not run), so the
+      // only correct answer is the safe one.
+      assertFalse(readPrivateField(manager, "realtimeAecEnabled") as Boolean)
+      // And the gate that reads it suppresses again, rather than forwarding on the
+      // strength of the previous session's hardware.
+      setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 1_000)
+      assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+      manager.stopAllCapture()
+    }
+
+  @Test
   fun absentAudioContractParsesToTheLegacyPcm16TwentyFourKhzWireFormat() {
     // talk.session.create's `audio` field is optional (TalkSessionCreateResultSchema);
     // older/simpler Gateway peers omit it, and iOS's RealtimeTalkRelaySession still

--- a/extensions/openai/realtime-voice-bridge-events.test.ts
+++ b/extensions/openai/realtime-voice-bridge-events.test.ts
@@ -84,8 +84,13 @@ describe("OpenAI realtime voice bridge events", () => {
     });
     const socket = await connectReadyBridge(bridge);
 
+    // 2016 bytes at the default g711_ulaw/8kHz output format (1 byte/sample)
+    // is 252ms of confirmed-played audio, comfortably above the default
+    // 250ms minimum barge-in window - so audio_end_ms below is derived from
+    // bytes actually acknowledged as played, not from a manually-set clock.
+    const audio = Buffer.alloc(2016, 0x41);
     bridge.setMediaTimestamp(1000);
-    emitAssistantPlayback(socket);
+    emitAssistantPlayback(socket, { audio });
     bridge.setMediaTimestamp(1300);
 
     bridge.handleBargeIn?.({ audioPlaybackActive: true });
@@ -98,7 +103,86 @@ describe("OpenAI realtime voice bridge events", () => {
         type: "conversation.item.truncate",
         item_id: "item_1",
         content_index: 0,
-        audio_end_ms: 300,
+        audio_end_ms: 252,
+        event_id: expect.any(String),
+      },
+    ]);
+  });
+
+  it("skips truncate when only a sub-minimum sliver of audio has been confirmed played", async () => {
+    // Regression guard for the truncate audio_end_ms bug: before the fix,
+    // audio_end_ms was derived from an unrelated input-media-timestamp diff
+    // that could report tens of seconds of "played" audio for an item that
+    // had only streamed a couple of bytes, which OpenAI's Realtime API
+    // rejects with "Audio content of Xms is already shorter than Yms".
+    // A tiny confirmed-played chunk must instead skip truncate via the
+    // existing minBargeInAudioEndMs gate, never send an inflated value.
+    const onClearAudio = vi.fn();
+    const bridge = createNativeBridge({
+      onClearAudio,
+      onMark: () => bridge.acknowledgeMark(),
+    });
+    const socket = await connectReadyBridge(bridge);
+
+    // A single-byte delta acknowledged immediately is far below the 250ms
+    // default minimum, even though a stale/unrelated wall clock could have
+    // advanced by any arbitrary amount in the meantime.
+    bridge.setMediaTimestamp(1000);
+    emitAssistantPlayback(socket, { audio: Buffer.from([0x00]) });
+    bridge.setMediaTimestamp(1_000_000);
+
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+
+    // Below minBargeInAudioEndMs, the provider-side truncate is skipped
+    // (audio_end_ms isn't trustworthy enough yet to tell OpenAI precisely
+    // where this item was cut) but response.cancel still fires immediately -
+    // a genuine barge-in must never let the assistant keep generating/
+    // talking over the user just because the played-byte confirmation
+    // hasn't caught up yet.
+    expect(hasSentEventType(socket, "conversation.item.truncate")).toBe(false);
+    expect(hasSentEventType(socket, "response.cancel")).toBe(true);
+  });
+
+  it("clamps audio_end_ms to delivered audio when no mark has been acknowledged yet", async () => {
+    // Real regression guard for the original production bug: audio_end_ms
+    // was derived from an unrelated input-media-timestamp diff whenever no
+    // mark had been acknowledged for the current item yet (the fast/early
+    // barge-in case - the single most common interruption timing). That
+    // diff could report tens of seconds of "played" audio for an item that
+    // had only streamed a couple thousand bytes, which OpenAI's Realtime
+    // API rejects with "Audio content of Xms is already shorter than Yms".
+    // Unlike the previous test (which acknowledges a mark immediately and
+    // so never touches the fallback at all), this scenario never
+    // acknowledges anything, so playedAudioMsForCurrentItem() stays null
+    // and the fallback path - and its delivered-bytes clamp - is what's
+    // actually under test.
+    const onClearAudio = vi.fn();
+    const bridge = createNativeBridge({ onClearAudio });
+    const socket = await connectReadyBridge(bridge);
+
+    // 2016 bytes at g711_ulaw/8kHz (1 byte/sample) is 252ms of audio OpenAI
+    // has actually sent us for this item - a hard upper bound on how much
+    // could possibly have been heard, regardless of what the input-audio
+    // clock below claims.
+    const audio = Buffer.alloc(2016, 0x41);
+    bridge.setMediaTimestamp(1000);
+    emitAssistantPlayback(socket, { audio });
+    // A wildly divergent input-audio clock: pre-fix this produced
+    // audio_end_ms = 999000, which sailed past the 250ms minimum and was
+    // sent to OpenAI as truncate for an item that was only 252ms long.
+    bridge.setMediaTimestamp(1_000_000);
+
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+
+    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+    expect(parseSent(socket).slice(-2)).toEqual([
+      expectedResponseCancelEvent(),
+      {
+        type: "conversation.item.truncate",
+        item_id: "item_1",
+        content_index: 0,
+        audio_end_ms: 252,
+        event_id: expect.any(String),
       },
     ]);
   });
@@ -129,12 +213,16 @@ describe("OpenAI realtime voice bridge events", () => {
     bridge.setMediaTimestamp(1300);
     bridge.handleBargeIn?.();
 
+    // 299 acknowledged chunks * 15 bytes ("assistant audio") = 4485 bytes,
+    // which at g711_ulaw/8kHz (1 byte/sample) is floor(4485 / 8) = 560ms of
+    // confirmed-played audio - independent of the media-timestamp diff.
     expect(parseSent(socket).slice(-1)).toEqual([
       {
         type: "conversation.item.truncate",
         item_id: "item_1",
         content_index: 0,
-        audio_end_ms: 300,
+        audio_end_ms: 560,
+        event_id: expect.any(String),
       },
     ]);
     expect(onClearAudio).toHaveBeenCalledWith("barge-in");
@@ -323,10 +411,17 @@ describe("OpenAI realtime voice bridge events", () => {
     const socket = await connectReadyBridge(bridge);
     emitServerEvent(socket, { type: "response.created", response: { id: "resp_1" } });
     bridge.setMediaTimestamp(1000);
+    // No mark handler is wired up here (only onEvent), so audio_end_ms is
+    // computed via the media-timestamp fallback, then clamped to delivered
+    // bytes (see the dedicated clamp regression test above). 2400 bytes at
+    // g711_ulaw/8kHz is 300ms delivered - at or above both the fallback's
+    // 300ms clock diff and the default 250ms minimum - so this scenario
+    // stays focused on its actual subject (no duplicate response.cancel)
+    // instead of incidentally falling below the truncate minimum.
     emitServerEvent(socket, {
       type: "response.audio.delta",
       item_id: "item_1",
-      delta: Buffer.from("assistant audio").toString("base64"),
+      delta: Buffer.alloc(2400, 0x41).toString("base64"),
     });
     bridge.setMediaTimestamp(1300);
 
@@ -346,7 +441,7 @@ describe("OpenAI realtime voice bridge events", () => {
     });
   });
 
-  it("ignores zero-length playback barge-in without clearing audio", async () => {
+  it("clears audio and cancels the response for zero-length playback barge-in, but skips provider truncate", async () => {
     const onClearAudio = vi.fn();
     const onEvent = vi.fn();
     const bridge = createNativeBridge({
@@ -359,8 +454,13 @@ describe("OpenAI realtime voice bridge events", () => {
 
     bridge.handleBargeIn?.({ audioPlaybackActive: true });
 
-    expect(onClearAudio).not.toHaveBeenCalled();
-    expect(hasSentEventType(socket, "response.cancel")).toBe(false);
+    // A genuine barge-in signal always stops local playback and cancels any
+    // in-flight provider response, regardless of whether audio_end_ms is
+    // trustworthy enough yet to send a precise provider-side truncate -
+    // otherwise the assistant could keep talking over the user for as long
+    // as confirmation lags real time.
+    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+    expect(hasSentEventType(socket, "response.cancel")).toBe(true);
     expect(parseSent(socket).some((event) => event.type === "conversation.item.truncate")).toBe(
       false,
     );
@@ -391,6 +491,7 @@ describe("OpenAI realtime voice bridge events", () => {
         item_id: "item_1",
         content_index: 0,
         audio_end_ms: 0,
+        event_id: expect.any(String),
       },
     ]);
     expect(onClearAudio).toHaveBeenCalled();
@@ -424,6 +525,7 @@ describe("OpenAI realtime voice bridge events", () => {
         item_id: "item_1",
         content_index: 0,
         audio_end_ms: 0,
+        event_id: expect.any(String),
       },
     ]);
   });

--- a/extensions/openai/realtime-voice-bridge-events.test.ts
+++ b/extensions/openai/realtime-voice-bridge-events.test.ts
@@ -444,6 +444,50 @@ describe("OpenAI realtime voice bridge events", () => {
     });
   });
 
+  it("leaves the cancel in flight when a truncate rejection arrives before it is answered", async () => {
+    // A barge-in sends response.cancel and conversation.item.truncate together and
+    // the truncate error can come back first. responseCancelInFlight and the
+    // cancel's event id belong to the cancel: releasing them on someone else's
+    // rejection drops the identity its own answer is matched on, and lets a later
+    // barge-in send a second response.cancel while the first is still outstanding.
+    const onError = vi.fn();
+    const bridge = createNativeBridge({
+      onError,
+      onMark: () => bridge.acknowledgeMark(),
+    });
+    const socket = await connectReadyBridge(bridge);
+    bridge.setMediaTimestamp(0);
+    emitAssistantPlayback(socket, { audio: Buffer.alloc(2016, 0x41) });
+    bridge.setMediaTimestamp(300);
+
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+    const truncate = parseSent(socket).findLast(
+      (event) => event.type === "conversation.item.truncate",
+    );
+    expect(truncate?.event_id).toBeTruthy();
+    const cancelsAfterFirstBargeIn = parseSent(socket).filter(
+      (event) => event.type === "response.cancel",
+    ).length;
+    expect(cancelsAfterFirstBargeIn).toBe(1);
+
+    emitServerEvent(socket, {
+      type: "error",
+      error: {
+        event_id: truncate?.event_id,
+        message: "Audio content of 600ms is already shorter than 65301ms",
+      },
+    });
+    expect(onError).toHaveBeenCalled();
+
+    // The first cancel is still unanswered, so a further barge-in must not issue
+    // a second one.
+    emitAssistantPlayback(socket, { audio: Buffer.alloc(2016, 0x41), itemId: "item_2" });
+    bridge.setMediaTimestamp(900);
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+
+    expect(parseSent(socket).filter((event) => event.type === "response.cancel").length).toBe(1);
+  });
+
   it("drops the in-flight tail of an item abandoned below the minimum window", async () => {
     // response.cancel is asynchronous, so the provider can still emit deltas for
     // the item we just stopped playing. Forwarding them would restart playback

--- a/extensions/openai/realtime-voice-bridge-events.test.ts
+++ b/extensions/openai/realtime-voice-bridge-events.test.ts
@@ -109,7 +109,7 @@ describe("OpenAI realtime voice bridge events", () => {
     ]);
   });
 
-  it("skips truncate when only a sub-minimum sliver of audio has been confirmed played", async () => {
+  it("skips truncate but still cancels for a sub-minimum sliver when the caller trusts its barge-in signal", async () => {
     // Regression guard for the truncate audio_end_ms bug: before the fix,
     // audio_end_ms was derived from an unrelated input-media-timestamp diff
     // that could report tens of seconds of "played" audio for an item that
@@ -121,6 +121,9 @@ describe("OpenAI realtime voice bridge events", () => {
     const bridge = createNativeBridge({
       onClearAudio,
       onMark: () => bridge.acknowledgeMark(),
+      // Relay-style caller: the barge-in signal is trustworthy, so the minimum
+      // window governs only truncate precision.
+      minBargeInScope: "truncate-only",
     });
     const socket = await connectReadyBridge(bridge);
 
@@ -441,12 +444,68 @@ describe("OpenAI realtime voice bridge events", () => {
     });
   });
 
-  it("clears audio and cancels the response for zero-length playback barge-in, but skips provider truncate", async () => {
+  it("drops the in-flight tail of an item abandoned below the minimum window", async () => {
+    // response.cancel is asynchronous, so the provider can still emit deltas for
+    // the item we just stopped playing. Forwarding them would restart playback
+    // and let the assistant talk over the user - the exact failure this endpoint
+    // work exists to remove.
+    const onAudio = vi.fn();
+    const onClearAudio = vi.fn();
+    const bridge = createNativeBridge({
+      onAudio,
+      onClearAudio,
+      minBargeInScope: "truncate-only",
+    });
+    const socket = await connectReadyBridge(bridge);
+    bridge.setMediaTimestamp(0);
+    emitAssistantPlayback(socket, { audio: Buffer.from([0x00]), itemId: "item_1" });
+    expect(onAudio).toHaveBeenCalledTimes(1);
+
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+    expect(parseSent(socket).some((event) => event.type === "conversation.item.truncate")).toBe(
+      false,
+    );
+
+    // Same item_id keeps streaming after the cancel request.
+    emitAssistantPlayback(socket, { audio: Buffer.from([0x01]), itemId: "item_1" });
+
+    expect(onAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves playback alone below the minimum window by default, preserving the shipped contract", async () => {
+    // Discord voice depends on this and documents it: below
+    // minBargeInAudioEndMs the signal is treated as likely echo and ignored, so
+    // local playback must keep running and no response.cancel may be sent. Its
+    // barge-in handler passes a deliberately empty fallback for that reason.
+    const onClearAudio = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = createNativeBridge({ onClearAudio, onEvent });
+    const socket = await connectReadyBridge(bridge);
+    bridge.setMediaTimestamp(1000);
+    emitAssistantPlayback(socket);
+
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+
+    expect(onClearAudio).not.toHaveBeenCalled();
+    expect(hasSentEventType(socket, "response.cancel")).toBe(false);
+    expect(parseSent(socket).some((event) => event.type === "conversation.item.truncate")).toBe(
+      false,
+    );
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "client",
+      type: "conversation.item.truncate.skipped",
+      detail: "reason=barge-in audioEndMs=0 minAudioEndMs=250",
+    });
+  });
+
+  it("clears audio and cancels the response for zero-length playback barge-in when the caller trusts its signal, but skips provider truncate", async () => {
     const onClearAudio = vi.fn();
     const onEvent = vi.fn();
     const bridge = createNativeBridge({
       onClearAudio,
       onEvent,
+      minBargeInScope: "truncate-only",
     });
     const socket = await connectReadyBridge(bridge);
     bridge.setMediaTimestamp(1000);

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -77,13 +77,35 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         if (!audioDelta) {
           return;
         }
+        // Stale tail of an item we already truncated: the truncate request
+        // and the provider's in-flight generation can race, so more deltas
+        // for that exact item_id can still arrive after we told the server
+        // (and the client) to stop at audioEndMs. Re-adopting it here as if
+        // it were a new item would restart clock/byte accounting mid-item
+        // and could produce a second truncate whose audio_end_ms looks
+        // small and plausible but is actually counted from the truncation
+        // point rather than the item's real start.
+        if (event.item_id && event.item_id === this.lastTruncatedItemId) {
+          return;
+        }
         const audio = base64ToBuffer(audioDelta);
         this.config.onAudio(audio);
         if (event.item_id && event.item_id !== this.lastAssistantItemId) {
           this.lastAssistantItemId = event.item_id;
           this.responseStartTimestamp = this.latestMediaTimestamp;
+          // New item: byte accounting from the previous item no longer applies.
+          this.resetItemAudioAccounting();
         } else if (this.responseStartTimestamp === null) {
           this.responseStartTimestamp = this.latestMediaTimestamp;
+        }
+        // item_id is optional on the wire type. Only count bytes toward a
+        // known item's duration - crediting an unidentified delta to
+        // whichever item happened to be current would let audio_end_ms
+        // exceed that item's real length again (the class of bug this
+        // accounting exists to prevent), whereas skipping the count merely
+        // makes truncate slightly more conservative.
+        if (event.item_id) {
+          this.deliveredAudioBytesForCurrentItem += audio.byteLength;
         }
         this.responseActive = true;
         this.sendMark();
@@ -149,6 +171,34 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
       case "error": {
         const detail = readRealtimeErrorDetail(event.error);
         const rejectedEventId = readRealtimeErrorEventId(event.error);
+        if (rejectedEventId && rejectedEventId === this.manualTruncateEventId) {
+          // A rejected conversation.item.truncate (e.g. "Audio content of
+          // Xms is already shorter than Yms") previously fell through to
+          // the generic onError branch below with no state repair. By that
+          // point handleBargeIn had already optimistically cleared
+          // lastAssistantItemId/responseStartTimestamp/marks, so there was
+          // nothing left to retry - but responseCancelInFlight, if this
+          // barge-in also sent response.cancel, is cleared ONLY by a
+          // response.cancelled event or a rejection whose detail exactly
+          // matches OPENAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR. A
+          // truncate rejection matches neither, so responseCancelInFlight
+          // could be left permanently true, which makes every future
+          // requestResponseCreate() queue as "pending" forever and the
+          // conversation never produces another assistant turn. Release it
+          // here so a truncate rejection can never strand the session.
+          this.manualTruncateEventId = null;
+          this.config.onError?.(new Error(detail));
+          if (this.responseCancelInFlight) {
+            this.responseCancelInFlight = false;
+            this.manualResponseCancelEventId = null;
+            if (this.responseCreatePending) {
+              this.flushPendingResponseCreate();
+            } else {
+              this.restoreAutoRespondAfterManualResponse();
+            }
+          }
+          return;
+        }
         if (rejectedEventId && rejectedEventId === this.standaloneSpeechEventId) {
           this.responseCreateInFlight = false;
           this.standaloneSpeechActive = false;

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -77,15 +77,14 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         if (!audioDelta) {
           return;
         }
-        // Stale tail of an item we already truncated: the truncate request
-        // and the provider's in-flight generation can race, so more deltas
-        // for that exact item_id can still arrive after we told the server
-        // (and the client) to stop at audioEndMs. Re-adopting it here as if
+        // Stale tail of an item we already abandoned on a barge-in: our request
+        // and the provider's in-flight generation can race, so more deltas for
+        // that exact item_id can still arrive after we stopped playing it. Re-adopting it here as if
         // it were a new item would restart clock/byte accounting mid-item
         // and could produce a second truncate whose audio_end_ms looks
         // small and plausible but is actually counted from the truncation
         // point rather than the item's real start.
-        if (event.item_id && event.item_id === this.lastTruncatedItemId) {
+        if (event.item_id && event.item_id === this.abandonedAssistantItemId) {
           return;
         }
         const audio = base64ToBuffer(audioDelta);

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -79,8 +79,9 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         }
         // Stale tail of an item we already abandoned on a barge-in: our request
         // and the provider's in-flight generation can race, so more deltas for
-        // that exact item_id can still arrive after we stopped playing it. Re-adopting it here as if
-        // it were a new item would restart clock/byte accounting mid-item
+        // that exact item_id can still arrive after we stopped playing it.
+        // Re-adopting it here as if it were a new item would restart
+        // clock/byte accounting mid-item
         // and could produce a second truncate whose audio_end_ms looks
         // small and plausible but is actually counted from the truncation
         // point rather than the item's real start.
@@ -171,31 +172,24 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         const detail = readRealtimeErrorDetail(event.error);
         const rejectedEventId = readRealtimeErrorEventId(event.error);
         if (rejectedEventId && rejectedEventId === this.manualTruncateEventId) {
-          // A rejected conversation.item.truncate (e.g. "Audio content of
-          // Xms is already shorter than Yms") previously fell through to
-          // the generic onError branch below with no state repair. By that
-          // point handleBargeIn had already optimistically cleared
-          // lastAssistantItemId/responseStartTimestamp/marks, so there was
-          // nothing left to retry - but responseCancelInFlight, if this
-          // barge-in also sent response.cancel, is cleared ONLY by a
-          // response.cancelled event or a rejection whose detail exactly
-          // matches OPENAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR. A
-          // truncate rejection matches neither, so responseCancelInFlight
-          // could be left permanently true, which makes every future
-          // requestResponseCreate() queue as "pending" forever and the
-          // conversation never produces another assistant turn. Release it
-          // here so a truncate rejection can never strand the session.
+          // A rejected conversation.item.truncate (e.g. "Audio content of Xms is
+          // already shorter than Yms") is reported and clears only its own
+          // pending-request state. By this point handleBargeIn has already
+          // cleared lastAssistantItemId/responseStartTimestamp/marks, so there
+          // is nothing to retry.
+          //
+          // It deliberately does NOT release responseCancelInFlight, even though
+          // the same barge-in usually sent response.cancel too: the provider
+          // answers that cancel separately, and a truncate error can arrive
+          // first. Releasing here makes handleBargeIn's !responseCancelInFlight
+          // guard believe no cancel is outstanding, so a further barge-in sends
+          // a second response.cancel for a cancel the provider has not answered
+          // yet. That flag is owned by the cancel's own completion
+          // (response.cancelled -> releaseResponseState) or its own rejection
+          // (the NO_ACTIVE_RESPONSE branch below, matched on
+          // manualResponseCancelEventId).
           this.manualTruncateEventId = null;
           this.config.onError?.(new Error(detail));
-          if (this.responseCancelInFlight) {
-            this.responseCancelInFlight = false;
-            this.manualResponseCancelEventId = null;
-            if (this.responseCreatePending) {
-              this.flushPendingResponseCreate();
-            } else {
-              this.restoreAutoRespondAfterManualResponse();
-            }
-          }
           return;
         }
         if (rejectedEventId && rejectedEventId === this.standaloneSpeechEventId) {

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -557,7 +557,14 @@ export abstract class OpenAIRealtimeProtocol {
       this.oldestOutstandingMarkSequence = sequence;
     }
     this.latestOutstandingMarkSequence = sequence;
-    this.markAudioByteOffsets.set(sequence, this.deliveredAudioBytesForCurrentItem);
+    // Only worth recording for a transport that can acknowledge: without an
+    // onMark consumer nothing ever calls acknowledgeMark, so every audio delta
+    // would add an entry no one can ever retire. Those transports fall back to
+    // the delivered-byte clamp, which is what they had before this accounting
+    // existed.
+    if (this.config.onMark) {
+      this.markAudioByteOffsets.set(sequence, this.deliveredAudioBytesForCurrentItem);
+    }
     const markName = `audio-${sequence}`;
     this.config.onMark?.(markName);
   }

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -61,12 +61,14 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected lastAssistantItemId: string | null = null;
 
-  // item_id of the assistant item we most recently sent
-  // conversation.item.truncate for. Deltas that keep arriving for this exact
-  // item after the truncate (a race between the request and the provider's
-  // in-flight generation) must not be re-adopted as a new item - see
-  // OpenAIRealtimeEvents' response.audio.delta handling.
-  protected lastTruncatedItemId: string | null = null;
+  // item_id of the assistant item we most recently abandoned on a barge-in.
+  // Deltas that keep arriving for this exact item afterwards (a race between our
+  // request and the provider's in-flight generation) must be dropped, not
+  // re-adopted as a new item - see OpenAIRealtimeEvents' response.audio.delta
+  // handling. Set whether or not a provider-side truncate was sent: an item
+  // abandoned without a trustworthy truncation point still must not restart
+  // playback after we cleared it.
+  protected abandonedAssistantItemId: string | null = null;
 
   // event_id of the most recently sent conversation.item.truncate, so a
   // provider-side rejection of that specific request can be recognized and
@@ -381,6 +383,14 @@ export abstract class OpenAIRealtimeProtocol {
         type: "conversation.item.truncate.skipped",
         detail: `reason=barge-in audioEndMs=${audioEndMs} minAudioEndMs=${minBargeInAudioEndMs}`,
       });
+      // Default scope keeps the shipped contract: below the threshold the whole
+      // barge-in is treated as likely echo and ignored, so local playback is left
+      // alone. Only a consumer that declares its barge-in signal trustworthy
+      // (minBargeInScope "truncate-only") continues past here to cancel the
+      // response and clear playback while skipping the imprecise truncate.
+      if ((this.config.minBargeInScope ?? "truncate-and-playback") === "truncate-and-playback") {
+        return;
+      }
     }
     if (
       options?.audioPlaybackActive === true &&
@@ -413,11 +423,21 @@ export abstract class OpenAIRealtimeProtocol {
       // instead of re-adopting it as a brand new item, which would restart
       // clock/byte accounting mid-stream and could trigger a second,
       // spuriously-small-looking truncate rejection for the same item.
-      this.lastTruncatedItemId = assistantItemId;
+      this.abandonedAssistantItemId = assistantItemId;
       this.clearOutstandingMarks();
       this.lastAssistantItemId = null;
       this.responseStartTimestamp = null;
       return;
+    }
+    if (shouldInterruptProvider && audioEndMsBelowMinimum) {
+      // No trustworthy truncation point, so no provider truncate - but this item
+      // is still being abandoned locally. Without marking it stale, its
+      // in-flight tail arrives after response.cancel (which is asynchronous),
+      // gets forwarded, and restarts playback over the user.
+      this.abandonedAssistantItemId = assistantItemId;
+      this.clearOutstandingMarks();
+      this.lastAssistantItemId = null;
+      this.responseStartTimestamp = null;
     }
     this.config.onClearAudio("barge-in");
   }
@@ -511,7 +531,7 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected resetRealtimeSessionState(): void {
     this.clearOutstandingMarks();
-    this.lastTruncatedItemId = null;
+    this.abandonedAssistantItemId = null;
     this.manualTruncateEventId = null;
     this.responseStartTimestamp = null;
     this.responseActive = false;

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -61,6 +61,19 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected lastAssistantItemId: string | null = null;
 
+  // item_id of the assistant item we most recently sent
+  // conversation.item.truncate for. Deltas that keep arriving for this exact
+  // item after the truncate (a race between the request and the provider's
+  // in-flight generation) must not be re-adopted as a new item - see
+  // OpenAIRealtimeEvents' response.audio.delta handling.
+  protected lastTruncatedItemId: string | null = null;
+
+  // event_id of the most recently sent conversation.item.truncate, so a
+  // provider-side rejection of that specific request can be recognized and
+  // used to repair state (in particular, release responseCancelInFlight if
+  // it was set for the same barge-in and nothing else will ever clear it).
+  protected manualTruncateEventId: string | null = null;
+
   protected completedToolCallIds = new Set<string>();
 
   protected standaloneSpeechQueue: string[] = [];
@@ -68,6 +81,24 @@ export abstract class OpenAIRealtimeProtocol {
   protected standaloneSpeechActive = false;
 
   protected standaloneSpeechEventId: string | null = null;
+
+  // Cumulative bytes of assistant audio delivered to the client for the item
+  // currently identified by lastAssistantItemId. Reset whenever that item
+  // changes (see OpenAIRealtimeEvents' response.audio.delta handling) or
+  // marks are cleared.
+  protected deliveredAudioBytesForCurrentItem = 0;
+
+  // Cumulative bytes of assistant audio the client has *confirmed playing*
+  // (via acknowledgeMark) for the current item. This can only ever be <=
+  // deliveredAudioBytesForCurrentItem, which is what makes it a safe source
+  // for conversation.item.truncate's audio_end_ms: it is derived from audio
+  // actually reaching the client, not from an unrelated input-audio clock.
+  protected playedAudioBytesForCurrentItem = 0;
+
+  // markSequence -> deliveredAudioBytesForCurrentItem snapshot at the moment
+  // that mark was sent, so acknowledging a mark tells us exactly how many
+  // bytes of the current item had been delivered by that point.
+  private readonly markAudioByteOffsets = new Map<number, number>();
 
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
@@ -94,6 +125,15 @@ export abstract class OpenAIRealtimeProtocol {
     ) {
       return;
     }
+    const playedBytes = this.markAudioByteOffsets.get(acknowledgedSequence);
+    if (playedBytes !== undefined && playedBytes > this.playedAudioBytesForCurrentItem) {
+      this.playedAudioBytesForCurrentItem = playedBytes;
+    }
+    for (const sequence of this.markAudioByteOffsets.keys()) {
+      if (sequence <= acknowledgedSequence) {
+        this.markAudioByteOffsets.delete(sequence);
+      }
+    }
     // Marks follow ordered playback. Reaching a named mark also acknowledges every
     // earlier mark, while late acknowledgements from that prefix remain harmless.
     if (acknowledgedSequence === latest) {
@@ -102,6 +142,60 @@ export abstract class OpenAIRealtimeProtocol {
       return;
     }
     this.oldestOutstandingMarkSequence = acknowledgedSequence + 1;
+  }
+
+  // Bytes-per-millisecond for the negotiated output audio format. Guards
+  // against NaN (not just <= 0) so a malformed sampleRateHz silently
+  // disables barge-in truncation instead of producing a bogus audio_end_ms.
+  private audioBytesPerMs(): number | null {
+    const bytesPerSample = this.audioFormat.encoding === "pcm16" ? 2 : 1;
+    const bytesPerMs = (this.audioFormat.sampleRateHz * bytesPerSample) / 1000;
+    return Number.isFinite(bytesPerMs) && bytesPerMs > 0 ? bytesPerMs : null;
+  }
+
+  /**
+   * Converts confirmed-played bytes for the current item into milliseconds
+   * using the negotiated output audio format, or null when no mark for the
+   * current item has been acknowledged yet (callers should fall back to
+   * another audio_end_ms source in that case).
+   */
+  protected playedAudioMsForCurrentItem(): number | null {
+    if (this.playedAudioBytesForCurrentItem <= 0) {
+      return null;
+    }
+    const bytesPerMs = this.audioBytesPerMs();
+    return bytesPerMs === null
+      ? null
+      : Math.floor(this.playedAudioBytesForCurrentItem / bytesPerMs);
+  }
+
+  /**
+   * Converts bytes of assistant audio actually DELIVERED to the client for
+   * the current item into milliseconds. This is a strict upper bound on how
+   * much of the item could possibly have been heard - OpenAI cannot reject
+   * conversation.item.truncate for exceeding item duration if audio_end_ms
+   * never exceeds this value, regardless of which clock produced the
+   * pre-clamp estimate.
+   */
+  protected deliveredAudioMsForCurrentItem(): number | null {
+    if (this.deliveredAudioBytesForCurrentItem <= 0) {
+      return null;
+    }
+    const bytesPerMs = this.audioBytesPerMs();
+    return bytesPerMs === null
+      ? null
+      : Math.floor(this.deliveredAudioBytesForCurrentItem / bytesPerMs);
+  }
+
+  // Clears all per-item audio-accounting state (delivered bytes, confirmed-
+  // played bytes, and the mark->byte-offset map). Must run on every item
+  // transition - markAudioByteOffsets is private specifically so this is
+  // the only way to clear it, preventing a subclass reset (see
+  // OpenAIRealtimeEvents) from forgetting a piece of this state.
+  protected resetItemAudioAccounting(): void {
+    this.deliveredAudioBytesForCurrentItem = 0;
+    this.playedAudioBytesForCurrentItem = 0;
+    this.markAudioByteOffsets.clear();
   }
 
   protected sendSessionUpdate(): void {
@@ -238,23 +332,55 @@ export abstract class OpenAIRealtimeProtocol {
       ((responseStartTimestamp !== null &&
         (this.oldestOutstandingMarkSequence !== null || options?.audioPlaybackActive === true)) ||
         force);
-    const audioEndMs = shouldInterruptProvider
-      ? Math.max(
+    // audio_end_ms must describe audio actually heard by the user for THIS
+    // item (OpenAI Realtime conversation.item.truncate contract). The
+    // mark-acknowledgement byte count is the client's own confirmation of
+    // playback progress, so prefer it whenever at least one mark for the
+    // current item has been acknowledged. Only fall back to the
+    // media-timestamp diff (which assumes input and output audio share one
+    // continuous real-time clock - true for telephony bridges, not
+    // guaranteed for a relayed mobile client) when no such confirmation
+    // exists yet.
+    const playedMs = shouldInterruptProvider ? this.playedAudioMsForCurrentItem() : null;
+    const rawAudioEndMs = shouldInterruptProvider
+      ? (playedMs ??
+        Math.max(
           0,
           responseStartTimestamp === null
             ? this.latestMediaTimestamp
             : this.latestMediaTimestamp - responseStartTimestamp,
-        )
+        ))
       : null;
+    // deliveredAudioBytesForCurrentItem bytes are bytes OpenAI has actually
+    // sent us for this item, so the millisecond equivalent is a hard upper
+    // bound on the item's true audio duration - clamping here makes an
+    // "Audio content of Xms is already shorter than Yms" rejection
+    // structurally impossible on every path, including the media-timestamp
+    // fallback above (which has no other relationship to this item's real
+    // duration and previously could report clock drift as "audio played").
+    const deliveredMs = shouldInterruptProvider ? this.deliveredAudioMsForCurrentItem() : null;
+    const audioEndMs =
+      rawAudioEndMs !== null && deliveredMs !== null
+        ? Math.min(rawAudioEndMs, deliveredMs)
+        : rawAudioEndMs;
     const minBargeInAudioEndMs =
       this.config.minBargeInAudioEndMs ?? OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS;
-    if (!force && audioEndMs !== null && audioEndMs < minBargeInAudioEndMs) {
+    // Below-minimum audio_end_ms only means "not confident enough yet to
+    // tell OpenAI precisely where to truncate this item" - it must NOT mean
+    // "not a real barge-in". A genuine barge-in signal always cancels any
+    // in-flight provider response and clears local playback immediately;
+    // only the provider-side truncate call (which requires a trustworthy
+    // audio_end_ms) is what gets skipped below the minimum. Gating local
+    // clear on this too would let the assistant keep talking over the user
+    // for as long as mark-acknowledgement round-trips lag real time.
+    const audioEndMsBelowMinimum =
+      !force && audioEndMs !== null && audioEndMs < minBargeInAudioEndMs;
+    if (audioEndMsBelowMinimum) {
       this.config.onEvent?.({
         direction: "client",
         type: "conversation.item.truncate.skipped",
         detail: `reason=barge-in audioEndMs=${audioEndMs} minAudioEndMs=${minBargeInAudioEndMs}`,
       });
-      return;
     }
     if (
       options?.audioPlaybackActive === true &&
@@ -266,17 +392,28 @@ export abstract class OpenAIRealtimeProtocol {
       this.sendEvent({ type: "response.cancel", event_id: eventId }, "reason=barge-in");
       this.responseCancelInFlight = true;
     }
-    if (shouldInterruptProvider) {
+    if (shouldInterruptProvider && !audioEndMsBelowMinimum) {
+      const truncateEventId = `openclaw-truncate-${randomUUID()}`;
+      this.manualTruncateEventId = truncateEventId;
       this.sendEvent(
         {
           type: "conversation.item.truncate",
           item_id: assistantItemId,
           content_index: 0,
           audio_end_ms: audioEndMs,
+          event_id: truncateEventId,
         },
         `reason=barge-in audioEndMs=${audioEndMs}`,
       );
       this.config.onClearAudio("barge-in");
+      // The item we just told the server to stop at audioEndMs may still
+      // have in-flight deltas arriving for the same item_id (the truncate
+      // request and the provider's in-progress generation race). Remember
+      // it so OpenAIRealtimeEvents can recognize and drop that stale tail
+      // instead of re-adopting it as a brand new item, which would restart
+      // clock/byte accounting mid-stream and could trigger a second,
+      // spuriously-small-looking truncate rejection for the same item.
+      this.lastTruncatedItemId = assistantItemId;
       this.clearOutstandingMarks();
       this.lastAssistantItemId = null;
       this.responseStartTimestamp = null;
@@ -374,6 +511,8 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected resetRealtimeSessionState(): void {
     this.clearOutstandingMarks();
+    this.lastTruncatedItemId = null;
+    this.manualTruncateEventId = null;
     this.responseStartTimestamp = null;
     this.responseActive = false;
     this.responseCreateInFlight = false;
@@ -398,6 +537,7 @@ export abstract class OpenAIRealtimeProtocol {
       this.oldestOutstandingMarkSequence = sequence;
     }
     this.latestOutstandingMarkSequence = sequence;
+    this.markAudioByteOffsets.set(sequence, this.deliveredAudioBytesForCurrentItem);
     const markName = `audio-${sequence}`;
     this.config.onMark?.(markName);
   }
@@ -405,6 +545,7 @@ export abstract class OpenAIRealtimeProtocol {
   protected clearOutstandingMarks(): void {
     this.oldestOutstandingMarkSequence = null;
     this.latestOutstandingMarkSequence = null;
+    this.resetItemAudioAccounting();
   }
 
   abstract submitToolResult(

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -220,6 +220,13 @@ async function createOpenAIRealtimeBrowserSession(
               apiKey,
               callId,
               gaSessionPolicy: sessionConfig,
+              // sessionConfig above negotiates PCM16/24kHz with OpenAI - the
+              // bridge's own audioFormat must match it (it defaults to
+              // g711_ulaw/8kHz otherwise), since audio_end_ms accounting
+              // converts delivered/played byte counts using this field. A
+              // mismatch here would silently multiply every ms estimate by
+              // the byte-rate ratio between the two formats.
+              audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
               model,
               voice,
               instructions: req.instructions,

--- a/extensions/openai/realtime-voice-response-control.test.ts
+++ b/extensions/openai/realtime-voice-response-control.test.ts
@@ -394,7 +394,13 @@ describe("OpenAI realtime voice response control", () => {
     const bridge = createNativeBridge({ onError });
     const socket = await connectReadyBridge(bridge);
     bridge.setMediaTimestamp(1000);
-    emitAssistantPlayback(socket);
+    // 2016 bytes at the default g711_ulaw/8kHz output format is 252ms of
+    // delivered audio, so the barge-in below is above minBargeInAudioEndMs on
+    // its own merits. audio_end_ms is clamped to audio the item actually
+    // delivered, so a media-clock jump alone no longer carries it over the
+    // threshold - and this test needs a real response.cancel as the precondition
+    // for its actual subject, the stale cancellation error.
+    emitAssistantPlayback(socket, { audio: Buffer.alloc(2016, 0x41) });
     bridge.setMediaTimestamp(1300);
 
     bridge.handleBargeIn?.({ audioPlaybackActive: true });

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -91,8 +91,16 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         if (event.item_id && event.item_id !== this.lastAssistantItemId) {
           this.lastAssistantItemId = event.item_id;
           this.responseStartTimestamp = this.latestMediaTimestamp;
+          // New item: the previous item's delivered-byte count no longer bounds it.
+          this.resetItemAudioAccounting();
         } else if (this.responseStartTimestamp === null) {
           this.responseStartTimestamp = this.latestMediaTimestamp;
+        }
+        if (event.item_id) {
+          this.deliveredAudioBytesForCurrentItem += Buffer.from(
+            canonicalAudio,
+            "base64",
+          ).byteLength;
         }
         this.responseActive = true;
         return;

--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -34,6 +34,14 @@ export abstract class XaiRealtimeVoiceProtocol {
   protected pendingToolCallIds = new Set<string>();
   protected latestMediaTimestamp = 0;
   protected lastAssistantItemId: string | null = null;
+
+  // Bytes of assistant audio delivered for the item currently identified by
+  // lastAssistantItemId. conversation.item.truncate's audio_end_ms is otherwise
+  // derived from the INPUT-audio media clock, which only tracks output for a
+  // transport where both share one real-time clock; a relayed mobile client's
+  // clocks drift independently, so the estimate must be clamped to audio this
+  // item actually produced.
+  protected deliveredAudioBytesForCurrentItem = 0;
   protected toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
   protected deliveredToolCallKeys = new Set<string>();
   protected pendingToolResultAcks = new Set<string>();
@@ -108,11 +116,13 @@ export abstract class XaiRealtimeVoiceProtocol {
       (this.responseActive || this.markQueue.length > 0 || options?.audioPlaybackActive === true);
     const shouldInterruptProvider = assistantItemId !== null && outputInterruptible;
     const audioEndMs = shouldInterruptProvider
-      ? Math.max(
-          0,
-          responseStartTimestamp === null
-            ? this.latestMediaTimestamp
-            : this.latestMediaTimestamp - responseStartTimestamp,
+      ? this.clampAudioEndMsToDelivered(
+          Math.max(
+            0,
+            responseStartTimestamp === null
+              ? this.latestMediaTimestamp
+              : this.latestMediaTimestamp - responseStartTimestamp,
+          ),
         )
       : null;
     if (this.responseActive && !this.responseCancelInFlight) {
@@ -133,6 +143,7 @@ export abstract class XaiRealtimeVoiceProtocol {
       this.markQueue = [];
       this.lastAssistantItemId = null;
       this.responseStartTimestamp = null;
+      this.resetItemAudioAccounting();
       return;
     }
     this.config.onClearAudio("barge-in");
@@ -147,7 +158,9 @@ export abstract class XaiRealtimeVoiceProtocol {
       this.responseStartTimestamp !== null &&
       this.markQueue.length > 0
     ) {
-      const audioEndMs = Math.max(0, this.latestMediaTimestamp - this.responseStartTimestamp);
+      const audioEndMs = this.clampAudioEndMsToDelivered(
+        Math.max(0, this.latestMediaTimestamp - this.responseStartTimestamp),
+      );
       this.sendEvent(
         {
           type: "conversation.item.truncate",
@@ -195,6 +208,29 @@ export abstract class XaiRealtimeVoiceProtocol {
           : {}),
       },
     };
+  }
+
+  /** Upper bound, in ms, on how much of the current item could possibly have played. */
+  protected deliveredAudioMsForCurrentItem(): number | null {
+    if (this.deliveredAudioBytesForCurrentItem <= 0) {
+      return null;
+    }
+    const bytesPerSample = this.audioFormat.encoding === "pcm16" ? 2 : 1;
+    const bytesPerMs = (this.audioFormat.sampleRateHz * bytesPerSample) / 1000;
+    if (!Number.isFinite(bytesPerMs) || bytesPerMs <= 0) {
+      return null;
+    }
+    return Math.floor(this.deliveredAudioBytesForCurrentItem / bytesPerMs);
+  }
+
+  /** Clamps a media-clock estimate to audio this item actually delivered. */
+  protected clampAudioEndMsToDelivered(audioEndMs: number): number {
+    const deliveredMs = this.deliveredAudioMsForCurrentItem();
+    return deliveredMs === null ? audioEndMs : Math.min(audioEndMs, deliveredMs);
+  }
+
+  protected resetItemAudioAccounting(): void {
+    this.deliveredAudioBytesForCurrentItem = 0;
   }
 
   private resolveRealtimeAudioFormat(): XaiRealtimeAudioFormatConfig {

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -902,7 +902,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
           type: "conversation.item.truncate",
           item_id: "item_1",
           content_index: 0,
-          audio_end_ms: 300,
+          audio_end_ms: 0,
         },
       ],
     },
@@ -915,7 +915,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
           type: "conversation.item.truncate",
           item_id: "item_1",
           content_index: 0,
-          audio_end_ms: 250,
+          audio_end_ms: 0,
         },
       ],
     },
@@ -946,7 +946,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
           type: "conversation.item.truncate",
           item_id: "item_1",
           content_index: 0,
-          audio_end_ms: 300,
+          audio_end_ms: 0,
         },
       ],
     },
@@ -960,6 +960,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       expectedActions: [],
     },
   ])(
+    // audio_end_ms below is 0, not the media-clock delta, because these cases deliver a
+    // 15-byte synthetic audio delta - well under 1ms at PCM16/24kHz - and audio_end_ms is
+    // clamped to audio the item actually delivered. The previous 250/300 values were the
+    // unclamped input-media-clock estimate, i.e. they encoded the defect.
     "$name",
     async ({
       hasAudio,
@@ -1019,6 +1023,39 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       ).toEqual(expectedActions);
     },
   );
+
+  it("clamps barge-in audio_end_ms to audio the current item actually delivered", async () => {
+    // The media clock is the client's INPUT-audio clock. On a relayed mobile
+    // client its drift against output is unbounded, so an unclamped
+    // audio_end_ms can claim minutes of playback for an item that produced
+    // milliseconds, trimming provider history at the wrong point.
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const onAudio = vi.fn();
+    const onClearAudio = vi.fn();
+    const bridge = createTestBridge({
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio,
+      onClearAudio,
+    });
+    const { socket } = await startRealtimeBridge(bridge);
+
+    socket.emitServer({ type: "response.created", response: { id: "resp_1" } });
+    bridge.setMediaTimestamp(0);
+    // 24000 bytes of PCM16 at 24kHz is exactly 500ms of assistant audio.
+    socket.emitServer({
+      type: "response.output_audio.delta",
+      item_id: "item_1",
+      delta: Buffer.alloc(24_000, 0x41).toString("base64"),
+    });
+
+    // Input clock jumps 10 minutes; only 500ms of audio was ever delivered.
+    bridge.setMediaTimestamp(600_000);
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+    bridge.close();
+
+    const truncate = parseSent(socket).find((event) => event.type === "conversation.item.truncate");
+    expect(truncate).toMatchObject({ item_id: "item_1", audio_end_ms: 500 });
+  });
 
   it("terminates realtime voice on non-canonical base64 audio", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -210,6 +210,12 @@ export function createTalkRealtimeRelaySession(
     interruptResponseOnInputAudio: !forceAgentConsultOnFinalTranscript,
     tools: params.tools,
     markStrategy: "transport",
+    // The relay's barge-in signals are trustworthy: they are either the provider's own
+    // VAD or an explicit client cancel, and the Android endpoint applies platform echo
+    // cancellation before forwarding. So the minimum window governs only whether a
+    // precise truncate point is known yet - it must never leave the assistant talking
+    // over the user while mark acknowledgements catch up.
+    minBargeInScope: "truncate-only",
     audioSink: {
       isOpen: () => Boolean(getActiveRelay()),
       sendAudio: (audio) => {

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -193,8 +193,25 @@ export type RealtimeVoiceAgentConsultRunner = (params: {
   signal?: AbortSignal;
 }) => Promise<{ text: string }>;
 
+/**
+ * What a provider's minimum barge-in audio window gates.
+ *
+ * `truncate-and-playback` (default) is the shipped behaviour: below the threshold the
+ * barge-in is treated as likely echo and ignored entirely, so local playback keeps going.
+ * Discord voice documents and relies on this — its echo-room remedy is to raise the
+ * threshold.
+ *
+ * `truncate-only` is for consumers whose barge-in signal is already trustworthy, such as a
+ * relay whose device applies platform echo cancellation and whose cancels are explicit.
+ * There the threshold should govern only whether a precise provider-side truncation point
+ * is known yet — never whether to stop playing over the user.
+ */
+export type RealtimeVoiceMinBargeInScope = "truncate-and-playback" | "truncate-only";
+
 export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   cfg?: OpenClawConfig;
+  /** See [RealtimeVoiceMinBargeInScope]; omitted means the shipped ignore-below-threshold behaviour. */
+  minBargeInScope?: RealtimeVoiceMinBargeInScope;
   /** Host-selected agent scope for provider auth and agent-owned bridge state. */
   agentId?: string;
   providerConfig: RealtimeVoiceProviderConfig;

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -5,6 +5,7 @@ import type {
   RealtimeVoiceBridge,
   RealtimeVoiceAudioClearReason,
   RealtimeVoiceAudioFormat,
+  RealtimeVoiceMinBargeInScope,
   RealtimeVoiceBargeInOptions,
   RealtimeVoiceCloseReason,
   RealtimeVoiceBridgeEvent,
@@ -61,6 +62,8 @@ export type RealtimeVoiceBridgeSessionParams = {
   agentId?: string;
   providerConfig: RealtimeVoiceProviderConfig;
   audioFormat?: RealtimeVoiceAudioFormat;
+  /** See [RealtimeVoiceMinBargeInScope]; omitted keeps the shipped ignore-below-threshold behaviour. */
+  minBargeInScope?: RealtimeVoiceMinBargeInScope;
   audioSink: RealtimeVoiceAudioSink;
   instructions?: string;
   language?: string;
@@ -169,6 +172,7 @@ export function createRealtimeVoiceBridgeSession(
     agentId: params.agentId,
     providerConfig: params.providerConfig,
     audioFormat: params.audioFormat,
+    minBargeInScope: params.minBargeInScope,
     instructions: params.instructions,
     language: params.language,
     autoRespondToAudio: params.autoRespondToAudio,


### PR DESCRIPTION
## What Problem This Solves

Android Realtime Talk cannot be interrupted while the assistant is speaking. This PR makes it
interruptible on devices where the platform reports acoustic echo cancellation actually enabled
for the Talk capture session; everywhere else the existing half-duplex behaviour is kept
deliberately, because forwarding the microphone through an uncancelled speaker path would make
the assistant interrupt itself.

The providers and the Gateway relay already support interruption — `clear` / barge-in is part
of the relay contract the other Talk surfaces use. The Android endpoint is what breaks it: for
the whole duration of assistant playback it drops its own microphone frames instead of
forwarding them, so the user's speech never reaches the provider. Talking over the assistant
does nothing.

Reproducing that on a device surfaced three more defects on the same path, each of which had
to be fixed before interruption works end to end:

- Realtime capture opened `AudioRecord` at the Gateway's declared wire rate. On the test
  device that recorder opens, reports an active unmuted route, and returns nothing but zeroes,
  so the first user turn was never accepted.
- Realtime playback wrote to `AudioTrack` while holding the same lock the Gateway message pump
  needs for inbound `audio` / `mark` / `clear`. Speaker backpressure therefore stalled realtime
  ingress, including in-flight `talk.session.appendAudio` responses, which tripped their own
  timeout and self-closed the session.
- Once interruption worked, the OpenAI session rejected `conversation.item.truncate` ("Audio
  content of 600ms is already shorter than 65301ms") and the conversation never recovered.

## Why This Change Was Made

This PR makes playback stop suppressing the microphone where the platform reports acoustic
echo cancellation actually enabled for the Talk capture session, and removes the three defects
between that gate and a working interruption.

1. **Capture rate and wire rate are separate contracts.** Candidates are tried in order — the
   portable rate (48 kHz) first, then the declared wire rate (24 kHz on the legacy contract) — and a candidate counts as usable only if
   `AudioRecord` opens *and* the rate it actually negotiated yields a supported converter to the
   wire rate (`talk.session.create`'s declared rate; an absent `audio` field is the legacy
   PCM16/24 kHz contract iOS also defaults to). A candidate that opens but yields no converter
   is closed and the next tried; a session fails closed only when none is usable. "Supported
   converter" is narrow on purpose: exact integer decimation (48 kHz to 24 kHz is the shipped
   case) or equal-rate passthrough. Nothing else is accepted. Note what this
   does and does not do: it does not detect a silent recorder, and "usable" here means only that
   the candidate opened and its negotiated rate converts. What makes the portable candidate the
   right preference is measurement, not the code — on the affected device, capturing at 48 kHz
   and resampling to the 24 kHz wire rate produced correct provider transcripts end to end,
   which is the development evidence recorded on the superseded PR. The wire rate remains the
   last resort, so a device that can only open the wire rate still captures whatever that rate
   gives it.
2. **AEC capability is read, not assumed.** Capture moves to `VOICE_COMMUNICATION` and playback
   to `USAGE_VOICE_COMMUNICATION`; a platform `AcousticEchoCanceler` is attached to the actual
   Talk `AudioRecord` session and the endpoint reads back whether Android accepted enabling it,
   never inferring it from source, route or device. If the effect cannot be set up at all, the
   capture session still opens and Talk keeps working — the failure costs echo cancellation, not
   the microphone. That is separate from what happens *during playback*: **only a session whose
   AEC the platform actually enabled forwards microphone frames while the assistant is
   speaking**, which is the interruptibility fix. Every other session, including one whose AEC
   setup failed, keeps the pre-existing playback-time suppression unchanged. The flag carrying
   that answer is cleared at the capture-generation boundary, and again in the capture job's own
   teardown — that second clear is generation-guarded, so a superseded job can never wipe a
   replacement session's answer. Between the two, the flag only ever describes the session
   currently running: a replaced session cannot leave its own answer behind for the next one to
   be gated on while that one is still opening.
3. **Communication usage needs a communication route.** `USAGE_VOICE_COMMUNICATION` maps to
   `STREAM_VOICE_CALL`, which Android's phone strategy sends to the **earpiece** on a handset,
   so adopting the usage without selecting a route routes Talk to
   the earpiece, at the in-call volume index. The communication route now requests
   `TYPE_BUILTIN_SPEAKER` as the output, but only when the available communication outputs are the built-in
   pair alone — i.e. only when the alternative is the earpiece. Bluetooth still wins when
   selected, and any external output already outranks the earpiece in Android's own routing, so
   none is claimed. Losing Bluetooth mid-session falls back to the built-in speaker, `close()`
   releases the route, and a rejected `setCommunicationDevice()` is recorded as no route
   held. That is route *ownership*, not the physical output: if the request is refused, the
   endpoint does not claim a route it never got, and the platform's own routing decides the
   output — which on a handset can still be the earpiece.
4. **Simultaneous uplink and downlink exposed a playout head-of-line block.** Playback is now
   owned by a single coroutine reading a command queue and writing with
   `AudioTrack.WRITE_NON_BLOCKING`; partial writes advance by the accepted byte count, an empty
   write retries within a bound derived from the track's real buffer, and the track is then
   retired rather than retried forever. Gateway ingress only ever enqueues. Commands are
   stamped with the playback epoch and enqueued as one atomic step, and the owner publishes its
   speaking state under the same lock, so channel order cannot contradict epoch order.
5. **Barge-in truncation must not claim more than the item delivered.** `audio_end_ms` was derived from
   the client's *input*-audio media clock minus the response start, which assumes input and
   output share one continuous real-time clock — true for a telephony bridge, not for a relayed
   mobile client whose clocks drift independently. It now prefers bytes confirmed played via mark
   acknowledgement; when no mark has been acknowledged for the current item — the common case on
   an early barge-in — it falls back to the old media-clock derivation, but clamped to the bytes
   actually delivered for that item. Only the first is a measurement of audio the client
   confirmed playing; the second is an estimate bounded by delivery. What both guarantee is the
   weaker property the provider actually checks. The rejection compares `audio_end_ms` against
   the item's real audio duration; what this bounds it by is the audio the provider has already
   streamed to us for that item. Those align in the only direction that matters, because the
   provider cannot have sent more audio for an item than it generated — delivered is a subset of
   generated, so a value at or below delivered is at or below the real duration.

**Cross-consumer care.** `OpenAIRealtimeBridge` is shared by Discord voice, the meeting bot,
the phone relay and telephony. Making `audio_end_ms` honest also made it fall below
`minBargeInAudioEndMs` far more often, and Discord *depends* on the shipped behaviour that
below the threshold a barge-in is treated as likely echo and left alone — it documents raising
the threshold as its echo remedy and passes a deliberately empty fallback for that reason. The
threshold was governing two decisions; `minBargeInScope` separates them. It is an optional
field on the bridge-create request (`RealtimeVoiceBridgeCreateRequest`), not user-facing config.
Exactly one caller sets it — `talk-realtime-relay-session-create.ts`, which declares
`truncate-only` — and every other caller omits it and so keeps the shipped behaviour unchanged.
Below the threshold:

| | provider truncate | `response.cancel` + stop local playback |
|---|---|---|
| omitted (default, `truncate-and-playback`) | no | **no** — the shipped Discord contract |
| `truncate-only` | no | yes |

Above the threshold both scopes truncate, cancel and stop playback, exactly as today.

Compatibility across every bridge consumer, enumerated rather than asserted. Two things must be
separated here, because they land differently: the `audio_end_ms` accounting is in the shared
protocol and therefore applies to **every** consumer, while `minBargeInScope` changes nothing for
a consumer that does not set it. There are four `createBridge` call sites in the tree:

| consumer | sets `minBargeInScope`? | below-threshold behaviour | `audio_end_ms` |
|---|---|---|---|
| `src/gateway/talk-realtime-relay-session-create.ts:218` (Gateway Talk relay) | yes, `truncate-only` | changed: now cancels and stops playback instead of ignoring the barge-in | mark-confirmed when available, else clamped media clock |
| `extensions/discord/src/voice/realtime-session.runtime.ts:285` | no | unchanged; it configures `minBargeInAudioEndMs` only (`extensions/discord/src/config-schema.ts:156`), which is the documented echo remedy | mark-confirmed when available, else clamped media clock |
| `extensions/voice-call/src/webhook/realtime-handler.ts:1071` (telephony) | no | unchanged | mark-confirmed when available, else clamped media clock |
| `src/meeting-bot/realtime-engine.ts:486` | no | unchanged | mark-confirmed when available, else clamped media clock |

So every consumer does see one change to how `audio_end_ms` is derived. Where a mark has been
acknowledged for the item it becomes confirmed-played bytes, which can land either side of the
old clock difference depending on how the two were drifting. Where none has, it stays the same
media-clock derivation as before, clamped to delivered bytes — and on that path the change can
only ever lower the value. For a telephony bridge, where input and
output really do share one continuous clock, the two agree and the clamp is the only thing that
can bite — and it can only ever lower the value, never raise it, so it cannot introduce the
rejection it exists to prevent. What it *does* change for those consumers is that on the fallback path the value can now fall
below `minBargeInAudioEndMs` where it previously would not have, which is precisely why the
threshold's second decision had to be separated rather than left to shift under them.

The option itself is optional on `RealtimeVoiceBridgeCreateRequest` and read once, at
`extensions/openai/realtime-voice-protocol.ts:391`, with `?? "truncate-and-playback"` — so a
consumer that does not set it cannot observe a difference in *that* decision.

On the truncate contract itself: `conversation.item.truncate` rejects an `audio_end_ms` past the
item's real audio, and the observed rejection text is quoted in the problem statement above
("Audio content of 600ms is already shorter than 65301ms"). That message is the contract this
change is written against, and it is what the delivered-byte clamp makes unreachable. The relay
takes `truncate-only` because its barge-in signals are the provider's own VAD or an explicit
client cancel, and both shipped relay clients suppress uplink when they cannot cancel echo —
Android through the AEC gate added here, iOS through its route check. A client that forwarded
microphone audio during playback without echo cancellation would want the default.

**Why one PR.** The Android root causes, across the five changes above, are causally chained, not
merely adjacent: with only the
endpoint fix the first turn is never captured on a device that cannot provide usable frames at
the wire rate; with
capture fixed but not the playout owner, simultaneous uplink and downlink self-close the
session; with both fixed, the first successful barge-in is rejected unrecoverably. Within that
Android chain, no prefix lands working behaviour earlier. The route work is part of that chain
rather than adjacent hardening: it exists because *this PR* moves playback to
`USAGE_VOICE_COMMUNICATION` so the platform AEC has a far-end reference to cancel against, and
that usage is what sends output to the earpiece. Splitting it out would land a PR that makes
hands-free Talk come out of the earpiece and then fix it separately. That chain covers the Android side only. Two further pieces are deliberately bundled follow-ons
rather than links in it, and are here by choice:
`extensions/xai`, which is the same defect in a sibling provider (the relay feeds every
provider the same client input clock, so its unclamped `audio_end_ms` could claim minutes for
an item that produced milliseconds) and is a two-site clamp depending on nothing else here; and
the `minBargeInScope` option. They are bundled for different reasons. `extensions/xai` is the same invariant —
`audio_end_ms` must not claim more audio than the item produced — and splitting it leaves that
half-enforced across providers sharing one relay. `minBargeInScope` is not that invariant; it
is a consequence of fixing it. Making the value honest moves its distribution downward, so it
now falls under `minBargeInAudioEndMs` far more often, and that threshold was already deciding
two unrelated things. Splitting it out would mean landing the honest value first and changing
Discord's effective barge-in behaviour in the window before the follow-up merges. If you would prefer either reviewed separately, I will split it out and rebase this PR on
top; neither split changes the Android behaviour.

## User Impact

Stated as intended behaviour: this head has no real-device proof yet, so none of it is claimed
as observed.

Where platform AEC is actually enabled for the Talk capture session, Realtime Talk is meant to
become interruptible while the assistant is speaking, stopping promptly on a barge-in without
resuming, with the session no longer self-closing when uplink and downlink run at once. On a
handset with no headset connected, assistant audio is meant to reach the built-in loudspeaker
rather than the earpiece. That is a routing change only: Talk stays on `STREAM_VOICE_CALL`, so
the volume index is still the voice-call one — the difference is that it comes out of the
speaker instead of requiring the phone at your ear. With Bluetooth or a wired/USB headset
connected, that headset is still the route.
Confirming that on the device is what this PR is a Draft for.

Where AEC is unavailable or was not enabled, Talk keeps its existing playback-time microphone
suppression (half-duplex), unchanged. For the shared OpenAI bridge, what `minBargeInScope` keeps
unchanged for consumers that omit it is specifically the **below-threshold action** — a
sub-threshold barge-in is still ignored. Their `audio_end_ms` does change, and crosses the
threshold less often; see Why This Change Was Made. Steady-state routing with a headset connected is intended
to be unchanged. Two routing behaviours *do* change on the communication path: losing Bluetooth
mid-session falls back to the built-in speaker instead of leaving the route stranded, and
closing the session releases the route Talk claimed. Manual Mic/STT dictation is unchanged — it keeps
`VOICE_RECOGNITION`, never claims the built-in speaker, and this change is a no-op on its call
sites. Its pre-existing Bluetooth communication-route selection is untouched; only the
built-in-speaker branch is new, and that branch is gated on the communication profile.

This change covers the Android Realtime Talk capture and playback path, the `audio_end_ms`
accounting in the OpenAI and xAI realtime providers, and the `minBargeInScope` option that keeps
the shared bridge's other consumers on their shipped behaviour. GPT-Live gating on Android,
the Google provider's response-completion projection, and per-device or per-OEM branches are
out of scope. One limitation carries over unchanged: playback still does not honour the
contract's `outputSampleRateHz`.

A deliberate divergence worth naming: iOS's
`RealtimeTalkRelaySession.shouldSuppressMicrophoneDuringOutput()` suppresses the microphone
whenever the built-in speaker is the output route, *even in* `.voiceChat`. This gate is
route-independent — it trusts the platform AEC's reported state instead of a route heuristic —
so the loudspeaker self-trigger case is an explicit acceptance requirement here rather than an
assumption.

## Evidence

**This PR is a Draft because real-behavior proof has not been captured yet.** The captured
output below is automated verification only. The device campaign runs against the frozen head
and will be posted here before this leaves Draft; nothing here is device acceptance.

**Behavior addressed:** Android Realtime Talk drops every captured microphone frame while the
assistant is speaking, so the user cannot interrupt it; and on the fixed path, assistant audio
must reach the built-in loudspeaker rather than the earpiece.

**Real environment tested:** none — everything in this section is automated. The results below
were captured at this PR's head commit, `7df1460531d683616c7fcd4e874be021c510ba3c`, on base
`49af98c12bb4748637353c575a9416df33549439`. The *planned* real environment, for the campaign
that runs before this leaves Draft, is a Xiaomi 11T Pro on Android 14 against a dev Gateway
with an isolated state directory and its own port, provider OpenAI GA realtime.

**Exact steps or command run after this patch:**

```
node scripts/run-vitest.mjs extensions/openai
node scripts/run-vitest.mjs extensions/xai
node scripts/run-vitest.mjs extensions/discord/src/voice
node scripts/run-vitest.mjs src/talk
node scripts/run-vitest.mjs src/gateway/talk-realtime-relay.test.ts
(cd apps/android && ./gradlew :app:testPlayDebugUnitTest)
(cd apps/android && ./gradlew :app:ktlintCheck :app:lintPlayDebug :app:assemblePlayDebug)
pnpm tsgo:core && pnpm tsgo:extensions
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/openai extensions/xai
git diff --check
```

**Evidence after fix:**

```
$ node scripts/run-vitest.mjs extensions/openai
 Test Files  51 passed (51)
      Tests  855 passed | 1 skipped (856)
   Duration  21.01s

$ node scripts/run-vitest.mjs extensions/xai
 Test Files  29 passed (29)
      Tests  484 passed (484)
   Duration  35.92s

$ node scripts/run-vitest.mjs extensions/discord/src/voice
 Test Files  22 passed (22)
      Tests  277 passed (277)

$ node scripts/run-vitest.mjs src/talk
 Test Files  29 passed (29)
      Tests  236 passed (236)

$ node scripts/run-vitest.mjs src/gateway/talk-realtime-relay.test.ts
 Test Files  1 passed (1)
      Tests  66 passed (66)

$ ./gradlew :app:testPlayDebugUnitTest
BUILD SUCCESSFUL in 1m 2s
# aggregated from the JUnit XML the task writes:
# suites=188 tests=2196 failures=0 errors=0 skipped=0

$ ./gradlew :app:ktlintCheck :app:lintPlayDebug :app:assemblePlayDebug
BUILD SUCCESSFUL in 2m 26s

$ pnpm tsgo:core && pnpm tsgo:extensions
(exit 0, no diagnostics)

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/openai extensions/xai
(exit 0, no diagnostics)

$ git diff --check
(exit 0)
```

**Observed result after fix:** these are automated results only. Every check listed above —
suites, Android build, type checks, lint and `git diff --check` — is green at this head,
including the pre-existing tests in those files.

Which of those tests actually have teeth was measured by reverting fixes — per fix, not per
test — and the result is reported rather than assumed:

| fix reverted | tests that fail | tests in the suite run |
|---|---|---|
| earlier over-broad route selection restored | the 2 headset tests | 26 in `AndroidAudioInputSessionTest` |
| route selection removed entirely | the 3 selection / fallback / release tests | 26 in `AndroidAudioInputSessionTest` |
| playback-time suppression back to unconditional | `aecEnabledCommunicationCaptureForwardsThroughPlayback` | 79 in `TalkModeManagerTest` |
| profile check removed so dictation claims the speaker | `recognitionCaptureDoesNotClaimAnyCommunicationRoute` | 26 in `AndroidAudioInputSessionTest` |
| generation-boundary AEC reset removed | `replacingCaptureClearsTheAecFlagBeforeTheNewSessionReportsItsOwn` | 80 in `TalkModeManagerTest` |
| OpenAI truncate accounting (drop the confirmed-played preference and the delivered clamp) | 4 truncate tests, reproducing the inflated `audio_end_ms` | 20 in `realtime-voice-bridge-events.test.ts` |
| xAI clamp made a no-op | 4 truncate tests | 74 in `realtime-voice-provider.test.ts` |
| **capture candidate ordering** | **none** | 80 in `TalkModeManagerTest` |

Each revert that has a discriminating test fails only its mapped cluster, which is what makes
the mapping checkable.

Two negatives are stated deliberately. **Capture candidate ordering has no discriminating
test**: reverting it to open only at the declared wire rate leaves the Android suite green,
because the failure it fixes — a recorder that opens, reports an active unmuted route and
returns zeroes — cannot be reproduced in the JVM test environment.
`declaredWireRateUnreachableFromTheRequestedRateIsNotRejectedBeforeOpening` pins where the gate
sits, not that the ordering works. That fix rests on device evidence, which is why it is in the
campaign below. And `communicationCaptureNeverFallsThroughToTheEarpiece` survives both routing
reverts, because the pre-fix code selects no route rather than selecting the earpiece; it guards
against a future change picking the earpiece explicitly and is not evidence for this one.
Playout ownership was not revert-checked — reverting it means removing the ownership boundary
itself, not a line — so its tests assert the properties directly instead: that ingress never
suspends whatever the owner is doing, and that a partial write advances by the accepted count.

The cross-consumer claims map to tests one to one:

| claim | test |
|---|---|
| `audio_end_ms` never exceeds what the current item delivered | `clamps barge-in audio_end_ms to audio the current item actually delivered` (xAI) |
| the same clamp on the fallback path, no mark acknowledged | `clamps audio_end_ms to delivered audio when no mark has been acknowledged yet` |
| omitting `minBargeInScope` preserves the shipped Discord contract | `leaves playback alone below the minimum window by default, preserving the shipped contract` |
| `truncate-only` still cancels below the threshold but sends no truncate | `skips truncate but still cancels for a sub-minimum sliver when the caller trusts its barge-in signal` |
| an abandoned item's in-flight tail does not restart playback | `drops the in-flight tail of an item abandoned below the minimum window` |
| a truncate rejection does not release the outstanding cancel | `leaves the cancel in flight when a truncate rejection arrives before it is answered` |
| the AEC gate never describes a capture session that has ended | `replacingCaptureClearsTheAecFlagBeforeTheNewSessionReportsItsOwn` |

All except the first and last are in `extensions/openai/realtime-voice-bridge-events.test.ts`;
the first is in `extensions/xai/realtime-voice-provider.test.ts` and the last in
`TalkModeManagerTest.kt`.

**Planned device acceptance, before this leaves Draft.** Each scenario runs from a fresh Talk
session with the route confirmed first, and captures a screen recording plus the platform audio
route evidence and the session/provider logs:

1. built-in loudspeaker is the actual output route with no headset connected;
2. one normal turn on that route;
3. barge-in during active assistant speech — playback stops, the new turn is accepted, the old
   audio does not resume;
4. loudspeaker self-trigger, three independent intervals with the room silent through a full
   response — no false barge-in, no false user turn — captured together with the
   `AcousticEchoCanceler` enabled read-back for that exact `AudioRecord` session, since without
   it a clean interval cannot be told apart from capture simply having stayed suppressed;
5. Bluetooth route, then Bluetooth loss falling back to the built-in speaker, then a wired/USB
   headset keeping its own route.

Scenario 4 is the one that matters most, because it is the case iOS handles by suppressing the
microphone outright. If the route in scenario 1 is still the earpiece, the rest does not run.
The pass/fail criterion for each scenario is stated with the captured evidence when it is
posted, so the verdict is checkable against the artifact rather than against a summary.

**What was not tested:** real-device behavior on this head — that assistant audio reaches the
built-in loudspeaker, that barge-in works audibly end to end, and that the route-independent AEC
gate is safe on the loudspeaker. Also not physically tested, though both are covered by the unit
tests above: devices without platform AEC (they keep the existing suppression unchanged), and
`extensions/xai`, which has no physical lane here at all. Device evidence from earlier heads located the all-zero capture, the
`appendAudio` self-close, the truncate rejection and the earpiece route; it is development
evidence, not acceptance of this head.

**Change surface.** 17 files: 11 production, 6 test. Production `+1215/-234`
(`apps/android/app/src/main` `+914/-222`, `extensions/openai` `+224/-6`, `extensions/xai`
`+50/-6`, `src/` `+27/-0`), test `+1629/-19`, reconciling to the diff's `+2844/-253`. The
Android growth is a capture→wire converter that did not exist, an ownership boundary replacing
a shared lock with a single playout owner (the deletions are that lock and its call sites),
AEC capability read-back and route ownership, in `TalkModeManager.kt`,
`AndroidAudioInputSession.kt` and the new `RealtimeCaptureResampler.kt` (tests alongside them in
`apps/android/app/src/test/java/ai/openclaw/app/voice/`). `extensions/openai` and
`extensions/xai` carry the `audio_end_ms` accounting. The `src/` change is only the
`minBargeInScope` option: its type in `src/talk/provider-types.ts`, forwarding in
`src/talk/session-runtime.ts`, and the single caller that sets it in
`src/gateway/talk-realtime-relay-session-create.ts`. Two Android seams exist so the playout
owner's partial-write, empty-write, preemption and teardown behaviour can be driven
deterministically; production behaviour through them is unchanged.

Supersedes https://github.com/openclaw/openclaw/pull/124083, which proposed step 1 alone. This
keeps its capture boundary and resolves the "Known limitation, deferred" recorded in that PR's
own body: `startRealtimeCaptureLocked`'s
`check(openedAudioInput.actualSampleRateHz == realtimeCapturePortableSampleRateHz)`, which
fails a session closed whenever the device negotiates anything but 48 kHz. This adapts instead,
but only within the converter's limits: a negotiated rate is usable when it equals the wire rate
or divides down to it by an exact integer ratio. That PR is left open on purpose until this
one leaves Draft with device proof: a replacement that is still unproven is not yet a safe
landing target for the work it supersedes.

Closes #125371
