### PR TITLE
test(ui): stop cloud-workers save assertions racing form state

### DIFF
--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -77,6 +77,8 @@ suite.define(() => {
       await page.getByRole("button", { name: "Add profile" }).click();
       await page.getByLabel("Profile ID").fill("build-fleet");
       await page.getByLabel("Crabbox backend").fill("hetzner");
+      await expect.poll(() => page.getByLabel("Profile ID").inputValue()).toBe("build-fleet");
+      await expect.poll(() => page.getByLabel("Crabbox backend").inputValue()).toBe("hetzner");
       await gateway.deferNext("config.patch");
       const addRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();
@@ -139,6 +141,19 @@ suite.define(() => {
         .locator("wa-switch")
         .click();
       await page.getByLabel("Crabbox binary").fill("/opt/bin/crabbox");
+      await expect
+        .poll(() => page.getByLabel("Machine class", { exact: true }).inputValue())
+        .toBe("custom");
+      await expect.poll(() => page.getByLabel("Custom machine class").inputValue()).toBe("ccx53");
+      await expect.poll(() => page.getByLabel("Max lifetime").inputValue()).toBe("12h");
+      await expect
+        .poll(() =>
+          page.getByRole("switch", { name: "Desktop", exact: true }).getAttribute("aria-checked"),
+        )
+        .toBe("true");
+      await expect
+        .poll(() => page.getByLabel("Crabbox binary").inputValue())
+        .toBe("/opt/bin/crabbox");
       await gateway.deferNext("config.patch");
       const editRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();
@@ -195,6 +210,8 @@ suite.define(() => {
       await page.getByRole("button", { name: "Add profile" }).click();
       await page.getByLabel("Profile ID").fill("pending");
       await page.getByLabel("Crabbox backend").fill("aws");
+      await expect.poll(() => page.getByLabel("Profile ID").inputValue()).toBe("pending");
+      await expect.poll(() => page.getByLabel("Crabbox backend").inputValue()).toBe("aws");
       await gateway.deferNext("config.patch");
       const pendingRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();


### PR DESCRIPTION
## What Problem This Solves

`ui/src/e2e/cloud-workers-settings.e2e.test.ts` ("adds and edits profiles while distinguishing advertised
state") fails intermittently on CI — it blocked PR #125105 with `expected { Object (cloudWorkers) } to match
object { Object (cloudWorkers) }`, while passing on `main`, passing isolated on that branch (3/3), and
passing when run directly after an unrelated e2e in the same invocation (12/12).

The cause is the gap between the last edit and the Save click. The test fills several Web Awesome form
controls and toggles a `wa-switch`, then clicks Save immediately:

```js
await page.getByLabel("Custom machine class").fill("ccx53");
await page.getByLabel("Max lifetime").fill("12h");
await page.locator(".settings-row").filter({ hasText: "Desktop" }).locator("wa-switch").click();
await page.getByLabel("Crabbox binary").fill("/opt/bin/crabbox");
await gateway.deferNext("config.patch");
await page.getByRole("button", { name: "Save" }).click();
```

Nothing there proves those controls have committed their values to component state, so the patch can be
assembled from a value the form has not absorbed yet. The test synchronized on *when a request arrived*
rather than on the UI reaching an asserted state — a timing dependency in the shape of a wait.

## Why This Change Was Made

A settings test that fails under load teaches people to hit rerun, which is how a real serialization
regression would slip past. The fix makes the precondition explicit: before each Save, every edited control
is asserted to hold its new value — inputs by `inputValue()`, the Desktop switch by `aria-checked="true"` —
so the click cannot outrun the form. All three save paths in the file get the same treatment.

Deliberately unchanged: the `toMatchObject` expectations. Trimming fields from them, polling the assertion
until it matched, sleeping, or raising timeouts would each have made the test stop failing without making it
correct — and this case exists to catch exactly the class of bug where an edited field never reaches the
patch.

## User Impact

None. Test-only; no production file is touched.

## Evidence

Ten consecutive runs, since one green run says nothing about a race:

```
10/10 passed
```

```
pnpm test ui/src/e2e/cloud-workers-settings.e2e.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `0`, tests `+17 / −0` — pure addition, so no existing
assertion was relaxed to achieve it.

No `CHANGELOG.md` edit — release-only per repo policy; test-only change.
