### PR TITLE
fix(models): reject unknown providers when setting a default model

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -30,6 +30,8 @@ openclaw models scan
 
 `status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `scan`, `aliases`, and `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
+`models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
+
 ### Status
 
 Bare `openclaw models` is equivalent to `openclaw models status`.

--- a/src/commands/models.set.e2e.test.ts
+++ b/src/commands/models.set.e2e.test.ts
@@ -9,28 +9,25 @@ const mocks = vi.hoisted(() => ({
   writtenConfig: undefined as Record<string, unknown> | undefined,
 }));
 
-vi.mock("./models/shared.js", async () => {
-  const actual = await vi.importActual<typeof import("./models/shared.js")>("./models/shared.js");
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
   return {
     ...actual,
-    updateConfig: async (
-      mutator: (
-        cfg: Record<string, unknown>,
-        context: {
-          runtimeConfig: Record<string, unknown>;
-        },
-      ) => Record<string, unknown>,
-    ) => {
-      const sourceConfig = structuredClone(mocks.currentConfig);
-      const runtimeConfig = structuredClone(mocks.currentConfig);
-      const next = mutator(sourceConfig, { runtimeConfig });
-      mocks.writtenConfig = next;
-      return next;
+    readConfigFileSnapshot: async () => ({
+      valid: true,
+      hash: "config-hash",
+      sourceConfig: structuredClone(mocks.currentConfig),
+      runtimeConfig: structuredClone(mocks.currentConfig),
+      config: structuredClone(mocks.currentConfig),
+    }),
+    replaceConfigFile: async ({ nextConfig }: { nextConfig: Record<string, unknown> }) => {
+      mocks.writtenConfig = nextConfig;
     },
   };
 });
 
 import { modelsFallbacksAddCommand } from "./models/fallbacks.js";
+import { modelsSetImageCommand } from "./models/set-image.js";
 import { modelsSetCommand } from "./models/set.js";
 
 function mockConfigSnapshot(config: Record<string, unknown> = {}) {
@@ -72,6 +69,61 @@ describe("models set + fallbacks", () => {
     await modelsSetCommand("z.ai/glm-4.7", runtime);
 
     expectWrittenPrimaryModel("zai/glm-4.7");
+  });
+
+  it("does not warn for a cataloged model under a known provider", async () => {
+    mockConfigSnapshot({});
+    const runtime = makeRuntime();
+
+    await modelsSetCommand("openai/gpt-5.6-sol", runtime);
+
+    expectWrittenPrimaryModel("openai/gpt-5.6-sol");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["text", modelsSetCommand],
+    ["image", modelsSetImageCommand],
+  ])("rejects an unknown %s model provider without writing config", async (_kind, command) => {
+    mockConfigSnapshot({});
+    const runtime = makeRuntime();
+
+    await expect(command("no-such-provider/no-such-model", runtime)).rejects.toThrow(
+      'Unknown model provider "no-such-provider"',
+    );
+
+    expect(mocks.writtenConfig).toBeUndefined();
+  });
+
+  it.each([
+    ["text", modelsSetCommand],
+    ["image", modelsSetImageCommand],
+  ])("warns but saves an unknown %s model for a known provider", async (_kind, command) => {
+    mockConfigSnapshot({});
+    const runtime = makeRuntime();
+
+    await command("openai/not-in-the-local-catalog", runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Model "openai/not-in-the-local-catalog" is not in the local model catalog',
+      ),
+    );
+    expect(getWrittenConfig().agents?.defaults?.models).toHaveProperty(
+      "openai/not-in-the-local-catalog",
+    );
+  });
+
+  it("recognizes a provider declared by a disabled installed plugin", async () => {
+    mockConfigSnapshot({ plugins: { entries: { ollama: { enabled: false } } } });
+    const runtime = makeRuntime();
+
+    await modelsSetCommand("ollama/site-local-model", runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining('Model "ollama/site-local-model" is not in the local model catalog'),
+    );
+    expect(getWrittenConfig().agents?.defaults?.models).toHaveProperty("ollama/site-local-model");
   });
 
   it("does not make an unlisted model override invalid on a fresh config", async () => {

--- a/src/commands/models/model-reference-validation.ts
+++ b/src/commands/models/model-reference-validation.ts
@@ -76,8 +76,11 @@ export function inspectConfiguredModelReferences(
   params: ModelReferenceInspectionParams,
 ): Array<ModelReferenceInspection & { active: boolean }> {
   const { inspect, snapshot } = createModelReferenceInspector(params);
-  return resolveConfiguredEntries(params.cfg, snapshot).entries.map((entry) => ({
-    ...inspect(entry.ref),
-    active: [...entry.tags].some((tag) => tag !== "configured"),
-  }));
+  // `inspect` returns a fresh object per call, so tagging it in place avoids a
+  // per-entry spread copy without sharing state between entries.
+  return resolveConfiguredEntries(params.cfg, snapshot).entries.map((entry) =>
+    Object.assign(inspect(entry.ref), {
+      active: [...entry.tags].some((tag) => tag !== "configured"),
+    }),
+  );
 }

--- a/src/commands/models/model-reference-validation.ts
+++ b/src/commands/models/model-reference-validation.ts
@@ -1,0 +1,83 @@
+import { buildModelCatalogMergeKey } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { planEffectiveModelCatalogRows } from "../../model-catalog/index.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { resolveConfiguredEntries } from "./list.configured.js";
+
+type ModelReferenceInspection = {
+  ref: string;
+  provider: string;
+  model: string;
+  status: "known" | "unknown-model" | "unknown-provider";
+};
+
+type ModelReferenceInspectionParams = {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  metadataSnapshot?: PluginMetadataSnapshot;
+  workspaceDir?: string;
+};
+
+function createModelReferenceInspector(params: ModelReferenceInspectionParams) {
+  const snapshot =
+    params.metadataSnapshot ??
+    loadManifestMetadataSnapshot({
+      config: params.cfg,
+      env: params.env ?? process.env,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    });
+  const knownProviders = new Set(
+    [
+      ...snapshot.owners.providers.keys(),
+      ...snapshot.owners.modelCatalogProviders.keys(),
+      ...snapshot.owners.cliBackends.keys(),
+      ...Object.keys(params.cfg.models?.providers ?? {}),
+    ]
+      .map(normalizeProviderId)
+      .filter(Boolean),
+  );
+  const knownModels = new Set(
+    planEffectiveModelCatalogRows({
+      registry: snapshot.manifestRegistry,
+      config: params.cfg,
+    }).rows.map((row) => row.mergeKey),
+  );
+  for (const [provider, providerConfig] of Object.entries(params.cfg.models?.providers ?? {})) {
+    for (const model of providerConfig.models ?? []) {
+      knownModels.add(buildModelCatalogMergeKey(provider, model.id));
+    }
+  }
+  const inspect = (candidate: { provider: string; model: string }): ModelReferenceInspection => {
+    const provider = normalizeProviderId(candidate.provider);
+    const model = candidate.model.trim();
+    const ref = `${provider}/${model}`;
+    if (!knownProviders.has(provider)) {
+      return { ref, provider, model, status: "unknown-provider" };
+    }
+    const status = knownModels.has(buildModelCatalogMergeKey(provider, model))
+      ? "known"
+      : "unknown-model";
+    return { ref, provider, model, status };
+  };
+  return { inspect, snapshot };
+}
+
+/** Classifies a resolved model ref without loading provider runtimes or making network calls. */
+export function inspectModelReference(
+  params: ModelReferenceInspectionParams & { ref: { provider: string; model: string } },
+): ModelReferenceInspection {
+  return createModelReferenceInspector(params).inspect(params.ref);
+}
+
+/** Inspects every default/fallback/image/configured model entry for Doctor. */
+export function inspectConfiguredModelReferences(
+  params: ModelReferenceInspectionParams,
+): Array<ModelReferenceInspection & { active: boolean }> {
+  const { inspect, snapshot } = createModelReferenceInspector(params);
+  return resolveConfiguredEntries(params.cfg, snapshot).entries.map((entry) => ({
+    ...inspect(entry.ref),
+    active: [...entry.tags].some((tag) => tag !== "configured"),
+  }));
+}

--- a/src/commands/models/set-image.ts
+++ b/src/commands/models/set-image.ts
@@ -2,13 +2,17 @@
 import { logConfigUpdated } from "../../config/logging.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
+import { updateDefaultModelPrimaryConfig } from "./shared.js";
 
 /** Sets agents.defaults.imageModel.primary after resolving aliases/catalog provider aliases. */
 export async function modelsSetImageCommand(modelRaw: string, runtime: RuntimeEnv) {
-  const updated = await updateConfig((cfg) => {
-    return applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "imageModel" });
+  const { updated, warning } = await updateDefaultModelPrimaryConfig({
+    modelRaw,
+    field: "imageModel",
   });
+  if (warning) {
+    runtime.error?.(warning);
+  }
 
   logConfigUpdated(runtime);
   runtime.log(

--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -8,9 +8,12 @@ import { updateDefaultModelPrimaryConfig } from "./shared.js";
 
 /** Sets agents.defaults.model.primary and repairs provider runtime plugin installs when needed. */
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
-  const { updated, warning } = await updateDefaultModelPrimaryConfig({ modelRaw, field: "model" });
-  if (warning) {
-    runtime.error?.(warning);
+  const { updated, warning: catalogWarning } = await updateDefaultModelPrimaryConfig({
+    modelRaw,
+    field: "model",
+  });
+  if (catalogWarning) {
+    runtime.error?.(catalogWarning);
   }
   const selectedModel = resolveAgentModelPrimaryValue(updated.agents?.defaults?.model) ?? modelRaw;
   const repaired = await repairCodexRuntimePluginInstallForModelSelection({

--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -4,18 +4,14 @@ import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runtime-plugin-install.js";
 import { repairCopilotRuntimePluginInstallForModelSelection } from "../copilot-runtime-plugin-install.js";
-import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
+import { updateDefaultModelPrimaryConfig } from "./shared.js";
 
 /** Sets agents.defaults.model.primary and repairs provider runtime plugin installs when needed. */
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
-  const updated = await updateConfig((cfg, context) => {
-    return applyDefaultModelPrimaryUpdate({
-      cfg,
-      resolveCfg: context.runtimeConfig,
-      modelRaw,
-      field: "model",
-    });
-  });
+  const { updated, warning } = await updateDefaultModelPrimaryConfig({ modelRaw, field: "model" });
+  if (warning) {
+    runtime.error?.(warning);
+  }
   const selectedModel = resolveAgentModelPrimaryValue(updated.agents?.defaults?.model) ?? modelRaw;
   const repaired = await repairCodexRuntimePluginInstallForModelSelection({
     cfg: updated,

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -18,6 +18,7 @@ import { normalizeAgentModelRefForConfig, toAgentModelListLike } from "../../con
 import type { AgentModelEntryConfig } from "../../config/types.agent-defaults.js";
 import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { inspectModelReference } from "./model-reference-validation.js";
 import { canonicalizeModelCatalogProviderRef } from "./provider-aliases.js";
 
 export { formatTokenK } from "./list.format.js";
@@ -236,21 +237,9 @@ export function applyDefaultModelPrimaryUpdate(params: {
   resolveCfg?: OpenClawConfig;
   modelRaw: string;
   field: "model" | "imageModel";
+  resolvedTarget?: { provider: string; model: string };
 }): OpenClawConfig {
-  const resolved =
-    params.resolveCfg && params.resolveCfg !== params.cfg
-      ? (resolveAuthoredModelAliasTarget({
-          raw: params.modelRaw,
-          cfg: params.cfg,
-        }) ??
-        resolveModelTarget({
-          raw: params.modelRaw,
-          cfg: params.resolveCfg,
-        }))
-      : resolveModelTarget({
-          raw: params.modelRaw,
-          cfg: params.cfg,
-        });
+  const resolved = params.resolvedTarget ?? resolveDefaultModelPrimaryTarget(params);
   const nextModels = {
     ...params.cfg.agents?.defaults?.models,
   } as Record<string, AgentModelEntryConfig>;
@@ -272,6 +261,49 @@ export function applyDefaultModelPrimaryUpdate(params: {
       },
     },
   };
+}
+
+function resolveDefaultModelPrimaryTarget(params: {
+  cfg: OpenClawConfig;
+  resolveCfg?: OpenClawConfig;
+  modelRaw: string;
+}): { provider: string; model: string } {
+  return params.resolveCfg && params.resolveCfg !== params.cfg
+    ? (resolveAuthoredModelAliasTarget({ raw: params.modelRaw, cfg: params.cfg }) ??
+        resolveModelTarget({ raw: params.modelRaw, cfg: params.resolveCfg }))
+    : resolveModelTarget({ raw: params.modelRaw, cfg: params.cfg });
+}
+
+/** Validates and persists one default text/image model selection. */
+export async function updateDefaultModelPrimaryConfig(params: {
+  modelRaw: string;
+  field: "model" | "imageModel";
+}): Promise<{ updated: OpenClawConfig; warning?: string }> {
+  let warning: string | undefined;
+  const updated = await updateConfig((cfg, context) => {
+    const resolvedTarget = resolveDefaultModelPrimaryTarget({
+      cfg,
+      resolveCfg: context.runtimeConfig,
+      modelRaw: params.modelRaw,
+    });
+    const inspection = inspectModelReference({ cfg: context.runtimeConfig, ref: resolvedTarget });
+    if (inspection.status === "unknown-provider") {
+      throw new Error(
+        `Unknown model provider "${inspection.provider}". Install a plugin that declares it or configure it under models.providers before selecting "${inspection.ref}". Config was not changed.`,
+      );
+    }
+    if (inspection.status === "unknown-model") {
+      warning = `Warning: Model "${inspection.ref}" is not in the local model catalog for provider "${inspection.provider}". The provider is installed or configured, so the selection was saved; verify the model ID if it is not a newly released or self-hosted model.`;
+    }
+    return applyDefaultModelPrimaryUpdate({
+      cfg,
+      resolveCfg: context.runtimeConfig,
+      modelRaw: params.modelRaw,
+      field: params.field,
+      resolvedTarget,
+    });
+  });
+  return { updated, ...(warning ? { warning } : {}) };
 }
 
 export { modelKey };

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -983,4 +983,34 @@ describe("CORE_HEALTH_CHECKS", () => {
       }),
     );
   });
+
+  it("distinguishes unknown model providers from unconfirmed models", async () => {
+    const check = getCheck(createCoreHealthChecks(), "core/doctor/model-references");
+
+    await expect(
+      check.detect({
+        mode: "doctor",
+        runtime,
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "openai/not-in-the-local-catalog" },
+              imageModel: { primary: "no-such-provider/no-such-model" },
+            },
+          },
+        },
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "info",
+          target: "openai/not-in-the-local-catalog",
+        }),
+        expect.objectContaining({
+          severity: "warning",
+          target: "no-such-provider/no-such-model",
+        }),
+      ]),
+    );
+  });
 });

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -662,6 +662,54 @@ function createProviderCatalogProjectionCheck(deps: CoreHealthCheckDeps): Health
   };
 }
 
+function createModelReferenceCheck(): HealthCheck {
+  return {
+    id: "core/doctor/model-references",
+    kind: "core",
+    description: "Configured model references have installed or configured provider owners.",
+    source: "doctor",
+    async detect(ctx) {
+      const { inspectConfiguredModelReferences } =
+        await import("../commands/models/model-reference-validation.js");
+      return inspectConfiguredModelReferences({
+        cfg: ctx.cfg,
+        env: ctx.env,
+        workspaceDir: ctx.cwd,
+      }).flatMap((inspection): HealthFinding[] => {
+        if (inspection.status === "unknown-provider") {
+          return [
+            {
+              checkId: "core/doctor/model-references",
+              severity: "warning",
+              source: "doctor",
+              target: inspection.ref,
+              message: `Configured model "${inspection.ref}" uses unknown provider "${inspection.provider}". No installed plugin manifest or models.providers entry declares it.`,
+              requirement: "an installed plugin manifest or models.providers configuration",
+              fixHint:
+                "Install a plugin that declares this provider, configure it under models.providers, or remove the model reference.",
+            },
+          ];
+        }
+        if (inspection.status === "unknown-model" && inspection.active) {
+          return [
+            {
+              checkId: "core/doctor/model-references",
+              severity: "info",
+              source: "doctor",
+              target: inspection.ref,
+              message: `Configured model "${inspection.ref}" uses a known provider but is not in the local model catalog. It may be newly released or self-hosted.`,
+              requirement: "a provider-supported model id",
+              fixHint:
+                "Verify the model id with the provider, or rerun with --severity-min info after refreshing the local catalog.",
+            },
+          ];
+        }
+        return [];
+      });
+    },
+  };
+}
+
 function normalizeDoctorNoteLine(line: string): string {
   return line.replace(/^- /, "").trim();
 }
@@ -1343,6 +1391,7 @@ function createConvertedWorkflowChecks(
     openAIOAuthTlsCheck,
     hooksModelCheck,
     bootstrapSizeCheck,
+    createModelReferenceCheck(),
     createProviderCatalogProjectionCheck(deps),
     {
       id: "core/doctor/local-audio-acceleration",

--- a/src/flows/doctor-health-contributions-final.ts
+++ b/src/flows/doctor-health-contributions-final.ts
@@ -184,6 +184,12 @@ export function resolveFinalDoctorHealthContributions(params: {
       run: runHooksModelHealth,
     }),
     createDoctorHealthContribution({
+      id: "doctor:model-references",
+      label: "Model references",
+      healthCheckIds: ["core/doctor/model-references"],
+      run: (ctx) => runCoreHealthFindingNote(ctx, "core/doctor/model-references"),
+    }),
+    createDoctorHealthContribution({
       id: "doctor:provider-catalog-projection",
       label: "Provider catalog projection",
       healthCheckIds: ["core/doctor/provider-catalog-projection"],


### PR DESCRIPTION
## What Problem This Solves

`openclaw models set` accepted a provider that does not exist, reported success, and every downstream surface stayed silent:

```
$ openclaw models set no-such-provider/no-such-model
Updated config: /tmp/ocp/openclaw.json
  Backup: /tmp/ocp/openclaw.json.bak
Default model: no-such-provider/no-such-model      # exit 0
```

| surface | result |
| --- | --- |
| `openclaw config validate` | `Config valid` (exit 0) |
| `openclaw doctor --json` | findings returned, none about the model |
| `openclaw models status` | prints it as `Default`, no warning |
| `openclaw gateway run` | logs `agent model: no-such-provider/no-such-model`, reaches `ready` |

The first signal was a failed agent turn, arbitrarily far from the typo. `models set-image` behaved the same way, and bare names were silently prefixed (`totally-bogus-model-xyz` → `openai/totally-bogus-model-xyz`).

What makes this a defect rather than a design choice is that the generic path already rejects the same input:

```
$ openclaw config set agents.defaults.model.primary garbage-not-a-ref
Cannot set model reference "garbage-not-a-ref" at agents.defaults.model.primary:
  Unknown model: openai/garbage-not-a-ref. Run openclaw models list to list available models.   # exit 1
```

Two commands wrote the same config key and disagreed. `models set` validated only the `provider/model` *shape*; nothing checked that the provider existed.

## Why This Change Was Made

Rejecting every ref missing from the local catalog would be wrong — new models ship constantly, catalogs go stale, and self-hosted models are legitimate. So the repair follows the distinction that actually holds:

- **Unknown provider** — providers are a closed, enumerable set, so the ref can never work. Hard error, **config is not modified**, message names the remediation (install a plugin that declares it, or configure it under `models.providers`).
- **Unknown model under a known provider** — the catalog may simply be behind. Saved, with a warning explaining why it was allowed.

The known-provider set is derived from the manifest registry — plugin-declared providers, model-catalog providers, CLI backends, plus anything configured under `models.providers` — so no provider name is hardcoded in core and a plugin-contributed provider is recognized automatically.

Configs already containing an unusable ref are not hard-blocked at startup; a doctor check reports them instead, which is the surface operators already run when something is wrong.

## User Impact

A mistyped provider now fails at the moment it is typed, with config untouched, instead of surfacing as a failed turn later. A newly released or self-hosted model under a real provider still works and warns rather than blocking. Existing configs keep loading; doctor surfaces the ones that cannot work.

## Evidence

- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.test.ts` — 24 pass.
- `src/commands/models.set.e2e.test.ts` extended for the new behavior; it is an e2e suite requiring a built dist, so it is proven in CI on this PR.
- Measured on the built CLI across a good ref, an unknown model under a known provider, and an unknown provider, through both `models set` and `config set`, confirming the two paths now agree.
