### PR TITLE
fix(openai): prevent realtime barge-in truncation errors

### DIFF
--- a/extensions/openai/realtime-voice-bridge-connection.test.ts
+++ b/extensions/openai/realtime-voice-bridge-connection.test.ts
@@ -194,6 +194,28 @@ describe("OpenAI realtime voice bridge connection", () => {
       type: "session.created",
       detail: "tools=1 toolChoice=auto",
     });
+
+    bridge.setMediaTimestamp(1_000);
+    emitServerEvent(socket, {
+      type: "response.output_audio.delta",
+      item_id: "item_pcm",
+      delta: Buffer.alloc(3_700 * 48).toString("base64"),
+    });
+    bridge.setMediaTimestamp(4_760);
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+
+    expect(parseSent(socket).slice(-2)).toEqual([
+      {
+        type: "response.cancel",
+        event_id: expect.stringMatching(/^openclaw-response-cancel-/),
+      },
+      {
+        type: "conversation.item.truncate",
+        item_id: "item_pcm",
+        content_index: 0,
+        audio_end_ms: 3_700,
+      },
+    ]);
     bridge.close();
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });

--- a/extensions/openai/realtime-voice-bridge-events.test.ts
+++ b/extensions/openai/realtime-voice-bridge-events.test.ts
@@ -1,4 +1,5 @@
 // Openai tests cover realtime voice provider plugin behavior.
+import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
@@ -74,34 +75,70 @@ describe("OpenAI realtime voice bridge events", () => {
     expect(hasSentEventType(socket, "conversation.item.truncate")).toBe(false);
   });
 
-  it("truncates externally interrupted playback after an immediate mark acknowledgement", async () => {
-    const onAudio = vi.fn();
-    const onClearAudio = vi.fn();
-    const bridge = createNativeBridge({
-      onAudio,
-      onClearAudio,
-      onMark: () => bridge.acknowledgeMark(),
-    });
-    const socket = await connectReadyBridge(bridge);
+  it.each([
+    {
+      name: "externally interrupted playback at the produced duration",
+      producedAudioMs: 300,
+      mediaElapsedMs: 300,
+      bytesPerMs: 8,
+      audioFormat: undefined,
+      providerVad: false,
+    },
+    {
+      name: "provider VAD after the media clock advances past produced audio",
+      producedAudioMs: 3_700,
+      mediaElapsedMs: 3_760,
+      bytesPerMs: 8,
+      audioFormat: undefined,
+      providerVad: true,
+    },
+    {
+      name: "provider VAD after a PCM16 playback clock overrun",
+      producedAudioMs: 3_700,
+      mediaElapsedMs: 3_760,
+      bytesPerMs: 48,
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      providerVad: true,
+    },
+  ])(
+    "truncates $name",
+    async ({ producedAudioMs, mediaElapsedMs, bytesPerMs, audioFormat, providerVad }) => {
+      const onAudio = vi.fn();
+      const onClearAudio = vi.fn();
+      const bridge = createNativeBridge({
+        onAudio,
+        onClearAudio,
+        ...(audioFormat ? { audioFormat } : {}),
+        ...(providerVad ? {} : { onMark: () => bridge.acknowledgeMark() }),
+      });
+      const socket = await connectReadyBridge(bridge);
 
-    bridge.setMediaTimestamp(1000);
-    emitAssistantPlayback(socket);
-    bridge.setMediaTimestamp(1300);
+      bridge.setMediaTimestamp(1000);
+      emitAssistantPlayback(socket, { audio: Buffer.alloc(producedAudioMs * bytesPerMs) });
+      bridge.setMediaTimestamp(1000 + mediaElapsedMs);
 
-    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+      if (providerVad) {
+        emitServerEvent(socket, { type: "input_audio_buffer.speech_started" });
+      } else {
+        bridge.handleBargeIn?.({ audioPlaybackActive: true });
+      }
 
-    expect(onAudio).toHaveBeenCalledTimes(1);
-    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
-    expect(parseSent(socket).slice(-2)).toEqual([
-      expectedResponseCancelEvent(),
-      {
+      expect(onAudio).toHaveBeenCalledTimes(1);
+      expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+      const truncation = parseSent(socket).findLast(
+        (event) => event.type === "conversation.item.truncate",
+      );
+      expect(truncation).toEqual({
         type: "conversation.item.truncate",
         item_id: "item_1",
         content_index: 0,
-        audio_end_ms: 300,
-      },
-    ]);
-  });
+        audio_end_ms: producedAudioMs,
+      });
+      expect(parseSent(socket).some((event) => event.type === "response.cancel")).toBe(
+        !providerVad,
+      );
+    },
+  );
 
   it("preserves FIFO playback acknowledgements after sustained output", async () => {
     const onClearAudio = vi.fn();
@@ -326,7 +363,7 @@ describe("OpenAI realtime voice bridge events", () => {
     emitServerEvent(socket, {
       type: "response.audio.delta",
       item_id: "item_1",
-      delta: Buffer.from("assistant audio").toString("base64"),
+      delta: Buffer.alloc(2_400).toString("base64"),
     });
     bridge.setMediaTimestamp(1300);
 

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -79,11 +79,16 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         }
         const audio = base64ToBuffer(audioDelta);
         this.config.onAudio(audio);
-        if (event.item_id && event.item_id !== this.lastAssistantItemId) {
-          this.lastAssistantItemId = event.item_id;
-          this.responseStartTimestamp = this.latestMediaTimestamp;
-        } else if (this.responseStartTimestamp === null) {
-          this.responseStartTimestamp = this.latestMediaTimestamp;
+        if (event.item_id && event.item_id !== this.assistantAudioItem?.itemId) {
+          this.assistantAudioItem = {
+            itemId: event.item_id,
+            bytes: 0,
+            startTimestamp: this.latestMediaTimestamp,
+          };
+        }
+        // Playback clocks can lead provider output, but truncate cannot exceed item audio.
+        if (this.assistantAudioItem) {
+          this.assistantAudioItem.bytes += audio.byteLength;
         }
         this.responseActive = true;
         this.sendMark();

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -37,8 +37,6 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected latestOutstandingMarkSequence: number | null = null;
 
-  protected responseStartTimestamp: number | null = null;
-
   protected responseActive = false;
 
   protected responseCreateInFlight = false;
@@ -59,7 +57,11 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected latestMediaTimestamp = 0;
 
-  protected lastAssistantItemId: string | null = null;
+  protected assistantAudioItem: {
+    itemId: string;
+    bytes: number;
+    startTimestamp: number;
+  } | null = null;
 
   protected completedToolCallIds = new Set<string>();
 
@@ -230,22 +232,24 @@ export abstract class OpenAIRealtimeProtocol {
   }
 
   handleBargeIn(options?: RealtimeVoiceBargeInOptions): void {
-    const assistantItemId = this.lastAssistantItemId;
-    const responseStartTimestamp = this.responseStartTimestamp;
+    const assistantAudioItem = this.assistantAudioItem;
     const force = options?.force === true;
     const shouldInterruptProvider =
-      assistantItemId !== null &&
-      ((responseStartTimestamp !== null &&
-        (this.oldestOutstandingMarkSequence !== null || options?.audioPlaybackActive === true)) ||
+      assistantAudioItem !== null &&
+      (this.oldestOutstandingMarkSequence !== null ||
+        options?.audioPlaybackActive === true ||
         force);
-    const audioEndMs = shouldInterruptProvider
-      ? Math.max(
-          0,
-          responseStartTimestamp === null
-            ? this.latestMediaTimestamp
-            : this.latestMediaTimestamp - responseStartTimestamp,
-        )
-      : null;
+    const bytesPerSample = this.audioFormat.encoding === "pcm16" ? 2 : 1;
+    const audioEndMs =
+      shouldInterruptProvider && assistantAudioItem
+        ? Math.min(
+            Math.floor(
+              (assistantAudioItem.bytes * 1000) /
+                (this.audioFormat.sampleRateHz * this.audioFormat.channels * bytesPerSample),
+            ),
+            Math.max(0, this.latestMediaTimestamp - assistantAudioItem.startTimestamp),
+          )
+        : null;
     const minBargeInAudioEndMs =
       this.config.minBargeInAudioEndMs ?? OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS;
     if (!force && audioEndMs !== null && audioEndMs < minBargeInAudioEndMs) {
@@ -266,11 +270,11 @@ export abstract class OpenAIRealtimeProtocol {
       this.sendEvent({ type: "response.cancel", event_id: eventId }, "reason=barge-in");
       this.responseCancelInFlight = true;
     }
-    if (shouldInterruptProvider) {
+    if (shouldInterruptProvider && assistantAudioItem) {
       this.sendEvent(
         {
           type: "conversation.item.truncate",
-          item_id: assistantItemId,
+          item_id: assistantAudioItem.itemId,
           content_index: 0,
           audio_end_ms: audioEndMs,
         },
@@ -278,8 +282,7 @@ export abstract class OpenAIRealtimeProtocol {
       );
       this.config.onClearAudio("barge-in");
       this.clearOutstandingMarks();
-      this.lastAssistantItemId = null;
-      this.responseStartTimestamp = null;
+      this.assistantAudioItem = null;
       return;
     }
     this.config.onClearAudio("barge-in");
@@ -374,7 +377,7 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected resetRealtimeSessionState(): void {
     this.clearOutstandingMarks();
-    this.responseStartTimestamp = null;
+    this.assistantAudioItem = null;
     this.responseActive = false;
     this.responseCreateInFlight = false;
     this.manualResponseCreateEventId = null;
@@ -384,7 +387,6 @@ export abstract class OpenAIRealtimeProtocol {
     this.autoRespondSuppressedForManualResponse = false;
     this.continuingToolCallIds.clear();
     this.pendingToolCallIds.clear();
-    this.lastAssistantItemId = null;
     this.completedToolCallIds.clear();
     this.standaloneSpeechQueue = [];
     this.standaloneSpeechActive = false;

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -219,6 +219,7 @@ async function createOpenAIRealtimeBrowserSession(
               providerConfig: req.providerConfig,
               apiKey,
               callId,
+              audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
               gaSessionPolicy: sessionConfig,
               model,
               voice,

--- a/extensions/openai/realtime-voice-response-control.test.ts
+++ b/extensions/openai/realtime-voice-response-control.test.ts
@@ -394,7 +394,7 @@ describe("OpenAI realtime voice response control", () => {
     const bridge = createNativeBridge({ onError });
     const socket = await connectReadyBridge(bridge);
     bridge.setMediaTimestamp(1000);
-    emitAssistantPlayback(socket);
+    emitAssistantPlayback(socket, { audio: Buffer.alloc(2_400) });
     bridge.setMediaTimestamp(1300);
 
     bridge.handleBargeIn?.({ audioPlaybackActive: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users interrupting OpenAI Realtime voice playback could hit a provider rejection instead of cleanly truncating the assistant response. A live clawstudio observation on 2026-08-17 showed OpenAI reject `conversation.item.truncate` with `Audio content of 3700ms is already shorter than 3760ms`.

The voice-call transport forwards Twilio's inbound `media.timestamp`, which is a stream-relative presentation clock. The OpenAI bridge had used elapsed clock time directly as `audio_end_ms`: 29,600 decoded G.711 µ-law bytes represented 3,700 ms of audio while the transport clock had advanced to 3,760 ms. OpenAI requires `audio_end_ms` not to exceed the item's actual audio duration.

## Why This Change Was Made

The OpenAI provider now owns and tracks decoded audio bytes per assistant item, then clamps the transport-clock estimate to the duration actually produced for negotiated G.711 µ-law and PCM16 audio. The GA browser sideband also passes its negotiated 24 kHz PCM16 format into the bridge so the same owner-boundary accounting applies there. Current transport marks establish outstanding playback but do not carry byte-position duration, so widening voice-call would duplicate provider-specific state.

Voice-call transport and disconnect-grace behavior are unchanged. xAI behavior and files are explicitly out of scope.

Production LOC: +35/-27 (net +8). Tests: +86/-27 (net +59). The production growth records the provider-owned duration fact and propagates the already-negotiated PCM16 format required by the external truncation contract.

Provenance: the elapsed-clock approach originated in direct commit `a23ab9b906dc6a4f6b24bb3f681f395eb792dbcd` on 2026-04-04 by Peter Steinberger (no associated PR found), and was carried forward by Peter Steinberger's PR #122414, merged by Peter Steinberger on 2026-08-12. This PR is authored by `steipete`.

External contracts:

- https://developers.openai.com/api/reference/resources/realtime/client-events/#conversation.item.truncate
- https://developers.openai.com/api/docs/guides/realtime-conversations
- https://www.twilio.com/docs/voice/media-streams/websocket-messages

AI-assisted: yes. The code and behavior were reviewed and verified by the maintainer.

## User Impact

Interrupting an OpenAI Realtime voice response now sends a truncation position that cannot run past the audio OpenAI actually produced, preventing the provider error and allowing barge-in to complete normally for G.711 µ-law and PCM16 sessions.

## Evidence

- Live observation before the fix (clawstudio, 2026-08-17): OpenAI rejected `conversation.item.truncate` because 3,700 ms of decoded audio was paired with a 3,760 ms transport-clock timestamp.
- Pre-fix regression proof: with only the production files reversed, `node scripts/run-vitest.mjs extensions/openai/realtime-voice-bridge-events.test.ts` failed exactly 2 cases (received 3760 vs expected 3700); 15 passed.
- Post-fix focused proof: 30 OpenAI tests passed across `extensions/openai/realtime-voice-bridge-events.test.ts` and `extensions/openai/realtime-voice-response-control.test.ts`.
- ClawSweeper sideband regression: before the one-line PCM16 format propagation, the browser sideband factory test received `3760` instead of `3700` while 17 other tests passed. The fixture produces 177,600 PCM16 bytes (3,700 ms) with a 3,760 ms playback clock.
- Sideband correction proof: 48 OpenAI connection, events, and response-control tests passed across three files after the format propagation.
- Sibling transport proof: 54 voice-call handler, adapter, and pacer tests passed across three files.
- Changed-surface gates: the full changed-path extension gate passed across all six PR files, including all selected `extensions` and `extensionTests` gates.
- Patch hygiene: `git diff --check` passed before commit and again after rebasing onto current `origin/main`.
- Live provider acceptance: a temporary authenticated OpenAI Realtime probe generated real µ-law output, advanced the transport clock 60 ms beyond decoded duration, sent barge-in, and received `conversation.item.truncated`; 1 live test passed. The temporary probe was deleted and no secret was printed.
- Source-blind repeatability: the focused event test passed 17/17 twice. Payload-level assertions were hidden by the reporter; the real OpenAI live probe supplied provider acceptance proof.
- Fresh Codex-backed autoreview in uncommitted mode completed cleanly with no accepted/actionable findings. A second fresh review of the uncommitted sideband correction was also clean.
- Rebase sanity on the original reviewed head: both focused OpenAI files passed, 30/30 tests.
- All actionable items and rank-up moves from ClawSweeper's review were applied: propagate the negotiated PCM16 format, add the sideband factory regression, and refresh the PR evidence. The review is under 12 hours old and its only finding was addressed exactly, so no re-review request is needed.
