### PR TITLE
fix(agents): preserve exec outcomes across lifecycle races

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -536,11 +536,15 @@ describe("processGatewayAllowlist", () => {
     outcome: ExecApprovalFollowupOutcome;
     sessionId?: string;
   }) {
-    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
-    createExecApprovalDecisionStateMock.mockReturnValue({
-      baseDecision: { timedOut: false },
-      approvedByAsk: true,
-      deniedReason: null,
+    resolveExecApprovalWaitOutcomeMock.mockResolvedValueOnce({
+      kind: "resolved",
+      decision: "allow-once",
+      state: {
+        baseDecision: { timedOut: false },
+        approvedByAsk: true,
+        deniedReason: null,
+        timeoutContext: undefined,
+      },
     });
     runExecProcessMock.mockResolvedValue({
       session: { id: params.sessionId ?? "sess-1" },
@@ -2251,16 +2255,31 @@ EOF`,
     }
   });
 
-  it("reports an unexpected detached pre-dispatch failure through a safe denial follow-up", async () => {
+  it.each([
+    {
+      name: "request failure",
+      outcome: { kind: "request-failed" as const },
+      firstFollowupReason: "approval-request-failed",
+    },
+    {
+      name: "denial",
+      outcome: {
+        kind: "resolved" as const,
+        decision: "deny",
+        state: {
+          baseDecision: { timedOut: false },
+          approvedByAsk: false,
+          deniedReason: "user-denied",
+          timeoutContext: undefined,
+        },
+      },
+      firstFollowupReason: "user-denied",
+    },
+  ])("consumes rejected detached pre-dispatch $name and fallback follow-ups", async (scenario) => {
     const unhandledRejections = captureProcessUnhandledRejections();
-    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
-    createExecApprovalDecisionStateMock.mockReturnValue({
-      baseDecision: { timedOut: false },
-      approvedByAsk: false,
-      deniedReason: "user-denied",
-    });
+    resolveExecApprovalWaitOutcomeMock.mockResolvedValueOnce(scenario.outcome);
     buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
-    sendExecApprovalFollowupResultMock.mockRejectedValueOnce(
+    sendExecApprovalFollowupResultMock.mockRejectedValue(
       new Error("pre-dispatch denial follow-up failed"),
     );
 
@@ -2277,7 +2296,7 @@ EOF`,
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(requireSentFollowupText(0)).toBe(
-        "Exec denied (gateway id=req-1, user-denied): side-effecting-command",
+        `Exec denied (gateway id=req-1, ${scenario.firstFollowupReason}): side-effecting-command`,
       );
       expect(requireSentFollowupText(1)).toBe(
         "Exec denied (gateway id=req-1, approval-request-failed): side-effecting-command",

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { onAgentEvent } from "../infra/agent-events.js";
 import {
@@ -393,6 +394,19 @@ function requireApprovalFollowupInput(
     throw new Error(`expected approval followup call ${callIndex}`);
   }
   return call[0];
+}
+
+function captureProcessUnhandledRejections() {
+  const reasons: unknown[] = [];
+  const originalProcessEmit = process.emit.bind(process);
+  const processEmit = vi.spyOn(process, "emit").mockImplementation((event, ...args) => {
+    if (event === "unhandledRejection") {
+      reasons.push(args[0]);
+      return true;
+    }
+    return originalProcessEmit(event, ...args);
+  });
+  return { reasons, restore: () => processEmit.mockRestore() };
 }
 
 function captureSecurityEvents(): {
@@ -2199,6 +2213,79 @@ EOF`,
     });
     expect(requireSentFollowupTarget(0)?.direct).toBe(false);
     expect(requireSentFollowupText(0)).toContain("done");
+  });
+
+  it("keeps a completed detached outcome terminal when agent follow-up registration fails", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+    const completedOutcome = {
+      status: "completed" as const,
+      exitCode: 0,
+      timedOut: false,
+      aggregated: "completed output",
+    };
+    const approvalFollowup = vi.fn<ExecApprovalFollowupFactory>(() => undefined);
+    mockApprovedDetachedExec({ outcome: completedOutcome });
+    sendExecApprovalFollowupResultMock.mockRejectedValueOnce(
+      new Error("synchronous runtime-handoff registration failure"),
+    );
+
+    try {
+      const result = await runGatewayAllowlist({
+        command: "side-effecting-command",
+        approvalFollowupMode: "agent",
+        approvalFollowup,
+        turnSourceChannel: "webchat",
+      });
+
+      expect(result.pendingResult?.details.status).toBe("approval-pending");
+      await vi.waitFor(() => expect(approvalFollowup).toHaveBeenCalledOnce());
+      await setImmediate();
+
+      expect(requireApprovalFollowupInput(approvalFollowup, 0).outcome).toEqual(completedOutcome);
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
+      expect(requireSentFollowupText(0)).toContain("completed output");
+      expect(requireSentFollowupText(0)).not.toContain("Exec denied");
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
+  it("reports an unexpected detached pre-dispatch failure through a safe denial follow-up", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: false,
+      deniedReason: "user-denied",
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+    sendExecApprovalFollowupResultMock.mockRejectedValueOnce(
+      new Error("pre-dispatch denial follow-up failed"),
+    );
+
+    try {
+      const result = await runGatewayAllowlist({
+        command: "side-effecting-command",
+        approvalFollowupMode: "agent",
+        turnSourceChannel: "webchat",
+      });
+
+      expect(result.pendingResult?.details.status).toBe("approval-pending");
+      await vi.waitFor(() => expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2));
+      await setImmediate();
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(requireSentFollowupText(0)).toBe(
+        "Exec denied (gateway id=req-1, user-denied): side-effecting-command",
+      );
+      expect(requireSentFollowupText(1)).toBe(
+        "Exec denied (gateway id=req-1, approval-request-failed): side-effecting-command",
+      );
+      expect(runExecProcessMock).not.toHaveBeenCalled();
+    } finally {
+      unhandledRejections.restore();
+    }
   });
 
   it("keeps multiline gateway approval follow-up output intact", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1329,9 +1329,7 @@ export async function processGatewayAllowlist(
     let gatewayInvocationStarted = false;
 
     void (async () => {
-      const approvalDecision = await resolveApprovalForExecution(
-        sendApprovalRequestFailedFollowup,
-      );
+      const approvalDecision = await resolveApprovalForExecution(sendApprovalRequestFailedFollowup);
       if (approvalDecision.requestFailed) {
         return;
       }

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1318,16 +1318,21 @@ export async function processGatewayAllowlist(
         `Exec denied (gateway id=${approvalId}, approval-state-write-failed): ${params.command}`,
       );
     };
+    const sendApprovalRequestFailedFollowup = async () => {
+      if (!params.signal?.aborted) {
+        await sendExecApprovalFollowupResult(
+          followupTarget,
+          `Exec denied (gateway id=${approvalId}, approval-request-failed): ${params.command}`,
+        );
+      }
+    };
+    let gatewayInvocationStarted = false;
 
     void (async () => {
       let approvalDecision: Awaited<ReturnType<typeof resolveApprovalForExecution>>;
       try {
         approvalDecision = await resolveApprovalForExecution(
-          () =>
-            void sendExecApprovalFollowupResult(
-              followupTarget,
-              `Exec denied (gateway id=${approvalId}, approval-request-failed): ${params.command}`,
-            ),
+          () => void sendApprovalRequestFailedFollowup(),
         );
       } catch {
         await denyApprovalStateWriteFailure();
@@ -1395,6 +1400,7 @@ export async function processGatewayAllowlist(
 
           let run: Awaited<ReturnType<typeof runExecProcess>>;
           try {
+            gatewayInvocationStarted = true;
             run = await runExecProcess({
               command: params.command,
               execCommand: approvalDecision.execCommandOverride,
@@ -1480,7 +1486,17 @@ export async function processGatewayAllowlist(
         approvalFollowupText,
       });
       await sendExecApprovalFollowupResult(followupTarget, summary);
-    })();
+    })().catch(async (error: unknown): Promise<void> => {
+      // Once dispatch starts, a delivery failure cannot mean execution was denied.
+      if (
+        gatewayInvocationStarted ||
+        params.signal?.aborted ||
+        isExecApprovalRunAbortedError(error)
+      ) {
+        return;
+      }
+      await sendApprovalRequestFailedFollowup();
+    });
 
     return {
       pendingResult: buildExecApprovalPendingToolResult({

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1122,7 +1122,7 @@ export async function processGatewayAllowlist(
       allowlistEval.segments[0]?.resolution ?? null,
       params.workdir,
     );
-    const resolveApprovalForExecution = async (onFailure: () => void) => {
+    const resolveApprovalForExecution = async (onFailure: () => void | Promise<void>) => {
       const approvalOutcome = await resolveExecApprovalWaitOutcome({
         approvalId,
         preResolvedDecision,
@@ -1151,7 +1151,7 @@ export async function processGatewayAllowlist(
         };
       }
       if (approvalOutcome.kind === "request-failed") {
-        onFailure();
+        await onFailure();
         emitGatewayExecApprovalSecurityEvent({
           action: "exec.approval.denied",
           outcome: "error",
@@ -1329,15 +1329,9 @@ export async function processGatewayAllowlist(
     let gatewayInvocationStarted = false;
 
     void (async () => {
-      let approvalDecision: Awaited<ReturnType<typeof resolveApprovalForExecution>>;
-      try {
-        approvalDecision = await resolveApprovalForExecution(
-          () => void sendApprovalRequestFailedFollowup(),
-        );
-      } catch {
-        await denyApprovalStateWriteFailure();
-        return;
-      }
+      const approvalDecision = await resolveApprovalForExecution(
+        sendApprovalRequestFailedFollowup,
+      );
       if (approvalDecision.requestFailed) {
         return;
       }
@@ -1486,17 +1480,15 @@ export async function processGatewayAllowlist(
         approvalFollowupText,
       });
       await sendExecApprovalFollowupResult(followupTarget, summary);
-    })().catch(async (error: unknown): Promise<void> => {
-      // Once dispatch starts, a delivery failure cannot mean execution was denied.
-      if (
-        gatewayInvocationStarted ||
-        params.signal?.aborted ||
-        isExecApprovalRunAbortedError(error)
-      ) {
-        return;
-      }
-      await sendApprovalRequestFailedFollowup();
-    });
+    })()
+      .catch(async (): Promise<void> => {
+        // Once dispatch starts, a delivery failure cannot mean execution was denied.
+        if (gatewayInvocationStarted || params.signal?.aborted) {
+          return;
+        }
+        await sendApprovalRequestFailedFollowup();
+      })
+      .catch(() => undefined);
 
     return {
       pendingResult: buildExecApprovalPendingToolResult({

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -937,12 +937,13 @@ describe("executeNodeHostCommand", () => {
     }
   });
 
-  it("reports unexpected detached node approval failures without an unhandled rejection", async () => {
+  it("consumes rejected detached node approval recovery and fallback follow-ups", async () => {
     const unhandledRejections = captureProcessUnhandledRejections();
 
     try {
-      resolveApprovalDecisionOrUndefinedMock.mockRejectedValueOnce(
-        new Error("approval wait unavailable"),
+      resolveExecApprovalWaitOutcomeMock.mockResolvedValueOnce({ kind: "request-failed" });
+      sendExecApprovalFollowupResultMock.mockRejectedValue(
+        new Error("approval failure follow-up unavailable"),
       );
       resolveExecHostApprovalContextMock.mockReturnValue({
         approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -954,14 +955,19 @@ describe("executeNodeHostCommand", () => {
       const result = await executeNodeHostCommand(createNodeHostRequest({}));
 
       expect(result.details?.status).toBe("approval-pending");
-      await vi.waitFor(() => {
-        expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-          expect.objectContaining({ approvalId: "approval-1" }),
-          "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
-        );
-      });
+      await vi.waitFor(() => expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2));
       await setImmediate();
       expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ approvalId: "approval-1" }),
+        "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
+      );
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ approvalId: "approval-1" }),
+        "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
+      );
       expect(
         callGatewayToolMock.mock.calls.some(
           ([method, , params]) =>

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -606,17 +606,19 @@ export async function executeNodeHostCommand(
               `Exec denied (node=${target.nodeId} id=${approvalId}, invoke-failed): ${params.command}`,
             );
           }
-        })().catch(async (error: unknown): Promise<void> => {
-          // Once dispatch starts, a delivery failure cannot mean execution was denied.
-          if (
-            nodeInvocationStarted ||
-            params.signal?.aborted ||
-            isExecApprovalRunAbortedError(error)
-          ) {
-            return;
-          }
-          await sendApprovalRequestFailedFollowup();
-        });
+        })()
+          .catch(async (error: unknown): Promise<void> => {
+            // Once dispatch starts, a delivery failure cannot mean execution was denied.
+            if (
+              nodeInvocationStarted ||
+              params.signal?.aborted ||
+              isExecApprovalRunAbortedError(error)
+            ) {
+              return;
+            }
+            await sendApprovalRequestFailedFollowup();
+          })
+          .catch(() => undefined);
 
         return execHostShared.buildExecApprovalPendingToolResult({
           host: "node",

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -679,7 +679,7 @@ export function createExecTool(
         };
 
         const onYieldNow = () => {
-          if (yielded || toolAborted) {
+          if (yielded || toolAborted || run.session.finalizing) {
             return;
           }
           if (settledOutcome) {

--- a/src/agents/bash-tools.exec-task-wiring.test.ts
+++ b/src/agents/bash-tools.exec-task-wiring.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 
 const taskTracking = vi.hoisted(() => ({
   createBackgroundExecTask: vi.fn(),
@@ -9,6 +10,7 @@ vi.mock("./bash-tools.exec-task-tracking.js", () => taskTracking);
 
 import { getFinishedSession } from "./bash-process-registry.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 describe("exec background task wiring", () => {
   beforeEach(() => {
@@ -36,6 +38,62 @@ describe("exec background task wiring", () => {
       handle: null,
       outcome: expect.objectContaining({ status: "completed" }),
     });
+  });
+
+  it("does not background a terminal process while sandbox finalization is pending", async () => {
+    const yieldMs = 250;
+    const finalizationStarted = createDeferred();
+    const finalization = createDeferred();
+    const finalizeExec = vi.fn<NonNullable<BashSandboxConfig["finalizeExec"]>>(async () => {
+      finalizationStarted.resolve();
+      await finalization.promise;
+    });
+    vi.useFakeTimers();
+
+    try {
+      const tool = createExecTool({
+        host: "sandbox",
+        security: "full",
+        ask: "off",
+        allowBackground: true,
+        sessionKey: "agent:main:main",
+        sandbox: {
+          containerName: "sandbox",
+          workspaceDir: process.cwd(),
+          containerWorkdir: process.cwd(),
+          buildExecSpec: async () => ({
+            argv: [process.execPath, "-e", ""],
+            env: process.env,
+            stdinMode: "pipe-closed",
+            finalizeToken: "sandbox-token",
+          }),
+          finalizeExec,
+        },
+      });
+
+      const execution = tool.execute("terminal-during-finalize", {
+        command: "sandbox-command",
+        yieldMs,
+      });
+      const executionSettled = vi.fn();
+      void execution.then(executionSettled, executionSettled);
+      await finalizationStarted.promise;
+      await vi.advanceTimersByTimeAsync(yieldMs + 1);
+
+      expect(executionSettled).not.toHaveBeenCalled();
+      expect(taskTracking.createBackgroundExecTask).not.toHaveBeenCalled();
+      finalization.resolve();
+      const result = await execution;
+
+      expect(result.details.status).toBe("completed");
+      expect(taskTracking.finalizeBackgroundExecTask).toHaveBeenCalledWith({
+        handle: null,
+        outcome: expect.objectContaining({ status: "completed" }),
+      });
+    } finally {
+      finalization.resolve();
+      vi.useRealTimers();
+    }
   });
 
   it.each([


### PR DESCRIPTION
Related: #125529

## What Problem This Solves

Fixes an issue where an approved Gateway command could finish successfully but a failure while registering or delivering its asynchronous follow-up would escape the detached promise chain as an unhandled rejection, obscuring the real execution outcome.

It also fixes a race where a sandboxed command that had already exited could be reported as still running when the foreground yield timer fired while asynchronous sandbox finalization was still in progress. That false promotion also created a background task row that immediately changed to terminal.

## Why This Change Was Made

The change builds on main's canonical `resolveExecApprovalWaitOutcome` owner. Gateway request-failure delivery is now awaited, and both Gateway and node detached continuations have terminal non-rejecting recovery handlers. Invocation-start provenance prevents any post-dispatch delivery failure from being reclassified as an execution denial; pre-dispatch failures still make a best-effort `approval-request-failed` delivery whose own failure is consumed.

Foreground exec yielding now observes the existing process-owned `finalizing` state, which is set before sandbox cleanup awaits. The command stays foregrounded until finalization produces the real terminal outcome.

Session reset/delete ownership was traced separately. The process scope remains reachable through the canonical session key; the unresolved policy is whether reset/delete should preserve or cancel inherited background work. That owner call is intentionally left to #125529 rather than being chosen silently in this PR.

## User Impact

Operators no longer lose the real result of an approved Gateway or node command to an unhandled follow-up rejection. Exited sandbox commands also no longer flash as running or create transient background task records while cleanup completes.

There is no behavior change yet for active background commands across session reset or deletion; #125529 records the verified current semantics and recommended policy split.

## Evidence

Pre-fix regressions:

- Gateway completed outcome: the test recorded the real terminal outcome but failed with an unhandled `synchronous runtime-handoff registration failure` rejection.
- Gateway pre-dispatch recovery: rejecting both the original follow-up and its fallback produced an unhandled rejection (1 failed, 93 passed).
- Node pre-dispatch recovery: the same double-rejection path produced an unhandled rejection (1 failed, 84 passed).
- Sandbox finalization race: the yield timer incorrectly called `createBackgroundExecTask` once while `finalizeExec` was pending (1 failed, 4 passed).

Post-fix proof on the rebased head:

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts` — 95/95 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-node.test.ts` — 85/85 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-task-wiring.test.ts` — 5/5 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-gateway-approval.e2e.test.ts` — 1/1 passed against a real isolated Gateway approval flow.
- `node scripts/check-changed.mjs -- src/agents/bash-tools.exec-host-gateway.ts src/agents/bash-tools.exec-host-node.ts src/agents/bash-tools.exec-run.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-task-wiring.test.ts` — core and coreTests lanes passed.
- `pnpm format:check` — repository-wide formatting passed.
- The previously failing core lint stripe passed on current `main`; the superseding UI fixes are already on `main`, so this PR contains no UI files.
- Fresh branch Codex autoreview — clean, no accepted/actionable findings.
- `git diff --check` — passed.

ClawSweeper's two P1 findings and both rank-up moves are addressed: request-failure delivery is owned, the final recovery handlers cannot reject, and focused Gateway/node double-rejection regressions cover both hosts.

Production LOC: +36/-28 (net +8) for explicit detached lifecycle/provenance ownership. Tests: +184/-14 (net +170).

AI-assisted; the final diff and lifecycle ownership paths were reviewed directly.
