### PR TITLE
fix(google-meet): classify gateway CLI fallback with typed guards instead of message matching

### DIFF
--- a/extensions/google-meet/src/cli-shared.gateway-fallback.test.ts
+++ b/extensions/google-meet/src/cli-shared.gateway-fallback.test.ts
@@ -1,0 +1,97 @@
+import type { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { callGoogleMeetGateway } from "./cli-shared.js";
+
+function gatewayTransportError(code?: number): Error {
+  return Object.assign(new Error("gateway transport failed"), {
+    name: "GatewayTransportError",
+    kind: "closed",
+    connectionDetails: { url: "ws://127.0.0.1:18789" },
+    ...(code === undefined ? {} : { code }),
+  });
+}
+
+function gatewayRequestError(message: string, gatewayCode = "INVALID_REQUEST"): Error {
+  return Object.assign(new Error(message), {
+    name: "GatewayClientRequestError",
+    gatewayCode,
+    retryable: false,
+  });
+}
+
+function rejectingGateway(error: Error): typeof callGatewayFromCli {
+  return vi.fn<typeof callGatewayFromCli>().mockRejectedValue(error);
+}
+
+describe("callGoogleMeetGateway local fallback", () => {
+  it("returns a successful gateway payload", async () => {
+    const payload = { found: true };
+    const callGateway = vi.fn<typeof callGatewayFromCli>().mockResolvedValue(payload);
+
+    await expect(
+      callGoogleMeetGateway({ callGateway, method: "googlemeet.status" }),
+    ).resolves.toEqual({ ok: true, payload });
+  });
+
+  it("falls back for an uncoded transport close", async () => {
+    const error = gatewayTransportError();
+
+    await expect(
+      callGoogleMeetGateway({
+        callGateway: rejectingGateway(error),
+        method: "googlemeet.status",
+      }),
+    ).resolves.toEqual({ ok: false, error });
+  });
+
+  it.each([1006, 1000])("propagates a transport close with code %s", async (code) => {
+    const error = gatewayTransportError(code);
+
+    await expect(
+      callGoogleMeetGateway({
+        callGateway: rejectingGateway(error),
+        method: "googlemeet.status",
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it("propagates a transport timeout", async () => {
+    const error = Object.assign(new Error("gateway timed out"), {
+      name: "GatewayTransportError",
+      kind: "timeout",
+      connectionDetails: { url: "ws://127.0.0.1:18789" },
+    });
+
+    await expect(
+      callGoogleMeetGateway({
+        callGateway: rejectingGateway(error),
+        method: "googlemeet.status",
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it("falls back when the exact Meet method is not registered", async () => {
+    const error = gatewayRequestError("unknown method: googlemeet.status");
+
+    await expect(
+      callGoogleMeetGateway({
+        callGateway: rejectingGateway(error),
+        method: "googlemeet.status",
+      }),
+    ).resolves.toEqual({ ok: false, error });
+  });
+
+  it.each([
+    gatewayRequestError("unknown method: voicecall.status"),
+    new Error("unknown method: googlemeet.status"),
+    new Error("gateway not connected"),
+    new Error("connect ECONNREFUSED 127.0.0.1:18789"),
+  ])("propagates a non-fallback error: $message", async (error) => {
+    await expect(
+      callGoogleMeetGateway({
+        callGateway: rejectingGateway(error),
+        method: "googlemeet.status",
+      }),
+    ).rejects.toBe(error);
+  });
+});

--- a/extensions/google-meet/src/cli-shared.ts
+++ b/extensions/google-meet/src/cli-shared.ts
@@ -2,8 +2,11 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { format } from "node:util";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import {
+  callGatewayFromCli,
+  isGatewayClientRequestError,
+  isGatewayTransportError,
+} from "openclaw/plugin-sdk/gateway-runtime";
 import {
   clampTimerTimeoutMs,
   parseStrictPositiveInteger,
@@ -210,15 +213,14 @@ function isGatewayUnavailableForLocalFallback(
   err: unknown,
   method: GoogleMeetGatewayMethod,
 ): boolean {
-  const message = formatErrorMessage(err);
-  return (
-    message.includes("ECONNREFUSED") ||
-    message.includes("ECONNRESET") ||
-    message.includes("EHOSTUNREACH") ||
-    message.includes("ENOTFOUND") ||
-    message.includes("gateway not connected") ||
-    message.includes(`unknown method: ${method}`)
-  );
+  if (isGatewayTransportError(err)) {
+    // Fall back only when nothing serves the gateway URL (connect-time socket
+    // failures: kind "closed" with no WS close code). A coded close (e.g. 1006
+    // during restart) means a live gateway may still own Meet sessions — surface it.
+    return err.kind === "closed" && err.code === undefined;
+  }
+  // Gateway alive but the Meet methods are not registered there: run locally.
+  return isGatewayClientRequestError(err) && err.message.includes(`unknown method: ${method}`);
 }
 
 export function writeStdoutLine(...values: unknown[]): void {

--- a/extensions/google-meet/src/test-support/cli-harness.ts
+++ b/extensions/google-meet/src/test-support/cli-harness.ts
@@ -231,7 +231,11 @@ export function setupCli(params: {
     callGatewayFromCli:
       params.callGatewayFromCli ??
       (vi.fn(async () => {
-        throw new Error("connect ECONNREFUSED 127.0.0.1:18789");
+        throw Object.assign(new Error("gateway transport failed"), {
+          name: "GatewayTransportError",
+          kind: "closed",
+          connectionDetails: { url: "ws://127.0.0.1:18789" },
+        });
       }) as NonNullable<Parameters<typeof registerGoogleMeetCli>[0]["callGatewayFromCli"]>),
   });
   return program;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1908,7 +1908,7 @@ describe("callGateway error details", () => {
     await expect(request).rejects.toBe(upgradeError);
   });
 
-  it.each(["ECONNREFUSED", "EHOSTUNREACH", "ETIMEDOUT"])(
+  it.each(["ECONNREFUSED", "ECONNRESET", "EHOSTUNREACH", "ETIMEDOUT"])(
     "renders %s connect failures as an actionable gateway-unreachable message",
     async (code) => {
       startMode = "silent";

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -265,6 +265,8 @@ function firstGatewayErrorLine(message: string): string {
 // next step; protocol/auth failures keep their own richer messages.
 const GATEWAY_UNREACHABLE_SOCKET_CODES = new Set([
   "ECONNREFUSED",
+  // RST during connect/handshake: the port is not serving a working gateway.
+  "ECONNRESET",
   "EHOSTUNREACH",
   "ENETUNREACH",
   "ENOTFOUND",

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -12,9 +13,18 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
-    return true;
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+  if (process.platform !== "linux") {
+    return true;
+  }
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    // kill(pid, 0) also succeeds for a terminated process awaiting reaping.
+    return stat.charAt(stat.lastIndexOf(")") + 2) !== "Z";
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`extensions/google-meet/src/cli-shared.ts` classified gateway failures for its local-runtime fallback by message substrings (`ECONNREFUSED`, `ECONNRESET`, `EHOSTUNREACH`, `ENOTFOUND`, `"gateway not connected"`, `"unknown method: X"`) — the same fragile pattern #125458 replaces in the voice-call CLI. String matching breaks silently when error wording changes and classifies arbitrary error text that merely embeds an errno.

## Why This Change Was Made

The classifier now uses the typed structural guards `isGatewayTransportError` / `isGatewayClientRequestError`, with google-meet's decision surface chosen deliberately per arm:

- **Unreachable socket errors → local fallback (kept, now typed).** Connect-time socket failures surface as `GatewayTransportError` kind `"closed"` with no WS close code. This also covers `ETIMEDOUT`/`ENETUNREACH`, which the old string list missed.
- **Connect-time `ECONNRESET` → fixed at the producer.** It was missing from `GATEWAY_UNREACHABLE_SOCKET_CODES` in `src/gateway/call.ts`, so it escaped as a raw Node error no typed guard could see. Added to the set: it now wraps into the same actionable unreachable transport error, preserving google-meet's historical `ECONNRESET` fallback (and restoring voice-call's once #125458 lands).
- **Coded closes incl. 1006 → still no fallback (deliberate divergence from voice-call).** A coded close means a live gateway answered and may still own Meet browser sessions; falling back would split session ownership into a second local Chrome. Voice-call retries 1006 because its calls live in Twilio, not in whoever launched the browser.
- **`unknown method: <exact method>` → fallback kept, tightened.** Must now be a structural `GatewayClientRequestError` (the server replies with the shared `INVALID_REQUEST` code, so the message check itself must stay), no longer arbitrary error text.
- **`"gateway not connected"` race arm dropped** (plain-Error race between hello and request; same accepted tradeoff as #125458).

Deliberately not migrated (different purpose, not provably behavior-preserving):
- **qa-lab** (`extensions/qa-lab/src/suite-runtime-gateway.ts`, `gateway-child-readiness.ts`): retry classifiers partly consume pre-formatted strings and child-gateway log text across a process boundary, where typed guards cannot reach.
- **doctor** (`src/commands/doctor-gateway-health.ts`, `doctor-gateway-daemon-flow.ts`): the outer `"gateway closed"` gate deliberately tolerates wrapped/stringified errors; the inner `formatGatewayClosedDiagnostic` already uses the typed guard.

Overlap note: three hunks (the `isGatewayClientRequestError` extraction in `src/gateway/call.ts`, the `plugin-sdk/gateway-runtime` barrel export, the +2 SDK surface-budget bumps) are intentionally verbatim-identical to open #125458 so whichever PR lands second rebases trivially.

## User Impact

`openclaw googlemeet ...` CLI fallback to the local runtime now keys off typed error structure instead of error prose. Behavior changes: unreachable-host timeouts (`ETIMEDOUT`/`ENETUNREACH`) now correctly fall back to local; connect-time `ECONNRESET` gets an actionable "Gateway not reachable" message everywhere instead of a raw Node error.

## Evidence

- New boundary test `extensions/google-meet/src/cli-shared.gateway-fallback.test.ts` covers the full decision surface through the exported `callGoogleMeetGateway` (10 cases incl. the deliberate 1006-no-fallback and the dropped string arms; the uncoded-close and dropped-arm cases fail on pre-migration code).
- `node scripts/run-vitest.mjs extensions/google-meet` — 345/345 passed.
- `node scripts/run-vitest.mjs src/gateway/call.test.ts` — passed, incl. new `ECONNRESET` case in the unreachable-rendering `it.each`.
- `pnpm plugin-sdk:surface:check` — passed at 4330/2574.
- `node scripts/check-changed.mjs` — passed.
- Codex autoreview (`--mode uncommitted`) — clean.

Production LOC delta: core +~30 (guard extraction is restructuring; ECONNRESET +2), google-meet classifier net −2; the SDK surface growth (+2 exports) is the named seam shared with #125458.
