### PR TITLE
fix(ui): show skill mentions in the new-session composer

### DIFF
--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -269,3 +269,7 @@ export function scrollActiveMenuOptionIntoView(activeId: string | null): void {
     }
   });
 }
+
+export function paneDomId(paneId: string, suffix: string): string {
+  return `chat-${encodeURIComponent(paneId)}-${suffix}`;
+}

--- a/ui/src/pages/chat/components/chat-composer-keydown.ts
+++ b/ui/src/pages/chat/components/chat-composer-keydown.ts
@@ -1,11 +1,7 @@
 import type { ChatSendShortcut } from "../../../app/settings.ts";
 import { steerableQueuedMessage } from "../chat-queue.ts";
 import { restoreHistoryCaret, scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
-import {
-  getActiveSkillMenuOptionId,
-  resetSkillMenuState,
-  selectSkillMention,
-} from "./chat-composer-skill-menu.ts";
+import { handleSkillMenuKeydown, type SkillMenuHost } from "./chat-composer-skill-menu.ts";
 import {
   getActiveSlashMenuOptionId,
   resetSlashMenuState,
@@ -18,6 +14,7 @@ import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types
 type ComposerKeyDownDeps = {
   state: ChatComposerState;
   props: ChatComposerProps;
+  skillMenuHost: SkillMenuHost;
   requestUpdate: () => void;
   sendShortcut: ChatSendShortcut;
   canSubmitDraft: (draft: string) => boolean;
@@ -35,37 +32,23 @@ function handleComposerMenuKeyDown<T>(
   requestUpdate: () => void,
   onSelect: (item: T, submit: boolean) => void,
   scrollActive: (state: ChatComposerState, paneId: string) => void,
-  menu: "slash" | "skill" = "slash",
 ): boolean {
   if (event.key === "Escape") {
     event.preventDefault();
-    if (menu === "skill") {
-      resetSkillMenuState(state);
-    } else {
-      state.slashMenuOpen = false;
-      resetSlashMenuState(state);
-    }
+    state.slashMenuOpen = false;
+    resetSlashMenuState(state);
     requestUpdate();
     return true;
   }
   if (items.length === 0) {
-    if (
-      menu === "skill" &&
-      state.skillCommandRefreshPending &&
-      ["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(event.key)
-    ) {
-      event.preventDefault();
-      return true;
-    }
     return false;
   }
-  const indexKey = menu === "skill" ? "skillMenuIndex" : "slashMenuIndex";
   switch (event.key) {
     case "ArrowDown":
     case "ArrowUp": {
       event.preventDefault();
       const offset = event.key === "ArrowDown" ? 1 : items.length - 1;
-      state[indexKey] = (state[indexKey] + offset) % items.length;
+      state.slashMenuIndex = (state.slashMenuIndex + offset) % items.length;
       requestUpdate();
       scrollActive(state, paneId);
       return true;
@@ -73,7 +56,7 @@ function handleComposerMenuKeyDown<T>(
     case "Tab":
     case "Enter": {
       event.preventDefault();
-      const item = items[state[indexKey]];
+      const item = items[state.slashMenuIndex];
       if (item !== undefined) {
         onSelect(item, event.key === "Enter");
       }
@@ -87,6 +70,7 @@ function handleComposerMenuKeyDown<T>(
 export function createComposerKeyDownHandler({
   state,
   props,
+  skillMenuHost,
   requestUpdate,
   sendShortcut,
   canSubmitDraft,
@@ -106,22 +90,8 @@ export function createComposerKeyDownHandler({
       return;
     }
 
-    if (props.connected && state.skillMenuOpen) {
-      if (
-        handleComposerMenuKeyDown(
-          event,
-          state,
-          state.skillCommandRefreshPending ? [] : state.skillMenuItems,
-          props.paneId,
-          requestUpdate,
-          (command) => selectSkillMention(command, props, requestUpdate),
-          (menuState, paneId) =>
-            scrollActiveMenuOptionIntoView(getActiveSkillMenuOptionId(menuState, paneId)),
-          "skill",
-        )
-      ) {
-        return;
-      }
+    if (props.connected && handleSkillMenuKeydown(event, state, skillMenuHost, requestUpdate)) {
+      return;
     }
 
     if (

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -7,9 +7,8 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
+import { scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
 import { paneDomId } from "./chat-composer-slash-menu.ts";
-import { commitComposerDraft, getChatComposerState } from "./chat-composer-state.ts";
-import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
 
 const SKILL_MENTION_CHAR = /[-a-zA-Z0-9_:]/u;
 
@@ -18,6 +17,36 @@ type SkillMentionTarget = {
   end: number;
   query: string;
 };
+
+export type SkillMenuState = {
+  skillMenuOpen: boolean;
+  skillMenuItems: SlashCommandDef[];
+  skillMenuIndex: number;
+  skillMenuTarget: SkillMentionTarget | null;
+  skillCommandRefreshPending: boolean;
+  skillCommandRefreshGeneration: number;
+  skillCommandRefreshTargetStart: number | null;
+};
+
+export type SkillMenuHost = {
+  paneId: string;
+  getDraft: () => string;
+  commitDraft: (next: string) => void;
+  getTextarea: () => HTMLTextAreaElement | null;
+  refreshCommands?: () => void | Promise<void>;
+};
+
+export function createSkillMenuState(): SkillMenuState {
+  return {
+    skillMenuOpen: false,
+    skillMenuItems: [],
+    skillMenuIndex: 0,
+    skillMenuTarget: null,
+    skillCommandRefreshPending: false,
+    skillCommandRefreshGeneration: 0,
+    skillCommandRefreshTargetStart: null,
+  };
+}
 
 function isEscapedReference(value: string, dollar: number): boolean {
   let backslashes = 0;
@@ -55,7 +84,7 @@ function findSkillMentionTarget(value: string, caret: number): SkillMentionTarge
   return { start: dollar, end: referenceEnd, query };
 }
 
-function hasVisibleSkillMenuState(state: ChatComposerState): boolean {
+function hasVisibleSkillMenuState(state: SkillMenuState): boolean {
   return (
     state.skillMenuOpen ||
     state.skillMenuItems.length > 0 ||
@@ -64,7 +93,7 @@ function hasVisibleSkillMenuState(state: ChatComposerState): boolean {
   );
 }
 
-export function resetSkillMenuState(state: ChatComposerState): void {
+export function resetSkillMenuState(state: SkillMenuState): void {
   state.skillCommandRefreshGeneration += 1;
   state.skillCommandRefreshPending = false;
   state.skillCommandRefreshTargetStart = null;
@@ -74,7 +103,7 @@ export function resetSkillMenuState(state: ChatComposerState): void {
   state.skillMenuTarget = null;
 }
 
-function closeSkillMenuIfNeeded(state: ChatComposerState, requestUpdate: () => void): void {
+function closeSkillMenuIfNeeded(state: SkillMenuState, requestUpdate: () => void): void {
   if (!hasVisibleSkillMenuState(state)) {
     return;
   }
@@ -83,16 +112,14 @@ function closeSkillMenuIfNeeded(state: ChatComposerState, requestUpdate: () => v
 }
 
 function requestSkillCommandRefresh(
-  props: ChatComposerProps,
+  state: SkillMenuState,
+  host: SkillMenuHost,
   requestUpdate: () => void,
-  getCurrentValue: () => string,
-  getCurrentCaret: () => number,
 ): void {
-  const state = getChatComposerState(props.paneId);
-  if (!props.onSlashIntent || state.skillCommandRefreshPending) {
+  if (!host.refreshCommands || state.skillCommandRefreshPending) {
     return;
   }
-  const refresh = props.onSlashIntent();
+  const refresh = host.refreshCommands();
   if (!refresh || typeof refresh.then !== "function") {
     return;
   }
@@ -106,28 +133,20 @@ function requestSkillCommandRefresh(
         return;
       }
       state.skillCommandRefreshPending = false;
-      updateSkillMenu(
-        getCurrentValue(),
-        getCurrentCaret(),
-        requestUpdate,
-        props,
-        { skipRefresh: true },
-        getCurrentValue,
-        getCurrentCaret,
-      );
+      const value = host.getDraft();
+      const caret = host.getTextarea()?.selectionStart ?? value.length;
+      updateSkillMenu(value, caret, state, host, requestUpdate, { skipRefresh: true });
     });
 }
 
 export function updateSkillMenu(
   value: string,
   caret: number,
+  state: SkillMenuState,
+  host: SkillMenuHost,
   requestUpdate: () => void,
-  props: ChatComposerProps,
   opts: { skipRefresh?: boolean } = {},
-  getCurrentValue: () => string = () => value,
-  getCurrentCaret: () => number = () => caret,
 ): void {
-  const state = getChatComposerState(props.paneId);
   if (value.trimStart().startsWith("/")) {
     closeSkillMenuIfNeeded(state, requestUpdate);
     return;
@@ -139,7 +158,7 @@ export function updateSkillMenu(
   }
   if (!opts.skipRefresh && state.skillCommandRefreshTargetStart !== target.start) {
     state.skillCommandRefreshTargetStart = target.start;
-    requestSkillCommandRefresh(props, requestUpdate, getCurrentValue, getCurrentCaret);
+    requestSkillCommandRefresh(state, host, requestUpdate);
   }
   const items = getSkillCommandCompletions(target.query);
   state.skillMenuTarget = target;
@@ -154,16 +173,13 @@ function skillOptionId(paneId: string, command: SlashCommandDef): string {
   return paneDomId(paneId, `skill-option-${name || "skill"}`);
 }
 
-export function isSkillMenuVisible(state: ChatComposerState): boolean {
+export function isSkillMenuVisible(state: SkillMenuState): boolean {
   return (
     state.skillMenuOpen && (state.skillMenuItems.length > 0 || state.skillCommandRefreshPending)
   );
 }
 
-export function getActiveSkillMenuOptionId(
-  state: ChatComposerState,
-  paneId: string,
-): string | null {
+export function getActiveSkillMenuOptionId(state: SkillMenuState, paneId: string): string | null {
   if (!isSkillMenuVisible(state) || state.skillCommandRefreshPending) {
     return null;
   }
@@ -171,7 +187,7 @@ export function getActiveSkillMenuOptionId(
   return command ? skillOptionId(paneId, command) : null;
 }
 
-export function getActiveSkillMenuOptionLabel(state: ChatComposerState): string {
+export function getActiveSkillMenuOptionLabel(state: SkillMenuState): string {
   if (state.skillCommandRefreshPending) {
     return "";
   }
@@ -179,18 +195,18 @@ export function getActiveSkillMenuOptionLabel(state: ChatComposerState): string 
   return command ? `${getSkillDisplayName(command)} ${getSlashCommandDescription(command)}` : "";
 }
 
-export function selectSkillMention(
+function selectSkillMention(
   command: SlashCommandDef,
-  props: ChatComposerProps,
+  state: SkillMenuState,
+  host: SkillMenuHost,
   requestUpdate: () => void,
 ): void {
-  const state = getChatComposerState(props.paneId);
   if (state.skillCommandRefreshPending) {
     return;
   }
-  const current = state.composerTextarea?.value ?? props.getDraft?.() ?? props.draft;
-  const currentCaret =
-    state.composerTextarea?.selectionStart ?? state.skillMenuTarget?.end ?? current.length;
+  const textarea = host.getTextarea();
+  const current = textarea?.value ?? host.getDraft();
+  const currentCaret = textarea?.selectionStart ?? state.skillMenuTarget?.end ?? current.length;
   const target = findSkillMentionTarget(current, currentCaret);
   if (!target) {
     resetSkillMenuState(state);
@@ -202,28 +218,70 @@ export function selectSkillMention(
   const next = `${current.slice(0, target.start)}${replacement}${current.slice(target.end)}`;
   const retainedBeforeCaret = Math.max(0, currentCaret - target.end);
   const nextCaret = target.start + replacement.length + retainedBeforeCaret;
-  commitComposerDraft(props, next);
+  host.commitDraft(next);
   resetSkillMenuState(state);
   requestUpdate();
   queueMicrotask(() => {
-    const textarea = state.composerTextarea;
-    if (!textarea) {
+    const currentTextarea = host.getTextarea();
+    if (!currentTextarea) {
       return;
     }
-    textarea.focus({ preventScroll: true });
-    textarea.setSelectionRange(nextCaret, nextCaret);
+    currentTextarea.focus({ preventScroll: true });
+    currentTextarea.setSelectionRange(nextCaret, nextCaret);
   });
 }
 
-export function renderSkillMenu(
+export function handleSkillMenuKeydown(
+  event: KeyboardEvent,
+  state: SkillMenuState,
+  host: SkillMenuHost,
   requestUpdate: () => void,
-  props: ChatComposerProps,
+): boolean {
+  if (!state.skillMenuOpen) {
+    return false;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    resetSkillMenuState(state);
+    requestUpdate();
+    return true;
+  }
+  const items = state.skillCommandRefreshPending ? [] : state.skillMenuItems;
+  if (items.length === 0) {
+    if (["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(event.key)) {
+      event.preventDefault();
+      return true;
+    }
+    return false;
+  }
+  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+    event.preventDefault();
+    const offset = event.key === "ArrowDown" ? 1 : items.length - 1;
+    state.skillMenuIndex = (state.skillMenuIndex + offset) % items.length;
+    requestUpdate();
+    scrollActiveMenuOptionIntoView(getActiveSkillMenuOptionId(state, host.paneId));
+    return true;
+  }
+  if (event.key === "Tab" || event.key === "Enter") {
+    event.preventDefault();
+    const command = items[state.skillMenuIndex];
+    if (command) {
+      selectSkillMention(command, state, host, requestUpdate);
+    }
+    return true;
+  }
+  return false;
+}
+
+export function renderSkillMenu(
+  state: SkillMenuState,
+  host: SkillMenuHost,
+  requestUpdate: () => void,
 ): TemplateResult | typeof nothing {
-  const state = getChatComposerState(props.paneId);
   if (!isSkillMenuVisible(state)) {
     return nothing;
   }
-  const listboxId = paneDomId(props.paneId, "skill-menu-listbox");
+  const listboxId = paneDomId(host.paneId, "skill-menu-listbox");
   return html`
     <div
       id=${listboxId}
@@ -241,14 +299,14 @@ export function renderSkillMenu(
               ${state.skillMenuItems.map(
                 (command, index) => html`
                   <div
-                    id=${skillOptionId(props.paneId, command)}
+                    id=${skillOptionId(host.paneId, command)}
                     class="slash-menu-item ${index === state.skillMenuIndex
                       ? "slash-menu-item--active"
                       : ""}"
                     role="option"
                     aria-selected=${index === state.skillMenuIndex}
                     @mousedown=${(event: MouseEvent) => event.preventDefault()}
-                    @click=${() => selectSkillMention(command, props, requestUpdate)}
+                    @click=${() => selectSkillMention(command, state, host, requestUpdate)}
                     @mouseenter=${() => {
                       state.skillMenuIndex = index;
                       requestUpdate();

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -7,8 +7,7 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
-import { scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
-import { paneDomId } from "./chat-composer-slash-menu.ts";
+import { paneDomId, scrollActiveMenuOptionIntoView } from "./chat-composer-dom.ts";
 
 const SKILL_MENTION_CHAR = /[-a-zA-Z0-9_:]/u;
 

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -9,6 +9,7 @@ import {
   type SlashCommandCategory,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
+import { paneDomId } from "./chat-composer-dom.ts";
 import { commitComposerDraft, getChatComposerState } from "./chat-composer-state.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
 
@@ -198,10 +199,6 @@ function slashOptionIdSegment(value: string): string {
       .replace(/[^a-z0-9_-]+/gu, "-")
       .replace(/^-+|-+$/gu, "") || "item"
   );
-}
-
-export function paneDomId(paneId: string, suffix: string): string {
-  return `chat-${encodeURIComponent(paneId)}-${suffix}`;
 }
 
 function getSlashCommandOptionId(paneId: string, cmd: SlashCommandDef): string {

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -26,6 +26,7 @@ import type {
   ChatComposerPlusMenuProps,
   ChatComposerPlusMenuView,
 } from "./chat-composer-plus-menu.ts";
+import type { SkillMenuState } from "./chat-composer-skill-menu.ts";
 import type { ChatPermissionPickerProps } from "./chat-permission-picker.ts";
 
 /** One shape for queued-row edit state and actions. */
@@ -155,13 +156,7 @@ type ComposingDraft = {
   value: string;
 };
 
-type SkillMenuTarget = {
-  start: number;
-  end: number;
-  query: string;
-};
-
-export type ChatComposerState = {
+export type ChatComposerState = SkillMenuState & {
   slashMenuOpen: boolean;
   slashMenuItems: SlashCommandDef[];
   slashMenuIndex: number;
@@ -169,13 +164,6 @@ export type ChatComposerState = {
   slashMenuCommand: SlashCommandDef | null;
   slashMenuArgItems: string[];
   slashCommandRefreshPending: boolean;
-  skillMenuOpen: boolean;
-  skillMenuItems: SlashCommandDef[];
-  skillMenuIndex: number;
-  skillMenuTarget: SkillMenuTarget | null;
-  skillCommandRefreshPending: boolean;
-  skillCommandRefreshGeneration: number;
-  skillCommandRefreshTargetStart: number | null;
   composerComposing: boolean;
   composingDraft: ComposingDraft | null;
   composerInputIntentKey: string | null;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -24,7 +24,7 @@ import { focusComposerFromChrome } from "./chat-composer-dom.ts";
 import { renderChatGoal } from "./chat-composer-goal.ts";
 import { renderChatComposerPlusMenu } from "./chat-composer-plus-menu.ts";
 import { renderChatQueue } from "./chat-composer-queue.ts";
-import { renderSkillMenu } from "./chat-composer-skill-menu.ts";
+import { renderSkillMenu, type SkillMenuHost } from "./chat-composer-skill-menu.ts";
 import { renderSlashMenu } from "./chat-composer-slash-menu.ts";
 import { commitComposerDraft } from "./chat-composer-state.ts";
 import {
@@ -65,6 +65,7 @@ type ChatComposerViewContext = {
   mirrorCameraPreview: boolean;
   slashMenuVisible: boolean;
   skillMenuVisible: boolean;
+  skillMenuHost: SkillMenuHost;
   activeSlashMenuOptionId: string | null;
   activeSlashMenuOptionLabel: string;
   slashMenuListboxId: string;
@@ -100,6 +101,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     mirrorCameraPreview,
     slashMenuVisible,
     skillMenuVisible,
+    skillMenuHost,
     activeSlashMenuOptionId,
     activeSlashMenuOptionLabel,
     slashMenuListboxId,
@@ -232,7 +234,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                 </div>`
               : nothing}
             ${slashMenuVisible ? renderSlashMenu(requestUpdate, props, visibleDraft) : nothing}
-            ${skillMenuVisible ? renderSkillMenu(requestUpdate, props) : nothing}
+            ${skillMenuVisible ? renderSkillMenu(state, skillMenuHost, requestUpdate) : nothing}
             ${renderAttachmentPreview(props)}
             ${props.replyTarget
               ? html`

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -13,6 +13,7 @@ import {
   adjustTextareaHeight,
   disconnectTextareaOverflowObserver,
   observeTextareaOverflow,
+  paneDomId,
   preserveComposerFocusOnPrimaryAction,
   replaceComposerPopoverAnchor,
   scheduleTextareaHeightAdjustment,
@@ -30,7 +31,6 @@ import {
   getActiveSlashMenuOptionId,
   getActiveSlashMenuOptionLabel,
   isSlashMenuVisible,
-  paneDomId,
   updateSlashMenu,
 } from "./chat-composer-slash-menu.ts";
 import {

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -23,6 +23,7 @@ import {
   getActiveSkillMenuOptionLabel,
   isSkillMenuVisible,
   resetSkillMenuState,
+  type SkillMenuHost,
   updateSkillMenu,
 } from "./chat-composer-skill-menu.ts";
 import {
@@ -136,6 +137,13 @@ export function renderChatComposer(props: ChatComposerProps) {
           ? t("chat.composer.runDone")
           : t("chat.composer.runInterrupted");
   const requestUpdate = props.onRequestUpdate ?? (() => {});
+  const skillMenuHost: SkillMenuHost = {
+    paneId: props.paneId,
+    getDraft: () => state.composerTextarea?.value ?? props.getDraft?.() ?? props.draft,
+    commitDraft: (next) => commitComposerDraft(props, next),
+    getTextarea: () => state.composerTextarea,
+    refreshCommands: props.onSlashIntent,
+  };
   const sendShortcut = normalizeChatSendShortcut(props.sendShortcut);
   const steerNowEnabled =
     props.connected &&
@@ -251,6 +259,7 @@ export function renderChatComposer(props: ChatComposerProps) {
   const handleKeyDown = createComposerKeyDownHandler({
     state,
     props,
+    skillMenuHost,
     requestUpdate,
     sendShortcut,
     canSubmitDraft,
@@ -264,15 +273,7 @@ export function renderChatComposer(props: ChatComposerProps) {
     adjustTextareaHeight(target);
     commitComposerDraft(props, target.value);
     updateSlashMenu(target.value, requestUpdate, props, {}, () => target.value);
-    updateSkillMenu(
-      target.value,
-      target.selectionStart,
-      requestUpdate,
-      props,
-      {},
-      () => target.value,
-      () => target.selectionStart,
-    );
+    updateSkillMenu(target.value, target.selectionStart, state, skillMenuHost, requestUpdate);
     requestUpdate();
   };
   const handleBeforeInput = (event: InputEvent) => {
@@ -307,15 +308,7 @@ export function renderChatComposer(props: ChatComposerProps) {
   };
   const handleSelect = (event: Event) => {
     const target = event.target as HTMLTextAreaElement;
-    updateSkillMenu(
-      target.value,
-      target.selectionStart,
-      requestUpdate,
-      props,
-      {},
-      () => target.value,
-      () => target.selectionStart,
-    );
+    updateSkillMenu(target.value, target.selectionStart, state, skillMenuHost, requestUpdate);
   };
   const handleCompositionEnd = (event: CompositionEvent) => {
     state.composerComposing = false;
@@ -566,6 +559,7 @@ export function renderChatComposer(props: ChatComposerProps) {
     mirrorCameraPreview,
     slashMenuVisible,
     skillMenuVisible,
+    skillMenuHost,
     activeSlashMenuOptionId,
     activeSlashMenuOptionLabel,
     slashMenuListboxId,

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -2,6 +2,7 @@
 
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildFallbackSlashCommands, replaceSlashCommands } from "../../lib/chat/commands.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { adjustTextareaHeight } from "../chat/components/chat-composer-dom.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
@@ -45,30 +46,38 @@ function renderComposer(
   if (!textareaControllers.includes(textareaController)) {
     textareaControllers.push(textareaController);
   }
-  render(
-    renderNewSessionDraftComposer({
-      agentId: "main",
-      attachmentDraft,
-      canSubmit: overrides.canSubmit ?? true,
-      context: undefined,
-      isCatalogTarget: true,
-      message: overrides.message ?? "",
-      visibility: overrides.visibility,
-      draftAvailable: overrides.draftAvailable,
-      modelControl: new NewSessionModelControl(() => undefined),
-      requiresModifier: overrides.requiresModifier ?? false,
-      submitDisabledReason: overrides.submitDisabledReason,
-      blockedSubmitNotice: overrides.blockedSubmitNotice,
-      terminalAction: overrides.terminalAction,
-      submitting: overrides.submitting ?? false,
-      textareaController,
-      messageLocked: overrides.messageLocked,
-      onInput: overrides.onInput ?? (() => undefined),
-      onVisibilityChange: overrides.onVisibilityChange,
-      onSubmit: overrides.onSubmit ?? (() => undefined),
-    }),
-    container,
-  );
+  let message = overrides.message ?? "";
+  const renderCurrent = () =>
+    render(
+      renderNewSessionDraftComposer({
+        agentId: "main",
+        attachmentDraft,
+        canSubmit: overrides.canSubmit ?? true,
+        context: undefined,
+        isCatalogTarget: true,
+        message,
+        visibility: overrides.visibility,
+        draftAvailable: overrides.draftAvailable,
+        modelControl: new NewSessionModelControl(() => undefined),
+        requiresModifier: overrides.requiresModifier ?? false,
+        requestUpdate: renderCurrent,
+        submitDisabledReason: overrides.submitDisabledReason,
+        blockedSubmitNotice: overrides.blockedSubmitNotice,
+        terminalAction: overrides.terminalAction,
+        submitting: overrides.submitting ?? false,
+        textareaController,
+        messageLocked: overrides.messageLocked,
+        onInput: (next) => {
+          message = next;
+          overrides.onInput?.(next);
+          renderCurrent();
+        },
+        onVisibilityChange: overrides.onVisibilityChange,
+        onSubmit: overrides.onSubmit ?? (() => undefined),
+      }),
+      container,
+    );
+  renderCurrent();
   const composer = container.querySelector<HTMLElement>(".new-session-page__composer");
   if (!composer) {
     throw new Error("Expected new-session composer");
@@ -95,9 +104,42 @@ afterEach(() => {
   textareaControllers.length = 0;
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  replaceSlashCommands(buildFallbackSlashCommands());
 });
 
 describe("new-session composer keyboard submission", () => {
+  it("opens skill mentions and inserts the selected skill with Enter", () => {
+    replaceSlashCommands([
+      {
+        key: "release_notes",
+        name: "release_notes",
+        description: "Draft release notes.",
+        source: "skill",
+        skillModelVisible: true,
+      },
+    ]);
+    let message = "";
+    const { composer } = renderComposer({
+      onInput: (next) => {
+        message = next;
+      },
+    });
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+
+    textarea.value = "$";
+    textarea.setSelectionRange(1, 1);
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+
+    expect(composer.querySelector(".skill-menu")?.textContent).toContain("release_notes");
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Enter" }),
+    );
+    expect(message).toBe("$release_notes ");
+  });
+
   it.each([
     { label: "Enter", requiresModifier: false, ctrlKey: false, metaKey: false },
     { label: "Ctrl+Enter", requiresModifier: true, ctrlKey: true, metaKey: false },
@@ -303,6 +345,7 @@ describe("new-session composer sizing lifecycle", () => {
         message: "typed",
         modelControl: new NewSessionModelControl(() => undefined),
         requiresModifier: false,
+        requestUpdate: () => undefined,
         submitting: false,
         textareaController,
         onInput,
@@ -327,6 +370,7 @@ describe("new-session composer sizing lifecycle", () => {
         message: "restored programmatically",
         modelControl: new NewSessionModelControl(() => undefined),
         requiresModifier: false,
+        requestUpdate: () => undefined,
         submitting: false,
         textareaController,
         onInput,

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 import { icons } from "../../components/icons.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
@@ -6,6 +7,7 @@ import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { refreshSlashCommands } from "../chat/chat-commands.ts";
 import {
   createChatAttachmentDropHandlers,
   handleChatAttachmentPaste,
@@ -19,6 +21,18 @@ import {
   observeTextareaOverflow,
   scheduleTextareaHeightAdjustment,
 } from "../chat/components/chat-composer-dom.ts";
+import {
+  createSkillMenuState,
+  getActiveSkillMenuOptionId,
+  getActiveSkillMenuOptionLabel,
+  handleSkillMenuKeydown,
+  isSkillMenuVisible,
+  renderSkillMenu,
+  resetSkillMenuState,
+  updateSkillMenu,
+  type SkillMenuHost,
+} from "../chat/components/chat-composer-skill-menu.ts";
+import { paneDomId } from "../chat/components/chat-composer-slash-menu.ts";
 import type { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
 import type { NewSessionModelControl } from "./model-control.ts";
@@ -33,6 +47,8 @@ type NewSessionComposerOptions = {
   pendingAttachmentReads: number;
   readSignal: AbortSignal;
   requiresModifier: boolean;
+  requestUpdate: () => void;
+  refreshCommands?: () => void | Promise<void>;
   submitDisabledReason?: string;
   blockedSubmitNotice?: string;
   terminalAction?: {
@@ -53,6 +69,14 @@ type NewSessionComposerOptions = {
   onSubmit: () => void;
 };
 
+function submitNewSession(
+  options: NewSessionComposerOptions,
+  skillMenuState: NewSessionComposerTextareaController["skillMenuState"],
+) {
+  resetSkillMenuState(skillMenuState);
+  options.onSubmit();
+}
+
 function renderStartControl(options: NewSessionComposerOptions) {
   const startLabel = options.submitting ? t("newSession.starting") : t("newSession.start");
   if (!options.terminalAction) {
@@ -64,7 +88,7 @@ function renderStartControl(options: NewSessionComposerOptions) {
           ?disabled=${!options.canSubmit}
           aria-busy=${String(options.submitting)}
           aria-label=${startLabel}
-          @click=${options.onSubmit}
+          @click=${() => submitNewSession(options, options.textareaController.skillMenuState)}
         >
           ${options.submitting ? icons.loader : icons.arrowUp}
         </button>
@@ -81,7 +105,7 @@ function renderStartControl(options: NewSessionComposerOptions) {
           ?disabled=${!options.canSubmit}
           aria-busy=${String(options.submitting)}
           aria-label=${startLabel}
-          @click=${options.onSubmit}
+          @click=${() => submitNewSession(options, options.textareaController.skillMenuState)}
         >
           ${options.submitting ? icons.loader : icons.arrowUp}
         </button>
@@ -116,6 +140,7 @@ function renderStartControl(options: NewSessionComposerOptions) {
 
 export class NewSessionComposerTextareaController {
   private textarea: HTMLTextAreaElement | null = null;
+  readonly skillMenuState = createSkillMenuState();
 
   readonly ref = (element?: Element) => {
     const nextTextarea = element instanceof HTMLTextAreaElement ? element : null;
@@ -137,7 +162,10 @@ export class NewSessionComposerTextareaController {
     }
   }
 
+  readonly getTextarea = () => this.textarea;
+
   disconnect() {
+    resetSkillMenuState(this.skillMenuState);
     if (this.textarea) {
       disconnectTextareaOverflowObserver(this.textarea);
       this.textarea = null;
@@ -181,8 +209,25 @@ export function renderDraftError(message: string) {
   `;
 }
 
-function handleComposerKeydown(event: KeyboardEvent, options: NewSessionComposerOptions) {
-  if (event.key !== "Enter" || event.shiftKey || event.isComposing || event.keyCode === 229) {
+function handleComposerKeydown(
+  event: KeyboardEvent,
+  options: NewSessionComposerOptions,
+  skillMenuHost: SkillMenuHost,
+) {
+  if (event.isComposing || event.keyCode === 229) {
+    return;
+  }
+  if (
+    handleSkillMenuKeydown(
+      event,
+      options.textareaController.skillMenuState,
+      skillMenuHost,
+      options.requestUpdate,
+    )
+  ) {
+    return;
+  }
+  if (event.key !== "Enter" || event.shiftKey) {
     return;
   }
   if (options.requiresModifier && !event.metaKey && !event.ctrlKey) {
@@ -193,12 +238,34 @@ function handleComposerKeydown(event: KeyboardEvent, options: NewSessionComposer
   // Only silent gates (busy button, empty draft) keep Enter native.
   if (options.canSubmit || options.submitDisabledReason !== undefined) {
     event.preventDefault();
-    options.onSubmit();
+    submitNewSession(options, options.textareaController.skillMenuState);
   }
 }
 
 /** Draft message box styled as the chat composer shell so both pickers match. */
 function renderNewSessionComposer(options: NewSessionComposerOptions) {
+  const skillMenuState = options.textareaController.skillMenuState;
+  const skillMenuHost: SkillMenuHost = {
+    paneId: "new-session",
+    getDraft: () => options.textareaController.getTextarea()?.value ?? options.message,
+    commitDraft: options.onInput,
+    getTextarea: options.textareaController.getTextarea,
+    refreshCommands: options.refreshCommands,
+  };
+  const updateSkills = (target: HTMLTextAreaElement) =>
+    updateSkillMenu(
+      target.value,
+      target.selectionStart,
+      skillMenuState,
+      skillMenuHost,
+      options.requestUpdate,
+    );
+  const handleSelect = (event: Event) => {
+    const target = event.currentTarget;
+    if (target instanceof HTMLTextAreaElement) {
+      updateSkills(target);
+    }
+  };
   const attachmentProps = {
     attachmentLimits: options.attachmentLimits,
     attachments: options.attachments,
@@ -217,6 +284,11 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
     canCompose: !options.submitting && !options.messageLocked,
   });
   options.textareaController.syncDraft(options.message);
+  const skillMenuVisible =
+    !options.submitting && !options.messageLocked && isSkillMenuVisible(skillMenuState);
+  const skillMenuListboxId = paneDomId(skillMenuHost.paneId, "skill-menu-listbox");
+  const activeSkillOptionId = getActiveSkillMenuOptionId(skillMenuState, skillMenuHost.paneId);
+  const skillMenuAnnouncementId = paneDomId(skillMenuHost.paneId, "skill-active-announcement");
   return html`
     <div
       class="agent-chat__composer-shell new-session-page__composer"
@@ -229,6 +301,9 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
         ${renderChatAttachmentInputs(attachmentProps)} ${renderAttachmentPreview(attachmentProps)}
         <div class="agent-chat__composer-input-row">
           <div class="agent-chat__composer-combobox">
+            ${skillMenuVisible
+              ? renderSkillMenu(skillMenuState, skillMenuHost, options.requestUpdate)
+              : nothing}
             <textarea
               ${ref(options.textareaController.ref)}
               class="new-session-page__message"
@@ -236,18 +311,34 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
               ?disabled=${options.submitting || options.messageLocked}
               placeholder=${t("newSession.messagePlaceholder")}
               .value=${options.message}
+              aria-autocomplete="list"
+              aria-controls=${ifDefined(skillMenuVisible ? skillMenuListboxId : undefined)}
+              aria-expanded=${ifDefined(skillMenuVisible ? "true" : undefined)}
+              aria-activedescendant=${ifDefined(activeSkillOptionId ?? undefined)}
+              aria-describedby=${skillMenuAnnouncementId}
               @input=${(event: Event) => {
                 const target = event.target as HTMLTextAreaElement;
                 adjustTextareaHeight(target);
+                updateSkills(target);
                 options.onInput(target.value);
               }}
-              @keydown=${(event: KeyboardEvent) => handleComposerKeydown(event, options)}
+              @select=${handleSelect}
+              @keydown=${(event: KeyboardEvent) =>
+                handleComposerKeydown(event, options, skillMenuHost)}
               @paste=${(event: ClipboardEvent) => {
                 if (!options.submitting && !options.messageLocked) {
                   handleChatAttachmentPaste(event, attachmentProps);
                 }
               }}
             ></textarea>
+            <span
+              id=${skillMenuAnnouncementId}
+              class="sr-only"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              >${getActiveSkillMenuOptionLabel(skillMenuState)}</span
+            >
           </div>
           <div class="agent-chat__composer-actions">${renderStartControl(options)}</div>
         </div>
@@ -294,6 +385,7 @@ export function renderNewSessionDraftComposer(options: {
   modelControl: NewSessionModelControl;
   textareaController: NewSessionComposerTextareaController;
   requiresModifier: boolean;
+  requestUpdate: () => void;
   submitDisabledReason?: string;
   blockedSubmitNotice?: string;
   terminalAction?: {
@@ -309,6 +401,7 @@ export function renderNewSessionDraftComposer(options: {
   onSubmit: () => void;
 }) {
   const readSignal = options.attachmentDraft.readSignal;
+  const commandClient = options.context?.gateway.snapshot.client;
   return renderNewSessionComposer({
     attachmentLimits: options.context?.gateway.snapshot.hello?.policy?.attachments,
     attachments: options.attachmentDraft.attachments,
@@ -328,6 +421,10 @@ export function renderNewSessionDraftComposer(options: {
     pendingAttachmentReads: options.attachmentDraft.pendingReads,
     readSignal,
     requiresModifier: options.requiresModifier,
+    requestUpdate: options.requestUpdate,
+    refreshCommands: commandClient
+      ? () => refreshSlashCommands({ client: commandClient, agentId: options.agentId })
+      : undefined,
     submitDisabledReason: options.submitDisabledReason,
     blockedSubmitNotice: options.blockedSubmitNotice,
     terminalAction: options.terminalAction,

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -19,6 +19,7 @@ import {
   adjustTextareaHeight,
   disconnectTextareaOverflowObserver,
   observeTextareaOverflow,
+  paneDomId,
   scheduleTextareaHeightAdjustment,
 } from "../chat/components/chat-composer-dom.ts";
 import {
@@ -32,7 +33,6 @@ import {
   updateSkillMenu,
   type SkillMenuHost,
 } from "../chat/components/chat-composer-skill-menu.ts";
-import { paneDomId } from "../chat/components/chat-composer-slash-menu.ts";
 import type { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
 import type { NewSessionModelControl } from "./model-control.ts";

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -607,6 +607,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
           draftAvailable: this.submission.canStartAsDraft(),
           modelControl: this.place.modelControl,
           requiresModifier: loadSettings().chatSendShortcut === "modifier-enter",
+          requestUpdate: () => this.requestUpdate(),
           submitting: this.submission.submitting,
           textareaController: this.submission.composerTextarea,
           messageLocked: Boolean(this.submission.pendingCloud.sessionKey),


### PR DESCRIPTION
## What Problem This Solves

On the Control UI `/new` route, typing `$` in the composer never opened the skills dropdown, while the same gesture on `/chat` offered completions. Skill mentions were effectively unavailable when starting a session.

## Why This Change Was Made

`/new` renders its own composer (`ui/src/pages/new-session/composer.ts`), a plain textarea that never wired the `$skill` mention menu owned by the chat composer (`ui/src/pages/chat/components/chat-composer-skill-menu.ts`). The menu also depended on `ChatComposerProps`/`ChatComposerState`, so it could not be reused, and the `commands.list` refresh that populates skill completions was only triggered by the chat page host.

Fix: narrow the skill-menu module to a small host contract (`SkillMenuHost`: draft, textarea, commit, command refresh) plus its own `SkillMenuState`, consolidate the keyboard handling into `handleSkillMenuKeydown`, and drive that one module from both composers. `/new` now runs the same open/filter/ArrowUp/Down/Enter/Tab/Escape/mouse behavior with the same aria wiring, and refreshes commands on the first `$`.

## User Impact

- `/new`: `$` opens the skills menu, filters as you type, Enter/Tab inserts `$name `.
- `/chat`: unchanged behavior; skill-menu code path is now shared instead of composer-private.
- Production LOC +236/−126 (shared chat refactor is roughly net-neutral; growth is the `/new` wiring + refresh hook).

| Before (`/new`, main build) | After (`/new`, this branch) |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/ec23edd2-345f-447d-b06e-11059cd12052) | ![after](https://github.com/user-attachments/assets/fe471dfc-1a57-4ce9-a7d1-780195e82748) |
| `$` typed, nothing happens | `$` opens the skills listbox from the live gateway |

Filtered (`$codex`):

![filter](https://github.com/user-attachments/assets/4195182b-365c-4940-82b2-a6ba4f48b7ad)

## Evidence

- Regression test `ui/src/pages/new-session/composer.test.ts` — `$` opens menu with registry skills, Enter inserts `$release_notes ` (fails on pre-fix code).
- `pnpm test ui/src/pages/new-session/composer.test.ts ui/src/pages/chat/components` — 30 passed.
- `pnpm check:changed` — format/tsgo/lint clean, exit 0.
- Live: screenshots above taken against a running local gateway (`/new` served by the gateway's main build vs. `pnpm ui:dev` on this branch pointed at the same gateway).

- `pnpm check:architecture` — clean after moving `paneDomId` to `chat-composer-dom.ts` (first push introduced a `composer-types → skill-menu → slash-menu → state → types` madge cycle).
- Inherited red on the first head (`check-lint-core-5`, `chat-pane-render.ts` max-lines from #125231) was healed on `main` by #125538; branch rebased onto healed `main`. Earlier hosted-shard timeout in `src/gateway/server-methods/sessions.dispatch.test.ts` is outside this PR (24/24 pass locally).

- `/chat` side (shared refactor): existing skill-menu coverage in `ui/src/pages/chat/chat-view.test.ts` (12 `$`-reference tests: open, hydrate-once, fill-without-submit, keyboard nav, loading gate, escape/stale-caret close) — `pnpm test ui/src/pages/chat/chat-view.test.ts -t skill` → 12 passed on this head.
