### PR TITLE
fix(plugins): preserve newer schema errors

### DIFF
--- a/src/infra/sqlite-user-version.ts
+++ b/src/infra/sqlite-user-version.ts
@@ -7,6 +7,12 @@ type SqliteUserVersionReader = {
   prepare: (sql: string) => { get: () => unknown };
 };
 
+const SQLITE_SCHEMA_VERSION_ERROR_NAME = "SqliteSchemaVersionError";
+
+export function isSqliteSchemaVersionError(error: unknown): error is Error {
+  return error instanceof Error && error.name === SQLITE_SCHEMA_VERSION_ERROR_NAME;
+}
+
 export function readSqliteUserVersion(db: SqliteUserVersionReader): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: unknown } | undefined;
   return Number(row?.user_version ?? 0);
@@ -39,6 +45,6 @@ export function createNewerSqliteSchemaVersionError(
       `Run a build that supports schema ${schemaVersion} or newer against this state directory — rebuild or update the install above — or point this build at a different OPENCLAW_STATE_DIR. ` +
       `See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
   );
-  error.name = "SqliteSchemaVersionError";
+  error.name = SQLITE_SCHEMA_VERSION_ERROR_NAME;
   return error;
 }

--- a/src/plugins/installed-plugin-index-record-state.ts
+++ b/src/plugins/installed-plugin-index-record-state.ts
@@ -3,6 +3,7 @@ import {
   inspectPluginInstallRecordMap,
   type PluginInstallRecordMapState,
 } from "../config/plugin-install-record-map.js";
+import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   resolveInstalledPluginIndexStateDatabaseOptions,
@@ -48,7 +49,10 @@ export function inspectPersistedInstalledPluginIndexInstallRecordsSync(
         return parsed === undefined ? { status: "invalid" } : inspectPluginInstallRecordMap(parsed);
       }, resolveInstalledPluginIndexStateDatabaseOptions(options)) ?? { status: "missing" }
     );
-  } catch {
+  } catch (error) {
+    if (isSqliteSchemaVersionError(error)) {
+      throw error;
+    }
     return { status: "invalid" };
   }
 }

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -10,8 +10,10 @@ import {
   setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawStateDatabaseForTest,
+  OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
@@ -204,6 +206,34 @@ describe("plugin index install records store", () => {
         spec: "persisted@1.0.0",
       },
     });
+  });
+
+  it("preserves newer shared-state schema errors while loading install records", async () => {
+    const stateDir = tempDirs.make("openclaw-plugin-index-records-");
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        persisted: {
+          source: "npm",
+          spec: "persisted@1.0.0",
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+    closeOpenClawStateDatabaseForTest();
+    const databasePath = resolveInstalledPluginIndexRecordsStorePath({ stateDir });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`);
+    database.close();
+
+    expect(() => loadInstalledPluginIndexInstallRecordsSync({ stateDir })).toThrow(
+      expect.objectContaining({
+        name: "SqliteSchemaVersionError",
+        message: expect.stringContaining(
+          `uses newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`,
+        ),
+      }),
+    );
   });
 
   it("returns prototype-safe map copies without cloning cached records", async () => {

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../infra/startup-migration-checkpoint.js";
 import {
   closeOpenClawStateDatabaseForTest,
+  OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import type { PluginCandidate } from "./discovery.js";
@@ -715,6 +716,24 @@ describe("installed plugin index persistence", () => {
     insertPersistedIndexRow(stateDir, { version: 999 });
 
     await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toBeNull();
+  });
+
+  it("preserves newer shared-state schema errors while reading the index", async () => {
+    const stateDir = makeTempDir();
+    await writePersistedInstalledPluginIndex(createIndex(), { stateDir });
+    closeOpenClawStateDatabaseForTest();
+    const databasePath = resolveInstalledPluginIndexStorePath({ stateDir });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`);
+    database.close();
+
+    await expect(readPersistedInstalledPluginIndex({ stateDir })).rejects.toMatchObject({
+      name: "SqliteSchemaVersionError",
+      message: expect.stringContaining(
+        `uses newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`,
+      ),
+    });
   });
 
   it("leaves retired JSON index files to the doctor migration owner", async () => {

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -13,6 +13,7 @@ import {
   setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
@@ -355,7 +356,10 @@ function readPersistedInstalledPluginIndexFromSqlite(
         resolveInstalledPluginIndexStateDatabaseOptions(options),
       ) ?? null
     );
-  } catch {
+  } catch (error) {
+    if (isSqliteSchemaVersionError(error)) {
+      throw error;
+    }
     return null;
   }
 }

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -16,6 +16,7 @@ import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
 } from "../infra/sqlite-transaction.js";
+import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import {
   configureSqliteConnectionPragmas,
   configureSqlitePreSchemaPragmas,
@@ -351,7 +352,7 @@ export function openOpenClawAgentDatabase(
         db.close();
         if (
           err instanceof Error &&
-          (err.name === "SqliteSchemaVersionError" || isTerminalSqliteIntegrityError(err))
+          (isSqliteSchemaVersionError(err) || isTerminalSqliteIntegrityError(err))
         ) {
           recordOpenClawAgentDatabaseOpenFailure(pathname, err);
         }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -29,7 +29,7 @@ import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
 } from "../infra/sqlite-transaction.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { isSqliteSchemaVersionError, readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
   configureSqliteConnectionPragmas,
   configureSqlitePreSchemaPragmas,
@@ -594,7 +594,7 @@ function openUnpublishedOpenClawStateDatabase(
       db.close();
       if (
         err instanceof Error &&
-        (err.name === "SqliteSchemaVersionError" || isTerminalSqliteIntegrityError(err))
+        (isSqliteSchemaVersionError(err) || isTerminalSqliteIntegrityError(err))
       ) {
         recordOpenClawStateDatabaseOpenFailure(pathname, err);
       }


### PR DESCRIPTION
Follow-up to #125115 and #125133.

AI-assisted: yes. I reviewed the implementation and proof.

## What Problem This Solves

Older OpenClaw builds correctly refuse a shared SQLite database created by a newer schema, but plugin install-record inspection caught that compatibility error and relabeled it as corrupt plugin metadata. Operators saw `Persisted plugin install records are invalid` even when the records were valid and the real action was to update the stale build.

## Why This Change Was Made

SQLite schema compatibility remains owned by the database boundary. A shared `isSqliteSchemaVersionError` guard now preserves that terminal error through both plugin-index read paths, while malformed plugin rows, missing state, and other unreadable index cases keep their existing soft classifications.

The same guard replaces duplicate string checks in shared and per-agent database open failure handling.

Provenance: the generic install-record failure path was introduced by #121045 (`1471881af7aa`, authored and merged by @vincentkoc) and made operational for schema-8 readers when #124728 (`4bc37cd59761`, authored and merged by @steipete) advanced shared state to schema 9. The sibling catch-to-null path came from #119228 (`ef11eae39b29`, authored and merged by @vincentkoc).

## User Impact

A stale CLI now reports the database path, observed and supported schema versions, refusing install identity, upgrade/rebuild or alternate-state-directory remediation, and database-schema documentation. Truly malformed plugin install records still produce the existing Doctor repair guidance.

Production LOC: `+21/-6` (net `+15`) for the canonical compatibility-error guard and two owner-boundary rethrows. Tests: `+49/-0`.

## Evidence

The focused regressions failed before the production fix for the intended reasons: the install-record loader emitted the generic invalid-record message and the full index reader resolved `null` (54 unaffected tests passed). After the fix:

```text
node scripts/run-vitest.mjs src/plugins/installed-plugin-index-records.test.ts src/plugins/installed-plugin-index-store.test.ts
2 files passed, 56 tests passed
```

Rebased intended-head proof: Blacksmith Testbox `tbx_01m097cx2xwx94jr0zy1wd6vjj`, https://github.com/openclaw/openclaw/actions/runs/32087981638

Changed-surface format, typechecks, lint, dead exports, import cycles, plugin boundaries, and database guards passed on Blacksmith Testbox `tbx_01m0968g3p66etxy5x79g5vhb3`: https://github.com/openclaw/openclaw/actions/runs/32086773934

Source-blind CLI behavior validation passed both clauses on Blacksmith Testbox `tbx_01m097kje0d3sfv5emw9zxk419`: https://github.com/openclaw/openclaw/actions/runs/32088201788

- Future schemas 10 and 11 each produced the actionable newer-schema diagnostic and never claimed install-record corruption.
- Supported schema 9 with malformed `install_records_json` retained the existing invalid-record Doctor diagnostic.

Final branch autoreview completed clean with no accepted/actionable findings, confidence 0.99.
