### PR TITLE
fix(pr): repeated review checkout recovers partial transitions

### DIFF
--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -22,7 +22,7 @@ review_claim() {
   # shared canonical checkout with no scripts/pr-owned .local, so a stray artifact
   # there can never be mistaken for this flow's output. Claiming still works on a
   # cold PR because enter_worktree provisions both the worktree and .local.
-  enter_worktree "$pr" false
+  enter_worktree "$pr" false || return 1
 
   local reviewer=""
   local max_attempts=3
@@ -73,10 +73,10 @@ review_claim() {
 
 review_checkout_main() {
   local pr="$1"
-  enter_worktree "$pr" false
+  enter_worktree "$pr" false || return 1
   mark_pr_operation_side_effects_started
   git fetch origin main
-  git checkout --detach origin/main
+  checkout_pr_worktree_target "$pr" origin/main || return 1
   set_review_mode main
 
   echo "review mode set to main baseline"
@@ -86,10 +86,10 @@ review_checkout_main() {
 
 review_checkout_pr() {
   local pr="$1"
-  enter_worktree "$pr" false
+  enter_worktree "$pr" false || return 1
   mark_pr_operation_side_effects_started
   git fetch origin "pull/$pr/head:pr-$pr" --force
-  git checkout --detach "pr-$pr"
+  checkout_pr_worktree_target "$pr" "pr-$pr" || return 1
   set_review_mode pr
 
   echo "review mode set to PR head"
@@ -314,7 +314,7 @@ review_tests() {
 review_init() {
   local pr="$1"
   mark_pr_operation_side_effects_started
-  enter_worktree "$pr" true
+  enter_worktree "$pr" true || return 1
 
   local json pr_url
   json=$(pr_meta_json "$pr")

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -39,6 +39,149 @@ ensure_full_pr_worktree_checkout() {
   fi
 }
 
+refuse_review_transition() {
+  local pr="$1"
+  local reason="$2"
+  echo "Refusing scripts/pr transition for PR #$pr: $reason" >&2
+  git status --short >&2
+  return 1
+}
+
+require_no_foreign_untracked() {
+  local pr="$1"
+  local foreign=()
+  local file
+  while IFS= read -r -d '' file; do
+    case "$file" in
+      .local|.local/*) ;;
+      *) foreign+=("$file") ;;
+    esac
+  done < <(git ls-files --others --exclude-standard -z)
+  [ "${#foreign[@]}" -eq 0 ] || refuse_review_transition "$pr" "untracked files are not owned by scripts/pr."
+}
+
+validate_review_transition_state() {
+  local pr="$1"
+  local source="$2"
+  local target="$3"
+  local current
+  current=$(git rev-parse HEAD)
+  if { [ "$current" != "$source" ] && [ "$current" != "$target" ]; } ||
+    [ -n "$(git ls-files -u)" ] || ! git diff --quiet ||
+    ! require_no_foreign_untracked "$pr"
+  then
+    refuse_review_transition "$pr" "the journaled transition state is ambiguous."
+    return 1
+  fi
+
+  # A path changed from source is owned only when its index mode and blob match target.
+  local file
+  while IFS= read -r -d '' file; do
+    if ! git diff --cached --quiet "$target" -- ":(literal)$file"; then
+      refuse_review_transition "$pr" "'$file' is neither its journaled source nor target entry."
+      return 1
+    fi
+  done < <(git diff --cached --name-only --no-renames -z "$source")
+}
+
+write_review_transition_journal() {
+  local pr="$1"
+  local source="$2"
+  local target="$3"
+  local mode="$4"
+  local branch="$5"
+  mkdir -p .local
+  local journal=.local/review-transition.json
+  local pending
+  pending=$(mktemp "$journal.XXXXXX") || return 1
+  if jq -cn --argjson pr "$pr" --arg source "$source" --arg target "$target" \
+    --arg mode "$mode" --arg branch "$branch" \
+    '{version:1,pr:$pr,source:$source,target:$target,mode:$mode,branch:(if $mode == "branch" then $branch else null end)}' \
+    >"$pending" && mv "$pending" "$journal"
+  then
+    return 0
+  fi
+  rm -f "$pending"
+  return 1
+}
+
+recover_review_transition() {
+  local pr="$1"
+  local journal=.local/review-transition.json
+  [ -e "$journal" ] || return 0
+
+  local fields source target mode branch
+  fields=$(jq -er --argjson pr "$pr" '
+    select(type == "object" and (keys | sort) == ["branch","mode","pr","source","target","version"])
+    | select(.version == 1 and .pr == $pr)
+    | select((.source | type == "string" and test("^[0-9a-f]{40}$")) and (.target | type == "string" and test("^[0-9a-f]{40}$")))
+    | select((.mode == "detached" and .branch == null) or (.mode == "branch" and (.branch | type == "string")))
+    | [.source,.target,.mode,(.branch // "")] | @tsv
+  ' "$journal" 2>/dev/null) || {
+    refuse_review_transition "$pr" "the transition journal is invalid."
+    return 1
+  }
+  IFS=$'\t' read -r source target mode branch <<<"$fields"
+  if ! git cat-file -e "$source^{commit}" 2>/dev/null ||
+    ! git cat-file -e "$target^{commit}" 2>/dev/null ||
+    { [ "$mode" = "branch" ] && [ "$branch" != "temp/pr-$pr" ]; }
+  then
+    refuse_review_transition "$pr" "the transition journal names an invalid endpoint or branch."
+    return 1
+  fi
+
+  validate_review_transition_state "$pr" "$source" "$target" || return 1
+  local paths=()
+  local file
+  while IFS= read -r -d '' file; do
+    paths+=(":(literal)$file")
+  done < <(git diff --name-only --no-renames -z "$source" "$target")
+  if [ "${#paths[@]}" -gt 0 ]; then
+    git restore --source="$target" --staged --worktree -- "${paths[@]}" || return 1
+  fi
+  if [ "$(git write-tree)" != "$(git rev-parse "$target^{tree}")" ] || ! git diff --quiet; then
+    refuse_review_transition "$pr" "the tracked tree did not reach the journaled target."
+    return 1
+  fi
+  if [ "$mode" = "branch" ]; then
+    git checkout -B "$branch" "$target" || return 1
+  else
+    git checkout --detach "$target" || return 1
+  fi
+
+  local actual_branch
+  actual_branch=$(git branch --show-current)
+  if [ "$(git rev-parse HEAD)" != "$target" ] || ! git diff --quiet || ! git diff --cached --quiet ||
+    { [ "$mode" = "branch" ] && [ "$actual_branch" != "$branch" ]; } ||
+    { [ "$mode" = "detached" ] && [ -n "$actual_branch" ]; } ||
+    ! require_no_foreign_untracked "$pr"
+  then
+    refuse_review_transition "$pr" "the journaled transition did not complete cleanly."
+    return 1
+  fi
+  rm -f "$journal"
+}
+
+checkout_pr_worktree_target() {
+  local pr="$1"
+  local target_ref="$2"
+  local branch="${3:-}"
+  recover_review_transition "$pr" || return 1
+  if [ -n "$(git ls-files -u)" ] || ! git diff --quiet || ! git diff --cached --quiet ||
+    ! require_no_foreign_untracked "$pr"
+  then
+    refuse_review_transition "$pr" "foreign state blocks a new transition."
+    return 1
+  fi
+
+  local source target mode=detached
+  source=$(git rev-parse HEAD) || return 1
+  target=$(git rev-parse "$target_ref^{commit}") || return 1
+  [ -z "$branch" ] || mode=branch
+  write_review_transition_journal "$pr" "$source" "$target" "$mode" "$branch" || return 1
+  recover_review_transition "$pr"
+}
+
 enter_worktree() {
   local pr="$1"
   local reset_to_main="${2:-false}"
@@ -91,10 +234,11 @@ enter_worktree() {
     return 1
   fi
 
+  recover_review_transition "$pr" || return 1
   ensure_full_pr_worktree_checkout
   git fetch origin main
   if [ "$reset_to_main" = "true" ]; then
-    git checkout -B "temp/pr-$pr" origin/main
+    checkout_pr_worktree_target "$pr" origin/main "temp/pr-$pr" || return 1
   fi
   mkdir -p .local
 }

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -60,6 +60,27 @@ require_no_foreign_untracked() {
   [ "${#foreign[@]}" -eq 0 ] || refuse_review_transition "$pr" "untracked files are not owned by scripts/pr."
 }
 
+require_no_ignored_transition_paths() {
+  local pr="$1"
+  local source="$2"
+  local target="$3"
+  local file ignored
+  while IFS= read -r -d '' file; do
+    case "$file" in
+      .local|.local/*)
+        refuse_review_transition "$pr" "the journaled transition touches the reserved .local artifact namespace."
+        return 1
+        ;;
+    esac
+    if IFS= read -r -d '' ignored < <(
+      git ls-files --others --ignored --exclude-standard -z -- ":(literal)$file"
+    ); then
+      refuse_review_transition "$pr" "ignored file '$ignored' would be overwritten by the journaled transition."
+      return 1
+    fi
+  done < <(git diff --name-only --no-renames -z "$source" "$target")
+}
+
 validate_review_transition_state() {
   local pr="$1"
   local source="$2"
@@ -73,6 +94,7 @@ validate_review_transition_state() {
     refuse_review_transition "$pr" "the journaled transition state is ambiguous."
     return 1
   fi
+  require_no_ignored_transition_paths "$pr" "$source" "$target" || return 1
 
   # A path changed from source is owned only when its index mode and blob match target.
   local file
@@ -177,6 +199,7 @@ checkout_pr_worktree_target() {
   local source target mode=detached
   source=$(git rev-parse HEAD) || return 1
   target=$(git rev-parse "$target_ref^{commit}") || return 1
+  require_no_ignored_transition_paths "$pr" "$source" "$target" || return 1
   [ -z "$branch" ] || mode=branch
   write_review_transition_journal "$pr" "$source" "$target" "$mode" "$branch" || return 1
   recover_review_transition "$pr"

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -305,4 +305,31 @@ describePosix("scripts/pr worktree containment", () => {
       expectCanonicalCheckoutUnchanged(fixture);
     });
   }
+
+  it("refuses and preserves an ignored file colliding with the transition target", () => {
+    const fixture = createReviewFixture();
+    const worktree = join(fixture.root, ".worktrees", "pr-42");
+    const result = runShell(fixture, [
+      "review_init 42",
+      "review_checkout_pr 42",
+      "source_sha=$(git rev-parse HEAD)",
+      "target_sha=$(git rev-parse origin/main)",
+      'jq -cn --arg source "$source_sha" --arg target "$target_sha" \'{version:1,pr:42,source:$source,target:$target,mode:"detached",branch:null}\' > .local/review-transition.json',
+      'git restore --source="$target_sha" --staged --worktree -- transition-a.txt',
+      'printf "main-only.txt\\n" >> "$(git rev-parse --git-path info/exclude)"',
+      'printf "foreign ignored\\n" > main-only.txt',
+      "git check-ignore -q main-only.txt",
+      "review_init 42",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("ignored file 'main-only.txt' would be overwritten");
+    expect(git(worktree, "rev-parse", "HEAD")).toBe(fixture.prASha);
+    expect(git(worktree, "status", "--short", "--ignored", "--", "main-only.txt")).toBe(
+      "!! main-only.txt",
+    );
+    expect(readFileSync(join(worktree, "main-only.txt"), "utf8")).toBe("foreign ignored\n");
+    expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(true);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
 });

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -16,6 +24,11 @@ type Fixture = {
   mainSha: string;
   siblingBranch: string;
   siblingSha: string;
+};
+
+type ReviewFixture = Fixture & {
+  prASha: string;
+  prBSha: string;
 };
 
 function git(root: string, ...args: string[]) {
@@ -46,6 +59,52 @@ function createFixture(): Fixture {
   };
 }
 
+function createReviewFixture(): ReviewFixture {
+  const root = tempDirs.make("openclaw-pr-review-transition-");
+  git(root, "init", "--initial-branch=main");
+  git(root, "config", "user.name", "OpenClaw Test");
+  git(root, "config", "user.email", "test@openclaw.invalid");
+  writeFileSync(join(root, "transition-a.txt"), "base-a\n");
+  writeFileSync(join(root, "transition-b.txt"), "base-b\n");
+  writeFileSync(join(root, "overlap.txt"), "base-overlap\n");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "base fixture");
+  const baseSha = git(root, "rev-parse", "HEAD");
+
+  git(root, "checkout", "-b", "review/pr", baseSha);
+  writeFileSync(join(root, "transition-a.txt"), "pr-a\n");
+  writeFileSync(join(root, "transition-b.txt"), "pr-b\n");
+  writeFileSync(join(root, "overlap.txt"), "pr-a-overlap\n");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "PR head A");
+  const prASha = git(root, "rev-parse", "HEAD");
+  writeFileSync(join(root, "overlap.txt"), "pr-b-overlap\n");
+  git(root, "commit", "-am", "PR head B");
+  const prBSha = git(root, "rev-parse", "HEAD");
+  git(root, "update-ref", "refs/pull/42/head", prASha);
+
+  git(root, "checkout", "main");
+  writeFileSync(join(root, "main-only.txt"), "main-only\n");
+  git(root, "add", "main-only.txt");
+  git(root, "commit", "-m", "advance main fixture");
+  const mainSha = git(root, "rev-parse", "HEAD");
+  git(root, "remote", "add", "origin", root);
+  git(root, "fetch", "origin");
+
+  git(root, "checkout", "-b", "sibling/work");
+  writeFileSync(join(root, "sibling.txt"), "sibling\n");
+  git(root, "add", "sibling.txt");
+  git(root, "commit", "-m", "sibling fixture");
+  return {
+    root,
+    mainSha,
+    prASha,
+    prBSha,
+    siblingBranch: git(root, "branch", "--show-current"),
+    siblingSha: git(root, "rev-parse", "HEAD"),
+  };
+}
+
 function makeStaleWorktreeDir(fixture: Fixture) {
   mkdirSync(join(fixture.root, ".worktrees", "pr-42"), { recursive: true });
 }
@@ -64,7 +123,7 @@ function runShell(fixture: Fixture, commands: string[]) {
         'repo_root() { printf "%s\\n" "$fixture_root"; }',
         "ensure_gh_api_auth() { :; }",
         "mark_pr_operation_side_effects_started() { :; }",
-        "set_review_mode() { :; }",
+        'pr_meta_json() { local head; head=$(git rev-parse refs/pull/42/head); jq -cn --arg head "$head" \'{number:42,title:"fixture",url:"https://example.invalid/42",state:"OPEN",isDraft:false,author:{login:"fixture"},baseRefName:"main",headRefName:"review/pr",headRefOid:$head,headRepository:{nameWithOwner:"fixture/repo",url:""},headRepositoryOwner:{login:"fixture"},additions:1,deletions:0,changedFiles:3}\'; }',
         ...commands,
       ].join("\n"),
       "pr-worktree-containment",
@@ -161,4 +220,89 @@ describePosix("scripts/pr worktree containment", () => {
     expect(result.stdout).toContain(`head=${fixture.mainSha}`);
     expectCanonicalCheckoutUnchanged(fixture);
   });
+
+  it("recovers an interrupted transition before repeated init, main, and PR checkout", () => {
+    const fixture = createReviewFixture();
+    const artifact = join(fixture.root, ".worktrees", "pr-42", ".local", "review-note");
+
+    const result = runShell(fixture, [
+      "review_init 42",
+      "review_checkout_main 42",
+      "review_checkout_pr 42",
+      'printf "preserve me\\n" > .local/review-note',
+      "source_sha=$(git rev-parse HEAD)",
+      "target_sha=$(git rev-parse origin/main)",
+      'jq -cn --arg source "$source_sha" --arg target "$target_sha" \'{version:1,pr:42,source:$source,target:$target,mode:"detached",branch:null}\' > .local/review-transition.json',
+      'git restore --source="$target_sha" --staged --worktree -- transition-a.txt main-only.txt',
+      'git update-ref --no-deref HEAD "$target_sha" "$source_sha"',
+      `git -C "$fixture_root" update-ref refs/pull/42/head ${fixture.prBSha}`,
+      "review_init 42",
+      "review_checkout_main 42",
+      "review_checkout_pr 42",
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(git(join(fixture.root, ".worktrees", "pr-42"), "rev-parse", "HEAD")).toBe(
+      fixture.prBSha,
+    );
+    expect(
+      git(join(fixture.root, ".worktrees", "pr-42"), "status", "--short", "--untracked-files=no"),
+    ).toBe("");
+    expect(readFileSync(artifact, "utf8")).toBe("preserve me\n");
+    expect(
+      existsSync(join(fixture.root, ".worktrees", "pr-42", ".local", "review-transition.json")),
+    ).toBe(false);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  for (const testCase of [
+    {
+      name: "staged",
+      setup: ['printf "foreign staged\\n" > overlap.txt', "git add overlap.txt"],
+      expectedStatus: "M  overlap.txt",
+      dirtyFile: "overlap.txt",
+      dirtyContent: "foreign staged\n",
+    },
+    {
+      name: "unstaged",
+      setup: ['printf "foreign unstaged\\n" > overlap.txt'],
+      expectedStatus: "M overlap.txt",
+      dirtyFile: "overlap.txt",
+      dirtyContent: "foreign unstaged\n",
+    },
+    {
+      name: "untracked",
+      setup: ['printf "foreign untracked\\n" > foreign.txt'],
+      expectedStatus: "?? foreign.txt",
+      dirtyFile: "foreign.txt",
+      dirtyContent: "foreign untracked\n",
+    },
+  ]) {
+    it(`refuses and preserves ${testCase.name} foreign state`, () => {
+      const fixture = createReviewFixture();
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const result = runShell(fixture, [
+        "review_init 42",
+        "review_checkout_pr 42",
+        "source_sha=$(git rev-parse HEAD)",
+        "target_sha=$(git rev-parse origin/main)",
+        'jq -cn --arg source "$source_sha" --arg target "$target_sha" \'{version:1,pr:42,source:$source,target:$target,mode:"detached",branch:null}\' > .local/review-transition.json',
+        'git restore --source="$target_sha" --staged --worktree -- transition-a.txt',
+        ...testCase.setup,
+        "git status --porcelain=v1 > .local/expected-status",
+        "review_init 42",
+      ]);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Refusing scripts/pr transition for PR #42");
+      expect(git(worktree, "rev-parse", "HEAD")).toBe(fixture.prASha);
+      expect(git(worktree, "status", "--porcelain=v1")).toBe(
+        readFileSync(join(worktree, ".local", "expected-status"), "utf8").trim(),
+      );
+      expect(git(worktree, "status", "--short")).toContain(testCase.expectedStatus);
+      expect(readFileSync(join(worktree, testCase.dirtyFile), "utf8")).toBe(testCase.dirtyContent);
+      expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(true);
+      expectCanonicalCheckoutUnchanged(fixture);
+    });
+  }
 });


### PR DESCRIPTION
Related: #125054

## What Problem This Solves

Fixes an issue where maintainers repeating the repo-native `scripts/pr` review flow could end up with `HEAD` moved to `origin/main` while a partially applied prior checkout remained staged in the native review worktree. The next `review-checkout-pr` then refused to overwrite those files, leaving the serialized review workflow blocked until a maintainer manually proved and removed the reconstructible state.

## Why This Change Was Made

Review worktree transitions now atomically journal their exact source commit, target commit, and branch/detached mode before touching tracked files. Recovery accepts only a source/target `HEAD`, a worktree matching the index, no foreign untracked or unmerged state, and index entries that exactly match either the journaled source or target per path. It then restores only source-to-target paths, completes the recorded checkout, verifies the exact clean target, and removes the journal. Unknown staged, unstaged, or untracked state fails closed and remains byte-for-byte untouched; `.local` review artifacts are preserved.

This replaces reliance on plain checkout idempotency without encoding the narrowly authorized `reset --hard` workaround used during #125054.

## User Impact

Maintainers can safely repeat `review-init`, `review-checkout-main`, and `review-checkout-pr` after an interrupted or partial native worktree transition. Reconstructible wrapper-owned state is repaired automatically, while foreign local work is never discarded.

No product runtime behavior changes.

## Evidence

- Archived #125054 incident evidence showed a successful `review-init` with `HEAD` on the main checkout while 16 source/target transition paths remained staged; the next PR checkout later refused to overwrite staged files.
- The committed real-Git regression exercises `review-init -> review-checkout-main -> review-checkout-pr`, simulates an interrupted partial PR-to-main transition, advances the PR from head A to overlapping head B, and repeats the sequence.
- Against the pre-fix scripts, that regression fails at the final checkout with `overlap.txt would be overwritten by checkout`.
- `node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts` — 10 tests passed, including staged, unstaged, ordinary untracked, and ignored target-path collision preservation plus `.local` artifact preservation.
- ClawSweeper identified that ignored files at target-tracked paths escaped the initial generic untracked scan. The repaired head checks ignored collisions only across source-to-target paths, preserving normal ignored build artifacts while refusing any path recovery could overwrite.
- `node scripts/check-changed.mjs -- scripts/pr-lib/worktree.sh scripts/pr-lib/review.sh test/scripts/pr-worktree-containment.test.ts` — formatting, root-test types, script lint, and repository guards passed after the safety repair.
- `bash -n scripts/pr-lib/worktree.sh scripts/pr-lib/review.sh` and `git diff --check` passed.
- Fresh Codex autoreview after the safety repair: clean, no accepted/actionable findings.
- Tooling LOC: +174/-7 (net +167). Tests: +173/-2 (net +171). The tooling growth is the explicit atomic journal, closed parser, per-path source/target ownership proof, ignored-collision guard, recovery state machine, and failure propagation needed to avoid blanket cleanup.
- AI-assisted: yes. The implementation, failure proof, and final diff were reviewed directly.
