### PR TITLE
fix: stabilize platform test fixtures on macOS

### DIFF
--- a/src/cli/logs-cli.runtime.test.ts
+++ b/src/cli/logs-cli.runtime.test.ts
@@ -40,7 +40,7 @@ describe("execFileUtf8Tail", () => {
   it("keeps a bounded stderr tail for failed commands", async () => {
     const result = await execFileUtf8Tail(
       process.execPath,
-      ["-e", "process.stderr.write('😀' + 'x'.repeat(64 * 1024)); process.exit(1)"],
+      ["-e", "require('node:fs').writeSync(2, '😀' + 'x'.repeat(64 * 1024)); process.exit(1)"],
       { maxBytes: 1024 },
     );
     expect(result.code).toBe(1);

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
+import { withMockedPlatform } from "../../test-utils/vitest-spies.js";
 import {
   runNodeDaemonInstall,
   runNodeDaemonRestart,
@@ -12,6 +13,10 @@ import {
 } from "./daemon.js";
 
 const TLS_FINGERPRINT = "ab".repeat(32);
+
+async function runLinuxNodeDaemonInstall(opts: Parameters<typeof runNodeDaemonInstall>[0]) {
+  return await withMockedPlatform("linux", () => runNodeDaemonInstall(opts));
+}
 
 const mocks = vi.hoisted(() => {
   const service = {
@@ -281,7 +286,7 @@ describe("runNodeDaemonInstall", () => {
     // isLoaded=true so the service-load verification passes and the linger
     // diagnostic runs on the verified-success path.
     mocks.service.isLoaded.mockResolvedValue(true);
-    await runNodeDaemonInstall({ force: true });
+    await runLinuxNodeDaemonInstall({ force: true });
 
     expect(mocks.readSystemdUserLingerStatus).toHaveBeenCalled();
     expect(mocks.runtime.log).toHaveBeenCalledWith(
@@ -294,7 +299,7 @@ describe("runNodeDaemonInstall", () => {
     mocks.resolveSystemdUserServiceAccount.mockReturnValue("debian");
     mocks.readSystemdUserLingerStatus.mockResolvedValue({ user: "debian", linger: "no" });
 
-    await runNodeDaemonInstall({ force: true });
+    await runLinuxNodeDaemonInstall({ force: true });
 
     expect(mocks.resolveSystemdUserServiceAccount).toHaveBeenCalledWith(process.env);
     expect(mocks.readSystemdUserLingerStatus).toHaveBeenCalledWith({
@@ -308,7 +313,7 @@ describe("runNodeDaemonInstall", () => {
 
   it("includes the linger warning in JSON warnings after a fresh install", async () => {
     mocks.service.isLoaded.mockResolvedValue(true);
-    await runNodeDaemonInstall({ force: true, json: true });
+    await runLinuxNodeDaemonInstall({ force: true, json: true });
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -319,7 +324,7 @@ describe("runNodeDaemonInstall", () => {
 
   it("warns about disabled lingering on the already-installed short-circuit path", async () => {
     mocks.service.isLoaded.mockResolvedValue(true);
-    await runNodeDaemonInstall({ force: false });
+    await runLinuxNodeDaemonInstall({ force: false });
 
     expect(mocks.readSystemdUserLingerStatus).toHaveBeenCalled();
     expect(mocks.runtime.log).toHaveBeenCalledWith(
@@ -330,7 +335,7 @@ describe("runNodeDaemonInstall", () => {
   it("does not warn when systemd lingering is already enabled", async () => {
     mocks.service.isLoaded.mockResolvedValue(true);
     mocks.readSystemdUserLingerStatus.mockResolvedValue({ user: "pi", linger: "yes" });
-    await runNodeDaemonInstall({ force: true });
+    await runLinuxNodeDaemonInstall({ force: true });
 
     expect(mocks.runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("enable-linger"));
   });
@@ -338,7 +343,7 @@ describe("runNodeDaemonInstall", () => {
   it("does not pollute the failure output when service.install throws", async () => {
     mocks.service.isLoaded.mockResolvedValue(true);
     mocks.service.install.mockRejectedValue(new Error("disk full"));
-    await runNodeDaemonInstall({ force: true, json: true });
+    await runLinuxNodeDaemonInstall({ force: true, json: true });
 
     // install() threw before verification, so onVerified never runs and no
     // linger warning accompanies the install-failure payload.
@@ -358,7 +363,7 @@ describe("runNodeDaemonInstall", () => {
     // must NOT run, so a failed verification never tells the operator to fix
     // lingering for a service that was not successfully installed.
     mocks.service.isLoaded.mockResolvedValue(false);
-    await runNodeDaemonInstall({ force: true, json: true });
+    await runLinuxNodeDaemonInstall({ force: true, json: true });
 
     expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
     const calls = mocks.runtime.writeJson.mock.calls;
@@ -375,7 +380,7 @@ describe("runNodeDaemonInstall", () => {
   it("skips the linger check when systemd user services are unavailable", async () => {
     mocks.service.isLoaded.mockResolvedValue(true);
     mocks.isSystemdUserServiceAvailable.mockResolvedValue(false);
-    await runNodeDaemonInstall({ force: true });
+    await runLinuxNodeDaemonInstall({ force: true });
 
     expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
   });

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -551,7 +551,7 @@ describe("update-cli", () => {
   };
 
   const createTrackedTempDir = async (prefix: string) => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
     tempDirsToCleanup.add(dir);
     return dir;
   };

--- a/src/infra/system-run-approval-binding.test.ts
+++ b/src/infra/system-run-approval-binding.test.ts
@@ -334,7 +334,7 @@ describe("missingSystemRunApprovalBinding", () => {
 });
 
 describe("mutable file operand binding", () => {
-  it("binds every script in a compound command and detects drift", async () => {
+  it("binds every script and mutable executable in a compound command", async () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-binding-"));
     const first = path.join(cwd, "first.sh");
     const second = path.join(cwd, "second.py");
@@ -344,7 +344,33 @@ describe("mutable file operand binding", () => {
       const command = { kind: "shell" as const, text: "sh first.sh && python3 second.py" };
       const prepared = expectOk(await prepareSystemRunMutableFileBinding({ command, cwd }));
 
-      expect(prepared.binding.operands).toHaveLength(2);
+      const scriptOperands = prepared.binding.operands.filter((operand) => !operand.executable);
+      expect(
+        scriptOperands.map(({ argv, snapshot }) => ({
+          argv,
+          argvIndex: snapshot.argvIndex,
+          path: snapshot.path,
+        })),
+      ).toEqual([
+        { argv: ["sh", "first.sh"], argvIndex: 1, path: fs.realpathSync(first) },
+        { argv: ["python3", "second.py"], argvIndex: 1, path: fs.realpathSync(second) },
+      ]);
+
+      const executableOperands = prepared.binding.operands.filter((operand) => operand.executable);
+      expect(new Set(executableOperands.map(({ argv }) => JSON.stringify(argv))).size).toBe(
+        executableOperands.length,
+      );
+      for (const operand of executableOperands) {
+        expect(prepared.binding.commands).toContainEqual(operand.argv);
+        expect(operand.snapshot.argvIndex).toBe(0);
+        expect([fs.realpathSync(first), fs.realpathSync(second)]).not.toContain(
+          operand.snapshot.path,
+        );
+        expect(operand.pathSearch).toEqual({
+          path: process.env.PATH,
+          pathExt: process.env.PATHEXT,
+        });
+      }
       await expect(
         revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
       ).resolves.toEqual({ ok: true });

--- a/test/scripts/install-npm-fixtures.ts
+++ b/test/scripts/install-npm-fixtures.ts
@@ -15,7 +15,7 @@ export function writeNpmInstallRetryFixture(path: string) {
       'if [[ "$is_install" -eq 0 ]]; then exit 0; fi',
       'spec="${!#}"',
       'printf "%s\\n" "$spec" >> "$NPM_FAKE_CALLS"',
-      'attempt="$(wc -l < "$NPM_FAKE_CALLS")"',
+      'attempt="$(awk \'END { print NR }\' "$NPM_FAKE_CALLS")"',
       'if [[ "$NPM_FAKE_OUTCOME" == "success" || "$NPM_FAKE_OUTCOME" == "transient" && "$attempt" -eq 2 ]]; then',
       '  if [[ -n "${NPM_FAKE_PACKAGE_DIR:-}" ]]; then',
       '    mkdir -p "$NPM_FAKE_PACKAGE_DIR/dist"',

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   rmSync,
   statSync,
@@ -28,7 +29,7 @@ import {
 const SCRIPT_PATH = "scripts/install.sh";
 
 function runInstallShell(script: string, env: NodeJS.ProcessEnv = {}) {
-  const home = mkdtempSync(join(tmpdir(), "openclaw-install-home-"));
+  const home = mkdtempSync(join(realpathSync(tmpdir()), "openclaw-install-home-"));
   try {
     return spawnSync("bash", ["-c", script], {
       encoding: "utf8",
@@ -301,6 +302,7 @@ describe("install.sh", () => {
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      tmp="$(cd "$tmp" && pwd -P)"
       repo="$tmp/repo"
       node_dir="node-bin"
       cd "$tmp"


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where deterministic installer, update, logging, system-run, and node-daemon tests inherited host-specific macOS path aliases, BSD utility formatting, buffered stderr timing, or the current operating system. Those fixture assumptions caused canonical recovery validation to fail even though the product behavior under test was unchanged.

## Why This Change Was Made

The fixtures now canonicalize temporary roots before comparing resolved paths, count retry attempts without BSD `wc` padding, write the stderr boundary synchronously, assert system-run operand roles instead of a host-dependent aggregate count, and establish an explicit Linux platform context for systemd-linger cases. Production behavior is unchanged.

## User Impact

There is no user-visible product change. Maintainers get deterministic platform-focused tests on macOS and Linux, with stronger system-run approval-binding assertions.

## Evidence

- Pre-fix macOS reproduction: `test/scripts/install-sh.test.ts` failed 4 cases (113 passed), showing `/var` versus `/private/var` path mismatches and padded retry attempts such as `attempt        2`.
- Exact rebased head: `OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs test/scripts/install-sh.test.ts src/infra/system-run-approval-binding.test.ts src/cli/update-cli.test.ts src/cli/logs-cli.runtime.test.ts src/cli/node-cli/daemon.test.ts` — 431 tests passed across 5 files.
- `node scripts/check-changed.mjs` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high --stream-engine-output` — clean, no accepted/actionable findings.
