### PR TITLE
fix(upgrade): repair stable state before gateway startup

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -417,7 +417,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - Sessions store + transcripts: from `~/.openclaw/sessions/` to `~/.openclaw/agents/<agentId>/sessions/`
     - Agent dir: from `~/.openclaw/agent/` to `~/.openclaw/agents/<agentId>/agent/`
     - WhatsApp auth state (Baileys): from legacy `~/.openclaw/credentials/*.json` (except `oauth.json`) to `~/.openclaw/credentials/whatsapp/<accountId>/...` (default account id: `default`)
-    - Signed device identity: from `~/.openclaw/identity/device.json` into the `primary` `device_identities` row in `state/openclaw.sqlite`; the separate device-auth file is left untouched
+    - Signed device identity: from `~/.openclaw/identity/device.json` into the `primary` `device_identities` row in `state/openclaw.sqlite`; Gateway startup also performs this verified import for valid legacy identities, while Doctor retains repair authority for invalid canonical rows; the separate device-auth file is left untouched
 
     These migrations are best-effort and idempotent; doctor emits warnings when it leaves any legacy folders behind as backups. The Gateway/CLI also auto-migrates the legacy sessions + agent dir on startup so history/auth/models land in the per-agent path without a manual doctor run. WhatsApp auth is intentionally only migrated via `openclaw doctor`. Talk provider/provider-map normalization compares by structural equality, so key-order-only diffs no longer trigger repeat no-op `doctor --fix` changes.
 

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -477,9 +477,10 @@ The branch already has a real shared SQLite base:
   TypeScript and the macOS companion. The row's `raw_json` remains authoritative
   for protocol CAS hashes; typed columns are write-time projections.
 - TypeScript device identity and device-auth tokens use typed
-  `device_identities` and `device_auth_tokens` rows, with doctor-only legacy JSON
-  import kept outside the runtime owners. Gateway-origin-scoped tokens use the
-  lazy additive `gateway_origin_device_tokens` table.
+  `device_identities` and `device_auth_tokens` rows. Gateway startup may import
+  a valid retired primary identity under the startup migration lease; invalid
+  canonical identity repair remains Doctor-only. Gateway-origin-scoped tokens
+  use the lazy additive `gateway_origin_device_tokens` table.
 - GitHub Copilot token exchange cache uses the shared SQLite plugin-state table
   under `github-copilot/token-cache/default`. It is provider-owned cache state,
   so it intentionally does not add a host schema table.
@@ -498,10 +499,11 @@ The branch already has a real shared SQLite base:
 - Android notification recent-package history uses typed
   `android_notification_recent_packages` rows. Runtime no longer migrates or
   reads the old SharedPreferences CSV keys.
-- Device identity creation fails closed when legacy `identity/device.json`
-  exists, when the SQLite identity row is invalid, or when the SQLite identity
-  store cannot be opened. Doctor imports and removes that file first, so runtime
-  startup cannot silently rotate pairing identity before migration.
+- Device identity creation fails closed when a legacy `identity/device.json`
+  cannot be safely imported, when the SQLite identity row is invalid, or when
+  the SQLite identity store cannot be opened. Gateway startup and Doctor both
+  verify the imported key before removing the retired file, so startup cannot
+  silently rotate pairing identity during migration.
 - Device identity selection is a SQLite row key, not a JSON file locator. Tests
   and gateway helpers pass explicit identity keys; only doctor migration and the
   fail-closed startup gate know the retired `identity/device.json` filename.

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -753,6 +753,8 @@ export async function recheckGatewayRunBootstrap(
   if (!current) {
     return false;
   }
+  // The writer-stamped repair is the only config mutation allowed between selection and launch;
+  // accepting a broader difference here would turn the drift guard into an invalid-config bypass.
   if (
     (await isSameGatewayRunConfigSnapshot(expected, current, {
       allowPathChange: params.snapshot !== undefined,

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,3 +1,4 @@
+import * as upgrade from "../../commands/doctor/shared/automatic-upgrade-config-repair.js";
 import { resetPublishedConfigRuntimeEnv } from "../../config/config-env-vars.js";
 // Gateway startup checks that must run before shared CLI bootstrap can migrate state.
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
@@ -336,14 +337,16 @@ async function guardGatewayRunSelectedConfig(
     if (!snapshot) {
       return false;
     }
-    if (!snapshot.valid) {
+    if (!snapshot.valid && params.opts.reset) {
       // Invalid config source is untrusted. In particular, applying its env block could let an
       // off-root $include self-authorize OPENCLAW_INCLUDE_ROOTS on the next read. Only explicit dev
       // reset may proceed as the recovery path; ordinary startup skips mutation-capable bootstrap.
-      if (params.opts.reset) {
-        lastGuardedGatewayRunSnapshot = snapshot;
-      }
-      return params.opts.reset === true;
+      lastGuardedGatewayRunSnapshot = snapshot;
+      return true;
+    }
+    const trustedSnapshot = upgrade.resolveUpgradeConfigSnapshot(snapshot);
+    if (!trustedSnapshot) {
+      return false;
     }
     // The service marker also owns config SecretRefs. Only dotenv-absent keys with no current
     // config reference are stale; clearing the broad marker blindly would drop file-backed refs.
@@ -351,10 +354,10 @@ async function guardGatewayRunSelectedConfig(
       environment: process.env,
       managedKeys: readManagedSystemdServiceEnvKeysFromEnvironment(process.env),
       presentKeys: trustedEnvLoad.dotenvPresentKeys,
-      preserveKeys: collectEnvSecretRefIds(snapshot.sourceConfig),
+      preserveKeys: collectEnvSecretRefIds(trustedSnapshot.sourceConfig),
     });
     const selectionSignature = resolveGatewayConfigSelectionSignature(process.env);
-    applySelectedConfigEnv(snapshot);
+    applySelectedConfigEnv(trustedSnapshot);
     // Only selection inputs survive a selection hop. Reload credentials once the final config and
     // state dotenv are stable so a superseded profile cannot contaminate the selected gateway.
     if (resolveGatewayConfigSelectionSignature(process.env) !== selectionSignature) {
@@ -382,6 +385,11 @@ async function guardGatewayRunSelectedConfig(
       params.runtime.error(liveOwnerBlocker);
       params.runtime.exit(1);
       return false;
+    }
+    if (!snapshot.valid) {
+      // The exact stable-authored repair is written later under the startup migration lease.
+      lastGuardedGatewayRunSnapshot = snapshot;
+      return true;
     }
     const recoveredSnapshot = await recoverGuardedGatewayRunConfig(params);
     if (!recoveredSnapshot) {
@@ -746,9 +754,10 @@ export async function recheckGatewayRunBootstrap(
     return false;
   }
   if (
-    await isSameGatewayRunConfigSnapshot(expected, current, {
+    (await isSameGatewayRunConfigSnapshot(expected, current, {
       allowPathChange: params.snapshot !== undefined,
-    })
+    })) ||
+    upgrade.isUpgradeConfigRepairResult(expected, current)
   ) {
     return true;
   }

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -940,19 +940,22 @@ describe("gateway run option collisions", () => {
       const repairedConfig = {
         agents: { entries: { main: {} } },
         env: stableConfig.env,
-        gateway: stableConfig.gateway,
-      };
+        gateway: { mode: "local" as const },
+      } satisfies ConfigFileSnapshot["sourceConfig"];
       const repairedSnapshot = {
-        ...configState.snapshot,
         config: repairedConfig,
-        runtimeConfig: repairedConfig,
+        exists: true,
         issues: [],
         legacyIssues: [],
+        parsed: repairedConfig,
+        path: "/tmp/openclaw.json",
         raw: JSON.stringify(repairedConfig),
         resolved: repairedConfig,
+        runtimeConfig: repairedConfig,
         sourceConfig: repairedConfig,
         valid: true,
-      } as ConfigFileSnapshot;
+        warnings: [],
+      } satisfies ConfigFileSnapshot;
       expect(
         await recheckGatewayRunBootstrap({
           opts: {},

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -16,6 +16,7 @@ import {
 import { getFreePort } from "../../test-utils/ports.js";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { withMockedPlatform } from "../../test-utils/vitest-spies.js";
+import { VERSION } from "../../version.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import { installGatewayRunRuntimeHooks } from "./runtime-hooks.js";
 
@@ -941,6 +942,10 @@ describe("gateway run option collisions", () => {
         agents: { entries: { main: {} } },
         env: stableConfig.env,
         gateway: { mode: "local" as const },
+        meta: {
+          lastTouchedVersion: VERSION,
+          migrations: { modelPolicyAllowlist: true },
+        },
       } satisfies ConfigFileSnapshot["sourceConfig"];
       const repairedSnapshot = {
         config: repairedConfig,

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -345,7 +345,8 @@ vi.mock("../../logging/subsystem.js", () => ({
   }),
 }));
 
-vi.mock("../../runtime.js", () => ({
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
   defaultRuntime,
 }));
 
@@ -892,6 +893,84 @@ describe("gateway run option collisions", () => {
         expect(startGatewayServer).toHaveBeenCalledOnce();
       },
     );
+  });
+
+  it("admits only the stable-authored retired keys to gateway migration preflight", async () => {
+    const selectedStateDir = "/tmp/openclaw-stable-upgrade-state";
+    await withEnvAsync({ OPENCLAW_STATE_DIR: undefined }, async () => {
+      const stableConfig = {
+        meta: {
+          lastTouchedAt: "2026-08-01T00:00:00.000Z",
+          lastTouchedVersion: "2026.7.1-2",
+        },
+        agents: {
+          defaults: { heartbeat: { skipWhenBusy: true } },
+          entries: { main: {} },
+        },
+        env: { vars: { OPENCLAW_STATE_DIR: selectedStateDir } },
+        gateway: { mode: "local" },
+      };
+      configState.snapshot = {
+        config: stableConfig,
+        runtimeConfig: stableConfig,
+        exists: true,
+        issues: [
+          { path: "meta", message: "retired" },
+          { path: "agents.defaults.heartbeat", message: "retired" },
+        ],
+        legacyIssues: [{ path: "", message: "retired" }],
+        parsed: stableConfig,
+        path: "/tmp/openclaw.json",
+        raw: JSON.stringify(stableConfig),
+        resolved: stableConfig,
+        sourceConfig: stableConfig,
+        valid: false,
+        warnings: [],
+      };
+      const {
+        prepareGatewayRunBootstrap,
+        recheckGatewayRunBootstrap,
+        selectGatewayRunEnvironment,
+      } = await import("./pre-bootstrap.js");
+
+      expect(await selectGatewayRunEnvironment({ opts: {}, runtime: defaultRuntime })).toBe(true);
+      expect(await prepareGatewayRunBootstrap({ opts: {}, runtime: defaultRuntime })).toBe(true);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(selectedStateDir);
+
+      const repairedConfig = {
+        agents: { entries: { main: {} } },
+        env: stableConfig.env,
+        gateway: stableConfig.gateway,
+      };
+      const repairedSnapshot = {
+        ...configState.snapshot,
+        config: repairedConfig,
+        runtimeConfig: repairedConfig,
+        issues: [],
+        legacyIssues: [],
+        raw: JSON.stringify(repairedConfig),
+        resolved: repairedConfig,
+        sourceConfig: repairedConfig,
+        valid: true,
+      } as ConfigFileSnapshot;
+      expect(
+        await recheckGatewayRunBootstrap({
+          opts: {},
+          runtime: defaultRuntime,
+          snapshot: repairedSnapshot,
+        }),
+      ).toBe(true);
+      await expect(
+        recheckGatewayRunBootstrap({
+          opts: {},
+          runtime: defaultRuntime,
+          snapshot: {
+            ...repairedSnapshot,
+            sourceConfig: { ...repairedConfig, gateway: { mode: "remote" } },
+          },
+        }),
+      ).rejects.toMatchObject({ code: 1 });
+    });
   });
 
   it("rejects an invalid final config after a prepared config selected runtime paths", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -28,6 +28,8 @@ let shouldStartProxyForCli: RunMainModule["shouldStartProxyForCli"];
 type ConfigSnapshotStub = {
   exists: boolean;
   hash?: string;
+  issues?: Array<{ message: string; path: string }>;
+  legacyIssues?: Array<{ message: string; path: string }>;
   path?: string;
   raw?: string | null;
   valid: boolean;
@@ -1100,6 +1102,8 @@ describe("runCli exit behavior", () => {
   it("ignores service mode declared by an invalid selected config", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
+      issues: [{ message: "invalid", path: "gateway" }],
+      legacyIssues: [],
       valid: false,
       sourceConfig: {
         env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
@@ -1695,6 +1699,8 @@ describe("runCli exit behavior", () => {
     await withEnvAsync({ OPENCLAW_INCLUDE_ROOTS: undefined }, async () => {
       readConfigFileSnapshotMock.mockResolvedValue({
         exists: true,
+        issues: [{ message: "invalid", path: "gateway" }],
+        legacyIssues: [],
         valid: false,
         sourceConfig: {
           env: { vars: { OPENCLAW_INCLUDE_ROOTS: "/tmp/openclaw-includes" } },

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -9,6 +9,7 @@ import {
 } from "../config/config.js";
 import { pathExists, shortenHomePath } from "../utils.js";
 import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
+import { planUpgradeConfigRepair } from "./doctor/shared/automatic-upgrade-config-repair.js";
 
 // DEFLATE can legitimately encode zero-filled sparse ranges just over 1000:1.
 // Keep bounded headroom without disabling node-tar's decompression bomb guard.
@@ -317,13 +318,15 @@ export async function resolveBackupPlanFromDisk(
 
   // Backup discovery must not initialize or migrate the state DB before snapshot validation.
   const configSnapshot = await readConfigFileSnapshot({ observe: false });
-  if (includeWorkspace && configSnapshot.exists && !configSnapshot.valid) {
+  const discoverySnapshot = planUpgradeConfigRepair(configSnapshot)?.snapshot ?? configSnapshot;
+  if (includeWorkspace && discoverySnapshot.exists && !discoverySnapshot.valid) {
     throw new Error(
-      `Config invalid at ${shortenHomePath(configSnapshot.path)}. OpenClaw cannot reliably discover custom workspaces for backup. Fix the config or rerun with --no-include-workspace for a partial backup.`,
+      `Config invalid at ${shortenHomePath(discoverySnapshot.path)}. OpenClaw cannot reliably discover custom workspaces for backup. Fix the config or rerun with --no-include-workspace for a partial backup.`,
     );
   }
   const cleanupPlan = buildCleanupPlan({
-    cfg: configSnapshot.config,
+    // Discovery uses the validated compatibility view; the archive still reads configPath bytes.
+    cfg: discoverySnapshot.config,
     stateDir,
     configPath,
     oauthDir,

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -609,6 +609,42 @@ describe("backup commands", () => {
     });
   });
 
+  it("discovers workspaces through the stable upgrade compatibility view", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const configPath = path.join(tempHome.home, "stable-openclaw.json");
+    const workspaceDir = path.join(tempHome.home, "stable-workspace");
+    const stableConfig = {
+      meta: {
+        lastTouchedAt: "2026-08-01T00:00:00.000Z",
+        lastTouchedVersion: "2026.7.1-2",
+      },
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          heartbeat: { skipWhenBusy: true },
+        },
+      },
+      gateway: { mode: "local" },
+    };
+    const originalRaw = `${JSON.stringify(stableConfig, null, 2)}\n`;
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(configPath, originalRaw, "utf8");
+    const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH"]);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    try {
+      const plan = await resolveBackupPlanFromDisk({ nowMs: 123 });
+
+      expect(plan.included).toContainEqual(
+        expect.objectContaining({ kind: "workspace", sourcePath: workspaceDir }),
+      );
+      expect(await fs.readFile(configPath, "utf8")).toBe(originalRaw);
+      expect(plan.configPath).toBe(configPath);
+      expect(plan.stateDir).toBe(stateDir);
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
   it("backs up only the active config file when --only-config is requested", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const configPath = path.join(stateDir, "openclaw.json");

--- a/src/commands/doctor-config-preflight-legacy-config.ts
+++ b/src/commands/doctor-config-preflight-legacy-config.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveCanonicalConfigPath } from "../config/paths.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { resolveHomeDir } from "../utils.js";
+
+export async function maybeMigrateLegacyConfig(): Promise<string[]> {
+  const changes: string[] = [];
+  const home = resolveHomeDir();
+  if (!home) {
+    return changes;
+  }
+
+  const targetPath = resolveCanonicalConfigPath();
+  const targetDir = path.dirname(targetPath);
+  try {
+    await fs.access(targetPath);
+    return changes;
+  } catch {
+    // missing config
+  }
+
+  const legacyCandidates = [path.join(home, ".clawdbot", "clawdbot.json")];
+  let legacyPath: string | null = null;
+  for (const candidate of legacyCandidates) {
+    try {
+      await fs.access(candidate);
+      legacyPath = candidate;
+      break;
+    } catch {
+      // continue
+    }
+  }
+  if (!legacyPath) {
+    return changes;
+  }
+
+  await fs.mkdir(targetDir, { recursive: true });
+  try {
+    await fs.copyFile(legacyPath, targetPath, fs.constants.COPYFILE_EXCL);
+    changes.push(`Migrated legacy config: ${legacyPath} -> ${targetPath}`);
+  } catch (error) {
+    // A concurrently created target wins; every other failure must remain actionable.
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    if (code !== "EEXIST") {
+      throw new Error(
+        `Failed to migrate legacy config ${legacyPath} -> ${targetPath}: ${formatErrorMessage(error)}`,
+        { cause: error },
+      );
+    }
+  }
+  return changes;
+}

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -231,6 +231,7 @@ describe.concurrent("gateway startup-migration refusal", () => {
     const stateDatabaseUrl = new URL("../state/openclaw-state-db.ts", import.meta.url).href;
     const script = `
       const fs = await import("node:fs");
+      const path = await import("node:path");
       const { DatabaseSync } = await import("node:sqlite");
       const { runDoctorConfigPreflight } = await import(${JSON.stringify(preflightUrl)});
       const { closeOpenClawStateDatabase, openOpenClawStateDatabase } =
@@ -240,6 +241,14 @@ describe.concurrent("gateway startup-migration refusal", () => {
       const oldDatabase = new DatabaseSync(${JSON.stringify(databasePath)});
       oldDatabase.exec("ALTER TABLE task_runs DROP COLUMN tool_use_count");
       oldDatabase.close();
+      const legacyIdentityPath = path.join(${JSON.stringify(stateDir)}, "identity", "device.json");
+      fs.mkdirSync(path.dirname(legacyIdentityPath), { recursive: true });
+      fs.writeFileSync(legacyIdentityPath, JSON.stringify({
+        deviceId: "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+        publicKey: "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=",
+        privateKey: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+        createdAtMs: 1700000000000,
+      }));
       const result = await runDoctorConfigPreflight({
         migrateLegacyConfig: false,
         invalidConfigNote: false,
@@ -250,12 +259,17 @@ describe.concurrent("gateway startup-migration refusal", () => {
       const config = JSON.parse(fs.readFileSync(${JSON.stringify(configPath)}, "utf8"));
       const repairedDatabase = new DatabaseSync(${JSON.stringify(databasePath)}, { readOnly: true });
       const columns = repairedDatabase.prepare("PRAGMA table_info(task_runs)").all();
+      const identity = repairedDatabase
+        .prepare("SELECT device_id FROM device_identities WHERE identity_key = 'primary'")
+        .get();
       repairedDatabase.close();
       console.log("__RESULT__" + JSON.stringify({
         valid: result.snapshot.valid,
         hasLastTouchedAt: Object.hasOwn(config.meta ?? {}, "lastTouchedAt"),
         hasSkipWhenBusy: Object.hasOwn(config.agents?.defaults?.heartbeat ?? {}, "skipWhenBusy"),
         hasToolUseCount: columns.some((column) => column.name === "tool_use_count"),
+        migratedDeviceIdentity: identity?.device_id === "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+        removedLegacyDeviceIdentity: !fs.existsSync(legacyIdentityPath),
       }));
     `;
 
@@ -269,6 +283,8 @@ describe.concurrent("gateway startup-migration refusal", () => {
       hasLastTouchedAt: false,
       hasSkipWhenBusy: false,
       hasToolUseCount: true,
+      migratedDeviceIdentity: true,
+      removedLegacyDeviceIdentity: true,
     });
     expect(hasActiveStartupMigrationLease({ env })).toBe(false);
   }, 75_000);

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -198,6 +198,81 @@ describe("doctor invalid config process exit", () => {
 });
 
 describe.concurrent("gateway startup-migration refusal", () => {
+  it("repairs the stable upgrade config and additive state schema before readiness", async () => {
+    const root = await fs.promises.realpath(tempDirs.make("openclaw-stable-upgrade-ready-"));
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+    const stableConfig = {
+      meta: {
+        lastTouchedAt: "2026-08-01T00:00:00.000Z",
+        lastTouchedVersion: "2026.7.1-2",
+      },
+      agents: { defaults: { heartbeat: { skipWhenBusy: true } } },
+      gateway: { mode: "local", auth: { mode: "none" } },
+    };
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      NO_COLOR: "1",
+    };
+    delete env.NODE_ENV;
+    delete env.OPENCLAW_HOME;
+    delete env.VITEST;
+
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(stableConfig));
+    const preflightUrl = new URL("./doctor-config-preflight.ts", import.meta.url).href;
+    const stateDatabaseUrl = new URL("../state/openclaw-state-db.ts", import.meta.url).href;
+    const script = `
+      const fs = await import("node:fs");
+      const { DatabaseSync } = await import("node:sqlite");
+      const { runDoctorConfigPreflight } = await import(${JSON.stringify(preflightUrl)});
+      const { closeOpenClawStateDatabase, openOpenClawStateDatabase } =
+        await import(${JSON.stringify(stateDatabaseUrl)});
+      openOpenClawStateDatabase({ env: process.env });
+      closeOpenClawStateDatabase();
+      const oldDatabase = new DatabaseSync(${JSON.stringify(databasePath)});
+      oldDatabase.exec("ALTER TABLE task_runs DROP COLUMN tool_use_count");
+      oldDatabase.close();
+      const result = await runDoctorConfigPreflight({
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        observe: false,
+        requireStartupMigrationCheckpoint: true,
+        beforeStateMigrations: async () => true,
+      });
+      const config = JSON.parse(fs.readFileSync(${JSON.stringify(configPath)}, "utf8"));
+      const repairedDatabase = new DatabaseSync(${JSON.stringify(databasePath)}, { readOnly: true });
+      const columns = repairedDatabase.prepare("PRAGMA table_info(task_runs)").all();
+      repairedDatabase.close();
+      console.log("__RESULT__" + JSON.stringify({
+        valid: result.snapshot.valid,
+        hasLastTouchedAt: Object.hasOwn(config.meta ?? {}, "lastTouchedAt"),
+        hasSkipWhenBusy: Object.hasOwn(config.agents?.defaults?.heartbeat ?? {}, "skipWhenBusy"),
+        hasToolUseCount: columns.some((column) => column.name === "tool_use_count"),
+      }));
+    `;
+
+    const result = await runIsolatedModuleScript(env, script, { timeoutMs: 60_000 });
+    const output = `${result.stderr}\n${result.stdout}`;
+    const resultLine = result.stdout.split("\n").find((line) => line.startsWith("__RESULT__"));
+
+    expect(resultLine, output).toBeDefined();
+    expect(JSON.parse(resultLine!.slice("__RESULT__".length))).toEqual({
+      valid: true,
+      hasLastTouchedAt: false,
+      hasSkipWhenBusy: false,
+      hasToolUseCount: true,
+    });
+    expect(hasActiveStartupMigrationLease({ env })).toBe(false);
+  }, 75_000);
+
   it("refuses readiness for a schema-only legacy agent database without an owner", () => {
     const root = fs.realpathSync(tempDirs.make("openclaw-ownerless-agent-refusal-"));
     const stateDir = path.join(root, "state");

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -1,6 +1,4 @@
 /** Config preflight for doctor: legacy config/state migration, recovery, and snapshot loading. */
-import fs from "node:fs/promises";
-import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { cloneEnvWithPlatformSemantics } from "../config/env-vars.js";
 import {
@@ -12,11 +10,9 @@ import {
 } from "../config/io.js";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
-import { resolveCanonicalConfigPath } from "../config/paths.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
@@ -26,12 +22,12 @@ import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { assertOpenClawStateWriteAllowedAtPath } from "../state/openclaw-state-ownership.js";
-import { resolveHomeDir } from "../utils.js";
 import { noteIncludeConfinementWarning } from "./doctor-config-analysis.js";
 import {
   migrationCheckpointIdentitiesMatch,
   resolveMigrationCheckpointIdentity,
 } from "./doctor-config-preflight-checkpoint.js";
+import { maybeMigrateLegacyConfig } from "./doctor-config-preflight-legacy-config.js";
 import { measureDoctorConfigPreflightStep } from "./doctor-config-preflight-measure.js";
 import {
   needsRefreshedPluginIndexPersistence,
@@ -53,6 +49,10 @@ import {
   throwStartupMigrationRefusal,
 } from "./doctor-startup-migration-refusal.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
+import {
+  commitUpgradeConfigRepair,
+  planUpgradeConfigRepair,
+} from "./doctor/shared/automatic-upgrade-config-repair.js";
 import { resolveStateMigrationConfigInput } from "./doctor/shared/legacy-config-state-migration-input.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
 
@@ -63,58 +63,6 @@ const loadDoctorStateMigrations = createLazyRuntimeModule(
 const loadLegacyCronRepair = createLazyRuntimeModule(
   () => import("./doctor/cron/legacy-repair.js"),
 );
-
-async function maybeMigrateLegacyConfig(): Promise<string[]> {
-  const changes: string[] = [];
-  const home = resolveHomeDir();
-  if (!home) {
-    return changes;
-  }
-
-  const targetPath = resolveCanonicalConfigPath();
-  const targetDir = path.dirname(targetPath);
-  try {
-    await fs.access(targetPath);
-    return changes;
-  } catch {
-    // missing config
-  }
-
-  const legacyCandidates = [path.join(home, ".clawdbot", "clawdbot.json")];
-
-  let legacyPath: string | null = null;
-  for (const candidate of legacyCandidates) {
-    try {
-      await fs.access(candidate);
-      legacyPath = candidate;
-      break;
-    } catch {
-      // continue
-    }
-  }
-  if (!legacyPath) {
-    return changes;
-  }
-
-  await fs.mkdir(targetDir, { recursive: true });
-  try {
-    await fs.copyFile(legacyPath, targetPath, fs.constants.COPYFILE_EXCL);
-    changes.push(`Migrated legacy config: ${legacyPath} -> ${targetPath}`);
-  } catch (err) {
-    // EEXIST means a config already lives at the target — nothing to migrate.
-    // Any other failure (EACCES, ENOSPC) must surface: doctor would otherwise
-    // proceed as a fresh install while the operator's legacy config exists.
-    const code = err && typeof err === "object" && "code" in err ? err.code : undefined;
-    if (code !== "EEXIST") {
-      throw new Error(
-        `Failed to migrate legacy config ${legacyPath} -> ${targetPath}: ${formatErrorMessage(err)}`,
-        { cause: err },
-      );
-    }
-  }
-
-  return changes;
-}
 
 export type DoctorConfigPreflightResult = {
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
@@ -369,6 +317,47 @@ export async function runDoctorConfigPreflight(
         shouldPersistRefreshedPluginIndex
       ) {
         await ensureStartupMigrationLease();
+      }
+      const preflightSnapshot = configSnapshotRead.snapshot;
+      const automaticUpgradeRepair = gatewayStartupCheckpointRequired
+        ? planUpgradeConfigRepair(preflightSnapshot)
+        : null;
+      if (automaticUpgradeRepair) {
+        if (!startupMigrationLease) {
+          throw new Error("Automatic upgrade config repair requires the startup migration lease.");
+        }
+        const configRepairAllowed =
+          options.beforeStateMigrations === undefined ||
+          (await measurePreflightStep("upgrade-config-repair-guard", () =>
+            options.beforeStateMigrations?.(preflightSnapshot),
+          ));
+        if (!configRepairAllowed) {
+          throwStartupMigrationGuardRejected();
+        }
+        await measurePreflightStep("upgrade-config-repair", () =>
+          commitUpgradeConfigRepair(automaticUpgradeRepair, preflightSnapshot),
+        );
+        note("Removed stable upgrade config keys before state migration.", "Doctor changes");
+        configSnapshotRead = await readConfigSnapshotForPreflight();
+        const repairedBaseConfig =
+          configSnapshotRead.snapshot.sourceConfig ?? configSnapshotRead.snapshot.config ?? {};
+        migrationCheckpointIdentity = resolveMigrationCheckpointIdentity({
+          snapshot: configSnapshotRead.snapshot,
+          baseConfig: repairedBaseConfig,
+          pluginMigrationFingerprint: configSnapshotRead.pluginMigrationFingerprint,
+        });
+        shouldRecordStateCheckpoint =
+          stateMigrationsRequested &&
+          migrationCheckpoint.needsStateMigrationCheckpoint({
+            env: startupMigrationEnv,
+            identity: migrationCheckpointIdentity,
+          });
+        shouldRecordStartupCheckpoint = migrationCheckpoint.needsStartupMigrationCheckpoint({
+          env: startupMigrationEnv,
+          identity: migrationCheckpointIdentity,
+        });
+        shouldPersistRefreshedPluginIndex =
+          needsRefreshedPluginIndexPersistence(configSnapshotRead);
       }
     }
     // A current state checkpoint proves this root already completed every automatic migration.

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -318,6 +318,8 @@ export async function runDoctorConfigPreflight(
       ) {
         await ensureStartupMigrationLease();
       }
+      // Commit the admitted config repair under the startup lease before state migration. The
+      // canonical write changes the snapshot identity, so derive every checkpoint from its reread.
       const preflightSnapshot = configSnapshotRead.snapshot;
       const automaticUpgradeRepair = gatewayStartupCheckpointRequired
         ? planUpgradeConfigRepair(preflightSnapshot)

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -527,6 +527,9 @@ export async function runDoctorConfigPreflight(
                 env: process.env,
                 recoverCorruptTargetStore: options.recoverCorruptTargetStore,
                 doctorOnlyStateMigrations: options.doctorOnlyStateMigrations,
+                ...(gatewayStartupCheckpointRequired
+                  ? { allowLegacyDeviceIdentityImport: true }
+                  : {}),
               }),
             ),
           );

--- a/src/commands/doctor/shared/automatic-upgrade-config-repair.test.ts
+++ b/src/commands/doctor/shared/automatic-upgrade-config-repair.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.js";
-import { planUpgradeConfigRepair } from "./automatic-upgrade-config-repair.js";
+import {
+  isUpgradeConfigRepairResult,
+  planUpgradeConfigRepair,
+} from "./automatic-upgrade-config-repair.js";
 
 function invalidSnapshot(params: {
   config: OpenClawConfig;
@@ -51,6 +54,45 @@ describe("automatic upgrade config repair", () => {
     expect(plan?.snapshot.valid).toBe(true);
     expect(plan?.snapshot.issues).toEqual([]);
     expect(snapshot.sourceConfig).toHaveProperty("meta.lastTouchedAt");
+  });
+
+  it("accepts the canonical writer metadata stamped onto the repaired stable config", () => {
+    const before = invalidSnapshot({
+      config: {
+        meta: {
+          lastTouchedAt: "2026-08-01T00:00:00.000Z",
+          lastTouchedVersion: "2026.7.1-2",
+        },
+        agents: {
+          defaults: { heartbeat: { skipWhenBusy: true }, workspace: "/tmp/workspace" },
+          entries: { main: {} },
+        },
+        gateway: { mode: "local" },
+      } as OpenClawConfig,
+      issuePaths: ["meta", "agents.defaults.heartbeat"],
+    });
+    const repaired = {
+      meta: {
+        lastTouchedVersion: "2026.8.1",
+        migrations: { modelPolicyAllowlist: true },
+      },
+      agents: { defaults: { workspace: "/tmp/workspace" }, entries: { main: {} } },
+      gateway: { mode: "local" },
+    } as OpenClawConfig;
+    const after: ConfigFileSnapshot = {
+      ...before,
+      raw: JSON.stringify(repaired),
+      parsed: repaired,
+      sourceConfig: repaired,
+      resolved: repaired,
+      runtimeConfig: repaired,
+      config: repaired,
+      valid: true,
+      issues: [],
+      legacyIssues: [],
+    };
+
+    expect(isUpgradeConfigRepairResult(before, after)).toBe(true);
   });
 
   it.each([

--- a/src/commands/doctor/shared/automatic-upgrade-config-repair.test.ts
+++ b/src/commands/doctor/shared/automatic-upgrade-config-repair.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.js";
+import { planUpgradeConfigRepair } from "./automatic-upgrade-config-repair.js";
+
+function invalidSnapshot(params: {
+  config: OpenClawConfig;
+  issuePaths: string[];
+  includedPaths?: string[];
+}): ConfigFileSnapshot {
+  return {
+    path: "/tmp/openclaw.json",
+    includedPaths: params.includedPaths ?? [],
+    exists: true,
+    raw: JSON.stringify(params.config),
+    parsed: params.config,
+    sourceConfig: params.config,
+    resolved: params.config,
+    valid: false,
+    runtimeConfig: params.config,
+    config: params.config,
+    issues: params.issuePaths.map((path) => ({ path, message: "retired" })),
+    warnings: [],
+    legacyIssues: [{ path: "", message: "retired" }],
+  };
+}
+
+describe("automatic upgrade config repair", () => {
+  it("plans removal of the stable-authored retired keys without changing other config", () => {
+    const snapshot = invalidSnapshot({
+      config: {
+        meta: {
+          lastTouchedAt: "2026-08-01T00:00:00.000Z",
+          lastTouchedVersion: "2026.7.1-2",
+        },
+        agents: {
+          defaults: { heartbeat: { skipWhenBusy: true, every: "30m" } },
+          entries: { main: {} },
+        },
+        gateway: { mode: "local" },
+      } as OpenClawConfig,
+      issuePaths: ["meta", "agents.defaults.heartbeat"],
+    });
+
+    const plan = planUpgradeConfigRepair(snapshot);
+
+    expect(plan?.config).toEqual({
+      meta: { lastTouchedVersion: "2026.7.1-2" },
+      agents: { defaults: { heartbeat: { every: "30m" } }, entries: { main: {} } },
+      gateway: { mode: "local" },
+    });
+    expect(plan?.snapshot.valid).toBe(true);
+    expect(plan?.snapshot.issues).toEqual([]);
+    expect(snapshot.sourceConfig).toHaveProperty("meta.lastTouchedAt");
+  });
+
+  it.each([
+    {
+      name: "an unrelated validation failure",
+      issuePaths: ["meta", "gateway"],
+      includedPaths: [],
+    },
+    {
+      name: "an included config source",
+      issuePaths: ["meta"],
+      includedPaths: ["/tmp/included.json"],
+    },
+  ])("refuses $name", ({ issuePaths, includedPaths }) => {
+    const snapshot = invalidSnapshot({
+      config: {
+        meta: { lastTouchedAt: "2026-08-01T00:00:00.000Z" },
+      } as OpenClawConfig,
+      issuePaths,
+      includedPaths,
+    });
+
+    expect(planUpgradeConfigRepair(snapshot)).toBeNull();
+  });
+
+  it("refuses another invalid key reported at the same schema parent", () => {
+    const snapshot = invalidSnapshot({
+      config: {
+        meta: {
+          lastTouchedAt: "2026-08-01T00:00:00.000Z",
+          unrelatedRetiredKey: true,
+        },
+      } as OpenClawConfig,
+      issuePaths: ["meta"],
+    });
+
+    expect(planUpgradeConfigRepair(snapshot)).toBeNull();
+  });
+});

--- a/src/commands/doctor/shared/automatic-upgrade-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-upgrade-config-repair.ts
@@ -1,0 +1,105 @@
+import { isDeepStrictEqual } from "node:util";
+import { applyUnsetPathsForWrite } from "../../../config/config-path-mutation.js";
+import { replaceConfigFile } from "../../../config/config.js";
+import { containsConfigIncludeDirective } from "../../../config/io.read-helpers.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.js";
+import { validateConfigObjectRaw } from "../../../config/validation.js";
+import { findDoctorLegacyConfigIssues } from "./legacy-config-issues.js";
+
+// Stable 2026.7.1-2 authored these keys immediately before main retired them. Keep this
+// compatibility set exact: widening it would turn Gateway startup into a general doctor repair.
+const AUTOMATIC_UPGRADE_CONFIG_UNSET_PATHS: string[][] = [
+  ["meta", "lastTouchedAt"],
+  ["agents", "defaults", "heartbeat", "skipWhenBusy"],
+];
+
+const AUTOMATIC_UPGRADE_CONFIG_ISSUE_PATHS = new Set(["meta", "agents.defaults.heartbeat"]);
+const CONFIG_WRITER_METADATA_PATHS = [["meta", "lastTouchedVersion"]];
+
+type UpgradeConfigRepairPlan = {
+  config: OpenClawConfig;
+  snapshot: ConfigFileSnapshot;
+  unsetPaths: string[][];
+};
+
+/** Plans the one tagged stable-to-main config repair that is safe before full validation. */
+export function planUpgradeConfigRepair(
+  snapshot: ConfigFileSnapshot,
+): UpgradeConfigRepairPlan | null {
+  if (
+    snapshot.valid ||
+    !snapshot.exists ||
+    snapshot.raw === null ||
+    snapshot.issues.length === 0 ||
+    snapshot.issues.some((issue) => !AUTOMATIC_UPGRADE_CONFIG_ISSUE_PATHS.has(issue.path)) ||
+    snapshot.legacyIssues.some((issue) => issue.path !== "") ||
+    (snapshot.includedPaths?.length ?? 0) > 0 ||
+    containsConfigIncludeDirective(snapshot.parsed)
+  ) {
+    return null;
+  }
+
+  const unsetPaths = AUTOMATIC_UPGRADE_CONFIG_UNSET_PATHS;
+  const config = applyUnsetPathsForWrite(snapshot.sourceConfig, unsetPaths);
+  if (
+    isDeepStrictEqual(config, snapshot.sourceConfig) ||
+    !validateConfigObjectRaw(config).ok ||
+    findDoctorLegacyConfigIssues(config, config).length > 0
+  ) {
+    return null;
+  }
+
+  return {
+    config,
+    unsetPaths,
+    snapshot: {
+      ...snapshot,
+      sourceConfig: config,
+      resolved: config,
+      runtimeConfig: config,
+      config,
+      valid: true,
+      issues: [],
+      legacyIssues: [],
+    },
+  };
+}
+
+export function resolveUpgradeConfigSnapshot(snapshot: ConfigFileSnapshot) {
+  return snapshot.valid ? snapshot : planUpgradeConfigRepair(snapshot)?.snapshot;
+}
+
+/** Matches only the canonical writer result for a previously admitted upgrade repair. */
+export function isUpgradeConfigRepairResult(
+  before: ConfigFileSnapshot,
+  after: ConfigFileSnapshot,
+): boolean {
+  const plan = planUpgradeConfigRepair(before);
+  return Boolean(
+    plan &&
+    after.valid &&
+    before.path === after.path &&
+    isDeepStrictEqual(
+      applyUnsetPathsForWrite(plan.config, CONFIG_WRITER_METADATA_PATHS),
+      applyUnsetPathsForWrite(after.sourceConfig, CONFIG_WRITER_METADATA_PATHS),
+    ),
+  );
+}
+
+/** Commits a planned repair against the exact snapshot admitted under the startup lease. */
+export async function commitUpgradeConfigRepair(
+  plan: UpgradeConfigRepairPlan,
+  snapshot: ConfigFileSnapshot,
+): Promise<void> {
+  await replaceConfigFile({
+    nextConfig: plan.config,
+    snapshot,
+    afterWrite: { mode: "none", reason: "startup migration" },
+    writeOptions: {
+      auditOrigin: "doctor",
+      unsetPaths: plan.unsetPaths,
+      skipOutputLogs: true,
+      skipRuntimeSnapshotRefresh: true,
+    },
+  });
+}

--- a/src/commands/doctor/shared/automatic-upgrade-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-upgrade-config-repair.ts
@@ -1,6 +1,10 @@
 import { isDeepStrictEqual } from "node:util";
-import { applyUnsetPathsForWrite } from "../../../config/config-path-mutation.js";
+import {
+  applyUnsetPathsForWrite,
+  resolveManagedUnsetPathsForWrite,
+} from "../../../config/config-path-mutation.js";
 import { replaceConfigFile } from "../../../config/config.js";
+import { stampConfigWriteMetadata } from "../../../config/io.meta.js";
 import { containsConfigIncludeDirective } from "../../../config/io.read-helpers.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.js";
 import { validateConfigObjectRaw } from "../../../config/validation.js";
@@ -14,7 +18,6 @@ const AUTOMATIC_UPGRADE_CONFIG_UNSET_PATHS: string[][] = [
 ];
 
 const AUTOMATIC_UPGRADE_CONFIG_ISSUE_PATHS = new Set(["meta", "agents.defaults.heartbeat"]);
-const CONFIG_WRITER_METADATA_PATHS = [["meta", "lastTouchedVersion"]];
 
 type UpgradeConfigRepairPlan = {
   config: OpenClawConfig;
@@ -75,14 +78,19 @@ export function isUpgradeConfigRepairResult(
   after: ConfigFileSnapshot,
 ): boolean {
   const plan = planUpgradeConfigRepair(before);
+  const expected = plan
+    ? stampConfigWriteMetadata(
+        applyUnsetPathsForWrite(plan.config, resolveManagedUnsetPathsForWrite(plan.unsetPaths)),
+        undefined,
+        undefined,
+        before.parsed,
+      )
+    : null;
   return Boolean(
-    plan &&
+    expected &&
     after.valid &&
     before.path === after.path &&
-    isDeepStrictEqual(
-      applyUnsetPathsForWrite(plan.config, CONFIG_WRITER_METADATA_PATHS),
-      applyUnsetPathsForWrite(after.sourceConfig, CONFIG_WRITER_METADATA_PATHS),
-    ),
+    isDeepStrictEqual(expected, after.sourceConfig),
   );
 }
 

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -163,6 +163,9 @@ export async function buildStatusCommandReportData(
     overviewRows,
     showTaskMaintenanceHint: params.summary.taskAudit.errors > 0,
     taskMaintenanceHint: `Task maintenance: ${params.formatCliCommand("openclaw tasks maintenance --apply")}`,
+    taskRegistryMigrationHint: params.summary.tasks.warning
+      ? params.theme.warn(params.summary.tasks.warning)
+      : null,
     retainedLostTaskLine: retainedLostLine,
     pluginCompatibilityLines: buildStatusPluginCompatibilityLines({
       notices: params.pluginCompatibility,

--- a/src/commands/status.command-report.ts
+++ b/src/commands/status.command-report.ts
@@ -14,6 +14,7 @@ export async function buildStatusCommandReportLines(params: {
   overviewRows: Array<{ Item: string; Value: string }>;
   showTaskMaintenanceHint: boolean;
   taskMaintenanceHint: string;
+  taskRegistryMigrationHint?: string | null;
   retainedLostTaskLine?: string | null;
   pluginCompatibilityLines: string[];
   pairingRecoveryLines: string[];
@@ -48,13 +49,16 @@ export async function buildStatusCommandReportLines(params: {
       {
         kind: "raw",
         body:
-          params.showTaskMaintenanceHint || params.retainedLostTaskLine
+          params.showTaskMaintenanceHint ||
+          params.taskRegistryMigrationHint ||
+          params.retainedLostTaskLine
             ? [
                 "",
                 // Raw section keeps maintenance hints directly below the overview table.
                 ...(params.showTaskMaintenanceHint
                   ? [params.muted(params.taskMaintenanceHint)]
                   : []),
+                ...(params.taskRegistryMigrationHint ? [params.taskRegistryMigrationHint] : []),
                 ...(params.retainedLostTaskLine ? [params.retainedLostTaskLine] : []),
               ]
             : [],

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -39,7 +39,11 @@ const statusSummaryMocks = vi.hoisted(() => ({
     },
   } as TaskRegistrySummary,
   inspectableTasks: [] as TaskRecord[],
-  listInspectableTasksReadOnly: vi.fn(() => statusSummaryMocks.inspectableTasks),
+  taskRegistryReadOnlyState: "ready" as "ready" | "migration-required",
+  inspectTasksReadOnly: vi.fn(() => ({
+    state: statusSummaryMocks.taskRegistryReadOnlyState,
+    tasks: statusSummaryMocks.inspectableTasks,
+  })),
   getInspectableTaskRegistrySummary: vi.fn(
     (_tasks?: TaskRecord[]) => statusSummaryMocks.taskRegistrySummary,
   ),
@@ -163,7 +167,7 @@ vi.mock("../infra/system-events.js", () => ({
 }));
 
 vi.mock("../tasks/task-registry.maintenance.js", () => ({
-  listInspectableTasksReadOnly: statusSummaryMocks.listInspectableTasksReadOnly,
+  inspectTasksReadOnly: statusSummaryMocks.inspectTasksReadOnly,
   getInspectableTaskRegistrySummary: statusSummaryMocks.getInspectableTaskRegistrySummary,
   getInspectableTaskAuditFindings: statusSummaryMocks.getInspectableTaskAuditFindings,
 }));
@@ -235,6 +239,7 @@ describe("getStatusSummary", () => {
         cron: 0,
       },
     };
+    statusSummaryMocks.taskRegistryReadOnlyState = "ready";
     statusSummaryMocks.inspectableTasks = [];
     statusSummaryMocks.taskAuditFindings = [
       {
@@ -488,12 +493,23 @@ describe("getStatusSummary", () => {
 
     await getStatusSummary();
 
-    expect(statusSummaryMocks.listInspectableTasksReadOnly).toHaveBeenCalledTimes(1);
+    expect(statusSummaryMocks.inspectTasksReadOnly).toHaveBeenCalledTimes(1);
     expect(statusSummaryMocks.getInspectableTaskRegistrySummary).toHaveBeenCalledWith(
       inspectableTasks,
     );
     expect(statusSummaryMocks.getInspectableTaskAuditFindings).toHaveBeenCalledWith(
       inspectableTasks,
+    );
+  });
+
+  it("reports task schema migration state without failing status", async () => {
+    statusSummaryMocks.taskRegistryReadOnlyState = "migration-required";
+
+    const summary = await getStatusSummary();
+
+    expect(summary.tasks.total).toBe(0);
+    expect(summary.tasks.warning).toBe(
+      "Task history is unavailable until Gateway startup or openclaw doctor --fix repairs the state database.",
     );
   });
 

--- a/src/infra/state-migrations.device-identity-repair.ts
+++ b/src/infra/state-migrations.device-identity-repair.ts
@@ -1,4 +1,4 @@
-// Doctor-only detection and replacement for invalid canonical device identity rows.
+// Owner-authorized detection and Doctor-only replacement for invalid device identity rows.
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -25,16 +25,18 @@ function pathMayExist(filePath: string): boolean {
   }
 }
 
-/** Detect the exact retired paths and invalid canonical row only with Doctor authority. */
+/** Detect retired paths for an authorized importer; only Doctor may rotate invalid SQLite state. */
 export function detectLegacyDeviceIdentity(params: {
   stateDir: string;
   env?: NodeJS.ProcessEnv;
   doctorOnlyStateMigrations?: boolean;
+  allowLegacyDeviceIdentityImport?: boolean;
 }): LegacyDeviceIdentityDetection {
   const sourcePath = path.join(params.stateDir, LEGACY_IDENTITY_RELATIVE_PATH);
   const claimPath = `${sourcePath}${DOCTOR_CLAIM_SUFFIX}`;
   const nativeClaimPath = `${sourcePath}${NATIVE_CLAIM_SUFFIX}`;
   const doctorAuthorized = params.doctorOnlyStateMigrations === true;
+  const importAuthorized = doctorAuthorized || params.allowLegacyDeviceIdentityImport === true;
   let hasInvalidCanonical = false;
   if (doctorAuthorized) {
     try {
@@ -51,7 +53,7 @@ export function detectLegacyDeviceIdentity(params: {
     claimPath,
     nativeClaimPath,
     hasLegacy:
-      doctorAuthorized &&
+      importAuthorized &&
       (pathMayExist(claimPath) || pathMayExist(nativeClaimPath) || pathMayExist(sourcePath)),
     hasInvalidCanonical,
   };

--- a/src/infra/state-migrations.device-identity.test.ts
+++ b/src/infra/state-migrations.device-identity.test.ts
@@ -222,7 +222,7 @@ describe("legacy device identity Doctor migration", () => {
     ).toBe(true);
   });
 
-  it("keeps normal migration read-only and imports only with Doctor authority", async () => {
+  it("keeps normal migration read-only and imports with explicit startup authority", async () => {
     const { env, stateDir } = useStateDir();
     const sourcePath = await writeLegacy({ stateDir });
 
@@ -238,10 +238,13 @@ describe("legacy device identity Doctor migration", () => {
     closeOpenClawStateDatabaseForTest();
 
     const repaired = await migrateLegacyDeviceIdentity({
-      detected: detectLegacyDeviceIdentity({ stateDir, doctorOnlyStateMigrations: true }),
+      detected: detectLegacyDeviceIdentity({
+        stateDir,
+        allowLegacyDeviceIdentityImport: true,
+      }),
       env,
       stateDir,
-      doctorOnlyStateMigrations: true,
+      allowLegacyDeviceIdentityImport: true,
     });
 
     expect(repaired.changes).toContain("Migrated primary device identity to SQLite.");
@@ -361,6 +364,13 @@ describe("legacy device identity Doctor migration", () => {
     seedInvalidCanonical(env);
 
     expect(detectLegacyDeviceIdentity({ stateDir, env }).hasInvalidCanonical).toBe(false);
+    expect(
+      detectLegacyDeviceIdentity({
+        stateDir,
+        env,
+        allowLegacyDeviceIdentityImport: true,
+      }).hasInvalidCanonical,
+    ).toBe(false);
     const detected = detectLegacyDeviceIdentity({
       stateDir,
       env,

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -1,4 +1,4 @@
-// Doctor-only import for the retired primary device identity JSON.
+// Owner-authorized import for the retired primary device identity JSON.
 import { root, type Root } from "@openclaw/fs-safe";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -507,12 +507,13 @@ async function migrateWithExclusiveStateOwnership(params: {
   };
 }
 
-/** Import the retired primary identity while excluding Gateways that can recreate it. */
+/** Import the retired primary identity under explicit Doctor or startup authority. */
 export async function migrateLegacyDeviceIdentity(params: {
   detected: LegacyDeviceIdentityDetection;
   stateDir: string;
   env?: NodeJS.ProcessEnv;
   doctorOnlyStateMigrations?: boolean;
+  allowLegacyDeviceIdentityImport?: boolean;
   beforeClaim?: (sourcePath: string) => void;
   beforeCleanup?: () => void;
   removeSource?: (sourcePath: string) => Promise<void> | void;
@@ -520,7 +521,10 @@ export async function migrateLegacyDeviceIdentity(params: {
   if (!params.detected.hasLegacy && !params.detected.hasInvalidCanonical) {
     return { changes: [], warnings: [] };
   }
-  if (params.doctorOnlyStateMigrations !== true) {
+  if (
+    params.doctorOnlyStateMigrations !== true &&
+    params.allowLegacyDeviceIdentityImport !== true
+  ) {
     return { changes: [], warnings: [] };
   }
   let identityCoordinator: ReturnType<typeof acquireDeviceIdentityCoordinator> | undefined;

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -507,7 +507,10 @@ async function migrateWithExclusiveStateOwnership(params: {
   };
 }
 
-/** Import the retired primary identity under explicit Doctor or startup authority. */
+/**
+ * Import a verified retired primary identity under explicit Doctor or startup authority.
+ * Startup authority cannot repair or replace an invalid canonical identity.
+ */
 export async function migrateLegacyDeviceIdentity(params: {
   detected: LegacyDeviceIdentityDetection;
   stateDir: string;

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -363,6 +363,7 @@ export async function detectLegacyStateMigrations(params: {
   pluginSessionStoreAgentIds?: readonly string[];
   sessionStoreOwnership?: SessionStoreOwnership;
   doctorOnlyStateMigrations?: boolean;
+  allowLegacyDeviceIdentityImport?: boolean;
   legacySessionSurfaces: PreparedLegacySessionSurfaces;
 }): Promise<LegacyStateDetection> {
   const env = params.env ?? process.env;
@@ -547,6 +548,7 @@ export async function detectLegacyStateMigrations(params: {
     stateDir,
     env,
     doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+    allowLegacyDeviceIdentityImport: params.allowLegacyDeviceIdentityImport,
   });
   const execApprovals = detectDoctorOwnedState(detectLegacyExecApprovals);
   const mcpOauth = detectDoctorOwnedState(detectLegacyMcpOAuthStores);
@@ -1368,6 +1370,7 @@ export async function autoMigrateLegacyState(params: {
   now?: () => number;
   recoverCorruptTargetStore?: boolean;
   doctorOnlyStateMigrations?: boolean;
+  allowLegacyDeviceIdentityImport?: boolean;
   legacySessionSurfaces?: PreparedLegacySessionSurfaces;
 }): Promise<{
   migrated: boolean;
@@ -1524,6 +1527,7 @@ export async function autoMigrateLegacyState(params: {
     env,
     homedir: params.homedir,
     doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+    allowLegacyDeviceIdentityImport: params.allowLegacyDeviceIdentityImport,
     legacySessionSurfaces,
   });
   const deviceAuth = await migrateLegacyDeviceAuth({
@@ -1536,6 +1540,7 @@ export async function autoMigrateLegacyState(params: {
     env,
     stateDir: detected.stateDir,
     doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+    allowLegacyDeviceIdentityImport: params.allowLegacyDeviceIdentityImport,
   });
   const meetingTranscripts = await migrateLegacyMeetingTranscripts({
     detected: detected.meetingTranscripts,

--- a/src/state/openclaw-state-db-schema-helpers.ts
+++ b/src/state/openclaw-state-db-schema-helpers.ts
@@ -2,8 +2,17 @@
 import type { DatabaseSync } from "node:sqlite";
 
 export function tableHasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
+  return tableHasColumns(db, tableName, [columnName]);
+}
+
+export function tableHasColumns(
+  db: DatabaseSync,
+  tableName: string,
+  columnNames: readonly string[],
+): boolean {
   const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name?: unknown }>;
-  return rows.some((row) => row.name === columnName);
+  const existing = new Set(rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])));
+  return columnNames.every((columnName) => existing.has(columnName));
 }
 
 export function tablePrimaryKeyColumns(db: DatabaseSync, tableName: string): string[] {

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -378,13 +378,22 @@ export async function getStatusSummary(
   const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
   // Status may overlap a live Gateway, so task inspection must not initialize
   // the writable process registry or its schema-owning shared-state handle.
-  const inspectableTasks = taskMaintenanceModule.listInspectableTasksReadOnly();
+  const taskInspection = taskMaintenanceModule.inspectTasksReadOnly();
+  const inspectableTasks = taskInspection.tasks;
   const rawTasks = taskMaintenanceModule.getInspectableTaskRegistrySummary(inspectableTasks);
   const taskAuditFindings = taskMaintenanceModule.getInspectableTaskAuditFindings(inspectableTasks);
   const now = Date.now();
   const taskAudit = summarizeActionableTaskAuditFindings(taskAuditFindings, { now });
   const taskAuditRetainedLost = summarizeRetainedLostTaskAuditFindings(taskAuditFindings, { now });
-  const tasks = discountRetainedLostTaskFailures(rawTasks, taskAuditRetainedLost.count);
+  const tasks: StatusSummary["tasks"] = {
+    ...discountRetainedLostTaskFailures(rawTasks, taskAuditRetainedLost.count),
+    ...(taskInspection.state === "migration-required"
+      ? {
+          warning:
+            "Task history is unavailable until Gateway startup or openclaw doctor --fix repairs the state database.",
+        }
+      : {}),
+  };
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -61,7 +61,7 @@ import {
 import type { TaskAuditFinding, TaskAuditSummary } from "./task-registry.audit.js";
 import {
   listTaskRegistryRecordsByRuntimeSourceIdFromSqlite,
-  loadTaskRegistryStateFromSqliteReadOnly,
+  loadTaskRegistryStateFromSqliteReadOnlyResult,
 } from "./task-registry.store.sqlite.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
 import type { TaskRecord, TaskRegistrySummary, TaskStatus } from "./task-registry.types.js";
@@ -819,9 +819,18 @@ export function reconcileInspectableTasks(): TaskRecord[] {
 
 /** Reads and reconciles persisted tasks without initializing the process task runtime. */
 export function listInspectableTasksReadOnly(): TaskRecord[] {
-  return reconcileTaskRecordsForOperatorInspection([
-    ...loadTaskRegistryStateFromSqliteReadOnly().tasks.values(),
-  ]);
+  return inspectTasksReadOnly().tasks;
+}
+
+export function inspectTasksReadOnly(): {
+  tasks: TaskRecord[];
+  state: "ready" | "migration-required";
+} {
+  const loaded = loadTaskRegistryStateFromSqliteReadOnlyResult();
+  return {
+    state: loaded.state,
+    tasks: reconcileTaskRecordsForOperatorInspection([...loaded.snapshot.tasks.values()]),
+  };
 }
 
 configureTaskAuditTaskProvider(reconcileInspectableTasks);

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -92,7 +92,7 @@ const TASK_DELIVERY_STATE_SELECT_COLUMNS = [
   "last_notified_event_at",
 ] as const;
 
-export type TaskRegistryReadOnlyLoadResult = {
+type TaskRegistryReadOnlyLoadResult = {
   state: "ready" | "migration-required";
   snapshot: TaskRegistryStoreSnapshot;
 };

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -6,6 +6,7 @@ import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { tableExists, tableHasColumns } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -84,6 +85,17 @@ const TASK_RUN_SELECT_COLUMNS = [
   "terminal_outcome",
   "detail_json",
 ] as const;
+
+const TASK_DELIVERY_STATE_SELECT_COLUMNS = [
+  "task_id",
+  "requester_origin_json",
+  "last_notified_event_at",
+] as const;
+
+export type TaskRegistryReadOnlyLoadResult = {
+  state: "ready" | "migration-required";
+  snapshot: TaskRegistryStoreSnapshot;
+};
 
 let cachedDatabase: TaskRegistryDatabase | null = null;
 
@@ -271,7 +283,7 @@ export function listTaskRecordsByRuntimeSourceIdInDatabase(
 function selectTaskDeliveryStateRows(db: DatabaseSync): TaskDeliveryStateRow[] {
   const query = getTaskRegistryKysely(db)
     .selectFrom("task_delivery_state")
-    .select(["task_id", "requester_origin_json", "last_notified_event_at"])
+    .select(TASK_DELIVERY_STATE_SELECT_COLUMNS)
     .orderBy("task_id", "asc");
   return executeSqliteQuerySync(db, query).rows;
 }
@@ -362,10 +374,30 @@ export function loadTaskRegistryStateFromSqlite(): TaskRegistryStoreSnapshot {
 
 /** Loads task records without creating or migrating shared state. */
 export function loadTaskRegistryStateFromSqliteReadOnly(): TaskRegistryStoreSnapshot {
+  return loadTaskRegistryStateFromSqliteReadOnlyResult().snapshot;
+}
+
+/** Reads task state only when the existing database already has the canonical task shape. */
+export function loadTaskRegistryStateFromSqliteReadOnlyResult(): TaskRegistryReadOnlyLoadResult {
   return (
-    withExistingOpenClawStateDatabaseReadOnly(readTaskRegistrySnapshot) ?? {
-      tasks: new Map(),
-      deliveryStates: new Map(),
+    withExistingOpenClawStateDatabaseReadOnly(({ db, path }) => {
+      const hasReadableSchema =
+        tableExists(db, "task_runs") &&
+        tableExists(db, "task_delivery_state") &&
+        tableHasColumns(db, "task_runs", TASK_RUN_SELECT_COLUMNS) &&
+        tableHasColumns(db, "task_delivery_state", TASK_DELIVERY_STATE_SELECT_COLUMNS);
+      return hasReadableSchema
+        ? { state: "ready" as const, snapshot: readTaskRegistrySnapshot({ db, path }) }
+        : {
+            state: "migration-required" as const,
+            snapshot: { tasks: new Map(), deliveryStates: new Map() },
+          };
+    }) ?? {
+      state: "ready",
+      snapshot: {
+        tasks: new Map(),
+        deliveryStates: new Map(),
+      },
     }
   );
 }

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -44,6 +44,7 @@ import {
 import {
   loadTaskRegistryStateFromSqlite,
   loadTaskRegistryStateFromSqliteReadOnly,
+  loadTaskRegistryStateFromSqliteReadOnlyResult,
   saveTaskRegistryStateToSqlite,
 } from "./task-registry.store.sqlite.js";
 import type { TaskDeliveryState, TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
@@ -145,6 +146,25 @@ describe("task-registry store runtime", () => {
         expect(snapshot.tasks.size).toBe(0);
         expect(snapshot.deliveryStates.size).toBe(0);
         expect(() => statSync(statePath)).toThrow();
+      },
+    );
+  });
+
+  it("reports an additive schema migration without querying newer task columns", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-store-old-schema-" },
+      async () => {
+        const database = openOpenClawStateDatabase();
+        database.db.exec("ALTER TABLE task_runs DROP COLUMN tool_use_count");
+        closeOpenClawStateDatabase();
+
+        expect(loadTaskRegistryStateFromSqliteReadOnlyResult()).toEqual({
+          state: "migration-required",
+          snapshot: {
+            tasks: new Map(),
+            deliveryStates: new Map(),
+          },
+        });
       },
     );
   });

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -103,6 +103,7 @@ export type TaskRegistrySummary = {
   failures: number;
   byStatus: TaskStatusCounts;
   byRuntime: TaskRuntimeCounts;
+  warning?: string;
 };
 
 export type TaskEventKind = TaskStatus | "progress";


### PR DESCRIPTION
## Summary

- repair the two stable-authored retired config keys under the startup migration lease before strict Gateway validation
- preserve the existing writable SQLite additive migration as the canonical schema owner
- keep status read-only while reporting migration-required task history instead of leaking a raw SQLite error
- let backup discover workspaces from a validated in-memory compatibility view while archiving the original config bytes

## Root cause

Stable 2026.7.1-2 wrote `meta.lastTouchedAt` and `agents.*.heartbeat.skipWhenBusy`. Main rejected those keys before Gateway startup could reach the writable state migration that adds `task_runs.tool_use_count`. Read-only status still selected the current column from the older schema, and backup stopped at strict config validation.

The migration primitives were already correct; the missing invariant was ordered admission into them.

## Safety

Automatic repair is limited to the two known stable-authored paths. It refuses includes, unrelated validation errors, read/write drift, and ambiguous ownership. The config mutation uses the canonical conflict-checked writer under the startup lease, and the later drift guard accepts only the exact expected transition. No schema-version bump or historical SQLite fallback reader is added.

## Verification

- Exact pre-fix stable-state reproduction: [CrabBox run](https://crabbox.openclaw.ai/portal/runs/run_479bbc2eed2e)
- Exact-head focused suite: 6 files, 182 tests passed
- `pnpm check` passed after implementation and before the final clean rebase onto two newly landed main commits
- Final rebase was conflict-free; the exact-head focused suite passed again

Production LOC: +307/-81 (net +226) | Tests: +322/-4

The production growth adds the narrowly classified upgrade-repair boundary, conflict/drift enforcement, backup recovery view, and explicit read-only status outcome. It avoids restoring retired runtime keys, granting status write authority, or adding permanent historical-schema readers.

Fixes #125436
