### PR TITLE
fix(discord): strip internal tool-trace scaffolding from outbound text

### DIFF
--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -16,6 +16,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatDiscordApprovalDisplayValue } from "./approval-message-safety.js";
 import { chunkDiscordTextWithMode } from "./chunk.js";
@@ -153,6 +154,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
     }),
   textChunkLimit: DISCORD_TEXT_CHUNK_LIMIT,
   pollMaxOptions: 10,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   normalizePayload: ({ payload }) => normalizeDiscordApprovalPayload(payload),
   presentationCapabilities: DISCORD_PRESENTATION_CAPABILITIES,
   deliveryCapabilities: {

--- a/src/channels/plugins/contracts/plugin-shape.contract.test.ts
+++ b/src/channels/plugins/contracts/plugin-shape.contract.test.ts
@@ -41,6 +41,7 @@ const SHARED_SANITIZER_CHANNEL_IDS = [
   "twitch",
   "matrix",
   "slack",
+  "discord",
 ] as const;
 const MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS = ["imessage", "slack"] as const;
 const SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS = ["feishu", "telegram"] as const;


### PR DESCRIPTION
## Summary

Discord's outbound adapter was one of the last bundled channels without a `sanitizeText` hook, so internal assistant scaffolding — `<tool_call>`/`<invoke>` XML, `<tool_result>` payloads, `<think>` blocks, `[Tool Call: …]` traces — was delivered verbatim to Discord channels and DMs. The adapter now applies the shared `sanitizeAssistantVisibleText` contract that slack, signal, irc, matrix, twitch, feishu, nextcloud-talk and zalo already wire.

## What Problem This Solves

The core delivery pipeline (`src/infra/outbound/deliver-payload.ts`) only strips internal *runtime-context* labels. Channel-visible tool traces are removed only when the channel's outbound adapter provides `sanitizeText`, which `deliver-channel.ts:304` wires into delivery. `discordOutbound` (`extensions/discord/src/outbound-adapter.ts:147`) defined no such hook, so outbound text was sent exactly as the model produced it — through both the bot and webhook persona send paths, which share this adapter.

Whenever a model's final text still contains tool-call scaffolding (verbose tool traces, thinking tags, exec-failure banners), Discord users see the raw internals — including tool arguments with local file paths.

**Code evidence**: before this change, `grep sanitizeText extensions/discord/src/` returned zero hits, while eight sibling channels wire the shared sanitizer and are pinned by the plugin-shape contract's `SHARED_SANITIZER_CHANNEL_IDS`. Discord was never enrolled, so the omission stayed invisible.

## Root Cause

- `discordOutbound` has carried no `sanitizeText` since the Discord implementation moved to `extensions/` in `5682ec37fad` ("refactor: move Discord channel implementation to extensions/ (#45660)").
- Violated invariant: the pipeline assumes every text-delivering channel opts into visible-text sanitization via `outbound.sanitizeText`; with no hook, `deliver-channel.ts` delivers the text unsanitized (`sanitizeText: outbound?.sanitizeText ? … : undefined`).
- Trigger: any assistant reply whose final text contains tool-call XML / thinking / tool-result scaffolding delivered over Discord.

## Why This Fix

- One line: `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)` — the exact shared-sanitizer shape used by slack (`extensions/slack/src/channel.ts:480`), signal, twitch and the other pinned channels, so Discord inherits the centrally maintained stripping rules instead of growing a bespoke regex.
- Applied at the adapter boundary (not inside Discord's send/chunk functions), so every outbound path — bot sends, webhook persona sends, forum posts, payload/components fallback — is covered through the single `deliver-channel.ts` wiring.
- Regression pin: `"discord"` added to `SHARED_SANITIZER_CHANNEL_IDS` in `plugin-shape.contract.test.ts`, which fails if the hook is removed or drifts from `sanitizeAssistantVisibleText` semantics.
- Rejected alternative: stripping inside Discord's chunker/send functions — that would miss the payload path and duplicate logic the shared sanitizer already owns.

## User Impact

- Before: Discord recipients could see raw `<tool_call>`/`<invoke>` markup, tool arguments (incl. local paths), and `<think>` content inline in bot messages.
- After: only the assistant's visible answer is delivered; scaffolding is removed before chunking and send. Normal message text is byte-identical to before.

## Evidence

- **Before**: on main, the adapter exposes no `sanitizeText`; a representative final-text payload reaches the delivery boundary with `<invoke …>`/`<tool_result>`/`<think>` intact → FAIL.
- **After**: same payload through the fixed adapter yields only `Visible answer for the Discord user.` → PASS.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
discordOutbound.sanitizeText present: false
--- text delivered to Discord ---
<invoke name="read">payload</invoke></minimax:tool_call>
<tool_result>{"output":"hidden"}</tool_result>
[Tool Call: read (ID: toolu_1)]
Arguments: {"path":"/tmp/x"}
<think>secret chain-of-thought</think>
Visible answer for the Discord user.
---------------------------------
FAIL: internal tool-trace scaffolding reaches Discord users unsanitized
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
discordOutbound.sanitizeText present: true
--- text delivered to Discord ---
Visible answer for the Discord user.
---------------------------------
PASS: internal scaffolding stripped, visible answer preserved
```

(The script imports the real `discordOutbound` adapter and applies it at the same boundary `deliver-channel.ts` uses: `outbound.sanitizeText` when present, raw text otherwise.)

### Media proof (screenshots)

**Before** — on `upstream/main` (`57c27b114b5`), scaffolding ships verbatim:

![before: discord outbound delivers tool-trace scaffolding](https://raw.githubusercontent.com/zenglingbiao/openclaw/proof-assets-20260809/proof/discord-sanitize-before.png)

**After** — on this branch (`75b160709eb`), only the visible answer remains:

![after: discord outbound strips internal scaffolding](https://raw.githubusercontent.com/zenglingbiao/openclaw/proof-assets-20260809/proof/discord-sanitize-after.png)

Full terminal transcripts and the proof script live at [`proof/`](https://github.com/zenglingbiao/openclaw/tree/proof-assets-20260809/proof) (`discord-sanitize-*.term` / `proof-discord-outbound-sanitize-text.mjs`).

## Tests and Validation

- `npx vitest run src/channels/plugins/contracts/plugin-shape.contract.test.ts` passed (620 tests — the shared-sanitizer contract now also pins `discord`)
- `npx vitest run extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/outbound-payload.contract.test.ts` passed (90 tests)
- `oxlint` and `oxfmt --check` clean on both touched files; `git diff --check` clean
- Proof above drives the real exported adapter with `node --import tsx`; before-run FAILs, after-run PASSes
