### PR TITLE
fix(test): prevent tooling stalls in large worktree registries

### DIFF
--- a/scripts/plugin-sdk-api-diff.mts
+++ b/scripts/plugin-sdk-api-diff.mts
@@ -225,26 +225,11 @@ async function main(): Promise<void> {
     { commit: baseCommit, name: "base" },
     { commit: headCommit, name: "head" },
   ] as const;
-  const addedWorktrees: string[] = [];
   const abortController = new AbortController();
   let interruptedExitCode: number | undefined;
   let cleanupPromise: Promise<void> | undefined;
   const cleanup = (): Promise<void> => {
-    cleanupPromise ??= (async () => {
-      let cleanupError: Error | undefined;
-      for (const worktree of addedWorktrees.toReversed()) {
-        try {
-          git(repoRoot, ["worktree", "remove", "--force", worktree]);
-        } catch (error) {
-          cleanupError ??=
-            error instanceof Error ? error : new Error("Plugin SDK API worktree cleanup failed");
-        }
-      }
-      await fs.rm(temporaryRoot, { force: true, recursive: true });
-      if (cleanupError) {
-        throw cleanupError;
-      }
-    })();
+    cleanupPromise ??= fs.rm(temporaryRoot, { force: true, recursive: true });
     return cleanupPromise;
   };
   const stop = (exitCode: number): void => {
@@ -258,12 +243,13 @@ async function main(): Promise<void> {
 
   try {
     for (const root of roots) {
-      const worktree = path.join(temporaryRoot, root.name);
-      git(repoRoot, ["worktree", "add", "--detach", "--no-checkout", worktree, root.commit]);
-      addedWorktrees.push(worktree);
-      git(worktree, ["sparse-checkout", "set", "src", "packages", "patches", "scripts"]);
-      git(worktree, ["checkout", "--detach", root.commit]);
-      await installRevisionDependencies(worktree, abortController.signal);
+      const revisionRoot = path.join(temporaryRoot, root.name);
+      // Each revision owns its Git metadata while hard-linking immutable objects;
+      // API diff runs must not mutate or scan the caller's worktree registry.
+      git(repoRoot, ["clone", "--no-checkout", "--local", "--no-tags", repoRoot, revisionRoot]);
+      git(revisionRoot, ["sparse-checkout", "set", "src", "packages", "patches", "scripts"]);
+      git(revisionRoot, ["checkout", "--detach", root.commit]);
+      await installRevisionDependencies(revisionRoot, abortController.signal);
     }
 
     const baseRenderPath = path.join(temporaryRoot, "base.json");

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1478,8 +1478,7 @@ function resolveImportSpecifier(
   return candidates.find((candidate) => fileSet.has(candidate)) ?? null;
 }
 
-let cachedImportGraph: ImportGraph | null = null;
-let cachedImportGraphCwd: string | null = null;
+const cachedImportGraphs = new Map<string, ImportGraph>();
 const cachedImportGraphFiles = new Map<string, string[]>();
 const cachedImportGraphGrepMatches = new Map<string, string[] | null>();
 const cachedDirectImporters = new Map<string, string[] | null>();
@@ -1746,12 +1745,16 @@ function resolveAffectedTestsFromTargetedImportScan(
   return [...new Set(targets)].toSorted((left, right) => left.localeCompare(right));
 }
 
-function getImportGraph(cwd: string) {
-  if (cachedImportGraph && cachedImportGraphCwd === cwd) {
-    return cachedImportGraph;
+function getImportGraph(cwd: string, options: ImportGraphOptions = {}) {
+  const tooling = options.tooling === true;
+  const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}`;
+  const cached = cachedImportGraphs.get(cacheKey);
+  if (cached) {
+    return cached;
   }
 
-  const files = listImportGraphFilesForCwd(cwd);
+  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  const files = listImportGraphFilesForCwd(cwd, { tooling });
   const fileSet = new Set(files);
   const reverseImports = new Map<string, string[]>();
   const reverseReexports = new Map<string, string[]>();
@@ -1767,7 +1770,12 @@ function getImportGraph(cwd: string) {
       continue;
     }
     for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
-      const imported = resolveImportSpecifier(file, match[1] ?? match[2] ?? "", fileSet);
+      const imported = resolveImportSpecifier(
+        file,
+        match[1] ?? match[2] ?? "",
+        fileSet,
+        extensions,
+      );
       if (!imported) {
         continue;
       }
@@ -1776,7 +1784,7 @@ function getImportGraph(cwd: string) {
       reverseImports.set(imported, importers);
     }
     for (const match of source.matchAll(REEXPORT_SPECIFIER_PATTERN)) {
-      const imported = resolveImportSpecifier(file, match[1] ?? "", fileSet);
+      const imported = resolveImportSpecifier(file, match[1] ?? "", fileSet, extensions);
       if (!imported) {
         continue;
       }
@@ -1786,9 +1794,9 @@ function getImportGraph(cwd: string) {
     }
   }
 
-  cachedImportGraph = { reverseImports, reverseReexports, testFiles };
-  cachedImportGraphCwd = cwd;
-  return cachedImportGraph;
+  const graph = { reverseImports, reverseReexports, testFiles };
+  cachedImportGraphs.set(cacheKey, graph);
+  return graph;
 }
 
 /** Returns whether any changed path reaches one of the requested import-graph targets. */
@@ -1828,17 +1836,17 @@ export function hasImportGraphImpactOnTargets(
 function resolveAffectedTestsFromImportGraph(
   changedPath: string,
   cwd: string,
-  options: { forceFull?: boolean } = {},
+  options: ImportGraphOptions & { direct?: boolean; forceFull?: boolean } = {},
 ) {
   const normalized = normalizePathPattern(changedPath);
   if (options.forceFull !== true) {
-    const targetedTargets = resolveAffectedTestsFromTargetedImportScan(normalized, cwd);
+    const targetedTargets = resolveAffectedTestsFromTargetedImportScan(normalized, cwd, options);
     if (targetedTargets !== null) {
       return targetedTargets;
     }
   }
 
-  const { reverseImports, testFiles } = getImportGraph(cwd);
+  const { reverseImports, testFiles } = getImportGraph(cwd, options);
   const queue = [normalized];
   const seen = new Set(queue);
   const targets = [];
@@ -1852,7 +1860,9 @@ function resolveAffectedTestsFromImportGraph(
       if (testFiles.has(importer)) {
         targets.push(importer);
       }
-      queue.push(importer);
+      if (options.direct !== true) {
+        queue.push(importer);
+      }
     }
   }
 
@@ -3004,15 +3014,14 @@ function resolveToolingTestTargets(changedPath: string, cwd = process.cwd()) {
     semanticTargets.length ||
     conventionalTargets?.length,
   );
-  const importGraphResult =
+  const importGraphTargets =
     !hasDirectOwner &&
     TOOLING_IMPORTABLE_FILE_EXTENSIONS.some((ext) => implementationPath.endsWith(ext))
-      ? resolveAffectedTestsFromTargetedImportScan(implementationPath, cwd, {
+      ? resolveAffectedTestsFromImportGraph(implementationPath, cwd, {
           tooling: true,
           direct: true,
         })
       : [];
-  const importGraphTargets = importGraphResult ?? [];
   const referenceTargets =
     semanticTargets.length === 0 && (githubYamlGuardTargets || !hasDirectOwner)
       ? resolveDirectToolingReferenceTests(implementationPath, cwd)

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -146,7 +146,10 @@ type ChangedTestTargetPlan = {
   skippedBroadFallbackPaths?: string[];
 };
 
-type ImportGraphOptions = { tooling?: boolean };
+type ImportGraphOptions = {
+  targetedScans?: { remaining: number };
+  tooling?: boolean;
+};
 type VitestSpecShape = Pick<VitestRunSpec, "config" | "env">;
 type WatchableVitestSpecShape = VitestSpecShape & Pick<VitestRunSpec, "watchMode">;
 type ImportGraph = {
@@ -813,6 +816,11 @@ const TOOLING_IMPORTABLE_FILE_EXTENSIONS = [
 const TOOLING_IMPORT_GRAPH_GREP_PATHS = TOOLING_IMPORT_GRAPH_ROOTS.flatMap((root) =>
   TOOLING_IMPORTABLE_FILE_EXTENSIONS.map((ext) => `:(glob)${root}/**/*${ext}`),
 );
+// Broad matches make one-rg-per-importer traversal more expensive than building
+// the in-memory graph once, especially for shared test support modules.
+const TARGETED_IMPORT_GRAPH_CANDIDATE_LIMIT = 256;
+// Bound subprocess fanout even when every individual search result is narrow.
+const TARGETED_IMPORT_GRAPH_SCAN_LIMIT = 2;
 const IMPORT_SPECIFIER_PATTERN =
   /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu;
 const REEXPORT_SPECIFIER_PATTERN =
@@ -1642,17 +1650,23 @@ function findDirectImportersWithGitGrep(
     return null;
   }
 
-  let skippedBroadTerm = false;
   const importers: string[] = [];
   for (const term of terms) {
+    if (options.targetedScans && options.targetedScans.remaining === 0) {
+      cachedDirectImporters.set(cacheKey, null);
+      return null;
+    }
+    if (options.targetedScans) {
+      options.targetedScans.remaining -= 1;
+    }
     const candidates = listImportGraphGrepMatches(cwd, term, { tooling });
     if (!candidates) {
       cachedDirectImporters.set(cacheKey, null);
       return null;
     }
-    if (candidates.length > 800) {
-      skippedBroadTerm = true;
-      continue;
+    if (candidates.length > TARGETED_IMPORT_GRAPH_CANDIDATE_LIMIT) {
+      cachedDirectImporters.set(cacheKey, null);
+      return null;
     }
     for (const file of candidates) {
       if (file === importedFile || !fileSet.has(file) || importers.includes(file)) {
@@ -1681,12 +1695,8 @@ function findDirectImportersWithGitGrep(
       break;
     }
   }
-  const result =
-    skippedBroadTerm && importers.length === 0 && !importedFile.startsWith("test/helpers/")
-      ? null
-      : importers;
-  cachedDirectImporters.set(cacheKey, result);
-  return result;
+  cachedDirectImporters.set(cacheKey, importers);
+  return importers;
 }
 
 function resolveAffectedTestsFromTargetedImportScan(
@@ -1708,9 +1718,13 @@ function resolveAffectedTestsFromTargetedImportScan(
   const queue = [normalized];
   const seen = new Set(queue);
   const targets = [];
+  const targetedScans = { remaining: TARGETED_IMPORT_GRAPH_SCAN_LIMIT };
 
   for (const current of queue) {
-    const importers = findDirectImportersWithGitGrep(cwd, current, fileSet, { tooling });
+    const importers = findDirectImportersWithGitGrep(cwd, current, fileSet, {
+      targetedScans,
+      tooling,
+    });
     if (importers === null) {
       return null;
     }

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { resolveVitestCliEntry, resolveVitestNodeArgs } from "../../scripts/run-vitest.mts";
 
 const {
@@ -26,16 +26,58 @@ const VITEST_NODE_PREFIX = [
   resolveVitestCliEntry(),
 ];
 
+let routingFixtureRoot = "";
+
+function writeRoutingFixture(relative: string, source: string) {
+  const target = path.join(routingFixtureRoot, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, source);
+}
+
 describe("test-projects args", () => {
   beforeAll(() => {
-    for (const target of [
-      "src/gateway/gateway-connection.test-mocks.ts",
-      "extensions/memory-core/src/memory/test-runtime-mocks.ts",
-      "test/helpers/temp-dir.ts",
-      "src/commands/onboard-non-interactive.test-helpers.ts",
+    routingFixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-projects-"));
+    writeRoutingFixture("src/gateway/gateway-connection.test-mocks.ts", "export {}\n");
+    writeRoutingFixture(
+      "src/gateway/call.test.ts",
+      'import "./gateway-connection.test-mocks.js";\n',
+    );
+    writeRoutingFixture(
+      "src/tui/gateway-chat.connection.test.ts",
+      'import "../gateway/gateway-connection.test-mocks.js";\n',
+    );
+    writeRoutingFixture("extensions/memory-core/src/memory/test-runtime-mocks.ts", "export {}\n");
+    writeRoutingFixture(
+      "extensions/memory-core/src/memory/test-runtime-consumer.ts",
+      'import "./test-runtime-mocks.js";\n',
+    );
+    for (const file of [
+      "manager.fts-only-reindex.test.ts",
+      "manager-session-update-race.test.ts",
     ]) {
-      buildVitestRunPlans([target]);
+      writeRoutingFixture(
+        `extensions/memory-core/src/memory/${file}`,
+        'import "./test-runtime-consumer.js";\n',
+      );
     }
+    writeRoutingFixture("test/helpers/temp-dir.ts", "export {}\n");
+    writeRoutingFixture("test/helpers/temp-dir.test.ts", 'import "./temp-dir.js";\n');
+    writeRoutingFixture(
+      "src/gateway/temp-dir-consumer.test.ts",
+      'import {} from "../../test/helpers/temp-dir.js";\n',
+    );
+    writeRoutingFixture(
+      "test/scripts/temp-dir-consumer.test.ts",
+      'import {} from "../helpers/temp-dir.js";\n',
+    );
+    spawnSync("git", ["init", "--quiet", "--initial-branch=main"], {
+      cwd: routingFixtureRoot,
+    });
+    spawnSync("git", ["add", "."], { cwd: routingFixtureRoot });
+  });
+
+  afterAll(() => {
+    fs.rmSync(routingFixtureRoot, { force: true, recursive: true });
   });
 
   it("drops a pnpm passthrough separator while preserving targeted filters", () => {
@@ -541,7 +583,9 @@ describe("test-projects args", () => {
   });
 
   it("routes non-test helper file targets to importing tests inside the routed suites", () => {
-    expect(buildVitestRunPlans(["src/gateway/gateway-connection.test-mocks.ts"])).toEqual([
+    expect(
+      buildVitestRunPlans(["src/gateway/gateway-connection.test-mocks.ts"], routingFixtureRoot),
+    ).toEqual([
       {
         config: "test/vitest/vitest.gateway.config.ts",
         forwardedArgs: [],
@@ -559,7 +603,7 @@ describe("test-projects args", () => {
 
   it("routes direct and transitive extension helper importers to the owning config", () => {
     const helper = "extensions/memory-core/src/memory/test-runtime-mocks.ts";
-    const plans = buildVitestRunPlans([helper]);
+    const plans = buildVitestRunPlans([helper], routingFixtureRoot);
 
     expect(plans).toEqual([
       {
@@ -579,7 +623,7 @@ describe("test-projects args", () => {
     // The importer inventory of test/helpers/temp-dir.ts churns with every new
     // test using the helper; frozen full lists broke main on unrelated test
     // additions. Assert the routing structure instead of the inventory.
-    const plans = buildVitestRunPlans(["test/helpers/temp-dir.ts"]);
+    const plans = buildVitestRunPlans(["test/helpers/temp-dir.ts"], routingFixtureRoot);
     const planFiles = plans.map((plan) => plan.includePatterns ?? plan.forwardedArgs);
     const expandedFiles = planFiles.flat();
 
@@ -589,14 +633,14 @@ describe("test-projects args", () => {
     expect(expandedFiles).not.toContain("test/helpers/temp-dir.ts");
     expect(expandedFiles.filter((file) => !file.endsWith(".test.ts"))).toEqual([]);
 
-    // Lower bound derived from the repo itself: every tracked test file that
+    // Lower bound derived from the fixture itself: every tracked test file that
     // directly imports the helper must be picked up by the expansion scan, so
     // dropped importers still fail without freezing the full inventory.
     const scanRoots = ["src", "test", "ui", "extensions", "packages"];
     const grep = spawnSync(
       "git",
       ["grep", "-l", "--fixed-strings", "helpers/temp-dir", "--", ...scanRoots],
-      { encoding: "utf8" },
+      { cwd: routingFixtureRoot, encoding: "utf8" },
     );
     expect(grep.status).toBe(0);
     const directImporterTests = grep.stdout
@@ -604,7 +648,7 @@ describe("test-projects args", () => {
       .map((line) => line.trim())
       .filter((file) => file.endsWith(".test.ts") && !file.endsWith(".live.test.ts"))
       .filter((file) => {
-        const source = fs.readFileSync(file, "utf8");
+        const source = fs.readFileSync(path.join(routingFixtureRoot, file), "utf8");
         return [...source.matchAll(/from\s+["'](\.[^"']+)["']/gu)].some((match) => {
           const importerDir = path.posix.dirname(file);
           const resolved = path.posix.normalize(
@@ -630,7 +674,7 @@ describe("test-projects args", () => {
     for (const plan of plans) {
       expect(plan.watchMode).toBe(false);
       for (const file of plan.includePatterns ?? plan.forwardedArgs) {
-        expect(buildVitestRunPlans([file])).toEqual([
+        expect(buildVitestRunPlans([file], routingFixtureRoot)).toEqual([
           {
             config: plan.config,
             forwardedArgs: plan.includePatterns ? [] : [file],

--- a/test/scripts/plugin-sdk-api-diff.test.ts
+++ b/test/scripts/plugin-sdk-api-diff.test.ts
@@ -23,11 +23,25 @@ async function waitFor(check: () => boolean, timeoutMs: number): Promise<void> {
 }
 
 describe("Plugin SDK API diff CLI", () => {
-  it("interrupts a running child and removes its registered worktree", async () => {
-    const repo = git(process.cwd(), ["rev-parse", "--show-toplevel"]).trim();
+  it("interrupts a running child and removes its isolated clones", async () => {
+    const repo = tempDirs.make("plugin-sdk-api-diff-repo-");
     const runnerTemp = tempDirs.make("plugin-sdk-api-diff-temp-");
     const binDir = tempDirs.make("plugin-sdk-api-diff-bin-");
     const pnpmMarker = join(binDir, "pnpm-started");
+
+    git(repo, ["init", "--initial-branch=main"]);
+    writeFileSync(join(repo, "README.md"), "fixture\n");
+    git(repo, ["add", "README.md"]);
+    git(repo, [
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "-m",
+      "fixture",
+    ]);
+    const worktreeRegistry = git(repo, ["worktree", "list", "--porcelain"]);
 
     const fakePnpm = join(binDir, "pnpm");
     writeFileSync(
@@ -54,6 +68,7 @@ describe("Plugin SDK API diff CLI", () => {
           PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
           PNPM_MARKER: pnpmMarker,
           RUNNER_TEMP: runnerTemp,
+          TSX_TSCONFIG_PATH: resolve("tsconfig.json"),
         },
         stdio: ["ignore", "ignore", "pipe"],
       },
@@ -74,7 +89,8 @@ describe("Plugin SDK API diff CLI", () => {
     try {
       await waitFor(() => existsSync(pnpmMarker) || closed, 10_000);
       expect(closed, stderr).toBe(false);
-      expect(git(repo, ["worktree", "list"])).toContain(runnerTemp);
+      expect(readdirSync(runnerTemp)).not.toEqual([]);
+      expect(git(repo, ["worktree", "list", "--porcelain"])).toBe(worktreeRegistry);
       const interruptedAt = Date.now();
       child.kill("SIGTERM");
       const exitCode = await Promise.race([
@@ -86,7 +102,7 @@ describe("Plugin SDK API diff CLI", () => {
 
       expect(exitCode).toBe(143);
       expect(Date.now() - interruptedAt).toBeLessThan(5_000);
-      expect(git(repo, ["worktree", "list"])).not.toContain(runnerTemp);
+      expect(git(repo, ["worktree", "list", "--porcelain"])).toBe(worktreeRegistry);
       expect(readdirSync(runnerTemp)).toEqual([]);
     } finally {
       if (!closed) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where internal test planning and Plugin SDK API-diff checks could stall or time out when run from a repository with a large shared worktree registry. The test planner repeatedly scanned broad importer sets, while the API-diff runner registered temporary worktrees in the caller's repository and could leave stale registry entries after interruption.

## Why This Change Was Made

Targeted importer discovery is now bounded to two scans and abandons candidate sets over 256 files, falling back to the existing canonical in-memory import graph for complete routing. Plugin SDK API-diff revisions now use sparse local clones with independent Git metadata, so temporary checkouts never read or mutate the caller's worktree registry.

This is AI-assisted work reviewed and understood by the author.

## User Impact

There is no product-facing behavior change. Contributors and CI get deterministic test-project planning and interruptible Plugin SDK API-diff checks even when the source repository has many registered worktrees.

## Evidence

Measured on the same dependency-complete checkout with repository-standard wrappers and unchanged test timeouts:

- Pre-fix `d802a8e8b4e`: `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts` failed the 180s `beforeAll` hook watchdog after 211.20s wall time; patched `f153ef9aa108`: 84/84 tests passed in 5.28s wall time.
- Pre-fix `d802a8e8b4e`: `node scripts/run-vitest.mjs test/scripts/plugin-sdk-api-diff.test.ts` failed waiting for its child after 25.75s and left a prunable temporary worktree registration; patched `f153ef9aa108`: 1/1 test passed in 7.25s with the caller registry unchanged.
- `node scripts/check-changed.mjs` passed all selected formatting, typecheck, lint, dependency, boundary, dead-export, and architecture gates.
- `git diff --check origin/main...HEAD` passed.
- Test audit: the changed tests protect observable importer routing and worktree-registry isolation, cover credible regressions, duplicate no stronger boundary proof, and add no test-only production seam.
- Codex-backed autoreview reported no accepted/actionable findings.
- Tooling LOC is net-neutral: +34/-34. Tests are +78/-18.

Exact-head pull-request CI is the dependency-complete final proof.
