### PR TITLE
refactor(ui): deduplicate session menus and hovercards

### DIFF
--- a/ui/src/components/github-link-hovercard-registration.ts
+++ b/ui/src/components/github-link-hovercard-registration.ts
@@ -1,80 +1,53 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import { ensureCustomElementDefined } from "../app/lazy-custom-element.ts";
 import type { GitHubLinkHovercardProvider } from "./github-link-hovercard.runtime.ts";
 import {
   GITHUB_HOVERCARD_OPEN_DELAY_MS,
   githubLinkAnchorFromEvent,
   parseGitHubLinkTarget,
 } from "./github-link-target.ts";
+import {
+  hovercardBootstrapIntentActive,
+  LazyHovercardBootstrap,
+  remainingHovercardOpenDelay,
+  type HovercardBootstrapTrigger,
+} from "./lazy-hovercard-registration.ts";
 
 const HOVERCARD_TAG = "openclaw-github-link-hovercard-provider";
 
-type HovercardProviderElement = HTMLElement & {
-  client: GatewayBrowserClient | null;
-};
+type HovercardProviderElement = GitHubLinkHovercardProvider;
 
-function providerForAnchor(anchor: HTMLAnchorElement): GitHubLinkHovercardProvider | null {
-  return anchor.closest<GitHubLinkHovercardProvider>(HOVERCARD_TAG);
-}
+const bootstrap = new LazyHovercardBootstrap<HovercardProviderElement, GatewayBrowserClient | null>(
+  {
+    tag: HOVERCARD_TAG,
+    load: async () =>
+      (await import("./github-link-hovercard.runtime.ts")).GitHubLinkHovercardProvider,
+    snapshot: (provider) => provider.client,
+    restore: (provider, client) => {
+      provider.client = client;
+    },
+  },
+);
 
-function removeBootstrapListeners(): void {
-  document.removeEventListener("pointerover", handleBootstrapPointerOver, true);
-  document.removeEventListener("focusin", handleBootstrapFocusIn, true);
-}
-
-async function activateHovercard(event: Event, trigger: "focus" | "pointer"): Promise<void> {
+async function activateHovercard(event: Event, trigger: HovercardBootstrapTrigger): Promise<void> {
   if (trigger === "pointer" && (event as PointerEvent).pointerType === "touch") {
     return;
   }
   const anchor = githubLinkAnchorFromEvent(event);
   const target = anchor ? parseGitHubLinkTarget(anchor.href) : null;
-  if (!anchor || !target || !providerForAnchor(anchor)) {
+  if (!anchor || !target || !bootstrap.providerFor(anchor)) {
     return;
   }
   const startedAt = performance.now();
-  const pendingClients = new Map(
-    [...document.querySelectorAll<HovercardProviderElement>(HOVERCARD_TAG)].map((provider) => [
-      provider,
-      provider.client,
-    ]),
-  );
-  await ensureCustomElementDefined(HOVERCARD_TAG, async () => {
-    const runtime = await import("./github-link-hovercard.runtime.ts");
-    // Sibling module instances can share one document + registry (the
-    // non-isolated jsdom lane evaluates this module once per test file), so a
-    // concurrent instance may have defined the tag while our load resolved.
-    if (!customElements.get(HOVERCARD_TAG)) {
-      customElements.define(HOVERCARD_TAG, runtime.GitHubLinkHovercardProvider);
-    }
-    for (const [provider, client] of pendingClients) {
-      provider.client = client;
-    }
-  });
-  removeBootstrapListeners();
-  const provider = providerForAnchor(anchor);
-  const stillActive =
-    trigger === "pointer" ? anchor.matches(":hover") : document.activeElement === anchor;
-  if (!provider || !anchor.isConnected || !stillActive) {
+  await bootstrap.define();
+  const provider = bootstrap.providerFor(anchor);
+  if (!provider || !anchor.isConnected || !hovercardBootstrapIntentActive(anchor, trigger)) {
     return;
   }
   const delay =
     trigger === "pointer"
-      ? Math.max(0, GITHUB_HOVERCARD_OPEN_DELAY_MS - (performance.now() - startedAt))
+      ? remainingHovercardOpenDelay(startedAt, GITHUB_HOVERCARD_OPEN_DELAY_MS)
       : 0;
   provider.activateFromBootstrap(anchor, target, trigger, delay);
 }
 
-function handleBootstrapPointerOver(event: Event): void {
-  void activateHovercard(event, "pointer");
-}
-
-function handleBootstrapFocusIn(event: Event): void {
-  void activateHovercard(event, "focus");
-}
-
-if (customElements.get(HOVERCARD_TAG)) {
-  removeBootstrapListeners();
-} else {
-  document.addEventListener("pointerover", handleBootstrapPointerOver, true);
-  document.addEventListener("focusin", handleBootstrapFocusIn, true);
-}
+bootstrap.install(activateHovercard);

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -16,15 +16,11 @@ import {
   parseGitHubLinkTarget,
   type GitHubLinkTarget,
 } from "./github-link-target.ts";
+import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
 
 const SUCCESS_CACHE_MS = 5 * 60_000;
 const FAILURE_CACHE_MS = 30_000;
 const CACHE_LIMIT = 100;
-const VIEWPORT_PADDING = 12;
-const CARD_GAP = 10;
-// Traversal grace: the pointer has to cross CARD_GAP of unowned page between the
-// link and the card, and neither surface is hovered during that crossing.
-const CLOSE_DELAY_MS = 120;
 
 type GitHubPreview = GitHubLinkTarget & ControlUiGitHubPreview;
 
@@ -265,13 +261,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   // the portaled card (e.g. clicking the title link) can hold it open, so a
   // pointer-driven open still fully releases on mouse-out (see handleCardPointerLeave).
   private activeTrigger: "focus" | "pointer" | null = null;
-  private card: HTMLDivElement | null = null;
-  private cardFocusInside = false;
-  private closeTimer: number | null = null;
-  private focusInside = false;
-  private openTimer: number | null = null;
-  private pointerInside = false;
-  private pointerOverCard = false;
+  private readonly hovercard = new PortaledHovercardController(() => this.close());
   private renderedPreview: GitHubPreview | null = null;
   private renderedUnavailable = false;
   private stopI18n: (() => void) | null = null;
@@ -283,22 +273,22 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     args: () => [this.activeTarget] as const,
     task: ([target], { signal }) => (target ? this.loadPreview(target, signal) : initialState),
     onComplete: (preview) => {
-      const card = this.card;
+      const card = this.hovercard.card;
       if (!card) {
         return;
       }
       this.renderedPreview = preview;
       renderPreview(card, preview);
-      this.positionCard();
+      this.hovercard.position();
     },
     onError: () => {
-      const card = this.card;
+      const card = this.hovercard.card;
       if (!card) {
         return;
       }
       this.renderedUnavailable = true;
       renderUnavailable(card);
-      this.positionCard();
+      this.hovercard.position();
     },
   });
   private readonly activeAnchorObserver = new MutationObserver(() => {
@@ -340,7 +330,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   }
 
   private readonly handleLocaleChange = () => {
-    const card = this.card;
+    const card = this.hovercard.card;
     if (!card) {
       return;
     }
@@ -351,7 +341,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     } else {
       renderLoading(card);
     }
-    this.positionCard();
+    this.hovercard.position();
   };
 
   private readonly handlePointerOver = (event: Event) => {
@@ -375,40 +365,40 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     if (event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) {
       return;
     }
-    this.pointerInside = false;
-    this.scheduleClose();
+    this.hovercard.pointerInside = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleCardPointerEnter = () => {
-    this.pointerOverCard = true;
-    this.clearCloseTimer();
+    this.hovercard.pointerOverCard = true;
+    this.hovercard.clearClose();
   };
 
   private readonly handleCardPointerLeave = () => {
-    this.pointerOverCard = false;
+    this.hovercard.pointerOverCard = false;
     // A pointer-opened card must release fully on mouse-out even if a click
     // inside the card (e.g. the title link) left it focused; otherwise it
     // would stay stuck open with nothing left driving the intent.
     if (this.activeTrigger === "pointer") {
-      this.cardFocusInside = false;
+      this.hovercard.cardFocusInside = false;
     }
-    this.scheduleClose();
+    this.hovercard.scheduleClose();
   };
 
   // The card is portaled to document.body, so focus landing on its title link
   // never reaches the provider's delegated focusin/focusout listeners; track it
   // directly so keyboard users can tab into the link without losing the card.
   private readonly handleCardFocusIn = () => {
-    this.cardFocusInside = true;
-    this.clearCloseTimer();
+    this.hovercard.cardFocusInside = true;
+    this.hovercard.clearClose();
   };
 
   private readonly handleCardFocusOut = (event: FocusEvent) => {
-    if (event.relatedTarget instanceof Node && this.card?.contains(event.relatedTarget)) {
+    if (event.relatedTarget instanceof Node && this.hovercard.card?.contains(event.relatedTarget)) {
       return;
     }
-    this.cardFocusInside = false;
-    this.scheduleClose();
+    this.hovercard.cardFocusInside = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleFocusIn = (event: Event) => {
@@ -430,42 +420,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     if (event.relatedTarget instanceof Node && this.activeAnchor.contains(event.relatedTarget)) {
       return;
     }
-    this.focusInside = false;
-    this.scheduleClose();
+    this.hovercard.focusInside = false;
+    this.hovercard.scheduleClose();
   };
-
-  private clearCloseTimer(): void {
-    if (this.closeTimer !== null) {
-      window.clearTimeout(this.closeTimer);
-      this.closeTimer = null;
-    }
-  }
-
-  // Hover intent spans link and card: dismissal waits out the traversal grace and
-  // re-checks every surface that holds the card open, so moving from one to the
-  // other keeps it alive and only leaving both closes it.
-  private scheduleClose(): void {
-    this.clearCloseTimer();
-    if (this.hoverIntentHeld) {
-      return;
-    }
-    // Without a card there is only a pending open timer, and no gap to cross:
-    // cancel the open now instead of granting grace to a card that never showed.
-    if (!this.card) {
-      this.close();
-      return;
-    }
-    this.closeTimer = window.setTimeout(() => {
-      this.closeTimer = null;
-      if (!this.hoverIntentHeld) {
-        this.close();
-      }
-    }, CLOSE_DELAY_MS);
-  }
-
-  private get hoverIntentHeld(): boolean {
-    return this.pointerInside || this.pointerOverCard || this.focusInside || this.cardFocusInside;
-  }
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
@@ -507,7 +464,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   };
 
   private cardFocusables(): HTMLElement[] {
-    return [...(this.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
+    return [...(this.hovercard.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
   }
 
   private readonly handleClick = () => {
@@ -523,9 +480,9 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.activate(anchor, target, delay);
     this.activeTrigger = trigger;
     if (trigger === "pointer") {
-      this.pointerInside = true;
+      this.hovercard.pointerInside = true;
     } else {
-      this.focusInside = true;
+      this.hovercard.focusInside = true;
     }
   }
 
@@ -538,27 +495,22 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.activeTarget = target;
     // Announce the popup affordance as soon as the link is recognized; show()
     // flips the state once the card exists, close() takes the whole set away.
-    anchor.setAttribute("aria-haspopup", "dialog");
-    anchor.setAttribute("aria-expanded", "false");
+    this.hovercard.markTrigger(anchor);
     this.activeAnchorObserver.observe(this, { childList: true, subtree: true });
-    this.openTimer = window.setTimeout(() => {
-      this.openTimer = null;
-      this.show(anchor, target);
-    }, delay);
+    this.hovercard.scheduleOpen(delay, () => this.show(anchor, target));
   }
 
   private show(anchor: HTMLAnchorElement, target: GitHubLinkTarget): void {
     if (this.activeAnchor !== anchor || this.activeTarget?.href !== target.href) {
       return;
     }
-    const card = document.createElement("div");
     nextHovercardId += 1;
-    card.id = `openclaw-github-hovercard-${nextHovercardId}`;
-    card.className = "github-link-hovercard";
-    card.dataset.open = "true";
+    const card = createPortaledHovercard(
+      `openclaw-github-hovercard-${nextHovercardId}`,
+      "github-link-hovercard",
+    );
     // A tooltip may not own controls: its content is flattened and unreachable.
     // The card is a non-modal dialog instead, named by the render functions.
-    card.setAttribute("role", "dialog");
     this.renderedPreview = null;
     this.renderedUnavailable = false;
     renderLoading(card);
@@ -569,12 +521,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     card.addEventListener("focusin", this.handleCardFocusIn);
     card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
-    document.body.append(card);
-    this.card = card;
-    anchor.setAttribute("aria-controls", card.id);
-    anchor.setAttribute("aria-expanded", "true");
-    this.listenForViewportChanges();
-    this.positionCard();
+    this.hovercard.mount(anchor, card, "vertical");
 
     void this.previewTask.run([target]);
   }
@@ -630,69 +577,13 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   }
 
   private close(): void {
-    if (this.openTimer !== null) {
-      window.clearTimeout(this.openTimer);
-      this.openTimer = null;
-    }
-    this.clearCloseTimer();
+    this.hovercard.reset();
     this.activeAnchorObserver.disconnect();
     void this.previewTask.run([null]);
-    if (this.activeAnchor) {
-      this.activeAnchor.removeAttribute("aria-controls");
-      this.activeAnchor.removeAttribute("aria-expanded");
-      this.activeAnchor.removeAttribute("aria-haspopup");
-    }
-    this.card?.remove();
-    this.card = null;
     this.renderedPreview = null;
     this.renderedUnavailable = false;
     this.activeAnchor = null;
     this.activeTarget = null;
     this.activeTrigger = null;
-    this.cardFocusInside = false;
-    this.focusInside = false;
-    this.pointerInside = false;
-    this.pointerOverCard = false;
-    this.stopListeningForViewportChanges();
-  }
-
-  private readonly handleViewportChange = () => {
-    this.positionCard();
-  };
-
-  private listenForViewportChanges(): void {
-    window.addEventListener("resize", this.handleViewportChange);
-    window.addEventListener("scroll", this.handleViewportChange, true);
-    window.visualViewport?.addEventListener("resize", this.handleViewportChange);
-    window.visualViewport?.addEventListener("scroll", this.handleViewportChange);
-  }
-
-  private stopListeningForViewportChanges(): void {
-    window.removeEventListener("resize", this.handleViewportChange);
-    window.removeEventListener("scroll", this.handleViewportChange, true);
-    window.visualViewport?.removeEventListener("resize", this.handleViewportChange);
-    window.visualViewport?.removeEventListener("scroll", this.handleViewportChange);
-  }
-
-  private positionCard(): void {
-    const anchor = this.activeAnchor;
-    const card = this.card;
-    if (!anchor || !card) {
-      return;
-    }
-    const anchorRect = anchor.getBoundingClientRect();
-    const cardRect = card.getBoundingClientRect();
-    const fitsBelow =
-      anchorRect.bottom + CARD_GAP + cardRect.height + VIEWPORT_PADDING <= innerHeight;
-    const side = fitsBelow ? "bottom" : "top";
-    const top =
-      side === "bottom"
-        ? anchorRect.bottom + CARD_GAP
-        : anchorRect.top - cardRect.height - CARD_GAP;
-    const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
-    const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
-    card.dataset.side = side;
-    card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.left), maxLeft)}px`;
-    card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, top), maxTop)}px`;
   }
 }

--- a/ui/src/components/lazy-hovercard-registration.ts
+++ b/ui/src/components/lazy-hovercard-registration.ts
@@ -1,0 +1,81 @@
+import { ensureCustomElementDefined } from "../app/lazy-custom-element.ts";
+
+export type HovercardBootstrapTrigger = "focus" | "pointer";
+
+export class LazyHovercardBootstrap<TElement extends HTMLElement, TProperties> {
+  private stopListeners: (() => void) | null = null;
+
+  constructor(
+    private readonly params: {
+      tag: string;
+      load: () => Promise<CustomElementConstructor>;
+      snapshot: (element: TElement) => TProperties;
+      restore: (element: TElement, properties: TProperties) => void;
+      onDefined?: () => void;
+    },
+  ) {}
+
+  install(activate: (event: Event, trigger: HovercardBootstrapTrigger) => Promise<void>): void {
+    if (!customElements.get(this.params.tag)) {
+      this.stopListeners = installHovercardBootstrapListeners(activate);
+    }
+  }
+
+  providerFor(target: Element): TElement | null {
+    return target.closest<TElement>(this.params.tag);
+  }
+
+  async define(): Promise<void> {
+    const pending = new Map(
+      [...document.querySelectorAll<TElement>(this.params.tag)].map((element) => [
+        element,
+        this.params.snapshot(element),
+      ]),
+    );
+    await ensureCustomElementDefined(this.params.tag, async () => {
+      const provider = await this.params.load();
+      // Non-isolated test modules can share one document and element registry.
+      if (!customElements.get(this.params.tag)) {
+        customElements.define(this.params.tag, provider);
+      }
+      for (const [element, properties] of pending) {
+        this.params.restore(element, properties);
+      }
+    });
+    this.stopListeners?.();
+    this.stopListeners = null;
+    this.params.onDefined?.();
+  }
+}
+
+function installHovercardBootstrapListeners(
+  activate: (event: Event, trigger: HovercardBootstrapTrigger) => Promise<void>,
+): () => void {
+  const listeners = {
+    focus: (event: Event) => void activate(event, "focus"),
+    pointer: (event: Event) => void activate(event, "pointer"),
+  };
+  document.addEventListener("pointerover", listeners.pointer, true);
+  document.addEventListener("focusin", listeners.focus, true);
+  return () => {
+    document.removeEventListener("pointerover", listeners.pointer, true);
+    document.removeEventListener("focusin", listeners.focus, true);
+  };
+}
+
+export function hovercardBootstrapIntentActive(
+  target: HTMLElement,
+  trigger: HovercardBootstrapTrigger,
+  focusWithin = false,
+): boolean {
+  if (trigger === "pointer") {
+    return target.matches(":hover");
+  }
+  return focusWithin
+    ? document.activeElement instanceof Node && target.contains(document.activeElement)
+    : document.activeElement === target;
+}
+
+export function remainingHovercardOpenDelay(startedAt: number, openDelayMs: number): number {
+  return Math.max(0, openDelayMs - (performance.now() - startedAt));
+}

--- a/ui/src/components/portaled-hovercard.ts
+++ b/ui/src/components/portaled-hovercard.ts
@@ -1,0 +1,189 @@
+const CARD_GAP = 10;
+const VIEWPORT_PADDING = 12;
+
+type PortaledHovercardPlacement = "horizontal" | "vertical";
+
+export class PortaledHovercardController {
+  card: HTMLDivElement | null = null;
+  pointerInside = false;
+  pointerOverCard = false;
+  focusInside = false;
+  cardFocusInside = false;
+
+  private closeTimer: number | null = null;
+  private anchor: HTMLElement | null = null;
+  private openTimer: number | null = null;
+  private placement: PortaledHovercardPlacement = "vertical";
+  private stopPositioning: (() => void) | null = null;
+  private trigger: HTMLElement | null = null;
+
+  constructor(
+    private readonly close: () => void,
+    private readonly closeDelayMs = 120,
+  ) {}
+
+  get held(): boolean {
+    return this.pointerInside || this.pointerOverCard || this.focusInside || this.cardFocusInside;
+  }
+
+  scheduleOpen(delay: number, open: () => void): void {
+    this.openTimer = window.setTimeout(() => {
+      this.openTimer = null;
+      open();
+    }, delay);
+  }
+
+  clearClose(): void {
+    if (this.closeTimer !== null) {
+      window.clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
+  }
+
+  scheduleClose(): void {
+    this.clearClose();
+    if (this.held) {
+      return;
+    }
+    // A pending open has no portal gap to cross, so it closes immediately.
+    if (!this.card) {
+      this.close();
+      return;
+    }
+    this.closeTimer = window.setTimeout(() => {
+      this.closeTimer = null;
+      if (!this.held) {
+        this.close();
+      }
+    }, this.closeDelayMs);
+  }
+
+  markTrigger(trigger: HTMLElement): void {
+    this.trigger = trigger;
+    markPortaledHovercardTrigger(trigger);
+  }
+
+  mount(
+    anchor: HTMLElement,
+    card: HTMLDivElement,
+    placement: PortaledHovercardPlacement,
+    observeVisualViewport = true,
+  ): void {
+    this.clearCard();
+    this.anchor = anchor;
+    this.card = card;
+    this.placement = placement;
+    this.stopPositioning = mountPortaledHovercard({
+      anchor,
+      trigger: this.trigger ?? anchor,
+      card,
+      placement,
+      observeVisualViewport,
+    });
+  }
+
+  clearCard(): void {
+    this.stopPositioning?.();
+    this.stopPositioning = null;
+    this.card?.remove();
+    this.card = null;
+  }
+
+  position(): void {
+    if (this.anchor && this.card) {
+      positionPortaledHovercard(this.anchor, this.card, this.placement);
+    }
+  }
+
+  reset(): void {
+    if (this.openTimer !== null) {
+      window.clearTimeout(this.openTimer);
+      this.openTimer = null;
+    }
+    this.clearClose();
+    this.pointerInside = false;
+    this.pointerOverCard = false;
+    this.focusInside = false;
+    this.cardFocusInside = false;
+    clearPortaledHovercardTrigger(this.trigger);
+    this.clearCard();
+    this.anchor = null;
+    this.trigger = null;
+  }
+}
+
+function markPortaledHovercardTrigger(trigger: HTMLElement): void {
+  trigger.setAttribute("aria-haspopup", "dialog");
+  trigger.setAttribute("aria-expanded", "false");
+}
+
+function clearPortaledHovercardTrigger(trigger: HTMLElement | null): void {
+  trigger?.removeAttribute("aria-controls");
+  trigger?.removeAttribute("aria-expanded");
+  trigger?.removeAttribute("aria-haspopup");
+}
+
+export function createPortaledHovercard(id: string, className: string): HTMLDivElement {
+  const card = document.createElement("div");
+  card.id = id;
+  card.className = className;
+  card.dataset.open = "true";
+  card.setAttribute("role", "dialog");
+  return card;
+}
+
+function mountPortaledHovercard(params: {
+  anchor: HTMLElement;
+  trigger: HTMLElement;
+  card: HTMLDivElement;
+  placement: PortaledHovercardPlacement;
+  observeVisualViewport?: boolean;
+}): () => void {
+  document.body.append(params.card);
+  params.trigger.setAttribute("aria-controls", params.card.id);
+  params.trigger.setAttribute("aria-expanded", "true");
+  const position = () => positionPortaledHovercard(params.anchor, params.card, params.placement);
+  window.addEventListener("resize", position);
+  window.addEventListener("scroll", position, true);
+  if (params.observeVisualViewport !== false) {
+    window.visualViewport?.addEventListener("resize", position);
+    window.visualViewport?.addEventListener("scroll", position);
+  }
+  position();
+  return () => {
+    window.removeEventListener("resize", position);
+    window.removeEventListener("scroll", position, true);
+    window.visualViewport?.removeEventListener("resize", position);
+    window.visualViewport?.removeEventListener("scroll", position);
+  };
+}
+
+function positionPortaledHovercard(
+  anchor: HTMLElement,
+  card: HTMLDivElement,
+  placement: PortaledHovercardPlacement,
+): void {
+  const anchorRect = anchor.getBoundingClientRect();
+  const cardRect = card.getBoundingClientRect();
+  const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
+  const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
+  if (placement === "horizontal") {
+    const fitsRight = anchorRect.right + CARD_GAP + cardRect.width + VIEWPORT_PADDING <= innerWidth;
+    const left = fitsRight
+      ? anchorRect.right + CARD_GAP
+      : anchorRect.left - cardRect.width - CARD_GAP;
+    card.dataset.side = fitsRight ? "right" : "left";
+    card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, left), maxLeft)}px`;
+    card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.top), maxTop)}px`;
+    return;
+  }
+  const fitsBelow =
+    anchorRect.bottom + CARD_GAP + cardRect.height + VIEWPORT_PADDING <= innerHeight;
+  const side = fitsBelow ? "bottom" : "top";
+  const top = fitsBelow
+    ? anchorRect.bottom + CARD_GAP
+    : anchorRect.top - cardRect.height - CARD_GAP;
+  card.dataset.side = side;
+  card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.left), maxLeft)}px`;
+  card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, top), maxTop)}px`;
+}

--- a/ui/src/components/session-link-hovercard-registration.ts
+++ b/ui/src/components/session-link-hovercard-registration.ts
@@ -1,6 +1,11 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationContext } from "../app/context.ts";
-import { ensureCustomElementDefined } from "../app/lazy-custom-element.ts";
+import {
+  hovercardBootstrapIntentActive,
+  LazyHovercardBootstrap,
+  remainingHovercardOpenDelay,
+  type HovercardBootstrapTrigger,
+} from "./lazy-hovercard-registration.ts";
 import {
   isPotentialSessionLink,
   SESSION_HOVERCARD_OPEN_DELAY_MS,
@@ -13,41 +18,25 @@ const SESSION_LINK_SELECTOR = "a.markdown-session-link";
 
 let bootstrapObserver: MutationObserver | null = null;
 
-type HovercardProviderElement = HTMLElement & {
-  client: GatewayBrowserClient | null;
-  context: ApplicationContext | null;
-};
+type HovercardProviderElement = SessionLinkHovercardProvider;
 
-function providerForAnchor(anchor: HTMLAnchorElement): SessionLinkHovercardProvider | null {
-  return anchor.closest<SessionLinkHovercardProvider>(HOVERCARD_TAG);
-}
-
-function removeBootstrapActivation(): void {
-  document.removeEventListener("pointerover", handleBootstrapPointerOver, true);
-  document.removeEventListener("focusin", handleBootstrapFocusIn, true);
-  bootstrapObserver?.disconnect();
-  bootstrapObserver = null;
-}
-
-async function defineProvider(): Promise<void> {
-  const pendingProviders = new Map(
-    [...document.querySelectorAll<HovercardProviderElement>(HOVERCARD_TAG)].map((provider) => [
-      provider,
-      { client: provider.client, context: provider.context },
-    ]),
-  );
-  await ensureCustomElementDefined(HOVERCARD_TAG, async () => {
-    const runtime = await import("./session-link-hovercard.runtime.ts");
-    if (!customElements.get(HOVERCARD_TAG)) {
-      customElements.define(HOVERCARD_TAG, runtime.SessionLinkHovercardProvider);
-    }
-    for (const [provider, properties] of pendingProviders) {
-      provider.client = properties.client;
-      provider.context = properties.context;
-    }
-  });
-  removeBootstrapActivation();
-}
+const bootstrap = new LazyHovercardBootstrap<
+  HovercardProviderElement,
+  { client: GatewayBrowserClient | null; context: ApplicationContext | null }
+>({
+  tag: HOVERCARD_TAG,
+  load: async () =>
+    (await import("./session-link-hovercard.runtime.ts")).SessionLinkHovercardProvider,
+  snapshot: (provider) => ({ client: provider.client, context: provider.context }),
+  restore: (provider, properties) => {
+    provider.client = properties.client;
+    provider.context = properties.context;
+  },
+  onDefined: () => {
+    bootstrapObserver?.disconnect();
+    bootstrapObserver = null;
+  },
+});
 
 function handleBootstrapMutations(records: MutationRecord[]): void {
   for (const record of records) {
@@ -56,53 +45,40 @@ function handleBootstrapMutations(records: MutationRecord[]): void {
         continue;
       }
       if (node.matches(SESSION_LINK_SELECTOR) || node.querySelector(SESSION_LINK_SELECTOR)) {
-        void defineProvider();
+        void bootstrap.define();
         return;
       }
     }
   }
 }
 
-async function activateHovercard(event: Event, trigger: "focus" | "pointer"): Promise<void> {
+async function activateHovercard(event: Event, trigger: HovercardBootstrapTrigger): Promise<void> {
   if (trigger === "pointer" && "pointerType" in event && event.pointerType === "touch") {
     return;
   }
   const anchor = sessionLinkAnchorFromEvent(event);
-  const provider = anchor ? providerForAnchor(anchor) : null;
+  const provider = anchor ? bootstrap.providerFor(anchor) : null;
   if (!anchor || !provider || !isPotentialSessionLink(anchor, provider.context?.basePath)) {
     return;
   }
   const startedAt = performance.now();
-  await defineProvider();
-  const upgraded = providerForAnchor(anchor);
-  const stillActive =
-    trigger === "pointer" ? anchor.matches(":hover") : document.activeElement === anchor;
-  if (!upgraded || !anchor.isConnected || !stillActive) {
+  await bootstrap.define();
+  const upgraded = bootstrap.providerFor(anchor);
+  if (!upgraded || !anchor.isConnected || !hovercardBootstrapIntentActive(anchor, trigger)) {
     return;
   }
   const delay =
     trigger === "pointer"
-      ? Math.max(0, SESSION_HOVERCARD_OPEN_DELAY_MS - (performance.now() - startedAt))
+      ? remainingHovercardOpenDelay(startedAt, SESSION_HOVERCARD_OPEN_DELAY_MS)
       : 0;
   upgraded.activateFromBootstrap(anchor, trigger, delay);
 }
 
-function handleBootstrapPointerOver(event: Event): void {
-  void activateHovercard(event, "pointer");
-}
-
-function handleBootstrapFocusIn(event: Event): void {
-  void activateHovercard(event, "focus");
-}
-
-if (customElements.get(HOVERCARD_TAG)) {
-  removeBootstrapActivation();
-} else {
-  document.addEventListener("pointerover", handleBootstrapPointerOver, true);
-  document.addEventListener("focusin", handleBootstrapFocusIn, true);
+bootstrap.install(activateHovercard);
+if (!customElements.get(HOVERCARD_TAG)) {
   bootstrapObserver = new MutationObserver(handleBootstrapMutations);
   bootstrapObserver.observe(document, { childList: true, subtree: true });
   if (document.querySelector(SESSION_LINK_SELECTOR)) {
-    void defineProvider();
+    void bootstrap.define();
   }
 }

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -20,6 +20,7 @@ import {
   resolveUiConfiguredMainKey,
 } from "../lib/sessions/session-key.ts";
 import { sessionKeyUuid } from "../pages/chat/route-loader-short-cache.ts";
+import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
 import {
   SESSION_HOVERCARD_OPEN_DELAY_MS,
   sessionLinkAnchorFromEvent,
@@ -29,9 +30,6 @@ const SESSION_LINK_SELECTOR = "a.markdown-session-link[data-session-key]";
 const SUCCESS_CACHE_MS = 5 * 60_000;
 const FAILURE_CACHE_MS = 30_000;
 const CACHE_LIMIT = 100;
-const VIEWPORT_PADDING = 12;
-const CARD_GAP = 10;
-const CLOSE_DELAY_MS = 120;
 
 type SessionPreview = Extract<ControlUiSessionPreview, { status: "ok" }>;
 
@@ -164,12 +162,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
   private readonly cache = new Map<string, CacheEntry>();
   private activeAnchor: HTMLAnchorElement | null = null;
   private activeTarget: SessionPreviewTarget | null = null;
-  private card: HTMLDivElement | null = null;
-  private closeTimer: number | null = null;
-  private focusInside = false;
-  private openTimer: number | null = null;
-  private pointerInside = false;
-  private pointerOverCard = false;
+  private readonly hovercard = new PortaledHovercardController(() => this.close());
   private renderedPreview: SessionPreview | null = null;
   private renderedUnavailable = false;
   private scanAnimationFrame: number | null = null;
@@ -180,7 +173,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     args: () => [this.activeTarget] as const,
     task: ([target]) => (target ? this.loadPreview(target) : initialState),
     onComplete: (preview) => {
-      const card = this.card;
+      const card = this.hovercard.card;
       if (!card) {
         return;
       }
@@ -189,16 +182,16 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
         this.stampAnchor(this.activeAnchor, this.activeTarget, preview);
       }
       renderPreview(card, preview);
-      this.positionCard();
+      this.hovercard.position();
     },
     onError: () => {
-      const card = this.card;
+      const card = this.hovercard.card;
       if (!card) {
         return;
       }
       this.renderedUnavailable = true;
       renderUnavailable(card);
-      this.positionCard();
+      this.hovercard.position();
     },
   });
   private readonly subtreeObserver = new MutationObserver((records) => {
@@ -276,7 +269,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
   }
 
   private readonly handleLocaleChange = () => {
-    const card = this.card;
+    const card = this.hovercard.card;
     if (!card) {
       return;
     }
@@ -287,7 +280,7 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     } else {
       renderLoading(card);
     }
-    this.positionCard();
+    this.hovercard.position();
   };
 
   private mainKey(): string {
@@ -479,8 +472,8 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     if (event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) {
       return;
     }
-    this.pointerInside = false;
-    this.scheduleClose();
+    this.hovercard.pointerInside = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleFocusIn = (event: Event) => {
@@ -496,19 +489,19 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
       this.activeAnchor &&
       !(event.relatedTarget instanceof Node && this.activeAnchor.contains(event.relatedTarget))
     ) {
-      this.focusInside = false;
-      this.scheduleClose();
+      this.hovercard.focusInside = false;
+      this.hovercard.scheduleClose();
     }
   };
 
   private readonly handleCardPointerEnter = () => {
-    this.pointerOverCard = true;
-    this.clearCloseTimer();
+    this.hovercard.pointerOverCard = true;
+    this.hovercard.clearClose();
   };
 
   private readonly handleCardPointerLeave = () => {
-    this.pointerOverCard = false;
-    this.scheduleClose();
+    this.hovercard.pointerOverCard = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
@@ -536,132 +529,39 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     this.close();
     this.activeAnchor = anchor;
     this.activeTarget = target;
-    anchor.setAttribute("aria-haspopup", "dialog");
-    anchor.setAttribute("aria-expanded", "false");
+    this.hovercard.markTrigger(anchor);
     if (trigger === "pointer") {
-      this.pointerInside = true;
+      this.hovercard.pointerInside = true;
     } else {
-      this.focusInside = true;
+      this.hovercard.focusInside = true;
     }
-    this.openTimer = window.setTimeout(() => {
-      this.openTimer = null;
-      this.show(anchor, target);
-    }, delay);
+    this.hovercard.scheduleOpen(delay, () => this.show(anchor, target));
   }
 
   private show(anchor: HTMLAnchorElement, target: SessionPreviewTarget): void {
     if (this.activeAnchor !== anchor || this.activeTarget?.sessionKey !== target.sessionKey) {
       return;
     }
-    const card = document.createElement("div");
     nextHovercardId += 1;
-    card.id = `openclaw-session-hovercard-${nextHovercardId}`;
-    card.className = "session-link-hovercard";
-    card.dataset.open = "true";
-    card.setAttribute("role", "dialog");
+    const card = createPortaledHovercard(
+      `openclaw-session-hovercard-${nextHovercardId}`,
+      "session-link-hovercard",
+    );
     this.renderedPreview = null;
     this.renderedUnavailable = false;
     renderLoading(card);
     card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
-    document.body.append(card);
-    this.card = card;
-    anchor.setAttribute("aria-controls", card.id);
-    anchor.setAttribute("aria-expanded", "true");
-    this.listenForViewportChanges();
-    this.positionCard();
+    this.hovercard.mount(anchor, card, "vertical");
     void this.previewTask.run([target]);
   }
 
-  private get hoverIntentHeld(): boolean {
-    return this.pointerInside || this.pointerOverCard || this.focusInside;
-  }
-
-  private clearCloseTimer(): void {
-    if (this.closeTimer !== null) {
-      window.clearTimeout(this.closeTimer);
-      this.closeTimer = null;
-    }
-  }
-
-  private scheduleClose(): void {
-    this.clearCloseTimer();
-    if (this.hoverIntentHeld) {
-      return;
-    }
-    if (!this.card) {
-      this.close();
-      return;
-    }
-    this.closeTimer = window.setTimeout(() => {
-      this.closeTimer = null;
-      if (!this.hoverIntentHeld) {
-        this.close();
-      }
-    }, CLOSE_DELAY_MS);
-  }
-
   private close(): void {
-    if (this.openTimer !== null) {
-      window.clearTimeout(this.openTimer);
-      this.openTimer = null;
-    }
-    this.clearCloseTimer();
+    this.hovercard.reset();
     void this.previewTask.run([null]);
-    if (this.activeAnchor) {
-      this.activeAnchor.removeAttribute("aria-controls");
-      this.activeAnchor.removeAttribute("aria-expanded");
-      this.activeAnchor.removeAttribute("aria-haspopup");
-    }
-    this.card?.remove();
-    this.card = null;
     this.renderedPreview = null;
     this.renderedUnavailable = false;
     this.activeAnchor = null;
     this.activeTarget = null;
-    this.focusInside = false;
-    this.pointerInside = false;
-    this.pointerOverCard = false;
-    this.stopListeningForViewportChanges();
-  }
-
-  private readonly handleViewportChange = () => {
-    this.positionCard();
-  };
-
-  private listenForViewportChanges(): void {
-    window.addEventListener("resize", this.handleViewportChange);
-    window.addEventListener("scroll", this.handleViewportChange, true);
-    window.visualViewport?.addEventListener("resize", this.handleViewportChange);
-    window.visualViewport?.addEventListener("scroll", this.handleViewportChange);
-  }
-
-  private stopListeningForViewportChanges(): void {
-    window.removeEventListener("resize", this.handleViewportChange);
-    window.removeEventListener("scroll", this.handleViewportChange, true);
-    window.visualViewport?.removeEventListener("resize", this.handleViewportChange);
-    window.visualViewport?.removeEventListener("scroll", this.handleViewportChange);
-  }
-
-  private positionCard(): void {
-    const anchor = this.activeAnchor;
-    const card = this.card;
-    if (!anchor || !card) {
-      return;
-    }
-    const anchorRect = anchor.getBoundingClientRect();
-    const cardRect = card.getBoundingClientRect();
-    const fitsBelow =
-      anchorRect.bottom + CARD_GAP + cardRect.height + VIEWPORT_PADDING <= innerHeight;
-    const side = fitsBelow ? "bottom" : "top";
-    const top =
-      side === "bottom"
-        ? anchorRect.bottom + CARD_GAP
-        : anchorRect.top - cardRect.height - CARD_GAP;
-    const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
-    const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
-    card.dataset.side = side;
-    card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.left), maxLeft)}px`;
-    card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, top), maxTop)}px`;
   }
 }

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -524,6 +524,12 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
       return;
     }
     if (anchor === this.activeAnchor && this.activeTarget?.sessionKey === target.sessionKey) {
+      if (trigger === "pointer") {
+        this.hovercard.pointerInside = true;
+      } else {
+        this.hovercard.focusInside = true;
+      }
+      this.hovercard.clearClose();
       return;
     }
     this.close();

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -290,6 +290,23 @@ describe("openclaw-session-link-hovercard-provider", () => {
     expect(document.activeElement).toBe(anchor);
   });
 
+  it("keeps a pointer-opened card while its trigger gains keyboard focus", async () => {
+    const { provider } = createProvider({ response: previewResponse() });
+    const anchor = sessionAnchor();
+    provider.append(anchor);
+    document.body.append(provider);
+
+    await hover(anchor);
+    anchor.focus();
+    anchor.dispatchEvent(
+      new MouseEvent("pointerout", { bubbles: true, composed: true, relatedTarget: document.body }),
+    );
+    await vi.advanceTimersByTimeAsync(121);
+
+    expect(document.activeElement).toBe(anchor);
+    expect(document.querySelector(".session-link-hovercard")).not.toBeNull();
+  });
+
   it("defers unseeded preview requests until intent across many attached anchors", async () => {
     const seededKey = "agent:main:seeded";
     const seededRow = {

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -275,14 +275,18 @@ describe("openclaw-session-link-hovercard-provider", () => {
 
     resolvePreview?.(previewResponse());
     await vi.advanceTimersByTimeAsync(0);
-    expect(document.querySelector(".session-link-hovercard")?.textContent).toContain(
-      "Research plan",
-    );
+    const card = document.querySelector<HTMLElement>(".session-link-hovercard");
+    expect(card?.textContent).toContain("Research plan");
+    expect(card?.getAttribute("role")).toBe("dialog");
+    expect(anchor.getAttribute("aria-haspopup")).toBe("dialog");
+    expect(anchor.getAttribute("aria-controls")).toBe(card?.id);
     expect(anchor.getAttribute("aria-expanded")).toBe("true");
 
     anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
     expect(document.querySelector(".session-link-hovercard")).toBeNull();
     expect(anchor.hasAttribute("aria-expanded")).toBe(false);
+    expect(anchor.hasAttribute("aria-controls")).toBe(false);
+    expect(anchor.hasAttribute("aria-haspopup")).toBe(false);
     expect(document.activeElement).toBe(anchor);
   });
 

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -4,6 +4,7 @@ import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "./session-menu.ts";
 import type { SessionMenuAction, SessionMenuActionKind, SessionMenuWork } from "./session-menu.ts";
+import type { SessionOwnerOption } from "./session-owner-chip.ts";
 
 type SessionMenuData = {
   label: string;
@@ -19,6 +20,7 @@ type SessionMenuElement = HTMLElement & {
   anchor: { x: number; y: number };
   lastActive: string;
   session: SessionMenuData;
+  ownerOptions: readonly SessionOwnerOption[];
   updateComplete: Promise<boolean>;
 };
 type SessionMenuItem = HTMLElement & { disabled: boolean; updateComplete: Promise<unknown> };
@@ -42,6 +44,9 @@ async function mountMenu(
     selectionCount?: number;
     lastActive?: string;
     groups?: readonly string[];
+    ownerOptions?: readonly SessionOwnerOption[];
+    selfOwner?: SessionOwnerOption | null;
+    currentOwnerId?: string | null;
     trigger?: HTMLElement | null;
     onAction?: (action: SessionMenuAction) => void;
     onClose?: () => void;
@@ -79,6 +84,9 @@ async function mountMenu(
       (session.archived || (options.archiveAllowed ?? true))}
       .cloudWorkerStopAllowed=${options.cloudWorkerStopAllowed ?? false}
       .groups=${options.groups ?? []}
+      .ownerOptions=${options.ownerOptions ?? []}
+      .selfOwner=${options.selfOwner ?? null}
+      .currentOwnerId=${options.currentOwnerId ?? null}
       .work=${options.work ?? null}
       .workboard=${options.workboard === undefined
         ? { captured: false, busy: false }
@@ -123,6 +131,47 @@ function iconChoices(menu: ParentNode): HTMLButtonElement[] {
 }
 
 describe("session menu", () => {
+  it("renders owner radio state and closes before dispatching assignment", async () => {
+    const onAction = vi.fn<(action: SessionMenuAction) => void>();
+    const onClose = vi.fn();
+    const selfOwner = { type: "human", id: "profile-ada", label: "Ada" } as const;
+    const menu = await mountMenu({
+      ownerOptions: [selfOwner, { type: "agent", id: "research:one", label: "Research" }],
+      selfOwner,
+      currentOwnerId: "research:one",
+      onAction,
+      onClose,
+    });
+    const selected = menuItem(menu, "Research");
+    expect(selected.getAttribute("role")).toBe("menuitemradio");
+    expect(selected.getAttribute("aria-checked")).toBe("true");
+    expect(selected.disabled).toBe(true);
+    expect(selected.querySelector("[slot='details']")).not.toBeNull();
+
+    menu.querySelector("wa-dropdown")?.dispatchEvent(
+      new CustomEvent("wa-select", {
+        bubbles: true,
+        composed: true,
+        detail: { item: { value: "assign-owner:self" } },
+      }),
+    );
+    expect(onAction).toHaveBeenCalledWith({ kind: "assign-owner", owner: selfOwner });
+    expect(onClose).toHaveBeenCalledOnce();
+    const closeOrder = onClose.mock.invocationCallOrder[0];
+    const actionOrder = onAction.mock.invocationCallOrder[0];
+    if (closeOrder === undefined || actionOrder === undefined) {
+      throw new Error("Expected close and action call order");
+    }
+    expect(closeOrder).toBeLessThan(actionOrder);
+
+    const batch = await mountMenu({
+      selectionCount: 2,
+      ownerOptions: [selfOwner],
+      selfOwner,
+    });
+    expect(batch.textContent).not.toContain("Assign to");
+  });
+
   it("disables only denied mutation actions and ignores forced selection", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
     const menu = await mountMenu({

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -11,7 +11,11 @@ import { icons } from "./icons.ts";
 import { activateMenuShortcut, menuShortcutHint } from "./menu-shortcuts.ts";
 import { promoteToPopoverTopLayer } from "./menu-surface.ts";
 import { renderSessionIconPicker } from "./session-icon-picker.ts";
-import { renderSessionOwnerMenuAvatar, type SessionOwnerOption } from "./session-owner-chip.ts";
+import type { SessionOwnerOption } from "./session-owner-chip.ts";
+import {
+  renderSessionOwnerAssignmentMenu,
+  sessionOwnerAssignmentFromMenuValue,
+} from "./session-owner-menu.ts";
 import { syncDropdownItemRadio } from "./web-awesome.ts";
 
 type SessionMenuData = {
@@ -175,46 +179,11 @@ class SessionMenu extends OpenClawLightDomElement {
       });
       return;
     }
-    if (value === "assign-owner:self" && this.selfOwner) {
-      this.runAction({ kind: "assign-owner", owner: this.selfOwner });
-      return;
-    }
-    if (value.startsWith("assign-owner:")) {
-      const [, type, encodedId] = value.split(":");
-      const id = encodedId ? decodeURIComponent(encodedId) : "";
-      if ((type === "human" || type === "agent") && id) {
-        this.runAction({ kind: "assign-owner", owner: { type, id } });
-      }
+    const owner = sessionOwnerAssignmentFromMenuValue(value, this.selfOwner);
+    if (owner) {
+      this.runAction({ kind: "assign-owner", owner });
     }
   };
-
-  private renderOwnerSubmenu() {
-    return this.ownerOptions.map((owner) => {
-      const checked = owner.id === this.currentOwnerId;
-      return html`
-        <wa-dropdown-item
-          slot="submenu"
-          class="session-menu__item"
-          value=${`assign-owner:${owner.type}:${encodeURIComponent(owner.id)}`}
-          role="menuitemradio"
-          aria-checked=${String(checked)}
-          ${ref((element) => syncDropdownItemRadio(element, checked))}
-          ?disabled=${this.actionDisabled("assign-owner", checked)}
-          title=${this.actionTitle("assign-owner")}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true"
-            >${renderSessionOwnerMenuAvatar(owner)}</span
-          >
-          <span class="session-menu__text">${owner.label ?? owner.id}</span>
-          ${checked
-            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
-                >${icons.check}</span
-              >`
-            : nothing}
-        </wa-dropdown-item>
-      `;
-    });
-  }
 
   private readonly handleAfterHide = (event: Event) => {
     // A keyed replacement can finish hiding after its successor opens.
@@ -559,35 +528,13 @@ class SessionMenu extends OpenClawLightDomElement {
                 <span class="session-menu__text">${t("sessionsView.renameSessionMenu")}</span>
                 ${menuShortcutHint("r")}
               </wa-dropdown-item>
-              ${this.selfOwner
-                ? html`<wa-dropdown-item
-                    class="session-menu__item"
-                    value="assign-owner:self"
-                    ?disabled=${this.actionDisabled(
-                      "assign-owner",
-                      this.currentOwnerId === this.selfOwner.id,
-                    )}
-                    title=${this.actionTitle("assign-owner")}
-                  >
-                    <span slot="icon" class="session-menu__icon" aria-hidden="true"
-                      >${icons.users}</span
-                    >
-                    <span class="session-menu__text">${t("sessionsView.assignToMe")}</span>
-                  </wa-dropdown-item>`
-                : nothing}
-              ${this.ownerOptions.length > 0
-                ? html`<wa-dropdown-item
-                    class="session-menu__item"
-                    ?disabled=${this.actionDisabled("assign-owner")}
-                    title=${this.actionTitle("assign-owner")}
-                  >
-                    <span slot="icon" class="session-menu__icon" aria-hidden="true"
-                      >${icons.users}</span
-                    >
-                    <span class="session-menu__text">${t("sessionsView.assignTo")}</span>
-                    ${this.renderOwnerSubmenu()}
-                  </wa-dropdown-item>`
-                : nothing}
+              ${renderSessionOwnerAssignmentMenu({
+                ownerOptions: this.ownerOptions,
+                selfOwner: this.selfOwner,
+                currentOwnerId: this.currentOwnerId,
+                disabled: this.actionDisabled("assign-owner"),
+                disabledReason: this.actionDisabledReasons["assign-owner"],
+              })}
               <wa-dropdown-item
                 class="session-menu__item"
                 data-shortcut="i"

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -12,6 +12,7 @@ import { t } from "../i18n/index.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import type { SessionDeleteBatchResult } from "../lib/sessions/session-capability.ts";
 import { showToast } from "../lib/toast.ts";
+import { SESSION_MUTATION_TEST_METHODS } from "../test-helpers/gateway-methods.ts";
 import {
   answerConfirmDialog,
   installDialogPolyfill,
@@ -90,7 +91,9 @@ function createHarness(
     phase: params.phase ?? "connected",
     hello: {
       features:
-        params.methods === null ? {} : { methods: params.methods ?? ["sessions.patchMany"] },
+        params.methods === null
+          ? {}
+          : { methods: params.methods ?? [...SESSION_MUTATION_TEST_METHODS] },
       auth: { role: "operator", scopes: params.scopes ?? ["operator.write"] },
     },
   } as ApplicationGatewaySnapshot;
@@ -276,15 +279,10 @@ describe("patchSessionRows", () => {
   });
 
   it.each([true, false])(
-    "uses the supplied fallback for a metadata-less legacy rejection with archived=%s",
+    "uses the supplied fallback when patchMany is not advertised with archived=%s",
     async (archived) => {
-      const rejection = new GatewayRequestError({
-        code: "INVALID_REQUEST",
-        message: "unknown method: sessions.patchMany",
-      });
       const harness = createHarness({
-        methods: null,
-        requestFailure: { at: 1, error: rejection },
+        methods: ["sessions.patch"],
       });
       const rows = [sessionRow(0)];
       const fallbackRows = [sessionRow(1)];
@@ -294,23 +292,7 @@ describe("patchSessionRows", () => {
         patchSessionRows(harness.host, rows, { archived }, harness.scope, { fallback }),
       ).resolves.toBe(fallbackRows);
 
-      expect(harness.request).toHaveBeenCalledOnce();
-      const requestCall = harness.request.mock.calls[0]!;
-      expect(requestCall.slice(0, 2)).toEqual([
-        "sessions.patchMany",
-        {
-          targets: [
-            {
-              key: rows[0]!.key,
-              agentId: "main",
-              expectedSessionId: rows[0]!.sessionId,
-            },
-          ],
-          patch: { archived },
-        },
-      ]);
-      expect(requestCall).toHaveLength(archived ? 3 : 2);
-      expect(requestCall[2]).toEqual(archived ? { timeoutMs: 10 * 60_000 } : undefined);
+      expect(harness.request).not.toHaveBeenCalled();
       expect(fallback).toHaveBeenCalledOnce();
       expect(harness.refreshReplacement).not.toHaveBeenCalled();
       expect(harness.publishSessionMutationError).not.toHaveBeenCalled();
@@ -323,7 +305,6 @@ describe("patchSessionRows", () => {
       message: "invalid archive request",
     });
     const harness = createHarness({
-      methods: null,
       requestFailure: { at: 1, error: rejection },
     });
     const fallback = vi.fn(async () => [sessionRow(1)]);
@@ -343,7 +324,6 @@ describe("patchSessionRows", () => {
   it("does not fallback for transport unavailability", async () => {
     const rejection = new GatewayRequestError({ code: "UNAVAILABLE", message: "disconnected" });
     const harness = createHarness({
-      methods: null,
       requestFailure: { at: 1, error: rejection },
     });
     const fallback = vi.fn(async () => [sessionRow(1)]);
@@ -374,6 +354,21 @@ describe("patchSessionRows", () => {
       harness.scope,
       "Connect to the Gateway to change sessions.",
     );
+  });
+
+  it("does not fallback when method metadata is missing", async () => {
+    const harness = createHarness({ methods: null });
+    const fallback = vi.fn(async () => [sessionRow(1)]);
+
+    await expect(
+      patchSessionRows(harness.host, [sessionRow(0)], { archived: true }, harness.scope, {
+        fallback,
+      }),
+    ).resolves.toBeNull();
+
+    expect(fallback).not.toHaveBeenCalled();
+    expect(harness.request).not.toHaveBeenCalled();
+    expect(harness.publishSessionMutationError).toHaveBeenCalledOnce();
   });
 
   it("does not fallback after an earlier chunk succeeds", async () => {

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -5,8 +5,8 @@ import {
   type SessionsPatchMutation,
 } from "../../../packages/gateway-protocol/src/schema/sessions-patch.js";
 import { SESSION_ARCHIVE_REQUEST_OPTIONS } from "../../../src/shared/session-archive-timeout.ts";
-import { GatewayRequestError } from "../api/gateway.ts";
 import { formatUiError } from "../lib/format-error.ts";
+import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import type {
@@ -54,14 +54,6 @@ export function requireSessionMutationAccess(
   }
   host.sessionData.publishSessionMutationError(scope, access.reason);
   return false;
-}
-
-function isLegacyPatchManyMethodRejection(error: unknown): boolean {
-  return (
-    error instanceof GatewayRequestError &&
-    error.gatewayCode === "INVALID_REQUEST" &&
-    error.message.includes("unknown method: sessions.patchMany")
-  );
 }
 
 export function sessionRowAgentId(
@@ -147,7 +139,12 @@ export async function patchSessionRows(
       params,
     });
     if (!access.allowed) {
-      if (dispatched.length === 0 && access.cause === "method-unavailable" && options.fallback) {
+      if (
+        dispatched.length === 0 &&
+        access.cause === "method-unavailable" &&
+        isGatewayMethodAdvertised(scope.gateway.snapshot, "sessions.patchMany") === false &&
+        options.fallback
+      ) {
         return options.fallback();
       }
       terminalError = access.reason;
@@ -170,11 +167,6 @@ export async function patchSessionRows(
       }
       dispatched.push({ rows: chunkRows, result });
     } catch (error) {
-      // Metadata-less legacy Gateways allow the optimistic request, then identify
-      // this one unsupported method through the canonical Gateway error contract.
-      if (dispatched.length === 0 && options.fallback && isLegacyPatchManyMethodRejection(error)) {
-        return options.fallback();
-      }
       terminalError = error;
       if (dispatched.length === 0) {
         host.sessionData.publishSessionMutationError(scope, error);

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -1,0 +1,81 @@
+import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
+import { t } from "../i18n/index.ts";
+import { icons } from "./icons.ts";
+import { renderSessionOwnerMenuAvatar, type SessionOwnerOption } from "./session-owner-chip.ts";
+import { syncDropdownItemRadio } from "./web-awesome.ts";
+
+type SessionOwnerAssignment = Pick<SessionOwnerOption, "type" | "id">;
+
+export function sessionOwnerAssignmentFromMenuValue(
+  value: string,
+  selfOwner: SessionOwnerOption | null,
+): SessionOwnerAssignment | null {
+  if (value === "assign-owner:self") {
+    return selfOwner;
+  }
+  if (!value.startsWith("assign-owner:")) {
+    return null;
+  }
+  const [, type, encodedId] = value.split(":");
+  const id = encodedId ? decodeURIComponent(encodedId) : "";
+  return (type === "human" || type === "agent") && id ? { type, id } : null;
+}
+
+export function renderSessionOwnerAssignmentMenu(params: {
+  ownerOptions: readonly SessionOwnerOption[];
+  selfOwner: SessionOwnerOption | null;
+  currentOwnerId: string | null;
+  disabled: boolean;
+  disabledReason?: string;
+}) {
+  const title = params.disabledReason ?? nothing;
+  return html`
+    ${params.selfOwner
+      ? html`<wa-dropdown-item
+          class="session-menu__item"
+          value="assign-owner:self"
+          ?disabled=${params.disabled || params.currentOwnerId === params.selfOwner.id}
+          title=${title}
+        >
+          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
+          <span class="session-menu__text">${t("sessionsView.assignToMe")}</span>
+        </wa-dropdown-item>`
+      : nothing}
+    ${params.ownerOptions.length > 0
+      ? html`<wa-dropdown-item
+          class="session-menu__item"
+          ?disabled=${params.disabled}
+          title=${title}
+        >
+          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
+          <span class="session-menu__text">${t("sessionsView.assignTo")}</span>
+          ${params.ownerOptions.map((owner) => {
+            const checked = owner.id === params.currentOwnerId;
+            return html`
+              <wa-dropdown-item
+                slot="submenu"
+                class="session-menu__item"
+                value=${`assign-owner:${owner.type}:${encodeURIComponent(owner.id)}`}
+                role="menuitemradio"
+                aria-checked=${String(checked)}
+                ${ref((element) => syncDropdownItemRadio(element, checked))}
+                ?disabled=${params.disabled || checked}
+                title=${title}
+              >
+                <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                  >${renderSessionOwnerMenuAvatar(owner)}</span
+                >
+                <span class="session-menu__text">${owner.label ?? owner.id}</span>
+                ${checked
+                  ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
+                      >${icons.check}</span
+                    >`
+                  : nothing}
+              </wa-dropdown-item>
+            `;
+          })}
+        </wa-dropdown-item>`
+      : nothing}
+  `;
+}

--- a/ui/src/components/session-progress-hovercard-registration.ts
+++ b/ui/src/components/session-progress-hovercard-registration.ts
@@ -1,9 +1,26 @@
 import type { ApplicationGateway } from "../app/gateway.ts";
-import { ensureCustomElementDefined } from "../app/lazy-custom-element.ts";
+import {
+  hovercardBootstrapIntentActive,
+  LazyHovercardBootstrap,
+  type HovercardBootstrapTrigger,
+} from "./lazy-hovercard-registration.ts";
 
 const HOVERCARD_TAG = "openclaw-session-progress-hovercard-provider";
 
 type HovercardProviderElement = HTMLElement & { gateway?: ApplicationGateway | null };
+
+const bootstrap = new LazyHovercardBootstrap<HovercardProviderElement, ApplicationGateway | null>({
+  tag: HOVERCARD_TAG,
+  load: async () =>
+    (await import("./session-progress-hovercard.runtime.ts")).SessionProgressHovercardProvider,
+  snapshot: (provider) => provider.gateway ?? null,
+  restore: (provider, gateway) => {
+    // Lit assigns .gateway before upgrade. Remove the expando so the runtime
+    // accessor can own store subscriptions after definition.
+    delete provider.gateway;
+    provider.gateway = gateway;
+  },
+});
 
 function sessionRowFromEvent(event: Event): HTMLElement | null {
   for (const target of event.composedPath()) {
@@ -14,69 +31,33 @@ function sessionRowFromEvent(event: Event): HTMLElement | null {
   return null;
 }
 
-function providerForRow(row: HTMLElement): HovercardProviderElement | null {
-  return row.closest<HovercardProviderElement>(HOVERCARD_TAG);
-}
-
-function removeBootstrapListeners(): void {
-  document.removeEventListener("pointerover", handleBootstrapIntent, true);
-  document.removeEventListener("focusin", handleBootstrapIntent, true);
-}
-
-async function activateHovercard(event: Event): Promise<void> {
+async function activateHovercard(event: Event, trigger: HovercardBootstrapTrigger): Promise<void> {
   if (
-    event.type === "pointerover" &&
+    trigger === "pointer" &&
     ((event instanceof PointerEvent && event.pointerType === "touch") ||
       !globalThis.matchMedia?.("(hover: hover)").matches)
   ) {
     return;
   }
   const row = sessionRowFromEvent(event);
-  if (!row || !providerForRow(row)) {
+  if (!row || !bootstrap.providerFor(row)) {
     return;
   }
-  const pendingGateways = new Map(
-    [...document.querySelectorAll<HovercardProviderElement>(HOVERCARD_TAG)].map((provider) => [
-      provider,
-      provider.gateway ?? null,
-    ]),
-  );
-  await ensureCustomElementDefined(HOVERCARD_TAG, async () => {
-    const runtime = await import("./session-progress-hovercard.runtime.ts");
-    if (!customElements.get(HOVERCARD_TAG)) {
-      customElements.define(HOVERCARD_TAG, runtime.SessionProgressHovercardProvider);
-    }
-    for (const [provider, gateway] of pendingGateways) {
-      // Lit assigns .gateway before the lazy element is defined. Remove that
-      // expando after upgrade so the runtime accessor can own subscriptions.
-      delete provider.gateway;
-      provider.gateway = gateway;
-    }
-  });
-  removeBootstrapListeners();
+  await bootstrap.define();
   const target = event.target;
-  const stillActive =
-    event.type === "pointerover"
-      ? row.matches(":hover")
-      : document.activeElement instanceof Node && row.contains(document.activeElement);
-  if (!(target instanceof EventTarget) || !row.isConnected || !stillActive) {
+  if (
+    !(target instanceof EventTarget) ||
+    !row.isConnected ||
+    !hovercardBootstrapIntentActive(row, trigger, true)
+  ) {
     return;
   }
   target.dispatchEvent(
-    new Event(event.type === "pointerover" ? "pointerover" : "focusin", {
+    new Event(trigger === "pointer" ? "pointerover" : "focusin", {
       bubbles: true,
       composed: true,
     }),
   );
 }
 
-function handleBootstrapIntent(event: Event): void {
-  void activateHovercard(event);
-}
-
-if (customElements.get(HOVERCARD_TAG)) {
-  removeBootstrapListeners();
-} else {
-  document.addEventListener("pointerover", handleBootstrapIntent, true);
-  document.addEventListener("focusin", handleBootstrapIntent, true);
-}
+bootstrap.install(activateHovercard);

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -6,12 +6,10 @@ import {
   sessionProgressCardsForGateway,
   type SessionProgressCardStore,
 } from "../lib/session-progress-cards.ts";
+import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
 
 const OPEN_DELAY_MS = 350;
-const CLOSE_DELAY_MS = 120;
-const CARD_GAP = 10;
-const VIEWPORT_PADDING = 12;
 let nextHovercardId = 0;
 
 function sessionRowFromEvent(event: Event): HTMLElement | null {
@@ -30,14 +28,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private activeRow: HTMLElement | null = null;
   private activeTrigger: HTMLElement | null = null;
   private activeSessionKey: string | null = null;
-  private card: HTMLDivElement | null = null;
-  private cardFocusInside = false;
-  private closeTimer: number | null = null;
-  private focusInside = false;
+  private readonly hovercard = new PortaledHovercardController(() => this.close());
   private loadGeneration = 0;
-  private openTimer: number | null = null;
-  private pointerInside = false;
-  private pointerOverCard = false;
   private readonly activeRowObserver = new MutationObserver(() => {
     if (this.activeRow && !this.contains(this.activeRow)) {
       this.close();
@@ -103,7 +95,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
 
   private readonly handleProgressCardUpdate = () => {
     const sessionKey = this.activeSessionKey;
-    if (!sessionKey || !this.intentHeld) {
+    if (!sessionKey || !this.hovercard.held) {
       return;
     }
     const card = this.progressCards?.get(sessionKey);
@@ -112,10 +104,9 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     } else if (card === null) {
       this.close();
     } else {
-      this.card?.remove();
-      this.card = null;
-      this.pointerOverCard = false;
-      this.cardFocusInside = false;
+      this.hovercard.clearCard();
+      this.hovercard.pointerOverCard = false;
+      this.hovercard.cardFocusInside = false;
     }
   };
 
@@ -128,7 +119,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     this.activate(row, row, OPEN_DELAY_MS);
-    this.pointerInside = true;
+    this.hovercard.pointerInside = true;
   };
 
   private readonly handlePointerOut = (event: PointerEvent) => {
@@ -139,8 +130,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (event.relatedTarget instanceof Node && row.contains(event.relatedTarget)) {
       return;
     }
-    this.pointerInside = false;
-    this.scheduleClose();
+    this.hovercard.pointerInside = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleFocusIn = (event: FocusEvent) => {
@@ -150,7 +141,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     this.activate(row, trigger, 0);
-    this.focusInside = true;
+    this.hovercard.focusInside = true;
   };
 
   private readonly handleFocusOut = (event: FocusEvent) => {
@@ -160,8 +151,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (event.relatedTarget instanceof Node && this.activeRow.contains(event.relatedTarget)) {
       return;
     }
-    this.focusInside = false;
-    this.scheduleClose();
+    this.hovercard.focusInside = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
@@ -189,14 +180,10 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.activeTrigger = trigger;
     this.activeSessionKey = sessionKey;
     this.progressCards?.watch(this, [sessionKey]);
-    trigger.setAttribute("aria-haspopup", "dialog");
-    trigger.setAttribute("aria-expanded", "false");
+    this.hovercard.markTrigger(trigger);
     this.activeRowObserver.observe(this, { childList: true, subtree: true });
     const generation = ++this.loadGeneration;
-    this.openTimer = window.setTimeout(() => {
-      this.openTimer = null;
-      void this.loadAndShow(sessionKey, generation);
-    }, delay);
+    this.hovercard.scheduleOpen(delay, () => void this.loadAndShow(sessionKey, generation));
   }
 
   private async loadAndShow(sessionKey: string, generation: number): Promise<void> {
@@ -206,7 +193,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
         generation !== this.loadGeneration ||
         this.activeSessionKey !== sessionKey ||
         !card ||
-        !this.intentHeld
+        !this.hovercard.held
       ) {
         return;
       }
@@ -222,17 +209,15 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (!row || !trigger) {
       return;
     }
-    if (this.card?.dataset.revision === String(progressCard.revision)) {
+    if (this.hovercard.card?.dataset.revision === String(progressCard.revision)) {
       return;
     }
-    this.card?.remove();
-    const card = document.createElement("div");
     nextHovercardId += 1;
-    card.id = `openclaw-session-progress-hovercard-${nextHovercardId}`;
-    card.className = "session-progress-hovercard";
-    card.dataset.open = "true";
+    const card = createPortaledHovercard(
+      `openclaw-session-progress-hovercard-${nextHovercardId}`,
+      "session-progress-hovercard",
+    );
     card.dataset.revision = String(progressCard.revision);
-    card.setAttribute("role", "dialog");
     card.setAttribute("aria-label", t("sessionProgressCard.ariaLabel"));
     render(renderSessionProgressCard(progressCard, "hovercard"), card);
     card.addEventListener("pointerenter", this.handleCardPointerEnter);
@@ -240,35 +225,30 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     card.addEventListener("focusin", this.handleCardFocusIn);
     card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
-    document.body.append(card);
-    this.card = card;
-    trigger.setAttribute("aria-controls", card.id);
-    trigger.setAttribute("aria-expanded", "true");
-    this.listenForViewportChanges();
-    this.positionCard();
+    this.hovercard.mount(row, card, "horizontal", false);
   }
 
   private readonly handleCardPointerEnter = () => {
-    this.pointerOverCard = true;
-    this.clearCloseTimer();
+    this.hovercard.pointerOverCard = true;
+    this.hovercard.clearClose();
   };
 
   private readonly handleCardPointerLeave = () => {
-    this.pointerOverCard = false;
-    this.scheduleClose();
+    this.hovercard.pointerOverCard = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleCardFocusIn = () => {
-    this.cardFocusInside = true;
-    this.clearCloseTimer();
+    this.hovercard.cardFocusInside = true;
+    this.hovercard.clearClose();
   };
 
   private readonly handleCardFocusOut = (event: FocusEvent) => {
-    if (event.relatedTarget instanceof Node && this.card?.contains(event.relatedTarget)) {
+    if (event.relatedTarget instanceof Node && this.hovercard.card?.contains(event.relatedTarget)) {
       return;
     }
-    this.cardFocusInside = false;
-    this.scheduleClose();
+    this.hovercard.cardFocusInside = false;
+    this.hovercard.scheduleClose();
   };
 
   private readonly handleCardKeyDown = (event: KeyboardEvent) => {
@@ -287,89 +267,16 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   };
 
   private cardFocusables(): HTMLElement[] {
-    return [...(this.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
-  }
-
-  private get intentHeld(): boolean {
-    return this.pointerInside || this.pointerOverCard || this.focusInside || this.cardFocusInside;
-  }
-
-  private scheduleClose(): void {
-    this.clearCloseTimer();
-    if (this.intentHeld) {
-      return;
-    }
-    if (!this.card) {
-      this.close();
-      return;
-    }
-    this.closeTimer = window.setTimeout(() => {
-      this.closeTimer = null;
-      if (!this.intentHeld) {
-        this.close();
-      }
-    }, CLOSE_DELAY_MS);
-  }
-
-  private clearCloseTimer(): void {
-    if (this.closeTimer !== null) {
-      window.clearTimeout(this.closeTimer);
-      this.closeTimer = null;
-    }
+    return [...(this.hovercard.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
   }
 
   private close(): void {
-    if (this.openTimer !== null) {
-      window.clearTimeout(this.openTimer);
-      this.openTimer = null;
-    }
-    this.clearCloseTimer();
+    this.hovercard.reset();
     this.loadGeneration += 1;
     this.activeRowObserver.disconnect();
     this.progressCards?.unwatch(this);
-    if (this.activeTrigger) {
-      this.activeTrigger.removeAttribute("aria-controls");
-      this.activeTrigger.removeAttribute("aria-expanded");
-      this.activeTrigger.removeAttribute("aria-haspopup");
-    }
-    this.card?.remove();
-    this.card = null;
     this.activeRow = null;
     this.activeTrigger = null;
     this.activeSessionKey = null;
-    this.pointerInside = false;
-    this.pointerOverCard = false;
-    this.focusInside = false;
-    this.cardFocusInside = false;
-    this.stopListeningForViewportChanges();
-  }
-
-  private readonly handleViewportChange = () => this.positionCard();
-
-  private listenForViewportChanges(): void {
-    window.addEventListener("resize", this.handleViewportChange);
-    window.addEventListener("scroll", this.handleViewportChange, true);
-  }
-
-  private stopListeningForViewportChanges(): void {
-    window.removeEventListener("resize", this.handleViewportChange);
-    window.removeEventListener("scroll", this.handleViewportChange, true);
-  }
-
-  private positionCard(): void {
-    const row = this.activeRow;
-    const card = this.card;
-    if (!row || !card) {
-      return;
-    }
-    const rowRect = row.getBoundingClientRect();
-    const cardRect = card.getBoundingClientRect();
-    const fitsRight = rowRect.right + CARD_GAP + cardRect.width + VIEWPORT_PADDING <= innerWidth;
-    const left = fitsRight ? rowRect.right + CARD_GAP : rowRect.left - cardRect.width - CARD_GAP;
-    const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
-    const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
-    card.dataset.side = fitsRight ? "right" : "left";
-    card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, left), maxLeft)}px`;
-    card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, rowRect.top), maxTop)}px`;
   }
 }

--- a/ui/src/e2e/operator-admin.e2e.test.ts
+++ b/ui/src/e2e/operator-admin.e2e.test.ts
@@ -152,7 +152,18 @@ suite.define(() => {
     const context = await createContext();
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "skills.install", "skills.update"],
+      featureMethods: [
+        "agents.list",
+        "chat.metadata",
+        "chat.startup",
+        "config.get",
+        "device.pair.list",
+        "exec.approvals.get",
+        "node.list",
+        "skills.install",
+        "skills.status",
+        "skills.update",
+      ],
       methodResponses: {
         "agents.list": {
           agents: agentRoster,
@@ -463,7 +474,7 @@ suite.define(() => {
     }
   });
 
-  it("retains legacy admin mutations when the Gateway omits method metadata", async () => {
+  it("disables admin mutations when the Gateway omits required method metadata", async () => {
     const context = await createContext();
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -486,9 +497,9 @@ suite.define(() => {
       await gateway.waitForRequest("agents.list");
       await selectAgentOnAgentsPage(page, "Reviewer");
       const setDefault = page.locator(".agents-toolbar-actions button").nth(1);
-      await expect.poll(() => setDefault.isEnabled()).toBe(true);
-      await setDefault.click();
-      await gateway.waitForRequest("config.set");
+      await expect.poll(() => setDefault.isDisabled()).toBe(true);
+      await setDefault.click({ force: true });
+      expect(await gateway.getRequests("config.set")).toHaveLength(0);
 
       await page.goto(`${suite.server.baseUrl}skills`);
       await gateway.waitForRequest("skills.status");
@@ -496,9 +507,9 @@ suite.define(() => {
       const install = page
         .locator("openclaw-modal-dialog", { hasText: "Deploy Helper" })
         .getByRole("button", { name: "Install Deploy Helper" });
-      await expect.poll(() => install.isEnabled()).toBe(true);
-      await install.click();
-      await gateway.waitForRequest("skills.install");
+      await expect.poll(() => install.isDisabled()).toBe(true);
+      await install.click({ force: true });
+      expect(await gateway.getRequests("skills.install")).toHaveLength(0);
     } finally {
       await context.close();
     }
@@ -546,6 +557,16 @@ suite.define(() => {
       },
     };
     const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "agents.list",
+        "chat.metadata",
+        "chat.startup",
+        "config.get",
+        "device.pair.list",
+        "exec.approvals.get",
+        "exec.approvals.set",
+        "node.list",
+      ],
       methodResponses: {
         "config.get": configResponse(),
         "device.pair.list": { paired: [], pending: [] },

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -179,6 +179,97 @@ suite.define(() => {
     );
   });
 
+  it("keeps the portaled progress dialog keyboard-reachable and viewport-contained", async () => {
+    const selectedSessionKey = "agent:main:selected-focus";
+    const sessionKey = "agent:main:focusable-progress";
+
+    await suite.withPage(
+      {
+        hasTouch: false,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          methodResponses: {
+            "progressCard.get": {
+              cases: [
+                { match: { sessionKey: selectedSessionKey }, response: { card: null } },
+                {
+                  match: { sessionKey },
+                  response: {
+                    card: {
+                      markdown: "[Open build log](https://example.com/build)",
+                      revision: 1,
+                      sessionKey,
+                      updatedAt: 1,
+                    },
+                  },
+                },
+              ],
+            },
+            "sessions.list": chatSessionListResponse([
+              {
+                key: selectedSessionKey,
+                kind: "direct",
+                label: "Selected session",
+                updatedAt: 2,
+              },
+              {
+                key: sessionKey,
+                kind: "direct",
+                label: "Focusable progress",
+                updatedAt: 1,
+              },
+            ]),
+          },
+          sessionKey: selectedSessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
+        const row = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
+        const trigger = row.locator(".sidebar-recent-session__link");
+        const card = page.locator(".session-progress-hovercard");
+        // Let pointer intent finish the one-time lazy upgrade before asserting
+        // the runtime's distinct keyboard-focus policy.
+        await row.hover();
+        await card.waitFor({ state: "visible" });
+        await page.mouse.move(1270, 890);
+        await expect.poll(() => card.count()).toBe(0);
+        await trigger.focus();
+        expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(true);
+        await expect
+          .poll(
+            async () =>
+              (await gateway.getRequests("progressCard.get")).filter(
+                (request) => isRecord(request.params) && request.params.sessionKey === sessionKey,
+              ).length,
+          )
+          .toBe(1);
+
+        await card.waitFor({ state: "visible" });
+        expect(await card.getAttribute("role")).toBe("dialog");
+        expect(await trigger.getAttribute("aria-haspopup")).toBe("dialog");
+        expect(await trigger.getAttribute("aria-expanded")).toBe("true");
+        expect(await trigger.getAttribute("aria-controls")).toBe(await card.getAttribute("id"));
+        const box = await card.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box?.x).toBeGreaterThanOrEqual(0);
+        expect(box?.y).toBeGreaterThanOrEqual(0);
+        expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(1280);
+        expect((box?.y ?? 0) + (box?.height ?? 0)).toBeLessThanOrEqual(900);
+
+        await page.keyboard.press("Tab");
+        await expect
+          .poll(() => page.locator(":focus").getAttribute("href"))
+          .toBe("https://example.com/build");
+        await captureProof(page, "keyboard-focus.png");
+      },
+    );
+  });
+
   it("keeps the hover surface closed when the session has no progress card", async () => {
     const sessionKey = "agent:main:no-progress-card";
 

--- a/ui/src/lib/config/config-test-harness.ts
+++ b/ui/src/lib/config/config-test-harness.ts
@@ -1,9 +1,14 @@
 import { afterEach, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { createRuntimeConfigCapability } from "./runtime-config-capability.ts";
 
 export const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
+
+function configGatewayHello(): GatewayHelloOk {
+  return gatewayHelloForMethods(["config.schema", "config.set", "config.apply", "config.patch"]);
+}
 
 export function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -21,7 +26,7 @@ export function createGatewayHarness(client: GatewayBrowserClient) {
     phase: ApplicationGatewayPhase;
     sessionKey: string;
     hello?: GatewayHelloOk | null;
-  } = { client, phase: "connected", sessionKey: "main" };
+  } = { client, phase: "connected", sessionKey: "main", hello: configGatewayHello() };
   const listeners = new Set<(next: typeof snapshot) => void>();
   return {
     gateway: {
@@ -42,7 +47,7 @@ export function createGatewayHarness(client: GatewayBrowserClient) {
         client: nextClient,
         phase: connected ? "connected" : "reconnecting",
         sessionKey: "main",
-        hello,
+        hello: hello === undefined ? configGatewayHello() : hello,
       };
       for (const listener of listeners) {
         listener(snapshot);

--- a/ui/src/lib/gateway-methods.test.ts
+++ b/ui/src/lib/gateway-methods.test.ts
@@ -38,21 +38,11 @@ describe("canCallGatewayMethod", () => {
     ["disconnected", { connected: false }],
     ["method unavailable", { methods: [], scopes: ["operator.admin"] }],
     ["scope insufficient", { methods: ["skills.update"], scopes: ["operator.write"] }],
+    ["method catalog omitted", { scopes: ["operator.admin"] }],
+    ["auth omitted", { methods: ["skills.update"], includeAuth: false }],
+    ["scopes omitted", { methods: ["skills.update"], includeScopes: false }],
   ])("blocks %s calls", (_name, params) => {
     expect(canCallGatewayMethod(snapshot(params), "skills.update", "operator.admin")).toBe(false);
-  });
-
-  it("preserves legacy behavior when methods or auth scopes are omitted", () => {
-    expect(
-      canCallGatewayMethod(snapshot({ includeAuth: false }), "skills.update", "operator.admin"),
-    ).toBe(true);
-    expect(
-      canCallGatewayMethod(
-        snapshot({ methods: ["skills.update"], includeScopes: false }),
-        "skills.update",
-        "operator.admin",
-      ),
-    ).toBe(true);
   });
 
   it("supports registered methods that are intentionally not advertised", () => {

--- a/ui/src/lib/gateway-methods.ts
+++ b/ui/src/lib/gateway-methods.ts
@@ -33,11 +33,7 @@ export function isGatewayCapabilityAdvertised(
   return capabilities.includes(capability);
 }
 
-/**
- * Combines the active connection, advertised method catalog, and operator
- * scopes. Older Gateways may omit either metadata surface, so only explicit
- * method absence or an explicit insufficient scope blocks the action.
- */
+/** Combines the active connection, advertised method catalog, and operator scopes. */
 export function canCallGatewayMethod(
   snapshot: Pick<ApplicationGatewaySnapshot, "client" | "hello" | "phase"> | null | undefined,
   method: string,
@@ -49,17 +45,17 @@ export function canCallGatewayMethod(
   }
   if (
     options.requireAdvertisement !== false &&
-    isGatewayMethodAdvertised(snapshot, method) === false
+    isGatewayMethodAdvertised(snapshot, method) !== true
   ) {
     return false;
   }
-  const auth = snapshot.hello?.auth ?? null;
-  return (
-    !auth?.scopes ||
-    roleScopesAllow({
-      role: auth.role ?? "operator",
-      requestedScopes: [requiredScope],
-      allowedScopes: auth.scopes,
-    })
-  );
+  const auth = snapshot.hello?.auth;
+  if (!auth || !Array.isArray(auth.scopes)) {
+    return false;
+  }
+  return roleScopesAllow({
+    role: auth.role,
+    requestedScopes: [requiredScope],
+    allowedScopes: auth.scopes,
+  });
 }

--- a/ui/src/lib/session-method-access.test.ts
+++ b/ui/src/lib/session-method-access.test.ts
@@ -7,6 +7,7 @@ function snapshot(params: {
   methods?: string[];
   scopes?: string[];
   includeAuth?: boolean;
+  includeScopes?: boolean;
 }): Pick<ApplicationGatewaySnapshot, "client" | "hello" | "phase"> {
   const connected = params.connected ?? true;
   return {
@@ -16,7 +17,14 @@ function snapshot(params: {
       features: { methods: params.methods ?? ["sessions.create"] },
       ...(params.includeAuth === false
         ? {}
-        : { auth: { role: "operator", scopes: params.scopes ?? ["operator.write"] } }),
+        : {
+            auth: {
+              role: "operator",
+              ...(params.includeScopes === false
+                ? {}
+                : { scopes: params.scopes ?? ["operator.write"] }),
+            },
+          }),
     } as ApplicationGatewaySnapshot["hello"],
   };
 }
@@ -96,13 +104,16 @@ describe("readSessionMethodAccess", () => {
     });
   });
 
-  it("preserves legacy snapshots without advertised auth scopes", () => {
+  it.each([
+    ["auth", { includeAuth: false }],
+    ["scopes", { includeScopes: false }],
+  ])("rejects snapshots without advertised %s", (_name, params) => {
     expect(
-      readSessionMethodAccess(snapshot({ includeAuth: false }), {
+      readSessionMethodAccess(snapshot(params), {
         method: "sessions.create",
         params: { agentId: "main" },
-      }).allowed,
-    ).toBe(true);
+      }),
+    ).toMatchObject({ allowed: false, cause: "missing-scope" });
   });
 
   it("rejects disconnected and unadvertised calls before scope checks", () => {
@@ -116,14 +127,14 @@ describe("readSessionMethodAccess", () => {
     ).toMatchObject({ allowed: false, cause: "method-unavailable" });
   });
 
-  it("allows legacy snapshots without method metadata", () => {
-    const legacy = snapshot({});
-    legacy.hello = { auth: legacy.hello?.auth } as ApplicationGatewaySnapshot["hello"];
+  it("rejects snapshots without method metadata", () => {
+    const incomplete = snapshot({});
+    incomplete.hello = { auth: incomplete.hello?.auth } as ApplicationGatewaySnapshot["hello"];
     expect(
-      readSessionMethodAccess(legacy, {
+      readSessionMethodAccess(incomplete, {
         method: "sessions.groups.put",
         requiredScope: "operator.write",
-      }).allowed,
-    ).toBe(true);
+      }),
+    ).toMatchObject({ allowed: false, cause: "method-unavailable" });
   });
 });

--- a/ui/src/lib/session-method-access.ts
+++ b/ui/src/lib/session-method-access.ts
@@ -65,8 +65,7 @@ export function readSessionMethodAccess(
       cause: "disconnected",
     };
   }
-  // Older Gateways may omit method metadata. Only an explicit absence is authoritative.
-  if (isGatewayMethodAdvertised(snapshot, request.method) === false) {
+  if (isGatewayMethodAdvertised(snapshot, request.method) !== true) {
     return {
       allowed: false,
       requiredScope,
@@ -74,12 +73,12 @@ export function readSessionMethodAccess(
       cause: "method-unavailable",
     };
   }
-  const auth = snapshot.hello?.auth ?? null;
-  // Older Gateways did not advertise auth scopes. Preserve their existing UI behavior.
+  const auth = snapshot.hello?.auth;
   if (
-    !auth?.scopes ||
+    auth &&
+    Array.isArray(auth.scopes) &&
     roleScopesAllow({
-      role: auth.role ?? "operator",
+      role: auth.role,
       requestedScopes: [requiredScope],
       allowedScopes: auth.scopes,
     })

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -3,6 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createRuntimeConfigCapability } from "../config/runtime-config-capability.ts";
 import { searchClawHub } from "./clawhub-search.ts";
@@ -905,7 +906,12 @@ describe("skill mutations", () => {
     });
     const client = expectDefined(state.client, "connected skill mutation client");
     const runtimeConfig = createRuntimeConfigCapability({
-      snapshot: { client, phase: "connected", sessionKey: "main" },
+      snapshot: {
+        client,
+        phase: "connected",
+        sessionKey: "main",
+        hello: gatewayHelloForMethods(["config.set"]),
+      },
       subscribe: () => () => undefined,
     });
     state.runtimeConfig = runtimeConfig;
@@ -951,7 +957,12 @@ describe("skill mutations", () => {
     });
     const client = expectDefined(state.client, "connected skill mutation client");
     const runtimeConfig = createRuntimeConfigCapability({
-      snapshot: { client, phase: "connected", sessionKey: "main" },
+      snapshot: {
+        client,
+        phase: "connected",
+        sessionKey: "main",
+        hello: gatewayHelloForMethods(["config.set"]),
+      },
       subscribe: () => () => undefined,
     });
     state.runtimeConfig = runtimeConfig;

--- a/ui/src/pages/agents/agent-file-lifecycle.test.ts
+++ b/ui/src/pages/agents/agent-file-lifecycle.test.ts
@@ -4,8 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsFilesListResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import type { AgentsRouteData } from "./route.ts";
 import "./agents-page.ts";
+
+const AGENT_FILE_GATEWAY_HELLO = gatewayHelloForMethods(["agents.files.set"]);
 
 type TestAgentsPage = HTMLElement & {
   context: ApplicationContext;
@@ -32,7 +35,7 @@ function snapshot(client: GatewayBrowserClient): ApplicationGatewaySnapshot {
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: AGENT_FILE_GATEWAY_HELLO,
     assistantAgentId: null,
     sessionKey: "main",
     lastError: null,

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -14,8 +14,11 @@ import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/c
 import type { AgentsPanel } from "../../lib/agents/panels.ts";
 import { invalidateChatMetadataStore } from "../../lib/chat/chat-metadata-store.ts";
 import { loadCronJobsPage, type CronState } from "../../lib/cron/index.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import type { AgentsRouteData } from "./route.ts";
 import "./agents-page.ts";
+
+const AGENTS_PAGE_GATEWAY_HELLO = gatewayHelloForMethods(["config.patch", "config.set"]);
 
 type TestAgentsPage = HTMLElement & {
   context: ApplicationContext;
@@ -91,7 +94,7 @@ function snapshot(
     phase: connected ? "connected" : "stopped",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: AGENTS_PAGE_GATEWAY_HELLO,
     assistantAgentId: null,
     sessionKey: "main",
     lastError: null,

--- a/ui/src/pages/agents/github-identity-controller.test.ts
+++ b/ui/src/pages/agents/github-identity-controller.test.ts
@@ -4,6 +4,7 @@ import {
   createRuntimeConfigCapability,
   type RuntimeConfigCapability,
 } from "../../lib/config/runtime-config-capability.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { GitHubIdentityController } from "./github-identity-controller.js";
 
 const availableStatus = {
@@ -239,7 +240,12 @@ describe("GitHubIdentityController", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const runtimeConfig = createRuntimeConfigCapability({
-      snapshot: { client, phase: "connected", sessionKey: "main" },
+      snapshot: {
+        client,
+        phase: "connected",
+        sessionKey: "main",
+        hello: gatewayHelloForMethods(["config.set"]),
+      },
       subscribe: () => () => undefined,
     });
     await runtimeConfig.ensureLoaded();

--- a/ui/src/pages/agents/identity-actions.test.ts
+++ b/ui/src/pages/agents/identity-actions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import * as avatarImage from "./avatar-image.ts";
 import { resetIdentityDraft, saveIdentityDraft, selectIdentityAvatar } from "./identity-actions.ts";
 
@@ -100,7 +101,12 @@ describe("agent identity actions", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const runtimeConfig = createRuntimeConfigCapability({
-      snapshot: { client, phase: "connected", sessionKey: "main" },
+      snapshot: {
+        client,
+        phase: "connected",
+        sessionKey: "main",
+        hello: gatewayHelloForMethods(["config.set"]),
+      },
       subscribe: () => () => undefined,
     });
     await runtimeConfig.ensureLoaded();

--- a/ui/src/pages/agents/memory/dreaming.test.ts
+++ b/ui/src/pages/agents/memory/dreaming.test.ts
@@ -5,6 +5,7 @@ import { i18n } from "../../../i18n/index.ts";
 import type { TranslationMap } from "../../../i18n/lib/types.ts";
 import { en } from "../../../i18n/locales/en.ts";
 import type { RuntimeConfigCapability } from "../../../lib/config/runtime-config-capability.ts";
+import { gatewayHelloForMethods } from "../../../test-helpers/gateway-methods.ts";
 import {
   backfillDreamDiary,
   copyDreamingArchivePath,
@@ -367,12 +368,7 @@ describe("dreaming controller", () => {
       const firstAgentA = createDeferred<unknown>();
       const agentB = createDeferred<unknown>();
       const secondAgentA = createDeferred<unknown>();
-      state.hello = {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: [] },
-        features: { methods: [method] },
-      };
+      state.hello = gatewayHelloForMethods([method], []);
       request
         .mockImplementationOnce(async () => firstAgentA.promise)
         .mockImplementationOnce(async () => agentB.promise)
@@ -405,12 +401,7 @@ describe("dreaming controller", () => {
     async ({ key, method, load, payload }) => {
       const { state, request } = createState();
       const deferred = createDeferred<unknown>();
-      state.hello = {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: [] },
-        features: { methods: [method] },
-      };
+      state.hello = gatewayHelloForMethods([method], []);
       request.mockImplementationOnce(async () => deferred.promise);
 
       const stale = load(state);
@@ -429,12 +420,7 @@ describe("dreaming controller", () => {
 
   it("loads authoritative wiki import insights", async () => {
     const { state, request } = createState();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.importInsights"] },
-    };
+    state.hello = gatewayHelloForMethods(["wiki.importInsights"], []);
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -501,12 +487,7 @@ describe("dreaming controller", () => {
   it("loads wiki import insights for the selected agent", async () => {
     const { state, request } = createState();
     state.selectedAgentId = "support";
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.importInsights"] },
-    };
+    state.hello = gatewayHelloForMethods(["wiki.importInsights"], []);
     request.mockResolvedValue({ sourceType: "chatgpt", totalItems: 1, clusters: [] });
 
     await loadWikiImportInsights(state);
@@ -518,12 +499,7 @@ describe("dreaming controller", () => {
     const { state, request } = createState();
     const agentA = createDeferred<unknown>();
     const agentB = createDeferred<unknown>();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.importInsights"] },
-    };
+    state.hello = gatewayHelloForMethods(["wiki.importInsights"], []);
     request.mockImplementation(async (_method: string, payload?: unknown) => {
       const agentId =
         typeof payload === "object" && payload !== null && "agentId" in payload
@@ -605,12 +581,7 @@ describe("dreaming controller", () => {
 
   it("skips wiki import insights when the gateway does not advertise the method", async () => {
     const { state, request } = createState();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["doctor.memory.status"] },
-    };
+    state.hello = gatewayHelloForMethods(["doctor.memory.status"], []);
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -641,12 +612,7 @@ describe("dreaming controller", () => {
 
   it("loads and normalizes the wiki wiki overview", async () => {
     const { state, request } = createState();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.overview"] },
-    };
+    state.hello = gatewayHelloForMethods(["wiki.overview"], []);
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -719,12 +685,7 @@ describe("dreaming controller", () => {
   it("loads the wiki wiki overview for the selected agent", async () => {
     const { state, request } = createState();
     state.selectedAgentId = "marketing";
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.overview"] },
-    };
+    state.hello = gatewayHelloForMethods(["wiki.overview"], []);
     request.mockResolvedValue({ totalItems: 1, clusters: [] });
 
     await loadWikiOverview(state);
@@ -736,12 +697,7 @@ describe("dreaming controller", () => {
     const { state, request } = createState();
     const agentA = createDeferred<unknown>();
     const agentB = createDeferred<unknown>();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["wiki.overview"] },
-    };
+    state.hello = gatewayHelloForMethods(["wiki.overview"], []);
     request.mockImplementation(async (_method: string, payload?: unknown) => {
       const agentId =
         typeof payload === "object" && payload !== null && "agentId" in payload
@@ -843,12 +799,7 @@ describe("dreaming controller", () => {
 
   it("skips wiki wiki overview when the gateway does not advertise the method", async () => {
     const { state, request } = createState();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: [] },
-      features: { methods: ["doctor.memory.status"] },
-    };
+    state.hello = gatewayHelloForMethods(["doctor.memory.status"], []);
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -888,6 +839,7 @@ describe("dreaming controller", () => {
 
   it("patches config to update global dreaming enablement", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(["config.patch"]);
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -956,6 +908,7 @@ describe("dreaming controller", () => {
 
   it("falls back to memory-core when selected memory slot is blank", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(["config.patch"]);
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -1240,6 +1193,7 @@ describe("dreaming controller", () => {
 
   it("backfills and reloads dream diary state", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(["doctor.memory.backfillDreamDiary"], ["operator.write"]);
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.backfillDreamDiary") {
         return { action: "backfill", written: 79, replaced: 79 };
@@ -1308,12 +1262,7 @@ describe("dreaming controller", () => {
 
   it("does not run a write action with read-only operator access", async () => {
     const { state, request } = createState();
-    state.hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: ["operator.read"] },
-      features: { methods: ["doctor.memory.backfillDreamDiary"] },
-    };
+    state.hello = gatewayHelloForMethods(["doctor.memory.backfillDreamDiary"], ["operator.read"]);
 
     await expect(backfillDreamDiary(state)).resolves.toBe(false);
     expect(request).not.toHaveBeenCalled();
@@ -1321,6 +1270,7 @@ describe("dreaming controller", () => {
 
   it("runs dream diary actions and reloads state for the selected agent", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(["doctor.memory.backfillDreamDiary"], ["operator.write"]);
     state.selectedAgentId = "fishing-bot";
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.backfillDreamDiary") {
@@ -1351,6 +1301,7 @@ describe("dreaming controller", () => {
 
   it("resets and reloads dream diary state", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(["doctor.memory.resetDreamDiary"], ["operator.write"]);
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.resetDreamDiary") {
         return { action: "reset", removedEntries: 79 };
@@ -1376,6 +1327,10 @@ describe("dreaming controller", () => {
 
   it("clears grounded staged entries and reloads only dreaming status", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(
+      ["doctor.memory.resetGroundedShortTerm"],
+      ["operator.write"],
+    );
     state.dreamDiaryContent = "keep existing diary";
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.resetGroundedShortTerm") {
@@ -1399,6 +1354,10 @@ describe("dreaming controller", () => {
 
   it("repairs dreaming artifacts and reloads only dreaming status", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(
+      ["doctor.memory.repairDreamingArtifacts"],
+      ["operator.write"],
+    );
     state.dreamDiaryContent = "keep existing diary";
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.repairDreamingArtifacts") {
@@ -1435,6 +1394,7 @@ describe("dreaming controller", () => {
 
   it("dedupes dream diary entries and reloads diary plus status", async () => {
     const { state, request } = createState();
+    state.hello = gatewayHelloForMethods(["doctor.memory.dedupeDreamDiary"], ["operator.write"]);
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.dedupeDreamDiary") {
         return {

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -11,6 +11,7 @@ import {
 import { i18n } from "../../../i18n/index.ts";
 import type { TranslationMap } from "../../../i18n/lib/types.ts";
 import { en } from "../../../i18n/locales/en.ts";
+import { gatewayHelloForMethods } from "../../../test-helpers/gateway-methods.ts";
 import type { DreamingState } from "./dreaming.ts";
 import type { DreamingViewState } from "./view.ts";
 import "./memory-panel.ts";
@@ -86,7 +87,7 @@ function contextWithGateway(
     phase: connected ? "connected" : "stopped",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: gatewayHelloForMethods(["config.patch"]),
     assistantAgentId: null,
     sessionKey: "main",
     lastError: null,

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -16,11 +16,12 @@ import {
   OPENAI_GPT5_MINI_MODEL,
 } from "../../test-helpers/chat-model.ts";
 import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import { executeSlashCommand as executeSlashCommandImpl } from "./chat-command-executor.ts";
 
 function createTestSessionCapability(client: GatewayBrowserClient): SessionCapability {
   const sessions = createSessionCapability({
-    snapshot: { client, phase: "connected", hello: null },
+    snapshot: { client, phase: "connected", hello: sessionMutationGatewayHello() },
     subscribe: () => () => undefined,
     subscribeEvents: () => () => undefined,
   });
@@ -50,7 +51,7 @@ function executeSlashCommand(
   const {
     sessionAccessSnapshot = {
       client,
-      hello: null,
+      hello: sessionMutationGatewayHello(),
       phase: "connected",
     },
     ...rest
@@ -175,7 +176,7 @@ describe("executeSlashCommand directives", () => {
       sessions,
       sessionAccessSnapshot: {
         client,
-        hello: null,
+        hello: sessionMutationGatewayHello(),
         phase: "connected",
       },
       agentId: "work",
@@ -213,7 +214,7 @@ describe("executeSlashCommand directives", () => {
       sessions,
       sessionAccessSnapshot: {
         client,
-        hello: null,
+        hello: sessionMutationGatewayHello(),
         phase: "connected",
       },
       agentId: "work",

--- a/ui/src/pages/chat/chat-commands.test.ts
+++ b/ui/src/pages/chat/chat-commands.test.ts
@@ -12,6 +12,7 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../lib/chat/commands.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import {
   applyRemoteSlashCommandsResult,
   dispatchChatSlashCommand,
@@ -36,11 +37,11 @@ function expectRecordFields(value: unknown, label: string, expected: Record<stri
   }
 }
 
-function legacyConnectedSessionAccess() {
+function connectedSessionAccess() {
   return {
     client: { request: vi.fn() } as unknown as GatewayBrowserClient,
     connected: true,
-    hello: null,
+    hello: sessionMutationGatewayHello(),
   };
 }
 
@@ -384,7 +385,7 @@ describe("conversation reset confirmation", () => {
     const sendResetMessage = vi.fn(async () => {});
     const result = await dispatchChatSlashCommand(
       {
-        ...legacyConnectedSessionAccess(),
+        ...connectedSessionAccess(),
         connectionEpoch: 1,
         sessionKey: "agent:main:current",
         confirmConversationReset: vi.fn(async () => false),
@@ -405,7 +406,7 @@ describe("conversation reset confirmation", () => {
     });
     const sendResetMessage = vi.fn(async () => {});
     const host = {
-      ...legacyConnectedSessionAccess(),
+      ...connectedSessionAccess(),
       connectionEpoch: 1,
       sessionKey: "agent:main:first",
       confirmConversationReset: vi.fn(async () => await confirmation),
@@ -460,7 +461,7 @@ describe("conversation reset confirmation", () => {
     });
     const sendResetMessage = vi.fn(async () => {});
     const host = {
-      ...legacyConnectedSessionAccess(),
+      ...connectedSessionAccess(),
       connectionEpoch: 1,
       hello: {
         auth: { role: "operator", scopes: ["operator.admin"] },
@@ -494,7 +495,7 @@ describe("conversation reset confirmation", () => {
     });
     const sendResetMessage = vi.fn(async () => {});
     const host = {
-      ...legacyConnectedSessionAccess(),
+      ...connectedSessionAccess(),
       connectionEpoch: 1,
       sessionKey: "main",
       confirmConversationReset: vi.fn(async () => await confirmation),
@@ -520,7 +521,7 @@ describe("conversation reset confirmation", () => {
       const sendResetMessage = vi.fn(async () => {});
       const reset = vi.fn();
       const host = {
-        ...legacyConnectedSessionAccess(),
+        ...connectedSessionAccess(),
         chatRunId: null as string | null,
         sessionKey: "agent:main:current",
         confirmConversationReset: vi.fn(async () => await confirmation),
@@ -542,7 +543,7 @@ describe("conversation reset confirmation", () => {
   it("keeps chat-only /reset unchanged", async () => {
     const sendResetMessage = vi.fn(async () => {});
     const host = {
-      ...legacyConnectedSessionAccess(),
+      ...connectedSessionAccess(),
       connectionEpoch: 1,
       sessionKey: "agent:main:current",
     };
@@ -567,7 +568,7 @@ describe("conversation reset confirmation", () => {
     const reset = vi.fn();
     const result = await dispatchChatSlashCommand(
       {
-        ...legacyConnectedSessionAccess(),
+        ...connectedSessionAccess(),
         sessionKey: "agent:main:current",
         confirmConversationReset: vi.fn(async () => false),
         sessions: { reset },
@@ -628,7 +629,7 @@ describe("conversation reset confirmation", () => {
     });
     const reset = vi.fn();
     const host = {
-      ...legacyConnectedSessionAccess(),
+      ...connectedSessionAccess(),
       connectionEpoch: 1,
       hello: {
         auth: { role: "operator", scopes: ["operator.admin"] },

--- a/ui/src/pages/chat/chat-composer-capability-host.test.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSnapshot, GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import {
+  gatewayHelloForMethods,
+  sessionMutationGatewayHello,
+} from "../../test-helpers/gateway-methods.ts";
 import { ChatComposerCapabilityHost } from "./chat-composer-capability-host.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
@@ -12,9 +16,7 @@ function createContext(configSnapshot: ConfigSnapshot | null): ApplicationContex
       snapshot: {
         client: {} as GatewayBrowserClient,
         phase: "connected",
-        hello: {
-          auth: { role: "operator", scopes: ["operator.admin", "operator.write"] },
-        },
+        hello: sessionMutationGatewayHello(["operator.admin", "operator.write"]),
       },
     },
     navigate: vi.fn(),
@@ -368,9 +370,7 @@ describe("ChatComposerCapabilityHost", () => {
     const notify = vi.fn();
     const host = new ChatComposerCapabilityHost(notify);
     const context = createContext({ runtimeConfig: {} });
-    context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.patch", "tools.effective"] },
-    } as NonNullable<typeof context.gateway.snapshot.hello>;
+    context.gateway.snapshot.hello = gatewayHelloForMethods(["sessions.patch", "tools.effective"]);
     let stateReads = 0;
     Object.defineProperty(context.sessions, "state", {
       configurable: true,

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -7,6 +7,7 @@ import {
   createTestGatewayClient,
   type GatewayRequestMock,
 } from "../../test-helpers/gateway-client.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
 import type { ChatComposerMemoryFallback } from "./chat-state-host.ts";
@@ -133,7 +134,7 @@ export function makeChatHost(
     lastError: null,
     sessionKey: "agent:main",
     basePath: "",
-    hello: null,
+    hello: sessionMutationGatewayHello(),
     chatAvatarUrl: null,
     chatAvatarSource: null,
     chatAvatarStatus: null,

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -12,6 +12,7 @@ import {
   type BoardProvider,
 } from "../../lib/board/provider.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import "./chat-pane.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
@@ -65,7 +66,7 @@ function createTestPane(sessions: SessionCapability = {} as SessionCapability) {
   Object.defineProperty(pane, "isConnected", { configurable: true, value: true });
   pane.context = {
     sessions,
-    gateway: { snapshot: { client, phase: "connected" } },
+    gateway: { snapshot: { client, phase: "connected", hello: sessionMutationGatewayHello() } },
   } as unknown as ApplicationContext;
   pane.state = {
     chatError: null,
@@ -184,7 +185,7 @@ describe("chat pane board shell", () => {
     pane.state.client = client;
     pane.context = {
       ...pane.context,
-      gateway: { snapshot: { client, phase: "connected" } },
+      gateway: { snapshot: { client, phase: "connected", hello: sessionMutationGatewayHello() } },
     } as unknown as ApplicationContext;
     pane.connectedClient = client;
     pane.boardProvider = mockBoardProvider("agent:main:current");

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -38,7 +38,7 @@ type ChatPaneLayoutRenderParams = {
   sessionWorkspace: SessionWorkspaceProps;
   backgroundTasks: BackgroundTasksProps;
   chatProps: ChatProps;
-  fullMessageLoader: SidebarFullMessageLoader;
+  fullMessageLoader: SidebarFullMessageLoader | null;
   observerDigest: SessionObserverDigest | null;
   observerRunId: string | null;
   catalog: boolean;

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -1,0 +1,157 @@
+import { html, nothing } from "lit";
+import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
+import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
+import {
+  availableSidebarSlots,
+  sidebarPanelActions,
+  sidebarPanelDefinitions,
+  sidebarPanelTemplates,
+} from "./chat-pane-embedded-panels.ts";
+import type { ResolvedBoardView } from "./chat-pane-shared.ts";
+import { renderSidebarRegion, sidebarRegionCallbacks } from "./chat-pane-sidebar-layout.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { renderChat, type ChatProps } from "./chat-view.ts";
+import { renderBackgroundTasksRail } from "./components/chat-background-tasks-render.ts";
+import type { BackgroundTasksProps } from "./components/chat-background-tasks.types.ts";
+import { detailSlotOpen, renderChatDetailSlot } from "./components/chat-detail-slot.ts";
+import { renderChatImageLightbox } from "./components/chat-image-lightbox.ts";
+import {
+  renderSessionWorkspaceRail,
+  type SessionWorkspaceProps,
+} from "./components/chat-session-workspace.ts";
+import type { SidebarFullMessageLoader } from "./components/chat-sidebar.ts";
+import {
+  SIDEBAR_NARROW_BREAKPOINT_PX,
+  type SidebarLayout,
+  type SidebarSlotId,
+} from "./sidebar-layout.ts";
+
+type ChatPaneLayoutRenderParams = {
+  state: ChatPageHost;
+  selectedSession: GatewaySessionRow | undefined;
+  currentAgentId: string;
+  board: ResolvedBoardView;
+  sidebarLayout: SidebarLayout;
+  progressCardInRail: boolean;
+  sessionWorkspace: SessionWorkspaceProps;
+  backgroundTasks: BackgroundTasksProps;
+  chatProps: ChatProps;
+  fullMessageLoader: SidebarFullMessageLoader;
+  observerDigest: SessionObserverDigest | null;
+  observerRunId: string | null;
+  catalog: boolean;
+  agentWorkspace: string | undefined;
+  workspaceGit: boolean;
+  openPanelSlot: (slot: SidebarSlotId) => void;
+  closePanelSlot: (slot: SidebarSlotId) => void;
+};
+
+export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRender {
+  protected renderChatPaneLayout(params: ChatPaneLayoutRenderParams) {
+    const {
+      state,
+      selectedSession,
+      currentAgentId,
+      board,
+      sidebarLayout,
+      progressCardInRail,
+      sessionWorkspace,
+      backgroundTasks,
+      chatProps,
+      fullMessageLoader,
+      observerDigest,
+      observerRunId,
+      catalog,
+      agentWorkspace,
+      workspaceGit,
+      openPanelSlot,
+      closePanelSlot,
+    } = params;
+    const header = this.renderPaneHeader(
+      sessionWorkspace,
+      backgroundTasks,
+      selectedSession,
+      catalog,
+      agentWorkspace,
+      workspaceGit,
+    );
+    const chat = renderChat({
+      ...chatProps,
+      header: board.face === "dashboard" ? nothing : header,
+    });
+    // Keep this root stable across board face changes so the guarded board runtime
+    // remains connected while Chat is active.
+    const primary = html`<div class="chat-pane-primary-column">
+      ${board.face === "dashboard" ? header : nothing}${this.renderBoardPrimary(board, chat)}
+    </div>`;
+    const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
+    const desktopAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot);
+    const companionThread = this.sessionCompanionThreads.view(state.sessionKey, currentAgentId);
+    const panelDefinitions = sidebarPanelDefinitions({
+      state,
+      agentId: currentAgentId,
+      desktopAvailable,
+      hasBoard: board.hasBoard,
+      chat,
+      workspace: renderSessionWorkspaceRail(sessionWorkspace, { embedded: true }),
+      tasks: renderBackgroundTasksRail(backgroundTasks, { embedded: true }),
+      detailOpen: this.presented && sidebarLayout.open === true && detailSlotOpen(sidebarLayout),
+      renderDetail: (content) =>
+        renderChatDetailSlot({
+          backgroundTasks,
+          chat: chatProps,
+          content,
+          fullMessageLoader,
+          host: state,
+          layout: sidebarLayout,
+          transcript: this.taskSidebarTranscript,
+        }),
+      digest: observerDigest,
+      activeRunId: observerRunId,
+      startedAt: selectedSession?.startedAt ?? state.chatStreamStartedAt ?? undefined,
+      lastReadAt: selectedSession?.lastReadAt,
+      pullRequests: this.sessionPullRequests,
+      progressCard: progressCardInRail ? this.progressCard.card : null,
+      companion: companionThread,
+      onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
+      onCompanionDraftChange: (draft) =>
+        this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),
+      onCompanionVisibilityChange: this.setSessionObserverVisibility,
+      connected: state.connected,
+      pendingQuestion: companionThread.pendingQuestion,
+      onClearCompanion: () => void this.clearSessionCompanion(),
+      discussion,
+      discussionOpenUrl: discussion?.openUrl ?? null,
+      discussionSourceGeneration: this.connectionGeneration,
+    });
+    const availableSlots = availableSidebarSlots(panelDefinitions);
+    const panelTemplates = sidebarPanelTemplates(panelDefinitions);
+    const panelActions = sidebarPanelActions(panelDefinitions);
+    const content = renderSidebarRegion({
+      availableWidth: this.paneWidth,
+      availableSlots,
+      callbacks: sidebarRegionCallbacks({
+        state,
+        closePanelSlot,
+        openPanelSlot,
+        hideBoard: () => this.handleBoardDockChange("hidden"),
+        forgetDiscussionUrl: () => this.sessionDiscussionOpenUrls.delete(state.sessionKey.trim()),
+        resizePanel: (columnId, size) =>
+          this.commitSidebarPanelResize(sidebarLayout, columnId, size),
+        setPanelOpen: (open) => this.setChatSidePanelOpen(open),
+      }),
+      layout: sidebarLayout,
+      panelDefinitions,
+      panelActions,
+      narrow: this.paneWidth < SIDEBAR_NARROW_BREAKPOINT_PX,
+      panelTemplates,
+      primary,
+    });
+    return html`${content}${renderChatImageLightbox(
+      state.imageLightbox,
+      state.handleCloseImage,
+    )}${this.renderResetConfirmation()}`;
+  }
+}

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -26,23 +26,13 @@ import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
 import { clearChatHistory } from "./chat-history.ts";
 import { resolveChatMessageAccess } from "./chat-message-access.ts";
 import { requiresChatModelSetup } from "./chat-model-setup.ts";
-import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
-import {
-  availableSidebarSlots,
-  sidebarPanelActions,
-  sidebarPanelDefinitions,
-  sidebarPanelTemplates,
-} from "./chat-pane-embedded-panels.ts";
+import { ChatPaneLayoutRender } from "./chat-pane-layout-render.ts";
 import {
   createChatPaneSessionActionCallbacks,
   readChatPaneMutationAccess,
   renderChatPaneComposerControls,
 } from "./chat-pane-session-controls.ts";
-import {
-  renderSidebarRegion,
-  resolveSidebarLayoutForBoard,
-  sidebarRegionCallbacks,
-} from "./chat-pane-sidebar-layout.ts";
+import { resolveSidebarLayoutForBoard } from "./chat-pane-sidebar-layout.ts";
 import {
   dismissChatError,
   resolveAssistantAttachmentAuthToken,
@@ -56,16 +46,13 @@ import {
   resolveChatAvatarUrl,
   selectedChatSessionRow,
 } from "./chat-state-route.ts";
-import { renderChat, type ChatProps } from "./chat-view.ts";
-import { renderBackgroundTasksRail } from "./components/chat-background-tasks-render.ts";
+import type { ChatProps } from "./chat-view.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
-import { detailSlotOpen, renderChatDetailSlot } from "./components/chat-detail-slot.ts";
-import { renderChatImageLightbox } from "./components/chat-image-lightbox.ts";
+import { detailSlotOpen } from "./components/chat-detail-slot.ts";
 import { chatPullRequestId, createPullRequestBranch } from "./components/chat-pull-requests.ts";
 import {
   createSessionWorkspaceProps,
   openSessionWorkspaceFile,
-  renderSessionWorkspaceRail,
   revealSessionWorkspaceFile,
 } from "./components/chat-session-workspace.ts";
 import { activeQueuedMessageEdit } from "./queued-message-edit.ts";
@@ -82,7 +69,7 @@ import { resolveActiveRunOutputTokens, resolveChatProjectionRunId } from "./tool
 import { configureToolTitleFetcher } from "./tool-titles.ts";
 import { workspaceResultConflictFromPlacement } from "./workspace-conflict.ts";
 
-export class ChatPane extends ChatPaneBrowserAnnotationRender {
+export class ChatPane extends ChatPaneLayoutRender {
   override render() {
     const state = this.state;
     if (!state) {
@@ -630,86 +617,24 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       resolveArtifactDownload: (params) => resolveChatArtifactDownload(state, params),
       basePath: state.basePath,
     };
-    const header = this.renderPaneHeader(
+    return this.renderChatPaneLayout({
+      state,
+      selectedSession,
+      currentAgentId,
+      board,
+      sidebarLayout,
+      progressCardInRail,
       sessionWorkspace,
       backgroundTasks,
-      selectedSession,
-      Boolean(catalogKey),
-      selectedAgent?.workspace,
-      selectedAgent?.workspaceGit === true,
-    );
-    const chat = renderChat({ ...props, header: board.face === "dashboard" ? nothing : header });
-    // Keep this root stable across board face changes so the guarded board runtime
-    // remains connected while Chat is active.
-    const primary = html`<div class="chat-pane-primary-column">
-      ${board.face === "dashboard" ? header : nothing}${this.renderBoardPrimary(board, chat)}
-    </div>`;
-    const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
-    const desktopAvailable = isDesktopPanelAvailable(gatewaySnapshot);
-    const companionThread = this.sessionCompanionThreads.view(state.sessionKey, currentAgentId);
-    const panelDefinitions = sidebarPanelDefinitions({
-      state,
-      agentId: currentAgentId,
-      desktopAvailable,
-      hasBoard: board.hasBoard,
-      chat,
-      workspace: renderSessionWorkspaceRail(sessionWorkspace, { embedded: true }),
-      tasks: renderBackgroundTasksRail(backgroundTasks, { embedded: true }),
-      detailOpen: this.presented && sidebarLayout.open === true && detailSlotOpen(sidebarLayout),
-      renderDetail: (content) =>
-        renderChatDetailSlot({
-          backgroundTasks,
-          chat: props,
-          content,
-          fullMessageLoader,
-          host: state,
-          layout: sidebarLayout,
-          transcript: this.taskSidebarTranscript,
-        }),
-      digest: observerDigest ?? null,
-      activeRunId: observerRunId ?? null,
-      startedAt: selectedSession?.startedAt ?? state.chatStreamStartedAt ?? undefined,
-      lastReadAt: selectedSession?.lastReadAt,
-      pullRequests: this.sessionPullRequests,
-      progressCard: progressCardInRail ? this.progressCard.card : null,
-      companion: companionThread,
-      onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
-      onCompanionDraftChange: (draft) =>
-        this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),
-      onCompanionVisibilityChange: this.setSessionObserverVisibility,
-      connected: state.connected,
-      pendingQuestion: companionThread.pendingQuestion,
-      onClearCompanion: () => void this.clearSessionCompanion(),
-      discussion,
-      discussionOpenUrl: discussion?.openUrl ?? null,
-      discussionSourceGeneration: this.connectionGeneration,
+      chatProps: props,
+      fullMessageLoader,
+      observerDigest,
+      observerRunId,
+      catalog: Boolean(catalogKey),
+      agentWorkspace: selectedAgent?.workspace,
+      workspaceGit: selectedAgent?.workspaceGit === true,
+      openPanelSlot,
+      closePanelSlot,
     });
-    const availableSlots = availableSidebarSlots(panelDefinitions);
-    const panelTemplates = sidebarPanelTemplates(panelDefinitions);
-    const panelActions = sidebarPanelActions(panelDefinitions);
-    const content = renderSidebarRegion({
-      availableWidth: this.paneWidth,
-      availableSlots,
-      callbacks: sidebarRegionCallbacks({
-        state,
-        closePanelSlot,
-        openPanelSlot,
-        hideBoard: () => this.handleBoardDockChange("hidden"),
-        forgetDiscussionUrl: () => this.sessionDiscussionOpenUrls.delete(state.sessionKey.trim()),
-        resizePanel: (columnId, size) =>
-          this.commitSidebarPanelResize(sidebarLayout, columnId, size),
-        setPanelOpen: (open) => this.setChatSidePanelOpen(open),
-      }),
-      layout: sidebarLayout,
-      panelDefinitions,
-      panelActions,
-      narrow: this.paneWidth < SIDEBAR_NARROW_BREAKPOINT_PX,
-      panelTemplates,
-      primary,
-    });
-    return html`${content}${renderChatImageLightbox(
-      state.imageLightbox,
-      state.handleCloseImage,
-    )}${this.renderResetConfirmation()}`;
   }
 }

--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -47,9 +47,10 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       return;
     }
     const offset = direction === "next" ? 1 : -1;
-    const next = this.taskSuggestions[
-      (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
-    ];
+    const next =
+      this.taskSuggestions[
+        (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
+      ];
     if (!next) {
       return;
     }

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -21,8 +21,13 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
-import "./chat-pane.ts";
 import type { TaskSuggestionAcceptMode } from "../../lib/task-suggestion-acceptance.ts";
+import "./chat-pane.ts";
+import {
+  gatewayHelloForMethods,
+  SESSION_MUTATION_TEST_METHODS,
+  sessionMutationGatewayHello,
+} from "../../test-helpers/gateway-methods.ts";
 import { attachChatRealtimeActions, createInitialChatRealtimeState } from "./chat-realtime.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
@@ -191,11 +196,11 @@ export function createSessionContext(
       snapshot: {
         client,
         phase: "connected" as const,
-        hello: {
-          features: {
-            methods: ["taskSuggestions.list", "session.suggestions.list", "sessions.patch"],
-          },
-        },
+        hello: gatewayHelloForMethods([
+          ...SESSION_MUTATION_TEST_METHODS,
+          "taskSuggestions.list",
+          "session.suggestions.list",
+        ]),
       },
       connection: { gatewayUrl: "ws://example.test", token: "", bootstrapToken: "", password: "" },
       eventLog: [],
@@ -271,7 +276,7 @@ export function createTestChatPane(params: {
     client: params.client,
     connected: true,
     connectionEpoch: 4,
-    hello: null,
+    hello: sessionMutationGatewayHello(),
     lastError: null,
     requestUpdate,
     sessionKey: "agent:main:current",

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -20,6 +20,7 @@ import {
   createTestGatewayClient,
   type GatewayRequestHandler,
 } from "../../test-helpers/gateway-client.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
@@ -383,9 +384,7 @@ describe("refreshChat", () => {
   it("uses prepared models delivered with startup metadata", async () => {
     const startup = createDeferred<unknown>();
     const host = makeChatHost({
-      hello: {
-        features: { methods: ["chat.metadata", "chat.startup"] },
-      } as TestChatHost["hello"],
+      hello: gatewayHelloForMethods(["chat.metadata", "chat.startup"], []),
       requestHandlers: {
         "chat.startup": () => startup.promise,
       },
@@ -434,9 +433,7 @@ describe("refreshChat", () => {
     const startup = createDeferred<unknown>();
     const host = makeChatHost({
       chatModelSwitchPromises: {},
-      hello: {
-        features: { methods: ["chat.metadata", "chat.startup"] },
-      } as TestChatHost["hello"],
+      hello: gatewayHelloForMethods(["chat.metadata", "chat.startup"], []),
       requestHandlers: {
         "chat.startup": () => startup.promise,
       },
@@ -515,9 +512,7 @@ describe("refreshChat", () => {
       {
         sessionKey: "global",
         hello: {
-          type: "hello-ok" as const,
-          protocol: 4,
-          auth: { role: "operator" as const, scopes: [] },
+          ...gatewayHelloForMethods([], []),
           snapshot: { sessionDefaults: { defaultAgentId: "ops" } },
         },
       },
@@ -784,6 +779,8 @@ describe("refreshChatAvatar", () => {
     await loadChatHelpers();
   });
 
+  const pairedDeviceHello = gatewayHelloForMethods([], []);
+
   it.each([
     {
       name: "uses a route-relative avatar endpoint before basePath bootstrap finishes",
@@ -800,7 +797,10 @@ describe("refreshChatAvatar", () => {
       overrides: {
         settings: { token: "session-token" },
         password: "shared-password",
-        hello: { auth: { deviceToken: "device-token" } } as ChatHost["hello"],
+        hello: {
+          ...pairedDeviceHello,
+          auth: { ...pairedDeviceHello.auth, deviceToken: "device-token" },
+        },
       },
     },
     {
@@ -2220,9 +2220,7 @@ describe("handleSendChat", () => {
       assistantAgentId: "work",
       chatMessage: "send to the agent main session",
       hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: [] },
+        ...gatewayHelloForMethods([], []),
         snapshot: {
           sessionDefaults: {
             defaultAgentId: "main",
@@ -4609,12 +4607,7 @@ describe("handleSendChat", () => {
       chatQueue: [item],
       connectionEpoch: 1,
       confirmConversationReset: vi.fn(async () => await confirmation.promise),
-      hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["chat.send"] },
-      },
+      hello: gatewayHelloForMethods(["chat.send"]),
     });
     admitHostQueueItems(host);
 
@@ -4648,12 +4641,7 @@ describe("handleSendChat", () => {
       chatQueue: [item],
       connectionEpoch: 1,
       confirmConversationReset: vi.fn(async () => true),
-      hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["chat.send"] },
-      },
+      hello: gatewayHelloForMethods(["chat.send"]),
     });
     const refreshSessions = vi.spyOn(host.sessions, "refresh");
     admitHostQueueItems(host);
@@ -4722,12 +4710,7 @@ describe("handleSendChat", () => {
       },
       chatQueue: [item],
       confirmConversationReset: vi.fn(async () => true),
-      hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["chat.send"] },
-      },
+      hello: gatewayHelloForMethods(["chat.send"]),
     });
     admitHostQueueItems(host);
 
@@ -5924,6 +5907,7 @@ describe("handleSendChat", () => {
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
       },
+      hello: gatewayHelloForMethods(["skills.proposals.requestRevision"]),
       chatMessage: "keep my draft",
     });
     (host as ChatHost & { currentSessionId?: string }).currentSessionId = "session-current";
@@ -5973,6 +5957,7 @@ describe("handleSendChat", () => {
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
       },
+      hello: gatewayHelloForMethods(["skills.proposals.requestRevision"]),
     });
 
     const send = handleSendChat(host, "Keep the source connection", {
@@ -6005,6 +5990,7 @@ describe("handleSendChat", () => {
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
       },
+      hello: gatewayHelloForMethods(["skills.proposals.requestRevision"]),
     });
 
     const send = handleSendChat(host, "Keep the rejected request visible", {
@@ -6032,10 +6018,7 @@ describe("handleSendChat", () => {
       requestHandlers: {
         "skills.proposals.requestRevision": {},
       },
-      hello: {
-        auth: { role: "operator", scopes: ["operator.read"] },
-        features: { methods: ["skills.proposals.requestRevision"] },
-      } as ChatHost["hello"],
+      hello: gatewayHelloForMethods(["skills.proposals.requestRevision"], ["operator.read"]),
     });
 
     await handleSendChat(host, "Revise this proposal", {
@@ -6055,6 +6038,7 @@ describe("handleSendChat", () => {
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
       },
+      hello: gatewayHelloForMethods(["skills.proposals.requestRevision"]),
     });
 
     const send = handleSendChat(host, "/reset examples", {
@@ -7186,6 +7170,7 @@ describe("handleSendChat", () => {
         "chat.history": () => idleChatHistory(),
         "skills.proposals.requestRevision": { runId: "revision-retry", status: "started" },
       },
+      hello: gatewayHelloForMethods(["skills.proposals.requestRevision"]),
       chatMessage: "keep my draft",
       pendingSettingsPatches: { "agent:main": settingsPatch.promise },
     });
@@ -9922,12 +9907,7 @@ describe("handleAbortChat", () => {
       requestHandlers: {},
       chatRunId: "run-main",
       chatMessage: "/stop",
-      hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: ["operator.read"] },
-        features: { methods: ["chat.abort"] },
-      },
+      hello: gatewayHelloForMethods(["chat.abort"], ["operator.read"]),
       sessionKey: "agent:main",
       chatRunError: { summary: "Previous run failed" },
     });

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -246,10 +246,11 @@ describe("chat header session menu", () => {
   it("offers direct and submenu owner assignment", async () => {
     const onAction = vi.fn<(action: HeaderMenuAction) => void>();
     const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
+    const research = { type: "agent", id: "research:one", label: "Research" } as const;
     const menu = await mountMenu({
-      ownerOptions: [ada, { type: "agent", id: "research", label: "Research" }],
+      ownerOptions: [ada, research],
       selfOwner: ada,
-      currentOwnerId: "research",
+      currentOwnerId: research.id,
       onAction,
     });
 
@@ -258,12 +259,17 @@ describe("chat header session menu", () => {
     expect(
       Array.from(submenu.querySelectorAll("wa-dropdown-item[slot='submenu']")).map(itemLabel),
     ).toEqual(["Ada", "Research"]);
+    const selected = item(menu, "Research");
+    expect(selected.getAttribute("role")).toBe("menuitemradio");
+    expect(selected.getAttribute("aria-checked")).toBe("true");
+    expect(selected.disabled).toBe(true);
+    expect(selected.querySelector("[slot='details']")).not.toBeNull();
 
     select(menu, "assign-owner:self");
-    select(menu, "assign-owner:agent:research");
+    select(menu, "assign-owner:agent:research%3Aone");
     expect(onAction.mock.calls).toEqual([
       [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada", label: "Ada" } }],
-      [{ kind: "assign-owner", owner: { type: "agent", id: "research" } }],
+      [{ kind: "assign-owner", owner: { type: "agent", id: "research:one" } }],
     ]);
   });
 

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -1,14 +1,13 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
 import type { UiSettings } from "../../../app/settings.ts";
 import { icons } from "../../../components/icons.ts";
 import { activateMenuShortcut, menuShortcutHint } from "../../../components/menu-shortcuts.ts";
+import type { SessionOwnerOption } from "../../../components/session-owner-chip.ts";
 import {
-  renderSessionOwnerMenuAvatar,
-  type SessionOwnerOption,
-} from "../../../components/session-owner-chip.ts";
-import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
+  renderSessionOwnerAssignmentMenu,
+  sessionOwnerAssignmentFromMenuValue,
+} from "../../../components/session-owner-menu.ts";
 import { t } from "../../../i18n/index.ts";
 import { EDITOR_IDS, EDITOR_LABELS, type EditorId } from "../../../lib/editor-links.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
@@ -104,16 +103,9 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       }
       return;
     }
-    if (value === "assign-owner:self" && this.selfOwner) {
-      this.onAction({ kind: "assign-owner", owner: this.selfOwner });
-      return;
-    }
-    if (value.startsWith("assign-owner:")) {
-      const [, type, encodedId] = value.split(":");
-      const id = encodedId ? decodeURIComponent(encodedId) : "";
-      if ((type === "human" || type === "agent") && id) {
-        this.onAction({ kind: "assign-owner", owner: { type, id } });
-      }
+    const owner = sessionOwnerAssignmentFromMenuValue(value, this.selfOwner);
+    if (owner) {
+      this.onAction({ kind: "assign-owner", owner });
       return;
     }
     if (
@@ -131,34 +123,6 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       }
     }
   };
-
-  private renderOwnerSubmenu() {
-    return this.ownerOptions.map((owner) => {
-      const checked = owner.id === this.currentOwnerId;
-      return html`
-        <wa-dropdown-item
-          slot="submenu"
-          class="session-menu__item"
-          value=${`assign-owner:${owner.type}:${encodeURIComponent(owner.id)}`}
-          role="menuitemradio"
-          aria-checked=${String(checked)}
-          ${ref((element) => syncDropdownItemRadio(element, checked))}
-          ?disabled=${this.actionDisabled("assign-owner", checked)}
-          title=${this.actionTitle("assign-owner")}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true"
-            >${renderSessionOwnerMenuAvatar(owner)}</span
-          >
-          <span class="session-menu__text">${owner.label ?? owner.id}</span>
-          ${checked
-            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
-                >${icons.check}</span
-              >`
-            : nothing}
-        </wa-dropdown-item>
-      `;
-    });
-  }
 
   private renderEditorSubmenu() {
     return EDITOR_IDS.map(
@@ -287,31 +251,13 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
           <span class="session-menu__text">${t("sessionsView.renameSessionMenu")}</span>
           ${menuShortcutHint("r")}
         </wa-dropdown-item>
-        ${this.selfOwner
-          ? html`<wa-dropdown-item
-              class="session-menu__item"
-              value="assign-owner:self"
-              ?disabled=${this.actionDisabled(
-                "assign-owner",
-                this.currentOwnerId === this.selfOwner.id,
-              )}
-              title=${this.actionTitle("assign-owner")}
-            >
-              <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
-              <span class="session-menu__text">${t("sessionsView.assignToMe")}</span>
-            </wa-dropdown-item>`
-          : nothing}
-        ${this.ownerOptions.length > 0
-          ? html`<wa-dropdown-item
-              class="session-menu__item"
-              ?disabled=${this.actionDisabled("assign-owner")}
-              title=${this.actionTitle("assign-owner")}
-            >
-              <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
-              <span class="session-menu__text">${t("sessionsView.assignTo")}</span>
-              ${this.renderOwnerSubmenu()}
-            </wa-dropdown-item>`
-          : nothing}
+        ${renderSessionOwnerAssignmentMenu({
+          ownerOptions: this.ownerOptions,
+          selfOwner: this.selfOwner,
+          currentOwnerId: this.currentOwnerId,
+          disabled: this.actionDisabled("assign-owner"),
+          disabledReason: this.actionDisabledReasons["assign-owner"],
+        })}
         <wa-dropdown-item class="session-menu__item">
           <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.eye}</span>
           <span class="session-menu__text">${t("chat.view.menu")}</span>

--- a/ui/src/pages/chat/components/chat-task-suggestions.ts
+++ b/ui/src/pages/chat/components/chat-task-suggestions.ts
@@ -94,10 +94,7 @@ function renderChatTaskSuggestions(props: {
     ? props.activeId
     : props.suggestions[0]?.id;
   return html`
-    <div
-      class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}"
-      aria-live="polite"
-    >
+    <div class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}" aria-live="polite">
       ${props.suggestions.map((suggestion, index) => {
         const busy = props.busyIds.has(suggestion.id);
         const title = sanitizeTaskSuggestionText(suggestion.title);
@@ -191,7 +188,8 @@ function renderChatTaskSuggestions(props: {
                         requestAnimationFrame(() => updateTaskSuggestionPathFade(element));
                       }
                     })}
-                    @scroll=${(event: Event) => updateTaskSuggestionPathFade(event.currentTarget as Element)}
+                    @scroll=${(event: Event) =>
+                      updateTaskSuggestionPathFade(event.currentTarget as Element)}
                     >${cwd}</code
                   >
                   <pre>${prompt}</pre>

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import {
   CHAT_RUN_STATUS_TOAST_DURATION_MS,
   handleAbortChat,
@@ -59,7 +60,7 @@ function makeAbortHost(over: Partial<AbortHost> = {}): AbortHost {
     chatInputHistoryItems: null,
     chatInputHistoryIndex: -1,
     chatDraftBeforeHistory: null,
-    hello: null,
+    hello: sessionMutationGatewayHello(),
     ...over,
   };
 }

--- a/ui/src/pages/plugins/plugins-page.test-support.ts
+++ b/ui/src/pages/plugins/plugins-page.test-support.ts
@@ -18,11 +18,21 @@ import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
 } from "../../test-helpers/application-context.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
 import type { PluginRowMessage } from "./view.ts";
 import "./plugins-page.ts";
 
 type RequestHandler = (method: string, params: unknown) => Promise<unknown>;
+
+const PLUGINS_GATEWAY_HELLO = gatewayHelloForMethods([
+  "config.set",
+  "plugins.install",
+  "plugins.list",
+  "plugins.search",
+  "plugins.setEnabled",
+  "plugins.uninstall",
+]);
 
 type GatewayHarness = {
   gateway: ApplicationGateway;
@@ -104,11 +114,7 @@ function createSnapshot(
     phase: connected ? "connected" : "reconnecting",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: {
-      type: "hello-ok",
-      protocol: 1,
-      auth: { role: "operator", scopes: ["operator.read", "operator.admin"] },
-    },
+    hello: PLUGINS_GATEWAY_HELLO,
     assistantAgentId: "main",
     sessionKey: "main",
     lastError: null,

--- a/ui/src/pages/portals/portals-page.test.ts
+++ b/ui/src/pages/portals/portals-page.test.ts
@@ -4,6 +4,7 @@ import type { PortalListResult, PortalSummary } from "@openclaw/gateway-protocol
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { resolvePortalUrl } from "./portal-url.ts";
 
 const probePortalReachable = vi.hoisted(() =>
@@ -43,7 +44,7 @@ function createContext(
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: { features: { methods } } as ApplicationGatewaySnapshot["hello"],
+    hello: gatewayHelloForMethods(methods, ["operator.write"]),
     assistantAgentId: null,
     sessionKey: "main",
     lastError: null,

--- a/ui/src/pages/sessions/sessions-page.roster.test.ts
+++ b/ui/src/pages/sessions/sessions-page.roster.test.ts
@@ -6,6 +6,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionCompactionCheckpoint, SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import {
   createContext,
   createGateway,
@@ -65,7 +66,7 @@ describe("sessions page managed roster", () => {
     };
 
     mutableGateway.emit({ phase: "reconnecting", client });
-    mutableGateway.emit({ phase: "connected", client });
+    mutableGateway.emit({ phase: "connected", client, hello: sessionMutationGatewayHello() });
     document.body.append(page);
     await page.updateComplete;
     await vi.waitFor(() => expect(refreshList).toHaveBeenCalledOnce());

--- a/ui/src/pages/sessions/sessions-page.test-support.ts
+++ b/ui/src/pages/sessions/sessions-page.test-support.ts
@@ -12,6 +12,7 @@ import type {
   SessionListSnapshot,
 } from "../../lib/sessions/index.ts";
 import type { SessionRefreshOptions } from "../../lib/sessions/session-capability.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import type { SessionsRouteData } from "./route.ts";
 import type { TranscriptSearchState } from "./view.ts";
 import "./sessions-page.ts";
@@ -75,7 +76,7 @@ export function createGateway(client: GatewayBrowserClient): MutableGateway {
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: sessionMutationGatewayHello(),
     assistantAgentId: null,
     sessionKey: "main",
     lastError: null,

--- a/ui/src/pages/skill-workshop/history-scan.test.ts
+++ b/ui/src/pages/skill-workshop/history-scan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ApplicationGateway } from "../../app/context.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { loadSkillWorkshopHistoryScanStatus, runSkillWorkshopHistoryScan } from "./history-scan.ts";
 import { createSkillWorkshopState } from "./proposals.ts";
 import type { SkillWorkshopHistoryScanResult } from "./state.ts";
@@ -21,11 +22,16 @@ function result(overrides: Partial<SkillWorkshopHistoryScanResult> = {}) {
   };
 }
 
-function gateway(request: ReturnType<typeof vi.fn>): ApplicationGateway {
+function gateway(
+  request: ReturnType<typeof vi.fn>,
+  methods: string[],
+  scopes: string[] = ["operator.admin"],
+): ApplicationGateway {
   return {
     snapshot: {
       phase: "connected",
       client: { request },
+      hello: gatewayHelloForMethods(methods, scopes),
     },
   } as unknown as ApplicationGateway;
 }
@@ -41,13 +47,7 @@ function deferred<T>() {
 describe("Skill Workshop history scan controller", () => {
   it("does not scan history with read-only operator access", async () => {
     const request = vi.fn();
-    const appGateway = gateway(request);
-    (appGateway.snapshot as ApplicationGateway["snapshot"]).hello = {
-      type: "hello-ok",
-      protocol: 4,
-      auth: { role: "operator", scopes: ["operator.read"] },
-      features: { methods: ["skills.proposals.historyScan"] },
-    } as ApplicationGateway["snapshot"]["hello"];
+    const appGateway = gateway(request, ["skills.proposals.historyScan"], ["operator.read"]);
 
     await expect(
       runSkillWorkshopHistoryScan({
@@ -65,7 +65,10 @@ describe("Skill Workshop history scan controller", () => {
       .mockResolvedValueOnce(result())
       .mockResolvedValueOnce(result({ hasScanned: true, hasMore: true, reviewedSessions: 20 }));
     const state = createSkillWorkshopHistoryScanState();
-    const appGateway = gateway(request);
+    const appGateway = gateway(request, [
+      "skills.proposals.historyStatus",
+      "skills.proposals.historyScan",
+    ]);
 
     await loadSkillWorkshopHistoryScanStatus({ agentId: "main", gateway: appGateway, state });
     expect(state.loaded).toBe(true);
@@ -85,7 +88,11 @@ describe("Skill Workshop history scan controller", () => {
     state.loaded = true;
     state.result = result({ hasScanned: true, hasMore: false });
 
-    await runSkillWorkshopHistoryScan({ agentId: "main", gateway: gateway(request), state });
+    await runSkillWorkshopHistoryScan({
+      agentId: "main",
+      gateway: gateway(request, ["skills.proposals.historyScan"]),
+      state,
+    });
 
     expect(request).toHaveBeenCalledWith("skills.proposals.historyScan", {
       agentId: "main",
@@ -102,7 +109,10 @@ describe("Skill Workshop history scan controller", () => {
       .mockResolvedValueOnce(result({ hasScanned: true, hasMore: false }))
       .mockResolvedValueOnce(result({ hasScanned: true, hasMore: false }));
     const state = createSkillWorkshopHistoryScanState();
-    const appGateway = gateway(request);
+    const appGateway = gateway(request, [
+      "skills.proposals.historyStatus",
+      "skills.proposals.historyScan",
+    ]);
 
     await loadSkillWorkshopHistoryScanStatus({ agentId: "main", gateway: appGateway, state });
     expect(state.loaded).toBe(true);
@@ -126,7 +136,10 @@ describe("Skill Workshop history scan controller", () => {
     const newRequest = vi.fn().mockResolvedValue(result({ hasScanned: true, hasMore: true }));
     const state = createSkillWorkshopHistoryScanState();
     state.loaded = true;
-    const appGateway = gateway(oldRequest);
+    const appGateway = gateway(oldRequest, [
+      "skills.proposals.historyStatus",
+      "skills.proposals.historyScan",
+    ]);
 
     const scan = runSkillWorkshopHistoryScan({ agentId: "main", gateway: appGateway, state });
     await vi.waitFor(() => expect(oldRequest).toHaveBeenCalledTimes(1));
@@ -148,7 +161,10 @@ describe("Skill Workshop history scan controller", () => {
         }),
     );
     const state = createSkillWorkshopHistoryScanState();
-    const appGateway = gateway(request);
+    const appGateway = gateway(request, [
+      "skills.proposals.historyStatus",
+      "skills.proposals.historyScan",
+    ]);
     const statusLoad = loadSkillWorkshopHistoryScanStatus({
       agentId: "main",
       gateway: appGateway,
@@ -175,7 +191,7 @@ describe("Skill Workshop history scan controller", () => {
       .mockReturnValueOnce(second.promise)
       .mockReturnValueOnce(third.promise);
     const state = createSkillWorkshopHistoryScanState();
-    const appGateway = gateway(request);
+    const appGateway = gateway(request, ["skills.proposals.historyStatus"]);
 
     const initial = loadSkillWorkshopHistoryScanStatus({
       agentId: "main",
@@ -221,7 +237,14 @@ describe("Skill Workshop history scan controller", () => {
     state.result = result();
 
     await expect(
-      runSkillWorkshopHistoryScan({ agentId: "main", gateway: gateway(request), state }),
+      runSkillWorkshopHistoryScan({
+        agentId: "main",
+        gateway: gateway(request, [
+          "skills.proposals.historyStatus",
+          "skills.proposals.historyScan",
+        ]),
+        state,
+      }),
     ).resolves.toBe(false);
 
     expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.historyStatus", {

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import {
   createSkillWorkshopState,
   loadSkillWorkshopProposals,
@@ -24,6 +25,7 @@ const REVISION_HASH = "b".repeat(64);
 function createFixture(
   overrides: Partial<SkillWorkshopState> = {},
   snapshotOverrides: Partial<ApplicationGatewaySnapshot> = {},
+  methods: string[] = ["skills.proposals.list", "skills.proposals.inspect"],
 ): {
   state: SkillWorkshopState;
   context: SkillWorkshopContext;
@@ -36,7 +38,7 @@ function createFixture(
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: gatewayHelloForMethods(methods),
     assistantAgentId: "research",
     sessionKey: "global",
     lastError: null,
@@ -143,18 +145,14 @@ describe("Skill Workshop proposal RPCs", () => {
     const { state, context, request } = createFixture(
       { skillWorkshopProposals: [proposal()] },
       {
-        hello: {
-          type: "hello-ok",
-          protocol: 4,
-          auth: { role: "operator", scopes: ["operator.read"] },
-          features: {
-            methods: [
-              "skills.proposals.apply",
-              "skills.proposals.evaluate",
-              "skills.proposals.requestRevision",
-            ],
-          },
-        } as ApplicationGatewaySnapshot["hello"],
+        hello: gatewayHelloForMethods(
+          [
+            "skills.proposals.apply",
+            "skills.proposals.evaluate",
+            "skills.proposals.requestRevision",
+          ],
+          ["operator.read"],
+        ),
       },
     );
 
@@ -219,6 +217,7 @@ describe("Skill Workshop proposal RPCs", () => {
     const { state, context, request } = createFixture(
       { skillWorkshopProposals: [proposal({ body: "" })] },
       { sessionKey: "agent:ops-team:main" },
+      ["skills.proposals.inspect"],
     );
     request.mockResolvedValue(inspectResult());
 
@@ -243,6 +242,7 @@ describe("Skill Workshop proposal RPCs", () => {
           skillWorkshopSelectedKey: "proposal-1",
         },
         { assistantAgentId: "reviewer" },
+        [method, "skills.proposals.list", "skills.proposals.inspect"],
       );
       request.mockImplementation(async (calledMethod: string) => {
         if (calledMethod === method) {
@@ -309,11 +309,15 @@ describe("Skill Workshop proposal RPCs", () => {
       evaluation,
     };
     let inspectCalls = 0;
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal({ revisionHash: "c".repeat(64) })],
-      skillWorkshopSelectedKey: "proposal-1",
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ revisionHash: "c".repeat(64) })],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
     request.mockImplementation(async (method: string) => {
       if (method === "skills.proposals.inspect") {
         inspectCalls += 1;
@@ -354,10 +358,14 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("does not evaluate after the initiating source changes during inspection", async () => {
     const detail = createDeferred<ReturnType<typeof inspectResult>>();
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal({ body: "" })],
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ body: "" })],
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
     let current = true;
     request.mockImplementation((method: string) =>
       method === "skills.proposals.inspect" ? detail.promise : Promise.resolve({}),
@@ -374,9 +382,11 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("drops an inspected evaluation that belongs to a different revision", async () => {
     const baseInspect = inspectResult();
-    const { state, context, request } = createFixture({
-      skillWorkshopProposals: [proposal({ body: "" })],
-    });
+    const { state, context, request } = createFixture(
+      { skillWorkshopProposals: [proposal({ body: "" })] },
+      {},
+      ["skills.proposals.inspect"],
+    );
     request.mockResolvedValue({
       ...baseInspect,
       record: {
@@ -410,10 +420,14 @@ describe("Skill Workshop proposal RPCs", () => {
       completedAt: ISO_NOW,
       outcomes: [],
     } as const;
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal()],
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
     request.mockImplementation(async (method: string) =>
       method === "skills.proposals.inspect"
         ? baseInspect
@@ -431,10 +445,14 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("loads legacy inspect responses but refuses revision-sensitive evaluation", async () => {
     const { revisionHash: _revisionHash, ...legacyInspect } = inspectResult();
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal()],
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
     request.mockResolvedValue(legacyInspect);
 
     await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
@@ -512,10 +530,14 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("discards selected proposal detail that resolves after the agent scope changes", async () => {
     const detail = createDeferred<ReturnType<typeof inspectResult>>();
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal({ body: "" })],
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ body: "" })],
+      },
+      {},
+      ["skills.proposals.inspect"],
+    );
     request.mockReturnValueOnce(detail.promise);
 
     const loading = selectSkillWorkshopProposal(state, context, "proposal-1");
@@ -531,11 +553,15 @@ describe("Skill Workshop proposal RPCs", () => {
   });
 
   it("preserves the loaded proposal agent for originless revisions", async () => {
-    const { state, context } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal()],
-      skillWorkshopRevisionDraft: "Tighten the trigger.",
-    });
+    const { state, context } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopRevisionDraft: "Tighten the trigger.",
+      },
+      {},
+      ["skills.proposals.requestRevision"],
+    );
     const sendRevisionRequest = vi.fn(async () => {});
 
     try {
@@ -553,11 +579,15 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("does not send an originless revision after the agent scope changes", async () => {
     const detail = createDeferred<ReturnType<typeof inspectResult>>();
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal({ body: "" })],
-      skillWorkshopRevisionDraft: "Tighten the trigger.",
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ body: "" })],
+        skillWorkshopRevisionDraft: "Tighten the trigger.",
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.requestRevision"],
+    );
     request.mockReturnValueOnce(detail.promise);
     const sendRevisionRequest = vi.fn(async () => {});
 
@@ -576,11 +606,15 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("does not prepare a revision after the initiating source changes during inspection", async () => {
     const detail = createDeferred<ReturnType<typeof inspectResult>>();
-    const { state, context, request } = createFixture({
-      skillWorkshopAgentId: "research",
-      skillWorkshopProposals: [proposal({ body: "" })],
-      skillWorkshopRevisionDraft: "Tighten the trigger.",
-    });
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ body: "" })],
+        skillWorkshopRevisionDraft: "Tighten the trigger.",
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.requestRevision"],
+    );
     let current = true;
     request.mockReturnValueOnce(detail.promise);
     const sendRevisionRequest = vi.fn(async () => {});

--- a/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
@@ -4,6 +4,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { createSkillWorkshopState, skillWorkshopRouteData } from "./proposals.ts";
 import type { SkillWorkshopRouteData, SkillWorkshopState } from "./proposals.ts";
 import { page as skillWorkshopRoute } from "./route.ts";
@@ -21,6 +22,9 @@ type SkillWorkshopPageTestElement = HTMLElement & {
   updateComplete: Promise<boolean>;
   requestUpdate: () => void;
 };
+
+const PAGE_LOAD_METHODS = ["skills.proposals.list", "skills.proposals.historyStatus"];
+const HISTORY_SCAN_METHODS = [...PAGE_LOAD_METHODS, "skills.proposals.historyScan"];
 
 function waitForSkillWorkshop(assertion: () => void) {
   return vi.waitFor(assertion, { interval: 1 });
@@ -61,6 +65,8 @@ function createContext(
   request: ReturnType<typeof vi.fn>,
   options?: {
     gatewaySubscribe?: (listener: (snapshot: ApplicationGatewaySnapshot) => void) => () => void;
+    methods?: string[];
+    scopes?: string[];
     sessions?: ApplicationContext["sessions"];
     runtimeConfig?: ReturnType<typeof createRuntimeConfigStub>;
   },
@@ -71,7 +77,7 @@ function createContext(
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: gatewayHelloForMethods(options?.methods ?? [], options?.scopes),
     assistantAgentId: "research",
     sessionKey: "global",
     lastError: null,
@@ -210,7 +216,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     await page.updateComplete;
     expect(firstRequest).not.toHaveBeenCalled();
 
-    page.context = createContext(secondRequest);
+    page.context = createContext(secondRequest, { methods: PAGE_LOAD_METHODS });
     page.requestUpdate();
     await page.updateComplete;
 
@@ -281,7 +287,9 @@ describe("SkillWorkshopPage lifecycle", () => {
       }
       return {};
     });
-    const context = createContext(request);
+    const context = createContext(request, {
+      methods: [...PAGE_LOAD_METHODS, "skills.proposals.inspect"],
+    });
     const options = {
       signal: new AbortController().signal,
       shouldRun: () => true,
@@ -317,7 +325,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     const page = document.createElement(
       "openclaw-skill-workshop-page",
     ) as SkillWorkshopPageTestElement;
-    page.context = createContext(request);
+    page.context = createContext(request, { methods: PAGE_LOAD_METHODS });
     document.body.append(page);
     await page.updateComplete;
 
@@ -346,7 +354,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     const page = document.createElement(
       "openclaw-skill-workshop-page",
     ) as SkillWorkshopPageTestElement;
-    page.context = createContext(request);
+    page.context = createContext(request, { methods: PAGE_LOAD_METHODS });
     document.body.append(page);
     await page.updateComplete;
     await waitForSkillWorkshop(() =>
@@ -365,6 +373,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     const request = vi.fn(() => manifest.promise);
     let gatewayListener: ((snapshot: ApplicationGatewaySnapshot) => void) | undefined;
     const context = createContext(request, {
+      methods: PAGE_LOAD_METHODS,
       gatewaySubscribe: (listener) => {
         gatewayListener = listener;
         return () => undefined;
@@ -447,7 +456,10 @@ describe("SkillWorkshopPage lifecycle", () => {
     const revision = page.handleRevisionRequest("revise it", proposal, "research");
     await waitForSkillWorkshop(() => expect(oldSessions.list).toHaveBeenCalledTimes(1));
 
-    const newContext = createContext(vi.fn(async () => ({})));
+    const newContext = createContext(
+      vi.fn(async () => ({})),
+      { methods: PAGE_LOAD_METHODS },
+    );
     page.context = newContext;
     page.requestUpdate();
     await page.updateComplete;
@@ -492,10 +504,6 @@ describe("SkillWorkshopPage lifecycle", () => {
       vi.fn(async () => ({})),
       { sessions },
     );
-    context.gateway.snapshot.hello = {
-      type: "hello-ok",
-      protocol: 4,
-    } as ApplicationGatewaySnapshot["hello"];
     const loadedState = createSkillWorkshopState();
     loadedState.skillWorkshopAgentId = "research";
     loadedState.skillWorkshopLoaded = true;
@@ -551,6 +559,8 @@ describe("SkillWorkshopPage lifecycle", () => {
     const context = createContext(
       vi.fn(async () => ({})),
       {
+        methods: ["sessions.create"],
+        scopes: ["operator.write"],
         sessions,
         gatewaySubscribe: (listener) => {
           gatewayListener = listener;
@@ -558,10 +568,6 @@ describe("SkillWorkshopPage lifecycle", () => {
         },
       },
     );
-    context.gateway.snapshot.hello = {
-      auth: { role: "operator", scopes: ["operator.write"] },
-      features: { methods: ["sessions.create"] },
-    } as ApplicationGatewaySnapshot["hello"];
     const loadedState = createSkillWorkshopState();
     loadedState.skillWorkshopAgentId = "research";
     loadedState.skillWorkshopLoaded = true;
@@ -632,12 +638,8 @@ describe("SkillWorkshopPage lifecycle", () => {
     } as unknown as ApplicationContext["sessions"];
     const context = createContext(
       vi.fn(async () => ({})),
-      { sessions },
+      { methods: ["sessions.create"], scopes: ["operator.read"], sessions },
     );
-    context.gateway.snapshot.hello = {
-      auth: { role: "operator", scopes: ["operator.read"] },
-      features: { methods: ["sessions.create"] },
-    } as ApplicationGatewaySnapshot["hello"];
     const loadedState = createSkillWorkshopState();
     loadedState.skillWorkshopAgentId = "research";
     loadedState.skillWorkshopLoaded = true;
@@ -701,7 +703,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     const page = document.createElement(
       "openclaw-skill-workshop-page",
     ) as SkillWorkshopPageTestElement;
-    page.context = createContext(oldRequest);
+    page.context = createContext(oldRequest, { methods: HISTORY_SCAN_METHODS });
     document.body.append(page);
     await page.updateComplete;
     await waitForSkillWorkshop(() =>
@@ -737,7 +739,7 @@ describe("SkillWorkshopPage lifecycle", () => {
             proposals: [],
           },
     );
-    const newContext = createContext(newRequest);
+    const newContext = createContext(newRequest, { methods: PAGE_LOAD_METHODS });
     newContext.agentSelection.state.selectedId = "writer";
     page.context = newContext;
     page.requestUpdate();
@@ -777,7 +779,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     const page = document.createElement(
       "openclaw-skill-workshop-page",
     ) as SkillWorkshopPageTestElement;
-    page.context = createContext(firstRequest);
+    page.context = createContext(firstRequest, { methods: HISTORY_SCAN_METHODS });
     document.body.append(page);
     await page.updateComplete;
     await waitForSkillWorkshop(() =>
@@ -798,7 +800,12 @@ describe("SkillWorkshopPage lifecycle", () => {
       }),
     );
 
-    const otherContext = createContext(vi.fn(async () => scanStatus));
+    const otherContext = createContext(
+      vi.fn(async () => scanStatus),
+      {
+        methods: PAGE_LOAD_METHODS,
+      },
+    );
     otherContext.agentSelection.state.selectedId = "writer";
     page.context = otherContext;
     page.requestUpdate();
@@ -819,7 +826,7 @@ describe("SkillWorkshopPage lifecycle", () => {
         proposals: [],
       });
     });
-    page.context = createContext(returnedRequest);
+    page.context = createContext(returnedRequest, { methods: PAGE_LOAD_METHODS });
     page.requestUpdate();
     await page.updateComplete;
     await waitForSkillWorkshop(() =>
@@ -861,7 +868,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     const page = document.createElement(
       "openclaw-skill-workshop-page",
     ) as SkillWorkshopPageTestElement;
-    page.context = createContext(request);
+    page.context = createContext(request, { methods: HISTORY_SCAN_METHODS });
     document.body.append(page);
     await page.updateComplete;
     await waitForSkillWorkshop(() =>
@@ -914,7 +921,11 @@ describe("SkillWorkshopPage self-learning toggle", () => {
     page.data = skillWorkshopRouteData(loadedState);
     page.context = createContext(
       vi.fn(async () => ({})),
-      { runtimeConfig, gatewaySubscribe: options?.gatewaySubscribe },
+      {
+        methods: ["config.patch"],
+        runtimeConfig,
+        gatewaySubscribe: options?.gatewaySubscribe,
+      },
     );
     document.body.append(page);
     return page;

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -219,7 +219,7 @@ describe("AppSidebar multi-select", () => {
     expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
   });
 
-  it("archives serially when an older Gateway omits method metadata and rejects patchMany", async () => {
+  it("disables batch archive when method metadata is missing", async () => {
     const rejection = new GatewayRequestError({
       code: "INVALID_REQUEST",
       message: "unknown method: sessions.patchMany",
@@ -234,36 +234,14 @@ describe("AppSidebar multi-select", () => {
 
     const menu = await sessionMenu(sidebar);
     const archive = menu.querySelector<HTMLButtonElement>('[data-shortcut="a"]');
-    expect(archive?.disabled).toBe(false);
+    expect(archive?.disabled).toBe(true);
     archive?.click();
+    await Promise.resolve();
 
-    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
-    expect(harness.patch).toHaveBeenNthCalledWith(
-      1,
-      "agent:main:a",
-      { archived: true },
-      {
-        agentId: "main",
-        expectedSessionId: "session:agent:main:a",
-        deferListRefresh: true,
-      },
-    );
-    expect(harness.patch).toHaveBeenNthCalledWith(
-      2,
-      "agent:main:b",
-      { archived: true },
-      {
-        agentId: "main",
-        expectedSessionId: "session:agent:main:b",
-        deferListRefresh: true,
-      },
-    );
-    expect(request.mock.calls.filter(([method]) => method === "sessions.patchMany")).toHaveLength(
-      1,
-    );
+    expect(harness.patch).not.toHaveBeenCalled();
+    expect(request.mock.calls.filter(([method]) => method === "sessions.patchMany")).toEqual([]);
     expect(harness.patchMany).not.toHaveBeenCalled();
-    await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledOnce());
-    expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
+    expect(harness.refreshReplacement).not.toHaveBeenCalled();
   });
 
   it("deletes the selection in one batch after a single confirm", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
   catalogPage,
   createGatewayHarness,
@@ -8,6 +7,7 @@ import {
   mountSidebar,
   type SidebarLifecycleState,
 } from "../app-sidebar.ts";
+import { gatewayHelloForMethods } from "../gateway-methods.ts";
 import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
@@ -51,15 +51,10 @@ describe("AppSidebar section reordering", () => {
     const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
     if (options.withCatalog || options.scopes) {
       gateway.publish({
-        hello: {
-          ...(options.scopes ? { auth: { role: "operator", scopes: options.scopes } } : {}),
-          features: {
-            methods: [
-              ...(options.withCatalog ? ["sessions.catalog.list"] : []),
-              "sessions.groups.put",
-            ],
-          },
-        } as ApplicationGatewaySnapshot["hello"],
+        hello: gatewayHelloForMethods(
+          [...(options.withCatalog ? ["sessions.catalog.list"] : []), "sessions.groups.put"],
+          options.scopes,
+        ),
       });
     }
     const harness = createSessionsHarness("main", [

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
   createGatewayHarness,
   createSessionState,
@@ -11,6 +10,7 @@ import {
   successfulSessionPatch,
   type TestSessionMenu,
 } from "../app-sidebar.ts";
+import { gatewayHelloForMethods } from "../gateway-methods.ts";
 import {
   answerConfirmDialog,
   installDialogPolyfill,
@@ -170,10 +170,7 @@ describe("AppSidebar session mutation feedback", () => {
     } as unknown as GatewayBrowserClient);
     gateway.publish({
       selfUser: { id: "profile-ada", name: "Ada" },
-      hello: {
-        features: { methods: ["sessions.assignOwner"] },
-        auth: { role: "operator", scopes: ["operator.write"] },
-      } as ApplicationGatewaySnapshot["hello"],
+      hello: gatewayHelloForMethods(["sessions.assignOwner"], ["operator.write"]),
     });
     const result = harness.sessions.state.result;
     const row = result?.sessions.find((session) => session.key === "agent:main:a");
@@ -219,7 +216,7 @@ describe("AppSidebar session mutation feedback", () => {
       request,
     } as unknown as GatewayBrowserClient);
     gateway.publish({
-      hello: { features: { methods: ["sessions.reclaim"] } } as ApplicationGatewaySnapshot["hello"],
+      hello: gatewayHelloForMethods(["sessions.reclaim"]),
     });
     const state = createSessionState("main", ["agent:main:main", "agent:main:a"]);
     const row = state.result?.sessions.find((candidate) => candidate.key === "agent:main:a");
@@ -266,9 +263,7 @@ describe("AppSidebar session mutation feedback", () => {
       request,
     } as unknown as GatewayBrowserClient);
     gateway.publish({
-      hello: {
-        features: { methods: ["environments.destroy"] },
-      } as ApplicationGatewaySnapshot["hello"],
+      hello: gatewayHelloForMethods(["environments.destroy"]),
     });
     const state = createSessionState("main", ["agent:main:main", "agent:main:a"]);
     const row = state.result?.sessions.find((candidate) => candidate.key === "agent:main:a");

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -30,7 +30,7 @@ import {
 } from "../lib/sessions/index.ts";
 import { reconcileSessionHistory } from "../lib/sessions/reconcile.ts";
 import { createApplicationContextProvider } from "./application-context.ts";
-import { sessionMutationGatewayHello } from "./gateway-methods.ts";
+import { gatewayHelloForMethods, SESSION_MUTATION_TEST_METHODS } from "./gateway-methods.ts";
 import { createStorageMock } from "./storage.ts";
 
 // The attention widget owns independent health RPC tests. Keep those requests
@@ -128,7 +128,7 @@ export function createGatewayHarness(client: GatewayBrowserClient) {
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: sessionMutationGatewayHello(),
+    hello: gatewayHelloForMethods([...SESSION_MUTATION_TEST_METHODS, "openclaw.chat"]),
     assistantAgentId: "main",
     sessionKey: "agent:main:main",
     lastError: null,

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -30,6 +30,7 @@ import {
 } from "../lib/sessions/index.ts";
 import { reconcileSessionHistory } from "../lib/sessions/reconcile.ts";
 import { createApplicationContextProvider } from "./application-context.ts";
+import { sessionMutationGatewayHello } from "./gateway-methods.ts";
 import { createStorageMock } from "./storage.ts";
 
 // The attention widget owns independent health RPC tests. Keep those requests
@@ -127,7 +128,7 @@ export function createGatewayHarness(client: GatewayBrowserClient) {
     phase: "connected",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: sessionMutationGatewayHello(),
     assistantAgentId: "main",
     sessionKey: "agent:main:main",
     lastError: null,

--- a/ui/src/test-helpers/gateway-methods.ts
+++ b/ui/src/test-helpers/gateway-methods.ts
@@ -1,0 +1,13 @@
+import type { GatewayHelloOk } from "../api/gateway.ts";
+
+export function gatewayHelloForMethods(
+  methods: readonly string[],
+  scopes: readonly string[] = ["operator.admin"],
+): GatewayHelloOk {
+  return {
+    type: "hello-ok",
+    protocol: 4,
+    features: { methods: [...methods] },
+    auth: { role: "operator", scopes: [...scopes] },
+  };
+}

--- a/ui/src/test-helpers/gateway-methods.ts
+++ b/ui/src/test-helpers/gateway-methods.ts
@@ -1,5 +1,40 @@
 import type { GatewayHelloOk } from "../api/gateway.ts";
 
+export const SESSION_MUTATION_TEST_METHODS = [
+  "chat.abort",
+  "chat.send",
+  "environments.destroy",
+  "projects.add",
+  "session.members.add",
+  "session.members.list",
+  "session.members.remove",
+  "session.visibility.set",
+  "sessions.assignOwner",
+  "sessions.abort",
+  "sessions.branches.switch",
+  "sessions.catalog.startTerminal",
+  "sessions.compact",
+  "sessions.compaction.branch",
+  "sessions.compaction.restore",
+  "sessions.create",
+  "sessions.delete",
+  "sessions.dispatch",
+  "sessions.fork",
+  "sessions.groups.delete",
+  "sessions.groups.put",
+  "sessions.groups.rename",
+  "sessions.groups.update",
+  "sessions.move",
+  "sessions.patch",
+  "sessions.patchMany",
+  "sessions.reclaim",
+  "sessions.recover",
+  "sessions.reset",
+  "sessions.rewind",
+  "worktrees.create",
+  "worktrees.remove",
+] as const;
+
 export function gatewayHelloForMethods(
   methods: readonly string[],
   scopes: readonly string[] = ["operator.admin"],
@@ -10,4 +45,10 @@ export function gatewayHelloForMethods(
     features: { methods: [...methods] },
     auth: { role: "operator", scopes: [...scopes] },
   };
+}
+
+export function sessionMutationGatewayHello(
+  scopes: readonly string[] = ["operator.admin"],
+): GatewayHelloOk {
+  return gatewayHelloForMethods(SESSION_MUTATION_TEST_METHODS, scopes);
 }


### PR DESCRIPTION
## What Problem This Solves

The Control UI carried two independent implementations of session-owner assignment menus and three copies of portaled-hovercard lifecycle/bootstrap behavior. Those copies already encoded subtle, surface-specific focus rules and were vulnerable to drifting independently. The Gateway method gate also retained an older-version tolerance for missing method/scopes metadata even though the bundled UI and Gateway ship as one version and the current hello protocol requires both fields.

## Why This Change Was Made

This extracts canonical session-owner menu rendering/parsing, lazy hovercard definition, and portaled hovercard intent/placement mechanics. Domain data loading and focus policy remain in each hovercard runtime: GitHub keeps its pointer-vs-focus release behavior, session links remain noninteractive, and progress cards retain store/revision ownership. Gateway method gating now fails closed when the current required metadata is absent while preserving the explicit registered-but-unadvertised method escape hatch.

The same required-metadata rule now owns session-specific mutation access too. Session-link focus intent is recorded across pointer-to-keyboard transitions, so a focused trigger continues holding its card open after the pointer leaves.

Protocol claims were checked against `packages/gateway-protocol/src/schema/frames.ts` and `src/gateway/server/ws-connection/connect-hello.ts`: `features.methods`, `auth.role`, and `auth.scopes` are required and emitted by the current producer.

### Red-main repair

While this PR was being prepared, canonical main CI run [32092049192](https://github.com/openclaw/openclaw/actions/runs/32092049192) failed `eslint(max-lines)`: `ui/src/pages/chat/chat-pane-render.ts` was 715 physical lines and 702 lint-counted lines. Clear provenance: commit [`47399310a08e`](https://github.com/openclaw/openclaw/commit/47399310a08e67c926875a3da8252467585dac6e) from PR #125231 added four task-suggestion properties, moving the effective count from 698 to 702; the code/PR author and merger were @vyctorbrzezowski on August 17, 2026.

This PR repairs main without a suppression by extracting the final header/board/sidebar/lightbox frame into the concept-owned `chat-pane-layout-render.ts` sibling. `chat-pane-render.ts` is now 640 physical lines, leaving comfortable headroom while keeping render order and behavior unchanged.

## User Impact

Normal current-version behavior is unchanged, with one shared implementation now protecting menu semantics, hovercard accessibility, traversal grace, viewport clamping, and lazy property restoration. Unsupported or malformed Gateway hello payloads no longer enable gated actions by omission.

Production LOC: +773/-827 (net -54) | Tests/test support: +631/-362 (net +269) | Tooling: +0/-0

AI-assisted: yes. I reviewed the implementation and verified the source contracts directly.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/session-menu.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts ui/src/components/github-link-hovercard.test.ts ui/src/components/session-link-hovercard.test.ts ui/src/app/native-link-routing.test.ts ui/src/lib/gateway-methods.test.ts` — 92 tests passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-hovercard.e2e.test.ts ui/src/e2e/github-link-hovercard.e2e.test.ts` — 7 real-browser mocked-Gateway tests passed, including pointer traversal, dialog ARIA, keyboard focus, viewport bounds, and lazy registration.
- `pnpm test:ui` — full Control UI suite passed: 687 files, 9,828 tests, 1 intentional skip.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/operator-admin.e2e.test.ts` — 4 tests passed; missing method metadata now disables admin mutations without dispatch.
- `node scripts/run-vitest.mjs ui/src/lib/gateway-methods.test.ts ui/src/lib/session-method-access.test.ts ui/src/components/session-link-hovercard.test.ts` — 27 tests passed, including missing metadata and hover-to-focus regressions.
- `node scripts/run-vitest.mjs ui/src/pages/chat` after rebasing onto main — 138 files passed, 2,931 tests passed, 2 files/11 tests intentionally skipped.
- CI-repair acceptance — 50 task-suggestion/chat-pane tests, `pnpm tsgo:ui`, and targeted `oxfmt --check` passed.
- `node scripts/check-changed.mjs` after the final commit — passed formatting, guards, max-lines, dead-export scans, UI/core test typechecks, lint/style checks, and Control UI i18n verification.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` plus the focused CI-repair autoreview — clean; no accepted/actionable findings.
- Exact-head CI run [32093252481](https://github.com/openclaw/openclaw/actions/runs/32093252481) — green.

Portaled progress card after lazy pointer activation:

![Portaled progress card](https://github.com/user-attachments/assets/b2d7b30d-4e6b-4bee-b01f-96ed01de1408)

Keyboard focus visibly transferred into the portaled card link:

![Keyboard focus inside progress hovercard](https://github.com/user-attachments/assets/0f69405b-c58e-40ae-be4a-cbe07be251ef)
