### PR TITLE
fix(ui): keep composer footer controls readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI composer permissions:** move the session permission picker to the footer's left side so model and thinking controls stay readable at common widths.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI composer permissions:** move the session permission picker to the footer's left side so model and thinking controls stay readable at common widths.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -131,6 +131,7 @@ suite.define(() => {
                 label: "Main",
                 model: "gpt-5.5",
                 modelProvider: "openai",
+                permissionMode: "workspace",
                 status: "done",
                 totalTokens: 46_000,
                 totalTokensFresh: true,
@@ -151,6 +152,7 @@ suite.define(() => {
       const chatMain = page.locator(".chat-workbench__main");
       const model = composer.locator('[data-chat-model-select="true"]');
       const effort = composer.locator('[data-chat-thinking-select="true"]');
+      const permission = composer.locator('[data-chat-permission-select="true"]');
       const usage = composer.locator('[data-chat-provider-usage="true"]');
       const contextUsage = composer.locator(".context-ring");
       const textarea = composer.locator("textarea");
@@ -166,6 +168,7 @@ suite.define(() => {
       const microphonePickerShell = page.locator(".chat-talk-input-picker");
 
       await expect.poll(() => model.isVisible()).toBe(true);
+      await expect.poll(() => permission.isVisible()).toBe(true);
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
       await expect.poll(() => contextUsage.isVisible()).toBe(true);
@@ -198,6 +201,25 @@ suite.define(() => {
         .poll(() => model.evaluate((node) => node.closest(".agent-chat__composer-footer") != null))
         .toBe(true);
       await expect
+        .poll(() =>
+          permission.evaluate((node) => node.closest(".agent-chat__composer-meta") != null),
+        )
+        .toBe(true);
+      await expect
+        .poll(() =>
+          permission.evaluate((node) => node.closest(".chat-composer-model-control") == null),
+        )
+        .toBe(true);
+      await expect
+        .poll(async () => {
+          const [permissionBox, modelBox] = await Promise.all([
+            permission.boundingBox(),
+            model.boundingBox(),
+          ]);
+          return Boolean(permissionBox && modelBox && permissionBox.x < modelBox.x);
+        })
+        .toBe(true);
+      await expect
         .poll(() => settings.evaluate((node) => node.closest(".chat-pane__header") != null))
         .toBe(true);
       await expect.poll(() => composer.locator(".agent-chat__composer-header").count()).toBe(0);
@@ -217,7 +239,7 @@ suite.define(() => {
         .toBe("Session context usage: 46k of 200k (23%)");
       await expect
         .poll(() =>
-          contextUsage.evaluate((node) => node.closest(".agent-chat__composer-meta") != null),
+          contextUsage.evaluate((node) => node.closest(".agent-chat__composer-context") != null),
         )
         .toBe(true);
       await contextUsage.click();

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -39,10 +39,32 @@ suite.define(() => {
       const trigger = pane.locator('[data-chat-permission-select="true"]');
       await trigger.waitFor({ state: "visible", timeout: 10_000 });
       expect(await trigger.getAttribute("data-chat-select-value")).toBe("guarded");
+      expect(
+        await trigger.evaluate((element) => element.closest(".agent-chat__composer-meta") != null),
+      ).toBe(true);
+      expect(
+        await trigger.evaluate(
+          (element) => element.closest(".chat-composer-model-control") != null,
+        ),
+      ).toBe(false);
 
       const firstListCount = (await gateway.getRequests("sessions.list")).length;
       await gateway.deferNext("sessions.list");
       await trigger.click();
+      const firstOption = pane.locator('[data-chat-permission-option="default"]');
+      await firstOption.waitFor({ state: "visible" });
+      const [triggerBox, firstOptionBox] = await Promise.all([
+        trigger.boundingBox(),
+        firstOption.boundingBox(),
+      ]);
+      expect(triggerBox).not.toBeNull();
+      expect(firstOptionBox).not.toBeNull();
+      if (!triggerBox || !firstOptionBox) {
+        throw new Error("expected permission picker geometry");
+      }
+      expect(firstOptionBox.y + firstOptionBox.height).toBeLessThanOrEqual(triggerBox.y - 1);
+      expect(firstOptionBox.x).toBeGreaterThanOrEqual(triggerBox.x);
+      expect(firstOptionBox.x - triggerBox.x).toBeLessThanOrEqual(32);
       await pane.locator('[data-chat-permission-option="workspace"]').click();
       const patchRequest = await gateway.waitForRequest("sessions.patch");
       expect(requireRecord(patchRequest.params)).toMatchObject({

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -299,6 +299,18 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       onFork: (entryId) => this.forkFromMessage(entryId),
       onReset: () => void clearChatHistory(state),
     });
+    const composerControls = catalogKey
+      ? undefined
+      : renderChatPaneComposerControls({
+          state,
+          selectedSession,
+          agentDefaultModel,
+          modelAccess: mutationAccess.model,
+          effortAccess: mutationAccess.effort,
+          permissionAccess: mutationAccess.permission,
+          canSelectFull: hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null),
+          onModelSetup: () => this.context.navigate("model-setup"),
+        });
     const props: ChatProps = {
       transcript: this.transcript,
       paneId: this.presentationId,
@@ -434,18 +446,8 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
         basePath: state.basePath,
         modelAuthStatusResult: state.modelAuthStatusResult,
       },
-      composerControls: catalogKey
-        ? nothing
-        : renderChatPaneComposerControls({
-            state,
-            selectedSession,
-            agentDefaultModel,
-            modelAccess: mutationAccess.model,
-            effortAccess: mutationAccess.effort,
-            permissionAccess: mutationAccess.permission,
-            canSelectFull: hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null),
-            onModelSetup: () => this.context.navigate("model-setup"),
-          }),
+      composerControls: composerControls?.composerControls ?? nothing,
+      permissionPicker: composerControls?.permissionPicker,
       backgroundTasks: catalogKey ? undefined : backgroundTasks,
       taskSuggestions: this.taskSuggestions,
       pullRequests: this.sessionPullRequests.filter(

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -4,9 +4,10 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { renderChatPaneComposerControls } from "./chat-pane-session-controls.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { renderChatPermissionPicker } from "./components/chat-permission-picker.ts";
 
 describe("chat pane composer controls", () => {
-  it("renders model and permission controls", () => {
+  it("assembles model and permission controls as separate footer inputs", () => {
     const container = document.createElement("div");
     const state = {
       chatRunId: null,
@@ -24,25 +25,28 @@ describe("chat pane composer controls", () => {
     } as unknown as ChatPageHost;
     const onModelSetup = vi.fn();
 
-    render(
-      renderChatPaneComposerControls({
-        state,
-        selectedSession: undefined,
-        agentDefaultModel: undefined,
-        modelAccess: { allowed: true, requiredScope: "operator.write" },
-        effortAccess: { allowed: true, requiredScope: "operator.write" },
-        permissionAccess: { allowed: true, requiredScope: "operator.write" },
-        canSelectFull: true,
-        onModelSetup,
-      }),
-      container,
-    );
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: undefined,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      onModelSetup,
+    });
+    render(controls.composerControls, container);
 
     expect(Array.from(container.children).map((node) => node.className)).toEqual([
       "chat-composer-model-control",
     ]);
     expect(container.querySelector('[data-chat-provider-usage="true"]')).toBeNull();
-    expect(container.querySelector('[data-chat-permission-select="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-chat-permission-select="true"]')).toBeNull();
+    const permissionContainer = document.createElement("div");
+    render(renderChatPermissionPicker(controls.permissionPicker), permissionContainer);
+    expect(
+      permissionContainer.querySelector('[data-chat-permission-select="true"]'),
+    ).not.toBeNull();
     container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
     expect(onModelSetup).toHaveBeenCalledOnce();
   });
@@ -65,24 +69,22 @@ describe("chat pane composer controls", () => {
       chatStream: null,
     } as unknown as ChatPageHost;
 
-    render(
-      renderChatPaneComposerControls({
-        state,
-        selectedSession: {
-          key: "agent:main:permission-test",
-          kind: "direct",
-          permissionMode: "full",
-          sessionRoot: "/workspace/projects/openclaw",
-        },
-        agentDefaultModel: undefined,
-        modelAccess: { allowed: true, requiredScope: "operator.write" },
-        effortAccess: { allowed: true, requiredScope: "operator.write" },
-        permissionAccess: { allowed: true, requiredScope: "operator.write" },
-        canSelectFull: false,
-        onModelSetup: vi.fn(),
-      }),
-      container,
-    );
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: {
+        key: "agent:main:permission-test",
+        kind: "direct",
+        permissionMode: "full",
+        sessionRoot: "/workspace/projects/openclaw",
+      },
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: false,
+      onModelSetup: vi.fn(),
+    });
+    render(renderChatPermissionPicker(controls.permissionPicker), container);
 
     const dropdown = container.querySelector<HTMLElement>(".chat-controls__permission-picker");
     dropdown?.setAttribute("open", "");

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -13,7 +13,7 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { refreshChatModelCatalogOnDemand } from "./chat-state-refresh.ts";
 import type { ChatProps } from "./chat-view.ts";
 import { renderChatModelControls } from "./components/chat-model-controls.ts";
-import { renderChatPermissionPicker } from "./components/chat-permission-picker.ts";
+import type { ChatPermissionPickerProps } from "./components/chat-permission-picker.ts";
 
 type SessionActionAccess = ReturnType<typeof readChatSessionActionAccess>;
 type SessionAction = keyof SessionActionAccess;
@@ -55,7 +55,10 @@ export function renderChatPaneComposerControls(params: {
   permissionAccess: SessionMethodAccess;
   canSelectFull: boolean;
   onModelSetup: () => void;
-}) {
+}): {
+  composerControls: NonNullable<ChatProps["composerControls"]>;
+  permissionPicker: ChatPermissionPickerProps;
+} {
   const {
     state,
     selectedSession,
@@ -69,80 +72,82 @@ export function renderChatPaneComposerControls(params: {
   const hasModelSnapshot =
     state.chatModelCatalog.length > 0 || (!state.chatModelsLoading && !state.chatModelCatalogError);
   const refreshModelCatalog = () => refreshChatModelCatalogOnDemand(state);
-  return html`
-    <div class="chat-composer-model-control">
-      ${renderChatModelControls({
-        activeRunId: state.chatRunId,
-        agentDefaultModel,
-        connected: state.connected,
-        gatewayAvailable: Boolean(state.client),
-        loading: state.chatLoading,
-        modelCatalog: state.chatModelCatalog,
-        modelCatalogState: {
-          hasSnapshot: hasModelSnapshot,
-          onRetry: () => void refreshModelCatalog(),
-          status: state.chatModelCatalogError
-            ? "error"
-            : state.chatModelsLoading
-              ? hasModelSnapshot
-                ? "refreshing"
-                : "loading"
-              : "ready",
-        },
-        modelOverrides: state.sessions.state.modelOverrides,
-        modelSelectionLocked: selectedSession?.modelSelectionLocked === true,
-        modelSelectionRuntimeId: selectedSession?.agentRuntime?.id,
-        modelSwitching: Boolean(state.chatModelSwitchPromises[state.sessionKey]),
-        modelsLoading: state.chatModelsLoading,
-        modelMutationDisabledReason: modelAccess.allowed ? undefined : modelAccess.reason,
-        effortMutationDisabledReason: effortAccess.allowed ? undefined : effortAccess.reason,
-        sending: state.chatSending,
-        sessionKey: state.sessionKey,
-        sessionsResult: state.sessionsResult,
-        stream: state.chatStream,
-        onRequestUpdate: () => state.requestUpdate?.(),
-        onModelSetup,
-        onFastModeSelect: (next, targetSessionKey) =>
-          effortAccess.allowed
-            ? switchChatFastMode(state, next, targetSessionKey)
-            : Promise.resolve(false),
-        onModelPickerOpen: refreshModelCatalog,
-        onModelSelect: (next, targetSessionKey) =>
-          modelAccess.allowed
-            ? switchChatModel(state, next, targetSessionKey)
-            : Promise.resolve(false),
-        onThinkingSelect: (next, targetSessionKey) =>
-          effortAccess.allowed
-            ? switchChatThinkingLevel(state, next, targetSessionKey)
-            : Promise.resolve(false),
-      })}
-      ${renderChatPermissionPicker({
-        canSelectFull,
-        disabled: !permissionAccess.allowed,
-        disabledReason: permissionAccess.allowed ? undefined : permissionAccess.reason,
-        mode: selectedSession?.permissionMode,
-        sessionRoot: selectedSession?.sessionRoot,
-        onSelect: async (permissionMode) => {
-          if (!permissionAccess.allowed) {
-            return;
-          }
-          try {
-            state.chatError = null;
-            await state.sessions.patch(
-              state.sessionKey,
-              { permissionMode },
-              scopedAgentParamsForSession(state, state.sessionKey),
-            );
-          } catch (error) {
-            state.chatError = t("chat.permissionControls.updateFailed", {
-              error: String(error),
-            });
-            state.requestUpdate?.();
-          }
-        },
-      })}
-    </div>
-  `;
+  return {
+    composerControls: html`
+      <div class="chat-composer-model-control">
+        ${renderChatModelControls({
+          activeRunId: state.chatRunId,
+          agentDefaultModel,
+          connected: state.connected,
+          gatewayAvailable: Boolean(state.client),
+          loading: state.chatLoading,
+          modelCatalog: state.chatModelCatalog,
+          modelCatalogState: {
+            hasSnapshot: hasModelSnapshot,
+            onRetry: () => void refreshModelCatalog(),
+            status: state.chatModelCatalogError
+              ? "error"
+              : state.chatModelsLoading
+                ? hasModelSnapshot
+                  ? "refreshing"
+                  : "loading"
+                : "ready",
+          },
+          modelOverrides: state.sessions.state.modelOverrides,
+          modelSelectionLocked: selectedSession?.modelSelectionLocked === true,
+          modelSelectionRuntimeId: selectedSession?.agentRuntime?.id,
+          modelSwitching: Boolean(state.chatModelSwitchPromises[state.sessionKey]),
+          modelsLoading: state.chatModelsLoading,
+          modelMutationDisabledReason: modelAccess.allowed ? undefined : modelAccess.reason,
+          effortMutationDisabledReason: effortAccess.allowed ? undefined : effortAccess.reason,
+          sending: state.chatSending,
+          sessionKey: state.sessionKey,
+          sessionsResult: state.sessionsResult,
+          stream: state.chatStream,
+          onRequestUpdate: () => state.requestUpdate?.(),
+          onModelSetup,
+          onFastModeSelect: (next, targetSessionKey) =>
+            effortAccess.allowed
+              ? switchChatFastMode(state, next, targetSessionKey)
+              : Promise.resolve(false),
+          onModelPickerOpen: refreshModelCatalog,
+          onModelSelect: (next, targetSessionKey) =>
+            modelAccess.allowed
+              ? switchChatModel(state, next, targetSessionKey)
+              : Promise.resolve(false),
+          onThinkingSelect: (next, targetSessionKey) =>
+            effortAccess.allowed
+              ? switchChatThinkingLevel(state, next, targetSessionKey)
+              : Promise.resolve(false),
+        })}
+      </div>
+    `,
+    permissionPicker: {
+      canSelectFull,
+      disabled: !permissionAccess.allowed,
+      disabledReason: permissionAccess.allowed ? undefined : permissionAccess.reason,
+      mode: selectedSession?.permissionMode,
+      sessionRoot: selectedSession?.sessionRoot,
+      onSelect: async (permissionMode) => {
+        if (!permissionAccess.allowed) {
+          return;
+        }
+        try {
+          state.chatError = null;
+          await state.sessions.patch(
+            state.sessionKey,
+            { permissionMode },
+            scopedAgentParamsForSession(state, state.sessionKey),
+          );
+        } catch (error) {
+          state.chatError = t("chat.permissionControls.updateFailed", {
+            error: String(error),
+          });
+          state.requestUpdate?.();
+        }
+      },
+    },
+  };
 }
 
 export function createChatPaneSessionActionCallbacks(params: {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -324,7 +324,7 @@ function composerControlsHtml(crowded = false) {
           </details>
           <details class="chat-controls__inline-select chat-controls__effort-picker">
           <summary class="chat-controls__inline-select-trigger chat-controls__effort-trigger" data-chat-composer-effort="true" aria-label="Effort">
-            <span class="chat-controls__inline-select-label">High</span>
+            <span class="chat-controls__inline-select-label">Medium</span>
           </summary>
           <div class="chat-controls__inline-select-menu chat-controls__effort-menu">
             <div class="chat-controls__reasoning-panel">Effort</div>
@@ -509,8 +509,16 @@ function chatHtml(opts: ChatFixtureOptions = {}, mobileNavLayout = false) {
                     </div>
                   </div>
                   <div class="agent-chat__composer-footer">
-                    ${composerControlsHtml(opts.crowdedComposerFooter)}
                     <div class="agent-chat__composer-meta">
+                      <details class="chat-controls__inline-select chat-controls__permission-picker">
+                        <summary class="chat-controls__inline-select-trigger chat-controls__permission-trigger" data-chat-permission-select="true" aria-label="Permissions: Workspace">
+                          <span class="chat-controls__permission-icon" aria-hidden="true">${iconSvg()}</span>
+                          <span class="chat-controls__inline-select-label">Workspace</span>
+                        </summary>
+                      </details>
+                    </div>
+                    ${composerControlsHtml(opts.crowdedComposerFooter)}
+                    <div class="agent-chat__composer-context">
                       <div class="context-usage">
                         <details>
                           <summary class="context-ring" role="status" aria-label="Session context usage: 46k/200k (23%)">
@@ -2463,6 +2471,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           };
         };
         return {
+          context: rectFor(".context-ring"),
           controls: rectFor(".agent-chat__composer-controls"),
           effort: rectFor(".chat-controls__effort-trigger"),
           footer: rectFor(".agent-chat__composer-footer"),
@@ -2470,6 +2479,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           model: rectFor(".chat-controls__model-trigger"),
           modelLabel: rectFor(".chat-controls__model-trigger .chat-controls__inline-select-label"),
           overrides: rectFor(".agent-chat__session-overrides-pill"),
+          permission: rectFor(".chat-controls__permission-trigger"),
           status: rectFor(".agent-chat__composer-run-status"),
           typing: rectFor(".agent-chat__typing-indicator--outside"),
         };
@@ -2481,6 +2491,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         layout.overrides,
         layout.model,
         layout.effort,
+        layout.permission,
+        layout.context,
         layout.typing,
       ]) {
         expect(control.x).toBeGreaterThanOrEqual(layout.footer.x - 1);
@@ -2488,16 +2500,17 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           layout.footer.x + layout.footer.width + 1,
         );
       }
-      for (const trigger of [layout.model, layout.effort]) {
+      for (const trigger of [layout.permission, layout.model, layout.effort]) {
         expect(trigger.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(trigger.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
       }
       expect(layout.modelLabel.scrollWidth).toBeLessThanOrEqual(layout.modelLabel.clientWidth + 1);
       for (const [left, right] of [
+        [layout.meta, layout.status],
         [layout.status, layout.overrides],
         [layout.overrides, layout.model],
         [layout.model, layout.effort],
-        [layout.effort, layout.meta],
+        [layout.effort, layout.context],
       ] as const) {
         expect(rectsOverlap(left, right)).toBe(false);
       }
@@ -2511,6 +2524,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     [320, 568],
     [393, 852],
     [568, 320],
+    [1024, 768],
     [1366, 900],
     [1920, 1080],
   ] as const)(
@@ -2555,6 +2569,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             effortLabel: rectFor(
               ".chat-controls__effort-trigger .chat-controls__inline-select-label",
             ),
+            permission: rectFor(".chat-controls__permission-trigger"),
+            permissionLabel: rectFor(
+              ".chat-controls__permission-trigger .chat-controls__inline-select-label",
+            ),
             context: rectFor(".context-ring"),
             attach: rectFor('.agent-chat__input-btn[aria-label="Add attachment"]'),
             send: rectFor(".chat-send-btn"),
@@ -2576,6 +2594,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           "composer thinking trigger",
         );
         const effortLabel = expectControlRect(controls.effortLabel, "composer thinking label");
+        const permission = expectControlRect(controls.permission, "composer permission trigger");
+        const permissionLabel = expectControlRect(
+          controls.permissionLabel,
+          "composer permission label",
+        );
         const context = expectControlRect(controls.context, "composer context control");
         const attach = expectControlRect(controls.attach, "composer attach control");
         const send = expectControlRect(controls.send, "composer send control");
@@ -2587,6 +2610,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           model,
           modelTrigger,
           effortTrigger,
+          permission,
           context,
           attach,
           send,
@@ -2609,6 +2633,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(send.x).toBeGreaterThanOrEqual(textarea.x + textarea.width - 1);
         expect(send.x + send.width).toBeLessThanOrEqual(input.x + input.width + 1);
         expect(rectsOverlap(model, send)).toBe(false);
+        expect(permission.x).toBeLessThan(model.x);
+        expect(rectsOverlap(permission, model)).toBe(false);
         const effortContextGap = context.x - (effortTrigger.x + effortTrigger.width);
         expect(effortContextGap).toBeGreaterThanOrEqual(-1);
         expect(effortContextGap).toBeLessThanOrEqual(9);
@@ -2619,18 +2645,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           expect(composerFontSize).toBe(16);
           expect(model.width).toBeGreaterThanOrEqual(40);
           expect(model.width).toBeLessThanOrEqual(footer.width);
-          for (const trigger of [modelTrigger, effortTrigger]) {
+          for (const trigger of [permission, modelTrigger, effortTrigger]) {
             expect(trigger.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
             expect(trigger.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
           }
-          for (const label of [modelLabel, effortLabel]) {
+          for (const label of [modelLabel, effortLabel, permissionLabel]) {
             expect(label.clientWidth).toBeDefined();
             expect(label.scrollWidth).toBeDefined();
             expect(label.scrollWidth ?? 0).toBeLessThanOrEqual((label.clientWidth ?? 0) + 1);
           }
           expect(send.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
           expect(send.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
-          for (const control of [model, context]) {
+          for (const control of [permission, model, context]) {
             expect(
               Math.abs(control.y + control.height / 2 - (model.y + model.height / 2)),
             ).toBeLessThanOrEqual(2);
@@ -2638,6 +2664,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           expect(footer.height).toBeLessThanOrEqual(49.1);
         } else {
           expect(composerFontSize).toBe(14);
+          for (const label of [permissionLabel, modelLabel, effortLabel]) {
+            expect(label.scrollWidth).toBeLessThanOrEqual((label.clientWidth ?? 0) + 1);
+          }
           expect(send.width).toBeCloseTo(36, 2);
           expect(send.height).toBeCloseTo(36, 2);
         }

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -458,19 +458,17 @@ describe("refreshChat", () => {
     expect(host.chatModelCatalog).toEqual([cachedModel]);
     expect(asChatPageHost(host).chatModelsLoading).toBe(true);
     const container = document.createElement("div");
-    render(
-      renderChatPaneComposerControls({
-        state: asChatPageHost(host),
-        selectedSession: undefined,
-        agentDefaultModel: undefined,
-        modelAccess: { allowed: true, requiredScope: "operator.write" },
-        effortAccess: { allowed: true, requiredScope: "operator.write" },
-        permissionAccess: { allowed: true, requiredScope: "operator.write" },
-        canSelectFull: true,
-        onModelSetup: vi.fn(),
-      }),
-      container,
-    );
+    const controls = renderChatPaneComposerControls({
+      state: asChatPageHost(host),
+      selectedSession: undefined,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      onModelSetup: vi.fn(),
+    });
+    render(controls.composerControls, container);
     expect(container.querySelector('[data-chat-model-catalog-state="refreshing"]')).not.toBeNull();
     expect(container.textContent).toContain("Refreshing models…");
     expect(container.textContent).not.toContain("Loading models…");

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1796,13 +1796,24 @@ describe("chat composer workbench", () => {
   it("renders session controls in the composer without owning side-panel content", () => {
     const container = renderChatView({
       composerControls: html`<button class="test-composer-control">Model</button>`,
+      permissionPicker: {
+        canSelectFull: true,
+        mode: "workspace",
+        onSelect: vi.fn(),
+      },
     });
 
     const composerControl = container.querySelector(
       ".agent-chat__composer-controls .test-composer-control",
     );
+    const permissionControl = container.querySelector('[data-chat-permission-select="true"]');
     expect(composerControl).not.toBeNull();
     expect(composerControl?.closest(".agent-chat__composer-footer")).not.toBeNull();
+    expect(permissionControl?.closest(".agent-chat__composer-meta")).not.toBeNull();
+    expect(permissionControl?.closest(".chat-composer-model-control")).toBeNull();
+    expect(permissionControl!.compareDocumentPosition(composerControl!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
     expect(container.querySelector(".agent-chat__composer-header")).toBeNull();
     expect(container.querySelector(".chat-workspace-rail")).toBeNull();
   });
@@ -2606,7 +2617,7 @@ describe("chat loading skeleton", () => {
       "Sending message",
     );
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
-    expect(contextUsage?.closest(".agent-chat__composer-meta")).not.toBeNull();
+    expect(contextUsage?.closest(".agent-chat__composer-context")).not.toBeNull();
   });
 
   it("places context usage after the composer controls in the bottom row", () => {
@@ -2639,7 +2650,7 @@ describe("chat loading skeleton", () => {
 
     const context = container.querySelector(".context-ring");
     expect(context).toBeInstanceOf(HTMLElement);
-    expect(context?.closest(".agent-chat__composer-meta")).not.toBeNull();
+    expect(context?.closest(".agent-chat__composer-context")).not.toBeNull();
     expect(context?.closest(".agent-chat__composer-footer")).not.toBeNull();
     // The session provider matches a plan-usage group, so dollar estimates
     // yield to the subscription windows.

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -48,6 +48,7 @@ import type {
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
 import { isImageLightboxEvent, openInlineChatImage } from "./components/chat-image-lightbox.ts";
 import type { ArtifactDownloadResolver } from "./components/chat-message-media.ts";
+import type { ChatPermissionPickerProps } from "./components/chat-permission-picker.ts";
 import { renderChatPullRequests } from "./components/chat-pull-requests.ts";
 import { renderChatSessionSuggestions } from "./components/chat-session-suggestions.ts";
 import type { SidebarContent, SidebarFullMessageLoader } from "./components/chat-sidebar.ts";
@@ -242,6 +243,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     onChatScroll?: (event: Event) => void;
     basePath?: string;
     composerControls?: TemplateResult | typeof nothing;
+    permissionPicker?: ChatPermissionPickerProps;
     replyTarget?: ChatReplyTarget | null;
     onClearReply?: () => void;
     onSetReply?: (target: ChatReplyTarget) => void;
@@ -418,6 +420,7 @@ export function renderChat(props: ChatProps) {
     typingActors: props.typingActors,
     onTypingChange: props.onTypingChange,
     composerControls: props.composerControls,
+    permissionPicker: props.permissionPicker,
     getDraft: props.getDraft,
     onDraftChange: props.onDraftChange,
     onRequestUpdate: requestUpdate,

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -26,6 +26,7 @@ import type {
   ChatComposerPlusMenuProps,
   ChatComposerPlusMenuView,
 } from "./chat-composer-plus-menu.ts";
+import type { ChatPermissionPickerProps } from "./chat-permission-picker.ts";
 
 /** One shape for queued-row edit state and actions. */
 export type ChatQueuedEditProps = {
@@ -120,6 +121,7 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   typingActors?: readonly { id: string; label: string }[];
   onTypingChange?: (typing: boolean) => void;
   composerControls?: TemplateResult | typeof nothing;
+  permissionPicker?: ChatPermissionPickerProps;
   onDraftChange: (next: string) => void;
   onHistoryKeydown?: (input: ChatInputHistoryKeyInput) => ChatInputHistoryKeyResult;
   onSlashIntent?: () => void | Promise<void>;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -34,6 +34,7 @@ import {
   type ComposerRunStatus,
 } from "./chat-composer-status.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
+import { renderChatPermissionPicker } from "./chat-permission-picker.ts";
 import type { createGatewayQuestionPanelProps } from "./chat-question-card.ts";
 import { renderChatVoiceError } from "./chat-voice-activity.ts";
 
@@ -458,6 +459,11 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             </div>
 
             <div class="agent-chat__composer-footer">
+              ${props.permissionPicker
+                ? html`<div class="agent-chat__composer-meta">
+                    ${renderChatPermissionPicker(props.permissionPicker)}
+                  </div>`
+                : nothing}
               ${composerControls !== nothing
                 ? html`
                     <div class="agent-chat__composer-controls">
@@ -511,7 +517,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                     </div>
                   `
                 : nothing}
-              <div class="agent-chat__composer-meta">${contextNotice}</div>
+              <div class="agent-chat__composer-context">${contextNotice}</div>
             </div>
           </div>`
         : nothing}

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -9,6 +9,15 @@ const PERMISSION_OPTIONS = [null, ...PERMISSION_MODES] as const;
 
 type PermissionSelection = SessionPermissionMode | null;
 
+export type ChatPermissionPickerProps = {
+  canSelectFull: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+  mode?: SessionPermissionMode;
+  sessionRoot?: string;
+  onSelect: (mode: PermissionSelection) => unknown;
+};
+
 function handlePermissionPickerKeydown(
   event: KeyboardEvent,
   onSelect: (mode: PermissionSelection) => void,
@@ -63,14 +72,7 @@ function permissionSelection(value: string | undefined): PermissionSelection | u
   return isPermissionMode(value) ? value : undefined;
 }
 
-export function renderChatPermissionPicker(params: {
-  canSelectFull: boolean;
-  disabled?: boolean;
-  disabledReason?: string;
-  mode?: SessionPermissionMode;
-  sessionRoot?: string;
-  onSelect: (mode: PermissionSelection) => unknown;
-}) {
+export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
   const selectMode = (mode: PermissionSelection) => {
     if (params.disabled || (mode === "full" && !params.canSelectFull)) {
       return;
@@ -82,7 +84,7 @@ export function renderChatPermissionPicker(params: {
   return html`
     <wa-dropdown
       class="chat-controls__inline-select chat-controls__permission-picker"
-      placement="top-end"
+      placement="top-start"
       @keydown=${(event: KeyboardEvent) => handlePermissionPickerKeydown(event, selectMode)}
       @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
         const mode = permissionSelection(event.detail.item.value);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2597,10 +2597,6 @@ button.chat-pr__diff {
   width: 100%;
 }
 
-.chat-composer-model-control .chat-controls__permission-picker {
-  flex: 0 0 auto;
-}
-
 .agent-chat__stt-interim {
   padding: 10px 14px 0;
   color: var(--muted);
@@ -2682,7 +2678,8 @@ button.chat-pr__diff {
   padding: calc(var(--chat-box-inset) / 2) var(--chat-box-inset);
 }
 
-.agent-chat__composer-meta {
+.agent-chat__composer-meta,
+.agent-chat__composer-context {
   display: flex;
   align-items: center;
   gap: 4px;
@@ -3758,7 +3755,8 @@ button.chat-pr__diff {
     flex: 0 0 26px;
   }
 
-  .agent-chat__composer-meta {
+  .agent-chat__composer-meta,
+  .agent-chat__composer-context {
     margin-left: 0;
   }
 
@@ -3775,7 +3773,7 @@ button.chat-pr__diff {
      text yields before either picker does. */
   .agent-chat__input .agent-chat__composer-controls .chat-composer-model-control {
     flex: 0 1 auto;
-    min-width: 138px;
+    min-width: 144px;
   }
 
   .agent-chat__input .agent-chat__composer-controls .chat-controls__model-picker {
@@ -3789,6 +3787,7 @@ button.chat-pr__diff {
 
   /* The borderless trigger is 30px on desktop; keep a >=44px touch target
      inside the mobile composer row. */
+  .agent-chat__input .agent-chat__composer-meta .chat-controls__inline-select-trigger,
   .agent-chat__input .agent-chat__composer-controls .chat-controls__inline-select-trigger {
     width: fit-content;
     max-width: 100%;
@@ -5364,6 +5363,16 @@ button.chat-pr__diff {
 }
 
 @media (max-width: 640px) {
+  .agent-chat__composer-meta .chat-controls__permission-trigger {
+    width: 44px;
+  }
+
+  .agent-chat__composer-meta
+    .chat-controls__permission-trigger
+    .chat-controls__inline-select-label {
+    display: none;
+  }
+
   .agent-chat__composer-controls {
     align-items: center;
     flex-direction: row;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the composer footer's right-side cluster overcrowded the model, thinking, permission, and context controls at common widths, truncating the model name and clipping the thinking level.

## Why This Change Was Made

The footer now reflects its semantic split: permission context—how the agent may act—lives on the left, while model and thinking controls remain on the right. The existing permission callback assembly, admin gating, keyboard handling, and `sessions.patch` flow are unchanged; the Web Awesome popup now opens above with left-edge alignment from its new position.

## User Impact

The Workspace permission chip appears on the left side of the composer footer. Model names and thinking levels remain readable at common desktop widths, while the mobile footer retains full touch targets and avoids overlap.

## Evidence

### 1050px viewport (clipping reproduction)

| Before | After |
| --- | --- |
| ![Before at 1050px: permission in the right cluster, model and thinking clipped](https://github.com/user-attachments/assets/4dfa9c6d-04f3-40af-afc5-4f768f66e617) | ![After at 1050px: permission on the left, full model and thinking labels](https://github.com/user-attachments/assets/0b2bcd05-58d3-48fc-a9fa-21f6eefa24de) |

### 1440px default viewport

| Before | After |
| --- | --- |
| ![Before at 1440px](https://github.com/user-attachments/assets/9c487c6e-d0b5-417c-aeef-6ea2123c79da) | ![After at 1440px](https://github.com/user-attachments/assets/53d90091-c9f0-465f-8ae3-c9f0f9df39b9) |

Focused proof:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-session-controls.test.ts ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-view.test.ts` — 553 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` — 83 passed, including 320px mobile and 1024px footer geometry/readability coverage.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts` — 11 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 2 passed.
- `node scripts/check-changed.mjs` — passed (formatting, TypeScript, lint/stylelint, i18n verification, architecture guards, dead exports).
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

At 1050px, the after capture measured full labels (`GPT-5.6 Sol`: 71/71 client/scroll px; `Medium`: 48/48) and placed `Workspace` in the left footer region. E2E geometry also verifies the permission popup stays above the trigger and uses left-edge placement.
