### PR TITLE
fix: validate every structured attachment source

### DIFF
--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -248,6 +248,68 @@ describe("message action media helpers", () => {
     }
   });
 
+  maybeIt.each([
+    "mediaUrl",
+    "media_url",
+    "path",
+    "filePath",
+    "file_path",
+    "fileUrl",
+    "file_url",
+    "url",
+  ])("rejects an out-of-sandbox %s hidden behind valid attachment media", async (shadowKey) => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-shadow-sandbox-"));
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-shadow-host-"));
+    try {
+      await expect(
+        normalizeSandboxMediaParams({
+          args: {
+            attachments: [
+              {
+                media: "/workspace/allowed.png",
+                [shadowKey]: path.join(outsideRoot, "restricted.png"),
+              },
+            ],
+          },
+          mediaPolicy: {
+            mode: "sandbox",
+            sandboxRoot,
+          },
+          structuredAttachments: "all",
+        }),
+      ).rejects.toThrow(/escapes sandbox root/i);
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  maybeIt("normalizes every allowed source in one structured attachment", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-multi-source-"));
+    try {
+      const attachment: Record<string, unknown> = {
+        media: "/workspace/allowed.png",
+        file_path: "/workspace/allowed-file.png",
+      };
+
+      await normalizeSandboxMediaParams({
+        args: { attachments: [attachment] },
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot,
+        },
+        structuredAttachments: "all",
+      });
+
+      expect(attachment).toEqual({
+        media: path.join(sandboxRoot, "allowed.png"),
+        file_path: path.join(sandboxRoot, "allowed-file.png"),
+      });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
   it("collects host media source hints from the shared media-source key set", () => {
     expect(
       collectActionMediaSourceHints(

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -147,7 +147,6 @@ export function collectAttachmentSources(
           readToolStringParam(item, "contentType") ?? readToolStringParam(item, "mimeType"),
         filename: readToolStringParam(item, "filename") ?? readToolStringParam(item, "name"),
       });
-      break;
     }
   }
   return sources;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where structured attachment records containing multiple supported media source fields could have only the first source normalized even though channel delivery may consume every populated source.

## Why This Change Was Made

The shared structured-attachment collector now returns every populated supported source. This keeps sandbox normalization, media-access construction, and channel delivery aligned without changing configuration, protocol, or public API behavior.

## User Impact

Structured attachments using compatibility source fields are consistently validated. Legitimate records containing multiple allowed sources continue to work.

## Evidence

- Added focused coverage for every supported secondary source alias behind a valid primary source.
- Added positive-path coverage for multiple allowed sources in one attachment record.
- `pnpm test src/infra/outbound/message-action-params.test.ts -- --reporter=verbose` — 41 passed.
- `pnpm test src/infra/outbound/message-action-send.media.test.ts src/infra/outbound/message-action-gateway.test.ts extensions/telegram/src/action-runtime.test.ts` — 126 passed.
- `node scripts/check-changed.mjs` — passed.
- `git diff --check` — passed.
- Local autoreview — clean, no actionable findings.
