### PR TITLE
fix(workboard): stop lifecycle sync errors with multiple agents

### DIFF
--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -53,7 +53,8 @@ export default definePluginEntry({
     api.registerService(
       createWorkboardLifecycleService({
         store,
-        readSessions: async () => await readWorkboardLifecycleSessions(api.runtime.gateway),
+        readSessions: async (options) =>
+          await readWorkboardLifecycleSessions(api.runtime.gateway, options),
       }),
     );
     api.on("subagent_ended", async (event) => {

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -20,7 +20,10 @@ import {
 } from "./dispatcher-workspace.js";
 import { workboardSessionKeyForCard } from "./session-link.js";
 import { cardBoardId } from "./store-card-helpers.js";
-import { isWorkboardClaimReclaimable } from "./store-constants.js";
+import {
+  DEFAULT_WORKBOARD_DISPATCH_OWNER,
+  isWorkboardClaimReclaimable,
+} from "./store-constants.js";
 import { WorkboardStore, type WorkboardDispatchResult } from "./store.js";
 import {
   assertCanonicalWorkboardRootAccess,
@@ -30,7 +33,6 @@ import {
 } from "./workspace-access.js";
 
 const DEFAULT_DISPATCH_MAX_STARTS = 3;
-const DEFAULT_DISPATCH_OWNER = "workboard-dispatcher";
 
 export type WorkboardSubagentRuntime = Pick<PluginRuntime["subagent"], "run">;
 export type WorkboardWorktreeRuntime = PluginRuntime["worktrees"];
@@ -224,7 +226,7 @@ function resolveDispatchOwner(card: WorkboardCard, now: number, ownerOverride?: 
     ownerOverride ||
     (cardHasActiveClaim(card, now) ? card.metadata?.claim?.ownerId : undefined) ||
     card.agentId ||
-    DEFAULT_DISPATCH_OWNER
+    DEFAULT_WORKBOARD_DISPATCH_OWNER
   );
 }
 

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -557,6 +557,148 @@ describe("Workboard gateway lifecycle sync", () => {
     expect((await store.get(card.id))?.metadata?.stale).toBeUndefined();
   });
 
+  it("skips session discovery for an empty board", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const readSessions = vi.fn().mockResolvedValue({ sessions: [], complete: true });
+    const warn = vi.fn();
+    const context = { logger: { warn } } as never;
+    const service = createWorkboardLifecycleService({ store, readSessions });
+
+    await service.start(context);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await service.stop?.(context);
+
+    expect(readSessions).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("skips session discovery when no unarchived card needs lifecycle reconciliation", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({ title: "Not dispatched", status: "ready" });
+    const archived = await createLinkedCard(store, {
+      sessionKey: "agent:retired:subagent:workboard-default-archived",
+    });
+    await store.archive(archived.id, true);
+    const readSessions = vi.fn().mockResolvedValue({ sessions: [], complete: true });
+    const context = { logger: { warn: vi.fn() } } as never;
+    const service = createWorkboardLifecycleService({ store, readSessions });
+
+    await service.start(context);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await service.stop?.(context);
+
+    expect(readSessions).not.toHaveBeenCalled();
+  });
+
+  it("reconciles an agent-prefixed Workboard session when discovery is relevant", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await createLinkedCard(store, { agentId: "worker", boardId: "ops" });
+    const sessionKey = workboardSessionKeyForCard(card);
+    const suffix = sessionKey.slice(sessionKey.indexOf("subagent:workboard-"));
+
+    await runSessionSweep({
+      store,
+      sessions: [
+        { key: sessionKey, status: "done", hasActiveRun: false, updatedAt: card.updatedAt + 1 },
+        {
+          key: `agent:other:${suffix}`,
+          status: "failed",
+          hasActiveRun: false,
+          updatedAt: card.updatedAt + 1,
+        },
+      ],
+    });
+
+    expect((await store.get(card.id))?.status).toBe("review");
+  });
+
+  it("does not suffix-match a uniquely wrong agent for an explicit target", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await createLinkedCard(store, { agentId: "worker", boardId: "ops" });
+    const sessionKey = workboardSessionKeyForCard(card);
+    const suffix = sessionKey.slice(sessionKey.indexOf("subagent:workboard-"));
+
+    await runSessionSweep({
+      store,
+      sessions: [
+        {
+          key: `agent:other:${suffix}`,
+          status: "done",
+          hasActiveRun: false,
+          updatedAt: card.updatedAt + 1,
+        },
+      ],
+    });
+
+    expect((await store.get(card.id))?.status).toBe("running");
+  });
+
+  it("suffix-matches an accepted agentless run whose link could not be persisted", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Accepted without link", status: "ready" });
+    const acceptedSessionKey = workboardSessionKeyForCard(card);
+    const claimed = await store.claim(card.id, { ownerId: "workboard-dispatcher" });
+
+    expect(claimed.card).toMatchObject({
+      status: "running",
+      agentId: "workboard-dispatcher",
+      metadata: { claim: { ownerId: "workboard-dispatcher" } },
+    });
+    await runSessionSweep({
+      store,
+      sessions: [
+        {
+          key: `agent:worker:${acceptedSessionKey}`,
+          status: "done",
+          hasActiveRun: false,
+          updatedAt: claimed.card.updatedAt + 1,
+        },
+      ],
+    });
+
+    expect((await store.get(card.id))?.status).toBe("review");
+  });
+
+  it("does not suffix-match an agentless card when configured-agent sessions are ambiguous", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Ambiguous accepted run", status: "ready" });
+    const acceptedSessionKey = workboardSessionKeyForCard(card);
+    const claimed = await store.claim(card.id, { ownerId: "workboard-dispatcher" });
+
+    await runSessionSweep({
+      store,
+      sessions: [
+        {
+          key: `agent:alpha:${acceptedSessionKey}`,
+          status: "done",
+          updatedAt: claimed.card.updatedAt + 1,
+        },
+        {
+          key: `agent:beta:${acceptedSessionKey}`,
+          status: "failed",
+          updatedAt: claimed.card.updatedAt + 1,
+        },
+      ],
+    });
+
+    expect((await store.get(card.id))?.status).toBe("running");
+  });
+
+  it("suffix-matches an agentless linked card to an agent-prefixed Workboard session", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await createLinkedCard(store, { boardId: "ops" });
+    const sessionKey = `agent:worker:${workboardSessionKeyForCard(card)}`;
+
+    await runSessionSweep({
+      store,
+      sessions: [
+        { key: sessionKey, status: "done", hasActiveRun: false, updatedAt: card.updatedAt + 1 },
+      ],
+    });
+
+    expect((await store.get(card.id))?.status).toBe("review");
+  });
+
   it("runs the bounded session reconciliation from the lifecycle-owned service interval", async () => {
     vi.useFakeTimers();
     const store = new WorkboardStore(createMemoryStore());
@@ -591,24 +733,35 @@ describe("Workboard gateway lifecycle sync", () => {
     expect(readSessions).toHaveBeenCalledTimes(2);
   });
 
-  it("reads live active-run facts through the public runtime gateway seam", async () => {
-    const request = vi.fn().mockResolvedValue({
-      sessions: [
-        {
-          key: "agent:main:dashboard:live",
-          status: "running",
-          hasActiveRun: false,
-          updatedAt: 1234,
+  it("federates configured agents without ownerless sentinels", async () => {
+    const request = vi
+      .fn()
+      .mockImplementation(
+        async (_method: string, options: { includeGlobal?: boolean; includeUnknown?: boolean }) => {
+          if (options.includeGlobal || options.includeUnknown) {
+            throw new Error(
+              'Multiple agents are configured, but session key "global" has no explicit owner.',
+            );
+          }
+          return {
+            sessions: [
+              {
+                key: "agent:alpha:dashboard:live",
+                status: "running",
+                hasActiveRun: false,
+                updatedAt: 1234,
+              },
+            ],
+          };
         },
-      ],
-    });
+      );
 
     await expect(
       readWorkboardLifecycleSessions({ isAvailable: async () => true, request }),
     ).resolves.toEqual({
       sessions: [
         {
-          key: "agent:main:dashboard:live",
+          key: "agent:alpha:dashboard:live",
           status: "running",
           hasActiveRun: false,
           updatedAt: 1234,
@@ -620,16 +773,26 @@ describe("Workboard gateway lifecycle sync", () => {
       "sessions.list",
       {
         limit: 10_000,
-        includeGlobal: true,
-        includeUnknown: true,
+        configuredAgentsOnly: true,
+        includeGlobal: false,
+        includeUnknown: false,
       },
       { scopes: ["operator.read"] },
     );
   });
 
+  it("returns an incomplete empty snapshot without requesting while Gateway is unavailable", async () => {
+    const request = vi.fn();
+
+    await expect(
+      readWorkboardLifecycleSessions({ isAvailable: async () => false, request }),
+    ).resolves.toEqual({ sessions: [], complete: false });
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("treats a full sessions.list page as possibly truncated", async () => {
-    // sessions.list has no hasMore field; a page that fills the requested limit
-    // must not be treated as complete, or absent sessions would be marked missing.
+    // Keep a full page conservative even when a mock or older peer omits pagination
+    // metadata, or absent sessions could be marked missing.
     const request = vi.fn().mockResolvedValue({
       sessions: Array.from({ length: 10_000 }, (_, index) => ({
         key: `agent:main:dashboard:${index}`,

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -565,7 +565,9 @@ describe("Workboard gateway lifecycle sync", () => {
     const service = createWorkboardLifecycleService({ store, readSessions });
 
     await service.start(context);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
     await service.stop?.(context);
 
     expect(readSessions).not.toHaveBeenCalled();
@@ -584,7 +586,9 @@ describe("Workboard gateway lifecycle sync", () => {
     const service = createWorkboardLifecycleService({ store, readSessions });
 
     await service.start(context);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
     await service.stop?.(context);
 
     expect(readSessions).not.toHaveBeenCalled();

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -594,6 +594,45 @@ describe("Workboard gateway lifecycle sync", () => {
     expect(readSessions).not.toHaveBeenCalled();
   });
 
+  it("reconciles a captured unknown session when agent ownership is unambiguous", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await createLinkedCard(store, { sessionKey: "unknown" });
+    const request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "agents.list") {
+        return { selectionRequired: false };
+      }
+      return {
+        sessions: [
+          {
+            key: "unknown",
+            status: "done",
+            hasActiveRun: false,
+            updatedAt: card.updatedAt + 1,
+          },
+        ],
+      };
+    });
+    const readSessions = vi.fn(
+      async (options: { includeUnknown: boolean }) =>
+        await readWorkboardLifecycleSessions({ isAvailable: async () => true, request }, options),
+    );
+    const context = { logger: { warn: vi.fn() } } as never;
+    const service = createWorkboardLifecycleService({ store, readSessions });
+
+    await service.start(context);
+    await vi.waitFor(async () => expect((await store.get(card.id))?.status).toBe("review"));
+    await service.stop?.(context);
+
+    expect(readSessions).toHaveBeenCalledWith({ includeUnknown: true });
+    expect(request).toHaveBeenNthCalledWith(1, "agents.list", {}, { scopes: ["operator.read"] });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.list",
+      expect.objectContaining({ includeGlobal: false, includeUnknown: true }),
+      { scopes: ["operator.read"] },
+    );
+  });
+
   it("reconciles an agent-prefixed Workboard session when discovery is relevant", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await createLinkedCard(store, { agentId: "worker", boardId: "ops" });
@@ -783,6 +822,24 @@ describe("Workboard gateway lifecycle sync", () => {
       },
       { scopes: ["operator.read"] },
     );
+  });
+
+  it("keeps unknown excluded when explicit ownership requires agent selection", async () => {
+    const request = vi.fn().mockImplementation(async (method: string, options: object) => {
+      if (method === "agents.list") {
+        return { selectionRequired: true };
+      }
+      expect(method).toBe("sessions.list");
+      expect(options).toMatchObject({ includeGlobal: false, includeUnknown: false });
+      return { sessions: [] };
+    });
+
+    await expect(
+      readWorkboardLifecycleSessions(
+        { isAvailable: async () => true, request },
+        { includeUnknown: true },
+      ),
+    ).resolves.toEqual({ sessions: [], complete: true });
   });
 
   it("returns an incomplete empty snapshot without requesting while Gateway is unavailable", async () => {

--- a/extensions/workboard/src/lifecycle-sync.ts
+++ b/extensions/workboard/src/lifecycle-sync.ts
@@ -9,6 +9,8 @@ import {
   workboardCardMatchesLifecycleLink,
   workboardCardSessionLookupKey,
 } from "./session-link.js";
+import { cardSessionKey } from "./store-card-helpers.js";
+import { DEFAULT_WORKBOARD_DISPATCH_OWNER } from "./store-constants.js";
 import type { WorkboardStore } from "./store.js";
 
 const WORKBOARD_LIFECYCLE_SWEEP_MS = 60_000;
@@ -44,6 +46,22 @@ type WorkboardLifecycleMatchHandler = (input: {
   cards: readonly WorkboardCard[];
   sessionKey?: string;
 }) => Promise<void>;
+
+function needsWorkboardLifecycleReconciliation(card: WorkboardCard): boolean {
+  if (card.metadata?.archivedAt) {
+    return false;
+  }
+  // A running claim can own an accepted session even when persisting its link failed.
+  // Keep those cards, and stale cleanup, in the missed-event recovery sweep.
+  return Boolean(
+    card.sessionKey ||
+    card.runId ||
+    card.execution ||
+    card.status === "running" ||
+    card.metadata?.claim ||
+    card.metadata?.stale,
+  );
+}
 
 const LIFECYCLE_TARGETS = {
   running: { card: "running", execution: "running" },
@@ -189,11 +207,20 @@ async function syncWorkboardLifecycleSessions(params: {
 }): Promise<number> {
   const now = params.now ?? Date.now();
   const sessionsByKey = new Map<string, WorkboardLifecycleSession>();
+  const sessionsByWorkboardSuffix = new Map<string, WorkboardLifecycleSession>();
+  const ambiguousWorkboardSuffixes = new Set<string>();
   for (const session of params.sessions) {
     sessionsByKey.set(session.key, session);
     const suffixIndex = session.key.lastIndexOf(":subagent:workboard-");
     if (suffixIndex >= 0) {
-      sessionsByKey.set(session.key.slice(suffixIndex + 1), session);
+      const suffix = session.key.slice(suffixIndex + 1);
+      const existing = sessionsByWorkboardSuffix.get(suffix);
+      if (existing && existing.key !== session.key) {
+        sessionsByWorkboardSuffix.delete(suffix);
+        ambiguousWorkboardSuffixes.add(suffix);
+      } else if (!ambiguousWorkboardSuffixes.has(suffix)) {
+        sessionsByWorkboardSuffix.set(suffix, session);
+      }
     }
   }
   let count = 0;
@@ -201,7 +228,22 @@ async function syncWorkboardLifecycleSessions(params: {
     if (card.metadata?.archivedAt) {
       continue;
     }
-    const session = sessionsByKey.get(workboardCardSessionLookupKey(card));
+    const lookupKey = workboardCardSessionLookupKey(card);
+    const suffixIndex = lookupKey.lastIndexOf("subagent:workboard-");
+    const linkedSessionKey = cardSessionKey(card);
+    const canUseAgentlessFallback =
+      linkedSessionKey?.startsWith("subagent:workboard-") === true ||
+      (!linkedSessionKey &&
+        (!card.agentId ||
+          (card.agentId === DEFAULT_WORKBOARD_DISPATCH_OWNER &&
+            card.metadata?.claim?.ownerId === DEFAULT_WORKBOARD_DISPATCH_OWNER)));
+    // Persisted links and explicit agent targets stay authoritative. The unique
+    // suffix fallback recovers a run accepted before its link could be persisted.
+    const session =
+      sessionsByKey.get(lookupKey) ??
+      (canUseAgentlessFallback && suffixIndex >= 0
+        ? sessionsByWorkboardSuffix.get(lookupKey.slice(suffixIndex))
+        : undefined);
     const observation = session
       ? lifecycleFromSession(session, now)
       : params.complete
@@ -250,8 +292,9 @@ export async function readWorkboardLifecycleSessions(
     "sessions.list",
     {
       limit: WORKBOARD_SESSION_SWEEP_LIMIT,
-      includeGlobal: true,
-      includeUnknown: true,
+      configuredAgentsOnly: true,
+      includeGlobal: false,
+      includeUnknown: false,
     },
     { scopes: ["operator.read"] },
   );
@@ -263,9 +306,8 @@ export async function readWorkboardLifecycleSessions(
       const session = normalizeSession(value);
       return session ? [session] : [];
     }),
-    // sessions.list has no hasMore/cursor field; it honors `limit` unclamped, so a
-    // short page proves the snapshot is complete. A full page may be truncated —
-    // treat it as incomplete so absent sessions are never inferred as "missing".
+    // A short page proves the snapshot is complete. Keep full pages conservative
+    // so absent sessions are never inferred as "missing" when the page is truncated.
     complete: payload.sessions.length < WORKBOARD_SESSION_SWEEP_LIMIT,
   };
 }
@@ -283,6 +325,13 @@ export function createWorkboardLifecycleService(params: {
       const owner = ++generation;
       const reconcile = async () => {
         try {
+          const cards = await params.store.list();
+          if (
+            generation !== owner ||
+            !cards.some((card) => needsWorkboardLifecycleReconciliation(card))
+          ) {
+            return;
+          }
           const snapshot = await params.readSessions();
           if (generation === owner) {
             await syncWorkboardLifecycleSessions({

--- a/extensions/workboard/src/lifecycle-sync.ts
+++ b/extensions/workboard/src/lifecycle-sync.ts
@@ -42,6 +42,10 @@ type WorkboardLifecycleSessionSnapshot = {
   complete: boolean;
 };
 
+type WorkboardLifecycleSessionReadOptions = {
+  includeUnknown: boolean;
+};
+
 type WorkboardLifecycleMatchHandler = (input: {
   cards: readonly WorkboardCard[];
   sessionKey?: string;
@@ -284,9 +288,20 @@ function normalizeSession(value: unknown): WorkboardLifecycleSession | undefined
 
 export async function readWorkboardLifecycleSessions(
   gateway: Pick<OpenClawPluginApi["runtime"]["gateway"], "isAvailable" | "request">,
+  options: WorkboardLifecycleSessionReadOptions = { includeUnknown: false },
 ): Promise<WorkboardLifecycleSessionSnapshot> {
   if (!(await gateway.isAvailable())) {
     return { sessions: [], complete: false };
+  }
+  let includeUnknown = false;
+  if (options.includeUnknown) {
+    const agentsPayload = await gateway.request("agents.list", {}, { scopes: ["operator.read"] });
+    if (!isRecord(agentsPayload) || typeof agentsPayload.selectionRequired !== "boolean") {
+      throw new Error("agents.list returned an invalid ownership snapshot");
+    }
+    // The unknown key is a legacy ownerless sentinel. Preserve an existing
+    // captured link only while the Gateway proves that its owner is unambiguous.
+    includeUnknown = !agentsPayload.selectionRequired;
   }
   const payload = await gateway.request(
     "sessions.list",
@@ -294,7 +309,7 @@ export async function readWorkboardLifecycleSessions(
       limit: WORKBOARD_SESSION_SWEEP_LIMIT,
       configuredAgentsOnly: true,
       includeGlobal: false,
-      includeUnknown: false,
+      includeUnknown,
     },
     { scopes: ["operator.read"] },
   );
@@ -314,7 +329,9 @@ export async function readWorkboardLifecycleSessions(
 
 export function createWorkboardLifecycleService(params: {
   store: WorkboardStore;
-  readSessions: () => Promise<WorkboardLifecycleSessionSnapshot>;
+  readSessions: (
+    options: WorkboardLifecycleSessionReadOptions,
+  ) => Promise<WorkboardLifecycleSessionSnapshot>;
   now?: () => number;
 }): OpenClawPluginService {
   let generation = 0;
@@ -332,7 +349,11 @@ export function createWorkboardLifecycleService(params: {
           ) {
             return;
           }
-          const snapshot = await params.readSessions();
+          const snapshot = await params.readSessions({
+            includeUnknown: cards.some(
+              (card) => !card.metadata?.archivedAt && cardSessionKey(card) === "unknown",
+            ),
+          });
           if (generation === owner) {
             await syncWorkboardLifecycleSessions({
               store: params.store,

--- a/extensions/workboard/src/store-constants.ts
+++ b/extensions/workboard/src/store-constants.ts
@@ -20,6 +20,7 @@ export const MAX_CARD_DIAGNOSTICS = 12;
 export const MAX_CARD_NOTIFICATIONS = 20;
 export const MAX_CARD_METADATA_BYTES = 24 * 1024;
 export const DEFAULT_CLAIM_TTL_MS = 30 * 60 * 1000;
+export const DEFAULT_WORKBOARD_DISPATCH_OWNER = "workboard-dispatcher";
 export const READY_STRANDED_MS = 60 * 60 * 1000;
 export const RUNNING_HEARTBEAT_STALE_MS = 20 * 60 * 1000;
 export const BLOCKED_TOO_LONG_MS = 24 * 60 * 60 * 1000;

--- a/src/gateway/server.sessions.list-explicit-ownership.test.ts
+++ b/src/gateway/server.sessions.list-explicit-ownership.test.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { expect, test } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { testState, writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  setupGatewaySessionsHandlerTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+setupGatewaySessionsHandlerTestHarness();
+
+test("sessions.list excludes ownerless sentinels for explicit multi-agent federation", async () => {
+  const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!rootStateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const stateDir = path.join(rootStateDir, "explicit-ownership-list-regression");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    const agentsDir = path.join(stateDir, "agents");
+    const storeTemplate = path.join(agentsDir, "{agentId}", "sessions", "sessions.json");
+    testState.sessionConfig = { store: storeTemplate };
+    testState.agentsConfig = {
+      ownership: "explicit",
+      list: [{ id: "ops" }, { id: "research" }],
+    };
+    testState.agentConfig = { sessionStore: { agentId: "ops" } };
+    await writeSessionStore({
+      storePath: storeTemplate.replace("{agentId}", "ops"),
+      agentId: "ops",
+      entries: {
+        main: { sessionId: "sess-ops", updatedAt: 20 },
+        global: { sessionId: "sess-global", updatedAt: 19 },
+        unknown: { sessionId: "sess-unknown", updatedAt: 18 },
+      },
+    });
+    await writeSessionStore({
+      storePath: storeTemplate.replace("{agentId}", "research"),
+      agentId: "research",
+      entries: { main: { sessionId: "sess-research", updatedAt: 21 } },
+    });
+
+    await expect(
+      directSessionReq("sessions.list", {
+        includeGlobal: true,
+        includeUnknown: true,
+        configuredAgentsOnly: true,
+      }),
+    ).rejects.toThrow(
+      'Multiple agents are configured, but session key "global" has no explicit owner.',
+    );
+
+    const configuredOnly = await directSessionReq<{ sessions: Array<{ key: string }> }>(
+      "sessions.list",
+      { includeGlobal: false, includeUnknown: false, configuredAgentsOnly: true },
+    );
+    expect(configuredOnly.ok).toBe(true);
+    expect(configuredOnly.payload?.sessions.map((session) => session.key)).toEqual([
+      "agent:research:main",
+      "agent:ops:main",
+    ]);
+  });
+});

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -673,7 +673,7 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
   const rootStateDir = expectDefined(process.env.OPENCLAW_STATE_DIR, "OPENCLAW_STATE_DIR");
   const stateDir = path.join(rootStateDir, "configured-list-regression");
   await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-    testState.agentsConfig = { ownership: "explicit", list: [{ id: "ops" }] };
+    testState.agentsConfig = { ownership: "explicit", list: [{ id: "ops" }, { id: "research" }] };
     testState.agentConfig = { sessionStore: { agentId: "ops" } };
     const configPath = expectDefined(process.env.OPENCLAW_CONFIG_PATH, "OPENCLAW_CONFIG_PATH");
     const configJson = '{"acp":{"defaultAgent":"claude","allowedAgents":["gemini"]}}';
@@ -684,6 +684,7 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
 
     const acpStorePath = path.join(agentsDir, "claude", "sessions", "sessions.json");
     const childStorePath = path.join(agentsDir, "codex", "sessions", "sessions.json");
+    const researchStorePath = path.join(agentsDir, "research", "sessions", "sessions.json");
     const diskOnlyStorePath = path.join(agentsDir, "local", "sessions", "sessions.json");
     const mainKey = "agent:ops:main";
     const acpKey = "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7";
@@ -700,7 +701,16 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
     await writeSessionStore({
       storePath: path.join(agentsDir, "ops", "sessions", "sessions.json"),
       agentId: "ops",
-      entries: { main: { sessionId: "sess-main", updatedAt: 20 } },
+      entries: {
+        main: { sessionId: "sess-main", updatedAt: 20 },
+        global: { sessionId: "sess-global", updatedAt: 19 },
+        unknown: { sessionId: "sess-unknown", updatedAt: 18 },
+      },
+    });
+    await writeSessionStore({
+      storePath: researchStorePath,
+      agentId: "research",
+      entries: { main: { sessionId: "sess-research", updatedAt: 21 } },
     });
     await writeSessionStore({
       storePath: acpStorePath,
@@ -724,6 +734,16 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
     });
     const enumerateAgentDirs = vi.spyOn(sessionDirs, "resolveAgentSessionDirsFromAgentsDirSync");
     try {
+      await expect(
+        directSessionHandlerReq("sessions.list", {
+          includeGlobal: true,
+          includeUnknown: true,
+          configuredAgentsOnly: true,
+        }),
+      ).rejects.toThrow(
+        'Multiple agents are configured, but session key "global" has no explicit owner.',
+      );
+
       const configuredOnly = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
         "sessions.list",
         { includeGlobal: false, includeUnknown: false, configuredAgentsOnly: true },
@@ -733,6 +753,7 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
         acpKey,
         parentChildKey,
         spawnedChildKey,
+        "agent:research:main",
         mainKey,
       ]);
       expect(enumerateAgentDirs).not.toHaveBeenCalled();
@@ -746,6 +767,7 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
         acpKey,
         parentChildKey,
         spawnedChildKey,
+        "agent:research:main",
         mainKey,
         "agent:local:main",
       ]);

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -673,7 +673,7 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
   const rootStateDir = expectDefined(process.env.OPENCLAW_STATE_DIR, "OPENCLAW_STATE_DIR");
   const stateDir = path.join(rootStateDir, "configured-list-regression");
   await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-    testState.agentsConfig = { ownership: "explicit", list: [{ id: "ops" }, { id: "research" }] };
+    testState.agentsConfig = { ownership: "explicit", list: [{ id: "ops" }] };
     testState.agentConfig = { sessionStore: { agentId: "ops" } };
     const configPath = expectDefined(process.env.OPENCLAW_CONFIG_PATH, "OPENCLAW_CONFIG_PATH");
     const configJson = '{"acp":{"defaultAgent":"claude","allowedAgents":["gemini"]}}';
@@ -684,7 +684,6 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
 
     const acpStorePath = path.join(agentsDir, "claude", "sessions", "sessions.json");
     const childStorePath = path.join(agentsDir, "codex", "sessions", "sessions.json");
-    const researchStorePath = path.join(agentsDir, "research", "sessions", "sessions.json");
     const diskOnlyStorePath = path.join(agentsDir, "local", "sessions", "sessions.json");
     const mainKey = "agent:ops:main";
     const acpKey = "agent:claude:acp:25f77580-de30-4d80-9bc3-7cbc6374bce7";
@@ -701,16 +700,7 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
     await writeSessionStore({
       storePath: path.join(agentsDir, "ops", "sessions", "sessions.json"),
       agentId: "ops",
-      entries: {
-        main: { sessionId: "sess-main", updatedAt: 20 },
-        global: { sessionId: "sess-global", updatedAt: 19 },
-        unknown: { sessionId: "sess-unknown", updatedAt: 18 },
-      },
-    });
-    await writeSessionStore({
-      storePath: researchStorePath,
-      agentId: "research",
-      entries: { main: { sessionId: "sess-research", updatedAt: 21 } },
+      entries: { main: { sessionId: "sess-main", updatedAt: 20 } },
     });
     await writeSessionStore({
       storePath: acpStorePath,
@@ -734,16 +724,6 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
     });
     const enumerateAgentDirs = vi.spyOn(sessionDirs, "resolveAgentSessionDirsFromAgentsDirSync");
     try {
-      await expect(
-        directSessionHandlerReq("sessions.list", {
-          includeGlobal: true,
-          includeUnknown: true,
-          configuredAgentsOnly: true,
-        }),
-      ).rejects.toThrow(
-        'Multiple agents are configured, but session key "global" has no explicit owner.',
-      );
-
       const configuredOnly = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
         "sessions.list",
         { includeGlobal: false, includeUnknown: false, configuredAgentsOnly: true },
@@ -753,7 +733,6 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
         acpKey,
         parentChildKey,
         spawnedChildKey,
-        "agent:research:main",
         mainKey,
       ]);
       expect(enumerateAgentDirs).not.toHaveBeenCalled();
@@ -767,7 +746,6 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
         acpKey,
         parentChildKey,
         spawnedChildKey,
-        "agent:research:main",
         mainKey,
         "agent:local:main",
       ]);


### PR DESCRIPTION
Related: #125023

## What Problem This Solves

Fixes an issue where operators using explicit multi-agent ownership would see Workboard lifecycle sync fail once per minute on ownerless `global` sessions, even when the board was empty.

## Why This Change Was Made

Workboard now skips Gateway discovery unless an unarchived card needs lifecycle reconciliation, and explicit-owner sweeps use the existing configured-agent federation boundary without ownerless `global` or `unknown` sentinels. Exact agent ownership remains authoritative; agentless recovery uses a suffix only when it identifies one session, so no configured agent is selected implicitly.

A pre-existing card linked to the legacy `unknown` sentinel requests that row only when the canonical `agents.list` selection state proves ownership is unambiguous. Explicit multi-agent installations keep `includeUnknown: false`.

## User Impact

Empty or inactive boards no longer trigger 10,000-row session scans or repeated multi-agent ownership warnings. Linked cards still recover missed lifecycle events across configured agents, including agentless runs whose accepted-session link could not be persisted and legacy `unknown` captures on unambiguous installations.

## Evidence

- Direct Gateway-handler regression with two explicit agents: the previous sentinel-inclusive request throws `AgentSelectionRequiredError`; the configured-only/no-sentinel request succeeds, retains configured and lineage sessions, and excludes the unrelated disk-only store.
- Source-blind behavior validation: 53/53 tests passed across all ten Workboard lifecycle and explicit-ownership Gateway clauses.
- Focused dispatcher/lifecycle regression coverage: 68/68 tests passed.
- Targeted configured-agent federation test: 1/1 passed (6 unrelated tests skipped).
- `git diff --check`, targeted `oxfmt`, and type-aware `oxlint` passed.
- Fresh exact-head autoreview reported no actionable findings at 0.99 confidence.