### PR TITLE
fix(plugins): load replaced public artifacts after metadata refresh

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2652,7 +2652,6 @@ src/commands/export-trajectory.ts	1
 src/commands/gateway-health-auth-diagnostic.ts	2
 src/commands/gateway-presence.ts	1
 src/commands/gateway-status/helpers.ts	11
-src/commands/health.ts	1
 src/commands/message-format.ts	21
 src/commands/message.ts	4
 src/commands/models/fallbacks-shared.ts	2

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -6,6 +6,10 @@ import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.
 import { formatChannelStatusState } from "../channels/plugins/status-state.js";
 import { isGatewayTransportError } from "../gateway/call.js";
 import type { ChannelAccountHealthSummary, HealthSummary } from "../gateway/health/types.js";
+import {
+  formatDurationCompact,
+  formatDurationHuman,
+} from "../infra/format-time/format-duration.js";
 
 export function formatGatewayClosedDiagnostic(err: unknown): string | undefined {
   if (!isGatewayTransportError(err) || err.kind !== "closed") {
@@ -259,3 +263,105 @@ export const formatHealthChannelLines = (
   }
   return lines;
 };
+
+export function formatHealthDurationParts(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return "unknown";
+  }
+  if (ms < 1000) {
+    return `${Math.max(0, Math.round(ms))}ms`;
+  }
+  const units: Array<{ label: string; size: number }> = [
+    { label: "w", size: 7 * 24 * 60 * 60 * 1000 },
+    { label: "d", size: 24 * 60 * 60 * 1000 },
+    { label: "h", size: 60 * 60 * 1000 },
+    { label: "m", size: 60 * 1000 },
+    { label: "s", size: 1000 },
+  ];
+  let remaining = Math.max(0, Math.floor(ms));
+  const parts: string[] = [];
+  for (const unit of units) {
+    const value = Math.floor(remaining / unit.size);
+    if (value > 0) {
+      parts.push(`${value}${unit.label}`);
+      remaining -= value * unit.size;
+    }
+  }
+  return parts.length > 0 ? parts.join(" ") : "0s";
+}
+
+export function formatEventLoopHealthLine(summary: HealthSummary): string | null {
+  const eventLoop = summary.eventLoop;
+  if (!eventLoop) {
+    return null;
+  }
+  const state = eventLoop.degraded ? "degraded" : "ok";
+  const degradedFor =
+    eventLoop.degraded && eventLoop.degradedSinceMs != null
+      ? ` for ${formatDurationCompact(eventLoop.degradedSinceMs) ?? "0s"}`
+      : "";
+  const reasons = eventLoop.reasons.length > 0 ? ` reasons=${eventLoop.reasons.join(",")}` : "";
+  return `Gateway event loop: ${state}${degradedFor}${reasons} max=${Math.round(
+    eventLoop.delayMaxMs,
+  )}ms p99=${Math.round(eventLoop.delayP99Ms)}ms util=${eventLoop.utilization} cpu=${
+    eventLoop.cpuCoreRatio
+  }`;
+}
+
+/** Formats context engine quarantine state for text health output. */
+export function formatContextEngineHealthLine(summary: HealthSummary): string | null {
+  const quarantined = summary.contextEngines?.quarantined ?? [];
+  if (quarantined.length === 0) {
+    return null;
+  }
+  const engines = quarantined.map((entry) => entry.engineId).join(", ");
+  return `Context engine: warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`;
+}
+
+/** Formats dead-lettered and pressured delivery queue entries for text health output. */
+export function formatDeliveryQueueHealthLine(
+  summary: HealthSummary,
+  now = Date.now(),
+): string | null {
+  const failed = summary.deliveryQueues?.failed ?? [];
+  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
+  const ingressPressure = summary.deliveryQueues?.ingressPressure ?? [];
+  const warnings: string[] = [];
+  const deadLetterCounts = [
+    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
+    ...ingressFailed.map(
+      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
+    ),
+  ].join(", ");
+  const oldest = [...failed, ...ingressFailed]
+    .map((queue) => queue.oldestFailedAt)
+    .filter((value): value is number => typeof value === "number");
+  const oldestNote =
+    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
+  if (deadLetterCounts) {
+    warnings.push(`dead-lettered entries — ${deadLetterCounts}${oldestNote}`);
+  }
+  if (ingressPressure.length > 0) {
+    const pressureCounts = ingressPressure
+      .map(
+        (queue) =>
+          `inbound ${queue.channelId}/${queue.accountId}: ${queue.laneCount} pressured ${
+            queue.laneCount === 1 ? "lane" : "lanes"
+          }, ${queue.pendingCount} pending, ${queue.claimedCount} claimed, ${queue.blockedCount} blocked`,
+      )
+      .join(", ");
+    const oldestPressure = Math.min(...ingressPressure.map((queue) => queue.oldestReceivedAt));
+    warnings.push(
+      `ingress pressure — ${pressureCounts}; oldest ${formatDurationHuman(now - oldestPressure)} ago`,
+    );
+  }
+  return warnings.length > 0 ? `Delivery queue: warning (${warnings.join("; ")})` : null;
+}
+
+/** Formats config hot-reload watcher degradation for text health output. */
+export function formatConfigReloadHealthLine(summary: HealthSummary): string | null {
+  if (summary.configReload?.hotReloadStatus !== "disabled") {
+    return null;
+  }
+  return "Config hot reload: disabled (watcher retries exhausted; restart the gateway to restore it)";
+}

--- a/src/commands/health-text.ts
+++ b/src/commands/health-text.ts
@@ -1,0 +1,283 @@
+/** Heavy local-state and presentation path for successful text health output. */
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { styleHealthChannelLine } from "../../packages/terminal-core/src/health-style.js";
+import { isRich } from "../../packages/terminal-core/src/theme.js";
+import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
+import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildGatewayConnectionDetails } from "../gateway/call.js";
+import { resolveHealthAccountContext } from "../gateway/health/account-context.js";
+import { buildHealthSessionSummary, resolveHealthAgentOrder } from "../gateway/health/collector.js";
+import type { AgentHealthSummary, HealthSummary } from "../gateway/health/types.js";
+import { info } from "../globals.js";
+import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  formatConfigReloadHealthLine,
+  formatContextEngineHealthLine,
+  formatDeliveryQueueHealthLine,
+  formatEventLoopHealthLine,
+  formatHealthChannelLines,
+  formatHealthDurationParts,
+} from "./health-format.js";
+import { logGatewayConnectionDetails } from "./status.gateway-connection.js";
+
+const healthLog = createSubsystemLogger("health");
+
+function debugHealth(cfg: OpenClawConfig, message: string, meta?: Record<string, unknown>): void {
+  if (isDiagnosticFlagEnabled("health", cfg)) {
+    healthLog.info(message, meta);
+  }
+}
+
+export async function renderHealthText(params: {
+  config: OpenClawConfig;
+  summary: HealthSummary;
+  runtime: RuntimeEnv;
+  verbose?: boolean;
+  ignoreEnvUrlOverride?: boolean;
+  localPortOverride?: number;
+}): Promise<void> {
+  const cfg = params.config;
+  const summary = params.summary;
+  const runtime = params.runtime;
+  const rich = isRich();
+  if (params.verbose) {
+    const details = buildGatewayConnectionDetails({
+      config: cfg,
+      ignoreEnvUrlOverride: params.ignoreEnvUrlOverride,
+      localPortOverride: params.localPortOverride,
+    });
+    logGatewayConnectionDetails({ runtime, info, message: details.message });
+  }
+
+  const localAgents = resolveHealthAgentOrder(cfg);
+  const defaultAgentId = summary.defaultAgentId ?? localAgents.defaultAgentId;
+  const agents = Array.isArray(summary.agents) ? summary.agents : [];
+  const resolvedAgents =
+    agents.length > 0
+      ? agents
+      : await Promise.all(
+          localAgents.ordered.map(async (entry) => {
+            const storePath = resolveSessionStorePathCore(cfg.session?.store, {
+              agentId: entry.id,
+            });
+            return {
+              agentId: entry.id,
+              name: entry.name,
+              isDefault: entry.id === localAgents.defaultAgentId,
+              heartbeat: resolveHeartbeatSummaryForAgent(cfg, entry.id),
+              sessions: await buildHealthSessionSummary(storePath, entry.id),
+            } satisfies AgentHealthSummary;
+          }),
+        );
+  const displayAgents =
+    params.verbose || !defaultAgentId
+      ? resolvedAgents
+      : resolvedAgents.filter((agent) => agent.agentId === defaultAgentId);
+  const channelBindings = buildChannelAccountBindings(cfg);
+  const displayPlugins = listReadOnlyChannelPluginsForConfig(cfg, {
+    includeSetupFallbackPlugins: false,
+  });
+
+  if (isDiagnosticFlagEnabled("health", cfg)) {
+    runtime.log(info("[debug] local channel accounts"));
+    for (const plugin of displayPlugins) {
+      const accountIds = plugin.config.listAccountIds(cfg);
+      const defaultAccountId = resolveChannelDefaultAccountId({
+        plugin,
+        cfg,
+        accountIds,
+      });
+      runtime.log(
+        `  ${plugin.id}: accounts=${accountIds.join(", ") || "(none)"} default=${defaultAccountId}`,
+      );
+      for (const accountId of accountIds) {
+        const { snapshotAccount, configured, diagnostics } = await resolveHealthAccountContext({
+          plugin,
+          cfg,
+          accountId,
+        });
+        const record = asNullableRecord(snapshotAccount);
+        const tokenSource =
+          record && typeof record.tokenSource === "string" ? record.tokenSource : undefined;
+        runtime.log(
+          `    - ${accountId}: configured=${configured}${tokenSource ? ` tokenSource=${tokenSource}` : ""}`,
+        );
+        for (const diagnostic of diagnostics) {
+          runtime.log(`      ! ${diagnostic}`);
+        }
+      }
+    }
+    runtime.log(info("[debug] bindings map"));
+    for (const [channelId, byAgent] of channelBindings.entries()) {
+      const entries = Array.from(byAgent.entries()).map(
+        ([agentId, ids]) => `${agentId}=[${ids.join(", ")}]`,
+      );
+      runtime.log(`  ${channelId}: ${entries.join(" ")}`);
+    }
+    runtime.log(info("[debug] gateway channel probes"));
+    for (const [channelId, channelSummary] of Object.entries(summary.channels ?? {})) {
+      const accounts = channelSummary.accounts ?? {};
+      const probes = Object.entries(accounts).map(([accountId, accountSummary]) => {
+        const probe = asNullableRecord(accountSummary.probe);
+        const bot = probe ? asNullableRecord(probe.bot) : null;
+        const username = bot && typeof bot.username === "string" ? bot.username : null;
+        return `${accountId}=${username ?? "(no bot)"}`;
+      });
+      runtime.log(`  ${channelId}: ${probes.join(", ") || "(none)"}`);
+    }
+  }
+
+  const channelAccountFallbacks = Object.fromEntries(
+    displayPlugins.map((plugin) => {
+      const accountIds = plugin.config.listAccountIds(cfg);
+      const defaultAccountId = resolveChannelDefaultAccountId({
+        plugin,
+        cfg,
+        accountIds,
+      });
+      const preferred = resolvePreferredAccountId({
+        accountIds,
+        defaultAccountId,
+        boundAccounts: defaultAgentId
+          ? (channelBindings.get(plugin.id)?.get(defaultAgentId) ?? [])
+          : [],
+      });
+      const fallbackIds: string[] = [preferred];
+      return [plugin.id, fallbackIds] as const;
+    }),
+  );
+  const accountIdsByChannel = (() => {
+    const entries = displayAgents.length > 0 ? displayAgents : resolvedAgents;
+    const byChannel: Record<string, string[]> = {};
+    for (const [channelId, byAgent] of channelBindings.entries()) {
+      const accountIds: string[] = [];
+      for (const agent of entries) {
+        const ids = byAgent.get(agent.agentId) ?? [];
+        for (const id of ids) {
+          if (!accountIds.includes(id)) {
+            accountIds.push(id);
+          }
+        }
+      }
+      if (accountIds.length > 0) {
+        byChannel[channelId] = accountIds;
+      }
+    }
+    for (const [channelId, fallbackIds] of Object.entries(channelAccountFallbacks)) {
+      if (!byChannel[channelId] || byChannel[channelId].length === 0) {
+        byChannel[channelId] = fallbackIds;
+      }
+    }
+    return byChannel;
+  })();
+  const channelLines =
+    Object.keys(accountIdsByChannel).length > 0
+      ? formatHealthChannelLines(summary, {
+          accountMode: params.verbose ? "all" : "default",
+          accountIdsByChannel,
+        })
+      : formatHealthChannelLines(summary, {
+          accountMode: params.verbose ? "all" : "default",
+        });
+  for (const line of channelLines) {
+    runtime.log(styleHealthChannelLine(line, rich));
+  }
+  for (const line of [
+    formatEventLoopHealthLine(summary),
+    formatContextEngineHealthLine(summary),
+    formatDeliveryQueueHealthLine(summary),
+    formatConfigReloadHealthLine(summary),
+  ]) {
+    if (line) {
+      runtime.log(styleHealthChannelLine(line, rich));
+    }
+  }
+
+  for (const plugin of displayPlugins) {
+    const channelSummary = summary.channels?.[plugin.id];
+    if (!channelSummary || channelSummary.linked !== true || !plugin.status?.logSelfId) {
+      continue;
+    }
+    const boundAccounts = defaultAgentId
+      ? (channelBindings.get(plugin.id)?.get(defaultAgentId) ?? [])
+      : [];
+    const accountIds = plugin.config.listAccountIds(cfg);
+    const defaultAccountId = resolveChannelDefaultAccountId({ plugin, cfg, accountIds });
+    const accountId = resolvePreferredAccountId({ accountIds, defaultAccountId, boundAccounts });
+    const accountContext = await resolveHealthAccountContext({
+      plugin,
+      cfg,
+      accountId,
+    });
+    if (
+      !accountContext.enabled ||
+      !accountContext.configured ||
+      accountContext.diagnostics.length > 0
+    ) {
+      continue;
+    }
+    try {
+      plugin.status.logSelfId({
+        account: accountContext.probeAccount,
+        cfg,
+        runtime,
+        includeChannelPrefix: true,
+      });
+    } catch (error) {
+      debugHealth(cfg, "logSelfId.failed", {
+        channel: plugin.id,
+        accountId,
+        error: formatErrorMessage(error),
+      });
+    }
+  }
+
+  if (Number.isFinite(summary.durationMs)) {
+    runtime.log(info(`Gateway probe duration: ${summary.durationMs}ms`));
+  }
+  if (resolvedAgents.length > 0) {
+    const agentLabels = resolvedAgents.map((agent) =>
+      agent.isDefault ? `${agent.agentId} (default)` : agent.agentId,
+    );
+    runtime.log(info(`Agents: ${agentLabels.join(", ")}`));
+  }
+  const heartbeatParts = displayAgents
+    .map((agent) => {
+      const everyMs = agent.heartbeat?.everyMs;
+      return `${everyMs ? formatHealthDurationParts(everyMs) : "disabled"} (${agent.agentId})`;
+    })
+    .filter(Boolean);
+  if (heartbeatParts.length > 0) {
+    runtime.log(info(`Heartbeat interval: ${heartbeatParts.join(", ")}`));
+  }
+  if (displayAgents.length === 0) {
+    runtime.log(
+      info(`Session store: ${summary.sessions.path} (${summary.sessions.count} entries)`),
+    );
+    for (const recent of summary.sessions.recent) {
+      runtime.log(
+        `- ${recent.key} (${recent.updatedAt ? `${Math.round((Date.now() - recent.updatedAt) / 60000)}m ago` : "no activity"})`,
+      );
+    }
+    return;
+  }
+  for (const agent of displayAgents) {
+    runtime.log(
+      info(
+        `Session store (${agent.agentId}): ${agent.sessions.path} (${agent.sessions.count} entries)`,
+      ),
+    );
+    for (const recent of agent.sessions.recent) {
+      runtime.log(
+        `- ${recent.key} (${recent.updatedAt ? `${Math.round((Date.now() - recent.updatedAt) / 60000)}m ago` : "no activity"})`,
+      );
+    }
+  }
+}

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,15 +1,8 @@
-/** Collects and renders gateway health for channels, agents, plugins, and sessions. */
-import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
-import { styleHealthChannelLine } from "../../packages/terminal-core/src/health-style.js";
-import { isRich } from "../../packages/terminal-core/src/theme.js";
-import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
-import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
+/** Collects gateway health while deferring heavy text presentation until success. */
 import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import { withProgress } from "../cli/progress.js";
-import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
-  buildGatewayConnectionDetails,
   buildGatewayProbeConnectionDetails,
   callGateway,
   formatGatewayAuthErrorJson,
@@ -18,22 +11,7 @@ import {
   isGatewayCredentialsRequiredError,
 } from "../gateway/call.js";
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
-import { resolveHealthAccountContext } from "../gateway/health/account-context.js";
-import {
-  buildHealthSessionSummary as buildSessionSummary,
-  resolveHealthAgentOrder as resolveAgentOrder,
-} from "../gateway/health/collector.js";
-import type { AgentHealthSummary, HealthSummary } from "../gateway/health/types.js";
-import { info } from "../globals.js";
-import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
-import { formatErrorMessage } from "../infra/errors.js";
-import {
-  formatDurationCompact,
-  formatDurationHuman,
-} from "../infra/format-time/format-duration.js";
-import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
-import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
+import type { HealthSummary } from "../gateway/health/types.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
   buildCredentialsRequiredHealthDiagnostic,
@@ -43,23 +21,17 @@ import {
   gatewayProbeResultSawGateway,
   gatewayProbeResultWasRateLimited,
 } from "./gateway-health-auth-diagnostic.js";
-import { formatHealthChannelLines } from "./health-format.js";
-import { logGatewayConnectionDetails } from "./status.gateway-connection.js";
-export { formatHealthChannelLines } from "./health-format.js";
+
+export {
+  formatConfigReloadHealthLine,
+  formatContextEngineHealthLine,
+  formatDeliveryQueueHealthLine,
+  formatHealthChannelLines,
+} from "./health-format.js";
 export type { HealthSummary } from "../gateway/health/types.js";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
-const healthLog = createSubsystemLogger("health");
-
-const debugHealth = (
-  cfg: OpenClawConfig | undefined,
-  message: string,
-  meta?: Record<string, unknown>,
-) => {
-  if (isDiagnosticFlagEnabled("health", cfg)) {
-    healthLog.info(message, meta);
-  }
-};
+const loadConfigRuntime = async () => await import("../config/config.js");
 
 function isGatewayHealthAuthUnavailableError(error: unknown): boolean {
   return isGatewayCredentialsRequiredError(error) || isGatewaySecretRefUnavailableError(error);
@@ -116,124 +88,13 @@ export async function emitReachableGatewayAuthDiagnostic(params: {
     : buildCredentialsRequiredHealthDiagnostic();
   if (params.json) {
     writeRuntimeJson(params.runtime, diagnostic);
-    params.runtime.exit(1);
-    return true;
+  } else {
+    params.runtime.log(GATEWAY_HEALTH_REACHABLE_LINE);
+    params.runtime.log(diagnostic.error.message);
   }
-  params.runtime.log(GATEWAY_HEALTH_REACHABLE_LINE);
-  params.runtime.log(diagnostic.error.message);
   params.runtime.exit(1);
   return true;
 }
-
-const loadConfigRuntime = async () => await import("../config/config.js");
-
-const formatDurationParts = (ms: number): string => {
-  if (!Number.isFinite(ms)) {
-    return "unknown";
-  }
-  if (ms < 1000) {
-    return `${Math.max(0, Math.round(ms))}ms`;
-  }
-  const units: Array<{ label: string; size: number }> = [
-    { label: "w", size: 7 * 24 * 60 * 60 * 1000 },
-    { label: "d", size: 24 * 60 * 60 * 1000 },
-    { label: "h", size: 60 * 60 * 1000 },
-    { label: "m", size: 60 * 1000 },
-    { label: "s", size: 1000 },
-  ];
-  let remaining = Math.max(0, Math.floor(ms));
-  const parts: string[] = [];
-  for (const unit of units) {
-    const value = Math.floor(remaining / unit.size);
-    if (value > 0) {
-      parts.push(`${value}${unit.label}`);
-      remaining -= value * unit.size;
-    }
-  }
-  if (parts.length === 0) {
-    return "0s";
-  }
-  return parts.join(" ");
-};
-
-function formatEventLoopHealthLine(summary: HealthSummary): string | null {
-  const eventLoop = summary.eventLoop;
-  if (!eventLoop) {
-    return null;
-  }
-  const state = eventLoop.degraded ? "degraded" : "ok";
-  const degradedFor =
-    eventLoop.degraded && eventLoop.degradedSinceMs != null
-      ? ` for ${formatDurationCompact(eventLoop.degradedSinceMs) ?? "0s"}`
-      : "";
-  const reasons = eventLoop.reasons.length > 0 ? ` reasons=${eventLoop.reasons.join(",")}` : "";
-  return `Gateway event loop: ${state}${degradedFor}${reasons} max=${Math.round(
-    eventLoop.delayMaxMs,
-  )}ms p99=${Math.round(eventLoop.delayP99Ms)}ms util=${eventLoop.utilization} cpu=${
-    eventLoop.cpuCoreRatio
-  }`;
-}
-
-/** Formats context engine quarantine state for text health output. */
-export function formatContextEngineHealthLine(summary: HealthSummary): string | null {
-  const quarantined = summary.contextEngines?.quarantined ?? [];
-  if (quarantined.length === 0) {
-    return null;
-  }
-  const engines = quarantined.map((entry) => entry.engineId).join(", ");
-  return `Context engine: warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`;
-}
-
-/** Formats dead-lettered and pressured delivery queue entries for text health output. */
-export function formatDeliveryQueueHealthLine(
-  summary: HealthSummary,
-  now = Date.now(),
-): string | null {
-  const failed = summary.deliveryQueues?.failed ?? [];
-  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
-  const ingressPressure = summary.deliveryQueues?.ingressPressure ?? [];
-  const warnings: string[] = [];
-  const deadLetterCounts = [
-    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
-    ...ingressFailed.map(
-      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
-    ),
-  ].join(", ");
-  const oldest = [...failed, ...ingressFailed]
-    .map((queue) => queue.oldestFailedAt)
-    .filter((value): value is number => typeof value === "number");
-  const oldestNote =
-    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
-  if (deadLetterCounts) {
-    warnings.push(`dead-lettered entries — ${deadLetterCounts}${oldestNote}`);
-  }
-  if (ingressPressure.length > 0) {
-    const pressureCounts = ingressPressure
-      .map(
-        (queue) =>
-          `inbound ${queue.channelId}/${queue.accountId}: ${queue.laneCount} pressured ${
-            queue.laneCount === 1 ? "lane" : "lanes"
-          }, ${queue.pendingCount} pending, ${queue.claimedCount} claimed, ${queue.blockedCount} blocked`,
-      )
-      .join(", ");
-    const oldestPressure = Math.min(...ingressPressure.map((queue) => queue.oldestReceivedAt));
-    warnings.push(
-      `ingress pressure — ${pressureCounts}; oldest ${formatDurationHuman(now - oldestPressure)} ago`,
-    );
-  }
-  return warnings.length > 0 ? `Delivery queue: warning (${warnings.join("; ")})` : null;
-}
-
-/** Formats config hot-reload watcher degradation for text health output. */
-export function formatConfigReloadHealthLine(summary: HealthSummary): string | null {
-  if (summary.configReload?.hotReloadStatus !== "disabled") {
-    return null;
-  }
-  return "Config hot reload: disabled (watcher retries exhausted; restart the gateway to restore it)";
-}
-
-const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
-  resolveHeartbeatSummaryForAgent(cfg, agentId);
 
 /** Runs the `openclaw health` command against the gateway and renders JSON or text. */
 export async function healthCommand(
@@ -248,9 +109,8 @@ export async function healthCommand(
     localPortOverride?: number;
   },
   runtime: RuntimeEnv,
-) {
-  const cfg = opts.config ?? (await readNonObservingHealthConfig());
-  // Always query the running gateway; do not open a direct Baileys socket here.
+): Promise<void> {
+  const config = opts.config ?? (await readNonObservingHealthConfig());
   let summary: HealthSummary;
   try {
     summary = await withProgress(
@@ -264,7 +124,7 @@ export async function healthCommand(
           method: "health",
           params: opts.verbose ? { probe: true } : undefined,
           timeoutMs: opts.timeoutMs,
-          config: cfg,
+          config,
           token: opts.token,
           password: opts.password,
           sharedStateMode: "read-only",
@@ -276,7 +136,7 @@ export async function healthCommand(
     if (
       await emitReachableGatewayAuthDiagnostic({
         error,
-        config: cfg,
+        config,
         runtime,
         timeoutMs: opts.timeoutMs,
         token: opts.token,
@@ -303,264 +163,17 @@ export async function healthCommand(
   }
   if (opts.json) {
     writeRuntimeJson(runtime, summary);
-  } else {
-    const debugEnabled = isDiagnosticFlagEnabled("health", cfg);
-    const rich = isRich();
-    if (opts.verbose) {
-      const details = buildGatewayConnectionDetails({
-        config: cfg,
-        ignoreEnvUrlOverride: opts.ignoreEnvUrlOverride,
-        localPortOverride: opts.localPortOverride,
-      });
-      logGatewayConnectionDetails({
-        runtime,
-        info,
-        message: details.message,
-      });
-    }
-    const localAgents = resolveAgentOrder(cfg);
-    const defaultAgentId = summary.defaultAgentId ?? localAgents.defaultAgentId;
-    const agents = Array.isArray(summary.agents) ? summary.agents : [];
-    const resolvedAgents =
-      agents.length > 0
-        ? agents
-        : await Promise.all(
-            localAgents.ordered.map(async (entry) => {
-              const storePath = resolveSessionStorePathCore(cfg.session?.store, {
-                agentId: entry.id,
-              });
-              return {
-                agentId: entry.id,
-                name: entry.name,
-                isDefault: entry.id === localAgents.defaultAgentId,
-                heartbeat: resolveHeartbeatSummary(cfg, entry.id),
-                sessions: await buildSessionSummary(storePath, entry.id),
-              } satisfies AgentHealthSummary;
-            }),
-          );
-    const displayAgents =
-      opts.verbose || !defaultAgentId
-        ? resolvedAgents
-        : resolvedAgents.filter((agent) => agent.agentId === defaultAgentId);
-    const channelBindings = buildChannelAccountBindings(cfg);
-    const displayPlugins = listReadOnlyChannelPluginsForConfig(cfg, {
-      includeSetupFallbackPlugins: false,
-    });
-    if (debugEnabled) {
-      runtime.log(info("[debug] local channel accounts"));
-      for (const plugin of displayPlugins) {
-        const accountIds = plugin.config.listAccountIds(cfg);
-        const defaultAccountId = resolveChannelDefaultAccountId({
-          plugin,
-          cfg,
-          accountIds,
-        });
-        runtime.log(
-          `  ${plugin.id}: accounts=${accountIds.join(", ") || "(none)"} default=${defaultAccountId}`,
-        );
-        for (const accountId of accountIds) {
-          const { snapshotAccount, configured, diagnostics } = await resolveHealthAccountContext({
-            plugin,
-            cfg,
-            accountId,
-          });
-          const record = asNullableRecord(snapshotAccount);
-          const tokenSource =
-            record && typeof record.tokenSource === "string" ? record.tokenSource : undefined;
-          runtime.log(
-            `    - ${accountId}: configured=${configured}${tokenSource ? ` tokenSource=${tokenSource}` : ""}`,
-          );
-          for (const diagnostic of diagnostics) {
-            runtime.log(`      ! ${diagnostic}`);
-          }
-        }
-      }
-      runtime.log(info("[debug] bindings map"));
-      for (const [channelId, byAgent] of channelBindings.entries()) {
-        const entries = Array.from(byAgent.entries()).map(
-          ([agentId, ids]) => `${agentId}=[${ids.join(", ")}]`,
-        );
-        runtime.log(`  ${channelId}: ${entries.join(" ")}`);
-      }
-      runtime.log(info("[debug] gateway channel probes"));
-      for (const [channelId, channelSummary] of Object.entries(summary.channels ?? {})) {
-        const accounts = channelSummary.accounts ?? {};
-        const probes = Object.entries(accounts).map(([accountId, accountSummary]) => {
-          const probe = asNullableRecord(accountSummary.probe);
-          const bot = probe ? asNullableRecord(probe.bot) : null;
-          const username = bot && typeof bot.username === "string" ? bot.username : null;
-          return `${accountId}=${username ?? "(no bot)"}`;
-        });
-        runtime.log(`  ${channelId}: ${probes.join(", ") || "(none)"}`);
-      }
-    }
-    const channelAccountFallbacks = Object.fromEntries(
-      displayPlugins.map((plugin) => {
-        const accountIds = plugin.config.listAccountIds(cfg);
-        const defaultAccountId = resolveChannelDefaultAccountId({
-          plugin,
-          cfg,
-          accountIds,
-        });
-        const preferred = resolvePreferredAccountId({
-          accountIds,
-          defaultAccountId,
-          boundAccounts: defaultAgentId
-            ? (channelBindings.get(plugin.id)?.get(defaultAgentId) ?? [])
-            : [],
-        });
-        return [plugin.id, [preferred] as string[]] as const;
-      }),
-    );
-    const accountIdsByChannel = (() => {
-      const entries = displayAgents.length > 0 ? displayAgents : resolvedAgents;
-      const byChannel: Record<string, string[]> = {};
-      for (const [channelId, byAgent] of channelBindings.entries()) {
-        const accountIds: string[] = [];
-        for (const agent of entries) {
-          const ids = byAgent.get(agent.agentId) ?? [];
-          for (const id of ids) {
-            if (!accountIds.includes(id)) {
-              accountIds.push(id);
-            }
-          }
-        }
-        if (accountIds.length > 0) {
-          byChannel[channelId] = accountIds;
-        }
-      }
-      for (const [channelId, fallbackIds] of Object.entries(channelAccountFallbacks)) {
-        if (!byChannel[channelId] || byChannel[channelId].length === 0) {
-          byChannel[channelId] = fallbackIds;
-        }
-      }
-      return byChannel;
-    })();
-    const channelLines =
-      Object.keys(accountIdsByChannel).length > 0
-        ? formatHealthChannelLines(summary, {
-            accountMode: opts.verbose ? "all" : "default",
-            accountIdsByChannel,
-          })
-        : formatHealthChannelLines(summary, {
-            accountMode: opts.verbose ? "all" : "default",
-          });
-    for (const line of channelLines) {
-      runtime.log(styleHealthChannelLine(line, rich));
-    }
-    const eventLoopLine = formatEventLoopHealthLine(summary);
-    if (eventLoopLine) {
-      runtime.log(styleHealthChannelLine(eventLoopLine, rich));
-    }
-    const contextEngineLine = formatContextEngineHealthLine(summary);
-    if (contextEngineLine) {
-      runtime.log(styleHealthChannelLine(contextEngineLine, rich));
-    }
-    const deliveryQueueLine = formatDeliveryQueueHealthLine(summary);
-    if (deliveryQueueLine) {
-      runtime.log(styleHealthChannelLine(deliveryQueueLine, rich));
-    }
-    const configReloadLine = formatConfigReloadHealthLine(summary);
-    if (configReloadLine) {
-      runtime.log(styleHealthChannelLine(configReloadLine, rich));
-    }
-    for (const plugin of displayPlugins) {
-      const channelSummary = summary.channels?.[plugin.id];
-      if (!channelSummary || channelSummary.linked !== true) {
-        continue;
-      }
-      if (!plugin.status?.logSelfId) {
-        continue;
-      }
-      const boundAccounts = defaultAgentId
-        ? (channelBindings.get(plugin.id)?.get(defaultAgentId) ?? [])
-        : [];
-      const accountIds = plugin.config.listAccountIds(cfg);
-      const defaultAccountId = resolveChannelDefaultAccountId({
-        plugin,
-        cfg,
-        accountIds,
-      });
-      const accountId = resolvePreferredAccountId({
-        accountIds,
-        defaultAccountId,
-        boundAccounts,
-      });
-      const accountContext = await resolveHealthAccountContext({
-        plugin,
-        cfg,
-        accountId,
-      });
-      if (!accountContext.enabled || !accountContext.configured) {
-        continue;
-      }
-      if (accountContext.diagnostics.length > 0) {
-        continue;
-      }
-      try {
-        plugin.status.logSelfId({
-          account: accountContext.probeAccount,
-          cfg,
-          runtime,
-          includeChannelPrefix: true,
-        });
-      } catch (error) {
-        debugHealth(cfg, "logSelfId.failed", {
-          channel: plugin.id,
-          accountId,
-          error: formatErrorMessage(error),
-        });
-      }
-    }
-
-    if (Number.isFinite(summary.durationMs)) {
-      runtime.log(info(`Gateway probe duration: ${summary.durationMs}ms`));
-    }
-
-    if (resolvedAgents.length > 0) {
-      const agentLabels = resolvedAgents.map((agent) =>
-        agent.isDefault ? `${agent.agentId} (default)` : agent.agentId,
-      );
-      runtime.log(info(`Agents: ${agentLabels.join(", ")}`));
-    }
-    const heartbeatParts = displayAgents
-      .map((agent) => {
-        const everyMs = agent.heartbeat?.everyMs;
-        const label = everyMs ? formatDurationParts(everyMs) : "disabled";
-        return `${label} (${agent.agentId})`;
-      })
-      .filter(Boolean);
-    if (heartbeatParts.length > 0) {
-      runtime.log(info(`Heartbeat interval: ${heartbeatParts.join(", ")}`));
-    }
-    if (displayAgents.length === 0) {
-      runtime.log(
-        info(`Session store: ${summary.sessions.path} (${summary.sessions.count} entries)`),
-      );
-      if (summary.sessions.recent.length > 0) {
-        for (const r of summary.sessions.recent) {
-          runtime.log(
-            `- ${r.key} (${r.updatedAt ? `${Math.round((Date.now() - r.updatedAt) / 60000)}m ago` : "no activity"})`,
-          );
-        }
-      }
-    } else {
-      for (const agent of displayAgents) {
-        runtime.log(
-          info(
-            `Session store (${agent.agentId}): ${agent.sessions.path} (${agent.sessions.count} entries)`,
-          ),
-        );
-        if (agent.sessions.recent.length > 0) {
-          for (const r of agent.sessions.recent) {
-            runtime.log(
-              `- ${r.key} (${r.updatedAt ? `${Math.round((Date.now() - r.updatedAt) / 60000)}m ago` : "no activity"})`,
-            );
-          }
-        }
-      }
-    }
+    return;
   }
+  const { renderHealthText } = await import("./health-text.js");
+  await renderHealthText({
+    config,
+    summary,
+    runtime,
+    verbose: opts.verbose,
+    ignoreEnvUrlOverride: opts.ignoreEnvUrlOverride,
+    localPortOverride: opts.localPortOverride,
+  });
 }
 
 export async function readNonObservingHealthConfig(): Promise<OpenClawConfig> {

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -301,6 +301,39 @@ describe("bundled plugin public surface loader", () => {
     },
   );
 
+  it("refreshes same-path native public artifact exports with plugin metadata", async () => {
+    const publicSurfaceLoader = await importFreshModule<
+      typeof import("./public-surface-loader.js")
+    >(import.meta.url, "./public-surface-loader.js?scope=same-path-native-artifact-refresh");
+    const { clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js");
+    const tempRoot = tempDirs.make("openclaw-public-surface-loader-");
+    const pluginRoot = path.join(tempRoot, "installed-plugin");
+    const modulePath = path.join(pluginRoot, "provider-policy-api.cjs");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+
+    const replaceArtifact = (marker: string) => {
+      const replacementPath = `${modulePath}.next`;
+      fs.writeFileSync(
+        replacementPath,
+        `module.exports = { marker: ${JSON.stringify(marker)} };\n`,
+      );
+      fs.renameSync(replacementPath, modulePath);
+    };
+    const loadArtifact = () =>
+      publicSurfaceLoader.loadPluginPublicArtifactModuleSync<{ marker: string }>({
+        pluginRoot,
+        artifactBasename: "provider-policy-api.cjs",
+      }).marker;
+
+    replaceArtifact("before-update");
+    expect(loadArtifact()).toBe("before-update");
+
+    replaceArtifact("after-update");
+    clearPluginMetadataLifecycleCaches();
+
+    expect(loadArtifact()).toBe("after-update");
+  });
+
   it.runIf(process.platform !== "win32")(
     "allows hardlinked bundled public artifacts under the trusted bundled root",
     async () => {

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -8,6 +8,7 @@ import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
+import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
   createPluginModuleLoaderCache,
@@ -26,6 +27,7 @@ const OPENCLAW_PACKAGE_ROOT =
     moduleUrl: import.meta.url,
   }) ?? fileURLToPath(new URL("../..", import.meta.url));
 const publicSurfaceModuleCache = new Map<string, unknown>();
+const publicSurfaceModuleRoots = new Map<string, string>();
 const sourceArtifactRequire = createRequire(import.meta.url);
 type PublicSurfaceLocation = {
   modulePath: string;
@@ -36,6 +38,12 @@ const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
 
 registerPluginMetadataProcessMemoLifecycleClear(() => {
   publicSurfaceLocationCache.clear();
+  moduleLoaders.clear();
+  for (const [modulePath, boundaryRoot] of publicSurfaceModuleRoots) {
+    clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot: boundaryRoot });
+  }
+  publicSurfaceModuleCache.clear();
+  publicSurfaceModuleRoots.clear();
 });
 
 function isSourceArtifactPath(modulePath: string): boolean {
@@ -160,6 +168,8 @@ function loadValidatedPublicSurfaceModule(params: {
   const sentinel: Record<string, unknown> = {};
   publicSurfaceModuleCache.set(params.modulePath, sentinel);
   publicSurfaceModuleCache.set(validatedPath, sentinel);
+  publicSurfaceModuleRoots.set(params.modulePath, params.boundaryRoot);
+  publicSurfaceModuleRoots.set(validatedPath, params.boundaryRoot);
   try {
     const loaded = loadPublicSurfaceModule(validatedPath) as object;
     Object.assign(sentinel, loaded);
@@ -167,6 +177,8 @@ function loadValidatedPublicSurfaceModule(params: {
   } catch (error) {
     publicSurfaceModuleCache.delete(params.modulePath);
     publicSurfaceModuleCache.delete(validatedPath);
+    publicSurfaceModuleRoots.delete(params.modulePath);
+    publicSurfaceModuleRoots.delete(validatedPath);
     throw error;
   }
 }


### PR DESCRIPTION
Related: #103571
Related: #103688

## What Problem This Solves

Fixes an issue where plugin public-surface consumers could keep serving old exports after an install, reload, doctor, or gateway lifecycle reset replaced a CommonJS artifact at the same path. The artifact location was refreshed, but the cached export object, module-loader/Jiti closure, and Node require cache survived, so the replacement could remain silently stale.

## Why This Change Was Made

The public-surface loader now owns the complete lifecycle reset for its cached facts: artifact locations, module loaders, bounded native require graphs, export sentinels, and their recorded plugin roots are cleared together through the existing plugin metadata lifecycle hook. This keeps invalidation at the owner boundary, avoids steady-state filesystem polling, and never broad-purges shared dependencies.

The first exact-head CI run exposed a separate cold-start owner problem: unreachable health commands eagerly imported successful text rendering, channel, session, and plugin inspection code before they could report the transport failure. Instead of retrying or relaxing the process guard, successful text rendering now lives behind an effective lazy module boundary; JSON, authentication diagnostics, and failure paths keep the light query owner.

This is a focused current-owner companion to the broader workspace-plugin restart work in #103688; it does not replace that PR's restart flow. Thanks to @ObliviateRickLin for the restart-cache investigation and to @pallaoro for the original production report.

## User Impact

When OpenClaw intentionally refreshes plugin metadata, a replaced public artifact at the same path now exposes its new exports instead of continuing to serve the old in-process module graph. Unreachable health commands also reach their useful error output without first loading success-only local inspection and presentation code.

## Evidence

- Parent regression proof: with production restored to parent `efde610a9f64` while retaining the new test, `node scripts/run-vitest.mjs src/plugins/public-surface-loader.test.ts -t "refreshes same-path native public artifact exports with plugin metadata"` failed as intended: expected `after-update`, received `before-update`.
- Plugin-cache proof: `node scripts/run-vitest.mjs src/plugins/public-surface-loader.test.ts src/plugins/native-module-require.test.ts` — 2 files, 31 tests passed.
- Health owner/sibling proof: `node scripts/run-vitest.mjs src/cli/gateway-backed-exit.process.test.ts src/commands/health.test.ts src/commands/health-format.test.ts src/cli/gateway-cli/health-route.test.ts src/cli/gateway-cli/register.option-collisions.test.ts` — 5 files, 89 tests passed, including all 17 real process cases.
- Cold-source proof with a fresh TSX cache: the unchanged ten-process unreachable-health group passed in 22.4s total / 21.2s test time, down from 28.6s / 27.3s before the owner split; every child keeps its original 20-second deadlock guard.
- Changed gate: `node scripts/check-changed.mjs` — passed, including core production/test types, full core/scripts lint, generated metadata, plugin boundaries, dead exports, runtime sidecar checks, and `check:import-cycles` with zero runtime value cycles.
- Build: `pnpm build` — passed; emitted a separate `dist/health-text-*.js` lazy chunk, with built plugin control-plane loads, public Plugin SDK exports, CLI bootstrap imports, runtime postbuild, and no ineffective dynamic import.
- Diff hygiene: `git diff --check` — passed.
- Test audit: no tests changed. An implementation-coupled test warmup was rejected; the existing process assertions and time limits remain untouched.
- Codex-backed autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high` — clean, no accepted/actionable findings; overall verdict: patch is correct.
- Failed exact-head CI: run 32067161227, job 95502002422. Replacement exact-head CI: run 32074780978 for `5d9d8585cf2b4f1ec07142f4542b5d3d486a5231`.
- LOC: production +429/-415; tests +33/-0; tooling ratchet +0/-1.

Proof gap: this focused plugin repair has no standalone interactive CLI surface, so no separate live gateway/provider run was added. The regression uses an actual sibling-write-plus-rename replacement, the real public-surface loader, the real metadata lifecycle clear, and Node's real CommonJS cache without mocks. The broader TypeScript workspace-plugin restart flow remains owned by #103688. The replacement CI run is attached and in progress; a bounded repository watcher observed no new failure before its three-minute cap.

AI-assisted: Codex was used for investigation, validation, and review; the implementation and evidence were manually verified.
