### PR TITLE
build(macos): pin final Peekaboo 4.2.1 source

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605"
+        "revision" : "d1217a9fdf02d882b7c170f294e1e75e20039320"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605"),
+            revision: "d1217a9fdf02d882b7c170f294e1e75e20039320"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's macOS package still pinned Peekaboo `6ba9ade8e76a3743e6c9a0ddd915a62fc59f4605`, which predates the final 4.2.1 held-pointer certification and warning-clean release source. Building the elevation host from that dependency would not match the sealed Peekaboo release candidate.

## Why This Change Was Made

Pin both SwiftPM ownership files to final landed Peekaboo source `d1217a9fdf02d882b7c170f294e1e75e20039320`. Keeping `Package.swift` and `Package.resolved` identical preserves the existing exact-source packaging contract and prevents transitive resolver drift.

## User Impact

The macOS app and elevation host compile against the exact Peekaboo 4.2.1 source that will be installed and certified. No OpenClaw product setting, runtime default, or public API changes.

## Evidence

- `swift package resolve` resolves Peekaboo exactly at `d1217a9fdf02d882b7c170f294e1e75e20039320` and changes no other lockfile entry.
- Focused package/source-pin contract tests: 3/3 passed.
- `swift build --package-path apps/macos --product OpenClaw` passed against the new dependency.
- `git diff --check` passed.
- Codex autoreview through P2: clean, no findings.

No changelog entry: OpenClaw changelog generation is release-owned, and this is a two-file dependency-source pin for the already documented elevation closeout.
