### PR TITLE
Android: request coarse location with fine for the precise toggle

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -324,7 +324,10 @@ fun SettingsSheet(viewModel: MainViewModel) {
       viewModel.setLocationPreciseEnabled(true)
     } else {
       pendingPreciseToggle = true
-      locationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION))
+      // Android 12+ ignores a FINE-only request; COARSE must be requested alongside it.
+      locationPermissionLauncher.launch(
+        arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix the **Precise Location** toggle in Settings, which can never be switched on
- `SettingsSheet.setPreciseLocationChecked()` launches a permission request for `ACCESS_FINE_LOCATION` alone. Since Android 12 the platform requires `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` to be requested together in a single runtime call and [ignores a fine-only request](https://developer.android.com/develop/sensors-and-location/location/permissions/runtime)
- `requestLocationPermissions()` ~15 lines above in the same file already passes both — the precise toggle just missed the coarse entry

`minSdk` is 31 and `targetSdk` is 36, so this affects every supported device. A user who picked **Approximate** in the location dialog has no way to upgrade to precise from inside the app: the request is dropped, `pendingPreciseToggle` resolves with `fineOk = false`, and the switch springs back off with no explanation.

Both permissions are already declared in `AndroidManifest.xml`, so no manifest change is needed.

## Test plan

- [x] `./gradlew :app:assembleDebug` builds successfully (matches CI)
- [x] `./gradlew :app:testDebugUnitTest` — 130 tests, no new failures
- [x] Code review: verified `requestLocationPermissions()` in the same file already requests both permissions, and that `AndroidManifest.xml:10-11` declares both
- [ ] Manual on an Android 12+ device: grant **Approximate** location, then enable **Precise Location** in Settings — the system dialog should now appear and the toggle should stick

Note: the full `:app:testDebugUnitTest` run has one unrelated pre-existing failure, `TalkModeConfigContractTest > selectionFixtures` (`legacy_payload_fallback expected:<legacy-key> but was:<xxxxx>`). I reproduced it on an unmodified `origin/main` checkout, so it is not caused by this PR.

AI-assisted: yes (Claude). Verified locally (build + unit tests). I understand what the code does.
