### PR TITLE
Android: stop clearing the saved gateway password on connect

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -203,7 +203,9 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
         if (config.token.isNotBlank()) {
           viewModel.setGatewayToken(config.token)
         }
-        viewModel.setGatewayPassword(config.password)
+        if (config.password.isNotBlank()) {
+          viewModel.setGatewayPassword(config.password)
+        }
         viewModel.connectManual()
       },
       modifier = Modifier.fillMaxWidth().height(52.dp),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -853,7 +853,9 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                   if (token.isNotEmpty()) {
                     viewModel.setGatewayToken(token)
                   }
-                  viewModel.setGatewayPassword(password)
+                  if (password.isNotEmpty()) {
+                    viewModel.setGatewayPassword(password)
+                  }
                   viewModel.connectManual()
                 },
                 modifier = Modifier.weight(1f).height(52.dp),


### PR DESCRIPTION
## Summary

- Fix the Connect tab and onboarding wiping the stored gateway password, which locks the user out of a password-authenticated gateway
- The password field is persisted unconditionally, while the token write right next to it is guarded by a blank check:

```kotlin
if (config.token.isNotBlank()) {
  viewModel.setGatewayToken(config.token)   // guarded
}
viewModel.setGatewayPassword(config.password)  // not guarded
```

- Guard both password writes with a blank check, matching the adjacent token handling

`passwordInput` (`ConnectTabScreen.kt:83`) is screen-local state that starts as `""` and is never seeded from storage, so it is empty on every fresh process. It flows into `resolveGatewayConnectConfig(fallbackPassword = passwordInput)`, which returns `password = fallbackPassword.trim()` for manual connects (`GatewayConfigResolver.kt:63`) and whenever a setup code carries no password (`:52`). `SecurePrefs.saveGatewayPassword("")` then overwrites the stored value, and `loadGatewayPassword()` returns `null` for an empty entry — so every later `NodeRuntime.connect()` authenticates with no password until the user retypes it.

`OnboardingFlow.kt` has the same pattern, and it is reachable there too: scanning a setup code without a password sets `gatewayPassword = ""` (`:776`) which is then persisted at `:856`.

Scope boundary: this does not add a way to clear a stored password. The token has never been clearable from these screens either; if an explicit "forget password" affordance is wanted, that belongs in its own change rather than being inferred from an empty text field.

## Test plan

- [x] `./gradlew :app:assembleDebug` builds successfully (matches CI)
- [x] `./gradlew :app:testDebugUnitTest` — 130 tests, no new failures
- [x] Code review: traced `passwordInput` → `resolveGatewayConnectConfig` → `setGatewayPassword` → `SecurePrefs.saveGatewayPassword` → `loadGatewayPassword` returning `null` for an empty stored value
- [ ] Manual: pair with a password-protected gateway, restart the app, tap **Connect Gateway** with the password field empty, then force-quit and reconnect — the stored password should survive

Note: the full `:app:testDebugUnitTest` run has one unrelated pre-existing failure, `TalkModeConfigContractTest > selectionFixtures` (`legacy_payload_fallback expected:<legacy-key> but was:<xxxxx>`). I reproduced it on an unmodified `origin/main` checkout, so it is not caused by this PR.

AI-assisted: yes (Claude). Verified locally (build + unit tests). I understand what the code does.
