### PR TITLE
fix: New Session stays on Models unavailable after a missing catalog owner

### DIFF
--- a/src/agents/prepared-model-runtime-materializations.test.ts
+++ b/src/agents/prepared-model-runtime-materializations.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearAllRuntimeAuthMaterializations,
+  recordRuntimeAuthMaterialization,
+} from "./auth-profiles/runtime-materializations.js";
+import { getPreparedModelRuntimeAuthMaterializations } from "./prepared-model-runtime-auth.js";
+import { registerPreparedRuntimeAuthMaterializationPublisher } from "./prepared-model-runtime-materializations.js";
+import type {
+  PreparedModelRuntimeOwner,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
+
+function createOwner(params: {
+  agentId: string;
+  agentDir: string;
+  needsRefresh?: boolean;
+}): PreparedModelRuntimeOwner {
+  const snapshot = {
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    config: {},
+    authModes: {},
+    activeProjectKeys: [],
+    allowGatewaySubagentBinding: true,
+    metadataSnapshot: { index: { plugins: [] }, plugins: [] },
+    modelCatalog: { entries: [], routeVariants: [] },
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+    createStores: () => ({ authStorage: { getAll: () => ({}) }, modelRegistry: {} }),
+  } as unknown as PreparedModelRuntimeSnapshot;
+  return {
+    input: { agentId: params.agentId, agentDir: params.agentDir, config: {} },
+    environmentFingerprint: "test-env",
+    catalogMode: "static",
+    provenance: "configured",
+    generation: 1,
+    needsRefresh: params.needsRefresh === true,
+    snapshot,
+  };
+}
+
+const materialization = {
+  provider: "openai",
+  modelId: "gpt-5.4",
+  modelApi: "openai-chatgpt-responses",
+  modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+  requestTransportOverrides: "none" as const,
+  authMode: "oauth",
+  runtimeOwnerId: "codex",
+};
+
+afterEach(() => {
+  clearAllRuntimeAuthMaterializations();
+});
+
+describe("prepared model runtime auth materialization publication", () => {
+  it("does not announce published while a sibling configured owner is stale", () => {
+    const main = createOwner({ agentId: "main", agentDir: "/tmp/configured-main" });
+    const atlas = createOwner({
+      agentId: "atlas",
+      agentDir: "/tmp/configured-atlas",
+      needsRefresh: true,
+    });
+    const owners = new Map<string, PreparedModelRuntimeOwner>([
+      ["main", main],
+      ["atlas", atlas],
+    ]);
+    const phases: string[] = [];
+    const unregister = registerPreparedRuntimeAuthMaterializationPublisher(owners, (event) => {
+      phases.push(event.phase);
+    });
+
+    expect(
+      recordRuntimeAuthMaterialization({
+        ...materialization,
+        agentDir: "/tmp/configured-main",
+      }),
+    ).toBe(true);
+    expect(phases).toEqual([]);
+    expect(getPreparedModelRuntimeAuthMaterializations(main.snapshot!)).toEqual([
+      expect.objectContaining({
+        provider: "openai",
+        runtimeOwnerId: "codex",
+      }),
+    ]);
+    unregister();
+  });
+
+  it("announces publication when every configured owner is request-visible", () => {
+    const main = createOwner({ agentId: "main", agentDir: "/tmp/configured-main" });
+    const owners = new Map<string, PreparedModelRuntimeOwner>([["main", main]]);
+    const phases: string[] = [];
+    const unregister = registerPreparedRuntimeAuthMaterializationPublisher(owners, (event) => {
+      phases.push(event.phase);
+    });
+
+    expect(
+      recordRuntimeAuthMaterialization({
+        ...materialization,
+        agentDir: "/tmp/configured-main",
+      }),
+    ).toBe(true);
+    expect(phases).toEqual(["invalidated", "published"]);
+    unregister();
+  });
+});

--- a/src/agents/prepared-model-runtime-materializations.ts
+++ b/src/agents/prepared-model-runtime-materializations.ts
@@ -14,6 +14,20 @@ type MaterializationMutationEvent = {
   affectsInheritedStores: boolean;
 };
 
+function configuredOwnersAreRequestVisible(
+  owners: ReadonlyMap<string, PreparedModelRuntimeOwner>,
+): boolean {
+  for (const owner of owners.values()) {
+    if (owner.provenance !== "configured") {
+      continue;
+    }
+    if (!owner.snapshot || owner.needsRefresh || owner.pending) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function registerPreparedRuntimeAuthMaterializationPublisher(
   owners: ReadonlyMap<string, PreparedModelRuntimeOwner>,
   notify: (event: { phase: "invalidated" | "published" }) => void,
@@ -51,7 +65,6 @@ function publishPreparedRuntimeAuthMaterializations(params: {
   if (affectedOwners.length === 0) {
     return;
   }
-  params.onInvalidated();
   const read = params.read ?? getPreparedRuntimeAuthMaterializations;
   for (const { owner, snapshot } of affectedOwners) {
     // A successful route only changes this bounded secret-free fact set. Rebuilding the model
@@ -61,5 +74,12 @@ function publishPreparedRuntimeAuthMaterializations(params: {
       Object.freeze([...read(owner.input.agentDir)]),
     );
   }
+  // Chat metadata treats published as "every configured owner is capturable".
+  // A bind on one agent must not announce while a sibling is stale or a replacement
+  // still holds needsRefresh; that refresh fail-closes the Control UI picker.
+  if (!configuredOwnersAreRequestVisible(params.owners)) {
+    return;
+  }
+  params.onInvalidated();
   params.onPublished();
 }

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -70,7 +70,7 @@ function createHarness(
   let pluginRegistryVersion = 1;
   let authStore: AuthProfileStore | undefined = { version: 1, profiles: {} };
   let authStoreRevision = 1;
-  const getPreparedOwner = vi.fn(() => owner);
+  const getPreparedOwner = vi.fn((): PreparedModelRuntimeSnapshot | undefined => owner);
   const getPreparedAuthStore = vi.fn(() => authStore);
   const getAuthStoreRevision = vi.fn(() => authStoreRevision);
   const getSkillsVersion = vi.fn(() => skillsVersion);
@@ -433,7 +433,7 @@ describe("gateway chat metadata runtime", () => {
       const harness = createHarness(undefined, { useDefaultProjection: true });
       harness.setAuthStore({ version: 1, profiles: {} });
       const preparedOwner = createOwner(
-        harness.getPreparedOwner().config,
+        harness.getPreparedOwner()!.config,
         "gpt-5.4",
         {
           openai: {

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -701,6 +701,30 @@ describe("gateway chat metadata runtime", () => {
     expect(result).not.toBe(timedOut);
   });
 
+  test("retries an unavailable owner on the next read once it is published again", async () => {
+    const harness = createHarness();
+    await harness.runtime.refresh();
+
+    harness.getPreparedOwner.mockReturnValue(undefined);
+    await expect(harness.runtime.refresh()).rejects.toThrow(
+      'prepared chat metadata owner is unavailable for agent "main"',
+    );
+    await expect(harness.runtime.read({ agentId: "main" })).rejects.toThrow(
+      'prepared chat metadata owner is unavailable for agent "main"',
+    );
+
+    const recovered = createOwner(
+      { agents: { list: [{ id: "main", default: true }] } },
+      "recovered",
+    );
+    harness.setOwner(recovered);
+    harness.getPreparedOwner.mockReturnValue(recovered);
+
+    await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [expect.objectContaining({ id: "recovered" })],
+    });
+  });
+
   test("rejects replacement waiters on failure and recovers on a later generation", async () => {
     const harness = createHarness();
     await harness.runtime.refresh();

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -472,7 +472,10 @@ export function createGatewayChatMetadataRuntime(params: {
         continue;
       }
       let generation = current;
-      if (!generation && params.refreshOnRead) {
+      // Unavailable means the prepared owner was missing, not that publication failed.
+      // Retry capture so a later published owner is not hidden behind lastError.
+      const retryUnavailableOwner = lastError instanceof ChatMetadataSnapshotUnavailableError;
+      if (!generation && (params.refreshOnRead || retryUnavailableOwner)) {
         await refresh();
         generation = current;
       }

--- a/src/gateway/server.chat-metadata-boundary.test.ts
+++ b/src/gateway/server.chat-metadata-boundary.test.ts
@@ -1,15 +1,73 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, expect, test, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
-import { clearConfigCache } from "../config/config.js";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { clearConfigCache, getRuntimeConfig } from "../config/config.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { installGatewayTestHooks, rpcReq, startConnectedServerWithClient } from "./test-helpers.js";
 
-installGatewayTestHooks();
+installGatewayTestHooks({ scope: "suite" });
+
+type ConnectedGateway = Awaited<ReturnType<typeof startConnectedServerWithClient>>;
+
+let gateway: ConnectedGateway | undefined;
+let minimalGatewayEnv: ReturnType<typeof captureEnv> | undefined;
+let preparedOwnerCaptureMiss = false;
+let resolvePreparedOwnerCaptureMiss: (() => void) | undefined;
+let restorePreparedOwnerSpy: (() => void) | undefined;
+
+function requireGateway(): ConnectedGateway {
+  if (!gateway) {
+    throw new Error("chat metadata Gateway is not ready");
+  }
+  return gateway;
+}
+
+beforeAll(async () => {
+  minimalGatewayEnv = captureEnv(["OPENCLAW_TEST_MINIMAL_GATEWAY"]);
+  const preparedModelCatalog = await import("../agents/prepared-model-catalog.js");
+  const originalGetPreparedOwner = preparedModelCatalog.getPreparedModelCatalogOwnerSnapshot;
+  const preparedOwnerSpy = vi
+    .spyOn(preparedModelCatalog, "getPreparedModelCatalogOwnerSnapshot")
+    .mockImplementation((params) => {
+      if (preparedOwnerCaptureMiss) {
+        resolvePreparedOwnerCaptureMiss?.();
+        return undefined;
+      }
+      return originalGetPreparedOwner(params);
+    });
+  restorePreparedOwnerSpy = () => preparedOwnerSpy.mockRestore();
+  // The production lifecycle has no refresh-on-read escape hatch. This must stay non-minimal,
+  // otherwise the old sticky behavior is hidden by the test-only lifecycle configuration.
+  setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "0");
+  await writeGatewayConfig(CHAT_METADATA_BOUNDARY_CONFIG);
+  gateway = await startConnectedServerWithClient();
+  await gateway.server.startupSettled;
+}, 60_000);
+
+beforeEach(async () => {
+  setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "0");
+  await writeGatewayConfig(CHAT_METADATA_BOUNDARY_CONFIG);
+  const { refreshPreparedModelRuntimeSnapshots } =
+    await import("../agents/prepared-model-runtime.js");
+  await refreshPreparedModelRuntimeSnapshots(getRuntimeConfig(), { gatewayLifecycle: true });
+  const ready = await rpcReq(requireGateway().ws, "chat.metadata", { agentId: "main" });
+  expect(ready.ok, JSON.stringify(ready)).toBe(true);
+});
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  preparedOwnerCaptureMiss = false;
+  resolvePreparedOwnerCaptureMiss = undefined;
+});
+
+afterAll(async () => {
+  if (gateway) {
+    gateway.ws.close();
+    await gateway.server.close();
+    gateway.envSnapshot.restore();
+  }
+  restorePreparedOwnerSpy?.();
+  clearConfigCache();
+  minimalGatewayEnv?.restore();
 });
 
 const CHAT_METADATA_BOUNDARY_CONFIG = {
@@ -40,112 +98,78 @@ async function writeGatewayConfig(config: Record<string, unknown>) {
   clearConfigCache();
 }
 
-async function withProductionChatMetadataGateway(
-  run: (ws: Awaited<ReturnType<typeof startConnectedServerWithClient>>["ws"]) => Promise<void>,
-) {
-  const envSnapshot = captureEnv(["OPENCLAW_TEST_MINIMAL_GATEWAY"]);
-  let started: Awaited<ReturnType<typeof startConnectedServerWithClient>> | undefined;
-  try {
-    // The production lifecycle has no refresh-on-read escape hatch. This must stay non-minimal,
-    // otherwise the old sticky behavior is hidden by the test-only lifecycle configuration.
-    setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "0");
-    await writeGatewayConfig(CHAT_METADATA_BOUNDARY_CONFIG);
-    started = await startConnectedServerWithClient();
-    await run(started.ws);
-  } finally {
-    if (started) {
-      started.ws.close();
-      await started.server.close();
-      started.envSnapshot.restore();
-    }
-    clearConfigCache();
-    envSnapshot.restore();
-  }
-}
+test("chat.metadata retries owner misses without broadly retrying cached failures", async () => {
+  const ws = requireGateway().ws;
+  const publicationEvents = await import("../agents/prepared-model-runtime.publication-events.js");
+  const initial = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+  expect(initial.ok).toBe(true);
 
-test("chat.metadata recovers a published prepared-owner capture miss on the next Gateway read", async () => {
-  await withProductionChatMetadataGateway(async (ws) => {
-    const preparedModelCatalog = await import("../agents/prepared-model-catalog.js");
-    const publicationEvents =
-      await import("../agents/prepared-model-runtime.publication-events.js");
-    const originalGetPreparedOwner = preparedModelCatalog.getPreparedModelCatalogOwnerSnapshot;
-    const initial = await rpcReq(ws, "chat.metadata", { agentId: "main" });
-    expect(initial.ok).toBe(true);
-
-    let ownerVisible = false;
-    const ownerCaptureMissed = createDeferred();
-    vi.spyOn(preparedModelCatalog, "getPreparedModelCatalogOwnerSnapshot").mockImplementation(
-      (params) => {
-        if (!ownerVisible) {
-          ownerCaptureMissed.resolve();
-          return undefined;
-        }
-        return originalGetPreparedOwner(params);
-      },
-    );
-
-    // This is the lifecycle listener's real published catch-up. The owner exists, but this one
-    // capture sees it missing, reproducing the stale publication announcement that wedged UI.
-    publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
-    await ownerCaptureMissed.promise;
-    const unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
-    expect(unavailable).toMatchObject({
-      ok: false,
-      error: {
-        code: "UNAVAILABLE",
-        message: expect.stringContaining("prepared chat metadata owner is unavailable"),
-      },
-    });
-
-    ownerVisible = true;
-    const recovered = await rpcReq<{
-      models?: Array<{ id?: string; provider?: string }>;
-    }>(ws, "chat.metadata", { agentId: "main" });
-
-    // On the merge-base this remains false: readCurrent rethrows the cached unavailable error.
-    expect(recovered.ok).toBe(true);
-    expect(recovered.payload?.models).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "gpt-boundary", provider: "openai" })]),
-    );
+  const ownerCaptureMissed = new Promise<void>((resolve) => {
+    resolvePreparedOwnerCaptureMiss = resolve;
   });
-});
+  preparedOwnerCaptureMiss = true;
 
-test("chat.metadata does not retry a cached non-owner failure without lifecycle invalidation", async () => {
-  await withProductionChatMetadataGateway(async (ws) => {
-    const publicationEvents =
-      await import("../agents/prepared-model-runtime.publication-events.js");
-    const modelsListResult = await import("./server-methods/models-list-result.js");
-    const initial = await rpcReq(ws, "chat.metadata", { agentId: "main" });
-    expect(initial.ok).toBe(true);
-    const projectionFailure = new Error("configured model catalog unavailable");
-    const projectionSpy = vi
-      .spyOn(modelsListResult, "buildModelsListResult")
-      .mockRejectedValue(projectionFailure);
+  // This is the lifecycle listener's real published catch-up. The owner exists, but this one
+  // capture sees it missing, reproducing the stale publication announcement that wedged UI.
+  publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
+  await ownerCaptureMissed;
+  const unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+  expect(unavailable).toMatchObject({
+    ok: false,
+    error: {
+      code: "UNAVAILABLE",
+      message: expect.stringContaining("prepared chat metadata owner is unavailable"),
+    },
+  });
 
-    publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
-    await vi.waitFor(() => expect(projectionSpy).toHaveBeenCalled(), {
-      interval: 1,
-      timeout: 2_000,
-    });
-    const unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
-    expect(unavailable).toMatchObject({
-      ok: false,
-      error: {
-        code: "UNAVAILABLE",
-        message: expect.stringContaining("configured model catalog unavailable"),
-      },
-    });
+  preparedOwnerCaptureMiss = false;
+  const recovered = await rpcReq<{
+    models?: Array<{ id?: string; provider?: string }>;
+  }>(ws, "chat.metadata", { agentId: "main" });
 
-    projectionSpy.mockRestore();
-    const stillUnavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+  // On the merge-base this remains false: readCurrent rethrows the cached unavailable error.
+  expect(recovered.ok).toBe(true);
+  expect(recovered.payload?.models).toEqual(
+    expect.arrayContaining([expect.objectContaining({ id: "gpt-boundary", provider: "openai" })]),
+  );
 
-    // A broad retry would turn this into a false recovery and hide a genuinely broken catalog.
-    expect(stillUnavailable).toMatchObject({
-      ok: false,
-      error: {
-        code: "UNAVAILABLE",
-        message: expect.stringContaining("configured model catalog unavailable"),
-      },
-    });
+  // Reset the published runtime between boundary cases without restarting the Gateway.
+  const { refreshPreparedModelRuntimeSnapshots } =
+    await import("../agents/prepared-model-runtime.js");
+  await refreshPreparedModelRuntimeSnapshots(getRuntimeConfig(), { gatewayLifecycle: true });
+  const reset = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+  expect(reset.ok).toBe(true);
+
+  const modelsListResult = await import("./server-methods/models-list-result.js");
+  const projectionFailure = new Error("configured model catalog unavailable");
+  const projectionSpy = vi
+    .spyOn(modelsListResult, "buildModelsListResult")
+    .mockRejectedValue(projectionFailure);
+
+  publicationEvents.notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+  publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
+  await vi.waitFor(() => expect(projectionSpy).toHaveBeenCalled(), {
+    interval: 1,
+    timeout: 2_000,
+  });
+  const projectionUnavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+  expect(projectionUnavailable).toMatchObject({
+    ok: false,
+    error: {
+      code: "UNAVAILABLE",
+      message: expect.stringContaining("configured model catalog unavailable"),
+    },
+  });
+
+  projectionSpy.mockRestore();
+  const stillUnavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+
+  // A broad retry would turn this into a false recovery and hide a genuinely broken catalog.
+  expect(stillUnavailable).toMatchObject({
+    ok: false,
+    error: {
+      code: "UNAVAILABLE",
+      message: expect.stringContaining("configured model catalog unavailable"),
+    },
   });
 });

--- a/src/gateway/server.chat-metadata-boundary.test.ts
+++ b/src/gateway/server.chat-metadata-boundary.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { clearConfigCache } from "../config/config.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { installGatewayTestHooks, rpcReq, startConnectedServerWithClient } from "./test-helpers.js";
+
+installGatewayTestHooks();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const CHAT_METADATA_BOUNDARY_CONFIG = {
+  agents: {
+    defaults: {
+      model: { primary: "openai/gpt-boundary" },
+      models: { "openai/gpt-boundary": {} },
+    },
+    entries: { main: { default: true } },
+  },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://openai.example.com/v1",
+        models: [{ id: "gpt-boundary", name: "GPT Boundary" }],
+      },
+    },
+  },
+} as const;
+
+async function writeGatewayConfig(config: Record<string, unknown>) {
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  if (!configPath) {
+    throw new Error("OPENCLAW_CONFIG_PATH missing in gateway test environment");
+  }
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  clearConfigCache();
+}
+
+async function withProductionChatMetadataGateway(
+  run: (ws: Awaited<ReturnType<typeof startConnectedServerWithClient>>["ws"]) => Promise<void>,
+) {
+  const envSnapshot = captureEnv(["OPENCLAW_TEST_MINIMAL_GATEWAY"]);
+  let started: Awaited<ReturnType<typeof startConnectedServerWithClient>> | undefined;
+  try {
+    // The production lifecycle has no refresh-on-read escape hatch. This must stay non-minimal,
+    // otherwise the old sticky behavior is hidden by the test-only lifecycle configuration.
+    setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "0");
+    await writeGatewayConfig(CHAT_METADATA_BOUNDARY_CONFIG);
+    started = await startConnectedServerWithClient();
+    await run(started.ws);
+  } finally {
+    if (started) {
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+    clearConfigCache();
+    envSnapshot.restore();
+  }
+}
+
+test("chat.metadata recovers a published prepared-owner capture miss on the next Gateway read", async () => {
+  await withProductionChatMetadataGateway(async (ws) => {
+    const preparedModelCatalog = await import("../agents/prepared-model-catalog.js");
+    const publicationEvents =
+      await import("../agents/prepared-model-runtime.publication-events.js");
+    const originalGetPreparedOwner = preparedModelCatalog.getPreparedModelCatalogOwnerSnapshot;
+    const initial = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+    expect(initial.ok).toBe(true);
+
+    let ownerVisible = false;
+    const ownerCaptureMissed = createDeferred();
+    vi.spyOn(preparedModelCatalog, "getPreparedModelCatalogOwnerSnapshot").mockImplementation(
+      (params) => {
+        if (!ownerVisible) {
+          ownerCaptureMissed.resolve();
+          return undefined;
+        }
+        return originalGetPreparedOwner(params);
+      },
+    );
+
+    // This is the lifecycle listener's real published catch-up. The owner exists, but this one
+    // capture sees it missing, reproducing the stale publication announcement that wedged UI.
+    publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
+    await ownerCaptureMissed.promise;
+    const unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+    expect(unavailable).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("prepared chat metadata owner is unavailable"),
+      },
+    });
+
+    ownerVisible = true;
+    const recovered = await rpcReq<{
+      models?: Array<{ id?: string; provider?: string }>;
+    }>(ws, "chat.metadata", { agentId: "main" });
+
+    // On the merge-base this remains false: readCurrent rethrows the cached unavailable error.
+    expect(recovered.ok).toBe(true);
+    expect(recovered.payload?.models).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "gpt-boundary", provider: "openai" })]),
+    );
+  });
+});
+
+test("chat.metadata does not retry a cached non-owner failure without lifecycle invalidation", async () => {
+  await withProductionChatMetadataGateway(async (ws) => {
+    const publicationEvents =
+      await import("../agents/prepared-model-runtime.publication-events.js");
+    const modelsListResult = await import("./server-methods/models-list-result.js");
+    const initial = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+    expect(initial.ok).toBe(true);
+    const projectionFailure = new Error("configured model catalog unavailable");
+    const projectionSpy = vi
+      .spyOn(modelsListResult, "buildModelsListResult")
+      .mockRejectedValue(projectionFailure);
+
+    publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
+    await vi.waitFor(() => expect(projectionSpy).toHaveBeenCalled(), {
+      interval: 1,
+      timeout: 2_000,
+    });
+    const unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+    expect(unavailable).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("configured model catalog unavailable"),
+      },
+    });
+
+    projectionSpy.mockRestore();
+    const stillUnavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+
+    // A broad retry would turn this into a false recovery and hide a genuinely broken catalog.
+    expect(stillUnavailable).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("configured model catalog unavailable"),
+      },
+    });
+  });
+});

--- a/src/gateway/server.chat-metadata-boundary.test.ts
+++ b/src/gateway/server.chat-metadata-boundary.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
-import { clearConfigCache, getRuntimeConfig } from "../config/config.js";
+import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+} from "../config/config.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { installGatewayTestHooks, rpcReq, startConnectedServerWithClient } from "./test-helpers.js";
 
@@ -11,9 +15,6 @@ type ConnectedGateway = Awaited<ReturnType<typeof startConnectedServerWithClient
 
 let gateway: ConnectedGateway | undefined;
 let minimalGatewayEnv: ReturnType<typeof captureEnv> | undefined;
-let preparedOwnerCaptureMiss = false;
-let resolvePreparedOwnerCaptureMiss: (() => void) | undefined;
-let restorePreparedOwnerSpy: (() => void) | undefined;
 
 function requireGateway(): ConnectedGateway {
   if (!gateway) {
@@ -24,18 +25,6 @@ function requireGateway(): ConnectedGateway {
 
 beforeAll(async () => {
   minimalGatewayEnv = captureEnv(["OPENCLAW_TEST_MINIMAL_GATEWAY"]);
-  const preparedModelCatalog = await import("../agents/prepared-model-catalog.js");
-  const originalGetPreparedOwner = preparedModelCatalog.getPreparedModelCatalogOwnerSnapshot;
-  const preparedOwnerSpy = vi
-    .spyOn(preparedModelCatalog, "getPreparedModelCatalogOwnerSnapshot")
-    .mockImplementation((params) => {
-      if (preparedOwnerCaptureMiss) {
-        resolvePreparedOwnerCaptureMiss?.();
-        return undefined;
-      }
-      return originalGetPreparedOwner(params);
-    });
-  restorePreparedOwnerSpy = () => preparedOwnerSpy.mockRestore();
   // The production lifecycle has no refresh-on-read escape hatch. This must stay non-minimal,
   // otherwise the old sticky behavior is hidden by the test-only lifecycle configuration.
   setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "0");
@@ -54,18 +43,12 @@ beforeEach(async () => {
   expect(ready.ok, JSON.stringify(ready)).toBe(true);
 });
 
-afterEach(() => {
-  preparedOwnerCaptureMiss = false;
-  resolvePreparedOwnerCaptureMiss = undefined;
-});
-
 afterAll(async () => {
   if (gateway) {
     gateway.ws.close();
     await gateway.server.close();
     gateway.envSnapshot.restore();
   }
-  restorePreparedOwnerSpy?.();
   clearConfigCache();
   minimalGatewayEnv?.restore();
 });
@@ -88,7 +71,21 @@ const CHAT_METADATA_BOUNDARY_CONFIG = {
   },
 } as const;
 
-async function writeGatewayConfig(config: Record<string, unknown>) {
+const CHAT_METADATA_MISSING_OWNER_CONFIG = {
+  ...CHAT_METADATA_BOUNDARY_CONFIG,
+  agents: {
+    ...CHAT_METADATA_BOUNDARY_CONFIG.agents,
+    entries: {
+      ...CHAT_METADATA_BOUNDARY_CONFIG.agents.entries,
+      missing: {},
+    },
+  },
+} as const;
+
+async function writeGatewayConfig(
+  config: Record<string, unknown>,
+  options: { clearRuntimeSnapshot?: boolean } = {},
+) {
   const configPath = process.env.OPENCLAW_CONFIG_PATH;
   if (!configPath) {
     throw new Error("OPENCLAW_CONFIG_PATH missing in gateway test environment");
@@ -96,6 +93,9 @@ async function writeGatewayConfig(config: Record<string, unknown>) {
   await fs.mkdir(path.dirname(configPath), { recursive: true });
   await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
   clearConfigCache();
+  if (options.clearRuntimeSnapshot) {
+    clearRuntimeConfigSnapshot();
+  }
 }
 
 test("chat.metadata retries owner misses without broadly retrying cached failures", async () => {
@@ -104,16 +104,18 @@ test("chat.metadata retries owner misses without broadly retrying cached failure
   const initial = await rpcReq(ws, "chat.metadata", { agentId: "main" });
   expect(initial.ok).toBe(true);
 
-  const ownerCaptureMissed = new Promise<void>((resolve) => {
-    resolvePreparedOwnerCaptureMiss = resolve;
-  });
-  preparedOwnerCaptureMiss = true;
-
-  // This is the lifecycle listener's real published catch-up. The owner exists, but this one
-  // capture sees it missing, reproducing the stale publication announcement that wedged UI.
+  // This is the lifecycle listener's real published catch-up. Config can expose an agent before
+  // its prepared owner exists, reproducing the stale publication announcement that wedged UI.
+  await writeGatewayConfig(CHAT_METADATA_MISSING_OWNER_CONFIG, { clearRuntimeSnapshot: true });
   publicationEvents.notifyPreparedModelRuntimePublication({ phase: "published" });
-  await ownerCaptureMissed;
-  const unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+  let unavailable: Awaited<ReturnType<typeof rpcReq>> | undefined;
+  await vi.waitFor(
+    async () => {
+      unavailable = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+      expect(unavailable.ok).toBe(false);
+    },
+    { interval: 1, timeout: 2_000 },
+  );
   expect(unavailable).toMatchObject({
     ok: false,
     error: {
@@ -122,7 +124,7 @@ test("chat.metadata retries owner misses without broadly retrying cached failure
     },
   });
 
-  preparedOwnerCaptureMiss = false;
+  await writeGatewayConfig(CHAT_METADATA_BOUNDARY_CONFIG, { clearRuntimeSnapshot: true });
   const recovered = await rpcReq<{
     models?: Array<{ id?: string; provider?: string }>;
   }>(ws, "chat.metadata", { agentId: "main" });


### PR DESCRIPTION
## What Problem This Solves

An auth-materialization update from one healthy agent could announce prepared-catalog publication while another configured agent owner was still not capturable. `chat.metadata` then cached that one unavailable-owner capture failure forever. This PR suppresses that premature publication and retries only that typed unavailable-owner cache error on the next read.

## Why This Change Was Made

`publishPreparedRuntimeAuthMaterializations()` updates the affected owner's secret-free auth facts, then previously emitted process-wide `invalidated` and `published` without checking its configured siblings. A listener immediately refreshes the shared `chat.metadata` generation; `captureGenerationFacts()` traverses every configured owner and throws `ChatMetadataSnapshotUnavailableError` for a missing/stale owner. The runtime retained that error as `lastError` with no generation. Before this PR, ordinary reads only refreshed when `refreshOnRead` was enabled, so subsequent picker reads rethrew the cached error even after the owner was available.

The producer-side gate is necessary: it makes the materialization path's `published` contract mean every configured owner is request-visible. The read-side change is intentionally narrow recovery for a cache already poisoned by this transient typed error; it does not retry other projection, config, or capture failures, which remain sticky until `invalidate()`.

## User Impact

Control UI New Session recovers its model picker on the next `chat.metadata` read after this specific transient missing-owner race, without restarting Gateway. It does not turn arbitrary Gateway errors into retries.

## Evidence

### Summary

The two changes work at their respective ownership boundaries: materialization publication no longer reports a process-wide ready state while a configured sibling owner is unavailable, and `chat.metadata` retries only `ChatMetadataSnapshotUnavailableError` when that exact error was cached.

### Real behavior proof

I used two independently built, session-owned dev Gateways with separate temporary state directories and loopback ports (not port 18789 and not the operator state). Both had two configured prepared owners. A controlled loader returned `undefined` exactly once at the real `getPreparedModelCatalogOwnerSnapshot()` capture boundary during a live config publication; Gateway logged the resulting `ChatMetadataSnapshotUnavailableError`.

On merge-base `682b05dcac0`, the real Control UI New Session picker rendered **Models unavailable** and its retry UI. A subsequent `chat.metadata` RPC on the same still-running process again returned `UNAVAILABLE` with the same typed error.

https://github.com/user-attachments/assets/9e369f11-6156-4cc5-99dc-b4bf2ba214cd

On PR head `23d2481c16fd`, the exact same one-time miss occurred during lifecycle refresh, but the next real New Session `chat.metadata` read rebuilt the generation. The visible picker showed the configured model and a following RPC succeeded; no Gateway restart occurred.

https://github.com/user-attachments/assets/78fb948e-0ca0-4995-9250-1632981e7c42

### Second failure-class investigation

Verdict: the observed prepared-catalog worker generation mismatch is a distinct `models.list` full-discovery failure, not a second `chat.metadata` cache error. `prepareWorkerGeneration()` throws when its reconstructed fingerprint differs (`src/agents/prepared-model-catalog.worker.ts:77-93`). That promise is created once per worker; a failed protocol response leaves the worker alive (`src/agents/prepared-model-catalog-worker.ts:229-247`), so another full discovery can reuse the rejected promise and fail quickly. This matches the sanitized 10.2s first failure followed by a 5ms same-error request in the read-only incident log.

It cannot poison this PR's `chat.metadata` generation: chat metadata deliberately uses the published configured catalog and `preloadedOnly: true` (`src/gateway/server-methods/chat-metadata-runtime.ts:225-255`), while `models.list` reaches deferred/full discovery (`src/gateway/server-methods/models-list-result.ts:520-580`). Broadening the retry here would therefore mask the wrong failure class.

Current `main` already includes #125596, which preserves Gateway lifecycle plugin-metadata ownership and is a plausible repair for the metadata-generation drift that produced this incident. The remaining worker mismatch recovery contract is tracked separately in #126108 with the failing-first regression required before changing it. PR #125450 intentionally remains limited to the missing prepared-owner invariant.

### Verification

- Merge-base regression proof: the new materialization test failed because it received `['invalidated', 'published']` instead of `[]`; the metadata test rejected with `ChatMetadataSnapshotUnavailableError` at its recovery assertion.
- PR behavioral head: `prepared-model-runtime-materializations.test.ts` (2), `prepared-model-runtime.lifecycle.test.ts` (44), `chat-metadata-runtime.test.ts` (24), and the two chat-metadata lifecycle suites (13) all passed. Final head `e09bda2ee9` adds only a nullable mock typing correction required by the current type gate; the focused metadata suite still passes (24).
- Focused worker/lifecycle review this round: `prepared-model-catalog-worker.integration.test.ts` and `prepared-model-runtime.startup-static.test.ts` cover the worker/full-catalog lifecycle; the source tracing above establishes that this error is excluded from chat metadata's preloaded path.
- Repeatable warm `chat.metadata` RPC benchmark in the same isolated two-owner configuration: 10 warmups and 30 samples per ref. Merge-base median/p95 was 0.30/1.01 ms; PR head was 0.25/0.37 ms. This is a local Gateway metadata-path measurement, not a provider-turn latency claim.
- `pnpm check:changed` passed. `git merge-tree --write-tree origin/main HEAD` was clean at validation time. Fresh `codex-review --mode local` on the final uncommitted correction reported no accepted/actionable findings.

### What was not tested

No external provider turn was sent: this proof exercises the Gateway and Control UI contract with two locally configured owners, not a third-party model credential. Telegram and `openclaw models list` remain separately routed consumers; their behavior is explained by their not consuming the poisoned shared `chat.metadata` generation, but was not replayed against a real provider.

The newly identified worker-generation mismatch was not reproduced against a live provider in this PR. It has a distinct owner and follow-up #126108; the incident-source candidate repair #125596 was inspected on current `main` but not runtime-reproduced in this validation worktree.

### Boundary regression coverage (2026-08-19)

`src/gateway/server.chat-metadata-boundary.test.ts` starts a non-minimal isolated Gateway and makes real WebSocket `chat.metadata` requests. It injects only the published-catch-up owner capture miss, asserts one `UNAVAILABLE` response, then asserts the next RPC succeeds without `invalidate()` or restart. A second test injects a generic model-projection failure and proves it remains cached after its cause is restored, guarding the retry scope to `ChatMetadataSnapshotUnavailableError`.

Pre-fix red proof: on merge-base `682b05dcac0`, after the same first unavailable response, `expect(recovered.ok).toBe(true)` fails because the next real `chat.metadata` RPC remains `UNAVAILABLE` (`ok: false`).