### PR TITLE
fix: hooks reject new agents after config hot reload

### DIFF
--- a/src/gateway/config-diff.ts
+++ b/src/gateway/config-diff.ts
@@ -35,22 +35,32 @@ export function diffConfigPaths(prev: unknown, next: unknown, prefix = ""): stri
   return [prefix || "<root>"];
 }
 
+function projectGatewayReloadBoundaries(config: OpenClawConfig) {
+  return {
+    mcp: { apps: config.mcp?.apps },
+    agents: {
+      ownership: config.agents?.ownership,
+      defaults: { sessionStore: config.agents?.defaults?.sessionStore },
+      entries: config.agents?.entries,
+    },
+    session: {
+      scope: config.session?.scope,
+      store: config.session?.store,
+    },
+  };
+}
+
 /** Preserve startup-only restart boundaries hidden by whole-object config changes. */
 export function diffGatewayReloadPaths(
   prevConfig: OpenClawConfig,
   nextConfig: OpenClawConfig,
 ): string[] {
   const changedPaths = diffConfigPaths(prevConfig, nextConfig);
-  if (!changedPaths.includes("mcp")) {
-    return changedPaths;
-  }
-  // Adding or removing the whole `mcp` object collapses to the broad `mcp`
-  // path. Preserve the Apps boundary so the listener still restarts.
-  return [
-    ...changedPaths,
-    ...diffConfigPaths(
-      { mcp: { apps: prevConfig.mcp?.apps } },
-      { mcp: { apps: nextConfig.mcp?.apps } },
-    ),
-  ];
+  const boundaryPaths = diffConfigPaths(
+    projectGatewayReloadBoundaries(prevConfig),
+    projectGatewayReloadBoundaries(nextConfig),
+  );
+  // Preserve only startup/reload ownership boundaries hidden by whole-object
+  // collapse without changing ordinary diff multiplicity or ordering.
+  return [...changedPaths, ...boundaryPaths.filter((path) => !changedPaths.includes(path))];
 }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -21,6 +21,8 @@ export type GatewayReloadPlan = {
   restartReasons: string[];
   hotReasons: string[];
   reloadHooks: boolean;
+  /** Refresh the hook target-policy snapshot without invalidating transform modules. */
+  refreshHooksPolicy?: boolean;
   restartGmailWatcher: boolean;
   restartCron: boolean;
   restartHeartbeat: boolean;
@@ -38,6 +40,7 @@ export function isNoopGatewayReloadPlan(plan: GatewayReloadPlan): boolean {
     !plan.restartGateway &&
     plan.hotReasons.length === 0 &&
     !plan.reloadHooks &&
+    !plan.refreshHooksPolicy &&
     !plan.restartGmailWatcher &&
     !plan.restartCron &&
     !plan.restartHeartbeat &&
@@ -62,6 +65,7 @@ type ConfigReloadMetadata = {
 
 type ReloadAction =
   | "reload-hooks"
+  | "refresh-hooks-policy"
   | "restart-gmail-watcher"
   | "restart-cron"
   | "restart-heartbeat"
@@ -95,6 +99,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
+  {
+    prefix: "agents.defaults.sessionStore",
+    kind: "hot",
+    actions: ["refresh-hooks-policy"],
+  },
   { prefix: "agents.defaults", kind: "hot" },
   {
     prefix: "agents.defaults.models",
@@ -119,8 +128,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   {
     prefix: "agents.entries",
     kind: "hot",
-    actions: ["restart-heartbeat"],
+    actions: ["restart-heartbeat", "refresh-hooks-policy"],
   },
+  { prefix: "agents.ownership", kind: "hot", actions: ["refresh-hooks-policy"] },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   // The dedicated Apps listener and origin are created once during Gateway
@@ -149,6 +159,8 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "talk", kind: "none" },
   { prefix: "skills", kind: "none" },
   { prefix: "secrets", kind: "none" },
+  { prefix: "session.scope", kind: "hot", actions: ["refresh-hooks-policy"] },
+  { prefix: "session.store", kind: "hot", actions: ["refresh-hooks-policy"] },
   { prefix: "plugins", kind: "hot", actions: ["reload-plugins", "dispose-mcp-runtimes"] },
   { prefix: "tui", kind: "none" },
   { prefix: "ui", kind: "none" },
@@ -444,6 +456,9 @@ export function buildGatewayReloadPlan(
     switch (action) {
       case "reload-hooks":
         plan.reloadHooks = true;
+        break;
+      case "refresh-hooks-policy":
+        plan.refreshHooksPolicy = true;
         break;
       case "restart-gmail-watcher":
         plan.restartGmailWatcher = true;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -159,6 +159,81 @@ describe("diffConfigPaths", () => {
     expect(changedPaths).toEqual(["mcp", "mcp.apps"]);
     expect(buildGatewayReloadPlan(changedPaths).restartReasons).toContain("mcp.apps");
   });
+
+  it.each([
+    {
+      name: "adds agents",
+      prev: {},
+      next: {
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "ops" } },
+          entries: { ops: {} },
+        },
+      },
+      expectedPaths: ["agents.ownership", "agents.defaults.sessionStore", "agents.entries"],
+    },
+    {
+      name: "removes agents",
+      prev: {
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "ops" } },
+          entries: { ops: {} },
+        },
+      },
+      next: {},
+      expectedPaths: ["agents.ownership", "agents.defaults.sessionStore", "agents.entries"],
+    },
+    {
+      name: "adds agent defaults",
+      prev: { agents: { ownership: "explicit", entries: { ops: {} } } },
+      next: {
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "ops" } },
+          entries: { ops: {} },
+        },
+      },
+      expectedPaths: ["agents.defaults.sessionStore"],
+    },
+    {
+      name: "removes agent defaults",
+      prev: {
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "ops" } },
+          entries: { ops: {} },
+        },
+      },
+      next: { agents: { ownership: "explicit", entries: { ops: {} } } },
+      expectedPaths: ["agents.defaults.sessionStore"],
+    },
+    {
+      name: "adds session config",
+      prev: {},
+      next: { session: { scope: "global", store: "/tmp/fixed.sqlite" } },
+      expectedPaths: ["session.scope", "session.store"],
+    },
+    {
+      name: "removes session config",
+      prev: { session: { scope: "global", store: "/tmp/fixed.sqlite" } },
+      next: {},
+      expectedPaths: ["session.scope", "session.store"],
+    },
+  ])("preserves hook policy dependencies when it $name", ({ prev, next, expectedPaths }) => {
+    const changedPaths = diffGatewayReloadPaths(prev as OpenClawConfig, next as OpenClawConfig);
+
+    for (const expectedPath of expectedPaths) {
+      expect(changedPaths).toContain(expectedPath);
+    }
+    expect(buildGatewayReloadPlan(changedPaths)).toMatchObject({
+      restartGateway: false,
+      refreshHooksPolicy: true,
+      reloadHooks: false,
+      restartGmailWatcher: false,
+    });
+  });
 });
 
 describe("buildGatewayReloadPlan", () => {
@@ -341,6 +416,37 @@ describe("buildGatewayReloadPlan", () => {
       noopPaths: [],
       ...expected,
     });
+  });
+
+  it.each([
+    { path: "agents.entries", restartHeartbeat: true },
+    { path: "agents.ownership", restartHeartbeat: false },
+    { path: "agents.defaults.sessionStore", restartHeartbeat: false },
+    { path: "agents.defaults.sessionStore.agentId", restartHeartbeat: false },
+    { path: "session.scope", restartHeartbeat: false },
+    { path: "session.store", restartHeartbeat: false },
+  ])("refreshes only hook target policy for $path", ({ path, restartHeartbeat }) => {
+    const plan = buildGatewayReloadPlan([path]);
+
+    expect(plan).toMatchObject({
+      restartGateway: false,
+      refreshHooksPolicy: true,
+      reloadHooks: false,
+      restartGmailWatcher: false,
+      restartHeartbeat,
+    });
+    expect(isNoopGatewayReloadPlan(plan)).toBe(false);
+  });
+
+  it.each([
+    "agents",
+    "agents.defaults",
+    "agents.defaults.systemAgent.agentId",
+    "agents.list",
+    "session",
+    "session.mainKey",
+  ])("does not broadly refresh hook target policy for %s", (path) => {
+    expect(buildGatewayReloadPlan([path]).refreshHooksPolicy).not.toBe(true);
   });
 
   it.each([

--- a/src/gateway/gateway-wizard.e2e.test.ts
+++ b/src/gateway/gateway-wizard.e2e.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  WizardNextResult,
+  WizardStartResult,
+} from "../../packages/gateway-protocol/src/index.js";
+import {
+  nextGatewayId,
+  removeGatewayTempHome,
+  resetGatewayTestState,
+  setupGatewayTempHome,
+} from "./gateway.test-support.js";
+import { startGatewayServer } from "./server.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+  getGatewayE2ePortBlock,
+} from "./test-helpers.e2e.js";
+
+const GATEWAY_E2E_TIMEOUT_MS = 90_000;
+
+describe("gateway wizard e2e", () => {
+  beforeEach(resetGatewayTestState);
+  afterEach(resetGatewayTestState);
+
+  it("contains hosted wizard exits", { timeout: GATEWAY_E2E_TIMEOUT_MS }, async () => {
+    const { envSnapshot, tempHome } = await setupGatewayTempHome({
+      prefix: "openclaw-wizard-contained-exit-home-",
+      minimalGateway: true,
+    });
+    const wizardToken = nextGatewayId("wiz-contained-exit");
+    let exitCode = 0;
+    const port = await getGatewayE2ePortBlock();
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token: wizardToken },
+      controlUiEnabled: false,
+      wizardRunner: async (_opts, runtime, prompter) => {
+        await prompter.outro("wizard complete");
+        runtime.exit(exitCode);
+      },
+      channelWizardRunner: async (_opts, runtime, prompter) => {
+        await prompter.outro("channel wizard complete");
+        runtime.exit(exitCode);
+      },
+    });
+    const client = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token: wizardToken,
+    });
+    // Intercept an actual host exit so the fail-first Gateway test cannot
+    // terminate its Vitest worker before reporting the regression.
+    const processExit = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`Gateway process exit ${code}`);
+    });
+
+    try {
+      for (const flow of ["setup", "channels"] as const) {
+        for (const nextExitCode of [0, 23] as const) {
+          exitCode = nextExitCode;
+          const status = exitCode === 0 ? "done" : "error";
+          const start = await client.request<WizardStartResult>(
+            "wizard.start",
+            flow === "channels" ? { flow } : { mode: "local" },
+          );
+          expect(start).toMatchObject({ done: false, status: "running" });
+          expect(start.step?.id).toBeTruthy();
+
+          const result = await client.request<WizardNextResult>("wizard.next", {
+            sessionId: start.sessionId,
+            answer: { stepId: start.step?.id, value: null },
+          });
+          expect(result).toMatchObject({ done: true, status });
+          if (exitCode !== 0) {
+            expect(result.error).toContain(String(exitCode));
+          }
+          expect(processExit).not.toHaveBeenCalled();
+          await expect(client.request("health", {})).resolves.toBeDefined();
+        }
+      }
+    } finally {
+      processExit.mockRestore();
+      await disconnectGatewayClient(client);
+      await server.close({ reason: "wizard runtime isolation E2E complete" });
+      await removeGatewayTempHome(tempHome);
+      envSnapshot.restore();
+    }
+  });
+
+  it(
+    "routes wizard.start flow channels to the channel wizard runner",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const { envSnapshot, tempHome } = await setupGatewayTempHome({
+        prefix: "openclaw-wizard-channels-home-",
+        minimalGateway: true,
+      });
+      const wizAuth = nextGatewayId("wiz-chan");
+      const port = await getGatewayE2ePortBlock();
+      const channelRuns: Array<string | undefined> = [];
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token: wizAuth },
+        controlUiEnabled: false,
+        wizardRunner: async () => {
+          throw new Error("setup wizard runner must not run for flow channels");
+        },
+        channelWizardRunner: async (opts, _runtime, prompter) => {
+          channelRuns.push(opts.channel);
+          await prompter.intro("Channel setup");
+          const choice = await prompter.select({
+            message: "channel",
+            options: [{ value: opts.channel ?? "none", label: opts.channel ?? "none" }],
+          });
+          opts.onConfigured?.([{ channel: choice, accountId: "default" }]);
+          await prompter.outro(`configured ${choice}`);
+        },
+      });
+
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: wizAuth,
+        clientDisplayName: "vitest-wizard-channels",
+      });
+
+      try {
+        for (const testCase of [
+          { label: "omitted", channel: undefined, expected: "none" },
+          { label: "canonical", channel: "telegram", expected: "telegram" },
+          { label: "alias", channel: "imsg", expected: "imsg" },
+        ]) {
+          const start = await client.request<WizardStartResult>("wizard.start", {
+            flow: "channels",
+            ...(testCase.channel === undefined ? {} : { channel: testCase.channel }),
+          });
+          const sessionId = start.sessionId;
+          expect(typeof sessionId, testCase.label).toBe("string");
+
+          let next: WizardStartResult | WizardNextResult = start;
+          const seenSteps: string[] = [];
+          while (!next.done) {
+            const step = next.step;
+            if (!step) {
+              throw new Error("wizard missing step");
+            }
+            seenSteps.push(step.type);
+            next = await client.request<WizardNextResult>(
+              "wizard.next",
+              {
+                sessionId,
+                answer: {
+                  stepId: step.id,
+                  value: step.type === "select" ? testCase.expected : null,
+                },
+              },
+              { timeoutMs: 60_000 },
+            );
+          }
+
+          expect(next.status, `${testCase.label}: seenSteps=${seenSteps.join(",")}`).toBe("done");
+          expect(seenSteps, testCase.label).toContain("select");
+          expect(next.channels, testCase.label).toEqual([testCase.expected]);
+          expect(next.accounts, testCase.label).toEqual([
+            { channel: testCase.expected, accountId: "default" },
+          ]);
+        }
+        expect(channelRuns).toEqual([undefined, "telegram", "imsg"]);
+      } finally {
+        await disconnectGatewayClient(client);
+        await server.close({ reason: "wizard channels flow complete" });
+        await removeGatewayTempHome(tempHome);
+        envSnapshot.restore();
+      }
+    },
+  );
+});

--- a/src/gateway/gateway.test-support.ts
+++ b/src/gateway/gateway.test-support.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { resetConfigOverrides } from "../config/runtime-overrides.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
+import { resetAgentEventsForTest } from "../infra/agent-events.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "./test-helpers.env.js";
+
+let gatewayTestSeq = 0;
+
+export const GATEWAY_TEST_ENV_KEYS = [
+  "HOME",
+  ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_TEST_GATEWAY_OVERRIDE_TOKEN",
+  "OPENCLAW_TEST_RUNTIME_OVERRIDE_TOKEN",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+export function nextGatewayId(prefix: string): string {
+  return `${prefix}-${process.pid}-${process.env.VITEST_POOL_ID ?? "0"}-${gatewayTestSeq++}`;
+}
+
+async function createEmptyBundledPluginsDir(tempHome: string): Promise<string> {
+  const bundledPluginsDir = path.join(tempHome, "openclaw-test-empty-bundled-plugins");
+  await fs.mkdir(bundledPluginsDir, { recursive: true });
+  return bundledPluginsDir;
+}
+
+export async function createGatewayConfigPath(tempHome: string): Promise<string> {
+  const configPath = path.join(tempHome, ".openclaw", "openclaw.json");
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  return configPath;
+}
+
+export async function removeGatewayTempHome(tempHome: string): Promise<void> {
+  await fs.rm(tempHome, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 50,
+  });
+}
+
+export async function setupGatewayTempHome(params: { prefix: string; minimalGateway?: boolean }) {
+  const envSnapshot = captureEnv([
+    ...GATEWAY_TEST_ENV_KEYS,
+    ...(params.minimalGateway ? (["OPENCLAW_TEST_MINIMAL_GATEWAY"] as const) : []),
+  ]);
+
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), params.prefix));
+  setTestEnvValue("HOME", tempHome);
+  setTestEnvValue("OPENCLAW_STATE_DIR", path.join(tempHome, ".openclaw"));
+  deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+  if (params.minimalGateway) {
+    setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "1");
+  } else {
+    deleteTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY");
+  }
+
+  const workspaceDir = path.join(tempHome, "openclaw");
+  await fs.mkdir(workspaceDir, { recursive: true });
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", await createEmptyBundledPluginsDir(tempHome));
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  return { envSnapshot, tempHome, workspaceDir };
+}
+
+export function resetGatewayTestState(): void {
+  resetConfigOverrides();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  clearSessionStoreCacheForTest();
+  resetAgentEventsForTest({ preserveListeners: true });
+}

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -4,10 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  WizardNextResult,
-  WizardStartResult,
-} from "../../packages/gateway-protocol/src/index.js";
+import type { WizardStartResult } from "../../packages/gateway-protocol/src/index.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -15,15 +12,21 @@ import {
   writeConfigFile,
 } from "../config/config.js";
 import { resetConfigOverrides, setConfigOverride } from "../config/runtime-overrides.js";
-import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
 import type { GatewayAuthConfig, GatewayTailscaleConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resetAgentEventsForTest } from "../infra/agent-events.js";
 import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getPairedDevice } from "../infra/device-pairing.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { callGateway } from "./call.js";
+import {
+  createGatewayConfigPath,
+  GATEWAY_TEST_ENV_KEYS,
+  nextGatewayId,
+  removeGatewayTempHome,
+  resetGatewayTestState,
+  setupGatewayTempHome,
+} from "./gateway.test-support.js";
 import { startGatewayServer } from "./server.js";
 import {
   connectDeviceAuthReq,
@@ -32,55 +35,11 @@ import {
   getGatewayE2ePortBlock,
   startGatewayWithClient,
 } from "./test-helpers.e2e.js";
-import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "./test-helpers.env.js";
 import { installOpenAiResponsesMock } from "./test-helpers.openai-mock.js";
 import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
 
 let createConfigIO: typeof import("../config/config.js").createConfigIO;
 const GATEWAY_E2E_TIMEOUT_MS = 90_000;
-let gatewayTestSeq = 0;
-const GATEWAY_TEST_ENV_KEYS = [
-  "HOME",
-  ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
-  "OPENCLAW_STATE_DIR",
-  "OPENCLAW_CONFIG_PATH",
-  "OPENCLAW_GATEWAY_TOKEN",
-  "OPENCLAW_TEST_GATEWAY_OVERRIDE_TOKEN",
-  "OPENCLAW_TEST_RUNTIME_OVERRIDE_TOKEN",
-  "OPENCLAW_SKIP_CHANNELS",
-  "OPENCLAW_SKIP_GMAIL_WATCHER",
-  "OPENCLAW_SKIP_CRON",
-  "OPENCLAW_SKIP_CANVAS_HOST",
-  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
-  "OPENCLAW_SKIP_PROVIDERS",
-  "OPENCLAW_BUNDLED_PLUGINS_DIR",
-  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
-] as const;
-
-function nextGatewayId(prefix: string): string {
-  return `${prefix}-${process.pid}-${process.env.VITEST_POOL_ID ?? "0"}-${gatewayTestSeq++}`;
-}
-
-async function createEmptyBundledPluginsDir(tempHome: string): Promise<string> {
-  const bundledPluginsDir = path.join(tempHome, "openclaw-test-empty-bundled-plugins");
-  await fs.mkdir(bundledPluginsDir, { recursive: true });
-  return bundledPluginsDir;
-}
-
-async function createGatewayConfigPath(tempHome: string): Promise<string> {
-  const configPath = path.join(tempHome, ".openclaw", "openclaw.json");
-  await fs.mkdir(path.dirname(configPath), { recursive: true });
-  return configPath;
-}
-
-async function removeGatewayTempHome(tempHome: string): Promise<void> {
-  await fs.rm(tempHome, {
-    recursive: true,
-    force: true,
-    maxRetries: 10,
-    retryDelay: 50,
-  });
-}
 
 async function startLoopbackTokenGateway(token: string) {
   const port = await getGatewayE2ePortBlock();
@@ -145,43 +104,6 @@ async function readCounterWithRetry(filePath: string): Promise<number> {
     throw new Error(`timed out waiting for counter file: ${filePath}`);
   }
   return counter;
-}
-
-async function setupGatewayTempHome(params: { prefix: string; minimalGateway?: boolean }) {
-  const envSnapshot = captureEnv([
-    ...GATEWAY_TEST_ENV_KEYS,
-    ...(params.minimalGateway ? (["OPENCLAW_TEST_MINIMAL_GATEWAY"] as const) : []),
-  ]);
-
-  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), params.prefix));
-  setTestEnvValue("HOME", tempHome);
-  setTestEnvValue("OPENCLAW_STATE_DIR", path.join(tempHome, ".openclaw"));
-  deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
-  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
-  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
-  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
-  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
-  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
-  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
-  if (params.minimalGateway) {
-    setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "1");
-  } else {
-    deleteTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY");
-  }
-
-  const workspaceDir = path.join(tempHome, "openclaw");
-  await fs.mkdir(workspaceDir, { recursive: true });
-  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", await createEmptyBundledPluginsDir(tempHome));
-  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
-  return { envSnapshot, tempHome, workspaceDir };
-}
-
-function resetGatewayTestState(): void {
-  resetConfigOverrides();
-  clearRuntimeConfigSnapshot();
-  clearConfigCache();
-  clearSessionStoreCacheForTest();
-  resetAgentEventsForTest({ preserveListeners: true });
 }
 
 describe("gateway e2e", () => {
@@ -415,6 +337,119 @@ describe("gateway e2e", () => {
       }
     },
   );
+
+  it("refreshes direct hook target policy after hot reload", async () => {
+    const { envSnapshot, tempHome } = await setupGatewayTempHome({
+      prefix: "openclaw-gw-hook-policy-reload-",
+    });
+    let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+    try {
+      const configPath = await createGatewayConfigPath(tempHome);
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      const gatewayToken = nextGatewayId("hook-policy-gateway-token");
+      const hookToken = nextGatewayId("hook-policy-token");
+      const fixedSessionStore = path.join(tempHome, ".openclaw", "sessions.json");
+      const initialConfig: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "old" } },
+          entries: { old: {} },
+        },
+        gateway: { auth: { mode: "token", token: gatewayToken } },
+        hooks: { enabled: true, token: hookToken, allowedAgentIds: [] },
+        session: { scope: "global", store: fixedSessionStore },
+      };
+      await createConfigIO({ configPath }).writeConfigFile(initialConfig, {
+        allowedAgentRosterRemovals: ["main"],
+      });
+      const port = await getGatewayE2ePortBlock();
+      const hotReloadRecovery = vi.fn(() => ({ status: "emitted" as const }));
+      server = await startGatewayServer(port, {
+        bind: "loopback",
+        controlUiEnabled: false,
+        hotReloadRecovery,
+      });
+      await expect
+        .poll(
+          async () => {
+            const health = await callGateway({
+              config: initialConfig,
+              localPortOverride: port,
+              method: "health",
+              timeoutMs: 5_000,
+            });
+            return (health as { configReload?: { hotReloadStatus?: string } }).configReload
+              ?.hotReloadStatus;
+          },
+          { timeout: 5_000, interval: 50 },
+        )
+        .toBe("active");
+      const writeConfigAtomically = async (config: OpenClawConfig) => {
+        const stagedConfigPath = `${configPath}.next`;
+        await fs.writeFile(stagedConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+        await fs.rename(stagedConfigPath, configPath);
+      };
+
+      const postAgentHook = async (agentId: string) => {
+        const response = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${hookToken}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ message: "policy probe", agentId }),
+        });
+        return {
+          status: response.status,
+          body: (await response.json()) as { error?: string },
+        };
+      };
+
+      await expect(postAgentHook("old")).resolves.toMatchObject({
+        status: 400,
+        body: { error: "agentId is not allowed by hooks.allowedAgentIds" },
+      });
+      await expect(postAgentHook("new")).resolves.toMatchObject({
+        status: 400,
+        body: { error: 'unknown agentId "new"' },
+      });
+
+      const nextConfig: OpenClawConfig = {
+        ...initialConfig,
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "new" } },
+          entries: { new: {} },
+        },
+      };
+      await writeConfigAtomically(nextConfig);
+      await expect
+        .poll(
+          () => ({
+            agentIds: Object.keys(getRuntimeConfig().agents?.entries ?? {}),
+            ownerAgentId: getRuntimeConfig().agents?.defaults?.sessionStore?.agentId,
+          }),
+          { timeout: 5_000, interval: 50 },
+        )
+        .toEqual({ agentIds: ["new"], ownerAgentId: "new" });
+
+      await expect(postAgentHook("new")).resolves.toMatchObject({
+        status: 400,
+        body: { error: "agentId is not allowed by hooks.allowedAgentIds" },
+      });
+      await expect(postAgentHook("old")).resolves.toMatchObject({
+        status: 400,
+        body: { error: 'unknown agentId "old"' },
+      });
+      expect(hotReloadRecovery).not.toHaveBeenCalled();
+    } finally {
+      if (server) {
+        await server.close({ reason: "hook policy reload test complete" });
+      }
+      await removeGatewayTempHome(tempHome);
+      envSnapshot.restore();
+    }
+  });
 
   it(
     "re-resolves a startup auth SecretRef override when secrets reload",
@@ -829,157 +864,6 @@ module.exports = {
         expect(resToken.ok).toBe(true);
       } finally {
         await server2.close({ reason: "wizard auth verify" });
-        await removeGatewayTempHome(tempHome);
-        envSnapshot.restore();
-      }
-    },
-  );
-
-  it("contains hosted wizard exits", { timeout: GATEWAY_E2E_TIMEOUT_MS }, async () => {
-    const { envSnapshot, tempHome } = await setupGatewayTempHome({
-      prefix: "openclaw-wizard-contained-exit-home-",
-      minimalGateway: true,
-    });
-    const wizardToken = nextGatewayId("wiz-contained-exit");
-    let exitCode = 0;
-    const port = await getGatewayE2ePortBlock();
-    const server = await startGatewayServer(port, {
-      bind: "loopback",
-      auth: { mode: "token", token: wizardToken },
-      controlUiEnabled: false,
-      wizardRunner: async (_opts, runtime, prompter) => {
-        await prompter.outro("wizard complete");
-        runtime.exit(exitCode);
-      },
-      channelWizardRunner: async (_opts, runtime, prompter) => {
-        await prompter.outro("channel wizard complete");
-        runtime.exit(exitCode);
-      },
-    });
-    const client = await connectGatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      token: wizardToken,
-    });
-    // Intercept an actual host exit so the fail-first Gateway test cannot
-    // terminate its Vitest worker before reporting the regression.
-    const processExit = vi.spyOn(process, "exit").mockImplementation((code) => {
-      throw new Error(`Gateway process exit ${code}`);
-    });
-
-    try {
-      for (const flow of ["setup", "channels"] as const) {
-        for (const nextExitCode of [0, 23] as const) {
-          exitCode = nextExitCode;
-          const status = exitCode === 0 ? "done" : "error";
-          const start = await client.request<WizardStartResult>(
-            "wizard.start",
-            flow === "channels" ? { flow } : { mode: "local" },
-          );
-          expect(start).toMatchObject({ done: false, status: "running" });
-          expect(start.step?.id).toBeTruthy();
-
-          const result = await client.request<WizardNextResult>("wizard.next", {
-            sessionId: start.sessionId,
-            answer: { stepId: start.step?.id, value: null },
-          });
-          expect(result).toMatchObject({ done: true, status });
-          if (exitCode !== 0) {
-            expect(result.error).toContain(String(exitCode));
-          }
-          expect(processExit).not.toHaveBeenCalled();
-          await expect(client.request("health", {})).resolves.toBeDefined();
-        }
-      }
-    } finally {
-      processExit.mockRestore();
-      await disconnectGatewayClient(client);
-      await server.close({ reason: "wizard runtime isolation E2E complete" });
-      await removeGatewayTempHome(tempHome);
-      envSnapshot.restore();
-    }
-  });
-
-  it(
-    "routes wizard.start flow channels to the channel wizard runner",
-    { timeout: GATEWAY_E2E_TIMEOUT_MS },
-    async () => {
-      const { envSnapshot, tempHome } = await setupGatewayTempHome({
-        prefix: "openclaw-wizard-channels-home-",
-        minimalGateway: true,
-      });
-      const wizAuth = nextGatewayId("wiz-chan");
-      const port = await getGatewayE2ePortBlock();
-      const channelRuns: Array<string | undefined> = [];
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token: wizAuth },
-        controlUiEnabled: false,
-        wizardRunner: async () => {
-          throw new Error("setup wizard runner must not run for flow channels");
-        },
-        channelWizardRunner: async (opts, _runtime, prompter) => {
-          channelRuns.push(opts.channel);
-          await prompter.intro("Channel setup");
-          const choice = await prompter.select({
-            message: "channel",
-            options: [{ value: opts.channel ?? "none", label: opts.channel ?? "none" }],
-          });
-          opts.onConfigured?.([{ channel: choice, accountId: "default" }]);
-          await prompter.outro(`configured ${choice}`);
-        },
-      });
-
-      const client = await connectGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token: wizAuth,
-        clientDisplayName: "vitest-wizard-channels",
-      });
-
-      try {
-        for (const testCase of [
-          { label: "omitted", channel: undefined, expected: "none" },
-          { label: "canonical", channel: "telegram", expected: "telegram" },
-          { label: "alias", channel: "imsg", expected: "imsg" },
-        ]) {
-          const start = await client.request<WizardStartResult>("wizard.start", {
-            flow: "channels",
-            ...(testCase.channel === undefined ? {} : { channel: testCase.channel }),
-          });
-          const sessionId = start.sessionId;
-          expect(typeof sessionId, testCase.label).toBe("string");
-
-          let next: WizardStartResult | WizardNextResult = start;
-          const seenSteps: string[] = [];
-          while (!next.done) {
-            const step = next.step;
-            if (!step) {
-              throw new Error("wizard missing step");
-            }
-            seenSteps.push(step.type);
-            next = await client.request<WizardNextResult>(
-              "wizard.next",
-              {
-                sessionId,
-                answer: {
-                  stepId: step.id,
-                  value: step.type === "select" ? testCase.expected : null,
-                },
-              },
-              { timeoutMs: 60_000 },
-            );
-          }
-
-          expect(next.status, `${testCase.label}: seenSteps=${seenSteps.join(",")}`).toBe("done");
-          expect(seenSteps, testCase.label).toContain("select");
-          expect(next.channels, testCase.label).toEqual([testCase.expected]);
-          expect(next.accounts, testCase.label).toEqual([
-            { channel: testCase.expected, accountId: "default" },
-          ]);
-        }
-        expect(channelRuns).toEqual([undefined, "telegram", "imsg"]);
-      } finally {
-        await disconnectGatewayClient(client);
-        await server.close({ reason: "wizard channels flow complete" });
         await removeGatewayTempHome(tempHome);
         envSnapshot.restore();
       }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -2090,7 +2090,7 @@ describe("gateway hot reload commit policy", () => {
     expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(false);
   });
 
-  it("preserves the active hook transform cache when hook preparation rejects the config", async () => {
+  it("preserves the active hook transform cache across rejected and policy-only reloads", async () => {
     const configDir = autoCleanupTempDirs.make("openclaw-rejected-hook-reload-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
@@ -2151,6 +2151,24 @@ describe("gateway hot reload commit policy", () => {
     expect(afterRejectedReload?.ok).toBe(true);
     if (afterRejectedReload?.ok && afterRejectedReload.action?.kind === "wake") {
       expect(afterRejectedReload.action.text).toBe("accepted");
+    }
+
+    await applyHotReload(
+      createHotTailPlan({
+        changedPaths: ["agents.entries"],
+        hotReasons: ["agents.entries"],
+        refreshHooksPolicy: true,
+      }),
+      {
+        agents: { ownership: "explicit", entries: { next: {} } },
+        hooks: { enabled: true, token: "hook-secret" },
+      },
+    );
+
+    const afterPolicyReload = await applyActiveTransform();
+    expect(afterPolicyReload?.ok).toBe(true);
+    if (afterPolicyReload?.ok && afterPolicyReload.action?.kind === "wake") {
+      expect(afterPolicyReload.action.text).toBe("accepted");
     }
   });
 });

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -104,11 +104,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
     resetPreparedModelRuntimeStateForHotReload();
 
-    let hooksReloadResolved = false;
-    if (plan.reloadHooks) {
+    if (plan.reloadHooks || plan.refreshHooksPolicy) {
       try {
         nextState.hooksConfig = resolveHooksConfig(nextConfig);
-        hooksReloadResolved = true;
       } catch (err) {
         params.logHooks.warn(`hooks config reload failed: ${String(err)}`);
         throw err;
@@ -188,7 +186,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         params.setState(nextState);
         // All rejecting work is complete. Publish pre-resolved lane limits at
         // the final synchronous commit edge, alongside the accepted state.
-        if (hooksReloadResolved) {
+        if (plan.reloadHooks) {
           commitHooksConfigReload();
         }
         applyGatewayLaneConcurrency(laneConcurrency);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators hot-reloading the Gateway after changing the agent roster, agent ownership, session-store owner, or session store/scope could have direct hooks reject newly configured agents against the previous policy snapshot. The runtime config was current, but hook target validation remained stale until a Gateway restart.

## Why This Change Was Made

Gateway config diffing now preserves the exact hook-policy ownership boundaries hidden by whole-object changes. The hot-reload plan refreshes the atomic hook policy snapshot for those boundaries while keeping hook transform-cache invalidation limited to actual `hooks.*` changes.

- [x] AI-assisted; the change was reviewed and its behavior is understood.
- [x] No agent transcript is attached or requested.

## User Impact

Direct hook target validation immediately reflects hot-reloaded agent and session ownership configuration. Operators do not need to restart the Gateway after these supported configuration changes, and existing hook transform modules remain cached when only target policy changes.

## Evidence

Before the fix, the real Gateway hot-reload regression command failed after adding agent `new`: expected `agentId is not allowed by hooks.allowedAgentIds`, but received `unknown agentId "new"`.

After the fix, the same real Gateway flow passes and verifies both sides of the policy transition: `new` is recognized and evaluated by the refreshed allowlist, while removed agent `old` becomes unknown. Focused validation completed successfully:

- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts` — 193 tests passed.
- `node scripts/run-vitest.mjs src/gateway/gateway.test.ts -t "refreshes direct hook target policy"` — real Gateway hot-reload regression passed.
- `node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts -t "preserves the active hook transform cache"` — transform-cache regression passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/gateway/gateway-wizard.e2e.test.ts` — 2 moved wizard E2E tests passed in their owning lane.
- `node scripts/check-changed.mjs` — passed.
- `git diff --check` — passed.
- Two independent Codex autoreviews completed cleanly with no accepted/actionable findings.

Raw LOC: production `+40/-17` (net `+23`); tests/test support `+513/-239`. Most test churn moves existing Gateway setup and wizard E2E coverage into `gateway.test-support.ts` and `gateway-wizard.e2e.test.ts` so the cases remain in the owning E2E lane and the main Gateway test stays within the max-lines guard.
