### PR TITLE
test(browser): use per-run temp dirs for shared /tmp profile fixtures

### DIFF
--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -1,9 +1,19 @@
 // Browser tests cover server context.existing session plugin behavior.
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../test-support/browser-security.mock.js";
 import type { BrowserServerState } from "./server-context.js";
+
+const braveProfileDir = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-brave-profile-")),
+);
+
+afterAll(() => {
+  fs.rmSync(braveProfileDir, { recursive: true, force: true });
+});
 
 const chromeMcpMock = vi.hoisted(() => ({
   closeChromeMcpSession: vi.fn(async () => true),
@@ -89,7 +99,7 @@ function makeState(): BrowserServerState {
           color: "#0066CC",
           driver: "existing-session",
           attachOnly: true,
-          userDataDir: "/tmp/brave-profile",
+          userDataDir: braveProfileDir,
         },
       },
       extraArgs: [],
@@ -130,7 +140,6 @@ afterEach(() => {
 
 describe("browser server-context existing-session profile", () => {
   it("fails closed for Chrome MCP endpoint mcpArgs under the default CDP policy", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     state.resolved.ssrfPolicy = {};
     state.resolved.profiles["chrome-live"] = {
@@ -151,7 +160,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("fails closed for explicit Chrome MCP cdpUrl under explicit restrictive CDP policy", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     state.resolved.ssrfPolicy = { dangerouslyAllowPrivateNetwork: false };
     state.resolved.profiles["chrome-live"] = {
@@ -174,7 +182,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("reports attach-only profiles as running when the MCP session is available but no page is selected", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     const ctx = createBrowserRouteContext({ getState: () => state });
 
@@ -196,7 +203,7 @@ describe("browser server-context existing-session profile", () => {
       )[0] ?? [];
     expect(ensuredProfile?.name).toBe("chrome-live");
     expect(ensuredProfile?.driver).toBe("existing-session");
-    expect(ensuredProfile?.userDataDir).toBe("/tmp/brave-profile");
+    expect(ensuredProfile?.userDataDir).toBe(braveProfileDir);
     expect(ensureOptions).toEqual({
       ephemeral: true,
       timeoutMs: 300,
@@ -210,12 +217,11 @@ describe("browser server-context existing-session profile", () => {
       )[0] ?? [];
     expect(countedProfile?.name).toBe("chrome-live");
     expect(countedProfile?.driver).toBe("existing-session");
-    expect(countedProfile?.userDataDir).toBe("/tmp/brave-profile");
+    expect(countedProfile?.userDataDir).toBe(braveProfileDir);
     expect(countOptions).toEqual({ ephemeral: true, signal: expect.any(AbortSignal) });
   });
 
   it("reports endpoint cdpUrl for existing-session profiles", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     const chromeLiveProfile = expectDefined(
       state.resolved.profiles["chrome-live"],
@@ -244,7 +250,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("keeps the next real attach on the normal sticky session path after an idle status probe", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     const ctx = createBrowserRouteContext({ getState: () => state });
     const live = ctx.forProfile("chrome-live");
@@ -269,22 +274,21 @@ describe("browser server-context existing-session profile", () => {
     expect(lastEnsureCall?.[0]).toBe("chrome-live");
     expect(lastEnsureCall?.[1]?.name).toBe("chrome-live");
     expect(lastEnsureCall?.[1]?.driver).toBe("existing-session");
-    expect(lastEnsureCall?.[1]?.userDataDir).toBe("/tmp/brave-profile");
+    expect(lastEnsureCall?.[1]?.userDataDir).toBe(braveProfileDir);
     const listCalls = vi.mocked(chromeMcp.listChromeMcpTabs).mock.calls as unknown as Array<
       [string, ChromeLiveProfile]
     >;
     expect(listCalls[0]?.[0]).toBe("chrome-live");
     expect(listCalls[0]?.[1]?.name).toBe("chrome-live");
     expect(listCalls[0]?.[1]?.driver).toBe("existing-session");
-    expect(listCalls[0]?.[1]?.userDataDir).toBe("/tmp/brave-profile");
+    expect(listCalls[0]?.[1]?.userDataDir).toBe(braveProfileDir);
     expect(listCalls[1]?.[0]).toBe("chrome-live");
     expect(listCalls[1]?.[1]?.name).toBe("chrome-live");
     expect(listCalls[1]?.[1]?.driver).toBe("existing-session");
-    expect(listCalls[1]?.[1]?.userDataDir).toBe("/tmp/brave-profile");
+    expect(listCalls[1]?.[1]?.userDataDir).toBe(braveProfileDir);
   });
 
   it("routes tab operations through the Chrome MCP backend", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     const ctx = createBrowserRouteContext({ getState: () => state });
     const live = ctx.forProfile("chrome-live");
@@ -366,7 +370,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("eagerly closes MCP while attach readiness is pending and prevents retry", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const readinessEntered = deferred<void>();
     const readiness = deferred<never>();
     vi.mocked(chromeMcp.listChromeMcpTabs).mockImplementationOnce(async () => {
@@ -404,7 +407,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("drains an admitted MCP tab open before the final session sweep", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const openEntered = deferred<void>();
     const opened = deferred<{
       targetId: string;
@@ -446,7 +448,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("expires Chrome MCP aliases instead of transferring them to a replacement tab", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const originalTab = {
       targetId: "TARGET-A",
       title: "Checkout",
@@ -482,7 +483,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("allows targetless selection when a fresh Chrome MCP profile has no stale identity", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const freshTab = {
       targetId: "chrome-mcp:fresh:1",
       title: "Fresh",
@@ -500,7 +500,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("does not sticky-adopt a Chrome MCP tab when the final URL is policy-blocked", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const goodTab = {
       targetId: "chrome-mcp:good:1",
       title: "Good",
@@ -555,7 +554,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("rejects invalid labels before asking Chrome MCP to create a page", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();
     const live = createBrowserRouteContext({ getState: () => state }).forProfile("chrome-live");
 
@@ -568,7 +566,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("does not adopt a Chrome MCP page when the operation aborts after creation", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const goodTab = {
       targetId: "chrome-mcp:good:1",
       title: "Good",
@@ -607,7 +604,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("clears only the sticky Chrome MCP target after a successful close", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const tabA = {
       targetId: "chrome-mcp:fresh:1",
       title: "A",
@@ -656,7 +652,6 @@ describe("browser server-context existing-session profile", () => {
   });
 
   it("keeps the sticky Chrome MCP target when close fails", async () => {
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const tab = {
       targetId: "chrome-mcp:fresh:1",
       title: "A",
@@ -679,10 +674,9 @@ describe("browser server-context existing-session profile", () => {
 
   it("surfaces DevToolsActivePort attach failures instead of a generic tab timeout", async () => {
     vi.useFakeTimers();
-    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     vi.mocked(chromeMcp.listChromeMcpTabs).mockRejectedValue(
       new Error(
-        "Could not connect to Chrome. Check if Chrome is running. Cause: Could not find DevToolsActivePort for chrome at /tmp/brave-profile/DevToolsActivePort",
+        `Could not connect to Chrome. Check if Chrome is running. Cause: Could not find DevToolsActivePort for chrome at ${braveProfileDir}/DevToolsActivePort`,
       ),
     );
 

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -1,5 +1,7 @@
 // Browser tests cover server.agent contract core plugin behavior.
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./constants.js";
@@ -849,6 +851,8 @@ describe("browser control server", () => {
 });
 
 describe("profile CRUD endpoints", () => {
+  const tempDirsToCleanup = new Set<string>();
+
   beforeEach(async () => {
     await resetBrowserControlServerTestContext();
 
@@ -865,7 +869,14 @@ describe("profile CRUD endpoints", () => {
   });
 
   afterEach(async () => {
-    await cleanupBrowserControlServerTestContext();
+    try {
+      await cleanupBrowserControlServerTestContext();
+    } finally {
+      await Promise.allSettled(
+        [...tempDirsToCleanup].map((dir) => fs.promises.rm(dir, { recursive: true, force: true })),
+      );
+      tempDirsToCleanup.clear();
+    }
   });
 
   it("validates profile create/delete endpoints", async () => {
@@ -941,8 +952,10 @@ describe("profile CRUD endpoints", () => {
     expect(createClawdBody.cdpPort).toBeTypeOf("number");
     expect(createClawdBody.userDataDir).toBeNull();
 
-    const explicitUserDataDir = "/tmp/openclaw-brave-profile";
-    await fs.promises.mkdir(explicitUserDataDir, { recursive: true });
+    const explicitUserDataDir = await fs.promises.realpath(
+      await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-brave-profile-")),
+    );
+    tempDirsToCleanup.add(explicitUserDataDir);
     const createExistingSession = await realFetch(`${base}/profiles/create`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## What Problem This Solves

Both browser test suites created real directories at fixed shared `/tmp` paths without removing them. `server-context.existing-session.test.ts` used `/tmp/brave-profile` at roughly 16 call sites, while `server.agent-contract-core.test.ts` used `/tmp/openclaw-brave-profile`. This littered shared machines and could fail with `EACCES` on multi-user CI hosts when another user owned the path.

## Why This Change Was Made

Per `test/AGENTS.md`, fixture roots now use per-run `fs.mkdtemp` directories under `os.tmpdir()`, canonicalized with `realpath` so macOS's `/var` to `/private/var` symlink does not cause path mismatches. Both suites clean up their temporary roots, following the established pattern in `src/cli/update-cli.test.ts`.

## User Impact

None at runtime—this is test-only. Shared CI hosts stay clean, and concurrent or multi-user test runs no longer contend for fixed profile directories.

## Evidence

`node scripts/run-vitest.mjs extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/server.agent-contract-core.test.ts` passed both test files and all 49/49 tests in approximately 37 seconds.

After the run, `os.tmpdir()` had no leftover `openclaw-brave-profile-*` roots, and the fixed `/tmp` paths were no longer created.

Codex autoreview reported no accepted/actionable findings and assessed the patch as correct (0.99).

Production LOC delta: 0. Test-only delta: +34/−27 lines.
