### PR TITLE
fix(telegram): keep send-policy-denied turns silent

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -2,6 +2,7 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { dispatchReplyWithBufferedBlockDispatcher as dispatchReplyWithBufferedBlockDispatcherRuntime } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   describeTelegramDispatch,
@@ -142,6 +143,36 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
       streamMode: "off",
     });
 
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("does not bypass sendPolicy denial with a no-visible-reply fallback", async () => {
+    let sharedDispatchResult:
+      | Awaited<ReturnType<typeof dispatchReplyWithBufferedBlockDispatcherRuntime>>
+      | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async (params) => {
+      sharedDispatchResult = await dispatchReplyWithBufferedBlockDispatcherRuntime({
+        ...params,
+        replyResolver: async () => undefined,
+      });
+      return sharedDispatchResult;
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      cfg: {
+        session: { sendPolicy: { default: "deny" } },
+      },
+      streamMode: "off",
+    });
+
+    expect(sharedDispatchResult).toMatchObject({
+      queuedFinal: false,
+      sendPolicyDenied: true,
+    });
+    expect(sharedDispatchResult).not.toHaveProperty("noVisibleReplyFallbackEligible");
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 

--- a/qa/scenarios/channels/telegram-send-policy-deny.yaml
+++ b/qa/scenarios/channels/telegram-send-policy-deny.yaml
@@ -1,0 +1,98 @@
+title: Telegram send-policy denial
+
+scenario:
+  id: telegram-send-policy-deny
+  surface: channels
+  category: channels.conversation-routing-and-delivery
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+    secondary:
+      - channels.automatic-final-reply
+  objective: Verify a directed Telegram turn remains intentionally quiet when session send policy denies delivery.
+  gatewayConfigPatch:
+    session:
+      sendPolicy:
+        default: deny
+    messages:
+      groupChat:
+        visibleReplies: automatic
+    channels:
+      telegram:
+        streaming:
+          mode: off
+  successCriteria:
+    - The scenario runs through Crabline Telegram, an ephemeral Gateway child, and mock-openai.
+    - The provider completes a directed turn while Telegram records zero outbound sends.
+    - The evidence verdict records the configured send-policy denial as the intentional non-outcome.
+  docsRefs:
+    - docs/gateway/config-agents.md
+    - docs/channels/telegram.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - src/auto-reply/reply/source-reply-delivery-mode.ts
+    - src/auto-reply/reply/dispatch-from-config.finalize.ts
+    - extensions/telegram/src/bot-message-dispatch.ts
+    - extensions/qa-lab/src/crabline-transport.ts
+  execution:
+    kind: flow
+    channel: telegram
+    suiteIsolation: isolated
+    isolationReason: Applies a gateway-wide default-deny send policy and must not leak that policy into another scenario worker.
+    retryCount: 0
+    transportPolicy:
+      requireGroupMention: true
+    summary: Run one denied directed turn through the real Telegram plugin and assert zero Bot API sends.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: "-1001234567890"
+      promptSnippet: Telegram send policy deny QA check
+      forbiddenMarker: QA-TELEGRAM-SEND-POLICY-DENY-FORBIDDEN
+
+flow:
+  steps:
+    - name: records a denied turn without sending a Telegram fallback
+      actions:
+        - assert:
+            expr: env.providerMode === config.requiredProviderMode
+            message: this deterministic policy proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: outboundStartIndex
+          value:
+            expr: "getTransportSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - sendInbound:
+            conversation:
+              id: { ref: config.conversationId }
+              kind: group
+            senderId: driver
+            senderName: QA Driver
+            text:
+              expr: "`@openclaw ${config.promptSnippet}. Reply exactly: ${config.forbiddenMarker}`"
+        - call: waitForCondition
+          saveAs: providerRequest
+          args:
+            - lambda:
+                async: true
+                expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 100
+        - call: waitForNoTransportOutbound
+          args:
+            - ref: state
+            - 2000
+            - sinceIndex: { ref: outboundStartIndex }
+        - set: verdict
+          value:
+            expr: "({ verdict: 'PASS', harness: 'Crabline Telegram + ephemeral Gateway child + mock-openai', providerRequestObserved: Boolean(providerRequest), configuredSendPolicy: env.cfg.session?.sendPolicy?.default ?? null, outboundCount: getTransportSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).length, forbiddenMarker: config.forbiddenMarker })"
+        - assert:
+            expr: verdict.providerRequestObserved === true && verdict.configuredSendPolicy === 'deny' && verdict.outboundCount === 0
+            message:
+              expr: "`Telegram send-policy verdict failed: ${JSON.stringify(verdict)}`"
+      detailsExpr: "JSON.stringify(verdict, null, 2)"

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -379,21 +379,11 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       : {}),
     ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
     ...(replyAdmission?.status === "accepted" ? { deferredToActiveRun: replyAdmission.mode } : {}),
-    // Eligibility keys off settled visible delivery: a suppressed or cancelled
-    // final (including the core fallback itself) leaves channel-level recovery
-    // eligible, while any settled visible delivery clears it. An aborted or
-    // timed-out settle leaves delivery unresolved, and a fallback reported as
-    // delivered must not stay recoverable — either could double-send.
-    ...(noVisibleReplyFallbackDirected &&
-    queuedSettleResult === "settled" &&
-    !turnLedger.hasVisibleDelivery() &&
+    // Channel recovery inherits the same delivery-policy gate as the core
+    // fallback. Settlement can prove invisibility, but cannot override policy.
+    ...(queuedSettleResult === "settled" &&
     !noVisibleReplyFallbackDelivered &&
-    !getObservedReplyDelivery() &&
-    !replyAcceptedByActiveRun &&
-    !emptyFinalAllowedAsSilent &&
-    !deliberateSilentTerminalReply &&
-    !pendingContinuation &&
-    !channelTransformSuppressed
+    noVisibleReplyFallbackAllowed()
       ? { noVisibleReplyFallbackEligible: true }
       : {}),
     ...(noVisibleReplyFallbackDelivered ? { noVisibleReplyFallbackDelivered: true } : {}),

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -884,7 +884,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(result.queuedFinal).toBe(false);
     expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
-    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
     expect(result.sendPolicyDenied).toBe(true);
   });
 
@@ -918,8 +918,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.queuedFinal).toBe(false);
     expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
     expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
-    // Direct silent policy is disallow; eligibility remains for transport fallbacks.
-    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
   });
 
   it("does not deliver no-visible fallback after observed reply delivery", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a directed Telegram turn could receive a generic "No response generated" fallback even though the session send policy intentionally denied delivery. The shared auto-reply layer suppressed its own reply correctly but still marked the turn eligible for channel-level recovery, allowing Telegram to bypass the policy.

## Why This Change Was Made

Channel recovery now reuses the shared auto-reply producer's canonical fallback-eligibility predicate instead of independently reconstructing only part of that decision. This keeps send-policy denial and message-tool-only delivery authoritative without hardcoding Telegram policy in core. AI-assisted; the final patch, regression behavior, and evidence were reviewed and verified.

## User Impact

Telegram conversations configured with `session.sendPolicy` denial remain intentionally quiet instead of receiving a misleading fallback. Genuine directed turns that produce no visible response and are allowed by policy remain eligible for the existing recovery message.

## Evidence

- Parent red proof: applying the new assertions to `2b3f0f9d72d^` fails both core policy cases because `noVisibleReplyFallbackEligible` is `true`; the Telegram boundary regression also fails for the same leaked flag.
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "sendPolicy deny"` — 107 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts -t "does not bypass sendPolicy denial"` — passed.
- `pnpm openclaw qa suite --provider-mode mock-openai --channel-driver crabline --channel telegram --scenario telegram-send-policy-deny --concurrency 1 --output-dir .artifacts/qa-e2e/telegram-send-policy-deny-81e37c2` — passed through Crabline Telegram, an ephemeral Gateway child, and mock-openai; provider request observed, configured policy `deny`, outbound count `0`. The command rebuilt private-QA dist successfully at the rebased head.
- `node scripts/check-changed.mjs` — passed all selected guards, full typechecks, lint, and import-cycle validation.
- `git diff --check origin/main...HEAD` — clean.
- Codex-backed autoreview — clean, no accepted/actionable findings; TruffleHog clean.

No external credentialed Telegram account was used; the repository's mock-gateway/Crabline harness exercised the real Telegram plugin and the changed delivery path.
