### PR TITLE
fix: deprioritize OAuth profiles after refresh failures

### DIFF
--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -426,6 +426,28 @@ describe("resolveProfilesUnavailableReason", () => {
     ).toBe("auth");
   });
 
+  it("returns session_expired when every cooled profile has an expired session", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now + 60_000,
+        failureCounts: { session_expired: 1 },
+      },
+      "anthropic:backup": {
+        cooldownUntil: now + 60_000,
+        failureCounts: { session_expired: 1 },
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["anthropic:default", "anthropic:backup"],
+        now,
+      }),
+    ).toBe("session_expired");
+  });
+
   it("returns overloaded for active overloaded cooldown windows", () => {
     const now = Date.now();
     const store = makeStore({

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -83,6 +83,7 @@ export function resolveInlineProviderApiKeyUsageId(provider: string): string {
 const FAILURE_REASON_PRIORITY: AuthProfileFailureReason[] = [
   "auth_permanent",
   "auth",
+  "session_expired",
   "billing",
   "format",
   "model_not_found",

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -1,4 +1,7 @@
 // Coverage for embedded run auth initialization and runtime credential refresh.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
@@ -10,6 +13,9 @@ import {
   resolveSecretSentinel,
 } from "../../../secrets/sentinel.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
+import { OAuthRefreshFailureError } from "../../auth-profiles/oauth-refresh-failure.js";
+import { resolveAuthProfileOrder } from "../../auth-profiles/order.js";
+import { ensureAuthProfileStore, saveAuthProfileStore } from "../../auth-profiles/store.js";
 import { FailoverError } from "../../failover-error.js";
 import type { RuntimeAuthState } from "./helpers.js";
 
@@ -104,13 +110,14 @@ function createMutableEmbeddedRunAuthController(params: {
   lockedProfileId?: string;
   allowTransientCooldownProbe?: boolean;
   warn?: (message: string) => void;
+  agentDir?: string;
   prepareModelForAuthProfile?: Parameters<
     typeof createEmbeddedRunAuthController
   >[0]["prepareModelForAuthProfile"];
 }) {
   return createEmbeddedRunAuthController({
     config: undefined,
-    agentDir: "/tmp/agent",
+    agentDir: params.agentDir ?? "/tmp/agent",
     workspaceDir: "/tmp/workspace",
     authStore:
       params.authStore ??
@@ -403,6 +410,95 @@ describe("createEmbeddedRunAuthController", () => {
     ).toHaveLength(1);
     expect(harness.profileIndex).toBe(2);
   });
+
+  it.each([
+    {
+      label: "initial candidate",
+      profileCandidates: ["expired", "healthy"],
+      expectedOrder: ["healthy", "expired"],
+      advanceAfterInitialization: false,
+    },
+    {
+      label: "rotated candidate",
+      profileCandidates: ["current", "expired", "healthy"],
+      expectedOrder: ["current", "healthy", "expired"],
+      advanceAfterInitialization: true,
+    },
+  ])(
+    "records a failed OAuth refresh for the $label and prefers the healthy profile next",
+    async ({ profileCandidates, expectedOrder, advanceAfterInitialization }) => {
+      const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-controller-"));
+      try {
+        const authStore: AuthProfileStore = {
+          version: 1,
+          profiles: {
+            current: { type: "api_key", provider: "custom-openai", key: "current-key" },
+            expired: {
+              type: "oauth",
+              provider: "custom-openai",
+              access: "expired-access",
+              refresh: "revoked-refresh",
+              expires: 0,
+            },
+            healthy: { type: "api_key", provider: "custom-openai", key: "healthy-key" },
+          },
+          order: { "custom-openai": profileCandidates },
+        };
+        saveAuthProfileStore(authStore, agentDir);
+        mocks.getApiKeyForModelCore.mockImplementation(async ({ profileId }) => {
+          if (profileId === "expired") {
+            throw new OAuthRefreshFailureError({
+              provider: "custom-openai",
+              profileId,
+              message: "OAuth token refresh failed for custom-openai: invalid_grant",
+            });
+          }
+          return {
+            apiKey: `${String(profileId)}-key`,
+            mode: "api-key" as const,
+            profileId,
+            source: `profile:${String(profileId)}`,
+          };
+        });
+        mocks.prepareProviderRuntimeAuth.mockResolvedValue(undefined);
+        const harness = createMutableAuthControllerHarness();
+        const warn = vi.fn<(message: string) => void>();
+        const controller = createMutableEmbeddedRunAuthController({
+          harness,
+          setRuntimeApiKey: vi.fn(),
+          profileCandidates,
+          authStore,
+          agentDir,
+          warn,
+        });
+
+        await controller.initializeAuthProfile();
+        if (advanceAfterInitialization) {
+          await expect(controller.advanceAuthProfile()).resolves.toBe(true);
+        }
+
+        expect(harness.lastProfileId).toBe("healthy");
+        const persistedStore = ensureAuthProfileStore(agentDir, { syncExternalCli: false });
+        expect(persistedStore.usageStats?.expired).toMatchObject({
+          disabledReason: "auth_permanent",
+          failureCounts: { auth_permanent: 1 },
+        });
+        expect(persistedStore.usageStats?.expired?.disabledUntil).toBeGreaterThan(Date.now());
+        expect(
+          resolveAuthProfileOrder({
+            store: persistedStore,
+            provider: "custom-openai",
+            forModel: "test-model",
+          }),
+        ).toEqual(expectedOrder);
+        expect(warn).toHaveBeenCalledWith(
+          'auth profile "expired" failed for provider "custom-openai": OAuth token refresh failed for custom-openai: invalid_grant',
+        );
+      } finally {
+        await fs.rm(agentDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("unwraps a sentinel for runtime auth exchange but keeps auth storage opaque", async () => {
     const harness = createMutableAuthControllerHarness();

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -10,9 +10,11 @@ import { SecretSurfaceUnavailableError } from "../../../secrets/runtime-degraded
 import {
   type AuthProfileStore,
   isProfileInCooldown,
+  markAuthProfileFailure,
   resolveProfilesUnavailableReason,
   resolveSubscriptionAuthModeForProfiles,
 } from "../../auth-profiles.js";
+import { OAuthRefreshFailureError } from "../../auth-profiles/oauth-refresh-failure.js";
 import {
   classifyFailoverReason,
   isFailoverErrorMessage,
@@ -37,6 +39,8 @@ import {
   unwrapSecretSentinelsForProviderEgress,
 } from "../../provider-secret-egress.js";
 import { clampRuntimeAuthRefreshDelayMs } from "../../runtime-auth-refresh.js";
+import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
+import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 import {
   RUNTIME_AUTH_REFRESH_MARGIN_MS,
   RUNTIME_AUTH_REFRESH_MIN_DELAY_MS,
@@ -117,6 +121,9 @@ export function createEmbeddedRunAuthController(params: {
   attemptedThinking: Set<ThinkLevel>;
   fallbackConfigured: boolean;
   allowTransientCooldownProbe: boolean;
+  authProfileFailurePolicy?: AuthProfileFailurePolicy;
+  authProfileStateMode?: "read-write" | "read-only";
+  runId?: string;
   getProvider(): string;
   getModelId(): string;
   getRuntimeModel(): Model;
@@ -398,6 +405,49 @@ export function createEmbeddedRunAuthController(params: {
     return classified ?? "auth";
   };
 
+  const recordOAuthRefreshFailure = async (
+    candidate: string | undefined,
+    error: unknown,
+  ): Promise<void> => {
+    if (!(error instanceof OAuthRefreshFailureError)) {
+      return;
+    }
+    const profileId = error.profileId ?? candidate;
+    const provider = error.provider || params.getProvider();
+    const errorText = formatErrorMessage(error);
+    params.log.warn(
+      `auth profile "${profileId ?? "(unknown)"}" failed for provider "${provider}": ${errorText}`,
+    );
+    if (!profileId || params.authProfileStateMode === "read-only") {
+      return;
+    }
+    const reason = resolveAuthProfileFailureReason({
+      failoverReason: resolveAuthProfileFailoverReason({
+        allInCooldown: false,
+        message: errorText,
+      }),
+      policy: params.authProfileFailurePolicy,
+    });
+    if (!reason) {
+      return;
+    }
+    try {
+      await markAuthProfileFailure({
+        store: params.authStore,
+        profileId,
+        reason,
+        cfg: params.config,
+        agentDir: params.agentDir,
+        runId: params.runId,
+        modelId: params.getModelId(),
+      });
+    } catch (markError) {
+      params.log.warn(
+        `auth profile "${profileId}" failure bookkeeping failed for provider "${provider}": ${formatErrorMessage(markError)}`,
+      );
+    }
+  };
+
   const throwAuthProfileFailover = (failoverParams: {
     allInCooldown: boolean;
     message?: string;
@@ -602,6 +652,7 @@ export function createEmbeddedRunAuthController(params: {
         if (err instanceof SecretSurfaceUnavailableError) {
           throw err;
         }
+        await recordOAuthRefreshFailure(candidate, err);
       }
     }
     params.setProfileIndex(params.profileCandidates.length);
@@ -652,6 +703,7 @@ export function createEmbeddedRunAuthController(params: {
       if (err instanceof FailoverError || err instanceof SecretSurfaceUnavailableError) {
         throw err;
       }
+      await recordOAuthRefreshFailure(params.profileCandidates[params.getProfileIndex()], err);
       const advanced = await advanceAuthProfile();
       if (!advanced) {
         throwAuthProfileFailover({ allInCooldown: false, error: err });

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -30,6 +30,7 @@ import {
 import { prepareEmbeddedRunAuthPlan } from "./auth-plan.js";
 import { createScopedAuthProfileStore } from "./auth-store.js";
 import type { RuntimeAuthState } from "./helpers.js";
+import type { RunEmbeddedAgentInternalParams } from "./internal-params.js";
 import {
   resolveEmbeddedRunEffectiveModel,
   selectEmbeddedRunHarness,
@@ -42,7 +43,7 @@ import { resolveInitialThinkLevel } from "./runtime-resolution.js";
 type ApiKeyInfo = ResolvedProviderAuth;
 
 export async function prepareEmbeddedRunRuntime(input: {
-  runParams: RunEmbeddedAgentParams;
+  runParams: RunEmbeddedAgentInternalParams;
   provider: string;
   modelId: string;
   agentDir: string;
@@ -329,6 +330,9 @@ export async function prepareEmbeddedRunRuntime(input: {
     attemptedThinking,
     fallbackConfigured: input.fallbackConfigured,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe === true,
+    authProfileFailurePolicy: params.authProfileFailurePolicy,
+    authProfileStateMode: params.authProfileStateMode,
+    runId: params.runId,
     getProvider: () => provider,
     getModelId: () => modelId,
     getRuntimeModel: () => runtimeModel,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a revoked or expired OAuth profile could fail during credential rotation without updating profile health, leaving it first in oldest-used ordering so every run paid the refresh failure again. Also fixes session-expired cooldown state collapsing to an unknown failure, which hid the re-authentication guidance and incorrectly consumed transient cooldown probe budget.

## Why This Change Was Made

Record typed OAuth refresh failures at the auth-candidate owner for both initial and advanced candidates, using the canonical failover classifier and profile-failure policy while preserving read-only runs and SecretRef fail-closed behavior. Add session_expired to unavailable-reason priority so persisted state retains its intended recovery semantics.

## User Impact

Healthy backup profiles are selected after a broken OAuth refresh and remain preferred on later runs while the failed profile is cooled or disabled. Operators also get a warning naming the failed profile/provider and targeted sign-in recovery instead of generic provider-unreachable copy.

## Evidence

- Pre-fix regression: initial and advanced OAuth candidates selected a healthy backup but left the failed profile without auth_permanent health; both new cases failed.
- Pre-fix regression: all cooled profiles with session_expired failure counts resolved to unknown.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/auth-controller.test.ts src/agents/auth-profiles/usage.test.ts` (21 + 100 passing)
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts` (8 + 31 passing)
- `node scripts/check-changed.mjs` (passed)
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Live credential mutation was not run because intentionally revoking a real OAuth refresh token would damage operator auth state; the deterministic persisted-store/order regression covers the owning boundary.

AI-assisted.
