### PR TITLE
fix(skills): resolve GitHub identity from authenticated account

### DIFF
--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -62,7 +62,7 @@ gitcrawl cluster-detail openclaw/openclaw --id <cluster-id> --member-limit 20 --
 
 When a maintainer asks Codex to review, triage, fix, or land a specific OpenClaw issue/PR, have the lead or assigned collaboration worker inspect live assignment before deep work. Assignment itself is a public GitHub write.
 
-- Identify the requesting maintainer's GitHub login. In this environment, default Peter to `steipete`; if another maintainer is clearly the requester, use that maintainer's bare login.
+- Resolve the assignment login from the GitHub account authenticated for the mutation: use `gh api user --jq .login` for direct commands or `gh_plain api user --jq .login` inside `scripts/pr`. Never infer a GitHub login from the chat user's name or identity. If the requester differs from the authenticated account or that relationship cannot be established safely, leave the target unassigned or require an explicit bare login.
 - Read current assignees with live `gh issue view` / `gh pr view`; `gitcrawl` is not enough for assignment state.
 - If unassigned, assign the requester only when an explicit land, fix-and-land, autonomous-resolution, or assignment request authorizes that mutation. For fix-only, review-only, triage-only, listing, or shortlist requests, report `unassigned` without assigning unless assignment is separately requested. Never auto-assign broad discovery candidates or shortlists.
 - If assigned to someone else, say so clearly before analysis and include assignment age:


### PR DESCRIPTION
AI-assisted: Codex

## What Problem This Solves

Fixes an issue where maintainer agents could infer a chat user's GitHub identity from an environment-specific hardcoded mapping and assign an issue or PR to the wrong account.

## Why This Change Was Made

The maintainer skill now resolves assignment identity from the GitHub account authenticated for the mutation, matching the canonical `scripts/pr` claim flow. When the requester differs from that account or the relationship is uncertain, the skill leaves the target unassigned or requires an explicit bare login.

## User Impact

Maintainer agents no longer guess GitHub assignment identity from chat identity.

## Evidence

- `python3 skills/skill-creator/scripts/quick_validate.py .agents/skills/openclaw-pr-maintainer` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Focused contract check confirmed `origin/main` contains `default Peter to steipete`, while this branch removes it and documents `gh api user --jq .login` / `gh_plain api user --jq .login`.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
