### PR TITLE
test(ui): close the Discussion no-URL gap in the cold-open invariant

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -41,6 +41,8 @@ const actionlessEmptyStateAllowlist = new Set<OfferedSlotLabel>([
   "Review",
   // Tasks: no background tasks, nothing to inspect.
   "Tasks",
+  // Discussion: no external URL, nothing to open.
+  "Discussion",
 ]);
 
 function coldOpenScenario(): ControlUiMockGatewayScenario {
@@ -67,7 +69,6 @@ function coldOpenScenario(): ControlUiMockGatewayScenario {
       },
       "environments.list": { environments: [] },
       "session.discussion.info": {
-        openUrl: "https://discussion.example/session",
         state: "open",
       },
       "sessions.files.list": {
@@ -282,7 +283,7 @@ suite.define(() => {
   it("preserves the production header-action shapes for Side chat and Discussion", async () => {
     const context = await suite.newBrowserContext({ serviceWorkers: "block" });
     const page = await context.newPage();
-    const choices = await openColdSidebar(page);
+    const choices = await openColdSidebar(page, populatedColdOpenScenario());
 
     await choices.filter({ hasText: "Side chat" }).click();
     const contentActions = page.locator(".side-panel__action-group--content");


### PR DESCRIPTION
## What Problem This Solves

PR #125174 landed the sidebar cold-open invariant: every offered slot with backing data must render content,
and any slot showing the generic empty state must name an action or sit in a small commented allowlist,
checked bidirectionally so stale entries fail too.

A live audit against merged `main` — mocked Control UI dev server, every tab opened cold in a fresh browser
context — found a state the invariant did not cover. Both of its scenarios always supplied a discussion
`openUrl`, so the **Discussion panel's no-URL state was never exercised**. In that state the panel renders
the generic empty state with no action, because `session-discussion-panel.ts` only offers "Open discussion in
a new tab" when a URL exists. Discussion is offered whenever a discussion exists at all, not only when it has
a URL, so the state is genuinely reachable in the product.

## Why This Change Was Made

An invariant with an unexercised hole is weaker than it looks: the audit found this by running the product,
not by running the suite, which is exactly the kind of gap the invariant exists to prevent.

The sparse scenario now returns a discussion without `openUrl` while keeping Discussion offered, and the
resulting actionless empty state joins the allowlist with its reason. The populated scenario keeps the
external-link assertion, so the with-URL path is still covered.

Deliberately not done: inventing an action for the no-URL case. With no URL there is nothing to open, and a
button that opens nothing would satisfy the letter of the invariant's second part while destroying its
meaning. The allowlist exists precisely so honestly-actionless states are declared rather than faked.

## User Impact

None — test-only, zero production lines.

## Evidence

The state was proven reachable and the invariant proven to catch it: before adding the allowlist entry, the
new scenario failed with

```
Discussion renders the generic empty state without an action
```

which is the invariant's own message naming the slot. Adding the commented entry turns it green, and the
unchanged exact-equality assertion still rejects the entry if Discussion ever gains an action.

Final allowlist: `Review` (no git checkout, nothing to diff), `Tasks` (no background tasks, nothing to
inspect), `Discussion` (no external URL, nothing to open).

```
 Test Files  1 passed (1)      Tests  15 passed (15)
 Test Files  3 passed (3)      Tests  14 passed (14)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `0`, tests `+3 / −2`.

No `CHANGELOG.md` edit — release-only per repo policy; test-only change.
