### PR TITLE
fix(agents): redact reflected credentials from native PDF provider error body and reason phrase

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -458,6 +458,64 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
     expect(pullCount).toBeLessThanOrEqual(18);
     expect(canceled).toBe(true);
   });
+
+  it.each([
+    {
+      channel: "error body",
+      response: (authorization: string) =>
+        new Response(`echoed ${authorization}`, { status: 401, statusText: "Unauthorized" }),
+    },
+    {
+      channel: "reason phrase",
+      response: (authorization: string) =>
+        new Response("", { status: 401, statusText: `echoed ${authorization}` }),
+    },
+    {
+      channel: "Trace-Id",
+      response: (authorization: string) =>
+        new Response("bad", {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "Trace-Id": `echoed ${authorization}` },
+        }),
+    },
+    {
+      channel: "application status message",
+      response: (authorization: string) =>
+        new Response(
+          JSON.stringify({
+            base_resp: { status_code: 1001, status_msg: `echoed ${authorization}` },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    },
+  ])("redacts the sent credential when reflected through $channel", async ({ response }) => {
+    const needle = "mm-short-7";
+    fetchWithSsrFGuardMock.mockImplementationOnce(
+      async (request: { init?: { headers?: HeadersInit } }) => {
+        const authorization = new Headers(request.init?.headers).get("Authorization");
+        expect(authorization).toBe(`Bearer ${needle}`);
+        return {
+          response: response(authorization ?? ""),
+          release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+          finalUrl: "https://api.minimax.io/v1/coding_plan/vlm",
+        };
+      },
+    );
+
+    const error = await minimaxUnderstandImage({
+      apiKey: needle,
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to throw an Error");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toContain("***");
+  });
 });
 
 describe("isMinimaxVlmModel", () => {

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -9,7 +9,10 @@ import {
 } from "../media-understanding/shared.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
-import { readProviderJsonResponse } from "./provider-http-errors.js";
+import {
+  createProviderErrorTextRedactor,
+  readProviderJsonResponse,
+} from "./provider-http-errors.js";
 import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
 import { resolveProviderTransportSsrFPolicy } from "./provider-transport-fetch.js";
 
@@ -161,17 +164,26 @@ export async function minimaxUnderstandImage(params: {
     auditContext: "minimax-vlm",
   });
   const res = guarded.response;
+  const redactErrorText = createProviderErrorTextRedactor({
+    headers,
+    request: params.request,
+    defaultAuthHeader: "Authorization",
+    defaultAuthPrefix: "Bearer ",
+  });
 
   try {
-    const traceId = res.headers.get("Trace-Id") ?? "";
+    // All response fields below are provider-controlled and may reflect the
+    // authenticated request, so sanitize them before any error branch uses them.
+    const traceId = redactErrorText(res.headers.get("Trace-Id") ?? "");
     if (!res.ok) {
       const body = await readResponseBodySnippet(res, {
         maxBytes: MINIMAX_VLM_ERROR_BODY_MAX_BYTES,
         maxChars: MINIMAX_VLM_ERROR_BODY_MAX_CHARS,
+        redact: redactErrorText,
       });
       const trace = traceId ? ` Trace-Id: ${traceId}` : "";
       throw new Error(
-        `MiniMax VLM request failed (${res.status} ${res.statusText}).${trace}${
+        `MiniMax VLM request failed (${res.status} ${redactErrorText(res.statusText)}).${trace}${
           body ? ` Body: ${body}` : ""
         }`,
       );
@@ -189,7 +201,7 @@ export async function minimaxUnderstandImage(params: {
     const baseResp = isRecord(json.base_resp) ? (json.base_resp as MinimaxBaseResp) : {};
     const code = typeof baseResp.status_code === "number" ? baseResp.status_code : -1;
     if (code !== 0) {
-      const msg = (baseResp.status_msg ?? "").trim();
+      const msg = redactErrorText((baseResp.status_msg ?? "").trim());
       const trace = traceId ? ` Trace-Id: ${traceId}` : "";
       throw new Error(`MiniMax VLM API error (${code})${msg ? `: ${msg}` : ""}.${trace}`);
     }

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -12,7 +12,8 @@ import {
   readResponseWithLimit,
   type ReadResponseTextPrefixOptions,
 } from "../infra/http-body.js";
-import { redactSensitiveText } from "../logging/redact.js";
+import { redactSensitiveText, redactToolPayloadText } from "../logging/redact.js";
+import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
 export { asFiniteNumber } from "../../packages/normalization-core/src/number-coercion.js";
 export { asBoolean } from "../utils/boolean.js";
 export { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
@@ -21,6 +22,69 @@ const ERROR_BODY_METADATA_LIMIT = 500;
 const PROVIDER_BINARY_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const PROVIDER_TEXT_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+const SHORT_BEARER_TOKEN_PATTERN =
+  /\b(Bearer)\s+[-A-Za-z0-9._~+/=]{1,17}(?![-A-Za-z0-9._~+/=…])/giu;
+
+type ProviderErrorTextRedactionContext = {
+  truncated?: boolean;
+};
+
+function extractHeaderCredential(headers: Headers, headerName: string, prefix = ""): string {
+  const value = headers.get(headerName) ?? "";
+  return prefix && value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function extractAuthorizationPayload(headers: Headers): string {
+  const value = headers.get("Authorization") ?? "";
+  const separator = value.search(/\s/u);
+  return separator === -1 ? value : value.slice(separator).trimStart();
+}
+
+/** Builds a redactor for response text that may reflect the request's active credential. */
+export function createProviderErrorTextRedactor(params: {
+  headers: Headers;
+  request?: ModelProviderRequestTransportOverrides;
+  defaultAuthHeader: string;
+  defaultAuthPrefix?: string;
+}): (text: string, context?: ProviderErrorTextRedactionContext) => string {
+  const auth = params.request?.auth;
+  const credentials = [
+    extractHeaderCredential(params.headers, params.defaultAuthHeader, params.defaultAuthPrefix),
+    auth?.mode === "header"
+      ? extractHeaderCredential(params.headers, auth.headerName, auth.prefix ?? "")
+      : auth?.mode === "authorization-bearer"
+        ? extractHeaderCredential(params.headers, "Authorization", "Bearer ")
+        : "",
+    extractAuthorizationPayload(params.headers),
+  ]
+    .filter(Boolean)
+    .toSorted((left, right) => right.length - left.length);
+
+  return (text, context) => {
+    let withoutActiveCredential = credentials.reduce(
+      (redacted, credential) => redacted.split(credential).join("***"),
+      text,
+    );
+    if (context?.truncated) {
+      const partialCredentialLength = credentials.reduce((longest, credential) => {
+        const maxLength = Math.min(credential.length - 1, withoutActiveCredential.length);
+        for (let length = maxLength; length > longest; length -= 1) {
+          if (withoutActiveCredential.endsWith(credential.slice(0, length))) {
+            return length;
+          }
+        }
+        return longest;
+      }, 0);
+      if (partialCredentialLength > 0) {
+        withoutActiveCredential = `${withoutActiveCredential.slice(0, -partialCredentialLength)}***`;
+      }
+    }
+    return redactToolPayloadText(withoutActiveCredential).replace(
+      SHORT_BEARER_TOKEN_PATTERN,
+      "$1 ***",
+    );
+  };
+}
 
 /** Shared timeout and byte-limit options for provider response consumption. */
 type ProviderResponseReadOptions = ReadResponseTextPrefixOptions & {

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -39,6 +39,7 @@ function makeGeminiAnalyzeParams(
     prompt: string;
     pdfs: Array<{ base64: string; filename: string }>;
     baseUrl: string;
+    requestConfig: Parameters<typeof pdfNativeProviders.geminiAnalyzePdf>[0]["requestConfig"];
   }> = {},
 ) {
   return {
@@ -74,6 +75,14 @@ describe("native PDF provider API calls", () => {
       throw new Error("expected fetch to be called");
     }
     return call;
+  };
+
+  const captureError = async (promise: Promise<unknown>, label: string): Promise<Error> => {
+    const error = await promise.catch((caught: unknown) => caught);
+    if (!(error instanceof Error)) {
+      throw new Error(`expected ${label} to throw an Error`);
+    }
+    return error;
   };
 
   afterEach(() => {
@@ -232,20 +241,17 @@ describe("native PDF provider API calls", () => {
       }),
     );
 
-    const error = await pdfNativeProviders
-      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams({ apiKey: needle }))
-      .catch((caught: unknown) => caught);
-
-    if (!(error instanceof Error)) {
-      throw new Error("expected Anthropic PDF request to throw an Error");
-    }
+    const error = await captureError(
+      pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams({ apiKey: needle })),
+      "Anthropic PDF request",
+    );
     expect(error.message).not.toContain(needle);
     expect(error.message).toContain("Anthropic PDF request failed (401");
-    expect(error.message).toContain("sk-ant…jL5k");
+    expect(error.message).toContain("x-api-key: ***");
   });
 
   it("redacts a reflected x-goog-api-key credential from Gemini API error bodies", async () => {
-    const needle = "AIzaSyD4iE0xmpl3K3yF0rG00gl3Pr0b3XYZ1234";
+    const needle = "gemini-test-credential-with-a-long-value";
     mockFetchResponse(
       textResponse(`upstream echoed x-goog-api-key: ${needle}`, {
         status: 401,
@@ -253,44 +259,120 @@ describe("native PDF provider API calls", () => {
       }),
     );
 
-    const error = await pdfNativeProviders
-      .geminiAnalyzePdf(makeGeminiAnalyzeParams({ apiKey: needle }))
-      .catch((caught: unknown) => caught);
-
-    if (!(error instanceof Error)) {
-      throw new Error("expected Gemini PDF request to throw an Error");
-    }
+    const error = await captureError(
+      pdfNativeProviders.geminiAnalyzePdf(makeGeminiAnalyzeParams({ apiKey: needle })),
+      "Gemini PDF request",
+    );
     expect(error.message).not.toContain(needle);
     expect(error.message).toContain("Gemini PDF request failed (401");
-    expect(error.message).toContain("AIzaSy…1234");
+    expect(error.message).toContain("x-goog-api-key: ***");
   });
 
-  it("masks a short reflected Bearer credential in the response reason phrase", async () => {
-    mockFetchResponse(textResponse("", { status: 401, statusText: "reflected Bearer abc" }));
+  it("masks a short Bearer credential actually sent through extra headers", async () => {
+    mockFetchResponse(textResponse("", { status: 401, statusText: "reflected token=abc" }));
 
-    const error = await pdfNativeProviders
-      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-      .catch((caught: unknown) => caught);
-
-    if (!(error instanceof Error)) {
-      throw new Error("expected Anthropic PDF request to throw an Error");
-    }
-    expect(error.message).not.toContain("Bearer abc");
-    expect(error.message).toContain("Anthropic PDF request failed (401 reflected Bearer ***)");
+    const error = await captureError(
+      pdfNativeProviders.anthropicAnalyzePdf(
+        makeAnthropicAnalyzeParams({
+          requestConfig: { headers: { Authorization: "bearer abc" } },
+        }),
+      ),
+      "Anthropic PDF request",
+    );
+    const fetchMock = global.fetch as unknown as { mock: { calls: unknown[][] } };
+    const [, opts] = firstFetchCall(fetchMock) as [string, { headers: Headers }];
+    expect(opts.headers.get("Authorization")).toBe("bearer abc");
+    expect(error.message).not.toContain("abc");
+    expect(error.message).toContain("Anthropic PDF request failed (401 reflected token=***)");
   });
 
-  it("masks a lowercase reflected bearer credential in the response reason phrase", async () => {
-    mockFetchResponse(textResponse("", { status: 401, statusText: "reflected bearer abc" }));
+  it("masks a reflected non-Bearer Authorization payload", async () => {
+    const credential = "dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=";
+    mockFetchResponse(textResponse(`reflected credential=${credential}`, { status: 401 }));
 
-    const error = await pdfNativeProviders
-      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-      .catch((caught: unknown) => caught);
+    const error = await captureError(
+      pdfNativeProviders.anthropicAnalyzePdf(
+        makeAnthropicAnalyzeParams({
+          requestConfig: { headers: { Authorization: `Basic ${credential}` } },
+        }),
+      ),
+      "Anthropic PDF request",
+    );
+    const fetchMock = global.fetch as unknown as { mock: { calls: unknown[][] } };
+    const [, opts] = firstFetchCall(fetchMock) as [string, { headers: Headers }];
+    expect(opts.headers.get("Authorization")).toBe(`Basic ${credential}`);
+    expect(error.message).not.toContain(credential);
+    expect(error.message).toContain("reflected credential=***");
+  });
 
-    if (!(error instanceof Error)) {
-      throw new Error("expected Anthropic PDF request to throw an Error");
-    }
-    expect(error.message).not.toContain("bearer abc");
-    expect(error.message).toContain("Anthropic PDF request failed (401 reflected bearer ***)");
+  it("masks a reflected custom request-auth credential and preserves its prefix", async () => {
+    mockFetchResponse(
+      textResponse("upstream echoed Token-abc123 and fallback-key", { status: 401 }),
+    );
+
+    const error = await captureError(
+      pdfNativeProviders.geminiAnalyzePdf(
+        makeGeminiAnalyzeParams({
+          apiKey: "fallback-key",
+          requestConfig: {
+            request: {
+              auth: {
+                mode: "header",
+                headerName: "X-Corp-Credential",
+                value: "abc123",
+                prefix: "Token-",
+              },
+            },
+          },
+        }),
+      ),
+      "Gemini PDF request",
+    );
+    const fetchMock = global.fetch as unknown as { mock: { calls: unknown[][] } };
+    const [, opts] = firstFetchCall(fetchMock) as [string, { headers: Headers }];
+    expect(opts.headers.get("X-Corp-Credential")).toBe("Token-abc123");
+    expect(error.message).not.toContain("abc123");
+    expect(error.message).not.toContain("fallback-key");
+    expect(error.message).toContain("Token-***");
+  });
+
+  it.each([
+    {
+      name: "character cutoff",
+      credential: "custom-secret-abcdefghij",
+      body: `${"x".repeat(390)} Token-custom-secret-abcdefghij`,
+    },
+    {
+      name: "byte cutoff",
+      credential: "a".repeat(7_900),
+      body: `${"x".repeat(390)} Token-${"a".repeat(7_900)}`,
+    },
+  ])("masks a reflected custom credential crossing the $name", async ({ credential, body }) => {
+    mockFetchResponse(textResponse(body, { status: 401 }));
+
+    const error = await captureError(
+      pdfNativeProviders.geminiAnalyzePdf(
+        makeGeminiAnalyzeParams({
+          requestConfig: {
+            request: {
+              auth: {
+                mode: "header",
+                headerName: "X-Corp-Credential",
+                value: credential,
+                prefix: "Token-",
+              },
+            },
+          },
+        }),
+      ),
+      "Gemini PDF request",
+    );
+    const fetchMock = global.fetch as unknown as { mock: { calls: unknown[][] } };
+    const [, opts] = firstFetchCall(fetchMock) as [string, { headers: Headers }];
+    expect(opts.headers.get("X-Corp-Credential")).toBe(`Token-${credential}`);
+    expect(error.message).not.toContain("Token-a");
+    expect(error.message).not.toContain("Token-custom");
+    expect(error.message).toContain("Token-***");
   });
 
   it("anthropicAnalyzePdf throws when response has no text", async () => {

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -223,6 +223,76 @@ describe("native PDF provider API calls", () => {
     expect(canceled).toBe(true);
   });
 
+  it("redacts a reflected x-api-key credential from Anthropic API error bodies", async () => {
+    const needle = "sk-ant-api03-vX7qP2mN9wKzR4tY8uI0oP3aS6dF7gH1jL5k";
+    mockFetchResponse(
+      textResponse(`upstream echoed x-api-key: ${needle}`, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    const error = await pdfNativeProviders
+      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams({ apiKey: needle }))
+      .catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected Anthropic PDF request to throw an Error");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toContain("Anthropic PDF request failed (401");
+    expect(error.message).toContain("sk-ant…jL5k");
+  });
+
+  it("redacts a reflected x-goog-api-key credential from Gemini API error bodies", async () => {
+    const needle = "AIzaSyD4iE0xmpl3K3yF0rG00gl3Pr0b3XYZ1234";
+    mockFetchResponse(
+      textResponse(`upstream echoed x-goog-api-key: ${needle}`, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    const error = await pdfNativeProviders
+      .geminiAnalyzePdf(makeGeminiAnalyzeParams({ apiKey: needle }))
+      .catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected Gemini PDF request to throw an Error");
+    }
+    expect(error.message).not.toContain(needle);
+    expect(error.message).toContain("Gemini PDF request failed (401");
+    expect(error.message).toContain("AIzaSy…1234");
+  });
+
+  it("masks a short reflected Bearer credential in the response reason phrase", async () => {
+    mockFetchResponse(textResponse("", { status: 401, statusText: "reflected Bearer abc" }));
+
+    const error = await pdfNativeProviders
+      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
+      .catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected Anthropic PDF request to throw an Error");
+    }
+    expect(error.message).not.toContain("Bearer abc");
+    expect(error.message).toContain("Anthropic PDF request failed (401 reflected Bearer ***)");
+  });
+
+  it("masks a lowercase reflected bearer credential in the response reason phrase", async () => {
+    mockFetchResponse(textResponse("", { status: 401, statusText: "reflected bearer abc" }));
+
+    const error = await pdfNativeProviders
+      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
+      .catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected Anthropic PDF request to throw an Error");
+    }
+    expect(error.message).not.toContain("bearer abc");
+    expect(error.message).toContain("Anthropic PDF request failed (401 reflected bearer ***)");
+  });
+
   it("anthropicAnalyzePdf throws when response has no text", async () => {
     mockFetchResponse(
       jsonResponse({

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -5,7 +5,6 @@
 
 import { resolveAnthropicMessagesUrl } from "@openclaw/ai/transports";
 import { readResponseBodySnippet } from "../../infra/http-error-body.js";
-import { redactToolPayloadText } from "../../logging/redact.js";
 import {
   postJsonRequest,
   readProviderJsonResponse,
@@ -14,6 +13,7 @@ import {
 import { normalizeProviderTransportWithPlugin } from "../../plugins/provider-runtime.js";
 import { isRecord } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
+import { createProviderErrorTextRedactor } from "../provider-http-errors.js";
 import type { ModelProviderRequestTransportOverrides } from "../provider-request-config.js";
 import { unwrapSecretSentinelsForProviderEgress } from "../provider-secret-egress.js";
 import { resolveProviderTransportSsrFPolicy } from "../provider-transport-fetch.js";
@@ -26,16 +26,6 @@ type PdfInput = {
 const NATIVE_PDF_PROVIDER_FETCH_TIMEOUT_MS = 120_000;
 const NATIVE_PDF_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const NATIVE_PDF_ERROR_BODY_MAX_CHARS = 400;
-
-// Standalone Bearer tokens below the shared redactor's 18-character prose floor are
-// still credentials on this authenticated error surface, so mask them regardless of
-// length and scheme casing. The lookahead keeps already-hinted tokens
-// (`Bearer abc…wxyz`) untouched.
-const SHORT_BEARER_TOKEN_PATTERN = /\b(Bearer)\s+[-A-Za-z0-9._~+/=]{1,17}(?![-A-Za-z0-9._~+/=…])/gi;
-
-function redactNativePdfErrorText(text: string): string {
-  return redactToolPayloadText(text).replace(SHORT_BEARER_TOKEN_PATTERN, "$1 ***");
-}
 
 type NativePdfProviderRequestConfig = {
   headers?: Record<string, string>;
@@ -52,6 +42,8 @@ type NativePdfJsonRequest = {
   failureLabel: string;
   responseLabel: string;
   nonJsonMessage: string;
+  request?: ModelProviderRequestTransportOverrides;
+  defaultAuthHeader: string;
   signal?: AbortSignal;
 };
 
@@ -63,6 +55,11 @@ async function postNativePdfJson(params: NativePdfJsonRequest): Promise<Record<s
       unwrapSecretSentinelsForProviderEgress(value, `${params.failureLabel} header handoff`),
     );
   }
+  const redactErrorText = createProviderErrorTextRedactor({
+    headers,
+    request: params.request,
+    defaultAuthHeader: params.defaultAuthHeader,
+  });
   const { response, release } = await postJsonRequest({
     url: params.url,
     headers,
@@ -80,13 +77,10 @@ async function postNativePdfJson(params: NativePdfJsonRequest): Promise<Record<s
       const body = await readResponseBodySnippet(response, {
         maxBytes: NATIVE_PDF_ERROR_BODY_MAX_BYTES,
         maxChars: NATIVE_PDF_ERROR_BODY_MAX_CHARS,
+        redact: redactErrorText,
       });
-      // The error body and reason phrase are provider-controlled: an edge or proxy
-      // can reflect the request's API-key headers (x-api-key / x-goog-api-key) into
-      // either, so redact credential material before it reaches error messages,
-      // logs, and transcripts.
       throw new Error(
-        `${params.failureLabel} (${response.status} ${redactNativePdfErrorText(response.statusText)})${body ? `: ${redactNativePdfErrorText(body)}` : ""}`,
+        `${params.failureLabel} (${response.status} ${redactErrorText(response.statusText)})${body ? `: ${body}` : ""}`,
       );
     }
 
@@ -188,6 +182,8 @@ export async function anthropicAnalyzePdf(params: {
     failureLabel: "Anthropic PDF request failed",
     responseLabel: "Anthropic PDF response",
     nonJsonMessage: "Anthropic PDF response was not JSON.",
+    request: params.requestConfig?.request,
+    defaultAuthHeader: "x-api-key",
     signal: params.signal,
   });
 
@@ -286,6 +282,8 @@ export async function geminiAnalyzePdf(params: {
     failureLabel: "Gemini PDF request failed",
     responseLabel: "Gemini PDF response",
     nonJsonMessage: "Gemini PDF response was not JSON.",
+    request: params.requestConfig?.request,
+    defaultAuthHeader: "x-goog-api-key",
     signal: params.signal,
   });
 

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -5,6 +5,7 @@
 
 import { resolveAnthropicMessagesUrl } from "@openclaw/ai/transports";
 import { readResponseBodySnippet } from "../../infra/http-error-body.js";
+import { redactToolPayloadText } from "../../logging/redact.js";
 import {
   postJsonRequest,
   readProviderJsonResponse,
@@ -25,6 +26,16 @@ type PdfInput = {
 const NATIVE_PDF_PROVIDER_FETCH_TIMEOUT_MS = 120_000;
 const NATIVE_PDF_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const NATIVE_PDF_ERROR_BODY_MAX_CHARS = 400;
+
+// Standalone Bearer tokens below the shared redactor's 18-character prose floor are
+// still credentials on this authenticated error surface, so mask them regardless of
+// length and scheme casing. The lookahead keeps already-hinted tokens
+// (`Bearer abc…wxyz`) untouched.
+const SHORT_BEARER_TOKEN_PATTERN = /\b(Bearer)\s+[-A-Za-z0-9._~+/=]{1,17}(?![-A-Za-z0-9._~+/=…])/gi;
+
+function redactNativePdfErrorText(text: string): string {
+  return redactToolPayloadText(text).replace(SHORT_BEARER_TOKEN_PATTERN, "$1 ***");
+}
 
 type NativePdfProviderRequestConfig = {
   headers?: Record<string, string>;
@@ -70,8 +81,12 @@ async function postNativePdfJson(params: NativePdfJsonRequest): Promise<Record<s
         maxBytes: NATIVE_PDF_ERROR_BODY_MAX_BYTES,
         maxChars: NATIVE_PDF_ERROR_BODY_MAX_CHARS,
       });
+      // The error body and reason phrase are provider-controlled: an edge or proxy
+      // can reflect the request's API-key headers (x-api-key / x-goog-api-key) into
+      // either, so redact credential material before it reaches error messages,
+      // logs, and transcripts.
       throw new Error(
-        `${params.failureLabel} (${response.status} ${response.statusText})${body ? `: ${body}` : ""}`,
+        `${params.failureLabel} (${response.status} ${redactNativePdfErrorText(response.statusText)})${body ? `: ${redactNativePdfErrorText(body)}` : ""}`,
       );
     }
 

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -8,24 +8,30 @@ const errorBodyLog = createSubsystemLogger("http-error-body");
 
 export async function readResponseBodySnippet(
   response: Response,
-  limits: { maxBytes: number; maxChars: number },
+  limits: {
+    maxBytes: number;
+    maxChars: number;
+    redact?: (text: string, context: { truncated: boolean }) => string;
+  },
 ): Promise<string> {
+  const normalize = (text: string, truncated: boolean) =>
+    truncateUtf16Safe(limits.redact?.(text, { truncated }) ?? text, limits.maxChars);
   try {
     const body = response.body;
     if (!body || typeof body.getReader !== "function") {
       const text = await response.text();
       const encoded = new TextEncoder().encode(text);
       if (encoded.byteLength > limits.maxBytes) {
-        return truncateUtf16Safe(
+        return normalize(
           decodeTextPrefix(encoded.subarray(0, limits.maxBytes), { truncated: true }),
-          limits.maxChars,
+          true,
         );
       }
-      return truncateUtf16Safe(text, limits.maxChars);
+      return normalize(text, false);
     }
 
     const prefix = await readResponseTextPrefix(response, limits.maxBytes);
-    return truncateUtf16Safe(prefix.text, limits.maxChars);
+    return normalize(prefix.text, prefix.truncated);
   } catch (err) {
     errorBodyLog.warn(`Failed to read response body snippet: ${formatErrorMessage(err)}`);
     return "";


### PR DESCRIPTION
## Summary

`postNativePdfJson()` (`src/agents/tools/pdf-native-providers.ts`) — the shared HTTP helper behind `anthropicAnalyzePdf()` and `geminiAnalyzePdf()` — splices the raw error response body and the raw HTTP reason phrase into the thrown `Error` message on non-2xx responses. Because these requests carry API-key headers (`x-api-key` for Anthropic, `x-goog-api-key` for Gemini), an edge or enterprise proxy that reflects request material leaks the provider key into user-facing error text. Both provider-controlled channels now pass through `redactToolPayloadText()` before reaching the message — one throw site, both providers fixed.

## What Problem This Solves

- Anthropic native PDF requests send `x-api-key: <key>` (`pdf-native-providers.ts:144`) and Gemini ones send `x-goog-api-key: <key>` (`:245`). On `!response.ok`, the shared helper throws `` `${failureLabel} (${response.status} ${response.statusText}): ${body}` `` with the **raw** body snippet and the **raw** reason phrase (`:68-75`). `readResponseBodySnippet` only truncates — it does not redact.
- When a provider edge or an enterprise proxy answers with an error page that echoes the request's API-key header, the key lands verbatim in the thrown `Error` message — and from there into tool results, transcripts, logs, and any UI surface that renders errors.
- The reason phrase is equally provider-controlled: undici surfaces the upstream reason phrase as response data, so an empty-body 401 can expose the key even when there is no body at all.
- The shared provider error helper (`extractProviderErrorInfo` in `src/agents/provider-http-errors.ts`) already redacts via `redactProviderErrorBody`, but this throw site bypasses that aggregation point entirely.

**代码证据**: on `main`, a loopback endpoint answering 401 with `x-api-key: <key>` reflected in the body produces `Error: Anthropic PDF request failed (401 Unauthorized): upstream echoed x-api-key: sk-ant-api03-…jL5k` (full key); the Gemini path leaks `x-goog-api-key: AIzaSy…` the same way through the same throw.

Same defect class as the merged #117304 (voice-call) and #119536 (discord) fixes, and the same body+reason-phrase shape as #120200 (web-search provider helpers).

## Root Cause

The error path was written to aid debugging (`status + statusText + body snippet`) before credential redaction became the house standard, and it never passed through the shared redacting error helper.

The violated invariant: text derived from an HTTP response to an authenticated request — body **and** reason phrase alike — must be treated as potentially containing the request's credentials and may only reach user-facing surfaces after redaction.

## Why This Fix

- Pass both provider-controlled interpolations through `redactToolPayloadText()` — the existing house redactor for tool payloads across `src/agents`. It stays in sync with the central pattern list (Bearer, `Authorization`, `api-key`/`x-api-key`, cookies, plus provider key formats such as `sk-ant-…` and `AIza…`) and masks with a short hint (`sk-ant…jL5k`) so diagnostics keep the non-secret context.
- Close the short-token gap locally: the shared standalone Bearer pattern keeps an 18-character floor to spare prose in general logs, which is wrong for a provider-controlled error surface where a reflected short generic key (`Bearer abc`) is exactly what must not survive. A supplementary `SHORT_BEARER_TOKEN_PATTERN` (1–17 token characters, case-insensitive so a lowercase `bearer abc` reflection is masked too, lookahead rejects the `…` ellipsis so an already-hinted token is never re-masked) runs only in this error path.
- One call site covers both providers: `anthropicAnalyzePdf` and `geminiAnalyzePdf` share `postNativePdfJson`, so the fix lands once and protects both.
- Redact at the throw site rather than inside `readResponseBodySnippet`: the reader is shared by other call sites and stays a pure truncation helper; redaction is a property of this authenticated error path.
- `redactToolPayloadText("")` returns `""`, so the `body ? … : ""` shape is preserved exactly; the body is still truncated to the same 8 KB / 400-char caps as before.
- Alternative considered: routing through `createProviderHttpError` — rejected here as a larger refactor of the per-provider error shape (`failureLabel`, `nonJsonMessage`) for no additional redaction coverage.

## User Impact

- Users running native-PDF analysis through Anthropic or Gemini models no longer expose their provider API key in error text when a provider edge or proxy reflects request material — whether in the error page or in the reason phrase.
- Error messages keep the provider label, HTTP status, and the non-secret portion of the body; diagnostics are unaffected.

## Evidence

- **Before**: loopback server on `main` answering (1) the Anthropic Messages POST with a 401 body echoing `x-api-key: <key>`, (2) the Gemini generateContent POST with a 401 body echoing `x-goog-api-key: <key>`, (3) an empty-body 401 whose reason phrase reflects a short generic `Bearer abc`, and (4) the same with a lowercase `bearer abc` scheme; the real `anthropicAnalyzePdf()`/`geminiAnalyzePdf()` → all four messages contain the credential verbatim → FAIL ×4.
- **After**: same loopback on this branch → both keys are masked with their hints (`sk-ant…jL5k`, `AIzaSy…1234`) and both short reason-phrase credentials are fully masked (`Bearer ***` / `bearer ***`), status and label intact → PASS ×4.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
proof server listening on http://127.0.0.1:36195
case 1 (anthropic x-api-key reflection) agent-facing error: Anthropic PDF request failed (401 Unauthorized): upstream echoed x-api-key: sk-ant-api03-vX7qP2mN9wKzR4tY8uI0oP3aS6dF7gH1jL5k
FAIL: reflected API key leaked into the agent-facing error message
case 2 (gemini x-goog-api-key reflection) agent-facing error: Gemini PDF request failed (401 Unauthorized): upstream echoed x-goog-api-key: AIzaSyD4iE0xmpl3K3yF0rG00gl3Pr0b3XYZ1234
FAIL: reflected API key leaked into the agent-facing error message
case 3 (short Bearer reason-phrase reflection) agent-facing error: Anthropic PDF request failed (401 reflected Bearer abc)
FAIL: reflected API key leaked into the agent-facing error message
case 4 (lowercase bearer reason-phrase reflection) agent-facing error: Anthropic PDF request failed (401 reflected bearer abc)
FAIL: reflected API key leaked into the agent-facing error message
RESULT: 4 case(s) FAIL
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
proof server listening on http://127.0.0.1:34689
case 1 (anthropic x-api-key reflection) agent-facing error: Anthropic PDF request failed (401 Unauthorized): upstream echoed x-***: sk-ant…jL5k
PASS: reflected API key masked in the agent-facing error message
case 2 (gemini x-goog-api-key reflection) agent-facing error: Gemini PDF request failed (401 Unauthorized): upstream echoed x-goog-***: AIzaSy…1234
PASS: reflected API key masked in the agent-facing error message
case 3 (short Bearer reason-phrase reflection) agent-facing error: Anthropic PDF request failed (401 reflected Bearer ***)
PASS: reflected API key masked in the agent-facing error message
case 4 (lowercase bearer reason-phrase reflection) agent-facing error: Anthropic PDF request failed (401 reflected bearer ***)
PASS: reflected API key masked in the agent-facing error message
RESULT: all cases PASS
```

(Real `node:http` server on 127.0.0.1 answering `POST /v1/messages` and `POST /v1beta/models/<model>:generateContent`: cases 1–2 echo the request's API-key header into the 401 body; cases 3–4 reflect a short generic Bearer credential into the reason phrase via `writeHead(401, "reflected Bearer abc")` / `writeHead(401, "reflected bearer abc")` on an empty body. All consumed by the real exported `anthropicAnalyzePdf()`/`geminiAnalyzePdf()` against the loopback `baseUrl`.)

## Tests and Validation

- `pnpm check` — all guards pass except the local `npm package-lock guard`, which fails on a pre-existing `set-blocking` integrity mismatch (registry-mirror sha1 vs lockfile sha512). The guard compares local `node_modules` against `pnpm-lock.yaml`; this PR changes no manifest or lockfile, so the failure is environmental and unrelated to the change.
- `npx vitest run src/agents/tools/pdf-native-providers.test.ts` passed (50 tests across both projects), including new regression coverage:
  - a 401 Anthropic error body echoing `x-api-key: <key>` reaches the thrown message with the key masked and the status/label intact;
  - a 401 Gemini error body echoing `x-goog-api-key: <key>` is masked the same way;
  - an empty-body 401 whose reason phrase reflects a short generic `Bearer abc` is fully masked (`Bearer ***`) despite the shared pattern's 18-character floor — and a lowercase `bearer abc` reflection is masked too (`bearer ***`).
