### PR TITLE
fix(workboard): avoid false lifecycle warning during gateway startup

### DIFF
--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -28,6 +28,11 @@ export default definePluginEntry({
       store,
       gateway: api.runtime.gateway,
     });
+    const lifecycleSync = createWorkboardLifecycleService({
+      store,
+      readSessions: async (options) =>
+        await readWorkboardLifecycleSessions(api.runtime.gateway, options),
+    });
     api.session.controls.registerControlUiDescriptor({
       surface: "widget",
       id: "board",
@@ -50,13 +55,9 @@ export default definePluginEntry({
     registerWorkboardCommand({ api, store });
     api.registerService(createWorkboardChangeEventService(store));
     api.registerService(automationNudge);
-    api.registerService(
-      createWorkboardLifecycleService({
-        store,
-        readSessions: async (options) =>
-          await readWorkboardLifecycleSessions(api.runtime.gateway, options),
-      }),
-    );
+    api.registerService(lifecycleSync);
+    api.on("gateway_start", () => lifecycleSync.onGatewayStart());
+    api.on("gateway_stop", () => lifecycleSync.onGatewayStop());
     api.on("subagent_ended", async (event) => {
       await Promise.all([
         syncWorkboardSubagentEnded({ store, event, onMatched: automationNudge.nudge }),

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -786,6 +786,41 @@ describe("Workboard gateway lifecycle sync", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("begins immediately when the lifecycle service reloads after gateway startup", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const sessionKey = "agent:main:dashboard:plugin-reload";
+    const card = await createLinkedCard(store, { status: "todo", sessionKey });
+    const readSessions = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessions: [
+          { key: sessionKey, status: "running", hasActiveRun: true, updatedAt: card.updatedAt + 1 },
+        ],
+        complete: true,
+      })
+      .mockResolvedValueOnce({
+        sessions: [{ key: sessionKey, status: "done", updatedAt: card.updatedAt + 2 }],
+        complete: true,
+      });
+    const warn = vi.fn();
+    const context = { logger: { warn } } as never;
+    const original = createWorkboardLifecycleService({ store, readSessions });
+
+    await original.start(context);
+    original.onGatewayStart();
+    await vi.waitFor(async () => expect((await store.get(card.id))?.status).toBe("running"));
+    await original.stop?.(context);
+
+    const replacement = createWorkboardLifecycleService({ store, readSessions });
+    await replacement.start(context);
+    await vi.waitFor(async () => expect((await store.get(card.id))?.status).toBe("review"));
+    replacement.onGatewayStop();
+    await replacement.stop?.(context);
+
+    expect(readSessions).toHaveBeenCalledTimes(2);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("runs the bounded session reconciliation from the lifecycle-owned service interval", async () => {
     vi.useFakeTimers();
     const store = new WorkboardStore(createMemoryStore());

--- a/extensions/workboard/src/lifecycle-sync.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.test.ts
@@ -91,10 +91,12 @@ async function runSessionSweep(params: {
     ...(now === undefined ? {} : { now: () => now }),
   });
   await service.start({ logger: { warn: vi.fn() } } as never);
+  service.onGatewayStart();
   await vi.waitFor(() => expect(readSessions).toHaveBeenCalledOnce());
   await new Promise((resolve) => {
     setTimeout(resolve, 0);
   });
+  service.onGatewayStop();
   await service.stop?.({ logger: { warn: vi.fn() } } as never);
 }
 
@@ -565,9 +567,11 @@ describe("Workboard gateway lifecycle sync", () => {
     const service = createWorkboardLifecycleService({ store, readSessions });
 
     await service.start(context);
+    service.onGatewayStart();
     await new Promise((resolve) => {
       setTimeout(resolve, 0);
     });
+    service.onGatewayStop();
     await service.stop?.(context);
 
     expect(readSessions).not.toHaveBeenCalled();
@@ -586,9 +590,11 @@ describe("Workboard gateway lifecycle sync", () => {
     const service = createWorkboardLifecycleService({ store, readSessions });
 
     await service.start(context);
+    service.onGatewayStart();
     await new Promise((resolve) => {
       setTimeout(resolve, 0);
     });
+    service.onGatewayStop();
     await service.stop?.(context);
 
     expect(readSessions).not.toHaveBeenCalled();
@@ -620,7 +626,9 @@ describe("Workboard gateway lifecycle sync", () => {
     const service = createWorkboardLifecycleService({ store, readSessions });
 
     await service.start(context);
+    service.onGatewayStart();
     await vi.waitFor(async () => expect((await store.get(card.id))?.status).toBe("review"));
+    service.onGatewayStop();
     await service.stop?.(context);
 
     expect(readSessions).toHaveBeenCalledWith({ includeUnknown: true });
@@ -742,6 +750,42 @@ describe("Workboard gateway lifecycle sync", () => {
     expect((await store.get(card.id))?.status).toBe("review");
   });
 
+  it("waits for gateway startup before beginning the lifecycle sweep", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const sessionKey = "agent:main:dashboard:startup-ready";
+    const card = await createLinkedCard(store, { status: "todo", sessionKey });
+    let gatewayReady = false;
+    const readSessions = vi.fn(async () => {
+      if (!gatewayReady) {
+        throw new Error("sessions.list unavailable during gateway startup");
+      }
+      return {
+        sessions: [{ key: sessionKey, status: "done" as const, updatedAt: card.updatedAt + 1 }],
+        complete: true,
+      };
+    });
+    const warn = vi.fn();
+    const service = createWorkboardLifecycleService({ store, readSessions });
+    const context = { logger: { warn } } as never;
+
+    await service.start(context);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(readSessions).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+
+    gatewayReady = true;
+    service.onGatewayStart();
+    await vi.waitFor(async () => expect((await store.get(card.id))?.status).toBe("review"));
+    service.onGatewayStop();
+    await service.stop?.(context);
+
+    expect(readSessions).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("runs the bounded session reconciliation from the lifecycle-owned service interval", async () => {
     vi.useFakeTimers();
     const store = new WorkboardStore(createMemoryStore());
@@ -763,6 +807,7 @@ describe("Workboard gateway lifecycle sync", () => {
       });
     const service = createWorkboardLifecycleService({ store, readSessions });
     await service.start({ logger: { warn: vi.fn() } } as never);
+    service.onGatewayStart();
     await vi.waitFor(async () => {
       expect((await store.get(card.id))?.status).toBe("running");
     });
@@ -771,6 +816,7 @@ describe("Workboard gateway lifecycle sync", () => {
     await vi.waitFor(async () => {
       expect((await store.get(card.id))?.status).toBe("review");
     });
+    service.onGatewayStop();
     await service.stop?.({ logger: { warn: vi.fn() } } as never);
 
     expect(readSessions).toHaveBeenCalledTimes(2);

--- a/extensions/workboard/src/lifecycle-sync.ts
+++ b/extensions/workboard/src/lifecycle-sync.ts
@@ -3,6 +3,7 @@ import type {
   WorkboardExecutionStatus,
   WorkboardStatus,
 } from "@openclaw/workboard-contract";
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawPluginApi, OpenClawPluginService } from "../api.js";
 import {
@@ -16,6 +17,15 @@ import type { WorkboardStore } from "./store.js";
 const WORKBOARD_LIFECYCLE_SWEEP_MS = 60_000;
 const WORKBOARD_STALE_SESSION_MS = 30 * 60 * 1000;
 const WORKBOARD_SESSION_SWEEP_LIMIT = 10_000;
+// Keep readiness across plugin-only reloads, while the singleton lifecycle
+// clears it before an in-process Gateway restart starts replacement services.
+const workboardLifecycleGatewayState = resolveGlobalSingleton(
+  Symbol.for("openclaw.workboard.lifecycleGatewayState"),
+  () => ({ ready: false }),
+  (state) => {
+    state.ready = false;
+  },
+);
 
 type WorkboardLifecycleState = "running" | "succeeded" | "failed" | "idle" | "missing" | "stale";
 
@@ -50,6 +60,11 @@ type WorkboardLifecycleMatchHandler = (input: {
   cards: readonly WorkboardCard[];
   sessionKey?: string;
 }) => Promise<void>;
+
+type WorkboardLifecycleService = OpenClawPluginService & {
+  onGatewayStart: () => void;
+  onGatewayStop: () => void;
+};
 
 function needsWorkboardLifecycleReconciliation(card: WorkboardCard): boolean {
   if (card.metadata?.archivedAt) {
@@ -333,13 +348,23 @@ export function createWorkboardLifecycleService(params: {
     options: WorkboardLifecycleSessionReadOptions,
   ) => Promise<WorkboardLifecycleSessionSnapshot>;
   now?: () => number;
-}): OpenClawPluginService {
+}): WorkboardLifecycleService {
   let generation = 0;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let begin: (() => void) | undefined;
+  const stop = () => {
+    generation += 1;
+    begin = undefined;
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
   return {
     id: "workboard-lifecycle-sync",
     start(ctx) {
       const owner = ++generation;
+      let begun = false;
       const reconcile = async () => {
         try {
           const cards = await params.store.list();
@@ -370,15 +395,27 @@ export function createWorkboardLifecycleService(params: {
           }
         }
       };
-      // This service owns one bounded session sweep; terminal hooks keep end-state writes immediate.
-      void reconcile();
-    },
-    stop() {
-      generation += 1;
-      if (timer) {
-        clearTimeout(timer);
-        timer = undefined;
+      begin = () => {
+        if (generation !== owner || begun) {
+          return;
+        }
+        begun = true;
+        // The Gateway lifecycle signal owns the first bounded sweep; terminal
+        // hooks keep end-state writes immediate between 60-second sweeps.
+        void reconcile();
+      };
+      if (workboardLifecycleGatewayState.ready) {
+        begin();
       }
+    },
+    stop,
+    onGatewayStart() {
+      workboardLifecycleGatewayState.ready = true;
+      begin?.();
+    },
+    onGatewayStop() {
+      workboardLifecycleGatewayState.ready = false;
+      stop();
     },
   };
 }

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -44,7 +44,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/index.ts": ["before_agent_reply", "before_prompt_build"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/onepassword/index.ts": ["before_tool_call", "tool_result_persist"],
-  "extensions/workboard/index.ts": ["agent_end", "subagent_ended"],
+  "extensions/workboard/index.ts": ["agent_end", "gateway_start", "gateway_stop", "subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],
   readonly string[]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators starting a healthy Gateway with Workboard enabled would see `workboard lifecycle sync failed: ... sessions.list unavailable during gateway startup` on every boot. The premature sweep also deferred the first recovery reconciliation to the next 60-second interval.

## Why This Change Was Made

Workboard now arms its first lifecycle sweep from the typed `gateway_start` lifecycle signal, after startup-gated RPC methods are available, while retaining the existing 60-second cadence. The readiness fact survives plugin-only service reloads and is cleared on Gateway stop/restart; terminal lifecycle hooks remain immediate.

## User Impact

Healthy Gateway startup no longer emits a false Workboard failure, and linked-card recovery reconciliation begins as soon as the Gateway is ready instead of waiting for the next interval.

## Evidence

The supplied stress run captured the same false warning on four isolated healthy starts:

```text
2026-08-17T16:15:14.734-07:00 [plugins] workboard lifecycle sync failed: GatewayClientRequestError: sessions.list unavailable during gateway startup
2026-08-17T16:18:45.736-07:00 [plugins] workboard lifecycle sync failed: GatewayClientRequestError: sessions.list unavailable during gateway startup
2026-08-17T16:19:22.808-07:00 [plugins] workboard lifecycle sync failed: GatewayClientRequestError: sessions.list unavailable during gateway startup
2026-08-17T16:20:41.204-07:00 [plugins] workboard lifecycle sync failed: GatewayClientRequestError: sessions.list unavailable during gateway startup
```

The new regression failed on pre-fix production because `readSessions` was called once before readiness:

```text
FAIL  extensions/workboard/src/lifecycle-sync.test.ts
expected "vi.fn()" to not be called at all, but actually been called 1 times
Tests  1 failed | 52 passed (53)
```

After the owner-boundary repair:

```text
node scripts/run-vitest.mjs extensions/workboard/src/lifecycle-sync.test.ts src/plugins/contracts/boundary-invariants.test.ts
Test Files  2 passed (2)
Tests       66 passed (66)
[test] passed 2 Vitest shards in 14.63s

node scripts/run-vitest.mjs extensions/workboard
PASS

node scripts/check-changed.mjs -- extensions/workboard/index.ts extensions/workboard/src/lifecycle-sync.ts extensions/workboard/src/lifecycle-sync.test.ts src/plugins/contracts/boundary-invariants.test.ts
PASS

.claude/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
```

Exact-head isolated Gateway proof also passed with Workboard enabled and a seeded `running` card. The Gateway reached ready, dispatched both typed `gateway_start` handlers, returned `{"ready":true,"failing":[]}` from `/readyz`, emitted no Workboard lifecycle warning through shutdown, ran both `gateway_stop` handlers, and shut down cleanly:

```text
17:25:34 [gateway] ready
17:25:34 [plugins] [hooks] running gateway_start (2 handlers)
17:25:54 [plugins] [hooks] running gateway_stop (2 handlers)
17:25:54 [shutdown] completed cleanly in 36ms
```

ClawSweeper's rank-up move is applied: a dedicated plugin-only service-reload regression now proves that a replacement lifecycle service inherits the established Gateway-ready fact and sweeps immediately without another `gateway_start` event. The lifecycle file passes 54/54 tests; its changed-surface gate and a fresh uncommitted autoreview are clean.

Production LOC: +54/-16 (net +38) for the readiness lifecycle and reload-safe ownership. Tests/test support: +82/-1 (net +81), including the pre-fix-failing startup regression, dedicated plugin-reload coverage, and typed-hook allowlist update.
