### PR TITLE
fix(state): register placement move machine class additive column

### DIFF
--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -185,6 +185,7 @@ describe("OpenClaw database maintenance schema validation", () => {
       "session_groups.worktree INTEGER",
       "installed_plugin_index.workspace_dir TEXT",
       "secret_store_entries.allowed_hosts TEXT",
+      "worker_session_placement_moves.target_machine_class TEXT",
     ]);
 
     const database = createGlobalDatabase();
@@ -205,6 +206,11 @@ describe("OpenClaw database maintenance schema validation", () => {
         database.exec(`ALTER TABLE "${tableName}" DROP COLUMN "${columnName}";`);
       }
 
+      expect(() =>
+        assertOpenClawStateDatabaseForMaintenance(database, {
+          pathname: "global.sqlite",
+        }),
+      ).not.toThrow();
       ensureAdditiveStateColumns(database);
       expect(() =>
         assertOpenClawStateDatabaseForMaintenance(database, {

--- a/src/state/openclaw-state-db-additive-columns.ts
+++ b/src/state/openclaw-state-db-additive-columns.ts
@@ -29,6 +29,11 @@ export const CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS = [
   { columnName: "worktree", dataType: "INTEGER", tableName: "session_groups" },
   { columnName: "workspace_dir", dataType: "TEXT", tableName: "installed_plugin_index" },
   { columnName: "allowed_hosts", dataType: "TEXT", tableName: "secret_store_entries" },
+  {
+    columnName: "target_machine_class",
+    dataType: "TEXT",
+    tableName: "worker_session_placement_moves",
+  },
 ] as const satisfies readonly LazyAdditiveStateColumnDefinition[];
 
 function isFirstUseAdditiveStateColumn({


### PR DESCRIPTION
## Summary
- register `worker_session_placement_moves.target_machine_class` in the canonical lazy additive-state column registry
- add maintenance regression coverage proving the old table shape is accepted before additive repair and canonical afterward

## Root cause
The feature in #125292 introduced the nullable `target_machine_class` column and lazy access path, but omitted the column from `CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS`. The official `update.run` path therefore completed dependency installation and build, then `doctor --non-interactive --fix` rejected an existing same-version database as noncanonical before the lazy repair could run.

## Scope
This is the smallest additive schema fix. It does not bump the state schema version, mutate runtime state, add compatibility fallbacks, or change the updater contract.

Fixes #125516

## Tests
- 38/38 focused state maintenance/preflight tests passed on the exact source worktree commit.
- `git diff --check` passed.