### PR TITLE
fix(release): authenticate performance health probes

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -779,6 +779,7 @@ jobs:
           gateway_home="$(mktemp -d)"
           gateway_readiness_home="$(mktemp -d)"
           gateway_port="$(node -e "const net=require('node:net'); const s=net.createServer(); s.listen(0,'127.0.0.1',()=>{ console.log(s.address().port); s.close(); });")"
+          gateway_token="$(node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))")"
           gateway_state="$gateway_home/.openclaw"
           gateway_config="$gateway_state/openclaw.json"
           gateway_readiness_state="$gateway_readiness_home/.openclaw"
@@ -803,7 +804,7 @@ jobs:
               "mode": "local",
               "port": ${gateway_port},
               "bind": "loopback",
-              "auth": { "mode": "none" },
+              "auth": { "mode": "token" },
               "controlUi": { "enabled": false },
               "tailscale": { "mode": "off" }
             },
@@ -823,8 +824,8 @@ jobs:
             rm -rf "$gateway_home" "$gateway_readiness_home"
           }
           trap cleanup_gateway EXIT
-          OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_CRON=1 \
-            node dist/entry.js gateway run --bind loopback --port "$gateway_port" --auth none --allow-unconfigured --force \
+          OPENCLAW_GATEWAY_TOKEN="$gateway_token" OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_CRON=1 \
+            node dist/entry.js gateway run --bind loopback --port "$gateway_port" --auth token --allow-unconfigured --force \
             >"$gateway_log" 2>&1 &
           gateway_pid="$!"
 
@@ -853,7 +854,7 @@ jobs:
             sleep 1
           done
 
-          # Exercise the real WebSocket handshake and health RPC without warming benchmark device state.
+          # Exercise the same shared-secret WebSocket path without creating benchmark device state.
           while true; do
             gateway_ready_remaining=$((gateway_ready_deadline - SECONDS))
             if (( gateway_ready_remaining <= 0 )); then
@@ -863,7 +864,7 @@ jobs:
               exit 1
             fi
             gateway_ready_remaining_ms=$((gateway_ready_remaining * 1000))
-            if OPENCLAW_HOME="$gateway_readiness_home" OPENCLAW_STATE_DIR="$gateway_readiness_state" OPENCLAW_CONFIG_PATH="$gateway_readiness_config" \
+            if OPENCLAW_GATEWAY_TOKEN="$gateway_token" OPENCLAW_HOME="$gateway_readiness_home" OPENCLAW_STATE_DIR="$gateway_readiness_state" OPENCLAW_CONFIG_PATH="$gateway_readiness_config" \
               node dist/entry.js gateway health \
                 --port "$gateway_port" \
                 --timeout "$gateway_ready_remaining_ms" \
@@ -882,11 +883,11 @@ jobs:
             fi
           done
 
-          OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
+          OPENCLAW_GATEWAY_TOKEN="$gateway_token" OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
             node --import tsx "$PERFORMANCE_HELPER_DIR/scripts/bench-cli-startup.ts" \
             --entry "$GITHUB_WORKSPACE/openclaw.mjs" \
-            --case gatewayHealthJsonConnected \
-            --case gatewayHealthJsonFirstDevice \
+            --case gatewayHealthJsonWarmState \
+            --case gatewayHealthJsonFreshState \
             --case configGetGatewayPort \
             --runs "$source_runs" \
             --warmup 1 \

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -453,17 +453,18 @@ const COMMAND_CASES: readonly CommandCase[] = [
     expectedNonzeroOutputIncludes: ['"ok"', '"gateway_transport_error"'],
   },
   {
-    id: "gatewayHealthJsonConnected",
-    name: "gateway health --json (connected)",
+    id: "gatewayHealthJsonWarmState",
+    name: "gateway health --json (warm state)",
     args: ["gateway", "health", "--json"],
     presets: [],
     stateScope: "case",
   },
   {
-    id: "gatewayHealthJsonFirstDevice",
-    name: "gateway health --json (first device)",
+    id: "gatewayHealthJsonFreshState",
+    name: "gateway health --json (fresh state)",
     args: ["gateway", "health", "--json"],
     presets: [],
+    stateScope: "sample",
   },
   {
     id: "configGetGatewayPort",
@@ -689,11 +690,13 @@ function collectExitSummary(samples: Sample[]): string {
 }
 
 function buildConfigFixture(commandCase: CommandCase): Record<string, unknown> | null {
+  const usesSharedToken =
+    commandCase.id === "gatewayHealthJsonWarmState" ||
+    commandCase.id === "gatewayHealthJsonFreshState";
   if (
     commandCase.id !== "configGetGatewayPort" &&
     commandCase.id !== "gatewayHealthJson" &&
-    commandCase.id !== "gatewayHealthJsonConnected" &&
-    commandCase.id !== "gatewayHealthJsonFirstDevice" &&
+    !usesSharedToken &&
     commandCase.id !== "health" &&
     commandCase.id !== "healthJson"
   ) {
@@ -702,7 +705,7 @@ function buildConfigFixture(commandCase: CommandCase): Record<string, unknown> |
   const port = parseGatewayPortEnv(process.env.OPENCLAW_GATEWAY_PORT);
   return {
     gateway: {
-      auth: { mode: "none" },
+      auth: { mode: usesSharedToken ? "token" : "none" },
       bind: "loopback",
       mode: "local",
       port,

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -424,11 +424,25 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
   );
 }
 
-export function releaseEvidenceVerificationArgs(parentRunId: unknown) {
+export function releaseEvidenceVerificationArgs(
+  parentRunId: unknown,
+  verifierSourceSha: string,
+  verifierSourceFile: string,
+) {
   if (!/^[1-9][0-9]*$/u.test(String(parentRunId))) {
     throw new Error("parent run ID must be a positive decimal");
   }
-  return ["--validate-run", String(parentRunId), "--trusted-workflow-ref", "main", "--json"];
+  return [
+    "--validate-run",
+    String(parentRunId),
+    "--trusted-workflow-ref",
+    "main",
+    "--json",
+    "--verifier-source-sha",
+    verifierSourceSha,
+    "--verifier-source-file",
+    verifierSourceFile,
+  ];
 }
 
 export function shouldDeleteTemporaryWorkflowRef(params: TemporaryRefParams) {
@@ -502,7 +516,10 @@ function verifyReleaseEvidence(parentRunId: string, workflowSha: string) {
     });
     const verifier = releaseEvidenceVerifierPath(verifierWorktree);
     const evidence: unknown = JSON.parse(
-      run(process.execPath, [verifier, ...releaseEvidenceVerificationArgs(parentRunId)]),
+      run(process.execPath, [
+        verifier,
+        ...releaseEvidenceVerificationArgs(parentRunId, workflowSha, verifier),
+      ]),
     );
     if (
       !isJsonRecord(evidence) ||

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -326,8 +326,8 @@ describe("bench-cli-startup", () => {
         entry: "dist/entry.js",
         cases: [
           {
-            id: "gatewayHealthJsonConnected",
-            name: "gateway health --json (connected)",
+            id: "gatewayHealthJsonWarmState",
+            name: "gateway health --json (warm state)",
             args: ["gateway", "health", "--json"],
             contract: null,
             warmupSamples: [{ ...passingSample, exitCode: 1 }],
@@ -342,7 +342,7 @@ describe("bench-cli-startup", () => {
           },
         ],
       }),
-    ).toEqual(["dist/entry.js gatewayHealthJsonConnected warmup 1: exited with code 1"]);
+    ).toEqual(["dist/entry.js gatewayHealthJsonWarmState warmup 1: exited with code 1"]);
   });
 
   it("fails reports with samples that did not report RSS", () => {
@@ -476,7 +476,7 @@ describe("bench-cli-startup", () => {
   });
 
   it("writes a config fixture for config get benchmarks", () => {
-    const expectedFixture = {
+    const unauthenticatedFixture = {
       gateway: {
         auth: { mode: "none" },
         bind: "loopback",
@@ -497,18 +497,6 @@ describe("bench-cli-startup", () => {
         args: ["gateway", "health", "--json"],
         presets: ["real"],
       },
-      {
-        id: "gatewayHealthJsonConnected",
-        name: "gateway health --json (connected)",
-        args: ["gateway", "health", "--json"],
-        presets: [],
-      },
-      {
-        id: "gatewayHealthJsonFirstDevice",
-        name: "gateway health --json (first device)",
-        args: ["gateway", "health", "--json"],
-        presets: [],
-      },
       { id: "health", name: "health", args: ["health"], presets: ["startup", "real"] },
       {
         id: "healthJson",
@@ -521,7 +509,35 @@ describe("bench-cli-startup", () => {
         withEnv({ OPENCLAW_GATEWAY_PORT: undefined }, () =>
           testing.buildConfigFixture(commandCase),
         ),
-      ).toEqual(expectedFixture);
+      ).toEqual(unauthenticatedFixture);
+    }
+
+    for (const commandCase of [
+      {
+        id: "gatewayHealthJsonWarmState",
+        name: "gateway health --json (warm state)",
+        args: ["gateway", "health", "--json"],
+        presets: [],
+      },
+      {
+        id: "gatewayHealthJsonFreshState",
+        name: "gateway health --json (fresh state)",
+        args: ["gateway", "health", "--json"],
+        presets: [],
+      },
+    ]) {
+      expect(
+        withEnv({ OPENCLAW_GATEWAY_PORT: undefined }, () =>
+          testing.buildConfigFixture(commandCase),
+        ),
+      ).toEqual({
+        gateway: {
+          auth: { mode: "token" },
+          bind: "loopback",
+          mode: "local",
+          port: 32123,
+        },
+      });
     }
   });
 
@@ -534,8 +550,8 @@ describe("bench-cli-startup", () => {
 
     for (const id of [
       "gatewayHealthJson",
-      "gatewayHealthJsonConnected",
-      "gatewayHealthJsonFirstDevice",
+      "gatewayHealthJsonWarmState",
+      "gatewayHealthJsonFreshState",
     ]) {
       expect(
         withEnv({ OPENCLAW_GATEWAY_PORT: "45678" }, () =>

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -34,7 +34,7 @@ describe("CLI startup benchmark script spawners", () => {
     );
   });
 
-  it("reuses warmed state for gateway health while isolating first-device samples", () => {
+  it("reuses warm state for gateway health while isolating fresh-state samples", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-state-scope-test-"));
     try {
       const fixturePath = path.join(tmpDir, "record-home.mjs");
@@ -84,7 +84,7 @@ describe("CLI startup benchmark script spawners", () => {
         };
       };
 
-      const warmed = runCase("gatewayHealthJsonConnected");
+      const warmed = runCase("gatewayHealthJsonWarmState");
       const warmedHomes = warmed.homes;
       expect(warmedHomes).toHaveLength(3);
       expect(new Set(warmedHomes).size).toBe(1);
@@ -98,7 +98,7 @@ describe("CLI startup benchmark script spawners", () => {
         expect(Date.parse(sample.endedAt)).toBeGreaterThanOrEqual(Date.parse(sample.startedAt));
       }
 
-      for (const caseId of ["gatewayHealthJson", "gatewayHealthJsonFirstDevice"]) {
+      for (const caseId of ["gatewayHealthJson", "gatewayHealthJsonFreshState"]) {
         const sampleHomes = runCase(caseId).homes;
         expect(sampleHomes).toHaveLength(3);
         expect(new Set(sampleHomes).size).toBe(3);
@@ -109,7 +109,7 @@ describe("CLI startup benchmark script spawners", () => {
     }
   });
 
-  it("requires connected gateway health probes to exit successfully", () => {
+  it("requires authenticated gateway health probes to exit successfully", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-connected-test-"));
     try {
       const fixturePath = path.join(tmpDir, "transport-error.mjs");
@@ -142,7 +142,7 @@ describe("CLI startup benchmark script spawners", () => {
         );
 
       expect(runCase("gatewayHealthJson").status).toBe(0);
-      for (const caseId of ["gatewayHealthJsonConnected", "gatewayHealthJsonFirstDevice"]) {
+      for (const caseId of ["gatewayHealthJsonWarmState", "gatewayHealthJsonFreshState"]) {
         const result = runCase(caseId);
         expect(result.status).toBe(1);
         expect(result.stderr).toContain(`${caseId} sample 1: exited with code 1`);

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -58,7 +58,19 @@ on:
   );
   writeFileSync(
     join(checkout, "scripts", "release-ci-summary.mjs"),
-    'console.log(JSON.stringify({ valid: true, current: { runId: "123" }, root: { runId: "123" }, evidenceReuse: false }));\n',
+    `const expected = [
+  "--validate-run", "123",
+  "--trusted-workflow-ref", "main",
+  "--json",
+  "--verifier-source-sha", process.env.MOCK_WORKFLOW_SHA,
+  "--verifier-source-file", process.argv[1],
+];
+if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(expected)) {
+  console.error("unexpected verifier args: " + JSON.stringify(process.argv.slice(2)));
+  process.exit(2);
+}
+console.log(JSON.stringify({ valid: true, current: { runId: "123" }, root: { runId: "123" }, evidenceReuse: false }));
+`,
   );
   runGit(checkout, ["add", "."]);
   runGit(checkout, ["commit", "-m", "test: trusted workflow"]);
@@ -274,14 +286,22 @@ describe("full-release-validation-at-sha", () => {
   });
 
   it("validates direct and reused runs through the strict evidence verifier", () => {
-    expect(releaseEvidenceVerificationArgs("123")).toEqual([
+    const workflowSha = "a".repeat(40);
+    const verifier = "/tmp/trusted/scripts/release-ci-summary.mjs";
+    expect(releaseEvidenceVerificationArgs("123", workflowSha, verifier)).toEqual([
       "--validate-run",
       "123",
       "--trusted-workflow-ref",
       "main",
       "--json",
+      "--verifier-source-sha",
+      workflowSha,
+      "--verifier-source-file",
+      verifier,
     ]);
-    expect(() => releaseEvidenceVerificationArgs("")).toThrow("positive decimal");
+    expect(() => releaseEvidenceVerificationArgs("", workflowSha, verifier)).toThrow(
+      "positive decimal",
+    );
   });
 
   it("bounds polling for the exact workflow run", () => {

--- a/test/scripts/openclaw-performance-source-isolation.test.ts
+++ b/test/scripts/openclaw-performance-source-isolation.test.ts
@@ -86,6 +86,7 @@ record_env() {
     printf 'OPENCLAW_STATE_DIR=%s\\n' "\${OPENCLAW_STATE_DIR-<unset>}"
     printf 'OPENCLAW_CONFIG_PATH=%s\\n' "\${OPENCLAW_CONFIG_PATH-<unset>}"
     printf 'OPENCLAW_GATEWAY_PORT=%s\\n' "\${OPENCLAW_GATEWAY_PORT-<unset>}"
+    printf 'OPENCLAW_GATEWAY_TOKEN=%s\\n' "\${OPENCLAW_GATEWAY_TOKEN-<unset>}"
     printf 'OPENCLAW_SKIP_CHANNELS=%s\\n' "\${OPENCLAW_SKIP_CHANNELS-<unset>}"
     printf 'OPENCLAW_SKIP_CRON=%s\\n' "\${OPENCLAW_SKIP_CRON-<unset>}"
   } > "$CAPTURE_DIR/$1.env"
@@ -195,6 +196,7 @@ exit "$RG_STATUS"
       for (const name of [
         "OPENCLAW_SKIP_CRON",
         "OPENCLAW_SKIP_CHANNELS",
+        "OPENCLAW_GATEWAY_TOKEN",
         "BASH_ENV",
         "ENV",
         "BASHOPTS",
@@ -247,6 +249,7 @@ exit "$RG_STATUS"
       expect(readFileSync(join(captureDir, "benchmark.config"), "utf8")).toBe(gatewayConfig);
       parse(gatewayConfig, { uniqueKeys: true });
       const parsedConfig = JSON.parse(gatewayConfig) as {
+        gateway?: { auth?: Record<string, unknown> };
         models?: { catalogRefresh?: { enabled?: boolean } };
       };
       expect(parsedConfig).toMatchObject({
@@ -257,13 +260,14 @@ exit "$RG_STATUS"
           mode: "local",
           port: Number(gatewayPort),
           bind: "loopback",
-          auth: { mode: "none" },
+          auth: { mode: "token" },
           controlUi: { enabled: false },
           tailscale: { mode: "off" },
         },
         plugins: { enabled: true, entries: { browser: { enabled: false } } },
       });
       expect(JSON.stringify(parsedConfig)).not.toContain('"dreaming":');
+      expect(parsedConfig.gateway?.auth).toEqual({ mode: "token" });
       if (expectsCatalogRefresh) {
         expect(parsedConfig.models?.catalogRefresh?.enabled).toBe(false);
       } else {
@@ -306,6 +310,9 @@ exit "$RG_STATUS"
       expect(benchmarkEnv.OPENCLAW_CONFIG_PATH).toBe(gatewayConfigPath);
       expect(benchmarkEnv.OPENCLAW_GATEWAY_PORT).toBe(gatewayPort);
       expect(gatewayEnv.OPENCLAW_GATEWAY_PORT).toBe(gatewayPort);
+      expect(gatewayEnv.OPENCLAW_GATEWAY_TOKEN).toMatch(/^[0-9a-f]{64}$/u);
+      expect(healthEnv.OPENCLAW_GATEWAY_TOKEN).toBe(gatewayEnv.OPENCLAW_GATEWAY_TOKEN);
+      expect(benchmarkEnv.OPENCLAW_GATEWAY_TOKEN).toBe(gatewayEnv.OPENCLAW_GATEWAY_TOKEN);
       expect(healthHome).not.toBe(gatewayHome);
       expect(healthState).not.toBe(gatewayState);
       expect(healthConfigPath).not.toBe(gatewayConfigPath);
@@ -323,7 +330,7 @@ exit "$RG_STATUS"
         "--port",
         gatewayPort,
         "--auth",
-        "none",
+        "token",
         "--allow-unconfigured",
         "--force",
       ]);

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -390,8 +390,8 @@ describe("OpenClaw performance workflow", () => {
 
     expect(run).toContain('"$PERFORMANCE_HELPER_DIR/scripts/bench-cli-startup.ts"');
     expect(run).toContain('--entry "$GITHUB_WORKSPACE/openclaw.mjs"');
-    expect(run).toContain("--case gatewayHealthJsonConnected \\");
-    expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
+    expect(run).toContain("--case gatewayHealthJsonWarmState \\");
+    expect(run).toContain("--case gatewayHealthJsonFreshState \\");
   });
 
   it("isolates required publication in a fresh artifact-consuming job", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-tooling failure where Full Release Validation could complete its product matrix but the Performance child timed out probing a deliberately unpaired, empty-state Gateway. The no-auth benchmark harness assumed a fresh CLI health probe could connect without device state, while the current non-mutating probe correctly refuses to create or pair an identity.

The affected evidence is:

- Full Release Validation parent: https://github.com/openclaw/openclaw/actions/runs/32073510484
- Performance child: https://github.com/openclaw/openclaw/actions/runs/32073550002
- Failed source-performance job: https://github.com/openclaw/openclaw/actions/runs/32073550002/job/95521803309

The same release helper also relied on implicit detached-checkout identity when verifying trusted producer lineage, which could reject an otherwise trusted workflow checkout before reporting the real child failure.

## Why This Change Was Made

The Performance workflow now generates one cryptographically random ephemeral token, configures the Gateway for token auth without persisting the token in config, and exposes the token only to the Gateway process, readiness probe, and benchmark process. The benchmark cases now describe the observable state accurately: warm state reuses one case-scoped home, while fresh state uses a sample-scoped home. No device identity is created, no pairing occurs, and no security check is bypassed. This also remains compatible with frozen release targets through the long-shipped `OPENCLAW_GATEWAY_TOKEN` and token-auth behavior.

The exact-SHA helper now binds strict verification to both the trusted workflow SHA and the exact verifier file from its detached tooling checkout. This removes ambient checkout identity from the lineage decision.

This is tooling-only. Product runtime LOC is 0, and release Code SHA `19dce6ceef2f3151d440dfccac516f1d0aaf52b9` is unchanged. There is no SDK, config, protocol, SQLite, dependency, package metadata, locale, changelog, tag, npm, release-ref, or publication change.

## User Impact

Release operators can rerun Performance and Full Release Validation against the frozen Code SHA without weakening Gateway security or mutating benchmark device state. Normal OpenClaw users see no runtime behavior change.

## Evidence

Focused tooling coverage (83/83):

```text
node scripts/run-vitest.mjs test/scripts/bench-cli-startup.test.ts test/scripts/cli-startup-bench-spawner.test.ts test/scripts/full-release-validation-at-sha.test.ts test/scripts/openclaw-performance-source-isolation.test.ts test/scripts/openclaw-performance-workflow.test.ts
```

Gateway probe/auth and CLI health coverage (25/25):

```text
node scripts/run-vitest.mjs src/gateway/probe-auth.test.ts src/gateway/server-methods/health.owner-routing.test.ts src/cli/gateway-cli/health-route.test.ts
```

Additional gates:

```text
node scripts/check-changed.mjs -- .github/workflows/openclaw-performance.yml scripts/bench-cli-startup.ts scripts/full-release-validation-at-sha.mts test/scripts/bench-cli-startup.test.ts test/scripts/cli-startup-bench-spawner.test.ts test/scripts/full-release-validation-at-sha.test.ts test/scripts/openclaw-performance-source-isolation.test.ts test/scripts/openclaw-performance-workflow.test.ts
pnpm check:workflows
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local --engine codex
```

`check:workflows` passed including zizmor. The fresh Codex review passed TruffleHog and reported no accepted/actionable findings (`overall: patch is correct (0.98)`).

LOC: tooling/workflows `+39/-18`; tests `+73/-30`; product runtime `+0/-0`.

Known gap: the repaired workflow itself must be rerun after merge with the new trusted Tooling SHA against the unchanged release Code SHA.
