### PR TITLE
feat(control-ui): move the Ask OpenClaw toggle to the sidebar footer

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -141,7 +141,7 @@ Theme, theme mode, language, and chat display preferences sync through the gatew
 
 ## OpenClaw system care
 
-Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. Toggle it from anywhere with the lobster button in the shell chrome or the **Ask OpenClaw** command-palette action. The full page and dockable panel share one machine-wide conversation whose durable history lives on the Gateway. Closing the UI never cancels a turn; reopening Ask OpenClaw shows the completed conversation. The panel docks on the right or bottom, remembers its placement and size in the browser profile, and hides itself while the full page is open.
+Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. Toggle it from anywhere with the lobster button in the sidebar footer or the **Ask OpenClaw** command-palette action. The full page and dockable panel share one machine-wide conversation whose durable history lives on the Gateway. Closing the UI never cancels a turn; reopening Ask OpenClaw shows the completed conversation. The panel docks on the right or bottom, remembers its placement and size in the browser profile, and hides itself while the full page is open.
 
 Each chat message carries the Control UI page you are currently viewing as an untrusted ambient hint, so requests like "configure this channel" or "why is this page empty?" resolve against the page you are looking at.
 

--- a/ui/src/app/app-host.dock-suppression.test.ts
+++ b/ui/src/app/app-host.dock-suppression.test.ts
@@ -218,5 +218,15 @@ describe("OpenClaw shell dock suppression", () => {
     context.sessions.state.result = null;
     renderLit(shell.render(), container);
     expect(desktopAvailable()).toBe(true);
+
+    // Collapsed-nav fallback: the Ask OpenClaw toggle joins the chrome strip
+    // only while the sidebar (its footer home) is hidden, and stays admin-gated.
+    expect(container.querySelector(".shell-chrome-controls__custodian")).toBeNull();
+    context.navigation.snapshot.navCollapsed = true;
+    renderLit(shell.render(), container);
+    expect(container.querySelector(".shell-chrome-controls__custodian")).not.toBeNull();
+    context.gateway.snapshot.hello!.auth = { role: "operator", scopes: ["operator.read"] };
+    renderLit(shell.render(), container);
+    expect(container.querySelector(".shell-chrome-controls__custodian")).toBeNull();
   });
 });

--- a/ui/src/app/app-host.dock-suppression.test.ts
+++ b/ui/src/app/app-host.dock-suppression.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
 import type { RouteId } from "../app-routes.ts";
-import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../components/panel-toggle-contract.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { resetAppHostTestGlobals } from "./app-host.test-support.ts";
 import "./app-host.ts";
@@ -163,15 +162,6 @@ describe("OpenClaw shell dock suppression", () => {
 
     shell.routeState = { routeId: "chat" };
     renderLit(shell.render(), container);
-    const custodianToggle = container.querySelector<HTMLButtonElement>(
-      ".shell-chrome-controls__custodian",
-    );
-    expect(custodianToggle).not.toBeNull();
-    const toggleListener = vi.fn();
-    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, toggleListener);
-    custodianToggle?.click();
-    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, toggleListener);
-    expect(toggleListener).toHaveBeenCalledOnce();
     expect(
       (
         container.querySelector("openclaw-terminal-panel") as HTMLElement & {
@@ -228,25 +218,5 @@ describe("OpenClaw shell dock suppression", () => {
     context.sessions.state.result = null;
     renderLit(shell.render(), container);
     expect(desktopAvailable()).toBe(true);
-
-    context.gateway.snapshot.hello!.features!.methods = [
-      "terminal.open",
-      "browser.request",
-      "desktop.observe",
-    ];
-    renderLit(shell.render(), container);
-    expect(container.querySelector(".shell-chrome-controls__custodian")).toBeNull();
-
-    // Advertised but read-scoped: openclaw.chat requires operator.admin, so the
-    // control must hide instead of opening a panel the store refuses to use.
-    context.gateway.snapshot.hello!.features!.methods = [
-      "terminal.open",
-      "browser.request",
-      "openclaw.chat",
-      "desktop.observe",
-    ];
-    context.gateway.snapshot.hello!.auth = { role: "operator", scopes: ["operator.read"] };
-    renderLit(shell.render(), container);
-    expect(container.querySelector(".shell-chrome-controls__custodian")).toBeNull();
   });
 });

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -7,6 +7,7 @@ import type {
   SidebarWorkboardSnapshot,
 } from "../components/app-sidebar-workboard.ts";
 import { icons } from "../components/icons.ts";
+import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../components/panel-toggle-contract.ts";
 import { renderSettingsSidebar } from "../components/settings-sidebar.ts";
 import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { t } from "../i18n/index.ts";
@@ -548,6 +549,19 @@ export function renderApplicationShell(host: ShellViewHost) {
                   ${icons.search}
                 </button>
               </openclaw-tooltip>
+              ${navCollapsed && custodianPanelAvailable
+                ? html`<openclaw-tooltip .content=${t("nav.askOpenClaw")}>
+                    <button
+                      type="button"
+                      class="shell-chrome-controls__button shell-chrome-controls__custodian"
+                      aria-label=${t("nav.askOpenClaw")}
+                      @click=${() =>
+                        window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))}
+                    >
+                      ${icons.lobster}
+                    </button>
+                  </openclaw-tooltip>`
+                : nothing}
             </div>
           `
         : nothing}

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -7,7 +7,6 @@ import type {
   SidebarWorkboardSnapshot,
 } from "../components/app-sidebar-workboard.ts";
 import { icons } from "../components/icons.ts";
-import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../components/panel-toggle-contract.ts";
 import { renderSettingsSidebar } from "../components/settings-sidebar.ts";
 import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { t } from "../i18n/index.ts";
@@ -549,19 +548,6 @@ export function renderApplicationShell(host: ShellViewHost) {
                   ${icons.search}
                 </button>
               </openclaw-tooltip>
-              ${custodianPanelAvailable
-                ? html`<openclaw-tooltip .content=${t("nav.askOpenClaw")}>
-                    <button
-                      type="button"
-                      class="shell-chrome-controls__button shell-chrome-controls__custodian"
-                      aria-label=${t("nav.askOpenClaw")}
-                      @click=${() =>
-                        window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))}
-                    >
-                      ${icons.lobster}
-                    </button>
-                  </openclaw-tooltip>`
-                : nothing}
             </div>
           `
         : nothing}

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -14,6 +14,7 @@ import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel, resolveAgentTextAvatar } from "../lib/agents/display.ts";
 import { deriveAvatarInitial, resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { sessionHasBoard } from "../lib/board/provider.ts";
+import { canCallGatewayMethod } from "../lib/gateway-methods.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import {
   resolveSessionPreferredFace,
@@ -30,6 +31,7 @@ import type { AppSidebarSessionNavigationElement } from "./app-sidebar-session-n
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
 import { icons } from "./icons.ts";
+import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "./panel-toggle-contract.ts";
 import {
   renderSessionAttentionIcon,
   renderSessionRunSpinner,
@@ -249,6 +251,11 @@ export function renderAppSidebarPagesHead(host: AppSidebarRenderHost) {
 
 /** Zone 5: product chrome recedes to one slim footer bar. */
 export function renderAppSidebarFooterBar(host: AppSidebarRenderHost) {
+  const custodianPanelAvailable = canCallGatewayMethod(
+    host.sessionDataContext?.gateway.snapshot,
+    "openclaw.chat",
+    "operator.admin",
+  );
   const selfUser = resolveCurrentSelfUser({
     snapshotUser: host.sessionDataContext?.gateway.snapshot.selfUser,
     presenceEntries: readPresenceEntries(host.sessionData.presencePayload),
@@ -287,7 +294,11 @@ export function renderAppSidebarFooterBar(host: AppSidebarRenderHost) {
         >
           <openclaw-viewer-avatar .user=${avatarUser} variant="footer"></openclaw-viewer-avatar>
           <span class="sidebar-identity-card__text">
-            <span class="sidebar-identity-card__name">${selfLabel}</span>
+            <span class="sidebar-identity-card__name"
+              >${selfLabel}<span class="sidebar-identity-card__chevron" aria-hidden="true"
+                >${icons.chevronDown}</span
+              ></span
+            >
             ${host.offline
               ? html`<span class="sidebar-identity-card__subtitle" aria-hidden="true"
                   >${t("connection.reconnecting")}</span
@@ -314,14 +325,23 @@ export function renderAppSidebarFooterBar(host: AppSidebarRenderHost) {
                     >`
                   : nothing}
           </span>
-          <span class="sidebar-identity-card__chevron" aria-hidden="true"
-            >${icons.chevronDown}</span
+          <span class="sidebar-identity-card__status" role="status" aria-live="polite"
+            >${host.offline ? t("connection.reconnecting") : ""}</span
           >
         </button>
       </openclaw-tooltip>
-      <span class="sidebar-identity-card__status" role="status" aria-live="polite"
-        >${host.offline ? t("connection.reconnecting") : ""}</span
-      >
+      ${custodianPanelAvailable
+        ? html`<openclaw-tooltip .content=${t("nav.askOpenClaw")}>
+            <button
+              type="button"
+              class="sidebar-brand__icon sidebar-footer-bar__custodian"
+              aria-label=${t("nav.askOpenClaw")}
+              @click=${() => window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))}
+            >
+              ${icons.lobster}
+            </button>
+          </openclaw-tooltip>`
+        : nothing}
     </div>
   `;
 }

--- a/ui/src/e2e/custodian-panel-toggle.e2e.test.ts
+++ b/ui/src/e2e/custodian-panel-toggle.e2e.test.ts
@@ -62,7 +62,7 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
     await server?.close();
   });
 
-  it("hides the chrome toggle when openclaw.chat is not advertised", async () => {
+  it("hides the sidebar footer toggle when openclaw.chat is not advertised", async () => {
     const context = await browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -76,7 +76,8 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
       const response = await page.goto(`${server.baseUrl}chat`);
       expect(response?.status()).toBe(200);
       await page.locator(".shell-chrome-controls__search").waitFor();
-      await expect.poll(() => page.locator(".shell-chrome-controls__custodian").count()).toBe(0);
+      await page.locator(".sidebar-identity-card").waitFor();
+      await expect.poll(() => page.locator(".sidebar-footer-bar__custodian").count()).toBe(0);
       await page.screenshot({
         animations: "disabled",
         path: path.join(artifactDir, "00-gated-off-no-button.png"),
@@ -86,7 +87,7 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
     }
   });
 
-  it("toggles the panel from chrome and palette and reuses the persisted session id", async () => {
+  it("toggles the panel from the sidebar and palette and reuses the persisted session id", async () => {
     const context = await browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -101,16 +102,16 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
       const response = await page.goto(`${server.baseUrl}chat`);
       expect(response?.status()).toBe(200);
 
-      // The lobster chrome button renders only while openclaw.chat is advertised.
-      const chromeToggle = page.locator(".shell-chrome-controls__custodian");
-      await chromeToggle.waitFor();
+      // The lobster footer button renders only while openclaw.chat is advertised.
+      const footerToggle = page.locator(".sidebar-footer-bar__custodian");
+      await footerToggle.waitFor();
       await page.screenshot({
         animations: "disabled",
-        path: path.join(artifactDir, "01-chrome-button.png"),
+        path: path.join(artifactDir, "01-sidebar-footer-button.png"),
       });
 
       // Opening the panel renders the durable machine-wide history from the Gateway.
-      await chromeToggle.click();
+      await footerToggle.click();
       const panel = page.locator("openclaw-custodian-panel");
       await panel.getByText("Channel repaired.").waitFor();
       const chatRequest = await gateway.waitForRequest("openclaw.chat");
@@ -122,13 +123,13 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
       });
 
       // The same button closes it again.
-      await chromeToggle.click();
+      await footerToggle.click();
       await panel.getByText("Channel repaired.").waitFor({ state: "hidden" });
 
       // The command palette exposes the same toggle from anywhere. Its action
-      // dispatches the identical toggle event the chrome button uses (pinned by
+      // dispatches the identical toggle event the footer button uses (pinned by
       // the palette unit test), so this asserts the gated entry exists and
-      // reopens through the chrome path — the palette click-through composition
+      // reopens through the footer path — the palette click-through composition
       // proved timing-flaky on loaded CI runners without adding coverage.
       await page.locator(".shell-chrome-controls__search").click();
       await page.getByPlaceholder("Search chats and commands…").fill("Ask OpenClaw");
@@ -139,7 +140,7 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
         path: path.join(artifactDir, "03-palette-item.png"),
       });
       await page.keyboard.press("Escape");
-      await chromeToggle.click();
+      await footerToggle.click();
       await panel.getByText("Channel repaired.").waitFor();
 
       // The server-confirmed session id persists and is reused after a full reload.

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -12,8 +12,7 @@
   --shell-chrome-controls-gap: 4px;
   --shell-chrome-controls-collapsed-width: calc(
     var(--shell-chrome-control-size) + var(--shell-chrome-control-size) +
-      var(--shell-chrome-control-size) + var(--shell-chrome-control-size) +
-      var(--shell-chrome-controls-gap) + var(--shell-chrome-controls-gap) +
+      var(--shell-chrome-control-size) + var(--shell-chrome-controls-gap) +
       var(--shell-chrome-controls-gap)
   );
   --shell-chrome-safe-area-left: calc(
@@ -998,13 +997,15 @@ openclaw-settings-save-indicator {
   stroke-linejoin: round;
 }
 
-.sidebar-brand__new-thread {
+.sidebar-brand__new-thread,
+.sidebar-footer-bar__custodian {
   width: 32px;
   height: 32px;
   color: var(--text);
 }
 
-.sidebar-brand__new-thread svg {
+.sidebar-brand__new-thread svg,
+.sidebar-footer-bar__custodian svg {
   width: 18px;
   height: 18px;
 }
@@ -3353,12 +3354,14 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-footer-bar {
   display: flex;
   align-items: center;
+  gap: 8px;
   padding: 6px 12px;
 }
 
 .sidebar-identity-card {
   display: flex;
   align-items: center;
+  flex: 1 1 auto;
   gap: 8px;
   width: 100%;
   min-width: 0;
@@ -3407,6 +3410,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-identity-card__name {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   color: var(--text-strong);
   font-size: calc(13px * var(--control-ui-text-scale));
   font-weight: 600;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -10,9 +10,12 @@
   --shell-chrome-controls-inset: 10px;
   --shell-chrome-control-size: 32px;
   --shell-chrome-controls-gap: 4px;
+  /* Four controls: the admin-gated Ask OpenClaw fallback joins the strip only
+     while the nav is collapsed, which is exactly when this width applies. */
   --shell-chrome-controls-collapsed-width: calc(
     var(--shell-chrome-control-size) + var(--shell-chrome-control-size) +
-      var(--shell-chrome-control-size) + var(--shell-chrome-controls-gap) +
+      var(--shell-chrome-control-size) + var(--shell-chrome-control-size) +
+      var(--shell-chrome-controls-gap) + var(--shell-chrome-controls-gap) +
       var(--shell-chrome-controls-gap)
   );
   --shell-chrome-safe-area-left: calc(

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import { sessionRefFromPath } from "../../app-session-route-paths.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../../components/panel-toggle-contract.ts";
 import {
   clearSessionBoardAvailability,
   recordSessionBoardAvailability,
@@ -195,7 +197,7 @@ describe("AppSidebar viewer presence", () => {
     ).toEqual(["Alice", "bob@example.test", "Carol", "Dave\nErin\nFrank"]);
 
     const identityCard = sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card");
-    expect(identityCard?.querySelector(".sidebar-identity-card__name")?.textContent).toBe(
+    expect(identityCard?.querySelector(".sidebar-identity-card__name")?.textContent?.trim()).toBe(
       "Self User",
     );
     expect(identityCard?.querySelector('[data-viewer-id="00-self"]')).not.toBeNull();
@@ -208,7 +210,7 @@ describe("AppSidebar viewer presence", () => {
     expect(footer?.querySelector(".sidebar-brand__logo-slot")).toBeNull();
     expect([...(footer?.children ?? [])].map((element) => element.localName)).toEqual([
       "openclaw-tooltip",
-      "span",
+      "openclaw-tooltip",
     ]);
     gatewayHarness.gateway.updateSelfUser?.({
       name: "Augusta Ada",
@@ -217,14 +219,16 @@ describe("AppSidebar viewer presence", () => {
     await sidebar.updateComplete;
 
     // Profile mutations update gateway state directly; no presence event follows them.
-    expect(identityCard?.querySelector(".sidebar-identity-card__name")?.textContent).toBe(
+    expect(identityCard?.querySelector(".sidebar-identity-card__name")?.textContent?.trim()).toBe(
       "Augusta Ada",
     );
     expect(avatar?.getAttribute("src")).toBe("/api/users/00-self/avatar?v=4");
 
     sidebar.connected = false;
     await sidebar.updateComplete;
-    expect(sidebar.querySelector(".sidebar-identity-card__name")?.textContent).toBe("Augusta Ada");
+    expect(sidebar.querySelector(".sidebar-identity-card__name")?.textContent?.trim()).toBe(
+      "Augusta Ada",
+    );
   });
 
   it("renders an Account fallback for an unidentified connection", async () => {
@@ -244,7 +248,7 @@ describe("AppSidebar viewer presence", () => {
     await sidebar.updateComplete;
 
     const identityCard = sidebar.querySelector(".sidebar-identity-card");
-    expect(identityCard?.querySelector(".sidebar-identity-card__name")?.textContent).toBe(
+    expect(identityCard?.querySelector(".sidebar-identity-card__name")?.textContent?.trim()).toBe(
       "Account",
     );
     expect(identityCard?.querySelector('[data-viewer-id="account"]')?.textContent).toContain("A");
@@ -292,6 +296,49 @@ describe("AppSidebar brand actions", () => {
       '[data-session-section="ungrouped"] .sidebar-new-session',
     );
     expect(headerButton?.getAttribute("aria-label")).toBe("New session");
+  });
+});
+
+describe("AppSidebar footer actions", () => {
+  it("gates Ask OpenClaw on the advertised method and admin scope", async () => {
+    const gatewayHarness = createGatewayHarness({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(
+      gatewayHarness.gateway,
+      createSessions("main", ["agent:main:main"]),
+    );
+
+    gatewayHarness.publish({
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin"] },
+        features: { methods: ["openclaw.chat"] },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    await sidebar.updateComplete;
+    const toggle = sidebar.querySelector<HTMLButtonElement>(".sidebar-footer-bar__custodian");
+    expect(toggle?.getAttribute("aria-label")).toBe("Ask OpenClaw");
+    const toggleListener = vi.fn();
+    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, toggleListener);
+    toggle?.click();
+    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, toggleListener);
+    expect(toggleListener).toHaveBeenCalledOnce();
+
+    gatewayHarness.publish({
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin"] },
+        features: { methods: [] as string[] },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-footer-bar__custodian")).toBeNull();
+
+    gatewayHarness.publish({
+      hello: {
+        auth: { role: "operator", scopes: ["operator.read"] },
+        features: { methods: ["openclaw.chat"] },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-footer-bar__custodian")).toBeNull();
   });
 });
 
@@ -431,7 +478,9 @@ describe("AppSidebar agent chip", () => {
     sidebar.offline = true;
     await sidebar.updateComplete;
     const card = sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card");
-    expect(card?.querySelector(".sidebar-identity-card__name")?.textContent).toBe("Account");
+    expect(card?.querySelector(".sidebar-identity-card__name")?.textContent?.trim()).toBe(
+      "Account",
+    );
     expect(card?.querySelector(".sidebar-identity-card__subtitle")?.textContent).toBe(
       "Reconnecting…",
     );


### PR DESCRIPTION
## What Problem This Solves

The Ask OpenClaw toggle shipped in #125107 as a third icon in the top-left `shell-chrome-controls` strip — a frame-utility cluster (nav collapse, palette) that is the wrong semantic neighborhood for a persistent agent companion, and its four-button width reservation charged read-scoped clients ~28px of dead inset for a button they never see.

## Why This Change Was Made

Product decision (maintainer): the sidebar's bottom now mirrors its top. Top = big agent selector with inline chevron + small square new-session button; bottom = big account identity card + small square lobster toggle. To complete the mirror, the account chevron moves from the row's far right to directly after the name, matching the top header treatment; the freed right edge hosts the toggle. The old chrome-strip placement is deleted along with its width reservation. Scope gating (`canCallGatewayMethod(…, "operator.admin")`), the command-palette entry, and all panel/deferred wiring are unchanged; the admin/read-scope/not-advertised regressions moved to the sidebar test cases.

## User Impact

Admins summon Ask OpenClaw from a labeled-by-position, always-visible spot that reads as part of the sidebar's identity zone rather than an anonymous chrome icon; read-scoped clients lose a layout wart. Palette access is unchanged.

## Evidence

- Full UI suite 9289 passed post-rebase; custodian e2e re-shot with the footer selectors (2/2); oxlint/oxfmt/tsgo:ui/stylelint/check-changed clean; Codex autoreview clean. Production delta +36/−24.
- Live screenshots (isolated dev gateway, real model, this branch's build):

**The mirror (light):**

![footer closed](https://github.com/user-attachments/assets/29260e69-0cb1-4e3c-9d5f-ab625e6cd9f5)

**Footer close-up — inline chevron + lobster:**

![footer close-up](https://github.com/user-attachments/assets/e502a238-8d59-48ca-8fbc-c454f049a392)

**Panel opened from the new button (prior session's history intact across gateway restart):**

![panel open](https://github.com/user-attachments/assets/52334fd3-f2a8-4e9a-bcfd-bc52c0693550)

**Dark theme (mocked rig):**

![dark](https://github.com/user-attachments/assets/edae3d80-3c60-4a98-8b4e-b9dfbc56bafc)
