### PR TITLE
test(scripts): stop managed-child descendant checks racing process startup

### DIFF
--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -240,12 +240,12 @@ describe("managed-child-process", () => {
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 
-const descendant = spawn(process.execPath, [
+spawn(process.execPath, [
   "-e",
-  "process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 5_000); setInterval(() => {}, 1000);",
+  "require('node:fs').writeFileSync(process.argv[1], String(process.pid)); process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 5_000); setInterval(() => {}, 1000);",
+  process.argv[3],
 ], { stdio: "ignore" });
 fs.writeFileSync(process.argv[2], String(process.pid));
-fs.writeFileSync(process.argv[3], String(descendant.pid));
 process.on("SIGTERM", () => {});
 setInterval(() => {}, 1_000);
 `,
@@ -506,10 +506,12 @@ setInterval(() => {}, 1_000);
             "-e",
             `
 const { spawn } = require("node:child_process");
-const fs = require("node:fs");
-const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-child.unref();
-fs.writeFileSync(process.argv[1], String(child.pid));
+const child = spawn(process.execPath, [
+  "-e",
+  "require('node:fs').writeFileSync(process.argv[1], String(process.pid)); process.send('ready'); process.disconnect(); setInterval(() => {}, 1000)",
+  process.argv[1],
+], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+child.once("message", () => process.exit(0));
 `,
             descendantPidPath,
           ],
@@ -545,12 +547,12 @@ fs.writeFileSync(process.argv[1], String(child.pid));
 	import { spawn } from "node:child_process";
 	import fs from "node:fs";
 
-	const descendant = spawn(process.execPath, [
+	spawn(process.execPath, [
 	  "-e",
-	  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+	  "require('node:fs').writeFileSync(process.argv[1], String(process.pid)); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+	  process.argv[3],
 	], { stdio: "ignore" });
 	fs.writeFileSync(process.argv[2], String(process.pid));
-	fs.writeFileSync(process.argv[3], String(descendant.pid));
 	for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
 	  process.on(signal, () => process.exit(0));
 	}


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/managed-child-process.test.ts` fails intermittently on loaded CI runners — most recently
blocking PR #124950, which went green on rerun with no code change. The failing assertion was
`expect(isProcessAlive(descendantPid)).toBe(true)` in "kills managed child process group descendants when
the runner is terminated".

The race was in the fixture, not the assertion. The generated child spawned its descendant and then wrote
the descendant's pid itself:

```js
const descendant = spawn(process.execPath, ["-e", "…setInterval…"], { stdio: "ignore" });
fs.writeFileSync(process.argv[3], String(descendant.pid));
```

`spawn()` returns a pid the moment the process is forked, before the descendant's Node runtime has booted.
So the test's `await waitFor(() => fs.existsSync(descendantPidPath))` proved only that *a pid had been
written*, never that the process was running — and under load the liveness check could observe a descendant
that had not finished starting.

## Why This Change Was Made

A flaky assertion guarding real process-group cleanup is worth fixing rather than rerunning: it fails often
enough to train people to hit retry, which is how a genuine cleanup regression would slip through.

The pid file becomes a genuine readiness signal — the descendant writes its own pid once its runtime is up,
so the existing `waitFor(existsSync)` now implies liveness. The lingering-child fixture, whose parent exits
immediately, uses an IPC `process.send('ready')` handshake instead, since a pid file alone cannot order
against the parent's exit. Two sibling fixtures carried the same optimistic-pid pattern and were fixed
identically.

Deliberately unchanged: every assertion, including the liveness check, and the `waitFor(..., 1_500)`
teardown bounds. Weakening the assertion, wrapping it in a retry, or stretching the timeouts would have hidden
the race rather than removed it — and would have left a test that can no longer fail.

## User Impact

None. Test-only; no production file is touched.

## Evidence

Ten consecutive runs of the file, since a single green run proves nothing about a race:

```
10/10 passed
```

```
pnpm test test/scripts/managed-child-process.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `0`, tests `+12 / −10` (net +2).

No `CHANGELOG.md` edit — release-only per repo policy; test-only change.
