### PR TITLE
fix(process): commands lose output during event-loop stalls

### DIFF
--- a/src/process/child-process.test.ts
+++ b/src/process/child-process.test.ts
@@ -18,33 +18,35 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
     vi.useRealTimers();
   });
 
-  it("drains active descendant output after the parent exits", async () => {
-    const command = 'printf "HEAD\\n"; ( sleep 0.05; printf "TAIL\\n" ) &';
-    child = execa("/bin/sh", ["-c", command], {
-      buffer: false,
-      detached: true,
-      reject: false,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const releaseOutput = releaseChildProcessOutputAfterExit(child.nodeChildProcess);
-    let output = "";
-    child.stdout?.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
-
-    // Simulate a contended worker after the direct child exits. The descendant
-    // writes while JS is parked, so its pipe data and the idle timer are both
-    // ready when the event loop resumes.
-    await new Promise<void>((resolve) => {
-      child?.nodeChildProcess.once("exit", () => {
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
-        resolve();
+  it.each([250, 1_250])(
+    "drains descendant output across a %ims event-loop stall",
+    async (stallMs) => {
+      const command =
+        'printf "HEAD\\n"; printf "HEAD\\n" >&2; ( sleep 0.05; printf "TAIL\\n"; printf "TAIL\\n" >&2 ) &';
+      child = execa("/bin/sh", ["-c", command], {
+        detached: true,
+        reject: false,
+        stdio: ["ignore", "pipe", "pipe"],
+        stripFinalNewline: false,
       });
-    });
-    await child.finally(releaseOutput);
-    expect(output).toContain("HEAD");
-    expect(output).toContain("TAIL");
-  });
+      const releaseOutput = releaseChildProcessOutputAfterExit(child.nodeChildProcess);
+
+      // Simulate a contended worker after the direct child exits. The descendant
+      // writes while JS is parked past the idle or hard deadline, so buffered
+      // pipe data and release timers are ready when the event loop resumes.
+      await new Promise<void>((resolve) => {
+        child?.nodeChildProcess.once("exit", () => {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, stallMs);
+          resolve();
+        });
+      });
+      expect(await child.finally(releaseOutput)).toMatchObject({
+        exitCode: 0,
+        stdout: "HEAD\nTAIL\n",
+        stderr: "HEAD\nTAIL\n",
+      });
+    },
+  );
 
   it("releases a quiet inherited pipe after the idle grace", async () => {
     child = execa("/bin/sh", ["-c", 'printf "DONE\\n"; ( sleep 30 ) &'], {
@@ -77,13 +79,38 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
     fakeChild.emit("exit", 0);
     const writer = setInterval(() => stdout.write("TICK\n"), 30);
 
-    await vi.advanceTimersByTimeAsync(999);
-    expect(stdout.destroyed).toBe(false);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(stdout.destroyed).toBe(true);
-    expect(stderr.destroyed).toBe(true);
+    try {
+      await vi.advanceTimersByTimeAsync(999);
+      expect(stdout.destroyed).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stdout.destroyed).toBe(false);
+      stdout.write("AFTER DEADLINE\n");
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stdout.destroyed).toBe(true);
+      expect(stderr.destroyed).toBe(true);
+    } finally {
+      clearInterval(writer);
+      cleanup();
+    }
+  });
 
-    clearInterval(writer);
+  it.each(["idle", "hard"])("cancels pending %s release when cleaned up", async (deadline) => {
+    vi.useFakeTimers();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const fakeChild = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+    }) as unknown as ChildProcess;
+    const cleanup = releaseChildProcessOutputAfterExit(fakeChild);
+    fakeChild.emit("exit", 0);
+    const writer = deadline === "hard" ? setInterval(() => stdout.write("TICK\n"), 30) : undefined;
+
+    await vi.advanceTimersByTimeAsync(deadline === "hard" ? 1_000 : 100);
     cleanup();
+    clearInterval(writer);
+    await vi.runAllTimersAsync();
+    expect(stdout.destroyed).toBe(false);
+    expect(stderr.destroyed).toBe(false);
   });
 });

--- a/src/process/child-process.test.ts
+++ b/src/process/child-process.test.ts
@@ -33,11 +33,11 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
     });
 
     // Simulate a contended worker after the direct child exits. The descendant
-    // writes while JS is parked, so its pipe data and the idle timer are both
-    // ready when the event loop resumes.
+    // writes while JS is parked past the hard drain deadline, so its pipe data
+    // and both release timers are ready when the event loop resumes.
     await new Promise<void>((resolve) => {
       child?.nodeChildProcess.once("exit", () => {
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1_250);
         resolve();
       });
     });
@@ -80,10 +80,13 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
     await vi.advanceTimersByTimeAsync(999);
     expect(stdout.destroyed).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
+    expect(stdout.destroyed).toBe(false);
+
+    clearInterval(writer);
+    await vi.runAllTimersAsync();
     expect(stdout.destroyed).toBe(true);
     expect(stderr.destroyed).toBe(true);
 
-    clearInterval(writer);
     cleanup();
   });
 });

--- a/src/process/child-process.ts
+++ b/src/process/child-process.ts
@@ -63,14 +63,18 @@ export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => v
     idleTimer.unref();
   };
   const onData = () => {
-    if (exited) {
+    if (exited && deadlineTimer) {
       armIdleTimer();
     }
   };
   const onExit = () => {
     exited = true;
     armIdleTimer();
-    deadlineTimer = setTimeout(release, EXIT_STDIO_MAX_DRAIN_MS);
+    deadlineTimer = setTimeout(() => {
+      deadlineTimer = undefined;
+      // Let poll drain output buffered during a stalled timers phase before the hard release.
+      setImmediate(release).unref();
+    }, EXIT_STDIO_MAX_DRAIN_MS);
     deadlineTimer.unref();
   };
 

--- a/src/process/child-process.ts
+++ b/src/process/child-process.ts
@@ -12,27 +12,14 @@ const EXIT_STDIO_MAX_DRAIN_MS = 1_000;
  * short output tails. The returned cleanup must run after awaiting the child.
  */
 export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => void {
-  let exited = false;
   let idleTimer: NodeJS.Timeout | undefined;
-  let idleReleaseImmediate: NodeJS.Immediate | undefined;
+  let releaseImmediate: NodeJS.Immediate | undefined;
   let deadlineTimer: NodeJS.Timeout | undefined;
 
-  const clearTimers = () => {
-    if (idleTimer) {
-      clearTimeout(idleTimer);
-      idleTimer = undefined;
-    }
-    if (idleReleaseImmediate) {
-      clearImmediate(idleReleaseImmediate);
-      idleReleaseImmediate = undefined;
-    }
-    if (deadlineTimer) {
-      clearTimeout(deadlineTimer);
-      deadlineTimer = undefined;
-    }
-  };
   const cleanup = () => {
-    clearTimers();
+    clearTimeout(idleTimer);
+    clearImmediate(releaseImmediate);
+    clearTimeout(deadlineTimer);
     child.removeListener("exit", onExit);
     child.stdout?.removeListener("data", onData);
     child.stderr?.removeListener("data", onData);
@@ -42,36 +29,32 @@ export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => v
     child.stdout?.destroy();
     child.stderr?.destroy();
   };
+  const scheduleRelease = () => {
+    // Either timer may run before already-buffered pipe data on a loaded loop.
+    // Share one cancellable release after poll has had a turn to drain it.
+    releaseImmediate ??= setImmediate(release);
+    releaseImmediate.unref();
+  };
   const armIdleTimer = () => {
-    if (idleTimer) {
-      clearTimeout(idleTimer);
-    }
-    if (idleReleaseImmediate) {
-      clearImmediate(idleReleaseImmediate);
-      idleReleaseImmediate = undefined;
-    }
-    idleTimer = setTimeout(() => {
-      idleTimer = undefined;
-      // A loaded event loop can observe the idle timer before already-buffered
-      // pipe data. Give the poll phase one turn so that data can rearm the grace.
-      idleReleaseImmediate = setImmediate(() => {
-        idleReleaseImmediate = undefined;
-        release();
-      });
-      idleReleaseImmediate.unref();
-    }, EXIT_STDIO_GRACE_MS);
+    clearTimeout(idleTimer);
+    clearImmediate(releaseImmediate);
+    releaseImmediate = undefined;
+    idleTimer = setTimeout(scheduleRelease, EXIT_STDIO_GRACE_MS);
     idleTimer.unref();
   };
   const onData = () => {
-    if (exited) {
+    if (deadlineTimer) {
       armIdleTimer();
     }
   };
   const onExit = () => {
-    exited = true;
-    armIdleTimer();
-    deadlineTimer = setTimeout(release, EXIT_STDIO_MAX_DRAIN_MS);
+    deadlineTimer = setTimeout(() => {
+      // Post-deadline data must not cancel release and extend the hard bound.
+      deadlineTimer = undefined;
+      scheduleRelease();
+    }, EXIT_STDIO_MAX_DRAIN_MS);
     deadlineTimer.unref();
+    armIdleTimer();
   };
 
   child.stdout?.on("data", onData);


### PR DESCRIPTION
Closes #125380
Closes #130504

## What Problem This Solves

Fixes an issue where users creating or opening worktree-backed sessions could receive a misleading "checkout root unavailable" error after a long Gateway event-loop stall. A successful Git command could lose its final output. The same shared subprocess owner can lose stdout or stderr for other command callers.

## Why This Change Was Made

Both the idle and hard post-exit deadlines now schedule one tracked release after the event loop has had a chance to drain buffered pipe data. Clearing the deadline marker prevents post-deadline output from cancelling that release, preserving bounded cleanup for continuously writing descendants. The returned cleanup cancels all pending work.

This maintainer refresh preserves the original PR's owner-level repair and strengthens it: one cancellable release replaces the separate hard/idle paths, the redundant exited flag is removed, and continuous-writer proof no longer stops the writer before asserting the cutoff. Production LOC: +21/-38 (net -17). Tests: +59/-32 (net +27, including table formatting). No new config, retries, Git-specific fallback, timeout increase, storage change, or dependency change.

Provenance: the direct hard-deadline release was introduced in #105939 (`4f287dd7404f`, July 13), authored and merged by @steipete. #111040 (`9a94beace77b`, July 19), also authored and merged by @steipete, repaired the idle deadline but carried the hard-deadline race forward. Source history and current behavior were checked; no released-version claim is made here.

## User Impact

Short-lived commands retain output already produced during a long event-loop stall instead of returning silently incomplete results. Quiet or continuously writing descendants still cannot hold command completion open indefinitely. Reporter/provenance: @vyctorbrzezowski (Vyctor H. Brzezowski); the independent macOS reproduction in #130504 is consolidated into this existing repair. AI-assisted maintainer refinement and verification.

## Evidence

- Tested from current-main baseline `29625bc310f58dc6d6a7d66bf84b9e06e89709b3` with installed Execa 10.0.1 and Node 26.7.0 on macOS. No credentials or external provider calls were used.
- Before production edits: the real-child 1,250ms stall regression lost `TAIL` from both stdout and stderr. The 250ms control passed. The original standalone long-stall probe also reproduced output loss twice on that baseline.
- After: `node scripts/run-vitest.mjs src/process/child-process.test.ts src/process/exec.test.ts src/process/exec.no-output-timer.test.ts --reporter verbose` passes 50 tests, with one platform skip. Coverage includes both streams, short/long stalls, quiet inherited pipes, output arriving after the hard cutoff, continued writers, cancellation of pending idle/hard release, ordinary exec results, output caps, and abort/timeout behavior.
- Real owner-to-caller proof: `runExec` and `runCommandWithTimeout` each executed a real shell child while the parent event loop was deliberately parked for 1,250ms after child exit. Both returned exactly `HEAD\nTAIL\n` on stdout and stderr. A separate real continuously writing descendant emitted 23 chunks and settled in 1,027ms; its process group was cleaned up. This is real subprocess proof, not a mocked command result or authenticated provider test.
- Reported-consumer proof: `resolveProjectCheckout` ran all three real Git commands with a 1,250ms stall after each child exit and returned the exact checkout path and repository root. No project-registry, Git consumer, or persistence code was changed.
- Dependency contract inspected directly in installed Execa `lib/resolve/wait-subprocess.js`, `stdio.js`, and `wait-stream.js`: exit and stream completion are awaited separately, and readable premature closure is tolerated. That explains successful exit with truncated output when our owner destroys streams too early.
- Fresh Codex autoreview at its default P0 threshold: no findings. A separate independent full lifecycle/code/test review found no actionable findings in the final diff; it checked the single release owner, cutoff, cleanup, caller contracts, and continued-writer assertion.
- Local `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/process/child-process.ts src/process/child-process.test.ts` passed, including production and core-test typechecks, lint, formatting, all three unused-export scans, import-cycle and boundary/storage guards. `node --import tsx scripts/build-all.mts cliStartup` passed.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33027761269) passed on `c9d901959c956324a10ea91e8e4a692e8e057e3c`, attempt 1. The refreshed ClawSweeper review found no actionable patch defects and independently reran all six lifecycle tests twice; its remaining hosted-CI Rank-up move is satisfied. Its missing installed-Execa inspection is covered by direct maintainer inspection in both proof and native PR checkouts.

<details>
<summary>Focused regression results</summary>

```text
PASS drains descendant output across a 250ms event-loop stall (263ms)
PASS drains descendant output across a 1250ms event-loop stall (1265ms)
PASS releases a quiet inherited pipe after the idle grace (1009ms)
PASS bounds draining from a continuously writing descendant (3ms)
PASS cancels pending idle release when cleaned up (0ms)
PASS cancels pending hard release when cleaned up (1ms)
```

</details>

The empty-SHA error in the unrelated worker-retention CI stress test that led to #130504 remains only a suspected consequence; this PR does not claim that exact causal chain is proven. No UI rendering or provider integration was modified.
