### PR TITLE
fix(lmstudio): auth failures point to a working login command

### DIFF
--- a/extensions/lmstudio/src/runtime.test.ts
+++ b/extensions/lmstudio/src/runtime.test.ts
@@ -62,7 +62,7 @@ describe("lmstudio-runtime", () => {
       resolveLmstudioRuntimeApiKey({
         config: buildLmstudioConfig({ auth: "api-key" }),
       }),
-    ).rejects.toThrow(/LM Studio API key is required/i);
+    ).rejects.toThrow('or run "openclaw models auth login --provider lmstudio".');
   });
 
   it("falls back to configured env marker key when profile resolution fails", async () => {

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -1,4 +1,5 @@
 // Lmstudio plugin module implements runtime behavior.
+import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
   isKnownEnvApiKeyMarker,
@@ -257,7 +258,7 @@ export async function resolveLmstudioRuntimeApiKey(params: {
       [
         "LM Studio API key is required.",
         `Set models.providers.lmstudio.apiKey (for example "${envMarker}")`,
-        'or run "openclaw models auth lmstudio".',
+        `or run "${formatCliCommand("openclaw models auth login --provider lmstudio")}".`,
       ].join(" "),
     );
   };

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -1,5 +1,3 @@
-// Lmstudio plugin module implements runtime behavior.
-import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
   isKnownEnvApiKeyMarker,
@@ -10,6 +8,8 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+// Lmstudio plugin module implements runtime behavior.
+import { formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
 import {
   LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
   LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators missing LM Studio API-key auth were told to run `openclaw models auth lmstudio`, which is not a valid subcommand and leaves recovery dead-ended.

## Why This Change Was Made

The runtime error points to the registered `models auth login --provider lmstudio` flow. It uses `formatCliCommand` through the supported `setup-tools` SDK subpath so active profile or container hints remain correct without adding a deprecated CLI-barrel import.

## User Impact

Operators who hit an LM Studio auth failure receive a working command for the plugin-owned authentication flow.

## Evidence

- The existing runtime regression and all 17 runtime tests pass on the final source.
- Five isolated real-source probes verify old-command rejection, replacement help, dispatch to the login handler, and missing-key diagnostics with and without a named profile. The login probe stops at the expected interactive-TTY guard; no credentials or successful authentication are claimed.
- The broader runtime/CLI/profile suites passed 109 tests before the final import-only adjustment.
- Final targeted type-aware lint, pinned formatting, whitespace checks, and fresh independent P2 review pass.
- Exact-head hosted CI is required before native landing.
