### PR TITLE
feat(voice-call): let realtime agents end calls

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -275,6 +275,7 @@ Current runtime behavior:
 - `realtime.provider` is optional. If unset, Voice Call uses the first registered realtime voice provider.
 - Bundled realtime voice providers: Google Gemini Live (`google`) and OpenAI (`openai`), registered by their provider plugins.
 - Provider-owned raw config lives under `realtime.providers.<providerId>`.
+- Voice Call exposes the built-in `openclaw_end_call` realtime tool on every call. It takes no arguments or call ID; the active voice bridge binds it to the current call.
 - Voice Call exposes the shared `openclaw_agent_consult` realtime tool by default. The realtime model can call it when the caller asks for deeper reasoning, current information, or normal OpenClaw tools.
 - `realtime.consultPolicy` optionally adds guidance for when the realtime model should call `openclaw_agent_consult`.
 - `realtime.agentContext.enabled` is default-off. When enabled, Voice Call injects a bounded agent identity and selected workspace-file capsule into the realtime provider instructions at session setup.
@@ -290,6 +291,13 @@ the media WebSocket. If an intermediary does not promptly forward that close,
 OpenClaw treats 30 seconds without inbound media as a disconnect, waits a
 2-second grace period for media to resume, and then ends the call.
 
+The realtime model can also call `openclaw_end_call` when the caller asks to
+hang up. The model must speak any final words before calling the tool: a
+successful call ends the current provider session and phone connection
+immediately, so no later reply is spoken. If the carrier cannot end the call,
+the bridge stays connected and the model receives an error it can explain to
+the caller. Configured `realtime.tools` cannot replace this built-in by name.
+
 For inbound Twilio numbers, also configure a Status Callback using `POST` to
 your public webhook URL with `?type=status` appended, for example
 `https://voice.example.com/voice/webhook?type=status`. Include the `completed`
@@ -299,13 +307,14 @@ close and the inactivity backstop remain independent of it.
 
 ### Tool policy
 
-`realtime.toolPolicy` controls the consult run:
+`realtime.toolPolicy` controls only the consult run. It never disables
+`openclaw_end_call`:
 
 | Policy           | Behavior                                                                                                                                 |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `safe-read-only` | Expose the consult tool and limit the regular agent to `read`, `web_search`, `web_fetch`, `x_search`, `memory_search`, and `memory_get`. |
 | `owner`          | Expose the consult tool and let the regular agent use the normal agent tool policy.                                                      |
-| `none`           | Do not expose the consult tool. Custom `realtime.tools` are still passed through to the realtime provider.                               |
+| `none`           | Do not expose the consult tool. The built-in end-call tool and custom `realtime.tools` remain available.                                 |
 
 `realtime.consultPolicy` controls only the realtime model instructions:
 

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -783,6 +783,8 @@ describe("normalizeVoiceCallConfig", () => {
       files: ["SOUL.md", "IDENTITY.md", "USER.md"],
     });
     expect(normalized.realtime.instructions).toContain("openclaw_agent_consult");
+    expect(normalized.realtime.instructions).toContain("openclaw_end_call");
+    expect(normalized.realtime.instructions).toContain("speak any final words first");
     expect(normalized.tunnel.provider).toBe("none");
     expect(normalized.webhookSecurity.allowedHosts).toStrictEqual([]);
   });

--- a/extensions/voice-call/src/realtime-call-control.ts
+++ b/extensions/voice-call/src/realtime-call-control.ts
@@ -1,0 +1,32 @@
+// Voice Call plugin module defines provider-facing realtime call controls.
+import {
+  resolveRealtimeVoiceAgentConsultTools,
+  type RealtimeVoiceAgentConsultToolPolicy,
+  type RealtimeVoiceTool,
+} from "openclaw/plugin-sdk/realtime-voice";
+
+/** Stable provider-facing tool name for ending the current phone call. */
+export const REALTIME_VOICE_END_CALL_TOOL_NAME = "openclaw_end_call";
+
+/** Closure-bound end-call control exposed on every realtime phone call. */
+const REALTIME_VOICE_END_CALL_TOOL: RealtimeVoiceTool = {
+  type: "function",
+  name: REALTIME_VOICE_END_CALL_TOOL_NAME,
+  description:
+    "End the current phone call immediately. Speak any final words to the caller before invoking this tool because the call ends as soon as it is invoked and no further reply will be spoken.",
+  parameters: {
+    type: "object",
+    properties: {},
+  },
+};
+
+/** Merge built-in call controls with consult and configured realtime tools. */
+export function resolveVoiceCallRealtimeTools(
+  policy: RealtimeVoiceAgentConsultToolPolicy,
+  customTools: RealtimeVoiceTool[] = [],
+): RealtimeVoiceTool[] {
+  const tools = resolveRealtimeVoiceAgentConsultTools(policy, customTools).filter(
+    (tool) => tool.name !== REALTIME_VOICE_END_CALL_TOOL_NAME,
+  );
+  return [REALTIME_VOICE_END_CALL_TOOL, ...tools];
+}

--- a/extensions/voice-call/src/realtime-defaults.ts
+++ b/extensions/voice-call/src/realtime-defaults.ts
@@ -1,7 +1,8 @@
 // Voice Call plugin module implements realtime defaults behavior.
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "openclaw/plugin-sdk/realtime-voice";
+import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "./realtime-call-control.js";
 
 // Default realtime instructions for the voice-call plugin's phone interface.
 
 /** Baseline instructions that keep realtime calls brief and route deep work to agent consult. */
-export const DEFAULT_VOICE_CALL_REALTIME_INSTRUCTIONS = `You are OpenClaw's phone-call realtime voice interface. Keep spoken replies brief and natural. When a question needs deeper reasoning, current information, or tools, call ${REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME} before answering.`;
+export const DEFAULT_VOICE_CALL_REALTIME_INSTRUCTIONS = `You are OpenClaw's phone-call realtime voice interface. Keep spoken replies brief and natural. When a question needs deeper reasoning, current information, or tools, call ${REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME} before answering. When the caller asks to end the call, speak any final words first, then call ${REALTIME_VOICE_END_CALL_TOOL_NAME}; it ends the call immediately and nothing after it will be spoken.`;

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -617,6 +617,7 @@ describe("createVoiceCallRuntime lifecycle", () => {
       throw new Error("expected realtime handler tools to be an array");
     }
     expect(tools.map((tool) => requireRecord(tool, "realtime tool").name)).toEqual([
+      "openclaw_end_call",
       "openclaw_agent_consult",
       "custom_tool",
     ]);
@@ -651,6 +652,53 @@ describe("createVoiceCallRuntime lifecycle", () => {
     expect(consultParams.extraSystemPrompt).toContain("one or two bounded read-only queries");
     expect(consultParams.prompt).toContain("Caller: Can you check shipment status?");
     expect(consultParams.prompt).toContain("Caller: Also check the ETA.");
+  });
+
+  it("always exposes the built-in end-call tool without allowing configured replacement", async () => {
+    const config = createBaseConfig();
+    config.realtime.enabled = true;
+    config.realtime.toolPolicy = "none";
+    config.realtime.tools = [
+      {
+        type: "function",
+        name: "openclaw_end_call",
+        description: "Configured replacement",
+        parameters: { type: "object", properties: { callId: { type: "string" } } },
+      },
+      {
+        type: "function",
+        name: "custom_tool",
+        description: "Custom tool",
+        parameters: { type: "object", properties: {} },
+      },
+    ];
+
+    await createVoiceCallRuntime({
+      config,
+      coreConfig: {} as OpenClawConfig,
+      agentRuntime: {} as never,
+    });
+
+    const realtimeHandlerOptions = requireRecord(
+      mocks.realtimeHandlerCtorArgs[0]?.[0],
+      "realtime handler options",
+    );
+    const tools = realtimeHandlerOptions.tools;
+    if (!Array.isArray(tools)) {
+      throw new Error("expected realtime handler tools to be an array");
+    }
+    expect(tools.map((tool) => requireRecord(tool, "realtime tool").name)).toEqual([
+      "openclaw_end_call",
+      "custom_tool",
+    ]);
+    const endCallTool = requireRecord(tools[0], "end-call tool");
+    expect(endCallTool.description).toContain("final words");
+    expect(endCallTool.description).toContain("no further reply");
+    expect(requireRecord(endCallTool.parameters, "end-call parameters")).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(mocks.realtimeHandlerRegisterToolHandler).not.toHaveBeenCalled();
   });
 
   it("rejects a realtime consult whose lifecycle owner already aborted", async () => {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -8,7 +8,6 @@ import {
   assertRealtimeVoiceAgentConsultModelSelectionUnlocked,
   consultRealtimeVoiceAgent,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
-  resolveRealtimeVoiceAgentConsultTools,
   resolveRealtimeVoiceAgentConsultToolsAllow,
   type RealtimeVoiceAgentConsultTranscriptEntry,
 } from "openclaw/plugin-sdk/realtime-voice";
@@ -28,6 +27,7 @@ import { CallManager } from "./manager.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import { buildRealtimeVoiceInstructions } from "./realtime-agent-context.js";
+import { resolveVoiceCallRealtimeTools } from "./realtime-call-control.js";
 import { resolveRealtimeFastContextConsult } from "./realtime-fast-context.js";
 import { resolveCallAgentId } from "./resolve-call-agent-id.js";
 import { resolveVoiceResponseModel } from "./response-model.js";
@@ -352,10 +352,7 @@ export async function createVoiceCallRuntime(params: {
     });
     const realtimeConfig = {
       ...config.realtime,
-      tools: resolveRealtimeVoiceAgentConsultTools(
-        config.realtime.toolPolicy,
-        config.realtime.tools,
-      ),
+      tools: resolveVoiceCallRealtimeTools(config.realtime.toolPolicy, config.realtime.tools),
     };
     const resolveCallRegistration = (call: CallRecord) => {
       const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1356,6 +1356,197 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("ends the closure-bound current call without requesting another provider response", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const closeBridge = vi.fn();
+    const submitToolResult = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({ close: closeBridge, submitToolResult });
+    });
+    const call = makeCallRecord("CA-end-current");
+    const endCall = vi.fn(async (_callId: string) => ({ success: true }));
+    const handler = makeHandler(undefined, {
+      manager: {
+        endCall,
+        getCallByProviderCallId: vi.fn(() => call),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-end-current", callSid: "CA-end-current" },
+        }),
+      );
+      await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledOnce());
+
+      const closed = waitForClose(ws);
+      callbacks?.onToolCall?.({
+        itemId: "item-end-current",
+        callId: "provider-end-current",
+        name: "openclaw_end_call",
+        args: {},
+      });
+
+      await waitForRealtimeTest(() => {
+        expect(endCall).toHaveBeenCalledExactlyOnceWith("call-1");
+        expect(closeBridge).toHaveBeenCalledOnce();
+      });
+      expect(await closed).toEqual({ code: 1000, reason: "Call ended" });
+      expect(submitToolResult).not.toHaveBeenCalled();
+      expect(recentTalkEvents(call)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "tool.result" })]),
+      );
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
+  it("reports an actionable end-call failure while leaving the current call connected", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const closeBridge = vi.fn();
+    const submitToolResult = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({ close: closeBridge, submitToolResult });
+    });
+    const call = makeCallRecord("CA-end-failed");
+    const endCall = vi.fn(async () => ({ success: false, error: "carrier rejected hangup" }));
+    const handler = makeHandler(undefined, {
+      manager: {
+        endCall,
+        getCallByProviderCallId: vi.fn(() => call),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-end-failed", callSid: "CA-end-failed" },
+        }),
+      );
+      await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledOnce());
+
+      callbacks?.onToolCall?.({
+        itemId: "item-end-failed",
+        callId: "provider-end-failed",
+        name: "openclaw_end_call",
+        args: {},
+      });
+
+      await waitForRealtimeTest(() => {
+        expect(submitToolResult).toHaveBeenCalledWith(
+          "provider-end-failed",
+          {
+            error:
+              "Could not end the current phone call: carrier rejected hangup. Tell the caller the call could not be ended and they can hang up or ask you to try again.",
+          },
+          undefined,
+        );
+      });
+      expect(endCall).toHaveBeenCalledExactlyOnceWith("call-1");
+      expect(closeBridge).not.toHaveBeenCalled();
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      expect(recentTalkEvents(call)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "tool.error" })]),
+      );
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        ws.close();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
+  it("ignores an end-call callback from a retired predecessor bridge", async () => {
+    const callbacks: RealtimeBridgeRequest[] = [];
+    const predecessorClose = vi.fn();
+    const replacementClose = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks.push(request);
+      return makeBridge({ close: callbacks.length === 1 ? predecessorClose : replacementClose });
+    });
+    const call = makeCallRecord("CA-end-replacement");
+    const endCall = vi.fn(async (_callId: string) => ({ success: true }));
+    const handler = makeHandler(undefined, {
+      manager: {
+        endCall,
+        getCallByProviderCallId: vi.fn(() => call),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const predecessorServer = await startRealtimeServer(handler);
+    const predecessorWs = await connectWs(predecessorServer.url);
+    let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
+    let replacementWs: WebSocket | undefined;
+
+    try {
+      predecessorWs.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-end-predecessor", callSid: "CA-end-replacement" },
+        }),
+      );
+      await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledTimes(1));
+
+      replacementServer = await startRealtimeServer(handler);
+      replacementWs = await connectWs(replacementServer.url);
+      replacementWs.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-end-replacement", callSid: "CA-end-replacement" },
+        }),
+      );
+      await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledTimes(2));
+      expect(predecessorClose).toHaveBeenCalledOnce();
+
+      callbacks[0]?.onToolCall?.({
+        itemId: "item-end-stale",
+        callId: "provider-end-stale",
+        name: "openclaw_end_call",
+        args: {},
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(endCall).not.toHaveBeenCalled();
+      expect(replacementClose).not.toHaveBeenCalled();
+      expect(replacementWs.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      if (
+        replacementWs &&
+        replacementWs.readyState !== WebSocket.CLOSED &&
+        replacementWs.readyState !== WebSocket.CLOSING
+      ) {
+        replacementWs.close();
+      }
+      if (
+        predecessorWs.readyState !== WebSocket.CLOSED &&
+        predecessorWs.readyState !== WebSocket.CLOSING
+      ) {
+        predecessorWs.close();
+      }
+      await handler.close();
+      await replacementServer?.close();
+      await predecessorServer.close();
+    }
+  });
+
   it("submits continuing responses only for realtime agent consult calls", async () => {
     let callbacks:
       | {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -30,6 +30,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
+import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "../realtime-call-control.js";
 import type { CallRecord, EndReason, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
@@ -319,6 +320,7 @@ type RealtimeCallEndCause = "disconnect" | "shutdown" | "inactivity" | "error";
 type RealtimeTelephonyBinding = {
   bridge: ActiveRealtimeVoiceBridge;
   close: (cause: RealtimeCallEndCause) => void;
+  endCall: () => void;
   noteMediaActivity: () => void;
   retire: () => void;
 };
@@ -1192,6 +1194,14 @@ export class RealtimeCallHandler {
     const telephonyBinding: RealtimeTelephonyBinding = {
       bridge: session,
       close: (cause) => closeBinding(telephonyBinding, cause),
+      endCall: () => {
+        // Close the provider session before the carrier socket so no pending
+        // response can reach the caller after the hang-up request succeeds.
+        closeBinding(telephonyBinding);
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.close(1000, "Call ended");
+        }
+      },
       noteMediaActivity: () => {
         if (
           bindingClosed ||
@@ -1731,6 +1741,61 @@ export class RealtimeCallHandler {
     });
   }
 
+  private async executeEndCallTool(params: {
+    bridge: ActiveRealtimeVoiceBridge;
+    callId: string;
+    bridgeCallId: string;
+    turnId: string;
+    harness: RealtimeVoiceSessionHarness;
+  }): Promise<void> {
+    const binding = this.activeTelephonyBindingsByCallId.get(params.callId);
+    if (
+      !binding ||
+      binding.bridge !== params.bridge ||
+      !this.isActiveBridgeOwner(params.callId, params.bridge)
+    ) {
+      return;
+    }
+
+    let result: { success: boolean; error?: string };
+    try {
+      result = await this.manager.endCall(params.callId);
+    } catch (error) {
+      result = { success: false, error: formatErrorMessage(error) };
+    }
+
+    if (
+      this.activeTelephonyBindingsByCallId.get(params.callId) !== binding ||
+      !this.isActiveBridgeOwner(params.callId, params.bridge)
+    ) {
+      return;
+    }
+    if (!result.success) {
+      const detail = result.error?.trim() || "the telephony provider returned no reason";
+      const toolResult = {
+        error: `Could not end the current phone call: ${detail}. Tell the caller the call could not be ended and they can hang up or ask you to try again.`,
+      };
+      await params.bridge.submitToolResult(params.bridgeCallId, toolResult);
+      params.harness.emit({
+        type: "tool.error",
+        turnId: params.turnId,
+        callId: params.bridgeCallId,
+        payload: { name: REALTIME_VOICE_END_CALL_TOOL_NAME, result: toolResult },
+        final: true,
+      });
+      return;
+    }
+
+    params.harness.emit({
+      type: "tool.result",
+      turnId: params.turnId,
+      callId: params.bridgeCallId,
+      payload: { name: REALTIME_VOICE_END_CALL_TOOL_NAME, result: { success: true } },
+      final: true,
+    });
+    binding.endCall();
+  }
+
   private async executeToolCall(
     bridge: ActiveRealtimeVoiceBridge,
     callId: string,
@@ -1741,6 +1806,10 @@ export class RealtimeCallHandler {
     harness: RealtimeVoiceSessionHarness,
     userTranscriptOwner: UserTranscriptState,
   ): Promise<void> {
+    if (name === REALTIME_VOICE_END_CALL_TOOL_NAME) {
+      await this.executeEndCallTool({ bridge, callId, bridgeCallId, turnId, harness });
+      return;
+    }
     const handler = this.toolHandlers.get(name);
     const startedAt = Date.now();
     const hasResultError = (result: unknown): boolean => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Realtime phone agents could converse with callers and consult a regular OpenClaw agent, but they could not end their own active call. Even after asking the agent to hang up, the caller or an operator still had to disconnect manually.

## Why This Change Was Made

Voice Call now gives every realtime call an always-available, no-argument `openclaw_end_call` built-in. The active voice bridge binds the tool to its exact current call and routes the request through the canonical `CallManager` owner, while bridge-generation checks fence stale predecessors and configured tools cannot replace the built-in.

On success, the agent's final words are spoken before the tool runs, then the provider bridge and carrier socket close without requesting post-tool speech. On provider failure, the call stays connected and the model receives an actionable explanation. Keeping this control plugin-local is safer and simpler than widening consult policy, accepting caller-supplied call IDs, adding a core or Plugin SDK seam, or calling Twilio directly; there is no core, SDK, configuration, persisted-state, or provider REST adapter expansion.

Release-note context: realtime voice agents can now end their current calls safely.

AI-assisted; the implementation and evidence were reviewed before publication.

## User Impact

Callers can ask a realtime voice agent to hang up. The agent can say its final words and then disconnect the active phone call itself. If the carrier rejects the hang-up, the call remains connected and the agent explains that the caller can hang up or ask it to try again.

## Evidence

- `node scripts/run-vitest.mjs extensions/voice-call/src/runtime.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts extensions/voice-call/src/config.test.ts` — 4 files, 125 tests passed on the final head.
- `node scripts/check-changed.mjs` — all selected formatting, typecheck, lint, boundary, dead-code, database-first, and import-cycle checks passed on the final head.
- `pnpm format:check` — 29,178 files passed after the current-main UI CI repair landed.
- `pnpm docs:check-mdx` — 776 files passed before publication; exact-head docs CI is green.
- `git diff --check` — passed.
- Fresh autoreview on the final head — no accepted or actionable findings.
- Exact-head CI run [32095042851](https://github.com/openclaw/openclaw/actions/runs/32095042851) — success for `881d3430904ee5281128a197f7c4c788eedbd26b`, with no failed jobs.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 125525` — passed in repository-native `hosted_exact_or_recent_parent` mode. It accepted the exact-head hosted CI above and did not dispatch a separate remote Testbox run.
- ClawSweeper's exact-head review found no code or security findings. Its proof move is addressed by exact-head CI plus the repository-native prepare gate; the persistent-data note is a test-path false positive, with no schema or migration change.
- LOC: production +105/-6, tests +241/-0, docs +11/-2. The positive production delta implements the new closure-bound realtime capability and its lifecycle authority boundary.
- Deterministic provider/WebSocket lifecycle coverage proves successful hang-up without post-tool speech, actionable provider failure while the call stays connected, and rejection of a stale predecessor bridge.
- The Twilio contract was checked against the official Call resource documentation: an active call is ended by updating its status to `completed`. This change continues to use `CallManager.endCall` and leaves the existing Twilio REST adapter unchanged.
- A live carrier phone call was not attempted because no external call target or cost was authorized. The deterministic provider/WebSocket coverage and hosted gates are not live carrier proof.
