### PR TITLE
fix: scope onboarding model browsing to the selected provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -4,7 +4,7 @@ import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/mod
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
-import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { stampConfigWriteMetadata } from "../config/io.meta.js";
 import type { WizardMultiSelectParams, WizardPrompter } from "../wizard/prompts.js";
@@ -43,8 +43,8 @@ const loadPreferredProviderPickerCatalog = vi.hoisted(() =>
       agentDir?: string;
       workspaceDir?: string;
       env?: NodeJS.ProcessEnv;
-    }) => Promise<ModelCatalogEntry[]>
-  >(async () => []),
+    }) => Promise<ModelCatalogSnapshot>
+  >(async () => ({ entries: [], routeVariants: [] })),
 );
 vi.mock("../flows/model-picker.provider-catalog.js", () => ({
   loadPreferredProviderPickerCatalog,
@@ -263,6 +263,10 @@ function catalogModel(provider: string, id: string, name: string): ModelCatalogE
   return { provider, id, name };
 }
 
+function providerCatalogSnapshot(entries: ModelCatalogEntry[]): ModelCatalogSnapshot {
+  return { entries, routeVariants: entries };
+}
+
 function configuredTextModel(id: string, name: string) {
   return {
     id,
@@ -391,7 +395,7 @@ beforeEach(() => {
     }),
   });
   loadStaticManifestCatalogRowsForList.mockReturnValue([]);
-  loadPreferredProviderPickerCatalog.mockResolvedValue([]);
+  loadPreferredProviderPickerCatalog.mockResolvedValue(providerCatalogSnapshot([]));
   listProfilesForProvider.mockReturnValue([]);
   resolveEnvApiKey.mockImplementation((_provider: string) => ({
     apiKey: "test-key",
@@ -995,10 +999,12 @@ describe("promptDefaultModel", () => {
   });
 
   it("loads the preferred provider catalog when the user chooses to browse", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
-      catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+        catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
+      ]),
+    );
     const select = vi
       .fn()
       .mockResolvedValueOnce("__browse__")
@@ -1037,11 +1043,69 @@ describe("promptDefaultModel", () => {
     expect(select.mock.calls[1]?.[0]?.searchable).toBe(true);
   });
 
+  it("keeps preferred-provider browsing off unrelated provider setup surfaces", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+        catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
+      ]),
+    );
+    providerModelPickerContributionRuntime.enabled = true;
+    providerModelPickerContributionRuntime.resolve.mockReturnValue([
+      {
+        option: {
+          value: "provider-plugin:nvidia:api-key",
+          label: "NVIDIA (custom)",
+        },
+      },
+    ] as never);
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupRegistry: () => {
+        throw new Error("preferred-provider browsing must not load the full setup registry");
+      },
+    });
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("__browse__")
+      .mockResolvedValueOnce("openai/gpt-5.5-pro");
+    const config = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+        },
+      },
+    } as OpenClawConfig;
+
+    await promptDefaultPicker({
+      config,
+      prompter: makePrompter({ select }),
+      allowKeep: true,
+      includeManual: true,
+      includeProviderPluginSetups: true,
+      preferredProvider: "openai",
+      browseCatalogOnDemand: true,
+      agentDir: "/tmp/openclaw-agent",
+      runtime: {} as never,
+    });
+
+    expect(resolvePluginProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerRefs: ["openai"],
+      }),
+    );
+    expect(providerModelPickerContributionRuntime.resolve).not.toHaveBeenCalled();
+    expect(optionValues(pickerOptions(select as MockCallSource, 1))).not.toContain(
+      "provider-plugin:nvidia:api-key",
+    );
+  });
+
   it("scopes on-demand preferred-provider loads before the first model prompt", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
-      catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+        catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
+      ]),
+    );
     const select = vi.fn(async (params) => params.options[0]?.value as never);
     const prompter = makePrompter({ select });
     const config = {
@@ -1073,10 +1137,12 @@ describe("promptDefaultModel", () => {
   });
 
   it("preselects the first live provider row when keep-current is disabled", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+      ]),
+    );
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
     const config = {
@@ -1108,11 +1174,13 @@ describe("promptDefaultModel", () => {
   });
 
   it("keeps on-demand NVIDIA vendor labels single-prefixed after browsing", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
-      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+        catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+        catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+      ]),
+    );
     resolvePluginProviders.mockReturnValue([
       {
         id: "nvidia",
@@ -1151,11 +1219,13 @@ describe("promptDefaultModel", () => {
   });
 
   it("omits local NVIDIA static fallback rows when browsing live provider rows", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
-      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+        catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+        catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+      ]),
+    );
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5", "deprecated"),
       manifestTextRow("nvidia", "z-ai/glm5", "GLM5", "deprecated"),
@@ -1197,9 +1267,9 @@ describe("promptDefaultModel", () => {
   });
 
   it("uses the configured default agent dir for provider-scoped catalog auth", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1")]),
+    );
     const select = vi.fn(async (params) => params.options[0]?.value as never);
     const prompter = makePrompter({ select });
     const env = {
@@ -1709,10 +1779,12 @@ describe("promptModelAllowlist", () => {
   });
 
   it("keeps live preferred-provider rows before configured fallback supplements", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+      ]),
+    );
 
     const multiselect = createSelectAllMultiselect();
     const prompter = makePrompter({ multiselect });
@@ -1752,14 +1824,16 @@ describe("promptModelAllowlist", () => {
   });
 
   it("keeps provider-scoped live rows authoritative over configured provider supplements", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
-      catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
-      catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
-      catalogModel("nvidia", "z-ai/glm5", "GLM5"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+        catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+        catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+        catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
+        catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
+        catalogModel("nvidia", "z-ai/glm5", "GLM5"),
+      ]),
+    );
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
       manifestTextRow("nvidia", "moonshotai/kimi-k2.5", "Bundled Kimi K2.5"),
@@ -1811,10 +1885,12 @@ describe("promptModelAllowlist", () => {
   });
 
   it("keeps custom configured rows after provider-scoped live rows", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+        catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+      ]),
+    );
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
       manifestTextRow("nvidia", "z-ai/glm-5.1", "Bundled GLM 5.1"),
@@ -1858,10 +1934,12 @@ describe("promptModelAllowlist", () => {
   });
 
   it("does not re-add configured static rows after filtering deprecated live rows", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
-      catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
-      catalogModel("nvidia", "z-ai/glm5", "GLM5"),
-    ]);
+    loadPreferredProviderPickerCatalog.mockResolvedValue(
+      providerCatalogSnapshot([
+        catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
+        catalogModel("nvidia", "z-ai/glm5", "GLM5"),
+      ]),
+    );
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "Bundled MiniMax M2.5", "deprecated"),
       manifestTextRow("nvidia", "z-ai/glm5", "Bundled GLM5", "deprecated"),

--- a/src/flows/model-picker.provider-catalog.test.ts
+++ b/src/flows/model-picker.provider-catalog.test.ts
@@ -1,28 +1,53 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ loadPreparedModelCatalogOwnerSnapshot: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  loadPreparedModelCatalogOwnerSnapshot: vi.fn(),
+  loadPreparedModelCatalogSnapshot: vi.fn(),
+  resolvePluginMetadataSnapshot: vi.fn(),
+}));
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   loadPreparedModelCatalogOwnerSnapshot: mocks.loadPreparedModelCatalogOwnerSnapshot,
+  loadPreparedModelCatalogSnapshot: mocks.loadPreparedModelCatalogSnapshot,
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
 import { loadPreferredProviderPickerCatalog } from "./model-picker.provider-catalog.js";
 
 describe("loadPreferredProviderPickerCatalog", () => {
   beforeEach(() => {
-    mocks.loadPreparedModelCatalogOwnerSnapshot.mockReset();
+    vi.clearAllMocks();
+    mocks.loadPreparedModelCatalogOwnerSnapshot.mockImplementation(() => {
+      throw new Error("preferred-provider browsing must not load the full catalog owner");
+    });
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      manifestRegistry: { plugins: [] },
+    });
   });
 
-  it("filters one committed generation by preferred provider", async () => {
-    mocks.loadPreparedModelCatalogOwnerSnapshot.mockResolvedValue({
-      metadataSnapshot: { manifestRegistry: { plugins: [] } },
-      modelCatalog: {
-        entries: [
-          { provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" },
-          { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
-        ],
-      },
+  it("loads only the canonical preferred provider through scoped live discovery", async () => {
+    mocks.loadPreparedModelCatalogSnapshot.mockResolvedValue({
+      entries: [
+        { provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" },
+        { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
+      ],
+      routeVariants: [
+        {
+          provider: "nvidia",
+          id: "nvidia/nemotron",
+          name: "Nemotron API route",
+          api: "openai-completions",
+        },
+        { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
+      ],
+      staticEntries: [
+        { provider: "nvidia", id: "nvidia/nemotron", name: "Static Nemotron" },
+        { provider: "openai", id: "gpt-5.4", name: "Static GPT-5.4" },
+      ],
     });
 
     await expect(
@@ -33,30 +58,44 @@ describe("loadPreferredProviderPickerCatalog", () => {
         workspaceDir: "/tmp/workspace",
         env: { NVIDIA_API_KEY: "test-nvidia-api-key" },
       }),
-    ).resolves.toEqual([{ provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" }]);
-    expect(mocks.loadPreparedModelCatalogOwnerSnapshot).toHaveBeenCalledWith({
+    ).resolves.toEqual({
+      entries: [{ provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" }],
+      routeVariants: [
+        {
+          provider: "nvidia",
+          id: "nvidia/nemotron",
+          name: "Nemotron API route",
+          api: "openai-completions",
+        },
+      ],
+      staticEntries: [{ provider: "nvidia", id: "nvidia/nemotron", name: "Static Nemotron" }],
+    });
+    expect(mocks.loadPreparedModelCatalogSnapshot).toHaveBeenCalledWith({
       config: {},
       agentDir: "/tmp/agent",
       workspaceDir: "/tmp/workspace",
       env: { NVIDIA_API_KEY: "test-nvidia-api-key" },
+      readOnly: true,
+      providerDiscoveryProviderIds: ["nvidia"],
+      scopedLiveProviderDiscovery: true,
     });
+    expect(mocks.loadPreparedModelCatalogOwnerSnapshot).not.toHaveBeenCalled();
   });
 
-  it("matches preferred provider aliases from the prepared metadata generation", async () => {
-    mocks.loadPreparedModelCatalogOwnerSnapshot.mockResolvedValue({
-      metadataSnapshot: {
-        manifestRegistry: {
-          plugins: [
-            {
-              id: "moonshot",
-              modelCatalog: { aliases: { kimi: { provider: "moonshot" } } },
-            },
-          ],
-        },
+  it("canonicalizes provider aliases before scoped discovery", async () => {
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "moonshot",
+            modelCatalog: { aliases: { kimi: { provider: "moonshot" } } },
+          },
+        ],
       },
-      modelCatalog: {
-        entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
-      },
+    });
+    mocks.loadPreparedModelCatalogSnapshot.mockResolvedValue({
+      entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
+      routeVariants: [],
     });
 
     await expect(
@@ -65,6 +104,16 @@ describe("loadPreferredProviderPickerCatalog", () => {
         preferredProvider: "kimi",
         agentDir: "/tmp/agent",
       }),
-    ).resolves.toEqual([{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }]);
+    ).resolves.toEqual({
+      entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
+      routeVariants: [],
+    });
+    expect(mocks.loadPreparedModelCatalogSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readOnly: true,
+        providerDiscoveryProviderIds: ["moonshot"],
+        scopedLiveProviderDiscovery: true,
+      }),
+    );
   });
 });

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -1,12 +1,26 @@
 // Model picker provider choices projected from the lifecycle-owned catalog.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
-import {
-  canonicalizePreparedModelCatalogProvider,
-  type ModelCatalogEntry,
-} from "../agents/model-catalog.js";
-import { loadPreparedModelCatalogOwnerSnapshot } from "../agents/prepared-model-catalog.js";
+import { canonicalizePreparedModelCatalogProvider } from "../agents/model-catalog.js";
+import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
+import { loadPreparedModelCatalogSnapshot } from "../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+
+function filterProviderSnapshot(
+  snapshot: ModelCatalogSnapshot,
+  provider: string,
+): ModelCatalogSnapshot {
+  const matchesProvider = (entry: { provider: string }) =>
+    normalizeProviderId(entry.provider) === provider;
+  return {
+    entries: snapshot.entries.filter(matchesProvider),
+    routeVariants: snapshot.routeVariants.filter(matchesProvider),
+    ...(snapshot.staticEntries
+      ? { staticEntries: snapshot.staticEntries.filter(matchesProvider) }
+      : {}),
+  };
+}
 
 /** Loads committed catalog models for the user's preferred provider. */
 export async function loadPreferredProviderPickerCatalog(params: {
@@ -15,22 +29,29 @@ export async function loadPreferredProviderPickerCatalog(params: {
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<ModelCatalogEntry[]> {
+}): Promise<ModelCatalogSnapshot> {
   const requestedProvider = normalizeProviderId(params.preferredProvider);
   if (!requestedProvider) {
-    return [];
+    return { entries: [], routeVariants: [] };
   }
-  const owner = await loadPreparedModelCatalogOwnerSnapshot({
+  const env = params.env ?? process.env;
+  const metadataSnapshot = resolvePluginMetadataSnapshot({
+    config: params.cfg,
+    env,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  });
+  const providerFilter = canonicalizePreparedModelCatalogProvider(
+    requestedProvider,
+    metadataSnapshot,
+  );
+  const snapshot = await loadPreparedModelCatalogSnapshot({
     config: params.cfg,
     agentDir: params.agentDir ?? resolveDefaultAgentDir(params.cfg, params.env),
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     ...(params.env ? { env: params.env } : {}),
+    readOnly: true,
+    providerDiscoveryProviderIds: [providerFilter],
+    scopedLiveProviderDiscovery: true,
   });
-  const providerFilter = canonicalizePreparedModelCatalogProvider(
-    requestedProvider,
-    owner.metadataSnapshot,
-  );
-  return owner.modelCatalog.entries.filter(
-    (entry) => normalizeProviderId(entry.provider) === providerFilter,
-  );
+  return filterProviderSnapshot(snapshot, providerFilter);
 }

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -201,8 +201,8 @@ function loadPickerModelCatalog(
         ...(opts.workspaceDir !== undefined ? { workspaceDir: opts.workspaceDir } : {}),
         ...(opts.env !== undefined ? { env: opts.env } : {}),
       }).then((providerCatalog) => {
-        if (providerCatalog.length > 0) {
-          return snapshot(providerCatalog);
+        if (providerCatalog.entries.length > 0) {
+          return providerCatalog;
         }
         if (opts.allowStaticFallbackCatalog !== false) {
           const manifestRows = loadStaticManifestCatalogRowsForList({
@@ -411,6 +411,7 @@ async function resolveLiteralPrefixProviderIds(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerRefs?: readonly string[];
 }): Promise<Set<string>> {
   const { resolvePluginProviders } = await loadResolvedModelPickerRuntime();
   const providers = resolvePluginProviders({
@@ -420,6 +421,7 @@ async function resolveLiteralPrefixProviderIds(params: {
     activate: false,
     cache: false,
     includeUntrustedWorkspacePlugins: false,
+    ...(params.providerRefs?.length ? { providerRefs: params.providerRefs } : {}),
   });
   const ids = new Set<string>();
   for (const provider of providers) {
@@ -820,6 +822,7 @@ export async function promptDefaultModel(
   const preferredProvider = preferredProviderRaw
     ? normalizeProviderId(preferredProviderRaw)
     : undefined;
+  const providerScopedCatalog = Boolean(browseCatalogOnDemand && preferredProvider);
   const configuredRaw = resolveConfiguredModelRaw(pickerConfig);
   const useStaticModelNormalization = !loadCatalog || browseCatalogOnDemand;
   const resolved = resolveConfiguredModelRef({
@@ -837,6 +840,9 @@ export async function promptDefaultModel(
         cfg,
         workspaceDir: params.workspaceDir,
         env: params.env,
+        ...(providerScopedCatalog && preferredProvider
+          ? { providerRefs: sortUniqueStrings([preferredProvider, resolved.provider]) }
+          : {}),
       });
     }
     return literalPrefixProvidersCache;
@@ -954,11 +960,10 @@ export async function promptDefaultModel(
   const catalogProgress = params.prompter.progress(t("wizard.model.loadingModels"));
   let catalogSnapshot: ModelCatalogSnapshot;
   try {
-    const providerScopedCatalog = browseCatalogOnDemand && preferredProvider;
     catalogSnapshot = await loadPickerModelCatalog(cfg, {
       preferredProvider: providerScopedCatalog ? preferredProvider : undefined,
-      preferLiveProviderCatalog: Boolean(providerScopedCatalog),
-      providerScoped: Boolean(providerScopedCatalog),
+      preferLiveProviderCatalog: providerScopedCatalog,
+      providerScoped: providerScopedCatalog,
       agentDir: pickerAgentDir,
       ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
       ...(params.env !== undefined ? { env: params.env } : {}),
@@ -1010,7 +1015,7 @@ export async function promptDefaultModel(
   const isVisibleProvider = createModelPickerVisibleProviderPredicate({
     config: cfg,
     env: params.env,
-    includeSetupRegistry: true,
+    includeSetupRegistry: !providerScopedCatalog,
   });
   const filteredModels = await maybeFilterModelsByProvider({
     models,
@@ -1061,7 +1066,7 @@ export async function promptDefaultModel(
   if (includeManual) {
     options.push({ value: MANUAL_VALUE, label: t("wizard.model.enterManually") });
   }
-  if (includeProviderPluginSetups && params.agentDir) {
+  if (includeProviderPluginSetups && params.agentDir && !providerScopedCatalog) {
     options.push(
       ...(await resolveProviderPluginSetupOptions({
         cfg,


### PR DESCRIPTION
## Summary

- Scope onboarding model discovery to the selected provider.
- Preserve provider route variants and static catalog entries.
- Avoid loading unrelated plugin setup registries and provider setup options.
- Keep the unscoped “Browse all models” flow unchanged.

## Root cause

The preferred-provider browse path loaded the complete lifecycle-owned model catalog and filtered it afterward. That unnecessarily initialized unrelated provider and plugin setup surfaces, causing slow model loading and unrelated setup-registry warnings.

## Fix

Use scoped live discovery for the selected provider, including canonical provider aliases and literal-prefix resolution. Provider-scoped browsing now carries the complete filtered catalog snapshot without materializing the global catalog.

This does not change setup-registry validation when the global catalog is intentionally requested.

## Verification

- 77 focused model-picker tests passed.
- Full build passed in Crabbox.
- Regression coverage confirms the full catalog owner and unrelated setup contributions are not loaded.
- Autoreview completed with no actionable findings.

Fixes #125363