### PR TITLE
refactor(agents): unify exec approval decisions

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -27,8 +27,8 @@ advances a milestone.
 | 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280, #123612, #123641, #123665, #123673, #123700, #123696, #123785, #123859, #123889, #123901 |
 | 7   | Bundle push consent + runner updates                       | in progress | #123985, #124037, #124356, #124590                                                                                                                                        |
 | 8   | Stop-and-continue moves                                    | landed      | #125036                                                                                                                                                                   |
-| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                                                                                                                                                         |
-| 10  | Cloud convergence (provisioners run `openclaw connect`)    | in progress | —                                                                                                                                                                         |
+| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | in progress | #125503                                                                                                                                                                   |
+| 10  | Cloud convergence (provisioners run `openclaw connect`)    | landed      | #125288, #125384, #125465                                                                                                                                                 |
 
 Revision history: revision 1 (2026-08-08) established the session/runner
 vocabulary, the naming rulings, and the milestone skeleton after a

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -44,8 +44,6 @@ import type {
   ExecApprovalFollowupOutcome,
 } from "./bash-tools.exec-types.js";
 
-type StrictInlineEvalBoundary =
-  typeof import("./bash-tools.exec-host-shared.js").enforceStrictInlineEvalApprovalBoundary;
 type SendExecApprovalFollowupResult =
   typeof import("./bash-tools.exec-host-shared.js").sendExecApprovalFollowupResult;
 type BuildExecApprovalFollowupTarget =
@@ -181,10 +179,62 @@ const shouldResolveExecApprovalUnavailableInlineMock = vi.hoisted(() =>
   vi.fn<ShouldResolveExecApprovalUnavailableInline>(() => false),
 );
 const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
-  vi.fn<StrictInlineEvalBoundary>((value) => ({
-    approvedByAsk: value.approvedByAsk,
-    deniedReason: value.deniedReason,
-  })),
+  vi.fn(
+    (value: {
+      baseDecision: { timedOut: boolean };
+      approvedByAsk: boolean;
+      deniedReason: string | null;
+      requiresInlineEvalApproval: boolean;
+      requiresAutoReviewHumanApproval?: boolean;
+    }) => ({
+      approvedByAsk: value.approvedByAsk,
+      deniedReason: value.deniedReason,
+    }),
+  ),
+);
+const resolveExecApprovalDecisionStateMock = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      decision: string | null;
+      askFallback: ExecSecurity;
+      resolveTimedOut?: (state: {
+        baseDecision: { timedOut: boolean };
+        approvedByAsk: boolean;
+        deniedReason: string | null;
+      }) =>
+        | Promise<{ approvedByAsk: boolean; deniedReason: string | null; context?: unknown }>
+        | { approvedByAsk: boolean; deniedReason: string | null; context?: unknown };
+      requiresExplicitApproval: boolean | ((context: unknown) => boolean);
+      requiresAutoReviewHumanApproval?: boolean;
+    }) => {
+      const initial = createExecApprovalDecisionStateMock();
+      let approvedByAsk = initial.approvedByAsk;
+      let deniedReason = initial.deniedReason;
+      let timeoutContext: unknown;
+      if (initial.baseDecision.timedOut && params.resolveTimedOut) {
+        const timedOut = await params.resolveTimedOut(initial);
+        approvedByAsk = timedOut.approvedByAsk;
+        deniedReason = timedOut.deniedReason;
+        timeoutContext = timedOut.context;
+      } else if (params.decision === "allow-once" || params.decision === "allow-always") {
+        approvedByAsk = true;
+      }
+      const requiresExplicitApproval =
+        typeof params.requiresExplicitApproval === "function"
+          ? params.requiresExplicitApproval(timeoutContext)
+          : params.requiresExplicitApproval;
+      const strict = enforceStrictInlineEvalApprovalBoundaryMock({
+        baseDecision: initial.baseDecision,
+        approvedByAsk,
+        deniedReason,
+        requiresInlineEvalApproval: requiresExplicitApproval,
+        ...(params.requiresAutoReviewHumanApproval !== undefined
+          ? { requiresAutoReviewHumanApproval: params.requiresAutoReviewHumanApproval }
+          : {}),
+      });
+      return { ...initial, ...strict, timeoutContext };
+    },
+  ),
 );
 const detectInterpreterInlineEvalArgvMock = vi.hoisted(() =>
   vi.fn(
@@ -233,6 +283,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   createAndRegisterDefaultExecApprovalRequest: createAndRegisterDefaultExecApprovalRequestMock,
   enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
+  resolveExecApprovalDecisionState: resolveExecApprovalDecisionStateMock,
   sendExecApprovalFollowupResult: sendExecApprovalFollowupResultMock,
   shouldResolveExecApprovalUnavailableInline: shouldResolveExecApprovalUnavailableInlineMock,
 }));

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -61,14 +61,12 @@ import {
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
 import {
-  buildDefaultExecApprovalRequestArgs,
   buildHeadlessExecApprovalDeniedMessage,
   buildExecApprovalFollowupTarget,
   buildExecApprovalPendingToolResult,
-  createExecApprovalDecisionState,
   createAndRegisterDefaultExecApprovalRequest,
-  enforceStrictInlineEvalApprovalBoundary,
   resolveApprovalDecisionOrUndefined,
+  resolveExecApprovalDecisionState,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
   shouldResolveExecApprovalUnavailableInline,
@@ -969,13 +967,6 @@ export async function processGatewayAllowlist(
       autoReviewRequiresHumanApproval = true;
     }
 
-    const requestArgs = buildDefaultExecApprovalRequestArgs({
-      warnings: params.warnings,
-      approvalRunningNoticeMs: params.approvalRunningNoticeMs,
-      createApprovalSlug,
-      turnSourceChannel: params.turnSourceChannel,
-      turnSourceAccountId: params.turnSourceAccountId,
-    });
     const registerGatewayApproval = async (approvalId: string) =>
       await registerExecApprovalRequestForHostOrThrow({
         approvalId,
@@ -1014,7 +1005,11 @@ export async function processGatewayAllowlist(
       sentApproverDms,
       unavailableReason,
     } = await createAndRegisterDefaultExecApprovalRequest({
-      ...requestArgs,
+      warnings: params.warnings,
+      approvalRunningNoticeMs: params.approvalRunningNoticeMs,
+      createApprovalSlug,
+      turnSourceChannel: params.turnSourceChannel,
+      turnSourceAccountId: params.turnSourceAccountId,
       register: registerGatewayApproval,
     });
     emitGatewayExecApprovalSecurityEvent({
@@ -1034,17 +1029,17 @@ export async function processGatewayAllowlist(
         preResolvedDecision,
       })
     ) {
-      const { baseDecision, approvedByAsk, deniedReason } = applyTimedOutAllowlistFallback(
-        createExecApprovalDecisionState({
-          decision: preResolvedDecision,
-          askFallback,
-        }),
-      );
-      const strictInlineEvalDecision = enforceStrictInlineEvalApprovalBoundary({
-        baseDecision,
-        approvedByAsk,
-        deniedReason,
-        requiresInlineEvalApproval,
+      const strictInlineEvalDecision = await resolveExecApprovalDecisionState({
+        decision: preResolvedDecision ?? null,
+        askFallback,
+        resolveTimedOut: (state) => {
+          const adjusted = applyTimedOutAllowlistFallback(state);
+          return {
+            approvedByAsk: adjusted.approvedByAsk,
+            deniedReason: adjusted.deniedReason,
+          };
+        },
+        requiresExplicitApproval: requiresInlineEvalApproval,
         requiresAutoReviewHumanApproval:
           autoReviewRequiresHumanApproval ||
           requiresHeredocApproval ||
@@ -1169,36 +1164,24 @@ export async function processGatewayAllowlist(
         };
       }
 
-      const initialDecisionState = createExecApprovalDecisionState({
+      const resolvedDecision = await resolveExecApprovalDecisionState({
         decision,
         askFallback,
-      });
-      const {
-        baseDecision,
-        approvedByAsk: baseApprovedByAsk,
-        deniedReason: baseDeniedReason,
-      } = applyTimedOutAllowlistFallback(initialDecisionState);
-      let approvedByAsk = baseApprovedByAsk;
-      let deniedReason = baseDeniedReason;
-
-      if (decision === "allow-once") {
-        approvedByAsk = true;
-      } else if (decision === "allow-always") {
-        approvedByAsk = true;
-      }
-
-      const strictBoundaryDecision = enforceStrictInlineEvalApprovalBoundary({
-        baseDecision,
-        approvedByAsk,
-        deniedReason,
-        requiresInlineEvalApproval,
+        resolveTimedOut: (state) => {
+          const adjusted = applyTimedOutAllowlistFallback(state);
+          return {
+            approvedByAsk: adjusted.approvedByAsk,
+            deniedReason: adjusted.deniedReason,
+          };
+        },
+        requiresExplicitApproval: requiresInlineEvalApproval,
         requiresAutoReviewHumanApproval:
           autoReviewRequiresHumanApproval ||
           requiresHeredocApproval ||
           timedOutFallbackRequiresHeredocApproval,
       });
-      approvedByAsk = strictBoundaryDecision.approvedByAsk;
-      deniedReason = strictBoundaryDecision.deniedReason;
+      const { approvedByAsk } = resolvedDecision;
+      let { deniedReason } = resolvedDecision;
 
       if (
         !approvedByAsk &&

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -12,8 +12,6 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import type { ExecAllowlistEntry } from "../infra/exec-approvals.types.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 
-type StrictInlineEvalBoundary =
-  typeof import("./bash-tools.exec-host-shared.js").enforceStrictInlineEvalApprovalBoundary;
 type ExecAutoReviewer = typeof import("../infra/exec-auto-review.js").defaultExecAutoReviewer;
 type ExecAutoReviewDecision = Awaited<ReturnType<ExecAutoReviewer>>;
 type ExecAsk = import("../infra/exec-approvals.js").ExecAsk;
@@ -214,10 +212,62 @@ const sendExecApprovalFollowupResultMock = vi.hoisted(() =>
   vi.fn(async (_target: unknown, _resultText: string) => undefined),
 );
 const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
-  vi.fn<StrictInlineEvalBoundary>((value) => ({
-    approvedByAsk: value.approvedByAsk,
-    deniedReason: value.deniedReason,
-  })),
+  vi.fn(
+    (value: {
+      baseDecision: { timedOut: boolean };
+      approvedByAsk: boolean;
+      deniedReason: string | null;
+      requiresInlineEvalApproval: boolean;
+      requiresAutoReviewHumanApproval?: boolean;
+    }) => ({
+      approvedByAsk: value.approvedByAsk,
+      deniedReason: value.deniedReason,
+    }),
+  ),
+);
+const resolveExecApprovalDecisionStateMock = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      decision: string | null;
+      askFallback: ExecSecurity;
+      resolveTimedOut?: (state: {
+        baseDecision: { timedOut: boolean };
+        approvedByAsk: boolean;
+        deniedReason: string | null;
+      }) =>
+        | Promise<{ approvedByAsk: boolean; deniedReason: string | null; context?: unknown }>
+        | { approvedByAsk: boolean; deniedReason: string | null; context?: unknown };
+      requiresExplicitApproval: boolean | ((context: unknown) => boolean);
+      requiresAutoReviewHumanApproval?: boolean;
+    }) => {
+      const initial = createExecApprovalDecisionStateMock();
+      let approvedByAsk = initial.approvedByAsk;
+      let deniedReason = initial.deniedReason;
+      let timeoutContext: unknown;
+      if (initial.baseDecision.timedOut && params.resolveTimedOut) {
+        const timedOut = await params.resolveTimedOut(initial);
+        approvedByAsk = timedOut.approvedByAsk;
+        deniedReason = timedOut.deniedReason;
+        timeoutContext = timedOut.context;
+      } else if (params.decision === "allow-once" || params.decision === "allow-always") {
+        approvedByAsk = true;
+      }
+      const requiresExplicitApproval =
+        typeof params.requiresExplicitApproval === "function"
+          ? params.requiresExplicitApproval(timeoutContext)
+          : params.requiresExplicitApproval;
+      const strict = enforceStrictInlineEvalApprovalBoundaryMock({
+        baseDecision: initial.baseDecision,
+        approvedByAsk,
+        deniedReason,
+        requiresInlineEvalApproval: requiresExplicitApproval,
+        ...(params.requiresAutoReviewHumanApproval !== undefined
+          ? { requiresAutoReviewHumanApproval: params.requiresAutoReviewHumanApproval }
+          : {}),
+      });
+      return { ...initial, ...strict, timeoutContext };
+    },
+  ),
 );
 const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
   vi.fn(async () => undefined),
@@ -283,6 +333,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   shouldResolveExecApprovalUnavailableInline: shouldResolveExecApprovalUnavailableInlineMock,
   buildExecApprovalFollowupTarget: vi.fn((value) => value),
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
+  resolveExecApprovalDecisionState: resolveExecApprovalDecisionStateMock,
   createExecApprovalDecisionState: createExecApprovalDecisionStateMock,
   enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
   sendExecApprovalFollowupResult: sendExecApprovalFollowupResultMock,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -393,13 +393,6 @@ export async function executeNodeHostCommand(
 
     if (!inlineApprovedByAsk) {
       // Human approval may complete after this tool call returns, so follow-up delivery owns invocation.
-      const requestArgs = execHostShared.buildDefaultExecApprovalRequestArgs({
-        warnings: params.warnings,
-        approvalRunningNoticeMs: params.approvalRunningNoticeMs,
-        createApprovalSlug,
-        turnSourceChannel: params.turnSourceChannel,
-        turnSourceAccountId: params.turnSourceAccountId,
-      });
       const {
         approvalId,
         approvalSlug,
@@ -410,7 +403,11 @@ export async function executeNodeHostCommand(
         sentApproverDms,
         unavailableReason,
       } = await execHostShared.createAndRegisterDefaultExecApprovalRequest({
-        ...requestArgs,
+        warnings: params.warnings,
+        approvalRunningNoticeMs: params.approvalRunningNoticeMs,
+        createApprovalSlug,
+        turnSourceChannel: params.turnSourceChannel,
+        turnSourceAccountId: params.turnSourceAccountId,
         register: registerNodeApproval,
       });
       if (
@@ -419,32 +416,23 @@ export async function executeNodeHostCommand(
           preResolvedDecision,
         })
       ) {
-        const {
-          baseDecision,
-          approvedByAsk: initialApprovedByAsk,
-          deniedReason: initialDeniedReason,
-        } = execHostShared.createExecApprovalDecisionState({
-          decision: preResolvedDecision,
+        const inlineDecision = await execHostShared.resolveExecApprovalDecisionState({
+          decision: preResolvedDecision ?? null,
           askFallback,
-        });
-        let approvedByAsk = initialApprovedByAsk;
-        let deniedReason = initialDeniedReason;
-        const currentFallback = baseDecision.timedOut
-          ? await resolveCurrentTimeoutFallback()
-          : null;
-        if (currentFallback) {
-          approvedByAsk = currentFallback.approvedByAsk;
-          deniedReason = currentFallback.deniedReason;
-        }
-        const strictInlineEvalDecision = execHostShared.enforceStrictInlineEvalApprovalBoundary({
-          baseDecision,
-          approvedByAsk,
-          deniedReason,
-          requiresInlineEvalApproval:
-            currentFallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
+          resolveTimedOut: async () => {
+            const fallback = await resolveCurrentTimeoutFallback();
+            return {
+              approvedByAsk: fallback.approvedByAsk,
+              deniedReason: fallback.deniedReason,
+              context: fallback,
+            };
+          },
+          requiresExplicitApproval: (fallback) =>
+            fallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
           requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
         });
-        if (strictInlineEvalDecision.deniedReason || !strictInlineEvalDecision.approvedByAsk) {
+        const currentFallback = inlineDecision.timeoutContext;
+        if (inlineDecision.deniedReason || !inlineDecision.approvedByAsk) {
           throw new Error(
             execHostShared.buildHeadlessExecApprovalDeniedMessage({
               trigger: params.trigger,
@@ -455,19 +443,15 @@ export async function executeNodeHostCommand(
             }),
           );
         }
-        inlineApprovedByAsk = strictInlineEvalDecision.approvedByAsk;
+        inlineApprovedByAsk = inlineDecision.approvedByAsk;
         inlineApprovalSource = preResolvedDecision === null ? "ask-fallback" : undefined;
         if (inlineApprovalSource) {
           inlineDispatchAuthority = "ask-fallback";
-          inlineFallbackPolicy = currentFallback ?? undefined;
+          inlineFallbackPolicy = currentFallback;
         } else {
           inlineDispatchAuthority = "human-approval";
         }
-        inlineApprovalDecision = inlineApprovalSource
-          ? null
-          : strictInlineEvalDecision.approvedByAsk
-            ? "allow-once"
-            : null;
+        inlineApprovalDecision = inlineApprovalSource ? null : "allow-once";
         inlineApprovalId = approvalId;
       } else {
         const followupTarget = execHostShared.buildExecApprovalFollowupTarget({
@@ -513,47 +497,33 @@ export async function executeNodeHostCommand(
             return;
           }
 
-          const {
-            baseDecision,
-            approvedByAsk: initialApprovedByAsk,
-            deniedReason: baseDeniedReason,
-          } = execHostShared.createExecApprovalDecisionState({
+          const resolvedDecision = await execHostShared.resolveExecApprovalDecisionState({
             decision,
             askFallback,
-          });
-          let approvedByAsk = initialApprovedByAsk;
-          let approvalDecision: "allow-once" | "allow-always" | null = null;
-          const approvalSource = decision === null ? "ask-fallback" : undefined;
-          let deniedReason = baseDeniedReason;
-          const currentFallback = baseDecision.timedOut
-            ? await resolveCurrentTimeoutFallback()
-            : null;
-
-          if (currentFallback) {
-            approvedByAsk = currentFallback.approvedByAsk;
-            deniedReason = currentFallback.deniedReason;
-            approvalDecision = approvedByAsk ? "allow-once" : null;
-          } else if (decision === "allow-once") {
-            approvedByAsk = true;
-            approvalDecision = "allow-once";
-          } else if (decision === "allow-always") {
-            approvedByAsk = true;
-            approvalDecision = "allow-always";
-          }
-
-          const strictBoundaryDecision = execHostShared.enforceStrictInlineEvalApprovalBoundary({
-            baseDecision,
-            approvedByAsk,
-            deniedReason,
-            requiresInlineEvalApproval:
-              currentFallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
+            resolveTimedOut: async () => {
+              const fallback = await resolveCurrentTimeoutFallback();
+              return {
+                approvedByAsk: fallback.approvedByAsk,
+                deniedReason: fallback.deniedReason,
+                context: fallback,
+              };
+            },
+            requiresExplicitApproval: (fallback) =>
+              fallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
             requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
           });
-          approvedByAsk = strictBoundaryDecision.approvedByAsk;
-          deniedReason = strictBoundaryDecision.deniedReason;
-          if (deniedReason) {
-            approvalDecision = null;
-          }
+          const { approvedByAsk, deniedReason } = resolvedDecision;
+          const currentFallback = resolvedDecision.timeoutContext;
+          const approvalSource = decision === null ? "ask-fallback" : undefined;
+          const approvalDecision: "allow-once" | "allow-always" | null = deniedReason
+            ? null
+            : currentFallback
+              ? approvedByAsk
+                ? "allow-once"
+                : null
+              : decision === "allow-once" || decision === "allow-always"
+                ? decision
+                : null;
 
           if (deniedReason) {
             await execHostShared.sendExecApprovalFollowupResult(

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -13,8 +13,7 @@ import {
 import {
   buildExecApprovalPendingToolResult,
   createAndRegisterDefaultExecApprovalRequest,
-  createExecApprovalDecisionState,
-  enforceStrictInlineEvalApprovalBoundary,
+  resolveExecApprovalDecisionState,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
   shouldResolveExecApprovalUnavailableInline,
@@ -487,66 +486,51 @@ describe("resolveExecHostApprovalContext", () => {
   });
 });
 
-describe("enforceStrictInlineEvalApprovalBoundary", () => {
-  it("denies unanswered approvals when ask fallback is fail-closed", () => {
-    expect(
-      createExecApprovalDecisionState({
+describe("resolveExecApprovalDecisionState", () => {
+  it.each([
+    {
+      name: "keeps fail-closed timeout denial",
+      decision: null,
+      askFallback: "deny" as const,
+      requiresExplicitApproval: false,
+      expected: { approvedByAsk: false, deniedReason: "approval-timeout" },
+    },
+    {
+      name: "accepts explicit approval across strict boundaries",
+      decision: "allow-once",
+      askFallback: "deny" as const,
+      requiresExplicitApproval: true,
+      expected: { approvedByAsk: true, deniedReason: null },
+    },
+  ])("$name", async ({ decision, askFallback, requiresExplicitApproval, expected }) => {
+    await expect(
+      resolveExecApprovalDecisionState({
+        decision,
+        askFallback,
+        requiresExplicitApproval,
+      }),
+    ).resolves.toMatchObject(expected);
+  });
+
+  it("applies current timeout policy before enforcing human-only approval", async () => {
+    const timeoutContext = { requiresExplicitApproval: true, policy: "current" };
+
+    await expect(
+      resolveExecApprovalDecisionState({
         decision: null,
-        askFallback: "deny",
+        askFallback: "full",
+        resolveTimedOut: async () => ({
+          approvedByAsk: true,
+          deniedReason: null,
+          context: timeoutContext,
+        }),
+        requiresExplicitApproval: (context) => context?.requiresExplicitApproval === true,
       }),
-    ).toEqual({
-      baseDecision: {
-        approvedByAsk: false,
-        deniedReason: "approval-timeout",
-        timedOut: true,
-      },
+    ).resolves.toEqual({
+      baseDecision: { approvedByAsk: true, deniedReason: null, timedOut: true },
       approvedByAsk: false,
       deniedReason: "approval-timeout",
-    });
-  });
-
-  it("denies timeout-based fallback when strict inline-eval approval is required", () => {
-    expect(
-      enforceStrictInlineEvalApprovalBoundary({
-        baseDecision: { timedOut: true },
-        approvedByAsk: true,
-        deniedReason: null,
-        requiresInlineEvalApproval: true,
-      }),
-    ).toEqual({
-      approvedByAsk: false,
-      deniedReason: "approval-timeout",
-    });
-  });
-
-  it("denies timeout-based fallback when auto-review defers to human approval", () => {
-    const params = {
-      baseDecision: { timedOut: true },
-      approvedByAsk: true,
-      deniedReason: null,
-      requiresInlineEvalApproval: false,
-      requiresAutoReviewHumanApproval: true,
-    } satisfies Parameters<typeof enforceStrictInlineEvalApprovalBoundary>[0] & {
-      requiresAutoReviewHumanApproval: true;
-    };
-
-    expect(enforceStrictInlineEvalApprovalBoundary(params)).toEqual({
-      approvedByAsk: false,
-      deniedReason: "approval-timeout",
-    });
-  });
-
-  it("keeps explicit approvals intact for strict inline-eval commands", () => {
-    expect(
-      enforceStrictInlineEvalApprovalBoundary({
-        baseDecision: { timedOut: false },
-        approvedByAsk: true,
-        deniedReason: null,
-        requiresInlineEvalApproval: true,
-      }),
-    ).toEqual({
-      approvedByAsk: true,
-      deniedReason: null,
+      timeoutContext,
     });
   });
 });

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -123,15 +123,6 @@ type ExecApprovalFollowupResultDeps = {
   logWarn?: typeof logWarn;
 };
 
-/** Common arguments used to build default approval request contexts. */
-type DefaultExecApprovalRequestArgs = {
-  warnings: string[];
-  approvalRunningNoticeMs: number;
-  createApprovalSlug: (approvalId: string) => string;
-  turnSourceChannel?: string;
-  turnSourceAccountId?: string;
-};
-
 /** Builds pending approval state with warnings and a bounded expiry. */
 function createExecApprovalPendingState(params: {
   warnings: string[];
@@ -343,19 +334,6 @@ export async function createAndRegisterDefaultExecApprovalRequest(params: {
   };
 }
 
-/** Builds the shared argument shape passed into default approval registration. */
-export function buildDefaultExecApprovalRequestArgs(
-  params: DefaultExecApprovalRequestArgs,
-): DefaultExecApprovalRequestArgs {
-  return {
-    warnings: params.warnings,
-    approvalRunningNoticeMs: params.approvalRunningNoticeMs,
-    createApprovalSlug: params.createApprovalSlug,
-    turnSourceChannel: params.turnSourceChannel,
-    turnSourceAccountId: params.turnSourceAccountId,
-  };
-}
-
 /** Builds the immutable follow-up target passed to async approval continuations. */
 export function buildExecApprovalFollowupTarget(
   params: ExecApprovalFollowupTarget,
@@ -376,7 +354,7 @@ export function buildExecApprovalFollowupTarget(
 }
 
 /** Builds mutable approval decision state from a raw decision. */
-export function createExecApprovalDecisionState(params: {
+function createExecApprovalDecisionState(params: {
   decision: string | null | undefined;
   askFallback: ExecApprovalsResolved["agent"]["askFallback"];
 }) {
@@ -392,7 +370,7 @@ export function createExecApprovalDecisionState(params: {
 }
 
 /** Prevents fallback approval from satisfying strict inline-eval/human-review paths. */
-export function enforceStrictInlineEvalApprovalBoundary(params: {
+function enforceStrictInlineEvalApprovalBoundary(params: {
   baseDecision: {
     timedOut: boolean;
   };
@@ -415,6 +393,69 @@ export function enforceStrictInlineEvalApprovalBoundary(params: {
   return {
     approvedByAsk: false,
     deniedReason: params.deniedReason ?? "approval-timeout",
+  };
+}
+
+/** Resolves explicit, timeout-fallback, and strict-human approval policy in one owner. */
+export async function resolveExecApprovalDecisionState<TTimeoutContext = undefined>(params: {
+  decision: string | null;
+  askFallback: ExecApprovalsResolved["agent"]["askFallback"];
+  resolveTimedOut?: (state: {
+    baseDecision: { timedOut: boolean };
+    approvedByAsk: boolean;
+    deniedReason: string | null;
+  }) =>
+    | {
+        approvedByAsk: boolean;
+        deniedReason: string | null;
+        context?: TTimeoutContext;
+      }
+    | Promise<{
+        approvedByAsk: boolean;
+        deniedReason: string | null;
+        context?: TTimeoutContext;
+      }>;
+  requiresExplicitApproval: boolean | ((context: TTimeoutContext | undefined) => boolean);
+  requiresAutoReviewHumanApproval?: boolean;
+}): Promise<{
+  baseDecision: { timedOut: boolean };
+  approvedByAsk: boolean;
+  deniedReason: string | null;
+  timeoutContext: TTimeoutContext | undefined;
+}> {
+  const initial = createExecApprovalDecisionState({
+    decision: params.decision,
+    askFallback: params.askFallback,
+  });
+  let approvedByAsk = initial.approvedByAsk;
+  let deniedReason = initial.deniedReason;
+  let timeoutContext: TTimeoutContext | undefined;
+
+  if (initial.baseDecision.timedOut && params.resolveTimedOut) {
+    const timedOut = await params.resolveTimedOut(initial);
+    approvedByAsk = timedOut.approvedByAsk;
+    deniedReason = timedOut.deniedReason;
+    timeoutContext = timedOut.context;
+  } else if (params.decision === "allow-once" || params.decision === "allow-always") {
+    approvedByAsk = true;
+  }
+
+  const requiresExplicitApproval =
+    typeof params.requiresExplicitApproval === "function"
+      ? params.requiresExplicitApproval(timeoutContext)
+      : params.requiresExplicitApproval;
+  const strictDecision = enforceStrictInlineEvalApprovalBoundary({
+    baseDecision: initial.baseDecision,
+    approvedByAsk,
+    deniedReason,
+    requiresInlineEvalApproval: requiresExplicitApproval,
+    requiresAutoReviewHumanApproval: params.requiresAutoReviewHumanApproval,
+  });
+  return {
+    baseDecision: initial.baseDecision,
+    approvedByAsk: strictDecision.approvedByAsk,
+    deniedReason: strictDecision.deniedReason,
+    timeoutContext,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Gateway-hosted and node-hosted exec approvals independently combined explicit decisions, timeout fallback policy, and strict human-only review rules. The duplicated orchestration made approval behavior easier to drift as either host evolved.

## Why This Change Was Made

This introduces one shared approval-decision owner that resolves explicit approval, current timeout fallback, and strict human-review boundaries. Gateway and node hosts retain their own policy refresh, security events, mutable-file checks, dispatch, and follow-up delivery; only the duplicated decision state machine moves into the shared owner. A no-op argument-copy helper and the old exported low-level decision helpers are removed.

## User Impact

No intended user-visible behavior change. Gateway and node exec approvals now apply the same decision ordering by construction, reducing the chance that timeout fallback or strict inline-eval/auto-review behavior diverges between hosts.

Production LOC: +138 / -144 (net -6). Tests: +154 / -68.

AI-assisted: yes. I understand and reviewed the resulting approval ownership boundary.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts` — 204 tests passed on the rebased head.
- `node scripts/check-changed.mjs` — passed, including core/test typechecks, lint, dead-export scans, import-cycle checks, and auth/storage guards.
- `pnpm tsgo` and `pnpm tsgo:core:test` — passed.
- `pnpm docs:check-links` — 6,520 internal links checked, 0 broken.
- Autoreview — clean, no accepted/actionable findings, including the runner-plan milestone update.
- The shared tests cover fail-closed timeout denial, explicit approval across strict boundaries, and current timeout policy followed by human-only enforcement. Existing gateway/node suites retain no-route, timeout fallback, auto-review, headless denial, and asynchronous follow-up coverage.
