### PR TITLE
fix(codex): allow restricted /btw side questions

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1209,23 +1209,81 @@ describe("runCodexAppServerSideQuestion", () => {
   it.each([
     { name: "deny all", toolsAllow: [] },
     { name: "narrow allowlist", toolsAllow: ["message"] },
-  ])("rejects /btw before forking when effective toolsAllow is $name", async ({ toolsAllow }) => {
-    await expect(
-      runCodexAppServerSideQuestion(
-        sideParams({
-          messageChannel: "telegram",
-          messageProvider: "telegram",
-          senderId: "restricted-sender",
-          toolsAllow,
-        }),
-      ),
-    ).rejects.toThrow(
-      "Codex-native /btw side-question mode is unavailable because the effective tool policy restricts Codex native tools for this session.",
-    );
+  ])(
+    "forks a restricted side thread without OpenClaw or native tools for $name",
+    async ({ toolsAllow }) => {
+      const client = createFakeClient();
+      client.request.mockImplementation(async (method: string) => {
+        if (method === "config/read") {
+          return {
+            config: { mcp_servers: { inherited: { command: "unsafe" } } },
+            layers: [{ name: { type: "user" } }],
+          };
+        }
+        if (method === "configRequirements/read") {
+          return { requirements: null };
+        }
+        if (method === "thread/fork") {
+          return threadResult("side-thread");
+        }
+        if (method === "mcpServerStatus/list") {
+          return {
+            data: [{ name: "inherited", serverInfo: null, tools: {} }],
+            nextCursor: null,
+          };
+        }
+        if (method === "thread/inject_items") {
+          return {};
+        }
+        if (method === "turn/start") {
+          queueMicrotask(() => {
+            client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
+            client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+          });
+          return turnStartResult("turn-1");
+        }
+        if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+          return {};
+        }
+        throw new Error(`unexpected request: ${method}`);
+      });
+      getSharedCodexAppServerClientMock.mockResolvedValue(client);
 
-    expect(getSharedCodexAppServerClientMock).not.toHaveBeenCalled();
-    expect(resolveCodexProviderWebSearchSupportForClientMock).not.toHaveBeenCalled();
-  });
+      await expect(
+        runCodexAppServerSideQuestion(
+          sideParams({
+            messageChannel: "telegram",
+            messageProvider: "telegram",
+            senderId: "restricted-sender",
+            toolsAllow,
+          }),
+          { nativeHookRelay: { enabled: true } },
+        ),
+      ).resolves.toEqual({ text: "Side answer." });
+
+      const forkParams = client.request.mock.calls.find(
+        ([method]) => method === "thread/fork",
+      )?.[1] as Record<string, unknown> | undefined;
+      expect(forkParams?.config).toMatchObject({
+        "features.code_mode": false,
+        "features.code_mode_only": false,
+        "features.hooks": false,
+        "features.shell_tool": false,
+        "features.standalone_web_search": false,
+        "features.unified_exec": false,
+        mcp_servers: { inherited: { enabled: false } },
+        web_search: "disabled",
+      });
+      expect(forkParams?.config).toMatchObject({
+        "hooks.PreToolUse": [],
+        "hooks.PostToolUse": [],
+        "hooks.PermissionRequest": [],
+        "hooks.Stop": [],
+      });
+      expect(createOpenClawCodingToolsMock).not.toHaveBeenCalled();
+      expect(resolveCodexProviderWebSearchSupportForClientMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("applies native search restrictions to side forks and suppresses managed search", async () => {
     const { forkConfig, result, toolResponse } = await runSideQuestionWithManagedWebSearchCall(

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -124,6 +124,12 @@ import {
   resolveCodexBindingModelProviderFallback,
   resolveReasoningEffort,
 } from "./thread-lifecycle.js";
+import {
+  attestCodexRestrictedToolSurfaceMcpServersDisabled,
+  assertCodexManagedRequirementsDoNotOverrideToolPolicy,
+  buildCodexRestrictedToolThreadConfigPatch,
+  readCodexInheritedMcpServerNames,
+} from "./thread-requests.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
 import {
   resolveCodexWebSearchPlan,
@@ -318,11 +324,6 @@ export async function runCodexAppServerSideQuestion(
   if (nativeExecutionBlock) {
     throw new Error(nativeExecutionBlock);
   }
-  if (!nativeToolSurfaceEnabled) {
-    throw new Error(
-      "Codex-native /btw side-question mode is unavailable because the effective tool policy restricts Codex native tools for this session.",
-    );
-  }
   const clientOptions = {
     startOptions: appServer.start,
     timeoutMs: appServer.requestTimeoutMs,
@@ -469,6 +470,18 @@ export async function runCodexAppServerSideQuestion(
             signal: runAbortController.signal,
           })
         : "unsupported";
+    const restrictedToolThreadConfig = !nativeToolSurfaceEnabled
+      ? buildCodexRestrictedToolThreadConfigPatch(
+          await readCodexInheritedMcpServerNames(client, cwd, runAbortController.signal),
+        )
+      : undefined;
+    if (!nativeToolSurfaceEnabled) {
+      await assertCodexManagedRequirementsDoNotOverrideToolPolicy(
+        client,
+        { restrictedToolSurface: true },
+        runAbortController.signal,
+      );
+    }
     const { toolBridge, webSearchPlan } = await createCodexSideToolBridge({
       params: effectiveParams,
       cwd,
@@ -498,6 +511,9 @@ export async function runCodexAppServerSideQuestion(
     const registerRequestHandler = (targetClient: CodexAppServerClient) =>
       targetClient.addRequestHandler(async (request) => {
         if (!childThreadId || !turnId) {
+          return undefined;
+        }
+        if (!nativeToolSurfaceEnabled) {
           return undefined;
         }
         if (request.method === "mcpServer/elicitation/request") {
@@ -605,53 +621,56 @@ export async function runCodexAppServerSideQuestion(
       configuredEvents: options.nativeHookRelay?.events,
       approvalPolicy,
     });
-    nativeHookRelay = options.nativeHookRelay
-      ? registerCodexSideNativeHookRelay({
-          options: options.nativeHookRelay,
-          events: nativeHookRelayEvents,
-          agentId: sessionAgentId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          config: params.cfg,
-          runId: sideRunParams.runId,
-          channelId: buildAgentHookContextChannelFields({
+    nativeHookRelay =
+      nativeToolSurfaceEnabled && options.nativeHookRelay
+        ? registerCodexSideNativeHookRelay({
+            options: options.nativeHookRelay,
+            events: nativeHookRelayEvents,
+            agentId: sessionAgentId,
+            sessionId: params.sessionId,
             sessionKey: params.sessionKey,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            currentChannelId: params.currentChannelId,
-          }).channelId,
-          requestTimeoutMs: appServer.requestTimeoutMs,
-          completionTimeoutMs: Math.max(
-            appServer.turnCompletionIdleTimeoutMs,
-            SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
-          ),
-          loopDetectionPreToolUseRelay: appServer.loopDetectionPreToolUseRelay,
-          signal: runAbortController.signal,
-          hostCapabilities: sideRunParams.hostCapabilities,
-          onPreToolUseFailure: (failure) => {
-            if (nativePreToolUseFailureFallbackActive) {
-              emitNativePreToolUseFailure(failure);
-            } else if (nativeToolLifecycleProjector) {
-              nativeToolLifecycleProjector.recordPreToolUseFailure(
-                failure,
-                nativeToolRunWasAbortedBeforeCleanup,
-              );
-            } else {
-              pendingNativePreToolUseFailures.push(failure);
-            }
-          },
-        })
-      : undefined;
-    const nativeHookRelayConfig = nativeHookRelay
-      ? buildCodexNativeHookRelayConfig({
-          relay: nativeHookRelay,
-          events: nativeHookRelayEvents,
-          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
-          clearOmittedEvents: true,
-        })
-      : options.nativeHookRelay?.enabled === false
-        ? buildCodexNativeHookRelayDisabledConfig()
+            config: params.cfg,
+            runId: sideRunParams.runId,
+            channelId: buildAgentHookContextChannelFields({
+              sessionKey: params.sessionKey,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              currentChannelId: params.currentChannelId,
+            }).channelId,
+            requestTimeoutMs: appServer.requestTimeoutMs,
+            completionTimeoutMs: Math.max(
+              appServer.turnCompletionIdleTimeoutMs,
+              SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
+            ),
+            loopDetectionPreToolUseRelay: appServer.loopDetectionPreToolUseRelay,
+            signal: runAbortController.signal,
+            hostCapabilities: sideRunParams.hostCapabilities,
+            onPreToolUseFailure: (failure) => {
+              if (nativePreToolUseFailureFallbackActive) {
+                emitNativePreToolUseFailure(failure);
+              } else if (nativeToolLifecycleProjector) {
+                nativeToolLifecycleProjector.recordPreToolUseFailure(
+                  failure,
+                  nativeToolRunWasAbortedBeforeCleanup,
+                );
+              } else {
+                pendingNativePreToolUseFailures.push(failure);
+              }
+            },
+          })
         : undefined;
+    const nativeHookRelayConfig = !nativeToolSurfaceEnabled
+      ? buildCodexNativeHookRelayDisabledConfig()
+      : nativeHookRelay
+        ? buildCodexNativeHookRelayConfig({
+            relay: nativeHookRelay,
+            events: nativeHookRelayEvents,
+            hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+            clearOmittedEvents: true,
+          })
+        : options.nativeHookRelay?.enabled === false
+          ? buildCodexNativeHookRelayDisabledConfig()
+          : undefined;
     const runtimeThreadConfig = buildCodexRuntimeThreadConfig(webSearchPlan.threadConfig, {
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
@@ -665,6 +684,7 @@ export async function runCodexAppServerSideQuestion(
       mergeCodexThreadConfigs(
         nativeHookRelayConfig,
         runtimeThreadConfig,
+        restrictedToolThreadConfig,
         pluginAppsConfigPatch,
         modelScopedAppServer.networkProxy?.configPatch,
       ) ?? runtimeThreadConfig;
@@ -701,6 +721,14 @@ export async function runCodexAppServerSideQuestion(
       }),
     );
     childThreadId = forkResponse.thread.id;
+    if (!nativeToolSurfaceEnabled) {
+      await attestCodexRestrictedToolSurfaceMcpServersDisabled(
+        client,
+        childThreadId,
+        threadConfig,
+        runAbortController.signal,
+      );
+    }
     if (
       supervisionModelSelection &&
       (forkResponse.model !== supervisionModelSelection.model ||
@@ -1017,7 +1045,7 @@ async function createCodexSideToolBridge(input: {
     ({ id: input.params.model, provider: input.params.provider } as never);
   const messageToolProvider = resolveCodexMessageToolProvider(input.params);
   let tools: AnyAgentTool[] = [];
-  if (supportsModelTools(runtimeModel)) {
+  if (input.nativeToolSurfaceEnabled && supportsModelTools(runtimeModel)) {
     const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
       .createOpenClawCodingTools;
     const sandboxSessionKey =

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -487,7 +487,7 @@ export function buildCodexRingZeroThreadConfigPatch(
   return buildCodexRestrictedToolThreadConfigPatch(inheritedMcpServerNames);
 }
 
-function buildCodexRestrictedToolThreadConfigPatch(
+export function buildCodexRestrictedToolThreadConfigPatch(
   inheritedMcpServerNames: readonly string[],
 ): JsonObject {
   // Restricted turns already send environments: [] and disable native code


### PR DESCRIPTION
## Summary

- allow Codex-native `/btw` forks under finite or empty OpenClaw tool policies
- reuse the attested restricted-thread config to disable Codex shell, unified exec, search, hooks, apps, delegation, skills, inherited MCP servers, and other native capability surfaces
- skip OpenClaw dynamic-tool construction and request handling, reject incompatible managed Codex requirements, and force native hook relay off

This supersedes the approach in #101733 and closes its hook-relay gap. It also accounts for Codex `thread/fork` inheriting persisted dynamic-tool metadata: inherited calls remain non-executable because no OpenClaw bridge/request handler is registered, while every configurable Codex-owned capability and inherited MCP server is disabled.

## Tests

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts` (178 passed)
- `node scripts/check-changed.mjs`
- autoreview: clean, no accepted/actionable findings

## Related

- #101733
- #121668
- #92294
- #124947