### PR TITLE
fix(memory): stop retained tools after memory is disabled

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -236,6 +236,35 @@ describe("memory tools", () => {
     expect(getMemorySearchManagerMockCalls()).toBe(0);
   });
 
+  it("revokes retained memory tools when live config disables memory", async () => {
+    const startupConfig = asOpenClawConfig({
+      agents: { list: [{ id: "main", default: true }] },
+    });
+    let liveConfig = startupConfig;
+    const getConfig = () => liveConfig;
+    const searchTool = createMemorySearchTool({ config: startupConfig, getConfig });
+    const getTool = createMemoryGetTool({ config: startupConfig, getConfig });
+    if (!searchTool || !getTool) {
+      throw new Error("memory tools missing");
+    }
+
+    liveConfig = asOpenClawConfig({
+      agents: {
+        list: [{ id: "main", default: true, memory: { search: { enabled: false } } }],
+      },
+    });
+    const disabledMessage =
+      "Memory is disabled for this agent. Enable memory search for this agent, then retry.";
+    await expect(
+      searchTool.execute("revoked-search", { query: "private preference" }),
+    ).rejects.toThrow(disabledMessage);
+    await expect(getTool.execute("revoked-get", { path: "MEMORY.md" })).rejects.toThrow(
+      disabledMessage,
+    );
+    expect(getMemorySearchManagerMockCalls()).toBe(0);
+    expect(getReadAgentMemoryFileMockCalls()).toBe(0);
+  });
+
   it("rejects fractional memory_get ranges before reading files", async () => {
     const tool = createMemoryGetToolOrThrow();
 

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -42,7 +42,7 @@ export const MemoryGetSchema = Type.Object({
 });
 
 function resolveMemoryToolContext(options: MemoryToolOptions) {
-  const cfg = options.getConfig?.() ?? options.config;
+  const cfg = options.getConfig ? options.getConfig() : options.config;
   if (!cfg) {
     return null;
   }
@@ -109,7 +109,14 @@ export function createMemoryTool(params: {
     description: params.description,
     parameters: params.parameters,
     execute: async (toolCallId, toolParams, signal, onUpdate) => {
-      const latestCtx = resolveMemoryToolContext(params.options) ?? ctx;
+      const latestCtx = params.options.getConfig ? resolveMemoryToolContext(params.options) : ctx;
+      // A live getter makes missing or disabled current config a revocation.
+      // The captured context is valid only for fixed-snapshot callers.
+      if (!latestCtx) {
+        throw new Error(
+          "Memory is disabled for this agent. Enable memory search for this agent, then retry.",
+        );
+      }
       return await params.execute(latestCtx)(toolCallId, toolParams, signal, onUpdate);
     },
   };

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -1854,6 +1854,7 @@ describe("memory plugin e2e", () => {
     }));
     const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
     const add = vi.fn(async () => undefined);
+    const deleteRows = vi.fn(async () => ({ numDeletedRows: 1 }));
     const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
@@ -1864,7 +1865,7 @@ describe("memory plugin e2e", () => {
           ),
           countRows: vi.fn(async () => 0),
           add,
-          delete: vi.fn(async () => undefined),
+          delete: deleteRows,
         })),
       })),
     }));
@@ -1925,14 +1926,13 @@ describe("memory plugin e2e", () => {
           }),
         ),
       ).toEqual([null, null, null]);
-      expect(
-        registeredToolFactories.map(({ toolOrFactory }) =>
-          materializeRegisteredTool(toolOrFactory, {
-            agentId: "main",
-            getRuntimeConfig: () => configFile,
-          }),
-        ),
-      ).toMatchObject([
+      const enabledTools = registeredToolFactories.map(({ toolOrFactory }) =>
+        materializeRegisteredTool(toolOrFactory, {
+          agentId: "main",
+          getRuntimeConfig: () => configFile,
+        }),
+      );
+      expect(enabledTools).toMatchObject([
         { name: "memory_recall" },
         { name: "memory_store" },
         { name: "memory_forget" },
@@ -1985,6 +1985,29 @@ describe("memory plugin e2e", () => {
 
         agents: { defaults: {} },
       };
+      const [recallTool, storeTool, forgetTool] = enabledTools;
+      embeddingsCreate.mockClear();
+      loadLanceDbModule.mockClear();
+      add.mockClear();
+      deleteRows.mockClear();
+      const disabledMessage =
+        "Memory is disabled for this agent. Enable memory search for this agent, then retry.";
+      await expect(
+        recallTool.execute("revoked-recall", { query: "private preference" }),
+      ).rejects.toThrow(disabledMessage);
+      await expect(
+        storeTool.execute("revoked-store", { text: "The user prefers Helix." }),
+      ).rejects.toThrow(disabledMessage);
+      await expect(
+        forgetTool.execute("revoked-forget", {
+          memoryId: "11111111-1111-4111-8111-111111111111",
+        }),
+      ).rejects.toThrow(disabledMessage);
+      expect(embeddingsCreate).not.toHaveBeenCalled();
+      expect(loadLanceDbModule).not.toHaveBeenCalled();
+      expect(add).not.toHaveBeenCalled();
+      expect(deleteRows).not.toHaveBeenCalled();
+
       const recallDefaultDisabled = await beforePromptBuild?.(recallEvent, {
         agentId: "unlisted",
       });

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -136,6 +136,20 @@ export default definePluginEntry({
       const enabled = overrides?.enabled ?? runtimeConfig.memory?.search?.enabled ?? true;
       return enabled ? agentId : undefined;
     };
+    const assertRetainedToolEnabled = (
+      agentId: string,
+      getRuntimeConfig: (() => OpenClawConfig | undefined) | undefined,
+    ): void => {
+      if (!getRuntimeConfig) {
+        return;
+      }
+      const runtimeConfig = getRuntimeConfig();
+      if (!runtimeConfig || !resolveEnabledAgentId(agentId, runtimeConfig)) {
+        throw new Error(
+          "Memory is disabled for this agent. Enable memory search for this agent, then retry.",
+        );
+      }
+    };
     const resolveCliAgentId = (rawAgentId: unknown): string => {
       if (typeof rawAgentId === "string" && rawAgentId.trim()) {
         return normalizeAgentId(rawAgentId);
@@ -221,6 +235,8 @@ export default definePluginEntry({
             limit: optionalPositiveIntegerSchema({ description: "Max results (default: 5)" }),
           }),
           async execute(_toolCallId, params) {
+            // Tool definitions outlive hot config reloads; revalidate before memory I/O.
+            assertRetainedToolEnabled(agentId, ctx.getRuntimeConfig);
             const rawParams = params as Record<string, unknown>;
             const query = rawParams.query as string;
             const limit = readPositiveIntegerParam(rawParams, "limit") ?? 5;
@@ -343,6 +359,7 @@ export default definePluginEntry({
             category: Type.Optional(Type.Enum(MEMORY_CATEGORIES, { type: "string" })),
           }),
           async execute(_toolCallId, params) {
+            assertRetainedToolEnabled(agentId, ctx.getRuntimeConfig);
             if (isIncognitoSessionKey(ctx.sessionKey)) {
               return {
                 content: [
@@ -438,6 +455,7 @@ export default definePluginEntry({
             memoryId: Type.Optional(Type.String({ description: "Specific memory ID" })),
           }),
           async execute(_toolCallId, params) {
+            assertRetainedToolEnabled(agentId, ctx.getRuntimeConfig);
             const { query, memoryId } = params as { query?: string; memoryId?: string };
 
             if (memoryId) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents already using memory could keep accessing it after an operator disabled memory for that agent through a hot configuration update.

## Why This Change Was Made

Retained memory tools now revalidate the current agent configuration at execution time across both the built-in memory tools and the LanceDB memory plugin. Fixed-snapshot tool callers without a live configuration getter keep their existing behavior.

## User Impact

Disabling memory now takes effect for active agents before any subsequent memory read, write, or delete. Enabled agents and ordinary configuration refreshes continue to work as before.

## Evidence

- Added enabled-to-disabled regression coverage for `memory_search` and `memory_get`, proving no manager or file access occurs after revocation.
- Extended LanceDB lifecycle coverage for retained `memory_recall`, `memory_store`, and `memory_forget`, proving no embedding, database load, write, or delete occurs after revocation.
- Pre-fix proof: both focused regressions failed; the tools returned a real memory hit and completed recall/store/delete after disable.
- `pnpm test extensions/memory-core/src/tools.test.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-lancedb/index.test.ts` — 206 tests passed.
- `pnpm check:changed` — passed formatting, lint, production/test typechecks, plugin boundaries, dead-export checks, and import-cycle checks.
- Autoreview completed with no accepted or actionable findings.
