### PR TITLE
fix: Doctor stalls while archiving large session histories

### DIFF
--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -229,28 +229,12 @@ export function updateMigrationManifestTarget(
   writeSessionSqliteMigrationManifest(activeRun);
 }
 
-export function recordPlannedMigrationMove(
-  activeRun: ActiveSessionSqliteMigrationRun | undefined,
-  target: SessionSqliteMigrationTargetInput,
-  move: SessionSqliteMigrationMove,
-): void {
-  recordPlannedMigrationMoves(activeRun, target, [move]);
-}
-
 export function recordPlannedMigrationMoves(
   activeRun: ActiveSessionSqliteMigrationRun | undefined,
   target: SessionSqliteMigrationTargetInput,
   moves: readonly SessionSqliteMigrationMove[],
 ): void {
   recordMigrationMoves(activeRun, target, "plannedMoves", moves);
-}
-
-export function recordCompletedMigrationMove(
-  activeRun: ActiveSessionSqliteMigrationRun | undefined,
-  target: SessionSqliteMigrationTargetInput,
-  move: SessionSqliteMigrationMove,
-): void {
-  recordCompletedMigrationMoves(activeRun, target, [move]);
 }
 
 export function recordCompletedMigrationMoves(

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1228,13 +1228,32 @@ describe("runDoctorSessionSqlite", () => {
     ]);
   });
 
-  it("checkpoints bulk unreferenced archive moves without per-file manifest rewrites", async () => {
+  it("checkpoints bulk archive moves without per-file manifest rewrites", async () => {
     const store = createLegacyStore();
+    const sessions = JSON.parse(fs.readFileSync(store.storePath, "utf-8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
     for (let index = 0; index < 64; index += 1) {
+      const sessionId = `bulk-session-${index}`;
+      const sessionFile = `${sessionId}.jsonl`;
+      sessions[`agent:main:bulk:${index}`] = {
+        channel: "cli",
+        chatType: "direct",
+        sessionFile,
+        sessionId,
+        updatedAt: 2000 + index,
+      };
+      fs.writeFileSync(
+        path.join(store.sessionDir, sessionFile),
+        `${JSON.stringify({ type: "session", sessionId })}\n`,
+        { mode: 0o600 },
+      );
       fs.writeFileSync(path.join(store.sessionDir, `orphan-${index}.jsonl`), "{}\n", {
         mode: 0o600,
       });
     }
+    fs.writeFileSync(store.storePath, JSON.stringify(sessions, null, 2), { mode: 0o600 });
     fs.writeFileSync(path.join(store.sessionDir, "orphan collision.jsonl"), "{}\n", {
       mode: 0o600,
     });
@@ -1256,12 +1275,18 @@ describe("runDoctorSessionSqlite", () => {
       const plannedUnreferencedMoves =
         manifest.targets[0]?.plannedMoves.filter((move) => move.kind === "unreferenced-jsonl") ??
         [];
+      const plannedTranscriptMoves =
+        manifest.targets[0]?.plannedMoves.filter((move) => move.kind === "transcript") ?? [];
 
       expect(plannedUnreferencedMoves).toHaveLength(67);
       expect(new Set(plannedUnreferencedMoves.map((move) => move.archivePath)).size).toBe(67);
+      expect(plannedTranscriptMoves).toHaveLength(65);
       expect(
         manifest.targets[0]?.completedMoves.filter((move) => move.kind === "unreferenced-jsonl"),
       ).toHaveLength(67);
+      expect(
+        manifest.targets[0]?.completedMoves.filter((move) => move.kind === "transcript"),
+      ).toHaveLength(65);
       expect(manifestWrites).toBeLessThan(20);
       expect(replaceFileAtomicSync).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -36,9 +36,7 @@ import {
   assertSafeSessionSqliteMigrationMove,
   canonicalMigrationFilePath,
   createSessionSqliteMigrationRun,
-  recordCompletedMigrationMove,
   recordCompletedMigrationMoves,
-  recordPlannedMigrationMove,
   recordPlannedMigrationMoves,
   updateMigrationManifestTarget,
   writeSessionSqliteMigrationFailureReports,
@@ -795,33 +793,6 @@ function validateImportedRecordBeforeArchive(
   }
 }
 
-function archiveImportedTranscript(
-  target: SessionStoreTarget,
-  record: LegacySessionRecord,
-  report: DoctorSessionSqliteTargetReport,
-  activeRun: ActiveSessionSqliteMigrationRun | undefined,
-): void {
-  if (!record.transcriptPath || !fs.existsSync(record.transcriptPath)) {
-    return;
-  }
-  try {
-    report.archivedTranscriptFiles.push(
-      ...moveImportedTranscriptArtifactsToArchive(
-        target,
-        record.sessionKey,
-        record.transcriptPath,
-        activeRun,
-      ),
-    );
-  } catch (err) {
-    report.issues.push({
-      code: "transcript_archive_failed",
-      message: `${record.transcriptPath}: ${String(err)}`,
-      sessionKey: record.sessionKey,
-    });
-  }
-}
-
 function archiveImportedTranscripts(
   target: SessionStoreTarget,
   records: readonly LegacySessionRecord[],
@@ -829,13 +800,63 @@ function archiveImportedTranscripts(
   activeRun: ActiveSessionSqliteMigrationRun | undefined,
 ): void {
   const archivedTranscriptPaths = new Set<string>();
+  const reservedArchivePaths = new Set<string>();
+  const plannedArchives: Array<{
+    moves: SessionSqliteMigrationMove[];
+    record: LegacySessionRecord;
+  }> = [];
   for (const record of records) {
     if (!record.transcriptPath || archivedTranscriptPaths.has(record.transcriptPath)) {
       continue;
     }
-    archiveImportedTranscript(target, record, report, activeRun);
     archivedTranscriptPaths.add(record.transcriptPath);
+    if (!fs.existsSync(record.transcriptPath)) {
+      continue;
+    }
+    try {
+      plannedArchives.push({
+        moves: planImportedTranscriptArtifactsToArchive(
+          target,
+          record.sessionKey,
+          record.transcriptPath,
+          reservedArchivePaths,
+        ),
+        record,
+      });
+    } catch (err) {
+      report.issues.push({
+        code: "transcript_archive_failed",
+        message: `${record.transcriptPath}: ${String(err)}`,
+        sessionKey: record.sessionKey,
+      });
+    }
   }
+  const migrationTarget = createMigrationTargetInput(target);
+  recordPlannedMigrationMoves(
+    activeRun,
+    migrationTarget,
+    plannedArchives.flatMap((archive) => archive.moves),
+  );
+  const completedMoves: SessionSqliteMigrationMove[] = [];
+  for (const { moves, record } of plannedArchives) {
+    try {
+      const archivePaths: string[] = [];
+      for (const move of moves) {
+        assertSafeSessionSqliteMigrationMove(move, migrationTarget);
+        fs.renameSync(move.sourcePath, move.archivePath);
+        archivePaths.push(move.archivePath);
+        completedMoves.push(move);
+      }
+      report.archivedTranscriptFiles.push(...archivePaths);
+    } catch (err) {
+      report.issues.push({
+        code: "transcript_archive_failed",
+        message: `${record.transcriptPath}: ${String(err)}`,
+        sessionKey: record.sessionKey,
+      });
+    }
+  }
+  recordCompletedMigrationMoves(activeRun, migrationTarget, completedMoves);
 }
 
 function archiveUnreferencedJsonlFiles(
@@ -969,8 +990,8 @@ function recordLegacyStoreMoveForTarget(
     kind: "legacy-store" as const,
     sourcePath: path.resolve(target.storePath),
   };
-  recordPlannedMigrationMove(activeRun, createMigrationTargetInput(target), move);
-  recordCompletedMigrationMove(activeRun, createMigrationTargetInput(target), move);
+  recordPlannedMigrationMoves(activeRun, createMigrationTargetInput(target), [move]);
+  recordCompletedMigrationMoves(activeRun, createMigrationTargetInput(target), [move]);
 }
 
 function validateLegacySessionRecords(
@@ -1234,34 +1255,36 @@ function resolveActiveSqliteTranscriptFile(
   return activePath;
 }
 
-function moveImportedTranscriptArtifactsToArchive(
+function planImportedTranscriptArtifactsToArchive(
   target: SessionStoreTarget,
   sessionKey: string,
   transcriptPath: string,
-  activeRun: ActiveSessionSqliteMigrationRun | undefined,
-): string[] {
-  const archived = [
-    moveImportedTranscriptToArchive(target, sessionKey, transcriptPath, "transcript", activeRun),
-  ];
+  reservedArchivePaths: Set<string>,
+): SessionSqliteMigrationMove[] {
+  const moves: SessionSqliteMigrationMove[] = [];
+  const addMove = (sourcePathRaw: string, kind: SessionSqliteMigrationMoveKind) => {
+    const move = planSessionJsonlArchiveMove({
+      archiveKey: sessionKey,
+      baseNameRaw: path.basename(sourcePathRaw),
+      kind,
+      reservedArchivePaths,
+      sessionKey,
+      sourcePathRaw,
+      target,
+    });
+    reservedArchivePaths.add(move.archivePath);
+    moves.push(move);
+  };
+  addMove(transcriptPath, "transcript");
   const trajectoryPath = resolveTrajectoryPath(transcriptPath);
   if (trajectoryPath && fs.existsSync(trajectoryPath)) {
-    archived.push(
-      moveImportedTranscriptToArchive(target, sessionKey, trajectoryPath, "trajectory", activeRun),
-    );
+    addMove(trajectoryPath, "trajectory");
   }
   const trajectoryPointerPath = resolveTrajectoryPointerPath(transcriptPath);
   if (trajectoryPointerPath && fs.existsSync(trajectoryPointerPath)) {
-    archived.push(
-      moveImportedTranscriptToArchive(
-        target,
-        sessionKey,
-        trajectoryPointerPath,
-        "trajectory",
-        activeRun,
-      ),
-    );
+    addMove(trajectoryPointerPath, "trajectory");
   }
-  return archived;
+  return moves;
 }
 
 function resolveTrajectoryPath(transcriptPath: string): string | undefined {
@@ -1276,24 +1299,6 @@ function resolveTrajectoryPointerPath(transcriptPath: string): string | undefine
     : undefined;
 }
 
-function moveImportedTranscriptToArchive(
-  target: SessionStoreTarget,
-  sessionKey: string,
-  sourcePathRaw: string,
-  kind: SessionSqliteMigrationMoveKind,
-  activeRun: ActiveSessionSqliteMigrationRun | undefined,
-): string {
-  return moveSessionJsonlToArchive({
-    activeRun,
-    archiveKey: sessionKey,
-    baseNameRaw: path.basename(sourcePathRaw),
-    kind,
-    sessionKey,
-    sourcePathRaw,
-    target,
-  });
-}
-
 function moveSessionJsonlToArchive(params: {
   activeRun: ActiveSessionSqliteMigrationRun | undefined;
   archiveKey: string;
@@ -1305,10 +1310,10 @@ function moveSessionJsonlToArchive(params: {
 }): string {
   const move = planSessionJsonlArchiveMove(params);
   const migrationTarget = createMigrationTargetInput(params.target);
-  recordPlannedMigrationMove(params.activeRun, migrationTarget, move);
+  recordPlannedMigrationMoves(params.activeRun, migrationTarget, [move]);
   assertSafeSessionSqliteMigrationMove(move, migrationTarget);
   fs.renameSync(move.sourcePath, move.archivePath);
-  recordCompletedMigrationMove(params.activeRun, migrationTarget, move);
+  recordCompletedMigrationMoves(params.activeRun, migrationTarget, [move]);
   return move.archivePath;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading large JSONL session histories to SQLite could spend hours in Doctor and generate extreme disk writes while archived transcript moves were checkpointed. A 10,000-session packaged upgrade timed out after writing roughly 99 GB even though the resulting SQLite database was about 130 MB.

## Why This Change Was Made

Doctor was atomically rewriting the entire growing crash-recovery manifest when every transcript archive move was planned and again when it completed. This change builds all transcript/trajectory moves first, checkpoints the complete plan once before any rename, performs the renames, then checkpoints completed moves once. Planned moves still let recovery restore a partially moved batch after a crash. The obsolete single-move wrappers are removed.

## User Impact

Large stable-to-current upgrades complete in practical, linear time without weakening migration recovery. Production LOC is +76/-87 (net -11); tests are +26/-1.

## Evidence

- Pre-fix focused regression on current `main`: failed as intended with `expected 140 to be less than 20` manifest writes for 65 transcripts plus unreferenced files.
- Exact fix head: full `src/commands/doctor-session-sqlite.test.ts` passed (84 passed, 2 skipped).
- Packaged stable `openclaw@2026.7.1-2` → current candidate stress proof using this fix:
  - 10,000 sessions / 79,640 events / 5,000 cron jobs: migration 35s, idempotence 34s, Gateway startup 16s.
  - 20,000 sessions / 238,920 events / 10,000 cron jobs: migration 62s, idempotence 61s, Gateway startup 21s; all 31 phases passed.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.98 confidence.
- `git diff --check` passed.
