### PR TITLE
fix(gateway): stop pointing local CLI token mismatches at gateway.remote

### DIFF
--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -37,6 +37,48 @@ describe("formatGatewayAuthFailureMessage", () => {
     expect(truncateCloseReason(message)).toBe(message);
   });
 
+  it("points local CLI token mismatches at gateway.auth.token, not gateway.remote", () => {
+    const message = formatGatewayAuthFailureMessage({
+      authMode: "token",
+      authProvided: "token",
+      reason: "token_mismatch",
+      client: { id: GATEWAY_CLIENT_IDS.CLI, mode: GATEWAY_CLIENT_MODES.CLI },
+      isLocalClient: true,
+    });
+
+    expect(message).toBe(
+      "unauthorized: gateway token mismatch (use this gateway's gateway.auth.token or pair the device)",
+    );
+    expect(message).not.toContain("gateway.remote");
+    expect(truncateCloseReason(message)).toBe(message);
+  });
+
+  it("keeps the gateway.remote.token hint for remote CLI token mismatches", () => {
+    expect(
+      formatGatewayAuthFailureMessage({
+        authMode: "token",
+        authProvided: "token",
+        reason: "token_mismatch",
+        client: { id: GATEWAY_CLIENT_IDS.CLI, mode: GATEWAY_CLIENT_MODES.CLI },
+        isLocalClient: false,
+      }),
+    ).toBe(
+      "unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)",
+    );
+  });
+
+  it("points local CLI password mismatches at gateway.auth.password", () => {
+    expect(
+      formatGatewayAuthFailureMessage({
+        authMode: "password",
+        authProvided: "password",
+        reason: "password_mismatch",
+        client: { id: GATEWAY_CLIENT_IDS.CLI, mode: GATEWAY_CLIENT_MODES.CLI },
+        isLocalClient: true,
+      }),
+    ).toBe("unauthorized: gateway password mismatch (use this gateway's gateway.auth.password)");
+  });
+
   it("tells rejected node hosts how to diagnose identity-header auth", () => {
     expect(
       formatGatewayAuthFailureMessage({

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -18,8 +18,9 @@ export function formatGatewayAuthFailureMessage(params: {
   authProvided: AuthProvidedKind;
   reason?: string;
   client?: { id?: string | null; mode?: string | null };
+  isLocalClient?: boolean;
 }): string {
-  const { authMode, authProvided, reason, client } = params;
+  const { authMode, authProvided, reason, client, isLocalClient } = params;
   const isCli = isGatewayCliClient(client);
   const isControlUi = isOperatorUiClient(client);
   const isWebchat = isWebchatClient(client);
@@ -29,13 +30,19 @@ export function formatGatewayAuthFailureMessage(params: {
   const uiHint = "open the dashboard URL and paste the token in Control UI settings";
   const missingUiTokenHint =
     "paste in Control UI settings or openclaw doctor --generate-gateway-token; restart";
+  // Local CLI clients share this gateway's config and have no gateway.remote
+  // block; pointing them at gateway.remote.* would be a dead end.
   const tokenHint = isCli
-    ? "set gateway.remote.token to match gateway.auth.token"
+    ? isLocalClient
+      ? "use this gateway's gateway.auth.token or pair the device"
+      : "set gateway.remote.token to match gateway.auth.token"
     : isControlUi || isWebchat
       ? uiHint
       : "provide gateway auth token";
   const passwordHint = isCli
-    ? "set gateway.remote.password to match gateway.auth.password"
+    ? isLocalClient
+      ? "use this gateway's gateway.auth.password"
+      : "set gateway.remote.password to match gateway.auth.password"
     : isControlUi || isWebchat
       ? "enter the password in Control UI settings"
       : "provide gateway auth password";

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -196,6 +196,7 @@ async function authenticateGatewayConnectCore(
       authProvided,
       reason: failedAuth.reason,
       client: connectParams.client,
+      isLocalClient,
     });
     const authLogDecision = shouldLimitMissingCredentialAuthLog({
       reason: failedAuth.reason,


### PR DESCRIPTION
## What Problem This Solves

A wrong-token CLI connect against a local-mode gateway surfaced:

```
unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)
```

`gateway.remote.token` is a dead end for `gateway.mode=local` connections: there is no `gateway.remote` block in that config, and the CLI actually resolves its token from `gateway.auth.token` directly.

## Why This Change Was Made

`formatGatewayAuthFailureMessage` in `src/gateway/server/ws-connection/auth-messages.ts` only distinguished CLI vs Control UI/webchat vs other clients, not local vs remote CLI connections. The connect pipeline already records `isLocalClient` at admission time (`ingressAttribution.kind === "direct-local"` in `src/gateway/server/ws-connection/message-handler.ts`), so this change threads that existing fact into the message formatter instead of inventing a new signal.

## User Impact

- Local CLI clients now get an actionable hint pointing at `gateway.auth.token` (or pairing) on token mismatch, and `gateway.auth.password` on password mismatch.
- Remote CLI clients (which do have a `gateway.remote` block) keep the existing `gateway.remote.token`/`gateway.remote.password` guidance unchanged.
- No other client kind (Control UI, webchat, node) is affected.

Observed 2026-08-17 while fixing voice-call CLI routing (#125458).

## Evidence

- New regression tests in `src/gateway/server/ws-connection/auth-messages.test.ts` covering local-CLI token mismatch, remote-CLI token mismatch, and local-CLI password mismatch (the local-CLI cases fail on pre-fix code since the `isLocalClient` parameter didn't exist).
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection/auth-messages.test.ts` — 7 passed
- `node scripts/run-vitest.mjs src/gateway/server.auth.compat-baseline.test.ts` — 21 passed
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts` — 40 passed
- `node scripts/check-changed.mjs` — clean
- autoreview (`--mode local`, codex/gpt-5.6-sol): clean, no accepted/actionable findings
