### PR TITLE
fix(claws): keep project archives stable across zlib versions

### DIFF
--- a/src/claws/project-build.ts
+++ b/src/claws/project-build.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { constants as zlibConstants } from "node:zlib";
 import * as tar from "tar";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import {
@@ -184,7 +185,8 @@ export async function buildClawProject(
       {
         cwd: stagingRoot,
         file: temporaryArtifact,
-        gzip: { level: 9, portable: true },
+        // Native zlib match selection varies by version; Huffman-only keeps artifact bytes portable.
+        gzip: { level: 9, portable: true, strategy: zlibConstants.Z_HUFFMAN_ONLY },
         mtime: new Date(0),
         portable: true,
         prefix: "package",

--- a/src/claws/project.test.ts
+++ b/src/claws/project.test.ts
@@ -8,6 +8,20 @@ import { buildClawProject } from "./project-build.js";
 import { ClawProjectError, createClawProject, validateClawProject } from "./project.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const GOLDEN_ARTIFACT_INTEGRITY =
+  "sha256:5fba54933e519f4fc12422a3d555d076ce373be993eed3f6b3575a89aaa62618";
+
+async function createDistinctFile(path: string, content: string): Promise<boolean> {
+  try {
+    await writeFile(path, content, { flag: "wx" });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+}
 
 async function writeRichProject(root: string): Promise<void> {
   await mkdir(join(root, "workspace"), { recursive: true });
@@ -50,9 +64,7 @@ describe("Claw projects", () => {
       output,
     );
 
-    expect(result.integrity).toBe(
-      "sha256:f7377ae66679a8d1088ac2d259b8567d19f584dbc4357949d3d4e0cc09d05874",
-    );
+    expect(result.integrity).toBe(GOLDEN_ARTIFACT_INTEGRITY);
   });
 
   it("matches the golden artifact digest under a restrictive umask", () => {
@@ -85,9 +97,7 @@ describe("Claw projects", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toBe(
-      "sha256:f7377ae66679a8d1088ac2d259b8567d19f584dbc4357949d3d4e0cc09d05874",
-    );
+    expect(result.stdout).toBe(GOLDEN_ARTIFACT_INTEGRITY);
   });
 
   it("creates a minimal project that validates through the canonical reader", async () => {
@@ -428,52 +438,57 @@ describe("Claw projects", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a workspace source that portably collides with CLAW.md",
-    async () => {
-      const project = tempDirs.make("openclaw-claw-manifest-case-collision-");
-      await writeRichProject(project);
-      const manifest = await readFile(join(project, "CLAW.md"), "utf8");
-      await writeFile(
-        join(project, "CLAW.md"),
-        manifest.replace("workspace/reference.md", "claw.md"),
-      );
-      await writeFile(join(project, "claw.md"), "# Conflicting source\n");
+  it("rejects a workspace source that portably collides with CLAW.md", async ({ skip }) => {
+    const project = tempDirs.make("openclaw-claw-manifest-case-collision-");
+    await writeRichProject(project);
+    if (!(await createDistinctFile(join(project, "claw.md"), "# Conflicting source\n"))) {
+      skip("filesystem cannot represent CLAW.md and claw.md as distinct paths");
+    }
+    const manifest = await readFile(join(project, "CLAW.md"), "utf8");
+    await writeFile(
+      join(project, "CLAW.md"),
+      manifest.replace("workspace/reference.md", "claw.md"),
+    );
 
-      await expect(validateClawProject(project)).resolves.toMatchObject({
-        ok: false,
-        diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
-      });
-    },
-  );
+    await expect(validateClawProject(project)).resolves.toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
+    });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a workspace source that portably collides with a custom profile",
-    async () => {
-      const project = tempDirs.make("openclaw-claw-profile-case-collision-");
-      await writeRichProject(project);
-      await rename(
-        join(project, "profiles", "openclaw.yml"),
-        join(project, "profiles", "custom.yaml"),
-      );
-      await writeFile(join(project, "profiles", "CUSTOM.yaml"), "schemaVersion: 1\nagent: {}\n");
-      const manifest = await readFile(join(project, "CLAW.md"), "utf8");
-      await writeFile(
-        join(project, "CLAW.md"),
-        manifest
-          .replace(
-            "agent:\n  id: demo-claw",
-            "agent:\n  id: demo-claw\nmetadata:\n  openclaw.config: profiles/custom.yaml",
-          )
-          .replace("workspace/reference.md", "profiles/CUSTOM.yaml"),
-      );
+  it("rejects a workspace source that portably collides with a custom profile", async ({
+    skip,
+  }) => {
+    const project = tempDirs.make("openclaw-claw-profile-case-collision-");
+    await writeRichProject(project);
+    await rename(
+      join(project, "profiles", "openclaw.yml"),
+      join(project, "profiles", "custom.yaml"),
+    );
+    if (
+      !(await createDistinctFile(
+        join(project, "profiles", "CUSTOM.yaml"),
+        "schemaVersion: 1\nagent: {}\n",
+      ))
+    ) {
+      skip("filesystem cannot represent custom.yaml and CUSTOM.yaml as distinct paths");
+    }
+    const manifest = await readFile(join(project, "CLAW.md"), "utf8");
+    await writeFile(
+      join(project, "CLAW.md"),
+      manifest
+        .replace(
+          "agent:\n  id: demo-claw",
+          "agent:\n  id: demo-claw\nmetadata:\n  openclaw.config: profiles/custom.yaml",
+        )
+        .replace("workspace/reference.md", "profiles/CUSTOM.yaml"),
+    );
 
-      await expect(validateClawProject(project)).resolves.toMatchObject({
-        ok: false,
-        diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
-      });
-    },
-  );
+    await expect(validateClawProject(project)).resolves.toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
+    });
+  });
 
   it.runIf(process.platform !== "win32")(
     "rejects Unicode-normalization collisions between workspace sources",


### PR DESCRIPTION
Related: #117037

## What Problem This Solves

Fixes an issue where Claw authors building the same project on hosts with different native zlib versions could receive different `.tgz` bytes and SHA-256 integrity values. It also fixes portable-path collision tests failing for the wrong reason when the host filesystem cannot represent both case-distinct paths.

## Why This Change Was Made

Claw project builds now select zlib's Huffman-only strategy explicitly through the existing `tar` gzip owner, producing one portable archive byte stream and one golden digest. Collision tests attempt an exclusive create and skip only when the filesystem reports that the second spelling already exists; representable collisions still exercise the canonical validation boundary.

No alternate golden hashes, platform-name skips, fallback compressor, dependency changes, or production test seams are added.

## User Impact

Claw project artifacts are byte-identical across supported native zlib versions, so their reported integrity remains stable across build hosts. Filesystems that can represent case-distinct paths continue to prove portable collision rejection, while filesystems that cannot no longer corrupt the fixture before validation.

## Evidence

- Pre-fix macOS reproduction: the focused suite failed both golden checks with native-zlib digest `sha256:1a65cb726d86a77587e85896b01a7f9184ee6aa451d25ec5de6d6ecbd136574f`; the `CLAW.md` collision case overwrote the manifest and failed with `missing_claw_frontmatter` instead of `project_path_collision`.
- Post-fix macOS: `node scripts/run-vitest.mjs src/claws/project.test.ts` — 25 passed, 3 capability skips, 0 failed. The single golden artifact integrity is `sha256:5fba54933e519f4fc12422a3d555d076ce373be993eed3f6b3575a89aaa62618`.
- Changed gate: `node scripts/check-changed.mjs` passed conflict, ratchet, formatting, dependency, dead-export, core production/test typecheck, changed-file lint, database-first, and media-helper stages. The linked worktree lacks `node_modules/playwright-core`, so the run stopped at the runtime-sidecar loader guard before the final architecture tail; exact-head CI supplies the dependency-complete Linux gate.
- `git diff --check origin/main...HEAD` — clean.
- Fresh Codex-backed autoreview — clean, no accepted/actionable findings.
- Prior reviewed Linux AWS proof was green. Normal pull-request CI is the current exact-head Linux proof; no additional paid remote host was started.

AI-assisted: yes. The resulting source, tests, dependency contracts, and archive bytes were reviewed directly.
