### PR TITLE
test(control-ui): pin repeated same-method e2e waits with after-cursor

### DIFF
--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -776,9 +776,14 @@ suite.define(() => {
       await everywhereDialog.getByLabel("URL or command").fill("docs-mcp --stdio");
       await everywhereDialog.getByLabel("Transport").selectOption("stdio");
       const sessionPatchCount = (await gateway.getRequests("sessions.patch")).length;
+      // Pin past the session-scoped config.patch above so a slow runner can't
+      // return it stale for the everywhere-scoped save.
+      const configPatchesBeforeEverywhereAdd = (await gateway.getRequests("config.patch")).length;
       await gateway.deferNext("config.patch");
       await everywhereDialog.getByRole("button", { name: "Add server" }).click();
-      const everywhereConfigPatch = await gateway.waitForRequest("config.patch");
+      const everywhereConfigPatch = await gateway.waitForRequest("config.patch", {
+        after: configPatchesBeforeEverywhereAdd,
+      });
       expect(configPatchRaw(everywhereConfigPatch)).toEqual({
         mcp: {
           servers: {

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -892,7 +892,9 @@ suite.define(() => {
       element.scrollTop = 0;
       element.parentElement?.querySelector<HTMLButtonElement>(".chat-history-available")?.click();
     });
-    await gateway.waitForRequest("chat.history");
+    // Pin each wait past the earlier chat.history traffic so a slow runner
+    // can't return a stale load-time or prior-page request.
+    await gateway.waitForRequest("chat.history", { after: initialRequestCount });
     await page.locator(".chat-history-loading").waitFor();
     expect(await showEarlier.getAttribute("aria-busy")).toBe("true");
     if (artifactDir) {
@@ -911,7 +913,7 @@ suite.define(() => {
     const failedRequestCount = (await gateway.getRequests("chat.history")).length;
     await gateway.deferNext("chat.history");
     await showEarlier.click();
-    await gateway.waitForRequest("chat.history");
+    await gateway.waitForRequest("chat.history", { after: failedRequestCount });
     await page.locator(".chat-history-loading").waitFor();
     expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 1);
     await gateway.resolveDeferred("chat.history", {
@@ -956,7 +958,7 @@ suite.define(() => {
     expect(await gateway.getRequests("chat.history")).toHaveLength(firstPageRequestCount);
     await gateway.deferNext("chat.history");
     await showEarlier.click();
-    await gateway.waitForRequest("chat.history");
+    await gateway.waitForRequest("chat.history", { after: firstPageRequestCount });
     expect((await gateway.getRequests("chat.history")).at(-1)?.params).toMatchObject({
       limit: 100,
       offset: 140,

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -652,9 +652,11 @@ suite.define(() => {
       await gateway.resolveDeferred("desktop.launch", { app: "browser", status: "ready" });
       await expect.poll(async () => await browserButton.getAttribute("aria-busy")).toBe("false");
 
+      // Pin past the first launch so a slow runner can't return it stale.
+      const launchesBeforeRetry = (await gateway.getRequests("desktop.launch")).length;
       await gateway.deferNext("desktop.launch");
       await browserButton.click();
-      await gateway.waitForRequest("desktop.launch");
+      await gateway.waitForRequest("desktop.launch", { after: launchesBeforeRetry });
       await gateway.rejectDeferred("desktop.launch", {
         message: "worker desktop app launch unavailable; try again",
       });

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -712,12 +712,15 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
 
       await openaiCard.getByRole("button", { name: "Replace key" }).click();
       await openaiCard.getByLabel("API key").fill(openaiInputValue);
+      // The { after } cursor waits for and returns the save-triggered patch,
+      // so a slow runner can't hand back an earlier config.patch stale.
       const patchCount = (await gateway.getRequests("config.patch")).length;
       await openaiCard.getByRole("button", { name: "Save" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("config.patch")).length)
-        .toBe(patchCount + 1);
-      const keyPatch = requestRaw(await gateway.waitForRequest("config.patch"));
+      const keyPatch = requestRaw(
+        await gateway.waitForRequest("config.patch", {
+          after: patchCount,
+        }),
+      );
       expect(keyPatch).toEqual({
         models: { providers: { openai: providerConfig(openaiInputValue) } },
       });
@@ -755,10 +758,9 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         })
         .getByRole("button", { name: "Save" })
         .click();
-      await expect
-        .poll(async () => (await gateway.getRequests("config.patch")).length)
-        .toBe(defaultPatchCount + 1);
-      expect(requestRaw(await gateway.waitForRequest("config.patch"))).toEqual({
+      expect(
+        requestRaw(await gateway.waitForRequest("config.patch", { after: defaultPatchCount })),
+      ).toEqual({
         agents: {
           defaults: {
             model: "anthropic/claude-sonnet-4-5",
@@ -822,10 +824,9 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       });
       const addPatchCount = (await gateway.getRequests("config.patch")).length;
       await addSection.getByRole("button", { name: "Save provider" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("config.patch")).length)
-        .toBe(addPatchCount + 1);
-      expect(requestRaw(await gateway.waitForRequest("config.patch"))).toEqual({
+      expect(
+        requestRaw(await gateway.waitForRequest("config.patch", { after: addPatchCount })),
+      ).toEqual({
         models: { providers: { google: providerConfig(googleInputValue) } },
       });
       await page.locator('[data-provider-id="google"]').waitFor();

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -275,19 +275,25 @@ suite.define(() => {
       await page.locator(".new-session-page__message").fill("wait for fresh defaults");
       await expect.poll(() => start.isEnabled()).toBe(true);
 
+      // Pin each wait past earlier sessions.groups.list traffic (the route
+      // load already fetched the catalog) so a slow runner can't return a
+      // stale earlier request.
+      const groupListsBeforeInvalidation = (await gateway.getRequests("sessions.groups.list"))
+        .length;
       await gateway.deferNext("sessions.groups.list");
       await gateway.emitGatewayEvent("sessions.changed", { reason: "groups" });
-      await gateway.waitForRequest("sessions.groups.list");
+      await gateway.waitForRequest("sessions.groups.list", { after: groupListsBeforeInvalidation });
       await expect.poll(() => start.isDisabled()).toBe(true);
       await expect
         .poll(() => page.locator(".new-session-page__catalog-unavailable button").isDisabled())
         .toBe(true);
+      const groupListsBeforeReject = (await gateway.getRequests("sessions.groups.list")).length;
       await gateway.deferNext("sessions.groups.list");
       await gateway.rejectDeferred("sessions.groups.list", {
         code: "UNAVAILABLE",
         message: "catalog reload failed",
       });
-      await gateway.waitForRequest("sessions.groups.list");
+      await gateway.waitForRequest("sessions.groups.list", { after: groupListsBeforeReject });
       await expect
         .poll(() => page.locator(".new-session-page__catalog-unavailable").textContent())
         .toContain("This session target is unavailable.");
@@ -405,9 +411,12 @@ suite.define(() => {
       await expect.poll(() => defaultsAction.textContent()).toContain("Retry");
       await expect.poll(() => defaultsAction.isEnabled()).toBe(true);
 
+      // Pin past the load-time sessions.groups.list so the retry wait can't
+      // return it stale.
+      const groupListsBeforeRetry = (await gateway.getRequests("sessions.groups.list")).length;
       await gateway.deferNext("sessions.groups.list");
       await defaultsAction.click();
-      await gateway.waitForRequest("sessions.groups.list");
+      await gateway.waitForRequest("sessions.groups.list", { after: groupListsBeforeRetry });
       await gateway.resolveDeferred("sessions.groups.list", {
         groups: [{ name: "Client work", position: 0 }],
       });

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -496,7 +496,14 @@ export type MockGatewayControls = {
     allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;
     hasMultipleSessionSharingIdentities: boolean;
   }) => Promise<void>;
-  waitForRequest: (method: string) => Promise<MockGatewayRequest>;
+  /**
+   * Resolves with a captured request for `method`. Without `after` this is
+   * satisfied by ANY prior request of the method (and returns the latest), so
+   * a second same-method wait can return a stale earlier request on slow
+   * runners; pass `after` = the pre-action count from `getRequests(method)`
+   * to wait for and return the next new request instead.
+   */
+  waitForRequest: (method: string, options?: { after?: number }) => Promise<MockGatewayRequest>;
 };
 
 const chromiumExecutableOverrideEnvKey = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH";
@@ -2619,12 +2626,13 @@ function createMockGatewayControls(
         gateway.setSessionSharingPolicy(nextPolicy);
       }, policy);
     },
-    async waitForRequest(method) {
+    async waitForRequest(method, options) {
       const deadline = Date.now() + controlUiE2eWaitTimeoutMs;
+      const after = options?.after;
       for (let attempt = 0; attempt < 2; attempt += 1) {
         try {
           await page.waitForFunction(
-            (targetMethod) => {
+            ({ targetMethod, priorCount }) => {
               const gateway = (
                 window as Window & {
                   openclawControlUiE2eGateway?: {
@@ -2632,14 +2640,19 @@ function createMockGatewayControls(
                   };
                 }
               ).openclawControlUiE2eGateway;
-              return Boolean(gateway?.requests.some((request) => request.method === targetMethod));
+              const matching =
+                gateway?.requests.filter((request) => request.method === targetMethod) ?? [];
+              return matching.length > (priorCount ?? 0);
             },
-            method,
+            { targetMethod: method, priorCount: after ?? 0 },
             // Request capture is non-rendering state. Interval polling avoids background-page
             // requestAnimationFrame throttling when CI runs several headless pages concurrently.
             { polling: 25, timeout: Math.max(1, deadline - Date.now()) },
           );
-          const request = (await getRequests(method)).at(-1);
+          const matching = await getRequests(method);
+          // With an `after` cursor, return the first NEW request; otherwise keep
+          // the historical latest-match behavior existing callers rely on.
+          const request = after === undefined ? matching.at(-1) : matching.at(after);
           if (request) {
             return request;
           }


### PR DESCRIPTION
## What Problem This Solves

Resolves a Control UI e2e flake where a repeated same-method gateway request wait could be satisfied by an earlier request from the same page context on slow runners. The shared mock-gateway helper returned the latest matching request from the whole request ring, so the second wait did not prove that a new request had occurred.

## Why This Change Was Made

This adds an opt-in `waitForRequest(method, { after: priorCount })` cursor and uses it for the 11 genuinely stale-prone repeated waits found by sweeping all Control UI e2e files. The helper hunks are byte-identical to the same change in #125107, so whichever PR lands second can rebase cleanly. Existing one-shot waits retain their current behavior.

The pinned waits cover the second MCP-server save, three `chat.history` pages, a `desktop.launch` retry, three `config.patch` saves, and three `sessions.groups.list` refetches. In the model-provider tests, the cursor replaces the former `expect.poll(count).toBe(n + 1)` workaround with the canonical wait primitive.

## User Impact

No production runtime behavior changes. Control UI e2e tests now wait for the request caused by the action under test instead of occasionally accepting stale request history, reducing slow-runner flakes while preserving existing test intent.

## Evidence

- `node scripts/check-changed.mjs -- ui/src/test-helpers/control-ui-e2e.ts ui/src/e2e/chat-composer-capability-menu.e2e.test.ts ui/src/e2e/claude-sessions.e2e.test.ts ui/src/e2e/desktop-panel.e2e.test.ts ui/src/e2e/model-providers.e2e.test.ts ui/src/e2e/session-management.group-defaults.e2e.test.ts` passed (format, Control UI tsgo typecheck, lint, and i18n verification).
- Three repetition rounds passed for all five touched e2e files plus `ui/src/e2e/login-gate.e2e.test.ts` as an untouched control, using `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner <file>`: 168 test executions, 0 failures.
- Codex autoreview (`gpt-5.6-sol`, high) reported no accepted/actionable findings.
- Production/test LOC: shared test infrastructure +18/-7; e2e test files +40/-19. No production runtime code touched.
- Deliberate non-changes from the sweep:
  - `cloud-workers-settings` cursor pins are owned by #125107.
  - `chat-attachment-read-lifecycle` asserts that the ring contains zero `chat.send` requests before its second wait, so that wait cannot match stale history.
  - `login-gate` second-connect waits follow app-initiated stale-build reloads that reinstall the init-script gateway and restart the request ring; pinning those waits would break the tests.
  - All other textual same-method duplicates across e2e files are cross-test repeats on fresh pages because each `it()` opens a new page.
