### PR TITLE
fix(voice-call): keep Funnel off occupied HTTPS ports

### DIFF
--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -196,7 +196,9 @@ JSON with `recordsScanned`, `turnLatency`, and `listenWait` summaries.
 
 Enable, disable, or change the Tailscale serve/funnel configuration for the
 voice webhook. When realtime or streaming audio is enabled, the command also
-exposes or clears that mode's WebSocket stream path.
+exposes or clears that mode's WebSocket stream path. The external HTTPS port
+comes from `tailscale.port` (default `443`); Funnel supports `443`, `8443`, or
+`10000`.
 
 | Flag                  | Default                                   | Description                                     |
 | --------------------- | ----------------------------------------- | ----------------------------------------------- |

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -156,7 +156,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
           // Public exposure (pick one)
           // publicUrl: "https://example.ngrok.app/voice/webhook",
           // tunnel: { provider: "ngrok" },
-          // tailscale: { mode: "funnel", path: "/voice/webhook" },
+          // tailscale: { mode: "funnel", port: 8443, path: "/voice/webhook" },
 
           outbound: {
             defaultMode: "notify", // notify | conversation
@@ -209,6 +209,7 @@ that Region. See
     - `tunnel.allowNgrokFreeTierLoopbackBypass: true` allows Twilio webhooks with invalid signatures **only** when `tunnel.provider="ngrok"` and `serve.bind` is loopback (ngrok local agent). Local dev only.
     - Ngrok free-tier URLs can change or add interstitial behavior; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
     - Tailscale Serve and Funnel automatically expose the realtime or streaming WebSocket path when that audio mode is enabled.
+    - `tailscale.port` selects the external HTTPS port for both `tailscale.mode` and unified `tunnel.provider: "tailscale-serve" | "tailscale-funnel"`. It defaults to `443`; use `8443` when another HTTPS server owns port 443. Funnel accepts only `443`, `8443`, or `10000`, while Serve accepts any valid TCP port. Non-default ports appear in the webhook and realtime stream URLs.
 
   </Accordion>
   <Accordion title="Streaming connection caps">
@@ -892,7 +893,7 @@ Use one public exposure path:
           // or
           tunnel: { provider: "ngrok" },
           // or
-          tailscale: { mode: "funnel", path: "/voice/webhook" },
+          tailscale: { mode: "funnel", port: 8443, path: "/voice/webhook" },
         },
       },
     },

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -67,7 +67,7 @@ Put under `plugins.entries.voice-call.config`:
   // Public exposure (pick one):
   // publicUrl: "https://example.ngrok.app/voice/webhook",
   // tunnel: { provider: "ngrok" },
-  // tailscale: { mode: "funnel", path: "/voice/webhook" }
+  // tailscale: { mode: "funnel", port: 8443, path: "/voice/webhook" }
 
   outbound: {
     defaultMode: "notify", // or "conversation"
@@ -98,6 +98,7 @@ Put under `plugins.entries.voice-call.config`:
 Notes:
 
 - Twilio/Telnyx/Plivo require a **publicly reachable** webhook URL.
+- `tailscale.port` defaults to `443` and owns the external HTTPS port for both legacy `tailscale.mode` and unified Tailscale tunnel providers. Funnel supports `443`, `8443`, or `10000`; Serve accepts any valid TCP port.
 - Twilio defaults to US1. For a non-US Region, set `twilio.region` to `ie1` or `au1` and use credentials created in that Region; see [Twilio's regional REST API guide](https://www.twilio.com/docs/global-infrastructure/using-the-twilio-rest-api-in-a-non-us-region).
 - `mock` is a local dev provider (no network calls).
 - Telnyx requires `telnyx.publicKey` (or `TELNYX_PUBLIC_KEY`) unless `skipSignatureVerification` is true.

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -92,6 +92,11 @@
       "label": "Tailscale Mode",
       "advanced": true
     },
+    "tailscale.port": {
+      "label": "Tailscale HTTPS Port",
+      "help": "External HTTPS port. Funnel supports 443, 8443, or 10000; Serve accepts any valid port.",
+      "advanced": true
+    },
     "tailscale.path": {
       "label": "Tailscale Path",
       "advanced": true
@@ -427,6 +432,12 @@
           "mode": {
             "type": "string",
             "enum": ["off", "serve", "funnel"]
+          },
+          "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "default": 443
           },
           "path": {
             "type": "string"

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -273,7 +273,7 @@ describe("voice-call CLI status fallback", () => {
       {},
       {
         serve: { port: 3334, path: "/voice/webhook" },
-        tailscale: { mode: "off", path: "/voice/webhook" },
+        tailscale: { mode: "off", port: 443, path: "/voice/webhook" },
         realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
         streaming: { enabled: true, streamPath: "/voice/stream" },
       },
@@ -301,6 +301,7 @@ describe("voice-call CLI status fallback", () => {
 
     expect(tailscaleMocks.setup).toHaveBeenCalledWith({
       mode: "funnel",
+      port: 443,
       routes: [
         {
           path: "/edge/custom/webhook",
@@ -329,7 +330,7 @@ describe("voice-call CLI status fallback", () => {
       {},
       {
         serve: { port: 3334, path: "/voice/webhook" },
-        tailscale: { mode: "off", path: "/voice/webhook" },
+        tailscale: { mode: "off", port: 443, path: "/voice/webhook" },
         realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
         streaming: { enabled: false },
       },
@@ -352,7 +353,7 @@ describe("voice-call CLI status fallback", () => {
       {},
       {
         serve: { port: 3334, path: "/voice/webhook" },
-        tailscale: { mode: "off", path: "/voice/webhook" },
+        tailscale: { mode: "off", port: 443, path: "/voice/webhook" },
         realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
         streaming: { enabled: true, streamPath: "/voice/stream" },
       },
@@ -366,8 +367,8 @@ describe("voice-call CLI status fallback", () => {
 
     expect(tailscaleMocks.cleanup.mock.calls).toEqual(
       ["/voice/webhook", "/voice/stream/realtime", "/voice/stream"].flatMap((exposurePath) => [
-        [{ mode: "serve", path: exposurePath }],
-        [{ mode: "funnel", path: exposurePath }],
+        [{ mode: "serve", port: 443, path: exposurePath }],
+        [{ mode: "funnel", port: 443, path: exposurePath }],
       ]),
     );
     expect(JSON.parse(capturer.output())).toMatchObject({

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -422,8 +422,13 @@ export function registerVoiceCallCli(params: {
 
         if (mode === "off") {
           for (const exposurePath of [tsPath, ...streamPaths]) {
-            await cleanupTailscaleExposureRoute({ mode: "serve", path: exposurePath });
-            await cleanupTailscaleExposureRoute({ mode: "funnel", path: exposurePath });
+            for (const tailscaleMode of ["serve", "funnel"] as const) {
+              await cleanupTailscaleExposureRoute({
+                mode: tailscaleMode,
+                port: config.tailscale.port,
+                path: exposurePath,
+              });
+            }
           }
           writeCliJson({ ok: true, mode: "off", path: tsPath, streamPaths });
           return;
@@ -431,6 +436,7 @@ export function registerVoiceCallCli(params: {
 
         const publicUrl = await setupTailscaleExposureRoutes({
           mode,
+          port: config.tailscale.port,
           routes: [
             { path: tsPath, localUrl },
             ...streamExposurePaths.map(({ publicPath, localPath }) => ({

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -417,6 +417,51 @@ describe("validateProviderConfig", () => {
   });
 });
 
+describe("Tailscale external HTTPS port", () => {
+  it.each([
+    {
+      name: "Serve on an arbitrary valid port",
+      input: { tailscale: { mode: "serve", port: 4545 } },
+    },
+    { name: "legacy Funnel on 8443", input: { tailscale: { mode: "funnel", port: 8443 } } },
+    {
+      name: "unified Funnel on 10000",
+      input: {
+        tailscale: { port: 10000 },
+        tunnel: { provider: "tailscale-funnel" },
+      },
+    },
+  ])("accepts $name", ({ input }) => {
+    expect(VoiceCallConfigSchema.safeParse(input).success).toBe(true);
+  });
+
+  it.each([0, 1.5, 65_536])("rejects invalid HTTPS port %s", (port) => {
+    expect(VoiceCallConfigSchema.safeParse({ tailscale: { port } }).success).toBe(false);
+  });
+
+  it.each([
+    { name: "legacy mode", input: { tailscale: { mode: "funnel", port: 4545 } } },
+    {
+      name: "unified provider",
+      input: {
+        tailscale: { port: 4545 },
+        tunnel: { provider: "tailscale-funnel" },
+      },
+    },
+  ])("rejects unsupported Funnel port for $name", ({ input }) => {
+    const result = VoiceCallConfigSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["tailscale", "port"],
+          message: "Tailscale Funnel HTTPS port must be one of 443, 8443, 10000",
+        }),
+      );
+    }
+  });
+});
+
 describe("resolveVoiceCallConfig session routing", () => {
   it("enables the pre-answer stale call reaper by default", () => {
     const config = resolveVoiceCallConfig({ enabled: true, provider: "mock" });
@@ -785,6 +830,7 @@ describe("normalizeVoiceCallConfig", () => {
     expect(normalized.realtime.instructions).toContain("openclaw_agent_consult");
     expect(normalized.realtime.instructions).toContain("openclaw_end_call");
     expect(normalized.realtime.instructions).toContain("speak any final words first");
+    expect(normalized.tailscale.port).toBe(443);
     expect(normalized.tunnel.provider).toBe("none");
     expect(normalized.webhookSecurity.allowedHosts).toStrictEqual([]);
   });

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -704,7 +704,7 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
     ...config.realtime?.agentContext,
     files: config.realtime?.agentContext?.files ?? defaults.realtime.agentContext.files,
   };
-  return VoiceCallConfigSchema.parse({
+  return {
     ...defaults,
     ...config,
     allowFrom: config.allowFrom ?? defaults.allowFrom,
@@ -746,7 +746,7 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
       providers: realtimeProviders,
     },
     tts: normalizeVoiceCallTtsConfig(defaults.tts, config.tts),
-  });
+  };
 }
 
 export type VoiceCallCoreSessionConfig = { mainKey?: string; scope?: SessionScope };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { TtsConfigSchema } from "../api.js";
 import { TWILIO_REGIONS } from "./providers/twilio-region.js";
 import { DEFAULT_VOICE_CALL_REALTIME_INSTRUCTIONS } from "./realtime-defaults.js";
+import { isTailscalePortAllowed, VoiceCallTailscaleConfigSchema } from "./tailscale-config.js";
 
 // -----------------------------------------------------------------------------
 // Phone Number Validation
@@ -118,21 +119,6 @@ const VoiceCallServeConfigSchema = z
   })
   .strict()
   .default({ port: 3334, bind: "127.0.0.1", path: "/voice/webhook" });
-
-const VoiceCallTailscaleConfigSchema = z
-  .object({
-    /**
-     * Tailscale exposure mode:
-     * - "off": No Tailscale exposure
-     * - "serve": Tailscale serve (private to tailnet)
-     * - "funnel": Tailscale funnel (public HTTPS)
-     */
-    mode: z.enum(["off", "serve", "funnel"]).default("off"),
-    /** Path for Tailscale serve/funnel (should usually match serve.path) */
-    path: z.string().min(1).default("/voice/webhook"),
-  })
-  .strict()
-  .default({ mode: "off", path: "/voice/webhook" });
 
 // -----------------------------------------------------------------------------
 // Tunnel Configuration (unified ngrok/tailscale)
@@ -501,7 +487,11 @@ export const VoiceCallConfigSchema = z
     /** Timeout for response generation in ms (default 30s) */
     responseTimeoutMs: z.number().int().positive().default(30000),
   })
-  .strict();
+  .strict()
+  .refine(isTailscalePortAllowed, {
+    path: ["tailscale", "port"],
+    message: "Tailscale Funnel HTTPS port must be one of 443, 8443, 10000",
+  });
 
 export type VoiceCallConfig = z.infer<typeof VoiceCallConfigSchema>;
 type VoiceCallEffectiveConfigResult = {
@@ -714,7 +704,7 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
     ...config.realtime?.agentContext,
     files: config.realtime?.agentContext?.files ?? defaults.realtime.agentContext.files,
   };
-  return {
+  return VoiceCallConfigSchema.parse({
     ...defaults,
     ...config,
     allowFrom: config.allowFrom ?? defaults.allowFrom,
@@ -756,7 +746,7 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
       providers: realtimeProviders,
     },
     tts: normalizeVoiceCallTtsConfig(defaults.tts, config.tts),
-  };
+  });
 }
 
 export type VoiceCallCoreSessionConfig = { mainKey?: string; scope?: SessionScope };

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -270,17 +270,20 @@ describe("createVoiceCallRuntime lifecycle", () => {
   });
 
   it("cleans up tunnel, tailscale, and webhook server when init fails after start", async () => {
+    const config = createBaseConfig();
+    config.tunnel.provider = "tailscale-funnel";
+    config.tailscale.port = 8443;
     const tunnelStop = vi.fn().mockResolvedValue(undefined);
     mocks.startTunnel.mockResolvedValue({
-      publicUrl: "https://public.example/voice/webhook",
-      provider: "ngrok",
+      publicUrl: "https://public.example:8443/voice/webhook",
+      provider: "tailscale-funnel",
       stop: tunnelStop,
     });
     mocks.managerInitialize.mockRejectedValue(new Error("init failed"));
 
     await expect(
       createVoiceCallRuntime({
-        config: createBaseConfig(),
+        config,
         coreConfig: {},
         agentRuntime: {} as never,
       }),
@@ -288,6 +291,8 @@ describe("createVoiceCallRuntime lifecycle", () => {
 
     expect(mocks.startTunnel).toHaveBeenCalledWith(
       expect.objectContaining({
+        provider: "tailscale-funnel",
+        tailscalePort: 8443,
         streamPaths: [
           {
             localPath: "/voice/stream/realtime",

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -483,6 +483,7 @@ export async function createVoiceCallRuntime(params: {
         const nextTunnelResult = await startTunnel({
           provider: config.tunnel.provider,
           port: config.serve.port,
+          tailscalePort: config.tailscale.port,
           path: config.serve.path,
           streamPaths: resolveVoiceCallStreamExposurePaths(config, {
             publicWebhookPath: config.serve.path,

--- a/extensions/voice-call/src/tailscale-config.ts
+++ b/extensions/voice-call/src/tailscale-config.ts
@@ -1,0 +1,22 @@
+import { MAX_TCP_PORT } from "openclaw/plugin-sdk/number-runtime";
+import { z } from "zod";
+
+export const VoiceCallTailscaleConfigSchema = z
+  .object({
+    mode: z.enum(["off", "serve", "funnel"]).default("off"),
+    port: z.number().int().positive().max(MAX_TCP_PORT).default(443),
+    path: z.string().min(1).default("/voice/webhook"),
+  })
+  .strict()
+  .default({ mode: "off", port: 443, path: "/voice/webhook" });
+
+const TAILSCALE_FUNNEL_HTTPS_PORTS = new Set([443, 8443, 10000]);
+
+export function isTailscalePortAllowed(config: {
+  tailscale: z.infer<typeof VoiceCallTailscaleConfigSchema>;
+  tunnel: { provider: string };
+}): boolean {
+  const usesFunnel =
+    config.tailscale.mode === "funnel" || config.tunnel.provider === "tailscale-funnel";
+  return !usesFunnel || TAILSCALE_FUNNEL_HTTPS_PORTS.has(config.tailscale.port);
+}

--- a/extensions/voice-call/src/test-fixtures.ts
+++ b/extensions/voice-call/src/test-fixtures.ts
@@ -22,7 +22,7 @@ export function createVoiceCallBaseConfig(params?: {
     maxConcurrentCalls: 1,
     sessionScope: "per-phone",
     serve: { port: 3334, bind: "127.0.0.1", path: "/voice/webhook" },
-    tailscale: { mode: "off", path: "/voice/webhook" },
+    tailscale: { mode: "off", port: 443, path: "/voice/webhook" },
     tunnel: {
       provider: params?.tunnelProvider ?? "none",
       allowNgrokFreeTierLoopbackBypass: false,

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -37,7 +37,8 @@ class FakeChildProcess extends EventEmitter {
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
   realSpawn: undefined as undefined | typeof import("node:child_process").spawn,
-  getTailscaleDnsName: vi.fn(),
+  setupTailscaleExposureRoutes: vi.fn(),
+  cleanupTailscaleExposureRoute: vi.fn(),
   runCommand: vi.fn(),
 }));
 
@@ -51,7 +52,8 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 vi.mock("./webhook/tailscale.js", () => ({
-  getTailscaleDnsName: mocks.getTailscaleDnsName,
+  setupTailscaleExposureRoutes: mocks.setupTailscaleExposureRoutes,
+  cleanupTailscaleExposureRoute: mocks.cleanupTailscaleExposureRoute,
 }));
 
 vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
@@ -89,6 +91,7 @@ function startTailscaleTunnel(config: {
   mode: "serve" | "funnel";
   port: number;
   path: string;
+  tailscalePort?: number;
   streamPaths?: Array<{ publicPath: string; localPath: string }>;
 }) {
   return requireTunnel(
@@ -96,6 +99,7 @@ function startTailscaleTunnel(config: {
       provider: config.mode === "serve" ? "tailscale-serve" : "tailscale-funnel",
       port: config.port,
       path: config.path,
+      tailscalePort: config.tailscalePort ?? 443,
       streamPaths: config.streamPaths,
     }),
   );
@@ -159,8 +163,10 @@ function commandResult(overrides: Record<string, unknown> = {}) {
 describe("voice-call tunnels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getTailscaleDnsName.mockReset();
-    mocks.runCommand.mockReset();
+    mocks.setupTailscaleExposureRoutes.mockResolvedValue(
+      "https://host.tailnet.ts.net/voice/webhook",
+    );
+    mocks.cleanupTailscaleExposureRoute.mockResolvedValue(undefined);
     mocks.runCommand.mockResolvedValue(commandResult());
   });
 
@@ -344,138 +350,54 @@ describe("voice-call tunnels", () => {
     await tunnel.stop();
   });
 
-  it("starts Tailscale serve using the resolved tailnet DNS name", async () => {
-    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
+  it("routes Tailscale Funnel setup and cleanup through the shared exposure owner", async () => {
+    mocks.setupTailscaleExposureRoutes.mockResolvedValue(
+      "https://host.tailnet.ts.net:8443/voice/webhook",
+    );
     const tunnel = await startTailscaleTunnel({
-      mode: "serve",
-      port: 3334,
-      path: "voice/webhook",
-    });
-
-    expect(tunnel.publicUrl).toBe("https://host.tailnet.ts.net/voice/webhook");
-    expect(tunnel.provider).toBe("tailscale-serve");
-    expect(tunnel.stop).toBeTypeOf("function");
-    expect(mocks.runCommand).toHaveBeenCalledWith(
-      [
-        "tailscale",
-        "serve",
-        "--bg",
-        "--yes",
-        "--set-path",
-        "/voice/webhook",
-        "http://127.0.0.1:3334/voice/webhook",
-      ],
-      expect.objectContaining({ timeoutMs: 10_000 }),
-    );
-  });
-
-  it.each(["serve", "funnel"] as const)(
-    "mounts and stops every Tailscale %s stream path",
-    async (mode) => {
-      mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
-      const tunnel = await startTailscaleTunnel({
-        mode,
-        port: 3334,
-        path: "/voice/webhook",
-        streamPaths: [
-          {
-            publicPath: "/edge/voice/stream/realtime",
-            localPath: "/voice/stream/realtime",
-          },
-          { publicPath: "/edge/voice/stream", localPath: "/voice/stream" },
-        ],
-      });
-
-      await tunnel.stop();
-
-      expect(mocks.runCommand.mock.calls.map(([command]) => command)).toEqual([
-        [
-          "tailscale",
-          mode,
-          "--bg",
-          "--yes",
-          "--set-path",
-          "/voice/webhook",
-          "http://127.0.0.1:3334/voice/webhook",
-        ],
-        [
-          "tailscale",
-          mode,
-          "--bg",
-          "--yes",
-          "--set-path",
-          "/edge/voice/stream/realtime",
-          "http://127.0.0.1:3334/voice/stream/realtime",
-        ],
-        [
-          "tailscale",
-          mode,
-          "--bg",
-          "--yes",
-          "--set-path",
-          "/edge/voice/stream",
-          "http://127.0.0.1:3334/voice/stream",
-        ],
-        ["tailscale", mode, "off", "/voice/webhook"],
-        ["tailscale", mode, "off", "/edge/voice/stream/realtime"],
-        ["tailscale", mode, "off", "/edge/voice/stream"],
-      ]);
-    },
-  );
-
-  it("rejects when a Tailscale stream path cannot be mounted", async () => {
-    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
-    mocks.runCommand
-      .mockResolvedValueOnce(commandResult())
-      .mockResolvedValueOnce(commandResult({ code: 1, stderr: "stream mount failed" }));
-
-    await expect(
-      startTailscaleTunnel({
-        mode: "funnel",
-        port: 3334,
-        path: "/voice/webhook",
-        streamPaths: [
-          {
-            publicPath: "/voice/stream/realtime",
-            localPath: "/voice/stream/realtime",
-          },
-        ],
-      }),
-    ).rejects.toThrow("Tailscale funnel failed with code 1: stream mount failed");
-    expect(mocks.runCommand).toHaveBeenLastCalledWith(
-      ["tailscale", "funnel", "off", "/voice/webhook"],
-      expect.objectContaining({ timeoutMs: 5_000 }),
-    );
-  });
-
-  it("drains and bounds Tailscale startup failure output", async () => {
-    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
-    mocks.runCommand.mockResolvedValueOnce(
-      commandResult({
-        code: 1,
-        stderr: `${"x".repeat(16_000)}-end`,
-        stderrTruncatedBytes: 4_000,
-      }),
-    );
-    const result = startTailscaleTunnel({
       mode: "funnel",
       port: 3334,
-      path: "/voice/webhook",
+      path: "voice/webhook",
+      tailscalePort: 8443,
+      streamPaths: [
+        {
+          publicPath: "voice/stream/realtime",
+          localPath: "voice/stream/realtime",
+        },
+      ],
     });
 
-    await expect(result).rejects.toThrow("Tailscale funnel failed with code 1");
-    await expect(result).rejects.toThrow("[output truncated]");
-    await expect(result).rejects.toThrow("-end");
+    expect(tunnel.publicUrl).toBe("https://host.tailnet.ts.net:8443/voice/webhook");
+    expect(tunnel.provider).toBe("tailscale-funnel");
+    expect(mocks.setupTailscaleExposureRoutes).toHaveBeenCalledWith({
+      mode: "funnel",
+      port: 8443,
+      routes: [
+        {
+          path: "/voice/webhook",
+          localUrl: "http://127.0.0.1:3334/voice/webhook",
+        },
+        {
+          path: "/voice/stream/realtime",
+          localUrl: "http://127.0.0.1:3334/voice/stream/realtime",
+        },
+      ],
+    });
+
+    await tunnel.stop();
+
+    expect(mocks.cleanupTailscaleExposureRoute.mock.calls).toEqual([
+      [{ mode: "funnel", port: 8443, path: "/voice/webhook" }],
+      [{ mode: "funnel", port: 8443, path: "/voice/stream/realtime" }],
+    ]);
   });
 
-  it("rejects Tailscale tunnel startup when the DNS name is unavailable", async () => {
-    mocks.getTailscaleDnsName.mockResolvedValue(null);
+  it("rejects when the shared Tailscale exposure owner cannot mount the routes", async () => {
+    mocks.setupTailscaleExposureRoutes.mockResolvedValue(null);
 
     await expect(
       startTailscaleTunnel({ mode: "funnel", port: 3334, path: "/hook" }),
-    ).rejects.toThrow("Could not get Tailscale DNS name");
-    expect(mocks.spawn).not.toHaveBeenCalled();
-    expect(mocks.runCommand).not.toHaveBeenCalled();
+    ).rejects.toThrow("Tailscale funnel failed");
   });
 
   it("dispatches tunnel providers from config", async () => {
@@ -488,18 +410,6 @@ describe("voice-call tunnels", () => {
     const tunnel = await result;
     expect(tunnel?.publicUrl).toBe("https://dispatch.ngrok.io/hook");
     expect(tunnel?.provider).toBe("ngrok");
-  });
-
-  it("handles wrapper errors on tailscale stop cleanup without crashing", async () => {
-    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
-    const tunnel = await startTailscaleTunnel({
-      mode: "serve",
-      port: 3334,
-      path: "/voice/stop",
-    });
-    mocks.runCommand.mockRejectedValueOnce(new Error("tailscale not found"));
-
-    await expect(tunnel.stop()).resolves.toBeUndefined();
   });
 
   it("rejects when ngrok stdout emits an error before the tunnel is ready", async () => {

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -8,7 +8,10 @@ import {
   formatBoundedChildOutput,
 } from "./bounded-child-output.js";
 import type { VoiceCallStreamExposurePath } from "./config.js";
-import { getTailscaleDnsName } from "./webhook/tailscale.js";
+import {
+  cleanupTailscaleExposureRoute,
+  setupTailscaleExposureRoutes,
+} from "./webhook/tailscale.js";
 
 const NGROK_LOG_BUFFER_MAX_CHARS = 16_384;
 const NGROK_ERROR_MARKER = "ERR_NGROK";
@@ -76,6 +79,8 @@ interface TunnelConfig {
   provider: "ngrok" | "tailscale-serve" | "tailscale-funnel" | "none";
   /** Local port to tunnel */
   port: number;
+  /** External HTTPS port used by Tailscale providers */
+  tailscalePort?: number;
   /** Path prefix for the tunnel (e.g., /voice/webhook) */
   path: string;
   /** Additional public-to-local WebSocket paths exposed by Tailscale */
@@ -279,80 +284,45 @@ async function runNgrokCommand(args: string[]): Promise<string> {
 async function startTailscaleTunnel(config: {
   mode: "serve" | "funnel";
   port: number;
+  tailscalePort: number;
   path: string;
   streamPaths?: VoiceCallStreamExposurePath[];
 }): Promise<TunnelResult> {
-  // Get Tailscale DNS name
-  const dnsName = await getTailscaleDnsName();
-  if (!dnsName) {
-    throw new Error("Could not get Tailscale DNS name. Is Tailscale running?");
-  }
-
   const path = config.path.startsWith("/") ? config.path : `/${config.path}`;
   const exposurePaths: VoiceCallStreamExposurePath[] = [
     { publicPath: path, localPath: path },
     ...(config.streamPaths ?? []),
   ];
-  const mountedPaths: string[] = [];
-
-  for (const exposure of exposurePaths) {
-    const publicPath = exposure.publicPath.startsWith("/")
-      ? exposure.publicPath
-      : `/${exposure.publicPath}`;
-    const localPath = exposure.localPath.startsWith("/")
-      ? exposure.localPath
-      : `/${exposure.localPath}`;
-    const localUrl = `http://127.0.0.1:${config.port}${localPath}`;
-    const result = await runCommandWithTimeout(
-      ["tailscale", config.mode, "--bg", "--yes", "--set-path", publicPath, localUrl],
-      {
-        killProcessTree: true,
-        maxOutputBytes: TUNNEL_COMMAND_OUTPUT_MAX_BYTES,
-        outputCapture: "tail",
-        timeoutMs: 10_000,
-      },
-    );
-    let failure: Error | undefined;
-    if (result.termination === "timeout") {
-      failure = new Error(`Tailscale ${config.mode} timed out`);
-    } else if (result.code !== 0) {
-      const output = result.stderr
-        ? { text: result.stderr, truncated: Boolean(result.stderrTruncatedBytes) }
-        : { text: result.stdout, truncated: Boolean(result.stdoutTruncatedBytes) };
-      const detail = output.text ? `: ${formatBoundedChildOutput(output)}` : "";
-      failure = new Error(`Tailscale ${config.mode} failed with code ${result.code}${detail}`);
-    }
-    if (failure) {
-      for (const mountedPath of mountedPaths) {
-        await stopTailscaleTunnel(config.mode, mountedPath);
-      }
-      throw failure;
-    }
-    mountedPaths.push(publicPath);
+  const routes = exposurePaths.map(({ publicPath, localPath }) => {
+    const normalizedPublicPath = publicPath.startsWith("/") ? publicPath : `/${publicPath}`;
+    const normalizedLocalPath = localPath.startsWith("/") ? localPath : `/${localPath}`;
+    return {
+      path: normalizedPublicPath,
+      localUrl: `http://127.0.0.1:${config.port}${normalizedLocalPath}`,
+    };
+  });
+  const publicUrl = await setupTailscaleExposureRoutes({
+    mode: config.mode,
+    port: config.tailscalePort,
+    routes,
+  });
+  if (!publicUrl) {
+    throw new Error(`Tailscale ${config.mode} failed`);
   }
-  const publicUrl = `https://${dnsName}${path}`;
-  console.log(`[voice-call] Tailscale ${config.mode} active: ${publicUrl}`);
 
   return {
     publicUrl,
     provider: `tailscale-${config.mode}`,
     stop: async () => {
-      for (const mountedPath of mountedPaths) {
-        await stopTailscaleTunnel(config.mode, mountedPath);
+      for (const route of routes) {
+        await cleanupTailscaleExposureRoute({
+          mode: config.mode,
+          port: config.tailscalePort,
+          path: route.path,
+        });
       }
     },
   };
-}
-
-/**
- * Stop a Tailscale serve/funnel tunnel.
- */
-async function stopTailscaleTunnel(mode: "serve" | "funnel", path: string): Promise<void> {
-  await runCommandWithTimeout(["tailscale", mode, "off", path], {
-    killProcessTree: true,
-    maxOutputBytes: 1,
-    timeoutMs: 5_000,
-  }).catch(() => {});
 }
 
 /**
@@ -372,6 +342,7 @@ export async function startTunnel(config: TunnelConfig): Promise<TunnelResult | 
       return startTailscaleTunnel({
         mode: "serve",
         port: config.port,
+        tailscalePort: config.tailscalePort ?? 443,
         path: config.path,
         streamPaths: config.streamPaths,
       });
@@ -380,6 +351,7 @@ export async function startTunnel(config: TunnelConfig): Promise<TunnelResult | 
       return startTailscaleTunnel({
         mode: "funnel",
         port: config.port,
+        tailscalePort: config.tailscalePort ?? 443,
         path: config.path,
         streamPaths: config.streamPaths,
       });

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -453,12 +453,12 @@ describe("RealtimeCallHandler path routing", () => {
 
   it("preserves a public path prefix ahead of serve.path", () => {
     const handler = makeHandler({ streamPath: "/custom/stream/realtime" });
-    handler.setPublicUrl("https://public.example/api/voice/webhook");
+    handler.setPublicUrl("https://public.example:8443/api/voice/webhook");
     const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook", "127.0.0.1:3334"));
 
     expect(handler.getStreamPathPattern()).toBe("/api/custom/stream/realtime");
     expect(payload.body).toMatch(
-      /wss:\/\/public\.example\/api\/custom\/stream\/realtime\/[0-9a-f-]{36}/,
+      /wss:\/\/public\.example:8443\/api\/custom\/stream\/realtime\/[0-9a-f-]{36}/,
     );
   });
 

--- a/extensions/voice-call/src/webhook/tailscale.test.ts
+++ b/extensions/voice-call/src/webhook/tailscale.test.ts
@@ -10,7 +10,6 @@ vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
 import {
   cleanupTailscaleExposure,
   cleanupTailscaleExposureRoute,
-  getTailscaleDnsName,
   getTailscaleSelfInfo,
   setupTailscaleExposure,
   setupTailscaleExposureRoutes,
@@ -44,7 +43,6 @@ describe("voice-call tailscale helpers", () => {
       dnsName: "bot.example.ts.net",
       nodeId: "node-123",
     });
-    await expect(getTailscaleDnsName()).resolves.toBe("bot.example.ts.net");
     expect(runCommandMock).toHaveBeenCalledWith(
       ["tailscale", "status", "--json", "--peers=false"],
       expect.objectContaining({

--- a/extensions/voice-call/src/webhook/tailscale.test.ts
+++ b/extensions/voice-call/src/webhook/tailscale.test.ts
@@ -86,10 +86,11 @@ describe("voice-call tailscale helpers", () => {
     await expect(
       setupTailscaleExposureRoutes({
         mode: "serve",
+        port: 443,
         routes: [{ path: "/voice", localUrl: "http://127.0.0.1:8787/webhook" }],
       }),
     ).resolves.toBe("https://bot.example.ts.net/voice");
-    await cleanupTailscaleExposureRoute({ mode: "serve", path: "/voice" });
+    await cleanupTailscaleExposureRoute({ mode: "serve", port: 443, path: "/voice" });
 
     expect(runCommandMock).toHaveBeenNthCalledWith(
       2,
@@ -122,12 +123,14 @@ describe("voice-call tailscale helpers", () => {
     await expect(
       setupTailscaleExposureRoutes({
         mode: "funnel",
+        port: 443,
         routes: [{ path: "/voice", localUrl: "http://127.0.0.1:8787/webhook" }],
       }),
     ).resolves.toBeNull();
     await expect(
       setupTailscaleExposureRoutes({
         mode: "funnel",
+        port: 443,
         routes: [{ path: "/voice", localUrl: "http://127.0.0.1:8787/webhook" }],
       }),
     ).resolves.toBeNull();
@@ -143,7 +146,7 @@ describe("voice-call tailscale helpers", () => {
 
     await expect(
       setupTailscaleExposure({
-        tailscale: { mode: "off", path: "/voice" },
+        tailscale: { mode: "off", port: 443, path: "/voice" },
         serve: { port: 8787, path: "/webhook" },
         realtime: { enabled: false },
         streaming: { enabled: false },
@@ -151,14 +154,14 @@ describe("voice-call tailscale helpers", () => {
     ).resolves.toBeNull();
     await expect(
       setupTailscaleExposure({
-        tailscale: { mode: "funnel", path: "/voice" },
+        tailscale: { mode: "funnel", port: 443, path: "/voice" },
         serve: { port: 8787, path: "/webhook" },
         realtime: { enabled: false },
         streaming: { enabled: false },
       } as never),
     ).resolves.toBe("https://bot.example.ts.net/voice");
     await cleanupTailscaleExposure({
-      tailscale: { mode: "serve", path: "/voice" },
+      tailscale: { mode: "serve", port: 443, path: "/voice" },
       serve: { port: 8787, path: "/webhook" },
       realtime: { enabled: false },
       streaming: { enabled: false },
@@ -200,7 +203,7 @@ describe("voice-call tailscale helpers", () => {
           : commandResult(),
       );
       const voiceCallConfig = {
-        tailscale: { mode: "funnel", path: "/edge/voice/webhook" },
+        tailscale: { mode: "funnel", port: 443, path: "/edge/voice/webhook" },
         serve: { port: 8787, path: "/voice/webhook" },
         realtime: { enabled: false },
         streaming: { enabled: false },
@@ -229,6 +232,75 @@ describe("voice-call tailscale helpers", () => {
     },
   );
 
+  it("uses HTTPS 8443 for legacy webhook and realtime routes and cleanup", async () => {
+    runCommandMock.mockImplementation(async (command: string[]) =>
+      command[1] === "status"
+        ? commandResult({
+            stdout: JSON.stringify({ Self: { DNSName: "bot.example.ts.net." } }),
+          })
+        : commandResult(),
+    );
+    const config = {
+      tailscale: { mode: "funnel", port: 8443, path: "/voice/webhook" },
+      serve: { port: 8787, path: "/voice/webhook" },
+      realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
+      streaming: { enabled: false },
+    } as never;
+
+    await expect(setupTailscaleExposure(config)).resolves.toBe(
+      "https://bot.example.ts.net:8443/voice/webhook",
+    );
+    await cleanupTailscaleExposure(config);
+
+    expect(runCommandMock.mock.calls.map(([command]) => command)).toEqual([
+      ["tailscale", "status", "--json", "--peers=false"],
+      [
+        "tailscale",
+        "funnel",
+        "--bg",
+        "--yes",
+        "--https",
+        "8443",
+        "--set-path",
+        "/voice/webhook",
+        "http://127.0.0.1:8787/voice/webhook",
+      ],
+      [
+        "tailscale",
+        "funnel",
+        "--bg",
+        "--yes",
+        "--https",
+        "8443",
+        "--set-path",
+        "/voice/stream/realtime",
+        "http://127.0.0.1:8787/voice/stream/realtime",
+      ],
+      [
+        "tailscale",
+        "funnel",
+        "--bg",
+        "--yes",
+        "--https",
+        "8443",
+        "--set-path",
+        "/voice/webhook",
+        "off",
+      ],
+      [
+        "tailscale",
+        "funnel",
+        "--bg",
+        "--yes",
+        "--https",
+        "8443",
+        "--set-path",
+        "/voice/stream/realtime",
+        "off",
+      ],
+    ]);
+  });
+
   it("deduplicates equal realtime and streaming paths", async () => {
     runCommandMock.mockImplementation(async (command: string[]) =>
       command[1] === "status"
@@ -238,7 +310,7 @@ describe("voice-call tailscale helpers", () => {
         : commandResult(),
     );
     const config = {
-      tailscale: { mode: "funnel", path: "/voice/webhook" },
+      tailscale: { mode: "funnel", port: 443, path: "/voice/webhook" },
       serve: { port: 8787, path: "/voice/webhook" },
       realtime: { enabled: true, streamPath: "/voice/stream" },
       streaming: { enabled: true, streamPath: "/voice/stream" },
@@ -265,7 +337,7 @@ describe("voice-call tailscale helpers", () => {
       return commandResult();
     });
     const config = {
-      tailscale: { mode: "funnel", path: "/voice/webhook" },
+      tailscale: { mode: "funnel", port: 443, path: "/voice/webhook" },
       serve: { port: 8787, path: "/voice/webhook" },
       realtime: { enabled: true, streamPath: "/voice/stream/realtime" },
       streaming: { enabled: false },

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -61,7 +61,7 @@ export async function getTailscaleSelfInfo(): Promise<TailscaleSelfInfo | null> 
   }
 }
 
-export async function getTailscaleDnsName(): Promise<string | null> {
+async function getTailscaleDnsName(): Promise<string | null> {
   const info = await getTailscaleSelfInfo();
   return info?.dnsName ?? null;
 }

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -8,6 +8,20 @@ type TailscaleSelfInfo = {
 };
 
 const TAILSCALE_COMMAND_STDOUT_MAX_BYTES = 4 * 1024 * 1024;
+const DEFAULT_TAILSCALE_HTTPS_PORT = 443;
+
+function buildTailscaleExposureArgs(opts: {
+  mode: "serve" | "funnel";
+  port: number;
+  path: string;
+  localUrl?: string;
+}): string[] {
+  if (!opts.localUrl && opts.port === DEFAULT_TAILSCALE_HTTPS_PORT) {
+    return [opts.mode, "off", opts.path];
+  }
+  const portArgs = opts.port === DEFAULT_TAILSCALE_HTTPS_PORT ? [] : ["--https", String(opts.port)];
+  return [opts.mode, "--bg", "--yes", ...portArgs, "--set-path", opts.path, opts.localUrl ?? "off"];
+}
 
 async function runTailscaleCommand(
   args: string[],
@@ -52,10 +66,18 @@ export async function getTailscaleDnsName(): Promise<string | null> {
   return info?.dnsName ?? null;
 }
 
-async function setupTailscaleExposureRoute(opts: {
+export async function cleanupTailscaleExposureRoute(opts: {
   mode: "serve" | "funnel";
+  port: number;
   path: string;
-  localUrl: string;
+}): Promise<void> {
+  await runTailscaleCommand(buildTailscaleExposureArgs(opts));
+}
+
+export async function setupTailscaleExposureRoutes(opts: {
+  mode: "serve" | "funnel";
+  port: number;
+  routes: Array<{ path: string; localUrl: string }>;
 }): Promise<string | null> {
   const dnsName = await getTailscaleDnsName();
   if (!dnsName) {
@@ -63,49 +85,24 @@ async function setupTailscaleExposureRoute(opts: {
     return null;
   }
 
-  const { code } = await runTailscaleCommand([
-    opts.mode,
-    "--bg",
-    "--yes",
-    "--set-path",
-    opts.path,
-    opts.localUrl,
-  ]);
-
-  if (code === 0) {
-    const publicUrl = `https://${dnsName}${opts.path}`;
-    console.log(`[voice-call] Tailscale ${opts.mode} active: ${publicUrl}`);
-    return publicUrl;
-  }
-
-  console.warn(`[voice-call] Tailscale ${opts.mode} failed`);
-  return null;
-}
-
-export async function cleanupTailscaleExposureRoute(opts: {
-  mode: "serve" | "funnel";
-  path: string;
-}): Promise<void> {
-  await runTailscaleCommand([opts.mode, "off", opts.path]);
-}
-
-export async function setupTailscaleExposureRoutes(opts: {
-  mode: "serve" | "funnel";
-  routes: Array<{ path: string; localUrl: string }>;
-}): Promise<string | null> {
   const mountedPaths: string[] = [];
   let publicUrl: string | null = null;
   for (const route of opts.routes) {
-    const routePublicUrl = await setupTailscaleExposureRoute({ mode: opts.mode, ...route });
-    if (!routePublicUrl) {
+    const { code } = await runTailscaleCommand(
+      buildTailscaleExposureArgs({ mode: opts.mode, port: opts.port, ...route }),
+    );
+    if (code !== 0) {
       for (const path of mountedPaths.toReversed()) {
-        await cleanupTailscaleExposureRoute({ mode: opts.mode, path });
+        await cleanupTailscaleExposureRoute({ mode: opts.mode, port: opts.port, path });
       }
       console.warn(
         `[voice-call] Tailscale ${opts.mode} exposure failed for ${route.path}; rolled back ${mountedPaths.length} mounted route(s)`,
       );
       return null;
     }
+    const portSuffix = opts.port === DEFAULT_TAILSCALE_HTTPS_PORT ? "" : `:${opts.port}`;
+    const routePublicUrl = `https://${dnsName}${portSuffix}${route.path}`;
+    console.log(`[voice-call] Tailscale ${opts.mode} active: ${routePublicUrl}`);
     publicUrl ??= routePublicUrl;
     mountedPaths.push(route.path);
   }
@@ -127,6 +124,7 @@ export async function setupTailscaleExposure(config: VoiceCallConfig): Promise<s
   );
   return setupTailscaleExposureRoutes({
     mode,
+    port: config.tailscale.port,
     routes: [
       {
         path: config.tailscale.path,
@@ -143,8 +141,12 @@ export async function cleanupTailscaleExposure(config: VoiceCallConfig): Promise
   }
 
   const mode = config.tailscale.mode === "funnel" ? "funnel" : "serve";
-  await cleanupTailscaleExposureRoute({ mode, path: config.tailscale.path });
+  await cleanupTailscaleExposureRoute({
+    mode,
+    port: config.tailscale.port,
+    path: config.tailscale.path,
+  });
   for (const { publicPath } of resolveVoiceCallStreamExposurePaths(config)) {
-    await cleanupTailscaleExposureRoute({ mode, path: publicPath });
+    await cleanupTailscaleExposureRoute({ mode, port: config.tailscale.port, path: publicPath });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running Voice Call through Tailscale Funnel alongside another HTTPS server would lose the other server's port 443 traffic because Voice Call always claimed Tailscale's default HTTPS listener. On clawstudio this made the custom-domain Caddy endpoint fail TLS while the voice webhook remained active.

## Why This Change Was Made

Voice Call now has one canonical `tailscale.port` setting, defaulting to 443 for unchanged existing behavior. The selected port is used consistently by legacy and unified Tailscale exposure, realtime and streaming routes, public URL construction, rollback, and cleanup; Funnel configuration is limited to Tailscale's supported public ports while Serve still accepts any valid TCP port. The implementation also collapses the duplicate Tailscale tunnel setup path into the shared exposure owner.

AI-assisted; implementation and final diff were inspected and validated by the maintainer.

## User Impact

Operators can set `tailscale.port: 8443` when another HTTPS server owns port 443. Webhook and realtime WebSocket URLs include the non-default port, cleanup removes routes from that same port, and configurations that omit the setting retain byte-compatible port 443 commands and URLs.

Production TypeScript: net -7 lines. Static schema/UI metadata: +11 lines. Tests/test support: net +32 lines. Docs: net +4 lines.

## Evidence

- Live root-cause proof on clawstudio: Tailscale Funnel owned HTTPS port 443 for the voice webhook and realtime route; an isolated HTTPS listener succeeded on 8443 but the same custom-domain TLS flow failed on 443.
- Tailscale source/docs verified that Funnel supports public ports 443, 8443, and 10000, while Serve accepts arbitrary valid listener ports.
- Focused Voice Call Vitest: 6 files, 163 tests passed.
- Targeted extension lint, formatting, and `git diff --check` passed.
- AWS Crabbox `check:changed` passed: https://crabbox.openclaw.ai/portal/runs/run_ac6f8c294a5e
- Final branch autoreview against `origin/main`: clean, no accepted/actionable findings.
