### PR TITLE
fix(cli): migrate legacy state for an explicit agent

### DIFF
--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -26,6 +26,7 @@ export async function ensureCliCommandBootstrap(params: {
   pluginRegistry?: CliPluginRegistryPolicy;
   skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
+  stateMigrationAgentId?: string;
 }) {
   if (!params.skipConfigGuard) {
     await measureCliCommandStartup("config-ready", async () => {
@@ -40,6 +41,7 @@ export async function ensureCliCommandBootstrap(params: {
           ? { beforeStateMigrations: params.beforeStateMigrations }
           : {}),
         ...(params.suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
+        stateMigrationAgentId: params.stateMigrationAgentId,
         ...(params.skipPristineStartupStateMigrations
           ? { skipPristineStartupStateMigrations: true }
           : {}),

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -72,6 +72,7 @@ export async function ensureCliExecutionBootstrap(params: {
   validateConfigOnly?: boolean;
   skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
+  stateMigrationAgentId?: string;
 }) {
   await ensureCliCommandBootstrap({
     runtime: params.runtime,
@@ -84,6 +85,7 @@ export async function ensureCliExecutionBootstrap(params: {
     loadPlugins: params.loadPlugins ?? params.startupPolicy.loadPlugins,
     pluginRegistry: params.startupPolicy.pluginRegistry,
     skipConfigGuard: params.skipConfigGuard ?? params.startupPolicy.skipConfigGuard,
+    stateMigrationAgentId: params.stateMigrationAgentId,
     ...((params.validateConfigOnly ?? params.startupPolicy.validateConfigOnly)
       ? { validateConfigOnly: true }
       : {}),

--- a/src/cli/command-options.test.ts
+++ b/src/cli/command-options.test.ts
@@ -139,6 +139,17 @@ describe("inheritOptionFromParent", () => {
     expect(inheritOptionFromParent<string>(run, "token")).toBe("gateway-env-token");
   });
 
+  it("can restrict inherited values to an explicit CLI source", () => {
+    const gateway = new Command().option("--token <token>", "Gateway token");
+    const run = gateway.command("run").option("--token <token>", "Run token");
+
+    gateway.setOptionValueWithSource("token", "gateway-env-token", "env");
+    expect(inheritOptionFromParent<string>(run, "token", "cli")).toBeUndefined();
+
+    gateway.setOptionValueWithSource("token", "gateway-cli-token", "cli");
+    expect(inheritOptionFromParent<string>(run, "token", "cli")).toBe("gateway-cli-token");
+  });
+
   it("skips default-valued ancestor options and keeps traversing", async () => {
     const program = new Command().option("--token <token>", "Root token");
     const gateway = program

--- a/src/cli/command-options.ts
+++ b/src/cli/command-options.ts
@@ -1,5 +1,5 @@
 // Commander option-source helpers for explicit flags and bounded parent inheritance.
-import type { Command } from "commander";
+import type { Command, OptionValueSource } from "commander";
 
 export function hasExplicitOptions(command: Command, names: readonly string[]): boolean {
   return names.some((name) => command.getOptionValueSource(name) === "cli");
@@ -12,6 +12,7 @@ const MAX_INHERIT_DEPTH = 2;
 export function inheritOptionFromParent<T = unknown>(
   command: Command | undefined,
   name: string,
+  requiredSource?: OptionValueSource,
 ): T | undefined {
   if (!command) {
     return undefined;
@@ -27,6 +28,9 @@ export function inheritOptionFromParent<T = unknown>(
   while (ancestor && depth < MAX_INHERIT_DEPTH) {
     const source = ancestor.getOptionValueSource(name);
     if (source && source !== "default") {
+      if (requiredSource && source !== requiredSource) {
+        return undefined;
+      }
       return ancestor.getOptionValue(name) as T | undefined;
     }
     depth += 1;

--- a/src/cli/preaction-agent-owner.process.test.ts
+++ b/src/cli/preaction-agent-owner.process.test.ts
@@ -1,18 +1,14 @@
 // Real CLI process coverage for pre-action legacy migration ownership.
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
-const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-preaction-owner-"));
-
-afterAll(() => {
-  fs.rmSync(tempRoot, { recursive: true, force: true });
-});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createFixture(label: string) {
-  const root = path.join(tempRoot, label);
+  const root = tempDirs.make(`openclaw-preaction-owner-${label}-`);
   const stateDir = path.join(root, "state");
   const pluginDir = path.join(root, "memory-owner");
   const markerPath = path.join(root, "action.json");

--- a/src/cli/preaction-agent-owner.process.test.ts
+++ b/src/cli/preaction-agent-owner.process.test.ts
@@ -1,0 +1,182 @@
+// Real CLI process coverage for pre-action legacy migration ownership.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-preaction-owner-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function createFixture(label: string) {
+  const root = path.join(tempRoot, label);
+  const stateDir = path.join(root, "state");
+  const pluginDir = path.join(root, "memory-owner");
+  const markerPath = path.join(root, "action.json");
+  const configPath = path.join(stateDir, "openclaw.json");
+  fs.mkdirSync(path.join(stateDir, "agent"), { recursive: true });
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "agent", "auth.json"), "{}\n");
+  fs.writeFileSync(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({
+      name: "@example/openclaw-memory-owner",
+      version: "1.0.0",
+      type: "commonjs",
+      openclaw: { extensions: ["./index.cjs"] },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "memory-owner",
+      name: "Memory Owner",
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+      commandAliases: [{ name: "fixture-memory", kind: "runtime-slash", cliCommand: "memory" }],
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "index.cjs"),
+    [
+      'const fs = require("node:fs");',
+      "module.exports = {",
+      '  id: "memory-owner",',
+      "  register(api) {",
+      "    api.registerCli(({ program }) => {",
+      '      const memory = program.command("memory").option("--agent <id>");',
+      "      memory",
+      '        .command("status")',
+      '        .option("--agent <id>")',
+      '        .option("--index")',
+      '        .option("--json")',
+      "        .action((opts, command) => {",
+      "          const agent = opts.agent ?? command.parent.opts().agent ?? null;",
+      '          fs.writeFileSync(process.env.ACTION_MARKER, JSON.stringify({ agent }), "utf8");',
+      '          if (agent && !["main", "work"].includes(agent)) {',
+      '            console.error(`Unknown agent id "${agent}".`);',
+      "            process.exitCode = 1;",
+      "            return;",
+      "          }",
+      "          console.log(JSON.stringify({ agent }));",
+      "        });",
+      '    }, { descriptors: [{ name: "memory", description: "Memory fixture", hasSubcommands: true }] });',
+      "  },",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { workspace: path.join(root, "workspace-main") },
+          work: { workspace: path.join(root, "workspace-work") },
+        },
+      },
+      plugins: {
+        load: { paths: [pluginDir] },
+        entries: { "memory-owner": { enabled: true } },
+      },
+    }),
+  );
+  return { configPath, markerPath, root, stateDir };
+}
+
+function runFixture(label: string, args: string[]) {
+  const fixture = createFixture(label);
+  const result = spawnSync(process.execPath, ["--import", "tsx", "src/entry.ts", ...args], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ACTION_MARKER: fixture.markerPath,
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      NODE_ENV: undefined,
+      VITEST: undefined,
+      OPENCLAW_CONFIG_PATH: fixture.configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_DEV_SOURCE_ROOT: path.resolve("."),
+      OPENCLAW_HOME: path.join(fixture.root, "home"),
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_STATE_DIR: fixture.stateDir,
+    },
+    timeout: 60_000,
+  });
+  const action = fs.existsSync(fixture.markerPath)
+    ? (JSON.parse(fs.readFileSync(fixture.markerPath, "utf8")) as { agent: string | null })
+    : null;
+  return { action, fixture, output: `${result.stdout}\n${result.stderr}`, result };
+}
+
+describe("CLI pre-action migration agent ownership", () => {
+  it.each([
+    {
+      label: "leaf-option",
+      args: ["memory", "status", "--index", "--agent", "main", "--json"],
+      agent: "main",
+    },
+    {
+      label: "parent-option",
+      args: ["memory", "--agent", "main", "status", "--index", "--json"],
+      agent: "main",
+    },
+    {
+      label: "leaf-over-parent",
+      args: ["memory", "--agent", "main", "status", "--index", "--agent", "work", "--json"],
+      agent: "work",
+    },
+  ])("uses the explicit agent from $label before the leaf action", ({ agent, args, label }) => {
+    const { action, fixture, output, result } = runFixture(label, args);
+
+    expect(result.status, output).toBe(0);
+    expect(action).toEqual({ agent });
+    expect(output).not.toContain("Deferred legacy agent/session migration");
+    expect(fs.existsSync(path.join(fixture.stateDir, "agent", "auth.json"))).toBe(false);
+    expect(fs.existsSync(path.join(fixture.stateDir, "agents", agent, "agent", "auth.json"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps an omitted owner safely deferred for an explicit multi-agent roster", () => {
+    const { action, fixture, output, result } = runFixture("omitted", [
+      "memory",
+      "status",
+      "--index",
+      "--json",
+    ]);
+
+    expect(result.status, output).toBe(0);
+    expect(action).toEqual({ agent: null });
+    expect(output).toContain("Deferred legacy agent/session migration: select an agent owner");
+    expect(fs.existsSync(path.join(fixture.stateDir, "agent", "auth.json"))).toBe(true);
+  });
+
+  it.each([
+    { agent: "missing", label: "unknown", normalizedTarget: "missing" },
+    { agent: "main!", label: "invalid", normalizedTarget: "main" },
+  ])(
+    "does not use an $label explicit agent as a migration owner",
+    ({ agent, label, normalizedTarget }) => {
+      const { action, fixture, output, result } = runFixture(label, [
+        "memory",
+        "status",
+        "--index",
+        "--agent",
+        agent,
+        "--json",
+      ]);
+
+      expect(result.status, output).toBe(1);
+      expect(action).toEqual({ agent });
+      expect(output).toContain(`Unknown agent id "${agent}".`);
+      expect(output).toContain("Deferred legacy agent/session migration: select an agent owner");
+      expect(fs.existsSync(path.join(fixture.stateDir, "agent", "auth.json"))).toBe(true);
+      expect(fs.existsSync(path.join(fixture.stateDir, "agents", normalizedTarget))).toBe(false);
+    },
+  );
+});

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -225,6 +225,7 @@ export async function ensureConfigReady(
     measure?: ConfigSnapshotReadMeasure;
     skipPristineCoreStateMigrations?: boolean;
     skipPristineStartupStateMigrations?: boolean;
+    stateMigrationAgentId?: string;
     validateConfigOnly?: boolean;
   },
   recoveryDeps?: InvalidConfigRecoveryDeps,
@@ -269,6 +270,7 @@ export async function ensureConfigReady(
         ...(params.skipPristineCoreStateMigrations
           ? { skipPristineCoreStateMigrations: true }
           : {}),
+        stateMigrationAgentId: params.stateMigrationAgentId,
       });
     try {
       return !params.suppressDoctorStdout

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -12,6 +12,7 @@ import {
   ensureCliExecutionBootstrap,
   resolveCliExecutionStartupContext,
 } from "../command-execution-startup.js";
+import { hasExplicitOptions, inheritOptionFromParent } from "../command-options.js";
 import { applyResolvedCommandOutputMode } from "../json-output-mode.js";
 import {
   resolvePluginInstallInvalidConfigPolicy,
@@ -55,6 +56,16 @@ function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
   }
   const logLevel = actionCommand.optsWithGlobals<{ logLevel?: unknown }>().logLevel;
   return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
+}
+
+function getStateMigrationAgentId(actionCommand: Command): string | undefined {
+  if (!actionCommand.options.some((option) => option.attributeName() === "agent")) {
+    return undefined;
+  }
+  const value = hasExplicitOptions(actionCommand, ["agent"])
+    ? actionCommand.getOptionValue("agent")
+    : inheritOptionFromParent(actionCommand, "agent", "cli");
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function isBareParentDefaultHelpInvocation(actionCommand: Command, argv: string[]): boolean {
@@ -124,6 +135,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       jsonOutputMode,
       env: process.env,
     });
+    const stateMigrationAgentId = getStateMigrationAgentId(actionCommand);
     await applyCliExecutionStartupPresentation({
       startupPolicy,
       version: programVersion,
@@ -186,6 +198,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       runtime: defaultRuntime,
       commandPath,
       startupPolicy,
+      stateMigrationAgentId,
       allowInvalid,
       ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
       ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -172,6 +172,8 @@ export async function runDoctorConfigPreflight(
     skipPristineCoreStateMigrations?: boolean;
     /** Prepared before Gateway bootstrap can create files under an otherwise pristine state root. */
     skipPristineStartupStateMigrations?: boolean;
+    /** Parsed CLI owner for automatic agent/session migration only. */
+    stateMigrationAgentId?: string;
     /** Enable migrations that may retire security-sensitive stores only during explicit repair. */
     doctorOnlyStateMigrations?: boolean;
   } = {},
@@ -447,7 +449,11 @@ export async function runDoctorConfigPreflight(
     }
 
     const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
-    const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
+    const stateMigrationInput = resolveStateMigrationConfigInput({
+      snapshot,
+      baseConfig,
+      stateMigrationAgentId: options.stateMigrationAgentId,
+    });
     if (migrationCheckpoint) {
       migrationCheckpointIdentity = resolveMigrationCheckpointIdentity({
         snapshot,

--- a/src/commands/doctor/shared/legacy-config-state-migration-input.ts
+++ b/src/commands/doctor/shared/legacy-config-state-migration-input.ts
@@ -1,3 +1,6 @@
+import { isValidAgentId, normalizeAgentId } from "@openclaw/normalization-core/agent-id";
+import { listAgentIds } from "../../../agents/agent-scope-config.js";
+import { retainLegacyDefaultAgentId } from "../../../config/legacy.default-agent-owner.js";
 import type { ConfigFileSnapshot } from "../../../config/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { migrateLegacyConfig } from "./legacy-config-migrate.js";
@@ -10,30 +13,40 @@ type StateMigrationConfigInput = {
 export function resolveStateMigrationConfigInput(params: {
   snapshot: ConfigFileSnapshot;
   baseConfig: OpenClawConfig;
+  stateMigrationAgentId?: string;
 }): StateMigrationConfigInput | null {
   const pluginDoctorConfig = (params.snapshot.sourceConfig ??
     params.snapshot.config ??
     params.snapshot.parsed) as OpenClawConfig | undefined;
+  let input: StateMigrationConfigInput;
   if (params.snapshot.valid) {
-    return params.snapshot.legacyIssues.length > 0 && pluginDoctorConfig !== undefined
-      ? { cfg: params.baseConfig, pluginDoctorConfig }
-      : { cfg: params.baseConfig };
+    input =
+      params.snapshot.legacyIssues.length > 0 && pluginDoctorConfig !== undefined
+        ? { cfg: params.baseConfig, pluginDoctorConfig }
+        : { cfg: params.baseConfig };
+  } else {
+    const migrationSource = pluginDoctorConfig ?? params.snapshot.parsed;
+    if (params.snapshot.legacyIssues.length === 0 || migrationSource === undefined) {
+      return null;
+    }
+    const migrated = migrateLegacyConfig(migrationSource);
+    if (!migrated.config) {
+      return null;
+    }
+    input = migrated.partiallyValid
+      ? { pluginDoctorConfig: (pluginDoctorConfig ?? migrationSource) as OpenClawConfig }
+      : {
+          cfg: migrated.config,
+          ...(pluginDoctorConfig ? { pluginDoctorConfig } : {}),
+        };
   }
-  const migrationSource = pluginDoctorConfig ?? params.snapshot.parsed;
-  if (params.snapshot.legacyIssues.length === 0 || migrationSource === undefined) {
-    return null;
+
+  const rawAgentId = params.stateMigrationAgentId?.trim();
+  if (input.cfg && rawAgentId && isValidAgentId(rawAgentId)) {
+    const agentId = normalizeAgentId(rawAgentId);
+    if (listAgentIds(input.cfg).includes(agentId)) {
+      retainLegacyDefaultAgentId(input.cfg, agentId);
+    }
   }
-  const migrated = migrateLegacyConfig(migrationSource);
-  if (!migrated.config) {
-    return null;
-  }
-  if (migrated.partiallyValid) {
-    return {
-      pluginDoctorConfig: (pluginDoctorConfig ?? migrationSource) as OpenClawConfig,
-    };
-  }
-  return {
-    cfg: migrated.config,
-    ...(pluginDoctorConfig ? { pluginDoctorConfig } : {}),
-  };
+  return input;
 }

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -5,6 +5,7 @@ export const cliProcessTestFiles = [
   "src/cli/gateway-backed-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",
+  "src/cli/preaction-agent-owner.process.test.ts",
 ];
 
 const cliProcessTestFileSet = new Set(cliProcessTestFiles);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a config-guarded CLI command could receive an explicit `--agent <id>` but automatic startup migration still deferred with “select an agent owner.” Commander had already resolved the command’s owner, but migration ran before the leaf action and never received that fact.

For example, `openclaw memory status --index --agent work` could act as `work` while leaving legacy agent/session state unmigrated.

## Why This Change Was Made

Commander pre-action now carries only an explicit CLI-sourced `agent` value through the existing startup/config-preflight chain. The migration input owner validates canonical agent-ID syntax and confirms the normalized ID exists in the loaded roster before retaining it as the in-memory legacy owner. A leaf value wins over its parent.

Omitted, default-derived, environment-derived, invalid, and unknown values continue to defer. No fallback owner or config key is introduced. `agent exec` is unchanged and remains outside this path because its startup policy skips the config guard.

Credit: this ownership gap was recovered from review work around #125141 by Stellar鱼 (@yu-xin-c). The maintainer repair commit preserves the contributor’s exact source attribution with `Co-authored-by: yu-xin-c <2182712990@qq.com>`.

## User Impact

Operators who explicitly select a configured agent for a migration-triggering CLI command now have legacy agent/session state migrated to that agent before the command runs. Ambiguous or invalid selections remain safely deferred, preserving the existing state rather than inventing ownership.

No configuration, SQLite schema, protocol, `agent exec`, or changelog surface changed.

## Evidence

- Current-main regression at `2f653a73c2b6bb0051047567514245ee238239fa`: the new real-process suite was overlaid without the production fix; the leaf, parent, and leaf-over-parent cases all failed because output contained `Deferred legacy agent/session migration` (3 failed, 3 safety cases passed).
- `pnpm test src/cli/command-options.test.ts src/cli/program/preaction.test.ts src/cli/preaction-agent-owner.process.test.ts src/cli/command-bootstrap.test.ts src/cli/command-execution-startup.test.ts src/cli/program/config-guard.test.ts` — 174 passed.
- `pnpm test 'src/commands/doctor-config-preflight*.test.ts' src/infra/state-migrations.test.ts` — 154 passed.
- `pnpm test test/vitest-scoped-config.test.ts test/scripts/test-projects.test.ts` — 368 passed; the child-process regression is registered in the serial isolated CLI-process lane.
- Source-blind built-CLI validation — all six clauses passed: leaf, parent, leaf precedence, omitted deferral, unknown deferral, and invalid-normalizable deferral.
- `pnpm check:changed` — passed on the rebased exact head, including production/test types, lint, max-lines, dead exports, import cycles, database-first guards, and test temp-directory hygiene.
- `pnpm build` — passed on the rebased exact head, including the CLI bootstrap import guard.
- Fresh Codex-backed branch autoreview against `origin/main` — clean, no accepted/actionable findings.
- Direct upstream boundary check at `openai/codex@d65d31593926f26bc6dd030240bc009be87ef75d`: `codex-rs/cli/src/main.rs:98-134` and `:1033-1047` confirm Codex’s own `exec` dispatch is downstream and unaffected by this OpenClaw startup migration path.

Compatibility risk: this intentionally changes startup behavior for config-guarded CLI leaves that declare `--agent`. An explicit, valid, configured selection can now cause legacy state to move instead of defer. The value is constrained by Commander source, leaf applicability and precedence, canonical syntax, and roster membership; skipped commands and ambiguous inputs remain unchanged.

Production LOC: +63/-21 (net +42). Tests/test support: +190/-0. The production growth is the explicit ownership carrier across the existing startup layers plus owner validation at the state-migration input boundary; no parallel migration path remains.

Proof gap: no live operator state was mutated. Migration behavior was validated through isolated temporary state roots and a built CLI process; exact-head CI remains the publication gate.
