### PR TITLE
fix(memory): record the omitted memory corpus in corpus=all searches

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -14,6 +14,7 @@ import {
   resetMemoryToolMockState,
   setMemoryReadFileImpl,
   setMemorySearchImpl,
+  setMemorySearchManagerImpl,
   setMemoryWorkspaceDir,
   type MemoryReadParams,
 } from "./memory-tool-manager.test-mocks.js";
@@ -652,6 +653,35 @@ describe("memory tools", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("surfaces a memory-corpus warning when corpus=all hits a returned manager error", async () => {
+    setMemorySearchManagerImpl(async () => ({ error: "sqlite support missing" }));
+    registerMemoryCorpusSupplement("memory-wiki", {
+      search: async () => [
+        {
+          corpus: "wiki",
+          path: "entities/alpha.md",
+          title: "Alpha",
+          kind: "entity",
+          score: 4,
+          snippet: "Alpha wiki entry",
+        },
+      ],
+      get: async () => null,
+    });
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("call_all_manager_error", { query: "alpha", corpus: "all" });
+    const details = result.details as {
+      results: Array<{ corpus: string }>;
+      warning?: string;
+    };
+
+    // Wiki supplements still serve, but the omitted memory corpus is recorded.
+    expect(details.results.map((entry) => entry.corpus)).toEqual(["wiki"]);
+    expect(details.warning).toContain("Memory corpus unavailable");
+    expect(details.warning).toContain("sqlite support missing");
   });
 
   it("cooldowns primary memory when corpus=all memory search stalls", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -510,12 +510,18 @@ export function createMemorySearchTool(options: {
                 )
               : null;
             const memory = memorySetup?.context ?? null;
-            if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
+            let memoryCorpusUnavailable: string | undefined;
+            if (shouldQueryMemory && memory && "error" in memory) {
               recordMemorySearchToolCooldown(
                 cooldownKey,
                 memory.error ?? "memory search unavailable",
               );
-              return jsonResult(buildMemorySearchUnavailableResult(memory.error));
+              if (!shouldQuerySupplements) {
+                return jsonResult(buildMemorySearchUnavailableResult(memory.error));
+              }
+              // corpus=all still serves wiki supplements, but the omitted memory
+              // corpus must be recorded or the degraded search reads as complete.
+              memoryCorpusUnavailable = memory.error ?? "memory search unavailable";
             }
 
             const citationsMode = resolveMemoryCitationsMode(cfg);
@@ -737,6 +743,11 @@ export function createMemorySearchTool(options: {
               fallback,
               citations: citationsMode,
               mode: searchMode,
+              ...(memoryCorpusUnavailable
+                ? {
+                    warning: `Memory corpus unavailable; results cover wiki supplements only: ${memoryCorpusUnavailable}`,
+                  }
+                : {}),
               ...staleness,
               debug: searchDebug,
             });


### PR DESCRIPTION
## What Problem This Solves

`memory_search corpus=all` silently swallowed a *returned* memory-manager error (missing `node:sqlite`, embedding provider misconfigured, corrupted index). The error branch was gated on `!shouldQuerySupplements`, so with `corpus: "all"` it was skipped entirely and the memory phase was skipped by the `!("error" in memory)` guard — the tool returned wiki-only results in a payload with **no** `error`/`warning`/`disabled` field and recorded no cooldown. The model and user saw a "successful" search that quietly omitted the entire memory corpus, contradicting the tool description's own contract ("If response has disabled=true … you must tell the user"). The *thrown*-error path already surfaced this; only the returned-error path was silent.

## Why This Change Was Made

Silent-failure doctrine: a degraded search must not read as complete. The cooldown is now recorded for returned errors regardless of corpus, and when supplements still serve (the best-effort value of corpus=all), the payload carries a warning naming the unavailable memory corpus and its reason.

## User Impact

Agents and operators see when memory-backend results are missing from a corpus=all search instead of trusting an incomplete result set; repeated backend failures now enter the existing cooldown machinery.

## Evidence

- New regression "surfaces a memory-corpus warning when corpus=all hits a returned manager error": **fails pre-fix** (stash run: 1 failed), passes post-fix. Uses the existing setMemorySearchManagerImpl mock for the returned-error shape.
- Full `tools.citations.test.ts`: 29 passed (29). `tsgo` core rc=0; oxlint/oxfmt clean.
- Codex autoreview clean (0.99).
- Production delta: +13 −2 (recording the previously-silent degradation; nothing to delete — the silence was the bug).
