### PR TITLE
fix(ui): stop restart errors from masquerading as model auth

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -46,8 +46,16 @@ suite.define(() => {
       await expect.poll(() => textarea.isEnabled()).toBe(true);
       await expect.poll(() => disabledReason.count()).toBe(0);
 
+      await gateway.deferNext("chat.startup");
       await gateway.setOnline(true);
       await gateway.waitForRequest("chat.startup", { after: 1 });
+      await expect
+        .poll(() => composer.locator('[data-chat-model-catalog-state="refreshing"]').count())
+        .toBe(1);
+      await expect.poll(() => textarea.isEnabled()).toBe(true);
+      await expect.poll(() => disabledReason.count()).toBe(0);
+
+      await gateway.resolveDeferred("chat.startup");
       await expect.poll(() => textarea.isDisabled()).toBe(true);
       await expect.poll(async () => (await disabledReason.textContent())?.trim()).toBe(authFailure);
 

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -9,6 +9,72 @@ const suite = createControlUiE2eSuite({
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
 suite.define(() => {
+  it("uses only authoritative catalog snapshots to gate the composer", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 800 } }, async ({ page }) => {
+      const coldModels = [
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          provider: "openai",
+          available: false,
+        },
+      ];
+      const gateway = await installMockGateway(page, {
+        agentModel: "openai/gpt-5.5",
+        models: coldModels,
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const composer = page.locator(".agent-chat__input");
+      const textarea = composer.locator("textarea");
+      const model = composer.locator('[data-chat-model-select="true"]');
+      const disabledReason = composer.locator(".agent-chat__disabled-reason");
+      const authFailure =
+        "Authentication failed. Review the provider credential or sign-in, then retry.";
+
+      await expect.poll(() => textarea.isDisabled()).toBe(true);
+      await expect.poll(async () => (await disabledReason.textContent())?.trim()).toBe(authFailure);
+      await expect.poll(() => textarea.getAttribute("placeholder")).toBe("Message OpenClaw");
+
+      await gateway.setOnline(false);
+      await expect
+        .poll(async () =>
+          (await model.locator(".chat-controls__inline-select-label").textContent())?.trim(),
+        )
+        .toBe("Offline");
+      await expect.poll(() => textarea.isEnabled()).toBe(true);
+      await expect.poll(() => disabledReason.count()).toBe(0);
+
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: 1 });
+      await expect.poll(() => textarea.isDisabled()).toBe(true);
+      await expect.poll(async () => (await disabledReason.textContent())?.trim()).toBe(authFailure);
+
+      await gateway.setMethodResponse("models.list", {
+        __mockError: { code: "UNAVAILABLE", message: "mock catalog refresh failed" },
+      });
+      const beforeFailure = (await gateway.getRequests("models.list")).length;
+      await model.click();
+      await gateway.waitForRequest("models.list", { after: beforeFailure });
+      await expect
+        .poll(() => composer.locator('[data-chat-model-catalog-state="error"]').textContent())
+        .toContain("Couldn’t refresh models");
+      await expect.poll(() => textarea.isEnabled()).toBe(true);
+      await expect.poll(() => disabledReason.count()).toBe(0);
+
+      await gateway.setMethodResponse("models.list", {
+        models: [{ ...coldModels[0], available: true }],
+      });
+      const beforeRetry = (await gateway.getRequests("models.list")).length;
+      await composer.locator('[data-chat-model-catalog-retry="true"]').click();
+      const retry = await gateway.waitForRequest("models.list", { after: beforeRetry });
+      expect(retry.params).toEqual({ agentId: "main", refresh: true, view: "configured" });
+      await expect.poll(() => textarea.isEnabled()).toBe(true);
+      await expect.poll(() => composer.locator("[data-chat-model-catalog-state]").count()).toBe(0);
+    });
+  });
+
   it("keeps mobile picker panels above an attachment-expanded composer", async () => {
     await suite.withPage({ viewport: { width: 667, height: 375 } }, async ({ page }) => {
       const gateway = await installMockGateway(page);

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -203,10 +203,13 @@ describe("renderChatComposer controls", () => {
       draft: "a draft that hides the placeholder",
     });
 
-    // The placeholder carries the reason only for an empty composer; the
-    // dedicated reason row must keep the explanation visible alongside a draft.
-    expect(container.querySelector(".agent-chat__disabled-reason")?.textContent).toContain(reason);
-    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.disabled).toBe(true);
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    const reasonRow = container.querySelector<HTMLElement>(".agent-chat__disabled-reason");
+    expect(reasonRow?.textContent).toContain(reason);
+    expect(container.textContent?.split(reason)).toHaveLength(2);
+    expect(textarea?.placeholder).toBe(t("chat.composer.placeholder", { name: "OpenClaw" }));
+    expect(textarea?.disabled).toBe(true);
+    expect(textarea?.getAttribute("aria-describedby")?.split(" ")).toContain(reasonRow?.id);
   });
 
   it("opens the microphone picker, marks the selected input, and persists a selection", async () => {

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -161,10 +161,12 @@ export class ChatPane extends ChatPaneLayoutRender {
       (agent) => agent.id === currentAgentId,
     );
     const agentDefaultModel = selectedAgent?.model?.primary;
+    const authoritativeModelCatalog =
+      state.connected && !state.chatModelCatalogError ? state.chatModelCatalog : [];
     const modelUnavailable = isChatModelUnavailable(
       selectedSession?.model ?? agentDefaultModel,
       selectedSession?.modelProvider,
-      state.chatModelCatalog,
+      authoritativeModelCatalog,
     );
     const modelSetupRequired = requiresChatModelSetup({
       catalog: catalogKey !== null,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -27,6 +27,7 @@ import {
   createChatPaneSessionActionCallbacks,
   readChatPaneMutationAccess,
   renderChatPaneComposerControls,
+  resolveChatModelCatalogState,
 } from "./chat-pane-session-controls.ts";
 import { resolveSidebarLayoutForBoard } from "./chat-pane-sidebar-layout.ts";
 import {
@@ -161,12 +162,11 @@ export class ChatPane extends ChatPaneLayoutRender {
       (agent) => agent.id === currentAgentId,
     );
     const agentDefaultModel = selectedAgent?.model?.primary;
-    const authoritativeModelCatalog =
-      state.connected && !state.chatModelCatalogError ? state.chatModelCatalog : [];
+    const modelCatalogState = resolveChatModelCatalogState(state);
     const modelUnavailable = isChatModelUnavailable(
       selectedSession?.model ?? agentDefaultModel,
       selectedSession?.modelProvider,
-      authoritativeModelCatalog,
+      modelCatalogState.status === "ready" ? state.chatModelCatalog : [],
     );
     const modelSetupRequired = requiresChatModelSetup({
       catalog: catalogKey !== null,

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -115,4 +115,55 @@ describe("chat pane composer controls", () => {
       {},
     );
   });
+
+  it.each([
+    ["ordinary picker open", false],
+    ["Retry", true],
+  ] as const)("uses the expected server-cache policy for %s", async (_label, refresh) => {
+    const container = document.createElement("div");
+    const request = vi.fn(async () => ({ models: [] }));
+    const state = {
+      chatRunId: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: { request },
+      chatLoading: false,
+      chatModelCatalog: [],
+      chatModelCatalogError: refresh ? "refresh failed" : null,
+      sessions: { state: { modelOverrides: {} }, patch: vi.fn() },
+      chatModelSwitchPromises: {},
+      sessionKey: "main",
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: undefined,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      onModelSetup: vi.fn(),
+    });
+    render(controls.composerControls, container);
+
+    if (refresh) {
+      container.querySelector<HTMLButtonElement>('[data-chat-model-catalog-retry="true"]')?.click();
+    } else {
+      const picker = container.querySelector<HTMLDetailsElement>(".chat-controls__model-picker");
+      picker!.open = true;
+      picker!.dispatchEvent(new Event("toggle"));
+    }
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    expect(request).toHaveBeenCalledWith("models.list", {
+      view: "configured",
+      agentId: "main",
+      ...(refresh ? { refresh: true } : {}),
+    });
+  });
 });

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -2,9 +2,68 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import { renderChatPaneComposerControls } from "./chat-pane-session-controls.ts";
+import {
+  renderChatPaneComposerControls,
+  resolveChatModelCatalogState,
+} from "./chat-pane-session-controls.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { renderChatPermissionPicker } from "./components/chat-permission-picker.ts";
+
+describe("chat model catalog state", () => {
+  const cachedCatalog = [
+    {
+      id: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      provider: "openai",
+      available: false,
+    },
+  ];
+
+  it.each([
+    {
+      label: "ready",
+      state: {
+        chatModelCatalog: [],
+        chatModelCatalogError: null,
+        chatModelsLoading: false,
+        connected: true,
+      },
+      expected: { hasSnapshot: true, status: "ready" },
+    },
+    {
+      label: "refreshing with a cached snapshot",
+      state: {
+        chatModelCatalog: cachedCatalog,
+        chatModelCatalogError: null,
+        chatModelsLoading: true,
+        connected: true,
+      },
+      expected: { hasSnapshot: true, status: "refreshing" },
+    },
+    {
+      label: "offline",
+      state: {
+        chatModelCatalog: cachedCatalog,
+        chatModelCatalogError: null,
+        chatModelsLoading: false,
+        connected: false,
+      },
+      expected: { hasSnapshot: true, status: "offline" },
+    },
+    {
+      label: "error",
+      state: {
+        chatModelCatalog: cachedCatalog,
+        chatModelCatalogError: "metadata unavailable",
+        chatModelsLoading: false,
+        connected: true,
+      },
+      expected: { hasSnapshot: true, status: "error" },
+    },
+  ])("resolves $label", ({ state, expected }) => {
+    expect(resolveChatModelCatalogState(state)).toEqual(expected);
+  });
+});
 
 describe("chat pane composer controls", () => {
   it("assembles model and permission controls as separate footer inputs", () => {

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -12,7 +12,10 @@ import { switchChatFastMode, switchChatModel, switchChatThinkingLevel } from "./
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { refreshChatModelCatalogOnDemand } from "./chat-state-refresh.ts";
 import type { ChatProps } from "./chat-view.ts";
-import { renderChatModelControls } from "./components/chat-model-controls.ts";
+import {
+  renderChatModelControls,
+  type ChatModelCatalogState,
+} from "./components/chat-model-controls.ts";
 import type { ChatPermissionPickerProps } from "./components/chat-permission-picker.ts";
 
 type SessionActionAccess = ReturnType<typeof readChatSessionActionAccess>;
@@ -46,6 +49,28 @@ export function readChatPaneMutationAccess(
   };
 }
 
+export function resolveChatModelCatalogState(
+  state: Pick<
+    ChatPageHost,
+    "chatModelCatalog" | "chatModelCatalogError" | "chatModelsLoading" | "connected"
+  >,
+): Omit<ChatModelCatalogState, "onRetry"> {
+  const hasSnapshot =
+    state.chatModelCatalog.length > 0 || (!state.chatModelsLoading && !state.chatModelCatalogError);
+  return {
+    hasSnapshot,
+    status: !state.connected
+      ? "offline"
+      : state.chatModelCatalogError
+        ? "error"
+        : state.chatModelsLoading
+          ? hasSnapshot
+            ? "refreshing"
+            : "loading"
+          : "ready",
+  };
+}
+
 export function renderChatPaneComposerControls(params: {
   state: ChatPageHost;
   selectedSession: GatewaySessionRow | undefined;
@@ -69,8 +94,7 @@ export function renderChatPaneComposerControls(params: {
     canSelectFull,
     onModelSetup,
   } = params;
-  const hasModelSnapshot =
-    state.chatModelCatalog.length > 0 || (!state.chatModelsLoading && !state.chatModelCatalogError);
+  const modelCatalogState = resolveChatModelCatalogState(state);
   return {
     composerControls: html`
       <div class="chat-composer-model-control">
@@ -82,17 +106,8 @@ export function renderChatPaneComposerControls(params: {
           loading: state.chatLoading,
           modelCatalog: state.chatModelCatalog,
           modelCatalogState: {
-            hasSnapshot: hasModelSnapshot,
+            ...modelCatalogState,
             onRetry: () => void refreshChatModelCatalogOnDemand(state, { refresh: true }),
-            status: !state.connected
-              ? "offline"
-              : state.chatModelCatalogError
-                ? "error"
-                : state.chatModelsLoading
-                  ? hasModelSnapshot
-                    ? "refreshing"
-                    : "loading"
-                  : "ready",
           },
           modelOverrides: state.sessions.state.modelOverrides,
           modelSelectionLocked: selectedSession?.modelSelectionLocked === true,

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -71,7 +71,6 @@ export function renderChatPaneComposerControls(params: {
   } = params;
   const hasModelSnapshot =
     state.chatModelCatalog.length > 0 || (!state.chatModelsLoading && !state.chatModelCatalogError);
-  const refreshModelCatalog = () => refreshChatModelCatalogOnDemand(state);
   return {
     composerControls: html`
       <div class="chat-composer-model-control">
@@ -84,14 +83,16 @@ export function renderChatPaneComposerControls(params: {
           modelCatalog: state.chatModelCatalog,
           modelCatalogState: {
             hasSnapshot: hasModelSnapshot,
-            onRetry: () => void refreshModelCatalog(),
-            status: state.chatModelCatalogError
-              ? "error"
-              : state.chatModelsLoading
-                ? hasModelSnapshot
-                  ? "refreshing"
-                  : "loading"
-                : "ready",
+            onRetry: () => void refreshChatModelCatalogOnDemand(state, { refresh: true }),
+            status: !state.connected
+              ? "offline"
+              : state.chatModelCatalogError
+                ? "error"
+                : state.chatModelsLoading
+                  ? hasModelSnapshot
+                    ? "refreshing"
+                    : "loading"
+                  : "ready",
           },
           modelOverrides: state.sessions.state.modelOverrides,
           modelSelectionLocked: selectedSession?.modelSelectionLocked === true,
@@ -110,7 +111,7 @@ export function renderChatPaneComposerControls(params: {
             effortAccess.allowed
               ? switchChatFastMode(state, next, targetSessionKey)
               : Promise.resolve(false),
-          onModelPickerOpen: refreshModelCatalog,
+          onModelPickerOpen: () => refreshChatModelCatalogOnDemand(state),
           onModelSelect: (next, targetSessionKey) =>
             modelAccess.allowed
               ? switchChatModel(state, next, targetSessionKey)

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -171,7 +171,10 @@ export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { re
   }
 }
 
-export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promise<void> {
+export async function refreshChatModelCatalogOnDemand(
+  host: ChatPageHost,
+  opts?: { refresh?: boolean },
+): Promise<void> {
   if (!host.client || !host.connected) {
     return;
   }
@@ -189,6 +192,7 @@ export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promi
   try {
     const models = await loadModels(client, {
       agentId,
+      ...(opts?.refresh ? { refresh: true } : {}),
       rejectOnFailure: true,
     });
     if (ownsRequest()) {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5248,6 +5248,51 @@ describe("chat model controls", () => {
     expect(onModelSetup).toHaveBeenCalledOnce();
   });
 
+  it("shows a successful empty catalog without authentication guidance", () => {
+    const { state } = createChatHeaderState({ models: [] });
+    const onModelSetup = vi.fn();
+    const container = renderModelControls(state, {
+      modelCatalogState: { hasSnapshot: true, status: "ready" },
+      onModelSetup,
+    });
+
+    expect(
+      container.querySelector('[data-chat-model-catalog-state="ready"]')?.textContent,
+    ).toContain("No models available");
+    expect(container.textContent).not.toContain("Authentication failed");
+    container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
+    expect(onModelSetup).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["offline", "Offline"],
+    ["error", "Couldn’t refresh models"],
+  ] as const)("gives %s precedence over a stale all-cold catalog", (status, expected) => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.6-sol",
+      modelProvider: "openai",
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          provider: "openai",
+          available: false,
+        },
+      ],
+    });
+    const container = renderModelControls(state, {
+      modelCatalogState: {
+        hasSnapshot: true,
+        status,
+        ...(status === "error" ? { onRetry: vi.fn() } : {}),
+      },
+    });
+
+    expect(container.textContent).toContain(expected);
+    expect(container.textContent).not.toContain("Authentication failed");
+    expect(container.querySelector('[data-chat-model-setup="true"]')).toBeNull();
+  });
+
   it("applies a model selection immediately", () => {
     const { state } = createOpenAiHeaderState();
     const onModelSelect = vi.fn(async () => true);

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -25,7 +25,7 @@ import { renderChatGoal } from "./chat-composer-goal.ts";
 import { renderChatComposerPlusMenu } from "./chat-composer-plus-menu.ts";
 import { renderChatQueue } from "./chat-composer-queue.ts";
 import { renderSkillMenu, type SkillMenuHost } from "./chat-composer-skill-menu.ts";
-import { renderSlashMenu } from "./chat-composer-slash-menu.ts";
+import { paneDomId, renderSlashMenu } from "./chat-composer-slash-menu.ts";
 import { commitComposerDraft } from "./chat-composer-state.ts";
 import {
   renderChatRunStatusIndicator,
@@ -157,6 +157,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     props.toolOverrides,
     t("chat.composer.menu.webSearch"),
   ).join(", ");
+  const disabledReasonId = paneDomId(props.paneId, "disabled-reason");
 
   return html`
     ${renderChatQueue({
@@ -352,7 +353,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
               : nothing}
             ${props.disabledReason
               ? html`
-                  <div class="agent-chat__disabled-reason">
+                  <div id=${disabledReasonId} class="agent-chat__disabled-reason">
                     <span>${props.disabledReason}</span>
                   </div>
                 `
@@ -414,7 +415,9 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                     slashMenuVisible || skillMenuVisible ? "true" : undefined,
                   )}
                   aria-activedescendant=${ifDefined(activeSlashMenuOptionId ?? undefined)}
-                  aria-describedby=${slashMenuAnnouncementId}
+                  aria-describedby=${`${slashMenuAnnouncementId}${
+                    props.disabledReason ? ` ${disabledReasonId}` : ""
+                  }`}
                   aria-keyshortcuts=${sendShortcut === "enter"
                     ? "Enter"
                     : "Control+Enter Meta+Enter"}

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -20,12 +20,12 @@ import {
 import { renderChatAuthorAvatar } from "./chat-author-avatar.ts";
 import type { ChatRunControlsProps } from "./chat-composer-controls.ts";
 import { renderChatPrimaryActions } from "./chat-composer-controls.ts";
-import { focusComposerFromChrome } from "./chat-composer-dom.ts";
+import { focusComposerFromChrome, paneDomId } from "./chat-composer-dom.ts";
 import { renderChatGoal } from "./chat-composer-goal.ts";
 import { renderChatComposerPlusMenu } from "./chat-composer-plus-menu.ts";
 import { renderChatQueue } from "./chat-composer-queue.ts";
 import { renderSkillMenu, type SkillMenuHost } from "./chat-composer-skill-menu.ts";
-import { paneDomId, renderSlashMenu } from "./chat-composer-slash-menu.ts";
+import { renderSlashMenu } from "./chat-composer-slash-menu.ts";
 import { commitComposerDraft } from "./chat-composer-state.ts";
 import {
   renderChatRunStatusIndicator,

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -222,12 +222,9 @@ export function renderChatComposer(props: ChatComposerProps) {
   state.questionTakeoverActive = questionTakeoverActive;
   const showComposer = !questionTakeoverActive;
 
-  const placeholder =
-    !canCompose && props.disabledReason
-      ? props.disabledReason
-      : hasVisualAttachments
-        ? t("chat.composer.placeholderWithAttachments")
-        : t("chat.composer.placeholder", { name: props.assistantName || "agent" });
+  const placeholder = hasVisualAttachments
+    ? t("chat.composer.placeholderWithAttachments")
+    : t("chat.composer.placeholder", { name: props.assistantName || "agent" });
 
   // Offline text and attachments may enter the persisted reconnect queue, but
   // slash commands are live controls and must not execute against stale state.

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -152,10 +152,6 @@ function formatPickerModelLabel(label: string): string {
   return match?.[1] ?? label;
 }
 
-function modelAuthenticationNeededText(): string {
-  return `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`;
-}
-
 export function renderChatModelControls(props: ChatModelControlsProps) {
   const {
     currentOverride,
@@ -333,16 +329,21 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   const catalogLoadingWithoutSnapshot =
     !managedCatalog.hasSnapshot &&
     ["idle", "loading", "refreshing"].includes(managedCatalog.status);
-  const catalogErrorWithoutSnapshot =
-    managedCatalog.status === "error" && !managedCatalog.hasSnapshot;
   const catalogSnapshotEmpty = managedCatalog.hasSnapshot && modelOptions.length === 0;
-  const catalogTriggerStatus = catalogLoadingWithoutSnapshot
-    ? t("chat.modelControls.loadingModels")
-    : catalogErrorWithoutSnapshot
-      ? t("chat.modelControls.modelsUnavailable")
-      : catalogSnapshotEmpty
-        ? modelAuthenticationNeededText()
-        : undefined;
+  const catalogTriggerStatus =
+    managedCatalog.status === "offline"
+      ? t("common.offline")
+      : managedCatalog.status === "error"
+        ? t(
+            managedCatalog.hasSnapshot
+              ? "chat.modelControls.modelsRefreshFailed"
+              : "chat.modelControls.modelsUnavailable",
+          )
+        : catalogLoadingWithoutSnapshot
+          ? t("chat.modelControls.loadingModels")
+          : catalogSnapshotEmpty
+            ? t("chat.modelControls.noModelsAvailable")
+            : undefined;
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;
   const commonDisabled =

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -16,7 +16,7 @@ import { syncChatPickerOverlay } from "./chat-picker-overlay.ts";
 export type ChatModelCatalogState = {
   hasSnapshot: boolean;
   onRetry?: () => void;
-  status: "idle" | "loading" | "refreshing" | "ready" | "error";
+  status: "idle" | "loading" | "refreshing" | "ready" | "error" | "offline";
 };
 
 type ChatModelPickerParams = {
@@ -231,15 +231,19 @@ function renderCatalogState(
     return nothing;
   }
   const label =
-    state.status === "refreshing"
-      ? t("chat.modelControls.refreshingModels")
-      : state.status === "error"
-        ? state.hasSnapshot
-          ? t("chat.modelControls.modelsRefreshFailed")
-          : t("chat.modelControls.modelsUnavailable")
-        : state.status === "ready"
-          ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
-          : t("chat.modelControls.loadingModels");
+    state.status === "offline"
+      ? t("common.offline")
+      : state.status === "refreshing"
+        ? t("chat.modelControls.refreshingModels")
+        : state.status === "error"
+          ? state.hasSnapshot
+            ? t("chat.modelControls.modelsRefreshFailed")
+            : t("chat.modelControls.modelsUnavailable")
+          : state.status === "ready"
+            ? hasOptions
+              ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
+              : t("chat.modelControls.noModelsAvailable")
+            : t("chat.modelControls.loadingModels");
   return html`
     <div
       class="chat-controls__model-catalog-state ${hasOptions

--- a/ui/src/pages/chat/models.ts
+++ b/ui/src/pages/chat/models.ts
@@ -58,6 +58,7 @@ export async function loadModels(
     cached?.models,
     agentId,
     opts.preparedOnly === true,
+    opts.refresh === true,
     rejectOnFailure,
   )
     .then((result) => {
@@ -97,6 +98,7 @@ async function requestModels(
   fallback: ModelCatalogEntry[] | undefined,
   agentId: string,
   preparedOnly: boolean,
+  refresh: boolean,
   rejectOnFailure: boolean,
 ): Promise<{ models: ModelCatalogEntry[]; fresh: boolean }> {
   try {
@@ -104,6 +106,7 @@ async function requestModels(
       view: "configured",
       agentId,
       ...(preparedOnly ? { preparedOnly: true } : {}),
+      ...(refresh ? { refresh: true } : {}),
     });
     return { models: result?.models ?? [], fresh: true };
   } catch (error) {

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -70,6 +70,7 @@ describe("loadModelProvidersData", () => {
     expect(request).toHaveBeenCalledWith("models.list", {
       view: "configured",
       agentId: "writer",
+      refresh: true,
     });
     expect(request).toHaveBeenCalledWith("usage.status");
     const sessionUsageCall = request.mock.calls.find(([method]) => method === "sessions.usage");

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -222,35 +222,42 @@ describe("new-session model runtime", () => {
     pending.resolve({ models: [] });
   });
 
-  it("renders a cached catalog immediately while a remounted control revalidates", async () => {
+  it("does not auth-block a cached all-cold catalog until revalidation completes", async () => {
     const models: ModelCatalogEntry[] = [
-      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        available: false,
+      },
     ];
+    const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
     const refresh = deferred<{ models: ModelCatalogEntry[] }>();
     const { context, request } = contextWith(models);
     const firstControl = new NewSessionModelControl(() => undefined);
-    firstControl.load(context, "main", true);
-    await vi.waitFor(() =>
-      expect(
-        renderControl(firstControl, context).querySelector(
-          '[data-chat-model-option="openai/gpt-5.6-luna"]',
-        ),
-      ).not.toBeNull(),
-    );
+    firstControl.load(context, "main", true, { agent });
+    await vi.waitFor(() => expect(firstControl.isModelUnavailable(agent)).toBe(true));
     request.mockReturnValueOnce(refresh.promise);
 
     const remountedControl = new NewSessionModelControl(() => undefined);
-    remountedControl.load(context, "main", true);
+    remountedControl.load(context, "main", true, { agent });
 
-    const container = renderControl(remountedControl, context);
+    let container = renderControl(remountedControl, context, "main", agent);
     expect(container.querySelector('[data-chat-model-catalog-state="refreshing"]')).not.toBeNull();
-    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).not.toContain(
-      "Loading models",
+    expect(remountedControl.isModelUnavailable(agent)).toBe(false);
+    expect(container.textContent).not.toContain(
+      "Authentication failed. Review the provider credential or sign-in, then retry.",
     );
     expect(
       container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
     ).not.toBeNull();
     refresh.resolve({ models });
+    await vi.waitFor(() => expect(remountedControl.isModelUnavailable(agent)).toBe(true));
+    container = renderControl(remountedControl, context, "main", agent);
+    expect(container.querySelector('[data-chat-model-catalog-state="ready"]')).not.toBeNull();
+    expect(container.textContent).toContain(
+      "Authentication failed. Review the provider credential or sign-in, then retry.",
+    );
   });
 
   it("keeps a shared metadata request alive when its first control is torn down", async () => {
@@ -589,9 +596,15 @@ describe("new-session model runtime", () => {
     request.mockResolvedValueOnce({ models: availableModels });
     container.querySelector<HTMLButtonElement>('[data-chat-model-catalog-retry="true"]')?.click();
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
-    await vi.waitFor(() => expect(control.isModelUnavailable(agent)).toBe(false));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context, "main", agent).querySelector(
+          "[data-chat-model-catalog-state]",
+        ),
+      ).toBeNull(),
+    );
+    expect(control.isModelUnavailable(agent)).toBe(false);
     container = renderControl(control, context, "main", agent);
-    expect(container.querySelector("[data-chat-model-catalog-state]")).toBeNull();
     expect(
       container.querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.6-luna"]')
         ?.disabled,

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -505,7 +505,8 @@ describe("new-session model runtime", () => {
     request.mockReturnValueOnce(refresh.promise);
 
     control.load(context, "main", true);
-    expect(renderControl(control, context).textContent).toContain("Authentication failed");
+    expect(renderControl(control, context).textContent).toContain("No models available");
+    expect(renderControl(control, context).textContent).not.toContain("Authentication failed");
 
     refresh.reject(new Error("refresh failed"));
     await vi.waitFor(() =>
@@ -516,9 +517,85 @@ describe("new-session model runtime", () => {
     const container = renderControl(control, context);
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
-      "Authentication failed",
+      "Couldn’t refresh models",
     );
+    expect(container.textContent).not.toContain("Authentication failed");
     expect(container.textContent).not.toContain("GPT-5.6 Luna");
+  });
+
+  it("treats a disconnected stale all-cold catalog as offline and non-authoritative", async () => {
+    const coldModels: ModelCatalogEntry[] = [
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        available: false,
+      },
+    ];
+    const { context } = contextWith(coldModels);
+    const control = new NewSessionModelControl(() => undefined);
+    const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
+    control.load(context, "main", true, { agent });
+    await vi.waitFor(() => expect(control.isModelUnavailable(agent)).toBe(true));
+
+    const offlineContext = {
+      ...context,
+      gateway: {
+        ...context.gateway,
+        snapshot: { ...context.gateway.snapshot, client: null, phase: "reconnecting" },
+      },
+    } as unknown as ApplicationContext;
+    control.load(offlineContext, "main", true, { agent });
+
+    const container = renderControl(control, offlineContext, "main", agent);
+    expect(container.querySelector('[data-chat-model-catalog-state="offline"]')).not.toBeNull();
+    expect(container.textContent).toContain("Offline");
+    expect(container.textContent).not.toContain("Authentication failed");
+    expect(control.isModelUnavailable(agent)).toBe(false);
+  });
+
+  it("drops the stale auth gate on refresh error and restores selection after recovery", async () => {
+    const coldModels: ModelCatalogEntry[] = [
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        available: false,
+      },
+    ];
+    const availableModels: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", available: true },
+    ];
+    const { context, request } = contextWith(coldModels);
+    const control = new NewSessionModelControl(() => undefined);
+    const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
+    control.load(context, "main", true, { agent });
+    await vi.waitFor(() => expect(control.isModelUnavailable(agent)).toBe(true));
+
+    request.mockRejectedValueOnce(new Error("refresh failed"));
+    control.load(context, "main", true, { agent });
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context, "main", agent).querySelector(
+          '[data-chat-model-catalog-state="error"]',
+        ),
+      ).not.toBeNull(),
+    );
+    let container = renderControl(control, context, "main", agent);
+    expect(container.textContent).toContain("Couldn’t refresh models");
+    expect(container.textContent).not.toContain("Authentication failed");
+    expect(control.isModelUnavailable(agent)).toBe(false);
+
+    request.mockResolvedValueOnce({ models: availableModels });
+    container.querySelector<HTMLButtonElement>('[data-chat-model-catalog-retry="true"]')?.click();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(control.isModelUnavailable(agent)).toBe(false));
+    container = renderControl(control, context, "main", agent);
+    expect(container.querySelector("[data-chat-model-catalog-state]")).toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.6-luna"]')
+        ?.disabled,
+    ).toBe(false);
   });
 
   it("preserves the remembered pair when metadata validation fails", async () => {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -397,7 +397,7 @@ export class NewSessionModelControl {
   isModelUnavailable(agent: GatewayAgentRow | undefined): boolean {
     return (
       this.metadataState.hasSnapshot &&
-      (this.metadataState.status === "ready" || this.metadataState.status === "refreshing") &&
+      this.metadataState.status === "ready" &&
       isChatModelUnavailable(this.selected || agent?.model?.primary, undefined, this.catalog)
     );
   }

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -358,10 +358,10 @@ export class NewSessionModelControl {
     if (!context || snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
       this.cancelMetadataRequest();
       this.restoringPreference = false;
-      if (snapshot?.phase !== "connected" && this.metadataState.hasSnapshot) {
+      if (context && snapshot?.phase !== "connected") {
         this.metadataState = {
           ...this.metadataState,
-          status: "error",
+          status: "offline",
         };
       }
       this.notify();
@@ -397,6 +397,7 @@ export class NewSessionModelControl {
   isModelUnavailable(agent: GatewayAgentRow | undefined): boolean {
     return (
       this.metadataState.hasSnapshot &&
+      (this.metadataState.status === "ready" || this.metadataState.status === "refreshing") &&
       isChatModelUnavailable(this.selected || agent?.model?.primary, undefined, this.catalog)
     );
   }


### PR DESCRIPTION
Closes #125509

## What Problem This Solves

Fixes an issue where opening the model picker during a Gateway restart, reconnect, or failed catalog refresh could show actionable authentication-failure guidance—and duplicate it in the composer—even when provider credentials were healthy.

The completed-ready catalog P1 findings in the durable ClawSweeper review are addressed: cached all-cold rows no longer auth-block Chat or New Session while catalog metadata is pending. Authentication gating now consumes availability only after the canonical catalog state is exactly `ready`.

## Why This Change Was Made

The catalog state now treats connection and refresh freshness as authoritative before model availability. Empty, offline, refresh-error, refreshing, and authoritative all-cold states are distinct. The shared `resolveChatModelCatalogState` helper is the canonical Chat freshness owner, and both Chat auth gating and New Session's `isModelUnavailable` predicate use completed-ready state as the authority boundary.

Deferred reconnect/startup browser coverage proves that a stale all-cold cache remains visible but does not auth-block while metadata is pending, then a completed ready all-cold response restores the intended block. A cached-refreshing New Session regression covers the same boundary. Retry still bypasses both browser and Gateway catalog caches, while the visible composer reason remains the single explanation owner for disabled input.

Current `main` also contained the task/session suggestion owner extraction needed to keep `chat-pane-render.ts` below the 700-line limit. During the required conflict rebase, the earlier PR-local extraction was dropped in favor of current `main`'s stronger combined `suggestionChatProps` owner. Before that rebase the renderer was 675 effective / 688 physical lines; the rebased renderer is 602 physical lines.

The latest integration rebase also followed current `main`'s ownership move for `paneDomId`: `chat-composer-view.ts` now imports the pane ID from `chat-composer-dom.ts`, its current owner, rather than from the slash-menu module that no longer exports it.

## User Impact

Operators now see Offline or catalog-refresh guidance during lifecycle interruptions, a generic `No models available` state for genuinely empty catalogs, and authentication recovery only when a completed authoritative catalog supports that diagnosis. Reconnect or Retry restores the picker without unnecessary credential churn. Model Setup remains available for empty catalogs, while ready all-cold catalogs still block send/start and show the configured unavailable models and recovery guidance.

## Evidence

The original live incident was correlated with a service restart and later successful HTTP 200 provider calls. The deterministic browser proof in this PR uses the mocked Gateway; the exact production auto-update restart was not repeated. Related history #121852 and #123130 informed the lifecycle context.

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-composer.test.ts ui/src/pages/chat/chat-pane-session-controls.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/models.test.ts ui/src/pages/model-providers/load.test.ts ui/src/pages/new-session/model-control.test.ts` — latest integration/import proof: 6 focused unit files, 334 tests passed. The completed-ready repair was also proven earlier across 7 focused files with 345 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 1 file, 3 tests passed for the latest integration/import proof.
- `node scripts/check-changed.mjs` — the first broad run hit the 10-minute harness timeout only after the full dead-code scan plus i18n and type checks passed. `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs` then skipped only that already-proven dead-code lane and completed the remaining changed-gate plan green.
- `git diff --check origin/main...HEAD` — passed.
- Fresh uncommitted autoreview covering the import fix: `.claude/skills/autoreview/scripts/autoreview --mode uncommitted --max-priority P1` — clean; no accepted/actionable findings, 0.99 correctness.
- Two flaky remote UI E2E shards on the prior head reproduced locally as 28/28 passing. Exact-head CI on the current rebased head is authoritative for landing.
- Earlier exact-head CI run [32091150641](https://github.com/openclaw/openclaw/actions/runs/32091150641) found one stale sibling expectation in `ui/src/pages/model-providers/load.test.ts`; the test reproduced locally and was mechanically updated to expect the already-reviewed `refresh: true` request shape, with no production change.
- Exact triple-dot patch against rebase base `9de3ca5fc93d77b358403ffae15879380a241f72`: production +81/-50 (net +31), tests +344/-21 (net +323), 15 UI files total. Current head: `d3455cb0b047961af3b774ff41b8243da4d5e69c`.

### Visual proof

Before: restart-time stale availability was presented as duplicate authentication guidance.

![Before: duplicate authentication guidance](https://github.com/user-attachments/assets/5db65e4f-49e7-4f60-bae1-6fafb3ff17c5)

After: an authoritative all-cold catalog retains configured models, authentication guidance, Model Setup, and blocked send/start behavior.

![After: authoritative all-cold catalog](https://github.com/user-attachments/assets/d0101e31-064e-46b4-b3e3-1c3afc172032)

Offline during a lifecycle interruption:

![Offline catalog state](https://github.com/user-attachments/assets/e8a29bd8-5324-4a09-bbf0-338e412ccc9a)

Catalog refresh failure takes precedence over stale unavailable rows:

![Catalog refresh error state](https://github.com/user-attachments/assets/bcef8323-9241-4eb7-ad29-a0b2731c2696)

Recovered after Retry:

![Recovered model catalog](https://github.com/user-attachments/assets/023203c8-b965-4881-a5da-d15c51ce4cca)

https://github.com/user-attachments/assets/1176f719-5420-4228-ad26-387b64bf0bdf

The executable browser E2E owns the deferred reconnect, ready transition, Retry request, and queue/action clauses that a short recording cannot establish on its own.

AI-assisted: Yes.
