### PR TITLE
fix: conversation turns bind discovered peers after threaded activity

### DIFF
--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -286,11 +286,11 @@ export function deriveSessionMetaPatch(params: {
   return Object.keys(patch).length > 0 ? patch : null;
 }
 
-function removeThreadFromDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
-  if (!context || context.threadId == null) {
-    return context;
+function withoutThread<T extends { threadId?: string | number }>(identity?: T): T | undefined {
+  if (!identity || identity.threadId == null) {
+    return identity;
   }
-  const next: DeliveryContext = { ...context };
+  const next: T = { ...identity };
   delete next.threadId;
   return next;
 }
@@ -344,8 +344,11 @@ export function deriveLastRoutePatch(params: {
   );
   const clearThreadFromFallback = explicitRouteProvided && explicitThreadValue == null;
   const fallbackContext = clearThreadFromFallback
-    ? removeThreadFromDeliveryContext(deliveryContextFromSession(existing))
+    ? withoutThread(deliveryContextFromSession(existing))
     : deliveryContextFromSession(existing);
+  const existingOrigin = sessionDeliveryOrigin(existing);
+  // Explicit thread absence owns both fallbacks, so origin cannot restore a stale thread.
+  const fallbackOrigin = clearThreadFromFallback ? withoutThread(existingOrigin) : existingOrigin;
   const merged = mergeDeliveryContext(mergedInput, fallbackContext);
   const delivery = normalizeSessionDeliveryState({
     route: params.route,
@@ -355,7 +358,7 @@ export function deriveLastRoutePatch(params: {
       accountId: merged?.accountId,
       threadId: merged?.threadId,
     },
-    origin: sessionDeliveryOrigin(existing),
+    origin: fallbackOrigin,
   });
   const nextEntry = existing ? { ...existing, delivery } : ({ delivery } as SessionEntry);
   const metaPatch = ctx

--- a/src/infra/outbound/outbound-session.integration.test.ts
+++ b/src/infra/outbound/outbound-session.integration.test.ts
@@ -4,6 +4,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import type { OpenClawConfig } from "../../config/config.js";
 import { buildConversationIdentity } from "../../config/sessions/conversation-identity.js";
 import {
+  listConversations,
   registerConversationAddresses,
   resolveConversation,
 } from "../../config/sessions/conversation-registry.js";
@@ -13,6 +14,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
+  deliveryContextFromSession,
   normalizeSessionDeliveryState,
   sessionDeliveryOrigin,
 } from "../../utils/delivery-context.shared.js";
@@ -81,6 +83,78 @@ describe("outbound session persistence", () => {
       role: "participant",
       target: "@molty",
     });
+  });
+
+  it("binds a newer threadless address without restoring the established thread", async () => {
+    const sessionKey = "agent:main:main";
+    const peerId = "reef:contact-42";
+    const target = "reef:contact-42";
+    const threadId = "thread-7";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey, storePath },
+      {
+        sessionId: "shared-main-session",
+        updatedAt: 100,
+        chatType: "direct",
+        delivery: normalizeSessionDeliveryState({
+          context: { channel: "reef", accountId: "default", to: target, threadId },
+          origin: {
+            provider: "reef",
+            accountId: "default",
+            chatType: "direct",
+            from: peerId,
+            to: target,
+            threadId,
+          },
+        }),
+      },
+    );
+    const threadlessIdentity = buildConversationIdentity({
+      channel: "reef",
+      accountId: "default",
+      kind: "direct",
+      peerId,
+      deliveryTarget: target,
+      nativeDirectUserId: "contact-42",
+    });
+    expect(threadlessIdentity).toBeDefined();
+    const established = loadExactSessionEntry({ agentId: "main", sessionKey, storePath });
+    expect(established).toBeDefined();
+    registerConversationAddresses(
+      { agentId: "main", storePath },
+      [threadlessIdentity!],
+      established!.entry.updatedAt + 1,
+    );
+
+    const discovered = listConversations({ agentId: "main", storePath }, { channel: "reef" });
+    expect(discovered[0]?.conversationRef).toBe(threadlessIdentity!.conversationRef);
+    expect(discovered[0]).not.toMatchObject({ sessionId: expect.any(String) });
+
+    await bindOutboundSessionEntry({
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      channel: "reef",
+      accountId: "default",
+      route: {
+        sessionKey,
+        baseSessionKey: sessionKey,
+        peer: { kind: "direct", id: "contact-42" },
+        chatType: "direct",
+        from: peerId,
+        to: target,
+      },
+    });
+
+    expect(
+      resolveConversation({ agentId: "main", storePath }, threadlessIdentity!.conversationRef),
+    ).toMatchObject({
+      sessionId: "shared-main-session",
+      sessionKey,
+      role: "participant",
+      target,
+    });
+    const persisted = loadExactSessionEntry({ agentId: "main", sessionKey, storePath });
+    expect(deliveryContextFromSession(persisted?.entry)?.threadId).toBeUndefined();
+    expect(sessionDeliveryOrigin(persisted?.entry)?.threadId).toBeUndefined();
   });
 
   it("creates the session row when a discovered peer has no local entry", async () => {


### PR DESCRIPTION
Related: #110018

## What Problem This Solves

Fixes an issue where an agent selecting a directory-discovered, threadless conversation after prior threaded activity with the same peer could fail before delivery because the conversation could not create its local context binding.

## Why This Change Was Made

An explicit threadless destination now clears the stale thread from both canonical delivery-context and origin fallbacks before session persistence. Directory-only and thread-bound addresses remain distinct and list ordering is unchanged; the repair makes every returned discovery address actionable instead of hiding the failure through ranking.

AI-assisted: yes. The change was source-audited, regression-tested, and independently reviewed. Agent transcripts are intentionally omitted.

## User Impact

`conversations_turn` can now lazily bind and send to a discovered peer even when the local session previously held a threaded route for that same channel, account, and peer.

## Evidence

- Live Reef observation on public source SHA `682b05dcac0d8324527d2ed0618e57c54e5f0282`: the fresh directory address appeared before an established threaded address and failed before send with a local-context-binding error; the threaded address succeeded.
- Pre-fix regression: `node scripts/run-vitest.mjs src/infra/outbound/outbound-session.integration.test.ts` failed because the selected threadless conversation still lacked `sessionId`, `sessionKey`, and `role` after binding.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/infra/outbound/outbound-session.integration.test.ts src/config/sessions/origin-channel-switch.test.ts src/utils/delivery-context.test.ts src/config/sessions/conversation-registry.test.ts src/gateway/conversation-turn.test.ts`.
- Changed-file validation: `node scripts/check-changed.mjs -- src/config/sessions/metadata.ts src/infra/outbound/outbound-session.integration.test.ts`.
- Fresh Codex autoreview: no accepted or actionable findings.
- Production LOC: +9/-6 (net +3). Tests: +74/-0.
- Post-fix live Reef replay was not run because this worktree has no isolated Reef credentials/state and the operator gateway was not touched. The user authorized landing with the deterministic owner-boundary regression, sibling coverage, independent review, and exact-head CI.
