### PR TITLE
fix(macos): avoid elevation codesign metadata SIGPIPE

### DIFF
--- a/scripts/mac-elevation-host.sh
+++ b/scripts/mac-elevation-host.sh
@@ -316,9 +316,10 @@ plist_file_value() {
 codesign_metadata_value() {
   local target="$1" key="$2" output
   shift 2
-  if ! output="$(codesign -dv --verbose=4 "$@" "$target" 2>&1)"; then
-    return 1
-  fi
+  output="$(codesign -dv --verbose=4 "$@" "$target" 2>&1)" || {
+    local rc=$?
+    return "$rc"
+  }
   awk -F= -v key="$key" '
     $1 == key && !found { value = $2; found = 1 }
     END { if (!found) exit 1; print value }

--- a/scripts/mac-elevation-host.sh
+++ b/scripts/mac-elevation-host.sh
@@ -313,12 +313,24 @@ plist_file_value() {
   plutil -extract "$2" raw -o - "$1" 2>/dev/null || true
 }
 
+codesign_metadata_value() {
+  local target="$1" key="$2" output
+  shift 2
+  if ! output="$(codesign -dv --verbose=4 "$@" "$target" 2>&1)"; then
+    return 1
+  fi
+  awk -F= -v key="$key" '
+    $1 == key && !found { value = $2; found = 1 }
+    END { if (!found) exit 1; print value }
+  ' <<<"$output"
+}
+
 codesign_value() {
-  codesign -dv --verbose=4 "$1" 2>&1 | awk -F= -v key="$2" '$1 == key {print $2; exit}'
+  codesign_metadata_value "$1" "$2"
 }
 
 codesign_value_for_arch() {
-  codesign -dv --verbose=4 --arch "$3" "$1" 2>&1 | awk -F= -v key="$2" '$1 == key {print $2; exit}'
+  codesign_metadata_value "$1" "$2" --arch "$3"
 }
 
 entitlements_for() {

--- a/test/scripts/mac-elevation-host.test.ts
+++ b/test/scripts/mac-elevation-host.test.ts
@@ -1286,7 +1286,7 @@ describe("mac elevation host command contract", () => {
     ]);
 
     const failed = run('codesign_value_for_arch "$1" CDHash arm64', true);
-    expect(failed.status).toBe(1);
+    expect(failed.status).toBe(7);
     expect(failed.stdout).toBe("");
   });
 

--- a/test/scripts/mac-elevation-host.test.ts
+++ b/test/scripts/mac-elevation-host.test.ts
@@ -1233,6 +1233,63 @@ function createInstallRollbackHarness(
 }
 
 describe("mac elevation host command contract", () => {
+  it("reads complete codesign metadata without SIGPIPE and preserves codesign failure", () => {
+    const root = tempDirs.make("openclaw-elevation-codesign-metadata-");
+    const binDir = path.join(root, "bin");
+    const fakeApp = path.join(root, "OpenClaw.app");
+    mkdirSync(binDir);
+    mkdirSync(fakeApp);
+    const codesign = path.join(binDir, "codesign");
+    writeExecutable(
+      codesign,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf '%s\\n' 'Authority=Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)' >&2",
+        "printf '%s\\n' 'Authority=Developer ID Certification Authority' >&2",
+        "printf '%s\\n' 'TeamIdentifier=FWJYW4S8P8' >&2",
+        'if [[ "$*" == *"--arch arm64"* ]]; then',
+        "  printf '%s\\n' 'CDHash=ARM64HASH' >&2",
+        'elif [[ "$*" == *"--arch x86_64"* ]]; then',
+        "  printf '%s\\n' 'CDHash=X8664HASH' >&2",
+        "else",
+        "  printf '%s\\n' 'CDHash=UNSCOPEDHASH' >&2",
+        "fi",
+        "for _ in $(seq 1 10000); do printf '%s\\n' 'Padding=0123456789abcdef' >&2; done",
+        '[[ "${CODESIGN_FAIL_AFTER_OUTPUT:-0}" != "1" ]] || exit 7',
+        "",
+      ].join("\n"),
+    );
+    const script = readFileSync(scriptPath, "utf8");
+    const start = script.indexOf("codesign_metadata_value() {");
+    const end = script.indexOf("entitlements_for()", start);
+    const helpers = script.slice(start, end);
+    const run = (command: string, failAfterOutput = false) =>
+      spawnSync("/bin/bash", ["-c", `set -euo pipefail\n${helpers}\n${command}`, "bash", fakeApp], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODESIGN_FAIL_AFTER_OUTPUT: failAfterOutput ? "1" : "0",
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      });
+
+    const values = run(
+      'printf "%s\\n" "$(codesign_value "$1" Authority)" "$(codesign_value_for_arch "$1" CDHash arm64)" "$(codesign_value_for_arch "$1" CDHash x86_64)"',
+    );
+    expect(values.status, values.stderr).toBe(0);
+    expect(values.stdout.trim().split("\n")).toEqual([
+      "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
+      "ARM64HASH",
+      "X8664HASH",
+    ]);
+
+    const failed = run('codesign_value_for_arch "$1" CDHash arm64', true);
+    expect(failed.status).toBe(1);
+    expect(failed.stdout).toBe("");
+  });
+
   it("documents package and transactional lifecycle commands without probing macOS", () => {
     const result = spawnSync("bash", [scriptPath, "--help"], {
       cwd: process.cwd(),


### PR DESCRIPTION
## What Problem This Solves

The landed CUA-free elevation package built, signed, notarized, and stapled successfully, then failed before publishing its receipt because `codesign_value_for_arch()` piped `codesign -dv` into an early-exiting `awk` under `set -o pipefail`. `codesign` emitted the requested CDHash but received SIGPIPE from the closed reader, so the command substitution returned 141.

The unscoped `codesign_value()` helper used the same unsafe pattern.

## Why This Change Was Made

Add one canonical `codesign_metadata_value()` helper that captures the complete diagnostic stream and preserves the real `codesign` exit status before selecting the first matching metadata key. Both scoped and unscoped callers delegate to it.

This is the same complete-producer-output rule already used by the macOS signing owner elsewhere; it removes the early-reader failure without weakening signature validation or hiding a real `codesign` error.

## User Impact

Signed elevation packaging can publish its immutable archive, installer, checksums, and receipt after notarization. Runtime app behavior is unchanged.

## Evidence

- The real landed-source package reproduced the failure after Accepted notarization: valid arm64/x86_64 CDHashes, pipeline status 141, no final receipt/checksums published.
- New regression emits Authority/Team/CDHash followed by more than 64 KiB of metadata under `pipefail`; unscoped and per-architecture reads pass, while a post-output `codesign` exit remains a failure.
- Focused regression: 1/1 passed.
- Full elevation suite: 107/107 passed.
- Changed-file macOS CI bundle: 7 Vitest shards passed, including 247 tooling tests plus gateway/infra/daemon/process suites.
- Bash syntax, ShellCheck, formatting, diff hygiene, typecheck, script lint, dependency guards: passed.
- Codex autoreview through P2: clean, no findings.

No changelog entry: OpenClaw changelog generation is release-owned, and this is a bounded release-packaging correction.
