### PR TITLE
refactor(ui): split chat-pane sidebar slot wiring out of render

### DIFF
--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -39,6 +39,8 @@ import {
   renderChatPaneComposerControls,
 } from "./chat-pane-session-controls.ts";
 import {
+  createSidebarRailProps,
+  createSidebarSlotControls,
   renderSidebarRegion,
   resolveSidebarLayoutForBoard,
   sidebarRegionCallbacks,
@@ -58,12 +60,10 @@ import {
 } from "./chat-state-route.ts";
 import { renderChat, type ChatProps } from "./chat-view.ts";
 import { renderBackgroundTasksRail } from "./components/chat-background-tasks-render.ts";
-import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import { detailSlotOpen, renderChatDetailSlot } from "./components/chat-detail-slot.ts";
 import { renderChatImageLightbox } from "./components/chat-image-lightbox.ts";
 import { chatPullRequestId, createPullRequestBranch } from "./components/chat-pull-requests.ts";
 import {
-  createSessionWorkspaceProps,
   openSessionWorkspaceFile,
   renderSessionWorkspaceRail,
   revealSessionWorkspaceFile,
@@ -71,13 +71,7 @@ import {
 import { activeQueuedMessageEdit } from "./queued-message-edit.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
-import {
-  SIDEBAR_NARROW_BREAKPOINT_PX,
-  closeSlot,
-  isSidebarSlotVisible,
-  openSlot,
-  type SidebarSlotId,
-} from "./sidebar-layout.ts";
+import { SIDEBAR_NARROW_BREAKPOINT_PX, isSidebarSlotVisible } from "./sidebar-layout.ts";
 import { resolveActiveRunOutputTokens, resolveChatProjectionRunId } from "./tool-stream.ts";
 import { configureToolTitleFetcher } from "./tool-titles.ts";
 import { workspaceResultConflictFromPlacement } from "./workspace-conflict.ts";
@@ -127,25 +121,15 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       layout: state.sidebarLayout,
       paneWidth: this.paneWidth,
     });
-    const hasPanelSlot = (slot: SidebarSlotId) =>
-      sidebarLayout.columns[0]?.panels.some((panel) => panel.slot === slot) === true;
+    const slotControls = createSidebarSlotControls({
+      state,
+      sidebarLayout,
+      setSessionObserverVisibility: this.setSessionObserverVisibility,
+    });
+    const { openPanelSlot, closePanelSlot } = slotControls;
     const progressCardInRail =
       this.paneWidth >= SIDEBAR_NARROW_BREAKPOINT_PX &&
       isSidebarSlotVisible(sidebarLayout, "companion");
-    const openPanelSlot = (slot: SidebarSlotId) => {
-      state.updateSidebarLayout(openSlot(state.sidebarLayout, slot));
-      if (slot === "companion") {
-        this.setSessionObserverVisibility(true);
-      }
-    };
-    const closePanelSlot = (slot: SidebarSlotId) => {
-      if (slot === "companion") {
-        this.setSessionObserverVisibility(false);
-      }
-      state.updateSidebarLayout(closeSlot(state.sidebarLayout, slot));
-    };
-    const togglePanelSlot = (slot: SidebarSlotId) =>
-      hasPanelSlot(slot) ? closePanelSlot(slot) : openPanelSlot(slot);
     state.chatFollowUpMode = resolveControlUiFollowUpMode(
       state.settings.chatFollowUpMode,
       resolveControlUiServerQueueMode(
@@ -238,36 +222,13 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
           ? t("chat.catalog.remoteViewOnly")
           : t("chat.catalog.unsupportedViewOnly")
         : null;
-    const sessionWorkspaceBase = createSessionWorkspaceProps(state, {
+    const { sessionWorkspace, backgroundTasks } = createSidebarRailProps({
+      state,
+      sidebarLayout,
+      slots: slotControls,
+      gatewaySnapshot,
       draftScope: this.presentationId,
-      expanded: hasPanelSlot("workspace"),
-      narrowLayout: false,
     });
-    const sessionWorkspace = {
-      ...sessionWorkspaceBase,
-      collapsed: !hasPanelSlot("workspace"),
-      narrowLayout: false,
-      onToggleCollapsed: () => togglePanelSlot("workspace"),
-      onToggleTerminal: state.terminalAvailable ? () => togglePanelSlot("terminal") : undefined,
-      onToggleBrowser: state.browserPanelAvailable ? () => togglePanelSlot("browser") : undefined,
-      onToggleDesktop: isDesktopPanelAvailable(gatewaySnapshot)
-        ? () => togglePanelSlot("desktop")
-        : undefined,
-    };
-    const backgroundTasksBase = createBackgroundTasksProps(state, {
-      narrowLayout: false,
-      openTaskId:
-        state.sidebarContent?.kind === "task" && detailSlotOpen(sidebarLayout)
-          ? state.sidebarContent.taskId
-          : undefined,
-      onOpenTaskDetail: (task) => state.handleOpenSidebar({ kind: "task", taskId: task.id }),
-    });
-    const backgroundTasks = {
-      ...backgroundTasksBase,
-      collapsed: !hasPanelSlot("tasks"),
-      narrowLayout: false,
-      onToggleCollapsed: () => togglePanelSlot("tasks"),
-    };
     const selfUser = resolveCurrentSelfUser({
       snapshotUser: gatewaySnapshot.selfUser,
       presenceEntries: readPresenceEntries(gatewaySnapshot.hello?.snapshot),

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -1,8 +1,13 @@
 import { html, type TemplateResult } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import { sidebarPanelDefinitions } from "./chat-pane-embedded-panels.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
+import { detailSlotOpen } from "./components/chat-detail-slot.ts";
+import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import type {
   SidebarPanelDefinition,
   SidebarPanelTemplates,
@@ -22,6 +27,85 @@ import {
   type SidebarLayout,
   type SidebarSlotId,
 } from "./sidebar-layout.ts";
+
+export type SidebarSlotControls = {
+  hasPanelSlot: (slot: SidebarSlotId) => boolean;
+  openPanelSlot: (slot: SidebarSlotId) => void;
+  closePanelSlot: (slot: SidebarSlotId) => void;
+  togglePanelSlot: (slot: SidebarSlotId) => void;
+};
+
+/**
+ * Slot open/close closures over the resolved layout. The companion slot doubles
+ * as the observer-visibility switch, so open/close must notify the pane or the
+ * observer stream keeps running behind a closed rail.
+ */
+export function createSidebarSlotControls(params: {
+  state: ChatPageHost;
+  sidebarLayout: SidebarLayout;
+  setSessionObserverVisibility: (visible: boolean) => void;
+}): SidebarSlotControls {
+  const { state, sidebarLayout, setSessionObserverVisibility } = params;
+  const hasPanelSlot = (slot: SidebarSlotId) =>
+    sidebarLayout.columns[0]?.panels.some((panel) => panel.slot === slot) === true;
+  const openPanelSlot = (slot: SidebarSlotId) => {
+    state.updateSidebarLayout(openSlot(state.sidebarLayout, slot));
+    if (slot === "companion") {
+      setSessionObserverVisibility(true);
+    }
+  };
+  const closePanelSlot = (slot: SidebarSlotId) => {
+    if (slot === "companion") {
+      setSessionObserverVisibility(false);
+    }
+    state.updateSidebarLayout(closeSlot(state.sidebarLayout, slot));
+  };
+  const togglePanelSlot = (slot: SidebarSlotId) =>
+    hasPanelSlot(slot) ? closePanelSlot(slot) : openPanelSlot(slot);
+  return { hasPanelSlot, openPanelSlot, closePanelSlot, togglePanelSlot };
+}
+
+/** Wide-layout workspace/tasks rail props: base factories plus slot wiring. */
+export function createSidebarRailProps(params: {
+  state: ChatPageHost;
+  sidebarLayout: SidebarLayout;
+  slots: SidebarSlotControls;
+  gatewaySnapshot: ApplicationGatewaySnapshot;
+  draftScope: string;
+}) {
+  const { state, sidebarLayout, slots, gatewaySnapshot } = params;
+  const sessionWorkspace = {
+    ...createSessionWorkspaceProps(state, {
+      draftScope: params.draftScope,
+      expanded: slots.hasPanelSlot("workspace"),
+      narrowLayout: false,
+    }),
+    collapsed: !slots.hasPanelSlot("workspace"),
+    narrowLayout: false,
+    onToggleCollapsed: () => slots.togglePanelSlot("workspace"),
+    onToggleTerminal: state.terminalAvailable ? () => slots.togglePanelSlot("terminal") : undefined,
+    onToggleBrowser: state.browserPanelAvailable
+      ? () => slots.togglePanelSlot("browser")
+      : undefined,
+    onToggleDesktop: isDesktopPanelAvailable(gatewaySnapshot)
+      ? () => slots.togglePanelSlot("desktop")
+      : undefined,
+  };
+  const backgroundTasks = {
+    ...createBackgroundTasksProps(state, {
+      narrowLayout: false,
+      openTaskId:
+        state.sidebarContent?.kind === "task" && detailSlotOpen(sidebarLayout)
+          ? state.sidebarContent.taskId
+          : undefined,
+      onOpenTaskDetail: (task) => state.handleOpenSidebar({ kind: "task", taskId: task.id }),
+    }),
+    collapsed: !slots.hasPanelSlot("tasks"),
+    narrowLayout: false,
+    onToggleCollapsed: () => slots.togglePanelSlot("tasks"),
+  };
+  return { sessionWorkspace, backgroundTasks };
+}
 
 const DETAIL_FULL_MESSAGE_MAX_CHARS = 500_000;
 let sidebarRegionLoad: Promise<boolean> | null = null;

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -28,7 +28,7 @@ import {
   type SidebarSlotId,
 } from "./sidebar-layout.ts";
 
-export type SidebarSlotControls = {
+type SidebarSlotControls = {
   hasPanelSlot: (slot: SidebarSlotId) => boolean;
   openPanelSlot: (slot: SidebarSlotId) => void;
   closePanelSlot: (slot: SidebarSlotId) => void;

--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -47,9 +47,10 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       return;
     }
     const offset = direction === "next" ? 1 : -1;
-    const next = this.taskSuggestions[
-      (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
-    ];
+    const next =
+      this.taskSuggestions[
+        (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
+      ];
     if (!next) {
       return;
     }

--- a/ui/src/pages/chat/components/chat-task-suggestions.ts
+++ b/ui/src/pages/chat/components/chat-task-suggestions.ts
@@ -94,10 +94,7 @@ function renderChatTaskSuggestions(props: {
     ? props.activeId
     : props.suggestions[0]?.id;
   return html`
-    <div
-      class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}"
-      aria-live="polite"
-    >
+    <div class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}" aria-live="polite">
       ${props.suggestions.map((suggestion, index) => {
         const busy = props.busyIds.has(suggestion.id);
         const title = sanitizeTaskSuggestionText(suggestion.title);
@@ -191,7 +188,8 @@ function renderChatTaskSuggestions(props: {
                         requestAnimationFrame(() => updateTaskSuggestionPathFade(element));
                       }
                     })}
-                    @scroll=${(event: Event) => updateTaskSuggestionPathFade(event.currentTarget as Element)}
+                    @scroll=${(event: Event) =>
+                      updateTaskSuggestionPathFade(event.currentTarget as Element)}
                     >${cwd}</code
                   >
                   <pre>${prompt}</pre>


### PR DESCRIPTION
## What Problem This Solves

`main` CI is red for every open PR after #125231 (suggested-task-card redesign, merged 2026-08-17) in two independent ways:

1. `check-lint-core-5`: `ui/src/pages/chat/chat-pane-render.ts` is 715 lines, over the 700-line `max-lines` cap.
2. `check-lint` (`oxfmt --check`): `chat-pane-task-suggestions.ts` and `components/chat-task-suggestions.ts` landed with format drift — reproduced on a clean `main` checkout.

Observed failing on unrelated PRs (e.g. #125530's run 32092561883).

## Why This Change Was Made

Repo policy is split-not-suppress for `max-lines`. The sidebar slot-control closures (`hasPanelSlot`/`openPanelSlot`/`closePanelSlot`/`togglePanelSlot`) and the wide-layout workspace/tasks rail prop assembly move from `render()` into `chat-pane-sidebar-layout.ts`, which already owns the pane's sidebar glue (region callbacks, board layout resolution, full-message loader). `createSidebarSlotControls` keeps the companion-slot ↔ observer-visibility coupling in one commented place; `createSidebarRailProps` wires the base prop factories to the slot toggles. `chat-pane-render.ts` drops to 676 lines. The second commit reformats the two drifted files (formatting-only). No behavior change; now-unused imports removed; no test bodies changed.

## User Impact

None at runtime. Unblocks CI for every open PR.

## Evidence

- `wc -l ui/src/pages/chat/chat-pane-render.ts` → 676 (was 715 on `main`)
- `oxfmt --check` drift reproduced on clean `main` for both task-suggestion files; clean after this branch
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` → rc 0 (both commits)
- `oxlint` on touched files → rc 0
- `pnpm deadcode:full` → green (first-run knip failure fixed by keeping `SidebarSlotControls` module-local)
- `node scripts/run-vitest.mjs run` on chat-pane.test.ts, chat-pane-sidebar-layout.test.ts, chat-pane-companion-lifecycle.test.ts, sidebar-layout.test.ts, chat-pane-lifecycle.test.ts, chat-pane-terminal.test.ts → 6 files, 90 tests, all pass
- `ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts` (failed on CI shard 4) → passes locally on this branch (15/15); CI failure is timing flake, unrelated to this diff
- Codex autoreview clean (0.99, branch mode, no actionable findings)
