### PR TITLE
chore(ui): format chat task suggestion files

### DIFF
--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -47,9 +47,10 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       return;
     }
     const offset = direction === "next" ? 1 : -1;
-    const next = this.taskSuggestions[
-      (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
-    ];
+    const next =
+      this.taskSuggestions[
+        (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
+      ];
     if (!next) {
       return;
     }

--- a/ui/src/pages/chat/components/chat-task-suggestions.ts
+++ b/ui/src/pages/chat/components/chat-task-suggestions.ts
@@ -94,10 +94,7 @@ function renderChatTaskSuggestions(props: {
     ? props.activeId
     : props.suggestions[0]?.id;
   return html`
-    <div
-      class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}"
-      aria-live="polite"
-    >
+    <div class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}" aria-live="polite">
       ${props.suggestions.map((suggestion, index) => {
         const busy = props.busyIds.has(suggestion.id);
         const title = sanitizeTaskSuggestionText(suggestion.title);
@@ -191,7 +188,8 @@ function renderChatTaskSuggestions(props: {
                         requestAnimationFrame(() => updateTaskSuggestionPathFade(element));
                       }
                     })}
-                    @scroll=${(event: Event) => updateTaskSuggestionPathFade(event.currentTarget as Element)}
+                    @scroll=${(event: Event) =>
+                      updateTaskSuggestionPathFade(event.currentTarget as Element)}
                     >${cwd}</code
                   >
                   <pre>${prompt}</pre>


### PR DESCRIPTION
## What Problem This Solves

`main` is currently red: #125231 landed `ui/src/pages/chat/chat-pane-task-suggestions.ts` and `ui/src/pages/chat/components/chat-task-suggestions.ts` with oxfmt violations, so `check-lint`/`check-docs` (`oxfmt --check`) fail on main and on every PR based on it.

## What Changed

`oxfmt` run on the two files. No semantic changes — formatting only.

## Evidence

```
$ oxfmt --check ui/src/pages/chat/chat-pane-task-suggestions.ts ui/src/pages/chat/components/chat-task-suggestions.ts
Format issues found in above 2 files.   # before, at 72243fbef0
# after this change:
Checking formatting...
All matched files use the configured style.
```
