### PR TITLE
fix(matrix): keep user ID authorization case-sensitive

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -93,6 +93,8 @@ Set `autoJoin: "allowlist"` plus `autoJoinAllowlist` to restrict accepted invite
 
 ### Allowlist target formats
 
+Matrix user IDs are case-sensitive. Copy the exact `@user:server` value Matrix reports for every allowlist and approver field. If an existing config used different casing, update it manually; OpenClaw cannot safely infer or rewrite the intended account because case-distinct IDs can identify different users.
+
 - DMs (`dm.allowFrom`, `groupAllowFrom`, `groups.<room>.users`): use `@user:server`. Display names are ignored by default (mutable); set `dangerouslyAllowNameMatching: true` only for explicit display-name compatibility.
 - Room allowlist keys (`groups`, legacy alias `rooms`): use `!room:server` or `#alias:server`. Plain names are ignored unless `dangerouslyAllowNameMatching: true`.
 - Invite allowlists (`autoJoinAllowlist`): use `!room:server`, `#alias:server`, or `*`. Plain names are always rejected.

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -93,9 +93,10 @@ Set `autoJoin: "allowlist"` plus `autoJoinAllowlist` to restrict accepted invite
 
 ### Allowlist target formats
 
-Matrix user IDs are case-sensitive. Copy the exact `@user:server` value Matrix reports for every allowlist and approver field. If an existing config used different casing, update it manually; OpenClaw cannot safely infer or rewrite the intended account because case-distinct IDs can identify different users.
+Matrix user IDs are case-sensitive. Copy the exact `@user:server` value Matrix reports for every allowlist, approver, and approval-target field. If an existing config used different casing, update it manually; OpenClaw cannot safely infer or rewrite the intended account because case-distinct IDs can identify different users.
 
 - DMs (`dm.allowFrom`, `groupAllowFrom`, `groups.<room>.users`): use `@user:server`. Display names are ignored by default (mutable); set `dangerouslyAllowNameMatching: true` only for explicit display-name compatibility.
+- Approval forwarding (`approvals.exec.targets[].to` with `channel: "matrix"`): use `user:@user:server` with the exact Matrix casing.
 - Room allowlist keys (`groups`, legacy alias `rooms`): use `!room:server` or `#alias:server`. Plain names are ignored unless `dangerouslyAllowNameMatching: true`.
 - Invite allowlists (`autoJoinAllowlist`): use `!room:server`, `#alias:server`, or `*`. Plain names are always rejected.
 

--- a/extensions/matrix/src/approval-auth.test.ts
+++ b/extensions/matrix/src/approval-auth.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { matrixApprovalAuth } from "./approval-auth.js";
 
 describe("matrixApprovalAuth", () => {
-  it("normalizes Matrix user ids before authorizing", () => {
+  it("authorizes exact Matrix user ids without case folding", () => {
     const cfg = {
       channels: {
         matrix: {
-          dm: { allowFrom: ["matrix:@Owner:Example.org"] },
+          dm: { allowFrom: ["matrix:@\u212A:example.org"] },
         },
       },
     };
@@ -15,10 +15,21 @@ describe("matrixApprovalAuth", () => {
     expect(
       matrixApprovalAuth.authorizeActorAction({
         cfg,
-        senderId: "@owner:example.org",
+        senderId: "@\u212A:example.org",
         action: "approve",
         approvalKind: "plugin",
       }),
     ).toEqual({ authorized: true });
+    expect(
+      matrixApprovalAuth.authorizeActorAction({
+        cfg,
+        senderId: "@k:example.org",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toEqual({
+      authorized: false,
+      reason: "\u274c You are not authorized to approve plugin requests on Matrix.",
+    });
   });
 });

--- a/extensions/matrix/src/approval-native.test.ts
+++ b/extensions/matrix/src/approval-native.test.ts
@@ -222,6 +222,41 @@ describe("matrix approval capability", () => {
     ).toEqual({ authorized: true });
   });
 
+  it("requires exact Matrix identities for native approval actions", () => {
+    const cfg = buildConfig({
+      dm: { allowFrom: ["@\u212A:example.org"] },
+      execApprovals: {
+        enabled: true,
+        approvers: ["@\u212A:example.org"],
+        target: "both",
+      },
+    });
+
+    for (const approvalKind of ["plugin", "exec"] as const) {
+      expect(
+        matrixApprovalCapability.authorizeActorAction?.({
+          cfg,
+          accountId: "default",
+          senderId: "@\u212A:example.org",
+          action: "approve",
+          approvalKind,
+        }),
+      ).toEqual({ authorized: true });
+      expect(
+        matrixApprovalCapability.authorizeActorAction?.({
+          cfg,
+          accountId: "default",
+          senderId: "@k:example.org",
+          action: "approve",
+          approvalKind,
+        }),
+      ).toEqual({
+        authorized: false,
+        reason: `\u274c You are not authorized to approve ${approvalKind} requests on Matrix.`,
+      });
+    }
+  });
+
   it("requires Matrix DM approvers before enabling plugin approval auth", () => {
     const cfg = buildConfig({
       dm: { allowFrom: [] },

--- a/extensions/matrix/src/approval-reaction-auth.test.ts
+++ b/extensions/matrix/src/approval-reaction-auth.test.ts
@@ -1,0 +1,38 @@
+// Matrix tests cover approval reaction auth behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { isMatrixApprovalReactionAuthorizedSender } from "./approval-reaction-auth.js";
+
+describe("isMatrixApprovalReactionAuthorizedSender", () => {
+  it.each(["plugin", "exec"] as const)(
+    "requires an exact Matrix identity for %s approval reactions",
+    (approvalKind) => {
+      const cfg = {
+        channels: {
+          matrix: {
+            homeserver: "https://matrix.example.org",
+            userId: "@bot:example.org",
+            accessToken: "tok",
+            dm: { allowFrom: ["@\u212A:example.org"] },
+            execApprovals: { enabled: true, approvers: ["@\u212A:example.org"] },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        isMatrixApprovalReactionAuthorizedSender({
+          cfg,
+          senderId: "@\u212A:example.org",
+          approvalKind,
+        }),
+      ).toBe(true);
+      expect(
+        isMatrixApprovalReactionAuthorizedSender({
+          cfg,
+          senderId: "@k:example.org",
+          approvalKind,
+        }),
+      ).toBe(false);
+    },
+  );
+});

--- a/extensions/matrix/src/exec-approvals.test.ts
+++ b/extensions/matrix/src/exec-approvals.test.ts
@@ -183,6 +183,15 @@ describe("matrix exec approvals", () => {
     );
   });
 
+  it("requires an exact Matrix id for exec approval authorization", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["user:@\u212A:example.org"] });
+
+    expect(isMatrixExecApprovalAuthorizedSender({ cfg, senderId: "@\u212A:example.org" })).toBe(
+      true,
+    );
+    expect(isMatrixExecApprovalAuthorizedSender({ cfg, senderId: "@k:example.org" })).toBe(false);
+  });
+
   it("ignores wildcard allowlist entries when inferring exec approvers", () => {
     const cfg = buildConfig({ enabled: true }, { dm: { allowFrom: ["*"] } });
 
@@ -225,6 +234,30 @@ describe("matrix exec approvals", () => {
     expect(isMatrixExecApprovalAuthorizedSender({ cfg, senderId: "@other:example.org" })).toBe(
       false,
     );
+  });
+
+  it("requires an exact Matrix id for approval target recipients", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+        },
+      },
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "matrix", to: "user:@\u212A:example.org" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(isMatrixExecApprovalAuthorizedSender({ cfg, senderId: "@\u212A:example.org" })).toBe(
+      true,
+    );
+    expect(isMatrixExecApprovalAuthorizedSender({ cfg, senderId: "@k:example.org" })).toBe(false);
   });
 
   it("suppresses local prompts only when the native client is enabled", () => {

--- a/extensions/matrix/src/matrix/monitor/access-state.test.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.test.ts
@@ -23,14 +23,39 @@ describe("resolveMatrixMonitorAccessState", () => {
       storeAllowFrom: ["user:@bob:example.org"],
       groupAllowFrom: ["@Carol:Example.org"],
       roomUsers: ["user:@Dana:Example.org"],
-      senderId: "@dana:example.org",
+      senderId: "@Dana:Example.org",
       isRoom: true,
       groupPolicy: "allowlist",
     });
 
-    expect(state.effectiveGroupAllowFrom).toEqual(["@carol:example.org"]);
-    expect(state.effectiveRoomUsers).toEqual(["user:@dana:example.org"]);
+    expect(state.effectiveGroupAllowFrom).toEqual(["@Carol:Example.org"]);
+    expect(state.effectiveRoomUsers).toEqual(["user:@Dana:Example.org"]);
     expect(state.messageIngress.ingress.decision).toBe("allow");
+  });
+
+  it.each([
+    { isRoom: false, allowFrom: ["@\u212A:example.org"], groupAllowFrom: [] },
+    { isRoom: true, allowFrom: [], groupAllowFrom: ["@\u212A:example.org"] },
+  ])("rejects case-folding collisions at ingress and command gates", async (params) => {
+    const state = await resolveMatrixMonitorAccessState({
+      ...params,
+      storeAllowFrom: [],
+      roomUsers: [],
+      senderId: "@k:example.org",
+      dmPolicy: "allowlist",
+      groupPolicy: "allowlist",
+    });
+
+    expect(state.messageIngress.ingress.decision).toBe("block");
+    await expectCommandAccess(
+      state,
+      {
+        useAccessGroups: true,
+        allowTextCommands: true,
+        hasControlCommand: true,
+      },
+      { authorized: false, shouldBlockControlCommand: true },
+    );
   });
 
   it("does not let DM pairing-store entries authorize room control commands", async () => {

--- a/extensions/matrix/src/matrix/monitor/allowlist.test.ts
+++ b/extensions/matrix/src/matrix/monitor/allowlist.test.ts
@@ -6,25 +6,39 @@ describe("resolveMatrixAllowListMatch", () => {
   it("matches full user IDs and prefixes", () => {
     const userId = "@Alice:Example.org";
     const direct = resolveMatrixAllowListMatch({
-      allowList: normalizeMatrixAllowList(["@alice:example.org"]),
+      allowList: normalizeMatrixAllowList([userId]),
       userId,
     });
     expect(direct.allowed).toBe(true);
     expect(direct.matchSource).toBe("id");
 
     const prefixedMatrix = resolveMatrixAllowListMatch({
-      allowList: normalizeMatrixAllowList(["matrix:@alice:example.org"]),
+      allowList: normalizeMatrixAllowList([`MATRIX:${userId}`]),
       userId,
     });
     expect(prefixedMatrix.allowed).toBe(true);
     expect(prefixedMatrix.matchSource).toBe("prefixed-id");
 
     const prefixedUser = resolveMatrixAllowListMatch({
-      allowList: normalizeMatrixAllowList(["user:@alice:example.org"]),
+      allowList: normalizeMatrixAllowList([`USER:${userId}`]),
       userId,
     });
     expect(prefixedUser.allowed).toBe(true);
     expect(prefixedUser.matchSource).toBe("prefixed-user");
+  });
+
+  it("keeps complete Matrix user IDs case-sensitive", () => {
+    const allowList = normalizeMatrixAllowList(["@\u212A:example.org"]);
+
+    expect(resolveMatrixAllowListMatch({ allowList, userId: "@\u212A:example.org" }).allowed).toBe(
+      true,
+    );
+    expect(resolveMatrixAllowListMatch({ allowList, userId: "@k:example.org" }).allowed).toBe(
+      false,
+    );
+    expect(resolveMatrixAllowListMatch({ allowList, userId: "@\u212A:EXAMPLE.org" }).allowed).toBe(
+      false,
+    );
   });
 
   it("ignores display names and localparts", () => {

--- a/extensions/matrix/src/matrix/monitor/allowlist.ts
+++ b/extensions/matrix/src/matrix/monitor/allowlist.ts
@@ -18,17 +18,7 @@ function normalizeMatrixUser(raw?: string | null): string {
   if (!value.startsWith("@") || !value.includes(":")) {
     return normalizeLowercaseStringOrEmpty(value);
   }
-  const withoutAt = value.slice(1);
-  const splitIndex = withoutAt.indexOf(":");
-  if (splitIndex === -1) {
-    return normalizeLowercaseStringOrEmpty(value);
-  }
-  const localpart = normalizeLowercaseStringOrEmpty(withoutAt.slice(0, splitIndex));
-  const server = normalizeLowercaseStringOrEmpty(withoutAt.slice(splitIndex + 1));
-  if (!server) {
-    return normalizeLowercaseStringOrEmpty(value);
-  }
-  return `@${localpart}:${server}`;
+  return value;
 }
 
 export function normalizeMatrixUserId(raw?: string | null): string {

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -92,13 +92,13 @@ describe("resolveMatrixMonitorConfig", () => {
       resolveTargets,
     });
 
-    expect(result.allowFrom).toEqual(["@alice:example.org", "@bob:example.org"]);
-    expect(result.groupAllowFrom).toEqual(["@carol:example.org"]);
+    expect(result.allowFrom).toEqual(["@Alice:Example.org", "@bob:example.org"]);
+    expect(result.groupAllowFrom).toEqual(["@Carol:Example.org"]);
     expect(result.roomsConfig).toEqual({
       "*": { enabled: true },
       "!ops:example.org": {
         enabled: true,
-        users: ["@dana:example.org", "@erin:example.org"],
+        users: ["@dana:example.org", "@Erin:Example.org"],
       },
       "!general:example.org": {
         enabled: true,
@@ -245,15 +245,15 @@ describe("resolveMatrixMonitorConfig", () => {
       resolveTargets,
     });
 
-    expect(result.allowFrom).toEqual(["@bob:example.org"]);
+    expect(result.allowFrom).toEqual(["@Bob:Example.org"]);
     expect(result.allowFromResolvedEntries).toEqual([
-      { input: "matrix:@Bob:Example.org", id: "@bob:example.org" },
+      { input: "matrix:@Bob:Example.org", id: "@Bob:Example.org" },
     ]);
     expect(result.groupAllowFrom).toEqual(["Carol"]);
     expect(result.roomsConfig).toEqual({
       "!ops:example.org": {
         enabled: true,
-        users: ["@erin:example.org", "Frank"],
+        users: ["@Erin:Example.org", "Frank"],
       },
     });
     expect(resolveTargets).toHaveBeenCalledTimes(1);
@@ -291,7 +291,7 @@ describe("resolveMatrixMonitorConfig", () => {
       resolveTargets,
     });
 
-    expect(result).toEqual(["@bob:example.org", "*"]);
+    expect(result).toEqual(["@Bob:Example.org", "*"]);
     expect(resolveTargets).not.toHaveBeenCalled();
   });
 
@@ -311,7 +311,7 @@ describe("resolveMatrixMonitorConfig", () => {
       resolveTargets,
     });
 
-    expect(result).toEqual(["Alice", "@bob:example.org"]);
+    expect(result).toEqual(["Alice", "@Bob:Example.org"]);
     expect(resolveTargets).not.toHaveBeenCalled();
   });
 
@@ -329,7 +329,7 @@ describe("resolveMatrixMonitorConfig", () => {
       resolveTargets,
     });
 
-    expect(result).toEqual(["@bob:example.org", "*", "@alice:example.org"]);
+    expect(result).toEqual(["@Bob:Example.org", "*", "@alice:example.org"]);
     expectResolveTargetCall(resolveTargets, 0, {
       accountId: "ops",
       kind: "user",

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -276,6 +276,37 @@ describe("resolveMatrixMonitorConfig", () => {
     );
   });
 
+  it("keeps case-distinct qualified user ids in startup allowlists", async () => {
+    const runtime = createRuntime();
+    const resolveTargets = vi.fn(async () => []);
+    const caseDistinctIds = ["@alice:Example.org", "@alice:example.org"];
+
+    const result = await resolveMatrixMonitorConfig({
+      cfg: createConfig(),
+      accountId: "ops",
+      allowFrom: caseDistinctIds,
+      groupAllowFrom: caseDistinctIds,
+      roomsConfig: {
+        "!ops:example.org": {
+          enabled: true,
+          users: caseDistinctIds,
+        },
+      },
+      runtime,
+      resolveTargets,
+    });
+
+    expect(result.allowFrom).toEqual(caseDistinctIds);
+    expect(result.groupAllowFrom).toEqual(caseDistinctIds);
+    expect(result.roomsConfig).toEqual({
+      "!ops:example.org": {
+        enabled: true,
+        users: caseDistinctIds,
+      },
+    });
+    expect(resolveTargets).not.toHaveBeenCalled();
+  });
+
   it("does not resolve mutable live allowlist entries by default", async () => {
     const runtime = createRuntime();
     const resolveTargets = vi.fn(async () => [
@@ -292,6 +323,23 @@ describe("resolveMatrixMonitorConfig", () => {
     });
 
     expect(result).toEqual(["@Bob:Example.org", "*"]);
+    expect(resolveTargets).not.toHaveBeenCalled();
+  });
+
+  it("keeps case-distinct qualified user ids in live allowlists", async () => {
+    const runtime = createRuntime();
+    const resolveTargets = vi.fn(async () => []);
+    const caseDistinctIds = ["@alice:Example.org", "@alice:example.org"];
+
+    const result = await resolveMatrixMonitorLiveUserAllowlist({
+      cfg: createConfig(),
+      accountId: "ops",
+      entries: caseDistinctIds,
+      runtime,
+      resolveTargets,
+    });
+
+    expect(result).toEqual(caseDistinctIds);
     expect(resolveTargets).not.toHaveBeenCalled();
   });
 

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -116,7 +116,7 @@ function addUniqueMatrixAllowlistEntry(params: {
   if (!trimmed) {
     return;
   }
-  const key = trimmed.toLowerCase();
+  const key = normalizeMatrixUserId(trimmed);
   if (params.seen.has(key)) {
     return;
   }
@@ -178,6 +178,7 @@ function resolveStableMatrixMonitorUserAllowlist(params: {
   const canonicalized = canonicalizeAllowlistWithResolvedIds({
     existing: allowList,
     resolvedMap: resolution.resolvedMap,
+    entryKey: normalizeMatrixUserId,
   });
   logStableMatrixAllowlistUnresolved({
     label: params.label,
@@ -289,6 +290,7 @@ async function resolveMatrixMonitorUserAllowlist(params: {
   const canonicalized = canonicalizeAllowlistWithResolvedIds({
     existing: allowList,
     resolvedMap: resolution.resolvedMap,
+    entryKey: normalizeMatrixUserId,
   });
 
   summarizeMapping(params.label, resolution.mapping, resolution.unresolved, params.runtime);
@@ -376,6 +378,7 @@ export async function resolveMatrixMonitorLiveUserAllowlist(params: {
   const canonicalized = canonicalizeAllowlistWithResolvedIds({
     existing: pending,
     resolvedMap: resolution.resolvedMap,
+    entryKey: normalizeMatrixUserId,
   });
   const resolvedEntries = params.failClosedOnUnresolved
     ? filterFailClosedMatrixAllowlistEntries(canonicalized)
@@ -490,6 +493,7 @@ async function resolveMatrixMonitorRoomsConfig(params: {
       entries: nextRooms,
       resolvedMap: resolution.resolvedMap,
       strategy: "canonicalize",
+      entryKey: normalizeMatrixUserId,
     });
     return patched;
   }
@@ -512,6 +516,7 @@ async function resolveMatrixMonitorRoomsConfig(params: {
     entries: nextRooms,
     resolvedMap: resolution.resolvedMap,
     strategy: "canonicalize",
+    entryKey: normalizeMatrixUserId,
   });
   return patched;
 }

--- a/src/channels/allowlists/resolve-utils.ts
+++ b/src/channels/allowlists/resolve-utils.ts
@@ -17,7 +17,10 @@ export type AllowlistUserResolutionLike = {
   id?: string;
 };
 
-function dedupeAllowlistEntries(entries: string[]): string[] {
+function dedupeAllowlistEntries(
+  entries: string[],
+  entryKey: (entry: string) => string = normalizeLowercaseStringOrEmpty,
+): string[] {
   const seen = new Set<string>();
   const deduped: string[] = [];
   for (const entry of entries) {
@@ -25,7 +28,7 @@ function dedupeAllowlistEntries(entries: string[]): string[] {
     if (!normalized) {
       continue;
     }
-    const key = normalizeLowercaseStringOrEmpty(normalized);
+    const key = entryKey(normalized);
     if (seen.has(key)) {
       continue;
     }
@@ -94,7 +97,11 @@ function resolveAllowlistIdAdditions<T extends AllowlistUserResolutionLike>(para
 /** Replaces resolvable user entries with canonical ids while preserving unresolved entries and `*`. */
 export function canonicalizeAllowlistWithResolvedIds<
   T extends AllowlistUserResolutionLike,
->(params: { existing?: Array<string | number>; resolvedMap: Map<string, T> }): string[] {
+>(params: {
+  existing?: Array<string | number>;
+  resolvedMap: Map<string, T>;
+  entryKey?: (entry: string) => string;
+}): string[] {
   const canonicalized: string[] = [];
   for (const entry of params.existing ?? []) {
     const trimmed = normalizeOptionalString(entry) ?? "";
@@ -109,7 +116,7 @@ export function canonicalizeAllowlistWithResolvedIds<
     const resolved = params.resolvedMap.get(trimmed);
     canonicalized.push(resolved?.resolved && resolved.id ? resolved.id : trimmed);
   }
-  return dedupeAllowlistEntries(canonicalized);
+  return dedupeAllowlistEntries(canonicalized, params.entryKey);
 }
 
 /** Updates nested `{ users }` allowlist entries using merge or canonicalize semantics. */
@@ -120,6 +127,7 @@ export function patchAllowlistUsersInConfigEntries<
   entries: TEntries;
   resolvedMap: Map<string, T>;
   strategy?: "merge" | "canonicalize";
+  entryKey?: (entry: string) => string;
 }): TEntries {
   const nextEntries: Record<string, unknown> = { ...params.entries };
   for (const [entryKey, entryConfig] of Object.entries(params.entries)) {
@@ -136,6 +144,7 @@ export function patchAllowlistUsersInConfigEntries<
         ? canonicalizeAllowlistWithResolvedIds({
             existing: users,
             resolvedMap: params.resolvedMap,
+            entryKey: params.entryKey,
           })
         : mergeAllowlist({
             existing: users,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix accounts whose complete user IDs differ after Unicode or server-name case folding could be treated as the same identity by allowlists, command access, and approval checks.

## Why This Change Was Made

Complete Matrix user IDs are now treated as opaque, case-sensitive identifiers. Matrix target wrapper prefixes remain case-insensitive, and legacy non-qualified entries retain their existing normalization behavior.

The same identity key is now used while resolving startup, live, and room-scoped allowlists. Other channels retain the shared helper's existing case-insensitive default.

## User Impact

Matrix operators can rely on configured full user IDs identifying only the exact account they authorized across DM and room ingress, commands, plugin and exec approvals, approval reactions, and native approval actions.

### Upgrade note

Existing Matrix configurations that relied on case-insensitive user ID matching must update allowlist, approver, and Matrix approval-forwarding target entries to the exact `@user:server` value reported by Matrix. OpenClaw intentionally does not rewrite these identities because case-distinct IDs can identify different accounts.

Maintainer decision: accept the documentation-only migration risk for this repair. No automatic rewrite or heuristic startup/Doctor warning is added because a stored casing variant does not reveal which case-distinct principal the operator intended, and warning on every qualified ID would create a permanent false-positive diagnostic. The upgrade path is explicit documentation plus exact-ID configuration guidance.

## Evidence

- The Matrix specification defines server names as case-sensitive and requires historical Unicode identifiers to remain accepted: https://spec.matrix.org/v1.15/appendices/#user-identifiers
- Before the repair, focused regressions showed both startup and live allowlist resolution collapsing `@alice:Example.org` and `@alice:example.org` to one entry.
- Added exact-identity positive coverage and case-fold collision rejection across Matrix ingress, commands, plugin approvals, exec approvals, approval targets, reactions, native actions, startup resolution, live resolution, and room-scoped resolution.
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/config.test.ts` — 9 tests passed.
- `node scripts/run-vitest.mjs src/channels/allowlists/resolve-utils.test.ts` — 11 tests passed.
- `pnpm test:changed` — 71 tests passed across eight changed-surface test files.
- `node scripts/check-changed.mjs` — passed, including core/plugin typechecks, lints, policy guards, and import-cycle checks.
- `pnpm check:docs` — passed formatting, markdown lint, MDX, i18n glossary, link, and config-example checks.
- Autoreview — no accepted or actionable findings; overall correctness 0.98.

Live homeserver proof was not run because the repaired boundary is deterministic identifier comparison and the regression suite exercises each affected authorization consumer directly.
