### PR TITLE
fix(state): tolerate a sidecar deleted while hardening the state database

### DIFF
--- a/src/state/openclaw-state-db-permissions.ts
+++ b/src/state/openclaw-state-db-permissions.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { createDedupeCache } from "../infra/dedupe.js";
+import { hasErrnoCode } from "../infra/errno.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -54,7 +55,7 @@ export function ensureOpenClawStatePermissions(pathname: string, env: NodeJS.Pro
         // SQLite removes -wal/-shm at checkpoint or close, so a concurrent opener
         // can delete a sidecar between this check and the chmod. A vanished sidecar
         // has nothing left to harden; other faults stay fatal and loud.
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        if (!hasErrnoCode(error, "ENOENT")) {
           throw error;
         }
       }

--- a/src/state/openclaw-state-db-permissions.ts
+++ b/src/state/openclaw-state-db-permissions.ts
@@ -54,8 +54,10 @@ export function ensureOpenClawStatePermissions(pathname: string, env: NodeJS.Pro
       } catch (error) {
         // SQLite removes -wal/-shm at checkpoint or close, so a concurrent opener
         // can delete a sidecar between this check and the chmod. A vanished sidecar
-        // has nothing left to harden; other faults stay fatal and loud.
-        if (!hasErrnoCode(error, "ENOENT")) {
+        // has nothing left to harden. The main database keeps its fail-loud
+        // boundary: swallowing its ENOENT would fall through to an open that
+        // creates a fresh empty database instead of surfacing the loss.
+        if (candidate === pathname || !hasErrnoCode(error, "ENOENT")) {
           throw error;
         }
       }

--- a/src/state/openclaw-state-db-permissions.ts
+++ b/src/state/openclaw-state-db-permissions.ts
@@ -48,7 +48,16 @@ export function ensureOpenClawStatePermissions(pathname: string, env: NodeJS.Pro
   }
   for (const candidate of resolveSqliteDatabaseFilePaths(pathname)) {
     if (existsSync(candidate)) {
-      bestEffortChmodSync(candidate, OPENCLAW_STATE_FILE_MODE);
+      try {
+        bestEffortChmodSync(candidate, OPENCLAW_STATE_FILE_MODE);
+      } catch (error) {
+        // SQLite removes -wal/-shm at checkpoint or close, so a concurrent opener
+        // can delete a sidecar between this check and the chmod. A vanished sidecar
+        // has nothing left to harden; other faults stay fatal and loud.
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
     }
   }
 }

--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -164,6 +164,23 @@ describe("state database permission hardening without chmod support", () => {
     expect(chmodFailHook.targets.some((target) => target.endsWith("-shm"))).toBe(true);
   });
 
+  it("rethrows when the main database vanishes between the existence check and the chmod", () => {
+    // resolveSqliteDatabaseFilePaths lists the unsuffixed database first. Losing
+    // it must stay fatal: swallowing that ENOENT would fall through to a SQLite
+    // open that creates a fresh empty database instead of surfacing the loss.
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    openOpenClawStateDatabase(options);
+    closeOpenClawStateDatabaseForTest();
+    chmodFailHook.error = chmodError("ENOENT");
+    chmodFailHook.failTargetSuffix = "openclaw.sqlite";
+    chmodFailHook.failProbe = false;
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(/ENOENT/);
+    // Guards against a vacuous pass if the main file were skipped before chmod.
+    expect(chmodFailHook.targets.some((target) => target.endsWith("openclaw.sqlite"))).toBe(true);
+  });
+
   it("repairs the schema when chmodSync throws ENOTSUP", () => {
     stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
     openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });

--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -13,14 +13,20 @@ const chmodFailHook = vi.hoisted(() => ({
   error: undefined as Error | undefined,
   calls: 0,
   failProbe: true,
+  failTargetSuffix: undefined as string | undefined,
+  targets: [] as string[],
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   const chmodSync: typeof actual.chmodSync = ((target: unknown, mode: unknown) => {
     chmodFailHook.calls += 1;
+    chmodFailHook.targets.push(String(target));
     const isProbe = String(target).includes(".openclaw-chmod-probe-");
-    if (chmodFailHook.error && (chmodFailHook.failProbe || !isProbe)) {
+    const matchesTarget =
+      chmodFailHook.failTargetSuffix === undefined ||
+      String(target).endsWith(chmodFailHook.failTargetSuffix);
+    if (chmodFailHook.error && matchesTarget && (chmodFailHook.failProbe || !isProbe)) {
       throw chmodFailHook.error;
     }
     return (actual.chmodSync as (...args: unknown[]) => unknown)(target, mode);
@@ -53,6 +59,8 @@ describe("state database permission hardening without chmod support", () => {
     chmodFailHook.error = undefined;
     chmodFailHook.calls = 0;
     chmodFailHook.failProbe = true;
+    chmodFailHook.failTargetSuffix = undefined;
+    chmodFailHook.targets = [];
     closeOpenClawStateDatabaseForTest();
     if (stateDir) {
       fs.rmSync(stateDir, { recursive: true, force: true });
@@ -133,6 +141,27 @@ describe("state database permission hardening without chmod support", () => {
     expect(() => openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } })).toThrow(
       /EACCES/,
     );
+  });
+
+  it("opens when a sidecar is deleted between the existence check and the chmod", () => {
+    // SQLite creates and removes -wal/-shm as connections open and checkpoint,
+    // so a concurrent opener can delete a sidecar after it is seen to exist.
+    // ENOENT then means there is nothing left to harden, not a fatal fault.
+    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    openOpenClawStateDatabase(options);
+    closeOpenClawStateDatabaseForTest();
+    // Present at the existence check so hardening reaches the chmod call.
+    const shmPath = join(stateDir, "state", "openclaw.sqlite-shm");
+    fs.writeFileSync(shmPath, "");
+    chmodFailHook.error = chmodError("ENOENT");
+    chmodFailHook.failTargetSuffix = "-shm";
+
+    const database = openOpenClawStateDatabase(options);
+
+    expect(database.db.isOpen).toBe(true);
+    // Guards against a vacuous pass if the sidecar were skipped before chmod.
+    expect(chmodFailHook.targets.some((target) => target.endsWith("-shm"))).toBe(true);
   });
 
   it("repairs the schema when chmodSync throws ENOTSUP", () => {

--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -13,7 +13,7 @@ const chmodFailHook = vi.hoisted(() => ({
   error: undefined as Error | undefined,
   calls: 0,
   failProbe: true,
-  failTargetSuffix: undefined as string | undefined,
+  removeTargetSuffix: undefined as string | undefined,
   targets: [] as string[],
 }));
 
@@ -22,11 +22,15 @@ vi.mock("node:fs", async (importOriginal) => {
   const chmodSync: typeof actual.chmodSync = ((target: unknown, mode: unknown) => {
     chmodFailHook.calls += 1;
     chmodFailHook.targets.push(String(target));
+    if (
+      chmodFailHook.removeTargetSuffix &&
+      String(target).endsWith(chmodFailHook.removeTargetSuffix)
+    ) {
+      // Remove the file after existsSync reaches chmod to reproduce the exact race.
+      actual.unlinkSync(String(target));
+    }
     const isProbe = String(target).includes(".openclaw-chmod-probe-");
-    const matchesTarget =
-      chmodFailHook.failTargetSuffix === undefined ||
-      String(target).endsWith(chmodFailHook.failTargetSuffix);
-    if (chmodFailHook.error && matchesTarget && (chmodFailHook.failProbe || !isProbe)) {
+    if (chmodFailHook.error && (chmodFailHook.failProbe || !isProbe)) {
       throw chmodFailHook.error;
     }
     return (actual.chmodSync as (...args: unknown[]) => unknown)(target, mode);
@@ -59,7 +63,7 @@ describe("state database permission hardening without chmod support", () => {
     chmodFailHook.error = undefined;
     chmodFailHook.calls = 0;
     chmodFailHook.failProbe = true;
-    chmodFailHook.failTargetSuffix = undefined;
+    chmodFailHook.removeTargetSuffix = undefined;
     chmodFailHook.targets = [];
     closeOpenClawStateDatabaseForTest();
     if (stateDir) {
@@ -143,26 +147,24 @@ describe("state database permission hardening without chmod support", () => {
     );
   });
 
-  it("opens when a sidecar is deleted between the existence check and the chmod", () => {
-    // SQLite creates and removes -wal/-shm as connections open and checkpoint,
-    // so a concurrent opener can delete a sidecar after it is seen to exist.
-    // ENOENT then means there is nothing left to harden, not a fatal fault.
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
-    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    openOpenClawStateDatabase(options);
-    closeOpenClawStateDatabaseForTest();
-    // Present at the existence check so hardening reaches the chmod call.
-    const shmPath = join(stateDir, "state", "openclaw.sqlite-shm");
-    fs.writeFileSync(shmPath, "");
-    chmodFailHook.error = chmodError("ENOENT");
-    chmodFailHook.failTargetSuffix = "-shm";
+  it.each(["-wal", "-shm", "-journal"])(
+    "opens when the %s sidecar disappears before chmod",
+    (suffix) => {
+      stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      openOpenClawStateDatabase(options);
+      closeOpenClawStateDatabaseForTest();
+      const sidecarPath = join(stateDir, "state", `openclaw.sqlite${suffix}`);
+      fs.writeFileSync(sidecarPath, "");
+      chmodFailHook.removeTargetSuffix = suffix;
 
-    const database = openOpenClawStateDatabase(options);
+      const database = openOpenClawStateDatabase(options);
 
-    expect(database.db.isOpen).toBe(true);
-    // Guards against a vacuous pass if the sidecar were skipped before chmod.
-    expect(chmodFailHook.targets.some((target) => target.endsWith("-shm"))).toBe(true);
-  });
+      expect(database.db.isOpen).toBe(true);
+      expect(fs.existsSync(sidecarPath)).toBe(false);
+      expect(chmodFailHook.targets).toContain(sidecarPath);
+    },
+  );
 
   it("rethrows when the main database vanishes between the existence check and the chmod", () => {
     // resolveSqliteDatabaseFilePaths lists the unsuffixed database first. Losing
@@ -172,9 +174,7 @@ describe("state database permission hardening without chmod support", () => {
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     openOpenClawStateDatabase(options);
     closeOpenClawStateDatabaseForTest();
-    chmodFailHook.error = chmodError("ENOENT");
-    chmodFailHook.failTargetSuffix = "openclaw.sqlite";
-    chmodFailHook.failProbe = false;
+    chmodFailHook.removeTargetSuffix = "openclaw.sqlite";
 
     expect(() => openOpenClawStateDatabase(options)).toThrow(/ENOENT/);
     // Guards against a vacuous pass if the main file were skipped before chmod.


### PR DESCRIPTION
## Problem

OpenClaw can abort a shared state database open when SQLite removes an optional `-wal`, `-shm`, or `-journal` sidecar after the permission sweep observes it but before `chmod` runs.

## Root cause

The shared state permission owner checked each SQLite file with `existsSync` and then hardened it. SQLite can remove sidecars inside that time-of-check/time-of-use window. The generic permission helper correctly treats `ENOENT` as fatal because other credentials-adjacent targets are required.

## Fix

The shared state permission owner now ignores `ENOENT` only for a suffixed SQLite sidecar that vanished after the existence check. It still rethrows main database `ENOENT` and every other permission error. This prevents a missing main database from falling through to a writable SQLite open that could create an empty replacement.

## Proof

- Exact current-main red: a deterministic fault removed each existing sidecar inside `chmod`; the real state database open aborted with `ENOENT` for `-wal`, `-shm`, and `-journal`.
- Exact-head green: the same three sidecar cases opened successfully, while the identical main database removal remained fatal.
- Focused state coverage: 191 tests passed across the permission and state database suites.
- Local guards: formatting, lint, assertion safety, max-lines, conflict markers, and native schema checks passed.
- Exact-head CI: run `33256187233` passed for `1ff92f61d55bd2214a83561b9373b998b8568f7d`.

## Change size

- Production: +13/-1 lines.
- Tests: +46/-0 lines.

The production growth keeps the exception at the only boundary that knows the main file from optional SQLite sidecars. Moving `ENOENT` into the generic permission helper would weaken unrelated required-file checks.

AI-assisted: yes. The contributor and maintainer verified the failure path, SQLite lifecycle contract, owner boundary, and exact-head behavior.
