### PR TITLE
fix(cli): exit non-zero when an agent turn fails

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -12,6 +12,8 @@ Run one agent turn through the Gateway. The explicit `--local` flag is the only 
 
 Pass at least one session selector: `--to`, `--session-key`, `--session-id`, or `--agent`.
 
+A completed turn exits `0`. Error, timeout, and cancellation outcomes exit `1`, after any text or JSON result is written. A received `SIGINT` or `SIGTERM` instead preserves the signal-specific exit status described below.
+
 Related: [Agent send tool](/tools/agent-send)
 
 ## `agent exec`

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -20,6 +20,7 @@ import { getFreePort } from "../test-utils/ports.js";
 import {
   closeActiveGatewayServers,
   EMPTY_STABILITY_SNAPSHOT,
+  startAgentTurnGateway,
   startCronListGateway,
   startGatewayStabilityRpcServer,
   startNodePairingGateway,
@@ -208,6 +209,44 @@ async function runIsolatedGatewayCli(params: {
 }
 
 describe("gateway-backed CLI process exit", () => {
+  it.each([
+    { status: "ok" as const, text: "pong", exitCode: 0 },
+    { status: "error" as const, text: "provider failed", exitCode: 1 },
+  ])(
+    "exits $exitCode after an agent turn reports $status",
+    async ({ status, text, exitCode }) => {
+      const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const gateway = await startAgentTurnGateway({ status, text });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          gateway: {
+            mode: "remote",
+            remote: { url: gateway.url, token: gateway.token },
+          },
+        }),
+      );
+
+      const result = await runIsolatedGatewayCli({
+        args: ["agent", "--agent", "main", "--message", "ping", "--json"],
+        root,
+        stateDir,
+        configPath,
+      });
+
+      expect(result, result.stderr).toMatchObject({ code: exitCode, signal: null, stderr: "" });
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        status,
+        summary: status === "ok" ? "completed" : "failed",
+        result: { payloads: [{ text }] },
+      });
+    },
+    30_000,
+  );
+
   it.each([
     {
       label: "root-health-json",

--- a/src/cli/gateway-backed-exit.test-helpers.ts
+++ b/src/cli/gateway-backed-exit.test-helpers.ts
@@ -224,6 +224,65 @@ export async function startGatewayStabilityRpcServer(
   return { authTokens, calls, url: `ws://${host}:${address.port}` };
 }
 
+/** Mock Gateway that answers one agent turn with the requested terminal status. */
+export async function startAgentTurnGateway(params: {
+  status: "ok" | "error";
+  text: string;
+}): Promise<{ url: string; token: string }> {
+  const token = "agent-turn-token";
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  activeServers.add(wss);
+  wss.on("connection", (ws) => {
+    sendMinimalGatewayConnectChallenge(ws);
+    ws.on("message", (data) => {
+      const frame = parseMinimalGatewayRequestFrame(data);
+      if (frame.type !== "req" || !frame.id) {
+        return;
+      }
+      if (frame.method === "connect") {
+        expect(frame.params?.auth?.token).toBe(token);
+        sendMinimalGatewayResponse(
+          ws,
+          frame.id,
+          buildMinimalGatewayHelloOkPayload({
+            methods: ["agent"],
+            auth: { role: "operator", scopes: ["operator.admin"] },
+          }),
+        );
+        return;
+      }
+      if (frame.method !== "agent") {
+        return;
+      }
+      const runId = "agent-turn-run";
+      sendMinimalGatewayResponse(ws, frame.id, {
+        runId,
+        status: "accepted",
+        sessionKey: "agent:main:main",
+      });
+      setImmediate(() => {
+        sendMinimalGatewayResponse(ws, frame.id!, {
+          runId,
+          status: params.status,
+          summary: params.status === "ok" ? "completed" : "failed",
+          result: {
+            payloads: [
+              {
+                text: params.text,
+                ...(params.status === "error" ? { isError: true } : {}),
+              },
+            ],
+            meta: {},
+          },
+        });
+      });
+    });
+  });
+  await once(wss, "listening");
+  const address = wss.address() as AddressInfo;
+  return { url: `ws://127.0.0.1:${address.port}`, token };
+}
+
 /** Closes every mock Gateway started by these helpers; call from the suite afterEach. */
 export async function closeActiveGatewayServers(): Promise<void> {
   await Promise.all(Array.from(activeServers, closeMinimalGatewayServer));

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -121,7 +121,10 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
       await runCommandWithRuntime(defaultRuntime, async () => {
         setVerbose(verboseLevel === "on");
         await agentCliCommand(opts, defaultRuntime);
-        requestExitAfterOneShotOutput(defaultRuntime);
+        requestExitAfterOneShotOutput(
+          defaultRuntime,
+          typeof process.exitCode === "number" ? process.exitCode : 0,
+        );
       });
     });
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -182,7 +182,7 @@ describe("agent command registration", () => {
 
     expect(agentCliCommandMock).toHaveBeenCalledTimes(1);
     expect(agentExecCommandMock).not.toHaveBeenCalled();
-    expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledWith(runtime);
+    expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledWith(runtime, 0);
   });
 
   it("keeps an exec-valued parent message on the existing parent action", async () => {

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -10,6 +10,7 @@ import {
   configureExecutionIdentityAdmissionSink,
   hasExecutionIdentityAdmissionSink,
 } from "../audit/execution-identity-admission.js";
+import { recordAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { acquireGatewayLock, type GatewayLockOptions } from "../infra/gateway-lock.js";
@@ -2459,6 +2460,27 @@ describe("agentCliCommand", () => {
       expect(localOpts.cleanupCliLiveSessionOnRunEnd).toBe(true);
       expect(localOpts.oneShotCliRun).toBe(true);
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("marks a failed local terminal outcome unsuccessful", async () => {
+    await withTempStore(async () => {
+      const signals = createSignalProcess();
+      agentCommand.mockResolvedValueOnce(
+        recordAgentRunTerminalOutcome(
+          {
+            payloads: [{ text: "provider failed", isError: true }],
+            meta: { error: new Error("provider failed") },
+          },
+          "failed",
+        ),
+      );
+
+      await agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime, {
+        process: signals.processLike,
+      });
+
+      expect(signals.processLike.exitCode).toBe(1);
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -12,12 +12,17 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { AgentsListResult } from "../../packages/gateway-protocol/src/index.js";
 import {
+  buildAgentRunTerminalOutcome,
+  classifyAgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
+import {
   AgentSelectionRequiredError,
   listAgentIds,
   tryResolveSoleAgentId,
 } from "../agents/agent-scope-config.js";
 import { measureAgentStartup } from "../agents/startup-timing.js";
 import { isExecutionIdentityCollectionEnabled } from "../audit/audit-config.js";
+import { readAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -924,18 +929,28 @@ function isInFlightGatewayAgentResponse(response: GatewayAgentResponse): boolean
   return response.status === "in_flight";
 }
 
-function markFailedGatewayAgentResponse(
-  response: GatewayAgentResponse,
+function markAgentRunExitCode(
+  status: unknown,
   signalBridge: ReturnType<typeof createAgentCliSignalBridge>,
 ): void {
-  if (
-    response.status === "timeout" ||
-    response.status === "error" ||
-    response.status === "cancelled"
-  ) {
-    // Let Node drain structured or text stdout before the process exits.
-    signalBridge.setExitCode(1);
+  // Gateway responses carry an open `status` string, so an unrecognized value must
+  // not read as success: only the known success words map to exit 0, and any other
+  // reported status fails closed. An absent status stays unmapped because callers
+  // that never observed a terminal state have nothing to report.
+  const waitStatus =
+    status === "ok" || status === "completed"
+      ? "ok"
+      : status === "timeout"
+        ? "timeout"
+        : status === undefined || status === null || status === ""
+          ? undefined
+          : "error";
+  if (!waitStatus) {
+    return;
   }
+  const outcome = buildAgentRunTerminalOutcome({ status: waitStatus });
+  // Let Node drain structured or text stdout before the process exits.
+  signalBridge.setExitCode(classifyAgentRunTerminalOutcome(outcome) === "success" ? 0 : 1);
 }
 
 function formatInFlightGatewayAgentMessage(response: GatewayAgentResponse): string {
@@ -1158,7 +1173,7 @@ async function agentViaGatewayCommand(
 
   if (opts.json) {
     writeRuntimeJson(runtime, buildGatewayJsonResponse(response));
-    markFailedGatewayAgentResponse(response, signalBridge);
+    markAgentRunExitCode(response.status, signalBridge);
     return response;
   }
 
@@ -1174,7 +1189,7 @@ async function agentViaGatewayCommand(
     if (response?.status !== "ok") {
       runtime.log(response?.summary ? response.summary : "No reply from agent.");
     }
-    markFailedGatewayAgentResponse(response, signalBridge);
+    markAgentRunExitCode(response.status, signalBridge);
     return response;
   }
 
@@ -1185,7 +1200,7 @@ async function agentViaGatewayCommand(
     }
   }
 
-  markFailedGatewayAgentResponse(response, signalBridge);
+  markAgentRunExitCode(response.status, signalBridge);
 
   return response;
 }
@@ -1268,6 +1283,7 @@ export async function agentCliCommand(
       } finally {
         await stateLock?.release();
       }
+      markAgentRunExitCode(readAgentRunTerminalOutcome(result), signalBridge);
       return returnAfterSignalExit(result, signalBridge.getReceivedSignal(), runtime);
     }
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw agent` exited `0` on a failed turn while its own JSON said the turn failed.

Driving a real turn against a small-context local model:

```
$ openclaw agent --message "Reply with exactly: pong" --json
{
  "runId": "366c06b1-00b1-440d-8a39-9f2f72746c91",
  "status": "error",
  "summary": "failed",
  "result": { "payloads": [ { "text": "Context overflow: prompt too large for the model. ..." } ] }
}
$ echo $?
0
```

The Gateway agreed it failed — `embedded run agent end: ... isError=true`, then
`exhausted provider overflow recovery ... livenessState=blocked` — and the process still reported success. Any script using `openclaw agent ... || handle_failure` treated a failed turn as a good one.

## Why This Change Was Made

The mapping was not missing, it was partial. `markFailedGatewayAgentResponse` already set exit 1 for `timeout`/`error`/`cancelled`, but only on the **gateway-routed** path; the local embedded path never called it. Failures thrown before the run (an unresolvable model, for example) already exited 1, which is why this looked inconsistent rather than absent.

Both paths now go through the canonical `buildAgentRunTerminalOutcome` / `classifyAgentRunTerminalOutcome` in `src/agents/agent-run-terminal-outcome.ts`, which root `AGENTS.md` names as the owner of run terminal state and explicitly warns against rederiving in projections. The CLI consumes the normalized outcome instead of matching on payload text, so nothing keys off the word "overflow" or any other message.

Signal handling is preserved: a received `SIGINT`/`SIGTERM` still yields its signal-specific exit status rather than being flattened to 1.

## User Impact

A completed turn exits `0`. Error, timeout, and cancellation outcomes exit `1`, after any text or JSON result is written, so output is unchanged and still fully drained — only the exit code moves. Scripts and CI that branch on `openclaw agent`'s exit status can now detect failed turns.

This is a behavior change for anyone scripting the command today, and worth calling out explicitly. I judge it a bug fix rather than a breaking change: the previous `0` was indistinguishable from success, so no script could have been depending on it for anything except accidentally ignoring failures. `docs/cli/agent.md` now documents the contract.

## Evidence

- `node scripts/run-vitest.mjs src/cli/program/register.agent.test.ts src/commands/agent-via-gateway.test.ts` — pass.
- Process-level coverage added to `src/cli/gateway-backed-exit.process.test.ts`, the established home for CLI exit-code contracts, since this is a process-level guarantee that a unit test of the mapping function cannot prove.
- Reproduced end to end against a local Ollama model whose 32k context is smaller than the system prompt, so the overflow is deterministic; verified both the failing turn (non-zero, envelope still `status: error`) and a healthy turn (still `0`).
