### PR TITLE
fix: parent messages fail while only subagents are active

### DIFF
--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -44,7 +44,7 @@ import {
   QUEUED_MESSAGE_RETRY_CONFLICT_ERROR,
   QUEUED_MESSAGE_REORDER_CONFLICT_ERROR,
 } from "./queued-message-edit.ts";
-import { hasAbortableSessionRun } from "./run-lifecycle.ts";
+import { hasDirectSessionRun } from "./run-lifecycle.ts";
 import {
   OFFLINE_QUEUE_STORAGE_ERROR,
   steerQueuedChatMessage as steerQueuedChatMessageLifecycle,
@@ -240,7 +240,7 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
       setChatError(host, t("chat.sendErrors.steerRunNoLongerActive"));
       return;
     }
-    if (hasAbortableSessionRun(host)) {
+    if (hasDirectSessionRun(host)) {
       const retry = updateQueuedMessage(host, id, (entry) => ({
         ...entry,
         sendAttempts: 0,

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -61,7 +61,7 @@ import { formatConnectError } from "./connect-error.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import { resetChatInputHistoryNavigation } from "./input-history.ts";
 import { controlUiNowMs, roundedControlUiDurationMs } from "./performance.ts";
-import { hasAbortableSessionRun, isChatBusy, reconcileChatRunLifecycle } from "./run-lifecycle.ts";
+import { hasDirectSessionRun, isChatBusy, reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { resetChatScroll, scheduleChatScroll } from "./scroll.ts";
 import {
   formatTerminalChatSendAckError,
@@ -614,7 +614,7 @@ export async function deliverChatQueueItem(
     if (
       drainResult === undefined &&
       routeVisible &&
-      (isChatBusy(host) || hasAbortableSessionRun(host))
+      (isChatBusy(host) || hasDirectSessionRun(host))
     ) {
       const parked = finishChatDeliveryAdmission(
         host,

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -19,7 +19,7 @@ import { recordChatSendTiming, schedulePendingSendPaintTiming } from "./chat-sen
 import { getPendingChatPickerPatch } from "./chat-session.ts";
 import { storedChatOutboxScopeKey, type StoredChatOutboxScope } from "./composer-persistence.ts";
 import { controlUiNowMs } from "./performance.ts";
-import { hasAbortableSessionRun, isChatBusy } from "./run-lifecycle.ts";
+import { hasDirectSessionRun, isChatBusy } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 import { OFFLINE_QUEUE_STORAGE_ERROR, surfaceChatDeliveryFailure } from "./steer-lifecycle.ts";
 
@@ -192,7 +192,7 @@ export function finishChatDeliveryAdmission(
     }
     return "pending";
   }
-  if (routeVisible(current.agentId) && (isChatBusy(host) || hasAbortableSessionRun(host))) {
+  if (routeVisible(current.agentId) && (isChatBusy(host) || hasDirectSessionRun(host))) {
     const parked = setState(host.connected && host.client ? "waiting-idle" : "waiting-reconnect");
     if (!parked) {
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -61,6 +61,7 @@ import { activeQueuedMessageEdit, retireEditedQueuedMessageSource } from "./queu
 import {
   handleAbortChat,
   hasAbortableSessionRun,
+  hasDirectSessionRun,
   isChatBusy,
   isChatStopCommand,
 } from "./run-lifecycle.ts";
@@ -584,7 +585,7 @@ export async function handleSendChat(
       pending?.sendState === "waiting-idle" &&
       host.sessionKey === submittedSessionKey &&
       visibleSessionMatches(host, submittedSessionKey, pending.agentId) &&
-      (isChatBusy(host) || hasAbortableSessionRun(host));
+      (isChatBusy(host) || hasDirectSessionRun(host));
     if (pendingBusySend) {
       recordChatSendTiming(host, pending, "queued-busy", submittedAtMs);
       // Only an explicit browser override replaces inherited Gateway policy.
@@ -596,7 +597,7 @@ export async function handleSendChat(
         !skillWorkshopRevision &&
         followUpMode !== "queue" &&
         host.connected &&
-        hasAbortableSessionRun(host)
+        hasDirectSessionRun(host)
       ) {
         void sendQueuedChatMessageWithQueueModeLifecycle(
           host,

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -3874,6 +3874,34 @@ describe("handleSendChat", () => {
     );
   });
 
+  it("sends normally when only a descendant run is active", async () => {
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.send": { status: "started", runId: "new-parent-run" },
+      },
+      chatMessage: "start another parent turn",
+      chatRunId: null,
+      sessionKey: "agent:main:main",
+      sessionsResult: createSessionsResult([
+        row("agent:main:main", {
+          hasActiveRun: false,
+          hasActiveSubagentRun: true,
+          status: "done",
+        }),
+      ]),
+      settings: { chatFollowUpMode: "steer" },
+    });
+
+    await handleSendChat(host);
+
+    await waitForFast(() => expect(host.request).toHaveBeenCalled());
+    const payload = findRequestPayload(host.request, "chat.send", "chat send payload");
+    expect(payload.message).toBe("start another parent turn");
+    expect(payload).not.toHaveProperty("queueMode");
+    expect(payload).not.toHaveProperty("expectedRunId");
+    expect(host.chatError).toBeNull();
+  });
+
   it("keeps a steered message visible when only the session row reports an active run", async () => {
     let wireRunId: unknown;
 

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   CHAT_RUN_STATUS_TOAST_DURATION_MS,
   handleAbortChat,
   hasAbortableSessionRun,
+  hasDirectSessionRun,
   reconcileChatRunFromCurrentSessionRow,
   reconcileChatRunFromSessionRow,
   reconcileChatRunLifecycle,
@@ -79,6 +80,7 @@ describe("handleAbortChat", () => {
       ]),
     });
 
+    expect(hasDirectSessionRun(host)).toBe(false);
     expect(hasAbortableSessionRun(host)).toBe(true);
     await handleAbortChat(host);
 

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -140,20 +140,32 @@ export function isChatBusy(host: { chatSending?: boolean; chatRunId?: string | n
   return Boolean(host.chatSending || host.chatRunId);
 }
 
-export function hasAbortableSessionRun(host: {
+type SessionRunHost = {
   chatRunId?: string | null;
   sessionKey: string;
   sessionsResult?: SessionsListResult | null;
-}): boolean {
-  if (host.chatRunId) {
-    return true;
-  }
+};
+
+export function hasDirectSessionRun(host: SessionRunHost): boolean {
   return Boolean(
+    host.chatRunId ||
     host.sessionsResult?.sessions.some(
       (session) =>
-        areUiSessionKeysEquivalent(session.key, host.sessionKey) &&
-        (isSessionRunActive(session) || session.hasActiveSubagentRun === true),
+        areUiSessionKeysEquivalent(session.key, host.sessionKey) && isSessionRunActive(session),
     ),
+  );
+}
+
+export function hasAbortableSessionRun(host: SessionRunHost): boolean {
+  return (
+    hasDirectSessionRun(host) ||
+    Boolean(
+      host.sessionsResult?.sessions.some(
+        (session) =>
+          areUiSessionKeysEquivalent(session.key, host.sessionKey) &&
+          session.hasActiveSubagentRun === true,
+      ),
+    )
   );
 }
 

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -41,7 +41,7 @@ import {
   isQueuedMessageBeingEdited,
   QUEUED_MESSAGE_STEER_CONFLICT_ERROR,
 } from "./queued-message-edit.ts";
-import { hasAbortableSessionRun } from "./run-lifecycle.ts";
+import { hasDirectSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll, type ChatScrollHost } from "./scroll.ts";
 import { appendChatMessageToCache, readChatMessagesFromCache } from "./session-message-cache.ts";
 import {
@@ -368,7 +368,7 @@ export async function sendQueuedChatMessageWithQueueMode(
   queueMode: QueueMode | undefined,
   dependencies: SteerSendDependencies,
 ): Promise<void> {
-  if (!host.connected || !hasAbortableSessionRun(host)) {
+  if (!host.connected || !hasDirectSessionRun(host)) {
     return;
   }
   const isSteer = queueMode === "steer";


### PR DESCRIPTION
Closes #125427

AI-assisted: Codex implemented and reviewed this change under maintainer supervision.

## What Problem This Solves

Fixes an issue where Control UI users sending a message in an idle parent session would see `The active run could not be identified uniquely. Review and retry.` when only a descendant subagent run remained active.

## Why This Change Was Made

The Control UI now distinguishes a direct session run, which can receive follow-up or steer delivery, from broader abortable activity that includes descendant runs. Send admission, follow-up delivery, steer retries, and target resolution use the direct-run predicate. Stop controls retain descendant-aware behavior.

## User Impact

Users can start a new parent turn while a persistent child session remains active. Direct active runs still receive the configured follow-up mode, and multiple direct run targets still fail closed.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts -t 'sends normally when only a descendant run is active'` failed because no `chat.send` request was made.
- Focused behavior suite: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/run-lifecycle.test.ts` passed 334 tests.
- Direct and ambiguous target cases: the focused run for descendant-only, one direct run, and multiple direct runs passed all three cases.
- Changed-file gates: `node scripts/check-changed.mjs` passed UI type checking, lint, formatting, i18n verification, dead-export scans, and repository policy checks.
- Build: `pnpm ui:build` passed, including Control UI performance limits and sidecar verification.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` reported `autoreview clean: no accepted/actionable findings reported`.
- Visual proof gap: the supplied failure screenshots contain private session content, and this agent environment does not expose the browser automation tool needed to capture a sanitized model-backed descendant-run flow against an isolated gateway. The regression test exercises the same published session shape and outbound request boundary.
