### PR TITLE
refactor(tooling): remove ratchet debris

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -70,7 +70,6 @@ const repositoryScriptEntries = [
   "scripts/ios-release-plan.ts!",
   "scripts/ios-release-signing.mts!",
   "scripts/lib/docker-plugin-selection.mjs!",
-  "scripts/lib/openclaw-test-state.mts!",
   "scripts/list-prod-store-packages.mjs!",
   // Invoked by scripts/lib/live-docker-stage.sh during container validation.
   "scripts/live-docker-normalize-config.ts!",

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -72,7 +72,6 @@ package-manager preflight:
 - Bounded focused proof with ready dependencies:
   `node scripts/run-vitest.mjs <path-or-filter>`.
 - Changed typecheck/lint/guard proof: `node scripts/check-changed.mjs`.
-- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree <local-heavy-check command>`: keeps heavy-check serialization inside the current worktree instead of the Git common dir for commands such as `pnpm check:changed` and targeted `pnpm test ...`. Use it only on high-capacity local hosts when you intentionally run independent checks across linked worktrees.
 
 For remote-environment proof, invoke `node scripts/crabbox-wrapper.mjs`
 directly. Avoid local `pnpm crabbox:run` in linked worktrees because pnpm may

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -543,23 +543,7 @@ export function createChangedCheckPlan(
     result.paths.some(
       (filePath) =>
         filePath === SHRINK_RATCHET_OWNER_PATH ||
-        /^(?:src\/|packages\/|extensions\/|config\/env-var-count-budget\.txt$|scripts\/check-env-var-count\.mts$)/u.test(
-          filePath,
-        ),
-    )
-  ) {
-    add("environment variable count ratchet", [
-      "check:env-var-count",
-      ...(options.staged ? ["--staged"] : []),
-      "--base",
-      options.staged ? "HEAD" : (options.base ?? "origin/main"),
-    ]);
-  }
-  if (
-    result.paths.some(
-      (filePath) =>
-        filePath === SHRINK_RATCHET_OWNER_PATH ||
-        /^(?:src\/|ui\/src\/|packages\/|extensions\/|\.oxlintrc\.json$|config\/max-lines-baseline\.txt$|scripts\/check-max-lines-ratchet\.mts$)/u.test(
+        /^(?:src\/|ui\/src\/|packages\/|extensions\/|\.oxlintrc\.json$|config\/(?:env-var-count-budget|max-lines-baseline)\.txt$|scripts\/check-(?:env-var-count|max-lines-ratchet)\.mts$)/u.test(
           filePath,
         ),
     )

--- a/scripts/check-env-var-count.mts
+++ b/scripts/check-env-var-count.mts
@@ -109,9 +109,7 @@ export function main(argv: string[] = process.argv.slice(2), root = process.cwd(
   }
   const budget = loadRatchetSnapshot(root, BUDGET_PATH, staged, parseBudget);
   const baseBudget = readBaseBudget(root, baseRef);
-  const approvedGrowth =
-    (baseBudget === 501 && budget === 502) || (baseBudget === 502 && budget === 503);
-  if (baseBudget !== null && !approvedGrowth) {
+  if (baseBudget !== null) {
     enforceRatchetScalar(budget, baseBudget, {
       increased: `OPENCLAW_* budget grew from ${baseBudget} to ${budget}`,
     });

--- a/scripts/check.mts
+++ b/scripts/check.mts
@@ -10,7 +10,6 @@ type RunManagedCheck = (options: { args: string[]; bin: string }) => Promise<num
 export const PREFLIGHT_CHECKS: CheckCommand[] = [
   { name: "conflict markers", args: ["check:no-conflict-markers"] },
   { name: "script TypeScript erasability", args: ["check:script-erasability"] },
-  { name: "environment variable count ratchet", args: ["check:env-var-count"] },
   { name: "max-lines suppression ratchet", args: ["check:max-lines-ratchet"] },
   { name: "assertion SAFETY comment ratchet", args: ["check:assertion-safety"] },
   { name: "changelog attributions", args: ["check:changelog-attributions"] },

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1392,7 +1392,6 @@ describe("scripts/changed-lanes", () => {
     });
     expect(plan.commands.map((command) => command.name)).toEqual([
       "conflict markers",
-      "environment variable count ratchet",
       "max-lines suppression ratchet",
       "assertion SAFETY comment ratchet",
       "changelog attributions",
@@ -2251,15 +2250,6 @@ describe("scripts/changed-lanes", () => {
       },
     },
     {
-      name: "adds the environment variable count ratchet for production source",
-      commandName: "environment variable count ratchet",
-      worktreeOptions: { base: "main" },
-      expected: {
-        worktree: ["check:env-var-count", "--base", "main"],
-        staged: ["check:env-var-count", "--staged", "--base", "HEAD"],
-      },
-    },
-    {
       name: "adds the assertion SAFETY comment ratchet for production source",
       commandName: "assertion SAFETY comment ratchet",
       worktreeOptions: { base: "main" },
@@ -2281,12 +2271,23 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
-  it("routes the shared shrink-ratchet owner to all three ratchets", () => {
+  it.each(["config/env-var-count-budget.txt", "scripts/check-env-var-count.mts"])(
+    "routes %s through the single baseline-ratchet entry",
+    (changedPath) => {
+      const commands = createChangedCheckPlan(detectChangedLanes([changedPath])).commands;
+
+      expect(commands).toContainEqual(
+        expect.objectContaining({ args: ["check:max-lines-ratchet", "--base", "origin/main"] }),
+      );
+      expect(commands.map((command) => command.args[0])).not.toContain("check:env-var-count");
+    },
+  );
+
+  it("routes the shared shrink-ratchet owner through both baseline entries", () => {
     const commands = createChangedCheckPlan(
       detectChangedLanes(["scripts/lib/shrink-ratchet.mts"]),
     ).commands.map((command) => command.args);
 
-    expect(commands).toContainEqual(["check:env-var-count", "--base", "origin/main"]);
     expect(commands).toContainEqual(["check:max-lines-ratchet", "--base", "origin/main"]);
     expect(commands).toContainEqual(["check:assertion-safety", "--base", "origin/main"]);
   });

--- a/test/scripts/check-env-var-count.test.ts
+++ b/test/scripts/check-env-var-count.test.ts
@@ -152,8 +152,8 @@ describe("check-env-var-count", () => {
   it.each([
     [501, 502],
     [502, 503],
-  ])("allows only the owner-approved %i to %i budget increase", (baseBudget, nextBudget) => {
-    const root = tempDirs.make("openclaw-env-count-approved-grow-");
+  ])("rejects the retired temporary %i to %i budget increase", (baseBudget, nextBudget) => {
+    const root = tempDirs.make("openclaw-env-count-retired-grow-");
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     const names = Array.from({ length: nextBudget + 1 }, (_, index) => `OPENCLAW_TEST_${index}`);
@@ -169,10 +169,6 @@ describe("check-env-var-count", () => {
 
     fs.writeFileSync(path.join(root, "src/runtime.ts"), names.slice(0, nextBudget).join("\n"));
     fs.writeFileSync(path.join(root, "config/env-var-count-budget.txt"), `${nextBudget}\n`);
-    expect(() => main(["--base", "HEAD"], root)).not.toThrow();
-
-    fs.writeFileSync(path.join(root, "src/runtime.ts"), names.join("\n"));
-    fs.writeFileSync(path.join(root, "config/env-var-count-budget.txt"), `${nextBudget + 1}\n`);
     expect(() => main(["--base", "HEAD"], root)).toThrow(/budget grew/u);
   });
 

--- a/test/scripts/check.test.ts
+++ b/test/scripts/check.test.ts
@@ -48,6 +48,14 @@ describe("scripts/check", () => {
   });
 
   it("keeps script policy guards in the aggregate preflight", () => {
+    expect(PREFLIGHT_CHECKS).not.toContainEqual({
+      name: "environment variable count ratchet",
+      args: ["check:env-var-count"],
+    });
+    expect(PREFLIGHT_CHECKS).toContainEqual({
+      name: "max-lines suppression ratchet",
+      args: ["check:max-lines-ratchet"],
+    });
     expect(PREFLIGHT_CHECKS).toContainEqual({
       name: "assertion SAFETY comment ratchet",
       args: ["check:assertion-safety"],


### PR DESCRIPTION
## What Problem This Solves

Resolves repository-check drift where temporary environment-budget exceptions could still admit growth and normal check paths repeated the same budget scan.

## Why This Change Was Made

The max-lines gate remains the canonical CI entry that chains the environment-budget ratchet, while aggregate and changed checks no longer invoke the budget scan separately. The freshly landed shared shrink-ratchet owner from #125301 remains unchanged. Stale Knip and test-lock documentation entries are removed.

## User Impact

No product behavior changes. Maintainers get a strictly shrink-only environment budget, one env scan per normal check path, and less stale tooling configuration.

## Evidence

- Pre-fix plan: source changes scheduled both `check:env-var-count` and `check:max-lines-ratchet`; the latter already chained the env check.
- Focused Vitest: 198 tests passed across the aggregate check, changed-lane, env-count, max-lines, assertion-safety, and shared shrink-ratchet suites.
- Executable ratchets: max-lines passed with 904 grandfathered suppressions; env count passed at 501/501 exactly once; assertion safety passed with 4,318 files and 13,706 grandfathered assertions.
- `node scripts/check-changed.mjs --base origin/main --head HEAD` passed, including format, script erasability, script/test typechecks, and script lint.
- `pnpm docs:list` and `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings.

Production LOC: +0/-0 | Tests: +23/-18 | Tooling/docs: +2/-23
