### PR TITLE
refactor(tooling): unify benchmark and process helpers

### DIFF
--- a/scripts/bench-agent-concurrency.ts
+++ b/scripts/bench-agent-concurrency.ts
@@ -1,9 +1,18 @@
-import { spawnSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { classifyBoundedUnsignedDecimal } from "./lib/arg-utils.mts";
+import {
+  emitBenchmarkReport,
+  parseBenchmarkInteger,
+  parseBenchmarkIntegerList,
+  parseBenchmarkOptions,
+  parseBenchmarkWorkerResult,
+  runBenchmarkEntrypoint,
+  runBenchmarkJobs,
+  runBenchmarkWorker,
+  summarizeBenchmarkTimings,
+  type BenchmarkTimingSummary,
+  type BenchmarkWorkerProcessResult,
+} from "./lib/benchmark-harness.mts";
 
 const DEFAULT_FANOUT = [1, 8, 32, 64];
 const DEFAULT_SWEEP_ROWS = [32, 128, 512];
@@ -37,15 +46,6 @@ type Options = {
   output?: string;
   json: boolean;
   help: boolean;
-};
-
-type TimingSummary = {
-  count: number;
-  min: number;
-  p50: number;
-  max: number;
-  p95?: number;
-  p99?: number;
 };
 
 const SCENARIO_SPECS: ReadonlyArray<{
@@ -114,13 +114,6 @@ const REQUIRED_INVARIANT_FIELDS: Record<WorkerScenario, readonly string[]> = {
   ],
 };
 
-type WorkerProcessResult = {
-  status: number | null;
-  stdout: string;
-  stderr: string;
-  error?: Error & { code?: string };
-};
-
 type BenchmarkRuntime = {
   runWorker?: typeof runWorker;
   writeProgress?: (line: string) => void;
@@ -144,98 +137,35 @@ Options:
 `;
 }
 
-function parseInteger(raw: string, flag: string, min: number, max: number): number {
-  const result = classifyBoundedUnsignedDecimal(raw, min, max);
-  if (result.kind === "syntax") {
-    throw new Error(`${flag} must be an integer`);
-  }
-  if (result.kind === "below") {
-    throw new Error(`${flag} must be at least ${min}`);
-  }
-  if (result.kind === "above") {
-    throw new Error(`${flag} must be at most ${max}`);
-  }
-  return result.value;
-}
-
-function parseList(raw: string, flag: string, max: number): number[] {
-  if (!raw || raw.split(",").some((value) => value.length === 0)) {
-    throw new Error(`${flag} requires a comma-separated integer list`);
-  }
-  const values = raw.split(",").map((value) => parseInteger(value, flag, 1, max));
-  if (new Set(values).size !== values.length) {
-    throw new Error(`${flag} contains duplicate values`);
-  }
-  return values;
-}
-
 function parseOptions(argv: string[]): Options {
-  const options: Options = {
-    runs: 5,
-    warmup: 1,
-    fanout: DEFAULT_FANOUT,
-    sweepRows: DEFAULT_SWEEP_ROWS,
-    json: false,
-    help: false,
-  };
-  const seen = new Set<string>();
-  const valueFlags = new Set(["--runs", "--warmup", "--fanout", "--sweep-rows", "--output"]);
-  for (let index = 0; index < argv.length; index += 1) {
-    const flag = argv[index];
-    if (!flag?.startsWith("--")) {
-      throw new Error(`Unknown argument: ${flag}`);
-    }
-    if (seen.has(flag)) {
-      throw new Error(`${flag} was provided more than once`);
-    }
-    seen.add(flag);
-    if (flag === "--json" || flag === "--help") {
-      options[flag === "--json" ? "json" : "help"] = true;
-      continue;
-    }
-    if (!valueFlags.has(flag)) {
-      throw new Error(`Unknown argument: ${flag}`);
-    }
-    const value = argv[index + 1];
-    if (!value || value.startsWith("--")) {
-      throw new Error(`${flag} requires a value`);
-    }
-    index += 1;
-    if (flag === "--runs") {
-      options.runs = parseInteger(value, flag, 1, 100);
-    } else if (flag === "--warmup") {
-      options.warmup = parseInteger(value, flag, 0, 20);
-    } else if (flag === "--fanout") {
-      options.fanout = parseList(value, flag, 256);
-    } else if (flag === "--sweep-rows") {
-      options.sweepRows = parseList(value, flag, 4096);
-    } else {
-      options.output = value;
-    }
-  }
-  return options;
-}
-
-function percentile(sorted: number[], ratio: number): number {
-  return sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)] ?? 0;
-}
-
-function summarizeTimings(values: number[]): TimingSummary {
-  if (values.length === 0) {
-    throw new Error("cannot summarize an empty timing set");
-  }
-  const sorted = values.toSorted((left, right) => left - right);
-  const summary: TimingSummary = {
-    count: sorted.length,
-    min: sorted[0] ?? 0,
-    p50: percentile(sorted, 0.5),
-    max: sorted.at(-1) ?? 0,
-  };
-  if (sorted.length >= 20) {
-    summary.p95 = percentile(sorted, 0.95);
-    summary.p99 = percentile(sorted, 0.99);
-  }
-  return summary;
+  return parseBenchmarkOptions<Options>(
+    argv,
+    {
+      runs: 5,
+      warmup: 1,
+      fanout: DEFAULT_FANOUT,
+      sweepRows: DEFAULT_SWEEP_ROWS,
+      json: false,
+      help: false,
+    },
+    {
+      "--runs": (options, value) => {
+        options.runs = parseBenchmarkInteger(value, "--runs", 1, 100);
+      },
+      "--warmup": (options, value) => {
+        options.warmup = parseBenchmarkInteger(value, "--warmup", 0, 20);
+      },
+      "--fanout": (options, value) => {
+        options.fanout = parseBenchmarkIntegerList(value, "--fanout", 256);
+      },
+      "--sweep-rows": (options, value) => {
+        options.sweepRows = parseBenchmarkIntegerList(value, "--sweep-rows", 4096);
+      },
+      "--output": (options, value) => {
+        options.output = value;
+      },
+    },
+  );
 }
 
 function expectedWorkerKeys(options: Options): string[] {
@@ -275,7 +205,7 @@ function aggregateWorkerResults(
         }
         return {
           size,
-          timingsMs: summarizeTimings(worker.timingsMs),
+          timingsMs: summarizeBenchmarkTimings(worker.timingsMs),
           memory: worker.memory,
           invariant: worker.invariant,
         };
@@ -285,7 +215,7 @@ function aggregateWorkerResults(
     WorkerScenario,
     Array<{
       size: number;
-      timingsMs: TimingSummary;
+      timingsMs: BenchmarkTimingSummary;
       memory: WorkerResult["memory"];
       invariant: WorkerResult["invariant"];
     }>
@@ -377,42 +307,21 @@ function validateWorkerResult(
 }
 
 function parseWorkerProcessResult(
-  result: WorkerProcessResult,
+  result: BenchmarkWorkerProcessResult,
   expected: { scenario: WorkerScenario; size: number; runs: number },
 ): WorkerResult {
-  if (result.error) {
-    const detail =
-      "code" in result.error && result.error.code === "ETIMEDOUT"
-        ? `timed out after ${WORKER_TIMEOUT_MS}ms`
-        : result.error.message;
-    throw new Error(`worker ${expected.scenario}:${expected.size} failed: ${detail}`);
-  }
-  if (result.status !== 0) {
-    throw new Error(
-      `worker ${expected.scenario}:${expected.size} failed (${result.status ?? "signal"}): ${result.stderr.trim() || result.stdout.trim()}`,
-    );
-  }
-  const payloads = result.stdout
-    .split(/\r?\n/u)
-    .filter((line) => line.startsWith(WORKER_RESULT_SENTINEL));
-  if (payloads.length !== 1) {
-    throw new Error(
-      `worker ${expected.scenario}:${expected.size} returned ${payloads.length} result payloads`,
-    );
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(payloads[0]!.slice(WORKER_RESULT_SENTINEL.length));
-  } catch {
-    throw new Error(`worker ${expected.scenario}:${expected.size} returned invalid JSON`);
-  }
-  return validateWorkerResult(parsed, expected);
+  return parseBenchmarkWorkerResult({
+    result,
+    label: `${expected.scenario}:${expected.size}`,
+    sentinel: WORKER_RESULT_SENTINEL,
+    timeoutMs: WORKER_TIMEOUT_MS,
+    validate: (value) => validateWorkerResult(value, expected),
+  });
 }
 
 function runWorker(options: Options, scenario: WorkerScenario, size: number): WorkerResult {
-  const result = spawnSync(
-    process.execPath,
-    [
+  return runBenchmarkWorker({
+    args: [
       "--import",
       "tsx",
       "scripts/bench-agent-concurrency-worker.ts",
@@ -425,16 +334,11 @@ function runWorker(options: Options, scenario: WorkerScenario, size: number): Wo
       "--warmup",
       String(options.warmup),
     ],
-    {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: { ...process.env, NODE_NO_WARNINGS: "1" },
-      timeout: WORKER_TIMEOUT_MS,
-      killSignal: "SIGTERM",
-      maxBuffer: 16 * 1024 * 1024,
-    },
-  );
-  return parseWorkerProcessResult(result, { scenario, size, runs: options.runs });
+    label: `${scenario}:${size}`,
+    sentinel: WORKER_RESULT_SENTINEL,
+    timeoutMs: WORKER_TIMEOUT_MS,
+    validate: (value) => validateWorkerResult(value, { scenario, size, runs: options.runs }),
+  });
 }
 
 function benchmark(options: Options, runtime: BenchmarkRuntime = {}) {
@@ -443,29 +347,12 @@ function benchmark(options: Options, runtime: BenchmarkRuntime = {}) {
     options[sizes].map((size) => ({ scenario, size })),
   );
   const run = runtime.runWorker ?? runWorker;
-  const writeProgress =
-    runtime.writeProgress ?? ((line: string) => process.stderr.write(`${line}\n`));
-  const now = runtime.now ?? Date.now;
-  const workers = jobs.map(({ scenario, size }, index) => {
-    const ordinal = index + 1;
-    writeProgress(
-      `[bench-agent-concurrency] worker ${ordinal}/${jobs.length} start scenario=${scenario} size=${size}`,
-    );
-    const startedAt = now();
-    try {
-      const worker = run(options, scenario, size);
-      const elapsedMs = Math.max(0, now() - startedAt);
-      writeProgress(
-        `[bench-agent-concurrency] worker ${ordinal}/${jobs.length} complete scenario=${scenario} size=${size} elapsed=${(elapsedMs / 1_000).toFixed(3)}s`,
-      );
-      return worker;
-    } catch (error) {
-      const elapsedMs = Math.max(0, now() - startedAt);
-      writeProgress(
-        `[bench-agent-concurrency] worker ${ordinal}/${jobs.length} failed scenario=${scenario} size=${size} elapsed=${(elapsedMs / 1_000).toFixed(3)}s`,
-      );
-      throw error;
-    }
+  const workers = runBenchmarkJobs(jobs, {
+    prefix: "bench-agent-concurrency",
+    describe: ({ scenario, size }) => `scenario=${scenario} size=${size}`,
+    run: ({ scenario, size }) => run(options, scenario, size),
+    now: runtime.now,
+    writeProgress: runtime.writeProgress,
   });
   return aggregateWorkerResults(options, workers, {
     rssStartBytes,
@@ -480,29 +367,18 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
   const report = benchmark(options);
-  const json = `${JSON.stringify(report, null, 2)}\n`;
-  if (options.output) {
-    fs.mkdirSync(path.dirname(path.resolve(options.output)), { recursive: true });
-    fs.writeFileSync(options.output, json);
-  }
-  if (options.json) {
-    process.stdout.write(json);
-    return;
-  }
-  for (const [name, scenarios] of Object.entries(report.scenarios)) {
-    for (const scenario of scenarios) {
-      const tail =
-        scenario.timingsMs.p95 === undefined
-          ? ""
-          : ` p95=${scenario.timingsMs.p95.toFixed(3)}ms p99=${scenario.timingsMs.p99?.toFixed(3)}ms`;
-      console.log(
-        `${name} size=${scenario.size} p50=${scenario.timingsMs.p50.toFixed(3)}ms max=${scenario.timingsMs.max.toFixed(3)}ms${tail}`,
-      );
-    }
-  }
-  console.log(
-    `max worker RSS ${(report.memory.workerProcessMaxRssBytes / 1024 / 1024).toFixed(1)} MiB`,
-  );
+  emitBenchmarkReport(report, options, (result) => [
+    ...Object.entries(result.scenarios).flatMap(([name, scenarios]) =>
+      scenarios.map((scenario) => {
+        const tail =
+          scenario.timingsMs.p95 === undefined
+            ? ""
+            : ` p95=${scenario.timingsMs.p95.toFixed(3)}ms p99=${scenario.timingsMs.p99?.toFixed(3)}ms`;
+        return `${name} size=${scenario.size} p50=${scenario.timingsMs.p50.toFixed(3)}ms max=${scenario.timingsMs.max.toFixed(3)}ms${tail}`;
+      }),
+    ),
+    `max worker RSS ${(result.memory.workerProcessMaxRssBytes / 1024 / 1024).toFixed(1)} MiB`,
+  ]);
 }
 
 export const testing = {
@@ -510,18 +386,9 @@ export const testing = {
   benchmark,
   parseOptions,
   parseWorkerProcessResult,
-  summarizeTimings,
+  summarizeTimings: summarizeBenchmarkTimings,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  try {
-    await main();
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  } finally {
-    if (process.exitCode && process.exitCode !== 0) {
-      console.error(`[bench-agent-concurrency] FAILED (exit ${process.exitCode})`);
-    }
-  }
+  await runBenchmarkEntrypoint("bench-agent-concurrency", main);
 }

--- a/scripts/bench-task-registry-sqlite.ts
+++ b/scripts/bench-task-registry-sqlite.ts
@@ -1,10 +1,21 @@
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { classifyBoundedUnsignedDecimal } from "./lib/arg-utils.mts";
+import {
+  emitBenchmarkReport,
+  parseBenchmarkInteger,
+  parseBenchmarkIntegerList,
+  parseBenchmarkOptions,
+  parseBenchmarkWorkerResult,
+  runBenchmarkEntrypoint,
+  runBenchmarkJobs,
+  runBenchmarkWorker,
+  summarizeBenchmarkTimings,
+  type BenchmarkWorkerProcessResult,
+  type BenchmarkWorkerSpawner,
+} from "./lib/benchmark-harness.mts";
 
 const DEFAULT_SIZES = [24, 64, 128];
 const WORKER_TIMEOUT_MS = 300_000;
@@ -72,37 +83,8 @@ type Options = {
   help: boolean;
 };
 
-type TimingSummary = {
-  count: number;
-  min: number;
-  p50: number;
-  max: number;
-  p95?: number;
-  p99?: number;
-};
-
-type WorkerProcessResult = {
-  status: number | null;
-  stdout: string;
-  stderr: string;
-  error?: Error & { code?: string };
-};
-
-type WorkerSpawner = (
-  command: string,
-  args: string[],
-  options: {
-    cwd: string;
-    encoding: "utf8";
-    env: NodeJS.ProcessEnv;
-    timeout: number;
-    killSignal: NodeJS.Signals;
-    maxBuffer: number;
-  },
-) => WorkerProcessResult;
-
 type WorkerLaunchRuntime = {
-  spawnWorker?: WorkerSpawner;
+  spawnWorker?: BenchmarkWorkerSpawner;
 };
 
 type BenchmarkRuntime = {
@@ -127,95 +109,31 @@ Options:
 `;
 }
 
-function parseInteger(raw: string, flag: string, min: number, max: number): number {
-  const result = classifyBoundedUnsignedDecimal(raw, min, max);
-  if (result.kind === "syntax") {
-    throw new Error(`${flag} must be an integer`);
-  }
-  if (result.kind === "below") {
-    throw new Error(`${flag} must be at least ${min}`);
-  }
-  if (result.kind === "above") {
-    throw new Error(`${flag} must be at most ${max}`);
-  }
-  return result.value;
-}
-
-function parseList(raw: string, flag: string): number[] {
-  if (!raw || raw.split(",").some((value) => value.length === 0)) {
-    throw new Error(`${flag} requires a comma-separated integer list`);
-  }
-  const values = raw.split(",").map((value) => parseInteger(value, flag, 1, 4096));
-  if (new Set(values).size !== values.length) {
-    throw new Error(`${flag} contains duplicate values`);
-  }
-  return values;
-}
-
 function parseOptions(argv: string[]): Options {
-  const options: Options = {
-    sizes: DEFAULT_SIZES,
-    cycles: 20,
-    warmup: 3,
-    json: false,
-    help: false,
-  };
-  const seen = new Set<string>();
-  const valueFlags = new Set(["--sizes", "--cycles", "--warmup", "--output"]);
-  for (let index = 0; index < argv.length; index += 1) {
-    const flag = argv[index];
-    if (!flag?.startsWith("--")) {
-      throw new Error(`Unknown argument: ${flag}`);
-    }
-    if (seen.has(flag)) {
-      throw new Error(`${flag} was provided more than once`);
-    }
-    seen.add(flag);
-    if (flag === "--json" || flag === "--help") {
-      options[flag === "--json" ? "json" : "help"] = true;
-      continue;
-    }
-    if (!valueFlags.has(flag)) {
-      throw new Error(`Unknown argument: ${flag}`);
-    }
-    const value = argv[index + 1];
-    if (!value || value.startsWith("--")) {
-      throw new Error(`${flag} requires a value`);
-    }
-    index += 1;
-    if (flag === "--sizes") {
-      options.sizes = parseList(value, flag);
-    } else if (flag === "--cycles") {
-      options.cycles = parseInteger(value, flag, 1, 200);
-    } else if (flag === "--warmup") {
-      options.warmup = parseInteger(value, flag, 0, 20);
-    } else {
-      options.output = value;
-    }
-  }
-  return options;
-}
-
-function percentile(sorted: number[], ratio: number): number {
-  return sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)] ?? 0;
-}
-
-function summarizeTimings(values: number[]): TimingSummary {
-  if (values.length === 0) {
-    throw new Error("cannot summarize an empty timing set");
-  }
-  const sorted = values.toSorted((left, right) => left - right);
-  const summary: TimingSummary = {
-    count: sorted.length,
-    min: sorted[0] ?? 0,
-    p50: percentile(sorted, 0.5),
-    max: sorted.at(-1) ?? 0,
-  };
-  if (sorted.length >= 20) {
-    summary.p95 = percentile(sorted, 0.95);
-    summary.p99 = percentile(sorted, 0.99);
-  }
-  return summary;
+  return parseBenchmarkOptions<Options>(
+    argv,
+    {
+      sizes: DEFAULT_SIZES,
+      cycles: 20,
+      warmup: 3,
+      json: false,
+      help: false,
+    },
+    {
+      "--sizes": (options, value) => {
+        options.sizes = parseBenchmarkIntegerList(value, "--sizes", 4096);
+      },
+      "--cycles": (options, value) => {
+        options.cycles = parseBenchmarkInteger(value, "--cycles", 1, 200);
+      },
+      "--warmup": (options, value) => {
+        options.warmup = parseBenchmarkInteger(value, "--warmup", 0, 20);
+      },
+      "--output": (options, value) => {
+        options.output = value;
+      },
+    },
+  );
 }
 
 function assertFinite(value: unknown, field: string): asserts value is number {
@@ -400,34 +318,16 @@ function validateWorkerResult(
 }
 
 function parseWorkerProcessResult(
-  result: WorkerProcessResult,
+  result: BenchmarkWorkerProcessResult,
   expected: { size: number; cycles: number; warmup: number },
 ): WorkerResult {
-  if (result.error) {
-    const detail =
-      result.error.code === "ETIMEDOUT"
-        ? `timed out after ${WORKER_TIMEOUT_MS}ms`
-        : result.error.message;
-    throw new Error(`worker size ${expected.size} failed: ${detail}`);
-  }
-  if (result.status !== 0) {
-    throw new Error(
-      `worker size ${expected.size} failed (${result.status ?? "signal"}): ${result.stderr.trim() || result.stdout.trim()}`,
-    );
-  }
-  const payloads = result.stdout
-    .split(/\r?\n/u)
-    .filter((line) => line.startsWith(WORKER_RESULT_SENTINEL));
-  if (payloads.length !== 1) {
-    throw new Error(`worker size ${expected.size} returned ${payloads.length} result payloads`);
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(payloads[0]!.slice(WORKER_RESULT_SENTINEL.length));
-  } catch {
-    throw new Error(`worker size ${expected.size} returned invalid JSON`);
-  }
-  return validateWorkerResult(parsed, expected);
+  return parseBenchmarkWorkerResult({
+    result,
+    label: `size ${expected.size}`,
+    sentinel: WORKER_RESULT_SENTINEL,
+    timeoutMs: WORKER_TIMEOUT_MS,
+    validate: (value) => validateWorkerResult(value, expected),
+  });
 }
 
 function buildWorkerArgs(options: Options, size: number, stateDir: string): string[] {
@@ -453,22 +353,19 @@ function runWorker(
   runtime: WorkerLaunchRuntime = {},
 ): WorkerResult {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-task-registry-bench-"));
-  const spawnWorker =
-    runtime.spawnWorker ??
-    ((command, args, spawnOptions) => spawnSync(command, args, spawnOptions));
   try {
-    const result = spawnWorker(process.execPath, buildWorkerArgs(options, size, stateDir), {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: { ...process.env, NODE_NO_WARNINGS: "1" },
-      timeout: WORKER_TIMEOUT_MS,
-      killSignal: "SIGTERM",
-      maxBuffer: 16 * 1024 * 1024,
-    });
-    return parseWorkerProcessResult(result, {
-      size,
-      cycles: options.cycles,
-      warmup: options.warmup,
+    return runBenchmarkWorker({
+      args: buildWorkerArgs(options, size, stateDir),
+      label: `size ${size}`,
+      sentinel: WORKER_RESULT_SENTINEL,
+      spawnWorker: runtime.spawnWorker,
+      timeoutMs: WORKER_TIMEOUT_MS,
+      validate: (value) =>
+        validateWorkerResult(value, {
+          size,
+          cycles: options.cycles,
+          warmup: options.warmup,
+        }),
     });
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });
@@ -495,9 +392,9 @@ function aggregateWorkerResults(options: Options, workers: WorkerResult[]) {
     return {
       size,
       timingsMs: {
-        registration: summarizeTimings(worker.timingsMs.registration),
-        terminal: summarizeTimings(worker.timingsMs.terminal),
-        teardown: summarizeTimings(worker.timingsMs.teardown),
+        registration: summarizeBenchmarkTimings(worker.timingsMs.registration),
+        terminal: summarizeBenchmarkTimings(worker.timingsMs.terminal),
+        teardown: summarizeBenchmarkTimings(worker.timingsMs.teardown),
       },
       memory: worker.memory,
       invariant: worker.invariant,
@@ -546,27 +443,12 @@ function aggregateWorkerResults(options: Options, workers: WorkerResult[]) {
 
 function benchmark(options: Options, runtime: BenchmarkRuntime = {}) {
   const run = runtime.runWorker ?? runWorker;
-  const writeProgress =
-    runtime.writeProgress ?? ((line: string) => process.stderr.write(`${line}\n`));
-  const now = runtime.now ?? Date.now;
-  const workers = options.sizes.map((size, index) => {
-    const ordinal = index + 1;
-    writeProgress(
-      `[bench-task-registry-sqlite] worker ${ordinal}/${options.sizes.length} start size=${size}`,
-    );
-    const startedAt = now();
-    try {
-      const worker = run(options, size);
-      writeProgress(
-        `[bench-task-registry-sqlite] worker ${ordinal}/${options.sizes.length} complete size=${size} elapsed=${(Math.max(0, now() - startedAt) / 1_000).toFixed(3)}s`,
-      );
-      return worker;
-    } catch (error) {
-      writeProgress(
-        `[bench-task-registry-sqlite] worker ${ordinal}/${options.sizes.length} failed size=${size} elapsed=${(Math.max(0, now() - startedAt) / 1_000).toFixed(3)}s`,
-      );
-      throw error;
-    }
+  const workers = runBenchmarkJobs(options.sizes, {
+    prefix: "bench-task-registry-sqlite",
+    describe: (size) => `size=${size}`,
+    run: (size) => run(options, size),
+    now: runtime.now,
+    writeProgress: runtime.writeProgress,
   });
   return aggregateWorkerResults(options, workers);
 }
@@ -578,24 +460,15 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
   const report = benchmark(options);
-  const json = `${JSON.stringify(report, null, 2)}\n`;
-  if (options.output) {
-    fs.mkdirSync(path.dirname(path.resolve(options.output)), { recursive: true });
-    fs.writeFileSync(options.output, json);
-  }
-  if (options.json) {
-    process.stdout.write(json);
-    return;
-  }
-  for (const entry of report.sizes) {
-    const registration = entry.timingsMs.registration;
-    const heapSlope = entry.memory.retainedSlopesBytesPerCycle.heapUsedBytes;
-    console.log(
-      `size=${entry.size} registration-p50=${registration.p50.toFixed(3)}ms registration-max=${registration.max.toFixed(3)}ms post-gc-heap-slope=${heapSlope.toFixed(1)}B/cycle`,
-    );
-  }
-  console.log(report.interpretation.timings);
-  console.log(report.interpretation.memory);
+  emitBenchmarkReport(report, options, (result) => [
+    ...result.sizes.map((entry) => {
+      const registration = entry.timingsMs.registration;
+      const heapSlope = entry.memory.retainedSlopesBytesPerCycle.heapUsedBytes;
+      return `size=${entry.size} registration-p50=${registration.p50.toFixed(3)}ms registration-max=${registration.max.toFixed(3)}ms post-gc-heap-slope=${heapSlope.toFixed(1)}B/cycle`;
+    }),
+    result.interpretation.timings,
+    result.interpretation.memory,
+  ]);
 }
 
 export const testing = {
@@ -605,18 +478,9 @@ export const testing = {
   parseOptions,
   parseWorkerProcessResult,
   runWorker,
-  summarizeTimings,
+  summarizeTimings: summarizeBenchmarkTimings,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  try {
-    await main();
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  } finally {
-    if (process.exitCode && process.exitCode !== 0) {
-      console.error(`[bench-task-registry-sqlite] FAILED (exit ${process.exitCode})`);
-    }
-  }
+  await runBenchmarkEntrypoint("bench-task-registry-sqlite", main);
 }

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -16,8 +16,8 @@ import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercio
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { parseStrictBooleanArg } from "../lib/arg-utils.mts";
 import { coerceErrorMessage, toStringifiedError } from "../lib/error-format.mts";
+import { terminateManagedChild } from "../lib/managed-child-process.mts";
 import { sleep } from "../lib/sleep.mjs";
-import { resolveWindowsTaskkillPath } from "../lib/windows-taskkill.mjs";
 import { createPnpmRunnerSpawnSpec } from "../pnpm-runner.mts";
 import { readPositiveIntEnv } from "./lib/env-limits.mjs";
 import { readTextFileTail } from "./lib/text-file-utils.mjs";
@@ -813,51 +813,6 @@ function timedOutError(message: string) {
 const activeCommandChildren = new Set<ChildProcess>();
 let commandCleanupHandlersInstalled = false;
 
-type CommandTreeTarget = Pick<ChildProcess, "kill" | "pid">;
-
-export function signalCommandTree(
-  child: CommandTreeTarget,
-  signal: NodeJS.Signals,
-  {
-    platform = process.platform,
-    runTaskkill = spawnSync,
-    useProcessGroup = platform !== "win32",
-  }: {
-    platform?: NodeJS.Platform;
-    runTaskkill?: (
-      command: string,
-      args: readonly string[],
-      options: { stdio: "ignore" },
-    ) => { error?: Error; status: number | null };
-    useProcessGroup?: boolean;
-  } = {},
-) {
-  if (child.pid && useProcessGroup) {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {}
-  }
-  if (platform === "win32" && typeof child.pid === "number") {
-    const args = ["/PID", String(child.pid), "/T"];
-    if (signal === "SIGKILL") {
-      args.push("/F");
-    }
-    const taskkillPath = resolveWindowsTaskkillPath();
-    const result = runTaskkill(taskkillPath, args, { stdio: "ignore" });
-    if (!result?.error && result?.status === 0) {
-      return;
-    }
-    if (signal !== "SIGKILL") {
-      const forceResult = runTaskkill(taskkillPath, [...args, "/F"], { stdio: "ignore" });
-      if (!forceResult?.error && forceResult?.status === 0) {
-        return;
-      }
-    }
-  }
-  child.kill(signal);
-}
-
 function commandProcessTreeAlive(child: ChildProcess) {
   if (!child.pid || process.platform === "win32") {
     return child.exitCode === null && child.signalCode === null;
@@ -902,7 +857,7 @@ async function finishTimedOutCommandProcessTree(
     await waitForCommandProcessTreeExit(child, graceRemainingMs);
   }
   if (commandProcessTreeAlive(child)) {
-    signalCommandTree(child, "SIGKILL");
+    terminateManagedChild(child, "SIGKILL");
     await waitForCommandProcessTreeExit(child, options.timeoutKillGraceMs);
   }
   activeCommandChildren.delete(child);
@@ -916,7 +871,7 @@ function untrackCommandChild(child: ChildProcess) {
 
 function signalActiveCommandChildren(signal: NodeJS.Signals) {
   for (const child of activeCommandChildren) {
-    signalCommandTree(child, signal);
+    terminateManagedChild(child, signal);
   }
 }
 
@@ -990,10 +945,10 @@ export function runCommand(params: {
           stderr,
         )}`,
       );
-      signalCommandTree(child, "SIGTERM");
+      terminateManagedChild(child, "SIGTERM");
       forceKillAt = Date.now() + timeoutKillGraceMs;
       killTimer = setTimeout(() => {
-        signalCommandTree(child, "SIGKILL");
+        terminateManagedChild(child, "SIGKILL");
       }, timeoutKillGraceMs);
       killTimer.unref?.();
     }, timeoutMs);
@@ -1010,7 +965,7 @@ export function runCommand(params: {
         const appended = appendCommandStdout(stdout, chunk);
         if (!appended.ok) {
           stdoutLimitError = appended.message;
-          signalCommandTree(child, "SIGKILL");
+          terminateManagedChild(child, "SIGKILL");
         } else {
           stdout = appended.value;
         }
@@ -1151,14 +1106,7 @@ function killTree(child: ChildProcess | undefined) {
   if (!child) {
     return;
   }
-  if (!child.pid) {
-    return;
-  }
-  try {
-    process.kill(-child.pid, "SIGTERM");
-  } catch {
-    child.kill("SIGTERM");
-  }
+  terminateManagedChild(child, "SIGTERM");
 }
 
 export function signalPidTree(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM") {

--- a/scripts/e2e/telegram-user-credential-io.ts
+++ b/scripts/e2e/telegram-user-credential-io.ts
@@ -1,15 +1,9 @@
 // Telegram User Credential Io script supports OpenClaw repository automation.
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
-import { resolveWindowsTaskkillPath } from "../lib/windows-taskkill.mjs";
+import { terminateManagedChild } from "../lib/managed-child-process.mts";
 
 export type JsonObject = Record<string, unknown>;
-
-type RunTaskkill = (
-  command: string,
-  args: string[],
-  options: { stdio: "ignore" },
-) => { error?: Error; status: number | null };
 
 type FetchJsonParams = {
   fetchImpl?: (url: string, init: RequestInit) => Promise<Response>;
@@ -251,49 +245,6 @@ async function finishTimedOutChildProcessTree(
   }
 }
 
-type ChildProcessTreeTarget = Pick<ReturnType<typeof spawn>, "kill" | "pid">;
-
-export function signalChildProcessTree(
-  child: ChildProcessTreeTarget,
-  signal: NodeJS.Signals,
-  {
-    platform = process.platform,
-    runTaskkill = spawnSync,
-    useProcessGroup = platform !== "win32",
-  }: {
-    platform?: NodeJS.Platform;
-    runTaskkill?: RunTaskkill;
-    useProcessGroup?: boolean;
-  } = {},
-) {
-  if (useProcessGroup && child.pid) {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {
-      // The process group can disappear between timeout and cleanup.
-    }
-  }
-  if (platform === "win32" && typeof child.pid === "number") {
-    const args = ["/PID", String(child.pid), "/T"];
-    if (signal === "SIGKILL") {
-      args.push("/F");
-    }
-    const taskkillPath = resolveWindowsTaskkillPath();
-    const result = runTaskkill(taskkillPath, args, { stdio: "ignore" });
-    if (!result?.error && result?.status === 0) {
-      return;
-    }
-    if (signal !== "SIGKILL") {
-      const forceResult = runTaskkill(taskkillPath, [...args, "/F"], { stdio: "ignore" });
-      if (!forceResult?.error && forceResult?.status === 0) {
-        return;
-      }
-    }
-  }
-  child.kill(signal);
-}
-
 function childProcessTreeMayStillExist(child: ReturnType<typeof spawn>) {
   if (process.platform === "win32" || !child.pid) {
     return false;
@@ -320,7 +271,7 @@ async function waitForChildProcessTreeExit(child: ReturnType<typeof spawn>, time
 }
 
 function registerActiveChildProcessTree(child: ReturnType<typeof spawn>) {
-  const killChildTree = (signal: NodeJS.Signals) => signalChildProcessTree(child, signal);
+  const killChildTree = (signal: NodeJS.Signals) => terminateManagedChild(child, signal);
   ACTIVE_CHILD_TREE_KILLERS.add(killChildTree);
   return {
     killChildTree,

--- a/scripts/lib/benchmark-harness.mts
+++ b/scripts/lib/benchmark-harness.mts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { classifyBoundedUnsignedDecimal } from "./arg-utils.mts";
 
-export type BenchmarkCliOptions = {
+type BenchmarkCliOptions = {
   help: boolean;
   json: boolean;
   output?: string;

--- a/scripts/lib/benchmark-harness.mts
+++ b/scripts/lib/benchmark-harness.mts
@@ -1,0 +1,248 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { classifyBoundedUnsignedDecimal } from "./arg-utils.mts";
+
+export type BenchmarkCliOptions = {
+  help: boolean;
+  json: boolean;
+  output?: string;
+};
+
+export type BenchmarkTimingSummary = {
+  count: number;
+  min: number;
+  p50: number;
+  max: number;
+  p95?: number;
+  p99?: number;
+};
+
+export type BenchmarkWorkerProcessResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error & { code?: string };
+};
+
+export type BenchmarkWorkerSpawner = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    encoding: "utf8";
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    killSignal: NodeJS.Signals;
+    maxBuffer: number;
+  },
+) => BenchmarkWorkerProcessResult;
+
+export function parseBenchmarkInteger(raw: string, flag: string, min: number, max: number) {
+  const result = classifyBoundedUnsignedDecimal(raw, min, max);
+  if (result.kind === "syntax") {
+    throw new Error(`${flag} must be an integer`);
+  }
+  if (result.kind === "below") {
+    throw new Error(`${flag} must be at least ${min}`);
+  }
+  if (result.kind === "above") {
+    throw new Error(`${flag} must be at most ${max}`);
+  }
+  return result.value;
+}
+
+export function parseBenchmarkIntegerList(raw: string, flag: string, max: number) {
+  if (!raw || raw.split(",").some((value) => value.length === 0)) {
+    throw new Error(`${flag} requires a comma-separated integer list`);
+  }
+  const values = raw.split(",").map((value) => parseBenchmarkInteger(value, flag, 1, max));
+  if (new Set(values).size !== values.length) {
+    throw new Error(`${flag} contains duplicate values`);
+  }
+  return values;
+}
+
+export function parseBenchmarkOptions<T extends BenchmarkCliOptions>(
+  argv: string[],
+  defaults: T,
+  valueFlags: Record<string, (options: T, value: string) => void>,
+) {
+  const options = { ...defaults };
+  const seen = new Set<string>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!flag?.startsWith("--")) {
+      throw new Error(`Unknown argument: ${flag}`);
+    }
+    if (seen.has(flag)) {
+      throw new Error(`${flag} was provided more than once`);
+    }
+    seen.add(flag);
+    if (flag === "--json" || flag === "--help") {
+      options[flag === "--json" ? "json" : "help"] = true;
+      continue;
+    }
+    const applyValue = valueFlags[flag];
+    if (!applyValue) {
+      throw new Error(`Unknown argument: ${flag}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    index += 1;
+    applyValue(options, value);
+  }
+  return options;
+}
+
+function percentile(sorted: number[], ratio: number) {
+  return sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)] ?? 0;
+}
+
+export function summarizeBenchmarkTimings(values: number[]): BenchmarkTimingSummary {
+  if (values.length === 0) {
+    throw new Error("cannot summarize an empty timing set");
+  }
+  const sorted = values.toSorted((left, right) => left - right);
+  const summary: BenchmarkTimingSummary = {
+    count: sorted.length,
+    min: sorted[0] ?? 0,
+    p50: percentile(sorted, 0.5),
+    max: sorted.at(-1) ?? 0,
+  };
+  if (sorted.length >= 20) {
+    summary.p95 = percentile(sorted, 0.95);
+    summary.p99 = percentile(sorted, 0.99);
+  }
+  return summary;
+}
+
+export function parseBenchmarkWorkerResult<T>(params: {
+  label: string;
+  result: BenchmarkWorkerProcessResult;
+  sentinel: string;
+  timeoutMs: number;
+  validate(value: unknown): T;
+}) {
+  if (params.result.error) {
+    const detail =
+      params.result.error.code === "ETIMEDOUT"
+        ? `timed out after ${params.timeoutMs}ms`
+        : params.result.error.message;
+    throw new Error(`worker ${params.label} failed: ${detail}`);
+  }
+  if (params.result.status !== 0) {
+    throw new Error(
+      `worker ${params.label} failed (${params.result.status ?? "signal"}): ${params.result.stderr.trim() || params.result.stdout.trim()}`,
+    );
+  }
+  const payloads = params.result.stdout
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith(params.sentinel));
+  if (payloads.length !== 1) {
+    throw new Error(`worker ${params.label} returned ${payloads.length} result payloads`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payloads[0]!.slice(params.sentinel.length));
+  } catch {
+    throw new Error(`worker ${params.label} returned invalid JSON`);
+  }
+  return params.validate(parsed);
+}
+
+export function runBenchmarkWorker<T>(params: {
+  args: string[];
+  label: string;
+  sentinel: string;
+  spawnWorker?: BenchmarkWorkerSpawner;
+  timeoutMs: number;
+  validate(value: unknown): T;
+}) {
+  const spawnWorker: BenchmarkWorkerSpawner = params.spawnWorker ?? spawnSync;
+  const result = spawnWorker(process.execPath, params.args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    timeout: params.timeoutMs,
+    killSignal: "SIGTERM",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return parseBenchmarkWorkerResult({
+    label: params.label,
+    result,
+    sentinel: params.sentinel,
+    timeoutMs: params.timeoutMs,
+    validate: (value) => params.validate(value),
+  });
+}
+
+export function runBenchmarkJobs<TJob, TResult>(
+  jobs: TJob[],
+  options: {
+    describe(job: TJob): string;
+    now?: () => number;
+    prefix: string;
+    run(job: TJob): TResult;
+    writeProgress?: (line: string) => void;
+  },
+) {
+  const now = options.now ?? Date.now;
+  const writeProgress =
+    options.writeProgress ?? ((line: string) => process.stderr.write(`${line}\n`));
+  return jobs.map((job, index) => {
+    const ordinal = index + 1;
+    const description = options.describe(job);
+    writeProgress(`[${options.prefix}] worker ${ordinal}/${jobs.length} start ${description}`);
+    const startedAt = now();
+    try {
+      const result = options.run(job);
+      const elapsedMs = Math.max(0, now() - startedAt);
+      writeProgress(
+        `[${options.prefix}] worker ${ordinal}/${jobs.length} complete ${description} elapsed=${(elapsedMs / 1_000).toFixed(3)}s`,
+      );
+      return result;
+    } catch (error) {
+      const elapsedMs = Math.max(0, now() - startedAt);
+      writeProgress(
+        `[${options.prefix}] worker ${ordinal}/${jobs.length} failed ${description} elapsed=${(elapsedMs / 1_000).toFixed(3)}s`,
+      );
+      throw error;
+    }
+  });
+}
+
+export function emitBenchmarkReport<T>(
+  report: T,
+  options: BenchmarkCliOptions,
+  renderLines: (report: T) => string[],
+) {
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.output) {
+    fs.mkdirSync(path.dirname(path.resolve(options.output)), { recursive: true });
+    fs.writeFileSync(options.output, json);
+  }
+  if (options.json) {
+    process.stdout.write(json);
+    return;
+  }
+  const lines = renderLines(report);
+  if (lines.length > 0) {
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+}
+
+export async function runBenchmarkEntrypoint(name: string, run: () => void | Promise<void>) {
+  try {
+    await run();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  } finally {
+    if (process.exitCode && process.exitCode !== 0) {
+      console.error(`[${name}] FAILED (exit ${process.exitCode})`);
+    }
+  }
+}

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -40,7 +40,7 @@ type RunManagedCommandOptions = ManagedCommandOptions & {
 type ManagedChild = {
   child: ChildProcess;
   forceKillTimer: ReturnType<typeof setTimeout> | null;
-  receivedSignal: NodeJS.Signals | null;
+  receivedSignal?: NodeJS.Signals;
 };
 
 const managedChildren = new Set<ManagedChild>();
@@ -60,35 +60,59 @@ export function signalExitCode(signal: NodeJS.Signals) {
 /**
  * @param {import("node:child_process").ChildProcess} child
  * @param {NodeJS.Signals} [signal]
- * @param {{ platform?: NodeJS.Platform; runTaskkill?: typeof spawnSync }} [options]
+ * @param {{
+ *   onProcessGroupSignalError?: (error: unknown) => void;
+ *   platform?: NodeJS.Platform;
+ *   runTaskkill?: typeof spawnSync;
+ *   useProcessGroup?: boolean;
+ * }} [options]
  * @returns {{ processTreeState: "indeterminate" | "signaled" | "terminated" } | undefined}
  */
 export function terminateManagedChild(
-  child: Pick<ChildProcess, "kill" | "pid">,
+  child: { kill(signal?: NodeJS.Signals): unknown; pid?: number },
   signal: NodeJS.Signals = "SIGTERM",
   {
+    onProcessGroupSignalError,
     platform = process.platform,
     runTaskkill = spawnSync,
-  }: { platform?: NodeJS.Platform; runTaskkill?: TaskkillRunner } = {},
+    useProcessGroup = platform !== "win32",
+  }: {
+    onProcessGroupSignalError?: (error: unknown) => void;
+    platform?: NodeJS.Platform;
+    runTaskkill?: TaskkillRunner;
+    useProcessGroup?: boolean;
+  } = {},
 ): ManagedChildTermination | undefined {
   if (!child.pid) {
+    try {
+      const delivered = child.kill(signal);
+      if (platform !== "win32") {
+        return { processTreeState: delivered === false ? "terminated" : "signaled" };
+      }
+    } catch {
+      // A child that never acquired a PID may already have failed to spawn.
+    }
     return platform === "win32" ? { processTreeState: "indeterminate" } : undefined;
   }
 
   try {
-    if (platform !== "win32") {
+    if (platform !== "win32" && useProcessGroup) {
       process.kill(-child.pid, signal);
       return { processTreeState: "signaled" };
     }
   } catch (error) {
     if (!isMissingProcessError(error)) {
-      try {
-        child.kill(signal);
-      } catch {
-        // The process may have already exited between the group kill and fallback kill.
-      }
+      onProcessGroupSignalError?.(error);
     }
-    return isMissingProcessError(error) ? { processTreeState: "terminated" } : undefined;
+  }
+
+  if (platform !== "win32") {
+    try {
+      const delivered = child.kill(signal);
+      return { processTreeState: delivered === false ? "terminated" : "signaled" };
+    } catch (error) {
+      return isMissingProcessError(error) ? { processTreeState: "terminated" } : undefined;
+    }
   }
 
   if (platform === "win32") {
@@ -172,10 +196,10 @@ export async function runManagedCommand({
     comSpec,
   });
   const child = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options);
-  const managedChild = {
+  const managedChild: ManagedChild = {
     child,
     forceKillTimer: null,
-    receivedSignal: null,
+    receivedSignal: undefined,
   };
   addManagedChild(managedChild);
   let timeoutTimer: ReturnType<typeof setTimeout> | null = null;

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -22,6 +22,7 @@ import {
   isLocalCheckEnabled,
   resolveRepoToolBinPath,
 } from "./lib/local-check-runtime.mts";
+import { terminateManagedChild } from "./lib/managed-child-process.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import {
   listPluginSdkDeclarationOutputs,
@@ -29,7 +30,6 @@ import {
   productionPluginSdkEntrypoints,
 } from "./lib/plugin-sdk-entries.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
-import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 const repoRoot = resolveRepoRoot(import.meta.url);
 const runTsgoScript = path.join(repoRoot, "scripts/run-tsgo.mjs");
 const TYPE_INPUT_EXTENSIONS = new Set([
@@ -93,11 +93,6 @@ type NodeStepParams = {
   env?: NodeJS.ProcessEnv;
   spawnImpl?: SpawnNodeStep;
 };
-type RunTaskkill = (
-  command: string,
-  args: string[],
-  options: { stdio: "ignore" },
-) => { error?: Error; status: number | null };
 const ACTIVE_NODE_STEP_KILLERS = new Map<(signal: NodeStepSignal) => void, number>();
 let nodeStepParentSignalForwardersInstalled = false;
 let exitingAfterParentSignal = false;
@@ -732,47 +727,6 @@ function abortSiblingSteps(abortController: AbortController | undefined) {
   }
 }
 
-export function signalNodeStep(
-  child: Pick<NodeStepChild, "kill" | "pid">,
-  signal: NodeStepSignal,
-  {
-    platform = process.platform,
-    runTaskkill = spawnSync,
-    useProcessGroup = platform !== "win32",
-  }: {
-    platform?: NodeJS.Platform;
-    runTaskkill?: RunTaskkill;
-    useProcessGroup?: boolean;
-  } = {},
-) {
-  if (useProcessGroup && typeof child.pid === "number") {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {
-      // The child process group can already be gone by the time cleanup runs.
-    }
-  }
-  if (platform === "win32" && typeof child.pid === "number") {
-    const args = ["/PID", String(child.pid), "/T"];
-    if (signal === "SIGKILL") {
-      args.push("/F");
-    }
-    const taskkillPath = resolveWindowsTaskkillPath();
-    const result = runTaskkill(taskkillPath, args, { stdio: "ignore" });
-    if (!result?.error && result?.status === 0) {
-      return;
-    }
-    if (signal !== "SIGKILL") {
-      const forceResult = runTaskkill(taskkillPath, [...args, "/F"], { stdio: "ignore" });
-      if (!forceResult?.error && forceResult?.status === 0) {
-        return;
-      }
-    }
-  }
-  child.kill(signal);
-}
-
 function signalActiveNodeSteps(signal: NodeStepSignal) {
   for (const killNodeStep of ACTIVE_NODE_STEP_KILLERS.keys()) {
     killNodeStep(signal);
@@ -844,7 +798,7 @@ export function runNodeStep(
     const stderrWriter = createPrefixedOutputWriter(label, process.stderr);
     const useProcessGroup = process.platform !== "win32";
     const killNodeStep = (signal: NodeStepSignal) =>
-      signalNodeStep(child, signal, { useProcessGroup });
+      terminateManagedChild(child, signal, { useProcessGroup });
     const processGroupAlive = () => {
       if (!useProcessGroup || !child.pid) {
         return false;

--- a/scripts/resolve-openclaw-package-candidate.mts
+++ b/scripts/resolve-openclaw-package-candidate.mts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Normalizes package-acceptance inputs into the tarball shape consumed by Docker E2E.
 import { Buffer } from "node:buffer";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { createHash } from "node:crypto";
 import { lookup as dnsLookupCb } from "node:dns";
@@ -20,9 +20,9 @@ import { fileURLToPath } from "node:url";
 import { isRecord as isJsonRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { booleanFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
 import { toErrorObject } from "./lib/error-format.mts";
+import { terminateManagedChild } from "./lib/managed-child-process.mts";
 import { resolveNpmJsonEntries } from "./lib/npm-json-output.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
-import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 import { resolveNpmRunner } from "./npm-runner.mts";
 import { createPrepublishPluginRegistryArtifact } from "./prepublish-plugin-registry-artifact.mjs";
 
@@ -39,11 +39,9 @@ const FORWARDED_SIGNAL_KILL_AFTER_MS = 250;
 const COMMAND_PROCESS_TREE_EXIT_POLL_MS = 50;
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 type ChildSignal = ChildProcess["signalCode"];
-type ProcessSignal = Parameters<ChildProcess["kill"]>[0];
 type TimerHandle = ReturnType<typeof setTimeout>;
-type ChildKiller = (signal: ProcessSignal) => void;
+type ChildKiller = (signal: NodeJS.Signals) => void;
 type ProcessTreeChild = Pick<ChildProcess, "exitCode" | "kill" | "pid" | "signalCode">;
-type ProcessTreeSignalTarget = Pick<ChildProcess, "kill" | "pid">;
 type CommandOutputBuffer = {
   text: string;
   truncatedChars: number;
@@ -363,7 +361,7 @@ function run(command: string, args: readonly string[], options: RunOptions = {})
     let killTimer: TimerHandle | undefined;
     let forceKillAt: number | undefined;
     const killChild: ChildKiller = (signal) =>
-      signalChildProcessTree(child, signal, { useProcessGroup });
+      terminateManagedChild(child, signal, { useProcessGroup });
     const terminateChild = () => {
       killChild("SIGTERM");
       forceKillAt = Date.now() + resolvedKillAfterMs;
@@ -477,53 +475,6 @@ async function finishTimedOutProcessTree(
     killChild("SIGKILL");
     await waitForProcessTreeExit(child, killAfterMs, useProcessGroup);
   }
-}
-
-export function signalChildProcessTree(
-  processChild: ProcessTreeSignalTarget,
-  processSignal: ProcessSignal,
-  {
-    platform = process.platform,
-    runTaskkill = (command, args, options) => spawnSync(command, args, options),
-    useProcessGroup = platform !== "win32",
-  }: {
-    platform?: typeof process.platform;
-    runTaskkill?:
-      | ((
-          command: string,
-          args: readonly string[],
-          options: { stdio: "ignore" },
-        ) => { error?: Error; status: number | null })
-      | undefined;
-    useProcessGroup?: boolean | undefined;
-  } = {},
-) {
-  if (useProcessGroup && processChild.pid) {
-    try {
-      process.kill(-processChild.pid, processSignal);
-      return;
-    } catch {
-      // The process group can disappear between timeout and cleanup.
-    }
-  }
-  if (platform === "win32" && typeof processChild.pid === "number") {
-    const taskkillPath = resolveWindowsTaskkillPath();
-    const args = ["/PID", String(processChild.pid), "/T"];
-    if (processSignal === "SIGKILL") {
-      args.push("/F");
-    }
-    const result = runTaskkill(taskkillPath, args, { stdio: "ignore" });
-    if (!result?.error && result?.status === 0) {
-      return;
-    }
-    if (processSignal !== "SIGKILL") {
-      const forceResult = runTaskkill(taskkillPath, [...args, "/F"], { stdio: "ignore" });
-      if (!forceResult?.error && forceResult?.status === 0) {
-        return;
-      }
-    }
-  }
-  processChild.kill(processSignal);
 }
 
 function childHasExited(child: ProcessTreeChild) {

--- a/scripts/run-with-env.mts
+++ b/scripts/run-with-env.mts
@@ -1,18 +1,12 @@
 // Runs a command with inline KEY=value assignments while preserving signal behavior.
-import { spawn, spawnSync } from "node:child_process";
-import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
+import { spawn } from "node:child_process";
+import { terminateManagedChild } from "./lib/managed-child-process.mts";
 
 const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/u;
 const USAGE =
   "Usage: node --import tsx scripts/run-with-env.mts KEY=value [KEY=value ...] -- command [args...]";
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
-
-type RunWithEnvChild = Pick<ReturnType<typeof spawn>, "kill" | "pid">;
-type TaskkillRunner = (
-  command: string,
-  args: string[],
-  options: { stdio: "ignore" },
-) => { error?: Error; status: number | null };
+type ForwardedSignal = "SIGHUP" | "SIGINT" | "SIGTERM";
 
 /**
  * Detects help requests before the command separator.
@@ -102,50 +96,6 @@ export function resolveForceKillDelayMs(env: NodeJS.ProcessEnv = process.env) {
 /**
  * Signals the wrapped command tree when this small parent wrapper is stopped.
  */
-export function signalRunWithEnvChild(
-  child: RunWithEnvChild,
-  signal: NodeJS.Signals,
-  {
-    platform = process.platform,
-    runTaskkill = spawnSync,
-    useChildProcessGroup = platform !== "win32",
-  }: {
-    platform?: NodeJS.Platform;
-    runTaskkill?: TaskkillRunner;
-    useChildProcessGroup?: boolean;
-  } = {},
-) {
-  if (useChildProcessGroup && typeof child.pid === "number") {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch (error) {
-      if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ESRCH") {
-        child.kill(signal);
-        return;
-      }
-    }
-  }
-  if (platform === "win32" && typeof child.pid === "number") {
-    const taskkillPath = resolveWindowsTaskkillPath();
-    const args = ["/PID", String(child.pid), "/T"];
-    if (signal === "SIGKILL") {
-      args.push("/F");
-    }
-    const result = runTaskkill(taskkillPath, args, { stdio: "ignore" });
-    if (!result?.error && result?.status === 0) {
-      return;
-    }
-    if (signal !== "SIGKILL") {
-      const forceResult = runTaskkill(taskkillPath, [...args, "/F"], { stdio: "ignore" });
-      if (!forceResult?.error && forceResult?.status === 0) {
-        return;
-      }
-    }
-  }
-  child.kill(signal);
-}
-
 function main(argv: string[] = process.argv.slice(2)) {
   if (isRunWithEnvHelpRequest(argv)) {
     console.log(USAGE);
@@ -178,16 +128,16 @@ function main(argv: string[] = process.argv.slice(2)) {
     },
     stdio: "inherit",
   });
-  let forwardedSignal: NodeJS.Signals | null = null;
-  let forceKillTimer: NodeJS.Timeout | null = null;
+  let forwardedSignal: ForwardedSignal | undefined;
+  let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
   // Keep the child in the foreground process group so TTY signals such as
   // Ctrl-C, Ctrl-Z, and window resizes stay native. Forward direct wrapper
   // shutdown signals that would otherwise only kill this small parent process.
-  const forwardedSignals: NodeJS.Signals[] = useChildProcessGroup
+  const forwardedSignals: ForwardedSignal[] = useChildProcessGroup
     ? ["SIGTERM", "SIGHUP", "SIGINT"]
     : ["SIGTERM", "SIGHUP"];
   const signalChild = (signal: NodeJS.Signals) =>
-    signalRunWithEnvChild(child, signal, { useChildProcessGroup });
+    terminateManagedChild(child, signal, { useProcessGroup: useChildProcessGroup });
   const childProcessGroupAlive = () => {
     if (!useChildProcessGroup || typeof child.pid !== "number") {
       return false;
@@ -234,7 +184,7 @@ function main(argv: string[] = process.argv.slice(2)) {
       process.off(signal, handler);
     }
   };
-  const signalHandlers = new Map<NodeJS.Signals, () => void>(
+  const signalHandlers = new Map<ForwardedSignal, () => void>(
     forwardedSignals.map((signal) => [
       signal,
       () => {

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -5,6 +5,7 @@
 import {
   spawn,
   spawnSync,
+  type StdioOptions,
   type SpawnSyncOptionsWithStringEncoding,
   type SpawnSyncReturns,
 } from "node:child_process";
@@ -12,6 +13,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
+import { terminateManagedChild } from "./lib/managed-child-process.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import {
@@ -23,7 +25,6 @@ import {
   TSDOWN_PACKAGE_OUTPUT_ROOTS,
   tsdownPackageOutputRoot,
 } from "./lib/tsdown-output-roots.mts";
-import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 import { resolvePnpmRunner } from "./pnpm-runner.mts";
 import {
   isSourceCheckoutRoot,
@@ -86,7 +87,7 @@ type TsdownBuildParams = MemoryLimitParams & {
 
 type TsdownBuildResult = ReturnType<ReturnType<typeof createTsdownOutputScanner>["finish"]> & {
   error: Error | null;
-  signal: NodeJS.Signals | null;
+  signal: string | null;
   status: number | null;
   timedOut: boolean;
 };
@@ -817,61 +818,8 @@ export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
 type TaskkillRunner = (
   command: string,
   args: string[],
-  options: { stdio: "ignore" },
+  options: { killSignal?: NodeJS.Signals; stdio?: StdioOptions; timeout?: number },
 ) => { error?: Error; status: number | null };
-
-function signalWindowsProcessTree(
-  pid: number,
-  signal: NodeJS.Signals,
-  runTaskkill: TaskkillRunner = spawnSync,
-) {
-  const args = ["/PID", String(pid), "/T"];
-  if (signal === "SIGKILL") {
-    args.push("/F");
-  }
-  const result = runTaskkill(resolveWindowsTaskkillPath(), args, { stdio: "ignore" });
-  return !result?.error && result?.status === 0;
-}
-
-function signalWindowsProcessTreeOrForce(
-  pid: number,
-  signal: NodeJS.Signals,
-  runTaskkill: TaskkillRunner = spawnSync,
-) {
-  if (signalWindowsProcessTree(pid, signal, runTaskkill)) {
-    return true;
-  }
-  return signal !== "SIGKILL" && signalWindowsProcessTree(pid, "SIGKILL", runTaskkill);
-}
-
-export function signalTsdownBuildProcessTree(
-  child: { pid?: number; kill(signal?: NodeJS.Signals): unknown },
-  signal: NodeJS.Signals,
-  {
-    platform = process.platform,
-    runTaskkill = spawnSync,
-    useProcessGroup = platform !== "win32",
-  }: {
-    platform?: NodeJS.Platform;
-    runTaskkill?: TaskkillRunner;
-    useProcessGroup?: boolean;
-  } = {},
-) {
-  if (useProcessGroup && child.pid) {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {
-      // The group may already be gone; fall back to the direct child handle.
-    }
-  }
-  if (platform === "win32" && child.pid) {
-    if (signalWindowsProcessTreeOrForce(child.pid, signal, runTaskkill)) {
-      return;
-    }
-  }
-  child.kill(signal);
-}
 
 export async function runTsdownBuildInvocation(
   invocation: TsdownBuildInvocation,
@@ -919,7 +867,7 @@ export async function runTsdownBuildInvocation(
   }
 
   function signalChild(signal: NodeJS.Signals) {
-    signalTsdownBuildProcessTree(child, signal, {
+    terminateManagedChild(child, signal, {
       platform,
       runTaskkill,
       useProcessGroup,

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -1,5 +1,5 @@
 // Write Cli Startup Metadata script supports OpenClaw repository automation.
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs, {
   existsSync,
@@ -17,7 +17,7 @@ import pMap from "p-map";
 import type { RootHelpRenderOptions } from "../src/cli/program/root-help.js";
 import type { OpenClawConfig } from "../src/config/config.js";
 import { resolveCliStartupRootHelpBundleIdentity } from "./lib/cli-startup-root-help-bundle.js";
-import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
+import { terminateManagedChild } from "./lib/managed-child-process.mts";
 
 function dedupe(values: string[]): string[] {
   const seen = new Set<string>();
@@ -104,16 +104,6 @@ type SourceHelpRenderer<T = string> = (
   renderContext: RootHelpRenderContext,
   taskContext?: RenderTaskContext,
 ) => Awaitable<T>;
-type KillableChild = {
-  kill(signal: NodeJS.Signals): boolean;
-  pid?: number;
-};
-type RunTaskkill = (
-  command: string,
-  args: string[],
-  options: { stdio: "ignore" },
-) => { error?: unknown; status?: number | null } | undefined;
-
 class CliStartupMetadataRenderSupervisor {
   readonly #abortController = new AbortController();
   readonly #parentSignalHandlers: Array<{ handler: () => void; signal: NodeJS.Signals }> = [];
@@ -212,65 +202,6 @@ class CliStartupMetadataRenderSupervisor {
     }
     throw failure;
   }
-}
-
-function signalWindowsProcessTree(
-  pid: number,
-  signal: NodeJS.Signals,
-  runTaskkill: RunTaskkill = spawnSync,
-): boolean {
-  const args = ["/PID", String(pid), "/T"];
-  if (signal === "SIGKILL") {
-    args.push("/F");
-  }
-  const result = runTaskkill(resolveWindowsTaskkillPath(), args, { stdio: "ignore" });
-  return !result?.error && result?.status === 0;
-}
-
-function signalWindowsProcessTreeOrForce(
-  pid: number,
-  signal: NodeJS.Signals,
-  runTaskkill: RunTaskkill = spawnSync,
-): boolean {
-  if (signalWindowsProcessTree(pid, signal, runTaskkill)) {
-    return true;
-  }
-  return signal !== "SIGKILL" && signalWindowsProcessTree(pid, "SIGKILL", runTaskkill);
-}
-
-function signalCliStartupMetadataProcessTree(
-  child: KillableChild,
-  signal: NodeJS.Signals,
-  {
-    appendDiagnostic = () => {},
-    platform = process.platform,
-    runTaskkill = spawnSync,
-    useProcessGroup = platform !== "win32",
-  }: {
-    appendDiagnostic?: (message: string) => void;
-    platform?: NodeJS.Platform;
-    runTaskkill?: RunTaskkill;
-    useProcessGroup?: boolean;
-  } = {},
-): void {
-  if (useProcessGroup && typeof child.pid === "number") {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
-        appendDiagnostic(
-          `failed to send ${signal} to process group: ${error instanceof Error ? error.message : String(error)}\n`,
-        );
-      }
-    }
-  }
-  if (platform === "win32" && typeof child.pid === "number") {
-    if (signalWindowsProcessTreeOrForce(child.pid, signal, runTaskkill)) {
-      return;
-    }
-  }
-  child.kill(signal);
 }
 
 function updateHashFromFiles(
@@ -580,9 +511,9 @@ async function spawnText(
     let childClosedResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
     const signalChild = (signal: NodeJS.Signals) => {
-      signalCliStartupMetadataProcessTree(child, signal, {
-        appendDiagnostic: (message) => {
-          stderr += message;
+      terminateManagedChild(child, signal, {
+        onProcessGroupSignalError: (error) => {
+          stderr += `failed to send ${signal} to process group: ${error instanceof Error ? error.message : String(error)}\n`;
         },
         useProcessGroup,
       });
@@ -1195,7 +1126,6 @@ function hasAllPrecomputedSubcommandHelpText(value: unknown): boolean {
 
 export const testing = {
   renderSourceRootHelpText,
-  signalCliStartupMetadataProcessTree,
   spawnText,
   writeCliStartupMetadata,
 };

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -194,6 +194,45 @@ describe("managed-child-process", () => {
     });
   });
 
+  it("signals the direct child when process-group ownership is disabled", () => {
+    const child = { kill: vi.fn(() => true), pid: 12345 };
+
+    expect(
+      terminateManagedChild(child, "SIGTERM", {
+        platform: "linux",
+        useProcessGroup: false,
+      }),
+    ).toEqual({ processTreeState: "signaled" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("reports process-group signal errors before falling back to the direct child", () => {
+    const originalKill = process.kill.bind(process);
+    const groupError = Object.assign(new Error("group signal denied"), { code: "EPERM" });
+    const child = { kill: vi.fn(() => true), pid: 12345 };
+    const onProcessGroupSignalError = vi.fn();
+    process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -12345 && signal === "SIGTERM") {
+        throw groupError;
+      }
+      return originalKill(pid, signal);
+    }) as typeof process.kill;
+
+    try {
+      expect(
+        terminateManagedChild(child, "SIGTERM", {
+          onProcessGroupSignalError,
+          platform: "linux",
+        }),
+      ).toEqual({ processTreeState: "signaled" });
+    } finally {
+      process.kill = originalKill;
+    }
+
+    expect(onProcessGroupSignalError).toHaveBeenCalledWith(groupError);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
   it("shares process signal listeners across parallel managed commands", async () => {
     const signals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
     const baseline = new Map(signals.map((signal) => [signal, process.listenerCount(signal)]));

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -12,7 +12,6 @@ import {
   listPluginSdkDeclarationOutputs,
   pluginSdkEntrypoints,
 } from "../../scripts/lib/plugin-sdk-entries.mjs";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import {
   computeArtifactInputsDigest,
   createPrefixedOutputWriter,
@@ -25,15 +24,10 @@ import {
   runNodeStep,
   runNodeSteps,
   runNodeStepsInParallel,
-  signalNodeStep,
 } from "../../scripts/prepare-extension-package-boundary-artifacts.mts";
 import { makeTempDir } from "../helpers/temp-dir.js";
 
 const tempRoots = new Set<string>();
-
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
-}
 
 function createMockPipe() {
   const pipe = new EventEmitter() as EventEmitter & {
@@ -204,75 +198,6 @@ describe("prepare-extension-package-boundary-artifacts", () => {
 
     expect(Date.now() - startedAt).toBeLessThan(abortBudgetMs);
   }, 45_000);
-
-  it("signals Windows node step process trees with taskkill", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    signalNodeStep(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-
-    signalNodeStep(child, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows node step process trees when graceful taskkill fails", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    signalNodeStep(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
-  });
 
   it.runIf(process.platform !== "win32")(
     "force-kills aborted sibling step process groups",

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -538,7 +538,6 @@ describe("resolve-openclaw-package-candidate", () => {
       "setInterval(() => {}, 1000);",
     ].join("");
 
-    const startedAt = Date.now();
     const timeoutAssertion = expect(
       runCommandForTest(process.execPath, ["-e", parentScript], {
         env: {
@@ -556,7 +555,6 @@ describe("resolve-openclaw-package-candidate", () => {
     await timeoutAssertion;
 
     expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
-    expect(Date.now() - startedAt).toBeLessThan(900);
   });
 
   it("forwards external termination to package runner process groups", async () => {

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -6,8 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core/error-coercion";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   assertExpectedSha256ForTest,
   cleanupPackageSourceWorktreeForTest,
@@ -21,13 +20,8 @@ import {
   readPackageBuildSourceSha,
   resolveNpmPackageCandidatePackRunner,
   runCommandForTest,
-  signalChildProcessTree,
   validateOpenClawPackageSpec,
 } from "../../scripts/resolve-openclaw-package-candidate.mts";
-
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
-}
 
 const tempDirs: string[] = [];
 
@@ -307,75 +301,6 @@ describe("resolve-openclaw-package-candidate", () => {
       shell: false,
       windowsVerbatimArguments: true,
     });
-  });
-
-  it("signals Windows package runner process trees with taskkill", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    signalChildProcessTree(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-
-    signalChildProcessTree(child, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows package runner process trees when graceful taskkill fails", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    signalChildProcessTree(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
   });
 
   it("keeps npm pack filenames inside the package candidate output directory", async () => {

--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -4,37 +4,13 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   isRunWithEnvHelpRequest,
   parseRunWithEnvArgs,
   resolveForceKillDelayMs,
   resolveSpawnCommand,
-  signalRunWithEnvChild,
 } from "../../scripts/run-with-env.mts";
-
-const taskkillPath = path.win32.join("C:\\Windows", "System32", "taskkill.exe");
-
-function restoreEnvValue(key: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[key];
-    return;
-  }
-  process.env[key] = value;
-}
-
-function withDefaultWindowsSystemRoot(run: () => void): void {
-  const originalSystemRoot = process.env.SystemRoot;
-  const originalWindir = process.env.WINDIR;
-  try {
-    process.env.SystemRoot = "C:\\Windows";
-    delete process.env.WINDIR;
-    run();
-  } finally {
-    restoreEnvValue("SystemRoot", originalSystemRoot);
-    restoreEnvValue("WINDIR", originalWindir);
-  }
-}
 
 async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3_000): Promise<void> {
   const startedAt = Date.now();
@@ -218,59 +194,6 @@ describe("run-with-env", () => {
     expect(result.stderr).toContain(
       "OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer",
     );
-  });
-
-  it("signals Windows wrapped command trees with taskkill", () => {
-    withDefaultWindowsSystemRoot(() => {
-      const child = {
-        kill: vi.fn(),
-        pid: 12345,
-      };
-      const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-      signalRunWithEnvChild(child, "SIGTERM", {
-        platform: "win32",
-        runTaskkill,
-      });
-      expect(runTaskkill).toHaveBeenNthCalledWith(1, taskkillPath, ["/PID", "12345", "/T"], {
-        stdio: "ignore",
-      });
-
-      signalRunWithEnvChild(child, "SIGKILL", {
-        platform: "win32",
-        runTaskkill,
-      });
-      expect(runTaskkill).toHaveBeenNthCalledWith(2, taskkillPath, ["/PID", "12345", "/T", "/F"], {
-        stdio: "ignore",
-      });
-      expect(child.kill).not.toHaveBeenCalled();
-    });
-  });
-
-  it("force-kills Windows wrapped command trees when graceful taskkill fails", () => {
-    withDefaultWindowsSystemRoot(() => {
-      const child = {
-        kill: vi.fn(),
-        pid: 12345,
-      };
-      const runTaskkill = vi
-        .fn()
-        .mockReturnValueOnce({ error: undefined, status: 1 })
-        .mockReturnValueOnce({ error: undefined, status: 0 });
-
-      signalRunWithEnvChild(child, "SIGTERM", {
-        platform: "win32",
-        runTaskkill,
-      });
-
-      expect(runTaskkill).toHaveBeenNthCalledWith(1, taskkillPath, ["/PID", "12345", "/T"], {
-        stdio: "ignore",
-      });
-      expect(runTaskkill).toHaveBeenNthCalledWith(2, taskkillPath, ["/PID", "12345", "/T", "/F"], {
-        stdio: "ignore",
-      });
-      expect(child.kill).not.toHaveBeenCalled();
-    });
   });
 
   it.runIf(process.platform !== "win32").each(["SIGTERM", "SIGHUP", "SIGINT"] as const)(

--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -12,7 +12,15 @@ import {
   resolveSpawnCommand,
 } from "../../scripts/run-with-env.mts";
 
-async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3_000): Promise<void> {
+// These subprocess fixtures expose explicit ready files. Cold tsx startup can exceed a few
+// seconds on a loaded maintainer host, so this only bounds genuine fixture hangs.
+const PROCESS_READY_TIMEOUT_MS = 30_000;
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = PROCESS_READY_TIMEOUT_MS,
+): Promise<void> {
   const startedAt = Date.now();
   while (!predicate()) {
     if (Date.now() - startedAt > timeoutMs) {

--- a/test/scripts/telegram-user-crabbox-proof.test.ts
+++ b/test/scripts/telegram-user-crabbox-proof.test.ts
@@ -43,6 +43,9 @@ import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
 const posixIt = process.platform === "win32" ? it.skip : it;
+// Proof subprocesses expose explicit ready files; the timeout only bounds broken fixtures and
+// must leave headroom for cold tsx startup on loaded maintainer hosts.
+const PROCESS_READY_TIMEOUT_MS = 30_000;
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -91,7 +94,10 @@ function runProofCli(args: string[]) {
   );
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = PROCESS_READY_TIMEOUT_MS,
+): Promise<void> {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
     if (predicate()) {

--- a/test/scripts/telegram-user-crabbox-proof.test.ts
+++ b/test/scripts/telegram-user-crabbox-proof.test.ts
@@ -32,7 +32,6 @@ import {
   runCommand,
   runSutContainerAction,
   selectCrabboxSshPort,
-  signalCommandTree,
   signalPidTree,
   stageFullSessionArtifacts,
   startLocalSut,
@@ -40,15 +39,10 @@ import {
   waitForLogAfterOffset,
   writeSutConfig,
 } from "../../scripts/e2e/telegram-user-crabbox-proof.ts";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
 const posixIt = process.platform === "win32" ? it.skip : it;
-
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
-}
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -1193,75 +1187,6 @@ setInterval(() => {}, 1000);
         process.kill(grandchildPid, "SIGKILL");
       }
     }
-  });
-
-  it("signals Windows proof command process trees with taskkill", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    signalCommandTree(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-
-    signalCommandTree(child, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows proof command process trees when graceful taskkill fails", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    signalCommandTree(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
   });
 
   posixIt("lets timed-out command descendants exit during kill grace", async () => {

--- a/test/scripts/telegram-user-credential.test.ts
+++ b/test/scripts/telegram-user-credential.test.ts
@@ -4,17 +4,12 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path, { win32 } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchJsonWithTimeout,
-  runCommand,
-  signalChildProcessTree,
-} from "../../scripts/e2e/telegram-user-credential-io.ts";
+import { fetchJsonWithTimeout, runCommand } from "../../scripts/e2e/telegram-user-credential-io.ts";
 import {
   expandHome,
   resolvePrivateJsonDirectory,
   writePrivateJson,
 } from "../../scripts/e2e/telegram-user-credential-paths.ts";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = createTempDirTracker();
@@ -30,10 +25,6 @@ const PROCESS_WAIT_TIMEOUT_MS = 30_000;
 // the timeout fires. This one is paid in wall-clock, so it stays modest while
 // keeping an order-of-magnitude margin over measured child startup.
 const TIMEOUT_TRIGGER_MS = 1_500;
-
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
-}
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -449,75 +440,6 @@ setInterval(() => {}, 1000);
         process.kill(childPid, "SIGKILL");
       }
     }
-  });
-
-  it("signals Windows credential helper process trees with taskkill", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    signalChildProcessTree(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-
-    signalChildProcessTree(child, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows credential helper process trees when graceful taskkill fails", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    signalChildProcessTree(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
   });
 
   it.runIf(process.platform !== "win32")(

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -10,7 +10,6 @@ import {
   TSDOWN_UNIFIED_CONFIG_GROUP,
   TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
 } from "../../scripts/lib/tsdown-config-groups.mts";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import {
   cleanTsdownOutputRoots,
   createTsdownOutputScanner,
@@ -24,7 +23,6 @@ import {
   resolveTsdownBuildInvocations,
   resolveTsdownCleanOutputRoots,
   runTsdownBuildInvocation,
-  signalTsdownBuildProcessTree,
 } from "../../scripts/tsdown-build.mts";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -33,10 +31,6 @@ const NO_MEMORY_LIMIT = {
   cgroupMemoryLimitPaths: [],
   procMeminfoPath: "/openclaw-test-missing-proc-meminfo",
 };
-
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
-}
 
 async function expectPathMissing(targetPath: string) {
   let statError: unknown;
@@ -1051,59 +1045,6 @@ describe("runTsdownBuildInvocation", () => {
     expect(result.status).toBeNull();
     expect(result.signal).toBe("SIGTERM");
     expect(output.chunks.join("")).toContain("timeout after 50ms");
-  });
-
-  it("signals Windows tsdown process trees with taskkill", () => {
-    const childKill = vi.fn(() => true);
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    signalTsdownBuildProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(1, expectedTaskkillPath(), ["/PID", "123", "/T"], {
-      stdio: "ignore",
-    });
-
-    signalTsdownBuildProcessTree({ pid: 123, kill: childKill }, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "123", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(childKill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows tsdown process trees when graceful taskkill fails", () => {
-    const childKill = vi.fn(() => true);
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    signalTsdownBuildProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(1, expectedTaskkillPath(), ["/PID", "123", "/T"], {
-      stdio: "ignore",
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "123", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(childKill).not.toHaveBeenCalled();
   });
 
   it.skipIf(process.platform === "win32")(

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -6,7 +6,6 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import { testing } from "../../scripts/write-cli-startup-metadata.ts";
 import { waitForPidFile } from "../helpers/process-wait.js";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -84,10 +83,6 @@ function processIsAlive(pid: number): boolean {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "EPERM";
   }
-}
-
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
 }
 
 function createSpawnTextChild() {
@@ -563,59 +558,6 @@ describe("write-cli-startup-metadata", () => {
       }
     },
   );
-
-  it("signals Windows command help render process trees with taskkill", () => {
-    const childKill = vi.fn(() => true);
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(1, expectedTaskkillPath(), ["/PID", "123", "/T"], {
-      stdio: "ignore",
-    });
-
-    testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "123", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(childKill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows command help render process trees when graceful taskkill fails", () => {
-    const childKill = vi.fn(() => true);
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(1, expectedTaskkillPath(), ["/PID", "123", "/T"], {
-      stdio: "ignore",
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "123", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(childKill).not.toHaveBeenCalled();
-  });
 
   it.runIf(process.platform !== "win32")(
     "kills descendant processes when command help rendering times out",


### PR DESCRIPTION
## What Problem This Solves

Resolves repository-tooling duplication where two benchmarks independently maintained the same CLI/worker/report lifecycle and seven scripts independently reimplemented process-group plus Windows task-tree signaling.

## Why This Change Was Made

One benchmark harness now owns bounded option parsing, timing summaries, worker sentinel decoding/spawn limits, deterministic progress, report emission, and failed-trailer handling while each benchmark keeps its domain schema and invariant validation. The existing managed-child primitive now supports foreground children and diagnostic callbacks, allowing all seven named scripts to use it directly while keeping their timeout grace, liveness polling, registries, and cleanup policy local.

Repeated caller-local Windows signaling tests were removed; the managed owner suite now covers taskkill, forced taskkill, foreground-child signaling, and group-error diagnostics. Caller boundary tests still exercise real timeout, descendant, forwarded-signal, cleanup, and report behavior.

## User Impact

No product behavior changes. Maintainers get one benchmark lifecycle, one cross-platform child-tree signaling primitive, less duplicated test machinery, and consistent process cleanup across build, package, QA, and wrapper scripts.

## Evidence

- Focused suites: 271 tests passed across both benchmarks, managed child processing, all seven migrated callers, and their real descendant/timeout paths before the final test-harness hardening; the 120 directly affected load-sensitive tests passed afterward on the rebased head.
- Real benchmark smoke: agent concurrency completed all five scenarios at size 1; durable task-registry churn completed size 2 / one cycle with invariants intact.
- `node scripts/check-changed.mjs --base origin/main --head HEAD` passed after rebase, including script/test typechecks, two targeted script-lint batches, erasability over 506 script implementations, and Docker E2E boundary guards.
- `pnpm build` passed end-to-end in 16m44s, including all nine tsdown invocations, package/plugin surfaces, runtime postbuild, Control UI build, and CLI startup metadata generation.
- Fresh Codex autoreview reported no accepted/actionable findings.

Kept local by design:

- Telegram raw-PID SUT/tunnel signaling stays local because it has no `ChildProcess` handle and owns explicit persisted-PID liveness/wait/escalation policy.
- Per-caller process-tree liveness polling, grace windows, registries, output handling, and failure classification remain with their lifecycle owners.
- Process helpers outside the seven requested sites were not folded into this tranche; their ownership and spawn contracts require separate audit.

Production LOC: +0/-0 | Tests: +57/-503 | Tooling: +475/-840
