### PR TITLE
improve(testing): prove live OpenAI turns after packaged upgrades

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -14,6 +14,23 @@ export OPENCLAW_NO_PROMPT=1
 export OPENCLAW_SKIP_PROVIDERS=1
 export OPENCLAW_SKIP_CHANNELS=1
 export OPENCLAW_DISABLE_BONJOUR=1
+LIVE_OPENAI="${OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI:-0}"
+LIVE_OPENAI_API_KEY=""
+case "$LIVE_OPENAI" in
+  0)
+    ;;
+  1)
+    if [ -z "${OPENAI_API_KEY:-}" ]; then
+      echo "OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=1 requires OPENAI_API_KEY" >&2
+      exit 2
+    fi
+    LIVE_OPENAI_API_KEY="$OPENAI_API_KEY"
+    ;;
+  *)
+    echo "OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI must be 0 or 1; got: $LIVE_OPENAI" >&2
+    exit 2
+    ;;
+esac
 export GATEWAY_AUTH_TOKEN_REF="upgrade-survivor-token"
 export OPENAI_API_KEY="sk-openclaw-upgrade-survivor"
 export DISCORD_BOT_TOKEN="upgrade-survivor-discord-token"
@@ -81,6 +98,8 @@ HEALTHZ_JSON="$ARTIFACT_ROOT/healthz.json"
 READYZ_JSON="$ARTIFACT_ROOT/readyz.json"
 STATUS_JSON="$ARTIFACT_ROOT/status.json"
 STATUS_ERR="$ARTIFACT_ROOT/status.err"
+LIVE_OPENAI_JSON="$ARTIFACT_ROOT/live-openai.json"
+LIVE_OPENAI_ERR="$ARTIFACT_ROOT/live-openai.err"
 BASELINE_CONFIG_VALIDATE_LOG="$ARTIFACT_ROOT/baseline-config-validate.log"
 BASELINE_SERVICE_INSTALL_JSON="$ARTIFACT_ROOT/baseline-service-install.json"
 BASELINE_SERVICE_INSTALL_ERR="$ARTIFACT_ROOT/baseline-service-install.err"
@@ -232,11 +251,12 @@ fs.writeFileSync(process.env.SUMMARY_JSON, `${JSON.stringify(summary, null, 2)}\
 NODE
 }
 
-cleanup() {
+stop_gateway() {
   if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
     systemctl --user stop openclaw-gateway.service >/dev/null 2>&1 || true
   fi
   openclaw_e2e_terminate_gateways "${gateway_pid:-}"
+  gateway_pid=""
   if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
     local shim_pid
     shim_pid="$(cat "$SYSTEMCTL_SHIM_PID_FILE" 2>/dev/null || true)"
@@ -244,6 +264,11 @@ cleanup() {
       openclaw_e2e_terminate_gateways "$shim_pid"
     fi
   fi
+  rm -f "$SYSTEMCTL_SHIM_PID_FILE"
+}
+
+cleanup() {
+  stop_gateway
   openclaw_e2e_stop_process "${plugin_registry_pid:-}"
   openclaw_e2e_stop_process "${clawhub_fixture_pid:-}"
 }
@@ -1530,6 +1555,41 @@ check_gateway_status() {
   node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-status-json "$STATUS_JSON"
 }
 
+run_live_openai() {
+  local marker="OPENCLAW_UPGRADE_SURVIVOR_LIVE_OK"
+  local model="${OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_MODEL:-openai/gpt-5.5}"
+  local timeout_seconds
+  local status=0
+  timeout_seconds="$(
+    openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_TIMEOUT_SECONDS 180
+  )"
+  stop_gateway
+  (
+    unset OPENCLAW_SKIP_PROVIDERS
+    export OPENAI_API_KEY="$LIVE_OPENAI_API_KEY"
+    openclaw_e2e_maybe_timeout "${timeout_seconds}s" \
+      openclaw agent \
+      --local \
+      --agent main \
+      --session-id upgrade-survivor-live-openai \
+      --model "$model" \
+      --message "Reply with exactly $marker and no other text." \
+      --thinking off \
+      --timeout "$timeout_seconds" \
+      --json
+  ) >"$LIVE_OPENAI_JSON" 2>"$LIVE_OPENAI_ERR" || status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "live OpenAI survivor turn failed" >&2
+    openclaw_e2e_print_log "$LIVE_OPENAI_ERR" >&2
+    openclaw_e2e_print_log "$LIVE_OPENAI_JSON" >&2
+    return "$status"
+  fi
+  node --input-type=module - "$marker" "$LIVE_OPENAI_JSON" <<'NODE'
+import { assertAgentReplyContainsMarker } from "./scripts/e2e/lib/agent-turn-output.mjs";
+assertAgentReplyContainsMarker(process.argv[2], process.argv[3]);
+NODE
+}
+
 phase storage-preflight storage_preflight
 phase validate-update-restart-mode validate_update_restart_mode
 phase reset-run-state reset_run_state
@@ -1573,5 +1633,8 @@ phase assert-survival assert_survival
 phase gateway-start ensure_gateway_started
 phase gateway-probes check_gateway_probes
 phase gateway-status check_gateway_status
+if [ "$LIVE_OPENAI" = "1" ]; then
+  phase live-openai run_live_openai
+fi
 
 echo "Upgrade survivor Docker E2E passed baseline=${baseline_spec} scenario=${SCENARIO} candidate=${candidate_version} updateRestartMode=${UPDATE_RESTART_MODE} startup=${start_seconds}s updateRestart=${update_restart_seconds:-manual}s healthz=${healthz_seconds}s readyz=${readyz_seconds}s status=${status_seconds}s."

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -28,6 +28,35 @@ PROBE_MAX_BODY_BYTES="$(
   openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_PROBE_MAX_BODY_BYTES 1048576
 )"
 ROOT_MANAGED_VPS="${OPENCLAW_UPGRADE_SURVIVOR_ROOT_MANAGED_VPS:-0}"
+LIVE_OPENAI="${OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI:-0}"
+LIVE_OPENAI_ENV_ARGS=()
+case "$LIVE_OPENAI" in
+  0)
+    ;;
+  1)
+    if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" != "1" ]; then
+      echo "OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=1 requires OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1" >&2
+      exit 2
+    fi
+    if [ -z "${OPENAI_API_KEY:-}" ]; then
+      echo "OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=1 requires OPENAI_API_KEY" >&2
+      exit 2
+    fi
+    LIVE_OPENAI_TIMEOUT_SECONDS="$(
+      openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_TIMEOUT_SECONDS 180
+    )"
+    LIVE_OPENAI_ENV_ARGS=(
+      -e OPENAI_API_KEY
+      -e OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=1
+      -e OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_MODEL="${OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_MODEL:-openai/gpt-5.5}"
+      -e OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_TIMEOUT_SECONDS="$LIVE_OPENAI_TIMEOUT_SECONDS"
+    )
+    ;;
+  *)
+    echo "OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI must be 0 or 1; got: $LIVE_OPENAI" >&2
+    exit 2
+    ;;
+esac
 
 resolve_lane_artifact_suffix() {
   if [ -n "${OPENCLAW_DOCKER_ALL_LANE_NAME:-}" ]; then
@@ -210,6 +239,7 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
     -e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=/tmp/openclaw-clawhub-fixture-server.cjs \
     "${PROBE_ENV_ARGS[@]}" \
+    "${LIVE_OPENAI_ENV_ARGS[@]}" \
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
     -v "$TRUSTED_TSX_NODE_MODULES:/tmp/openclaw-release-harness/node_modules:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \

--- a/test/scripts/upgrade-survivor-plugin-registry.test.ts
+++ b/test/scripts/upgrade-survivor-plugin-registry.test.ts
@@ -125,3 +125,33 @@ describe("standalone upgrade survivor plugin registry", () => {
     expect(existsSync(packageTarball)).toBe(true);
   });
 });
+
+describe("standalone upgrade survivor live OpenAI probe", () => {
+  it("fails closed before Docker when the opted-in key is missing", () => {
+    const { captureDir, result } = runSurvivor({
+      OPENAI_API_KEY: undefined,
+      OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI: "1",
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      "OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=1 requires OPENAI_API_KEY",
+    );
+    expect(existsSync(join(captureDir, "docker-args"))).toBe(false);
+  });
+
+  it("forwards the opted-in key by environment name without putting it in Docker arguments", () => {
+    const key = "live-openai-key-must-not-appear-in-arguments";
+    const { captureDir, result } = runSurvivor({
+      OPENAI_API_KEY: key,
+      OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI: "1",
+      OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_MODEL: "openai/test-model",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const args = readFileSync(join(captureDir, "docker-args"), "utf8");
+    expect(args).toContain("-e OPENAI_API_KEY");
+    expect(args).toContain("-e OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI_MODEL=openai/test-model");
+    expect(args).not.toContain(key);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a testing gap where packaged stable-to-current upgrade survivors could prove migration, Doctor, and Gateway startup but could not safely prove that the upgraded installation still completed a real provider turn. One-off checks could also mistake a prompt echo for successful model output.

## Why This Change Was Made

Adds a fail-closed, published-baseline-only `OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=1` mode. The wrapper forwards the credential by environment name rather than argument value; after the normal offline update, Doctor, survival, health, readiness, and status phases pass, the runner stops the Gateway and performs an isolated local turn with channels and scheduled Gateway work out of the credential-bearing process. The existing structured agent-output parser verifies the marker appears in a successful reply payload. Default runs remain offline.

Product/runtime production LOC: +0/-0. Upgrade harness: +94/-1. Tests: +30/-0.

## User Impact

No product runtime behavior changes. Maintainers can now run one repeatable command to prove a stable-to-current packaged upgrade with configured plugins and a real OpenAI response, while preserving the existing provider/channel-skipped default.

## Evidence

- Before the Gateway-stop correction, the real opt-in run failed in the intended `live-openai` phase because local mode refused to share the active state directory; no provider request was made.
- Final packaged run: `openclaw@2026.7.1-2` → tarball `openclaw@2026.8.1` (SHA-256 `3c8a807f55352b565a0112732128fa787cf6e36ade2f7200c5e5a92c7ffdb675`), `configured-plugin-installs`, 30/30 phases passed, Gateway startup 14s, health 1s, readiness 1s, status 3s.
- Real `openai/gpt-5.5` turn returned an exact `OPENCLAW_UPGRADE_SURVIVOR_LIVE_OK` reply in a successful structured payload.
- Exact inherited API-key bytes appeared in 0 of 35,373 artifact files. No live channel request was made.
- Focused tooling: 2 files / 21 tests passed.
- Docker harness owner suite: 195/195 passed.
- Changed-file gate passed formatting, test-root typecheck, script lint/Oxlint, Docker E2E boundary checks, ratchets, and guards.
- `bash -n` for both shell scripts and `git diff --check` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings; patch correct at 0.99 confidence.
