### PR TITLE
docs(onboard): match classic setup order

### DIFF
--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -470,9 +470,10 @@ and troubleshooting see the main [FAQ](/help/faq).
     2. **Workspace** - location + bootstrap files.
     3. **Gateway** - port, bind address, auth mode, Tailscale exposure.
     4. **Channels** - built-in and official plugin chat channels: iMessage, Discord, Feishu, Google Chat, Mattermost, Microsoft Teams, QQ Bot, Signal, Slack, Telegram, WhatsApp, and more.
-    5. **Daemon** - LaunchAgent (macOS), systemd user unit (Linux/WSL2), or native Windows Scheduled Task.
-    6. **Health check** - starts the Gateway and verifies it is running.
-    7. **Skills** - installs recommended skills and optional dependencies.
+    5. **Web search** - configures an optional search provider.
+    6. **Skills** - installs recommended skills and optional dependencies.
+    7. **Daemon** - LaunchAgent (macOS), systemd user unit (Linux/WSL2), or native Windows Scheduled Task.
+    8. **Health check** - starts the Gateway and verifies it is running.
 
     It sets duration expectations up front and warns if your configured model is unknown
     or missing auth. Full breakdown: [Onboarding (CLI)](/start/wizard).

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -133,6 +133,13 @@ behavior and outputs, see [CLI setup reference](/start/wizard-cli-reference).
     - Configure later: `openclaw configure --section web`.
 
   </Step>
+  <Step title="Skills (recommended)">
+    - Reads the available skills and checks requirements.
+    - Lets you choose a node manager: **npm / pnpm / bun**.
+    - Auto-installs optional dependencies for trusted bundled skills (some use Homebrew on macOS).
+    - Skips skills whose Homebrew, uv, or Go installer prerequisite is unavailable, groups them with manual setup guidance, and points you at `openclaw doctor` once the prerequisite is installed.
+
+  </Step>
   <Step title="Daemon install">
     - macOS: LaunchAgent
       - Requires a logged-in user session; for headless, use a custom LaunchDaemon (not shipped).
@@ -149,13 +156,6 @@ behavior and outputs, see [CLI setup reference](/start/wizard-cli-reference).
   <Step title="Health check">
     - Starts the Gateway (if needed) and runs `openclaw health`.
     - Tip: `openclaw status --deep` adds the live gateway health probe to status output, including channel probes when supported (requires a reachable gateway).
-
-  </Step>
-  <Step title="Skills (recommended)">
-    - Reads the available skills and checks requirements.
-    - Lets you choose a node manager: **npm / pnpm / bun**.
-    - Auto-installs optional dependencies for trusted bundled skills (some use Homebrew on macOS).
-    - Skips skills whose Homebrew, uv, or Go installer prerequisite is unavailable, groups them with manual setup guidance, and points you at `openclaw doctor` once the prerequisite is installed.
 
   </Step>
   <Step title="Finish">

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -21,9 +21,9 @@ Local mode (default) walks you through:
 - Gateway settings (port, bind, auth, Tailscale)
 - Channels and providers (Discord, Feishu, Google Chat, iMessage, Mattermost, Microsoft Teams, QQ Bot, Signal, Slack, Telegram, WhatsApp, and other bundled or plugin channels)
 - Web search provider (optional)
+- Skills setup
 - Daemon install (LaunchAgent, systemd user unit, or native Windows Scheduled Task with Startup-folder fallback)
 - Health check
-- Skills setup
 
 Remote mode configures this machine to connect to a Gateway elsewhere. It does
 not install or modify anything on the remote host.
@@ -98,6 +98,16 @@ not install or modify anything on the remote host.
     - Skip this step with `--skip-search`; reconfigure later with `openclaw configure --section web`.
 
   </Step>
+  <Step title="Skills">
+    - Reads available skills and checks requirements.
+    - Lets you choose node manager: npm, pnpm, or bun.
+    - Installs optional dependencies for trusted bundled skills when the required
+      installer is available.
+    - Skips unavailable Homebrew, uv, and Go installers, then groups the affected
+      skills with manual setup guidance. Run `openclaw doctor` after installing
+      the missing prerequisites.
+
+  </Step>
   <Step title="Daemon install">
     - macOS: LaunchAgent
       - Requires logged-in user session; for headless, use a custom LaunchDaemon (not shipped).
@@ -113,16 +123,6 @@ not install or modify anything on the remote host.
   <Step title="Health check">
     - Starts gateway (if needed) and runs `openclaw health`.
     - `openclaw status --deep` adds the live gateway health probe to status output, including channel probes when supported.
-
-  </Step>
-  <Step title="Skills">
-    - Reads available skills and checks requirements.
-    - Lets you choose node manager: npm, pnpm, or bun.
-    - Installs optional dependencies for trusted bundled skills when the required
-      installer is available.
-    - Skips unavailable Homebrew, uv, and Go installers, then groups the affected
-      skills with manual setup guidance. Run `openclaw doctor` after installing
-      the missing prerequisites.
 
   </Step>
   <Step title="Finish">

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -188,7 +188,9 @@ Local mode (default) walks through these steps:
 4. **Channels** - built-in and official plugin chat channels, including
    Discord, Feishu, Google Chat, iMessage, Mattermost, Microsoft Teams,
    QQ Bot, Signal, Slack, Telegram, WhatsApp, and more.
-5. **Daemon** - installs a LaunchAgent (macOS), a systemd user unit
+5. **Web search** - configures an optional search provider.
+6. **Skills** - installs recommended skills and their optional dependencies.
+7. **Daemon** - installs a LaunchAgent (macOS), a systemd user unit
    (Linux/WSL2), or a native Windows Scheduled Task with a per-user
    Startup-folder fallback.
    If token auth is required and `gateway.auth.token` is SecretRef-managed,
@@ -197,8 +199,7 @@ Local mode (default) walks through these steps:
    install with guidance. If both `gateway.auth.token` and
    `gateway.auth.password` are set while `gateway.auth.mode` is unset, install
    is blocked until you set the mode explicitly.
-6. **Health check** - starts the Gateway and verifies it is reachable.
-7. **Skills** - installs recommended skills and their optional dependencies.
+8. **Health check** - starts the Gateway and verifies it is reachable.
 
 <Note>
 Re-running onboarding does **not** wipe anything unless you pass `--reset`.


### PR DESCRIPTION
Related: #124712

## What Problem This Solves

Fixes a remaining documentation mismatch where classic onboarding references placed Skills after daemon installation and health checks, and one overview omitted Web search entirely.

## Why This Change Was Made

The four affected sequence descriptions now match the runtime owner: after workspace, model/auth, Gateway, and channels, `runSetupWizard` runs Web search and Skills before entering `finalizeSetupWizard`, which owns daemon installation and health checks. No other onboarding wording changed.

## User Impact

Operators following the classic onboarding docs now see the prompts in the order the CLI actually presents them.

## Evidence

- Runtime source: `src/wizard/setup.ts` runs `runSearchSetupFlow` and `setupSkills` before calling `finalizeSetupWizard`; `src/wizard/setup.finalize.ts` begins finalization with daemon setup and then health.
- `pnpm docs:list` — passed.
- `node scripts/check-docs-mdx.mjs docs README.md` — 776 files passed.
- `node scripts/docs-link-audit.mjs` — 6,518 internal links checked, 0 broken.
- `node scripts/check-docs-config-examples.mjs` — 1,177 fences validated.
- Target oxfmt and `git diff --check` — passed.
- `node scripts/check-changed.mjs -- docs/help/faq-first-run.md docs/reference/wizard.md docs/start/wizard-cli-reference.md docs/start/wizard.md` — docs-only lane passed.
- Fresh Codex autoreview — no actionable findings (0.99 confidence).

Docs delta: +2 lines across four existing pages. Production/test delta: 0.

AI-assisted: yes. No agent transcript is included.
