### PR TITLE
fix(doctor): migrate pairing state on multi-agent updates

### DIFF
--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -568,6 +568,19 @@ export async function detectLegacyStateMigrations(params: {
   const subagentRegistry = detectDoctorOwnedState(detectLegacySubagentRegistry);
   const rescuePending = detectDoctorOwnedState(detectLegacyRescuePending);
   const configuredChannels = Object.entries(params.cfg.channels ?? {});
+  // Doctor already resolved this migration owner; plugin defaults must not infer it again.
+  let migrationOwnerConfig = params.cfg;
+  if (listAgentIds(params.cfg).length > 1 && params.cfg.agents) {
+    const agents = structuredClone(params.cfg.agents);
+    delete agents.ownership;
+    for (const [agentId, entry] of Object.entries(agents.entries ?? {})) {
+      entry.default = normalizeAgentId(agentId) === targetAgentId;
+    }
+    for (const entry of agents.list ?? []) {
+      entry.default = normalizeAgentId(entry.id) === targetAgentId;
+    }
+    migrationOwnerConfig = { ...params.cfg, agents };
+  }
   const configuredAccountIds = Object.fromEntries(
     configuredChannels.map(([channelId, value]) => {
       const channelConfig =
@@ -623,7 +636,8 @@ export async function detectLegacyStateMigrations(params: {
         }
         const plugin = getChannelPlugin(channelId as ChannelId);
         if (plugin) {
-          return [[channelId, resolveChannelDefaultAccountId({ plugin, cfg: params.cfg })]];
+          const accountId = resolveChannelDefaultAccountId({ plugin, cfg: migrationOwnerConfig });
+          return [[channelId, accountId]];
         }
         return [[channelId, configuredAccountIds[channelId]?.toSorted()[0] ?? DEFAULT_ACCOUNT_ID]];
       }),

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -570,7 +570,7 @@ export async function detectLegacyStateMigrations(params: {
   const configuredChannels = Object.entries(params.cfg.channels ?? {});
   // Doctor already resolved this migration owner; plugin defaults must not infer it again.
   let migrationOwnerConfig = params.cfg;
-  if (listAgentIds(params.cfg).length > 1 && params.cfg.agents) {
+  if (migrationAgentId && listAgentIds(params.cfg).length > 1 && params.cfg.agents) {
     const agents = structuredClone(params.cfg.agents);
     delete agents.ownership;
     for (const [agentId, entry] of Object.entries(agents.entries ?? {})) {

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -5,7 +5,9 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { readExactSessionEntryRowForCanonicalRepair } from "../config/sessions/session-accessor.sqlite-canonical-repair.js";
 import { writeSessionEntry } from "../config/sessions/session-accessor.sqlite-entry-store.js";
 import { readMemoryHostEventRecords } from "../memory-host-sdk/events.js";
@@ -17,6 +19,7 @@ import type {
   PluginDoctorStateMigrationContext,
 } from "../plugins/doctor-contract-registry.js";
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   ensureOpenClawAgentDatabaseSchema,
@@ -31,6 +34,7 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
 import {
@@ -774,6 +778,7 @@ afterEach(() => {
   resetAutoMigrateLegacyStateDirForTest();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
+  resetPluginRuntimeStateForTest();
 });
 
 afterAll(async () => {
@@ -834,6 +839,55 @@ describe("state migrations", () => {
     });
     await expectMissingPath(path.join(credentialsDir, "chatapp-allowFrom.json"));
     await expectMissingPath(path.join(credentialsDir, "chatapp-alpha-allowFrom.json"));
+  });
+
+  it("uses the retained migration owner for channel pairing account selection", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = retainLegacyDefaultAgentId(
+      {
+        agents: {
+          ownership: "explicit",
+          defaults: { pdfMaxPages: 42 },
+          entries: { main: { name: "Main" }, ops: { name: "Ops" } },
+        },
+        channels: { chatapp: {} },
+      },
+      "main",
+    );
+    const credentialsDir = path.join(stateDir, "credentials");
+    await fs.mkdir(credentialsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(credentialsDir, "chatapp-allowFrom.json"),
+      '["123456789"]\n',
+      "utf8",
+    );
+    const plugin = createChannelTestPluginBase({
+      id: "chatapp",
+      config: {
+        defaultAccountId: (config) => {
+          const ownerAgentId = resolveDefaultAgentId(config);
+          const owner = config.agents?.entries?.[ownerAgentId];
+          return owner?.name === "Main" && config.agents?.defaults?.pdfMaxPages === 42
+            ? "default"
+            : "lost-owner-config";
+        },
+      },
+    });
+    setActivePluginRegistry(createTestRegistry([{ pluginId: plugin.id, source: "test", plugin }]));
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+    const result = await runLegacyStateMigrations({ detected, config: cfg, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(readChannelPairingStateSnapshot("chatapp", env).allowFrom).toEqual({
+      default: ["123456789"],
+    });
   });
 
   it("keeps automatic migration read-only when the shared schema is current", async () => {

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { AgentSelectionRequiredError, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { readExactSessionEntryRowForCanonicalRepair } from "../config/sessions/session-accessor.sqlite-canonical-repair.js";
@@ -888,6 +888,32 @@ describe("state migrations", () => {
     expect(readChannelPairingStateSnapshot("chatapp", env).allowFrom).toEqual({
       default: ["123456789"],
     });
+  });
+
+  it("preserves ambiguous pairing ownership when only the session fallback exists", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { main: {}, ops: {} } },
+      channels: { chatapp: {} },
+    };
+    const credentialsDir = path.join(stateDir, "credentials");
+    await fs.mkdir(credentialsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(credentialsDir, "chatapp-allowFrom.json"),
+      '["123456789"]\n',
+      "utf8",
+    );
+    const plugin = createChannelTestPluginBase({
+      id: "chatapp",
+      config: { defaultAccountId: (config) => resolveDefaultAgentId(config) },
+    });
+    setActivePluginRegistry(createTestRegistry([{ pluginId: plugin.id, source: "test", plugin }]));
+
+    await expect(
+      detectLegacyStateMigrations({ cfg, env, homedir: () => root }),
+    ).rejects.toBeInstanceOf(AgentSelectionRequiredError);
   });
 
   it("keeps automatic migration read-only when the shared schema is current", async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users updating an existing multi-agent installation could have the freshly installed `openclaw doctor --non-interactive --fix` step fail with `AgentSelectionRequiredError` while migrating legacy channel pairing state.

This was observed in Full Release Validation [32054692083](https://github.com/openclaw/openclaw/actions/runs/32054692083), Release Checks [32056107942](https://github.com/openclaw/openclaw/actions/runs/32056107942), upgrade-survivor job [95469425476](https://github.com/openclaw/openclaw/actions/runs/32056107942/job/95469425476).

## Why This Change Was Made

Doctor already resolves the legacy migration owner before detecting channel pairing state. The migration now gives plugin default-account selection a full-fidelity, migration-only agents projection in which that prepared owner is the sole legacy default. This preserves the original direct binding scan and keeps owner selection at the Doctor migration boundary instead of adding a Telegram-specific runtime exception.

There is no public SDK, config, protocol, storage, or SQLite contract change. The projection is gated on a real Doctor state-migration owner, so an ambiguous roster with only the session-compatibility fallback remains fail-closed. Production LOC: +15/-1. Test LOC: +80/-0.

## User Impact

Existing multi-agent installations can complete update-time Doctor pairing migration without being prompted to select an agent, while configured agent defaults, entries, and account bindings remain intact.

## Evidence

- Regression coverage exercises the state-migration boundary with a strict plugin default-account resolver, a retained migration owner, preserved agent defaults/entry data, and a legacy pairing file. A second boundary case proves an explicit multi-agent roster without a real migration owner still raises `AgentSelectionRequiredError` rather than assigning pairing authorization to the session fallback.
- `node scripts/run-vitest.mjs src/infra/state-migrations.test.ts src/commands/doctor-state-migrations.test.ts extensions/telegram/src/accounts.test.ts` — 94 + 97 + 38 tests passed.
- `node scripts/check-changed.mjs -- src/infra/state-migrations.doctor.ts src/infra/state-migrations.test.ts` — all selected gates passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — TruffleHog clean; no accepted/actionable findings; patch correct 0.99 after addressing ClawSweeper's no-owner P1.
- Full packaged upgrade-survivor was not rerun locally; exact-head required CI is the remaining hosted proof.

AI-assisted; the final diff, owner boundary, regression behavior, and validation output were reviewed directly.
