### PR TITLE
fix(agents): report node exec timeouts and process kills truthfully

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -179,8 +179,34 @@ describe("direct node run", () => {
     const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
     const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
 
-    expect(visibleText).toBe(`${stdout}\n${stderr}\n${errorText}`);
+    expect(visibleText).toBe(`${stdout}\n${stderr}\n${errorText}\n(Command exited with code 1)`);
     expect(result.details).toMatchObject({ aggregated: visibleText });
+  });
+
+  it("renders a nonzero exit code in the model-visible text", async () => {
+    callGatewayToolMock.mockResolvedValueOnce({
+      payload: { success: false, stdout: "done", stderr: "", error: null, exitCode: 3 },
+    });
+
+    const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
+    const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+    // Output alone must not read as success when the command failed.
+    expect(visibleText).toContain("done");
+    expect(visibleText).toContain("(Command exited with code 3)");
+    expect(result.details).toMatchObject({ status: "failed", exitCode: 3 });
+  });
+
+  it("renders a timeout marker and records timedOut in details", async () => {
+    callGatewayToolMock.mockResolvedValueOnce({
+      payload: { success: false, stdout: "", stderr: "", error: null, timedOut: true },
+    });
+
+    const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
+    const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+    expect(visibleText).toContain("Command timed out.");
+    expect(result.details).toMatchObject({ status: "failed", timedOut: true });
   });
 
   it("never dispatches a direct node run after cancellation", async () => {

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -42,7 +42,7 @@ import {
   invokeNodeSystemRun,
 } from "./bash-tools.exec-host-node-failure.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
-import { renderExecUpdateText } from "./bash-tools.exec-output.js";
+import { appendExecTimeoutRetryGuidance, renderExecUpdateText } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -253,7 +253,15 @@ export function formatNodeRunToolResult(params: {
   const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
   const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
   const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
-  const output = [stdout, stderr, errorText].filter(Boolean).join("\n");
+  const timedOut = payloadObj.timedOut === true;
+  // Failure must be visible in the text the model reads, matching the
+  // local/gateway host rendering — output alone reads as success.
+  const outcomeNote = timedOut
+    ? appendExecTimeoutRetryGuidance("Command timed out.", "overall-timeout")
+    : !success && exitCode !== null && exitCode !== 0
+      ? `(Command exited with code ${exitCode})`
+      : "";
+  const output = [stdout, stderr, errorText, outcomeNote].filter(Boolean).join("\n");
   return {
     content: [
       {
@@ -269,6 +277,7 @@ export function formatNodeRunToolResult(params: {
       exitCode,
       durationMs: Date.now() - params.startedAt,
       aggregated: output,
+      ...(timedOut ? { timedOut: true } : {}),
       cwd: params.cwd,
     } satisfies ExecToolDetails,
   };

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -416,6 +416,8 @@ test.skipIf(process.platform === "win32")(
         sessionId,
       });
       expect(textContent(killed)).toBe(`Termination requested for session ${sessionId}.`);
+      // A performed kill must not read as a failed tool call.
+      expect(killed.details).toMatchObject({ status: "completed" });
 
       await expect
         .poll(

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -665,6 +665,8 @@ export function createProcessTool(
             );
           }
           resetPollRetrySuggestion(params.sessionId);
+          // The kill was performed; "failed" here would flag a successful
+          // action as a tool error and invite the model to retry it.
           return {
             content: [
               {
@@ -673,7 +675,7 @@ export function createProcessTool(
               },
             ],
             details: {
-              status: "failed",
+              status: "completed",
               name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
             },
           };
@@ -716,6 +718,8 @@ export function createProcessTool(
             scopedSession.backgrounded = false;
             deleteSession(params.sessionId);
             resetPollRetrySuggestion(params.sessionId);
+            // Removal succeeded (termination requested + registry row dropped);
+            // match the finished-session remove branch's success shape.
             return {
               content: [
                 {
@@ -724,7 +728,7 @@ export function createProcessTool(
                 },
               ],
               details: {
-                status: "failed",
+                status: "completed",
                 name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
               },
             };


### PR DESCRIPTION
## What Problem This Solves

Two exec-surface results lie to the model:

1. **Node-host timeouts read as success.** `formatNodeRunToolResult` reads only `stdout`/`stderr`/`error` from the node payload — `timedOut` is never read. `exec host=node` with a timeout renders `"(no output)"` with zero mention of the timeout, and a nonzero-exit command with stdout (e.g. `echo done; exit 3`) renders just `"done"`. `details` carried no `timedOut`, so failure-kind classification saw a plain "failed" instead of "timed_out". The local/gateway host renders `"Command timed out after N seconds"` + retry guidance and `"(Command exited with code N)"`; even the node *detached follow-up* path renders `timeout`/`code N` — the direct path just forgot.

2. **Successful kills read as tool errors.** `process kill` and `process remove` (running) perform the termination, say so in the text — and return `details.status: "failed"`, which flips `isToolResultError()` to true. The model sees a successful kill flagged as an error and may retry it or report failure. The finished-session `remove`/`clear` branches already return `"completed"`, so this was an internal inconsistency, not a contract.

## Why This Change Was Made

Doctrine: tool results are prompts; truncated/failed output must never read as success; every action ends in a correctly reported visible outcome. The fix reuses the existing `appendExecTimeoutRetryGuidance` helper and matches the local-host exit-code note verbatim.

## User Impact

Agents driving node-host execs now see timeouts and nonzero exits in the result text and can react (retry-safety guidance included); kills no longer produce spurious tool-error retries.

## Evidence

- New regressions: nonzero-exit note, timeout marker + `timedOut` details (both **fail pre-fix**: 3 failed on stashed prod code), kill `status: "completed"` assertion in the e2e test.
- One existing test updated: it pinned the pre-fix omission (`stdout\nstderr\nerror` exactly); now asserts the exit-code note.
- `bash-tools.exec-host-node-phases.test.ts` 11/11, `bash-tools.process.e2e.test.ts` 9/9. `tsgo` core + test shards rc=0; oxlint/oxfmt clean.
- Codex autoreview clean (0.99).
- Production delta: +17 −4 (visible-outcome rendering; justified — the silence was the bug, no structure to delete).
