### PR TITLE
fix(backup): report Git restore cleanup failures

### DIFF
--- a/src/infra/required-cleanup.ts
+++ b/src/infra/required-cleanup.ts
@@ -1,0 +1,45 @@
+import { formatErrorMessage } from "./errors.js";
+
+export type RequiredCleanupOutcome<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+export async function captureRequiredCleanupOutcome<T>(
+  operation: () => Promise<T>,
+): Promise<RequiredCleanupOutcome<T>> {
+  try {
+    return { ok: true, value: await operation() };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+export async function finishRequiredCleanup<T>(params: {
+  outcome: RequiredCleanupOutcome<T>;
+  cleanup: () => Promise<void>;
+  afterCleanup?: () => Promise<void>;
+  cleanupFailureMessage?: string;
+  combinedFailureMessage: string;
+}): Promise<T> {
+  const cleanupOutcome = await captureRequiredCleanupOutcome(params.cleanup);
+  if (!cleanupOutcome.ok) {
+    const cleanupError = cleanupOutcome.error;
+    const cleanupDetail = `Cleanup error: ${formatErrorMessage(cleanupError)}`;
+    if (!params.outcome.ok) {
+      throw new AggregateError(
+        [params.outcome.error, cleanupError],
+        `${params.combinedFailureMessage} ${cleanupDetail}`,
+        { cause: params.outcome.error },
+      );
+    }
+    throw new Error(
+      `${params.cleanupFailureMessage ?? "Required cleanup failed."} ${cleanupDetail}`,
+      {
+        cause: cleanupError,
+      },
+    );
+  }
+  await params.afterCleanup?.();
+  if (!params.outcome.ok) {
+    throw params.outcome.error;
+  }
+  return params.outcome.value;
+}

--- a/src/snapshot/git-backup-codec.ts
+++ b/src/snapshot/git-backup-codec.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
+import { finishRequiredCleanup, type RequiredCleanupOutcome } from "../infra/required-cleanup.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { createPrivateSqliteTempDirectory } from "../infra/sqlite-private-directory.js";
 import { publishVerifiedSqliteFile } from "../infra/sqlite-snapshot.js";
@@ -535,6 +536,7 @@ export async function restoreGitBackupDirectory(params: {
   const stagedHandle = await fs.open(stagedPath, "wx", 0o600);
   await stagedHandle.close();
   const database = openNodeSqliteDatabase(stagedPath);
+  let outcome: RequiredCleanupOutcome<GitBackupRestoreResult>;
   try {
     database.exec("PRAGMA foreign_keys = OFF; PRAGMA journal_mode = DELETE;");
     for (const statement of [...plainTables, ...indexes]) {
@@ -622,13 +624,24 @@ export async function restoreGitBackupDirectory(params: {
         guard.assertTargetMatchesExpectedContent(() => assertNoSqliteSidecarsSync(targetPath));
       },
     });
-    return { manifest, targetPath, tables, excludedTables: manifest.excludedTables };
+    outcome = {
+      ok: true,
+      value: { manifest, targetPath, tables, excludedTables: manifest.excludedTables },
+    };
   } catch (error) {
     if (database.isOpen) {
       database.close();
     }
-    throw error;
-  } finally {
-    await fs.rm(stagingDirectory, { recursive: true, force: true }).catch(() => undefined);
+    outcome = { ok: false, error };
   }
+
+  // Publication can succeed before cleanup. Preserve that verified target, but never
+  // report success while its sensitive private staging copy remains.
+  const recovery = `Remove the private staging directory manually: ${stagingDirectory}`;
+  return await finishRequiredCleanup({
+    outcome,
+    cleanup: async () => await fs.rm(stagingDirectory, { recursive: true, force: true }),
+    cleanupFailureMessage: `Git backup restore completed, but private staging cleanup failed. The verified target remains at ${targetPath}. ${recovery}`,
+    combinedFailureMessage: `Git backup restore and private staging cleanup both failed. ${recovery}`,
+  });
 }

--- a/src/snapshot/git-backup.test.ts
+++ b/src/snapshot/git-backup.test.ts
@@ -17,7 +17,12 @@ import {
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createPathResolutionEnv, withEnvAsync } from "../test-utils/env.js";
 import { dumpGitBackupDatabase, restoreGitBackupDirectory } from "./git-backup-codec.js";
-import { createGitBackup, initializeGitBackupRepository } from "./git-backup.js";
+import {
+  createGitBackup,
+  initializeGitBackupRepository,
+  restoreGitBackupRef,
+  verifyGitBackupRef,
+} from "./git-backup.js";
 
 const mocks = vi.hoisted(() => ({ pushDiagnostic: undefined as string | undefined }));
 
@@ -42,6 +47,50 @@ async function tempRoot(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-backup-test-"));
   roots.push(root);
   return root;
+}
+
+async function captureCleanupFailure<T>(
+  operation: () => Promise<T>,
+  options: { prefix: string; message: string },
+) {
+  const originalRm = fs.rm.bind(fs);
+  let stagingPath: string | undefined;
+  const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, rmOptions) => {
+    const targetPath = String(target);
+    if (path.basename(targetPath).startsWith(options.prefix)) {
+      stagingPath = targetPath;
+      throw Object.assign(new Error(options.message), { code: "EACCES" });
+    }
+    return await originalRm(target, rmOptions);
+  });
+  try {
+    const outcome = await operation().then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    if (!stagingPath) {
+      throw new Error("Git restore did not attempt private staging cleanup.");
+    }
+    return { outcome, stagingPath };
+  } finally {
+    rmSpy.mockRestore();
+    if (stagingPath) {
+      await originalRm(stagingPath, { recursive: true, force: true });
+    }
+  }
+}
+
+async function createGitRestoreFixture(root: string): Promise<{
+  repositoryPath: string;
+  stateDir: string;
+}> {
+  const { stateDir, database } = createStateDatabaseFixture(root);
+  const repositoryPath = path.join(root, "repository");
+  await initializeGitBackupRepository({ repositoryPath, stateDir });
+  await requireGit(repositoryPath, ["config", "user.name", "OpenClaw Backup Test"]);
+  await requireGit(repositoryPath, ["config", "user.email", "backup@example.invalid"]);
+  await createGitBackup({ repositoryPath, stateDir, databases: [database] });
+  return { repositoryPath, stateDir };
 }
 
 afterEach(async () => {
@@ -593,6 +642,189 @@ describe("Git-backed SQLite snapshots", () => {
     } finally {
       database.close();
     }
+  });
+
+  it("rejects cleanup failure after preserving the verified target", async () => {
+    const root = await tempRoot();
+    const source = path.join(root, "source.sqlite");
+    const dump = path.join(root, "dump");
+    const restoredPath = path.join(root, "restored.sqlite");
+    await createFormatFixture(source);
+    await dumpGitBackupDatabase({
+      snapshotPath: source,
+      outputPath: dump,
+      identity: { role: "global" },
+    });
+
+    const { outcome, stagingPath } = await captureCleanupFailure(
+      () =>
+        restoreGitBackupDirectory({
+          sourcePath: dump,
+          targetPath: restoredPath,
+          expectedIdentity: { role: "global" },
+        }),
+      { prefix: ".git-backup-restore-", message: "restore cleanup denied" },
+    );
+
+    if (outcome.ok) {
+      throw new Error("Restore reported success despite staging cleanup failure.");
+    }
+    expect(outcome.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(`The verified target remains at ${restoredPath}`),
+      }),
+    );
+    expect((outcome.error as Error).message).toContain(stagingPath);
+    const restored = new DatabaseSync(restoredPath, { readOnly: true });
+    try {
+      expect(restored.prepare("SELECT COUNT(*) AS count FROM content").get()).toEqual({ count: 2 });
+    } finally {
+      restored.close();
+    }
+  });
+
+  it("reports restore and cleanup failures together", async () => {
+    const root = await tempRoot();
+    const source = path.join(root, "source.sqlite");
+    const dump = path.join(root, "dump");
+    const restoredPath = path.join(root, "restored.sqlite");
+    await createFormatFixture(source);
+    const database = new DatabaseSync(source);
+    try {
+      database.exec("DROP TABLE schema_meta;");
+    } finally {
+      database.close();
+    }
+    await dumpGitBackupDatabase({
+      snapshotPath: source,
+      outputPath: dump,
+      identity: { role: "global" },
+    });
+
+    const { outcome, stagingPath } = await captureCleanupFailure(
+      () =>
+        restoreGitBackupDirectory({
+          sourcePath: dump,
+          targetPath: restoredPath,
+          expectedIdentity: { role: "global" },
+        }),
+      { prefix: ".git-backup-restore-", message: "restore cleanup denied" },
+    );
+
+    if (outcome.ok) {
+      throw new Error("Invalid restore reported success.");
+    }
+    expect(outcome.error).toBeInstanceOf(AggregateError);
+    expect((outcome.error as AggregateError).message).toContain(stagingPath);
+    expect((outcome.error as AggregateError).errors.map(String)).toEqual([
+      expect.stringMatching(/schema role missing; expected global/u),
+      expect.stringMatching(/restore cleanup denied/u),
+    ]);
+    await expect(fs.lstat(restoredPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves a verified target when Git materialization cleanup fails", async () => {
+    const root = await tempRoot();
+    const { repositoryPath } = await createGitRestoreFixture(root);
+    const restoredPath = path.join(root, "restored.sqlite");
+
+    const { outcome, stagingPath } = await captureCleanupFailure(
+      () =>
+        restoreGitBackupRef({
+          repositoryPath,
+          identity: { role: "global" },
+          targetPath: restoredPath,
+        }),
+      { prefix: "openclaw-git-restore-", message: "materialized cleanup denied" },
+    );
+
+    if (outcome.ok) {
+      throw new Error("Restore reported success despite materialized source cleanup failure.");
+    }
+    expect((outcome.error as Error).message).toContain(
+      `The verified target remains at ${restoredPath}`,
+    );
+    expect((outcome.error as Error).message).toContain(stagingPath);
+    const restored = new DatabaseSync(restoredPath, { readOnly: true });
+    try {
+      expect(
+        restored.prepare("SELECT role FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ role: "global" });
+    } finally {
+      restored.close();
+    }
+  });
+
+  it("aggregates restore and Git materialization cleanup failures", async () => {
+    const root = await tempRoot();
+    const { repositoryPath } = await createGitRestoreFixture(root);
+    const restoredPath = path.join(root, "restored.sqlite");
+    await fs.writeFile(restoredPath, "occupied");
+
+    const { outcome, stagingPath } = await captureCleanupFailure(
+      () =>
+        restoreGitBackupRef({
+          repositoryPath,
+          identity: { role: "global" },
+          targetPath: restoredPath,
+        }),
+      { prefix: "openclaw-git-restore-", message: "materialized cleanup denied" },
+    );
+
+    if (outcome.ok) {
+      throw new Error("Invalid restore reported success.");
+    }
+    expect(outcome.error).toBeInstanceOf(AggregateError);
+    expect((outcome.error as AggregateError).message).toContain(stagingPath);
+    expect((outcome.error as AggregateError).errors.map(String)).toEqual([
+      expect.stringMatching(/Fresh SQLite restore path already exists/u),
+      expect.stringMatching(/materialized cleanup denied/u),
+    ]);
+  });
+
+  it("aggregates Git materialization and staging cleanup failures", async () => {
+    const root = await tempRoot();
+    const { repositoryPath } = await createGitRestoreFixture(root);
+    const unexpectedPath = path.join(repositoryPath, "global", "unexpected.txt");
+    await fs.writeFile(unexpectedPath, "unexpected\n");
+    await requireGit(repositoryPath, ["add", "global/unexpected.txt"]);
+    await requireGit(repositoryPath, ["commit", "-m", "inject unexpected backup content"]);
+
+    const { outcome, stagingPath } = await captureCleanupFailure(
+      () =>
+        restoreGitBackupRef({
+          repositoryPath,
+          identity: { role: "global" },
+          targetPath: path.join(root, "restored.sqlite"),
+        }),
+      { prefix: "openclaw-git-restore-", message: "materialized cleanup denied" },
+    );
+
+    if (outcome.ok) {
+      throw new Error("Invalid materialization reported success.");
+    }
+    expect(outcome.error).toBeInstanceOf(AggregateError);
+    expect((outcome.error as AggregateError).message).toContain(stagingPath);
+    expect((outcome.error as AggregateError).errors.map(String)).toEqual([
+      expect.stringMatching(/Git backup ref contains an unexpected file/u),
+      expect.stringMatching(/materialized cleanup denied/u),
+    ]);
+  });
+
+  it("rejects verification when private scratch cleanup fails", async () => {
+    const root = await tempRoot();
+    const { repositoryPath } = await createGitRestoreFixture(root);
+
+    const { outcome, stagingPath } = await captureCleanupFailure(
+      () => verifyGitBackupRef({ repositoryPath, identity: { role: "global" } }),
+      { prefix: "openclaw-git-verify-", message: "verification cleanup denied" },
+    );
+
+    if (outcome.ok) {
+      throw new Error("Verification reported success despite private scratch cleanup failure.");
+    }
+    expect((outcome.error as Error).message).toContain("private scratch cleanup failed");
+    expect((outcome.error as Error).message).toContain(stagingPath);
   });
 
   it("omits secret tables and reports the restore gap", async () => {

--- a/src/snapshot/git-backup.ts
+++ b/src/snapshot/git-backup.ts
@@ -7,6 +7,7 @@ import {
   requireGitCommand as requireGit,
   requireGitCommandBuffer as requireGitBuffer,
 } from "../infra/git-exec.js";
+import { captureRequiredCleanupOutcome, finishRequiredCleanup } from "../infra/required-cleanup.js";
 import {
   GIT_BACKUP_MANIFEST,
   GIT_BACKUP_SCHEMA,
@@ -327,7 +328,7 @@ async function materializeGitBackupRef(params: {
   repositoryPath: string;
   identity: GitBackupIdentity;
   ref?: string;
-}): Promise<{ commit: string; path: string; cleanup: () => Promise<void> }> {
+}): Promise<{ commit: string; path: string; cleanupPath: string; cleanup: () => Promise<void> }> {
   const repositoryPath = path.resolve(params.repositoryPath);
   await assertGitRepository(repositoryPath);
   const commit = await resolveGitCommit(repositoryPath, params.ref);
@@ -369,11 +370,15 @@ async function materializeGitBackupRef(params: {
     return {
       commit,
       path: outputPath,
+      cleanupPath: root,
       cleanup: async () => await fs.rm(root, { recursive: true, force: true }),
     };
   } catch (error) {
-    await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
-    throw error;
+    return await finishRequiredCleanup({
+      outcome: { ok: false, error },
+      cleanup: async () => await fs.rm(root, { recursive: true, force: true }),
+      combinedFailureMessage: `Git backup materialization and private staging cleanup both failed: ${root}.`,
+    });
   }
 }
 
@@ -385,18 +390,21 @@ export async function restoreGitBackupRef(params: {
   targetPath: string;
 }): Promise<GitBackupRestoreResult & { commit: string }> {
   const materialized = await materializeGitBackupRef(params);
-  try {
-    return {
-      ...(await restoreGitBackupDirectory({
-        sourcePath: materialized.path,
-        targetPath: params.targetPath,
-        expectedIdentity: params.identity,
-      })),
-      commit: materialized.commit,
-    };
-  } finally {
-    await materialized.cleanup();
-  }
+  const outcome = await captureRequiredCleanupOutcome(async () => ({
+    ...(await restoreGitBackupDirectory({
+      sourcePath: materialized.path,
+      targetPath: params.targetPath,
+      expectedIdentity: params.identity,
+    })),
+    commit: materialized.commit,
+  }));
+  const recovery = `Remove the private staging directory manually: ${materialized.cleanupPath}`;
+  return await finishRequiredCleanup({
+    outcome,
+    cleanup: materialized.cleanup,
+    cleanupFailureMessage: `Git backup restore completed, but materialized source cleanup failed. The verified target remains at ${path.resolve(params.targetPath)}. ${recovery}`,
+    combinedFailureMessage: `Git backup restore and materialized source cleanup both failed. ${recovery}`,
+  });
 }
 
 /** Verify a Git snapshot by restoring it privately and comparing every table digest. */
@@ -407,14 +415,20 @@ export async function verifyGitBackupRef(params: {
 }): Promise<GitBackupRestoreResult & { commit: string }> {
   const scratch = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-verify-"));
   await fs.chmod(scratch, 0o700);
-  try {
-    return await restoreGitBackupRef({
-      ...params,
-      targetPath: path.join(scratch, "database.sqlite"),
-    });
-  } finally {
-    await fs.rm(scratch, { recursive: true, force: true }).catch(() => undefined);
-  }
+  const outcome = await captureRequiredCleanupOutcome(
+    async () =>
+      await restoreGitBackupRef({
+        ...params,
+        targetPath: path.join(scratch, "database.sqlite"),
+      }),
+  );
+  const recovery = `Remove the private verification directory manually: ${scratch}`;
+  return await finishRequiredCleanup({
+    outcome,
+    cleanup: async () => await fs.rm(scratch, { recursive: true, force: true }),
+    cleanupFailureMessage: `Git backup verification completed, but private scratch cleanup failed. ${recovery}`,
+    combinedFailureMessage: `Git backup verification and private scratch cleanup both failed. ${recovery}`,
+  });
 }
 
 /** Return bounded Git backup log entries for CLI rendering. */

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -25,6 +25,7 @@ import {
 } from "../infra/fs-safe.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
+import { finishRequiredCleanup, type RequiredCleanupOutcome } from "../infra/required-cleanup.js";
 import { resolveSystemBin } from "../infra/resolve-system-bin.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
@@ -1161,7 +1162,7 @@ async function withPrivateSqliteStagingDirectory<T>(options: {
   const directoryPath = await createPrivateSqliteTempDirectory(trustedRootPath, options.prefix);
   const directoryIdentity = await fs.lstat(directoryPath);
 
-  let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+  let outcome: RequiredCleanupOutcome<T>;
   try {
     applyPrivateModeSync(directoryPath, SNAPSHOT_DIRECTORY_MODE);
     await assertPrivateStagingDirectory(directoryIdentity, directoryPath);
@@ -1174,44 +1175,31 @@ async function withPrivateSqliteStagingDirectory<T>(options: {
     outcome = { ok: false, error };
   }
 
-  let cleanupOutcome: { ok: true } | { ok: false; error: unknown };
-  try {
-    const removed = await removePrivateDirectoryIfOwned(
-      directoryPath,
-      directoryIdentity,
-      options.allowedEntries,
-    );
-    if (!removed) {
-      throw new Error(`Private SQLite staging directory disappeared: ${directoryPath}`);
-    }
-    cleanupOutcome = { ok: true };
-  } catch (error) {
-    cleanupOutcome = { ok: false, error };
-  }
-
-  if (!cleanupOutcome.ok) {
-    if (!outcome.ok) {
-      throw new AggregateError(
-        [outcome.error, cleanupOutcome.error],
-        `SQLite staging operation and cleanup both failed: ${directoryPath}`,
+  return await finishRequiredCleanup({
+    outcome,
+    cleanup: async () => {
+      const removed = await removePrivateDirectoryIfOwned(
+        directoryPath,
+        directoryIdentity,
+        options.allowedEntries,
       );
-    }
-    throw new Error(`Failed to clean private SQLite staging directory: ${directoryPath}`, {
-      cause: cleanupOutcome.error,
-    });
-  }
-  requireDirectorySync(
-    await syncDirectory({
-      path: trustedRootPath,
-      realPath: trustedRootPath,
-      identity: options.expectedRootIdentity,
-    }),
-    "Private SQLite staging root",
-  );
-  if (!outcome.ok) {
-    throw outcome.error;
-  }
-  return outcome.value;
+      if (!removed) {
+        throw new Error(`Private SQLite staging directory disappeared: ${directoryPath}`);
+      }
+    },
+    afterCleanup: async () => {
+      requireDirectorySync(
+        await syncDirectory({
+          path: trustedRootPath,
+          realPath: trustedRootPath,
+          identity: options.expectedRootIdentity,
+        }),
+        "Private SQLite staging root",
+      );
+    },
+    cleanupFailureMessage: `Failed to clean private SQLite staging directory: ${directoryPath}`,
+    combinedFailureMessage: `SQLite staging operation and cleanup both failed: ${directoryPath}`,
+  });
 }
 
 async function assertTrustedStagingRoot(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Git-backed SQLite restore and verification could report success, or lose the primary restore error, when cleanup of private staging data failed. A verified restore target could remain usable, but the operator received no recovery path for the leaked private copy.

## Why This Change Was Made

Restore success now requires cleanup at every Git restore boundary: codec staging, materialized Git source data, and verification scratch space. One shared required-cleanup outcome finalizer preserves the primary operation error, aggregates simultaneous cleanup failures, and keeps verified target paths in recovery diagnostics. The existing local SQLite repository now uses the same canonical finalizer instead of maintaining a duplicate policy block.

Production growth is +125/-65 (net +60); tests are +233/-1. The net production growth is the explicit recovery capability across four lifecycle boundaries: cleanup-only diagnostics, ordered dual-failure aggregation, verified-target preservation, and manual cleanup paths. The shared finalizer absorbs the previously duplicated local-repository implementation; a smaller codec-only patch would leave the public restore caller able to mask errors and verification able to swallow cleanup failures.

## User Impact

Operators no longer receive a false successful restore when sensitive staging cleanup fails. Errors identify the recoverable verified target and the private directory that must be removed; when restore and cleanup both fail, both causes remain available.

No schema, protocol, fallback store, configuration, dependency, or changelog changes are included.

## Evidence

- Pre-fix reproduction on current `origin/main`: all 6 cleanup regressions failed for the intended reasons.
- `node scripts/run-vitest.mjs src/snapshot/git-backup.test.ts -t 'cleanup failure|cleanup fails|cleanup failures|private scratch cleanup|materialization and staging cleanup'` — 6 passed.
- `node scripts/run-vitest.mjs src/snapshot/git-backup.test.ts` — 23 passed.
- `node scripts/run-vitest.mjs src/snapshot/local-repository.test.ts` — 65 passed, 1 intentional skip.
- `node scripts/check-changed.mjs -- src/infra/required-cleanup.ts src/snapshot/git-backup-codec.ts src/snapshot/git-backup.ts src/snapshot/local-repository.ts src/snapshot/git-backup.test.ts` — passed, including core/test typecheck, lint, database-first legacy-store guard, and runtime import cycles.
- `pnpm check:database-first-legacy-stores` — passed.
- `pnpm check:import-cycles` — 0 runtime value cycles.
- Source-blind isolated CLI: `backup git init`, `create --global`, `verify`, and fresh restore passed; restored SQLite reported `integrity_check=ok`; occupied-target restore failed visibly without changing its hash; no restore/verify scratch directory remained.
- Fresh Codex-backed autoreview after rebase — no accepted/actionable findings.

AI-assisted: yes. The implementation and proof were reviewed against the complete restore owner/caller chain.
