### PR TITLE
fix(ui): do not report ready empty catalogs as auth failures

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5243,7 +5243,7 @@ describe("chat model controls", () => {
     );
     expect(
       container.querySelector('[data-chat-model-catalog-state="ready"]')?.textContent,
-    ).toContain("Authentication failed. Review the provider credential or sign-in, then retry.");
+    ).toContain("Models unavailable");
     container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
     expect(onModelSetup).toHaveBeenCalledOnce();
   });

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -152,10 +152,6 @@ function formatPickerModelLabel(label: string): string {
   return match?.[1] ?? label;
 }
 
-function modelAuthenticationNeededText(): string {
-  return `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`;
-}
-
 export function renderChatModelControls(props: ChatModelControlsProps) {
   const {
     currentOverride,
@@ -341,7 +337,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     : catalogErrorWithoutSnapshot
       ? t("chat.modelControls.modelsUnavailable")
       : catalogSnapshotEmpty
-        ? modelAuthenticationNeededText()
+        ? t("chat.modelControls.modelsUnavailable")
         : undefined;
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -238,7 +238,7 @@ function renderCatalogState(
           ? t("chat.modelControls.modelsRefreshFailed")
           : t("chat.modelControls.modelsUnavailable")
         : state.status === "ready"
-          ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
+          ? t("chat.modelControls.modelsUnavailable")
           : t("chat.modelControls.loadingModels");
   return html`
     <div

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -483,9 +483,7 @@ describe("new-session model runtime", () => {
     expect(options).toHaveLength(2);
     expect(options[0]?.textContent).toContain("Sign-in needed");
     expect([...options].every((option) => option.disabled)).toBe(true);
-    expect(container.textContent).toContain(
-      "Authentication failed. Review the provider credential or sign-in, then retry.",
-    );
+    expect(container.textContent).toContain("Models unavailable");
     expect(container.querySelector('[data-chat-model-catalog-retry="true"]')).toBeNull();
     container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
     expect(navigate).toHaveBeenCalledWith("model-setup");
@@ -505,7 +503,7 @@ describe("new-session model runtime", () => {
     request.mockReturnValueOnce(refresh.promise);
 
     control.load(context, "main", true);
-    expect(renderControl(control, context).textContent).toContain("Authentication failed");
+    expect(renderControl(control, context).textContent).toContain("Models unavailable");
 
     refresh.reject(new Error("refresh failed"));
     await vi.waitFor(() =>
@@ -516,7 +514,7 @@ describe("new-session model runtime", () => {
     const container = renderControl(control, context);
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
-      "Authentication failed",
+      "Models unavailable",
     );
     expect(container.textContent).not.toContain("GPT-5.6 Luna");
   });


### PR DESCRIPTION
## Summary
- stop rendering a `ready` model catalog with no selectable options as `Authentication failed`
- use the existing `Models unavailable` catalog state instead
- keep the existing model setup action and error-state messaging unchanged

## Root cause
The Control UI currently maps `status: ready` plus an empty/non-selectable catalog to the authentication failure copy. A ready provider/catalog state is not evidence that authentication failed; the underlying catalog omission is tracked in #124008.

## Scope
This is intentionally a UI-only presentation fix. It does not fabricate provider authentication, add hidden models, or change the prepared-only `chat.metadata` contract.

Related to #124008 (partial UX correction; the catalog population issue remains tracked there.)

## Tests
- `pnpm test ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/model-control.test.ts`
- `pnpm test ui/src/lib/chat/model-select-state.test.ts ui/src/pages/chat/chat-send.test.ts`
- `pnpm check:changed -- ui/src/pages/chat/components/chat-model-picker.ts ui/src/pages/chat/components/chat-model-controls.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/model-control.test.ts`
