### PR TITLE
fix(gateway): support shared Tailscale ingress

### DIFF
--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -6,7 +6,7 @@ read_when:
 title: "Tailscale"
 ---
 
-OpenClaw can auto-configure Tailscale **Serve** (tailnet) or **Funnel** (public) for the Gateway dashboard and WebSocket port. This keeps the gateway bound to loopback while Tailscale provides HTTPS, routing, and (for Serve) identity headers.
+OpenClaw can auto-configure Tailscale **Serve** (tailnet) or **Funnel** (public) for the Gateway dashboard and WebSocket port. It can also expose a dedicated attributed listener for a Serve/Funnel route managed elsewhere. Both paths keep the gateway bound to loopback while Tailscale provides HTTPS, routing, and (for Serve) identity headers.
 
 <Note>
 Looking for the step-by-step setup? See [Give your Gateway a stable HTTPS URL](/gateway/stable-https-url).
@@ -38,6 +38,34 @@ Status and audit output use **Tailscale exposure** for this OpenClaw Serve/Funne
 ```
 
 Open: `https://<magicdns>/` (or your configured `gateway.controlUi.basePath`)
+
+### Share an existing Tailscale HTTPS listener
+
+Use external ingress when another process owns the host's Tailscale Serve or Funnel configuration, such as a shared port 443 listener with several path handlers. Choose a dedicated unused loopback port that differs from `gateway.port`:
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    auth: { mode: "token", allowTailscale: false },
+    tailscale: {
+      mode: "serve",
+      externalIngressPort: 19012,
+    },
+  },
+}
+```
+
+Then point the externally owned route at that listener. For example:
+
+```bash
+tailscale serve --bg --https=443 --set-path=/openclaw \
+  http://127.0.0.1:19012/openclaw
+```
+
+With `externalIngressPort` set, OpenClaw binds the dedicated listener but never creates, changes, or removes Tailscale routes. The external route owner controls the shared listener lifecycle. Match `tailscale.mode` to the external route (`serve` or `funnel`), keep the backend loopback-only, and make the route target only this dedicated port. Set `gateway.auth.allowTailscale: false` when every client must still present the configured token or password.
+
+Do not point the external route at the ordinary `gateway.port`. That listener intentionally rejects Tailscale-owned attribution headers so an arbitrary local reverse proxy cannot impersonate a Tailscale client.
 
 ### Tailnet-only (bind to Tailnet IP)
 
@@ -110,7 +138,7 @@ Scope of the bypass:
 
 - Tailscale Serve/Funnel requires the `tailscale` CLI installed and logged in.
 - `tailscale.mode: "funnel"` refuses to start unless auth mode is `password`, to avoid public exposure.
-- OpenClaw holds Serve/Funnel as a foreground Tailscale claim. Gateway startup succeeds only after the claim is active, and stopping or losing the Gateway releases it automatically.
+- By default, OpenClaw holds Serve/Funnel as a foreground Tailscale claim. Gateway startup succeeds only after the claim is active, and stopping or losing the Gateway releases it automatically. `externalIngressPort` leaves route ownership and cleanup to the external operator instead.
 - Named Tailscale Services are not supported by managed ingress because Tailscale requires them to run as persistent background routes. Existing `gateway.tailscale.serviceName` installs must run `openclaw doctor --fix`; Doctor disables managed ingress and removes the key. Inspect the retained Service route, clear it with `tailscale serve clear <service-name>`, then enable device Serve with `gateway.tailscale.mode: "serve"` if desired.
 - Older releases could advertise an externally configured default HTTPS Serve route that targeted a `gateway.bind: "lan"` listener. That route no longer has trusted ingress provenance. Run `openclaw doctor` to preview an atomic migration to `gateway.bind: "loopback"` plus `gateway.tailscale.mode: "serve"`; apply it with `openclaw doctor --fix`, then restart the Gateway so it can claim the route through managed ingress. Doctor does not reset Tailscale state or guess how to rewrite custom Serve ports and Tailscale Services; migrate those manually.
 - `gateway.tailscale.preserveFunnel: true` is a deprecated migration guard. It detects an externally configured `tailscale funnel` route before reapplying Serve. If that route still targets the ordinary Gateway listener, OpenClaw leaves it unchanged and warns because requests lack managed-ingress provenance. Plugin-authenticated webhook routes such as Google Chat and SMS keep using their own signature/auth checks and ignore forwarded client claims; Gateway-authenticated HTTP and WebSocket routes reject that ingress. First configure a durable `gateway.auth.password` (prefer a SecretRef) or `OPENCLAW_GATEWAY_PASSWORD`, then set `gateway.auth.mode` to `password`. After password auth is ready, run `openclaw config set gateway.tailscale.mode funnel`, then `openclaw config unset gateway.tailscale.preserveFunnel`; managed Funnel targets the dedicated ingress.
@@ -122,7 +150,7 @@ Scope of the bypass:
 
 - Serve requires HTTPS enabled for your tailnet; the CLI prompts if it is missing.
 - Serve injects Tailscale identity headers; Funnel does not.
-- OpenClaw-managed Serve/Funnel proxy to a dedicated `127.0.0.1:<ephemeral-port>` listener while ordinary local clients keep the configured Gateway port. Startup fails closed rather than sharing listener provenance, and the foreground claim releases the route when its Gateway owner disappears.
+- OpenClaw-managed Serve/Funnel proxy to a dedicated `127.0.0.1:<ephemeral-port>` listener while ordinary local clients keep the configured Gateway port. External ingress uses the configured fixed loopback port instead. Startup fails closed rather than sharing listener provenance; only OpenClaw-owned foreground claims are released when the Gateway exits.
 - Funnel requires Tailscale v1.38.3+, MagicDNS, HTTPS enabled, and a funnel node attribute.
 - Funnel only supports ports `443`, `8443`, and `10000` over TLS.
 - Funnel on macOS requires the open-source Tailscale app variant.

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -35,6 +35,34 @@ describe("gateway tailscale bind validation", () => {
     expect(funnelRes.ok).toBe(true);
   });
 
+  it("accepts a dedicated external ingress port when Tailscale ingress is enabled", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "serve", externalIngressPort: 19012 },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects a dedicated external ingress port when Tailscale ingress is off", () => {
+    const res = validateConfigObject({
+      gateway: {
+        tailscale: { mode: "off", externalIngressPort: 19012 },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues).toContainEqual({
+        path: "gateway.tailscale.externalIngressPort",
+        message:
+          "gateway.tailscale.externalIngressPort requires gateway.tailscale.mode=serve or funnel",
+      });
+    }
+  });
+
   it("rejects the retired Tailscale serviceName key from canonical config", () => {
     const res = validateConfigObject({
       gateway: {

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -143,6 +143,8 @@ export const CORE_FIELD_HELP: Record<string, string> = {
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":
     'Tailscale publish mode: "off", "serve", or "funnel" for private or public exposure paths. Use "serve" for tailnet-only access and "funnel" only when public internet reachability is required.',
+  "gateway.tailscale.externalIngressPort":
+    "Fixed loopback port for a Tailscale Serve or Funnel route managed outside OpenClaw. Set this when sharing an existing Tailscale HTTPS listener; OpenClaw validates attributed ingress on this port but never creates, changes, or removes the external route.",
   "gateway.tailscale.preserveFunnel":
     "Deprecated migration guard for mode='serve'. If an external Funnel still targets the ordinary Gateway listener, OpenClaw leaves exposure unchanged and warns that only plugin-authenticated webhooks remain usable until password auth is configured and mode is migrated to 'funnel'.",
   "gateway.remote":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -140,6 +140,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools.deny": "Gateway Tool Denylist",
   "gateway.tailscale": "Gateway Tailscale",
   "gateway.tailscale.mode": "Gateway Tailscale Mode",
+  "gateway.tailscale.externalIngressPort": "Gateway Tailscale External Ingress Port",
   "gateway.tailscale.preserveFunnel": "Gateway Tailscale External Funnel Migration Guard",
   "gateway.remote": "Remote Gateway",
   "gateway.remote.transport": "Remote Gateway Transport",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -257,6 +257,11 @@ export type GatewayTailscaleConfig = {
   /** Tailscale exposure mode for the Gateway control UI. */
   mode?: GatewayTailscaleMode;
   /**
+   * Fixed loopback port for a Tailscale Serve/Funnel route managed outside
+   * OpenClaw. When set, OpenClaw does not create or remove the Tailscale route.
+   */
+  externalIngressPort?: number;
+  /**
    * Detect an external Funnel route left on the ordinary Gateway listener and
    * leave exposure unchanged with migration guidance. Gateway-authenticated
    * routes reject that ingress; plugin-authenticated webhooks keep their owner auth.

--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -232,6 +232,32 @@ function validateGatewayTailscaleAuth(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function validateGatewayTailscaleExternalIngress(config: OpenClawConfig): ConfigValidationIssue[] {
+  const externalIngressPort = config.gateway?.tailscale?.externalIngressPort;
+  if (externalIngressPort === undefined) {
+    return [];
+  }
+  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
+  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") {
+    return [
+      {
+        path: "gateway.tailscale.externalIngressPort",
+        message:
+          "gateway.tailscale.externalIngressPort requires gateway.tailscale.mode=serve or funnel",
+      },
+    ];
+  }
+  if (config.gateway?.port === externalIngressPort) {
+    return [
+      {
+        path: "gateway.tailscale.externalIngressPort",
+        message: "gateway.tailscale.externalIngressPort must differ from the ordinary gateway port",
+      },
+    ];
+  }
+  return [];
+}
+
 function collectModelPolicyAllowIssues(config: OpenClawConfig): ConfigValidationIssue[] {
   const issues: ConfigValidationIssue[] = [];
   const defaultModels = config.agents?.defaults?.models;
@@ -384,6 +410,11 @@ export function validateConfigObjectRaw(
   const gatewayTailscaleAuthIssues = validateGatewayTailscaleAuth(validatedConfig);
   if (gatewayTailscaleAuthIssues.length > 0) {
     return { ok: false, issues: gatewayTailscaleAuthIssues };
+  }
+  const gatewayTailscaleExternalIngressIssues =
+    validateGatewayTailscaleExternalIngress(validatedConfig);
+  if (gatewayTailscaleExternalIngressIssues.length > 0) {
+    return { ok: false, issues: gatewayTailscaleExternalIngressIssues };
   }
   const modelPolicyAllowIssues = collectModelPolicyAllowIssues(validatedConfig);
   if (modelPolicyAllowIssues.length > 0) {

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -140,6 +140,7 @@ export const GatewayConfigSchema = z
     tailscale: z
       .strictObject({
         mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),
+        externalIngressPort: z.number().int().min(1).max(65535).optional(),
         preserveFunnel: z.boolean().optional(),
       })
       .optional(),

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -320,6 +320,22 @@ describe("resolveGatewayRuntimeConfig", () => {
       ).rejects.toThrow("gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve");
     });
 
+    it("rejects an external Tailscale ingress port that collides with the ordinary gateway", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              auth: TOKEN_AUTH,
+              tailscale: { mode: "serve", externalIngressPort: 18789 },
+            },
+          },
+          port: 18789,
+        }),
+      ).rejects.toThrow(
+        "gateway.tailscale.externalIngressPort must differ from the ordinary gateway port",
+      );
+    });
+
     it("respects explicit loopback config even inside a container", async () => {
       const fs = require("node:fs");
       vi.spyOn(fs, "accessSync").mockImplementation(() => undefined); // /.dockerenv exists

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -122,6 +122,18 @@ export async function resolveGatewayRuntimeConfig(params: {
   const tailscaleOverrides = params.tailscale ?? {};
   const tailscaleConfig = mergeGatewayTailscaleConfig(tailscaleBase, tailscaleOverrides);
   const tailscaleMode = tailscaleConfig.mode ?? "off";
+  if (tailscaleConfig.externalIngressPort !== undefined) {
+    if (tailscaleMode === "off") {
+      throw new Error(
+        "gateway.tailscale.externalIngressPort requires gateway.tailscale.mode=serve or funnel",
+      );
+    }
+    if (tailscaleConfig.externalIngressPort === params.port) {
+      throw new Error(
+        "gateway.tailscale.externalIngressPort must differ from the ordinary gateway port",
+      );
+    }
+  }
   const resolvedAuth = resolveGatewayAuth({
     authConfig: params.cfg.gateway?.auth,
     authOverride: params.auth,

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -472,6 +472,7 @@ export async function prepareGatewayKernelState(params: {
     nodeDesktopStreamBroker,
     clients: connectionState.clients,
     tailscaleMode,
+    tailscaleIngressPort: tailscaleConfig.externalIngressPort,
   });
   const {
     clients,

--- a/src/gateway/server-runtime-state.tailscale.test.ts
+++ b/src/gateway/server-runtime-state.tailscale.test.ts
@@ -1,4 +1,5 @@
 import { request as httpRequest, type RequestOptions } from "node:http";
+import { createServer as createNetServer } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
@@ -57,6 +58,23 @@ async function requestUpgrade(options: RequestOptions): Promise<{
   });
 }
 
+async function reserveLoopbackPort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("failed to reserve a loopback port");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
+
 describe("managed Tailscale gateway ingress", () => {
   const openServers: Array<Awaited<ReturnType<typeof createGatewayRuntimeStateForTest>>> = [];
 
@@ -99,6 +117,22 @@ describe("managed Tailscale gateway ingress", () => {
     releaseRouteClaim();
     await starting;
     expect(runtime.httpServer.listening).toBe(true);
+  });
+
+  it("binds externally routed Tailscale ingress to its configured loopback port", async () => {
+    const externalIngressPort = await reserveLoopbackPort();
+    const runtime = await createGatewayRuntimeStateForTest(undefined, {
+      tailscaleMode: "serve",
+      tailscaleIngressPort: externalIngressPort,
+    });
+    openServers.push(runtime);
+
+    await runtime.startListening();
+
+    expect(runtime.getTailscaleIngressEndpoint()).toEqual({
+      host: "127.0.0.1",
+      port: externalIngressPort,
+    });
   });
 
   it("binds a distinct private listener and rejects the same headers on the ordinary listener", async () => {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -140,6 +140,7 @@ export async function createGatewayHttpTransport(params: {
   nodeDesktopStreamBroker?: NodeDesktopStreamBroker;
   clients: Set<GatewayWsClient>;
   tailscaleMode?: "off" | GatewayTailscaleIngressMode;
+  tailscaleIngressPort?: number;
   prepareManagedTailscaleIngress?: (endpoint: GatewayTailscaleIngressEndpoint) => Promise<void>;
 }): Promise<{
   httpServer: HttpServer;
@@ -486,7 +487,7 @@ export async function createGatewayHttpTransport(params: {
         await listenGatewayHttpServer({
           httpServer: tailscaleHttpServer,
           bindHost: "127.0.0.1",
-          port: 0,
+          port: params.tailscaleIngressPort ?? 0,
           retryEaddrinuse: false,
           serviceName: "Tailscale gateway ingress",
         });

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -51,6 +51,10 @@ export async function startGatewayServerCore(
               const { startGatewayTailscaleExposure } = await import("./server-tailscale.js");
               const cleanup = await startGatewayTailscaleExposure({
                 tailscaleMode: gatewayKernel.tailscaleMode,
+                routeOwner:
+                  gatewayKernel.tailscaleConfig.externalIngressPort === undefined
+                    ? "openclaw"
+                    : "external",
                 preserveFunnel: gatewayKernel.tailscaleConfig.preserveFunnel ?? false,
                 port,
                 backend,

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -74,6 +74,28 @@ describe("startGatewayTailscaleExposure", () => {
     expect(mocks.claimTailscaleRoute).not.toHaveBeenCalled();
   });
 
+  it.each(["serve", "funnel"] as const)(
+    "leaves externally owned %s routing unchanged",
+    async (mode) => {
+      const logTailscale = createLogger();
+      const cleanup = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        routeOwner: "external",
+        port: 18789,
+        logTailscale,
+      });
+
+      expect(cleanup).toBeNull();
+      expect(mocks.claimTailscaleRoute).not.toHaveBeenCalled();
+      expect(mocks.hasTailscaleFunnelRouteForPort).not.toHaveBeenCalled();
+      expect(mocks.getTailnetHostname).not.toHaveBeenCalled();
+      expect(mocks.getTailnetHostnameAfterServe).not.toHaveBeenCalled();
+      expect(logTailscale.info).toHaveBeenCalledWith(
+        expect.stringContaining("routing remains externally managed"),
+      );
+    },
+  );
+
   it("does not change Tailscale state before the private backend is bound", async () => {
     await expect(
       startGatewayTailscaleExposureBase({

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -13,6 +13,7 @@ import { prepareMcpAppChannelOrigin } from "./mcp-app-channel-origin.js";
 
 export async function startGatewayTailscaleExposure(params: {
   tailscaleMode: "off" | "serve" | "funnel";
+  routeOwner?: "openclaw" | "external";
   port: number;
   backend?: GatewayTailscaleIngressEndpoint;
   preserveFunnel?: boolean;
@@ -24,6 +25,12 @@ export async function startGatewayTailscaleExposure(params: {
   }
   if (!params.backend) {
     throw new Error("Managed Tailscale ingress failed to start");
+  }
+  if (params.routeOwner === "external") {
+    params.logTailscale.info(
+      `${params.tailscaleMode} ingress listening on ${params.backend.host}:${params.backend.port}; routing remains externally managed`,
+    );
+    return null;
   }
   const backendTarget = params.backend.port;
   const effectiveMode = params.tailscaleMode;


### PR DESCRIPTION
Related: #119950

## What Problem This Solves

Fixes an issue where operators sharing one Tailscale Serve HTTPS listener across several path-based services could no longer route a path to OpenClaw after the ingress-attribution hardening in #119950. Pointing the shared route at the ordinary Gateway listener correctly fails closed with `proxy_attribution_required`, while managed Tailscale mode attempts to own the listener rather than coexist with its other routes.

## Why This Change Was Made

Adds an explicit `gateway.tailscale.externalIngressPort` deployment mode. OpenClaw binds its existing attributed-ingress transport to that fixed loopback port, while an external owner keeps responsibility for the Tailscale Serve/Funnel route map. Existing managed Serve/Funnel behavior and lifecycle ownership remain unchanged when the setting is absent, and the ordinary Gateway listener still rejects forged Tailscale attribution headers.

## User Impact

Operators can safely route one path from an existing shared Tailscale listener to OpenClaw without granting OpenClaw ownership of sibling routes. Tokenless Tailscale identity remains optional; deployments can keep `gateway.auth.allowTailscale: false` and require the configured token or password on every connection.

## Evidence

- Red on upstream `3a7df7a78855193e1299ac2792349e622eb609ac` using the Joey fleet instance: direct readiness returned 200, while HTTP and WebSocket requests through its existing shared `/rosita-1` Serve route both returned 403 `proxy_attribution_required`.
- Green on Joey using the proposed tree, now committed as `ae7462fbee1bb09db6c0a16fdf78e41fa6ab521e`: the ordinary Gateway stayed on `127.0.0.1:19011`, attributed ingress bound to `127.0.0.1:19012`, public HTTP returned 200, and a token-authenticated WebSocket `health` call returned `ok: true`.
- Negative controls remained closed: an invalid token was rejected, missing attribution on the dedicated listener returned 403, and forged attribution on the ordinary listener returned 403.
- A real browser completed token authentication plus device pairing and loaded the Control UI with no console errors. Joey has unrelated missing model-provider credentials, so no model turn is claimed.
- Shared-route preservation: the sibling-only route-map SHA-256 stayed `efe9de3aa4c4d5ad8198104bf54417e75145add595e24a9dabd6419f1856289b`; after proof, the complete Serve map was restored to its original SHA-256 `1f8ed252ef3a187d967d987b36ea557a0b8512d44244ab11a9218241420851f0`. Joey's config was restored byte-for-byte and both test listeners were closed.
- Focused regression coverage: 101 config/runtime/Tailscale tests passed; 85 schema/help tests passed; source-blind behavior validation passed 8/8 clauses.
- Repository gates passed: formatting, production typecheck, Gateway/config test-type shards, targeted type-aware lint, dead exports, import cycles, config metadata, database/storage, sidecar, pairing/auth, and policy guards.
- Autoreview: clean, with no accepted/actionable findings.
- The raw browser recording was retained privately because it contains a private Tailscale hostname; it was not uploaded to this PR.

@joshavant, this follows up on the shared-listener ownership boundary introduced by #119950. Please take a look at the explicit external-route ownership contract.

AI-assisted implementation.
