### PR TITLE
fix(scripts): release the PR operation lock when review-init metadata fails

### DIFF
--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -313,11 +313,16 @@ review_tests() {
 
 review_init() {
   local pr="$1"
+  local root json pr_url
+  root=$(repo_root) || return 1
+  # Metadata reads are read-only, so fetching before the side-effect marker keeps a
+  # transient GitHub failure inside the lock's auto-release window. Command substitution
+  # is already a subshell, so this cd gives gh its repo context without moving the
+  # caller - enter_worktree still reports the real invocation cwd.
+  json=$(cd "$root" && pr_meta_json "$pr") || return 1
+
   mark_pr_operation_side_effects_started
   enter_worktree "$pr" true || return 1
-
-  local json pr_url
-  json=$(pr_meta_json "$pr")
   write_pr_meta_files "$json"
   pr_url=$(printf '%s\n' "$json" | jq -r .url)
 

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -240,6 +240,14 @@ function installPrCliFixture(repoDir: string) {
   return { binDir, cli };
 }
 
+function installRequiredPrCommandStubs(binDir: string) {
+  for (const command of ["gh", "jq", "pnpm", "rg"]) {
+    const stub = join(binDir, command);
+    writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+    chmodSync(stub, 0o755);
+  }
+}
+
 interface SupervisedFixtureOptions {
   accelerateTimeouts?: boolean;
   cwd?: string;
@@ -884,11 +892,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
     const { binDir, cli } = installPrCliFixture(repoDir);
     const reviewScript = join(repoDir, "scripts/pr-lib/review.sh");
     writeFileSync(reviewScript, `${readFileSync(reviewScript, "utf8")}\nreview_init() { :; }\n`);
-    for (const command of ["gh", "jq", "pnpm", "rg"]) {
-      const stub = join(binDir, command);
-      writeFileSync(stub, "#!/bin/sh\nexit 0\n");
-      chmodSync(stub, 0o755);
-    }
+    installRequiredPrCommandStubs(binDir);
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       OPENCLAW_PR_DEDICATED_PROCESS_GROUP: "1",
@@ -912,11 +916,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
       reviewScript,
       `${readFileSync(reviewScript, "utf8")}\nreview_init() { printf 'review ran\\n'; }\n`,
     );
-    for (const command of ["gh", "jq", "pnpm", "rg"]) {
-      const stub = join(binDir, command);
-      writeFileSync(stub, "#!/bin/sh\nexit 0\n");
-      chmodSync(stub, 0o755);
-    }
+    installRequiredPrCommandStubs(binDir);
     const mktempStub = join(binDir, "mktemp");
     writeFileSync(mktempStub, "#!/bin/sh\necho 'mktemp: No space left on device' >&2\nexit 1\n");
     chmodSync(mktempStub, 0o755);
@@ -935,6 +935,29 @@ describePosix("scripts/pr per-PR operation lock", () => {
     expect(result.stderr).not.toContain("scripts/pr lock-recover");
     expect(result.stdout).not.toContain("review ran");
     expect(refExists(repoDir)).toBe(false);
+  });
+  it("releases a validation-phase lock when review-init metadata fails", () => {
+    const repoDir = createRepo();
+    const { binDir, cli } = installPrCliFixture(repoDir);
+    const reviewScript = join(repoDir, "scripts/pr-lib/review.sh");
+    writeFileSync(
+      reviewScript,
+      `${readFileSync(reviewScript, "utf8")}\nenter_worktree() { printf 'entered-worktree\\n'; }\npr_meta_json() { echo 'fixture metadata failure' >&2; return 1; }\n`,
+    );
+    installRequiredPrCommandStubs(binDir);
+
+    const result = spawnSync(cli, ["review-init", "42"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+    expect(refExists(repoDir), result.stderr).toBe(false);
+    expect(result.stderr).toContain("fixture metadata failure");
+    expect(result.stderr).not.toContain("Retaining the operation lock");
+    expect(result.stderr).not.toContain("scripts/pr lock-recover");
+    expect(result.stdout).not.toContain("entered-worktree");
   });
   it.each([["--dryrun"], ["--dry-run", "extra"]])(
     "rejects invalid gc arguments before cleanup: %s",


### PR DESCRIPTION
Follow-up to #125517, which named this as the remaining gap.

## What Problem This Solves

Resolves a problem where a transient GitHub outage during `scripts/pr review-init <PR>`
leaves the per-PR operation lock behind. #125517 stopped the misleading
"PR head changed" diagnosis and added a bounded retry, but when all retries fail the
maintainer still gets:

```
Retaining the operation lock for PR #124995; detached child tools cannot be ruled out.
```

and has to run `scripts/pr lock-recover <pr> <token> --confirmed-no-running-tools` before
retrying. The recover token changes on every attempt, so a flaky GitHub window turns into a
manual recover-and-retry loop.

## Why This Change Was Made

The lock auto-releases on failure only while the pre-side-effect validation marker is still
active. `review_init` called `mark_pr_operation_side_effects_started` as its very first
statement, before `enter_worktree`, so a purely read-only metadata failure was classified as
post-mutation and the lock was held.

`pr_meta_json` performs no mutation, so it now runs before the marker. The fetch uses
`json=$(cd "$root" && pr_meta_json "$pr")`: command substitution is already a subshell, so
`gh` gets the repo context it needs to resolve `repos/{owner}/{repo}` without moving the
caller's working directory, and `enter_worktree` still reports the real invocation cwd. The
assignment also gained an explicit `|| return 1` — it had none, so if `review_init` were ever
called from an OR-list (which disables errexit) an empty payload would have flowed into
`write_pr_meta_files`. `review.sh` already documents that hazard in
`review_validate_artifacts`.

Deliberate non-goal: `ensure_gh_api_auth` is untouched. Hoisting it alongside the metadata
fetch looks tempting for its actionable "run gh auth login" hint, but it runs a **GraphQL**
viewer query and is intentionally non-fatal. During exactly the GraphQL degradation this work
targets it can fail spuriously, so hoisting or hardening it would block `review-init` in the
scenario being fixed. Lock lifecycle, the recover token, and the compare-and-swap owner OID
are also untouched.

## User Impact

A `review-init` that fails because GitHub was briefly unavailable now releases its lock
automatically. Maintainers can simply re-run the command instead of copying a fresh recover
token out of the error and confirming no detached tools are running. Failures that occur
after real mutation still retain the lock, exactly as before. Maintainer tooling only; no
user-facing product behavior changes.

## Evidence

New regression test in `test/scripts/pr-operation-lock.test.ts`, driving the real
`scripts/pr review-init` CLI with a failing `pr_meta_json` fixture. It asserts the lock ref
is gone, the metadata error is surfaced, neither the retention warning nor the
`lock-recover` guidance is printed, and `enter_worktree` never ran.

Verified failing on pre-change code for the intended reason — the lock ref still existed:

```
expect(refExists(repoDir), result.stderr).toBe(false)
- Expected: false
+ Received: true
```

Full suite after the change:

```
node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts \
  test/scripts/pr-metadata.test.ts test/scripts/pr-worktree-containment.test.ts \
  test/scripts/pr-review-artifact-validation.test.ts test/scripts/pr-wrappers.test.ts \
  test/scripts/pr-merge.test.ts
Test Files  6 passed (6)
Tests       155 passed | 1 skipped (156)
```

`node scripts/check-changed.mjs` green (format, typecheck, lint, guards, Testbox lane).
Fresh Codex autoreview clean: no accepted/actionable findings.

Production LOC is net-neutral (a move plus one `|| return 1` guard); the test file also
absorbed three duplicated stub-installation blocks into one helper.
