### PR TITLE
feat: support step-level audit with in-flight rollback for review plugins

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -46,6 +46,7 @@ import {
   resolveOrphanRepairPlan,
 } from "./attempt-orphan-repair.js";
 import { buildAfterTurnRuntimeContext } from "./attempt-prompt-helpers.js";
+import { installStepAuditApi, STEP_AUDIT_FEEDBACK_MARKER } from "./attempt-step-audit.js";
 import { resolveExistingAttemptTranscriptState } from "./attempt-transcript-helpers.js";
 import type { EmbeddedAttemptTranscriptLifecycle } from "./attempt-transcript-lifecycle.js";
 import { createUserTranscriptContextRegistry } from "./attempt-user-transcript-context-registry.js";
@@ -216,6 +217,15 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
   input.onSessionCreated(activeSession);
   installToolLoopRecoveryCleanup({ agent: activeSession.agent, runId: attempt.runId });
   activeSession.setActiveToolsByName(sessionToolAllowlist);
+  // Step-audit checkpoints: review plugins capture the transcript tail before
+  // each tool/text step and roll a rejected step back via the returned API
+  // (published on `globalThis.__openclawStepAuditRegistry` keyed by runId).
+  installStepAuditApi({
+    runId: attempt.runId,
+    activeSession,
+    sessionManager: input.sessionManager,
+    feedbackMarker: STEP_AUDIT_FEEDBACK_MARKER,
+  });
   const setActiveSessionSystemPrompt = (nextSystemPrompt: string) => {
     input.onSystemPromptChanged(nextSystemPrompt);
     applySystemPromptToSession(activeSession, nextSystemPrompt);

--- a/src/agents/embedded-agent-runner/run/attempt-step-audit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-step-audit.ts
@@ -1,0 +1,252 @@
+/**
+ * Step-audit checkpoint support for review-style plugins.
+ *
+ * `before_agent_finalize` audits the run only after it finishes, which is too
+ * late for review plugins that want each tool/text step verified before the
+ * run moves on. This module gives such plugins a per-run checkpoint API:
+ *
+ * - `capture(stepSeq)` records the current transcript tail as the rollback
+ *   checkpoint for one step. The plugin calls it synchronously from its
+ *   `before_tool_call` hook (zero cost).
+ * - `rollback(feedback, stepSeq?)` truncates the rejected step from both the
+ *   active agent state and the persisted session transcript, then injects a
+ *   feedback message so the agent redoes the step immediately.
+ *
+ * The API handle is published on `globalThis.__openclawStepAuditRegistry`
+ * keyed by runId because plugin hook callbacks only receive the runId and
+ * cannot reach attempt-scoped runtime any other way. Entries are removed when
+ * the attempt tears down (see `runEmbeddedAttempt`).
+ */
+import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentSession } from "../../sessions/index.js";
+import type { SessionEntry } from "../../sessions/session-manager-types.js";
+import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import { log } from "../logger.js";
+
+/** Maximum in-flight rollbacks per run; guards against feedback storms. */
+export const MAX_STEP_AUDIT_ROLLBACKS_PER_RUN = 3;
+
+/**
+ * Prefix for injected audit-feedback messages. Also the detection marker used
+ * to recognize an already-rolled-back transcript range.
+ */
+export const STEP_AUDIT_FEEDBACK_MARKER = "[audit-feedback]";
+
+/** Persisted roles that belong to the rejected step suffix and can be removed. */
+const REMOVABLE_STEP_AUDIT_ROLES = new Set(["assistant", "toolResult", "bashExecution", "custom"]);
+
+type AttemptSessionManager = ReturnType<typeof guardSessionManager>;
+
+interface StepAuditCut {
+  cut: number;
+  len: number;
+}
+
+export type StepAuditCaptureResult =
+  | { ok: true; cut: number; stepSeq: number }
+  | { ok: false; reason: string };
+
+export type StepAuditRollbackResult =
+  | { ok: true; removed: number; cut: number }
+  | {
+      ok: false;
+      reason:
+        | "bad-args"
+        | "rollback-limit"
+        | "no-checkpoint"
+        | "no-messages"
+        | "nothing-to-remove"
+        | "already-rolled-back"
+        | string;
+    };
+
+export interface StepAuditApi {
+  capture(stepSeq: number): StepAuditCaptureResult;
+  rollback(feedbackText: string, stepSeq?: number): StepAuditRollbackResult;
+}
+
+/**
+ * Process-wide bridge between plugin hook callbacks and attempt-scoped
+ * checkpoints. Review plugins look their runId up here; see module docs.
+ */
+const globalRegistry = globalThis as unknown as {
+  __openclawStepAuditRegistry?: Map<string, StepAuditApi>;
+};
+
+/** Typed accessor for review plugins that prefer an import over the global. */
+export function getStepAuditApi(runId: string | null | undefined): StepAuditApi | undefined {
+  return runId ? globalRegistry.__openclawStepAuditRegistry?.get(runId) : undefined;
+}
+
+/** Installs the step-audit checkpoint API for one embedded-agent attempt. */
+export function installStepAuditApi(input: {
+  runId: string;
+  activeSession: AgentSession;
+  sessionManager: AttemptSessionManager;
+  /** Prefix marking injected audit feedback; used to detect repeated rollbacks. */
+  feedbackMarker: string;
+}): void {
+  const { runId, activeSession, sessionManager, feedbackMarker } = input;
+  const registry =
+    globalRegistry.__openclawStepAuditRegistry ??
+    (globalRegistry.__openclawStepAuditRegistry = new Map<string, StepAuditApi>());
+
+  const cuts = new Map<number, StepAuditCut>();
+  let rollbackCount = 0;
+
+  const readMessages = (): AgentMessage[] | undefined => activeSession.agent.state.messages;
+
+  /**
+   * Locates the newest assistant message that starts the current step:
+   * scanning backwards, a user/custom message terminates the step, and the
+   * first assistant message marks where the step began.
+   */
+  const findStepCut = (): number => {
+    const messages = readMessages();
+    if (!Array.isArray(messages)) {
+      return -1;
+    }
+    for (let k = messages.length - 1; k >= 0; k -= 1) {
+      const role = messages[k]?.role;
+      if (role === "user" || role === "custom") {
+        break;
+      }
+      if (role === "assistant") {
+        return k;
+      }
+    }
+    return -1;
+  };
+
+  /** True when the range already contains an injected audit-feedback message. */
+  const hasFeedbackInjectionFrom = (from: number): boolean => {
+    const messages = readMessages();
+    if (!Array.isArray(messages) || from < 0 || from >= messages.length) {
+      return true;
+    }
+    for (let k = from; k < messages.length; k += 1) {
+      const message = messages[k];
+      if (message?.role !== "user") {
+        continue;
+      }
+      const serialized = JSON.stringify(message.content ?? "").slice(0, 4000);
+      if (serialized.includes(feedbackMarker)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const buildFeedbackMessage = (
+    feedbackText: string,
+  ): Extract<AgentMessage, { role: "user" }> => ({
+    role: "user",
+    content: [{ type: "text", text: `${feedbackMarker} ${feedbackText.trim()}` }],
+    timestamp: Date.now(),
+  });
+
+  const api: StepAuditApi = {
+    capture(stepSeq: number): StepAuditCaptureResult {
+      try {
+        const messages = readMessages();
+        if (!Array.isArray(messages)) {
+          return { ok: false, reason: "no-messages" };
+        }
+        const cut = findStepCut();
+        if (cut < 0) {
+          return { ok: false, reason: "no-step" };
+        }
+        const seq = Number.isFinite(stepSeq) ? stepSeq : -1;
+        cuts.set(seq, { cut, len: messages.length });
+        return { ok: true, cut, stepSeq: seq };
+      } catch (error) {
+        return { ok: false, reason: String(error) };
+      }
+    },
+    rollback(feedbackText: string, stepSeq?: number): StepAuditRollbackResult {
+      try {
+        if (typeof feedbackText !== "string" || !feedbackText.trim()) {
+          return { ok: false, reason: "bad-args" };
+        }
+        if (rollbackCount >= MAX_STEP_AUDIT_ROLLBACKS_PER_RUN) {
+          return { ok: false, reason: "rollback-limit" };
+        }
+        let slot: StepAuditCut | undefined;
+        if (Number.isFinite(stepSeq)) {
+          slot = cuts.get(stepSeq as number);
+          if (!slot) {
+            return { ok: false, reason: "no-checkpoint" };
+          }
+        } else {
+          // No stepSeq: roll back the most recent checkpointed step.
+          let bestCut = -1;
+          for (const [seq, cut] of cuts) {
+            if (seq === -1) {
+              continue;
+            }
+            if (cut.cut > bestCut) {
+              bestCut = cut.cut;
+              slot = cut;
+            }
+          }
+          slot ??= cuts.get(-1);
+          if (!slot) {
+            return { ok: false, reason: "no-checkpoint" };
+          }
+        }
+        const messages = readMessages();
+        if (!Array.isArray(messages)) {
+          return { ok: false, reason: "no-messages" };
+        }
+        const { cut } = slot;
+        if (cut >= messages.length) {
+          return { ok: false, reason: "nothing-to-remove" };
+        }
+        if (hasFeedbackInjectionFrom(cut)) {
+          return { ok: false, reason: "already-rolled-back" };
+        }
+        rollbackCount += 1;
+        const removed = messages.length - cut;
+        const feedbackMessage = buildFeedbackMessage(feedbackText);
+        const truncated = [...messages.slice(0, cut), feedbackMessage];
+        activeSession.agent.state.messages = truncated;
+
+        // Keep the persisted transcript consistent with the active state so
+        // the redone step replaces the rejected suffix instead of duplicating.
+        try {
+          let budget = removed;
+          sessionManager.removeTrailingEntries(
+            (entry: SessionEntry) => {
+              if (budget <= 0) {
+                return false;
+              }
+              if (entry.type === "message" && REMOVABLE_STEP_AUDIT_ROLES.has(entry.message.role)) {
+                budget -= 1;
+                return true;
+              }
+              return false;
+            },
+            {
+              preserveTrailing: (entry) => entry.type === "label" || entry.type === "session_info",
+            },
+          );
+          sessionManager.appendMessage(feedbackMessage);
+        } catch (error) {
+          log.warn(
+            `step-audit rollback persistence sync failed: runId=${runId} ${String(error)}`,
+          );
+        }
+        return { ok: true, removed, cut };
+      } catch (error) {
+        return { ok: false, reason: String(error) };
+      }
+    },
+  };
+
+  registry.set(runId, api);
+}
+
+/** Removes the step-audit checkpoint API when an attempt tears down. */
+export function uninstallStepAuditApi(runId: string): void {
+  globalRegistry.__openclawStepAuditRegistry?.delete(runId);
+}

--- a/src/agents/embedded-agent-runner/run/attempt-step-audit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-step-audit.ts
@@ -52,11 +52,14 @@ export type StepAuditRollbackResult =
       ok: false;
       reason:
         | "bad-args"
+        | "disposed"
         | "rollback-limit"
         | "no-checkpoint"
         | "no-messages"
         | "nothing-to-remove"
         | "already-rolled-back"
+        | "persistence-blocked"
+        | "persistence-failed"
         | string;
     };
 
@@ -65,12 +68,17 @@ export interface StepAuditApi {
   rollback(feedbackText: string, stepSeq?: number): StepAuditRollbackResult;
 }
 
+/** Internal handle that can be revoked when the attempt tears down. */
+interface StepAuditApiInternal extends StepAuditApi {
+  dispose(): void;
+}
+
 /**
  * Process-wide bridge between plugin hook callbacks and attempt-scoped
  * checkpoints. Review plugins look their runId up here; see module docs.
  */
 const globalRegistry = globalThis as unknown as {
-  __openclawStepAuditRegistry?: Map<string, StepAuditApi>;
+  __openclawStepAuditRegistry?: Map<string, StepAuditApiInternal>;
 };
 
 /** Typed accessor for review plugins that prefer an import over the global. */
@@ -89,10 +97,11 @@ export function installStepAuditApi(input: {
   const { runId, activeSession, sessionManager, feedbackMarker } = input;
   const registry =
     globalRegistry.__openclawStepAuditRegistry ??
-    (globalRegistry.__openclawStepAuditRegistry = new Map<string, StepAuditApi>());
+    (globalRegistry.__openclawStepAuditRegistry = new Map<string, StepAuditApiInternal>());
 
   const cuts = new Map<number, StepAuditCut>();
   let rollbackCount = 0;
+  let disposed = false;
 
   const readMessages = (): AgentMessage[] | undefined => activeSession.agent.state.messages;
 
@@ -145,9 +154,12 @@ export function installStepAuditApi(input: {
     timestamp: Date.now(),
   });
 
-  const api: StepAuditApi = {
+  const api: StepAuditApiInternal = {
     capture(stepSeq: number): StepAuditCaptureResult {
       try {
+        if (disposed) {
+          return { ok: false, reason: "disposed" };
+        }
         const messages = readMessages();
         if (!Array.isArray(messages)) {
           return { ok: false, reason: "no-messages" };
@@ -165,6 +177,9 @@ export function installStepAuditApi(input: {
     },
     rollback(feedbackText: string, stepSeq?: number): StepAuditRollbackResult {
       try {
+        if (disposed) {
+          return { ok: false, reason: "disposed" };
+        }
         if (typeof feedbackText !== "string" || !feedbackText.trim()) {
           return { ok: false, reason: "bad-args" };
         }
@@ -208,14 +223,15 @@ export function installStepAuditApi(input: {
         rollbackCount += 1;
         const removed = messages.length - cut;
         const feedbackMessage = buildFeedbackMessage(feedbackText);
-        const truncated = [...messages.slice(0, cut), feedbackMessage];
-        activeSession.agent.state.messages = truncated;
 
-        // Keep the persisted transcript consistent with the active state so
-        // the redone step replaces the rejected suffix instead of duplicating.
+        // Persistence first: the session manager owns the durable transcript,
+        // so rewrite it before touching the in-memory state. On any failure the
+        // active state is left untouched and the rollback reports failure
+        // instead of silently diverging memory from the persisted transcript.
+        let removedFromPersistence = 0;
         try {
           let budget = removed;
-          sessionManager.removeTrailingEntries(
+          removedFromPersistence = sessionManager.removeTrailingEntries(
             (entry: SessionEntry) => {
               if (budget <= 0) {
                 return false;
@@ -232,14 +248,34 @@ export function installStepAuditApi(input: {
           );
           sessionManager.appendMessage(feedbackMessage);
         } catch (error) {
+          rollbackCount -= 1;
           log.warn(
             `step-audit rollback persistence sync failed: runId=${runId} ${String(error)}`,
           );
+          return { ok: false, reason: "persistence-failed" };
         }
+        if (removedFromPersistence < removed) {
+          // A non-removable entry (e.g. a queued steering/custom entry) stopped
+          // the contiguous removal early. The durable transcript would diverge
+          // from the active state, so refuse the rollback instead of reporting
+          // success.
+          rollbackCount -= 1;
+          log.warn(
+            `step-audit rollback persistence incomplete: runId=${runId} removed=${removedFromPersistence}/${removed}`,
+          );
+          return { ok: false, reason: "persistence-blocked" };
+        }
+
+        // Durable rewrite succeeded: now mirror it in the active state.
+        const truncated = [...messages.slice(0, cut), feedbackMessage];
+        activeSession.agent.state.messages = truncated;
         return { ok: true, removed, cut };
       } catch (error) {
         return { ok: false, reason: String(error) };
       }
+    },
+    dispose(): void {
+      disposed = true;
     },
   };
 
@@ -248,5 +284,12 @@ export function installStepAuditApi(input: {
 
 /** Removes the step-audit checkpoint API when an attempt tears down. */
 export function uninstallStepAuditApi(runId: string): void {
-  globalRegistry.__openclawStepAuditRegistry?.delete(runId);
+  const registry = globalRegistry.__openclawStepAuditRegistry;
+  if (!registry) {
+    return;
+  }
+  // Revoke handles plugins may have retained: after teardown, capture/rollback
+  // calls report `disposed` instead of mutating a closing attempt.
+  registry.get(runId)?.dispose();
+  registry.delete(runId);
 }

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -216,7 +216,7 @@ export function prepareEmbeddedAttemptStream(input: {
           if (outcome.action !== "revise") {
             return;
           }
-          if (event.hadDeterministicSideEffect) {
+          if (event.hadDeterministicSideEffect && !outcome.forceRevision) {
             log.warn(
               `before_agent_finalize requested revision after potential side effects; finalizing ` +
                 `runId=${attempt.runId} sessionId=${attempt.sessionId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -26,6 +26,7 @@ import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js"
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { runEmbeddedAttemptExecutionPhase } from "./attempt-execution-phase.js";
 import type { EmbeddedAttemptExecutionState } from "./attempt-execution-types.js";
+import { uninstallStepAuditApi } from "./attempt-step-audit.js";
 import {
   createEmbeddedAttemptExternalAbortController,
   type EmbeddedAttemptAbortStatePort,
@@ -538,6 +539,7 @@ export async function runEmbeddedAttempt(
   } finally {
     externalAbortController.dispose();
     clearToolActivityRun(params.runId);
+    uninstallStepAuditApi(params.runId);
     try {
       await cleanupEmbeddedPrepResourcesAfterEarlyExit();
     } catch (cleanupErr) {

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -138,7 +138,7 @@ export async function awaitAgentHarnessAgentEndHook(params: {
 /** Normalized before-finalize hook decision consumed by harness loops. */
 type AgentHarnessBeforeAgentFinalizeOutcome =
   | { action: "continue" }
-  | { action: "revise"; reason: string }
+  | { action: "revise"; reason: string; forceRevision?: boolean }
   | { action: "finalize"; reason?: string };
 
 /** Runs before-finalize hooks and normalizes finalize/revise/continue decisions. */
@@ -214,12 +214,22 @@ function normalizeBeforeAgentFinalizeResult(
           reason && reason.includes(retryInstruction)
             ? reason
             : [reason, retryInstruction].filter(Boolean).join("\n\n");
-        return { action: "revise", reason: revisedReason };
+        return {
+          action: "revise",
+          reason: revisedReason,
+          ...(result.forceRevision === true ? { forceRevision: true } : {}),
+        };
       }
       return { action: "continue" };
     }
     const reason = normalizeTrimmedString(result.reason);
-    return reason ? { action: "revise", reason } : { action: "continue" };
+    return reason
+      ? {
+          action: "revise",
+          reason,
+          ...(result.forceRevision === true ? { forceRevision: true } : {}),
+        }
+      : { action: "continue" };
   }
   return { action: "continue" };
 }

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1718,6 +1718,44 @@ export function createAgentEventHandler({
           },
         );
       }
+      // Review plugins emit `<plugin>.audit` agent events to surface step-level
+      // audit rejections. Show a visible chat notice so users understand why the
+      // agent appears to redo a step instead of finalizing its output.
+      if (
+        !isAborted &&
+        typeof evt.stream === "string" &&
+        evt.stream.endsWith(".audit") &&
+        evt.data?.kind === "reject"
+      ) {
+        const turnIndex = evt.data.turnIndex ?? "?";
+        const summary =
+          typeof evt.data.summary === "string" && evt.data.summary.trim()
+            ? evt.data.summary.trim()
+            : "output rejected by audit";
+        const issueCount = Array.isArray(evt.data.errors) ? evt.data.errors.length : 0;
+        const text =
+          `Audit rejected output (turn ${turnIndex})` +
+          (issueCount > 0
+            ? ` with ${issueCount} issue${issueCount === 1 ? "" : "s"}`
+            : "") +
+          `: ${summary} The rejected output was rolled back; ` +
+          `the agent is redoing the step automatically.`;
+        sendChatPayload(
+          sessionKey,
+          {
+            runId: eventRunId,
+            sessionKey,
+            ...(sessionKey === "global" && sessionAgentId ? { agentId: sessionAgentId } : {}),
+            seq: (agentRunSeq.get(evt.runId) ?? 0) + 1,
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: Date.now(),
+            },
+          },
+          { agentId: sessionAgentId, controlUiVisible: isControlUiVisible },
+        );
+      }
     }
 
     if (lifecyclePhase === "error") {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -474,6 +474,16 @@ export type PluginHookBeforeAgentFinalizeResult = {
     idempotencyKey?: string;
     maxAttempts?: number;
   };
+  /**
+   * Bypass the deterministic-side-effect safeguard for a `revise` request.
+   *
+   * By default a revision requested after the attempt already produced
+   * deterministic side effects (e.g. an executed tool) is ignored to avoid
+   * unsafe re-execution. Review-style hooks that verified the output *after*
+   * those side effects and explicitly want the attempt redone can set this to
+   * true to override the safeguard.
+   */
+  forceRevision?: boolean;
 };
 
 export type PluginHookBeforeCompactionEvent = {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -547,6 +547,9 @@ export function createHookRunner(
             left: acc.reason,
             right: next.reason,
           }),
+          ...(acc.forceRevision === true || next.forceRevision === true
+            ? { forceRevision: true }
+            : {}),
           ...(retry ? { retry } : {}),
         },
         retryCandidates,
@@ -560,6 +563,7 @@ export function createHookRunner(
       return {
         action: "revise",
         reason: next.reason,
+        ...(next.forceRevision === true ? { forceRevision: true } : {}),
         ...(retry ? { retry } : {}),
       };
     }


### PR DESCRIPTION
### Summary

Adds host support for **step-level auditing with immediate rollback**: a review
plugin can capture a transcript checkpoint before each tool/text step, run an
independent audit on the step product, and — when the audit rejects it —
truncate the rejected step and inject feedback so the agent **redoes the step
in place**, without waiting for the whole run to finish.

Today `before_agent_finalize` is the only revision mechanism, which audits the
entire run after it completes ("review after the fact"). Two limitations make
it unsuitable for step-level review:

1. When the run already produced deterministic side effects (e.g. tools were
   executed), a `revise` request is safely ignored — which is almost always the
   case for data-analysis style runs.
2. There is no primitive to roll back a *single rejected step* while the run is
   still in progress.

### Motivation (why step-level audit)

This capability comes from a real data-analysis workflow: agents run chains of
tool/text steps (read data, write code, execute computations) where one bad
step silently poisons everything downstream. `before_agent_finalize` can only
review the whole run after it finishes, and its `revise` request is safely
ignored whenever the run already produced deterministic side effects — which is
almost always true for data tasks, so end-of-run review is effectively a no-op.

Step-level audit fixes both problems: every step product is verified by an
independent reviewer before the run moves on, and a rejected step is truncated
and redone in place. Mistakes stop propagating at the step where they occur,
and the user sees exactly why the agent appears to redo work.

### Changes

**1. `forceRevision` on `before_agent_finalize` (plugin surface)**

- `PluginHookBeforeAgentFinalizeResult` gains `forceRevision?: boolean`
  (`src/plugins/hook-types.ts`).
- `mergeBeforeAgentFinalize` preserves it across multiple hooks with OR
  semantics (`src/plugins/hooks.ts`).
- Outcome normalization carries it through
  (`src/agents/harness/lifecycle-hook-helpers.ts`).
- The `hadDeterministicSideEffect` safeguard is bypassed when a hook explicitly
  sets `forceRevision`
  (`src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts`).

**2. Per-run step-audit checkpoint API (`src/agents/embedded-agent-runner/run/attempt-step-audit.ts`)**

- New module installed for every embedded attempt after session preparation
  (`attempt-session-prepare.ts`) and uninstalled on attempt teardown
  (`attempt.ts`).
- Published on `globalThis.__openclawStepAuditRegistry` keyed by `runId`, so
  plugin hook callbacks (which only receive `runId`) can reach the
  attempt-scoped runtime.
- API:
  - `capture(stepSeq)` — records the current transcript tail as the rollback
    checkpoint for a step. Called synchronously from `before_tool_call`.
  - `rollback(feedbackText, stepSeq?)` — truncates the rejected suffix from
    both the active agent state and the persisted session transcript, then
    injects a feedback message so the agent redoes the step immediately.
- Safety guards:
  - max 3 rollbacks per run (`rollback-limit`),
  - feedback-marker detection prevents double rollback of the same range
    (`already-rolled-back`),
  - missing checkpoint / empty range rejections (`no-checkpoint`,
    `nothing-to-remove`).
- Persistence first: the durable transcript is rewritten through the session
  manager before the active state is touched. Persistence errors and partial
  removals (e.g. a non-removable steering/custom entry stops the contiguous
  removal) fail the rollback with `persistence-failed` / `persistence-blocked`
  instead of silently diverging memory from the transcript.
- Teardown revocation: uninstalling the attempt disposes the handle, so a late
  asynchronous audit call reports `disposed` instead of mutating a closing
  attempt.

**3. Visible audit-rejection notices in the gateway (`src/gateway/server-chat.ts`)**

- Agent events with stream `<plugin>.audit` and `data.kind === "reject"` are
  broadcast as a visible chat notice, so users understand why the agent appears
  to redo a step. Payload: `turnIndex?`, `summary?`, `errors?`.

### Plugin contract (how review plugins use this)

```ts
// before_tool_call (sync): capture the step checkpoint
globalThis.__openclawStepAuditRegistry?.get(runId)?.capture(stepSeq);

// after audit rejects a step (async): roll back and inject feedback
const result = globalThis.__openclawStepAuditRegistry
  ?.get(runId)
  ?.rollback("calculation is wrong, recompute with ...", stepSeq);
// result: { ok: true, removed, cut } | { ok: false, reason }

// notify the UI
emitAgentEvent({ stream: "my-reviewer.audit", data: { kind: "reject", turnIndex, summary, errors } });
```

### Validation

- Pass path verified: audits that pass leave the transcript untouched.
- Reject path verified end-to-end in a live session: 3 steps rejected → rolled
  back in place, agent redid each step immediately, feedback injected, UI notice
  visible; further rollbacks rejected by the storm guard; run finalizes
  normally (fail-open). Redacted runtime log of that session (messages
  translated from the Chinese runtime log, runId shortened):

```text
[StepAudit][TEST] force reject: step=1, tool=read
[StepAudit] rejected: run=51bdf641, step=1, tool=read
[TurnChain] rollback: turnIndex=1, stepSeq=1, count=1
[StepAudit][TEST] force reject: step=2, tool=read
[StepAudit] rejected: run=51bdf641, step=2, tool=read
[TurnChain] rollback: turnIndex=1, stepSeq=2, count=2
[StepAudit][TEST] force reject: step=3, tool=exec
[StepAudit] rejected: run=51bdf641, step=3, tool=exec
[TurnChain] rollback: turnIndex=1, stepSeq=3, count=3
[StepAudit][TEST] force reject: step=4, tool=exec
[StepAudit] rejected: run=51bdf641, step=4, tool=exec
[StepAudit] rollback refused: reason=rollback-limit
```

  The counters 1→2→3 record the three successful in-place rollbacks; steps 4+ 
  are refused by the storm guard, which also proves the first three were
  counted. Each rejected step was redone immediately after its rollback.
- No public API baseline snapshots are affected (optional field only).

### Notes for reviewers

- The global registry is the deliberate bridge for plugin hooks; happy to
  discuss alternatives (e.g. a plugin-SDK accessor) if preferred.
- Step-audit is orthogonal to `before_agent_finalize`: the latter still guards
  the final delivery.
- `forceRevision` deliberately lets review plugins request a redo after
  deterministic side effects: redoing a rejected step is the whole point of
  step-level review. The capability is opt-in per hook and remains subject to
  maintainer decision on the tool-replay contract (idempotency/compensation).
- Fully atomic memory+durable rollback would need a session-manager
  transaction API; this PR instead fails the rollback and leaves the active
  state untouched when persistence cannot be rewritten consistently.