### PR TITLE
fix(android): preserve photo capture dates and requested image resolution

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/PhotosHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/PhotosHandler.kt
@@ -113,7 +113,8 @@ private object SystemPhotosDataSource : PhotosDataSource {
         MediaStore.Images.Media.DATE_ADDED,
       )
     val sortOrder =
-      "${MediaStore.Images.Media.DATE_TAKEN} DESC, ${MediaStore.Images.Media.DATE_ADDED} DESC"
+      "COALESCE(NULLIF(${MediaStore.Images.Media.DATE_TAKEN}, 0), " +
+        "${MediaStore.Images.Media.DATE_ADDED} * 1000) DESC, ${MediaStore.Images.Media._ID} DESC"
     val args =
       Bundle().apply {
         putString(ContentResolver.QUERY_ARG_SQL_SORT_ORDER, sortOrder)
@@ -182,10 +183,8 @@ private object SystemPhotosDataSource : PhotosDataSource {
     maxWidth: Int,
   ): Int {
     var sample = 1
-    var candidate = width
-    while (candidate > maxWidth && sample < 64) {
+    while (width / sample / 2 >= maxWidth) {
       sample *= 2
-      candidate = width / sample
     }
     return sample
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/PhotosHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/PhotosHandlerTest.kt
@@ -1,17 +1,42 @@
 package ai.openclaw.app.node
 
+import android.Manifest
+import android.content.ContentProvider
+import android.content.ContentResolver
+import android.content.ContentValues
 import android.content.Context
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Bundle
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.MediaStore
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowContentResolver
+import java.io.File
 
 class PhotosHandlerTest : NodeHandlerRobolectricTest() {
+  private val photoStores = mutableListOf<TestPhotoStore>()
+
+  @After
+  fun closePhotoStores() {
+    photoStores.forEach(TestPhotoStore::close)
+  }
+
   @Test
   fun handlePhotosLatest_requiresPermission() {
     val handler = PhotosHandler.forTesting(appContext(), FakePhotosDataSource(hasPermission = false))
@@ -60,6 +85,87 @@ class PhotosHandlerTest : NodeHandlerRobolectricTest() {
     assertEquals("jpeg", first.getValue("format").jsonPrimitive.content)
     assertEquals(640, first.getValue("width").jsonPrimitive.int)
   }
+
+  @Test
+  fun handlePhotosLatest_usesAddedTimeWhenCaptureMetadataIsMissing() {
+    val handler =
+      systemPhotosHandler(
+        TestPhotoRow(id = 1, dateTakenMs = 100_000, dateAddedSeconds = 100),
+        TestPhotoRow(id = 2, dateTakenMs = null, dateAddedSeconds = 200),
+      )
+
+    val photo = onlyPhoto(handler.handlePhotosLatest("""{"limit":1}"""))
+
+    assertEquals("1970-01-01T00:03:20Z", photo.getValue("createdAt").jsonPrimitive.content)
+  }
+
+  @Test
+  fun handlePhotosLatest_preservesCaptureOrderingForNewlyImportedOldPhotos() {
+    val handler =
+      systemPhotosHandler(
+        TestPhotoRow(id = 1, dateTakenMs = 250_000, dateAddedSeconds = 250),
+        TestPhotoRow(id = 2, dateTakenMs = 50_000, dateAddedSeconds = 300),
+      )
+
+    val photo = onlyPhoto(handler.handlePhotosLatest("""{"limit":1}"""))
+
+    assertEquals("1970-01-01T00:04:10Z", photo.getValue("createdAt").jsonPrimitive.content)
+  }
+
+  @Test
+  fun handlePhotosLatest_treatsZeroCaptureTimeAsMissing() {
+    val handler =
+      systemPhotosHandler(
+        TestPhotoRow(id = 1, dateTakenMs = 100_000, dateAddedSeconds = 100),
+        TestPhotoRow(id = 2, dateTakenMs = 0, dateAddedSeconds = 200),
+      )
+
+    val photo = onlyPhoto(handler.handlePhotosLatest("""{"limit":1}"""))
+
+    assertEquals("1970-01-01T00:03:20Z", photo.getValue("createdAt").jsonPrimitive.content)
+  }
+
+  @Test
+  fun handlePhotosLatest_scalesLargePhotoToRequestedWidth() {
+    val handler =
+      systemPhotosHandler(
+        TestPhotoRow(id = 1, dateTakenMs = 100_000, dateAddedSeconds = 100, width = 4032),
+      )
+
+    val photo = onlyPhoto(handler.handlePhotosLatest("""{"limit":1,"maxWidth":1600}"""))
+
+    assertEquals(1600, photo.getValue("width").jsonPrimitive.int)
+  }
+
+  @Test
+  fun handlePhotosLatest_usesNewestIdForEqualEffectiveCaptureTimes() {
+    val handler =
+      systemPhotosHandler(
+        TestPhotoRow(id = 1, dateTakenMs = 100_000, dateAddedSeconds = 100, width = 640),
+        TestPhotoRow(id = 2, dateTakenMs = 100_000, dateAddedSeconds = 100, width = 320),
+      )
+
+    val photo = onlyPhoto(handler.handlePhotosLatest("""{"limit":1}"""))
+
+    assertEquals(320, photo.getValue("width").jsonPrimitive.int)
+  }
+
+  private fun systemPhotosHandler(vararg rows: TestPhotoRow): PhotosHandler {
+    shadowOf(RuntimeEnvironment.getApplication()).grantPermissions(Manifest.permission.READ_MEDIA_IMAGES)
+    val store = TestPhotoStore(appContext(), rows.toList()).also(photoStores::add)
+    store.attachInfo(appContext(), ProviderInfo().apply { authority = MediaStore.AUTHORITY })
+    ShadowContentResolver.registerProviderInternal(MediaStore.AUTHORITY, store)
+    return PhotosHandler(appContext())
+  }
+
+  private fun onlyPhoto(result: ai.openclaw.app.gateway.GatewaySession.InvokeResult) =
+    Json
+      .parseToJsonElement(result.payloadJson ?: error("missing photo payload: ${result.error?.message}"))
+      .jsonObject
+      .getValue("photos")
+      .jsonArray
+      .single()
+      .jsonObject
 }
 
 private class FakePhotosDataSource(
@@ -72,4 +178,108 @@ private class FakePhotosDataSource(
     context: Context,
     request: PhotosLatestRequest,
   ): List<EncodedPhotoPayload> = latest
+}
+
+private data class TestPhotoRow(
+  val id: Long,
+  val dateTakenMs: Long?,
+  val dateAddedSeconds: Long,
+  val width: Int = 640,
+)
+
+private class TestPhotoStore(
+  context: Context,
+  rows: List<TestPhotoRow>,
+) : ContentProvider(),
+  AutoCloseable {
+  private val database = SQLiteDatabase.create(null)
+  private val images = mutableMapOf<Long, File>()
+
+  init {
+    database.execSQL("CREATE TABLE images (_id INTEGER PRIMARY KEY, datetaken INTEGER, date_added INTEGER)")
+    rows.forEach { row ->
+      database.insert(
+        "images",
+        null,
+        ContentValues().apply {
+          put(MediaStore.Images.Media._ID, row.id)
+          if (row.dateTakenMs == null) {
+            putNull(MediaStore.Images.Media.DATE_TAKEN)
+          } else {
+            put(MediaStore.Images.Media.DATE_TAKEN, row.dateTakenMs)
+          }
+          put(MediaStore.Images.Media.DATE_ADDED, row.dateAddedSeconds)
+        },
+      )
+      val image = File.createTempFile("photos-handler-${row.id}-", ".jpg", context.cacheDir)
+      val bitmap = Bitmap.createBitmap(row.width, 32, Bitmap.Config.ARGB_8888)
+      try {
+        image.outputStream().use { output -> check(bitmap.compress(Bitmap.CompressFormat.JPEG, 90, output)) }
+      } finally {
+        bitmap.recycle()
+      }
+      images[row.id] = image
+    }
+  }
+
+  override fun onCreate(): Boolean = true
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    queryArgs: Bundle?,
+    cancellationSignal: CancellationSignal?,
+  ): Cursor =
+    database.query(
+      "images",
+      projection?.toList()?.toTypedArray(),
+      null,
+      null,
+      null,
+      null,
+      queryArgs?.getString(ContentResolver.QUERY_ARG_SQL_SORT_ORDER),
+      queryArgs?.getInt(ContentResolver.QUERY_ARG_LIMIT)?.toString(),
+    )
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?,
+  ): Cursor = database.query("images", projection?.toList()?.toTypedArray(), null, null, null, null, sortOrder)
+
+  override fun openFile(
+    uri: Uri,
+    mode: String,
+  ): ParcelFileDescriptor =
+    ParcelFileDescriptor.open(
+      images.getValue(requireNotNull(uri.lastPathSegment).toLong()),
+      ParcelFileDescriptor.MODE_READ_ONLY,
+    )
+
+  override fun getType(uri: Uri): String = "image/jpeg"
+
+  override fun insert(
+    uri: Uri,
+    values: ContentValues?,
+  ): Uri? = null
+
+  override fun delete(
+    uri: Uri,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  override fun close() {
+    database.close()
+    images.values.forEach(File::delete)
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

`photos.latest` in Android's third-party build can return an older camera image instead of a newly added screenshot without capture metadata, pick an unstable winner when image timestamps tie, and return a 4032-pixel photo at only 1008 pixels when the caller requested a 1600-pixel image.

The original contributor report correctly identified the stale-image and undersampling defects. Its earlier `DATE_ADDED`-only sort would additionally have changed existing capture-date semantics and allowed a newly imported old photograph to outrank a recently captured photo, so this update fixes the same bugs at their existing owner without introducing that regression.

## Why This Change Was Made

Keep `SystemPhotosDataSource` as the single owner of MediaStore selection and bitmap sampling:

- Order by one effective creation timestamp: valid `DATE_TAKEN` in milliseconds, or `DATE_ADDED` converted from seconds when capture metadata is null or zero; break identical timestamps with descending MediaStore `_ID`.
- Keep the existing private decoder and exact resize path, but choose the largest power-of-two sample whose decoded width still meets the request. The division order cannot overflow and removes the previous arbitrary 64x ceiling.
- Preserve existing capture-time behavior, query limits, permissions, payload budgets, request bounds, and third-party-only feature availability. No new helper, config, dependency, or persistence path is added.

This supersedes the earlier insertion-time-only sort and standalone sampling helper in the same contributor PR. Thanks to @Kaneki-x for the original investigation and regression scenarios.

## Evidence

- Authoritative enabled third-party owner baseline: 8 tests, 4 genuine failures covering null capture metadata, zero capture metadata, unstable equal-timestamp ordering, and a real 4032-pixel JPEG decoded to 1008 instead of the requested 1600; the imported-old-photo capture-time compatibility control already passed.
- Candidate: `:app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.node.PhotosHandlerTest` passes all 8 owner tests; the shared Play-flavor sibling also passes all 8.
- Exact hosted Android lint equivalent passes all four modules: `:app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck`.
- The permanent owner tests exercise the production `PhotosHandler`, a framework-attached SQLite-backed MediaStore provider, real JPEG decoding, SQL `ORDER BY`/`LIMIT`, capture-or-added timestamp conversion, deterministic IDs, and the full requested output width.
- Fresh independent structured review found no accepted/actionable P0 or P1 findings.
- Production delta: +3/-4, net **-1 production line**; stronger regression coverage is test-only.
- Real Android 36 third-party app UID proof used the actual `READ_MEDIA_IMAGES` permission, production `PhotosHandler`, live MediaStore provider, and three real 4032×3024 JPEGs. The baseline selected an old blue imported image (`createdAt=2020-01-02T03:04:05Z`, `1008×756`, RGB `0,0,254`) instead of a new screenshot without `DATE_TAKEN`. The corrected app selected the newest green screenshot at the requested `1600×1200` (`createdAt=2026-08-24T13:14:22Z`, RGB `0,255,1`, newest MediaStore ID `28`); the actual Android instrumentation finished `OK (1 test)` and every temporary MediaStore row was deleted.
- ClawSweeper capture-date compatibility finding and both rank-up moves are addressed: old imports retain capture-date priority, screenshots without metadata use their actual insertion-date fallback, and real third-party app MediaStore proof must be provided before landing.
