### PR TITLE
fix(whatsapp): resolve LID-addressed inbound identity from the envelope

### DIFF
--- a/extensions/whatsapp/src/inbound/message-normalization.ts
+++ b/extensions/whatsapp/src/inbound/message-normalization.ts
@@ -75,13 +75,18 @@ export function createWhatsAppInboundMessageNormalizer(options: {
     }
 
     const participantJid = msg.key?.participant ?? undefined;
-    const from = group ? remoteJid : await socketSession.resolveInboundJid(remoteJid);
+    // The envelope alternate JID always names the sender, so it stands in for the direct
+    // chat only when the peer sent it; our own echoes carry this account's number there.
+    const directChatAlternateJid = msg.key?.fromMe ? undefined : msg.key?.remoteJidAlt;
+    const from = group
+      ? remoteJid
+      : await socketSession.resolveInboundJid(remoteJid, directChatAlternateJid);
     if (!from) {
       return null;
     }
     const senderE164 = group
       ? participantJid
-        ? await socketSession.resolveInboundJid(participantJid)
+        ? await socketSession.resolveInboundJid(participantJid, msg.key?.participantAlt)
         : null
       : from;
 

--- a/extensions/whatsapp/src/inbound/socket-session.ts
+++ b/extensions/whatsapp/src/inbound/socket-session.ts
@@ -178,10 +178,18 @@ export async function createWhatsAppAttachedSocketSession(options: SocketSession
   };
 
   const lidLookup = sock.signalRepository?.lidMapping;
-  const resolveInboundJid = async (jid: string | null | undefined): Promise<string | null> =>
-    resolveJidToE164(jid, { authDir: options.authDir, lidLookup });
+  const jidResolveOptions = { authDir: options.authDir, lidLookup };
+  // A LID-addressed sender can be missing from the mapping store while its phone JID
+  // rides along on the envelope. Without that second source the direct chat has no
+  // identity and inbound normalization drops the message.
+  const resolveInboundJid = async (
+    jid: string | null | undefined,
+    alternateJid?: string | null,
+  ): Promise<string | null> =>
+    (await resolveJidToE164(jid, jidResolveOptions)) ??
+    (await resolveJidToE164(alternateJid, jidResolveOptions));
   const resolveReactionTargetJids = async (jid: string): Promise<string[]> =>
-    resolveEquivalentWhatsAppDirectChatJids(jid, { authDir: options.authDir, lidLookup });
+    resolveEquivalentWhatsAppDirectChatJids(jid, jidResolveOptions);
 
   const rememberBaileysMessage = (
     remoteJid: string | null | undefined,

--- a/extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts
@@ -306,6 +306,45 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("does not adopt this account's number as the chat identity for fromMe LID direct chats", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          allowFrom: ["+123"],
+          selfChatMode: true,
+        },
+      },
+      messages: DEFAULT_MESSAGES_CFG,
+    });
+    const { onMessage, listener, sock } = await openInboxMonitor();
+
+    try {
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: {
+              id: "fromme-lid-1",
+              fromMe: true,
+              remoteJid: "777@lid",
+              remoteJidAlt: "123@s.whatsapp.net",
+              addressingMode: "lid",
+            },
+            message: { conversation: "sent from my phone" },
+            messageTimestamp: nowSeconds(),
+          },
+        ],
+      });
+      await settleInboundWork();
+
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(sock.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      await listener.close();
+    }
+  });
+
   it("skips pairing replies for outbound DMs in same-phone mode", async () => {
     await expectOutboundDmSkipsPairing({
       selfChatMode: true,

--- a/extensions/whatsapp/src/monitor-inbox.reply-context.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.reply-context.test.ts
@@ -177,6 +177,58 @@ describe("web monitor inbox reply context", () => {
     await listener.close();
   });
 
+  it("delivers LID-addressed DMs from the envelope phone JID when no mapping exists", async () => {
+    const onMessage = vi.fn(async () => {});
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const getPNForLID = vi.spyOn(sock.signalRepository.lidMapping, "getPNForLID");
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("lid-envelope-dm"),
+      remoteJid: "777@lid",
+      remoteJidAlt: "1777@s.whatsapp.net",
+      addressingMode: "lid",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(getPNForLID).toHaveBeenCalledWith("777@lid");
+    const inbound = inboundMessage(onMessage);
+    expect(inbound.payload.body).toBe("ping");
+    expect(inbound.admission?.conversation.id).toBe("+1777");
+    expect(inbound.admission?.conversation.kind).toBe("direct");
+
+    await listener.close();
+  });
+
+  it("resolves group participant identity from the envelope phone JID when no mapping exists", async () => {
+    const onMessage = vi.fn(async () => {});
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("lid-envelope-group"),
+      remoteJid: "123@g.us",
+      participant: "888@lid",
+      participantAlt: "1888@s.whatsapp.net",
+      addressingMode: "lid",
+      text: "ping",
+      timestamp: 1_700_000_000,
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = inboundMessage(onMessage);
+    expect(inbound.payload.body).toBe("ping");
+    expect(inbound.platform.senderE164).toBe("+1888");
+    expect(inbound.admission?.conversation.id).toBe("123@g.us");
+
+    await listener.close();
+  });
+
   it("resolves group participant LID JIDs via Baileys mapping", async () => {
     const onMessage = vi.fn(async () => {});
 

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -334,6 +334,9 @@ export function buildNotifyMessageUpsert(params: {
   timestamp: number;
   pushName?: string;
   participant?: string;
+  addressingMode?: string;
+  remoteJidAlt?: string;
+  participantAlt?: string;
 }) {
   return {
     type: "notify",
@@ -344,6 +347,9 @@ export function buildNotifyMessageUpsert(params: {
           fromMe: false,
           remoteJid: params.remoteJid,
           participant: params.participant,
+          addressingMode: params.addressingMode,
+          remoteJidAlt: params.remoteJidAlt,
+          participantAlt: params.participantAlt,
         },
         message: { conversation: params.text },
         messageTimestamp: params.timestamp,

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -283,7 +283,7 @@ export function jidToE164(jid: string, opts?: JidToE164Options): string | null {
   }
   const shouldLog = opts?.logMissing ?? shouldLogVerbose();
   if (shouldLog) {
-    logVerbose(`LID mapping not found for ${lidMatch[1]}; skipping inbound message`);
+    logVerbose(`LID mapping not found for ${lidMatch[1]}`);
   }
   return null;
 }


### PR DESCRIPTION
### Summary

- **Problem**: An inbound WhatsApp message addressed by LID is silently discarded whenever the sender has no LID/PN mapping entry. Identity resolution in `extensions/whatsapp/src/inbound/message-normalization.ts` returns `null`, normalization treats that as nothing to deliver, and the durable dispatch reports `completed` — so the ingress row is retired as a success while no agent ever sees the message. Driving that input through the production inbound monitor on current `main` records zero agent deliveries alongside zero pending, zero claimed, and zero failed rows: the message is gone and nothing in the queue records that it existed. This is the worst outcome shape in the repo's severity order, because there is no error, no retry, and no dead-letter for an operator to notice.
- **Root Cause**: `resolveInboundJid` in `extensions/whatsapp/src/inbound/socket-session.ts` resolves a LID JID through exactly two sources: the `lid-mapping-<lid>_reverse.json` files in the auth dir, and Baileys' `signalRepository.lidMapping` store. Neither is guaranteed to hold an entry for a sender that has only ever been seen LID-addressed, so both return `null` and the identity is reported as unknown. Baileys does supply the sender's phone JID for exactly this case: `extractAddressingContext` reads `participant_pn`/`sender_pn`/`peer_recipient_pn` off the LID-addressed stanza and `decodeMessageNode` puts it on the decoded key as `remoteJidAlt` for direct chats and `participantAlt` for groups (verified against the installed `baileys@7.0.0-rc13` in `lib/Utils/decode-wa-message.js`). The plugin already reads `remoteJidAlt` for outbound-echo dedupe but never for identity, so a fact that arrives on every LID envelope is discarded and the message is dropped as unidentifiable. Because an unresolved identity is indistinguishable from "nothing to deliver", the dispatch reports success and the loss is silent.
- **Fix**: Give `resolveInboundJid` an optional second JID and consult it only after the primary lookup returns no identity, then pass the matching envelope field from inbound normalization — `key.remoteJidAlt` for direct chats and `key.participantAlt` for groups. The mapping store and auth-dir files stay authoritative and are still tried first, so no currently-resolving message changes identity; the envelope is consulted only on the path that previously produced `null` and dropped the message. The direct-chat case is additionally gated on `fromMe`, because the envelope alternate always names the *sender*: on our own echoes it holds this account's own number, and adopting it would misattribute the chat to ourselves in front of `allowFrom` and self-chat policy. Group participants need no such gate — `participantAlt` names the actual sender there, which is the value the group path wants even for `fromMe` messages. This repairs the identity at the resolver that owns it rather than compensating in the ingress queue, the debouncer, or the delivery path downstream.
- **What changed**:
  - `extensions/whatsapp/src/inbound/socket-session.ts` — `resolveInboundJid` accepts an optional alternate JID and falls back to it when the primary lookup yields no identity; the shared resolver options are hoisted so all three call sites use one object.
  - `extensions/whatsapp/src/inbound/message-normalization.ts` — passes the envelope alternate JID for direct chats (peer-sent only) and group participants.
  - `extensions/whatsapp/src/targets-runtime.ts` — the verbose "LID mapping not found" line no longer claims the message is being skipped, which is no longer implied by a failed primary lookup.
  - `extensions/whatsapp/src/monitor-inbox.test-harness.ts` — the shared upsert builder can set `addressingMode`, `remoteJidAlt`, and `participantAlt`.
  - `extensions/whatsapp/src/monitor-inbox.reply-context.test.ts` — regression coverage for the LID direct chat and the LID group participant with an unpopulated mapping store.
  - `extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts` — pins that a `fromMe` LID direct chat does not adopt this account's own number as the chat identity.
- **What did NOT change (scope boundary)**:
  - Mapping-store and auth-dir resolution order and results: both are still tried first and still win whenever they resolve.
  - `resolveJidToE164`, `resolveEquivalentWhatsAppDirectChatJids`, and `jidToE164` resolution logic; only a verbose log string was reworded.
  - Reaction-target resolution, group metadata participant mapping, and approval-reaction actor resolution keep their existing single-JID behavior.
  - Access control, pairing, `allowFrom`, group policy, and self-chat gating: unchanged, and the identities handed to them are produced by the same resolver as before.
  - Durable ingress queue, retry schedule, dead-letter window, debounce batching, and read receipts. The reported `undefined.catch` failure and the misleading `retry-limit-exceeded` reason on a time-bound window are separate defects and are untouched here.
  - The outbound-echo dedupe path, which already consumed `remoteJidAlt` independently.
  - Config surface unchanged. Plugin surface unchanged. No dependency changes.

### Reproduction

1. Run a gateway with the WhatsApp channel linked to an account that receives messages from senders using LID addressing.
2. Have such a sender message the account, in a group or a direct chat, so the inbound event carries `key.addressingMode: "lid"` with the sender's phone JID on `key.remoteJidAlt` (direct chat) or `key.participantAlt` (group), while the LID/PN mapping store holds no entry for that sender.
3. Watch what the agent receives, and inspect the account's ingress rows in the state database.
4. **Before this PR**: identity resolution returns no phone number, inbound normalization returns `null`, and the message never reaches an agent — while the durable dispatch reports `completed`, so nothing is left pending, claimed, or failed to show that a message was lost.
5. **After this PR**: the envelope's phone JID resolves the identity, the message is normalized and delivered to the agent, and the ingress row completes for a message that was actually handled.

### Real behavior proof

**Behavior addressed (linked issue)**: silent loss of LID-addressed inbound messages whose sender has no mapping entry, found while investigating the linked report and verified on its own terms rather than assumed from it. What is claimed here is only what was reproduced against current `main` with production code: such a message resolves to no identity, is discarded, and its ingress row is retired as `completed`. What is deliberately not claimed: this is not offered as the cause of the linked report's `Cannot read properties of undefined (reading 'catch')` dead-letters. That error cannot arise on current `main` along the paths it was attributed to — the two-argument flush contract is in place on both sides here, and the socket `end()` behind the one surviving `.catch` returns a Promise in the installed Baileys — and the reporter has since retracted the LID correlation that framed it, showing LID-addressed traffic succeeding most of the time on the same account. That retraction does not reach the defect fixed here, and cannot: a message lost this way leaves a `completed` row whose payload is cleared, so it is structurally absent from the completed-versus-failed comparison in either direction. Both facts point the same way — LID senders that hold a mapping entry resolve and deliver normally, and only the unmapped ones fall into this path.

**Real environment tested (Linux x64, Node 22.22.3 — Vitest against the production inbound monitor, plus a tsx harness driving the production JID resolver over a real on-disk auth directory)**: the monitor tests emit real `messages.upsert` events through the production listener and assert what reaches the message callback; the harness calls `resolveJidToE164` with a real empty auth dir and a mapping store that returns no entry, matching a sender never seen PN-addressed.

**Exact steps or command run after this patch**: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/whatsapp/src/monitor-inbox.reply-context.test.ts extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts`; then `node --import tsx /tmp/qmd125079/repro.mts`; then the full plugin suite in four parts via `node scripts/run-vitest.mjs` over every `extensions/whatsapp/**/*.test.ts` file.

**Evidence after fix (verbatim Vitest output and harness run)**:

```text
[test] starting test/vitest/vitest.extension-whatsapp.config.ts
 RUN  v4.1.10 /root/main/openclaw
 Test Files  2 passed (2)
      Tests  34 passed (34)
   Start at  09:46:11
   Duration  46.94s (transform 22.09s, setup 1.53s, import 4.06s, tests 40.79s, environment 0ms)
[test] passed 1 Vitest shard in 58.61s

auth dir (real, empty): /tmp/qmd125079-auth-ifQQ0r
auth dir entries: []

=== BEFORE (identity resolved from the mapping store only) ===
direct chat  777@lid -> null
group sender 888@lid -> null
direct chat identity resolvable: false (a falsy identity makes inbound normalization return null)

=== AFTER (mapping store first, then the envelope alternate JID) ===
direct chat  777@lid (alt 1777@s.whatsapp.net) -> +1777
group sender 888@lid (alt 1888@s.whatsapp.net) -> +1888
direct chat identity resolvable: true

=== dependency contract witness (installed baileys) ===
baileys@7.0.0-rc13
decode-wa-message.js:17: if (senderAlt && isLidUser(senderAlt) && isPnUser(sender) && decryptionJid === sender) {
decode-wa-message.js:19: await repository.lidMapping.storeLIDPNMappings([{ lid: senderAlt, pn: sender }]);
decode-wa-message.js:77: senderAlt = stanza.attrs.participant_pn || stanza.attrs.sender_pn || stanza.attrs.peer_recipient_pn;
decode-wa-message.js:180: remoteJidAlt: !isJidGroup(chatId) ? addressingContext.senderAlt : undefined,
decode-wa-message.js:187: participantAlt: isJidGroup(chatId) ? addressingContext.senderAlt : undefined,
```

**Observed result after fix**: a LID direct chat and a LID group participant that resolve to no identity through the mapping store now resolve through the envelope, so the messages are normalized and delivered instead of dropped, while the `fromMe` direct-chat case still refuses the account's own number as a chat identity. The silent-loss claim was measured the same way before the change: driving the same LID direct chat through the production monitor on unpatched `main` and then reading the account's durable queue returns zero agent deliveries alongside zero pending, zero claimed, and zero failed rows, so the message disappears with no operator-visible trace. The dependency witness shows why the mapping store can be empty for these senders: the envelope-driven store write requires the alternate to be a LID and the sender to be a phone number, which is the PN-addressed direction, while a LID-addressed stanza carries the phone number as the alternate and lands on the decoded key as `remoteJidAlt` or `participantAlt`. The whole WhatsApp plugin suite was also run in four parts: 95 files and 1317 tests passed.

**What was not tested**: no live WhatsApp account was linked, because LID addressing is chosen by the sender's client and cannot be forced on demand — the reporter noted the same constraint. Repository-wide typecheck and lint were not completed on this host: both toolchains were terminated by the kernel out-of-memory killer on a 8 GB machine that had roughly 2.5 GB free, so they are left to CI. Formatting was verified locally on every touched file.

**Repro confirmation**: with only the test files applied and the production change reverted, the two new LID regression tests fail on current `main` — the direct-chat case delivers zero messages and the group case reports an undefined sender identity — and both pass with the production change applied.

### Risk / Mitigation

- **Risk**: a message could be attributed to the wrong identity if the envelope alternate did not name the sender. **Mitigation**: the alternate is read from the same decoded key that Baileys populates from the stanza's own `participant_pn`/`sender_pn` attributes — the same server-attested source that feeds the mapping store this code already trusted — and the field is only consulted when the authoritative lookup produced nothing.
- **Risk**: a `fromMe` echo in a LID direct chat could adopt this account's own number and be treated as a self-chat, bypassing `allowFrom`. **Mitigation**: the direct-chat fallback is gated on `fromMe`, preserving the existing drop for that case, with a dedicated test pinning the behavior under `dmPolicy: "pairing"` and `selfChatMode: true`.
- **Risk**: a currently-working message could change identity. **Mitigation**: the fallback runs strictly after the existing lookup and only when it yields no identity, so every message that resolves today keeps its current identity; the existing mapping-store and auth-dir LID tests continue to pass unchanged.
- **Risk**: relying on an optional envelope field could regress if upstream stops populating it. **Mitigation**: the field is optional throughout and its absence restores exactly the prior behavior, and the resolver contract accepts `null`/`undefined` without branching.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Integrations
- [x] Sessions / storage
- [x] Diagnostics / logging

### Linked Issue/PR

Refs #125079
