### PR TITLE
fix(voice-call): expose realtime/streaming stream paths through tailscale serve/funnel

### DIFF
--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -187,7 +187,8 @@ JSON with `recordsScanned`, `turnLatency`, and `listenWait` summaries.
 ### `expose`
 
 Enable, disable, or change the Tailscale serve/funnel configuration for the
-voice webhook.
+voice webhook. When realtime or streaming audio is enabled, the command also
+exposes or clears that mode's WebSocket stream path.
 
 | Flag                  | Default                                   | Description                                     |
 | --------------------- | ----------------------------------------- | ----------------------------------------------- |

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -202,6 +202,7 @@ that Region. See
     - On ngrok free tier, set `publicUrl` to the exact ngrok URL; signature verification is always enforced.
     - `tunnel.allowNgrokFreeTierLoopbackBypass: true` allows Twilio webhooks with invalid signatures **only** when `tunnel.provider="ngrok"` and `serve.bind` is loopback (ngrok local agent). Local dev only.
     - Ngrok free-tier URLs can change or add interstitial behavior; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
+    - Tailscale Serve and Funnel automatically expose the realtime or streaming WebSocket path when that audio mode is enabled.
 
   </Accordion>
   <Accordion title="Streaming connection caps">

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -8,6 +8,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const callGatewayFromCliMock = vi.hoisted(() => vi.fn());
 const findCallMatchesInStoreMock = vi.hoisted(() => vi.fn());
 const loadActiveCallsFromStoreMock = vi.hoisted(() => vi.fn());
+const tailscaleMocks = vi.hoisted(() => ({
+  cleanup: vi.fn(),
+  getSelfInfo: vi.fn(),
+  setup: vi.fn(),
+}));
 const sleepMock = vi.hoisted(() =>
   vi.fn(
     async (ms: number) =>
@@ -30,6 +35,12 @@ vi.mock("./manager/store.js", async (importOriginal) => ({
   findCallMatchesInStore: findCallMatchesInStoreMock,
   loadActiveCallsFromStore: loadActiveCallsFromStoreMock,
 }));
+vi.mock("./webhook/tailscale.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./webhook/tailscale.js")>()),
+  cleanupTailscaleExposureRoute: tailscaleMocks.cleanup,
+  getTailscaleSelfInfo: tailscaleMocks.getSelfInfo,
+  setupTailscaleExposureRoute: tailscaleMocks.setup,
+}));
 
 import { registerVoiceCallCli } from "./cli.js";
 
@@ -50,6 +61,9 @@ describe("voice-call CLI status fallback", () => {
     callGatewayFromCliMock.mockReset();
     findCallMatchesInStoreMock.mockReset();
     loadActiveCallsFromStoreMock.mockReset();
+    tailscaleMocks.cleanup.mockReset();
+    tailscaleMocks.getSelfInfo.mockReset();
+    tailscaleMocks.setup.mockReset();
     sleepMock.mockReset();
     sleepMock.mockImplementation(
       async (ms: number) =>
@@ -149,6 +163,96 @@ describe("voice-call CLI status fallback", () => {
     await expect(
       program.parseAsync(["voicecall", "tail", "--since", "0x10"], { from: "user" }),
     ).rejects.toThrow("Invalid numeric value for --since: 0x10");
+  });
+
+  it("exposes the webhook target and enabled stream paths", async () => {
+    tailscaleMocks.setup.mockResolvedValue("https://bot.example.ts.net/voice/webhook");
+    const program = buildProgram(
+      {},
+      {
+        serve: { port: 3334, path: "/voice/webhook" },
+        tailscale: { mode: "off", path: "/voice/webhook" },
+        realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
+        streaming: { enabled: true, streamPath: "/voice/stream" },
+      },
+    );
+    const capturer = captureStdout();
+    try {
+      await program.parseAsync(
+        [
+          "voicecall",
+          "expose",
+          "--mode",
+          "funnel",
+          "--port",
+          "4444",
+          "--path",
+          "/custom/webhook",
+          "--serve-path",
+          "/custom/webhook",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      capturer.restore();
+    }
+
+    expect(tailscaleMocks.setup.mock.calls).toEqual([
+      [
+        {
+          mode: "funnel",
+          path: "/custom/webhook",
+          localUrl: "http://127.0.0.1:4444/custom/webhook",
+        },
+      ],
+      [
+        {
+          mode: "funnel",
+          path: "/voice/stream/realtime",
+          localUrl: "http://127.0.0.1:4444/voice/stream/realtime",
+        },
+      ],
+      [
+        {
+          mode: "funnel",
+          path: "/voice/stream",
+          localUrl: "http://127.0.0.1:4444/voice/stream",
+        },
+      ],
+    ]);
+    expect(JSON.parse(capturer.output())).toMatchObject({
+      localUrl: "http://127.0.0.1:4444/custom/webhook",
+      streamPaths: ["/voice/stream/realtime", "/voice/stream"],
+    });
+  });
+
+  it("clears webhook and stream paths for both Tailscale modes", async () => {
+    const program = buildProgram(
+      {},
+      {
+        serve: { port: 3334, path: "/voice/webhook" },
+        tailscale: { mode: "off", path: "/voice/webhook" },
+        realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
+        streaming: { enabled: true, streamPath: "/voice/stream" },
+      },
+    );
+    const capturer = captureStdout();
+    try {
+      await program.parseAsync(["voicecall", "expose", "--mode", "off"], { from: "user" });
+    } finally {
+      capturer.restore();
+    }
+
+    expect(tailscaleMocks.cleanup.mock.calls).toEqual(
+      ["/voice/webhook", "/voice/stream/realtime", "/voice/stream"].flatMap((exposurePath) => [
+        [{ mode: "serve", path: exposurePath }],
+        [{ mode: "funnel", path: exposurePath }],
+      ]),
+    );
+    expect(JSON.parse(capturer.output())).toMatchObject({
+      mode: "off",
+      streamPaths: ["/voice/stream/realtime", "/voice/stream"],
+    });
   });
 
   async function runCustomLogTailShortRead(

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -209,14 +209,14 @@ describe("voice-call CLI status fallback", () => {
           localUrl: "http://127.0.0.1:4444/voice/stream/realtime",
         },
         {
-          path: "/edge/voice/stream",
+          path: "/voice/stream",
           localUrl: "http://127.0.0.1:4444/voice/stream",
         },
       ],
     });
     expect(JSON.parse(capturer.output())).toMatchObject({
       localUrl: "http://127.0.0.1:4444/custom/webhook",
-      streamPaths: ["/edge/voice/stream/realtime", "/edge/voice/stream"],
+      streamPaths: ["/edge/voice/stream/realtime", "/voice/stream"],
     });
   });
 

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -39,7 +39,7 @@ vi.mock("./webhook/tailscale.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./webhook/tailscale.js")>()),
   cleanupTailscaleExposureRoute: tailscaleMocks.cleanup,
   getTailscaleSelfInfo: tailscaleMocks.getSelfInfo,
-  setupTailscaleExposureRoute: tailscaleMocks.setup,
+  setupTailscaleExposureRoutes: tailscaleMocks.setup,
 }));
 
 import { registerVoiceCallCli } from "./cli.js";
@@ -187,7 +187,7 @@ describe("voice-call CLI status fallback", () => {
           "--port",
           "4444",
           "--path",
-          "/custom/webhook",
+          "/edge/custom/webhook",
           "--serve-path",
           "/custom/webhook",
         ],
@@ -197,32 +197,51 @@ describe("voice-call CLI status fallback", () => {
       capturer.restore();
     }
 
-    expect(tailscaleMocks.setup.mock.calls).toEqual([
-      [
+    expect(tailscaleMocks.setup).toHaveBeenCalledWith({
+      mode: "funnel",
+      routes: [
         {
-          mode: "funnel",
-          path: "/custom/webhook",
+          path: "/edge/custom/webhook",
           localUrl: "http://127.0.0.1:4444/custom/webhook",
         },
-      ],
-      [
         {
-          mode: "funnel",
-          path: "/voice/stream/realtime",
+          path: "/edge/voice/stream/realtime",
           localUrl: "http://127.0.0.1:4444/voice/stream/realtime",
         },
-      ],
-      [
         {
-          mode: "funnel",
-          path: "/voice/stream",
+          path: "/edge/voice/stream",
           localUrl: "http://127.0.0.1:4444/voice/stream",
         },
       ],
-    ]);
+    });
     expect(JSON.parse(capturer.output())).toMatchObject({
       localUrl: "http://127.0.0.1:4444/custom/webhook",
-      streamPaths: ["/voice/stream/realtime", "/voice/stream"],
+      streamPaths: ["/edge/voice/stream/realtime", "/edge/voice/stream"],
+    });
+  });
+
+  it("reports failure when any exposure route cannot be mounted", async () => {
+    tailscaleMocks.setup.mockResolvedValue(null);
+    tailscaleMocks.getSelfInfo.mockResolvedValue(null);
+    const program = buildProgram(
+      {},
+      {
+        serve: { port: 3334, path: "/voice/webhook" },
+        tailscale: { mode: "off", path: "/voice/webhook" },
+        realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
+        streaming: { enabled: false },
+      },
+    );
+    const capturer = captureStdout();
+    try {
+      await program.parseAsync(["voicecall", "expose", "--mode", "funnel"], { from: "user" });
+    } finally {
+      capturer.restore();
+    }
+
+    expect(JSON.parse(capturer.output())).toMatchObject({
+      ok: false,
+      publicUrl: null,
     });
   });
 

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -18,7 +18,11 @@ import {
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sleep } from "../api.js";
-import { validateProviderConfig, type VoiceCallConfig } from "./config.js";
+import {
+  resolveVoiceCallStreamExposurePaths,
+  validateProviderConfig,
+  type VoiceCallConfig,
+} from "./config.js";
 import {
   findCallMatchesInStore,
   getCallHistoryFromStore,
@@ -893,13 +897,15 @@ export function registerVoiceCallCli(params: {
         );
         const servePath = options.servePath ?? config.serve.path ?? "/voice/webhook";
         const tsPath = options.path ?? config.tailscale?.path ?? servePath;
-
-        const localUrl = `http://127.0.0.1:${servePort}`;
+        const streamPaths = resolveVoiceCallStreamExposurePaths(config);
+        const localUrl = `http://127.0.0.1:${servePort}${servePath}`;
 
         if (mode === "off") {
-          await cleanupTailscaleExposureRoute({ mode: "serve", path: tsPath });
-          await cleanupTailscaleExposureRoute({ mode: "funnel", path: tsPath });
-          writeStdoutJson({ ok: true, mode: "off", path: tsPath });
+          for (const exposurePath of [tsPath, ...streamPaths]) {
+            await cleanupTailscaleExposureRoute({ mode: "serve", path: exposurePath });
+            await cleanupTailscaleExposureRoute({ mode: "funnel", path: exposurePath });
+          }
+          writeStdoutJson({ ok: true, mode: "off", path: tsPath, streamPaths });
           return;
         }
 
@@ -908,6 +914,13 @@ export function registerVoiceCallCli(params: {
           path: tsPath,
           localUrl,
         });
+        for (const streamPath of streamPaths) {
+          await setupTailscaleExposureRoute({
+            mode,
+            path: streamPath,
+            localUrl: `http://127.0.0.1:${servePort}${streamPath}`,
+          });
+        }
 
         const tsInfo = publicUrl ? null : await getTailscaleSelfInfo();
         const enableUrl = tsInfo?.nodeId
@@ -918,6 +931,7 @@ export function registerVoiceCallCli(params: {
           ok: Boolean(publicUrl),
           mode,
           path: tsPath,
+          streamPaths,
           localUrl,
           publicUrl,
           hint: publicUrl

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -36,7 +36,7 @@ import { resolveWebhookExposureStatus } from "./webhook-exposure.js";
 import {
   cleanupTailscaleExposureRoute,
   getTailscaleSelfInfo,
-  setupTailscaleExposureRoute,
+  setupTailscaleExposureRoutes,
 } from "./webhook/tailscale.js";
 
 type Logger = {
@@ -897,7 +897,11 @@ export function registerVoiceCallCli(params: {
         );
         const servePath = options.servePath ?? config.serve.path ?? "/voice/webhook";
         const tsPath = options.path ?? config.tailscale?.path ?? servePath;
-        const streamPaths = resolveVoiceCallStreamExposurePaths(config);
+        const streamExposurePaths = resolveVoiceCallStreamExposurePaths(config, {
+          publicWebhookPath: tsPath,
+          localWebhookPath: servePath,
+        });
+        const streamPaths = streamExposurePaths.map(({ publicPath }) => publicPath);
         const localUrl = `http://127.0.0.1:${servePort}${servePath}`;
 
         if (mode === "off") {
@@ -909,18 +913,16 @@ export function registerVoiceCallCli(params: {
           return;
         }
 
-        const publicUrl = await setupTailscaleExposureRoute({
+        const publicUrl = await setupTailscaleExposureRoutes({
           mode,
-          path: tsPath,
-          localUrl,
+          routes: [
+            { path: tsPath, localUrl },
+            ...streamExposurePaths.map(({ publicPath, localPath }) => ({
+              path: publicPath,
+              localUrl: `http://127.0.0.1:${servePort}${localPath}`,
+            })),
+          ],
         });
-        for (const streamPath of streamPaths) {
-          await setupTailscaleExposureRoute({
-            mode,
-            path: streamPath,
-            localUrl: `http://127.0.0.1:${servePort}${streamPath}`,
-          });
-        }
 
         const tsInfo = publicUrl ? null : await getTailscaleSelfInfo();
         const enableUrl = tsInfo?.nodeId

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -886,7 +886,7 @@ describe("resolveVoiceCallStreamExposurePaths", () => {
         localPath: "/voice/stream/realtime",
         publicPath: "/edge/voice/stream/realtime",
       },
-      { localPath: "/voice/stream", publicPath: "/edge/voice/stream" },
+      { localPath: "/voice/stream", publicPath: "/voice/stream" },
     ]);
   });
 });

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -842,7 +842,12 @@ describe("resolveVoiceCallStreamExposurePaths", () => {
       realtime: { enabled: true },
     });
 
-    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual(["/custom/stream/realtime"]);
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual([
+      {
+        localPath: "/custom/stream/realtime",
+        publicPath: "/custom/stream/realtime",
+      },
+    ]);
   });
 
   it("normalizes explicit realtime and streaming paths", () => {
@@ -852,8 +857,8 @@ describe("resolveVoiceCallStreamExposurePaths", () => {
     });
 
     expect(resolveVoiceCallStreamExposurePaths(config)).toEqual([
-      "/custom/realtime",
-      "/custom/stream",
+      { localPath: "/custom/realtime", publicPath: "/custom/realtime" },
+      { localPath: "/custom/stream", publicPath: "/custom/stream" },
     ]);
   });
 
@@ -863,7 +868,26 @@ describe("resolveVoiceCallStreamExposurePaths", () => {
       streaming: { enabled: true, streamPath: "/voice/stream" },
     });
 
-    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual(["/voice/stream"]);
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual([
+      { localPath: "/voice/stream", publicPath: "/voice/stream" },
+    ]);
+  });
+
+  it("maps stream paths through a distinct public Tailscale prefix", () => {
+    const config = normalizeVoiceCallConfig({
+      serve: { path: "/voice/webhook" },
+      tailscale: { path: "/edge/voice/webhook" },
+      realtime: { enabled: true },
+      streaming: { enabled: true, streamPath: "/voice/stream" },
+    });
+
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual([
+      {
+        localPath: "/voice/stream/realtime",
+        publicPath: "/edge/voice/stream/realtime",
+      },
+      { localPath: "/voice/stream", publicPath: "/edge/voice/stream" },
+    ]);
   });
 });
 

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -6,6 +6,7 @@ import {
   resolveVoiceCallEffectiveConfig,
   resolveVoiceCallNumberRouteKeyForCall,
   resolveVoiceCallSessionKey,
+  resolveVoiceCallStreamExposurePaths,
   validateProviderConfig,
   normalizeVoiceCallConfig,
   resolveVoiceCallConfig,
@@ -825,6 +826,44 @@ describe("normalizeVoiceCallConfig", () => {
       id: "ELEVENLABS_API_KEY",
     });
     expect(elevenlabs.voiceSettings).toEqual({ speed: 1.1 });
+  });
+});
+
+describe("resolveVoiceCallStreamExposurePaths", () => {
+  it("returns no paths when both audio modes are disabled", () => {
+    const config = normalizeVoiceCallConfig({});
+
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual([]);
+  });
+
+  it("derives the default realtime path from the webhook path", () => {
+    const config = normalizeVoiceCallConfig({
+      serve: { path: "/custom/webhook" },
+      realtime: { enabled: true },
+    });
+
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual(["/custom/stream/realtime"]);
+  });
+
+  it("normalizes explicit realtime and streaming paths", () => {
+    const config = normalizeVoiceCallConfig({
+      realtime: { enabled: true, streamPath: "custom/realtime" },
+      streaming: { enabled: true, streamPath: "custom/stream" },
+    });
+
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual([
+      "/custom/realtime",
+      "/custom/stream",
+    ]);
+  });
+
+  it("deduplicates equal realtime and streaming paths", () => {
+    const config = normalizeVoiceCallConfig({
+      realtime: { enabled: true, streamPath: "/voice/stream" },
+      streaming: { enabled: true, streamPath: "/voice/stream" },
+    });
+
+    expect(resolveVoiceCallStreamExposurePaths(config)).toEqual(["/voice/stream"]);
   });
 });
 

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -539,19 +539,41 @@ function defaultRealtimeStreamPathForServePath(servePath: string): string {
   return `${normalized}/stream/realtime`;
 }
 
-export function resolveVoiceCallStreamExposurePaths(config: VoiceCallConfig): string[] {
-  const paths: string[] = [];
+export type VoiceCallStreamExposurePath = {
+  publicPath: string;
+  localPath: string;
+};
+
+export function resolveVoiceCallPublicPathPrefix(
+  publicWebhookPath: string,
+  localWebhookPath: string,
+): string {
+  const normalizedPublicPath = normalizeWebhookPath(publicWebhookPath);
+  const normalizedLocalPath = normalizeWebhookPath(localWebhookPath);
+  const localPathIndex = normalizedPublicPath.indexOf(normalizedLocalPath);
+  return localPathIndex > 0 ? normalizedPublicPath.slice(0, localPathIndex) : "";
+}
+
+export function resolveVoiceCallStreamExposurePaths(
+  config: VoiceCallConfig,
+  webhookPaths: { publicWebhookPath?: string; localWebhookPath?: string } = {},
+): VoiceCallStreamExposurePath[] {
+  const streamPaths: string[] = [];
   if (config.realtime.enabled) {
-    paths.push(
+    streamPaths.push(
       config.realtime.streamPath ?? defaultRealtimeStreamPathForServePath(config.serve.path),
     );
   }
   if (config.streaming.enabled) {
-    paths.push(config.streaming.streamPath);
+    streamPaths.push(config.streaming.streamPath);
   }
-  // Accepted tradeoff: exotic prefixed tailscale paths are not prefix-mapped;
-  // stream mounts keep the proven public-path-equals-local-path shape.
-  return [...new Set(paths.map((path) => normalizeWebhookPath(path)))];
+  const localWebhookPath = webhookPaths.localWebhookPath ?? config.serve.path;
+  const publicWebhookPath = webhookPaths.publicWebhookPath ?? config.tailscale.path;
+  const publicPathPrefix = resolveVoiceCallPublicPathPrefix(publicWebhookPath, localWebhookPath);
+  return [...new Set(streamPaths.map((path) => normalizeWebhookPath(path)))].map((localPath) => ({
+    localPath,
+    publicPath: `${publicPathPrefix}${localPath}`,
+  }));
 }
 
 function normalizeVoiceCallTtsConfig(

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -539,6 +539,21 @@ function defaultRealtimeStreamPathForServePath(servePath: string): string {
   return `${normalized}/stream/realtime`;
 }
 
+export function resolveVoiceCallStreamExposurePaths(config: VoiceCallConfig): string[] {
+  const paths: string[] = [];
+  if (config.realtime.enabled) {
+    paths.push(
+      config.realtime.streamPath ?? defaultRealtimeStreamPathForServePath(config.serve.path),
+    );
+  }
+  if (config.streaming.enabled) {
+    paths.push(config.streaming.streamPath);
+  }
+  // Accepted tradeoff: exotic prefixed tailscale paths are not prefix-mapped;
+  // stream mounts keep the proven public-path-equals-local-path shape.
+  return [...new Set(paths.map((path) => normalizeWebhookPath(path)))];
+}
+
 function normalizeVoiceCallTtsConfig(
   defaults: VoiceCallTtsConfig,
   overrides: DeepPartial<NonNullable<VoiceCallTtsConfig>> | undefined,

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -548,32 +548,37 @@ export function resolveVoiceCallPublicPathPrefix(
   publicWebhookPath: string,
   localWebhookPath: string,
 ): string {
-  const normalizedPublicPath = normalizeWebhookPath(publicWebhookPath);
-  const normalizedLocalPath = normalizeWebhookPath(localWebhookPath);
-  const localPathIndex = normalizedPublicPath.indexOf(normalizedLocalPath);
-  return localPathIndex > 0 ? normalizedPublicPath.slice(0, localPathIndex) : "";
+  const publicPath = normalizeWebhookPath(publicWebhookPath);
+  const localPathIndex = publicPath.indexOf(normalizeWebhookPath(localWebhookPath));
+  return localPathIndex > 0 ? publicPath.slice(0, localPathIndex) : "";
 }
 
 export function resolveVoiceCallStreamExposurePaths(
   config: VoiceCallConfig,
   webhookPaths: { publicWebhookPath?: string; localWebhookPath?: string } = {},
 ): VoiceCallStreamExposurePath[] {
-  const streamPaths: string[] = [];
-  if (config.realtime.enabled) {
-    streamPaths.push(
-      config.realtime.streamPath ?? defaultRealtimeStreamPathForServePath(config.serve.path),
-    );
-  }
-  if (config.streaming.enabled) {
-    streamPaths.push(config.streaming.streamPath);
-  }
+  const exposurePaths: VoiceCallStreamExposurePath[] = [];
   const localWebhookPath = webhookPaths.localWebhookPath ?? config.serve.path;
   const publicWebhookPath = webhookPaths.publicWebhookPath ?? config.tailscale.path;
   const publicPathPrefix = resolveVoiceCallPublicPathPrefix(publicWebhookPath, localWebhookPath);
-  return [...new Set(streamPaths.map((path) => normalizeWebhookPath(path)))].map((localPath) => ({
-    localPath,
-    publicPath: `${publicPathPrefix}${localPath}`,
-  }));
+  if (config.realtime.enabled) {
+    const localPath = normalizeWebhookPath(
+      config.realtime.streamPath ?? defaultRealtimeStreamPathForServePath(config.serve.path),
+    );
+    exposurePaths.push({
+      localPath,
+      publicPath: `${publicPathPrefix}${localPath}`,
+    });
+  }
+  if (config.streaming.enabled) {
+    const localPath = normalizeWebhookPath(config.streaming.streamPath);
+    if (
+      !exposurePaths.some((path) => path.localPath === localPath && path.publicPath === localPath)
+    ) {
+      exposurePaths.push({ localPath, publicPath: localPath });
+    }
+  }
+  return exposurePaths;
 }
 
 function normalizeVoiceCallTtsConfig(

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -7,6 +7,7 @@ import { createVoiceCallBaseConfig } from "./test-fixtures.js";
 
 const mocks = vi.hoisted(() => ({
   resolveVoiceCallConfig: vi.fn(),
+  resolveVoiceCallStreamExposurePaths: vi.fn(),
   resolveTwilioAuthToken: vi.fn(),
   validateProviderConfig: vi.fn(),
   managerInitialize: vi.fn(),
@@ -66,6 +67,7 @@ vi.mock("./config.js", () => ({
     return route ? { config: { ...config, ...route }, numberRouteKey } : { config };
   },
   resolveVoiceCallConfig: mocks.resolveVoiceCallConfig,
+  resolveVoiceCallStreamExposurePaths: mocks.resolveVoiceCallStreamExposurePaths,
   resolveTwilioAuthToken: mocks.resolveTwilioAuthToken,
   validateProviderConfig: mocks.validateProviderConfig,
 }));
@@ -248,6 +250,8 @@ describe("createVoiceCallRuntime lifecycle", () => {
     });
     mocks.resolveRealtimeFastContextConsult.mockReset();
     mocks.resolveRealtimeFastContextConsult.mockResolvedValue({ handled: false });
+    mocks.resolveVoiceCallStreamExposurePaths.mockReset();
+    mocks.resolveVoiceCallStreamExposurePaths.mockReturnValue(["/voice/stream/realtime"]);
     mocks.startTunnel.mockResolvedValue(null);
     mocks.setupTailscaleExposure.mockResolvedValue(null);
     mocks.cleanupTailscaleExposure.mockResolvedValue(undefined);
@@ -270,6 +274,9 @@ describe("createVoiceCallRuntime lifecycle", () => {
       }),
     ).rejects.toThrow("init failed");
 
+    expect(mocks.startTunnel).toHaveBeenCalledWith(
+      expect.objectContaining({ streamPaths: ["/voice/stream/realtime"] }),
+    );
     expect(tunnelStop).toHaveBeenCalledTimes(1);
     expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);
     expect(mocks.webhookStop).toHaveBeenCalledTimes(1);

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -251,7 +251,12 @@ describe("createVoiceCallRuntime lifecycle", () => {
     mocks.resolveRealtimeFastContextConsult.mockReset();
     mocks.resolveRealtimeFastContextConsult.mockResolvedValue({ handled: false });
     mocks.resolveVoiceCallStreamExposurePaths.mockReset();
-    mocks.resolveVoiceCallStreamExposurePaths.mockReturnValue(["/voice/stream/realtime"]);
+    mocks.resolveVoiceCallStreamExposurePaths.mockReturnValue([
+      {
+        localPath: "/voice/stream/realtime",
+        publicPath: "/voice/stream/realtime",
+      },
+    ]);
     mocks.startTunnel.mockResolvedValue(null);
     mocks.setupTailscaleExposure.mockResolvedValue(null);
     mocks.cleanupTailscaleExposure.mockResolvedValue(undefined);
@@ -275,7 +280,14 @@ describe("createVoiceCallRuntime lifecycle", () => {
     ).rejects.toThrow("init failed");
 
     expect(mocks.startTunnel).toHaveBeenCalledWith(
-      expect.objectContaining({ streamPaths: ["/voice/stream/realtime"] }),
+      expect.objectContaining({
+        streamPaths: [
+          {
+            localPath: "/voice/stream/realtime",
+            publicPath: "/voice/stream/realtime",
+          },
+        ],
+      }),
     );
     expect(tunnelStop).toHaveBeenCalledTimes(1);
     expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -486,7 +486,10 @@ export async function createVoiceCallRuntime(params: {
           provider: config.tunnel.provider,
           port: config.serve.port,
           path: config.serve.path,
-          streamPaths: resolveVoiceCallStreamExposurePaths(config),
+          streamPaths: resolveVoiceCallStreamExposurePaths(config, {
+            publicWebhookPath: config.serve.path,
+            localWebhookPath: config.serve.path,
+          }),
           ngrokAuthToken: config.tunnel.ngrokAuthToken,
           ngrokDomain: config.tunnel.ngrokDomain,
         });

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -19,6 +19,7 @@ import {
   resolveVoiceCallEffectiveConfig,
   resolveVoiceCallNumberRouteKeyForCall,
   resolveVoiceCallSessionKey,
+  resolveVoiceCallStreamExposurePaths,
   resolveTwilioAuthToken,
   resolveVoiceCallConfig,
   validateProviderConfig,
@@ -485,6 +486,7 @@ export async function createVoiceCallRuntime(params: {
           provider: config.tunnel.provider,
           port: config.serve.port,
           path: config.serve.path,
+          streamPaths: resolveVoiceCallStreamExposurePaths(config),
           ngrokAuthToken: config.tunnel.ngrokAuthToken,
           ngrokDomain: config.tunnel.ngrokDomain,
         });

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -85,12 +85,18 @@ function startNgrokTunnel(config: {
   );
 }
 
-function startTailscaleTunnel(config: { mode: "serve" | "funnel"; port: number; path: string }) {
+function startTailscaleTunnel(config: {
+  mode: "serve" | "funnel";
+  port: number;
+  path: string;
+  streamPaths?: string[];
+}) {
   return requireTunnel(
     startTunnel({
       provider: config.mode === "serve" ? "tailscale-serve" : "tailscale-funnel",
       port: config.port,
       path: config.path,
+      streamPaths: config.streamPaths,
     }),
   );
 }
@@ -154,6 +160,7 @@ describe("voice-call tunnels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getTailscaleDnsName.mockReset();
+    mocks.runCommand.mockReset();
     mocks.runCommand.mockResolvedValue(commandResult());
   });
 
@@ -359,6 +366,74 @@ describe("voice-call tunnels", () => {
         "http://127.0.0.1:3334/voice/webhook",
       ],
       expect.objectContaining({ timeoutMs: 10_000 }),
+    );
+  });
+
+  it.each(["serve", "funnel"] as const)(
+    "mounts and stops every Tailscale %s stream path",
+    async (mode) => {
+      mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
+      const tunnel = await startTailscaleTunnel({
+        mode,
+        port: 3334,
+        path: "/voice/webhook",
+        streamPaths: ["/voice/stream/realtime", "/voice/stream"],
+      });
+
+      await tunnel.stop();
+
+      expect(mocks.runCommand.mock.calls.map(([command]) => command)).toEqual([
+        [
+          "tailscale",
+          mode,
+          "--bg",
+          "--yes",
+          "--set-path",
+          "/voice/webhook",
+          "http://127.0.0.1:3334/voice/webhook",
+        ],
+        [
+          "tailscale",
+          mode,
+          "--bg",
+          "--yes",
+          "--set-path",
+          "/voice/stream/realtime",
+          "http://127.0.0.1:3334/voice/stream/realtime",
+        ],
+        [
+          "tailscale",
+          mode,
+          "--bg",
+          "--yes",
+          "--set-path",
+          "/voice/stream",
+          "http://127.0.0.1:3334/voice/stream",
+        ],
+        ["tailscale", mode, "off", "/voice/webhook"],
+        ["tailscale", mode, "off", "/voice/stream/realtime"],
+        ["tailscale", mode, "off", "/voice/stream"],
+      ]);
+    },
+  );
+
+  it("rejects when a Tailscale stream path cannot be mounted", async () => {
+    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
+    mocks.runCommand
+      .mockResolvedValueOnce(commandResult())
+      .mockResolvedValueOnce(commandResult({ code: 1, stderr: "stream mount failed" }));
+
+    await expect(
+      startTailscaleTunnel({
+        mode: "funnel",
+        port: 3334,
+        path: "/voice/webhook",
+        streamPaths: ["/voice/stream/realtime"],
+      }),
+    ).rejects.toThrow("Tailscale funnel failed with code 1: stream mount failed");
+    expect(mocks.runCommand).toHaveBeenLastCalledWith(
+      ["tailscale", "funnel", "off", "/voice/webhook"],
+      expect.objectContaining({ timeoutMs: 5_000 }),
     );
   });
 

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -89,7 +89,7 @@ function startTailscaleTunnel(config: {
   mode: "serve" | "funnel";
   port: number;
   path: string;
-  streamPaths?: string[];
+  streamPaths?: Array<{ publicPath: string; localPath: string }>;
 }) {
   return requireTunnel(
     startTunnel({
@@ -377,7 +377,13 @@ describe("voice-call tunnels", () => {
         mode,
         port: 3334,
         path: "/voice/webhook",
-        streamPaths: ["/voice/stream/realtime", "/voice/stream"],
+        streamPaths: [
+          {
+            publicPath: "/edge/voice/stream/realtime",
+            localPath: "/voice/stream/realtime",
+          },
+          { publicPath: "/edge/voice/stream", localPath: "/voice/stream" },
+        ],
       });
 
       await tunnel.stop();
@@ -398,7 +404,7 @@ describe("voice-call tunnels", () => {
           "--bg",
           "--yes",
           "--set-path",
-          "/voice/stream/realtime",
+          "/edge/voice/stream/realtime",
           "http://127.0.0.1:3334/voice/stream/realtime",
         ],
         [
@@ -407,12 +413,12 @@ describe("voice-call tunnels", () => {
           "--bg",
           "--yes",
           "--set-path",
-          "/voice/stream",
+          "/edge/voice/stream",
           "http://127.0.0.1:3334/voice/stream",
         ],
         ["tailscale", mode, "off", "/voice/webhook"],
-        ["tailscale", mode, "off", "/voice/stream/realtime"],
-        ["tailscale", mode, "off", "/voice/stream"],
+        ["tailscale", mode, "off", "/edge/voice/stream/realtime"],
+        ["tailscale", mode, "off", "/edge/voice/stream"],
       ]);
     },
   );
@@ -428,7 +434,12 @@ describe("voice-call tunnels", () => {
         mode: "funnel",
         port: 3334,
         path: "/voice/webhook",
-        streamPaths: ["/voice/stream/realtime"],
+        streamPaths: [
+          {
+            publicPath: "/voice/stream/realtime",
+            localPath: "/voice/stream/realtime",
+          },
+        ],
       }),
     ).rejects.toThrow("Tailscale funnel failed with code 1: stream mount failed");
     expect(mocks.runCommand).toHaveBeenLastCalledWith(

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -77,6 +77,8 @@ interface TunnelConfig {
   port: number;
   /** Path prefix for the tunnel (e.g., /voice/webhook) */
   path: string;
+  /** Additional local WebSocket paths exposed by Tailscale */
+  streamPaths?: string[];
   /** ngrok auth token (optional, enables longer sessions) */
   ngrokAuthToken?: string;
   /** ngrok custom domain (paid feature) */
@@ -277,6 +279,7 @@ async function startTailscaleTunnel(config: {
   mode: "serve" | "funnel";
   port: number;
   path: string;
+  streamPaths?: string[];
 }): Promise<TunnelResult> {
   // Get Tailscale DNS name
   const dnsName = await getTailscaleDnsName();
@@ -285,26 +288,42 @@ async function startTailscaleTunnel(config: {
   }
 
   const path = config.path.startsWith("/") ? config.path : `/${config.path}`;
-  const localUrl = `http://127.0.0.1:${config.port}${path}`;
+  const exposurePaths = [
+    path,
+    ...(config.streamPaths ?? []).map((streamPath) =>
+      streamPath.startsWith("/") ? streamPath : `/${streamPath}`,
+    ),
+  ];
+  const mountedPaths: string[] = [];
 
-  const result = await runCommandWithTimeout(
-    ["tailscale", config.mode, "--bg", "--yes", "--set-path", path, localUrl],
-    {
-      killProcessTree: true,
-      maxOutputBytes: TUNNEL_COMMAND_OUTPUT_MAX_BYTES,
-      outputCapture: "tail",
-      timeoutMs: 10_000,
-    },
-  );
-  if (result.termination === "timeout") {
-    throw new Error(`Tailscale ${config.mode} timed out`);
-  }
-  if (result.code !== 0) {
-    const output = result.stderr
-      ? { text: result.stderr, truncated: Boolean(result.stderrTruncatedBytes) }
-      : { text: result.stdout, truncated: Boolean(result.stdoutTruncatedBytes) };
-    const detail = output.text ? `: ${formatBoundedChildOutput(output)}` : "";
-    throw new Error(`Tailscale ${config.mode} failed with code ${result.code}${detail}`);
+  for (const exposurePath of exposurePaths) {
+    const localUrl = `http://127.0.0.1:${config.port}${exposurePath}`;
+    const result = await runCommandWithTimeout(
+      ["tailscale", config.mode, "--bg", "--yes", "--set-path", exposurePath, localUrl],
+      {
+        killProcessTree: true,
+        maxOutputBytes: TUNNEL_COMMAND_OUTPUT_MAX_BYTES,
+        outputCapture: "tail",
+        timeoutMs: 10_000,
+      },
+    );
+    let failure: Error | undefined;
+    if (result.termination === "timeout") {
+      failure = new Error(`Tailscale ${config.mode} timed out`);
+    } else if (result.code !== 0) {
+      const output = result.stderr
+        ? { text: result.stderr, truncated: Boolean(result.stderrTruncatedBytes) }
+        : { text: result.stdout, truncated: Boolean(result.stdoutTruncatedBytes) };
+      const detail = output.text ? `: ${formatBoundedChildOutput(output)}` : "";
+      failure = new Error(`Tailscale ${config.mode} failed with code ${result.code}${detail}`);
+    }
+    if (failure) {
+      for (const mountedPath of mountedPaths) {
+        await stopTailscaleTunnel(config.mode, mountedPath);
+      }
+      throw failure;
+    }
+    mountedPaths.push(exposurePath);
   }
   const publicUrl = `https://${dnsName}${path}`;
   console.log(`[voice-call] Tailscale ${config.mode} active: ${publicUrl}`);
@@ -313,7 +332,9 @@ async function startTailscaleTunnel(config: {
     publicUrl,
     provider: `tailscale-${config.mode}`,
     stop: async () => {
-      await stopTailscaleTunnel(config.mode, path);
+      for (const exposurePath of exposurePaths) {
+        await stopTailscaleTunnel(config.mode, exposurePath);
+      }
     },
   };
 }
@@ -347,6 +368,7 @@ export async function startTunnel(config: TunnelConfig): Promise<TunnelResult | 
         mode: "serve",
         port: config.port,
         path: config.path,
+        streamPaths: config.streamPaths,
       });
 
     case "tailscale-funnel":
@@ -354,6 +376,7 @@ export async function startTunnel(config: TunnelConfig): Promise<TunnelResult | 
         mode: "funnel",
         port: config.port,
         path: config.path,
+        streamPaths: config.streamPaths,
       });
 
     default:

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -7,6 +7,7 @@ import {
   emptyBoundedChildOutput,
   formatBoundedChildOutput,
 } from "./bounded-child-output.js";
+import type { VoiceCallStreamExposurePath } from "./config.js";
 import { getTailscaleDnsName } from "./webhook/tailscale.js";
 
 const NGROK_LOG_BUFFER_MAX_CHARS = 16_384;
@@ -77,8 +78,8 @@ interface TunnelConfig {
   port: number;
   /** Path prefix for the tunnel (e.g., /voice/webhook) */
   path: string;
-  /** Additional local WebSocket paths exposed by Tailscale */
-  streamPaths?: string[];
+  /** Additional public-to-local WebSocket paths exposed by Tailscale */
+  streamPaths?: VoiceCallStreamExposurePath[];
   /** ngrok auth token (optional, enables longer sessions) */
   ngrokAuthToken?: string;
   /** ngrok custom domain (paid feature) */
@@ -279,7 +280,7 @@ async function startTailscaleTunnel(config: {
   mode: "serve" | "funnel";
   port: number;
   path: string;
-  streamPaths?: string[];
+  streamPaths?: VoiceCallStreamExposurePath[];
 }): Promise<TunnelResult> {
   // Get Tailscale DNS name
   const dnsName = await getTailscaleDnsName();
@@ -288,18 +289,22 @@ async function startTailscaleTunnel(config: {
   }
 
   const path = config.path.startsWith("/") ? config.path : `/${config.path}`;
-  const exposurePaths = [
-    path,
-    ...(config.streamPaths ?? []).map((streamPath) =>
-      streamPath.startsWith("/") ? streamPath : `/${streamPath}`,
-    ),
+  const exposurePaths: VoiceCallStreamExposurePath[] = [
+    { publicPath: path, localPath: path },
+    ...(config.streamPaths ?? []),
   ];
   const mountedPaths: string[] = [];
 
-  for (const exposurePath of exposurePaths) {
-    const localUrl = `http://127.0.0.1:${config.port}${exposurePath}`;
+  for (const exposure of exposurePaths) {
+    const publicPath = exposure.publicPath.startsWith("/")
+      ? exposure.publicPath
+      : `/${exposure.publicPath}`;
+    const localPath = exposure.localPath.startsWith("/")
+      ? exposure.localPath
+      : `/${exposure.localPath}`;
+    const localUrl = `http://127.0.0.1:${config.port}${localPath}`;
     const result = await runCommandWithTimeout(
-      ["tailscale", config.mode, "--bg", "--yes", "--set-path", exposurePath, localUrl],
+      ["tailscale", config.mode, "--bg", "--yes", "--set-path", publicPath, localUrl],
       {
         killProcessTree: true,
         maxOutputBytes: TUNNEL_COMMAND_OUTPUT_MAX_BYTES,
@@ -323,7 +328,7 @@ async function startTailscaleTunnel(config: {
       }
       throw failure;
     }
-    mountedPaths.push(exposurePath);
+    mountedPaths.push(publicPath);
   }
   const publicUrl = `https://${dnsName}${path}`;
   console.log(`[voice-call] Tailscale ${config.mode} active: ${publicUrl}`);
@@ -332,8 +337,8 @@ async function startTailscaleTunnel(config: {
     publicUrl,
     provider: `tailscale-${config.mode}`,
     stop: async () => {
-      for (const exposurePath of exposurePaths) {
-        await stopTailscaleTunnel(config.mode, exposurePath);
+      for (const mountedPath of mountedPaths) {
+        await stopTailscaleTunnel(config.mode, mountedPath);
       }
     },
   };

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -125,6 +125,58 @@ async function connectCarrierStream(handler: RealtimeCallHandler) {
 }
 
 describe("RealtimeCallHandler lifecycle", () => {
+  it("warns and removes a stream token when the provider never connects", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { handler } = createCarrierLifecycleHarness(() => createBridge(vi.fn()));
+
+    try {
+      handler.issueStreamSession({
+        callId: "call-never-connected",
+        from: "+15550001111",
+        to: "+15550002222",
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("never connected"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("call-never-connected"));
+      expect(
+        (
+          handler as unknown as {
+            pendingStreamTokens: Map<string, unknown>;
+          }
+        ).pendingStreamTokens.size,
+      ).toBe(0);
+    } finally {
+      await handler.close();
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not warn after the provider consumes a stream token", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { handler } = createCarrierLifecycleHarness(() => createBridge(vi.fn()));
+    const { token } = handler.issueStreamSession({ callId: "call-connected" });
+
+    try {
+      (
+        handler as unknown as {
+          consumeStreamToken(token: string): unknown;
+        }
+      ).consumeStreamToken(token);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      await handler.close();
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     { closeOutcome: undefined, closeReason: "Failed to connect" },
     { closeOutcome: "completed" as const, closeReason: "Failed to connect" },

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -615,11 +615,26 @@ export class RealtimeCallHandler {
     const expiry = resolveExpiresAtMsFromDurationMs(STREAM_TOKEN_TTL_MS, { nowMs: now });
     if (expiry !== undefined) {
       this.pendingStreamTokens.set(token, { expiry, ...meta });
-    }
-    for (const [candidate, entry] of this.pendingStreamTokens) {
-      if (!isFutureDateTimestampMs(entry.expiry, { nowMs: now })) {
-        this.pendingStreamTokens.delete(candidate);
-      }
+      const host = this.publicOrigin || DEFAULT_HOST;
+      const streamPathPattern = this.getStreamPathPattern();
+      const timer = setTimeout(() => {
+        if (!this.pendingStreamTokens.has(token)) {
+          return;
+        }
+        this.pendingStreamTokens.delete(token);
+        if (this.closing) {
+          return;
+        }
+        const call = meta.callId ? ` for call ${meta.callId}` : "";
+        const endpoints = [meta.from ? `from ${meta.from}` : "", meta.to ? `to ${meta.to}` : ""]
+          .filter(Boolean)
+          .join(" ");
+        const participants = endpoints ? ` (${endpoints})` : "";
+        console.warn(
+          `[voice-call] Realtime stream WebSocket never connected within ${STREAM_TOKEN_TTL_MS / 1000}s${call}${participants} — the provider could not reach wss://${host}${streamPathPattern}/<token>. Verify the stream path is exposed (tailscale serve/funnel --set-path).`,
+        );
+      }, STREAM_TOKEN_TTL_MS);
+      timer.unref?.();
     }
     return token;
   }

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -27,7 +27,7 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import WebSocket, { WebSocketServer } from "ws";
-import type { VoiceCallRealtimeConfig } from "../config.js";
+import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
@@ -383,10 +383,7 @@ export class RealtimeCallHandler {
     try {
       const parsed = new URL(url);
       this.publicOrigin = parsed.host;
-      const normalizedServePath = normalizeWebhookPath(this.servePath);
-      const normalizedPublicPath = normalizeWebhookPath(parsed.pathname);
-      const idx = normalizedPublicPath.indexOf(normalizedServePath);
-      this.publicPathPrefix = idx > 0 ? normalizedPublicPath.slice(0, idx) : "";
+      this.publicPathPrefix = resolveVoiceCallPublicPathPrefix(parsed.pathname, this.servePath);
     } catch {
       this.publicOrigin = null;
       this.publicPathPrefix = "";

--- a/extensions/voice-call/src/webhook/tailscale.test.ts
+++ b/extensions/voice-call/src/webhook/tailscale.test.ts
@@ -148,17 +148,23 @@ describe("voice-call tailscale helpers", () => {
       setupTailscaleExposure({
         tailscale: { mode: "off", path: "/voice" },
         serve: { port: 8787, path: "/webhook" },
+        realtime: { enabled: false },
+        streaming: { enabled: false },
       } as never),
     ).resolves.toBeNull();
     await expect(
       setupTailscaleExposure({
         tailscale: { mode: "funnel", path: "/voice" },
         serve: { port: 8787, path: "/webhook" },
+        realtime: { enabled: false },
+        streaming: { enabled: false },
       } as never),
     ).resolves.toBe("https://bot.example.ts.net/voice");
     await cleanupTailscaleExposure({
       tailscale: { mode: "serve", path: "/voice" },
       serve: { port: 8787, path: "/webhook" },
+      realtime: { enabled: false },
+      streaming: { enabled: false },
     } as never);
 
     expect(runCommandMock.mock.calls[1]?.[0]).toEqual([
@@ -171,5 +177,76 @@ describe("voice-call tailscale helpers", () => {
       "http://127.0.0.1:8787/webhook",
     ]);
     expect(runCommandMock.mock.calls[2]?.[0]).toEqual(["tailscale", "serve", "off", "/voice"]);
+  });
+
+  it.each([
+    {
+      name: "realtime",
+      config: { realtime: { enabled: true, streamPath: "/voice/stream/realtime" } },
+      streamPath: "/voice/stream/realtime",
+    },
+    {
+      name: "streaming",
+      config: { streaming: { enabled: true, streamPath: "/voice/stream" } },
+      streamPath: "/voice/stream",
+    },
+  ])("mounts and cleans up the enabled $name stream path", async ({ config, streamPath }) => {
+    runCommandMock.mockImplementation(async (command: string[]) =>
+      command[1] === "status"
+        ? commandResult({
+            stdout: JSON.stringify({ Self: { DNSName: "bot.example.ts.net." } }),
+          })
+        : commandResult(),
+    );
+    const voiceCallConfig = {
+      tailscale: { mode: "funnel", path: "/voice/webhook" },
+      serve: { port: 8787, path: "/voice/webhook" },
+      realtime: { enabled: false },
+      streaming: { enabled: false },
+      ...config,
+    } as never;
+
+    await setupTailscaleExposure(voiceCallConfig);
+    await cleanupTailscaleExposure(voiceCallConfig);
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      [
+        "tailscale",
+        "funnel",
+        "--bg",
+        "--yes",
+        "--set-path",
+        streamPath,
+        `http://127.0.0.1:8787${streamPath}`,
+      ],
+      expect.any(Object),
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
+      ["tailscale", "funnel", "off", streamPath],
+      expect.any(Object),
+    );
+  });
+
+  it("deduplicates equal realtime and streaming paths", async () => {
+    runCommandMock.mockImplementation(async (command: string[]) =>
+      command[1] === "status"
+        ? commandResult({
+            stdout: JSON.stringify({ Self: { DNSName: "bot.example.ts.net." } }),
+          })
+        : commandResult(),
+    );
+    const config = {
+      tailscale: { mode: "funnel", path: "/voice/webhook" },
+      serve: { port: 8787, path: "/voice/webhook" },
+      realtime: { enabled: true, streamPath: "/voice/stream" },
+      streaming: { enabled: true, streamPath: "/voice/stream" },
+    } as never;
+
+    await setupTailscaleExposure(config);
+
+    const streamMounts = runCommandMock.mock.calls.filter(
+      ([command]) => command[5] === "/voice/stream",
+    );
+    expect(streamMounts).toHaveLength(1);
   });
 });

--- a/extensions/voice-call/src/webhook/tailscale.test.ts
+++ b/extensions/voice-call/src/webhook/tailscale.test.ts
@@ -181,48 +181,53 @@ describe("voice-call tailscale helpers", () => {
       name: "realtime",
       config: { realtime: { enabled: true, streamPath: "/voice/stream/realtime" } },
       streamPath: "/voice/stream/realtime",
+      publicStreamPath: "/edge/voice/stream/realtime",
     },
     {
       name: "streaming",
       config: { streaming: { enabled: true, streamPath: "/voice/stream" } },
       streamPath: "/voice/stream",
+      publicStreamPath: "/voice/stream",
     },
-  ])("mounts and cleans up the enabled $name stream path", async ({ config, streamPath }) => {
-    runCommandMock.mockImplementation(async (command: string[]) =>
-      command[1] === "status"
-        ? commandResult({
-            stdout: JSON.stringify({ Self: { DNSName: "bot.example.ts.net." } }),
-          })
-        : commandResult(),
-    );
-    const voiceCallConfig = {
-      tailscale: { mode: "funnel", path: "/edge/voice/webhook" },
-      serve: { port: 8787, path: "/voice/webhook" },
-      realtime: { enabled: false },
-      streaming: { enabled: false },
-      ...config,
-    } as never;
+  ])(
+    "mounts and cleans up the enabled $name stream path",
+    async ({ config, streamPath, publicStreamPath }) => {
+      runCommandMock.mockImplementation(async (command: string[]) =>
+        command[1] === "status"
+          ? commandResult({
+              stdout: JSON.stringify({ Self: { DNSName: "bot.example.ts.net." } }),
+            })
+          : commandResult(),
+      );
+      const voiceCallConfig = {
+        tailscale: { mode: "funnel", path: "/edge/voice/webhook" },
+        serve: { port: 8787, path: "/voice/webhook" },
+        realtime: { enabled: false },
+        streaming: { enabled: false },
+        ...config,
+      } as never;
 
-    await setupTailscaleExposure(voiceCallConfig);
-    await cleanupTailscaleExposure(voiceCallConfig);
+      await setupTailscaleExposure(voiceCallConfig);
+      await cleanupTailscaleExposure(voiceCallConfig);
 
-    expect(runCommandMock).toHaveBeenCalledWith(
-      [
-        "tailscale",
-        "funnel",
-        "--bg",
-        "--yes",
-        "--set-path",
-        `/edge${streamPath}`,
-        `http://127.0.0.1:8787${streamPath}`,
-      ],
-      expect.any(Object),
-    );
-    expect(runCommandMock).toHaveBeenCalledWith(
-      ["tailscale", "funnel", "off", `/edge${streamPath}`],
-      expect.any(Object),
-    );
-  });
+      expect(runCommandMock).toHaveBeenCalledWith(
+        [
+          "tailscale",
+          "funnel",
+          "--bg",
+          "--yes",
+          "--set-path",
+          publicStreamPath,
+          `http://127.0.0.1:8787${streamPath}`,
+        ],
+        expect.any(Object),
+      );
+      expect(runCommandMock).toHaveBeenCalledWith(
+        ["tailscale", "funnel", "off", publicStreamPath],
+        expect.any(Object),
+      );
+    },
+  );
 
   it("deduplicates equal realtime and streaming paths", async () => {
     runCommandMock.mockImplementation(async (command: string[]) =>

--- a/extensions/voice-call/src/webhook/tailscale.test.ts
+++ b/extensions/voice-call/src/webhook/tailscale.test.ts
@@ -13,7 +13,7 @@ import {
   getTailscaleDnsName,
   getTailscaleSelfInfo,
   setupTailscaleExposure,
-  setupTailscaleExposureRoute,
+  setupTailscaleExposureRoutes,
 } from "./tailscale.js";
 
 function commandResult(overrides: Record<string, unknown> = {}) {
@@ -84,10 +84,9 @@ describe("voice-call tailscale helpers", () => {
       .mockResolvedValueOnce(commandResult());
 
     await expect(
-      setupTailscaleExposureRoute({
+      setupTailscaleExposureRoutes({
         mode: "serve",
-        path: "/voice",
-        localUrl: "http://127.0.0.1:8787/webhook",
+        routes: [{ path: "/voice", localUrl: "http://127.0.0.1:8787/webhook" }],
       }),
     ).resolves.toBe("https://bot.example.ts.net/voice");
     await cleanupTailscaleExposureRoute({ mode: "serve", path: "/voice" });
@@ -121,17 +120,15 @@ describe("voice-call tailscale helpers", () => {
       .mockResolvedValueOnce(commandResult({ code: 1 }));
 
     await expect(
-      setupTailscaleExposureRoute({
+      setupTailscaleExposureRoutes({
         mode: "funnel",
-        path: "/voice",
-        localUrl: "http://127.0.0.1:8787/webhook",
+        routes: [{ path: "/voice", localUrl: "http://127.0.0.1:8787/webhook" }],
       }),
     ).resolves.toBeNull();
     await expect(
-      setupTailscaleExposureRoute({
+      setupTailscaleExposureRoutes({
         mode: "funnel",
-        path: "/voice",
-        localUrl: "http://127.0.0.1:8787/webhook",
+        routes: [{ path: "/voice", localUrl: "http://127.0.0.1:8787/webhook" }],
       }),
     ).resolves.toBeNull();
   });
@@ -199,7 +196,7 @@ describe("voice-call tailscale helpers", () => {
         : commandResult(),
     );
     const voiceCallConfig = {
-      tailscale: { mode: "funnel", path: "/voice/webhook" },
+      tailscale: { mode: "funnel", path: "/edge/voice/webhook" },
       serve: { port: 8787, path: "/voice/webhook" },
       realtime: { enabled: false },
       streaming: { enabled: false },
@@ -216,13 +213,13 @@ describe("voice-call tailscale helpers", () => {
         "--bg",
         "--yes",
         "--set-path",
-        streamPath,
+        `/edge${streamPath}`,
         `http://127.0.0.1:8787${streamPath}`,
       ],
       expect.any(Object),
     );
     expect(runCommandMock).toHaveBeenCalledWith(
-      ["tailscale", "funnel", "off", streamPath],
+      ["tailscale", "funnel", "off", `/edge${streamPath}`],
       expect.any(Object),
     );
   });
@@ -248,5 +245,31 @@ describe("voice-call tailscale helpers", () => {
       ([command]) => command[5] === "/voice/stream",
     );
     expect(streamMounts).toHaveLength(1);
+  });
+
+  it("rolls back direct exposure when a stream route cannot be mounted", async () => {
+    runCommandMock.mockImplementation(async (command: string[]) => {
+      if (command[1] === "status") {
+        return commandResult({
+          stdout: JSON.stringify({ Self: { DNSName: "bot.example.ts.net." } }),
+        });
+      }
+      if (command[1] === "funnel" && command[5] === "/voice/stream/realtime") {
+        return commandResult({ code: 1 });
+      }
+      return commandResult();
+    });
+    const config = {
+      tailscale: { mode: "funnel", path: "/voice/webhook" },
+      serve: { port: 8787, path: "/voice/webhook" },
+      realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
+      streaming: { enabled: false },
+    } as never;
+
+    await expect(setupTailscaleExposure(config)).resolves.toBeNull();
+    expect(runCommandMock).toHaveBeenCalledWith(
+      ["tailscale", "funnel", "off", "/voice/webhook"],
+      expect.any(Object),
+    );
   });
 });

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -1,6 +1,6 @@
 // Voice Call plugin module implements tailscale behavior.
 import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
-import type { VoiceCallConfig } from "../config.js";
+import { resolveVoiceCallStreamExposurePaths, type VoiceCallConfig } from "../config.js";
 
 type TailscaleSelfInfo = {
   dnsName: string | null;
@@ -96,11 +96,25 @@ export async function setupTailscaleExposure(config: VoiceCallConfig): Promise<s
 
   const mode = config.tailscale.mode === "funnel" ? "funnel" : "serve";
   const localUrl = `http://127.0.0.1:${config.serve.port}${config.serve.path}`;
-  return setupTailscaleExposureRoute({
+  const publicUrl = await setupTailscaleExposureRoute({
     mode,
     path: config.tailscale.path,
     localUrl,
   });
+  for (const streamPath of resolveVoiceCallStreamExposurePaths(config)) {
+    const streamLocalUrl = `http://127.0.0.1:${config.serve.port}${streamPath}`;
+    const streamPublicUrl = await setupTailscaleExposureRoute({
+      mode,
+      path: streamPath,
+      localUrl: streamLocalUrl,
+    });
+    if (!streamPublicUrl) {
+      console.warn(
+        `[voice-call] Realtime/streaming calls will fail because Tailscale ${mode} could not expose ${streamPath}. Run tailscale ${mode} --bg --yes --set-path ${streamPath} ${streamLocalUrl} manually.`,
+      );
+    }
+  }
+  return publicUrl;
 }
 
 export async function cleanupTailscaleExposure(config: VoiceCallConfig): Promise<void> {
@@ -110,4 +124,7 @@ export async function cleanupTailscaleExposure(config: VoiceCallConfig): Promise
 
   const mode = config.tailscale.mode === "funnel" ? "funnel" : "serve";
   await cleanupTailscaleExposureRoute({ mode, path: config.tailscale.path });
+  for (const streamPath of resolveVoiceCallStreamExposurePaths(config)) {
+    await cleanupTailscaleExposureRoute({ mode, path: streamPath });
+  }
 }

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -52,7 +52,7 @@ export async function getTailscaleDnsName(): Promise<string | null> {
   return info?.dnsName ?? null;
 }
 
-export async function setupTailscaleExposureRoute(opts: {
+async function setupTailscaleExposureRoute(opts: {
   mode: "serve" | "funnel";
   path: string;
   localUrl: string;
@@ -89,6 +89,29 @@ export async function cleanupTailscaleExposureRoute(opts: {
   await runTailscaleCommand([opts.mode, "off", opts.path]);
 }
 
+export async function setupTailscaleExposureRoutes(opts: {
+  mode: "serve" | "funnel";
+  routes: Array<{ path: string; localUrl: string }>;
+}): Promise<string | null> {
+  const mountedPaths: string[] = [];
+  let publicUrl: string | null = null;
+  for (const route of opts.routes) {
+    const routePublicUrl = await setupTailscaleExposureRoute({ mode: opts.mode, ...route });
+    if (!routePublicUrl) {
+      for (const path of mountedPaths.toReversed()) {
+        await cleanupTailscaleExposureRoute({ mode: opts.mode, path });
+      }
+      console.warn(
+        `[voice-call] Tailscale ${opts.mode} exposure failed for ${route.path}; rolled back ${mountedPaths.length} mounted route(s)`,
+      );
+      return null;
+    }
+    publicUrl ??= routePublicUrl;
+    mountedPaths.push(route.path);
+  }
+  return publicUrl;
+}
+
 export async function setupTailscaleExposure(config: VoiceCallConfig): Promise<string | null> {
   if (config.tailscale.mode === "off") {
     return null;
@@ -96,25 +119,22 @@ export async function setupTailscaleExposure(config: VoiceCallConfig): Promise<s
 
   const mode = config.tailscale.mode === "funnel" ? "funnel" : "serve";
   const localUrl = `http://127.0.0.1:${config.serve.port}${config.serve.path}`;
-  const publicUrl = await setupTailscaleExposureRoute({
+  const streamRoutes = resolveVoiceCallStreamExposurePaths(config).map(
+    ({ publicPath, localPath }) => ({
+      path: publicPath,
+      localUrl: `http://127.0.0.1:${config.serve.port}${localPath}`,
+    }),
+  );
+  return setupTailscaleExposureRoutes({
     mode,
-    path: config.tailscale.path,
-    localUrl,
+    routes: [
+      {
+        path: config.tailscale.path,
+        localUrl,
+      },
+      ...streamRoutes,
+    ],
   });
-  for (const streamPath of resolveVoiceCallStreamExposurePaths(config)) {
-    const streamLocalUrl = `http://127.0.0.1:${config.serve.port}${streamPath}`;
-    const streamPublicUrl = await setupTailscaleExposureRoute({
-      mode,
-      path: streamPath,
-      localUrl: streamLocalUrl,
-    });
-    if (!streamPublicUrl) {
-      console.warn(
-        `[voice-call] Realtime/streaming calls will fail because Tailscale ${mode} could not expose ${streamPath}. Run tailscale ${mode} --bg --yes --set-path ${streamPath} ${streamLocalUrl} manually.`,
-      );
-    }
-  }
-  return publicUrl;
 }
 
 export async function cleanupTailscaleExposure(config: VoiceCallConfig): Promise<void> {
@@ -124,7 +144,7 @@ export async function cleanupTailscaleExposure(config: VoiceCallConfig): Promise
 
   const mode = config.tailscale.mode === "funnel" ? "funnel" : "serve";
   await cleanupTailscaleExposureRoute({ mode, path: config.tailscale.path });
-  for (const streamPath of resolveVoiceCallStreamExposurePaths(config)) {
-    await cleanupTailscaleExposureRoute({ mode, path: streamPath });
+  for (const { publicPath } of resolveVoiceCallStreamExposurePaths(config)) {
+    await cleanupTailscaleExposureRoute({ mode, path: publicPath });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the voice-call plugin with Tailscale Serve or Funnel and realtime or streaming audio would see calls terminate after roughly one second because Twilio could not reach the advertised WebSocket stream path. The webhook path was exposed, but the realtime and streaming WebSocket paths were not, and the failure produced no gateway warning.

## Why This Change Was Made

Voice-call now resolves enabled realtime and streaming exposure routes as public-to-local path pairs and uses that canonical set across runtime tunnel startup, direct Tailscale setup/cleanup, and `voicecall expose`. Realtime routes preserve the public webhook prefix that the realtime handler advertises; streaming routes mount the configured path Twilio emits. Tailscale mounts are symmetric and transactional, and an unconnected realtime stream token emits a bounded warning after its 30-second TTL. ngrok remains unchanged because it exposes the whole local port.

## User Impact

Operators using Tailscale Serve or Funnel can now receive realtime and streaming voice calls without manually mounting extra WebSocket paths, including configurations where the public Tailscale webhook has an additional prefix. CLI exposure and cleanup cover the same paths, failed setup does not leave partial mounts behind or report false success, and a missing provider WebSocket connection is visible in logs instead of failing silently.

## Evidence

- Root cause: the Tailscale tunnel branch in `extensions/voice-call/src/tunnel.ts:279` and its Serve/Funnel dispatch at `extensions/voice-call/src/tunnel.ts:371` previously mounted only the webhook path; the direct runtime setup in `extensions/voice-call/src/webhook/tailscale.ts:115` likewise exposed only the webhook route. Meanwhile `issueStreamSession()` in `extensions/voice-call/src/webhook/realtime-handler.ts:596` advertised `wss://<host><streamPath>/<token>`, leaving that path unreachable through Tailscale.
- Live observation on 2026-08-17 on clawstudio: Twilio showed affected calls completing with 0-1 second duration and the gateway logged no stream-connection failure.
- Live-proven manual workaround: `tailscale funnel --bg --yes --set-path /voice/stream/realtime http://127.0.0.1:3334/voice/stream/realtime` restored working calls. The regression tests assert this exact public-to-local mount shape.
- Focused proof: 161 tests passed across the original six touched test files plus `providers/twilio.test.ts`. These include pre-fix-failing regressions for realtime/streaming mounts, distinct public prefixes, the streaming path Twilio emits, path deduplication, partial-mount rollback, CLI failure reporting, symmetric cleanup, and the never-connected warning.
- `node scripts/check-changed.mjs` passed on the final head, including extension production/test typechecks, lint, dead exports, database-first, and import-cycle checks.
- The initial `173dc1af7f0d4345fb5d0f824645cd622b34763d` diff had a clean Codex-backed autoreview. Per the maintainer work order, review engines were not rerun after the ClawSweeper-directed follow-ups.
- ClawSweeper findings on `173dc1af7f0d4345fb5d0f824645cd622b34763d` were applied: public prefixes are mapped to local realtime paths, direct setup rolls back atomically, and `voicecall expose` uses the same transactional result instead of reporting partial success.
- The `33ad5e0120be8ceb559d62cbb5e139fd67d8351f` review's streaming-connectivity finding was applied by mounting `streaming.streamPath` exactly as Twilio advertises it. Its optional rank-up moves to change Twilio provider output and add a new TwiML test were skipped because `providers/twilio.ts` and `providers/twilio.test.ts` are outside the work order's strict 14-file edit boundary; the existing provider suite was run, and the canonical resolver now makes its emitted URL reachable without adding a parallel provider mapping rule.
- Full live Twilio call E2E is infeasible from this development checkout because the Twilio credentials and tailnet are on the operator's production gateway. The mount argument shape is live-proven by the manual workaround above; this PR does not claim a full checkout-driven live call E2E.
- Production LOC: +186/-46. The growth supplies the missing public-to-local stream exposure capability, one shared transactional route setup/rollback owner, and failure visibility for streams that never connect.
