### PR TITLE
fix(voice-call): tear down realtime calls on stream close and media inactivity

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -276,6 +276,20 @@ Current runtime behavior:
 - `inboundPolicy` must not be `"disabled"` when `realtime.enabled` is true; `validateProviderConfig` rejects that combination.
 - Consult session keys reuse the stored call session when available, then fall back to the configured `sessionScope` (`per-phone` by default, `per-call` for isolated calls, or `main` for the configured agent's main session).
 
+### Hangup detection
+
+Realtime calls normally end when the carrier sends a stream stop event or closes
+the media WebSocket. If an intermediary does not promptly forward that close,
+OpenClaw treats 30 seconds without inbound media as a disconnect, waits a
+2-second grace period for media to resume, and then ends the call.
+
+For inbound Twilio numbers, also configure a Status Callback using `POST` to
+your public webhook URL with `?type=status` appended, for example
+`https://voice.example.com/voice/webhook?type=status`. Include the `completed`
+call event. OpenClaw-created outbound calls configure their callback
+automatically. The callback provides the fastest teardown signal, while stream
+close and the inactivity backstop remain independent of it.
+
 ### Tool policy
 
 `realtime.toolPolicy` controls the consult run:

--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type {
   RealtimeVoiceBridge,
+  RealtimeVoiceBridgeCreateRequest,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
@@ -48,13 +49,15 @@ function createStateRuntime(): VoiceCallStateRuntime["state"] {
 function createRealtimeProvider(params: {
   id: string;
   connect: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  requests?: RealtimeVoiceBridgeCreateRequest[];
 }): RealtimeVoiceProviderPlugin {
   return {
     id: params.id,
     label: params.id,
     isConfigured: () => true,
-    createBridge: vi.fn(
-      (): RealtimeVoiceBridge => ({
+    createBridge: vi.fn((request): RealtimeVoiceBridge => {
+      params.requests?.push(request);
+      return {
         connect: params.connect,
         sendAudio: vi.fn(),
         setMediaTimestamp: vi.fn(),
@@ -63,8 +66,8 @@ function createRealtimeProvider(params: {
         close: vi.fn(),
         isConnected: () => true,
         triggerGreeting: vi.fn(),
-      }),
-    ),
+      };
+    }),
   };
 }
 
@@ -83,7 +86,12 @@ describe("voice-call realtime route ownership", () => {
     let runtime: VoiceCallRuntime | undefined;
     const salesConnect = vi.fn(async () => {});
     const supportConnect = vi.fn(async () => {});
-    const salesProvider = createRealtimeProvider({ id: "openai", connect: salesConnect });
+    const salesRequests: RealtimeVoiceBridgeCreateRequest[] = [];
+    const salesProvider = createRealtimeProvider({
+      id: "openai",
+      connect: salesConnect,
+      requests: salesRequests,
+    });
     const supportProvider = createRealtimeProvider({ id: "xai", connect: supportConnect });
     const registrations = new Map([
       [
@@ -195,12 +203,21 @@ describe("voice-call realtime route ownership", () => {
         ),
       ).toEqual(["sales", "support"]);
 
+      const hangupCall = vi.spyOn(runtime.provider, "hangupCall");
+      salesRequests[0]?.onClose?.("completed");
       for (const ws of sockets) {
         const closed = waitForClose(ws);
         ws.close(1000);
         await closed;
       }
       await vi.waitFor(() => expect(runtime?.manager.getActiveCalls()).toHaveLength(0));
+      expect(hangupCall).not.toHaveBeenCalled();
+      await expect(runtime.manager.getCallHistory()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ providerCallId: "CA-sales", state: "completed" }),
+          expect.objectContaining({ providerCallId: "CA-support", state: "completed" }),
+        ]),
+      );
     } finally {
       await runtime?.stop();
       for (const ws of sockets) {

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -426,6 +426,114 @@ describe("RealtimeCallHandler lifecycle", () => {
     }
   });
 
+  it("ends an idle realtime call after the media inactivity grace", async () => {
+    let resolveBridgeStarted = () => {};
+    const bridgeStarted = new Promise<void>((resolve) => {
+      resolveBridgeStarted = resolve;
+    });
+    const closeBridge = vi.fn();
+    const { call, handler, hangupCall, processEvent } = createCarrierLifecycleHarness(() => {
+      resolveBridgeStarted();
+      return createBridge(closeBridge);
+    });
+    const { server, ws } = await connectCarrierStream(handler);
+
+    try {
+      vi.useFakeTimers();
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-inactivity", callSid: call.providerCallId },
+        }),
+      );
+      await bridgeStarted;
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
+        0,
+      );
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
+        0,
+      );
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(closeBridge).toHaveBeenCalledOnce();
+      expect(processEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callId: call.callId,
+          providerCallId: call.providerCallId,
+          reason: "timeout",
+          type: "call.ended",
+        }),
+      );
+      expect(hangupCall).toHaveBeenCalledExactlyOnceWith({
+        callId: call.callId,
+        providerCallId: call.providerCallId,
+        reason: "timeout",
+      });
+    } finally {
+      vi.useRealTimers();
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
+  it("renews realtime liveness when inbound media continues", async () => {
+    let resolveBridgeStarted = () => {};
+    const bridgeStarted = new Promise<void>((resolve) => {
+      resolveBridgeStarted = resolve;
+    });
+    let resolveMediaReceived = () => {};
+    const mediaReceived = new Promise<void>((resolve) => {
+      resolveMediaReceived = resolve;
+    });
+    const sendAudio = vi.fn(() => resolveMediaReceived());
+    const { call, handler, hangupCall, processEvent } = createCarrierLifecycleHarness(() => {
+      resolveBridgeStarted();
+      return createBridge(vi.fn(), { sendAudio });
+    });
+    const { server, ws } = await connectCarrierStream(handler);
+
+    try {
+      vi.useFakeTimers();
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-active-media", callSid: call.providerCallId },
+        }),
+      );
+      await bridgeStarted;
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      ws.send(
+        JSON.stringify({
+          event: "media",
+          media: { payload: Buffer.from([0xff]).toString("base64") },
+        }),
+      );
+      await mediaReceived;
+      await vi.advanceTimersByTimeAsync(29_999);
+
+      expect(sendAudio).toHaveBeenCalledOnce();
+      expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
+        0,
+      );
+      expect(hangupCall).not.toHaveBeenCalled();
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      vi.useRealTimers();
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
   it("terminates active sockets and treats server shutdown as completed", async () => {
     const bridgeClose = vi.fn();
     const createBridgeForCall = vi.fn(() => createBridge(bridgeClose));

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1916,8 +1916,7 @@ describe("RealtimeCallHandler path routing", () => {
         });
         expect(clearAudio).toHaveBeenCalledTimes(2);
         expect(oldSendUserMessage).not.toHaveBeenCalled();
-        expect(oldCoordinator.handles()).toContainEqual(oldForcedHandle);
-        expect(oldCoordinator.isCancelled(oldForcedHandle)).toBe(true);
+        expect(oldCoordinator.handles()).not.toContainEqual(oldForcedHandle);
 
         const oldClosed = waitForClose(oldWs);
         oldWs.close();
@@ -1953,7 +1952,7 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
-  it("isolates replacement transcripts and late old bridge events", async () => {
+  it("retires predecessor audio and isolates late bridge events from its replacement", async () => {
     const callbacks: RealtimeBridgeRequest[] = [];
     const oldCloseBridge = vi.fn();
     const replacementCloseBridge = vi.fn();
@@ -2003,6 +2002,10 @@ describe("RealtimeCallHandler path routing", () => {
 
       replacementServer = await startRealtimeServer(handler);
       const replacementWs = await connectWs(replacementServer.url);
+      const replacementOutboundMessages: Array<Record<string, unknown>> = [];
+      replacementWs.on("message", (data) => {
+        replacementOutboundMessages.push(parseWebSocketMessage(data));
+      });
       try {
         replacementWs.send(
           JSON.stringify({
@@ -2015,6 +2018,23 @@ describe("RealtimeCallHandler path routing", () => {
         );
         await waitForRealtimeTest(() => {
           expect(callbacks).toHaveLength(2);
+          expect(oldCloseBridge).toHaveBeenCalledOnce();
+        });
+
+        callbacks[0]?.onAudio(Buffer.from([0x01]));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(replacementOutboundMessages).toHaveLength(0);
+
+        callbacks[1]?.onAudio(Buffer.from([0x02]));
+        await waitForRealtimeTest(() => {
+          expect(replacementOutboundMessages).toEqual([
+            expect.objectContaining({
+              event: "media",
+              media: { payload: Buffer.from([0x02]).toString("base64") },
+            }),
+          ]);
         });
 
         callbacks[0]?.onTranscript?.("user", "stale partial", false);

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -30,7 +30,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
-import type { CallRecord, NormalizedEvent } from "../types.js";
+import type { CallRecord, EndReason, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
 import {
@@ -53,6 +53,8 @@ const STREAM_TOKEN_TTL_MS = 30_000;
 const DEFAULT_HOST = "localhost:8443";
 const MAX_REALTIME_MESSAGE_BYTES = 256 * 1024;
 const MAX_REALTIME_WS_BUFFERED_BYTES = 1024 * 1024;
+const REALTIME_MEDIA_INACTIVITY_TIMEOUT_MS = 30_000;
+const REALTIME_DISCONNECT_HANGUP_GRACE_MS = 2_000;
 const FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const FORCED_CONSULT_NATIVE_DEDUPE_MS = 2_000;
 const FORCED_CONSULT_RESULT_MAX_CHARS = 1800;
@@ -309,7 +311,16 @@ type UserTranscriptOwnerAdoption = {
   previous?: UserTranscriptState;
 };
 
-type TelephonyCloseReason = "completed" | "error";
+type RealtimeCallEndCause = "hangup" | "stream-close" | "inactivity" | "error";
+
+// Each socket keeps its exact binding; the call map only grants current-generation
+// record termination. Replacement can retire old audio without a late close killing its successor.
+type RealtimeTelephonyBinding = {
+  bridge: ActiveRealtimeVoiceBridge;
+  close: (cause: RealtimeCallEndCause) => void;
+  noteMediaActivity: () => void;
+  retire: () => void;
+};
 
 async function waitForNativeConsult(state: NativeConsultState): Promise<NativeConsultOutcome> {
   return await Promise.race([
@@ -354,13 +365,7 @@ export class RealtimeCallHandler {
   private readonly activeSockets = new Set<WebSocket>();
   private readonly serverClosingSockets = new WeakSet<WebSocket>();
   private readonly activeBridgesByCallId = new Map<string, ActiveRealtimeVoiceBridge>();
-  private readonly activeTelephonyClosersByCallId = new Map<
-    string,
-    {
-      owner: ActiveRealtimeVoiceBridge;
-      close: (reason: TelephonyCloseReason) => void;
-    }
-  >();
+  private readonly activeTelephonyBindingsByCallId = new Map<string, RealtimeTelephonyBinding>();
   private readonly userTranscriptStatesByCallId = new Map<string, UserTranscriptState>();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
@@ -453,7 +458,7 @@ export class RealtimeCallHandler {
     });
     wss.handleUpgrade(request, socket, head, (ws) => {
       this.activeSockets.add(ws);
-      let bridge: ActiveRealtimeVoiceBridge | null = null;
+      let telephonyBinding: RealtimeTelephonyBinding | null = null;
       let initialized = false;
       let activeCallSid = "unknown";
       let stopReceived = false;
@@ -472,25 +477,26 @@ export class RealtimeCallHandler {
             }
             initialized = true;
             activeCallSid = frame.providerCallId;
-            const nextBridge = this.handleCall(
+            const nextBinding = this.handleCall(
               frame.streamId,
               frame.providerCallId,
               ws,
               callerMeta,
               adapter,
             );
-            if (!nextBridge) {
+            if (!nextBinding) {
               return;
             }
-            bridge = nextBridge;
+            telephonyBinding = nextBinding;
             return;
           }
-          if (!bridge) {
+          if (!telephonyBinding) {
             return;
           }
           if (frame.kind === "media") {
             const audio = Buffer.from(frame.payloadBase64, "base64");
-            bridge.sendAudio(audio);
+            telephonyBinding.noteMediaActivity();
+            telephonyBinding.bridge.sendAudio(audio);
             if (frame.timestampMs !== undefined) {
               if (lastMediaTimestamp !== undefined) {
                 const gapMs = frame.timestampMs - lastMediaTimestamp;
@@ -503,12 +509,12 @@ export class RealtimeCallHandler {
                 }
               }
               lastMediaTimestamp = frame.timestampMs;
-              bridge.setMediaTimestamp(frame.timestampMs);
+              telephonyBinding.bridge.setMediaTimestamp(frame.timestampMs);
             }
             return;
           }
           if (frame.kind === "mark") {
-            bridge.acknowledgeMark();
+            telephonyBinding.bridge.acknowledgeMark();
             return;
           }
           if (frame.kind === "error") {
@@ -519,7 +525,7 @@ export class RealtimeCallHandler {
           }
           if (frame.kind === "stop") {
             stopReceived = true;
-            this.closeTelephonyBridge(activeCallSid, bridge, "completed");
+            telephonyBinding.close("hangup");
           }
         } catch (error) {
           console.error("[voice-call] realtime WS parse failed:", error);
@@ -530,13 +536,15 @@ export class RealtimeCallHandler {
         this.activeSockets.delete(ws);
         const reason =
           this.serverClosingSockets.has(ws) || stopReceived || code === 1000 || code === 1005
-            ? "completed"
+            ? "stream-close"
             : "error";
-        this.closeTelephonyBridge(activeCallSid, bridge, reason);
+        telephonyBinding?.close(reason);
       });
 
       ws.on("error", (error) => {
         console.error("[voice-call] realtime WS error:", error);
+        telephonyBinding?.close("error");
+        ws.terminate();
       });
 
       if (this.closing) {
@@ -648,7 +656,7 @@ export class RealtimeCallHandler {
     ws: WebSocket,
     callerMeta: Omit<PendingStreamToken, "expiry">,
     adapter: StreamFrameAdapter,
-  ): ActiveRealtimeVoiceBridge | null {
+  ): RealtimeTelephonyBinding | null {
     const preparedCall = this.prepareCallInManager(callSid, callerMeta);
     if (!preparedCall) {
       ws.close(1008, "Caller rejected by policy");
@@ -658,14 +666,20 @@ export class RealtimeCallHandler {
     const { callRecord } = preparedCall;
     const callId = callRecord.callId;
     const hadPredecessorOnAdmission = this.activeBridgesByCallId.has(callId);
+    const previousTelephonyBinding = this.activeTelephonyBindingsByCallId.get(callId);
     let callEndEmitted = false;
-    const emitCallEnd = (reason: "completed" | "error") => {
+    const emitCallEnd = (cause: RealtimeCallEndCause) => {
       if (callEndEmitted) {
         return;
       }
       callEndEmitted = true;
+      const reason: EndReason =
+        cause === "error" ? "error" : cause === "inactivity" ? "timeout" : "completed";
       this.endCallInManager(callSid, callId, reason);
-      if (reason !== "error") {
+      console.log(
+        `[voice-call] Realtime call ended callId=${callId} providerCallId=${callSid} reason=${cause}`,
+      );
+      if (cause !== "error" && cause !== "inactivity") {
         return;
       }
       void Promise.resolve(
@@ -1087,13 +1101,6 @@ export class RealtimeCallHandler {
     nativeConsultOwner.current = session;
     providerHandlesInputAudioBargeIn =
       session.bridge.handlesInputAudioBargeIn ?? providerHandlesInputAudioBargeIn;
-    const closeTelephony = (reason: TelephonyCloseReason) => {
-      try {
-        session.close();
-      } finally {
-        emitCallEnd(reason);
-      }
-    };
     const previousConsultSession = this.consultSessionsByCallId.get(callId);
     if (previousConsultSession && previousConsultSession.owner !== session) {
       this.cancelConsultSession(callId, previousConsultSession.owner);
@@ -1102,11 +1109,6 @@ export class RealtimeCallHandler {
       owner: session,
       coordinator: harness.forcedConsults,
     });
-    this.activeBridgesByCallId.set(callId, session);
-    this.activeBridgesByCallId.set(callSid, session);
-    const telephonyCloser = { owner: session, close: closeTelephony };
-    this.activeTelephonyClosersByCallId.set(callId, telephonyCloser);
-    this.activeTelephonyClosersByCallId.set(callSid, telephonyCloser);
     const sendAudioToSession = session.sendAudio.bind(session);
     session.sendAudio = (audio) => {
       if (speechDetector.accept({ rms: calculateMulawRms(audio), peak: 0 })) {
@@ -1142,6 +1144,72 @@ export class RealtimeCallHandler {
       }
     };
 
+    let livenessTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearLivenessTimer = () => {
+      if (livenessTimer) {
+        clearTimeout(livenessTimer);
+        livenessTimer = undefined;
+      }
+    };
+    let bindingClosed = false;
+    const closeBinding = (
+      binding: RealtimeTelephonyBinding,
+      cause?: RealtimeCallEndCause,
+    ): void => {
+      if (bindingClosed) {
+        return;
+      }
+      bindingClosed = true;
+      clearLivenessTimer();
+      const ownsCall = this.activeTelephonyBindingsByCallId.get(callId) === binding;
+      try {
+        session.close();
+      } catch (error) {
+        console.warn(
+          `[voice-call] Failed to close realtime bridge ${callSid}: ${formatErrorMessage(error)}`,
+        );
+      } finally {
+        this.clearActiveTelephonyBinding(callId, binding);
+        if (ownsCall && cause) {
+          emitCallEnd(cause);
+        }
+      }
+    };
+    const telephonyBinding: RealtimeTelephonyBinding = {
+      bridge: session,
+      close: (cause) => closeBinding(telephonyBinding, cause),
+      noteMediaActivity: () => {
+        if (
+          bindingClosed ||
+          this.activeTelephonyBindingsByCallId.get(callId) !== telephonyBinding
+        ) {
+          return;
+        }
+        clearLivenessTimer();
+        livenessTimer = setTimeout(() => {
+          console.warn(
+            `[voice-call] Realtime media inactive callId=${callId} providerCallId=${callSid} timeoutMs=${REALTIME_MEDIA_INACTIVITY_TIMEOUT_MS} graceMs=${REALTIME_DISCONNECT_HANGUP_GRACE_MS}`,
+          );
+          livenessTimer = setTimeout(() => {
+            telephonyBinding.close("inactivity");
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.close(1000, "Media inactivity");
+            }
+          }, REALTIME_DISCONNECT_HANGUP_GRACE_MS);
+          livenessTimer.unref?.();
+        }, REALTIME_MEDIA_INACTIVITY_TIMEOUT_MS);
+        livenessTimer.unref?.();
+      },
+      retire: () => closeBinding(telephonyBinding),
+    };
+    this.activeBridgesByCallId.set(callId, session);
+    this.activeBridgesByCallId.set(callSid, session);
+    this.activeTelephonyBindingsByCallId.set(callId, telephonyBinding);
+    telephonyBinding.noteMediaActivity();
+    if (previousTelephonyBinding && previousTelephonyBinding !== telephonyBinding) {
+      previousTelephonyBinding.retire();
+    }
+
     session.connect().catch((error: unknown) => {
       console.error("[voice-call] Failed to connect realtime bridge:", error);
       const ownsCallState = this.isActiveBridgeOwner(callId, session);
@@ -1159,7 +1227,7 @@ export class RealtimeCallHandler {
       }
     });
 
-    return session;
+    return telephonyBinding;
   }
 
   private beginUserTranscriptOwnerAdoption(callId: string): UserTranscriptOwnerAdoption {
@@ -1361,7 +1429,12 @@ export class RealtimeCallHandler {
         continue;
       }
       this.activeBridgesByCallId.delete(key);
-      this.activeTelephonyClosersByCallId.delete(key);
+    }
+  }
+
+  private clearActiveTelephonyBinding(callId: string, binding: RealtimeTelephonyBinding): void {
+    if (this.activeTelephonyBindingsByCallId.get(callId) === binding) {
+      this.activeTelephonyBindingsByCallId.delete(callId);
     }
   }
 
@@ -1429,19 +1502,6 @@ export class RealtimeCallHandler {
         setTimeout(resolve, Math.min(CONSULT_TRANSCRIPT_SETTLE_MS - quietFor, deadline - now));
       });
     }
-  }
-
-  private closeTelephonyBridge(
-    callIdOrSid: string,
-    bridge: ActiveRealtimeVoiceBridge | null,
-    reason: TelephonyCloseReason,
-  ): void {
-    const closer = this.activeTelephonyClosersByCallId.get(callIdOrSid);
-    if (closer && closer.owner === bridge) {
-      closer.close(reason);
-      return;
-    }
-    bridge?.close();
   }
 
   private scheduleForcedAgentConsult(params: {
@@ -1645,7 +1705,7 @@ export class RealtimeCallHandler {
       : undefined;
   }
 
-  private endCallInManager(callSid: string, callId: string, reason: "completed" | "error"): void {
+  private endCallInManager(callSid: string, callId: string, reason: EndReason): void {
     this.manager.processEvent({
       id: `realtime-ended-${callSid}-${Date.now()}`,
       type: "call.ended",


### PR DESCRIPTION
## What Problem This Solves

Answered realtime voice calls could become zombies: live incident on a production gateway (2026-08-17, Twilio + OpenAI realtime via Tailscale funnel) where a caller hung up, no teardown of any kind ran — no logs, no terminal state — and the still-running realtime session produced overlapping audio when the caller redialed seconds later. Two structural holes: `closeTelephonyBridge`'s `closer.owner === bridge` identity guard silently fell through to `bridge?.close()` (bridge closed, call record never ended, no carrier hangup), and the realtime path had no transport-liveness backstop, so a WS close that never propagates (proxy/funnel edge cases; missing Twilio StatusCallback) left the call alive until `maxDurationSeconds`.

## Why This Change Was Made

Teardown is now socket-bound: each realtime WS owns an exact `RealtimeTelephonyBinding` closure, and terminal ownership is decided at close time by current-generation map identity — a predecessor's late close cleans up its own bridge but cannot end a successor's call, while successor admission actively `retire()`s the predecessor's audio (the overlapping-voices mechanism). A 30s inbound-media inactivity watchdog (plus 2s grace, timers unref'd) ends calls whose transport died silently, mirroring the documented streaming-path disconnect-grace semantics. Every realtime call end now logs its cause (`hangup`/`stream-close`/`inactivity`/`error`), making silent zombies structurally impossible. `ws.on("error")` also tears down the binding instead of only logging.

## User Impact

Hanging up a realtime call reliably ends it: session terminates, carrier leg is released on error/inactivity, and rapid hangup-redial no longer produces two overlapping voices. Operators get a logged terminal reason for every call. Docs now recommend configuring a Twilio StatusCallback to the webhook URL for fastest hangup detection (the watchdog covers its absence).

## Evidence

- Pre-fix reproduction: three intended test failures — provider-close/WS-close left a manager call active, predecessor was not retired on successor admission, inactivity never fired.
- `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts extensions/voice-call/src/runtime.realtime-routing.test.ts` — green (rerun independently by reviewer).
- Full plugin suite: 61 files, 652/652 passed. `node scripts/check-changed.mjs` passed (import-cycle count 0).
- Fresh autoreview: clean, no actionable findings (0.96).
- Production LOC +111/−51 (net +60), justified by two named capabilities: transport-liveness backstop and per-cause terminal logging; tests net +145.
- Live incident evidence and mechanism analysis in the PR discussion: gateway trace showed `openclaw_agent_consult` completing and barge-in events firing after caller hangup, with zero end/reap/disconnect lines for either call.
