### PR TITLE
fix(ui): stop the browser panel throwing on upgrade without ResizeObserver

### DIFF
--- a/ui/src/components/browser/browser-panel.test.ts
+++ b/ui/src/components/browser/browser-panel.test.ts
@@ -69,6 +69,22 @@ describe("normalizeBrowserUrlDraft", () => {
     expect(panel.browserPanelIsOpen()).toBe(true);
   });
 
+  it("mounts when ResizeObserver is unavailable", async () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const panel = document.createElement("openclaw-browser-panel") as unknown as HTMLElement & {
+      available: boolean;
+      embedded: boolean;
+      renderRoot: ShadowRoot;
+      updateComplete: Promise<unknown>;
+    };
+    panel.available = true;
+    panel.embedded = true;
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    expect(panel.renderRoot.querySelector(".bp")).not.toBeNull();
+  });
+
   it("uses the shared surface empty state when the embedded browser has no tabs", async () => {
     const panel = document.createElement("openclaw-browser-panel") as unknown as HTMLElement & {
       available: boolean;

--- a/ui/src/components/browser/browser-panel.ts
+++ b/ui/src/components/browser/browser-panel.ts
@@ -60,15 +60,7 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
   });
   private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
   private embeddedRefreshTimer: number | null = null;
-  private readonly viewportResizeObserver = new ResizeObserver((entries) => {
-    const entry = entries[0];
-    if (entry) {
-      this.browserPanelController.handleViewportResize(
-        entry.contentRect.width,
-        entry.contentRect.height,
-      );
-    }
-  });
+  private viewportResizeObserver: ResizeObserver | null = null;
   private observedViewportElement: Element | null = null;
 
   static override styles = [
@@ -95,7 +87,8 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
     this.clearEmbeddedRefresh();
     super.disconnectedCallback();
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.onToggleRequest);
-    this.viewportResizeObserver.disconnect();
+    this.viewportResizeObserver?.disconnect();
+    this.viewportResizeObserver = null;
     this.observedViewportElement = null;
   }
 
@@ -135,9 +128,18 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
     const viewportElement = this.renderRoot.querySelector(".bp-viewport");
     if (viewportElement !== this.observedViewportElement) {
       // The viewport is transient while the dock opens, closes, or becomes unavailable.
-      this.viewportResizeObserver.disconnect();
+      this.viewportResizeObserver?.disconnect();
       this.observedViewportElement = viewportElement;
-      if (viewportElement) {
+      if (viewportElement && typeof ResizeObserver === "function") {
+        this.viewportResizeObserver ??= new ResizeObserver((entries) => {
+          const entry = entries[0];
+          if (entry) {
+            this.browserPanelController.handleViewportResize(
+              entry.contentRect.width,
+              entry.contentRect.height,
+            );
+          }
+        });
         this.viewportResizeObserver.observe(viewportElement);
       }
     }


### PR DESCRIPTION
## What Problem This Solves

The `checks-ui` shard has been failing intermittently on `main` and reproducibly on PRs with:

```
Vitest caught 2 unhandled errors during the test run.
ReferenceError: ResizeObserver is not defined
This error originated in "src/app/app-host.dock-suppression.test.ts"
```

The named test **passes** — the run fails only on the unhandled errors, which is why this reads as a flaky
test and isn't one. That test renders the app shell under `@vitest-environment jsdom`, which upgrades
dockable panel custom elements, and `browser-panel.ts` constructed its `ResizeObserver` in a **class-field
initializer**:

```ts
private readonly viewportResizeObserver = new ResizeObserver((entries) => { … });
```

A field initializer runs at element upgrade, so in any environment without `ResizeObserver` — jsdom, and any
runtime where it is unavailable — merely upgrading the element throws. Because that happens during upgrade
rather than in a test body, it surfaces as an unhandled error instead of a failing assertion.

Every other construction site in the Control UI already handled this: `mcp-app-view.ts`,
`chat-pane-lifecycle.ts`, `session-data-scroll-controller.ts`, `chat-composer-dom.ts`, and both sites in
`panel-tab-strip.ts` guard on `typeof ResizeObserver`. The browser panel was the odd one out.

## Why This Change Was Made

The observer now has an explicit lifecycle instead of an implicit one. The field starts `null`, the observer
is created lazily at the point a viewport element actually exists and only when `ResizeObserver` is a
function, and the component's existing `disconnectedCallback` disconnects and nulls it so it cannot outlive
its element.

A global `ResizeObserver` polyfill in the UI vitest setup would have turned the shard green in one line, and
was deliberately not used: it would hide this defect and mask any future component that constructs an
observer after teardown. The point is that the component tolerates a missing `ResizeObserver`, not that the
test environment pretends to have one.

## User Impact

The browser panel no longer throws on upgrade in environments without `ResizeObserver`, and the shared
`checks-ui` shard stops failing for every PR that happens to run alongside the shell tests. Behavior with
`ResizeObserver` present is unchanged — same callback, same controller wiring, just created on demand.

## Evidence

A regression test constructs the panel with `vi.stubGlobal("ResizeObserver", undefined)`, reproducing the
pre-fix unhandled error deterministically rather than relying on shard ordering.

```
pnpm test ui/src/app/app-host.dock-suppression.test.ts
 Test Files  1 passed (1)      Tests  1 passed (1)
```

Full Control UI unit lane, the one the shard runs:

```
vitest run --config vitest.config.ts --maxWorkers 3
 Test Files  686 passed (686)
      Tests  9813 passed | 1 skipped (9814)
   Duration  126.24s
```

Neither run contains an `Unhandled Errors` block or a `ResizeObserver` exception — which is the actual
assertion here, since the tests passed even while the shard was failing. Owner tests for the touched
components pass unchanged (5 files, 346 tests).

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `+14 / −12` (net **+2**), tests `+16 / −0`. The
growth is the nullable field plus lazy guarded construction; it buys an explicit teardown path where a field
initializer previously had none.

No `CHANGELOG.md` edit — release-only per repo policy.
