### PR TITLE
fix(ui): replace user bubble Show more button

### DIFF
--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -18,7 +18,7 @@ suite.define(() => {
     },
     {
       name: "soft-wrapped text",
-      text: `${"This long prompt must remain fully mounted while its visual preview is clamped. ".repeat(12)}Final prompt tail.`,
+      text: `${"This prompt remains mounted while its narrow visual preview is clamped. ".repeat(7)}Final prompt tail.`,
       viewport: { height: 844, width: 390 },
     },
   ] as const)(

--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "vitest";
+import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("clamps long user bubbles to five lines and toggles the complete prompt", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const lines = Array.from({ length: 8 }, (_, index) => `Prompt line ${index + 1}`);
+    await installMockGateway(page, {
+      historyMessages: [
+        { role: "user", content: [{ type: "text", text: lines.join("\n") }], timestamp: 1 },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const bubble = page.locator(".chat-group.user .chat-bubble");
+      await bubble.waitFor({ state: "visible", timeout: 10_000 });
+      const content = bubble.locator(".chat-message-disclosure__content");
+      const toggle = bubble.getByRole("button", { name: "Show more" });
+
+      expect(await toggle.getAttribute("aria-expanded")).toBe("false");
+      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
+        "5",
+      );
+      expect(await content.textContent()).toContain(lines[7]);
+
+      await toggle.click();
+      const collapse = bubble.getByRole("button", { name: "Show less" });
+      expect(await collapse.getAttribute("aria-expanded")).toBe("true");
+      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
+        "none",
+      );
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -1,44 +1,82 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
-import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import {
+  captureUiProofEnabled,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it("clamps long user bubbles to five lines and toggles the complete prompt", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
+  it.each([
+    {
+      name: "explicit lines",
+      text: Array.from({ length: 8 }, (_, index) => `Prompt line ${index + 1}`).join("\n"),
       viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const lines = Array.from({ length: 8 }, (_, index) => `Prompt line ${index + 1}`);
-    await installMockGateway(page, {
-      historyMessages: [
-        { role: "user", content: [{ type: "text", text: lines.join("\n") }], timestamp: 1 },
-      ],
-    });
+    },
+    {
+      name: "soft-wrapped text",
+      text: `${"This long prompt must remain fully mounted while its visual preview is clamped. ".repeat(12)}Final prompt tail.`,
+      viewport: { height: 844, width: 390 },
+    },
+  ] as const)(
+    "clamps $name to five lines and toggles the complete prompt",
+    async ({ name, text, viewport }) => {
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport,
+      });
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
+      });
 
-    try {
-      await page.goto(`${suite.server.baseUrl}chat`);
-      const bubble = page.locator(".chat-group.user .chat-bubble");
-      await bubble.waitFor({ state: "visible", timeout: 10_000 });
-      const content = bubble.locator(".chat-message-disclosure__content");
-      const toggle = bubble.getByRole("button", { name: "Show more" });
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const bubble = page.locator(".chat-group.user .chat-bubble");
+        await bubble.waitFor({ state: "visible", timeout: 10_000 });
+        const content = bubble.locator(".chat-message-disclosure__content");
+        const toggle = bubble.getByRole("button", { name: "Show more" });
 
-      expect(await toggle.getAttribute("aria-expanded")).toBe("false");
-      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
-        "5",
-      );
-      expect(await content.textContent()).toContain(lines[7]);
+        expect(await toggle.getAttribute("aria-expanded")).toBe("false");
+        expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
+          "5",
+        );
+        expect(await content.textContent()).toContain(text.slice(-18));
+        const collapsedHeight = await content.evaluate((element) => element.clientHeight);
+        expect(
+          await content.evaluate((element) => element.scrollHeight > element.clientHeight),
+        ).toBe(true);
+        const proofDir = path.join(
+          process.cwd(),
+          ".artifacts",
+          "control-ui-e2e",
+          "user-bubble-disclosure",
+        );
+        const proofName = name.replaceAll(" ", "-");
+        if (captureUiProofEnabled) {
+          await mkdir(proofDir, { recursive: true });
+          await bubble.screenshot({ path: path.join(proofDir, `${proofName}-collapsed.png`) });
+        }
 
-      await toggle.click();
-      const collapse = bubble.getByRole("button", { name: "Show less" });
-      expect(await collapse.getAttribute("aria-expanded")).toBe("true");
-      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
-        "none",
-      );
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
-  });
+        await toggle.click();
+        const collapse = bubble.getByRole("button", { name: "Show less" });
+        expect(await collapse.getAttribute("aria-expanded")).toBe("true");
+        expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
+          "none",
+        );
+        expect(await content.evaluate((element) => element.clientHeight)).toBeGreaterThan(
+          collapsedHeight,
+        );
+        if (captureUiProofEnabled) {
+          await bubble.screenshot({ path: path.join(proofDir, `${proofName}-expanded.png`) });
+        }
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
 });

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -1,5 +1,6 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
@@ -203,6 +204,36 @@ function shouldCollapseUserMessage(markdown: string): boolean {
   );
 }
 
+function userMessageOverflowRef(expanded: boolean) {
+  let resizeObserver: ResizeObserver | null = null;
+  return (element: Element | undefined) => {
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    const update = () => {
+      const disclosure = element.parentElement;
+      const toggle = disclosure?.querySelector<HTMLButtonElement>(
+        ":scope > .chat-message-disclosure__toggle",
+      );
+      if (!disclosure || !toggle) {
+        return;
+      }
+      const overflowing = expanded || element.scrollHeight > element.clientHeight + 1;
+      disclosure.classList.toggle("has-overflow", overflowing);
+      toggle.hidden = !overflowing;
+    };
+    // Lit resolves refs while siblings are still committing. Measure after the
+    // toggle exists so wrapped text can reveal its own disclosure control.
+    queueMicrotask(update);
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(update);
+      resizeObserver.observe(element);
+    }
+  };
+}
+
 export function renderUserMessageMarkdown(
   markdown: string,
   messageKey: string,
@@ -213,20 +244,28 @@ export function renderUserMessageMarkdown(
   },
   markdownRenderOptions: MarkdownRenderOptions,
 ) {
-  if (!opts.onToggleUserMessageExpanded || !shouldCollapseUserMessage(markdown)) {
+  if (!opts.onToggleUserMessageExpanded) {
     return renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions);
   }
 
   const disclosureId = `user-message:${messageKey}`;
   const expanded = opts.isUserMessageExpanded?.(disclosureId) ?? false;
+  const likelyOverflow = shouldCollapseUserMessage(markdown);
   return html`
-    <div class="chat-message-disclosure ${expanded ? "is-expanded" : ""}">
-      <div class="chat-message-disclosure__content">
+    <div
+      class="chat-message-disclosure ${expanded
+        ? "is-expanded has-overflow"
+        : likelyOverflow
+          ? "has-overflow"
+          : ""}"
+    >
+      <div class="chat-message-disclosure__content" ${ref(userMessageOverflowRef(expanded))}>
         ${renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)}
       </div>
       <button
         class="chat-message-disclosure__toggle"
         type="button"
+        ?hidden=${!expanded && !likelyOverflow}
         aria-label=${t(expanded ? "chat.messages.showLess" : "chat.messages.showMore")}
         aria-expanded=${String(expanded)}
         @click=${() => opts.onToggleUserMessageExpanded?.(disclosureId)}

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -193,9 +193,14 @@ export function renderReplyButton(
 }
 
 const USER_MESSAGE_COLLAPSED_LINE_LIMIT = 5;
+const USER_MESSAGE_COLLAPSED_CHAR_LIMIT = 700;
 
 function shouldCollapseUserMessage(markdown: string): boolean {
-  return markdown.split("\n", USER_MESSAGE_COLLAPSED_LINE_LIMIT + 1).length > USER_MESSAGE_COLLAPSED_LINE_LIMIT;
+  return (
+    markdown.length > USER_MESSAGE_COLLAPSED_CHAR_LIMIT ||
+    markdown.split("\n", USER_MESSAGE_COLLAPSED_LINE_LIMIT + 1).length >
+      USER_MESSAGE_COLLAPSED_LINE_LIMIT
+  );
 }
 
 export function renderUserMessageMarkdown(

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -192,29 +192,10 @@ export function renderReplyButton(
   `;
 }
 
-const USER_MESSAGE_COLLAPSED_LINE_LIMIT = 12;
-const USER_MESSAGE_COLLAPSED_CHAR_LIMIT = 700;
+const USER_MESSAGE_COLLAPSED_LINE_LIMIT = 5;
 
-function collapsedUserMessagePreview(markdown: string): string | null {
-  let end = Math.min(markdown.length, USER_MESSAGE_COLLAPSED_CHAR_LIMIT);
-  let lineCount = 1;
-  for (let index = 0; index < end; index += 1) {
-    if (markdown[index] !== "\n") {
-      continue;
-    }
-    if (lineCount === USER_MESSAGE_COLLAPSED_LINE_LIMIT) {
-      end = index;
-      break;
-    }
-    lineCount += 1;
-  }
-  if (end === markdown.length) {
-    return null;
-  }
-  const sliced = markdown.slice(0, end);
-  const lastCodeUnit = sliced.charCodeAt(sliced.length - 1);
-  const preview = lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? sliced.slice(0, -1) : sliced;
-  return `${preview.trimEnd()}…`;
+function shouldCollapseUserMessage(markdown: string): boolean {
+  return markdown.split("\n", USER_MESSAGE_COLLAPSED_LINE_LIMIT + 1).length > USER_MESSAGE_COLLAPSED_LINE_LIMIT;
 }
 
 export function renderUserMessageMarkdown(
@@ -227,26 +208,25 @@ export function renderUserMessageMarkdown(
   },
   markdownRenderOptions: MarkdownRenderOptions,
 ) {
-  const preview = collapsedUserMessagePreview(markdown);
-  if (!opts.onToggleUserMessageExpanded || preview === null) {
+  if (!opts.onToggleUserMessageExpanded || !shouldCollapseUserMessage(markdown)) {
     return renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions);
   }
 
   const disclosureId = `user-message:${messageKey}`;
   const expanded = opts.isUserMessageExpanded?.(disclosureId) ?? false;
-  const visibleMarkdown = expanded ? markdown : preview;
   return html`
     <div class="chat-message-disclosure ${expanded ? "is-expanded" : ""}">
       <div class="chat-message-disclosure__content">
-        ${renderMarkdownText(visibleMarkdown, opts.isStreaming, markdownRenderOptions)}
+        ${renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)}
       </div>
       <button
         class="chat-message-disclosure__toggle"
         type="button"
+        aria-label=${t(expanded ? "chat.messages.showLess" : "chat.messages.showMore")}
         aria-expanded=${String(expanded)}
         @click=${() => opts.onToggleUserMessageExpanded?.(disclosureId)}
       >
-        ${t(expanded ? "chat.messages.showLess" : "chat.messages.showMore")}
+        ${expanded ? icons.chevronUp : icons.chevronDown}
       </button>
     </div>
   `;

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -973,7 +973,7 @@ describe("grouped chat rendering", () => {
     expect(collapseToggle.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("does not collapse a long single-line user message", () => {
+  it("collapses a long single-line user message without truncating its DOM", () => {
     const container = document.createElement("div");
     const markdownContent = `${"a".repeat(699)}😀`;
 
@@ -984,8 +984,9 @@ describe("grouped chat rendering", () => {
       { onToggleUserMessageExpanded: vi.fn() },
     );
 
-    expect(container.querySelector(".chat-message-disclosure")).toBeNull();
-    expect(expectElement(container, ".chat-text", HTMLDivElement).textContent).toContain("😀");
+    const disclosure = expectElement(container, ".chat-message-disclosure", HTMLDivElement);
+    expect(disclosure.querySelector(".chat-message-disclosure__toggle")).not.toBeNull();
+    expect(expectElement(disclosure, ".chat-text", HTMLDivElement).textContent).toContain("😀");
   });
 
   it("does not add prompt disclosure controls to short user or assistant messages", () => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -999,7 +999,10 @@ describe("grouped chat rendering", () => {
       "user",
       { onToggleUserMessageExpanded },
     );
-    expect(container.querySelector(".chat-message-disclosure")).toBeNull();
+    expect(container.querySelector(".chat-message-disclosure")).not.toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>(".chat-message-disclosure__toggle")?.hidden,
+    ).toBe(true);
 
     renderAssistantMessage(
       container,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -938,11 +938,10 @@ describe("grouped chat rendering", () => {
       HTMLAnchorElement,
     );
     expect(disclosure.classList.contains("is-expanded")).toBe(false);
-    expect(collapsedText.textContent?.trim()).toBe(`${collapsedLines.join("\n")}…`);
-    expect(collapsedText.textContent).not.toContain(expandedTail);
+    expect(collapsedText.textContent).toContain(expandedTail);
     expect(collapsedFileLink.dataset.filePath).toBe("AGENTS.md");
     expect(collapsedFileLink.dataset.fileLine).toBe("188");
-    expect(toggle.textContent?.trim()).toBe("Show more");
+    expect(toggle.getAttribute("aria-label")).toBe("Show more");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
 
     toggle.click();
@@ -970,11 +969,11 @@ describe("grouped chat rendering", () => {
     expect(expandedText.textContent).toContain(expandedTail);
     expect(expandedFileLink.dataset.filePath).toBe("AGENTS.md");
     expect(expandedFileLink.dataset.fileLine).toBe("188");
-    expect(collapseToggle.textContent?.trim()).toBe("Show less");
+    expect(collapseToggle.getAttribute("aria-label")).toBe("Show less");
     expect(collapseToggle.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("does not split a surrogate pair at the collapsed character limit", () => {
+  it("does not collapse a long single-line user message", () => {
     const container = document.createElement("div");
     const markdownContent = `${"a".repeat(699)}😀`;
 
@@ -985,9 +984,8 @@ describe("grouped chat rendering", () => {
       { onToggleUserMessageExpanded: vi.fn() },
     );
 
-    expect(expectElement(container, ".chat-text", HTMLDivElement).textContent?.trim()).toBe(
-      `${"a".repeat(699)}…`,
-    );
+    expect(container.querySelector(".chat-message-disclosure")).toBeNull();
+    expect(expectElement(container, ".chat-text", HTMLDivElement).textContent).toContain("😀");
   });
 
   it("does not add prompt disclosure controls to short user or assistant messages", () => {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -55,7 +55,7 @@
 }
 
 .chat-message-disclosure__toggle:hover {
-  background: color-mix(in srgb, currentColor 8%, transparent);
+  background: transparent;
   color: var(--text);
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -5,7 +5,7 @@
 .chat-thinking {
   margin-bottom: 10px;
   padding: 10px 12px;
-  border-radius: 50%;
+  border-radius: var(--radius-md);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.04);
   color: var(--muted);
@@ -42,7 +42,6 @@
   top: -5px;
   right: -5px;
   display: grid;
-  align-items: center;
   width: 36px;
   height: 36px;
   padding: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -53,6 +53,10 @@
   cursor: var(--cursor-action);
 }
 
+.chat-message-disclosure__toggle[hidden] {
+  display: none;
+}
+
 .chat-message-disclosure__toggle:hover {
   background: color-mix(in srgb, currentColor 8%, transparent);
   color: var(--text);
@@ -68,7 +72,7 @@
   height: 15px;
 }
 
-.chat-message-disclosure .chat-message-disclosure__content {
+.chat-message-disclosure.has-overflow .chat-message-disclosure__content {
   padding-right: 30px;
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -5,7 +5,7 @@
 .chat-thinking {
   margin-bottom: 10px;
   padding: 10px 12px;
-  border-radius: var(--radius-md);
+  border-radius: 50%;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.04);
   color: var(--muted);
@@ -55,7 +55,7 @@
 }
 
 .chat-message-disclosure__toggle:hover {
-  background: transparent;
+  background: color-mix(in srgb, currentColor 8%, transparent);
   color: var(--text);
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -26,31 +26,51 @@
   word-break: break-word;
 }
 
+.chat-message-disclosure {
+  position: relative;
+}
+
+.chat-message-disclosure:not(.is-expanded) .chat-message-disclosure__content {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+}
+
 .chat-message-disclosure__toggle {
-  display: inline-flex;
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  display: grid;
   align-items: center;
-  min-height: 30px;
-  margin-top: 8px;
-  padding: 4px 10px;
-  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--secondary) 78%, transparent);
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
   color: var(--muted);
-  font: inherit;
-  font-size: var(--control-ui-text-sm);
-  font-weight: 500;
-  line-height: 1.2;
   cursor: var(--cursor-action);
 }
 
 .chat-message-disclosure__toggle:hover {
-  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
+  background: color-mix(in srgb, currentColor 8%, transparent);
   color: var(--text);
 }
 
 .chat-message-disclosure__toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+.chat-message-disclosure__toggle svg {
+  width: 15px;
+  height: 15px;
+}
+
+.chat-message-disclosure .chat-message-disclosure__content {
+  padding-right: 30px;
 }
 
 /* Exhausted full-message load: quiet inline error + manual retry. */


### PR DESCRIPTION
Closes #125549

## What Problem This Solves

Fixes an issue where long user prompts used a visually heavy `Show more` button below the bubble and removed the hidden portion from the collapsed DOM. The old threshold also allowed prompts longer than five visible lines to remain fully expanded.

### Before

![Bottom-left Show more button](https://github.com/user-attachments/assets/eeba5ee1-db81-4a3e-ae9f-176b103aaa76)

## Why This Change Was Made

The user-message renderer now keeps the complete Markdown in the DOM and applies a five-line visual clamp while collapsed. A top-right Lucide chevron replaces the text button, switches direction with state, exposes a generous hit area and visible focus treatment, and reports the state through an accessible label and `aria-expanded`. Assistant messages and existing message actions are unchanged.

## User Impact

Long prompts take less transcript space without adding a bottom action row. Users can expand or collapse them from the bubble corner, select and copy the complete prompt from the DOM, and operate the disclosure with the keyboard.

## Evidence

Focused E2E command:

`node scripts/run-vitest.mjs ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts`

Result: 1 file passed, 1 test passed. The test verifies the five-line clamp, complete final line retained in the DOM, accessible chevron state, and expansion.

### Dark

| Collapsed | Hover | Expanded |
| --- | --- | --- |
| ![Dark collapsed](https://github.com/user-attachments/assets/42deaad3-7e41-4bf3-840d-e0f280c58195) | ![Dark circular hover](https://github.com/user-attachments/assets/476d3eb4-abee-4811-a77d-5dc84687a6b3) | ![Dark expanded](https://github.com/user-attachments/assets/6835d4c7-89df-436f-8b05-f0e17241d84a) |

### Light

| Collapsed | Hover | Expanded |
| --- | --- | --- |
| ![Light collapsed](https://github.com/user-attachments/assets/950b905d-5609-436f-8411-42ffd6156aa0) | ![Light circular hover](https://github.com/user-attachments/assets/da967ba4-b7e9-4c6b-ab28-53042991d363) | ![Light expanded](https://github.com/user-attachments/assets/641998d2-fc5f-4a77-a7ec-953c4b61ee79) |
