### PR TITLE
fix: keep Workboard visible in the sidebar

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3990,7 +3990,7 @@ src/worker/worker-process.ts	2
 src/worker/worker-session-tools.ts	4
 src/worker/workspace-rsync-receiver.ts	1
 ui/src/api/gateway.ts	1
-ui/src/app-navigation.ts	3
+ui/src/app-navigation.ts	2
 ui/src/app-route-paths.ts	1
 ui/src/app-routes.ts	1
 ui/src/app/app-host-route-state.ts	1
@@ -4016,7 +4016,7 @@ ui/src/app/overlays.ts	1
 ui/src/app/question-prompt.ts	2
 ui/src/app/server-prefs-state.ts	14
 ui/src/app/server-prefs.ts	17
-ui/src/app/settings.ts	10
+ui/src/app/settings.ts	9
 ui/src/app/stale-chunk-reload.ts	1
 ui/src/app/startup-settings.ts	1
 ui/src/app/theme.ts	4
@@ -4089,7 +4089,7 @@ ui/src/components/session-data-controller.ts	2
 ui/src/components/session-data-scroll-controller.ts	1
 ui/src/components/session-group-defaults-dialog.ts	1
 ui/src/components/session-menu.ts	1
-ui/src/components/session-organizer-controller.ts	9
+ui/src/components/session-organizer-controller.ts	5
 ui/src/components/settings-sidebar.ts	3
 ui/src/components/settings-ui.ts	7
 ui/src/components/sidebar-agent-card.ts	1

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -399,6 +399,10 @@ plugins can set `path` to a plugin HTTP route (see
 (`control` or `agent`), `order` sorts among plugin tabs, and `requiredScopes`
 hides the tab from connections lacking those operator scopes:
 
+Bundled plugins whose page already has a native Control UI route can set
+`placement: "route:<routeId>"`. The sidebar then opens that route directly while
+the descriptor is present instead of mounting the generic plugin-tab page.
+
 For a gateway-protected external tab, register the descriptor `path` under a
 same-plugin `auth: "gateway"` HTTP route. After authenticated bootstrap, the browser gets a
 short-lived, HttpOnly grant scoped to that plugin and route root so the

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -399,9 +399,11 @@ plugins can set `path` to a plugin HTTP route (see
 (`control` or `agent`), `order` sorts among plugin tabs, and `requiredScopes`
 hides the tab from connections lacking those operator scopes:
 
-Bundled plugins whose page already has a native Control UI route can set
-`placement: "route:<routeId>"`. The sidebar then opens that route directly while
-the descriptor is present instead of mounting the generic plugin-tab page.
+Bundled plugins whose page already has a matching native Control UI route can set
+`placement: "route:<pluginId>"`. The host rejects native-route claims from external
+plugins or from bundled plugins whose ID does not own that route. The sidebar opens
+the native route while the descriptor is present instead of mounting the generic
+plugin-tab page.
 
 For a gateway-protected external tab, register the descriptor `path` under a
 same-plugin `auth: "gateway"` HTTP route. After authenticated bootstrap, the browser gets a

--- a/extensions/workboard/index.test.ts
+++ b/extensions/workboard/index.test.ts
@@ -1,0 +1,28 @@
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./src/store.js", () => ({
+  WorkboardStore: { openSqlite: () => ({}) },
+}));
+
+import plugin from "./index.js";
+
+describe("Workboard plugin registration", () => {
+  it("advertises its native route only while the plugin runtime is active", () => {
+    const captured = capturePluginRegistration({
+      id: "workboard",
+      name: "Workboard",
+      register: plugin.register,
+    });
+
+    expect(captured.controlUiDescriptors).toContainEqual({
+      surface: "tab",
+      id: "workboard",
+      label: "Workboard",
+      placement: "route:workboard",
+      icon: "kanban",
+      group: "control",
+      requiredScopes: ["operator.read"],
+    });
+  });
+});

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -29,6 +29,15 @@ export default definePluginEntry({
       gateway: api.runtime.gateway,
     });
     api.session.controls.registerControlUiDescriptor({
+      surface: "tab",
+      id: "workboard",
+      label: "Workboard",
+      placement: "route:workboard",
+      icon: "kanban",
+      group: "control",
+      requiredScopes: ["operator.read"],
+    });
+    api.session.controls.registerControlUiDescriptor({
       surface: "widget",
       id: "board",
       label: "Workboard board",

--- a/packages/gateway-protocol/CHANGELOG.md
+++ b/packages/gateway-protocol/CHANGELOG.md
@@ -14,6 +14,7 @@ version and the additive schema surface. Dates are authoring dates (2026).
 - Slim worker and session-catalog payloads to the active wire contract.
 - Remove dead protocol surfaces and add since-vintage metadata to retained schemas and methods.
 - Add optional `step` on `SystemAgentChatResult` carrying the full awaited wizard step.
+- Project plugin tab `placement` in `hello-ok` so active plugins can target native Control UI routes.
 
 ## Protocol v4 (current)
 

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -111,6 +111,7 @@ export const HelloOkSchema = closedObject({
         description: Type.Optional(Type.String()),
         icon: Type.Optional(Type.String()),
         path: Type.Optional(Type.String()),
+        placement: Type.Optional(Type.String()),
         requiresGatewayAuth: Type.Optional(Type.Boolean()),
         group: Type.Optional(Type.Union([Type.Literal("control"), Type.Literal("agent")])),
         order: Type.Optional(Type.Number()),

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1659,6 +1659,19 @@ async function createChatPickerScenario(
           ]
         : []),
     ],
+    controlUiTabs:
+      fixture === "workboard"
+        ? [
+            {
+              group: "control",
+              icon: "kanban",
+              id: "workboard",
+              label: "Workboard",
+              placement: "route:workboard",
+              pluginId: "workboard",
+            },
+          ]
+        : [],
     controlUiWidgetKinds: [
       { pluginId: "session", kind: "session:progress", label: "Session progress" },
       ...(fixture === "workboard"

--- a/src/gateway/control-ui-plugin-tabs.test.ts
+++ b/src/gateway/control-ui-plugin-tabs.test.ts
@@ -53,7 +53,7 @@ describe("listControlUiPluginTabs", () => {
   it("projects only tab descriptors", () => {
     activateDescriptors([
       {
-        pluginId: "logbook",
+        pluginId: "workboard",
         descriptor: tabDescriptor({ placement: "route:workboard" }),
       },
       { pluginId: "other", descriptor: tabDescriptor({ id: "run-panel", surface: "run" }) },
@@ -63,7 +63,7 @@ describe("listControlUiPluginTabs", () => {
     expect(tabs.map((tab) => tab.id)).toEqual(["logbook"]);
     expect(expectDefined(tabs[0], "tabs[0] test invariant")).toMatchObject({
       placement: "route:workboard",
-      pluginId: "logbook",
+      pluginId: "workboard",
     });
   });
 

--- a/src/gateway/control-ui-plugin-tabs.test.ts
+++ b/src/gateway/control-ui-plugin-tabs.test.ts
@@ -52,13 +52,19 @@ describe("listControlUiPluginTabs", () => {
 
   it("projects only tab descriptors", () => {
     activateDescriptors([
-      { pluginId: "logbook", descriptor: tabDescriptor() },
+      {
+        pluginId: "logbook",
+        descriptor: tabDescriptor({ placement: "route:workboard" }),
+      },
       { pluginId: "other", descriptor: tabDescriptor({ id: "run-panel", surface: "run" }) },
     ]);
 
     const tabs = listControlUiPluginTabs(["operator.admin"]);
     expect(tabs.map((tab) => tab.id)).toEqual(["logbook"]);
-    expect(expectDefined(tabs[0], "tabs[0] test invariant").pluginId).toBe("logbook");
+    expect(expectDefined(tabs[0], "tabs[0] test invariant")).toMatchObject({
+      placement: "route:workboard",
+      pluginId: "logbook",
+    });
   });
 
   it("hides tabs whose required scopes are not granted", () => {

--- a/src/gateway/control-ui-plugin-tabs.ts
+++ b/src/gateway/control-ui-plugin-tabs.ts
@@ -20,6 +20,7 @@ type ControlUiPluginTab = {
   description?: string;
   icon?: string;
   path?: string;
+  placement?: string;
   group?: "control" | "agent";
   order?: number;
   requiresGatewayAuth?: boolean;
@@ -94,6 +95,7 @@ function projectControlUiPluginTabs(
       description: descriptor.description,
       icon: descriptor.icon,
       path: descriptor.path,
+      placement: descriptor.placement,
       group: descriptor.group,
       order: descriptor.order,
     });

--- a/src/plugins/host-hooks.ts
+++ b/src/plugins/host-hooks.ts
@@ -99,6 +99,7 @@ export type PluginControlUiDescriptor = {
   surface: "session" | "tool" | "run" | "settings" | "tab" | "widget";
   label: string;
   description?: string;
+  /** Bundled plugins may claim their matching native route as `route:<pluginId>`. */
   placement?: string;
   schema?: PluginJsonValue;
   requiredScopes?: OperatorScope[];

--- a/src/plugins/registry-control-ui-policy.ts
+++ b/src/plugins/registry-control-ui-policy.ts
@@ -1,0 +1,22 @@
+import type { PluginRegistryState } from "./registry-state.js";
+import type { PluginRecord } from "./registry-types.js";
+
+export function validateControlUiNativeRoutePlacement(params: {
+  record: PluginRecord;
+  placement: string | undefined;
+  pushDiagnostic: PluginRegistryState["pushDiagnostic"];
+}): boolean {
+  if (!params.placement?.startsWith("route:")) {
+    return true;
+  }
+  if (params.record.origin === "bundled" && params.placement === `route:${params.record.id}`) {
+    return true;
+  }
+  params.pushDiagnostic({
+    level: "error",
+    pluginId: params.record.id,
+    source: params.record.source,
+    message: `native Control UI route placement must be owned by its bundled plugin: ${params.placement}`,
+  });
+  return false;
+}

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -391,6 +391,18 @@ export function createHostRegistrars(state: PluginRegistryState) {
         return;
       }
     }
+    if (
+      placement?.startsWith("route:") &&
+      (record.origin !== "bundled" || placement !== `route:${record.id}`)
+    ) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `native Control UI route placement must be owned by its bundled plugin: ${placement}`,
+      });
+      return;
+    }
     if (descriptor.schema !== undefined && !isPluginJsonValue(descriptor.schema)) {
       pushDiagnostic({
         level: "error",

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -15,6 +15,7 @@ import {
   type PluginToolMetadataRegistration,
   type PluginTrustedToolPolicyRegistration,
 } from "./host-hooks.js";
+import { validateControlUiNativeRoutePlacement } from "./registry-control-ui-policy.js";
 import type { PluginRegistryState } from "./registry-state.js";
 import type {
   PluginRecord,
@@ -391,16 +392,7 @@ export function createHostRegistrars(state: PluginRegistryState) {
         return;
       }
     }
-    if (
-      placement?.startsWith("route:") &&
-      (record.origin !== "bundled" || placement !== `route:${record.id}`)
-    ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `native Control UI route placement must be owned by its bundled plugin: ${placement}`,
-      });
+    if (!validateControlUiNativeRoutePlacement({ record, placement, pushDiagnostic })) {
       return;
     }
     if (descriptor.schema !== undefined && !isPluginJsonValue(descriptor.schema)) {

--- a/src/plugins/registry.control-ui.test.ts
+++ b/src/plugins/registry.control-ui.test.ts
@@ -37,18 +37,19 @@ describe("plugin registry Control UI descriptors", () => {
     ]);
   });
 
-  it("accepts tab descriptors and normalizes their placement fields", () => {
+  it("accepts a bundled plugin's matching native route placement", () => {
     const { config, registry } = createPluginRegistryFixture();
     registerTestPlugin({
       registry,
       config,
-      record: createPluginRecord({ id: "tab-fixture", name: "Tab Fixture" }),
+      record: createPluginRecord({ id: "workboard", name: "Workboard", origin: "bundled" }),
       register(api) {
         api.registerControlUiDescriptor({
           surface: "tab",
-          id: "journal",
-          label: "Journal",
-          icon: "sun",
+          id: "workboard",
+          label: "Workboard",
+          placement: "route:workboard",
+          icon: "kanban",
           group: "control",
           order: 5,
           requiredScopes: ["operator.read"],
@@ -58,18 +59,48 @@ describe("plugin registry Control UI descriptors", () => {
 
     expect(registry.registry.controlUiDescriptors).toEqual([
       expect.objectContaining({
-        pluginId: "tab-fixture",
+        pluginId: "workboard",
         descriptor: expect.objectContaining({
-          id: "journal",
+          id: "workboard",
           surface: "tab",
-          label: "Journal",
-          icon: "sun",
+          label: "Workboard",
+          placement: "route:workboard",
+          icon: "kanban",
           group: "control",
           order: 5,
           requiredScopes: ["operator.read"],
         }),
       }),
     ]);
+  });
+
+  it.each([
+    { id: "workboard", origin: "workspace" as const },
+    { id: "logbook", origin: "bundled" as const },
+  ])("rejects unowned native route placement from $origin plugin $id", ({ id, origin }) => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({ id, origin }),
+      register(api) {
+        api.registerControlUiDescriptor({
+          surface: "tab",
+          id: "panel",
+          label: "Panel",
+          placement: "route:workboard",
+        });
+      },
+    });
+
+    expect(registry.registry.controlUiDescriptors).toEqual([]);
+    expect(registry.registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: id,
+        message: expect.stringContaining("must be owned by its bundled plugin"),
+      }),
+    );
   });
 
   it("accepts trusted dashboard widget descriptors", () => {

--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -31,6 +31,12 @@ describe("sidebar entries", () => {
     expect(normalizeSidebarEntries(["route:worktrees", "route:usage"])).toEqual(["route:usage"]);
   });
 
+  it("keeps the plugin-owned Workboard parent out of customizable routes", () => {
+    expect(normalizeSidebarEntries(["route:workboard", "workboard:ops"])).toEqual([
+      "workboard:ops",
+    ]);
+  });
+
   it("recognizes every settings navigation route", () => {
     expect(settingsRoutes.every((routeId) => isSettingsNavigationRoute(routeId))).toBe(true);
   });

--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -31,10 +31,12 @@ describe("sidebar entries", () => {
     expect(normalizeSidebarEntries(["route:worktrees", "route:usage"])).toEqual(["route:usage"]);
   });
 
-  it("keeps the plugin-owned Workboard parent out of customizable routes", () => {
+  it("preserves the shipped Workboard placement slot outside customizable routes", () => {
     expect(normalizeSidebarEntries(["route:workboard", "workboard:ops"])).toEqual([
+      "route:workboard",
       "workboard:ops",
     ]);
+    expect(sidebarMoreRoutes([])).not.toContain("workboard");
   });
 
   it("recognizes every settings navigation route", () => {

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -24,14 +24,15 @@ import { sessionNavigationTarget } from "./lib/sessions/route-navigation.ts";
 import { pluginTabKey, pluginTabRefFromSearch, pluginTabSearch } from "./pages/plugin/route.ts";
 
 /**
- * All route identifiers derived from sidebar nav routes plus routed settings
- * slices and the Plugins hub tabs, which route without their own sidebar item.
+ * All route identifiers derived from core sidebar routes, plugin-owned native
+ * routes, routed settings slices, and hub tabs without their own sidebar item.
  */
 const ALL_ROUTES: RouteId[] = Array.from(
   new Set<RouteId>([
     "chat",
     "custodian",
     ...SIDEBAR_NAV_ROUTES,
+    "workboard",
     "skills",
     "skill-workshop",
     // Hub tabs and settings subpages route without their own nav entry.
@@ -515,7 +516,6 @@ describe("plugin tabs route", () => {
 describe("SIDEBAR_NAV_ROUTES", () => {
   it("keeps the canonical sidebar route order", () => {
     expect(SIDEBAR_NAV_ROUTES).toEqual([
-      "workboard",
       "dashboards",
       "usage",
       "cron",

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -17,7 +17,6 @@ type NavigationItem = {
 // Skills and Skill Workshop are tabs inside the Plugins hub, not sidebar items.
 // Worktrees is a tab of the Sessions hub, so it is not listed either.
 export const SIDEBAR_NAV_ROUTES = [
-  "workboard",
   "dashboards",
   "usage",
   "cron",

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -29,6 +29,10 @@ export const SIDEBAR_NAV_ROUTES = [
   "portals",
 ] as const satisfies readonly NavigationRouteId[];
 
+// `route:workboard` shipped in browser and synced preferences before Workboard
+// became plugin-owned. Keep it as a placement slot, but not a customizable core route.
+const PERSISTED_SIDEBAR_ROUTES = ["workboard", ...SIDEBAR_NAV_ROUTES] as const;
+
 // Routes presented as tabs of the Plugins hub. The sidebar highlights the
 // Plugins entry for all of them, mirroring how config covers settings routes.
 const PLUGINS_HUB_ROUTES: ReadonlySet<NavigationRouteId> = new Set([
@@ -50,9 +54,14 @@ export function isSessionsHubRoute(routeId: NavigationRouteId): boolean {
 }
 
 export type SidebarNavRoute = (typeof SIDEBAR_NAV_ROUTES)[number];
+export type PersistedSidebarRoute = (typeof PERSISTED_SIDEBAR_ROUTES)[number];
+
+export function isPersistedSidebarRoute(value: unknown): value is PersistedSidebarRoute {
+  return PERSISTED_SIDEBAR_ROUTES.includes(value as PersistedSidebarRoute);
+}
 
 export type SidebarZoneEntry =
-  | { type: "route"; route: SidebarNavRoute }
+  | { type: "route"; route: PersistedSidebarRoute }
   | { type: "workboard"; boardId: string }
   | { type: "session"; key: string };
 
@@ -71,9 +80,7 @@ export function parseSidebarEntry(value: unknown): SidebarZoneEntry | null {
   }
   if (value.startsWith("route:")) {
     const route = value.slice("route:".length);
-    return SIDEBAR_NAV_ROUTES.includes(route as SidebarNavRoute)
-      ? { type: "route", route: route as SidebarNavRoute }
-      : null;
+    return isPersistedSidebarRoute(route) ? { type: "route", route } : null;
   }
   if (value.startsWith("session:")) {
     const key = value.slice("session:".length).trim();

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -16,6 +16,7 @@ type NavigationItem = {
 // list and Settings/Docs live in the sidebar footer, so neither is listed here.
 // Skills and Skill Workshop are tabs inside the Plugins hub, not sidebar items.
 // Worktrees is a tab of the Sessions hub, so it is not listed either.
+// Workboard is plugin-owned and enters the zone through its Control UI descriptor.
 export const SIDEBAR_NAV_ROUTES = [
   "dashboards",
   "usage",

--- a/ui/src/app/settings.sidebar-prefs.node.test.ts
+++ b/ui/src/app/settings.sidebar-prefs.node.test.ts
@@ -97,12 +97,16 @@ describe("sidebar preference persistence", () => {
     const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
     const legacy = makeSettings(gwUrl) as unknown as Record<string, unknown>;
     delete legacy.sidebarEntries;
-    legacy.sidebarPinnedRoutes = ["usage", "tasks", "usage", "worktrees", 7];
+    legacy.sidebarPinnedRoutes = ["workboard", "usage", "tasks", "usage", "worktrees", 7];
     localStorage.setItem(scopedKey, JSON.stringify(legacy));
 
-    expect(loadSettings().sidebarEntries).toEqual(["route:usage", "route:tasks"]);
+    expect(loadSettings().sidebarEntries).toEqual([
+      "route:workboard",
+      "route:usage",
+      "route:tasks",
+    ]);
     const migrated = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<string, unknown>;
-    expect(migrated.sidebarEntries).toEqual(["route:usage", "route:tasks"]);
+    expect(migrated.sidebarEntries).toEqual(["route:workboard", "route:usage", "route:tasks"]);
     expect(migrated).not.toHaveProperty("sidebarPinnedRoutes");
   });
 });

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -5,8 +5,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import {
   DEFAULT_SIDEBAR_ENTRIES,
+  isPersistedSidebarRoute,
   normalizeSidebarEntries,
-  SIDEBAR_NAV_ROUTES,
   serializeSidebarEntry,
 } from "../app-navigation.ts";
 import { isSupportedLocale } from "../i18n/index.ts";
@@ -480,11 +480,11 @@ export function loadSettings(): UiSettings {
       : Array.isArray(parsedRecord.sidebarPinnedRoutes)
         ? normalizeSidebarEntries(
             parsedRecord.sidebarPinnedRoutes.flatMap((value) =>
-              typeof value === "string" && SIDEBAR_NAV_ROUTES.some((route) => route === value)
+              isPersistedSidebarRoute(value)
                 ? [
                     serializeSidebarEntry({
                       type: "route",
-                      route: value as (typeof SIDEBAR_NAV_ROUTES)[number],
+                      route: value,
                     }),
                   ]
                 : [],

--- a/ui/src/components/app-sidebar-nav-menus.ts
+++ b/ui/src/components/app-sidebar-nav-menus.ts
@@ -128,7 +128,6 @@ type SidebarMoreMenuParams = SidebarMenuNavigationHandlers & {
   position: SidebarMenuPosition | null;
   basePath: string;
   activeRouteId: NavigationRouteId | undefined;
-  activeWorkboardBoardId: string;
   sidebarEntries: readonly string[];
   isRouteEnabled: (routeId: NavigationRouteId) => boolean;
   onEditPinnedItems: () => void;
@@ -137,9 +136,7 @@ type SidebarMoreMenuParams = SidebarMenuNavigationHandlers & {
 };
 
 function renderMoreMenuRoute(params: SidebarMoreMenuParams, routeId: SidebarNavRoute) {
-  const active =
-    isSidebarRouteActive(params.activeRouteId, routeId) &&
-    !(routeId === "workboard" && params.activeWorkboardBoardId);
+  const active = isSidebarRouteActive(params.activeRouteId, routeId);
   return html`
     <wa-dropdown-item
       value=${routeId}

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -5,7 +5,7 @@ import {
   type NavigationRouteId,
   type SidebarZoneEntry,
 } from "../app-navigation.ts";
-import { isSessionRouteId } from "../app-route-paths.ts";
+import { isRouteId, isSessionRouteId } from "../app-route-paths.ts";
 import { resolveControlUiAuthToken } from "../app/control-ui-auth.ts";
 import { isNativeWebChromeHost } from "../app/native-web-chrome.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
@@ -383,14 +383,20 @@ export function renderAppSidebarPluginTabEntry(
 ) {
   const ref = { pluginId: tab.pluginId, id: tab.id };
   const key = pluginTabKey(ref);
+  const routePlacement = tab.placement?.startsWith("route:")
+    ? tab.placement.slice("route:".length)
+    : "";
+  const routeId = isRouteId(routePlacement) ? routePlacement : null;
   return html`
     <div class="sidebar-zone-entry" data-sidebar-entry=${`plugin:${key}`}>
-      ${renderSidebarPluginTab({
-        tab,
-        basePath: host.basePath,
-        active: host.activeRouteId === "plugin" && host.activePluginTabId === key,
-        onNavigate: (search) => host.onNavigate?.("plugin", { search }),
-      })}
+      ${routeId
+        ? host.sidebarMenus.renderRoute(routeId)
+        : renderSidebarPluginTab({
+            tab,
+            basePath: host.basePath,
+            active: host.activeRouteId === "plugin" && host.activePluginTabId === key,
+            onNavigate: (search) => host.onNavigate?.("plugin", { search }),
+          })}
     </div>
   `;
 }

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { GatewayControlUiPluginTab } from "../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import { SIDEBAR_NAV_ROUTES, type NavigationRouteId } from "../app-navigation.ts";
 import type { RouteId } from "../app-route-paths.ts";
@@ -364,6 +365,7 @@ export function buildReconciledSidebarZone(input: {
   workboardBoards: readonly SidebarWorkboardBoard[];
   enabledRouteIds: readonly NavigationRouteId[] | undefined;
   workboardBoardsReady: boolean;
+  controlUiTabs: readonly GatewayControlUiPluginTab[] | undefined;
 }) {
   const pinnedRows = input.rows.filter((row) => row.pinned);
   // Only loaded rows count as authoritative unpinned state; entries for
@@ -377,6 +379,7 @@ export function buildReconciledSidebarZone(input: {
     input.workboardBoards,
     input.enabledRouteIds?.includes("workboard") ?? true,
     input.workboardBoardsReady,
+    input.controlUiTabs?.some((tab) => tab.placement === "route:workboard") === true,
   );
   return {
     ...reconciled,

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -363,6 +363,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       workboardBoards: this.workboardBoards,
       enabledRouteIds: this.enabledRouteIds,
       workboardBoardsReady: this.workboardBoardsReady,
+      controlUiTabs: this.context?.gateway.snapshot.hello?.controlUiTabs,
     });
   }
 

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -475,6 +475,11 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
 
   override render() {
     const sidebarZone = this.reconciledSidebarZone();
+    const occupiedPluginPlacements = new Set(
+      sidebarZone.entries.flatMap((entry) =>
+        entry.type === "route" ? [`route:${entry.route}`] : [],
+      ),
+    );
     return html`
       <aside
         class="sidebar"
@@ -512,9 +517,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
                     sidebarZone.workboardRows,
                   ),
                 )}
-                ${sidebarPluginTabs(this.context?.gateway.snapshot.hello?.controlUiTabs).map(
-                  (tab) => renderAppSidebarPluginTabEntry(this, tab),
-                )}
+                ${sidebarPluginTabs(this.context?.gateway.snapshot.hello?.controlUiTabs)
+                  .filter((tab) => !tab.placement || !occupiedPluginPlacements.has(tab.placement))
+                  .map((tab) => renderAppSidebarPluginTabEntry(this, tab))}
               </div>
             </nav>
             ${this.renderSessions()}

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -1,9 +1,8 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   parseSidebarEntry,
-  SIDEBAR_NAV_ROUTES,
   serializeSidebarEntry,
-  type SidebarNavRoute,
+  type PersistedSidebarRoute,
 } from "../app-navigation.ts";
 import { t } from "../i18n/index.ts";
 import {
@@ -184,7 +183,7 @@ export class SessionOrganizerController {
     await operations?.deleteSession(this.host, session, scope, { offerSkip: true });
   }
 
-  startSidebarRouteDrag(event: DragEvent, route: SidebarNavRoute) {
+  startSidebarRouteDrag(event: DragEvent, route: PersistedSidebarRoute) {
     if (!event.dataTransfer) {
       return;
     }
@@ -241,8 +240,9 @@ export class SessionOrganizerController {
 
   private draggedSidebarEntry(dataTransfer: DataTransfer | null): string | null {
     const route = readSidebarRouteDragData(dataTransfer);
-    if (route && SIDEBAR_NAV_ROUTES.includes(route as SidebarNavRoute)) {
-      return serializeSidebarEntry({ type: "route", route: route as SidebarNavRoute });
+    const routeEntry = parseSidebarEntry(route ? `route:${route}` : null);
+    if (routeEntry?.type === "route") {
+      return serializeSidebarEntry(routeEntry);
     }
     const dynamicEntry = parseSidebarEntry(route);
     if (dynamicEntry?.type === "workboard") {
@@ -363,10 +363,11 @@ export class SessionOrganizerController {
 
   handleSessionListDrop(event: DragEvent) {
     const draggedNavigation = readSidebarRouteDragData(event.dataTransfer);
+    const routeEntry = parseSidebarEntry(draggedNavigation ? `route:${draggedNavigation}` : null);
     const dynamicEntry = parseSidebarEntry(draggedNavigation);
     const entry =
-      draggedNavigation && SIDEBAR_NAV_ROUTES.includes(draggedNavigation as SidebarNavRoute)
-        ? ({ type: "route", route: draggedNavigation as SidebarNavRoute } as const)
+      routeEntry?.type === "route"
+        ? routeEntry
         : dynamicEntry?.type === "workboard"
           ? dynamicEntry
           : null;

--- a/ui/src/components/sidebar-menus-controller.test.ts
+++ b/ui/src/components/sidebar-menus-controller.test.ts
@@ -8,10 +8,7 @@ import {
   createSessions,
   TWO_AGENTS,
 } from "../test-helpers/app-sidebar.ts";
-import {
-  SidebarMenusController,
-  type SidebarMenusControllerHost,
-} from "./sidebar-menus-controller.ts";
+import { SidebarMenusController } from "./sidebar-menus-controller.ts";
 
 describe("SidebarMenusController session routes", () => {
   it("keeps the current catalog session when switching either face", () => {
@@ -38,7 +35,7 @@ describe("SidebarMenusController session routes", () => {
       requestUpdate: vi.fn(),
       sessionDataContext: context,
       terminalAvailable: false,
-    } as unknown as SidebarMenusControllerHost;
+    } as unknown as ConstructorParameters<typeof SidebarMenusController>[0];
     const controller = new SidebarMenusController(host);
     const container = document.createElement("div");
 

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -67,7 +67,7 @@ type SidebarMenusRenderer = {
   renderSidebarSessionSortMenuForController(controller: SidebarMenusController): unknown;
 };
 
-export interface SidebarMenusControllerHost
+interface SidebarMenusControllerHost
   extends ReactiveControllerHost, SessionOrganizerControllerHost {
   readonly activeRouteId?: NavigationRouteId;
   readonly activeWorkboardBoardId: string;

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -26,10 +26,7 @@ import {
 import { sessionMenuReasons } from "./session-menu-access.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 import { listAssignableSessionOwners } from "./session-owner-chip.ts";
-import type {
-  SidebarMenusController,
-  SidebarMenusControllerHost,
-} from "./sidebar-menus-controller.ts";
+import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
 
 export function renderSidebarCustomizeMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
@@ -463,7 +460,6 @@ export function renderSidebarMoreMenuForController(controller: SidebarMenusContr
     position,
     basePath: host.basePath,
     activeRouteId: host.activeRouteId,
-    activeWorkboardBoardId: activeWorkboardBoardIsPinned(host) ? host.activeWorkboardBoardId : "",
     sidebarEntries: host.sidebarEntries,
     isRouteEnabled: (routeId) => controller.isRouteEnabled(routeId),
     onTabAway: () => trigger?.focus(),
@@ -487,15 +483,4 @@ export function renderSidebarMoreMenuForController(controller: SidebarMenusContr
       }
     },
   });
-}
-
-function activeWorkboardBoardIsPinned(host: SidebarMenusControllerHost): boolean {
-  return Boolean(
-    host.activeWorkboardBoardId &&
-    host
-      .reconciledSidebarZone()
-      .entries.some(
-        (entry) => entry.type === "workboard" && entry.boardId === host.activeWorkboardBoardId,
-      ),
-  );
 }

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -669,36 +669,6 @@ suite.define(() => {
     }
   });
 
-  it("shows the Workboard route when the plugin is enabled in config", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1440 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, {
-          methodResponses: {
-            "config.get": {
-              config: { plugins: { entries: { workboard: { enabled: true } } } },
-            },
-          },
-        });
-
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const sidebar = page.locator("openclaw-app-sidebar");
-        await sidebar.locator(".sidebar-nav__head-action").click();
-        await expect
-          .poll(() =>
-            trimmedTextContents(
-              sidebar.locator("wa-dropdown.sidebar-more-menu").getByRole("menuitem"),
-            ),
-          )
-          .toContain("Workboard");
-      },
-    );
-  });
-
   it("opens the start screen from the sidebar action without carrying the active session", async () => {
     await suite.withPage(
       {

--- a/ui/src/lib/sidebar-zone.test.ts
+++ b/ui/src/lib/sidebar-zone.test.ts
@@ -64,6 +64,30 @@ describe("reconcileSidebarZone", () => {
     ).toEqual(["route:usage"]);
   });
 
+  it("preserves a shipped Workboard parent slot and renders it only for its descriptor", () => {
+    const args = [
+      ["route:usage", "route:workboard", "route:plugins"],
+      [],
+      SIDEBAR_NAV_ROUTES,
+      new Set<string>(),
+      [],
+      true,
+      true,
+    ] as const;
+    expect(reconcileSidebarZone(...args, false)).toEqual({
+      entries: [
+        { type: "route", route: "usage" },
+        { type: "route", route: "plugins" },
+      ],
+      sidebarEntries: ["route:usage", "route:workboard", "route:plugins"],
+    });
+    expect(reconcileSidebarZone(...args, true).entries).toEqual([
+      { type: "route", route: "usage" },
+      { type: "route", route: "workboard" },
+      { type: "route", route: "plugins" },
+    ]);
+  });
+
   it("keeps active Workboard boards, drops stale ids, and preserves plugin-off pins", () => {
     const boards = [
       { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },

--- a/ui/src/lib/sidebar-zone.ts
+++ b/ui/src/lib/sidebar-zone.ts
@@ -24,6 +24,7 @@ export function reconcileSidebarZone(
   workboardBoards: readonly SidebarWorkboardBoard[] = [],
   workboardEnabled = false,
   workboardBoardsReady = false,
+  workboardParentVisible = false,
 ): { entries: SidebarZoneEntry[]; sidebarEntries: string[] } {
   const pinnedKeys = new Set(pinnedSessions.map((session) => session.key));
   const validRouteSet = new Set(validRoutes);
@@ -42,6 +43,14 @@ export function reconcileSidebarZone(
       continue;
     }
     if (entry.type === "route") {
+      if (entry.route === "workboard") {
+        seen.add(canonicalKey);
+        canonical.push(canonicalKey);
+        if (workboardParentVisible) {
+          entries.push(entry);
+        }
+        continue;
+      }
       if (!validRouteSet.has(entry.route)) {
         continue;
       }

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -4,7 +4,7 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { serializeSidebarEntry, subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { pathForPluginsHubTab, pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -700,18 +700,6 @@ class PluginsPage extends OpenClawLightDomElement {
     this.replaceResult(withPlugin(this.result, result.plugin), true);
   }
 
-  private pinEnabledPluginRoute(pluginId: string) {
-    const navigation = this.context.navigation;
-    if (pluginId !== "workboard" || !navigation) {
-      return;
-    }
-    const entry = serializeSidebarEntry({ type: "route", route: "workboard" });
-    const current = navigation.snapshot.sidebarEntries;
-    if (!current.includes(entry)) {
-      navigation.update({ sidebarEntries: [...current, entry] });
-    }
-  }
-
   /** Plugin changes can affect both catalog state and route visibility (for example Workboard). */
   private async refreshCatalogAfterMutation(client: GatewayBrowserClient): Promise<void> {
     this.error = null;
@@ -843,9 +831,6 @@ class PluginsPage extends OpenClawLightDomElement {
             refreshError,
           ),
         );
-        if (enabled) {
-          this.pinEnabledPluginRoute(pluginId);
-        }
         await this.refreshCatalogAfterMutation(client);
         if (isCurrent() && !result.restartRequired) {
           // Plugin tabs come from hello; reconnect after the registry refresh.

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -265,6 +265,27 @@ function readOnlyConnectResponse() {
   };
 }
 
+function enabledWorkboardConnectResponse() {
+  return {
+    ...readOnlyConnectResponse(),
+    auth: {
+      deviceToken: "plugins-workboard-device-token",
+      role: "operator",
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+    },
+    controlUiTabs: [
+      {
+        group: "control",
+        icon: "kanban",
+        id: "workboard",
+        label: "Workboard",
+        placement: "route:workboard",
+        pluginId: "workboard",
+      },
+    ],
+  };
+}
+
 const requireRecord = createRequireRecord("record", "expected-object-value");
 
 function requestParams(request: MockGatewayRequest): Record<string, unknown> {
@@ -601,6 +622,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       expect(requestParams(postEnableConfigRequest)).toEqual({});
       await gateway.setMethodResponse("plugins.list", finalInventory);
       await gateway.setMethodResponse("config.get", configSnapshot(true));
+      await gateway.setMethodResponse("connect", enabledWorkboardConnectResponse());
       await gateway.resolveDeferred("config.get", configSnapshot(true));
       const postEnableListRequest = await waitForNextRequest(
         gateway,
@@ -680,7 +702,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.waitFor({ state: "visible" });
       const workboardSidebarItem = sidebar.locator(
-        '.sidebar-zone-entry[data-sidebar-entry="route:workboard"] > .nav-item',
+        '.sidebar-zone-entry[data-sidebar-entry="plugin:workboard/workboard"] > .nav-item',
       );
       await workboardSidebarItem.waitFor({ state: "visible" });
       expect(await workboardSidebarItem.getAttribute("href")).toBe("/workboard");

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -306,6 +306,14 @@ describe("AppSidebar interleaved zone", () => {
     expect(entry?.getAttribute("href")).toBe("/workboard");
     expect(entry?.classList.contains("nav-item--active")).toBe(true);
 
+    sidebar.sidebarEntries = ["route:workboard", "route:plugins"];
+    await sidebar.updateComplete;
+    const savedEntry = sidebar.querySelector<HTMLAnchorElement>(
+      '[data-sidebar-entry="route:workboard"] > .nav-item',
+    );
+    expect(savedEntry?.getAttribute("href")).toBe("/workboard");
+    expect(sidebar.querySelector('[data-sidebar-entry="plugin:workboard/workboard"]')).toBeNull();
+
     gateway.publish({
       hello: {
         type: "hello-ok",
@@ -316,6 +324,7 @@ describe("AppSidebar interleaved zone", () => {
     });
     await sidebar.updateComplete;
     expect(sidebar.querySelector('[data-sidebar-entry="plugin:workboard/workboard"]')).toBeNull();
+    expect(sidebar.querySelector('[data-sidebar-entry="route:workboard"]')).toBeNull();
   });
 
   it("renders a pinned Workboard board with its icon, color, label, and route", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -272,6 +272,52 @@ describe("AppSidebar interleaved zone", () => {
     expect(sidebar.querySelector('[data-sidebar-entry="plugin:logbook/logbook"]')).toBeNull();
   });
 
+  it("routes active native plugin tabs to their app page and hides inactive tabs", async () => {
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    const sessions = createSessionsHarness("main", ["agent:main:main"]);
+    const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+
+    gateway.publish({
+      hello: {
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "operator", scopes: ["operator.read"] },
+        controlUiTabs: [
+          {
+            group: "control",
+            id: "workboard",
+            label: "Workboard",
+            placement: "route:workboard",
+            pluginId: "workboard",
+          },
+        ],
+      },
+    });
+    sidebar.workboardBoards = [sidebarBoard("ops", { name: "Operations" })];
+    sidebar.workboardBoardsReady = true;
+    sidebar.activeRouteId = "workboard";
+    sidebar.activeWorkboardBoardId = "ops";
+    await sidebar.updateComplete;
+
+    const entry = sidebar.querySelector<HTMLAnchorElement>(
+      '[data-sidebar-entry="plugin:workboard/workboard"] > .nav-item',
+    );
+    expect(entry?.textContent).toContain("Workboard");
+    expect(entry?.getAttribute("href")).toBe("/workboard");
+    expect(entry?.classList.contains("nav-item--active")).toBe(true);
+
+    gateway.publish({
+      hello: {
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "operator", scopes: ["operator.read"] },
+        controlUiTabs: [],
+      },
+    });
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector('[data-sidebar-entry="plugin:workboard/workboard"]')).toBeNull();
+  });
+
   it("renders a pinned Workboard board with its icon, color, label, and route", async () => {
     const { sidebar } = await mountZone();
     sidebar.workboardBoards = [
@@ -296,22 +342,6 @@ describe("AppSidebar interleaved zone", () => {
 
     link?.click();
     expect(onNavigate).toHaveBeenCalledWith("workboard", { pathname: "/workboard/ops" });
-  });
-
-  it("keeps the Workboard parent active when the current board is not pinned", async () => {
-    const { sidebar } = await mountZone();
-    sidebar.workboardBoards = [sidebarBoard("ops", { name: "Operations" })];
-    sidebar.workboardBoardsReady = true;
-    sidebar.sidebarEntries = ["route:workboard"];
-    sidebar.activeRouteId = "workboard";
-    sidebar.activeWorkboardBoardId = "ops";
-    await sidebar.updateComplete;
-
-    expect(
-      sidebar
-        .querySelector('[data-sidebar-entry="route:workboard"] .nav-item')
-        ?.classList.contains("nav-item--active"),
-    ).toBe(true);
   });
 
   it("hides Workboard board pins and editor choices when the plugin is inactive", async () => {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -253,6 +253,7 @@ export type ControlUiMockGatewayScenario = {
     icon?: string;
     id: string;
     label: string;
+    placement?: string;
     pluginId: string;
   }>;
   controlUiWidgetKinds?: Array<{


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with the Workboard plugin enabled could lose the Workboard entry from the Control UI sidebar unless a previous click in the Plugins page happened to pin the route. Fresh and already-enabled installations could therefore have a working Workboard with no direct navigation entry.

## Why This Change Was Made

Workboard now advertises its native route through the plugin-owned Control UI descriptor contract. The Gateway carries that placement to the client, and the sidebar renders it as the existing native Workboard route. The registry accepts native-route placement only when a bundled plugin claims `route:<its own plugin id>`. This removes the click-time pinning side effect and duplicate core-owned route policy while preserving previously saved `route:workboard` placement slots.

## User Impact

Enabled Workboard installations consistently show a Workboard sidebar link, including crowded sidebars and fresh sessions. Disabling the plugin removes the link, and pinned individual boards continue to work independently.

## Owner Decision

The primary Workboard entry is intentional product behavior for every enabled installation. The prior More/customize-only path and click-time pinning side effect are not retained. Existing saved `route:workboard` slots still keep their chosen position, while installations without one receive the active plugin descriptor as a primary entry.

## Evidence

The same deterministic mocked Workboard stress fixture (650 sessions) was captured against the rebased parent and this PR head.

| Before: enabled Workboard, missing entry | After: native Workboard entry |
| --- | --- |
| ![Before: Workboard is enabled but absent from the crowded sidebar](https://github.com/user-attachments/assets/8f5c436d-52f9-414f-b71b-10a0db340f67) | ![After: Workboard appears in the crowded sidebar](https://github.com/user-attachments/assets/730e68e2-dffd-4bde-a29f-945286c8d694) |

Existing saved placement proof: the active descriptor occupies the persisted Workboard slot and suppresses the appended duplicate (`savedWorkboardEntries = 1`, `appendedDuplicates = 0`).

![After: Workboard preserved in its pre-existing saved sidebar slot](https://github.com/user-attachments/assets/ba1ef3d3-ff3c-450c-9a44-fc4419fd5b04)

Mocked browser assertions:

- Parent `b295ae1625b`: `workboardEntries = 0`
- PR head `b54ec01d2c6`: `workboardEntries = 1`, `href = /workboard`

Local validation:

- `node --import tsx scripts/check-deadcode-exports.mts`
- `node scripts/run-vitest.mjs ui/src/app-navigation.test.ts` (74 passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/plugins/plugins.e2e.test.ts` (6 passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-customization.e2e.test.ts` (5 passed)
- UI owner suite covering navigation normalization, saved settings, zone reconciliation, and rendered placement (9,284 passed, 50 skipped)
- Combined sidebar customization and plugin E2E proof (11 passed)
- `pnpm tsgo:ui`
- Registry owner validation (7 passed), Gateway projection (13 passed), and Workboard registration tests
- Core and plugin production/test typechecks and targeted lint
- Fresh Codex autoreview: clean, no accepted/actionable findings
