### PR TITLE
fix(android): normalize null calendar and contact write fields

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CalendarHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CalendarHandler.kt
@@ -402,15 +402,15 @@ class CalendarHandler private constructor(
     val isAllDay = (params["isAllDay"] as? JsonPrimitive)?.content?.toBooleanStrictOrNull() ?: false
     val addRange = normalizeAddRange(start, end, isAllDay)
     return CalendarAddRequest(
-      title = (params["title"] as? JsonPrimitive)?.content?.trim().orEmpty(),
+      title = parseJsonString(params, "title")?.trim().orEmpty(),
       startMs = addRange.start.toEpochMilli(),
       endMs = addRange.end.toEpochMilli(),
       isAllDay = isAllDay,
       timeZoneId = if (isAllDay) "UTC" else TimeZone.getDefault().id,
-      location = (params["location"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
-      notes = (params["notes"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
+      location = parseJsonString(params, "location")?.trim()?.ifEmpty { null },
+      notes = parseJsonString(params, "notes")?.trim()?.ifEmpty { null },
       calendarId = (params["calendarId"] as? JsonPrimitive)?.content?.toLongOrNull(),
-      calendarTitle = (params["calendarTitle"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
+      calendarTitle = parseJsonString(params, "calendarTitle")?.trim()?.ifEmpty { null },
     )
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ContactsHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ContactsHandler.kt
@@ -451,10 +451,10 @@ class ContactsHandler private constructor(
         null
       } ?: return null
     return ContactsAddRequest(
-      givenName = (params["givenName"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
-      familyName = (params["familyName"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
-      organizationName = (params["organizationName"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
-      displayName = (params["displayName"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
+      givenName = parseJsonString(params, "givenName")?.trim()?.ifEmpty { null },
+      familyName = parseJsonString(params, "familyName")?.trim()?.ifEmpty { null },
+      organizationName = parseJsonString(params, "organizationName")?.trim()?.ifEmpty { null },
+      displayName = parseJsonString(params, "displayName")?.trim()?.ifEmpty { null },
       phoneNumbers = stringArray(params["phoneNumbers"] as? JsonArray),
       // Store emails case-normalized so repeated model calls do not create casing-only duplicates.
       emails = stringArray(params["emails"] as? JsonArray).map { it.lowercase() },
@@ -464,7 +464,7 @@ class ContactsHandler private constructor(
   private fun stringArray(array: JsonArray?): List<String> {
     if (array == null) return emptyList()
     return array.mapNotNull { element ->
-      (element as? JsonPrimitive)?.content?.trim()?.ifEmpty { null }
+      element.asStringOrNull()?.trim()?.ifEmpty { null }
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/CalendarHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/CalendarHandlerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
@@ -68,6 +69,44 @@ class CalendarHandlerTest : NodeHandlerRobolectricTest() {
         .getValue("title")
         .jsonPrimitive.content,
     )
+  }
+
+  @Test
+  fun handleCalendarAdd_omitsExplicitJsonNullFields() {
+    val source = FakeCalendarDataSource(canRead = true, canWrite = true)
+    val handler = CalendarHandler.forTesting(appContext(), source)
+
+    val result =
+      handler.handleCalendarAdd(
+        """
+        {"title":"Standup","startISO":"2026-02-28T10:00:00Z","endISO":"2026-02-28T11:00:00Z",
+         "location":null,"notes":null,"calendarTitle":null,"calendarId":null,"isAllDay":null}
+        """.trimIndent(),
+      )
+
+    assertTrue(result.ok)
+    val request = source.addedRequest ?: error("missing add request")
+    assertEquals("Standup", request.title)
+    assertNull(request.location)
+    assertNull(request.notes)
+    assertNull(request.calendarTitle)
+    assertNull(request.calendarId)
+    assertFalse(request.isAllDay)
+  }
+
+  @Test
+  fun handleCalendarAdd_rejectsExplicitJsonNullTitle() {
+    val source = FakeCalendarDataSource(canRead = true, canWrite = true)
+    val handler = CalendarHandler.forTesting(appContext(), source)
+
+    val result =
+      handler.handleCalendarAdd(
+        """{"title":null,"startISO":"2026-02-28T10:00:00Z","endISO":"2026-02-28T11:00:00Z"}""",
+      )
+
+    assertFalse(result.ok)
+    assertEquals("CALENDAR_INVALID", result.error?.code)
+    assertNull(source.addedRequest)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ContactsHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ContactsHandlerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -70,6 +71,18 @@ class ContactsHandlerTest : NodeHandlerRobolectricTest() {
   }
 
   @Test
+  fun handleContactsSearch_preservesExplicitJsonNullQuery() {
+    val source = FakeContactsDataSource(canRead = true)
+    val handler = ContactsHandler.forTesting(appContext(), source)
+
+    val result = handler.handleContactsSearch("""{"query":null}""")
+
+    assertTrue(result.ok)
+    assertEquals("null", source.searchedRequest?.query)
+    assertEquals(25, source.searchedRequest?.limit)
+  }
+
+  @Test
   fun handleContactsAdd_returnsAddedContact() {
     val added =
       ContactRecord(
@@ -95,6 +108,58 @@ class ContactsHandlerTest : NodeHandlerRobolectricTest() {
     assertEquals("Grace Hopper", contact.getValue("displayName").jsonPrimitive.content)
     assertEquals(1, source.addCalls)
   }
+
+  @Test
+  fun handleContactsAdd_omitsExplicitJsonNullFields() {
+    val source = FakeContactsDataSource(canRead = true, canWrite = true)
+    val handler = ContactsHandler.forTesting(appContext(), source)
+
+    val result =
+      handler.handleContactsAdd(
+        """
+        {"givenName":"Grace","familyName":null,"organizationName":null,"displayName":null,
+         "phoneNumbers":[null,"+15550100"],"emails":[null]}
+        """.trimIndent(),
+      )
+
+    assertTrue(result.ok)
+    val request = source.addedRequest ?: error("missing add request")
+    assertEquals("Grace", request.givenName)
+    assertNull(request.familyName)
+    assertNull(request.organizationName)
+    assertNull(request.displayName)
+    assertEquals(listOf("+15550100"), request.phoneNumbers)
+    assertTrue(request.emails.isEmpty())
+  }
+
+  @Test
+  fun handleContactsAdd_rejectsOnlyExplicitJsonNullFields() {
+    val source = FakeContactsDataSource(canRead = true, canWrite = true)
+    val handler = ContactsHandler.forTesting(appContext(), source)
+
+    val result =
+      handler.handleContactsAdd(
+        """{"givenName":null,"familyName":null,"organizationName":null,"phoneNumbers":[null],"emails":[null]}""",
+      )
+
+    assertFalse(result.ok)
+    assertEquals("CONTACTS_INVALID", result.error?.code)
+    assertEquals(0, source.addCalls)
+    assertNull(source.addedRequest)
+  }
+
+  @Test
+  fun handleContactsAdd_preservesLiteralNullStrings() {
+    val source = FakeContactsDataSource(canRead = true, canWrite = true)
+    val handler = ContactsHandler.forTesting(appContext(), source)
+
+    val result = handler.handleContactsAdd("""{"givenName":"null","phoneNumbers":["null"]}""")
+
+    assertTrue(result.ok)
+    val request = source.addedRequest ?: error("missing add request")
+    assertEquals("null", request.givenName)
+    assertEquals(listOf("null"), request.phoneNumbers)
+  }
 }
 
 private class FakeContactsDataSource(
@@ -115,6 +180,12 @@ private class FakeContactsDataSource(
   var addCalls: Int = 0
     private set
 
+  var searchedRequest: ContactsSearchRequest? = null
+    private set
+
+  var addedRequest: ContactsAddRequest? = null
+    private set
+
   override fun hasReadPermission(context: Context): Boolean = canRead
 
   override fun hasWritePermission(context: Context): Boolean = canWrite
@@ -122,13 +193,17 @@ private class FakeContactsDataSource(
   override fun search(
     context: Context,
     request: ContactsSearchRequest,
-  ): List<ContactRecord> = searchResults
+  ): List<ContactRecord> {
+    searchedRequest = request
+    return searchResults
+  }
 
   override fun add(
     context: Context,
     request: ContactsAddRequest,
   ): ContactRecord {
     addCalls += 1
+    addedRequest = request
     return addResult
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Android `calendar.add` and `contacts.add` treated an explicit JSON `null` as the literal string `"null"`, which could create an event named `null`, prevent default calendar selection, or persist bogus contact names, phone numbers, and email addresses.

The root cause is that `kotlinx.serialization.json.JsonNull` extends `JsonPrimitive`, while `JsonNull.content` is the literal string `"null"`. The write handlers bypassed Android's existing canonical null-aware JSON helpers.

## Why This Change Was Made

Reuse the existing `parseJsonString` helper for calendar/contact write fields and the existing `asStringOrNull` helper for contact phone/email array entries. This repairs the producer boundary before Android `CalendarProvider` or `ContactsProvider` receives invalid user data.

The original proposed patch also normalized `contacts.search` query parameters. That would change an explicit `{"query":null}` from a narrow literal-`null` search into an unfiltered result containing up to 25 contacts. This revision deliberately preserves the existing read/search behavior and adds a regression test for that privacy-sensitive contract.

Production delta: +9/-9, net zero. No new helpers, dependencies, configuration, permissions, schema changes, or compatibility fallbacks.

## User Impact

Explicit JSON nulls are omitted from new calendar events and contacts, missing required titles or entirely empty contacts are rejected, real phone/email values still persist, and an actual JSON string containing `"null"` remains legitimate user data. Calendar event reads, contact searches, permissions, numeric parsing, and boolean parsing retain their existing behavior.

## Evidence

Fail-first owner-boundary proof against current `main`:

```text
CalendarHandlerTest > handleCalendarAdd_rejectsExplicitJsonNullTitle FAILED
CalendarHandlerTest > handleCalendarAdd_omitsExplicitJsonNullFields FAILED
ContactsHandlerTest > handleContactsAdd_omitsExplicitJsonNullFields FAILED
ContactsHandlerTest > handleContactsAdd_rejectsOnlyExplicitJsonNullFields FAILED

17 tests completed, 4 failed
```

After the canonical producer-boundary repair:

```text
:app:testPlayDebugUnitTest

CalendarHandlerTest: 9 tests, 0 failures, 0 errors
ContactsHandlerTest: 8 tests, 0 failures, 0 errors

BUILD SUCCESSFUL
```

The passing cases include both explicit-null search privacy and preservation of an actual JSON string `"null"`.

Real Android API 36 emulator proof uses a temporary instrumentation APK, the production Android handlers, granted calendar/contact runtime permissions, and the actual platform content providers:

```text
adb -s emulator-5580 shell am instrument -w \
  -e class ai.openclaw.app.node.ProviderNullWriteProofTest \
  ai.openclaw.app.debug.test/androidx.test.runner.AndroidJUnitRunner

ai.openclaw.app.node.ProviderNullWriteProofTest:..

Time: 0.055

OK (2 tests)
```

The instrumentation creates a local calendar through the real `CalendarContract` sync-adapter interface, invokes `CalendarHandler.handleCalendarAdd`, queries persisted `CalendarContract.Events` rows, and confirms optional fields remain SQL NULL while a null title is rejected. It also invokes `ContactsHandler.handleContactsAdd`, queries actual `ContactsContract.Data` rows, confirms only the real phone number persists, rejects all-null contacts, and proves `contacts.search({"query":null})` does not enumerate the newly created contact. Both tests clean up their inserted platform-provider rows.

Fresh structured review reported no accepted/actionable findings. Independent review verified the complete caller, producer, existing helper, actual provider sink, dependency contract, privacy boundary, fail-first tests, and real-device proof.

Original report and implementation: @Kaneki-x. Maintainer revision preserves the original contributor as a human co-author.
