### PR TITLE
fix(tts): classify real transport timeouts as timeouts

### DIFF
--- a/src/tts/tts-runtime-models.test.ts
+++ b/src/tts/tts-runtime-models.test.ts
@@ -284,9 +284,11 @@ describe("TTS runtime voice model and streaming behavior", () => {
   });
 
   it("classifies streaming timeouts before falling back with raw text", async () => {
+    // Real transport timeouts arrive as "TimeoutError" (fetch-timeout.ts), not
+    // AbortError; the classifier must catch the shape providers actually throw.
     const timeoutStreamSynthesize = vi.fn(async () => {
-      const error = new Error("stalled");
-      error.name = "AbortError";
+      const error = new Error("request timed out");
+      error.name = "TimeoutError";
       throw error;
     });
     const fallbackStreamSynthesize = vi.fn(async () => ({

--- a/src/tts/tts-synthesis-support.ts
+++ b/src/tts/tts-synthesis-support.ts
@@ -24,9 +24,20 @@ import {
 } from "./tts-settings.js";
 import type { VoiceModelRef, VoiceProviderCandidate } from "./voice-models.js";
 
+// The transport names its abort "TimeoutError" (fetch-timeout.ts) and provider
+// deadlines throw plain Errors ending in "timed out"; AbortError alone misses both.
+function isTtsTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return (
+    err.name === "AbortError" || err.name === "TimeoutError" || /\btimed out\b/iu.test(err.message)
+  );
+}
+
 export function formatTtsProviderError(provider: TtsProvider, err: unknown): string {
   const error = err instanceof Error ? err : new Error(String(err));
-  if (error.name === "AbortError") {
+  if (isTtsTimeoutError(error)) {
     return `${provider}: request timed out`;
   }
   return `${provider}: ${redactSensitiveText(error.message)}`;
@@ -386,8 +397,7 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
       attempts.push({
         provider,
         outcome: "failed",
-        reasonCode:
-          err instanceof Error && err.name === "AbortError" ? "timeout" : "provider_error",
+        reasonCode: isTtsTimeoutError(err) ? "timeout" : "provider_error",
         latencyMs,
         persona: persona?.id,
         personaBinding: resolvePersonaBinding(persona, provider),


### PR DESCRIPTION
## What Problem This Solves

TTS attempt records only recognized `err.name === "AbortError"` as a timeout — but the shared transport names its abort **"TimeoutError"** (`src/utils/fetch-timeout.ts:102-105`) and provider operation deadlines throw plain `Error`s ending in "timed out" (`src/media-understanding/shared.ts:148-152`). No HTTP provider ever throws an AbortError, so every real provider timeout was recorded as `reasonCode: "provider_error"` — the timeout classifier was dead code. `/tts status` and telemetry showed "provider error" for genuine timeouts, dead-ending diagnosis.

## Why This Change Was Made

Record facts correctly at their producer. One small helper recognizes all three real shapes (AbortError, TimeoutError, "timed out" message) and feeds both the `reasonCode` and the formatted `"request timed out"` error text — they previously used separate, both-wrong checks.

## User Impact

Operators diagnosing slow/unresponsive TTS providers now see `timeout` in attempt records instead of a generic provider error.

## Evidence

- The existing classification test crafted an AbortError by hand, green-lighting the misclassification; it now uses the real `TimeoutError` transport shape and **fails pre-fix** (stash run: 1 failed).
- `tts-runtime-models.test.ts` 7/7; `tsgo` core rc=0; oxlint/oxfmt clean.
- Codex autoreview clean (0.99).
- Production delta: +13 −3 (the helper consolidates two divergent checks).
- Sibling checked: `tts-core.ts:167` uses its own AbortController where AbortError is the correct shape — left as-is.
