### PR TITLE
fix(cli): accept --port across automation commands

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -18,6 +18,11 @@ Run `openclaw automations --help` for the full command surface. See [Automations
 All automation mutations (`add`/`create`, `update`/`edit`, `remove`, `run`) require `operator.admin`. Command-payload runs execute directly in the Gateway process, not as an agent `tools.exec` tool call; `tools.exec.*` and exec approvals still govern model-visible exec tools.
 </Note>
 
+Every automation subcommand accepts the shared Gateway connection options. Use
+`--port <port>` for a Gateway on a non-default local port, or `--url <url>` for
+an explicit WebSocket URL; do not combine them. Connection options such as
+`--port`, `--url`, and `--token` may appear before or after the subcommand.
+
 ## Create jobs quickly
 
 `openclaw automations create` is an alias for `openclaw automations add`. For new jobs, put the schedule first and the prompt second:

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -157,6 +157,30 @@ function buildProgram() {
   return program;
 }
 
+const CRON_GATEWAY_COMMANDS = [
+  { name: "status", args: [] },
+  { name: "list", args: [] },
+  { name: "add", args: [] },
+  { name: "rm", args: ["job-1"] },
+  { name: "enable", args: ["job-1"] },
+  { name: "disable", args: ["job-1"] },
+  { name: "get", args: ["job-1"] },
+  { name: "show", args: ["job-1"] },
+  { name: "runs", args: ["--id", "job-1"] },
+  { name: "run", args: ["job-1"] },
+  { name: "scratch", args: ["job-1"] },
+  { name: "edit", args: ["job-1"] },
+] as const;
+
+function findCronCommand(program: Command, name: string): Command {
+  const cron = program.commands.find((command) => command.name() === "cron");
+  const command = cron?.commands.find((candidate) => candidate.name() === name);
+  if (!command) {
+    throw new Error(`missing cron command: ${name}`);
+  }
+  return command;
+}
+
 function createCronJob(id: string, name: string): CronJob {
   const now = Date.now();
   return {
@@ -338,6 +362,65 @@ async function runCronRunAndCaptureExit(params: {
 }
 
 describe("cron cli", () => {
+  it.each(CRON_GATEWAY_COMMANDS)(
+    "inherits parent Gateway options for cron $name",
+    async ({ name, args }) => {
+      const program = buildProgram();
+      const command = findCronCommand(program, name);
+      command.action(() => {});
+
+      await program.parseAsync(
+        ["automations", "--port", "65267", "--token", "parent-token", name, ...args],
+        { from: "user" },
+      );
+
+      expect(command.opts()).toMatchObject({ port: "65267", token: "parent-token" });
+    },
+  );
+
+  it.each(CRON_GATEWAY_COMMANDS)(
+    "accepts leaf Gateway options for cron $name",
+    async ({ name, args }) => {
+      const program = buildProgram();
+      const command = findCronCommand(program, name);
+      command.action(() => {});
+
+      await program.parseAsync(
+        ["automations", name, ...args, "--port", "65268", "--token", "leaf-token"],
+        { from: "user" },
+      );
+
+      expect(command.opts()).toMatchObject({
+        port: "65268",
+        token: "leaf-token",
+      });
+    },
+  );
+
+  it("prefers explicit leaf Gateway options over cron parent options", async () => {
+    const program = buildProgram();
+    const command = findCronCommand(program, "add");
+    command.action(() => {});
+
+    await program.parseAsync(
+      [
+        "cron",
+        "--port",
+        "65267",
+        "--token",
+        "parent-token",
+        "add",
+        "--port",
+        "65268",
+        "--token",
+        "leaf-token",
+      ],
+      { from: "user" },
+    );
+
+    expect(command.opts()).toMatchObject({ port: "65268", token: "leaf-token" });
+  });
+
   it("documents the gateway-host timezone default for cron --tz help", () => {
     const program = buildProgram();
     const cronCommand = program.commands.find((command) => command.name() === "cron");

--- a/src/cli/cron-cli/register.ts
+++ b/src/cli/cron-cli/register.ts
@@ -2,6 +2,8 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { inheritOptionFromParent } from "../command-options.js";
+import { addGatewayClientOptions } from "../gateway-rpc.js";
 import { setCommandJsonMode } from "../program/json-mode.js";
 import { applyParentDefaultHelpAction } from "../program/parent-default-help.js";
 import { isCronMachineOutput } from "./output-mode.js";
@@ -14,6 +16,25 @@ import { registerCronEditCommand } from "./register.cron-edit.js";
 import { registerCronScratchCommand } from "./register.cron-scratch.js";
 import { registerCronSimpleCommands } from "./register.cron-simple.js";
 
+const CRON_GATEWAY_OPTION_NAMES = [
+  "url",
+  "port",
+  "token",
+  "password",
+  "timeout",
+  "expectFinal",
+] as const;
+
+function inheritCronGatewayOptions(command: Command): void {
+  for (const name of CRON_GATEWAY_OPTION_NAMES) {
+    const inherited = inheritOptionFromParent(command, name);
+    const source = command.parent?.getOptionValueSource(name);
+    if (inherited !== undefined && source && source !== "default") {
+      command.setOptionValueWithSource(name, inherited, source);
+    }
+  }
+}
+
 export function registerCronCli(program: Command) {
   const cron = program
     .command("cron")
@@ -24,6 +45,9 @@ export function registerCronCli(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/cron", "docs.openclaw.ai/cli/cron")}\n${theme.muted("Upgrade tip:")} run \`openclaw doctor --fix\` to normalize legacy automation storage.\n`,
     );
+
+  addGatewayClientOptions(cron);
+  cron.hook("preAction", (_parent, command) => inheritCronGatewayOptions(command));
 
   registerCronStatusCommand(cron);
   registerCronListCommand(cron);

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -156,13 +156,8 @@ function expectLocalGatewayCall(method: string, port: number, params?: unknown) 
   if (params !== undefined) {
     expect(actualParams).toEqual(params);
   }
-  const gatewayOpts = opts as
-    | { config?: { gateway?: { port?: number } }; localPortOverride?: number }
-    | undefined;
+  const gatewayOpts = opts as { localPortOverride?: number } | undefined;
   expect(gatewayOpts?.localPortOverride).toBe(port);
-  expect(gatewayOpts?.config).toEqual({
-    gateway: { mode: "local", port },
-  });
 }
 
 describe("gateway register option collisions", () => {
@@ -225,7 +220,7 @@ describe("gateway register option collisions", () => {
       },
     },
     {
-      name: "projects gateway call --port into local config",
+      name: "projects gateway call --port into the local override",
       argv: ["gateway", "call", "health", "--port", "19084", "--json"],
       assert: () => {
         expectLocalGatewayCall("health", 19084, {});
@@ -293,7 +288,7 @@ describe("gateway register option collisions", () => {
       },
     },
     {
-      name: "projects gateway health --port into local config",
+      name: "projects gateway health --port into the local override",
       argv: ["gateway", "health", "--port", "19081", "--json"],
       assert: () => {
         expectLocalGatewayCall("health", 19081);
@@ -344,7 +339,7 @@ describe("gateway register option collisions", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("uses the effective local port config for gateway health auth diagnostics", async () => {
+  it("uses the effective local port override for gateway health auth diagnostics", async () => {
     const authError = new Error("gateway auth required");
     callGatewayCli.mockRejectedValueOnce(authError);
     emitReachableGatewayAuthDiagnostic.mockResolvedValueOnce(true);
@@ -356,9 +351,7 @@ describe("gateway register option collisions", () => {
     expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
     expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledWith({
       error: authError,
-      config: {
-        gateway: { mode: "local", port: 19081 },
-      },
+      config: {},
       runtime: defaultRuntime,
       timeoutMs: 10000,
       token: undefined,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -199,10 +199,10 @@ function resolveGatewayRpcOptions<T extends { token?: string; password?: string 
   };
 }
 
-async function resolveGatewayRpcOptionsWithLocalPort(
+function resolveGatewayRpcOptionsWithLocalPort(
   opts: GatewayRpcOpts & { port?: unknown },
   command?: Command,
-): Promise<GatewayRpcOpts> {
+): GatewayRpcOpts {
   const rpcOpts = resolveGatewayRpcOptions(opts, command);
   const port = parseGatewayPortOption(opts.port ?? inheritOptionFromParent(command, "port"));
   if (port === undefined) {
@@ -211,19 +211,9 @@ async function resolveGatewayRpcOptionsWithLocalPort(
   if (typeof opts.url === "string" && opts.url.trim()) {
     throw new Error("Use either --url or --port, not both.");
   }
-  const { readBestEffortConfig } = await loadConfigModule();
-  const config = await readBestEffortConfig();
   return {
     ...rpcOpts,
     localPortOverride: port,
-    config: {
-      ...config,
-      gateway: {
-        ...config.gateway,
-        mode: "local",
-        port,
-      },
-    },
   };
 }
 
@@ -587,7 +577,7 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
               command.getOptionValueSource("timeout") === "default"
                 ? { ...opts, timeout: String(SETUP_INFERENCE_DETECT_RPC_TIMEOUT_MS) }
                 : opts;
-            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(callOpts, command);
+            const rpcOpts = resolveGatewayRpcOptionsWithLocalPort(callOpts, command);
             const params = parseGatewayCallParams(String(opts.params ?? "{}"));
             const result = await callGatewayReadOnlyCli(method, rpcOpts, params);
             if (rpcOpts.json) {
@@ -616,7 +606,7 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
+            const rpcOpts = resolveGatewayRpcOptionsWithLocalPort(opts, command);
             await runGatewaySuspend(
               {
                 rpcOpts,
@@ -642,7 +632,7 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .action(async (suspensionId, opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
+            const rpcOpts = resolveGatewayRpcOptionsWithLocalPort(opts, command);
             await runGatewayResume(
               { rpcOpts, suspensionId: String(suspensionId), json: Boolean(rpcOpts.json) },
               { callGateway: callGatewayReadOnlyCli, runtime: defaultRuntime },
@@ -700,7 +690,7 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
+            const rpcOpts = resolveGatewayRpcOptionsWithLocalPort(opts, command);
             let result: unknown;
             try {
               result = await callGatewayReadOnlyCli("health", rpcOpts);

--- a/src/cli/gateway-rpc.runtime.test.ts
+++ b/src/cli/gateway-rpc.runtime.test.ts
@@ -41,6 +41,19 @@ describe("addGatewayClientOptions", () => {
       });
     },
   );
+
+  it("registers and parses a local Gateway port", async () => {
+    const program = new Command().exitOverride();
+    const action = vi.fn((_opts: GatewayRpcOpts) => {});
+    addGatewayClientOptions(program.command("gateway-command")).action(action);
+
+    await program.parseAsync(["gateway-command", "--port", "19083"], { from: "user" });
+
+    expect(action).toHaveBeenCalledWith(
+      expect.objectContaining({ port: "19083" }),
+      expect.anything(),
+    );
+  });
 });
 
 describe("callGatewayFromCliRuntime", () => {
@@ -93,6 +106,25 @@ describe("callGatewayFromCliRuntime", () => {
         requireLocalBackendSharedAuth: true,
       }),
     );
+  });
+
+  it("projects --port to the canonical local Gateway override", async () => {
+    await callGatewayFromCliRuntime("cron.status", { port: "19083" });
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({ localPortOverride: 19_083 }),
+    );
+  });
+
+  it("rejects combining --url and --port before opening a Gateway connection", async () => {
+    await expect(
+      callGatewayFromCliRuntime("cron.status", {
+        url: "ws://127.0.0.1:19083",
+        port: "19083",
+      }),
+    ).rejects.toThrow("Use either --url or --port, not both.");
+
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/gateway-rpc.runtime.ts
+++ b/src/cli/gateway-rpc.runtime.ts
@@ -5,6 +5,7 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway, isImplicitLocalGatewayTarget } from "../gateway/call.js";
+import { parseGatewayPortOption } from "./gateway-port-option.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.types.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 import { withProgress } from "./progress.js";
@@ -36,13 +37,21 @@ type GatewayCliTransportRpcOpts = Omit<GatewayRpcOpts, "timeout"> & {
 
 const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 30_000;
 
+function resolveLocalPortOverride(opts: GatewayCliTransportRpcOpts): number | undefined {
+  const port = opts.localPortOverride ?? parseGatewayPortOption(opts.port);
+  if (port !== undefined && typeof opts.url === "string" && opts.url.trim()) {
+    throw new Error("Use either --url or --port, not both.");
+  }
+  return port;
+}
+
 export async function isImplicitLocalGatewayTargetFromCliRuntime(
   opts: GatewayCliTransportRpcOpts,
 ): Promise<boolean> {
   return await isImplicitLocalGatewayTarget({
     config: opts.config,
     url: opts.url,
-    localPortOverride: opts.localPortOverride,
+    localPortOverride: resolveLocalPortOverride(opts),
   });
 }
 
@@ -52,6 +61,7 @@ export async function callGatewayFromCliRuntime(
   params?: unknown,
   extra?: CallGatewayFromCliRuntimeExtra,
 ) {
+  const localPortOverride = resolveLocalPortOverride(opts);
   // Progress is disabled for JSON output so stdout stays parseable.
   const showProgress = extra?.progress ?? opts.json !== true;
   const timeoutMs =
@@ -87,7 +97,7 @@ export async function callGatewayFromCliRuntime(
         sharedStateMode: extra?.sharedStateMode,
         signal: extra?.signal,
         timeoutMs,
-        localPortOverride: opts.localPortOverride,
+        localPortOverride,
         clientName: extra?.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
         mode: extra?.mode ?? GATEWAY_CLIENT_MODES.CLI,
       }),

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -24,6 +24,7 @@ async function loadGatewayRpcRuntime(): Promise<GatewayRpcRuntimeModule> {
 export function addGatewayClientOptions(cmd: Command, defaults?: { timeoutMs?: number }) {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--port <port>", "Local Gateway port")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (if required)")
     .option("--timeout <ms>", "Timeout in ms", String(defaults?.timeoutMs ?? 30_000))

--- a/src/cli/gateway-rpc.types.ts
+++ b/src/cli/gateway-rpc.types.ts
@@ -2,6 +2,7 @@
 /** Common gateway RPC flags accepted by direct gateway command helpers. */
 export type GatewayRpcOpts = {
   url?: string;
+  port?: string;
   token?: string;
   password?: string;
   timeout?: string;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -425,6 +425,7 @@ describe("callGateway url resolution", () => {
 
     setGatewayConfig({ mode: "remote", remote: { url: "wss://gateway.example/ws" } });
     await expect(isImplicitLocalGatewayTarget({})).resolves.toBe(false);
+    await expect(isImplicitLocalGatewayTarget({ localPortOverride: 19082 })).resolves.toBe(true);
 
     setLocalLoopbackGatewayConfig();
     await expect(isImplicitLocalGatewayTarget({ url: "ws://127.0.0.1:18789" })).resolves.toBe(
@@ -783,6 +784,25 @@ describe("callGateway url resolution", () => {
     process.env.OPENCLAW_GATEWAY_URL = "wss://gateway-in-container.internal:9443/ws";
     process.env.OPENCLAW_GATEWAY_PORT = "19001";
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+
+    await callGateway({
+      method: "health",
+      token: "explicit-token",
+      localPortOverride: 19082,
+    });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:19082");
+    expect(lastClientOptions?.token).toBe("explicit-token");
+  });
+
+  it("lets an explicit local port override bypass the configured remote URL", async () => {
+    setGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      remote: { url: "wss://gateway.example/ws", token: "remote-token" },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
 
     await callGateway({
       method: "health",

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -645,7 +645,7 @@ async function resolveGatewayCallContext(
   const config =
     opts.config ?? (canSkipConfigLoad ? ({} as OpenClawConfig) : await loadGatewayConfig());
   const configPath = opts.configPath ?? resolveGatewayConfigPath(process.env);
-  const isRemoteMode = config.gateway?.mode === "remote";
+  const isRemoteMode = opts.localPortOverride === undefined && config.gateway?.mode === "remote";
   return {
     config,
     configPath,
@@ -668,7 +668,7 @@ export async function isImplicitLocalGatewayTarget(
     return false;
   }
   const config = opts.config ?? (await loadGatewayConfig());
-  return config.gateway?.mode !== "remote";
+  return opts.localPortOverride !== undefined || config.gateway?.mode !== "remote";
 }
 
 function ensureRemoteModeUrlConfigured(params: {

--- a/src/gateway/client-bootstrap.ts
+++ b/src/gateway/client-bootstrap.ts
@@ -269,7 +269,11 @@ export async function resolveGatewayClientBootstrap(params: {
   const surface =
     configuredTarget?.authSurface ??
     params.modeOverride ??
-    (params.config.gateway?.mode === "remote" ? "remote" : "local");
+    (params.localPortOverride !== undefined
+      ? "local"
+      : params.config.gateway?.mode === "remote"
+        ? "remote"
+        : "local");
   let auth: { token?: string; password?: string; failureReason?: string };
   if (params.skipImplicitAuth) {
     auth = explicitAuth;

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -53,7 +53,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
     options.configPath ??
     resolvers.resolveConfigPath?.(process.env) ??
     resolveConfigPath(process.env);
-  const isRemoteMode = config.gateway?.mode === "remote";
+  const isRemoteMode = options.localPortOverride === undefined && config.gateway?.mode === "remote";
   const remote = isRemoteMode ? config.gateway?.remote : undefined;
   const tlsEnabled = config.gateway?.tls?.enabled === true;
   const localPort =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users targeting a non-default local Gateway port from `openclaw automations` would get `OpenClaw does not recognize option "--port"`, even though the automation commands are Gateway-backed and sibling Gateway commands support local port selection. Shared connection flags also only worked after the leaf subcommand, so parent placement such as `automations --token ... list` was rejected.

## Why This Change Was Made

The shared Gateway CLI option owner now registers and projects `--port`, while the `cron|automations` parent declares the same connection options as every Gateway-backed leaf and inherits only non-default parent values. The canonical Gateway connection resolver now treats an explicit local port as authoritative over configured remote URLs and local auth selection, which allowed removal of the older Gateway CLI workaround that rewrote config into local mode.

## User Impact

Operators can place `--port`, `--url`, `--token`, `--password`, `--timeout`, and `--expect-final` before or after every automation leaf command. `--port <port>` reliably selects that local Gateway even when the active profile is configured for a remote Gateway; combining `--url` and `--port` fails explicitly.

## Evidence

- Before: `openclaw automations add ... --port 65267 --json` exited 1 with `OpenClaw does not recognize option "--port"`.
- Regression-first parser proof: the new real-Commander matrix failed 25 cases on the pre-fix tree, then passed for all 12 Gateway-backed leaves in both parent and leaf positions, including leaf-over-parent precedence.
- Owner-boundary reproduction: a remote-mode config plus `localPortOverride: 19082` incorrectly selected `wss://gateway.example/ws` before the fix; it now selects `ws://127.0.0.1:19082`.
- Source-blind CLI proof: both `automations --port 1 status` and `automations status --port 1` reached `ws://127.0.0.1:1` and reported `ECONNREFUSED`, rather than an unknown-option or configured-remote error. `--url` plus `--port` returned the explicit conflict error. No automation state changed.
- Focused tests: 5 files, 387 tests passed across automation parsing, shared Gateway RPC options, Gateway CLI option collisions, bootstrap, and canonical connection resolution.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- <13 changed paths>` passed the full core/coreTests/docs plan.
- `pnpm docs:check-mdx` passed 776 files; `pnpm docs:check-links` checked 6,518 internal links with 0 broken.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` reported clean with no accepted/actionable findings.
- LOC: production +52/-22 (net +30); tests +140/-12; docs +5/-0. Production growth is the shared local-port capability and parent inheritance; the obsolete per-command config rewrite was removed.
- Changelog intentionally unchanged per the maintainer work order.
