### PR TITLE
fix(ui): prevent side panel tab labels from clipping

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -511,7 +511,7 @@ openclaw-chat-sidebar-region,
   width: max-content;
   max-width: 100%;
   min-width: 24px;
-  align-self: stretch;
+  align-self: center;
   align-items: center;
   flex: 1 1 auto;
 }


### PR DESCRIPTION
Closes #125504

## What Problem This Solves

Fixes an issue where users opening Chat side panel tabs would see labels such as Terminal and Review vertically clipped and difficult to read.

## Why This Change Was Made

The tab label tooltip wrapper was stretched inside the tab while its custom element renders through `display: contents`, collapsing the actual trigger to 4 px and clipping its text. Keeping that wrapper intrinsically centered restores the full line box without changing tab height, horizontal overflow, or tooltip behavior.

## User Impact

Side panel tab labels are fully legible in dark and light themes.

## Evidence

Reproduced and verified with `node --import tsx scripts/control-ui-mock-dev.ts --port 5212` and headless Chromium. No local test or build commands were run.

### Dark

Before:

![Dark side panel tabs before](https://github.com/user-attachments/assets/fc47162b-9d1c-431c-831c-8103b1f07713)

After:

![Dark side panel tabs after](https://github.com/user-attachments/assets/a1fc38cb-3ac7-4afd-96e7-720324db54f4)

### Light

Before:

![Light side panel tabs before](https://github.com/user-attachments/assets/3779316f-3a1b-4cb1-935a-cbfeb1753bb6)

After:

![Light side panel tabs after](https://github.com/user-attachments/assets/4f04c31f-9c60-4e6a-bdfe-759eb8bbb57b)

Browser geometry after the fix measured both visible labels at 18.59 px inside 18.59 px triggers, fully contained in both themes.
