### PR TITLE
feat(gateway): allow a custom tailnet port for managed Tailscale ingress

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -812,6 +812,14 @@ Gateway or node host and check `openclaw nodes pending` again.
   route is active and the route is released when the Gateway stops. Named
   Tailscale Services are unsupported because the Tailscale CLI permits them
   only as persistent background routes.
+- `tailscale.port`: tailnet-facing HTTPS port for the managed route. Defaults to
+  `443`. Set it when another service already owns 443 on the host: a reverse
+  proxy bound to `0.0.0.0:443` also covers the Tailscale IP, so the managed
+  claim fails and startup aborts. The chosen port is published in the URLs
+  clients dial, including the Control UI address, pairing setup codes, and
+  `openclaw qr` output (`https://<magicdns>:8443/`, `wss://<magicdns>:8443`).
+  Serve accepts any port; Funnel accepts only `443`, `8443`, and `10000`, and
+  other values are rejected at config validation.
 - `tailscale.preserveFunnel`: deprecated migration guard. When `true` and
   `tailscale.mode = "serve"`, OpenClaw checks `tailscale funnel status` before
   re-applying Serve at startup. If that status cannot be inspected, startup

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -24,6 +24,27 @@ Looking for the step-by-step setup? See [Give your Gateway a stable HTTPS URL](/
 
 Status and audit output use **Tailscale exposure** for this OpenClaw Serve/Funnel mode. `off` means OpenClaw is not managing Serve or Funnel; it does not mean the local Tailscale daemon is stopped or logged out.
 
+## Tailnet port
+
+`gateway.tailscale.port` sets the tailnet-facing HTTPS port for the managed route. It defaults to `443`.
+
+Change it when another service already owns port 443 on the host. A reverse proxy bound to `0.0.0.0:443` also covers the Tailscale IP, so the managed claim fails with `listener already exists for port 443` and the Gateway refuses to start. Moving the managed route to a free port lets both coexist:
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    tailscale: { mode: "serve", port: 8443 },
+  },
+}
+```
+
+Open: `https://<magicdns>:8443/`
+
+Serve accepts any port. Funnel accepts only `443`, `8443`, and `10000`; other values are rejected at config validation.
+
+Keep the managed route rather than replacing it with a hand-made `tailscale serve` on another port: identity headers are only trusted on OpenClaw's own managed listener, so a manual route leaves Gateway-authenticated requests unattributable and they are rejected. See [Tailscale identity headers](#tailscale-identity-headers-serve-only).
+
 ## Config examples
 
 ### Tailnet-only (Serve)

--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -140,6 +140,7 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
       buildTailscaleHttpsUrl({
         tailscaleMode,
         tailscaleDns: await tailscaleDnsPromise,
+        tailscalePort: params.cfg.gateway?.tailscale?.port,
         controlUiBasePath: params.cfg.gateway?.controlUi?.basePath,
       }),
   };

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -547,6 +547,27 @@ describe("buildTailscaleHttpsUrl", () => {
       }),
     ).toBe("https://100.64.0.8");
   });
+
+  it("keeps a non-default tailnet port so the URL stays dialable", () => {
+    expect(
+      buildTailscaleHttpsUrl({
+        tailscaleMode: "serve",
+        tailscaleDns: "node.tailnet.ts.net",
+        tailscalePort: 8443,
+        controlUiBasePath: "/control",
+      }),
+    ).toBe("https://node.tailnet.ts.net:8443/control");
+  });
+
+  it("leaves the default port implicit", () => {
+    expect(
+      buildTailscaleHttpsUrl({
+        tailscaleMode: "serve",
+        tailscaleDns: "node.tailnet.ts.net",
+        tailscalePort: 443,
+      }),
+    ).toBe("https://node.tailnet.ts.net");
+  });
 });
 
 describe("resolveSharedMemoryStatusSnapshot", () => {

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -23,6 +23,7 @@ import type { MemoryProviderStatus } from "../memory-host-sdk/engine-storage.js"
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { formatTailscaleAuthority } from "../shared/tailscale-ports.js";
 import { resolveTailscalePublishedHost } from "../shared/tailscale-status.js";
 import { pickGatewaySelfPresence } from "./gateway-presence.js";
 import { isProbeReachable } from "./gateway-status/helpers.js";
@@ -369,6 +370,8 @@ export async function resolveGatewayProbeSnapshot(params: {
 export function buildTailscaleHttpsUrl(params: {
   tailscaleMode: string;
   tailscaleDns: string | null;
+  /** Tailnet-facing HTTPS port of the managed route. Defaults to 443. */
+  tailscalePort?: number;
   controlUiBasePath?: string;
 }): string | null {
   const host = resolveTailscalePublishedHost({
@@ -376,7 +379,7 @@ export function buildTailscaleHttpsUrl(params: {
     tailnetHost: params.tailscaleDns,
   });
   return params.tailscaleMode !== "off" && host
-    ? `https://${host}${normalizeControlUiBasePath(params.controlUiBasePath)}`
+    ? `https://${formatTailscaleAuthority(host, params.tailscalePort)}${normalizeControlUiBasePath(params.controlUiBasePath)}`
     : null;
 }
 

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -35,6 +35,62 @@ describe("gateway tailscale bind validation", () => {
     expect(funnelRes.ok).toBe(true);
   });
 
+  it("accepts a custom tailnet port for serve", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "serve", port: 8443 },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts any port for serve because Serve has no port restriction", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "serve", port: 9443 },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects a port Funnel cannot expose", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "funnel", port: 9443 },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.map((issue) => issue.path)).toContain("gateway.tailscale");
+    }
+  });
+
+  it("accepts the ports Funnel does expose", () => {
+    for (const port of [443, 8443, 10_000]) {
+      const res = validateConfigObject({
+        gateway: {
+          bind: "loopback",
+          tailscale: { mode: "funnel", port },
+        },
+      });
+      expect(res.ok).toBe(true);
+    }
+  });
+
+  it("rejects an out-of-range tailnet port", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "serve", port: 70_000 },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
   it("rejects the retired Tailscale serviceName key from canonical config", () => {
     const res = validateConfigObject({
       gateway: {

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -143,6 +143,8 @@ export const CORE_FIELD_HELP: Record<string, string> = {
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":
     'Tailscale publish mode: "off", "serve", or "funnel" for private or public exposure paths. Use "serve" for tailnet-only access and "funnel" only when public internet reachability is required.',
+  "gateway.tailscale.port":
+    "Tailnet-facing HTTPS port for the managed Serve/Funnel route. Defaults to 443; change it when another service already owns 443 on the host, since a reverse proxy bound to 0.0.0.0:443 also covers the Tailscale IP and the managed claim fails. Serve accepts any port; Funnel accepts only 443, 8443, and 10000.",
   "gateway.tailscale.preserveFunnel":
     "Deprecated migration guard for mode='serve'. If an external Funnel still targets the ordinary Gateway listener, OpenClaw leaves exposure unchanged and warns that only plugin-authenticated webhooks remain usable until password auth is configured and mode is migrated to 'funnel'.",
   "gateway.remote":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -140,6 +140,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools.deny": "Gateway Tool Denylist",
   "gateway.tailscale": "Gateway Tailscale",
   "gateway.tailscale.mode": "Gateway Tailscale Mode",
+  "gateway.tailscale.port": "Gateway Tailscale Tailnet Port",
   "gateway.tailscale.preserveFunnel": "Gateway Tailscale External Funnel Migration Guard",
   "gateway.remote": "Remote Gateway",
   "gateway.remote.transport": "Remote Gateway Transport",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -259,6 +259,14 @@ export type GatewayTailscaleConfig = {
   /** Tailscale exposure mode for the Gateway control UI. */
   mode?: GatewayTailscaleMode;
   /**
+   * Tailnet-facing HTTPS port for the managed Serve/Funnel route. Defaults to
+   * 443, which fails when another service already owns port 443 on the host
+   * (for example a reverse proxy bound to `0.0.0.0:443`). Funnel accepts only
+   * 443, 8443, and 10000; Serve accepts any port.
+   * @default 443
+   */
+  port?: number;
+  /**
    * Detect an external Funnel route left on the ordinary Gateway listener and
    * leave exposure unchanged with migration guidance. Gateway-authenticated
    * routes reject that ingress; plugin-authenticated webhooks keep their owner auth.

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -9,6 +9,7 @@ import {
   TALK_SECRETS_SCOPE,
   WRITE_SCOPE,
 } from "../gateway/operator-scopes.js";
+import { TAILSCALE_FUNNEL_PORTS } from "../shared/tailscale-ports.js";
 import { SecretInputSchema } from "./zod-schema.core.js";
 import {
   GatewayRemoteConfigSchema,
@@ -141,8 +142,16 @@ export const GatewayConfigSchema = z
     tailscale: z
       .strictObject({
         mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),
+        port: z.number().int().min(1).max(65_535).optional(),
         preserveFunnel: z.boolean().optional(),
       })
+      .refine(
+        (value) =>
+          value.mode !== "funnel" ||
+          value.port === undefined ||
+          TAILSCALE_FUNNEL_PORTS.includes(value.port),
+        `gateway.tailscale.port must be one of ${TAILSCALE_FUNNEL_PORTS.join(", ")} when mode is "funnel"; Tailscale Funnel rejects other ports`,
+      )
       .optional(),
     remote: GatewayRemoteConfigSchema,
     reload: z

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -52,6 +52,7 @@ export async function startGatewayServerCore(
                 tailscaleMode: gatewayKernel.tailscaleMode,
                 preserveFunnel: gatewayKernel.tailscaleConfig.preserveFunnel ?? false,
                 port,
+                tailscalePort: gatewayKernel.tailscaleConfig.port,
                 backend,
                 controlUiBasePath: gatewayKernel.controlUiBasePath,
                 logTailscale,

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -6,11 +6,13 @@ const mocks = vi.hoisted(() => {
   const stopRouteClaim = vi.fn(async () => undefined);
   return {
     stopRouteClaim,
-    claimTailscaleRoute: vi.fn(async (_mode: "serve" | "funnel", _target: number | string) => ({
-      exited: new Promise<void>(() => {}),
-      isActive: (): boolean => true,
-      stop: stopRouteClaim,
-    })),
+    claimTailscaleRoute: vi.fn(
+      async (_mode: "serve" | "funnel", _target: number | string, _exposedPort?: number) => ({
+        exited: new Promise<void>(() => {}),
+        isActive: (): boolean => true,
+        stop: stopRouteClaim,
+      }),
+    ),
     getTailnetHostname: vi.fn<() => Promise<string | null>>(async () => null),
     getTailnetHostnameAfterServe: vi.fn<() => Promise<string | null>>(async () => null),
     hasTailscaleFunnelRouteForPort: vi.fn(async (_port: number) => false),
@@ -95,7 +97,7 @@ describe("startGatewayTailscaleExposure", () => {
       logTailscale,
     });
 
-    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("serve", MANAGED_BACKEND_PORT);
+    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("serve", MANAGED_BACKEND_PORT, 443);
     expect(mocks.getTailnetHostnameAfterServe).toHaveBeenCalledOnce();
     expect(mocks.getTailnetHostname).not.toHaveBeenCalled();
     expect(mocks.hasTailscaleFunnelRouteForPort).not.toHaveBeenCalled();
@@ -142,7 +144,7 @@ describe("startGatewayTailscaleExposure", () => {
 
       await cleanup?.();
 
-      expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith(mode, MANAGED_BACKEND_PORT);
+      expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith(mode, MANAGED_BACKEND_PORT, 443);
       expect(mocks.stopRouteClaim).toHaveBeenCalledOnce();
     },
   );
@@ -197,7 +199,7 @@ describe("startGatewayTailscaleExposure", () => {
     });
 
     expect(mocks.hasTailscaleFunnelRouteForPort).toHaveBeenCalledWith(18789);
-    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("serve", MANAGED_BACKEND_PORT);
+    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("serve", MANAGED_BACKEND_PORT, 443);
   });
 
   it("prepares one tailnet-only Serve origin for the Gateway lifecycle", async () => {
@@ -215,6 +217,43 @@ describe("startGatewayTailscaleExposure", () => {
     });
     await cleanup?.();
     expect(getMcpAppChannelOrigin()).toBeUndefined();
+  });
+
+  it("claims the configured tailnet port instead of the default", async () => {
+    const logTailscale = createLogger();
+
+    await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      port: 18789,
+      tailscalePort: 8443,
+      logTailscale,
+    });
+
+    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("serve", MANAGED_BACKEND_PORT, 8443);
+  });
+
+  it("keeps a non-default tailnet port in the published origin and log line", async () => {
+    mocks.getTailnetHostnameAfterServe.mockResolvedValue("node.tailnet.ts.net");
+    const logTailscale = createLogger();
+
+    const cleanup = await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      port: 18789,
+      tailscalePort: 8443,
+      logTailscale,
+    });
+
+    expect(getMcpAppChannelOrigin()).toEqual({
+      origin: "https://node.tailnet.ts.net:8443",
+      reachability: "tailnet",
+    });
+    expect(logTailscale.info).toHaveBeenCalledWith(
+      expect.stringContaining("https://node.tailnet.ts.net:8443/"),
+    );
+    expect(logTailscale.info).toHaveBeenCalledWith(
+      expect.stringContaining("wss://node.tailnet.ts.net:8443"),
+    );
+    await cleanup?.();
   });
 
   it("clears the published origin and warns when the foreground claim exits", async () => {
@@ -269,6 +308,6 @@ describe("startGatewayTailscaleExposure", () => {
     });
 
     expect(mocks.hasTailscaleFunnelRouteForPort).not.toHaveBeenCalled();
-    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("funnel", MANAGED_BACKEND_PORT);
+    expect(mocks.claimTailscaleRoute).toHaveBeenCalledWith("funnel", MANAGED_BACKEND_PORT, 443);
   });
 });

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -7,6 +7,7 @@ import {
   getTailnetHostnameAfterServe,
   hasTailscaleFunnelRouteForPort,
 } from "../infra/tailscale.js";
+import { TAILSCALE_DEFAULT_ROUTE_PORT } from "../shared/tailscale-ports.js";
 import { resolveTailscalePublishedHost } from "../shared/tailscale-status.js";
 import type { GatewayTailscaleIngressEndpoint } from "./ingress-attribution.js";
 import { prepareMcpAppChannelOrigin } from "./mcp-app-channel-origin.js";
@@ -14,6 +15,8 @@ import { prepareMcpAppChannelOrigin } from "./mcp-app-channel-origin.js";
 export async function startGatewayTailscaleExposure(params: {
   tailscaleMode: "off" | "serve" | "funnel";
   port: number;
+  /** Tailnet-facing HTTPS port for the managed route. Defaults to 443. */
+  tailscalePort?: number;
   backend?: GatewayTailscaleIngressEndpoint;
   preserveFunnel?: boolean;
   controlUiBasePath?: string;
@@ -26,6 +29,10 @@ export async function startGatewayTailscaleExposure(params: {
     throw new Error("Managed Tailscale ingress failed to start");
   }
   const backendTarget = params.backend.port;
+  const exposedPort = params.tailscalePort ?? TAILSCALE_DEFAULT_ROUTE_PORT;
+  // Non-default ports must stay in every published origin: clients dial the
+  // tailnet route directly, so dropping it would advertise an unreachable URL.
+  const hostSuffix = exposedPort === TAILSCALE_DEFAULT_ROUTE_PORT ? "" : `:${exposedPort}`;
   const effectiveMode = params.tailscaleMode;
   let clearPublishedOrigin: (() => void) | undefined;
   if (params.tailscaleMode === "serve" && params.preserveFunnel === true) {
@@ -51,7 +58,7 @@ export async function startGatewayTailscaleExposure(params: {
 
   let claim: Awaited<ReturnType<typeof claimTailscaleRoute>> | undefined;
   try {
-    claim = await claimTailscaleRoute(params.tailscaleMode, backendTarget);
+    claim = await claimTailscaleRoute(params.tailscaleMode, backendTarget, exposedPort);
     const host = await (
       params.tailscaleMode === "serve" ? getTailnetHostnameAfterServe() : getTailnetHostname()
     ).catch(() => null);
@@ -65,12 +72,13 @@ export async function startGatewayTailscaleExposure(params: {
         tailnetHost: host,
       });
       if (publicHost) {
+        const publicAuthority = `${publicHost}${hostSuffix}`;
         clearPublishedOrigin = prepareMcpAppChannelOrigin({
-          origin: `https://${publicHost}`,
+          origin: `https://${publicAuthority}`,
           reachability: effectiveMode === "funnel" ? "internet" : "tailnet",
         });
         params.logTailscale.info(
-          `${params.tailscaleMode} enabled: https://${publicHost}${uiPath} (WS via wss://${publicHost})`,
+          `${params.tailscaleMode} enabled: https://${publicAuthority}${uiPath} (WS via wss://${publicAuthority})`,
         );
       } else {
         params.logTailscale.info(`${params.tailscaleMode} enabled`);

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -7,7 +7,10 @@ import {
   getTailnetHostnameAfterServe,
   hasTailscaleFunnelRouteForPort,
 } from "../infra/tailscale.js";
-import { TAILSCALE_DEFAULT_ROUTE_PORT } from "../shared/tailscale-ports.js";
+import {
+  formatTailscaleAuthority,
+  TAILSCALE_DEFAULT_ROUTE_PORT,
+} from "../shared/tailscale-ports.js";
 import { resolveTailscalePublishedHost } from "../shared/tailscale-status.js";
 import type { GatewayTailscaleIngressEndpoint } from "./ingress-attribution.js";
 import { prepareMcpAppChannelOrigin } from "./mcp-app-channel-origin.js";
@@ -30,9 +33,7 @@ export async function startGatewayTailscaleExposure(params: {
   }
   const backendTarget = params.backend.port;
   const exposedPort = params.tailscalePort ?? TAILSCALE_DEFAULT_ROUTE_PORT;
-  // Non-default ports must stay in every published origin: clients dial the
-  // tailnet route directly, so dropping it would advertise an unreachable URL.
-  const hostSuffix = exposedPort === TAILSCALE_DEFAULT_ROUTE_PORT ? "" : `:${exposedPort}`;
+
   const effectiveMode = params.tailscaleMode;
   let clearPublishedOrigin: (() => void) | undefined;
   if (params.tailscaleMode === "serve" && params.preserveFunnel === true) {
@@ -72,7 +73,7 @@ export async function startGatewayTailscaleExposure(params: {
         tailnetHost: host,
       });
       if (publicHost) {
-        const publicAuthority = `${publicHost}${hostSuffix}`;
+        const publicAuthority = formatTailscaleAuthority(publicHost, exposedPort);
         clearPublishedOrigin = prepareMcpAppChannelOrigin({
           origin: `https://${publicAuthority}`,
           reachability: effectiveMode === "funnel" ? "internet" : "tailnet",

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -67,6 +67,20 @@ describe("mergeGatewayTailscaleConfig", () => {
       ),
     ).toEqual({ mode: "serve", preserveFunnel: true });
   });
+
+  it("carries a tailnet port override into the merged config", () => {
+    expect(mergeGatewayTailscaleConfig({ mode: "serve" }, { port: 8443 })).toEqual({
+      mode: "serve",
+      port: 8443,
+    });
+  });
+
+  it("keeps the base tailnet port when the override omits it", () => {
+    expect(mergeGatewayTailscaleConfig({ mode: "serve", port: 8443 }, { mode: "funnel" })).toEqual({
+      mode: "funnel",
+      port: 8443,
+    });
+  });
 });
 
 describe("ensureGatewayStartupAuth", () => {

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -63,6 +63,9 @@ export function mergeGatewayTailscaleConfig(
   if (override.mode !== undefined) {
     merged.mode = override.mode;
   }
+  if (override.port !== undefined) {
+    merged.port = override.port;
+  }
   if (override.preserveFunnel !== undefined) {
     merged.preserveFunnel = override.preserveFunnel;
   }

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -244,6 +244,39 @@ describe("tailscale helpers", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "passes --https for a non-default tailnet port",
+    async () => {
+      // The fixture exits non-zero unless it receives exactly the expected argv,
+      // so a successful claim proves --https=8443 was emitted before the target.
+      process.env.OPENCLAW_TEST_TAILSCALE_BINARY = fileURLToPath(
+        new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
+      );
+
+      const claim = await claimTailscaleRoute("serve", 18789, 8443);
+      expect(claim.isActive()).toBe(true);
+
+      await claim.stop();
+      await expect(claim.exited).resolves.toBeUndefined();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "omits --https when the tailnet port is the default",
+    async () => {
+      // The fixture only accepts the default-port argv without --https here.
+      process.env.OPENCLAW_TEST_TAILSCALE_BINARY = fileURLToPath(
+        new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
+      );
+
+      const claim = await claimTailscaleRoute("serve", 18789, 443);
+      expect(claim.isActive()).toBe(true);
+
+      await claim.stop();
+      await expect(claim.exited).resolves.toBeUndefined();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "preserves route diagnostics when startup readiness times out",
     async () => {
       vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -14,6 +14,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { runExec } from "../process/exec.js";
 import { signalProcessTree } from "../process/kill-tree.js";
+import { TAILSCALE_DEFAULT_ROUTE_PORT } from "../shared/tailscale-ports.js";
 import { isVitestRuntimeEnv } from "./env.js";
 import { toErrorObject } from "./errors.js";
 import { retryAsync } from "./retry.js";
@@ -396,9 +397,16 @@ async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteC
 export async function claimTailscaleRoute(
   mode: "serve" | "funnel",
   target: number | string,
+  exposedPort?: number,
 ): Promise<TailscaleRouteClaim> {
   const tailscaleBin = await getTailscaleBinary();
-  const args = [mode, "--yes", "--bg=false", `${target}`];
+  // Omit --https when the caller wants the default so the emitted command keeps
+  // matching what operators see documented for Serve and Funnel.
+  const portArgs =
+    exposedPort === undefined || exposedPort === TAILSCALE_DEFAULT_ROUTE_PORT
+      ? []
+      : [`--https=${exposedPort}`];
+  const args = [mode, "--yes", "--bg=false", ...portArgs, `${target}`];
   try {
     return await startTailscaleRouteOwner([tailscaleBin, ...args]);
   } catch (error) {

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -924,6 +924,30 @@ describe("pairing setup code", () => {
       },
     },
     {
+      name: "keeps a non-default tailnet port in the pairing URL",
+      createOptions: () => {
+        const runCommandWithTimeout = createTailnetDnsRunner();
+        return {
+          options: {
+            runCommandWithTimeout,
+          } satisfies ResolveSetupOptions,
+          runCommandWithTimeout,
+          expectedRunCommandCalls: 1,
+        };
+      },
+      config: {
+        gateway: {
+          tailscale: { mode: "serve", port: 8443 },
+          auth: { mode: "password", password: "secret" },
+        },
+      } satisfies ResolveSetupConfig,
+      expected: {
+        authLabel: "password",
+        url: "wss://mb-server.tailnet.ts.net:8443",
+        urlSource: "gateway.tailscale.mode=serve",
+      },
+    },
+    {
       name: "prefers gateway.remote.url over tailscale when requested",
       createOptions: () => {
         const runCommandWithTimeout = createTailnetDnsRunner();

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -35,6 +35,7 @@ import {
   type PairingSetupAccess,
 } from "../shared/device-bootstrap-profile.js";
 import { resolveGatewayBindUrl } from "../shared/gateway-bind-url.js";
+import { formatTailscaleAuthority } from "../shared/tailscale-ports.js";
 import {
   resolveTailnetHostWithRunner,
   resolveTailscalePublishedHost,
@@ -367,7 +368,14 @@ async function resolveGatewayUrl(
       tailscaleMode,
       tailnetHost: host,
     });
-    return { url: `wss://${publishedHost}`, source: `gateway.tailscale.mode=${tailscaleMode}` };
+    if (!publishedHost) {
+      return {
+        error:
+          "Tailscale exposure is enabled, but its published tailnet host could not be resolved.",
+      };
+    }
+    const authority = formatTailscaleAuthority(publishedHost, cfg.gateway?.tailscale?.port);
+    return { url: `wss://${authority}`, source: `gateway.tailscale.mode=${tailscaleMode}` };
   }
 
   if (remoteUrl) {

--- a/src/shared/tailscale-ports.test.ts
+++ b/src/shared/tailscale-ports.test.ts
@@ -1,0 +1,40 @@
+// Authority formatting decides the endpoint clients dial, so the port and the
+// IPv6 bracketing rules are covered directly.
+import { describe, expect, it } from "vitest";
+import { formatTailscaleAuthority, TAILSCALE_DEFAULT_ROUTE_PORT } from "./tailscale-ports.js";
+
+describe("formatTailscaleAuthority", () => {
+  it("leaves the default port implicit", () => {
+    expect(formatTailscaleAuthority("node.tailnet.ts.net", TAILSCALE_DEFAULT_ROUTE_PORT)).toBe(
+      "node.tailnet.ts.net",
+    );
+    expect(formatTailscaleAuthority("node.tailnet.ts.net")).toBe("node.tailnet.ts.net");
+  });
+
+  it("keeps a non-default port visible", () => {
+    expect(formatTailscaleAuthority("node.tailnet.ts.net", 8443)).toBe("node.tailnet.ts.net:8443");
+  });
+
+  it("brackets an IPv6 fallback host before appending a port", () => {
+    // Unbracketed, `fd7a::1:8443` parses as a longer address, not host plus port.
+    expect(formatTailscaleAuthority("fd7a:115c:a1e0::3734:8d3c", 8443)).toBe(
+      "[fd7a:115c:a1e0::3734:8d3c]:8443",
+    );
+  });
+
+  it("brackets an IPv6 fallback host even on the default port", () => {
+    expect(formatTailscaleAuthority("fd7a:115c:a1e0::3734:8d3c")).toBe(
+      "[fd7a:115c:a1e0::3734:8d3c]",
+    );
+  });
+
+  it("does not double-bracket an already bracketed literal", () => {
+    expect(formatTailscaleAuthority("[fd7a:115c:a1e0::3734:8d3c]", 8443)).toBe(
+      "[fd7a:115c:a1e0::3734:8d3c]:8443",
+    );
+  });
+
+  it("leaves an IPv4 fallback host untouched", () => {
+    expect(formatTailscaleAuthority("100.99.141.60", 8443)).toBe("100.99.141.60:8443");
+  });
+});

--- a/src/shared/tailscale-ports.ts
+++ b/src/shared/tailscale-ports.ts
@@ -7,3 +7,13 @@ export const TAILSCALE_DEFAULT_ROUTE_PORT = 443;
 
 /** Ports Tailscale Funnel accepts. Serve has no such restriction. */
 export const TAILSCALE_FUNNEL_PORTS: readonly number[] = [443, 8443, 10_000];
+
+/**
+ * Builds the tailnet authority for a published URL. The default port is left
+ * implicit so published URLs keep the documented Serve/Funnel form, while any
+ * other port must stay visible: clients dial the tailnet route directly, so an
+ * authority without it points at whatever else owns 443 on the host.
+ */
+export function formatTailscaleAuthority(host: string, port?: number): string {
+  return port === undefined || port === TAILSCALE_DEFAULT_ROUTE_PORT ? host : `${host}:${port}`;
+}

--- a/src/shared/tailscale-ports.ts
+++ b/src/shared/tailscale-ports.ts
@@ -15,5 +15,12 @@ export const TAILSCALE_FUNNEL_PORTS: readonly number[] = [443, 8443, 10_000];
  * authority without it points at whatever else owns 443 on the host.
  */
 export function formatTailscaleAuthority(host: string, port?: number): string {
-  return port === undefined || port === TAILSCALE_DEFAULT_ROUTE_PORT ? host : `${host}:${port}`;
+  // The host resolver falls back to `TailscaleIPs`, which can yield an IPv6
+  // literal. Those must be bracketed in a URL authority: `fd7a::1:8443` parses
+  // as a longer address rather than host plus port, and a bare `fd7a::1` is not
+  // a valid authority either, so bracket regardless of the port.
+  const authorityHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return port === undefined || port === TAILSCALE_DEFAULT_ROUTE_PORT
+    ? authorityHost
+    : `${authorityHost}:${port}`;
 }

--- a/src/shared/tailscale-ports.ts
+++ b/src/shared/tailscale-ports.ts
@@ -1,0 +1,9 @@
+// Tailnet-facing port constants shared by config validation and the runtime
+// route claim. Kept dependency-free so config schemas can import it without
+// pulling in the process-spawning Tailscale runtime helpers.
+
+/** Tailnet-facing HTTPS port used when the caller does not pick one. */
+export const TAILSCALE_DEFAULT_ROUTE_PORT = 443;
+
+/** Ports Tailscale Funnel accepts. Serve has no such restriction. */
+export const TAILSCALE_FUNNEL_PORTS: readonly number[] = [443, 8443, 10_000];

--- a/test/fixtures/tailscale-foreground-fixture.mjs
+++ b/test/fixtures/tailscale-foreground-fixture.mjs
@@ -1,15 +1,20 @@
 #!/usr/bin/env node
 const args = process.argv.slice(2);
 const serveArgs = ["serve", "--yes", "--bg=false", "18789"];
+const servePortArgs = ["serve", "--yes", "--bg=false", "--https=8443", "18789"];
 const stalledFunnelArgs = ["funnel", "--yes", "--bg=false", "18790"];
 if (
   JSON.stringify(args) !== JSON.stringify(serveArgs) &&
+  JSON.stringify(args) !== JSON.stringify(servePortArgs) &&
   JSON.stringify(args) !== JSON.stringify(stalledFunnelArgs)
 ) {
   process.stderr.write(`unexpected arguments: ${JSON.stringify(process.argv.slice(2))}\n`);
   process.exit(2);
 }
-if (JSON.stringify(args) === JSON.stringify(serveArgs)) {
+if (
+  JSON.stringify(args) === JSON.stringify(serveArgs) ||
+  JSON.stringify(args) === JSON.stringify(servePortArgs)
+) {
   process.stdout.write("Press Ctrl+C to exit.\n");
 } else {
   process.stderr.write("Funnel is not enabled on your tailnet.\n");


### PR DESCRIPTION
Related: #125369

<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is enabled on this PR.

</details>

## What Problem This Solves

**Updated 26 Aug:** the original problem statement is out of date, and I want to correct it rather than leave it standing.

When I opened this, managed Serve was the only way to get trusted ingress, and an external route was rejected before `gateway.trustedProxies` was consulted. #125412 changed that two hours after this PR was filed: the Tailscale-header check now runs *after* the trusted-proxy branch, so an external `tailscale serve` plus a narrow `trustedProxies` is attributed and works. That was the stronger half of my case and it is gone. The startup failure I hit — `sending serve config: updating config: listener already exists for port 443` on a host where nginx owns `0.0.0.0:443` — has a supported answer today.

What remains is narrower, and it is about ownership rather than reachability.

Managed ingress holds the route as a foreground claim: the Gateway creates it, watches it, and releases it when it exits. An externally managed route has no owner. If the Gateway dies, the route stays.

That is not hypothetical for me. In August a `tailscale serve` on 443 outlived the process that created it and kept nginx from binding for three days, because nothing owned it and nothing released it. Managed ingress is precisely what prevents that.

So the remaining question is narrow: today, changing the tailnet port means giving up managed ingress — and its lifecycle guarantee — for a reason that has nothing to do with lifecycle. This PR lets an operator keep the managed claim and move it off 443.

I have no strong view on whether that is worth a permanent config key; that is a maintainer call, and I understand if the answer is no. I would rather the record be accurate than the PR survive.

## Why This Change Was Made

Adds `gateway.tailscale.port`, defaulting to 443, threaded through to `claimTailscaleRoute` as `--https=<port>`. Keeping the route *managed* is the point: it preserves identity-header attribution, which is exactly what the manual-Serve workaround loses.

Design decisions:

- **The flag is omitted for the default port**, so the emitted `tailscale serve`/`funnel` command is byte-identical to today for anyone who does not set the key.
- **A non-default port stays in every published origin and log line** (`https://<magicdns>:8443/`, `wss://<magicdns>:8443`). Clients dial the tailnet route directly, so dropping it would advertise an unreachable URL.
- **Funnel ports are validated at config time.** Serve accepts any port; Funnel accepts only 443, 8443, and 10000, so a bad value is rejected with a clear message instead of failing inside the CLI at startup.
- **One helper owns the published authority.** `formatTailscaleAuthority()` in the new dependency-free `src/shared/tailscale-ports.ts` is the single place that decides whether the port appears, and the managed route, pairing/QR setup, and status output all go through it. That file stays free of runtime imports so the config schema can use the port constants without pulling in the process-spawning Tailscale helpers.
- **Pairing fails loudly when the tailnet host is unresolvable.** That path previously interpolated a possibly-`null` host straight into the URL, producing `wss://null`; it now returns an explicit error.

Non-goals: no auto-detection of port conflicts and no auto-selection of a free port — silently changing a URL operators have to type is worse than failing loudly. No change to trusted-proxy or attribution semantics.

## User Impact

Operators whose Gateway host already uses 443 can now run managed Tailscale ingress on another port:

```json5
{
  gateway: {
    bind: "loopback",
    tailscale: { mode: "serve", port: 8443 },
  },
}
```

The dashboard is then at `https://<magicdns>:8443/`, identity-header auth keeps working, and the reverse proxy keeps 443. Misconfigured Funnel ports now fail config validation with an explicit message instead of a CLI error during startup.

No behavior change for existing installs: the key is optional and the default is the current behavior.

## Evidence

### Live run on a host where nginx owns 443

OpenClaw 2026.8.1, Ubuntu 24.04, Tailscale Serve, reverse proxy bound to `0.0.0.0:443`. Hostnames are this tailnet's real MagicDNS names; secrets are redacted.

**Before**, with `gateway.tailscale.mode: "serve"` and no port setting, startup died:

```
reason:         gateway.startup_failed
error.message:  sending serve config: updating config: listener already exists for port 443
```

**After**, with `tailscale: { mode: "serve", port: 8443 }`, the managed route comes up and the Gateway reports ready:

```
[tailscale] serve enabled: https://ingil.tail37360.ts.net:8443/ (WS via wss://ingil.tail37360.ts.net:8443)
[gateway] ready
```

Listener layout — the managed route and the reverse proxy coexist, and the Gateway itself stays on loopback:

```
LISTEN  127.0.0.1:18789          # gateway, bind=loopback
LISTEN  100.99.141.60:8443       # managed Serve route (tailnet IP)
LISTEN  0.0.0.0:443              # nginx, untouched
```

Authenticated client flow over the non-default route:

```
$ curl -o /dev/null -w '%{http_code}' https://ingil.tail37360.ts.net:8443/
200
```

On 17 Aug, before #125412 landed, the same request returned 403, with the Gateway logging
`observed unattributable proxy-shaped traffic from 127.0.0.1` on every attempt; that log line has not reappeared since the managed route took over. A real Android device then completed pairing against this endpoint and is connected.

### Endpoint publication (the P1 raised in review)

The first push threaded the port only into the managed claim, so pairing and status still advertised 443. Fixed in `d2ef555bb65`, verified by running the two commands that were wrong, with no override:

```
$ openclaw qr --json
  gatewayUrl: wss://ingil.tail37360.ts.net:8443
  urlSource:  gateway.tailscale.mode=serve

$ openclaw status
  Tailscale exposure   serve · ingil.tail37360.ts.net · https://ingil.tail37360.ts.net:8443
```

Both previously emitted the bare host. The QR produced by that command was decoded back to confirm the payload carries `url: wss://ingil.tail37360.ts.net:8443`, and the device paired from it.

### Tests

`136 passed` across the five affected suites:

```
$ npx vitest run src/pairing/setup-code.test.ts src/commands/status.scan.shared.test.ts \
    src/gateway/server-tailscale.test.ts src/config/config.gateway-tailscale-bind.test.ts \
    src/infra/tailscale.test.ts

 Test Files  5 passed (5)
      Tests  136 passed (136)
```

New coverage:

- `infra/tailscale.test.ts` — `--https=8443` is emitted for a non-default port and omitted for the default. The foreground fixture exits non-zero on unexpected argv, so the emitted command is genuinely asserted rather than mocked.
- `server-tailscale.test.ts` — the configured port reaches `claimTailscaleRoute` and is retained in the published MCP app-channel origin and the `wss://` log line.
- `setup-code.test.ts` — a configured port lands in the pairing URL (`wss://mb-server.tailnet.ts.net:8443`).
- `status.scan.shared.test.ts` — a non-default port appears in the Control UI URL; the default stays implicit.
- `config.gateway-tailscale-bind.test.ts` — Serve accepts arbitrary ports; Funnel accepts 443/8443/10000 and rejects 9443; out-of-range values are rejected.

### Repo checks

`pnpm build` and `pnpm check` pass, along with `pnpm check:base-config-schema` (still `ok` after registering the new key in the help and label maps) and `pnpm format:docs`.

`pnpm test` has failures on this machine that predate the branch — TUI PTY e2e, markdown file-link wrapping, UI radius/icon tokens, browser launch, OAuth callback, macOS CA trust, IPv6 dial. None touch Tailscale, gateway config, or ingress attribution. Verified by running the same suite on the base commit `793669c8f6d` with and without the branch:

```
this branch:          Test Files  3 failed (3)   Tests  3 failed | 27 passed (30)
793669c8f6d (base):   Test Files  3 failed (3)   Tests  3 failed | 27 passed (30)
```

Identical either way, so I have left them alone per CONTRIBUTING's guidance on known `main` failures.

