### PR TITLE
refactor(agents): unify exec approval wait outcomes

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -27,7 +27,7 @@ advances a milestone.
 | 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280, #123612, #123641, #123665, #123673, #123700, #123696, #123785, #123859, #123889, #123901 |
 | 7   | Bundle push consent + runner updates                       | in progress | #123985, #124037, #124356, #124590                                                                                                                                        |
 | 8   | Stop-and-continue moves                                    | landed      | #125036                                                                                                                                                                   |
-| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | in progress | #125503                                                                                                                                                                   |
+| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | in progress | #125503, #125524                                                                                                                                                          |
 | 10  | Cloud convergence (provisioners run `openclaw connect`)    | landed      | #125288, #125384, #125465                                                                                                                                                 |
 
 Revision history: revision 1 (2026-08-08) established the session/runner

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -157,7 +157,13 @@ const defaultExecAutoReviewerMock = vi.hoisted(() =>
 );
 const commitExecAuthorizationMock = vi.hoisted(() => vi.fn(async () => undefined));
 const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() =>
-  vi.fn(async (): Promise<string | null | undefined> => undefined),
+  vi.fn(
+    async (_params?: {
+      approvalId: string;
+      preResolvedDecision: string | null | undefined;
+      onFailure: () => void;
+    }): Promise<string | null | undefined> => undefined,
+  ),
 );
 const runAbortedApprovalError = vi.hoisted(() => new Error("run aborted"));
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
@@ -236,6 +242,48 @@ const resolveExecApprovalDecisionStateMock = vi.hoisted(() =>
     },
   ),
 );
+const resolveExecApprovalWaitOutcomeMock = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      approvalId: string;
+      preResolvedDecision: string | null | undefined;
+      signal?: AbortSignal;
+      askFallback: ExecSecurity;
+      resolveTimedOut?: (state: {
+        baseDecision: { timedOut: boolean };
+        approvedByAsk: boolean;
+        deniedReason: string | null;
+      }) =>
+        | Promise<{ approvedByAsk: boolean; deniedReason: string | null; context?: unknown }>
+        | { approvedByAsk: boolean; deniedReason: string | null; context?: unknown };
+      requiresExplicitApproval: boolean | ((context: unknown) => boolean);
+      requiresAutoReviewHumanApproval?: boolean;
+    }) => {
+      let decision: string | null | undefined;
+      try {
+        decision = await resolveApprovalDecisionOrUndefinedMock({
+          approvalId: params.approvalId,
+          preResolvedDecision: params.preResolvedDecision,
+          onFailure: () => {},
+        });
+      } catch (error) {
+        return error === runAbortedApprovalError
+          ? { kind: "run-aborted" as const }
+          : { kind: "request-failed" as const };
+      }
+      if (decision === undefined) {
+        return { kind: "request-failed" as const };
+      }
+      if (params.signal?.aborted) {
+        return { kind: "run-aborted" as const };
+      }
+      const state = await resolveExecApprovalDecisionStateMock({ ...params, decision });
+      return params.signal?.aborted
+        ? { kind: "run-aborted" as const }
+        : { kind: "resolved" as const, decision, state };
+    },
+  ),
+);
 const detectInterpreterInlineEvalArgvMock = vi.hoisted(() =>
   vi.fn(
     (): {
@@ -284,6 +332,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
   resolveExecApprovalDecisionState: resolveExecApprovalDecisionStateMock,
+  resolveExecApprovalWaitOutcome: resolveExecApprovalWaitOutcomeMock,
   sendExecApprovalFollowupResult: sendExecApprovalFollowupResultMock,
   shouldResolveExecApprovalUnavailableInline: shouldResolveExecApprovalUnavailableInlineMock,
 }));
@@ -2676,9 +2725,9 @@ EOF`,
 
     abortController.abort();
     resolveApproval("allow-once");
-    await vi.waitFor(() => {
-      expect(createExecApprovalDecisionStateMock).toHaveBeenCalledOnce();
-    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(createExecApprovalDecisionStateMock).not.toHaveBeenCalled();
     expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
     expect(runExecProcessMock).not.toHaveBeenCalled();
     expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -57,7 +57,6 @@ import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-ap
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
-  isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
 import {
@@ -65,8 +64,8 @@ import {
   buildExecApprovalFollowupTarget,
   buildExecApprovalPendingToolResult,
   createAndRegisterDefaultExecApprovalRequest,
-  resolveApprovalDecisionOrUndefined,
   resolveExecApprovalDecisionState,
+  resolveExecApprovalWaitOutcome,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
   shouldResolveExecApprovalUnavailableInline,
@@ -1124,17 +1123,25 @@ export async function processGatewayAllowlist(
       params.workdir,
     );
     const resolveApprovalForExecution = async (onFailure: () => void) => {
-      const decision = await resolveApprovalDecisionOrUndefined({
+      const approvalOutcome = await resolveExecApprovalWaitOutcome({
         approvalId,
         preResolvedDecision,
-        onFailure,
-      }).catch((error: unknown) => {
-        if (isExecApprovalRunAbortedError(error)) {
-          return "run-aborted" as const;
-        }
-        throw error;
+        signal: params.signal,
+        askFallback,
+        resolveTimedOut: (state) => {
+          const adjusted = applyTimedOutAllowlistFallback(state);
+          return {
+            approvedByAsk: adjusted.approvedByAsk,
+            deniedReason: adjusted.deniedReason,
+          };
+        },
+        requiresExplicitApproval: requiresInlineEvalApproval,
+        requiresAutoReviewHumanApproval:
+          autoReviewRequiresHumanApproval ||
+          requiresHeredocApproval ||
+          timedOutFallbackRequiresHeredocApproval,
       });
-      if (decision === "run-aborted") {
+      if (approvalOutcome.kind === "run-aborted") {
         return {
           deniedReason: "run-aborted",
           requestFailed: false,
@@ -1143,7 +1150,8 @@ export async function processGatewayAllowlist(
           allowAlwaysDecision: undefined,
         };
       }
-      if (decision === undefined) {
+      if (approvalOutcome.kind === "request-failed") {
+        onFailure();
         emitGatewayExecApprovalSecurityEvent({
           action: "exec.approval.denied",
           outcome: "error",
@@ -1164,22 +1172,7 @@ export async function processGatewayAllowlist(
         };
       }
 
-      const resolvedDecision = await resolveExecApprovalDecisionState({
-        decision,
-        askFallback,
-        resolveTimedOut: (state) => {
-          const adjusted = applyTimedOutAllowlistFallback(state);
-          return {
-            approvedByAsk: adjusted.approvedByAsk,
-            deniedReason: adjusted.deniedReason,
-          };
-        },
-        requiresExplicitApproval: requiresInlineEvalApproval,
-        requiresAutoReviewHumanApproval:
-          autoReviewRequiresHumanApproval ||
-          requiresHeredocApproval ||
-          timedOutFallbackRequiresHeredocApproval,
-      });
+      const { decision, state: resolvedDecision } = approvalOutcome;
       const { approvedByAsk } = resolvedDecision;
       let { deniedReason } = resolvedDecision;
 

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -269,6 +269,48 @@ const resolveExecApprovalDecisionStateMock = vi.hoisted(() =>
     },
   ),
 );
+const resolveExecApprovalWaitOutcomeMock = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      approvalId: string;
+      preResolvedDecision: string | null | undefined;
+      signal?: AbortSignal;
+      askFallback: ExecSecurity;
+      resolveTimedOut?: (state: {
+        baseDecision: { timedOut: boolean };
+        approvedByAsk: boolean;
+        deniedReason: string | null;
+      }) =>
+        | Promise<{ approvedByAsk: boolean; deniedReason: string | null; context?: unknown }>
+        | { approvedByAsk: boolean; deniedReason: string | null; context?: unknown };
+      requiresExplicitApproval: boolean | ((context: unknown) => boolean);
+      requiresAutoReviewHumanApproval?: boolean;
+    }) => {
+      let decision: string | null | undefined;
+      try {
+        decision = await resolveApprovalDecisionOrUndefinedMock({
+          approvalId: params.approvalId,
+          preResolvedDecision: params.preResolvedDecision,
+          onFailure: () => {},
+        });
+      } catch (error) {
+        return error === runAbortedApprovalError
+          ? { kind: "run-aborted" as const }
+          : { kind: "request-failed" as const };
+      }
+      if (decision === undefined) {
+        return { kind: "request-failed" as const };
+      }
+      if (params.signal?.aborted) {
+        return { kind: "run-aborted" as const };
+      }
+      const state = await resolveExecApprovalDecisionStateMock({ ...params, decision });
+      return params.signal?.aborted
+        ? { kind: "run-aborted" as const }
+        : { kind: "resolved" as const, decision, state };
+    },
+  ),
+);
 const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
   vi.fn(async () => undefined),
 );
@@ -334,6 +376,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   buildExecApprovalFollowupTarget: vi.fn((value) => value),
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
   resolveExecApprovalDecisionState: resolveExecApprovalDecisionStateMock,
+  resolveExecApprovalWaitOutcome: resolveExecApprovalWaitOutcomeMock,
   createExecApprovalDecisionState: createExecApprovalDecisionStateMock,
   enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
   sendExecApprovalFollowupResult: sendExecApprovalFollowupResultMock,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -478,27 +478,10 @@ export async function executeNodeHostCommand(
         let nodeInvocationCompleted = false;
 
         void (async () => {
-          let decision: string | null | undefined;
-          try {
-            decision = await execHostShared.resolveApprovalDecisionOrUndefined({
-              approvalId,
-              preResolvedDecision,
-              onFailure: () => void sendApprovalRequestFailedFollowup(),
-            });
-          } catch (error) {
-            // Detached run cancellation has no awaiting tool caller to catch it.
-            if (isExecApprovalRunAbortedError(error)) {
-              return;
-            }
-            await sendApprovalRequestFailedFollowup();
-            return;
-          }
-          if (decision === undefined || params.signal?.aborted) {
-            return;
-          }
-
-          const resolvedDecision = await execHostShared.resolveExecApprovalDecisionState({
-            decision,
+          const approvalOutcome = await execHostShared.resolveExecApprovalWaitOutcome({
+            approvalId,
+            preResolvedDecision,
+            signal: params.signal,
             askFallback,
             resolveTimedOut: async () => {
               const fallback = await resolveCurrentTimeoutFallback();
@@ -512,6 +495,14 @@ export async function executeNodeHostCommand(
               fallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
             requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
           });
+          if (approvalOutcome.kind !== "resolved") {
+            if (approvalOutcome.kind === "request-failed") {
+              await sendApprovalRequestFailedFollowup();
+            }
+            return;
+          }
+
+          const { decision, state: resolvedDecision } = approvalOutcome;
           const { approvedByAsk, deniedReason } = resolvedDecision;
           const currentFallback = resolvedDecision.timeoutContext;
           const approvalSource = decision === null ? "ask-fallback" : undefined;

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -14,6 +14,7 @@ import {
   buildExecApprovalPendingToolResult,
   createAndRegisterDefaultExecApprovalRequest,
   resolveExecApprovalDecisionState,
+  resolveExecApprovalWaitOutcome,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
   shouldResolveExecApprovalUnavailableInline,
@@ -37,6 +38,8 @@ const mocks = vi.hoisted(() => ({
     file: { version: 1, agents: {} },
     hash: "approvals-hash",
   })),
+  approvalRunAbortedError: new Error("approval owning run aborted"),
+  resolveRegisteredExecApprovalDecision: vi.fn(async (): Promise<string | null> => "allow-once"),
 }));
 
 vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
@@ -44,6 +47,15 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   return {
     ...mod,
     resolveExecApprovalsLocked: mocks.resolveExecApprovals,
+  };
+});
+
+vi.mock("./bash-tools.exec-approval-request.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./bash-tools.exec-approval-request.js")>();
+  return {
+    ...mod,
+    isExecApprovalRunAbortedError: (error: unknown) => error === mocks.approvalRunAbortedError,
+    resolveRegisteredExecApprovalDecision: mocks.resolveRegisteredExecApprovalDecision,
   };
 });
 
@@ -532,6 +544,96 @@ describe("resolveExecApprovalDecisionState", () => {
       deniedReason: "approval-timeout",
       timeoutContext,
     });
+  });
+});
+
+describe("resolveExecApprovalWaitOutcome", () => {
+  beforeEach(() => {
+    mocks.resolveRegisteredExecApprovalDecision.mockReset();
+    mocks.resolveRegisteredExecApprovalDecision.mockResolvedValue("allow-once");
+  });
+
+  it.each([
+    ["allow-once", true, null],
+    ["allow-always", true, null],
+    ["deny", false, "user-denied"],
+  ] as const)("returns a resolved %s decision", async (decision, approvedByAsk, deniedReason) => {
+    mocks.resolveRegisteredExecApprovalDecision.mockResolvedValue(decision);
+
+    await expect(
+      resolveExecApprovalWaitOutcome({
+        approvalId: "approval-1",
+        preResolvedDecision: undefined,
+        askFallback: "deny",
+        requiresExplicitApproval: false,
+      }),
+    ).resolves.toMatchObject({
+      kind: "resolved",
+      decision,
+      state: { approvedByAsk, deniedReason },
+    });
+  });
+
+  it("applies timeout policy before returning a resolved outcome", async () => {
+    mocks.resolveRegisteredExecApprovalDecision.mockResolvedValue(null);
+
+    await expect(
+      resolveExecApprovalWaitOutcome({
+        approvalId: "approval-timeout",
+        preResolvedDecision: undefined,
+        askFallback: "full",
+        resolveTimedOut: async () => ({ approvedByAsk: false, deniedReason: "policy-revoked" }),
+        requiresExplicitApproval: false,
+      }),
+    ).resolves.toMatchObject({
+      kind: "resolved",
+      decision: null,
+      state: { approvedByAsk: false, deniedReason: "policy-revoked" },
+    });
+  });
+
+  it("classifies an approval waiter failure", async () => {
+    mocks.resolveRegisteredExecApprovalDecision.mockRejectedValue(new Error("store unavailable"));
+
+    await expect(
+      resolveExecApprovalWaitOutcome({
+        approvalId: "approval-failed",
+        preResolvedDecision: undefined,
+        askFallback: "deny",
+        requiresExplicitApproval: false,
+      }),
+    ).resolves.toEqual({ kind: "request-failed" });
+  });
+
+  it("classifies owning-run cancellation", async () => {
+    mocks.resolveRegisteredExecApprovalDecision.mockRejectedValue(mocks.approvalRunAbortedError);
+
+    await expect(
+      resolveExecApprovalWaitOutcome({
+        approvalId: "approval-aborted",
+        preResolvedDecision: undefined,
+        askFallback: "deny",
+        requiresExplicitApproval: false,
+      }),
+    ).resolves.toEqual({ kind: "run-aborted" });
+  });
+
+  it("does not consume a decision after the owning signal aborts", async () => {
+    const controller = new AbortController();
+    mocks.resolveRegisteredExecApprovalDecision.mockImplementation(async () => {
+      controller.abort(new Error("run stopped"));
+      return "allow-once";
+    });
+
+    await expect(
+      resolveExecApprovalWaitOutcome({
+        approvalId: "approval-aborted-after-wait",
+        preResolvedDecision: undefined,
+        signal: controller.signal,
+        askFallback: "deny",
+        requiresExplicitApproval: false,
+      }),
+    ).resolves.toEqual({ kind: "run-aborted" });
   });
 });
 

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -238,26 +238,6 @@ export async function resolveExecHostApprovalContext(params: {
   return { approvals, hostSecurity, hostAsk, askFallback };
 }
 
-/** Waits for approval while converting wait failures to an undefined sentinel. */
-export async function resolveApprovalDecisionOrUndefined(params: {
-  approvalId: string;
-  preResolvedDecision: string | null | undefined;
-  onFailure: () => void;
-}): Promise<string | null | undefined> {
-  try {
-    return await resolveRegisteredExecApprovalDecision({
-      approvalId: params.approvalId,
-      preResolvedDecision: params.preResolvedDecision,
-    });
-  } catch (error) {
-    if (isExecApprovalRunAbortedError(error)) {
-      throw error;
-    }
-    params.onFailure();
-    return undefined;
-  }
-}
-
 /** Resolves approval delivery availability for the initiating channel/account. */
 function resolveExecApprovalUnavailableState(params: {
   turnSourceChannel?: string;
@@ -396,8 +376,7 @@ function enforceStrictInlineEvalApprovalBoundary(params: {
   };
 }
 
-/** Resolves explicit, timeout-fallback, and strict-human approval policy in one owner. */
-export async function resolveExecApprovalDecisionState<TTimeoutContext = undefined>(params: {
+type ExecApprovalDecisionParams<TTimeoutContext> = {
   decision: string | null;
   askFallback: ExecApprovalsResolved["agent"]["askFallback"];
   resolveTimedOut?: (state: {
@@ -417,12 +396,16 @@ export async function resolveExecApprovalDecisionState<TTimeoutContext = undefin
       }>;
   requiresExplicitApproval: boolean | ((context: TTimeoutContext | undefined) => boolean);
   requiresAutoReviewHumanApproval?: boolean;
-}): Promise<{
-  baseDecision: { timedOut: boolean };
-  approvedByAsk: boolean;
-  deniedReason: string | null;
-  timeoutContext: TTimeoutContext | undefined;
-}> {
+};
+
+type ExecApprovalDecisionState<TTimeoutContext> = ReturnType<
+  typeof createExecApprovalDecisionState
+> & { timeoutContext: TTimeoutContext | undefined };
+
+/** Resolves explicit, timeout-fallback, and strict-human approval policy in one owner. */
+export async function resolveExecApprovalDecisionState<TTimeoutContext = undefined>(
+  params: ExecApprovalDecisionParams<TTimeoutContext>,
+): Promise<ExecApprovalDecisionState<TTimeoutContext>> {
   const initial = createExecApprovalDecisionState({
     decision: params.decision,
     askFallback: params.askFallback,
@@ -457,6 +440,38 @@ export async function resolveExecApprovalDecisionState<TTimeoutContext = undefin
     deniedReason: strictDecision.deniedReason,
     timeoutContext,
   };
+}
+
+/** Waits for an approval and normalizes cancellation, request failure, and resolved policy. */
+export async function resolveExecApprovalWaitOutcome<TTimeoutContext = undefined>(
+  params: Omit<ExecApprovalDecisionParams<TTimeoutContext>, "decision"> & {
+    approvalId: string;
+    preResolvedDecision: string | null | undefined;
+    signal?: AbortSignal;
+  },
+): Promise<
+  | { kind: "request-failed" }
+  | { kind: "run-aborted" }
+  | {
+      kind: "resolved";
+      decision: string | null;
+      state: ExecApprovalDecisionState<TTimeoutContext>;
+    }
+> {
+  let decision: string | null;
+  try {
+    decision = await resolveRegisteredExecApprovalDecision({
+      approvalId: params.approvalId,
+      preResolvedDecision: params.preResolvedDecision,
+    });
+  } catch (error) {
+    return { kind: isExecApprovalRunAbortedError(error) ? "run-aborted" : "request-failed" };
+  }
+  if (params.signal?.aborted) {
+    return { kind: "run-aborted" };
+  }
+  const state = await resolveExecApprovalDecisionState({ ...params, decision });
+  return params.signal?.aborted ? { kind: "run-aborted" } : { kind: "resolved", decision, state };
 }
 
 /** Returns true when registration proved no approval decision can arrive later. */


### PR DESCRIPTION
## What Problem This Solves

Gateway and node exec hosts still independently waited for registered approvals, classified owning-run cancellation versus request failure, checked abort state, and then entered the shared approval-decision resolver. That duplicated lifecycle could drift at the point where delayed approval authority is consumed.

## Why This Change Was Made

This adds one shared waiter outcome with three closed results: `resolved`, `request-failed`, or `run-aborted`. It checks the owning signal both after the waiter settles and after current timeout policy is resolved. Gateway and node adapters continue to own security events, denial/follow-up copy, mutable-file and current-policy revalidation, authorization commits, and actual dispatch.

The old undefined-sentinel waiter is deleted. No compatibility or fallback path remains.

## User Impact

No intended user-visible behavior change. Cancelled runs now fail closed before consuming a late approval decision, and both exec hosts classify waiter failures and cancellation through the same owner.

Production LOC: +75 / -76 (net -1). Tests: +198 / -4.

AI-assisted: yes. I understand and reviewed the delayed approval-authority boundary.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts` — 211 tests passed on the rebased head.
- `node scripts/check-changed.mjs` — passed, including core/test typechecks, lint, dead-export scans, import-cycle checks, and auth/storage guards.
- `pnpm tsgo` and `pnpm tsgo:core:test` — passed.
- `pnpm docs:check-links` — 6,520 internal links checked, 0 broken.
- Autoreview — clean, no accepted/actionable findings, including the milestone ledger update.
- Shared tests cover explicit allow/deny, timeout policy, request failure, owning-run cancellation, and abort after the waiter resolves. Existing gateway/node tests retain follow-up, no-route, concurrent cancellation, timeout provenance, and no-dispatch-after-abort proof.
