### PR TITLE
fix(policy): derive exec posture from mode (#124797)

### DIFF
--- a/extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts
+++ b/extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts
@@ -854,6 +854,32 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it("accepts agent exec mode posture that matches policy", async () => {
+    const cfg = cfgWithPolicyOverrides({
+      agents: {
+        list: [{ id: "reviewer", tools: { exec: { mode: "ask" } } }],
+      },
+    });
+    const configPath = await writePolicyFixture({
+      scopes: {
+        reviewer: {
+          agentIds: ["reviewer"],
+          tools: {
+            exec: {
+              allowSecurity: ["allowlist"],
+              requireAsk: ["on-miss"],
+            },
+          },
+        },
+      },
+    });
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
   it("reports global and agent-scoped tool claims independently", async () => {
     const cfg = cfgWithPolicyOverrides({
       tools: {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1,6 +1,8 @@
 import { vi } from "vitest";
 
-vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async () => {
+vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/exec-approvals-runtime")>();
   const nodeFs = await import("node:fs");
   const nodePath = await import("node:path");
   const displayPath = () => {
@@ -10,6 +12,7 @@ vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async () => {
       : "~/.openclaw/state/openclaw.sqlite#exec_approvals_config";
   };
   return {
+    ...actual,
     resolveExecApprovalsDisplayPath: displayPath,
     readExecApprovalsSnapshot: () => {
       const fixtureRoot =

--- a/extensions/policy/src/policy-state-tool-posture.ts
+++ b/extensions/policy/src/policy-state-tool-posture.ts
@@ -1,3 +1,4 @@
+import { resolveExecModePolicy } from "openclaw/plugin-sdk/exec-approvals-runtime";
 import {
   asNonArrayRecord,
   isRecord,
@@ -6,6 +7,8 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { collectPolicyConfiguredAgents, ocPathSegment } from "./policy-state-helpers.js";
 import type { PolicyToolPostureEvidence } from "./policy-state-types.js";
+
+type ExecMode = "deny" | "allowlist" | "ask" | "auto" | "full";
 
 export function scanPolicyToolPosture(
   cfg: Record<string, unknown>,
@@ -112,28 +115,69 @@ function pushToolExecPosture(
 
   const localSecurity = readString(localExec.security);
   const inheritedSecurity = readString(inheritedExec.security);
+  const localAsk = readString(localExec.ask);
+  const inheritedAsk = readString(inheritedExec.ask);
+  const localMode = readExecMode(localExec.mode);
+  const inheritedMode = readExecMode(inheritedExec.mode);
   // Config conformance intentionally ignores exec-approvals.json runtime/operator state.
   const sandboxMode = readString(params.sandbox.mode) ?? readString(params.inheritedSandbox.mode);
   const sandboxCanApply = sandboxMode === "all";
+  const defaultSecurity =
+    host === "sandbox" || (host === "auto" && sandboxCanApply) ? "deny" : "full";
+  const selectedMode =
+    localMode === undefined
+      ? inheritedMode === undefined
+        ? undefined
+        : { value: inheritedMode, inherited: true }
+      : { value: localMode, inherited: false };
+  const modePosture =
+    selectedMode === undefined
+      ? undefined
+      : {
+          ...selectedMode,
+          // A selected mode owns both posture fields, so the resolver ignores legacy inputs.
+          ...resolveExecModePolicy({
+            mode: selectedMode.value,
+            security: "full",
+            ask: "off",
+          }),
+        };
+  const securityUsesMode =
+    modePosture?.inherited === false ||
+    (localSecurity === undefined && modePosture?.inherited === true);
+  const security =
+    modePosture?.inherited === false
+      ? modePosture.security
+      : (localSecurity ?? modePosture?.security ?? inheritedSecurity ?? defaultSecurity);
   pushToolPostureValue(entries, params, {
     suffix: "exec/security",
+    sourceSuffix: securityUsesMode ? "exec/mode" : undefined,
     kind: "execSecurity",
-    value:
-      localSecurity ??
-      inheritedSecurity ??
-      (host === "sandbox" || (host === "auto" && sandboxCanApply) ? "deny" : "full"),
-    explicit: localSecurity !== undefined || inheritedSecurity !== undefined,
-    inherited: localSecurity === undefined && inheritedSecurity !== undefined,
+    value: security,
+    explicit:
+      modePosture !== undefined || localSecurity !== undefined || inheritedSecurity !== undefined,
+    inherited:
+      modePosture?.inherited === true
+        ? localSecurity === undefined
+        : localSecurity === undefined && inheritedSecurity !== undefined,
   });
 
-  const localAsk = readString(localExec.ask);
-  const inheritedAsk = readString(inheritedExec.ask);
+  const askUsesMode =
+    modePosture?.inherited === false || (localAsk === undefined && modePosture?.inherited === true);
+  const ask =
+    modePosture?.inherited === false
+      ? modePosture.ask
+      : (localAsk ?? modePosture?.ask ?? inheritedAsk ?? "off");
   pushToolPostureValue(entries, params, {
     suffix: "exec/ask",
+    sourceSuffix: askUsesMode ? "exec/mode" : undefined,
     kind: "execAsk",
-    value: localAsk ?? inheritedAsk ?? "off",
-    explicit: localAsk !== undefined || inheritedAsk !== undefined,
-    inherited: localAsk === undefined && inheritedAsk !== undefined,
+    value: ask,
+    explicit: modePosture !== undefined || localAsk !== undefined || inheritedAsk !== undefined,
+    inherited:
+      modePosture?.inherited === true
+        ? localAsk === undefined
+        : localAsk === undefined && inheritedAsk !== undefined,
   });
 }
 
@@ -199,6 +243,7 @@ function pushToolPostureValue(
   params: ToolPostureParams,
   entry: {
     readonly suffix: string;
+    readonly sourceSuffix?: string;
     readonly kind: PolicyToolPostureEvidence["kind"];
     readonly value: boolean | string | undefined;
     readonly explicit: boolean;
@@ -208,12 +253,26 @@ function pushToolPostureValue(
   entries.push({
     id: `${params.id}-${entry.suffix.replaceAll("/", "-")}`,
     kind: entry.kind,
-    source: `${entry.inherited ? params.inheritedSourceBase : params.sourceBase}/${entry.suffix}`,
+    source: `${entry.inherited ? params.inheritedSourceBase : params.sourceBase}/${entry.sourceSuffix ?? entry.suffix}`,
     scope: params.scope,
     ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
     ...(entry.value === undefined ? {} : { value: entry.value }),
     explicit: entry.explicit,
   });
+}
+
+function readExecMode(value: unknown): ExecMode | undefined {
+  const mode = readString(value)?.toLowerCase();
+  switch (mode) {
+    case "deny":
+    case "allowlist":
+    case "ask":
+    case "auto":
+    case "full":
+      return mode;
+    default:
+      return undefined;
+  }
 }
 
 function pushToolPostureList(

--- a/extensions/policy/src/policy-state.test.ts
+++ b/extensions/policy/src/policy-state.test.ts
@@ -1,6 +1,7 @@
 // Policy tests cover policy state plugin behavior.
 import { describe, expect, it } from "vitest";
 import { scanPolicySandboxPosture } from "./policy-state-sandbox.js";
+import { scanPolicyToolPosture } from "./policy-state-tool-posture.js";
 import {
   collectPolicyEvidence,
   createPolicyAttestation,
@@ -194,6 +195,61 @@ describe("scanPolicySandboxPosture", () => {
           kind: "containerMount",
           bindSurface: "docker",
           bind: "/host/data:/data:ro",
+        }),
+      ]),
+    );
+  });
+});
+
+describe("scanPolicyToolPosture", () => {
+  it("derives exec posture from normalized agent entries", () => {
+    const evidence = scanPolicyToolPosture({
+      agents: {
+        entries: { reviewer: { tools: { exec: { mode: "ask" } } } },
+      },
+    });
+
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "reviewer-exec-security",
+          kind: "execSecurity",
+          value: "allowlist",
+          source: "oc://openclaw.config/agents/entries/reviewer/tools/exec/mode",
+          explicit: true,
+        }),
+        expect.objectContaining({
+          id: "reviewer-exec-ask",
+          kind: "execAsk",
+          value: "on-miss",
+          source: "oc://openclaw.config/agents/entries/reviewer/tools/exec/mode",
+          explicit: true,
+        }),
+      ]),
+    );
+  });
+
+  it("merges legacy agent fields with an inherited exec mode", () => {
+    const evidence = scanPolicyToolPosture({
+      tools: { exec: { mode: "auto" } },
+      agents: {
+        list: [{ id: "reviewer", tools: { exec: { ask: "always" } } }],
+      },
+    });
+
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "reviewer-exec-security",
+          kind: "execSecurity",
+          value: "allowlist",
+          source: "oc://openclaw.config/tools/exec/mode",
+        }),
+        expect.objectContaining({
+          id: "reviewer-exec-ask",
+          kind: "execAsk",
+          value: "always",
+          source: "oc://openclaw.config/agents/list/#0/tools/exec/ask",
         }),
       ]),
     );


### PR DESCRIPTION
## What Problem This Solves

`openclaw policy check` treated `tools.exec.mode: "ask"` as exec security `full` with asking disabled. This contradicted the documented permission-mode contract and produced false policy findings.

Fixes #124797

## Why This Change Was Made

The Policy evidence producer now selects the applicable local or inherited mode once and derives both posture fields through the existing `resolveExecModePolicy` owner. Local legacy `security` or `ask` overrides keep their existing precedence over an inherited mode. No new policy, fallback, configuration, or storage path was added.

The repair also removes the unused alternate agent-roster implementation from the earlier PR head.

## User Impact

`openclaw policy check` now agrees with the exec policy owner for mode-configured agents. Evidence points to `tools.exec.mode`, so operators can see which setting produced the posture.

## Evidence

- Current-main red at `c0cafd728947c55085dcd34742dd05d5adeab994`: the built CLI reported `full/off`, exited 1, and emitted both exec posture findings for `mode: "ask"`.
- Repaired-head green at `9b630b25c570caaf6fde654dddb9a35c85adde4b`: the same built CLI command reported `allowlist/on-miss`, exited 0, and emitted no findings.
- Anti-cheat probe: changing only the mode to `full` changed the repaired-head result to `full/off`, exit 1, with both findings restored.
- `node scripts/run-vitest.mjs extensions/policy/src/policy-state.test.ts extensions/policy/src/cli.test.ts extensions/policy/src/doctor/register.test.ts`: 363 passed.
- `pnpm check:changed`: passed, including extension production/test types, lint, formatting, plugin boundaries, doctor contracts, dead exports, and import cycles.
- Production delta: `+71/-12`; test and test-support delta: `+86/-1`. The mode mapping stays in the existing exec resolver, and the scanner adds only source and layer selection.

AI-assisted: built with Codex
