### PR TITLE
fix(cron): cancellation reason survives late delivery finalization

### DIFF
--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
 import * as taskExecutor from "../../tasks/task-executor.js";
-import { finalizeTaskRunByRunIdCore } from "../../tasks/task-executor.js";
 import * as taskRegistry from "../../tasks/task-registry.js";
 import { markTaskLostById } from "../../tasks/task-registry.js";
 import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../../tasks/task-registry.store.sqlite.js";
@@ -412,7 +411,7 @@ describe("cron task run terminal records", () => {
     );
   });
 
-  it("keeps operator cancellation while attaching terminal run history", async () => {
+  it("keeps operator cancellation reason when webhook delivery is interrupted", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-cron-cancelled-task-" },
       async () => {
@@ -443,13 +442,12 @@ describe("cron task run terminal records", () => {
         if (!taskRunId) {
           throw new Error("expected cron task run id");
         }
-        finalizeTaskRunByRunIdCore({
+        taskExecutor.finalizeTaskRunByRunIdCore({
           runId: taskRunId,
           runtime: "cron",
           status: "cancelled",
           endedAt: startedAt + 50,
-          error: "cancelled by operator",
-          terminalSummary: "Cancelled by operator.",
+          error: "Cancelled by operator.",
         });
 
         tryFinishCronTaskRun(state, {
@@ -460,6 +458,9 @@ describe("cron task run terminal records", () => {
             action: "finished",
             job,
             status: "ok",
+            summary: "payload complete",
+            delivered: false,
+            deliveryError: "cron webhook delivery cancelled: Cancelled by operator.",
             runAtMs: startedAt,
             durationMs: 100,
           },
@@ -472,9 +473,9 @@ describe("cron task run terminal records", () => {
         expect(row).toMatchObject({
           status: "cancelled",
           endedAt: startedAt + 100,
+          error: "Cancelled by operator.",
           detail: { kind: "cron-run", status: "ok", durationMs: 100 },
         });
-        expect(row?.error).toBeUndefined();
         expect(row?.terminalSummary).toBeUndefined();
         expect(
           readCronTaskRunHistoryPage({
@@ -486,6 +487,9 @@ describe("cron task run terminal records", () => {
             jobId: job.id,
             status: "ok",
             error: undefined,
+            summary: "payload complete",
+            delivered: false,
+            deliveryError: "cron webhook delivery cancelled: Cancelled by operator.",
           }),
         ]);
       },
@@ -810,7 +814,7 @@ describe("cron task run terminal records", () => {
           }),
         );
         expect(recovery.taskRunId).toBe(legacyRunId);
-        finalizeTaskRunByRunIdCore({
+        taskExecutor.finalizeTaskRunByRunIdCore({
           runId: legacyRunId,
           runtime: "cron",
           status: "timed_out",

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -365,10 +365,14 @@ export function tryFinishCronTaskRun(
         status,
         endedAt: entry.ts,
         lastEventAt: entry.ts,
-        error: entry.error,
-        clearError: entry.error === undefined,
-        terminalSummary: entry.summary ?? null,
-        preserveTerminalSummary: true,
+        ...(status === "cancelled"
+          ? {}
+          : {
+              error: entry.error,
+              clearError: entry.error === undefined,
+              terminalSummary: entry.summary ?? null,
+              preserveTerminalSummary: true,
+            }),
         childSessionKey: entry.sessionKey ?? null,
         detail,
       });
@@ -376,7 +380,7 @@ export function tryFinishCronTaskRun(
     if (updated.length === 0) {
       const existing = findTaskByRunId(taskRunId);
       if (existing?.runtime === "cron" && existing.status === "cancelled") {
-        // Operator cancellation owns task status, but its finished event still owns history detail.
+        // Operator cancellation owns task status and reason; its finished event owns history detail.
         updated = finalize(taskRunId, "cancelled");
       } else if (
         existing?.runtime === "cron" &&

--- a/src/cron/service/timer-job-runner.interruption.test.ts
+++ b/src/cron/service/timer-job-runner.interruption.test.ts
@@ -50,8 +50,13 @@ describe("resolveInterruptedRunProgress", () => {
       job: webhookJob,
       error: "cron webhook delivery cancelled: operator",
     });
-    expect(resolved?.delivered).toBe(false);
-    expect(resolved?.deliveryError).toBe("cron webhook delivery cancelled: operator");
+    expect(resolved).toMatchObject({
+      status: "ok",
+      summary: "payload",
+      delivered: false,
+      deliveryError: "cron webhook delivery cancelled: operator",
+    });
+    expect(resolved?.error).toBeUndefined();
   });
 
   it("returns undefined when no core result completed", () => {

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -198,6 +198,8 @@ export function cronRunLogEntryToTaskDetail(
   const detail = toJsonValue({
     kind: CRON_TASK_DETAIL_KIND,
     status: entry.status,
+    error: entry.error ?? null,
+    summary: entry.summary ?? null,
     storeKey: options.storeKey,
     errorReason: entry.errorReason,
     diagnostics: entry.diagnostics,
@@ -312,13 +314,15 @@ export function cronTaskRecordToRunLogEntry(task: TaskRecord): CronRunLogEntry |
   // Task detail is canonical write-time state; history reads do not rederive error reasons.
   const entry = parseCronRunLogEntryObject(
     {
+      // Released rows stored these only on the generic task; current detail wins
+      // when task cancellation and the underlying execution have different outcomes.
+      error: task.error,
+      summary: task.terminalSummary,
       ...wireDetail,
       ts: resolveCronTaskRecordTimestamp(task),
       jobId: task.sourceId,
       action: "finished",
       status: isCronRunStatus(task.detail.status) ? task.detail.status : undefined,
-      error: task.error,
-      summary: task.terminalSummary,
       sessionKey: task.childSessionKey,
       runId: typeof task.detail.runId === "string" ? task.detail.runId : undefined,
     },

--- a/src/cron/task-run-history.test.ts
+++ b/src/cron/task-run-history.test.ts
@@ -451,8 +451,12 @@ describe("cron task run history", () => {
       1,
       storeKey,
     );
+    task.error = "legacy error";
+    task.terminalSummary = "legacy summary";
     task.detail = {
-      ...(task.detail as Record<string, TaskRecord["detail"]>),
+      kind: "cron-run",
+      status: "ok",
+      storeKey,
       internalFutureField: "secret",
       triggerState: { secret: true },
       delivery: "malformed",
@@ -463,6 +467,7 @@ describe("cron task run history", () => {
     expect(Object.hasOwn(entry ?? {}, "storeKey")).toBe(false);
     expect(Object.hasOwn(entry ?? {}, "internalFutureField")).toBe(false);
     expect(Object.hasOwn(entry ?? {}, "triggerState")).toBe(false);
+    expect(entry).toMatchObject({ error: "legacy error", summary: "legacy summary" });
     expect(entry?.delivery).toBeUndefined();
     expect(entry?.failureNotificationDelivery).toBeUndefined();
   });


### PR DESCRIPTION
Related: #117425

AI-assisted: Codex implemented and independently reviewed this repair.

## What Problem This Solves

Fixes an issue where cancelling a cron task after its execution completed but while webhook delivery was still pending could leave the task marked cancelled while silently clearing the accepted operator cancellation reason. The same task row also could not represent that execution succeeded while delivery was interrupted.

## Why This Change Was Made

Late cron finalization now preserves the generic task lifecycle's accepted `cancelled` status and reason, while cron-owned detail stores the underlying execution error/summary and delivery result for history projection. Current detail wins over the unchanged released-row fallback, so this adds no config, schema, protocol, or fallback reader. PR #117425 owns admission provenance and stale-delivery policy; it has no file overlap with this terminal task/history projection repair.

Production LOC: +15/-7 (net +8) to separate the two owner-native outcomes at write time; tests: +24/-10. The production growth adds the missing canonical cron detail fields and prevents cancellation finalization from overwriting generic lifecycle fields.

## User Impact

Operators can trust a successful cancellation response to remain visible on the task. Cron history separately reports the completed execution and interrupted delivery, for example `status: ok`, the execution summary, `delivered: false`, and the delivery cancellation error.

## Evidence

- Pre-fix reproduction: `node scripts/run-vitest.mjs src/cron/service/task-runs.test.ts -t 'keeps operator cancellation reason when webhook delivery is interrupted'` failed because the persisted task had no `error`; expected `Cancelled by operator.`
- Rebased focused suites: `node scripts/run-vitest.mjs src/cron/service/task-runs.test.ts src/cron/service/timer-job-runner.interruption.test.ts src/cron/task-run-history.test.ts` — 41 passed.
- Rebased real-flow sibling coverage: `node scripts/run-vitest.mjs src/cron/service.persists-delivered-status.test.ts src/cron/service/timer.regression.test.ts -t 'finalizes immediately when a command webhook is cancelled|cancels timeout-disabled cron task runs without waiting for the runner'` — 2 passed, 83 skipped.
- `node scripts/check-changed.mjs` — passed after the rebase, including core and core-test typechecks, lint, database-first, and import-cycle guards.
- `git diff --check origin/main...HEAD` — passed.
- Codex-backed autoreview: clean, no accepted/actionable findings.
- Test-audit authoring gate: the regression protects the producer-owned ordering, fails pre-fix for the intended reason, is not duplicated by existing coverage, and adds no test-only production seam.

Live operator-Gateway proof was not run: reproducing the narrow post-execution/pre-webhook cancellation window requires coordinating an authenticated task cancellation with a deliberately hanging webhook. The focused owner-boundary regression captures that exact ordering, while the two existing real-flow tests independently prove accepted cancellation and hanging-webhook interruption.
