### PR TITLE
fix(ui): restore oxfmt formatting in the task-suggestion cards

### DIFF
--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -47,9 +47,10 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       return;
     }
     const offset = direction === "next" ? 1 : -1;
-    const next = this.taskSuggestions[
-      (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
-    ];
+    const next =
+      this.taskSuggestions[
+        (current + offset + this.taskSuggestions.length) % this.taskSuggestions.length
+      ];
     if (!next) {
       return;
     }

--- a/ui/src/pages/chat/components/chat-task-suggestions.ts
+++ b/ui/src/pages/chat/components/chat-task-suggestions.ts
@@ -94,10 +94,7 @@ function renderChatTaskSuggestions(props: {
     ? props.activeId
     : props.suggestions[0]?.id;
   return html`
-    <div
-      class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}"
-      aria-live="polite"
-    >
+    <div class="task-suggestions ${multiple ? "task-suggestions--stack" : ""}" aria-live="polite">
       ${props.suggestions.map((suggestion, index) => {
         const busy = props.busyIds.has(suggestion.id);
         const title = sanitizeTaskSuggestionText(suggestion.title);
@@ -191,7 +188,8 @@ function renderChatTaskSuggestions(props: {
                         requestAnimationFrame(() => updateTaskSuggestionPathFade(element));
                       }
                     })}
-                    @scroll=${(event: Event) => updateTaskSuggestionPathFade(event.currentTarget as Element)}
+                    @scroll=${(event: Event) =>
+                      updateTaskSuggestionPathFade(event.currentTarget as Element)}
                     >${cwd}</code
                   >
                   <pre>${prompt}</pre>


### PR DESCRIPTION
## What Problem This Solves

`oxfmt --check` currently fails on `main`, which takes `check-lint` and `check-lint-core-5` red on every open PR.

On main tip `72243fbef08`:

```
$ ./node_modules/.bin/oxfmt --check
ui/src/pages/chat/chat-pane-task-suggestions.ts (0ms)
ui/src/pages/chat/components/chat-task-suggestions.ts (17ms)

Format issues found in above 2 files. Run without `--check` to fix.
Finished in 10310ms on 29177 files using 10 threads.
```

Those two files are the only unformatted files in the repository, so this is the whole failure.

It is easy to misread the red mark, which is why I want to be specific about where it lands. The `check-lint` job runs the oxlint shards first and they all pass:

```
[oxlint] shard concurrency 2 (cpus=8, memGB=31)
[oxlint:scripts] finished
[oxlint:extensions] finished
$ oxfmt --check
...
Format issues found in above 2 files.
[ELIFECYCLE] Command failed with exit code 1.
```

So there are no rule violations. The job dies on the formatting step that runs after them.

The drift came in with #125231 (`47399310a08`, "improve(ui): redesign suggested task cards"), which is the same commit where `check-lint` first goes red in the recent main history. Checking main's completed check runs, `check-lint` and `check-lint-core-5` have failed on `47399310a08`, `44b41d5686d`, `a928da457f8`, `aa8be5acf90` and the current tip `72243fbef08`.

## Why This Change Was Made

Running the formatter over the two files is the smallest correct fix, and red `main` should not sit. There is nothing to decide here: the formatter output is canonical and this just records it.

I did not touch anything else. In particular I did not reformat neighbouring files, and I did not add a lint suppression or adjust the formatter configuration to make the check pass.

## User Impact

None at runtime. This is formatting only, with no behavior change. The effect is on contributors: `check-lint` and `check-lint-core-5` go green again, so PRs stop carrying a red mark they did not cause.

## Evidence

The whole diff is formatter output, three hunks:

- a wrapped `const next = this.taskSuggestions[...]` index expression
- a `<div class="task-suggestions ...">` attribute list collapsed back onto one line
- a `@scroll=${...}` arrow body wrapped

Net `-1` line, and no tokens changed.

```
./node_modules/.bin/oxfmt --check                    All matched files use the correct format.
                                                     (29177 files, repo-wide)
node scripts/run-oxlint.mjs <both files>              clean
node scripts/run-vitest.mjs ui/src/pages/chat         138 files, 2931 passed | 11 skipped
```

The chat suite includes `chat-pane-task-suggestions.test.ts` and `chat-task-suggestions.test.ts`, the tests owning both touched files.

No test is added. A formatting-only change is covered by `oxfmt --check` itself, which is the gate that caught it, and a test asserting on source text would be the wrong tool.

AI-assisted: yes, with the failing CI log read directly and every command above run by me.
