### PR TITLE
chore: make async lifecycle tests deterministic

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -726,12 +726,20 @@ describe("active-memory plugin", () => {
     expect(typeof hooks.agent_end).toBe("function");
   });
 
-  it("prewarms a cold lane-1 lookup before the first QA-channel turn budget starts", async () => {
+  it("completes lane-1 prewarm before the first QA-channel prompt hook", async () => {
     registerPluginConfig({ mode: "off" });
-    let cold = true;
-    const simulatedBudgetMs = 500;
-    const coldDelayMs = 650;
-    const runtimePreparationMs = 500;
+    let releaseLookup: () => void = () => {
+      throw new Error("lookup gate was not initialized");
+    };
+    let resolveLookupStarted: () => void = () => {
+      throw new Error("lookup start gate was not initialized");
+    };
+    const lookupGate = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    const lookupStarted = new Promise<void>((resolve) => {
+      resolveLookupStarted = resolve;
+    });
     const runId = "run-cold-qa-channel";
     const triggerEntry = {
       path: "MEMORY.md",
@@ -743,27 +751,18 @@ describe("active-memory plugin", () => {
       originClass: "agent" as const,
       triggers: "booking a flight",
     };
-    const warmLookup = async () => {
-      if (cold) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, coldDelayMs);
-        });
-        cold = false;
-      }
-    };
-    const search = vi.fn(async () => {
-      await warmLookup();
-      return [];
-    });
+    const search = vi.fn(async () => []);
     const listTriggerCandidates = vi.fn(async () => {
-      await warmLookup();
+      resolveLookupStarted();
+      await lookupGate;
       return [triggerEntry];
     });
     hoisted.getActiveMemorySearchManager.mockResolvedValue({
       manager: { search, listTriggerCandidates },
     } as never);
 
-    const prewarmResult = await requireHook("before_model_resolve")(
+    let prewarmHookReturned = false;
+    const prewarmHook = requireHook("before_model_resolve")(
       { prompt: "Help when booking a flight" },
       {
         agentId: "main",
@@ -773,14 +772,23 @@ describe("active-memory plugin", () => {
         messageProvider: "qa-channel",
         channelId: "owner",
       },
-    );
-    expect(prewarmResult).toBeUndefined();
-    expect(coldDelayMs).toBeGreaterThan(simulatedBudgetMs);
+    ).then((result: unknown) => {
+      prewarmHookReturned = true;
+      return result;
+    });
+    await lookupStarted;
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, runtimePreparationMs);
+      setImmediate(resolve);
     });
 
-    const startedAt = performance.now();
+    expect(prewarmHookReturned).toBe(true);
+    await expect(prewarmHook).resolves.toBeUndefined();
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(listTriggerCandidates).toHaveBeenCalledTimes(1);
+    releaseLookup();
+    await listTriggerCandidates.mock.results[0]?.value;
+    await Promise.resolve();
+
     const result = await runPromptBuild(
       { prompt: "Help when booking a flight" },
       {
@@ -790,11 +798,8 @@ describe("active-memory plugin", () => {
         runId,
       },
     );
-    const firstTurnMs = performance.now() - startedAt;
 
     expectPrependContextContains(result, "Prefer aisle seats.");
-    expect(cold).toBe(false);
-    expect(firstTurnMs).toBeLessThan(simulatedBudgetMs);
     expect(search).toHaveBeenCalledTimes(1);
     expect(listTriggerCandidates).toHaveBeenCalledTimes(1);
     expect(runEmbeddedAgent).not.toHaveBeenCalled();

--- a/src/infra/tailscale-route-owner.worker.test.ts
+++ b/src/infra/tailscale-route-owner.worker.test.ts
@@ -63,12 +63,39 @@ describe("Tailscale route owner", () => {
         ],
         { execArgv: ["--import", "tsx"], stdio: ["ignore", "ignore", "ignore", "ipc"] },
       );
-      const messages: TailscaleRouteOwnerMessage[] = [];
-      worker.on("message", (message: TailscaleRouteOwnerMessage) => messages.push(message));
+      const ready = new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          worker.off("message", onMessage);
+          worker.off("error", onError);
+          worker.off("exit", onExit);
+        };
+        const onMessage = (message: TailscaleRouteOwnerMessage) => {
+          if (message.type === "ready") {
+            cleanup();
+            resolve();
+          } else if (message.type === "failed") {
+            cleanup();
+            reject(new Error(message.stderr || message.stdout || "route owner failed"));
+          }
+        };
+        const onError = (error: Error) => {
+          cleanup();
+          reject(error);
+        };
+        const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          cleanup();
+          reject(
+            new Error(
+              `route owner exited before readiness (${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`})`,
+            ),
+          );
+        };
+        worker.on("message", onMessage);
+        worker.once("error", onError);
+        worker.once("exit", onExit);
+      });
       try {
-        await vi.waitFor(() => {
-          expect(messages).toContainEqual({ type: "ready" });
-        });
+        await ready;
         const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
           (resolve) => {
             worker.once("exit", (code, signal) => resolve({ code, signal }));

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -704,12 +704,12 @@ describe.sequential("TUI PTY harness", () => {
     "preserves xAI account limit errors in terminal output",
     async () => {
       await fixture.run.write("xai limit proof\r");
-      await fixture.run.waitForOutput("monthly spending limit");
-      expect(fixture.run.visibleOutput()).not.toContain("Run /auth");
       await fixture.waitForLogEntry(
         (entry) =>
           entry.method === "sendChat" && objectFieldEquals(entry, "message", "xai limit proof"),
       );
+      await fixture.run.waitForOutput("monthly spending limit");
+      expect(fixture.run.visibleOutput()).not.toContain("Run /auth");
     },
     TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
<!-- AI-assisted maintainer-directed recovery validation follow-up. -->

## What Problem This Solves

Resolves nondeterministic lifecycle coverage found during canonical recovery validation. The affected tests could observe Tailscale IPC readiness through polling, infer active-memory prewarm ordering from wall-clock delays, or check PTY output before the fixture send was synchronized.

## Why This Change Was Made

The tests now synchronize on the asynchronous boundaries they own: worker readiness/error/exit events, explicit active-memory lookup gates, and the recorded TUI send before checking terminal output. This is test-only; it adds no production behavior, timeout, retry, or weaker assertion.

## User Impact

No user-visible runtime impact. Maintainers get deterministic failure signals for Tailscale owner cleanup, TUI provider-limit rendering, and active-memory first-turn prewarm ordering.

## Evidence

- `node scripts/run-vitest.mjs src/infra/tailscale-route-owner.worker.test.ts -t 'terminates the claim when the Gateway IPC owner disappears'` — 1 passed.
- `node scripts/run-vitest.mjs extensions/active-memory/index.test.ts -t 'completes lane-1 prewarm before the first QA-channel prompt hook'` — 1 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts` — 62 passed, including the xAI account-limit case.
- `node scripts/check-changed.mjs` — passed after the final rebase.
- `git diff --check` — passed.
- Test-audit authoring/value review — all three cases protect observable lifecycle ordering, cover credible regressions not duplicated by stronger tests, and require no production-only test seam.
- Fresh Codex-backed autoreview — clean; no accepted/actionable findings.

The TUI file is a sequential shared-fixture suite; a name-filtered single-case run is not standalone and timed out, while the canonical owning file passed all 62 cases.
