### PR TITLE
fix: preserve message delivery after result middleware

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1806,7 +1806,6 @@ src/agents/embedded-agent-helpers/images.ts	8
 src/agents/embedded-agent-helpers/openai.ts	21
 src/agents/embedded-agent-helpers/turns.ts	23
 src/agents/embedded-agent-live-edit-diff.ts	3
-src/agents/embedded-agent-message-tool-source-reply.ts	1
 src/agents/embedded-agent-messaging-extraction.ts	1
 src/agents/embedded-agent-messaging.ts	1
 src/agents/embedded-agent-runner/cache-ttl.ts	2

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1806,7 +1806,7 @@ src/agents/embedded-agent-helpers/images.ts	8
 src/agents/embedded-agent-helpers/openai.ts	21
 src/agents/embedded-agent-helpers/turns.ts	23
 src/agents/embedded-agent-live-edit-diff.ts	3
-src/agents/embedded-agent-message-tool-source-reply.ts	15
+src/agents/embedded-agent-message-tool-source-reply.ts	1
 src/agents/embedded-agent-messaging-extraction.ts	1
 src/agents/embedded-agent-messaging.ts	1
 src/agents/embedded-agent-runner/cache-ttl.ts	2

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -2416,6 +2416,12 @@ describe("createCodexDynamicToolBridge", () => {
     const bridge = createBridgeWithToolResult(
       "message",
       textToolResult("Sent.", {
+        messageDelivery: {
+          status: "settled",
+          primaryPlatformMessageId: "imessage-6264",
+          partialDelivery: false,
+          createdThreadIds: [],
+        },
         receipt: {
           primaryPlatformMessageId: "imessage-6264",
           platformMessageIds: ["imessage-6264"],

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1295,6 +1295,11 @@ describe("runCliAgent reliability", () => {
         result: {
           details: {
             deliveryStatus: "sent",
+            messageDelivery: {
+              status: "settled",
+              partialDelivery: false,
+              createdThreadIds: [],
+            },
             sourceReplySink: "internal-ui",
             sourceReply: { text: "sent before failure" },
           },
@@ -1395,6 +1400,11 @@ describe("runCliAgent reliability", () => {
         result: {
           details: {
             deliveryStatus: "sent",
+            messageDelivery: {
+              status: "settled",
+              partialDelivery: false,
+              createdThreadIds: [],
+            },
             sourceReplySink: "internal-ui",
             sourceReply: { text: "sent through source reply" },
           },
@@ -1458,6 +1468,11 @@ describe("runCliAgent reliability", () => {
         result: {
           details: {
             deliveryStatus: "sent",
+            messageDelivery: {
+              status: "settled",
+              partialDelivery: false,
+              createdThreadIds: [],
+            },
             sourceReplySink: "internal-ui",
             sourceReply: { text: "visible source reply" },
           },

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -8,6 +8,7 @@ import {
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { shouldUseInternalSourceReplySink } from "../../infra/outbound/internal-source-reply.js";
 import type { CliOutput, CliToolUseStartDelta } from "../cli-output-contracts.js";
+import { readEmbeddedMessageDeliveryFact } from "../embedded-agent-message-delivery.js";
 import {
   isDeliveredMessageToolOnlySourceReplyResult,
   isDeliveredMessagingToolResult,
@@ -21,6 +22,7 @@ import {
   isMessagingTool,
   isMessagingToolDeliveryAction,
   isMessagingToolSendAction,
+  isPluginNativeMessagingTool,
 } from "../embedded-agent-messaging.js";
 import type {
   MessagingToolSend,
@@ -30,6 +32,7 @@ import {
   extractToolResultMediaArtifact,
   filterToolResultMediaUrls,
 } from "../embedded-agent-tool-media.js";
+import { readToolResultDetails } from "../tool-result-error.js";
 import { closeClaudeSession } from "./claude-live-registry.js";
 import { attachCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
 import {
@@ -229,7 +232,14 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     result?: unknown;
     isError?: boolean;
   }) => {
-    if (!isDeliveredMessagingToolResult(params)) {
+    const deliveryFact = readEmbeddedMessageDeliveryFact(
+      readToolResultDetails(params.result)?.messageDelivery,
+    );
+    const delivered = deliveryFact
+      ? deliveryFact.status === "settled" &&
+        (params.isError !== true || deliveryFact.partialDelivery)
+      : isPluginNativeMessagingTool(params.toolName) && isDeliveredMessagingToolResult(params);
+    if (!delivered) {
       return;
     }
     didSendViaMessagingTool = true;
@@ -244,6 +254,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         args: params.args,
         result: params.result,
         isError: params.isError,
+        deliveryConfirmed: true,
       });
     const sourceReplyFinal = deliveredCurrentSourceReply
       ? resolveMessageToolSourceReplyFinal(toolArgs)

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -262,9 +262,11 @@ export function projectEmbeddedMessageDeliveryFact(
     // legacy visible-envelope shape accepted by pluginBroadcastHasDelivery.
     fact: entry.result
       ? projectSend(entry.result)
-      : entry.ok
-        ? projectPluginPayload(entry.payload)
-        : undefined,
+      : entry.sentBeforeError
+        ? { status: "settled" as const, partialDelivery: true, createdThreadIds: [] }
+        : entry.ok
+          ? projectPluginPayload(entry.payload)
+          : undefined,
   }));
   const facts = entries.flatMap(({ fact }) => (fact ? [fact] : []));
   const settled = facts.find((fact) => fact.status === "settled");

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -1,0 +1,154 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
+import type { MessagePollResult, MessageSendResult } from "../infra/outbound/message.js";
+import type { AgentToolResult } from "./runtime/index.js";
+
+type EmbeddedMessageDeliveryFact = {
+  status: "settled" | "suppressed" | "dryRun" | "failed";
+  primaryPlatformMessageId?: string;
+  partialDelivery: boolean;
+  createdThreadIds: string[];
+};
+
+const NON_DELIVERY_IDS = new Set(["skipped", "suppressed"]);
+const STATUSES = new Set(["settled", "suppressed", "dryRun", "failed"]);
+
+function isDeliveryStatus(value: unknown): value is EmbeddedMessageDeliveryFact["status"] {
+  return typeof value === "string" && STATUSES.has(value);
+}
+
+function deliveryId(value: unknown): string | undefined {
+  const id = typeof value === "string" ? value.trim() : "";
+  return id && !NON_DELIVERY_IDS.has(id.toLowerCase()) ? id : undefined;
+}
+
+function projectSend(result: MessageSendResult): EmbeddedMessageDeliveryFact {
+  const delivery = result.result;
+  const receipt = delivery && "receipt" in delivery ? delivery.receipt : undefined;
+  const primaryPlatformMessageId = [
+    receipt?.primaryPlatformMessageId,
+    delivery?.messageId,
+    delivery && "pollId" in delivery ? delivery.pollId : undefined,
+    ...(receipt?.platformMessageIds ?? []),
+    ...(receipt?.parts.map((part) => part.platformMessageId) ?? []),
+  ]
+    .map(deliveryId)
+    .find(Boolean);
+  const createdThreadIds = [
+    receipt?.threadId,
+    ...(receipt?.parts.map((part) => part.threadId) ?? []),
+  ].flatMap((id) => (typeof id === "string" && id.trim() ? [id.trim()] : []));
+  const partialDelivery =
+    result.deliveryStatus === "partial_failed" || result.sentBeforeError === true;
+  const nonDeliveryId =
+    typeof delivery?.messageId === "string" &&
+    NON_DELIVERY_IDS.has(delivery.messageId.trim().toLowerCase());
+  const status = result.dryRun
+    ? "dryRun"
+    : partialDelivery
+      ? "settled"
+      : result.deliveryStatus === "suppressed" || nonDeliveryId
+        ? "suppressed"
+        : result.deliveryStatus === "sent" || primaryPlatformMessageId
+          ? "settled"
+          : "failed";
+  return {
+    status,
+    ...(primaryPlatformMessageId ? { primaryPlatformMessageId } : {}),
+    partialDelivery,
+    createdThreadIds: [...new Set(createdThreadIds)],
+  };
+}
+
+function projectPoll(result: MessagePollResult): EmbeddedMessageDeliveryFact {
+  const primaryPlatformMessageId =
+    deliveryId(result.result?.messageId) ?? deliveryId(result.result?.pollId);
+  return {
+    status: result.dryRun ? "dryRun" : primaryPlatformMessageId ? "settled" : "failed",
+    ...(primaryPlatformMessageId ? { primaryPlatformMessageId } : {}),
+    partialDelivery: false,
+    createdThreadIds: [],
+  };
+}
+
+export function projectEmbeddedMessageDeliveryFact(
+  result: MessageActionResult,
+): EmbeddedMessageDeliveryFact | undefined {
+  if (result.kind === "send") {
+    return result.handledBy === "core" && result.sendResult
+      ? projectSend(result.sendResult)
+      : result.handledBy === "internal-source"
+        ? {
+            status: result.dryRun ? "dryRun" : "settled",
+            partialDelivery: false,
+            createdThreadIds: [],
+          }
+        : undefined;
+  }
+  if (result.kind === "poll") {
+    return result.handledBy === "core" && result.pollResult
+      ? projectPoll(result.pollResult)
+      : undefined;
+  }
+  if (result.kind !== "broadcast") {
+    return undefined;
+  }
+  const facts = result.payload.results.flatMap((entry) =>
+    entry.result ? [projectSend(entry.result)] : [],
+  );
+  const settled = facts.find((fact) => fact.status === "settled");
+  if (settled || result.payload.results.some((entry) => entry.ok && !entry.result)) {
+    return settled;
+  }
+  return (
+    facts.find((fact) => fact.status === "suppressed") ??
+    facts.find((fact) => fact.status === "dryRun") ?? {
+      status: "failed",
+      partialDelivery: false,
+      createdThreadIds: [],
+    }
+  );
+}
+
+export function attachEmbeddedMessageDeliveryFact(
+  result: AgentToolResult<unknown>,
+  fact: EmbeddedMessageDeliveryFact | undefined,
+): AgentToolResult<unknown> {
+  const details = asOptionalRecord(result.details);
+  if (!fact) {
+    if (!details || !("messageDelivery" in details)) {
+      return result;
+    }
+    const { messageDelivery: _reserved, ...rest } = details;
+    return { ...result, details: rest };
+  }
+  return { ...result, details: { ...details, messageDelivery: fact } };
+}
+
+export function readEmbeddedMessageDeliveryFact(
+  value: unknown,
+): EmbeddedMessageDeliveryFact | undefined {
+  const fact = asOptionalRecord(value);
+  const createdThreadIds = Array.isArray(fact?.createdThreadIds)
+    ? fact.createdThreadIds.filter((id): id is string => typeof id === "string")
+    : [];
+  if (
+    !fact ||
+    !isDeliveryStatus(fact.status) ||
+    typeof fact.partialDelivery !== "boolean" ||
+    !Array.isArray(fact.createdThreadIds) ||
+    createdThreadIds.length !== fact.createdThreadIds.length ||
+    (fact.primaryPlatformMessageId !== undefined &&
+      typeof fact.primaryPlatformMessageId !== "string")
+  ) {
+    return undefined;
+  }
+  return {
+    status: fact.status,
+    ...(fact.primaryPlatformMessageId
+      ? { primaryPlatformMessageId: fact.primaryPlatformMessageId }
+      : {}),
+    partialDelivery: fact.partialDelivery,
+    createdThreadIds,
+  };
+}

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -1,4 +1,6 @@
+import { safeParseJsonRecord } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
 import type { MessagePollResult, MessageSendResult } from "../infra/outbound/message.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -12,6 +14,15 @@ type EmbeddedMessageDeliveryFact = {
 
 const NON_DELIVERY_IDS = new Set(["skipped", "suppressed"]);
 const STATUSES = new Set(["settled", "suppressed", "dryRun", "failed"]);
+const PLUGIN_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
+
+const EMPTY_DELIVERY_FACT: Pick<
+  EmbeddedMessageDeliveryFact,
+  "partialDelivery" | "createdThreadIds"
+> = {
+  partialDelivery: false,
+  createdThreadIds: [],
+};
 
 function isDeliveryStatus(value: unknown): value is EmbeddedMessageDeliveryFact["status"] {
   return typeof value === "string" && STATUSES.has(value);
@@ -20,6 +31,158 @@ function isDeliveryStatus(value: unknown): value is EmbeddedMessageDeliveryFact[
 function deliveryId(value: unknown): string | undefined {
   const id = typeof value === "string" ? value.trim() : "";
   return id && !NON_DELIVERY_IDS.has(id.toLowerCase()) ? id : undefined;
+}
+
+function normalizeStatus(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+}
+
+function visitPluginEnvelope(
+  value: unknown,
+  predicate: (record: Record<string, unknown>) => boolean,
+  depth = 0,
+): boolean {
+  if (!value || typeof value !== "object" || depth > 4) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => visitPluginEnvelope(item, predicate, depth + 1));
+  }
+  const record = asOptionalRecord(value);
+  if (!record) {
+    return false;
+  }
+  if (predicate(record)) {
+    return true;
+  }
+  if (typeof record.text === "string") {
+    const parsed = safeParseJsonRecord(record.text);
+    if (parsed && visitPluginEnvelope(parsed, predicate, depth + 1)) {
+      return true;
+    }
+  }
+  if (
+    Array.isArray(record.content) &&
+    record.content.some((item) => visitPluginEnvelope(item, predicate, depth + 1))
+  ) {
+    return true;
+  }
+  return PLUGIN_ENVELOPE_KEYS.some((key) => visitPluginEnvelope(record[key], predicate, depth + 1));
+}
+
+const PLUGIN_SIGNALS = {
+  dryRun: (record: Record<string, unknown>) =>
+    record.dryRun === true || normalizeStatus(record.status) === "dry_run",
+  partial: (record: Record<string, unknown>) =>
+    record.sentBeforeError === true ||
+    record.visibleReplySent === true ||
+    normalizeStatus(record.status) === "partial_failed",
+  conversation: (record: Record<string, unknown>) =>
+    [
+      record.topicId,
+      record.threadId,
+      record.messageThreadId,
+      asOptionalRecord(record.thread)?.id,
+    ].some((id) => hasNonEmptyString(id) || (typeof id === "number" && Number.isFinite(id))),
+  nonDelivery: (record: Record<string, unknown>) => {
+    const id = normalizeStatus(record.messageId);
+    return (
+      (id !== undefined && NON_DELIVERY_IDS.has(id)) ||
+      normalizeStatus(record.status) === "suppressed"
+    );
+  },
+  noOp: (record: Record<string, unknown>) => {
+    const removed = record.removed;
+    const status = normalizeStatus(record.status);
+    return (
+      removed === null ||
+      removed === false ||
+      removed === 0 ||
+      (Array.isArray(removed) && removed.length === 0) ||
+      record.applied === false ||
+      record.changed === false ||
+      record.created === false ||
+      record.deleted === false ||
+      record.sent === false ||
+      record.updated === false ||
+      status === "noop" ||
+      status === "no_op" ||
+      status === "not_found"
+    );
+  },
+  delivery: (record: Record<string, unknown>) => {
+    const message = asOptionalRecord(record.message);
+    const ids = [record.messageId, record.pollId, message?.id]
+      .map(normalizeStatus)
+      .filter((id): id is string => Boolean(id));
+    return (
+      ids.some((id) => !NON_DELIVERY_IDS.has(id)) ||
+      normalizeStatus(record.status) === "sent" ||
+      normalizeStatus(record.text) === "sent"
+    );
+  },
+  deliveryId: (record: Record<string, unknown>) =>
+    [record.messageId, record.pollId, asOptionalRecord(record.message)?.id]
+      .map(normalizeStatus)
+      .some((id) => Boolean(id && !NON_DELIVERY_IDS.has(id))),
+  ok: (record: Record<string, unknown>) =>
+    record.ok === true || normalizeStatus(record.text) === "ok",
+} satisfies Record<string, (record: Record<string, unknown>) => boolean>;
+
+export function pluginEnvelopeHas(value: unknown, signal: keyof typeof PLUGIN_SIGNALS): boolean {
+  return visitPluginEnvelope(value, PLUGIN_SIGNALS[signal]);
+}
+
+function readPluginDeliveryId(value: unknown): string | undefined {
+  let found: string | undefined;
+  visitPluginEnvelope(value, (record) => {
+    found = [record.messageId, record.pollId, asOptionalRecord(record.message)?.id]
+      .map(deliveryId)
+      .find(Boolean);
+    return found !== undefined;
+  });
+  return found;
+}
+
+function projectPluginPayload(value: unknown): EmbeddedMessageDeliveryFact | undefined {
+  if (pluginEnvelopeHas(value, "dryRun")) {
+    return { status: "dryRun", ...EMPTY_DELIVERY_FACT };
+  }
+  if (pluginEnvelopeHas(value, "partial")) {
+    return { status: "settled", partialDelivery: true, createdThreadIds: [] };
+  }
+  if (pluginEnvelopeHas(value, "nonDelivery")) {
+    return { status: "suppressed", ...EMPTY_DELIVERY_FACT };
+  }
+  if (pluginEnvelopeHas(value, "noOp")) {
+    return { status: "failed", ...EMPTY_DELIVERY_FACT };
+  }
+  if (!pluginEnvelopeHas(value, "delivery") && !pluginEnvelopeHas(value, "ok")) {
+    return undefined;
+  }
+  const primaryPlatformMessageId = readPluginDeliveryId(value);
+  return {
+    status: "settled",
+    ...(primaryPlatformMessageId ? { primaryPlatformMessageId } : {}),
+    ...EMPTY_DELIVERY_FACT,
+  };
+}
+
+export function pluginBroadcastHasDelivery(value: unknown): boolean {
+  return visitPluginEnvelope(
+    value,
+    (record) =>
+      Array.isArray(record.results) &&
+      record.results.some((item) => {
+        const entry = asOptionalRecord(item);
+        if (!entry || entry.ok !== true || pluginEnvelopeHas(entry, "nonDelivery")) {
+          return false;
+        }
+        return [entry.payload, entry.toolResult].some(
+          (payload) => projectPluginPayload(payload)?.status === "settled",
+        );
+      }),
+  );
 }
 
 function projectSend(result: MessageSendResult): EmbeddedMessageDeliveryFact {
@@ -93,11 +256,19 @@ export function projectEmbeddedMessageDeliveryFact(
   if (result.kind !== "broadcast") {
     return undefined;
   }
-  const facts = result.payload.results.flatMap((entry) =>
-    entry.result ? [projectSend(entry.result)] : [],
-  );
+  const entries = result.payload.results.map((entry) => ({
+    entry,
+    // The broadcast producer normalizes plugin tool output into payload; toolResult is only a
+    // legacy visible-envelope shape accepted by pluginBroadcastHasDelivery.
+    fact: entry.result
+      ? projectSend(entry.result)
+      : entry.ok
+        ? projectPluginPayload(entry.payload)
+        : undefined,
+  }));
+  const facts = entries.flatMap(({ fact }) => (fact ? [fact] : []));
   const settled = facts.find((fact) => fact.status === "settled");
-  if (settled || result.payload.results.some((entry) => entry.ok && !entry.result)) {
+  if (settled || entries.some(({ entry, fact }) => entry.ok && !entry.result && !fact)) {
     return settled;
   }
   return (

--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -132,6 +132,36 @@ describe("isDeliveredMessagingToolResult", () => {
     },
   );
 
+  it.each([
+    ["provider message id", { ok: true, messageId: "plugin-message-1" }, true],
+    ["provider bare ok", { ok: true, to: "spaces/AAA" }, true],
+    ["provider suppressed status", { ok: true, status: "suppressed" }, false],
+    ["provider no-op marker", { ok: true, changed: false }, false],
+    ["missing provider payload", undefined, false],
+  ] satisfies Array<[string, unknown, boolean]>)(
+    "preserves the differential payload-only broadcast verdict for $0",
+    (_name, payload, expected) => {
+      const actionResult: MessageActionResult = {
+        kind: "broadcast",
+        channel: "googlechat",
+        action: "broadcast",
+        handledBy: "core",
+        payload: {
+          results: [{ channel: "googlechat", to: "space-1", ok: true, payload }],
+        },
+        dryRun: false,
+      };
+
+      expect(projectEmbeddedMessageDeliveryFact(actionResult)?.status === "settled").toBe(expected);
+      expect(
+        isDeliveredMessagingToolResult({
+          args: { action: "broadcast" },
+          result: actionResult.payload,
+        }),
+      ).toBe(expected);
+    },
+  );
+
   it("accepts confirmed delivery receipts from direct CLI text blocks", () => {
     expect(
       isDeliveredMessagingToolResult({

--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
+import type { MessageSendResult } from "../infra/outbound/message.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { projectEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
 import {
   isDeliveredMessageToolOnlySourceReplyResult,
   isDeliveredMessagingToolResult,
@@ -76,6 +79,59 @@ describe("messaging delivery action classification", () => {
 });
 
 describe("isDeliveredMessagingToolResult", () => {
+  it.each([
+    ["sent status", { deliveryStatus: "sent" }, true],
+    ["gateway id", { result: { messageId: "msg-1" } }, true],
+    ["unknown id", { result: { messageId: "unknown" } }, true],
+    ["skipped id", { result: { messageId: "skipped" } }, false],
+    ["suppressed id", { result: { messageId: "suppressed" } }, false],
+    ["suppressed status", { deliveryStatus: "suppressed" }, false],
+    ["dry run", { dryRun: true }, false],
+    ["partial status", { deliveryStatus: "partial_failed" }, true],
+    ["partial marker", { sentBeforeError: true }, true],
+    ["failed status", { deliveryStatus: "failed" }, false],
+    [
+      "receipt id",
+      {
+        result: {
+          channel: "telegram",
+          messageId: "",
+          receipt: {
+            primaryPlatformMessageId: "receipt-1",
+            platformMessageIds: ["receipt-1"],
+            parts: [],
+            sentAt: 1,
+          },
+        },
+      },
+      true,
+    ],
+  ] satisfies Array<[string, Partial<MessageSendResult>, boolean]>)(
+    "preserves the differential core-send verdict for $0",
+    (_name, partial, expected) => {
+      const sendResult: MessageSendResult = {
+        channel: "telegram",
+        to: "chat-1",
+        via: "direct",
+        mediaUrl: null,
+        ...partial,
+      };
+      const actionResult: MessageActionResult = {
+        kind: "send",
+        channel: "telegram",
+        action: "send",
+        to: "chat-1",
+        handledBy: "core",
+        payload: sendResult,
+        sendResult,
+        dryRun: sendResult.dryRun === true,
+      };
+      const fact = projectEmbeddedMessageDeliveryFact(actionResult);
+
+      expect(fact?.status === "settled").toBe(expected);
+    },
+  );
+
   it("accepts confirmed delivery receipts from direct CLI text blocks", () => {
     expect(
       isDeliveredMessagingToolResult({
@@ -128,51 +184,6 @@ describe("isDeliveredMessagingToolResult", () => {
     }
   });
 
-  it("accepts sessions_send acknowledgement statuses only for sessions_send", () => {
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "sessions_send",
-        result: { status: "accepted" },
-      }),
-    ).toBe(true);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "sessions_send",
-        result: { status: "ok" },
-      }),
-    ).toBe(true);
-    expect(isDeliveredMessagingToolResult({ toolName: "message", result: { status: "ok" } })).toBe(
-      false,
-    );
-  });
-
-  it("accepts post-start sessions_send timeout and error evidence", () => {
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "sessions_send",
-        result: { status: "timeout", sentBeforeError: true },
-      }),
-    ).toBe(true);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "sessions_send",
-        result: { status: "error", sentBeforeError: true },
-      }),
-    ).toBe(true);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "sessions_send",
-        result: { status: "timeout" },
-      }),
-    ).toBe(false);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "sessions_send",
-        result: { status: "error" },
-      }),
-    ).toBe(false);
-  });
-
   it("accepts poll delivery identifiers", () => {
     expect(isDeliveredMessagingToolResult({ result: { pollId: "poll-1" } })).toBe(true);
   });
@@ -200,12 +211,6 @@ describe("isDeliveredMessagingToolResult", () => {
   });
 
   it("accepts only broadcast result entries with concrete delivery evidence", () => {
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "message",
-        result: { results: [{ ok: true, messageId: "message-1" }] },
-      }),
-    ).toBe(true);
     expect(
       isDeliveredMessagingToolResult({
         args: { action: "broadcast" },
@@ -244,41 +249,16 @@ describe("isDeliveredMessagingToolResult", () => {
     ).toBe(true);
   });
 
-  it("rejects successful broadcast wrappers around suppressed sends", () => {
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "message",
-        args: { action: "broadcast" },
-        result: { results: [{ ok: true, result: { messageId: "suppressed" } }] },
-      }),
-    ).toBe(false);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "message",
-        args: { action: "broadcast" },
-        result: { results: [{ ok: true, result: { deliveryStatus: "suppressed" } }] },
-      }),
-    ).toBe(false);
+  it("rejects successful plugin broadcast wrappers around suppressed sends", () => {
     expect(
       isDeliveredMessagingToolResult({
         toolName: "message",
         args: { action: "broadcast" },
         result: {
-          results: [{ ok: true, payload: { ok: true, deliveryStatus: "suppressed" } }],
+          results: [{ ok: true, payload: { ok: true, status: "suppressed" } }],
         },
       }),
     ).toBe(false);
-  });
-
-  it("accepts failed broadcast entries with partial-delivery evidence", () => {
-    expect(
-      isDeliveredMessagingToolResult({
-        args: { action: "broadcast" },
-        result: {
-          results: [{ channel: "telegram", to: "chat-1", ok: false, sentBeforeError: true }],
-        },
-      }),
-    ).toBe(true);
   });
 
   it("rejects non-delivery message id sentinels", () => {
@@ -311,12 +291,6 @@ describe("isDeliveredMessagingToolResult", () => {
       isDeliveredMessagingToolResult({
         isError: true,
         result: Object.assign(new Error("second chunk failed"), { sentBeforeError: true }),
-      }),
-    ).toBe(true);
-    expect(
-      isDeliveredMessagingToolResult({
-        isError: true,
-        result: { deliveryStatus: "partial_failed" },
       }),
     ).toBe(true);
   });
@@ -403,6 +377,7 @@ describe("isDeliveredMessageToolOnlySourceReplyResult", () => {
         toolName: "message",
         args: { action: "send", message: "reply" },
         result: { deliveryStatus: "sent" },
+        deliveryConfirmed: true,
       }),
     ).toBe(true);
     expect(
@@ -411,6 +386,7 @@ describe("isDeliveredMessageToolOnlySourceReplyResult", () => {
         toolName: "message",
         args: { action: "send", target: "elsewhere", message: "reply" },
         result: { deliveryStatus: "sent" },
+        deliveryConfirmed: true,
       }),
     ).toBe(false);
   });

--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -133,21 +133,30 @@ describe("isDeliveredMessagingToolResult", () => {
   );
 
   it.each([
-    ["provider message id", { ok: true, messageId: "plugin-message-1" }, true],
-    ["provider bare ok", { ok: true, to: "spaces/AAA" }, true],
-    ["provider suppressed status", { ok: true, status: "suppressed" }, false],
-    ["provider no-op marker", { ok: true, changed: false }, false],
-    ["missing provider payload", undefined, false],
-  ] satisfies Array<[string, unknown, boolean]>)(
+    [
+      "provider message id",
+      { ok: true, payload: { ok: true, messageId: "plugin-message-1" } },
+      true,
+    ],
+    ["provider bare ok", { ok: true, payload: { ok: true, to: "spaces/AAA" } }, true],
+    [
+      "provider suppressed status",
+      { ok: true, payload: { ok: true, status: "suppressed" } },
+      false,
+    ],
+    ["provider no-op marker", { ok: true, payload: { ok: true, changed: false } }, false],
+    ["missing provider payload", { ok: true }, false],
+    ["failed entry after partial delivery", { ok: false, sentBeforeError: true as const }, true],
+  ] satisfies Array<[string, Record<string, unknown>, boolean]>)(
     "preserves the differential payload-only broadcast verdict for $0",
-    (_name, payload, expected) => {
+    (_name, entry, expected) => {
       const actionResult: MessageActionResult = {
         kind: "broadcast",
         channel: "googlechat",
         action: "broadcast",
         handledBy: "core",
         payload: {
-          results: [{ channel: "googlechat", to: "space-1", ok: true, payload }],
+          results: [{ channel: "googlechat", to: "space-1", ...entry }],
         },
         dryRun: false,
       };

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -1,8 +1,11 @@
-import { safeParseJsonRecord } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString, readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
-import { readEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
+import {
+  pluginBroadcastHasDelivery,
+  pluginEnvelopeHas,
+  readEmbeddedMessageDeliveryFact,
+} from "./embedded-agent-message-delivery.js";
 import {
   isMessageToolConversationCreateActionName,
   isMessageToolSendActionName,
@@ -12,8 +15,6 @@ import { normalizeToolPolicyName } from "./tool-policy.js";
 import { isToolResultError, readToolResultDetails } from "./tool-result-error.js";
 
 const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
-const NON_DELIVERY_MESSAGE_IDS = new Set(["skipped", "suppressed"]);
-const FALLBACK_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
 export function resolveMessageToolSourceReplyFinal(args: unknown): boolean {
   return (asOptionalRecord(args) ?? {}).final !== false;
 }
@@ -53,123 +54,8 @@ function normalizeStatus(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim().toLowerCase() : undefined;
 }
 
-function visitPluginEnvelope(
-  value: unknown,
-  predicate: (record: Record<string, unknown>) => boolean,
-  depth = 0,
-): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => visitPluginEnvelope(item, predicate, depth + 1));
-  }
-  const record = value as Record<string, unknown>;
-  if (predicate(record)) {
-    return true;
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && visitPluginEnvelope(parsed, predicate, depth + 1)) {
-      return true;
-    }
-  }
-  if (
-    Array.isArray(record.content) &&
-    record.content.some((item) => visitPluginEnvelope(item, predicate, depth + 1))
-  ) {
-    return true;
-  }
-  return FALLBACK_ENVELOPE_KEYS.some((key) =>
-    visitPluginEnvelope(record[key], predicate, depth + 1),
-  );
-}
-
-const PLUGIN_SIGNALS = {
-  dryRun: (record: Record<string, unknown>) =>
-    record.dryRun === true || normalizeStatus(record.status) === "dry_run",
-  partial: (record: Record<string, unknown>) =>
-    record.sentBeforeError === true ||
-    record.visibleReplySent === true ||
-    normalizeStatus(record.status) === "partial_failed",
-  conversation: (record: Record<string, unknown>) =>
-    [
-      record.topicId,
-      record.threadId,
-      record.messageThreadId,
-      asOptionalRecord(record.thread)?.id,
-    ].some((id) => hasNonEmptyString(id) || (typeof id === "number" && Number.isFinite(id))),
-  nonDelivery: (record: Record<string, unknown>) => {
-    const id = normalizeStatus(record.messageId);
-    return (
-      (id !== undefined && NON_DELIVERY_MESSAGE_IDS.has(id)) ||
-      normalizeStatus(record.status) === "suppressed"
-    );
-  },
-  noOp: (record: Record<string, unknown>) => {
-    const removed = record.removed;
-    const status = normalizeStatus(record.status);
-    return (
-      removed === null ||
-      removed === false ||
-      removed === 0 ||
-      (Array.isArray(removed) && removed.length === 0) ||
-      record.applied === false ||
-      record.changed === false ||
-      record.created === false ||
-      record.deleted === false ||
-      record.sent === false ||
-      record.updated === false ||
-      status === "noop" ||
-      status === "no_op" ||
-      status === "not_found"
-    );
-  },
-  delivery: (record: Record<string, unknown>) => {
-    const message = asOptionalRecord(record.message);
-    const ids = [record.messageId, record.pollId, message?.id]
-      .map(normalizeStatus)
-      .filter((id): id is string => Boolean(id));
-    return (
-      ids.some((id) => !NON_DELIVERY_MESSAGE_IDS.has(id)) ||
-      normalizeStatus(record.status) === "sent" ||
-      normalizeStatus(record.text) === "sent"
-    );
-  },
-  deliveryId: (record: Record<string, unknown>) =>
-    [record.messageId, record.pollId, asOptionalRecord(record.message)?.id]
-      .map(normalizeStatus)
-      .some((id) => Boolean(id && !NON_DELIVERY_MESSAGE_IDS.has(id))),
-  ok: (record: Record<string, unknown>) =>
-    record.ok === true || normalizeStatus(record.text) === "ok",
-} satisfies Record<string, (record: Record<string, unknown>) => boolean>;
-
-function pluginEnvelopeHas(value: unknown, signal: keyof typeof PLUGIN_SIGNALS): boolean {
-  return visitPluginEnvelope(value, PLUGIN_SIGNALS[signal]);
-}
-
 export function hasPluginMessagingDeliveryId(value: unknown): boolean {
   return pluginEnvelopeHas(value, "deliveryId");
-}
-
-function pluginBroadcastHasDelivery(value: unknown): boolean {
-  return visitPluginEnvelope(
-    value,
-    (record) =>
-      Array.isArray(record.results) &&
-      record.results.some((item) => {
-        const entry = asOptionalRecord(item);
-        if (!entry || entry.ok !== true || pluginEnvelopeHas(entry, "nonDelivery")) {
-          return false;
-        }
-        return [entry.payload, entry.toolResult].some((payload) => {
-          return (
-            !pluginEnvelopeHas(payload, "noOp") &&
-            (pluginEnvelopeHas(payload, "delivery") || pluginEnvelopeHas(payload, "ok"))
-          );
-        });
-      }),
-  );
 }
 
 export function isDeliveredMessagingToolResult(params: {

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -1,6 +1,3 @@
-/**
- * Detects message-tool sends that delivered a visible reply to the current source.
- */
 import { safeParseJsonRecord } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString, readStringValue } from "@openclaw/normalization-core/string-coerce";
@@ -14,26 +11,10 @@ import { normalizeToolPolicyName } from "./tool-policy.js";
 import { isToolResultError } from "./tool-result-error.js";
 
 const MESSAGE_TOOL_NAME = "message";
-const SESSIONS_SEND_TOOL_NAME = "sessions_send";
 const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
-const DRY_RUN_DELIVERY_STATUS = "dry_run";
-const PARTIAL_FAILED_DELIVERY_STATUS = "partial_failed";
-const SENT_DELIVERY_STATUS = "sent";
 const NON_DELIVERY_MESSAGE_IDS = new Set(["skipped", "suppressed"]);
-const RESULT_ENVELOPE_KEYS = [
-  "details",
-  "payload",
-  "result",
-  "results",
-  "sendResult",
-  "toolResult",
-];
-const BROADCAST_SEND_ENVELOPE_KEYS = ["payload", "result", "sendResult", "toolResult"];
-const PARTIAL_DELIVERY_ENVELOPE_KEYS = [...RESULT_ENVELOPE_KEYS, "error", "cause"];
-const SESSIONS_SEND_DELIVERY_STATUSES = new Set(["accepted", "ok"]);
-const BARE_OK_DELIVERY_STATUS = "ok";
+const FALLBACK_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
 
-/** Omission preserves the established one-shot send behavior. */
 export function resolveMessageToolSourceReplyFinal(args: unknown): boolean {
   return (asOptionalRecord(args) ?? {}).final !== false;
 }
@@ -44,32 +25,20 @@ function resultConfirmsCurrentSourceRoute(value: unknown): boolean {
   );
 }
 
-function hasConversationIdValue(value: unknown): boolean {
-  return hasNonEmptyString(value) || (typeof value === "number" && Number.isFinite(value));
-}
-
 function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
-  if (EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasNonEmptyString(args[key]))) {
-    return true;
-  }
-  return Array.isArray(args.targets) && args.targets.some((value) => hasNonEmptyString(value));
+  return (
+    EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasNonEmptyString(args[key])) ||
+    (Array.isArray(args.targets) && args.targets.some((value) => hasNonEmptyString(value)))
+  );
 }
 
 function isMessageToolSourceReplyActionName(action: unknown): boolean {
-  if (isMessageToolSendActionName(action)) {
-    return true;
-  }
-  if (typeof action !== "string") {
-    return false;
-  }
-  // Polls and reply-type actions deliver the visible source answer too; they
-  // qualify only when the runner confirmed the current-source route (or the
-  // caller allows explicit routes), enforced by the caller below.
-  const normalized = action.trim().toLowerCase();
-  return normalized === "reply" || normalized === "thread-reply" || normalized === "poll";
+  return (
+    isMessageToolSendActionName(action) ||
+    ["reply", "thread-reply", "poll"].includes(normalizeStatus(action) ?? "")
+  );
 }
 
-/** Read the visible text delivered by a source-reply message action. */
 export function readMessageToolSourceReplyText(args: unknown): string | undefined {
   const record = asOptionalRecord(args) ?? {};
   if (!isMessageToolSourceReplyActionName(record.action)) {
@@ -78,419 +47,135 @@ export function readMessageToolSourceReplyText(args: unknown): string | undefine
   if (normalizeStatus(record.action) === "poll") {
     return readStringValue(record.pollQuestion) ?? readStringValue(record.poll_question);
   }
-  for (const key of ["content", "message", "text", "body"]) {
-    const value = readStringValue(record[key]);
-    if (value) {
-      return value;
-    }
-  }
-  return undefined;
+  return ["content", "message", "text", "body"]
+    .map((key) => readStringValue(record[key]))
+    .find((value) => value !== undefined);
 }
 
 function normalizeStatus(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim().toLowerCase() : undefined;
 }
 
-function isBareOkDeliveryStatus(value: unknown): boolean {
-  return normalizeStatus(value) === BARE_OK_DELIVERY_STATUS;
-}
-
-function isBareSentDeliveryStatus(value: unknown): boolean {
-  return normalizeStatus(value) === SENT_DELIVERY_STATUS;
-}
-
-function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
-  const hasDeliveredId = (value: unknown) => {
-    const normalized = normalizeStatus(value);
-    return Boolean(normalized && !NON_DELIVERY_MESSAGE_IDS.has(normalized));
-  };
-  const message = asOptionalRecord(record.message) ?? {};
-  if (
-    hasDeliveredId(record.messageId) ||
-    hasDeliveredId(record.pollId) ||
-    hasDeliveredId(message.id)
-  ) {
-    return true;
-  }
-  const receipt = record.receipt;
-  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) {
-    return false;
-  }
-  const receiptRecord = receipt as Record<string, unknown>;
-  return (
-    hasDeliveredId(receiptRecord.primaryPlatformMessageId) ||
-    (Array.isArray(receiptRecord.platformMessageIds) &&
-      receiptRecord.platformMessageIds.some((value) => hasDeliveredId(value)))
-  );
-}
-
-function deliveryEnvelopeHasCreatedConversationId(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeHasCreatedConversationId(item, depth + 1));
-  }
-
-  const record = value as Record<string, unknown>;
-  if (
-    hasConversationIdValue(record.topicId) ||
-    hasConversationIdValue(record.threadId) ||
-    hasConversationIdValue(record.messageThreadId)
-  ) {
-    return true;
-  }
-  const thread = record.thread;
-  if (thread && typeof thread === "object" && !Array.isArray(thread)) {
-    if (hasConversationIdValue((thread as Record<string, unknown>).id)) {
-      return true;
-    }
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeHasCreatedConversationId(parsed, depth + 1)) {
-      return true;
-    }
-  }
-  const content = record.content;
-  if (
-    Array.isArray(content) &&
-    content.some((item) => deliveryEnvelopeHasCreatedConversationId(item, depth + 1))
-  ) {
-    return true;
-  }
-  return PARTIAL_DELIVERY_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeHasCreatedConversationId(record[key], depth + 1),
-  );
-}
-
-function deliveryEnvelopeIndicatesOk(value: unknown, depth = 0): boolean {
-  if (isBareOkDeliveryStatus(value)) {
-    return true;
-  }
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesOk(item, depth + 1));
-  }
-  const record = value as Record<string, unknown>;
-  if (record.ok === true) {
-    return true;
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesOk(parsed, depth + 1)) {
-      return true;
-    }
-    if (isBareOkDeliveryStatus(record.text)) {
-      return true;
-    }
-  }
-  const content = record.content;
-  if (
-    Array.isArray(content) &&
-    content.some((item) => deliveryEnvelopeIndicatesOk(item, depth + 1))
-  ) {
-    return true;
-  }
-  return RESULT_ENVELOPE_KEYS.some((key) => deliveryEnvelopeIndicatesOk(record[key], depth + 1));
-}
-
-function deliveryEnvelopeIndicatesNonDelivery(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesNonDelivery(item, depth + 1));
-  }
-  const record = value as Record<string, unknown>;
-  const messageId = normalizeStatus(record.messageId);
-  if (
-    (messageId && NON_DELIVERY_MESSAGE_IDS.has(messageId)) ||
-    normalizeStatus(record.deliveryStatus) === "suppressed" ||
-    normalizeStatus(record.status) === "suppressed"
-  ) {
-    return true;
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesNonDelivery(parsed, depth + 1)) {
-      return true;
-    }
-  }
-  const content = record.content;
-  if (
-    Array.isArray(content) &&
-    content.some((item) => deliveryEnvelopeIndicatesNonDelivery(item, depth + 1))
-  ) {
-    return true;
-  }
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesNonDelivery(record[key], depth + 1),
-  );
-}
-
-function deliveryEnvelopeIndicatesNoOp(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesNoOp(item, depth + 1));
-  }
-  const record = value as Record<string, unknown>;
-  const removed = record.removed;
-  if (
-    removed === null ||
-    removed === false ||
-    removed === 0 ||
-    (Array.isArray(removed) && removed.length === 0) ||
-    record.applied === false ||
-    record.changed === false ||
-    record.created === false ||
-    record.deleted === false ||
-    record.sent === false ||
-    record.updated === false
-  ) {
-    return true;
-  }
-  const status = normalizeStatus(record.status);
-  if (status === "noop" || status === "no_op" || status === "not_found") {
-    return true;
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesNoOp(parsed, depth + 1)) {
-      return true;
-    }
-  }
-  const content = record.content;
-  if (
-    Array.isArray(content) &&
-    content.some((item) => deliveryEnvelopeIndicatesNoOp(item, depth + 1))
-  ) {
-    return true;
-  }
-  return RESULT_ENVELOPE_KEYS.some((key) => deliveryEnvelopeIndicatesNoOp(record[key], depth + 1));
-}
-
-function broadcastEntryHasSuccessfulBareOkSend(
-  record: Record<string, unknown>,
-  depth: number,
-): boolean {
-  return BROADCAST_SEND_ENVELOPE_KEYS.some((key) => {
-    const value = record[key];
-    return (
-      deliveryEnvelopeIndicatesOk(value, depth + 1) &&
-      !deliveryEnvelopeIndicatesNonDelivery(value, depth + 1) &&
-      !deliveryEnvelopeIndicatesNoOp(value, depth + 1)
-    );
-  });
-}
-
-function deliveryEnvelopeIndicatesSuccessfulBroadcast(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some(
-      (item) =>
-        item !== null &&
-        typeof item === "object" &&
-        !Array.isArray(item) &&
-        (item as Record<string, unknown>).ok === true &&
-        !deliveryEnvelopeIndicatesNonDelivery(item) &&
-        !deliveryEnvelopeIndicatesNoOp(item) &&
-        (deliveryEnvelopeIndicatesDelivered(item, depth + 1) ||
-          broadcastEntryHasSuccessfulBareOkSend(item as Record<string, unknown>, depth + 1)),
-    );
-  }
-  const record = value as Record<string, unknown>;
-  if (deliveryEnvelopeIndicatesSuccessfulBroadcast(record.results, depth + 1)) {
-    return true;
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesSuccessfulBroadcast(parsed, depth + 1)) {
-      return true;
-    }
-  }
-  const content = record.content;
-  if (
-    Array.isArray(content) &&
-    content.some((item) => deliveryEnvelopeIndicatesSuccessfulBroadcast(item, depth + 1))
-  ) {
-    return true;
-  }
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesSuccessfulBroadcast(record[key], depth + 1),
-  );
-}
-
-function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesDryRun(item, depth + 1));
-  }
-
-  const record = value as Record<string, unknown>;
-  if (
-    record.dryRun === true ||
-    normalizeStatus(record.deliveryStatus) === DRY_RUN_DELIVERY_STATUS ||
-    normalizeStatus(record.status) === DRY_RUN_DELIVERY_STATUS
-  ) {
-    return true;
-  }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesDryRun(parsed, depth + 1)) {
-      return true;
-    }
-  }
-
-  const content = record.content;
-  if (Array.isArray(content)) {
-    for (const item of content) {
-      if (deliveryEnvelopeIndicatesDryRun(item, depth + 1)) {
-        return true;
-      }
-      if (item && typeof item === "object" && !Array.isArray(item)) {
-        const text = (item as Record<string, unknown>).text;
-        if (typeof text === "string") {
-          const parsed = safeParseJsonRecord(text);
-          if (parsed && deliveryEnvelopeIndicatesDryRun(parsed, depth + 1)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesDryRun(record[key], depth + 1),
-  );
-}
-
-function deliveryEnvelopeIndicatesDelivered(
+function visitPluginEnvelope(
   value: unknown,
+  predicate: (record: Record<string, unknown>) => boolean,
   depth = 0,
-  requireReceipt = false,
 ): boolean {
-  if (!requireReceipt && isBareSentDeliveryStatus(value)) {
-    return true;
-  }
   if (!value || typeof value !== "object" || depth > 4) {
     return false;
   }
   if (Array.isArray(value)) {
-    return value.some((item) =>
-      deliveryEnvelopeIndicatesDelivered(item, depth + 1, requireReceipt),
-    );
+    return value.some((item) => visitPluginEnvelope(item, predicate, depth + 1));
   }
-
   const record = value as Record<string, unknown>;
-  if (
-    (!requireReceipt && normalizeStatus(record.deliveryStatus) === SENT_DELIVERY_STATUS) ||
-    (!requireReceipt && normalizeStatus(record.status) === SENT_DELIVERY_STATUS) ||
-    recordHasDeliveredMessageId(record)
-  ) {
+  if (predicate(record)) {
     return true;
   }
   if (typeof record.text === "string") {
     const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesDelivered(parsed, depth + 1, requireReceipt)) {
-      return true;
-    }
-    if (!requireReceipt && isBareSentDeliveryStatus(record.text)) {
+    if (parsed && visitPluginEnvelope(parsed, predicate, depth + 1)) {
       return true;
     }
   }
-
-  const content = record.content;
-  if (Array.isArray(content)) {
-    for (const item of content) {
-      if (deliveryEnvelopeIndicatesDelivered(item, depth + 1, requireReceipt)) {
-        return true;
-      }
-      if (item && typeof item === "object" && !Array.isArray(item)) {
-        const text = (item as Record<string, unknown>).text;
-        if (typeof text === "string") {
-          const parsed = safeParseJsonRecord(text);
-          if (parsed && deliveryEnvelopeIndicatesDelivered(parsed, depth + 1, requireReceipt)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesDelivered(record[key], depth + 1, requireReceipt),
-  );
-}
-
-/** Return true when a result envelope carries a provider message identifier. */
-export function hasMessagingDeliveryReceipt(value: unknown): boolean {
-  return deliveryEnvelopeIndicatesDelivered(value, 0, true);
-}
-
-function deliveryEnvelopeIndicatesSessionsSendAccepted(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesSessionsSendAccepted(item, depth + 1));
-  }
-  const record = value as Record<string, unknown>;
   if (
-    SESSIONS_SEND_DELIVERY_STATUSES.has(normalizeStatus(record.deliveryStatus) ?? "") ||
-    SESSIONS_SEND_DELIVERY_STATUSES.has(normalizeStatus(record.status) ?? "")
+    Array.isArray(record.content) &&
+    record.content.some((item) => visitPluginEnvelope(item, predicate, depth + 1))
   ) {
     return true;
   }
-  if (typeof record.text === "string") {
-    const parsed = safeParseJsonRecord(record.text);
-    if (parsed && deliveryEnvelopeIndicatesSessionsSendAccepted(parsed, depth + 1)) {
-      return true;
-    }
-  }
-  const content = record.content;
-  if (
-    Array.isArray(content) &&
-    content.some((item) => deliveryEnvelopeIndicatesSessionsSendAccepted(item, depth + 1))
-  ) {
-    return true;
-  }
-  return RESULT_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesSessionsSendAccepted(record[key], depth + 1),
+  return FALLBACK_ENVELOPE_KEYS.some((key) =>
+    visitPluginEnvelope(record[key], predicate, depth + 1),
   );
 }
 
-function deliveryEnvelopeIndicatesPartialDelivery(value: unknown, depth = 0): boolean {
-  if (!value || typeof value !== "object" || depth > 4) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.some((item) => deliveryEnvelopeIndicatesPartialDelivery(item, depth + 1));
-  }
-
-  const record = value as Record<string, unknown>;
-  if (
+const PLUGIN_SIGNALS = {
+  dryRun: (record: Record<string, unknown>) =>
+    record.dryRun === true || normalizeStatus(record.status) === "dry_run",
+  partial: (record: Record<string, unknown>) =>
     record.sentBeforeError === true ||
     record.visibleReplySent === true ||
-    normalizeStatus(record.deliveryStatus) === PARTIAL_FAILED_DELIVERY_STATUS ||
-    normalizeStatus(record.status) === PARTIAL_FAILED_DELIVERY_STATUS
-  ) {
-    return true;
-  }
-  return PARTIAL_DELIVERY_ENVELOPE_KEYS.some((key) =>
-    deliveryEnvelopeIndicatesPartialDelivery(record[key], depth + 1),
+    normalizeStatus(record.status) === "partial_failed",
+  conversation: (record: Record<string, unknown>) =>
+    [
+      record.topicId,
+      record.threadId,
+      record.messageThreadId,
+      asOptionalRecord(record.thread)?.id,
+    ].some((id) => hasNonEmptyString(id) || (typeof id === "number" && Number.isFinite(id))),
+  nonDelivery: (record: Record<string, unknown>) => {
+    const id = normalizeStatus(record.messageId);
+    return (
+      (id !== undefined && NON_DELIVERY_MESSAGE_IDS.has(id)) ||
+      normalizeStatus(record.status) === "suppressed"
+    );
+  },
+  noOp: (record: Record<string, unknown>) => {
+    const removed = record.removed;
+    const status = normalizeStatus(record.status);
+    return (
+      removed === null ||
+      removed === false ||
+      removed === 0 ||
+      (Array.isArray(removed) && removed.length === 0) ||
+      record.applied === false ||
+      record.changed === false ||
+      record.created === false ||
+      record.deleted === false ||
+      record.sent === false ||
+      record.updated === false ||
+      status === "noop" ||
+      status === "no_op" ||
+      status === "not_found"
+    );
+  },
+  delivery: (record: Record<string, unknown>) => {
+    const message = asOptionalRecord(record.message);
+    const ids = [record.messageId, record.pollId, message?.id]
+      .map(normalizeStatus)
+      .filter((id): id is string => Boolean(id));
+    return (
+      ids.some((id) => !NON_DELIVERY_MESSAGE_IDS.has(id)) ||
+      normalizeStatus(record.status) === "sent" ||
+      normalizeStatus(record.text) === "sent"
+    );
+  },
+  deliveryId: (record: Record<string, unknown>) =>
+    [record.messageId, record.pollId, asOptionalRecord(record.message)?.id]
+      .map(normalizeStatus)
+      .some((id) => Boolean(id && !NON_DELIVERY_MESSAGE_IDS.has(id))),
+  ok: (record: Record<string, unknown>) =>
+    record.ok === true || normalizeStatus(record.text) === "ok",
+} satisfies Record<string, (record: Record<string, unknown>) => boolean>;
+
+function pluginEnvelopeHas(value: unknown, signal: keyof typeof PLUGIN_SIGNALS): boolean {
+  return visitPluginEnvelope(value, PLUGIN_SIGNALS[signal]);
+}
+
+export function hasPluginMessagingDeliveryId(value: unknown): boolean {
+  return pluginEnvelopeHas(value, "deliveryId");
+}
+
+function pluginBroadcastHasDelivery(value: unknown): boolean {
+  return visitPluginEnvelope(
+    value,
+    (record) =>
+      Array.isArray(record.results) &&
+      record.results.some((item) => {
+        const entry = asOptionalRecord(item);
+        if (!entry || entry.ok !== true || pluginEnvelopeHas(entry, "nonDelivery")) {
+          return false;
+        }
+        return [entry.payload, entry.toolResult].some((payload) => {
+          return (
+            !pluginEnvelopeHas(payload, "noOp") &&
+            (pluginEnvelopeHas(payload, "delivery") || pluginEnvelopeHas(payload, "ok"))
+          );
+        });
+      }),
   );
 }
 
-/** Return true only when a messaging tool result proves a real visible delivery. */
+/** Return true only when a plugin-native messaging result proves visible delivery. */
 export function isDeliveredMessagingToolResult(params: {
   toolName?: string;
   args?: unknown;
@@ -500,71 +185,39 @@ export function isDeliveredMessagingToolResult(params: {
 }): boolean {
   const args = asOptionalRecord(params.args) ?? {};
   const action = normalizeStatus(args.action);
-  if (
-    args.dryRun === true ||
-    deliveryEnvelopeIndicatesDryRun(params.result) ||
-    deliveryEnvelopeIndicatesDryRun(params.hookResult)
-  ) {
+  const results = [params.result, params.hookResult];
+  if (args.dryRun === true || results.some((result) => pluginEnvelopeHas(result, "dryRun"))) {
     return false;
   }
-  if (
-    deliveryEnvelopeIndicatesPartialDelivery(params.result) ||
-    deliveryEnvelopeIndicatesPartialDelivery(params.hookResult)
-  ) {
+  if (results.some((result) => pluginEnvelopeHas(result, "partial"))) {
     return true;
   }
   if (
     action &&
     isMessageToolConversationCreateActionName(action) &&
-    (deliveryEnvelopeHasCreatedConversationId(params.result) ||
-      deliveryEnvelopeHasCreatedConversationId(params.hookResult))
+    results.some((result) => pluginEnvelopeHas(result, "conversation"))
   ) {
     return true;
   }
-  if (
-    action === "broadcast" &&
-    (deliveryEnvelopeIndicatesSuccessfulBroadcast(params.result) ||
-      deliveryEnvelopeIndicatesSuccessfulBroadcast(params.hookResult))
-  ) {
+  if (action === "broadcast" && results.some(pluginBroadcastHasDelivery)) {
     return true;
   }
-  if (params.isError || isToolResultError(params.result) || isToolResultError(params.hookResult)) {
+  if (params.isError || results.some(isToolResultError)) {
     return false;
   }
   const normalizedToolName = normalizeToolPolicyName(params.toolName ?? MESSAGE_TOOL_NAME);
-  const mutationHasBareOk =
+  const nonDelivery = results.some((result) => pluginEnvelopeHas(result, "nonDelivery"));
+  const noOp = results.some((result) => pluginEnvelopeHas(result, "noOp"));
+  if (
+    !nonDelivery &&
+    !noOp &&
     isMessagingToolDeliveryAction(normalizedToolName, args) &&
     action !== "broadcast" &&
-    (deliveryEnvelopeIndicatesOk(params.result) || deliveryEnvelopeIndicatesOk(params.hookResult));
-  if (
-    mutationHasBareOk &&
-    !deliveryEnvelopeIndicatesNonDelivery(params.result) &&
-    !deliveryEnvelopeIndicatesNonDelivery(params.hookResult) &&
-    !deliveryEnvelopeIndicatesNoOp(params.result) &&
-    !deliveryEnvelopeIndicatesNoOp(params.hookResult)
+    results.some((result) => pluginEnvelopeHas(result, "ok"))
   ) {
     return true;
   }
-  if (
-    deliveryEnvelopeIndicatesNonDelivery(params.result) ||
-    deliveryEnvelopeIndicatesNonDelivery(params.hookResult) ||
-    deliveryEnvelopeIndicatesNoOp(params.result) ||
-    deliveryEnvelopeIndicatesNoOp(params.hookResult)
-  ) {
-    return false;
-  }
-  if (normalizedToolName === SESSIONS_SEND_TOOL_NAME) {
-    return (
-      deliveryEnvelopeIndicatesSessionsSendAccepted(params.result) ||
-      deliveryEnvelopeIndicatesSessionsSendAccepted(params.hookResult) ||
-      deliveryEnvelopeIndicatesDelivered(params.result) ||
-      deliveryEnvelopeIndicatesDelivered(params.hookResult)
-    );
-  }
-  return (
-    deliveryEnvelopeIndicatesDelivered(params.result) ||
-    deliveryEnvelopeIndicatesDelivered(params.hookResult)
-  );
+  return !nonDelivery && !noOp && results.some((result) => pluginEnvelopeHas(result, "delivery"));
 }
 
 /**
@@ -579,6 +232,7 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   hookResult?: unknown;
   isError?: boolean;
   allowExplicitSourceRoute?: boolean;
+  deliveryConfirmed?: boolean;
 }): boolean {
   const confirmedCurrentSourceRoute =
     resultConfirmsCurrentSourceRoute(params.result) ||
@@ -596,10 +250,12 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   if (!isMessageToolSendActionName(args.action) && !sourceRouteReplyAction) {
     return false;
   }
-  const hasConfirmedExplicitSourceRoute =
-    params.allowExplicitSourceRoute === true || confirmedCurrentSourceRoute;
-  if (hasExplicitMessageRoute(args) && !hasConfirmedExplicitSourceRoute) {
+  if (
+    hasExplicitMessageRoute(args) &&
+    params.allowExplicitSourceRoute !== true &&
+    !confirmedCurrentSourceRoute
+  ) {
     return false;
   }
-  return isDeliveredMessagingToolResult(params);
+  return params.deliveryConfirmed ?? isDeliveredMessagingToolResult(params);
 }

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -2,27 +2,24 @@ import { safeParseJsonRecord } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString, readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
+import { readEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
 import {
   isMessageToolConversationCreateActionName,
   isMessageToolSendActionName,
   isMessagingToolDeliveryAction,
 } from "./embedded-agent-messaging.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
-import { isToolResultError } from "./tool-result-error.js";
+import { isToolResultError, readToolResultDetails } from "./tool-result-error.js";
 
-const MESSAGE_TOOL_NAME = "message";
 const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
 const NON_DELIVERY_MESSAGE_IDS = new Set(["skipped", "suppressed"]);
 const FALLBACK_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
-
 export function resolveMessageToolSourceReplyFinal(args: unknown): boolean {
   return (asOptionalRecord(args) ?? {}).final !== false;
 }
 
 function resultConfirmsCurrentSourceRoute(value: unknown): boolean {
-  return (
-    (asOptionalRecord(asOptionalRecord(value)?.details) ?? {}).sourceReplyRoute === "current-source"
-  );
+  return asOptionalRecord(asOptionalRecord(value)?.details)?.sourceReplyRoute === "current-source";
 }
 
 function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
@@ -175,7 +172,6 @@ function pluginBroadcastHasDelivery(value: unknown): boolean {
   );
 }
 
-/** Return true only when a plugin-native messaging result proves visible delivery. */
 export function isDeliveredMessagingToolResult(params: {
   toolName?: string;
   args?: unknown;
@@ -205,7 +201,7 @@ export function isDeliveredMessagingToolResult(params: {
   if (params.isError || results.some(isToolResultError)) {
     return false;
   }
-  const normalizedToolName = normalizeToolPolicyName(params.toolName ?? MESSAGE_TOOL_NAME);
+  const normalizedToolName = normalizeToolPolicyName(params.toolName ?? "message");
   const nonDelivery = results.some((result) => pluginEnvelopeHas(result, "nonDelivery"));
   const noOp = results.some((result) => pluginEnvelopeHas(result, "noOp"));
   if (
@@ -220,10 +216,6 @@ export function isDeliveredMessagingToolResult(params: {
   return !nonDelivery && !noOp && results.some((result) => pluginEnvelopeHas(result, "delivery"));
 }
 
-/**
- * Only delivered message actions on the confirmed current route qualify.
- * Explicit routes require an authoritative current-source marker from the action runner.
- */
 export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   toolName: string;
@@ -237,10 +229,13 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   const confirmedCurrentSourceRoute =
     resultConfirmsCurrentSourceRoute(params.result) ||
     resultConfirmsCurrentSourceRoute(params.hookResult);
+  const deliveryFact = readEmbeddedMessageDeliveryFact(
+    readToolResultDetails(params.hookResult ?? params.result)?.messageDelivery,
+  );
   if (params.sourceReplyDeliveryMode !== "message_tool_only" && !confirmedCurrentSourceRoute) {
     return false;
   }
-  if (normalizeToolPolicyName(params.toolName) !== MESSAGE_TOOL_NAME) {
+  if (normalizeToolPolicyName(params.toolName) !== "message") {
     return false;
   }
   const args = asOptionalRecord(params.args) ?? {};
@@ -257,5 +252,10 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   ) {
     return false;
   }
-  return params.deliveryConfirmed ?? isDeliveredMessagingToolResult(params);
+  return (
+    params.deliveryConfirmed ??
+    (deliveryFact
+      ? deliveryFact.status === "settled" && (!params.isError || deliveryFact.partialDelivery)
+      : isDeliveredMessagingToolResult(params))
+  );
 }

--- a/src/agents/embedded-agent-messaging.ts
+++ b/src/agents/embedded-agent-messaging.ts
@@ -67,8 +67,12 @@ export function isMessagingTool(toolName: string): boolean {
   if (CORE_MESSAGING_TOOLS.has(toolName)) {
     return true;
   }
+  return isPluginNativeMessagingTool(toolName);
+}
+
+export function isPluginNativeMessagingTool(toolName: string): boolean {
   const providerId = normalizeChannelId(toolName);
-  return Boolean(providerId && getChannelPlugin(providerId)?.actions);
+  return toolName === "message" || Boolean(providerId && getChannelPlugin(providerId)?.actions);
 }
 
 /** Return true when the specific tool invocation is an outbound send. */

--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -25,7 +25,7 @@ import {
   recordAdjustedParamsForToolCall,
 } from "./agent-tools.before-tool-call.js";
 import { buildEmbeddedExtensionFactories } from "./embedded-agent-runner/extensions.js";
-import { consumeEmbeddedToolSendReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
+import { consumeEmbeddedToolReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
 import { cleanupTempPluginTestEnvironment } from "./test-helpers/temp-plugin-extension-fixtures.js";
 import { jsonResult } from "./tools/common.js";
 
@@ -447,7 +447,7 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
   });
 
-  it("stores provider send receipts without overriding middleware details", async () => {
+  it("stores private send receipts without overriding middleware details", async () => {
     const registry = createEmptyPluginRegistry();
     registry.agentToolResultMiddlewares.push({
       pluginId: "redactor",
@@ -489,6 +489,12 @@ describe("buildEmbeddedExtensionFactories", () => {
             to: "channel:resolved-id",
             threadId: "root-1",
           },
+          messageDelivery: {
+            status: "settled",
+            primaryPlatformMessageId: "message-1",
+            partialDelivery: false,
+            createdThreadIds: ["root-1"],
+          },
         },
       },
       { cwd: "/tmp" },
@@ -498,15 +504,21 @@ describe("buildEmbeddedExtensionFactories", () => {
       content: [{ type: "text", text: "Sent." }],
       details: { redacted: true },
     });
-    expect(consumeEmbeddedToolSendReceipt(sessionManager, "call-message")).toEqual({
+    expect(consumeEmbeddedToolReceipt(sessionManager, "call-message")).toEqual({
       details: {
         toolSend: {
           to: "channel:resolved-id",
           threadId: "root-1",
         },
+        messageDelivery: {
+          status: "settled",
+          primaryPlatformMessageId: "message-1",
+          partialDelivery: false,
+          createdThreadIds: ["root-1"],
+        },
       },
     });
-    expect(consumeEmbeddedToolSendReceipt(sessionManager, "call-message")).toBeUndefined();
+    expect(consumeEmbeddedToolReceipt(sessionManager, "call-message")).toBeUndefined();
   });
 
   it("keeps a confirmed send successful when result middleware fails", async () => {
@@ -548,6 +560,12 @@ describe("buildEmbeddedExtensionFactories", () => {
           ok: true,
           result: { messageId: "1700000000.000100", channelId: "C123" },
           toolSend: { to: "channel:C123" },
+          messageDelivery: {
+            status: "settled",
+            primaryPlatformMessageId: "1700000000.000100",
+            partialDelivery: false,
+            createdThreadIds: [],
+          },
         },
       },
       { cwd: "/tmp" },
@@ -561,8 +579,16 @@ describe("buildEmbeddedExtensionFactories", () => {
         middlewareWarning: "post-processing failed",
       },
     });
-    expect(consumeEmbeddedToolSendReceipt(sessionManager, "call-message")).toEqual({
-      details: { toolSend: { to: "channel:C123" } },
+    expect(consumeEmbeddedToolReceipt(sessionManager, "call-message")).toEqual({
+      details: {
+        toolSend: { to: "channel:C123" },
+        messageDelivery: {
+          status: "settled",
+          primaryPlatformMessageId: "1700000000.000100",
+          partialDelivery: false,
+          createdThreadIds: [],
+        },
+      },
     });
   });
 

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -19,7 +19,7 @@ import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-mi
 import type { AgentToolResult } from "../runtime/index.js";
 import type { ExtensionFactory, SessionManager } from "../sessions/index.js";
 import { isToolResultError } from "../tool-result-error.js";
-import { recordEmbeddedToolSendReceipt } from "./tool-send-receipts.js";
+import { recordEmbeddedToolReceipt } from "./tool-send-receipts.js";
 
 type AgentToolResultEvent = {
   threadId?: string;
@@ -32,10 +32,24 @@ type AgentToolResultEvent = {
   isError?: boolean;
 };
 
-function snapshotToolSendReceipt(details: unknown): unknown {
-  const toolSend = (asOptionalRecord(details) ?? {}).toolSend;
-  const toolSendRecord = asOptionalRecord(toolSend);
-  return toolSendRecord ? { ...toolSendRecord } : toolSend;
+function snapshotToolReceipt(
+  details: unknown,
+  includeMessageDelivery: boolean,
+): { toolSend?: unknown; messageDelivery?: unknown } | undefined {
+  const record = asOptionalRecord(details);
+  const snapshot = (value: unknown) => {
+    const valueRecord = asOptionalRecord(value);
+    return valueRecord ? { ...valueRecord } : value;
+  };
+  const toolSend = record?.toolSend;
+  const messageDelivery = includeMessageDelivery ? record?.messageDelivery : undefined;
+  if (toolSend === undefined && messageDelivery === undefined) {
+    return undefined;
+  }
+  return {
+    ...(toolSend !== undefined ? { toolSend: snapshot(toolSend) } : {}),
+    ...(messageDelivery !== undefined ? { messageDelivery: snapshot(messageDelivery) } : {}),
+  };
 }
 
 function buildAgentToolResultMiddlewareFactory(
@@ -74,10 +88,10 @@ function buildAgentToolResultMiddlewareFactory(
         content,
         details: event.details,
       } satisfies AgentToolResult<unknown>;
-      const rawToolSend = snapshotToolSendReceipt(current.details);
-      if (eventToolCallId && rawToolSend !== undefined) {
-        // Routing evidence stays private so middleware may fully replace result details.
-        recordEmbeddedToolSendReceipt(sessionManager, eventToolCallId, rawToolSend);
+      const receipt = snapshotToolReceipt(current.details, event.toolName === "message");
+      if (eventToolCallId && receipt) {
+        // Delivery evidence stays private so middleware may fully replace result details.
+        recordEmbeddedToolReceipt(sessionManager, eventToolCallId, receipt);
       }
       const inputHadErrorStatus = isToolResultError(current);
       const adjustedInput = eventToolCallId

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -71,7 +71,7 @@ describe("message-tool-only source replies", () => {
       context: createAfterToolCallContext({
         toolName: "message",
         args: { action: "send", message: "visible reply" },
-        result: createSuppressedSendResult(),
+        result: { content: [], details: {} },
       }),
       hookResult: { details: { result: { messageId: "discord-message-2" } } },
       expected: true,
@@ -136,15 +136,6 @@ describe("message-tool-only source replies", () => {
           details: { payload: { deliveryStatus: "dry_run", dryRun: true } },
         },
       }),
-      expected: false,
-    },
-    {
-      label: "dry-run hook result",
-      context: createAfterToolCallContext({
-        toolName: "message",
-        args: { action: "send", message: "preview reply" },
-      }),
-      hookResult: { details: { deliveryStatus: "dry_run" } },
       expected: false,
     },
     {
@@ -316,6 +307,11 @@ function createAfterToolCallContext(params: {
       details: {
         status: "ok",
         deliveryStatus: "sent",
+        messageDelivery: {
+          status: params.args.dryRun ? "dryRun" : params.isError ? "failed" : "settled",
+          partialDelivery: false,
+          createdThreadIds: [],
+        },
         sourceReplySink: "internal-ui",
         sourceReply: { text: params.args.message },
       },
@@ -344,7 +340,15 @@ function createDirectSendResult(params: { messageId: string }): AfterToolCallCon
   };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
-    details: payload,
+    details: {
+      ...payload,
+      messageDelivery: {
+        status: "settled",
+        primaryPlatformMessageId: params.messageId,
+        partialDelivery: false,
+        createdThreadIds: [],
+      },
+    },
   };
 }
 
@@ -359,7 +363,14 @@ function createSuppressedSendResult(): AfterToolCallContext["result"] {
   };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
-    details: payload,
+    details: {
+      ...payload,
+      messageDelivery: {
+        status: "suppressed",
+        partialDelivery: false,
+        createdThreadIds: [],
+      },
+    },
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -1,4 +1,5 @@
 import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-options.types.js";
+import { readEmbeddedMessageDeliveryFact } from "../../embedded-agent-message-delivery.js";
 /**
  * Detects message-tool-only sends that delivered a visible source reply.
  */
@@ -7,6 +8,7 @@ import {
   resolveMessageToolSourceReplyFinal,
 } from "../../embedded-agent-message-tool-source-reply.js";
 import type { AfterToolCallContext, AfterToolCallResult, Agent } from "../../runtime/index.js";
+import { readToolResultDetails } from "../../tool-result-error.js";
 
 function argsRecordForToolCall(context: AfterToolCallContext): Record<string, unknown> {
   if (context.args && typeof context.args === "object" && !Array.isArray(context.args)) {
@@ -28,13 +30,23 @@ function isDeliveredMessageToolOnlySourceReply(params: {
   context: AfterToolCallContext;
   hookResult?: AfterToolCallResult;
 }): boolean {
+  const deliveryFact = readEmbeddedMessageDeliveryFact(
+    readToolResultDetails(params.context.result)?.messageDelivery,
+  );
+  const isError = params.hookResult?.isError ?? params.context.isError;
   return isDeliveredMessageToolOnlySourceReplyResult({
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     toolName: params.context.toolCall.name,
     args: argsRecordForToolCall(params.context),
     result: params.context.result,
     hookResult: params.hookResult,
-    isError: params.hookResult?.isError ?? params.context.isError,
+    isError,
+    ...(deliveryFact
+      ? {
+          deliveryConfirmed:
+            deliveryFact.status === "settled" && (!isError || deliveryFact.partialDelivery),
+        }
+      : {}),
   });
 }
 

--- a/src/agents/embedded-agent-runner/tool-send-receipts.ts
+++ b/src/agents/embedded-agent-runner/tool-send-receipts.ts
@@ -1,27 +1,28 @@
 import { createSessionManagerRuntimeRegistry } from "../agent-hooks/session-manager-runtime-registry.js";
 
-type ToolSendReceiptResult = {
+type EmbeddedToolReceiptResult = {
   details: {
-    toolSend: unknown;
+    toolSend?: unknown;
+    messageDelivery?: unknown;
   };
 };
 
-const registry = createSessionManagerRuntimeRegistry<Map<string, ToolSendReceiptResult>>();
+const registry = createSessionManagerRuntimeRegistry<Map<string, EmbeddedToolReceiptResult>>();
 
-export function recordEmbeddedToolSendReceipt(
+export function recordEmbeddedToolReceipt(
   sessionManager: unknown,
   toolCallId: string,
-  toolSend: unknown,
+  details: EmbeddedToolReceiptResult["details"],
 ): void {
-  const receipts = registry.get(sessionManager) ?? new Map<string, ToolSendReceiptResult>();
-  receipts.set(toolCallId, { details: { toolSend } });
+  const receipts = registry.get(sessionManager) ?? new Map<string, EmbeddedToolReceiptResult>();
+  receipts.set(toolCallId, { details });
   registry.set(sessionManager, receipts);
 }
 
-export function consumeEmbeddedToolSendReceipt(
+export function consumeEmbeddedToolReceipt(
   sessionManager: unknown,
   toolCallId: string,
-): ToolSendReceiptResult | undefined {
+): EmbeddedToolReceiptResult | undefined {
   const receipts = registry.get(sessionManager);
   const receipt = receipts?.get(toolCallId);
   if (!receipts || !receipt) {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -20,6 +20,7 @@ import {
   consumeTrackedToolExecutionStarted,
 } from "./agent-tools.before-tool-call.state.js";
 import { normalizeTextForComparison } from "./embedded-agent-helpers.js";
+import { readEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
 import {
   isDeliveredMessageToolOnlySourceReplyResult,
   isDeliveredMessagingToolResult,
@@ -33,6 +34,7 @@ import {
 } from "./embedded-agent-messaging-extraction.js";
 import {
   isMessagingTool,
+  isPluginNativeMessagingTool,
   isMessagingToolSendAction,
   isMessagingToolTargetEvidenceAction,
 } from "./embedded-agent-messaging.js";
@@ -96,7 +98,7 @@ import {
 } from "./tool-error-summary.js";
 import { resolveFileMutationToolName } from "./tool-mutation-names.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
-import { isToolResultError } from "./tool-result-error.js";
+import { isToolResultError, readToolResultDetails } from "./tool-result-error.js";
 import { cancelAskUserPromptDelivery } from "./tools/ask-user-tool.js";
 import { isAutomationsToolName } from "./tools/automations-tool-name.js";
 
@@ -254,15 +256,21 @@ export async function handleToolExecutionEnd(
   const isMessagingSend = isMessagingInvocation && isMessagingToolSendAction(toolName, startArgs);
   const hasMessagingTargetEvidence =
     isMessagingInvocation && isMessagingToolTargetEvidenceAction(toolName, startArgs);
+  const messageDelivery = readEmbeddedMessageDeliveryFact(
+    readToolResultDetails(toolSendReceiptResult)?.messageDelivery,
+  );
   const didDeliverMessagingResult =
     isMessagingInvocation &&
-    isDeliveredMessagingToolResult({
-      toolName,
-      args: startArgs,
-      result,
-      hookResult: toolSendReceiptResult,
-      isError: isToolError,
-    });
+    (messageDelivery
+      ? messageDelivery.status === "settled" && (!isToolError || messageDelivery.partialDelivery)
+      : isPluginNativeMessagingTool(toolName) &&
+        isDeliveredMessagingToolResult({
+          toolName,
+          args: startArgs,
+          result,
+          hookResult: toolSendReceiptResult,
+          isError: isToolError,
+        }));
   const messageText = isMessagingSend ? readMessagingText(startArgs) : undefined;
   const argumentMediaUrls = isMessagingSend ? collectMessagingMediaUrlsFromRecord(startArgs) : [];
   const hasRichContent = isMessagingSend && hasMessagingRichContent(startArgs);
@@ -290,6 +298,7 @@ export async function handleToolExecutionEnd(
       args: startArgs,
       result,
       isError: isToolError,
+      deliveryConfirmed: didDeliverMessagingResult,
     });
   const sourceReplyFinal = deliveredCurrentSourceReply
     ? resolveMessageToolSourceReplyFinal(startArgs)

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -3653,6 +3653,45 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.messageToolOnlySourceReplyDelivered).toBe(true);
   });
 
+  it("commits partial broadcast delivery after middleware replaces details", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+    const messageDelivery = projectEmbeddedMessageDeliveryFact({
+      kind: "broadcast",
+      channel: "googlechat",
+      action: "broadcast",
+      handledBy: "core",
+      payload: {
+        results: [
+          {
+            channel: "googlechat",
+            to: "spaces/AAA",
+            ok: false,
+            sentBeforeError: true,
+          },
+        ],
+      },
+      dryRun: false,
+    });
+    expect(messageDelivery).toEqual({
+      status: "settled",
+      partialDelivery: true,
+      createdThreadIds: [],
+    });
+    ctx.consumeToolSendReceipt = () => ({ details: { messageDelivery } });
+
+    await executeTool(ctx, {
+      toolName: "message",
+      toolCallId: "tool-private-partial-broadcast-delivery",
+      args: { action: "send", message: "visible before failure" },
+      isError: true,
+      result: { details: { redacted: true } },
+    });
+
+    expect(ctx.state.messagingToolSentTexts).toEqual(["visible before failure"]);
+    expect(ctx.state.messageToolOnlySourceReplyDelivered).toBe(true);
+  });
+
   it("does not commit dry-run or external message sends as internal-ui source replies", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -3560,6 +3560,15 @@ describe("messaging tool media URL tracking", () => {
   it("commits internal-ui source replies from successful message sends", async () => {
     const { ctx } = createTestContext();
     ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+    ctx.consumeToolSendReceipt = () => ({
+      details: {
+        messageDelivery: {
+          status: "settled",
+          partialDelivery: false,
+          createdThreadIds: [],
+        },
+      },
+    });
 
     const startEvt: ToolExecutionStartEvent = {
       toolName: "message",
@@ -3597,6 +3606,31 @@ describe("messaging tool media URL tracking", () => {
         sourceReplyFinal: true,
       },
     ]);
+  });
+
+  it("commits core delivery from the private receipt after middleware replaces details", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+    ctx.consumeToolSendReceipt = () => ({
+      details: {
+        messageDelivery: {
+          status: "settled",
+          partialDelivery: false,
+          createdThreadIds: [],
+        },
+      },
+    });
+
+    await executeTool(ctx, {
+      toolName: "message",
+      toolCallId: "tool-private-core-delivery",
+      args: { action: "send", message: "visible after redaction" },
+      isError: false,
+      result: { details: { redacted: true } },
+    });
+
+    expect(ctx.state.messagingToolSentTexts).toEqual(["visible after redaction"]);
+    expect(ctx.state.messageToolOnlySourceReplyDelivered).toBe(true);
   });
 
   it("does not commit dry-run or external message sends as internal-ui source replies", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -20,6 +20,7 @@ import {
   buildAdjustedParamsKey,
   recordToolExecutionTracked,
 } from "./agent-tools.before-tool-call.state.js";
+import { projectEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
 import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
 import {
@@ -3608,22 +3609,41 @@ describe("messaging tool media URL tracking", () => {
     ]);
   });
 
-  it("commits core delivery from the private receipt after middleware replaces details", async () => {
+  it("commits projected payload-only delivery after middleware replaces details", async () => {
     const { ctx } = createTestContext();
     ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+    const messageDelivery = projectEmbeddedMessageDeliveryFact({
+      kind: "broadcast",
+      channel: "googlechat",
+      action: "broadcast",
+      handledBy: "core",
+      payload: {
+        results: [
+          {
+            channel: "googlechat",
+            to: "spaces/AAA",
+            ok: true,
+            payload: { ok: true, messageId: "plugin-message-1" },
+          },
+        ],
+      },
+      dryRun: false,
+    });
+    expect(messageDelivery).toEqual({
+      status: "settled",
+      primaryPlatformMessageId: "plugin-message-1",
+      partialDelivery: false,
+      createdThreadIds: [],
+    });
     ctx.consumeToolSendReceipt = () => ({
       details: {
-        messageDelivery: {
-          status: "settled",
-          partialDelivery: false,
-          createdThreadIds: [],
-        },
+        messageDelivery,
       },
     });
 
     await executeTool(ctx, {
       toolName: "message",
-      toolCallId: "tool-private-core-delivery",
+      toolCallId: "tool-private-broadcast-delivery",
       args: { action: "send", message: "visible after redaction" },
       isError: false,
       result: { details: { redacted: true } },

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
@@ -1,6 +1,8 @@
 // Source-reply suppression after message-tool delivery.
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
+import { recordEmbeddedToolReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
 import {
   createSubscribedSessionHarness,
   createStubSessionHarness,
@@ -29,7 +31,24 @@ function createBlockReplyHarness(
 ) {
   // Harness exposes both emitted block replies and subscription state so tests
   // can distinguish suppression from missing delivery tracking.
-  const { session, emit } = createStubSessionHarness();
+  const { session, emit: rawEmit } = createStubSessionHarness();
+  const sessionManager = {};
+  Object.assign(session, { sessionManager });
+  const emit = (evt: unknown) => {
+    const event = asOptionalRecord(evt);
+    const details = asOptionalRecord(asOptionalRecord(event?.result)?.details);
+    if (
+      event?.type === "tool_execution_end" &&
+      event.toolName === "message" &&
+      typeof event.toolCallId === "string" &&
+      details?.messageDelivery !== undefined
+    ) {
+      recordEmbeddedToolReceipt(sessionManager, event.toolCallId, {
+        messageDelivery: details.messageDelivery,
+      });
+    }
+    rawEmit(evt);
+  };
   const onBlockReply = vi.fn();
   const onPartialReply = vi.fn();
   const onAgentEvent = vi.fn();
@@ -78,8 +97,37 @@ async function emitMessageToolLifecycle(params: {
     toolName: "message",
     toolCallId: params.toolCallId,
     isError: false,
-    result: params.result,
+    result: attachCoreMessageDeliveryFact(params.result),
   });
+}
+
+function attachCoreMessageDeliveryFact(result: unknown): unknown {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  const record = result as Record<string, unknown>;
+  const details =
+    record.details && typeof record.details === "object" && !Array.isArray(record.details)
+      ? (record.details as Record<string, unknown>)
+      : undefined;
+  const deliveryStatus = details?.deliveryStatus;
+  const status =
+    deliveryStatus === "sent"
+      ? "settled"
+      : deliveryStatus === "dry_run"
+        ? "dryRun"
+        : deliveryStatus === "suppressed"
+          ? "suppressed"
+          : undefined;
+  return status && details
+    ? {
+        ...record,
+        details: {
+          ...details,
+          messageDelivery: { status, partialDelivery: false, createdThreadIds: [] },
+        },
+      }
+    : result;
 }
 
 function emitAssistantMessageEnd(
@@ -414,7 +462,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       emit,
       toolCallId: "tool-message-final",
       message: "Final answer sent through the message tool.",
-      result: { details: { deliveryStatus: "sent" } },
+      result: { details: { status: "sent" } },
     });
     onToolResult.mockClear();
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.text-end-reconciliation.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.text-end-reconciliation.test.ts
@@ -182,7 +182,11 @@ describe("text_end snapshot reconciliation", () => {
       toolName: "message",
       toolCallId: "message-tool-1",
       isError: false,
-      result: { details: { deliveryStatus: "sent" } },
+      result: {
+        details: {
+          status: "sent",
+        },
+      },
     });
     await Promise.resolve();
     await new Promise<void>((resolve) => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -11,7 +11,7 @@ import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/m
 import { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "./embedded-agent-runner/delivery-evidence.js";
 import { mergeEmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
-import { consumeEmbeddedToolSendReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
+import { consumeEmbeddedToolReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
 import type { EmbeddedRunLivenessState } from "./embedded-agent-runner/types.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { createEmbeddedAgentSessionEventHandler } from "./embedded-agent-subscribe.handlers.js";
@@ -499,7 +499,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     finalizeAssistantTexts,
     trimMessagingToolSent,
     consumeToolSendReceipt: (toolCallId) =>
-      consumeEmbeddedToolSendReceipt(params.session.sessionManager, toolCallId),
+      consumeEmbeddedToolReceipt(params.session.sessionManager, toolCallId),
     ensureCompactionPromise,
     noteCompactionRetry,
     resolveCompactionRetry,

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -12,11 +12,15 @@ import type {
 } from "../../plugins/agent-tool-result-middleware-types.js";
 import { createLazyPromiseLoader } from "../../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import { readEmbeddedMessageDeliveryFact } from "../embedded-agent-message-delivery.js";
 import {
-  hasMessagingDeliveryReceipt,
+  hasPluginMessagingDeliveryId,
   isDeliveredMessagingToolResult,
 } from "../embedded-agent-message-tool-source-reply.js";
-import { isMessagingToolSendAction } from "../embedded-agent-messaging.js";
+import {
+  isMessagingToolSendAction,
+  isPluginNativeMessagingTool,
+} from "../embedded-agent-messaging.js";
 import { isToolResultError } from "../tool-result-error.js";
 
 const log = createSubsystemLogger("agents/harness");
@@ -369,16 +373,23 @@ function buildDeliveredMessagingFailureFallback(
   event: AgentToolResultMiddlewareEvent,
   result: OpenClawAgentToolResult,
 ): OpenClawAgentToolResult | undefined {
+  const deliveryFact = readEmbeddedMessageDeliveryFact(
+    isRecord(result.details) ? result.details.messageDelivery : undefined,
+  );
+  const delivered = deliveryFact
+    ? deliveryFact.status === "settled"
+    : isPluginNativeMessagingTool(event.toolName) &&
+      isDeliveredMessagingToolResult({
+        toolName: event.toolName,
+        args: event.args,
+        result,
+      }) &&
+      hasPluginMessagingDeliveryId(result);
   if (
     event.isError === true ||
     isToolResultError(result) ||
     !isMessagingToolSendAction(event.toolName, event.args) ||
-    !isDeliveredMessagingToolResult({
-      toolName: event.toolName,
-      args: event.args,
-      result,
-    }) ||
-    !hasMessagingDeliveryReceipt(result)
+    !delivered
   ) {
     return undefined;
   }

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -38,6 +38,10 @@ import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-to
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
+import {
+  attachEmbeddedMessageDeliveryFact,
+  projectEmbeddedMessageDeliveryFact,
+} from "../embedded-agent-message-delivery.js";
 import { type AnyAgentTool, jsonResult, readToolStringParam } from "./common.js";
 import {
   readGatewayCallOptions,
@@ -704,13 +708,17 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         resolveTrustedDecisionChannel(result.channel, preparedMessageToolCatalog),
       );
       const toolResult = getToolResult(result);
+      const messageDelivery = projectEmbeddedMessageDeliveryFact(result);
       const normalizationNotice = result.kind === "send" ? result.normalization?.notice : undefined;
       if (normalizationNotice) {
         const normalizedResult = toolResult ?? jsonResult(result.payload);
-        return {
-          ...normalizedResult,
-          content: [...normalizedResult.content, { type: "text", text: normalizationNotice }],
-        };
+        return attachEmbeddedMessageDeliveryFact(
+          {
+            ...normalizedResult,
+            content: [...normalizedResult.content, { type: "text", text: normalizationNotice }],
+          },
+          messageDelivery,
+        );
       }
       if (
         action === "poll-vote" &&
@@ -739,9 +747,9 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         }
       }
       if (toolResult) {
-        return toolResult;
+        return attachEmbeddedMessageDeliveryFact(toolResult, messageDelivery);
       }
-      return jsonResult(result.payload);
+      return attachEmbeddedMessageDeliveryFact(jsonResult(result.payload), messageDelivery);
     },
   };
 }

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -547,6 +547,56 @@ describe("message tool gateway timeout", () => {
     });
   });
 
+  it("carries core send settlement in private result details", async () => {
+    const sendResult = {
+      channel: "telegram",
+      to: "telegram:123",
+      via: "direct" as const,
+      mediaUrl: null,
+      deliveryStatus: "partial_failed" as const,
+      sentBeforeError: true as const,
+      result: {
+        channel: "telegram",
+        messageId: "message-1",
+        receipt: {
+          primaryPlatformMessageId: "message-1",
+          platformMessageIds: ["message-1"],
+          parts: [{ platformMessageId: "message-1", kind: "text" as const, index: 0 }],
+          threadId: "thread-1",
+          sentAt: 1,
+        },
+      },
+    };
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "telegram",
+      to: "telegram:123",
+      handledBy: "core",
+      payload: sendResult,
+      sendResult,
+      dryRun: false,
+    } satisfies MessageActionResult);
+
+    const { result } = await executeSendWithResult({
+      action: { channel: "telegram", target: "telegram:123", message: "hello" },
+    });
+
+    expect(result.details).toMatchObject({
+      messageDelivery: {
+        status: "settled",
+        primaryPlatformMessageId: "message-1",
+        partialDelivery: true,
+        createdThreadIds: ["thread-1"],
+      },
+    });
+    expect(result.content).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: expect.stringContaining("messageDelivery") }),
+      ]),
+    );
+  });
+
   it("does not advertise source-reply finality on ordinary message tools", () => {
     expect(getToolProperties(createMessageTool())).not.toHaveProperty("final");
     expect(getToolProperties(createMessageTool())).not.toHaveProperty("idempotencyKey");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a successful core message-tool send could be forgotten after tool-result middleware replaced its structured details. The embedded subscriber then guessed delivery from the rewritten envelope and could miss a real send, allowing duplicate fallback replies or incorrect delivery accounting.

## Why This Change Was Made

The message tool now projects its typed `MessageSendResult` into a private delivery fact with `settled | suppressed | dryRun | failed`, primary platform-message evidence, partial-delivery state, and created thread ids. The existing private tool receipt channel snapshots that fact alongside `toolSend`, and embedded, CLI, terminal-hook, and middleware-failure consumers prefer it. Recursive envelope inspection remains only for plugin-native actions that do not return a core receipt; core receipt/status, `sessions_send`, and core broadcast-result inference were removed.

## User Impact

Core message sends retain exactly the previous delivered/not-delivered semantics, including partial, dry-run, suppressed, skipped, and failed outcomes, even when middleware rewrites the visible tool result. This reduces duplicate or missing source-reply settlement without changing model-visible tool text or the `sourceReplyFinal` marker.

## Evidence

- Pre-fix regression: `commits core delivery from the private receipt after middleware replaces details` failed with no committed text; it passes after the repair.
- Before deleting core scanner branches, 11 existing core-send fixtures were run through both the legacy scanner and typed projection; all verdicts matched.
- Focused producer/subscriber/scanner tests: 222 agent-core tests and 234 message-tool tests passed.
- Additional focused proof: 25 middleware tests, 18 terminal-hook tests, the internal source-reply integration, 80 non-E2E runreplyagent tests, and 39 embedded delivery-resolution tests passed.
- `pnpm check:changed` passed on the final diff (core, coreTests, tooling).
- Final Codex autoreview: clean, no actionable findings (`overall: patch is correct (0.98)`).
- Production LOC: +402/-522 (net -120). Tests: +276/-106. Tooling ratchet: +1/-1.
- The first exact-head CI run exposed stale direct-event fixtures in CLI, subscriber, and Codex bridge suites. The follow-up models the private receipt channel; the exact failing files then passed 132/132 core tests plus the targeted Codex bridge case.
- The broad runreplyagent E2E run passed 152/153 cases; the unrelated CLI-usage snapshot case (`does not persist cumulative CLI usage as a fresh context snapshot`) failed twice with `totalTokens=42000`. No touched file participates in that usage path; exact-head CI remains the merge gate.

Contract checks: OpenClaw agent-core marks `details` as logs/UI metadata while provider transports serialize tool `content`; sibling Codex likewise keeps function-call `success` internal rather than in the model-facing output (`codex-rs/tools/src/tool_output.rs:135`, `codex-rs/protocol/src/models.rs:1987`).
