### PR TITLE
fix: keep onboarding provider metadata scoped

### DIFF
--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1043,11 +1043,11 @@ describe("promptDefaultModel", () => {
     expect(select.mock.calls[1]?.[0]?.searchable).toBe(true);
   });
 
-  it("keeps preferred-provider browsing off unrelated provider setup surfaces", async () => {
+  it("keeps empty-default provider browsing off unrelated provider setup surfaces", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue(
       providerCatalogSnapshot([
-        catalogModel("openai", "gpt-5.5", "GPT-5.5"),
-        catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
+        catalogModel("ollama", "minimax-m2.7:cloud", "MiniMax M2.7"),
+        catalogModel("ollama", "gemma4", "Gemma 4"),
       ]),
     );
     providerModelPickerContributionRuntime.enabled = true;
@@ -1064,17 +1064,8 @@ describe("promptDefaultModel", () => {
         throw new Error("preferred-provider browsing must not load the full setup registry");
       },
     });
-    const select = vi
-      .fn()
-      .mockResolvedValueOnce("__browse__")
-      .mockResolvedValueOnce("openai/gpt-5.5-pro");
-    const config = {
-      agents: {
-        defaults: {
-          model: "openai/gpt-5.5",
-        },
-      },
-    } as OpenClawConfig;
+    const select = vi.fn().mockResolvedValueOnce("ollama/gemma4");
+    const config = { agents: { defaults: {} } } as OpenClawConfig;
 
     await promptDefaultPicker({
       config,
@@ -1082,7 +1073,7 @@ describe("promptDefaultModel", () => {
       allowKeep: true,
       includeManual: true,
       includeProviderPluginSetups: true,
-      preferredProvider: "openai",
+      preferredProvider: "ollama",
       browseCatalogOnDemand: true,
       agentDir: "/tmp/openclaw-agent",
       runtime: {} as never,
@@ -1090,11 +1081,11 @@ describe("promptDefaultModel", () => {
 
     expect(resolvePluginProviders).toHaveBeenCalledWith(
       expect.objectContaining({
-        providerRefs: ["openai"],
+        providerRefs: ["ollama"],
       }),
     );
     expect(providerModelPickerContributionRuntime.resolve).not.toHaveBeenCalled();
-    expect(optionValues(pickerOptions(select as MockCallSource, 1))).not.toContain(
+    expect(optionValues(pickerOptions(select as MockCallSource, 0))).not.toContain(
       "provider-plugin:nvidia:api-key",
     );
   });

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -841,7 +841,7 @@ export async function promptDefaultModel(
         workspaceDir: params.workspaceDir,
         env: params.env,
         ...(providerScopedCatalog && preferredProvider
-          ? { providerRefs: sortUniqueStrings([preferredProvider, resolved.provider]) }
+          ? { providerRefs: [preferredProvider] }
           : {}),
       });
     }


### PR DESCRIPTION
## Summary

- Restrict provider-scoped onboarding metadata resolution to the selected provider.
- Cover Ollama onboarding with an empty configured model.
- Keep unscoped model browsing behavior unchanged.

## Root cause

The provider-scoped picker also passed the resolved default provider into literal-prefix metadata discovery. With no configured primary model, that fallback is OpenAI, so selecting Ollama still loaded an unrelated provider runtime.

## Verification

- The regression failed before the fix with `providerRefs: ["ollama", "openai"]`.
- 77 focused model-picker tests passed.
- The full changed-file gate passed.
- Autoreview completed with no actionable findings.

Follow-up to #125373 and #125363.