### PR TITLE
fix(agents): redact reflected credentials from MiniMax VLM error body and reason phrase

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -458,6 +458,149 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
     expect(pullCount).toBeLessThanOrEqual(18);
     expect(canceled).toBe(true);
   });
+
+  it("redacts reflected credentials from the error body of a failed request", async () => {
+    const needle = "mmVlmProbe0123456789abcdefWXYZ";
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(`upstream echoed Authorization: Bearer ${needle}`, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+      release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+    });
+
+    const error = await minimaxUnderstandImage({
+      apiKey: needle,
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((err: unknown) => err);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject a 401 response");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toContain("MiniMax VLM request failed (401");
+    expect(error.message).toContain("Bearer mmVlmP…WXYZ");
+  });
+
+  it("redacts a reflected Bearer credential from the response reason phrase", async () => {
+    const needle = "mmVlmProbe0123456789abcdefWXYZ";
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("", { status: 401, statusText: `reflected Bearer ${needle}` }),
+      release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+    });
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((err: unknown) => err);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject a 401 response");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toContain("MiniMax VLM request failed (401 reflected Bearer");
+  });
+
+  it("masks a short reflected Bearer credential below the shared pattern's length floor", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("", { status: 401, statusText: "reflected Bearer abc" }),
+      release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+    });
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((err: unknown) => err);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject a 401 response");
+    }
+    expect(error.message).not.toContain("Bearer abc");
+    expect(error.message).toBe("MiniMax VLM request failed (401 reflected Bearer ***).");
+  });
+
+  it("masks a lowercase reflected bearer credential in the response reason phrase", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("", { status: 401, statusText: "reflected bearer abc" }),
+      release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+    });
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((err: unknown) => err);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject a 401 response");
+    }
+    expect(error.message).not.toContain("bearer abc");
+    expect(error.message).toBe("MiniMax VLM request failed (401 reflected bearer ***).");
+  });
+
+  it("redacts a reflected Bearer credential from the Trace-Id response header", async () => {
+    const needle = "mmVlmProbe0123456789abcdefWXYZ";
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("bad", {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "Trace-Id": `trace-Bearer ${needle}` },
+      }),
+      release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+    });
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((err: unknown) => err);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject a 401 response");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toContain("Trace-Id: trace-Bearer mmVlmP…WXYZ");
+  });
+
+  it("redacts a reflected Bearer credential from the application-level status_msg", async () => {
+    const needle = "mmVlmProbe0123456789abcdefWXYZ";
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({
+          base_resp: { status_code: 1001, status_msg: `invalid key Bearer ${needle}` },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+      release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+    });
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((err: unknown) => err);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject a non-zero base_resp");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toBe("MiniMax VLM API error (1001): invalid key Bearer mmVlmP…WXYZ.");
+  });
 });
 
 describe("isMinimaxVlmModel", () => {

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,5 +1,6 @@
 import { resolvePositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { readResponseBodySnippet } from "../infra/http-error-body.js";
+import { redactToolPayloadText } from "../logging/redact.js";
 /**
  * Adapts MiniMax VLM image-understanding requests for agent image inputs.
  */
@@ -21,6 +22,16 @@ type MinimaxBaseResp = {
 const MINIMAX_VLM_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const MINIMAX_VLM_ERROR_BODY_MAX_CHARS = 400;
 const DEFAULT_MINIMAX_VLM_TIMEOUT_MS = 60_000;
+
+// Standalone Bearer tokens below the shared redactor's 18-character prose floor are
+// still credentials on this authenticated error surface, so mask them regardless of
+// length and scheme casing. The lookahead keeps already-hinted tokens
+// (`Bearer abc…wxyz`) untouched.
+const SHORT_BEARER_TOKEN_PATTERN = /\b(Bearer)\s+[-A-Za-z0-9._~+/=]{1,17}(?![-A-Za-z0-9._~+/=…])/gi;
+
+function redactVlmErrorText(text: string): string {
+  return redactToolPayloadText(text).replace(SHORT_BEARER_TOKEN_PATTERN, "$1 ***");
+}
 
 export function isMinimaxVlmProvider(provider: string): boolean {
   const normalized = provider.trim().toLowerCase();
@@ -163,7 +174,11 @@ export async function minimaxUnderstandImage(params: {
   const res = guarded.response;
 
   try {
-    const traceId = res.headers.get("Trace-Id") ?? "";
+    // The Trace-Id header, error body, reason phrase, and base_resp.status_msg are
+    // all provider-controlled: an edge or proxy can reflect the request's
+    // Authorization credential into any of them. Redact once at ingestion so every
+    // error branch below stays safe.
+    const traceId = redactVlmErrorText(res.headers.get("Trace-Id") ?? "");
     if (!res.ok) {
       const body = await readResponseBodySnippet(res, {
         maxBytes: MINIMAX_VLM_ERROR_BODY_MAX_BYTES,
@@ -171,8 +186,8 @@ export async function minimaxUnderstandImage(params: {
       });
       const trace = traceId ? ` Trace-Id: ${traceId}` : "";
       throw new Error(
-        `MiniMax VLM request failed (${res.status} ${res.statusText}).${trace}${
-          body ? ` Body: ${body}` : ""
+        `MiniMax VLM request failed (${res.status} ${redactVlmErrorText(res.statusText)}).${trace}${
+          body ? ` Body: ${redactVlmErrorText(body)}` : ""
         }`,
       );
     }
@@ -189,7 +204,7 @@ export async function minimaxUnderstandImage(params: {
     const baseResp = isRecord(json.base_resp) ? (json.base_resp as MinimaxBaseResp) : {};
     const code = typeof baseResp.status_code === "number" ? baseResp.status_code : -1;
     if (code !== 0) {
-      const msg = (baseResp.status_msg ?? "").trim();
+      const msg = redactVlmErrorText((baseResp.status_msg ?? "").trim());
       const trace = traceId ? ` Trace-Id: ${traceId}` : "";
       throw new Error(`MiniMax VLM API error (${code})${msg ? `: ${msg}` : ""}.${trace}`);
     }


### PR DESCRIPTION
## Summary

`minimaxUnderstandImage()` (`src/agents/minimax-vlm.ts`) splices provider-controlled response material — the error body, the HTTP reason phrase, the `Trace-Id` response header, and the application-level `base_resp.status_msg` — into thrown `Error` messages. Because the request carries `Authorization: Bearer <api-key>`, an edge or enterprise proxy that reflects request material through any of these channels leaks the MiniMax API key into user-facing error text. All four channels now pass through a redacting helper (`redactToolPayloadText()` plus a short-Bearer supplement) before reaching any error branch.

## What Problem This Solves

- The VLM request sends `Authorization: Bearer ${apiKey}` (`src/agents/minimax-vlm.ts:128`). On `!res.ok`, the handler throws with the **raw** body snippet, the **raw** reason phrase, and the **raw** `Trace-Id` response header (`:167-178`); the non-JSON / no-content branches append the same raw trace, and the application-error branch interpolates the **raw** `base_resp.status_msg` (`:190-205`). `readResponseBodySnippet` only truncates — it does not redact.
- When a provider edge or an enterprise proxy answers with an error page that echoes the request's `Authorization` header, the API key lands verbatim in the thrown `Error` message — and from there into tool results, transcripts, logs, and any UI surface that renders errors.
- The reason phrase and the `Trace-Id` header are equally provider-controlled: undici surfaces the upstream reason phrase as response data, and the trace header is echoed into every error branch — so an empty-body 401 can expose the key even when there is no body at all.
- The shared provider error helper (`extractProviderErrorInfo` in `src/agents/provider-http-errors.ts`) already redacts via `redactProviderErrorBody`, but these throw sites bypass that aggregation point entirely.

**代码证据**: on `main`, a loopback endpoint answering 401 with `Authorization: Bearer <key>` reflected in the body produces `Error: MiniMax VLM request failed (401 Unauthorized). Body: upstream echoed Authorization: Bearer mmVlmProbe…WXYZ`; the same key reflected in the reason phrase, the `Trace-Id` header, or a 200 `base_resp.status_msg` leaks identically.

Same defect class as the merged #117304 (voice-call) and #119536 (discord) fixes, and the same body+reason-phrase shape as #120200 (web-search provider helpers).

## Root Cause

The error paths were written to aid debugging (`status + statusText + trace + body snippet`) before credential redaction became the house standard, and they never passed through the shared redacting error helper.

The violated invariant: text derived from an HTTP response to an authenticated request — body, reason phrase, response headers, and application-level status fields alike — must be treated as potentially containing the request's credentials and may only reach user-facing surfaces after redaction.

## Why This Fix

- Redact once at ingestion: the `Trace-Id` header value is sanitized where it is read, so every downstream error branch (non-2xx, non-JSON, API error, no-content) is covered by construction; `base_resp.status_msg` is sanitized at its single interpolation point.
- Pass everything through `redactToolPayloadText()` — the existing house redactor for tool payloads across `src/agents` (used by `session-activity-notes.ts`, `sessions-search-tool.ts`, `tool-display-exec.ts`, …). It stays in sync with the central pattern list (Bearer, `Authorization`, `api-key`/`x-api-key`, cookies, …) and masks with a short hint (`Bearer mmVlmP…WXYZ`) so diagnostics keep the non-secret context.
- Close the short-token gap locally: the shared standalone Bearer pattern keeps an 18-character floor to spare prose in general logs, which is wrong for a provider-controlled error surface where a reflected short generic key (`Bearer abc`) is exactly what must not survive. A supplementary `SHORT_BEARER_TOKEN_PATTERN` (1–17 token characters, case-insensitive so a lowercase `bearer abc` reflection is masked too, lookahead rejects the `…` ellipsis so an already-hinted token is never re-masked) runs only in this error path.
- Redact at the throw/ingestion sites rather than inside `readResponseBodySnippet`: the reader is shared by other call sites and stays a pure truncation helper; redaction is a property of this authenticated error path.
- `redactVlmErrorText("")` returns `""`, so every `value ? … : ""` shape is preserved exactly; the body is still truncated to the same byte/char caps as before.
- Alternative considered: routing through `createProviderHttpError` — rejected here as a larger refactor of the VLM error shape (trace-id suffix, `Body:` prefix, `base_resp` mapping) for no additional redaction coverage.

## User Impact

- Users running MiniMax VLM image understanding no longer expose their API key in error text when a provider edge or proxy reflects request material — whether in the error page, the reason phrase, the `Trace-Id` header, or the application-level status message, and whether the credential is long or a short generic value like `Bearer abc`.
- Error messages keep the provider label, HTTP status, trace id, and the non-secret portion of the detail; diagnostics are unaffected.

## Evidence

- **Before**: loopback server on `main` reflecting the Bearer credential through (1) a 401 body, (2) an empty-body 401 reason phrase (short generic `Bearer abc`), (3) the same with a lowercase `bearer abc` scheme, (4) a 401 `Trace-Id` header, and (5) a 200 `base_resp.status_msg`; the real `minimaxUnderstandImage()` → all five messages contain the credential verbatim → FAIL ×5.
- **After**: same loopback on this branch → the long key is masked with its hint (`Bearer mmVlmP…WXYZ`) in every channel and both short reason-phrase credentials are fully masked (`Bearer ***` / `bearer ***`), status/label/trace shape intact → PASS ×5.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
proof server listening on http://127.0.0.1:38259
case 1 (body reflection) agent-facing error: MiniMax VLM request failed (401 Unauthorized). Body: upstream echoed Authorization: Bearer mmVlmProbe0123456789abcdefWXYZ
FAIL: reflected credential leaked into the agent-facing error message
case 2 (short Bearer reason-phrase reflection) agent-facing error: MiniMax VLM request failed (401 reflected Bearer abc).
FAIL: reflected credential leaked into the agent-facing error message
case 3 (lowercase bearer reason-phrase reflection) agent-facing error: MiniMax VLM request failed (401 reflected bearer abc).
FAIL: reflected credential leaked into the agent-facing error message
case 4 (Trace-Id header reflection) agent-facing error: MiniMax VLM request failed (401 Unauthorized). Trace-Id: trace-Bearer mmVlmProbe0123456789abcdefWXYZ Body: bad
FAIL: reflected credential leaked into the agent-facing error message
case 5 (status_msg reflection) agent-facing error: MiniMax VLM API error (1001): invalid key Bearer mmVlmProbe0123456789abcdefWXYZ.
FAIL: reflected credential leaked into the agent-facing error message
RESULT: 5 case(s) FAIL
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
proof server listening on http://127.0.0.1:41975
case 1 (body reflection) agent-facing error: MiniMax VLM request failed (401 Unauthorized). Body: upstream echoed Authorization: Bearer mmVlmP…WXYZ
PASS: reflected credential masked in the agent-facing error message
case 2 (short Bearer reason-phrase reflection) agent-facing error: MiniMax VLM request failed (401 reflected Bearer ***).
PASS: reflected credential masked in the agent-facing error message
case 3 (lowercase bearer reason-phrase reflection) agent-facing error: MiniMax VLM request failed (401 reflected bearer ***).
PASS: reflected credential masked in the agent-facing error message
case 4 (Trace-Id header reflection) agent-facing error: MiniMax VLM request failed (401 Unauthorized). Trace-Id: trace-Bearer mmVlmP…WXYZ Body: bad
PASS: reflected credential masked in the agent-facing error message
case 5 (status_msg reflection) agent-facing error: MiniMax VLM API error (1001): invalid key Bearer mmVlmP…WXYZ.
PASS: reflected credential masked in the agent-facing error message
RESULT: all cases PASS
```

(Real `node:http` server on 127.0.0.1 answering `POST /v1/coding_plan/vlm`: case 1 reflects the Bearer key into the 401 body; cases 2–3 reflect a short generic credential into the reason phrase via `writeHead(401, "reflected Bearer abc")` / `writeHead(401, "reflected bearer abc")` on an empty body; case 4 reflects the key into the `Trace-Id` response header; case 5 reflects it into a 200 JSON `base_resp.status_msg`. All consumed by the real exported `minimaxUnderstandImage()` with `allowPrivateNetwork: true`.)

## Tests and Validation

- `pnpm check` — all guards pass except the local `npm package-lock guard`, which fails on a pre-existing `set-blocking` integrity mismatch (registry-mirror sha1 vs lockfile sha512). The guard compares local `node_modules` against `pnpm-lock.yaml`; this PR changes no manifest or lockfile, so the failure is environmental and unrelated to the change.
- `npx vitest run src/agents/minimax-vlm.normalizes-api-key.test.ts` passed (56 tests across both projects), including new regression coverage:
  - a 401 error body echoing `Authorization: Bearer <key>` reaches the thrown message with the key masked and the status/label intact;
  - an empty-body 401 whose reason phrase reflects a long key is masked the same way;
  - a short generic `Bearer abc` in the reason phrase is fully masked (`Bearer ***`) despite the shared pattern's 18-character floor — and a lowercase `bearer abc` reflection is masked too (`bearer ***`);
  - a key reflected through the `Trace-Id` response header is masked in every error branch;
  - a key reflected through the application-level `base_resp.status_msg` on a 200 response is masked in the API-error branch.
