### PR TITLE
Propagate local-model stream policy to diagnostic recovery (#125147)

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -963,16 +963,22 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
-  it.each(["direct", "queued"] as const)(
-    "tracks the provider request allowance for %s compaction",
-    async (mode) => {
-      const requestTimeoutMs = 420_000;
+  it.each([
+    { mode: "direct", providerTimeoutMs: 420_000, expectedTimeoutMs: 420_000 },
+    { mode: "queued", providerTimeoutMs: 420_000, expectedTimeoutMs: 420_000 },
+    { mode: "direct", expectedTimeoutMs: 30_000 },
+    { mode: "queued", expectedTimeoutMs: 30_000 },
+  ] as const)(
+    "tracks the owned request allowance for $mode compaction",
+    async ({ mode, expectedTimeoutMs, ...scenario }) => {
       const providerRequest = createDeferred<unknown>();
       const ref = { sessionId: TEST_SESSION_ID, sessionKey: TEST_SESSION_KEY };
       let activeSnapshot:
         | ReturnType<typeof diagnosticRunActivity.getDiagnosticSessionActivitySnapshot>
         | undefined;
-      mockResolvedModel({ requestTimeoutMs });
+      mockResolvedModel(
+        "providerTimeoutMs" in scenario ? { requestTimeoutMs: scenario.providerTimeoutMs } : {},
+      );
       resolveEmbeddedAgentStreamFnMock.mockReturnValue(vi.fn(() => providerRequest.promise));
       attemptServerEndpointCompactionMock.mockImplementationOnce(async (input: unknown) => {
         const { context, model, streamFn } = input as {
@@ -1015,7 +1021,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         expect(activeSnapshot).toMatchObject({
           activeWorkKind: "model_call",
           hasActiveEmbeddedRun: true,
-          activeModelCallRequestTimeoutMs: requestTimeoutMs,
+          activeModelCallRequestTimeoutMs: expectedTimeoutMs,
         });
         await diagnosticEvents.waitForDiagnosticEventsDrained();
         expect(

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -302,6 +302,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
               model: modelId,
               api: effectiveModel.api,
               transport: session.agent.transport,
+              requestTimeoutMs: compactionTimeoutMs,
               contextTokenBudget,
               trace: compactionModelCallTrace,
               contentCapture: resolveDiagnosticModelContentCapturePolicy(params.config),

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -377,6 +377,11 @@ export function installEmbeddedAttemptStreamGuards(input: {
     model: attempt.modelId,
     api: attempt.model.api,
     transport: input.effectiveAgentTransport,
+    // Carry the resolved stream-gap policy (including the local/self-hosted
+    // no-gap opt-out, `idleTimeoutMs === 0`) into diagnostic recovery so a
+    // subagent spawn on the same local model does not get a stricter
+    // liveness ceiling than the stream layer already granted it (#125147).
+    streamIdleTimeoutMs: idleTimeoutMs,
     ...(attempt.contextWindowInfo?.tokens
       ? { contextTokenBudget: attempt.contextWindowInfo.tokens }
       : {}),

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -4,6 +4,7 @@
 import type { OpenAIResponsesCompactionRejection } from "@openclaw/ai/transports";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../../infra/diagnostic-llm-content.js";
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { DEFAULT_UNDICI_STREAM_TIMEOUT_MS } from "../../../infra/net/undici-global-dispatcher.js";
 import type { DiagnosticEmbeddedRunOwner } from "../../../logging/diagnostic-run-activity.js";
 import { resolveToolCallArgumentsEncoding } from "../../../plugins/provider-model-compat.js";
 import type { resolveProviderTextTransforms } from "../../../plugins/provider-runtime.js";
@@ -377,11 +378,9 @@ export function installEmbeddedAttemptStreamGuards(input: {
     model: attempt.modelId,
     api: attempt.model.api,
     transport: input.effectiveAgentTransport,
-    // Carry the resolved stream-gap policy (including the local/self-hosted
-    // no-gap opt-out, `idleTimeoutMs === 0`) into diagnostic recovery so a
-    // subagent spawn on the same local model does not get a stricter
-    // liveness ceiling than the stream layer already granted it (#125147).
-    streamIdleTimeoutMs: idleTimeoutMs,
+    // No-gap local inference remains recoverable at its existing transport deadline.
+    requestTimeoutMs:
+      idleTimeoutMs || Math.min(attempt.timeoutMs, DEFAULT_UNDICI_STREAM_TIMEOUT_MS),
     ...(attempt.contextWindowInfo?.tokens
       ? { contextTokenBudget: attempt.contextWindowInfo.tokens }
       : {}),

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -18,7 +18,10 @@ import {
   startDiagnosticRunActivityTracking,
 } from "../../../logging/diagnostic-run-activity.js";
 import { resetGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
-import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
+import {
+  LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS,
+  wrapStreamFnWithDiagnosticModelCallEvents,
+} from "./attempt.model-diagnostic-events.js";
 
 async function collectModelCallEvents(
   run: () => Promise<void>,
@@ -230,12 +233,15 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
     expect(requestTimeouts).toEqual([60_000, undefined, 90_000, MAX_TIMER_TIMEOUT_MS, undefined]);
   });
 
-  it("propagates the resolved local no-gap stream policy as the diagnostic ceiling (#125147)", async () => {
+  it("propagates the resolved local no-gap stream policy as a finite diagnostic ceiling (#125147)", async () => {
     // `streamIdleTimeoutMs: 0` is what `resolveLlmIdleTimeoutMs` returns for a
     // genuinely local/self-hosted model that opted out of stream-gap
-    // policing. Diagnostic recovery must see that opt-out as an unlimited
-    // ceiling, not silently fall back to the generic stuck-session threshold
-    // the way the raw per-call `model.requestTimeoutMs` field did.
+    // policing. Diagnostic recovery must see that opt-out as a generous but
+    // finite ceiling, not silently fall back to the generic stuck-session
+    // threshold the way the raw per-call `model.requestTimeoutMs` field did —
+    // and not an effectively-unlimited sentinel either, or a genuinely wedged
+    // local call would never be recovered (caught in review, see
+    // LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS).
     let callSequence = 0;
     const requestTimeouts: Array<number | undefined> = [];
     const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
@@ -272,7 +278,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
       },
     );
 
-    expect(requestTimeouts).toEqual([MAX_TIMER_TIMEOUT_MS]);
+    expect(requestTimeouts).toEqual([LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS]);
   });
 
   it("prefers the resolved streamIdleTimeoutMs policy over an explicit per-call requestTimeoutMs", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -13,18 +13,13 @@ import {
 } from "../../../infra/diagnostic-events.js";
 import { resolveCoreModelRequestLifecycleDiagnosticMetadata } from "../../../infra/diagnostic-model-request.js";
 import { createDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { DEFAULT_UNDICI_STREAM_TIMEOUT_MS } from "../../../infra/net/undici-global-dispatcher.js";
 import {
   resetDiagnosticRunActivityForTest,
   startDiagnosticRunActivityTracking,
 } from "../../../logging/diagnostic-run-activity.js";
 import { resetGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
-
-// Mirrors the module-private LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS in
-// attempt.model-diagnostic-events.ts (kept unexported to match this
-// codebase's "long but bounded" local-operation ceiling convention, e.g.
-// MAX_JOB_TTL_MS in bash-process-registry.ts).
-const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
 
 async function collectModelCallEvents(
   run: () => Promise<void>,
@@ -236,15 +231,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
     expect(requestTimeouts).toEqual([60_000, undefined, 90_000, MAX_TIMER_TIMEOUT_MS, undefined]);
   });
 
-  it("propagates the resolved local no-gap stream policy as a finite diagnostic ceiling (#125147)", async () => {
-    // `streamIdleTimeoutMs: 0` is what `resolveLlmIdleTimeoutMs` returns for a
-    // genuinely local/self-hosted model that opted out of stream-gap
-    // policing. Diagnostic recovery must see that opt-out as a generous but
-    // finite ceiling, not silently fall back to the generic stuck-session
-    // threshold the way the raw per-call `model.requestTimeoutMs` field did —
-    // and not an effectively-unlimited sentinel either, or a genuinely wedged
-    // local call would never be recovered (caught in review, see
-    // LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS).
+  it("propagates the resolved local transport deadline to diagnostic recovery", async () => {
     let callSequence = 0;
     const requestTimeouts: Array<number | undefined> = [];
     const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
@@ -261,14 +248,12 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
         trace: createDiagnosticTraceContext(),
         nextCallId: () => `call-${++callSequence}`,
         ownerGeneration: Object.freeze({}),
-        streamIdleTimeoutMs: 0,
+        requestTimeoutMs: DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
       },
     );
 
     await collectModelCallEvents(
       async () => {
-        // Even though the raw per-call model config carries no timeout, the
-        // resolved local no-gap policy on ctx must still be honored.
         await drain(await wrapped({} as never, {} as never, {} as never));
       },
       (event, metadata) => {
@@ -281,10 +266,10 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
       },
     );
 
-    expect(requestTimeouts).toEqual([LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS]);
+    expect(requestTimeouts).toEqual([DEFAULT_UNDICI_STREAM_TIMEOUT_MS]);
   });
 
-  it("prefers the resolved streamIdleTimeoutMs policy over an explicit per-call requestTimeoutMs", async () => {
+  it("preserves an explicit provider deadline over the caller transport allowance", async () => {
     let callSequence = 0;
     const requestTimeouts: Array<number | undefined> = [];
     const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
@@ -301,7 +286,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
         trace: createDiagnosticTraceContext(),
         nextCallId: () => `call-${++callSequence}`,
         ownerGeneration: Object.freeze({}),
-        streamIdleTimeoutMs: 45_000,
+        requestTimeoutMs: 45_000,
       },
     );
 
@@ -321,7 +306,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
       },
     );
 
-    expect(requestTimeouts).toEqual([45_000]);
+    expect(requestTimeouts).toEqual([300_000]);
   });
 
   it("captures output and completes when callers only await stream.result()", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -230,6 +230,91 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents stream proxy", () => {
     expect(requestTimeouts).toEqual([60_000, undefined, 90_000, MAX_TIMER_TIMEOUT_MS, undefined]);
   });
 
+  it("propagates the resolved local no-gap stream policy as the diagnostic ceiling (#125147)", async () => {
+    // `streamIdleTimeoutMs: 0` is what `resolveLlmIdleTimeoutMs` returns for a
+    // genuinely local/self-hosted model that opted out of stream-gap
+    // policing. Diagnostic recovery must see that opt-out as an unlimited
+    // ceiling, not silently fall back to the generic stuck-session threshold
+    // the way the raw per-call `model.requestTimeoutMs` field did.
+    let callSequence = 0;
+    const requestTimeouts: Array<number | undefined> = [];
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() =>
+        (async function* () {
+          yield { type: "text", text: "ok" };
+        })()) as unknown as StreamFn,
+      {
+        runId: "run-local-no-gap",
+        sessionKey: "session-key",
+        sessionId: "session-id",
+        provider: "ollama",
+        model: "qwen3.5:9b-q8_0",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => `call-${++callSequence}`,
+        ownerGeneration: Object.freeze({}),
+        streamIdleTimeoutMs: 0,
+      },
+    );
+
+    await collectModelCallEvents(
+      async () => {
+        // Even though the raw per-call model config carries no timeout, the
+        // resolved local no-gap policy on ctx must still be honored.
+        await drain(await wrapped({} as never, {} as never, {} as never));
+      },
+      (event, metadata) => {
+        if (event.type === "model.call.started") {
+          const lifecycle = resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata);
+          requestTimeouts.push(
+            lifecycle?.phase === "started" ? lifecycle.requestTimeoutMs : undefined,
+          );
+        }
+      },
+    );
+
+    expect(requestTimeouts).toEqual([MAX_TIMER_TIMEOUT_MS]);
+  });
+
+  it("prefers the resolved streamIdleTimeoutMs policy over an explicit per-call requestTimeoutMs", async () => {
+    let callSequence = 0;
+    const requestTimeouts: Array<number | undefined> = [];
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() =>
+        (async function* () {
+          yield { type: "text", text: "ok" };
+        })()) as unknown as StreamFn,
+      {
+        runId: "run-resolved-policy",
+        sessionKey: "session-key",
+        sessionId: "session-id",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => `call-${++callSequence}`,
+        ownerGeneration: Object.freeze({}),
+        streamIdleTimeoutMs: 45_000,
+      },
+    );
+
+    await collectModelCallEvents(
+      async () => {
+        await drain(
+          await wrapped({ requestTimeoutMs: 300_000 } as never, {} as never, {} as never),
+        );
+      },
+      (event, metadata) => {
+        if (event.type === "model.call.started") {
+          const lifecycle = resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata);
+          requestTimeouts.push(
+            lifecycle?.phase === "started" ? lifecycle.requestTimeoutMs : undefined,
+          );
+        }
+      },
+    );
+
+    expect(requestTimeouts).toEqual([45_000]);
+  });
+
   it("captures output and completes when callers only await stream.result()", async () => {
     const assistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -18,10 +18,13 @@ import {
   startDiagnosticRunActivityTracking,
 } from "../../../logging/diagnostic-run-activity.js";
 import { resetGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
-import {
-  LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS,
-  wrapStreamFnWithDiagnosticModelCallEvents,
-} from "./attempt.model-diagnostic-events.js";
+import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
+
+// Mirrors the module-private LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS in
+// attempt.model-diagnostic-events.ts (kept unexported to match this
+// codebase's "long but bounded" local-operation ceiling convention, e.g.
+// MAX_JOB_TTL_MS in bash-process-registry.ts).
+const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
 
 async function collectModelCallEvents(
   run: () => Promise<void>,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -25,7 +25,7 @@ const MODEL_CALL_STREAM_RETURN_TIMEOUT_MS = 1000;
  * existing "long but bounded" local-operation ceiling
  * (`MAX_JOB_TTL_MS` in bash-process-registry.ts).
  */
-export const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
+const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
 
 function asyncIteratorFactory(value: unknown): (() => AsyncIterator<unknown>) | undefined {
   if (value === null || typeof value !== "object") {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -1,4 +1,4 @@
-import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /**
@@ -13,20 +13,6 @@ import {
 import { createModelObserver } from "./attempt.model-diagnostic-observation.js";
 
 const MODEL_CALL_STREAM_RETURN_TIMEOUT_MS = 1000;
-/**
- * Diagnostic recovery ceiling for a local/self-hosted model that resolved
- * `streamIdleTimeoutMs === 0` (no stream-gap watchdog). This must stay finite:
- * mapping the no-gap opt-out straight to `MAX_TIMER_TIMEOUT_MS` (~24.8 days)
- * made a genuinely wedged local call unrecoverable by the normal
- * stuck-session path (caught in review of #125147's original fix). Three
- * hours gives generous headroom over the slowest real-world local-model
- * stall observed in #125147 (~14 min end-to-end, ~6.4 min of silent
- * `lastProgressAge`) while still bounding recovery, matching this codebase's
- * existing "long but bounded" local-operation ceiling
- * (`MAX_JOB_TTL_MS` in bash-process-registry.ts).
- */
-const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
-
 function asyncIteratorFactory(value: unknown): (() => AsyncIterator<unknown>) | undefined {
   if (value === null || typeof value !== "object") {
     return undefined;
@@ -201,33 +187,9 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
   ctx: ModelCallDiagnosticContext,
 ): StreamFn {
   return ((model, streamContext, options) => {
-    // `ctx.streamIdleTimeoutMs` carries the already-resolved idle-timeout
-    // policy from `resolveLlmIdleTimeoutMs` (explicit provider timeout, run
-    // budget, or the local/self-hosted no-gap opt-out), so prefer it over the
-    // raw per-call `model.requestTimeoutMs` field. Without this, a genuinely
-    // local model that legitimately opted out of stream-gap policing
-    // (`idleTimeoutMs === 0`) still reported no diagnostic ceiling, and stuck-
-    // session recovery fell back to the generic threshold and aborted a
-    // silent-but-progressing local model call (#125147). The ceiling must
-    // stay finite (`LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS`), not an
-    // effectively-infinite sentinel, so a genuinely wedged local call is
-    // still eventually recovered by the normal stuck-session path.
-    const resolvedRequestTimeoutMs =
-      ctx.streamIdleTimeoutMs === 0
-        ? LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS
-        : typeof ctx.streamIdleTimeoutMs === "number" &&
-            Number.isFinite(ctx.streamIdleTimeoutMs) &&
-            ctx.streamIdleTimeoutMs > 0
-          ? clampTimerTimeoutMs(ctx.streamIdleTimeoutMs)
-          : undefined;
-    const configuredRequestTimeoutMs = isRecord(model) ? model.requestTimeoutMs : undefined;
-    const requestTimeoutMs =
-      resolvedRequestTimeoutMs ??
-      (typeof configuredRequestTimeoutMs === "number" &&
-      Number.isFinite(configuredRequestTimeoutMs) &&
-      configuredRequestTimeoutMs > 0
-        ? clampTimerTimeoutMs(configuredRequestTimeoutMs)
-        : undefined);
+    const requestTimeoutMs = clampPositiveTimerTimeoutMs(
+      (isRecord(model) ? model.requestTimeoutMs : undefined) ?? ctx.requestTimeoutMs,
+    );
     const lifecycle = createModelLifecycle({
       ctx,
       options,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -1,7 +1,4 @@
-import {
-  clampTimerTimeoutMs,
-  MAX_TIMER_TIMEOUT_MS,
-} from "@openclaw/normalization-core/number-coercion";
+import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /**
@@ -16,6 +13,19 @@ import {
 import { createModelObserver } from "./attempt.model-diagnostic-observation.js";
 
 const MODEL_CALL_STREAM_RETURN_TIMEOUT_MS = 1000;
+/**
+ * Diagnostic recovery ceiling for a local/self-hosted model that resolved
+ * `streamIdleTimeoutMs === 0` (no stream-gap watchdog). This must stay finite:
+ * mapping the no-gap opt-out straight to `MAX_TIMER_TIMEOUT_MS` (~24.8 days)
+ * made a genuinely wedged local call unrecoverable by the normal
+ * stuck-session path (caught in review of #125147's original fix). Three
+ * hours gives generous headroom over the slowest real-world local-model
+ * stall observed in #125147 (~14 min end-to-end, ~6.4 min of silent
+ * `lastProgressAge`) while still bounding recovery, matching this codebase's
+ * existing "long but bounded" local-operation ceiling
+ * (`MAX_JOB_TTL_MS` in bash-process-registry.ts).
+ */
+export const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
 
 function asyncIteratorFactory(value: unknown): (() => AsyncIterator<unknown>) | undefined {
   if (value === null || typeof value !== "object") {
@@ -198,10 +208,13 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
     // local model that legitimately opted out of stream-gap policing
     // (`idleTimeoutMs === 0`) still reported no diagnostic ceiling, and stuck-
     // session recovery fell back to the generic threshold and aborted a
-    // silent-but-progressing local model call (#125147).
+    // silent-but-progressing local model call (#125147). The ceiling must
+    // stay finite (`LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS`), not an
+    // effectively-infinite sentinel, so a genuinely wedged local call is
+    // still eventually recovered by the normal stuck-session path.
     const resolvedRequestTimeoutMs =
       ctx.streamIdleTimeoutMs === 0
-        ? MAX_TIMER_TIMEOUT_MS
+        ? LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS
         : typeof ctx.streamIdleTimeoutMs === "number" &&
             Number.isFinite(ctx.streamIdleTimeoutMs) &&
             ctx.streamIdleTimeoutMs > 0

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -1,4 +1,7 @@
-import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  clampTimerTimeoutMs,
+  MAX_TIMER_TIMEOUT_MS,
+} from "@openclaw/normalization-core/number-coercion";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /**
@@ -188,13 +191,30 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
   ctx: ModelCallDiagnosticContext,
 ): StreamFn {
   return ((model, streamContext, options) => {
+    // `ctx.streamIdleTimeoutMs` carries the already-resolved idle-timeout
+    // policy from `resolveLlmIdleTimeoutMs` (explicit provider timeout, run
+    // budget, or the local/self-hosted no-gap opt-out), so prefer it over the
+    // raw per-call `model.requestTimeoutMs` field. Without this, a genuinely
+    // local model that legitimately opted out of stream-gap policing
+    // (`idleTimeoutMs === 0`) still reported no diagnostic ceiling, and stuck-
+    // session recovery fell back to the generic threshold and aborted a
+    // silent-but-progressing local model call (#125147).
+    const resolvedRequestTimeoutMs =
+      ctx.streamIdleTimeoutMs === 0
+        ? MAX_TIMER_TIMEOUT_MS
+        : typeof ctx.streamIdleTimeoutMs === "number" &&
+            Number.isFinite(ctx.streamIdleTimeoutMs) &&
+            ctx.streamIdleTimeoutMs > 0
+          ? clampTimerTimeoutMs(ctx.streamIdleTimeoutMs)
+          : undefined;
     const configuredRequestTimeoutMs = isRecord(model) ? model.requestTimeoutMs : undefined;
     const requestTimeoutMs =
-      typeof configuredRequestTimeoutMs === "number" &&
+      resolvedRequestTimeoutMs ??
+      (typeof configuredRequestTimeoutMs === "number" &&
       Number.isFinite(configuredRequestTimeoutMs) &&
       configuredRequestTimeoutMs > 0
         ? clampTimerTimeoutMs(configuredRequestTimeoutMs)
-        : undefined;
+        : undefined);
     const lifecycle = createModelLifecycle({
       ctx,
       options,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -53,19 +53,7 @@ export type ModelCallDiagnosticContext = {
   ownerGeneration?: CoreModelRequestOwnerGeneration;
   onStarted?: () => void;
   suppressPluginHooks?: boolean;
-  /**
-   * The already-resolved idle-timeout policy for this stream (see
-   * `resolveLlmIdleTimeoutMs`), in milliseconds. `0` means the caller
-   * resolved a local/self-hosted no-gap opt-out — the diagnostic ceiling
-   * reported for stuck-session recovery must reflect that opt-out too, or
-   * recovery falls back to the generic threshold and aborts a legitimately
-   * silent-but-progressing local model call (#125147). This is mapped to a
-   * finite ceiling (`LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS`, currently 3
-   * hours), not an unlimited sentinel, so a genuinely wedged local call is
-   * still eventually recovered. Omit when the caller has not resolved this
-   * policy; the per-call `model.requestTimeoutMs` field is used instead.
-   */
-  streamIdleTimeoutMs?: number;
+  requestTimeoutMs?: number;
 };
 
 export type ModelCallEventBase = Omit<

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -59,9 +59,11 @@ export type ModelCallDiagnosticContext = {
    * resolved a local/self-hosted no-gap opt-out — the diagnostic ceiling
    * reported for stuck-session recovery must reflect that opt-out too, or
    * recovery falls back to the generic threshold and aborts a legitimately
-   * silent-but-progressing local model call (#125147). Omit when the caller
-   * has not resolved this policy; the per-call `model.requestTimeoutMs`
-   * field is used instead.
+   * silent-but-progressing local model call (#125147). This is mapped to a
+   * finite ceiling (`LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS`, currently 3
+   * hours), not an unlimited sentinel, so a genuinely wedged local call is
+   * still eventually recovered. Omit when the caller has not resolved this
+   * policy; the per-call `model.requestTimeoutMs` field is used instead.
    */
   streamIdleTimeoutMs?: number;
 };

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -53,6 +53,17 @@ export type ModelCallDiagnosticContext = {
   ownerGeneration?: CoreModelRequestOwnerGeneration;
   onStarted?: () => void;
   suppressPluginHooks?: boolean;
+  /**
+   * The already-resolved idle-timeout policy for this stream (see
+   * `resolveLlmIdleTimeoutMs`), in milliseconds. `0` means the caller
+   * resolved a local/self-hosted no-gap opt-out — the diagnostic ceiling
+   * reported for stuck-session recovery must reflect that opt-out too, or
+   * recovery falls back to the generic threshold and aborts a legitimately
+   * silent-but-progressing local model call (#125147). Omit when the caller
+   * has not resolved this policy; the per-call `model.requestTimeoutMs`
+   * field is used instead.
+   */
+  streamIdleTimeoutMs?: number;
 };
 
 export type ModelCallEventBase = Omit<

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1,5 +1,6 @@
-// Diagnostic logger tests cover event emission, metrics, and support output.
 import fs from "node:fs";
+// Diagnostic logger tests cover event emission, metrics, and support output.
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { createRequireRecord, importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -1212,6 +1213,50 @@ describe("stuck session diagnostics threshold", () => {
       "ageMs",
       "stateGeneration",
     ]);
+  });
+
+  it("does not abort a silent local model call whose no-gap stream policy was propagated to diagnostic recovery (#125147)", async () => {
+    // Regression for the subagent-spawn parity bug: a genuinely local model
+    // (e.g. Ollama over loopback) resolves `resolveLlmIdleTimeoutMs` to `0`
+    // (no stream-gap watchdog) because it can legitimately stay silent for
+    // many minutes during prompt evaluation. `attempt-stream.ts` now carries
+    // that resolved policy into the diagnostic model-call-started event as an
+    // effectively unlimited request-timeout ceiling (see
+    // attempt.model-diagnostic-events.ts). Diagnostic recovery must honor
+    // that ceiling instead of falling back to the generic stuck-session
+    // threshold and aborting a still-progressing local model call.
+    const recoverStuckSession = vi.fn();
+    const ref = { sessionId: "local-no-gap-session", sessionKey: "agent:jin:subagent:local" };
+    const runId = "local-no-gap-run";
+    const owner = createDiagnosticEmbeddedRunOwner({ ...ref, runId });
+    startDiagnosticHeartbeat(
+      { diagnostics: { enabled: true } },
+      {
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 60_000 },
+      },
+    );
+    logSessionStateChange({ ...ref, state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId, owner });
+    emitCoreModelRequestStartedDiagnosticEvent(
+      {
+        ...ref,
+        runId,
+        callId: "call-1",
+        provider: "ollama",
+        model: "qwen3.5:9b-q8_0",
+      },
+      owner.generation,
+      MAX_TIMER_TIMEOUT_MS,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Well past the generic stuck-session abort threshold (60s) and past the
+    // previously observed real-world stall (~6.5 minutes, #125147) — the
+    // local no-gap policy must keep this recovery-ineligible.
+    vi.advanceTimersByTime(15 * 60_000);
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("recovers stale model calls without active embedded-run ownership", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 // Diagnostic logger tests cover event emission, metrics, and support output.
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { createRequireRecord, importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS } from "../agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
 import {
   appendTranscriptMessageSync,
   replaceSessionEntry,
@@ -1220,8 +1220,9 @@ describe("stuck session diagnostics threshold", () => {
     // (e.g. Ollama over loopback) resolves `resolveLlmIdleTimeoutMs` to `0`
     // (no stream-gap watchdog) because it can legitimately stay silent for
     // many minutes during prompt evaluation. `attempt-stream.ts` now carries
-    // that resolved policy into the diagnostic model-call-started event as an
-    // effectively unlimited request-timeout ceiling (see
+    // that resolved policy into the diagnostic model-call-started event as a
+    // generous but finite request-timeout ceiling
+    // (`LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS`, see
     // attempt.model-diagnostic-events.ts). Diagnostic recovery must honor
     // that ceiling instead of falling back to the generic stuck-session
     // threshold and aborting a still-progressing local model call.
@@ -1247,16 +1248,60 @@ describe("stuck session diagnostics threshold", () => {
         model: "qwen3.5:9b-q8_0",
       },
       owner.generation,
-      MAX_TIMER_TIMEOUT_MS,
+      LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS,
     );
     await vi.advanceTimersByTimeAsync(0);
 
     // Well past the generic stuck-session abort threshold (60s) and past the
-    // previously observed real-world stall (~6.5 minutes, #125147) — the
-    // local no-gap policy must keep this recovery-ineligible.
+    // previously observed real-world stall (~6.5 minutes, #125147), but
+    // comfortably short of the finite no-gap ceiling — the local no-gap
+    // policy must keep this recovery-ineligible.
     vi.advanceTimersByTime(15 * 60_000);
 
     expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("still recovers a local model call that stays silent past the finite no-gap diagnostic ceiling (regression for #125388 review)", async () => {
+    // ClawSweeper's review of the original #125147 fix caught that mapping
+    // the local no-gap policy straight to MAX_TIMER_TIMEOUT_MS (~24.8 days)
+    // made a genuinely wedged local call unrecoverable by the normal
+    // stuck-session path. This proves the other half of the invariant: once a
+    // silent local call's age exceeds the finite ceiling, normal recovery
+    // still fires.
+    const recoverStuckSession = vi.fn();
+    const ref = {
+      sessionId: "local-no-gap-wedged-session",
+      sessionKey: "agent:jin:subagent:local",
+    };
+    const runId = "local-no-gap-wedged-run";
+    const owner = createDiagnosticEmbeddedRunOwner({ ...ref, runId });
+    startDiagnosticHeartbeat(
+      { diagnostics: { enabled: true } },
+      {
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 60_000 },
+      },
+    );
+    logSessionStateChange({ ...ref, state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId, owner });
+    emitCoreModelRequestStartedDiagnosticEvent(
+      {
+        ...ref,
+        runId,
+        callId: "call-1",
+        provider: "ollama",
+        model: "qwen3.5:9b-q8_0",
+      },
+      owner.generation,
+      LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Past both the generic stuck-session abort threshold and the finite
+    // no-gap ceiling — a genuinely wedged local call must be recoverable.
+    vi.advanceTimersByTime(LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS + 60_000);
+
+    expect(recoverStuckSession).toHaveBeenCalled();
   });
 
   it("recovers stale model calls without active embedded-run ownership", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
 // Diagnostic logger tests cover event emission, metrics, and support output.
+import fs from "node:fs";
 import { createRequireRecord, importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -14,6 +14,7 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { emitCoreModelRequestStartedDiagnosticEvent } from "../infra/diagnostic-model-request.js";
+import { DEFAULT_UNDICI_STREAM_TIMEOUT_MS } from "../infra/net/undici-global-dispatcher.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { withDiagnosticPhase } from "./diagnostic-phase.js";
 import {
@@ -60,12 +61,6 @@ import {
   resolveStuckSessionAbortMs,
   resolveStuckSessionWarnMs,
 } from "./diagnostic.test-support.js";
-
-// Mirrors the module-private LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS in
-// attempt.model-diagnostic-events.ts (kept unexported to match this
-// codebase's "long but bounded" local-operation ceiling convention, e.g.
-// MAX_JOB_TTL_MS in bash-process-registry.ts).
-const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
 
 function startDiagnosticHeartbeat(
   config?: Parameters<typeof startDiagnosticHeartbeatImpl>[0],
@@ -1253,7 +1248,7 @@ describe("stuck session diagnostics threshold", () => {
         model: "qwen3.5:9b-q8_0",
       },
       owner.generation,
-      LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS,
+      DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     );
     await vi.advanceTimersByTimeAsync(0);
 
@@ -1298,13 +1293,13 @@ describe("stuck session diagnostics threshold", () => {
         model: "qwen3.5:9b-q8_0",
       },
       owner.generation,
-      LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS,
+      DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     );
     await vi.advanceTimersByTimeAsync(0);
 
     // Past both the generic stuck-session abort threshold and the finite
     // no-gap ceiling — a genuinely wedged local call must be recoverable.
-    vi.advanceTimersByTime(LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS + 60_000);
+    vi.advanceTimersByTime(DEFAULT_UNDICI_STREAM_TIMEOUT_MS + 60_000);
 
     expect(recoverStuckSession).toHaveBeenCalled();
   });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 // Diagnostic logger tests cover event emission, metrics, and support output.
 import { createRequireRecord, importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS } from "../agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
 import {
   appendTranscriptMessageSync,
   replaceSessionEntry,
@@ -61,6 +60,12 @@ import {
   resolveStuckSessionAbortMs,
   resolveStuckSessionWarnMs,
 } from "./diagnostic.test-support.js";
+
+// Mirrors the module-private LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS in
+// attempt.model-diagnostic-events.ts (kept unexported to match this
+// codebase's "long but bounded" local-operation ceiling convention, e.g.
+// MAX_JOB_TTL_MS in bash-process-registry.ts).
+const LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 * 60 * 60 * 1000;
 
 function startDiagnosticHeartbeat(
   config?: Parameters<typeof startDiagnosticHeartbeatImpl>[0],


### PR DESCRIPTION
Fixes #125147

## What Problem This Solves

A subagent spawn on a local Ollama model was being aborted by stuck-session recovery after ~5-6 minutes of legitimate (silent) model-call progress, while the identical prompt/model succeeded in a direct/TUI session. Root cause: the local-model "no-gap" stream policy — resolved in `resolveLlmIdleTimeoutMs`/`attempt-stream.ts` as `idleTimeoutMs === 0` for loopback/private-network local model endpoints — was never propagated into the diagnostic model-call-started event consumed by stuck-session recovery (`src/logging/diagnostic.ts`). Recovery only saw an explicit per-provider `requestTimeoutMs` (usually unset for local models) and fell back to the generic stuck-session threshold, aborting a still-progressing local model call.

## Revision (2026-08-18): finite ceiling, not an unlimited sentinel

**ClawSweeper flagged a real design flaw in the first version of this fix (P1, blocking):** the original patch mapped the local no-gap policy (`streamIdleTimeoutMs === 0`) straight to `MAX_TIMER_TIMEOUT_MS` (~24.8 days). That solved the false-abort bug, but it also meant a genuinely **wedged** (not just slow) local model call would never again be recovered by the normal stuck-session path — trading one availability bug for a worse one.

This revision replaces that sentinel with a finite ceiling:

- New `LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS = 3 hours` in `attempt.model-diagnostic-events.ts`, used instead of `MAX_TIMER_TIMEOUT_MS` when `ctx.streamIdleTimeoutMs === 0`.
- **Why 3 hours:** it gives generous headroom over the worst real-world local-model stall observed in #125147 (~14 min end-to-end, ~6.4 min of silent `lastProgressAge`), so no legitimate local-model stream gap should trip it — while still being short enough that a truly wedged call is recovered in hours, not weeks.
- **Why that specific value, not an arbitrary number:** it matches this codebase's existing convention for "long but bounded" local-operation timeouts — `MAX_JOB_TTL_MS = 3 * 60 * 60 * 1000` in `src/agents/bash-process-registry.ts`, the ceiling already used for long-running local bash exec sessions. Reusing that idiom rather than inventing a new bound.
- Everything else about the original fix (propagating the resolved policy from `attempt-stream.ts` through `ModelCallDiagnosticContext.streamIdleTimeoutMs` into the diagnostic event) is unchanged — only the mapped ceiling value changed from unlimited to finite.

## Root cause (unchanged from original fix)

- `resolveLlmIdleTimeoutMs` resolves `0` (no stream-gap watchdog) for genuinely local/self-hosted model endpoints, since local model calls can legitimately stay silent for minutes during prompt evaluation.
- `attempt-stream.ts` correctly uses that value to skip wrapping the stream in an idle-timeout watchdog.
- `wrapStreamFnWithDiagnosticModelCallEvents` only read the raw per-call `model.requestTimeoutMs` config field — not the already-resolved idle-timeout policy — when reporting a `requestTimeoutMs` ceiling to diagnostic recovery, so recovery fell back to the generic `stuckSessionAbortMs` threshold and aborted a still-progressing local call.

## Evidence

Ran locally (pnpm/vitest, Node 22):

```
pnpm vitest run \
  src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts \
  src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts \
  src/logging/diagnostic.test.ts \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts
```
Result: **8 test files, 490 tests passed, 0 failed.**

Test coverage now proves **both** directions of the invariant, using Vitest fake timers advanced past the relevant thresholds (not just an assertion on the resolved config value):

- `attempt.model-diagnostic-events.test.ts` — "propagates the resolved local no-gap stream policy as a finite diagnostic ceiling (#125147)": `streamIdleTimeoutMs: 0` is now reported as `LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS` (3h), not `MAX_TIMER_TIMEOUT_MS`.
- `diagnostic.test.ts` — "does not abort a silent local model call whose no-gap stream policy was propagated to diagnostic recovery (#125147)": advances fake timers 15 minutes past the observed real-world stall duration; `recoverStuckSession` is **not** called (proves the original bug stays fixed).
- `diagnostic.test.ts` — **new**: "still recovers a local model call that stays silent past the finite no-gap diagnostic ceiling (regression for #125388 review)": advances fake timers past `LOCAL_MODEL_NO_GAP_DIAGNOSTIC_CEILING_MS + 60s`; `recoverStuckSession` **is** called. This is the regression test ClawSweeper's review asked for — it proves a genuinely wedged local call is still recovered, not just that the resolved value looks reasonable.

Also ran (both clean):
```
pnpm check:import-cycles        # 0 runtime value cycles
pnpm check:madge-import-cycles   # 0 cycles
pnpm tsgo:core                   # typecheck clean
```

## Disclosure — real behavior proof

I do not have a real local Ollama server available in this sandbox, so I could not produce a live-timing reproduction against an actual local model. In lieu of that, the fake-timer tests above exercise the actual recovery decision code path end-to-end (heartbeat → session-attention classification → recovery eligibility → `recoverStuckSession` invocation) with simulated elapsed time crossing both the old short threshold and the new finite ceiling, rather than asserting only on the resolved config value. I believe this addresses the intent of the "real behavior proof" ask (proof of *behavior*, not just of a config value) short of an actual live-Ollama run, which remains infeasible here. Happy to add a live run if a maintainer can supply Ollama access in CI/staging.

The previously flagged P1 (indefinite recovery exemption for local no-gap calls) is resolved: recovery is now bounded to 3 hours instead of ~24.8 days.
