### PR TITLE
fix(ui): side panel tab labels render without vertical clipping

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -301,14 +301,25 @@ suite.define(() => {
         panel.dir = dir;
         const tabBase = node.shadowRoot?.querySelector<HTMLElement>("[part~='base']");
         const leadingGlyph = node.querySelector<HTMLElement>(".tabstrip-tab__icon svg");
+        const label = node.querySelector<HTMLElement>(".tabstrip-tab__label");
+        const labelClipper = node.querySelector<HTMLElement>(".tabstrip-tab__tooltip-trigger");
         const close = node.nextElementSibling;
         const trailingGlyph = close?.querySelector<HTMLElement>("svg");
-        if (!(close instanceof HTMLElement) || !tabBase || !leadingGlyph || !trailingGlyph) {
-          throw new Error("Active side-panel tab must render both edge glyphs");
+        if (
+          !(close instanceof HTMLElement) ||
+          !tabBase ||
+          !leadingGlyph ||
+          !label ||
+          !labelClipper ||
+          !trailingGlyph
+        ) {
+          throw new Error("Active side-panel tab must render its label and both edge glyphs");
         }
         const tabBounds = tabBase.getBoundingClientRect();
         const closeBounds = close.getBoundingClientRect();
         const leadingBounds = leadingGlyph.getBoundingClientRect();
+        const labelBounds = label.getBoundingClientRect();
+        const labelClipperBounds = labelClipper.getBoundingClientRect();
         const trailingBounds = trailingGlyph.getBoundingClientRect();
         const rtl = dir === "rtl";
         const tabStyle = getComputedStyle(tabBase);
@@ -320,6 +331,8 @@ suite.define(() => {
           trailing: rtl
             ? trailingBounds.left - closeBounds.left
             : closeBounds.right - trailingBounds.right,
+          labelBlockStartInset: labelBounds.top - labelClipperBounds.top,
+          labelBlockEndInset: labelClipperBounds.bottom - labelBounds.bottom,
           tabOuterRadius: Number.parseFloat(
             rtl ? tabStyle.borderTopRightRadius : tabStyle.borderTopLeftRadius,
           ),
@@ -335,6 +348,14 @@ suite.define(() => {
         };
       }, direction);
       expect(tabPadding.trailing, `${direction} glyph insets`).toBeCloseTo(tabPadding.leading, 0);
+      expect(
+        tabPadding.labelBlockStartInset,
+        `${direction} label block-start containment`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        tabPadding.labelBlockEndInset,
+        `${direction} label block-end containment`,
+      ).toBeGreaterThanOrEqual(0);
       expect(tabPadding.tabJoinRadius, `${direction} tab join`).toBe(0);
       expect(tabPadding.closeJoinRadius, `${direction} close join`).toBe(0);
       expect(tabPadding.tabOuterRadius, `${direction} tab outer`).toBeGreaterThan(0);

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -427,6 +427,7 @@ openclaw-chat-sidebar-region,
   align-items: center;
   justify-content: flex-start;
   gap: 7px;
+  padding-block: 0;
   padding-inline: 8px 0;
   border: 0;
   border-radius: var(--radius-md);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Terminal or another tool in the chat side panel could see the outer tab label vertically clipped into a few illegible pixels. The inner shell tab remained readable, which made the broken top-level header especially distracting.

## Why This Change Was Made

The side-panel pill keeps the RTL-aware inline spacing from #125368, but once again resets Web Awesome's inherited block padding at the tab-base owner. That restores the full label line box without changing the 28 px close target, tab dimensions, tooltip behavior, or shared Terminal/Browser tab strip.

The existing browser geometry contract now verifies that the rendered label remains fully inside its overflow clipper in both LTR and RTL. The regression test fails on the pre-fix CSS with a `-7.296875px` block-start inset.

Regression provenance: #125368 changed the previous all-axis padding reset to inline-only padding. The exact follow-up was commit `3aa2263bb75f9097b323f8c0127f3acb08cc7dc1`; the PR was merged as `29fc91fe99d8832e5031a272f4afb74b05a1da70`.

AI-assisted; I reviewed the implementation, dependency CSS contract, history, tests, and screenshots directly.

## User Impact

Side-panel tab labels are fully legible and vertically centered again in right- and bottom-docked layouts, while the newer balanced close-button spacing and RTL pill geometry remain intact.

## Evidence

| Before | After |
| --- | --- |
| ![Clipped Terminal side-panel label](https://github.com/user-attachments/assets/7c518faf-c5a0-4500-8f3c-03c2d0cb6943) | ![Fully visible Terminal side-panel label](https://github.com/user-attachments/assets/f846d1a4-5f8a-4b06-82ee-331116af2f62) |

The deterministic Control UI E2E harness exercised the real Chromium-rendered surface with a mocked Gateway. The real-profile Chrome extension relay was unavailable, so no authenticated live account data was used or captured.

- Pre-fix regression proof: focused browser contract fails at `ltr label block-start containment` with `-7.296875`.
- Exact after-fix Terminal geometry: the 18.59375 px label line box is fully contained by a 28 px clipper.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts` — 3 passed.
- Dark single-Terminal screenshot scenario in `ui/src/e2e/chat-rail-columns.e2e.test.ts` — 1 passed, 4 skipped.
- `node scripts/check-changed.mjs -- ui/src/styles/chat/sidebar.css ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts` — passed formatting, typecheck, lint, guards, and UI build.
- `pnpm ui:build` — passed; Control UI performance budgets remained green.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
- Source-blind visual validation — 5/5 contract clauses passed on the tight before/after crops.

Production LOC: +1/-0 | Tests: +23/-2
