### PR TITLE
fix: correct setup provider drift diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -107,9 +107,10 @@ choices, and install-catalog metadata without loading provider runtime. Explicit
 `requiresRuntime` keeps the legacy setup-api fallback for compatibility. If
 more than one discovered plugin claims the same normalized setup provider or
 CLI backend id, setup lookup refuses the ambiguous owner instead of relying on
-discovery order. When setup runtime does execute, registry diagnostics report
-drift between `setup.providers` / `setup.cliBackends` and the providers or CLI
-backends actually registered by setup-api, without blocking legacy plugins.
+discovery order. When setup runtime executes, registry diagnostics reject
+undeclared provider and CLI backend registrations. CLI backend descriptors also
+report missing runtime registrations; provider descriptors may stay
+metadata-only while the setup module contributes other setup hooks.
 
 ### Plugin cache boundary
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -610,7 +610,7 @@ Set `requiresRuntime: false` only when those descriptors are sufficient for the 
 
 Because setup lookup can execute plugin-owned `setup-api` code, normalized `setup.providers[].id` and `setup.cliBackends[]` values must stay unique across discovered plugins. Ambiguous ownership fails closed instead of picking a winner from discovery order.
 
-When setup runtime does execute, setup registry diagnostics report descriptor drift if `setup-api` registers a provider or CLI backend that the manifest descriptors do not declare, or if a descriptor has no matching runtime registration. These diagnostics are additive and do not reject legacy plugins.
+When setup runtime executes, setup registry diagnostics report providers or CLI backends that `setup-api` registers without matching manifest declarations. CLI backend descriptors also report a missing runtime registration because setup lookup needs the registered backend configuration. Provider descriptors may remain metadata-only even when the same setup module contributes migrations, CLI backends, probes, or selected provider runtimes.
 
 ### setup.providers reference
 
@@ -637,12 +637,12 @@ Supported evidence entries:
 
 ### setup fields
 
-| Field              | Required | Type       | What it means                                                                                       |
-| ------------------ | -------- | ---------- | --------------------------------------------------------------------------------------------------- |
-| `providers`        | No       | `object[]` | Provider setup descriptors exposed during setup and onboarding.                                     |
-| `cliBackends`      | No       | `string[]` | Setup-time backend ids used for descriptor-first setup lookup. Keep normalized ids globally unique. |
-| `configMigrations` | No       | `string[]` | Config migration ids owned by this plugin's setup surface.                                          |
-| `requiresRuntime`  | No       | `boolean`  | Whether setup still needs `setup-api` execution after descriptor lookup.                            |
+| Field              | Required | Type       | What it means                                                                                                                                  |
+| ------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `providers`        | No       | `object[]` | Provider setup descriptors exposed during setup and onboarding.                                                                                |
+| `cliBackends`      | No       | `string[]` | Setup-time backend ids used for descriptor-first setup lookup. Keep normalized ids globally unique.                                            |
+| `configMigrations` | No       | `string[]` | Config migration ids owned by this plugin's setup surface.                                                                                     |
+| `requiresRuntime`  | No       | `boolean`  | Whether setup still needs `setup-api` execution after descriptor lookup. Explicit `false` disables it; omission preserves the legacy fallback. |
 
 ## uiHints reference
 

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -229,7 +229,7 @@ export type PluginManifestSetup = {
   configMigrations?: string[];
   /**
    * Whether setup still needs plugin runtime execution after descriptor lookup.
-   * Defaults to false when omitted.
+   * Explicit false disables setup runtime; omission preserves the legacy fallback.
    */
   requiresRuntime?: boolean;
 };

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -581,7 +581,51 @@ describe("setup-registry module loader", () => {
     expect(mocks.createJiti).not.toHaveBeenCalled();
   });
 
-  it("reports setup descriptor drift without rejecting runtime registrations", () => {
+  it("allows provider descriptors to remain metadata-only beside other setup hooks", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openai",
+          rootDir: pluginRoot,
+          setup: {
+            providers: [{ id: "openai" }, { id: "elevenlabs" }],
+            cliBackends: ["codex-cli"],
+            requiresRuntime: true,
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.createJiti.mockImplementation(() => {
+      return () => ({
+        default: {
+          register(api: SetupRegistryApi) {
+            api.registerCliBackend({
+              id: "codex-cli",
+              config: { command: "codex" },
+            });
+            api.registerConfigMigration((config) => ({
+              config,
+              changes: ["openai"],
+            }));
+            api.registerAutoEnableProbe(() => "openai configured");
+          },
+        },
+      });
+    });
+
+    const registry = resolvePluginSetupRegistry({ env: {} });
+
+    expect(registry.providers).toStrictEqual([]);
+    expect(registry.cliBackends.map((entry) => entry.backend.id)).toEqual(["codex-cli"]);
+    expect(registry.configMigrations).toHaveLength(1);
+    expect(registry.autoEnableProbes).toHaveLength(1);
+    expect(registry.diagnostics).toStrictEqual([]);
+  });
+
+  it("reports undeclared runtime contributions and missing CLI backends", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
     mocks.loadPluginManifestRegistry.mockReturnValue({
@@ -623,19 +667,16 @@ describe("setup-registry module loader", () => {
 
     expect(registry.providers.map((entry) => entry.provider.id)).toEqual(["anthropic"]);
     expect(registry.cliBackends.map((entry) => entry.backend.id)).toEqual(["claude-cli"]);
-    expect(registry.diagnostics).toHaveLength(4);
+    expect(registry.diagnostics).toHaveLength(3);
     expect(registry.diagnostics[0]?.pluginId).toBe("openai");
-    expect(registry.diagnostics[0]?.code).toBe("setup-descriptor-provider-missing-runtime");
-    expect(registry.diagnostics[0]?.declaredId).toBe("openai");
+    expect(registry.diagnostics[0]?.code).toBe("setup-descriptor-provider-runtime-undeclared");
+    expect(registry.diagnostics[0]?.runtimeId).toBe("anthropic");
     expect(registry.diagnostics[1]?.pluginId).toBe("openai");
-    expect(registry.diagnostics[1]?.code).toBe("setup-descriptor-provider-runtime-undeclared");
-    expect(registry.diagnostics[1]?.runtimeId).toBe("anthropic");
+    expect(registry.diagnostics[1]?.code).toBe("setup-descriptor-cli-backend-missing-runtime");
+    expect(registry.diagnostics[1]?.declaredId).toBe("codex-cli");
     expect(registry.diagnostics[2]?.pluginId).toBe("openai");
-    expect(registry.diagnostics[2]?.code).toBe("setup-descriptor-cli-backend-missing-runtime");
-    expect(registry.diagnostics[2]?.declaredId).toBe("codex-cli");
-    expect(registry.diagnostics[3]?.pluginId).toBe("openai");
-    expect(registry.diagnostics[3]?.code).toBe("setup-descriptor-cli-backend-runtime-undeclared");
-    expect(registry.diagnostics[3]?.runtimeId).toBe("claude-cli");
+    expect(registry.diagnostics[2]?.code).toBe("setup-descriptor-cli-backend-runtime-undeclared");
+    expect(registry.diagnostics[2]?.runtimeId).toBe("claude-cli");
   });
 
   it("does not report drift when setup descriptors match runtime registrations", () => {

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -61,7 +61,6 @@ type SetupAutoEnableProbeEntry = {
 
 type PluginSetupRegistryDiagnosticCode =
   | "setup-descriptor-runtime-disabled"
-  | "setup-descriptor-provider-missing-runtime"
   | "setup-descriptor-provider-runtime-undeclared"
   | "setup-descriptor-cli-backend-missing-runtime"
   | "setup-descriptor-cli-backend-runtime-undeclared"
@@ -553,16 +552,6 @@ function pushSetupDescriptorDriftDiagnostics(params: {
 }): void {
   const declaredProviderIds = params.record.setup?.providers?.map((entry) => entry.id);
   if (declaredProviderIds) {
-    for (const declaredId of declaredProviderIds) {
-      if (!params.providers.some((provider) => matchesProvider(provider, declaredId))) {
-        params.diagnostics.push({
-          pluginId: params.record.id,
-          code: "setup-descriptor-provider-missing-runtime",
-          declaredId,
-          message: `setup.providers declares "${declaredId}" but setup runtime did not register a matching provider.`,
-        });
-      }
-    }
     for (const provider of params.providers) {
       if (!declaredProviderIds.some((declaredId) => matchesProvider(provider, declaredId))) {
         params.diagnostics.push({


### PR DESCRIPTION
## Summary

Stop reporting valid metadata-only provider descriptors as missing setup runtime registrations.

This removes false warnings for Tencent, Anthropic, ElevenLabs, Google, and xAI while preserving diagnostics for genuine setup contract violations and failures.

## Problem

The setup registry currently emits warnings such as:

```text
setup.providers declares "anthropic" but setup runtime did not register a matching provider.
setup.providers declares "elevenlabs" but setup runtime did not register a matching provider.
setup.providers declares "xai" but setup runtime did not register a matching provider.
```

These warnings imply that the affected plugins have incomplete or broken setup implementations, but the plugins are operating according to the intended descriptor-first setup contract.

## Root cause

`setup.providers` serves as cheap manifest metadata for:

- provider ownership;
- authentication methods;
- credential environment variables;
- local authentication evidence;
- setup and onboarding discovery.

It does not require the lightweight `setup-api` module to register every declared provider.

A setup module can legitimately contribute a different subset of setup behavior. Current bundled examples include:

- Tencent registering a configuration migration;
- Anthropic registering the Claude CLI backend;
- ElevenLabs registering a configuration migration;
- Google registering Google Vertex and the Gemini CLI backend;
- xAI registering an auto-enable probe.

The registry incorrectly enforced provider parity in both directions. That conflated manifest metadata with runtime setup contributions.

## Changes

- Remove the invalid requirement that every `setup.providers` descriptor must have a matching runtime provider registration.
- Continue reporting providers registered at runtime without a corresponding manifest declaration.
- Keep bidirectional CLI backend drift diagnostics because a runtime-backed `setup.cliBackends` descriptor must resolve to backend configuration.
- Preserve setup module loading and registration failure diagnostics.
- Correct the `requiresRuntime` type documentation:
  - explicit `false` disables setup runtime execution;
  - omission preserves the legacy runtime fallback.
- Update the plugin manifest and architecture documentation with the asymmetric provider contract.

## Behavior after this change

Valid metadata-only provider descriptors no longer produce warnings during setup registry construction.

The registry still reports:

- undeclared runtime provider registrations;
- missing or undeclared CLI backend registrations;
- setup entry loading failures;
- setup registration exceptions;
- runtime entries incorrectly shipped behind `requiresRuntime: false`.

No no-op provider registrations or plugin-specific warning suppressions are introduced.

## Verification

- Added an owner-boundary regression covering metadata-only provider descriptors alongside CLI backend, migration, and auto-enable probe registrations.
- Confirmed the regression fails on the previous implementation with `setup-descriptor-provider-missing-runtime`.
- Verified the real bundled setup registry for Tencent, Anthropic, ElevenLabs, Google, and xAI:
  - zero false diagnostics;
  - Google Vertex remains registered;
  - Anthropic and Google CLI backends remain registered;
  - Tencent and ElevenLabs migrations remain registered;
  - the xAI auto-enable probe remains registered.
- 67 focused setup-registry, provider-auth, model-auth, and CLI-backend tests passed locally and in Testbox.
- Full changed-file gate and production build passed.
- Autoreview completed with no actionable findings.

Fixes #125506
