### PR TITLE
perf(test): reuse proxy CLI runtime module

### DIFF
--- a/src/cli/proxy-cli.runtime.test.ts
+++ b/src/cli/proxy-cli.runtime.test.ts
@@ -1,9 +1,9 @@
 // Proxy CLI runtime tests cover proxy runtime process handling and lifecycle events.
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const { getRuntimeConfigMock, runProxyValidationMock, serverStopSpy, spawnMock } = vi.hoisted(
   () => ({
@@ -37,6 +37,21 @@ vi.mock("../infra/net/proxy/proxy-validation.js", () => ({
   runProxyValidation: runProxyValidationMock,
 }));
 
+vi.mock("../../packages/terminal-core/src/theme.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../packages/terminal-core/src/theme.js")>();
+  return {
+    ...actual,
+    isRich: () => false,
+  };
+});
+
+import {
+  closeDebugProxyCaptureStore,
+  getDebugProxyCaptureStore,
+} from "../proxy-capture/store.sqlite.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import * as proxyCliRuntime from "./proxy-cli.runtime.js";
+
 describe("proxy cli runtime", () => {
   const envKeys = [
     "OPENCLAW_STATE_DIR",
@@ -47,10 +62,13 @@ describe("proxy cli runtime", () => {
     "NO_COLOR",
   ] as const;
   const savedEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
-  let tempDir = "";
+  const tempDirs = new Set<string>();
+  const tempDir = makeTempDir(tempDirs, "openclaw-proxy-cli-runtime-");
 
   beforeEach(() => {
-    tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-cli-runtime-"));
+    // Reuse the path so missing store/DB cleanup is observable as sessions leaking across cases.
+    mkdirSync(tempDir, { recursive: true });
+    tempDirs.add(tempDir);
     process.env.OPENCLAW_STATE_DIR = tempDir;
     process.env.OPENCLAW_DEBUG_PROXY_CERT_DIR = path.join(tempDir, "certs");
     delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
@@ -88,13 +106,10 @@ describe("proxy cli runtime", () => {
     spawnMock.mockReset();
   });
 
-  afterEach(async () => {
-    const { closeDebugProxyCaptureStore } = await import("../proxy-capture/store.sqlite.js");
-    const { closeOpenClawStateDatabaseForTest } = await import("../state/openclaw-state-db.js");
+  afterEach(() => {
     closeDebugProxyCaptureStore();
     closeOpenClawStateDatabaseForTest();
     vi.restoreAllMocks();
-    vi.resetModules();
     process.exitCode = undefined;
     for (const key of envKeys) {
       const value = savedEnv[key];
@@ -104,13 +119,11 @@ describe("proxy cli runtime", () => {
         process.env[key] = value;
       }
     }
-    rmSync(tempDir, { recursive: true, force: true });
+    cleanupTempDirs(tempDirs);
   });
 
   it("prints proxy validation text and leaves exit code unset on success", async () => {
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({
+    await proxyCliRuntime.runProxyValidateCommand({
       proxyUrl: "http://override.example:3128",
       proxyCaFile: "./ca.pem",
       allowedUrls: ["https://allowed.example/"],
@@ -157,9 +170,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation passed\n\n" +
@@ -180,9 +191,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({ json: true });
+    await proxyCliRuntime.runProxyValidateCommand({ json: true });
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       `${JSON.stringify(
@@ -213,9 +222,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation failed\n\n" +
@@ -241,9 +248,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation failed\n\n" +
@@ -269,9 +274,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation failed\n\n" +
@@ -296,9 +299,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation failed\n\n" +
@@ -323,9 +324,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({ json: true });
+    await proxyCliRuntime.runProxyValidateCommand({ json: true });
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       `${JSON.stringify(
@@ -363,9 +362,7 @@ describe("proxy cli runtime", () => {
         },
       ],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation passed\n\n" +
@@ -375,34 +372,6 @@ describe("proxy cli runtime", () => {
         "Checks\n" +
         "  ✓ denied  http://127.0.0.1:12345/ — fetch failed\n",
     );
-  });
-
-  it("applies the terminal color theme when rich output is enabled", async () => {
-    vi.resetModules();
-    vi.doMock("../../packages/terminal-core/src/theme.js", () => ({
-      colorize: (rich: boolean, color: (value: string) => string, value: string) =>
-        rich ? color(value) : value,
-      isRich: () => true,
-      theme: {
-        heading: (value: string) => `<heading>${value}</heading>`,
-        success: (value: string) => `<success>${value}</success>`,
-        error: (value: string) => `<error>${value}</error>`,
-        muted: (value: string) => `<muted>${value}</muted>`,
-        warn: (value: string) => `<warn>${value}</warn>`,
-      },
-    }));
-    try {
-      const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-      await runProxyValidateCommand({});
-
-      const output = String(vi.mocked(process.stdout["write"]).mock.calls.at(0)?.[0] ?? "");
-      expect(output).toContain("<success>Proxy validation passed</success>");
-      expect(output).toContain("<heading>Checks</heading>");
-      expect(output).toContain("<success>✓</success>");
-    } finally {
-      vi.doUnmock("../../packages/terminal-core/src/theme.js");
-    }
   });
 
   it("prints actionable check failure output", async () => {
@@ -430,9 +399,7 @@ describe("proxy cli runtime", () => {
         },
       ],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({});
+    await proxyCliRuntime.runProxyValidateCommand({});
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       "Proxy validation failed\n\n" +
@@ -458,9 +425,7 @@ describe("proxy cli runtime", () => {
       },
       checks: [],
     });
-    const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
-
-    await runProxyValidateCommand({ json: true });
+    await proxyCliRuntime.runProxyValidateCommand({ json: true });
 
     expect(process.stdout["write"]).toHaveBeenCalledWith(
       `${JSON.stringify(
@@ -480,6 +445,51 @@ describe("proxy cli runtime", () => {
       )}\n`,
     );
     expect(process.exitCode).toBe(1);
+  });
+
+  it.each([
+    { signal: "SIGINT" as const, exitCode: 130 },
+    { signal: "SIGTERM" as const, exitCode: 143 },
+  ])(
+    "preserves exit code $exitCode when the proxied child exits from $signal",
+    async (testCase) => {
+      spawnMock.mockImplementation(() => {
+        const child = new EventEmitter();
+        queueMicrotask(() => {
+          child.emit("exit", null, testCase.signal);
+        });
+        return child;
+      });
+
+      await proxyCliRuntime.runDebugProxyRunCommand({ commandArgs: ["example-command"] });
+
+      expect(process.exitCode).toBe(testCase.exitCode);
+      expect(serverStopSpy).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("stops the proxy server and ends the session when child spawn fails", async () => {
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter();
+      queueMicrotask(() => {
+        child.emit("error", new Error("spawn failed"));
+      });
+      return child;
+    });
+
+    const beforeRun = Date.now();
+    await expect(
+      proxyCliRuntime.runDebugProxyRunCommand({
+        commandArgs: ["does-not-exist"],
+      }),
+    ).rejects.toThrow("spawn failed");
+
+    expect(serverStopSpy).toHaveBeenCalledTimes(1);
+
+    const store = getDebugProxyCaptureStore();
+    const [session] = store.listSessions(5);
+    expect(session?.mode).toBe("proxy-run");
+    expect(session?.endedAt).toBeGreaterThanOrEqual(beforeRun);
   });
 
   it.each([
@@ -506,9 +516,7 @@ describe("proxy cli runtime", () => {
       assertShape: (value: unknown) => expect(value).toEqual({ rows: [] }),
     },
   ])("prints one undecorated JSON object for proxy $name --json", async ({ run, assertShape }) => {
-    const runtime = await import("./proxy-cli.runtime.js");
-
-    await run(runtime);
+    await run(proxyCliRuntime);
 
     expect(process.stdout["write"]).toHaveBeenCalledOnce();
     const output = String(vi.mocked(process.stdout["write"]).mock.calls[0]?.[0] ?? "");
@@ -528,61 +536,9 @@ describe("proxy cli runtime", () => {
         await runtime.runDebugProxyQueryCommand({ preset: "double-sends" }),
     },
   ])("preserves the legacy bare-array proxy $name output without --json", async ({ run }) => {
-    const runtime = await import("./proxy-cli.runtime.js");
-
-    await run(runtime);
+    await run(proxyCliRuntime);
 
     const output = String(vi.mocked(process.stdout["write"]).mock.calls[0]?.[0] ?? "");
     expect(JSON.parse(output)).toEqual([]);
-  });
-
-  it.each([
-    { signal: "SIGINT" as const, exitCode: 130 },
-    { signal: "SIGTERM" as const, exitCode: 143 },
-  ])(
-    "preserves exit code $exitCode when the proxied child exits from $signal",
-    async (testCase) => {
-      spawnMock.mockImplementation(() => {
-        const child = new EventEmitter();
-        queueMicrotask(() => {
-          child.emit("exit", null, testCase.signal);
-        });
-        return child;
-      });
-
-      const { runDebugProxyRunCommand } = await import("./proxy-cli.runtime.js");
-
-      await runDebugProxyRunCommand({ commandArgs: ["example-command"] });
-
-      expect(process.exitCode).toBe(testCase.exitCode);
-      expect(serverStopSpy).toHaveBeenCalledOnce();
-    },
-  );
-
-  it("stops the proxy server and ends the session when child spawn fails", async () => {
-    spawnMock.mockImplementation(() => {
-      const child = new EventEmitter();
-      queueMicrotask(() => {
-        child.emit("error", new Error("spawn failed"));
-      });
-      return child;
-    });
-
-    const { runDebugProxyRunCommand } = await import("./proxy-cli.runtime.js");
-    const { getDebugProxyCaptureStore } = await import("../proxy-capture/store.sqlite.js");
-
-    const beforeRun = Date.now();
-    await expect(
-      runDebugProxyRunCommand({
-        commandArgs: ["does-not-exist"],
-      }),
-    ).rejects.toThrow("spawn failed");
-
-    expect(serverStopSpy).toHaveBeenCalledTimes(1);
-
-    const store = getDebugProxyCaptureStore();
-    const [session] = store.listSessions(5);
-    expect(session?.mode).toBe("proxy-run");
-    expect(session?.endedAt).toBeGreaterThanOrEqual(beforeRun);
   });
 });

--- a/src/cli/proxy-cli.runtime.theme.test.ts
+++ b/src/cli/proxy-cli.runtime.theme.test.ts
@@ -1,0 +1,79 @@
+// Proxy CLI rich-theme coverage stays isolated because the theme mock must precede runtime import.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getRuntimeConfigMock, runProxyValidationMock } = vi.hoisted(() => ({
+  getRuntimeConfigMock: vi.fn(),
+  runProxyValidationMock: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: getRuntimeConfigMock,
+}));
+
+vi.mock("../infra/net/proxy/proxy-validation.js", () => ({
+  runProxyValidation: runProxyValidationMock,
+}));
+
+describe("proxy cli runtime theme", () => {
+  beforeEach(() => {
+    getRuntimeConfigMock.mockReset();
+    getRuntimeConfigMock.mockReturnValue({
+      proxy: {
+        enabled: true,
+        proxyUrl: "http://config-proxy.example:3128",
+      },
+    });
+    runProxyValidationMock.mockReset();
+    runProxyValidationMock.mockResolvedValue({
+      ok: true,
+      config: {
+        enabled: true,
+        proxyUrl: "http://config-proxy.example:3128",
+        source: "config",
+        errors: [],
+      },
+      checks: [
+        {
+          kind: "allowed",
+          url: "https://example.com/",
+          ok: true,
+          status: 200,
+        },
+      ],
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("applies the terminal color theme when rich output is enabled", async () => {
+    vi.resetModules();
+    vi.doMock("../../packages/terminal-core/src/theme.js", () => ({
+      colorize: (rich: boolean, color: (value: string) => string, value: string) =>
+        rich ? color(value) : value,
+      isRich: () => true,
+      theme: {
+        heading: (value: string) => `<heading>${value}</heading>`,
+        success: (value: string) => `<success>${value}</success>`,
+        error: (value: string) => `<error>${value}</error>`,
+        muted: (value: string) => `<muted>${value}</muted>`,
+        warn: (value: string) => `<warn>${value}</warn>`,
+      },
+    }));
+    try {
+      const { runProxyValidateCommand } = await import("./proxy-cli.runtime.js");
+
+      await runProxyValidateCommand({});
+
+      const output = String(vi.mocked(process.stdout["write"]).mock.calls.at(0)?.[0] ?? "");
+      expect(output).toContain("<success>Proxy validation passed</success>");
+      expect(output).toContain("<heading>Checks</heading>");
+      expect(output).toContain("<success>✓</success>");
+    } finally {
+      vi.doUnmock("../../packages/terminal-core/src/theme.js");
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The 19 ordinary proxy CLI runtime cases rebuilt the runtime module graph between cases. That made this focused suite slower and more memory-hungry, while a fresh state directory per case could hide store or state-database cleanup leaks.

## Why This Change Was Made

The ordinary cases now import the proxy CLI runtime once, reuse one state directory, and explicitly close the canonical proxy-capture store and OpenClaw state database after every case. Reusing the state directory makes a missed cleanup observable as leaked session state instead of masking it with a new directory.

The rich-theme case remains in a separate cold-import test file because its theme mock must be installed before importing the runtime module. This preserves the mock-before-import contract without forcing the other 19 cases to reset and rebuild the full graph.

## User Impact

There is no production behavior change. Maintainers get a faster, lower-memory proxy CLI suite with a sharper cleanup regression signal. Production LOC is +0/-0; tests are +161/-126. No changelog entry is needed for this test-only change.

## Evidence

### Performance

- Testbox A/B run: https://github.com/openclaw/openclaw/actions/runs/32062033272
- Wall time: 4.63s -> 4.03s (-0.61s, -13.1%)
- Test body: 1.19s -> 0.452s
- Peak RSS: 514,076 KiB -> 418,948 KiB

### Fault signal and cleanup

- The ordinary suite reuses one state directory, so leaked proxy sessions persist into later cases if either canonical cleanup call is removed.
- The spawn-failure case proves the proxy server stops and the session receives an end timestamp.
- SIGINT and SIGTERM cases preserve exit codes 130 and 143.

### Tests and review

- Exact hosted Testbox: `tbx_01m08mdmgz0528v25v87dhzetg`
- Exact-head run: https://github.com/openclaw/openclaw/actions/runs/32062591806
- Changed gate: green in 11m15s
- Focused targets: 20 passed
- Owner/sibling coverage: 343 passed
- Lint: clean
- Autoreview: 0.99, no actionable findings
