### PR TITLE
fix(agents): rebind tool search snapshot executors

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2063,7 +2063,7 @@ src/agents/tool-mutation-names.ts	2
 src/agents/tool-policy-shared.ts	1
 src/agents/tool-result-error.ts	3
 src/agents/tool-schema-hints.ts	1
-src/agents/tool-search-catalog.ts	6
+src/agents/tool-search-catalog.ts	4
 src/agents/tool-search-directory.ts	1
 src/agents/tool-search-runtime.ts	4
 src/agents/tool-search-transcript.ts	3

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "@openclaw/normalization-core";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { generateSecureToken } from "../infra/secure-random.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
@@ -26,19 +27,14 @@ import {
 import { ToolInputError, type AnyAgentTool } from "./tools/common.js";
 
 const MAX_REUSABLE_CATALOG_SNAPSHOTS = 256;
+type ReusableCatalogDescriptor = Readonly<Omit<ToolSearchCatalogEntry, "tool">>;
 const reusableCatalogSnapshots = new Map<
   string,
-  { entries: ToolSearchCatalogEntry[]; fingerprint: string }
+  { descriptors: readonly ReusableCatalogDescriptor[]; fingerprint: string }
 >();
 const catalogFingerprints = new WeakMap<ToolSearchCatalogSession, string>();
-const catalogToolIdentities = new WeakMap<object, number>();
 const untrustedSchemaIdentities = new WeakMap<object, number>();
-let nextCatalogToolIdentity = 1;
 let nextUntrustedSchemaIdentity = 1;
-
-export function getReusableCatalogSnapshotCountForTest(): number {
-  return reusableCatalogSnapshots.size;
-}
 
 function reusableCatalogKey(input: {
   sessionId?: string;
@@ -55,76 +51,61 @@ function reusableCatalogKey(input: {
   return agentId ? `agent:${agentId}` : undefined;
 }
 
-function stableJsonFingerprint(value: unknown, seen = new WeakSet<object>()): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value) ?? "undefined";
-  }
-  if (seen.has(value)) {
-    return '"[Circular]"';
-  }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJsonFingerprint(item, seen)).join(",")}]`;
-  }
-  const record = value as Record<string, unknown>;
-  const entries = Object.keys(record)
+function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): string {
+  return entries
+    .map((entry) =>
+      stableStringify([
+        entry.id,
+        entry.source,
+        entry.sourceName ?? "",
+        entry.mcp,
+        entry.name,
+        entry.label ?? "",
+        entry.description,
+        entry.source === "openclaw"
+          ? stableStringify(entry.parameters)
+          : untrustedSchemaFingerprint(entry.parameters),
+        entry.source === "openclaw"
+          ? stableStringify(entry.outputSchema)
+          : untrustedSchemaFingerprint(entry.outputSchema),
+      ]),
+    )
     .toSorted()
-    .map((key) => `${JSON.stringify(key)}:${stableJsonFingerprint(record[key], seen)}`);
-  return `{${entries.join(",")}}`;
-}
-
-function catalogToolIdentity(tool: CatalogTool): number {
-  const existing = catalogToolIdentities.get(tool);
-  if (existing !== undefined) {
-    return existing;
-  }
-  const next = nextCatalogToolIdentity;
-  nextCatalogToolIdentity += 1;
-  catalogToolIdentities.set(tool, next);
-  return next;
+    .join("\n");
 }
 
 function untrustedSchemaFingerprint(schema: unknown): string {
   if (schema === null || typeof schema !== "object") {
-    return stableJsonFingerprint(schema);
+    return stableStringify(schema);
   }
+  // Remote/client schemas may be attacker-sized or lazy hostile objects. Identity
+  // invalidates reuse when their owning runtime replaces them without traversing them.
   const existing = untrustedSchemaIdentities.get(schema);
   if (existing !== undefined) {
     return `object:${existing}`;
   }
-  const next = nextUntrustedSchemaIdentity;
-  nextUntrustedSchemaIdentity += 1;
+  const next = nextUntrustedSchemaIdentity++;
   untrustedSchemaIdentities.set(schema, next);
   return `object:${next}`;
 }
 
-function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): string {
-  // Executable identities are part of reuse because function bodies are not JSON-stable.
-  return entries
-    .map((entry) =>
-      [
-        entry.id,
-        entry.source,
-        entry.sourceName ?? "",
-        stableJsonFingerprint(entry.mcp),
-        entry.name,
-        entry.label ?? "",
-        entry.description,
-        // Remote/client schemas may be attacker-sized. Object identity still
-        // invalidates reuse when a schema object is replaced without walking it.
-        entry.source === "openclaw"
-          ? stableJsonFingerprint(entry.parameters)
-          : untrustedSchemaFingerprint(entry.parameters),
-        entry.source === "openclaw"
-          ? stableJsonFingerprint(entry.outputSchema)
-          : untrustedSchemaFingerprint(entry.outputSchema),
-        String(catalogToolIdentity(entry.tool)),
-      ]
-        .map((part) => JSON.stringify(part))
-        .join(":"),
-    )
-    .toSorted()
-    .join("\n");
+function rebindCatalogExecutors(
+  descriptors: readonly ReusableCatalogDescriptor[],
+  currentEntries: readonly ToolSearchCatalogEntry[],
+): ToolSearchCatalogEntry[] | undefined {
+  const currentTools = new Map(currentEntries.map((entry) => [entry.id, entry.tool]));
+  if (currentTools.size !== currentEntries.length || currentTools.size !== descriptors.length) {
+    return undefined;
+  }
+  const rebound = descriptors.map((descriptor) => {
+    // Catalog ids are the callable identity. Every hit binds that exact entry to
+    // this run's closure; a missing id must miss instead of retaining stale authority.
+    const tool = currentTools.get(descriptor.id);
+    return tool ? { ...descriptor, tool } : undefined;
+  });
+  return rebound.every((entry): entry is ToolSearchCatalogEntry => entry !== undefined)
+    ? rebound
+    : undefined;
 }
 
 function restoreToolSearchCatalog(params: {
@@ -156,7 +137,12 @@ function rememberReusableCatalog(key: string | undefined, catalog: ToolSearchCat
   if (reusableCatalogSnapshots.has(key)) {
     reusableCatalogSnapshots.delete(key);
   }
-  reusableCatalogSnapshots.set(key, { entries: catalog.entries, fingerprint });
+  reusableCatalogSnapshots.set(key, {
+    descriptors: Object.freeze(
+      catalog.entries.map(({ tool: _tool, ...descriptor }) => Object.freeze(descriptor)),
+    ),
+    fingerprint,
+  });
   pruneMapToMaxSize(reusableCatalogSnapshots, MAX_REUSABLE_CATALOG_SNAPSHOTS);
 }
 
@@ -485,6 +471,7 @@ export function applyToolCatalogCompaction(
 
   const visible: AnyAgentTool[] = [];
   const catalog: ToolSearchCatalogEntry[] = [];
+  let hasPrewrappedInput = false;
   const shouldCatalog = (tool: AnyAgentTool) =>
     shouldCatalogTool(tool) && (params.shouldCatalogTool?.(tool) ?? true);
   for (const tool of params.tools) {
@@ -496,6 +483,7 @@ export function applyToolCatalogCompaction(
       continue;
     }
     if (shouldCatalog(tool)) {
+      hasPrewrappedInput ||= isToolWrappedWithBeforeToolCallHook(tool);
       catalog.push(toCatalogEntry(tool, undefined, params.toolHookContext));
       if (!params.isVisibleCatalogTool?.(tool)) {
         continue;
@@ -503,30 +491,39 @@ export function applyToolCatalogCompaction(
     }
     visible.push(tool);
   }
-  // Hook-wrapped entries carry run context and have fresh executable identities, so
-  // their snapshots cannot be reused and would only retain the completed run.
-  const hasHookBoundEntry = catalog.some((entry) =>
-    isToolWrappedWithBeforeToolCallHook(entry.tool as AnyAgentTool),
-  );
-  const reusableKey = hasHookBoundEntry ? undefined : reusableCatalogKey(params);
+  // Prewrapped inputs already close over a run's hook and abort state. Only
+  // wrappers created during cataloging are safe to reuse through executor rebinding.
+  const reusableKey = hasPrewrappedInput ? undefined : reusableCatalogKey(params);
   const existingCatalog = catalogRef.current;
   const incomingFingerprint =
     existingCatalog || reusableKey ? catalogEntriesFingerprint(catalog) : undefined;
   if (existingCatalog && catalogFingerprints.get(existingCatalog) === incomingFingerprint) {
-    return {
-      tools: visible,
-      compacted: catalog.length > 0,
-      catalogToolCount: catalog.length,
-      catalogRegistered: true,
-      catalogReused: true,
-    };
+    const reboundEntries = rebindCatalogExecutors(existingCatalog.entries, catalog);
+    if (reboundEntries) {
+      if (
+        existingCatalog.entries.some((entry, index) => entry.tool !== reboundEntries[index]?.tool)
+      ) {
+        existingCatalog.entries = reboundEntries;
+      }
+      return {
+        tools: visible,
+        compacted: catalog.length > 0,
+        catalogToolCount: catalog.length,
+        catalogRegistered: true,
+        catalogReused: true,
+      };
+    }
   }
 
   const reusableSnapshot = reusableKey ? reusableCatalogSnapshots.get(reusableKey) : undefined;
-  if (reusableSnapshot && reusableSnapshot.fingerprint === incomingFingerprint) {
+  const reboundEntries =
+    reusableSnapshot && reusableSnapshot.fingerprint === incomingFingerprint
+      ? rebindCatalogExecutors(reusableSnapshot.descriptors, catalog)
+      : undefined;
+  if (reusableSnapshot && reboundEntries) {
     restoreToolSearchCatalog({
       catalogRef,
-      entries: reusableSnapshot.entries,
+      entries: reboundEntries,
       fingerprint: reusableSnapshot.fingerprint,
     });
     if (reusableKey) {

--- a/src/agents/tool-search.test-support.ts
+++ b/src/agents/tool-search.test-support.ts
@@ -2,7 +2,6 @@ import type { ToolSearchConfig, ToolSearchRuntime } from "./tool-search.js";
 import "./tool-search.js";
 
 type ToolSearchTestApi = {
-  getReusableCatalogSnapshotCountForTest(): number;
   maxToolSchemaDirectoryPromptChars: number;
   setToolSearchCodeModeSupportedForTest(value: boolean | undefined): void;
   setToolSearchMinCodeTimeoutMsForTest(value: number | undefined): void;
@@ -24,8 +23,6 @@ function getTestApi(): ToolSearchTestApi {
 }
 
 export const testing: ToolSearchTestApi = {
-  getReusableCatalogSnapshotCountForTest: () =>
-    getTestApi().getReusableCatalogSnapshotCountForTest(),
   get maxToolSchemaDirectoryPromptChars() {
     return getTestApi().maxToolSchemaDirectoryPromptChars;
   },

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
+import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { toToolDefinitions } from "./agent-tool-definition-adapter.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
@@ -3752,8 +3754,28 @@ describe("Tool Search", () => {
     });
     expect(later.catalogReused).toBe(true);
     expect(laterRef.current).not.toBe(catalogAfterFirst);
-    expect(laterRef.current?.entries).toBe(catalogAfterFirst.entries);
+    expect(laterRef.current?.entries).not.toBe(catalogAfterFirst.entries);
+    expect(laterRef.current?.entries).toEqual(catalogAfterFirst.entries);
     expect(laterRef.current?.counterScope).not.toBe(catalogAfterFirst.counterScope);
+  });
+
+  it("rebinds fresh non-MCP executors on same-run reuse", async () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = { tools: { toolSearch: true } } as never;
+    const catalogRef = createToolSearchCatalogRef();
+    const first = pluginTool("fake_current_run", "Current-run capability");
+    first.execute = vi.fn(async () => jsonResult({ marker: "first" }));
+    applyToolSearchCatalog({ tools: [codeTool, first], config, catalogRef });
+
+    const second = pluginTool("fake_current_run", "Current-run capability");
+    second.execute = vi.fn(async () => jsonResult({ marker: "second" }));
+    const reused = applyToolSearchCatalog({ tools: [codeTool, second], config, catalogRef });
+
+    expect(reused.catalogReused).toBe(true);
+    const runtime = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(config));
+    await expect(runtime.callValue("fake_current_run")).resolves.toEqual({ marker: "second" });
+    expect(first.execute).not.toHaveBeenCalled();
+    expect(second.execute).toHaveBeenCalledOnce();
   });
 
   it.each(["fresh", "same"] as const)(
@@ -3809,9 +3831,13 @@ describe("Tool Search", () => {
       expect(second.catalogRegistered).toBe(true);
       expect(second.catalogReused).toBe(true);
       const restoredCatalog = expectDefined(restoredRef.current, "restored run catalog");
-      expect(restoredCatalog.entries.find((entry) => entry.name === alpha.name)).toBe(
-        firstAlphaEntry,
+      const restoredAlphaEntry = expectDefined(
+        restoredCatalog.entries.find((entry) => entry.name === alpha.name),
+        "restored alpha entry",
       );
+      expect(restoredAlphaEntry).not.toBe(firstAlphaEntry);
+      expect(restoredAlphaEntry).toEqual(firstAlphaEntry);
+      expect(restoredAlphaEntry.tool).toBe(alpha);
       expect(restoredCatalog.counterScope).not.toBe(firstCatalog.counterScope);
       expect(restoredCatalog.searchCount).toBe(0);
       const restoredRuntime = new ToolSearchRuntime(
@@ -3836,42 +3862,153 @@ describe("Tool Search", () => {
     },
   );
 
-  it("does not retain hook-bound catalogs, including prewrapped tools", () => {
+  it("notifies catalog-ref lifecycle hooks across snapshot restore and disposal", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const alpha = pluginTool("fake_lifecycle_alpha", "Alpha tool");
+    const config = { tools: { toolSearch: true } } as never;
+    const sessionId = "session-lifecycle-hooks";
+
+    const firstRef = createToolSearchCatalogRef();
+    const firstChange = vi.fn();
+    firstRef.onChange = firstChange;
+    applyToolSearchCatalog({
+      tools: [codeTool, alpha],
+      config,
+      sessionId,
+      runId: "run-lifecycle-1",
+      catalogRef: firstRef,
+    });
+    expect(firstChange).toHaveBeenCalledOnce();
+
+    const firstDispose = vi.fn();
+    firstRef.onDispose = new Set([firstDispose]);
+    clearToolSearchCatalog({ sessionId, runId: "run-lifecycle-1", catalogRef: firstRef });
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(firstRef.onChange).toBeUndefined();
+    expect(firstRef.onDispose).toBeUndefined();
+
+    const secondRef = createToolSearchCatalogRef();
+    const secondChange = vi.fn();
+    secondRef.onChange = secondChange;
+    const second = applyToolSearchCatalog({
+      tools: [codeTool, alpha],
+      config,
+      sessionId,
+      runId: "run-lifecycle-2",
+      catalogRef: secondRef,
+    });
+    expect(second.catalogReused).toBe(true);
+    expect(secondChange).toHaveBeenCalledOnce();
+  });
+
+  it("applies Code Mode projection filtering to restored catalogs", async () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    // The unprojected tool is the stronger match for the query; only projection
+    // filtering can keep it out of a one-result search on the restored catalog.
+    const shadowing = pluginTool("fake_projection_probe", "Projection probe projection probe");
+    shadowing.execute = vi.fn(async () => jsonResult({ marker: "shadowing" }));
+    const projected = pluginTool("fake_projection_secondary", "Projection probe secondary");
+    projected.execute = vi.fn(async () => jsonResult({ marker: "projected" }));
+    const config = { tools: { toolSearch: true } } as never;
+    const sessionId = "session-projection-restore";
+
+    const firstRef = createToolSearchCatalogRef();
+    applyToolSearchCatalog({
+      tools: [codeTool, shadowing, projected],
+      config,
+      sessionId,
+      runId: "run-projection-1",
+      catalogRef: firstRef,
+    });
+    clearToolSearchCatalog({ sessionId, runId: "run-projection-1", catalogRef: firstRef });
+
+    const secondRef = createToolSearchCatalogRef();
+    const second = applyToolSearchCatalog({
+      tools: [codeTool, shadowing, projected],
+      config,
+      sessionId,
+      runId: "run-projection-2",
+      catalogRef: secondRef,
+    });
+    expect(second.catalogReused).toBe(true);
+    const restored = expectDefined(secondRef.current, "restored projection catalog");
+    const projectedId = expectDefined(
+      restored.entries.find((entry) => entry.name === projected.name),
+      "restored projected entry",
+    ).id;
+
+    const runtime = new ToolSearchRuntime(
+      { catalogRef: secondRef },
+      resolveToolSearchConfig(config),
+    );
+    await expect(runtime.search("projection probe", { limit: 1 })).resolves.toEqual([
+      expect.objectContaining({ name: shadowing.name }),
+    ]);
+    const matches = await runtime.search("projection probe", {
+      limit: 1,
+      allowedIds: new Set([projectedId]),
+    });
+    expect(matches).toEqual([expect.objectContaining({ id: projectedId, name: projected.name })]);
+    await expect(runtime.callValue(projected.name)).resolves.toEqual({ marker: "projected" });
+    expect(projected.execute).toHaveBeenCalledOnce();
+    expect(shadowing.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse snapshots for prewrapped input tools across runs", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const config = { tools: { toolSearch: true } } as never;
-    const snapshotsBefore = testing.getReusableCatalogSnapshotCountForTest();
-
-    for (const mode of ["context", "prewrapped"] as const) {
-      const sessionId = `session-hook-bound-${mode}`;
-      const runId = `run-hook-bound-${mode}`;
-      const catalogRef = createToolSearchCatalogRef();
-      const hookContext = {
-        agentId: "agent-main",
-        sessionId,
-        sessionKey: "agent:main:main",
-        runId,
-        onToolOutcome: vi.fn(),
+    const sessionId = "session-prewrapped-tool";
+    const createRunTool = (runId: string, marker: string) => {
+      const target = pluginTool("fake_prewrapped_tool", "Prewrapped run capability");
+      target.execute = vi.fn(async () => jsonResult({ marker }));
+      return {
+        target,
+        wrapped: wrapToolWithBeforeToolCallHook(target, { sessionId, runId }),
       };
-      const target = pluginTool(`fake_hook_bound_${mode}`, "Hook-bound probe tool");
-      const catalogTarget =
-        mode === "prewrapped"
-          ? wrapToolWithAbortSignal(
-              wrapToolWithBeforeToolCallHook(target, hookContext),
-              new AbortController().signal,
-            )
-          : target;
-      applyToolSearchCatalog({
-        tools: [codeTool, catalogTarget],
-        config,
-        sessionId,
-        runId,
-        catalogRef,
-        ...(mode === "context" ? { toolHookContext: hookContext } : {}),
-      });
-      clearToolSearchCatalog({ sessionId, runId, catalogRef });
-    }
+    };
 
-    expect(testing.getReusableCatalogSnapshotCountForTest()).toBe(snapshotsBefore);
+    const firstTool = createRunTool("run-prewrapped-1", "first-run");
+    const firstRef = createToolSearchCatalogRef();
+    const first = applyToolSearchCatalog({
+      tools: [codeTool, firstTool.wrapped],
+      config,
+      sessionId,
+      runId: "run-prewrapped-1",
+      catalogRef: firstRef,
+    });
+    expect(first.catalogReused).toBe(false);
+    const firstRuntime = new ToolSearchRuntime(
+      { catalogRef: firstRef },
+      resolveToolSearchConfig(config),
+    );
+    await expect(firstRuntime.callValue("fake_prewrapped_tool")).resolves.toEqual({
+      marker: "first-run",
+    });
+    clearToolSearchCatalog({
+      sessionId,
+      runId: "run-prewrapped-1",
+      catalogRef: firstRef,
+    });
+
+    const secondTool = createRunTool("run-prewrapped-2", "second-run");
+    const secondRef = createToolSearchCatalogRef();
+    const second = applyToolSearchCatalog({
+      tools: [codeTool, secondTool.wrapped],
+      config,
+      sessionId,
+      runId: "run-prewrapped-2",
+      catalogRef: secondRef,
+    });
+    expect(second.catalogReused).toBe(false);
+    const secondRuntime = new ToolSearchRuntime(
+      { catalogRef: secondRef },
+      resolveToolSearchConfig(config),
+    );
+    await expect(secondRuntime.callValue("fake_prewrapped_tool")).resolves.toEqual({
+      marker: "second-run",
+    });
+    expect(firstTool.target.execute).toHaveBeenCalledOnce();
+    expect(secondTool.target.execute).toHaveBeenCalledOnce();
   });
 
   it("serializes a fresh hook-bound catalog schema only once", () => {
@@ -3938,39 +4075,103 @@ describe("Tool Search", () => {
     ]);
   });
 
-  it("does not reuse when a same-named tool uses a different executable", () => {
+  it("reuses fresh MCP wrappers while executing the current run wrapper", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
-    const original = pluginTool("fake_exec_swap", "Stable description");
     const config = { tools: { toolSearch: true } } as never;
-    const sessionId = "session-tool-exec-change";
+    const sessionId = "session-mcp-wrapper-reuse";
+    const retainedCatalog = {
+      version: 1,
+      generatedAt: 0,
+      servers: {
+        "remote-demo": {
+          serverName: "remote-demo",
+          safeServerName: "remoteDemo",
+          launchSummary: "retained test server",
+          toolCount: 1,
+        },
+      },
+      tools: [
+        {
+          serverName: "remote-demo",
+          safeServerName: "remoteDemo",
+          toolName: "echo",
+          description: "Reuse a remote capability",
+          fallbackDescription: "Reuse a remote capability",
+          inputSchema: {
+            type: "object",
+            properties: { value: { type: "string" } },
+          },
+        },
+      ],
+    } satisfies McpToolCatalog;
+    const mcpRuntime = {
+      sessionId,
+      workspaceDir: "/tmp",
+      configFingerprint: "retained-catalog",
+      createdAt: 0,
+      lastUsedAt: 0,
+      markUsed: () => {},
+      getCatalog: async () => retainedCatalog,
+      peekCatalog: () => retainedCatalog,
+      callTool: vi.fn(async () => ({ content: [{ type: "text" as const, text: "echo" }] })),
+      dispose: async () => {},
+    } satisfies SessionMcpRuntime;
+
+    const firstMaterialized = await materializeBundleMcpToolsForRun({ runtime: mcpRuntime });
+    const secondMaterialized = await materializeBundleMcpToolsForRun({ runtime: mcpRuntime });
+    const firstWrapper = expectDefined(firstMaterialized.tools[0], "first MCP wrapper");
+    const secondWrapper = expectDefined(secondMaterialized.tools[0], "second MCP wrapper");
+    expect(secondWrapper).not.toBe(firstWrapper);
+    expect(secondWrapper.parameters).toBe(firstWrapper.parameters);
+    const firstExecute = firstWrapper.execute;
+    firstWrapper.execute = vi.fn(async (toolCallId, input, signal, onUpdate) => {
+      await firstExecute(toolCallId, input, signal, onUpdate);
+      return jsonResult({ marker: "first-run" });
+    });
+    const secondExecute = secondWrapper.execute;
+    secondWrapper.execute = vi.fn(async (toolCallId, input, signal, onUpdate) => {
+      await secondExecute(toolCallId, input, signal, onUpdate);
+      return jsonResult({ marker: "second-run" });
+    });
     const firstRef = createToolSearchCatalogRef();
 
-    applyToolSearchCatalog({
-      tools: [codeTool, original],
+    const first = applyToolSearchCatalog({
+      tools: [codeTool, firstWrapper],
       config,
       sessionId,
-      runId: "run-exec-1",
+      runId: "run-mcp-1",
       catalogRef: firstRef,
+      toolHookContext: { sessionId, runId: "run-mcp-1" },
     });
+    expect(first.catalogReused).toBe(false);
     clearToolSearchCatalog({
       sessionId,
-      runId: "run-exec-1",
+      runId: "run-mcp-1",
       catalogRef: firstRef,
     });
 
-    const replacement = pluginTool("fake_exec_swap", "Stable description");
     const secondRef = createToolSearchCatalogRef();
     const second = applyToolSearchCatalog({
-      tools: [codeTool, replacement],
+      tools: [codeTool, secondWrapper],
       config,
       sessionId,
-      runId: "run-exec-2",
+      runId: "run-mcp-2",
       catalogRef: secondRef,
+      toolHookContext: { sessionId, runId: "run-mcp-2" },
     });
-    expect(second.catalogReused).toBe(false);
-    expect(secondRef.current?.entries.find((entry) => entry.name === replacement.name)?.tool).toBe(
-      replacement,
+    expect(second.catalogReused).toBe(true);
+
+    const runtime = new ToolSearchRuntime(
+      { catalogRef: secondRef },
+      resolveToolSearchConfig(config),
     );
+    await expect(runtime.callValue("remoteDemo__echo")).resolves.toEqual({
+      marker: "second-run",
+    });
+    expect(firstWrapper.execute).not.toHaveBeenCalled();
+    expect(secondWrapper.execute).toHaveBeenCalledOnce();
+    await firstMaterialized.dispose();
+    await secondMaterialized.dispose();
   });
 
   it("does not reuse when a same-named tool changes parameters", () => {
@@ -4005,7 +4206,11 @@ describe("Tool Search", () => {
     const config = { tools: { toolSearch: true } } as never;
     const sessionId = "session-remote-schema-change";
 
-    applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
+    applyToolSearchCatalog({
+      tools: [codeTool, tool],
+      config,
+      sessionId,
+    });
     tool.parameters = new Proxy(
       { type: "object", properties: {} },
       {
@@ -4015,8 +4220,44 @@ describe("Tool Search", () => {
       },
     );
 
-    const second = applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
+    const second = applyToolSearchCatalog({
+      tools: [codeTool, tool],
+      config,
+      sessionId,
+    });
     expect(second.catalogReused).toBe(false);
+  });
+
+  it("degrades to a miss when a tool disappears from the current run", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = { tools: { toolSearch: true } } as never;
+    const sessionId = "session-tool-removed";
+    const firstRef = createToolSearchCatalogRef();
+
+    applyToolSearchCatalog({
+      tools: [
+        codeTool,
+        mcpPluginTool("remote_keep", "Keep a remote capability"),
+        mcpPluginTool("remote_remove", "Remove a remote capability"),
+      ],
+      config,
+      sessionId,
+      runId: "run-tools-1",
+      catalogRef: firstRef,
+    });
+    clearToolSearchCatalog({ sessionId, runId: "run-tools-1", catalogRef: firstRef });
+
+    const secondRef = createToolSearchCatalogRef();
+    const second = applyToolSearchCatalog({
+      tools: [codeTool, mcpPluginTool("remote_keep", "Keep a remote capability")],
+      config,
+      sessionId,
+      runId: "run-tools-2",
+      catalogRef: secondRef,
+    });
+
+    expect(second.catalogReused).toBe(false);
+    expect(secondRef.current?.entries.map((entry) => entry.name)).toEqual(["remote_keep"]);
   });
 
   it("does not reuse when a same-named tool changes its output schema", () => {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -10,7 +10,6 @@ import { resolveToolResultFailureKind } from "./tool-result-error.js";
 import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
-  getReusableCatalogSnapshotCountForTest,
   isDirectVisibleCatalogTool,
   resolveCatalog,
 } from "./tool-search-catalog.js";
@@ -418,7 +417,6 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
 }
 
 const testing = {
-  getReusableCatalogSnapshotCountForTest,
   maxToolSchemaDirectoryPromptChars: MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS,
   resolveToolSearchConfig,
   isToolSearchCodeModeSupported,


### PR DESCRIPTION
## What Problem This Solves

Tool Search keeps reusable catalog snapshots between runs. Session MCP tools use one retained descriptor catalog, but each run gets a fresh executable wrapper. The old fingerprint included that wrapper object's identity, so the second run always missed the snapshot and registered the same catalog again.

Reusing the old entry objects would be unsafe. Those objects can retain the prior run's hook and abort authority.

## Why This Change Was Made

The catalog owner now stores descriptor-only snapshots. A snapshot hit maps every descriptor ID to the current run's executor. Duplicate or missing IDs return a normal cache miss.

MCP and client schemas still use object identity. Tool Search does not recursively traverse these untrusted schemas. Inputs that already contain a `before_tool_call` wrapper remain excluded because that wrapper can retain run authority.

This matches the upstream Codex boundary: Tool Search caches immutable MCP metadata, while MCP execution prepares the call from the current invocation session ([tool_search.rs:45-104](https://github.com/openai/codex/blob/7625343977154efed8c0dadba956374992a1580b/codex-rs/core/src/tools/handlers/tool_search.rs#L45-L104), [mcp.rs:174-197](https://github.com/openai/codex/blob/7625343977154efed8c0dadba956374992a1580b/codex-rs/core/src/tools/handlers/mcp.rs#L174-L197)).

## User Impact

Retained sessions can reuse unchanged Tool Search metadata for MCP tools. Calls still use the current run's executor, hooks, cancellation signal, and real MCP connection.

## Implementation

- `src/agents/tool-search-catalog.ts` fingerprints metadata without executable identity.
- Reusable snapshots contain frozen top-level descriptors without `tool` executors.
- Same-run and cross-run hits bind exact IDs to the current entries.
- Code Mode projections, catalog counters, lifecycle callbacks, and untrusted-schema limits stay intact.

The cache is process-local and capped at 256 entries. It does not change config, SQLite, files, transcripts, or protocol payloads.

## Evidence

Real red/green proof used the repository's stdio MCP server fixture and one retained session catalog for two materialized runs:

| Revision | Run 2 reused snapshot | Duplicate registration | Executor | Real server result |
| --- | --- | --- | --- | --- |
| main `a696e4f68750` | No | Yes | Run 2 | `tool-search-live / turn-2 / pid [redacted]` |
| head `526830540e80` | Yes | No | Run 2 only | `tool-search-live / turn-2 / pid [redacted]` |

The same final-head flow also returned cache misses for duplicate IDs, a missing ID, and prewrapped inputs. The retained schema object stayed identical across both MCP materializations.

- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts src/agents/tool-search-runtime.test.ts src/agents/tool-search-runtime-config.test.ts src/agents/tool-search-ranking.test.ts src/agents/tool-search.mcp-error.test.ts src/agents/tool-search.stream-errors.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts` — 7 files, 290 tests passed.
- Focused Oxfmt and Oxlint passed.
- Assertion-safety, max-lines, conflict-marker, and `git diff --check` gates passed.
- Exact-head hosted CI owns the build and type checks.

## Scope and LOC

The architectural owner is `src/agents/tool-search-catalog.ts`. MCP materialization and dispatch remain unchanged.

- Runtime source: +74/-79, net -5.
- Test-facing support: +0/-3, net -3.
- Tests: +290/-49, net +241.
- Baseline: +1/-1, net 0.
