### PR TITLE
test(ui): stop new-session draft restore racing durable persistence

### DIFF
--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -16,6 +16,7 @@ import {
   pastePng,
   pollLocatorText,
   reconnectProofArtifactDir,
+  waitForPersistedNewSessionDraft,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -47,6 +48,7 @@ suite.define(() => {
       await firstPage.goto(`${suite.server.baseUrl}new`);
       const firstMessage = firstPage.locator(".new-session-page__message");
       await firstMessage.fill(text);
+      await waitForPersistedNewSessionDraft(firstPage, text, 0);
       await firstPage.reload();
       await expect.poll(() => firstMessage.inputValue()).toBe(text);
       await firstPage.close();
@@ -86,10 +88,16 @@ suite.define(() => {
       const incognito = firstPage.getByRole("switch", { name: "Incognito" });
       await incognito.click();
       await expect.poll(() => incognito.getAttribute("aria-checked")).toBe("true");
+      await waitForPersistedNewSessionDraft(firstPage, null, 0);
       await incognito.click();
       await expect.poll(() => incognito.getAttribute("aria-checked")).toBe("false");
       await firstMessage.fill("restore this prompt after restart and incognito");
       await expect.poll(() => firstPage.locator(".chat-attachment-thumb").count()).toBe(1);
+      await waitForPersistedNewSessionDraft(
+        firstPage,
+        "restore this prompt after restart and incognito",
+        1,
+      );
       await firstPage.reload();
       await expect
         .poll(() => firstMessage.inputValue())

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -194,6 +194,67 @@ export async function pastePng(target: Locator, count = 1) {
   );
 }
 
+export async function waitForPersistedNewSessionDraft(
+  page: Page,
+  expectedText: string | null,
+  expectedAttachmentCount: number,
+): Promise<void> {
+  // Filling only proves DOM state. The durable read waits for the IndexedDB
+  // transaction so reload or navigation cannot beat the snapshot write.
+  await page.waitForFunction(
+    async ({ text, attachmentCount }) => {
+      try {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            context: {
+              gateway: {
+                connection: { gatewayUrl: string };
+                snapshot: { client: { recoveryScope?: string } | null };
+              };
+            };
+          };
+        };
+        const gateway = app.runtime?.context.gateway;
+        const recoveryScope = gateway?.snapshot.client?.recoveryScope;
+        if (!gateway || !recoveryScope) {
+          return false;
+        }
+        const storeUrl = performance
+          .getEntriesByType("resource")
+          .map((entry) => entry.name)
+          .find((name) => /\/composer-draft-store\.runtime-[^/]+\.js$/u.test(name));
+        if (!storeUrl) {
+          return false;
+        }
+        const draftStore = (await import(
+          /* @vite-ignore */ storeUrl
+        )) as typeof import("../lib/chat/composer-draft-store.runtime.ts");
+        const params = new URLSearchParams(window.location.search);
+        const result = await draftStore.readDurableComposerDraft({
+          gatewayOwner: gateway.connection.gatewayUrl.trim() || "default",
+          recoveryScope,
+          scopeKey: JSON.stringify([
+            params.get("agent")?.trim() ?? "",
+            params.get("catalog")?.trim() ?? "",
+            params.get("group")?.trim() ?? "",
+          ]),
+        });
+        if (text === null) {
+          return result.status === "not-found" && result.revision !== undefined;
+        }
+        return (
+          result.status === "found" &&
+          result.draft.text === text &&
+          result.draft.attachments.length === attachmentCount
+        );
+      } catch {
+        return false;
+      }
+    },
+    { text: expectedText, attachmentCount: expectedAttachmentCount },
+  );
+}
+
 export async function replaceGatewayClient(page: Page) {
   await page.evaluate(() => {
     const app = document.querySelector("openclaw-app") as HTMLElement & {


### PR DESCRIPTION
## What Problem This Solves

`ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts` ("restores a text-only prompt in a fresh page")
fails intermittently on CI — it blocked PR #125498 twice, once as a timeout and once as
`AssertionError: expected '' to be 'restore this text-only prompt after r…'`. The empty string is the tell:
the draft was gone, not late.

```js
await firstMessage.fill(text);
await firstPage.reload();
await expect.poll(() => firstMessage.inputValue()).toBe(text);
```

`git blame` attributes these lines to `6b72d65ffe4` / #125332, which introduced both durable draft
persistence and this test. That feature persists through `NewSessionDraftPersistence` into the durable
composer draft store, which is loaded by dynamic `import()` and written asynchronously to IndexedDB. So
`fill()` returning proves only that the input holds the text — it says nothing about a snapshot existing. A
reload that beats the write destroys the draft, and the poll then waits for a value that no longer exists.

## Why This Change Was Made

The test synchronized on an action (`fill` returned) instead of on the state that action is supposed to
produce (a persisted snapshot). That is the same defect already fixed in #125441 (a pid file written before
the process was running) and #125456 (a Save click racing form-state commit); this is the third instance of
the pattern.

The fix waits on the persisted snapshot itself, using the existing exported `readDurableComposerDraft`
reader — scoped by gateway URL, recovery scope, and route parameters — and verifying the exact text and
attachment count after the IndexedDB transaction commits. Sibling cases that fill-then-reload get the same
treatment, including incognito retirement, which waits for its persisted tombstone.

Deliberately not done: raising the poll timeout, inserting a sleep, retrying the reload, or weakening the
assertion. Each would have stopped the failure without removing the race, leaving a test that passes whether
or not drafts actually survive a restart — which is the entire behavior #125332 shipped.

## User Impact

None. Test-only; production is untouched.

## Evidence

Ten consecutive runs, since one green run proves nothing about a race:

```
10/10 passed
```

```
pnpm test ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `0`, tests `+69 / −0` — pure addition, so no existing
assertion was relaxed. The bulk is a reusable persisted-draft probe in `new-session-page.test-support.ts`.

No `CHANGELOG.md` edit — release-only per repo policy; test-only change.
