### PR TITLE
fix: clean up orphaned media attachments

### DIFF
--- a/src/gateway/agent-turn/agent-content-phase.ts
+++ b/src/gateway/agent-turn/agent-content-phase.ts
@@ -93,8 +93,31 @@ export async function prepareAgentContentPhase(params: {
   let imageOrder: PromptImageOrderEntry[] = [];
   let media: MediaFact[] = [];
   let offloadedRefs: OffloadedRef[] = [];
+  let supportsInlineImages: boolean | undefined;
   let agentId = params.agentId;
   let requestedSessionKey = params.requestedSessionKey;
+
+  const isKnownGatewayChannel = (value: string): boolean =>
+    isGatewayMessageChannel(value) || isInternalNonDeliveryChannel(value);
+  const channelHints = normalizeStringEntries(
+    [params.request.channel, params.request.replyChannel].filter(
+      (value): value is string => typeof value === "string",
+    ),
+  );
+  for (const rawChannel of channelHints) {
+    const normalized = normalizeMessageChannel(rawChannel);
+    if (normalized && normalized !== "last" && !isKnownGatewayChannel(normalized)) {
+      params.respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid agent params: unknown channel: ${normalized}`,
+        ),
+      );
+      return undefined;
+    }
+  }
 
   if (params.normalizedAttachments.length > 0) {
     let baseProvider: string | undefined;
@@ -117,7 +140,7 @@ export async function prepareAgentContentPhase(params: {
       params.request.acpTurnSource === "manual_spawn" &&
       isAcpSessionKey(params.requestedSessionKeyRaw) &&
       requestedAcpMeta != null;
-    const supportsInlineImages = isConfirmedAcpSession
+    supportsInlineImages = isConfirmedAcpSession
       ? true
       : await resolveGatewayModelSupportsImages({
           loadGatewayModelCatalog: params.context.loadGatewayModelCatalog,
@@ -126,52 +149,6 @@ export async function prepareAgentContentPhase(params: {
           provider: params.providerOverride || baseProvider,
           model: params.modelOverride || baseModel,
         });
-    try {
-      const parsed = await parseMessageWithAttachments(message, params.normalizedAttachments, {
-        maxBytes: resolveChatAttachmentMaxBytes(params.cfg),
-        log: params.context.logGateway,
-        supportsInlineImages,
-        acceptNonImage: false,
-      });
-      message = parsed.message.trim();
-      images = parsed.images;
-      imageOrder = parsed.imageOrder;
-      media = parsed.media;
-      offloadedRefs = parsed.offloadedRefs;
-    } catch (err) {
-      logAttachmentFailure(params.context.logGateway, "agent attachment parse failed", err);
-      params.respond(
-        false,
-        undefined,
-        errorShape(
-          err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-          String(err),
-        ),
-      );
-      return undefined;
-    }
-  }
-
-  const isKnownGatewayChannel = (value: string): boolean =>
-    isGatewayMessageChannel(value) || isInternalNonDeliveryChannel(value);
-  const channelHints = normalizeStringEntries(
-    [params.request.channel, params.request.replyChannel].filter(
-      (value): value is string => typeof value === "string",
-    ),
-  );
-  for (const rawChannel of channelHints) {
-    const normalized = normalizeMessageChannel(rawChannel);
-    if (normalized && normalized !== "last" && !isKnownGatewayChannel(normalized)) {
-      params.respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid agent params: unknown channel: ${normalized}`,
-        ),
-      );
-      return undefined;
-    }
   }
 
   const voiceWakeTrigger = normalizeOptionalString(params.request.voiceWakeTrigger) ?? "";
@@ -237,6 +214,33 @@ export async function prepareAgentContentPhase(params: {
       }
     } catch (err) {
       params.context.logGateway.warn(`voicewake routing load failed: ${formatForLog(err)}`);
+    }
+  }
+
+  if (params.normalizedAttachments.length > 0) {
+    try {
+      const parsed = await parseMessageWithAttachments(message, params.normalizedAttachments, {
+        maxBytes: resolveChatAttachmentMaxBytes(params.cfg),
+        log: params.context.logGateway,
+        supportsInlineImages,
+        acceptNonImage: false,
+      });
+      message = parsed.message.trim();
+      images = parsed.images;
+      imageOrder = parsed.imageOrder;
+      media = parsed.media;
+      offloadedRefs = parsed.offloadedRefs;
+    } catch (err) {
+      logAttachmentFailure(params.context.logGateway, "agent attachment parse failed", err);
+      params.respond(
+        false,
+        undefined,
+        errorShape(
+          err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+          String(err),
+        ),
+      );
+      return undefined;
     }
   }
 

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -111,6 +111,7 @@ export async function prepareAgentRunDispatch(params: {
   effectiveTranscriptInputText: string;
   images: ChatImageContent[];
   offloadedRefs: OffloadedRef[];
+  onUserTurnMediaPersisted: () => void;
   requestedPromptPersistenceSuppression: boolean;
   runId: string;
   agentDedupeKeys: readonly string[];
@@ -477,6 +478,11 @@ export async function prepareAgentRunDispatch(params: {
       client: params.client,
       context: params.context,
     });
+    if (userTurn.recorder) {
+      // The recorder already persisted the media references, so later admission
+      // rejection must preserve the files now owned by durable history.
+      params.onUserTurnMediaPersisted();
+    }
   } catch (err) {
     activeRunAbort.cleanup({ force: true });
     activeGatewayWorkAdmission.release();

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -9,6 +9,7 @@ import { mergeSessionEntry, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
+import { discardPreparedInboundMedia, type OffloadedRef } from "../chat-attachments.js";
 import { errorShapeFromError } from "../error-shape.js";
 import { createCronContinuationController } from "../server-methods/agent-cron-continuation.js";
 import { runAgentResetPhase } from "../server-methods/agent-reset-phase.js";
@@ -181,6 +182,7 @@ export function createAgentTurnService({
     let agentId = routing.agentId;
     let requestedSessionKey = routing.requestedSessionKey;
     let gatewayAdmissionTransferred = false;
+    let preparedOffloadedRefs: OffloadedRef[] = [];
     let mainRestartRecoveryOwnerLease: MainSessionRecoveryOwnerLease | undefined;
     let releaseGatewayAdmission = () => {};
     const cronContinuation = createCronContinuationController({
@@ -212,6 +214,7 @@ export function createAgentTurnService({
       if (!content) {
         return;
       }
+      preparedOffloadedRefs = content.offloadedRefs;
       agentId = content.agentId;
       requestedSessionKey = content.requestedSessionKey;
       // Participation is authorized below against the canonical session the run
@@ -536,6 +539,9 @@ export function createAgentTurnService({
         effectiveTranscriptInputText,
         images,
         offloadedRefs,
+        onUserTurnMediaPersisted: () => {
+          preparedOffloadedRefs = [];
+        },
         requestedPromptPersistenceSuppression,
         runId,
         agentDedupeKeys,
@@ -557,6 +563,9 @@ export function createAgentTurnService({
         return;
       }
       resolvedSessionId = admittedSessionId;
+      // Sessionless and persistence-suppressed runs transfer prepared media to
+      // execution only after dispatch is fully admitted.
+      preparedOffloadedRefs = [];
       gatewayAdmissionTransferred = true;
       // This captures ambient root admission synchronously, then settles the final
       // frame on the existing detached chain after the router returns its acceptance.
@@ -622,6 +631,7 @@ export function createAgentTurnService({
           }
         }
       } finally {
+        await discardPreparedInboundMedia(preparedOffloadedRefs);
         clearUnacceptedAgentDedupe();
       }
     }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -48,6 +48,11 @@ export type OffloadedRef = {
   height?: number;
 };
 
+/** Deletes prepared inbound files that never reached a durable owner. */
+export async function discardPreparedInboundMedia(refs: readonly OffloadedRef[]): Promise<void> {
+  await Promise.allSettled(refs.map((ref) => deleteMediaBuffer(ref.id, "inbound")));
+}
+
 type ParsedMessageWithImages = {
   message: string;
   images: ChatImageContent[];

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -12,6 +12,7 @@ import { pendingChatSendDedupeKey } from "./server-shared.js";
 import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
 
 const cleanOldMediaMock = vi.fn(async () => {});
+const pruneOutboundMediaMock = vi.fn(async () => {});
 const prunePlaybackTranscodeCacheMock = vi.fn(async () => {});
 const cleanupManagedOutgoingMediaRecordsMock = vi.fn(async () => ({
   deletedRecordCount: 0,
@@ -48,6 +49,7 @@ vi.mock("../media/store.js", async () => {
   return {
     ...actual,
     cleanOldMedia: cleanOldMediaMock,
+    pruneOutboundMedia: pruneOutboundMediaMock,
     prunePlaybackTranscodeCache: prunePlaybackTranscodeCacheMock,
   };
 });
@@ -171,6 +173,7 @@ describe("startGatewayMaintenanceTimers", () => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
     cleanOldMediaMock.mockReset().mockResolvedValue(undefined);
+    pruneOutboundMediaMock.mockReset().mockResolvedValue(undefined);
     prunePlaybackTranscodeCacheMock.mockReset().mockResolvedValue(undefined);
     pruneExpiredDevicePairSetupCompletionsMock.mockReset().mockResolvedValue(0);
     cleanupManagedOutgoingMediaRecordsMock.mockReset().mockResolvedValue({
@@ -211,10 +214,12 @@ describe("startGatewayMaintenanceTimers", () => {
 
     await vi.advanceTimersByTimeAsync(0);
     expect(prunePlaybackTranscodeCacheMock).toHaveBeenCalledTimes(1);
+    expect(pruneOutboundMediaMock).toHaveBeenCalledTimes(1);
     expect(cleanOldMediaMock).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(60 * 60_000);
     expect(prunePlaybackTranscodeCacheMock).toHaveBeenCalledTimes(2);
+    expect(pruneOutboundMediaMock).toHaveBeenCalledTimes(2);
     expect(cleanOldMediaMock).not.toHaveBeenCalled();
 
     await stopMaintenanceTimers(timers);
@@ -376,6 +381,7 @@ describe("startGatewayMaintenanceTimers", () => {
 
     await vi.advanceTimersByTimeAsync(0);
     expect(prunePlaybackTranscodeCacheMock).toHaveBeenCalledTimes(1);
+    expect(pruneOutboundMediaMock).not.toHaveBeenCalled();
     expect(cleanOldMediaMock).toHaveBeenCalledWith(MEDIA_CLEANUP_TTL_MS, {
       recursive: true,
       pruneEmptyDirs: true,
@@ -386,6 +392,7 @@ describe("startGatewayMaintenanceTimers", () => {
     });
     await vi.advanceTimersByTimeAsync(60 * 60_000);
     expect(prunePlaybackTranscodeCacheMock).toHaveBeenCalledTimes(2);
+    expect(pruneOutboundMediaMock).not.toHaveBeenCalled();
     expect(cleanOldMediaMock).toHaveBeenCalledTimes(2);
     expect(cleanOldMediaMock).toHaveBeenLastCalledWith(MEDIA_CLEANUP_TTL_MS, {
       recursive: true,
@@ -556,6 +563,37 @@ describe("startGatewayMaintenanceTimers", () => {
 
     resolveCleanup();
     await vi.advanceTimersByTimeAsync(0);
+    await stopMaintenanceTimers(timers);
+  });
+
+  it("does not overlap default outbound cleanup and drains it on shutdown", async () => {
+    vi.useFakeTimers();
+    let resolveCleanup = () => {};
+    pruneOutboundMediaMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const timers = startGatewayMaintenanceTimers(createMaintenanceTimerDeps());
+    timers.startMediaCleanup();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(pruneOutboundMediaMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(pruneOutboundMediaMock).toHaveBeenCalledTimes(1);
+
+    let stopped = false;
+    const stopping = timers.stopMediaCleanup().then(() => {
+      stopped = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(stopped).toBe(false);
+    resolveCleanup();
+    await stopping;
+    expect(stopped).toBe(true);
+
     await stopMaintenanceTimers(timers);
   });
 

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -14,7 +14,7 @@ import { pruneExpiredDeliveryQueueTombstones } from "../infra/delivery-queue-sql
 import { pruneExpiredDevicePairSetupCompletions } from "../infra/device-bootstrap.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { pruneOrphanedDeliveryQueueMedia } from "../infra/outbound/delivery-queue-media-spool.js";
-import { cleanOldMedia, prunePlaybackTranscodeCache } from "../media/store.js";
+import { cleanOldMedia, pruneOutboundMedia, prunePlaybackTranscodeCache } from "../media/store.js";
 import { isGatewayWorkAdmissionClosed } from "../process/gateway-work-admission.js";
 import { createLazyPromiseLoader } from "../shared/lazy-promise.js";
 import {
@@ -427,15 +427,16 @@ export function startGatewayMaintenanceTimers(params: {
   });
 
   let mediaCleanupInFlight: Promise<void> | null = null;
-  const runConfiguredMediaCleanup = () => {
+  const runMediaCleanup = () => {
     const ttlMs = params.mediaCleanupTtlMs;
-    if (typeof ttlMs !== "number" || mediaCleanupInFlight) {
+    if (mediaCleanupInFlight) {
       return mediaCleanupInFlight;
     }
-    mediaCleanupInFlight = cleanOldMedia(ttlMs, {
-      recursive: true,
-      pruneEmptyDirs: true,
-    })
+    const cleanup =
+      typeof ttlMs === "number"
+        ? cleanOldMedia(ttlMs, { recursive: true, pruneEmptyDirs: true })
+        : pruneOutboundMedia();
+    mediaCleanupInFlight = cleanup
       .catch((err: unknown) => {
         params.logHealth.error(`media cleanup failed: ${formatError(err)}`);
       })
@@ -451,11 +452,11 @@ export function startGatewayMaintenanceTimers(params: {
     if (mediaCleanupStopped) {
       return;
     }
-    // Playback and managed outgoing have fixed owner lifecycles and must not
-    // depend on the optional attachment-retention sweep being configured or healthy.
+    // Playback and managed outgoing have independent owner lifecycles and must
+    // not depend on the selected general-or-outbound media sweep being healthy.
     void playbackTranscodeCacheCleanupLoader.load();
     void managedOutgoingCleanupLoader.load();
-    void runConfiguredMediaCleanup();
+    void runMediaCleanup();
   };
   let mediaCleanupStartPromise: Promise<void> | undefined;
   const startMediaCleanup = () => {

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -13,15 +13,13 @@ import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gatewa
 import { isOperatorUiClient } from "../../utils/message-channel.js";
 import { setGatewayDedupeEntry } from "../agent-turn/agent-job.js";
 import { updateChatRunProvider } from "../chat-abort.js";
+import { discardPreparedInboundMedia } from "../chat-attachments.js";
 import { chatRunBelongsToSelectedAgent } from "../chat-run-owner.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import type { AdmittedChatSend } from "./chat-send-admission.js";
-import {
-  discardPreparedChatSendAttachments,
-  type prepareChatSendAttachments,
-} from "./chat-send-attachments.js";
+import type { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
   resolveWebchatPromptCacheKey,
   scheduleChatDashboardSessionTitle,
@@ -517,7 +515,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
         // markers — so the prepared inbound media stays unreferenced forever
         // (sweep is off by default). Same custody rule as the pre-ACK owner
         // in chat-send-admission.ts: unreferenced staged media is discarded.
-        void discardPreparedChatSendAttachments(attachments.offloadedRefs);
+        void discardPreparedInboundMedia(attachments.offloadedRefs);
       }
     });
   // Title work starts at turn admission, concurrently with the launched run. It must never run

--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -13,9 +13,10 @@ import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { parseInboundMediaUri } from "../../media/media-reference.js";
-import { deleteMediaBuffer, MEDIA_MAX_BYTES } from "../../media/store.js";
+import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import {
+  discardPreparedInboundMedia,
   MediaOffloadError,
   type OffloadedRef,
   logAttachmentFailure,
@@ -59,13 +60,6 @@ function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolea
   // Oversized managed PDFs remain host-readable. A sandbox copy only hits the
   // 5 MB staging cap without making the attachment more available.
   return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
-}
-
-// Prepared inbound media has no transcript reference until the user turn
-// persists; abort/routing exits before that point must delete it here or the
-// files are orphaned forever (the inbound sweep is off unless attachments.ttlHours is set).
-export async function discardPreparedChatSendAttachments(refs: OffloadedRef[]): Promise<void> {
-  await Promise.allSettled(refs.map((ref) => deleteMediaBuffer(ref.id, "inbound")));
 }
 
 // Stage media before ACK so permanent client errors stay 4xx and retryable
@@ -173,9 +167,7 @@ async function prestageMediaPathOffloads(params: {
       workspaceDir: sandbox.workspaceDir,
     };
   } catch (err) {
-    await Promise.allSettled(
-      params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),
-    );
+    await discardPreparedInboundMedia(params.offloadedRefs);
     if (err instanceof MediaOffloadError || err instanceof UnsupportedAttachmentError) {
       throw err;
     }

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -3,13 +3,11 @@ import { performance } from "node:perf_hooks";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { emitDiagnosticsTimelineEvent } from "../../infra/diagnostics-timeline.js";
+import { discardPreparedInboundMedia } from "../chat-attachments.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
 import { startChatDispatch } from "./chat-send-agent-dispatch.js";
-import {
-  discardPreparedChatSendAttachments,
-  prepareChatSendAttachments,
-} from "./chat-send-attachments.js";
+import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import { handleChatSendSetupError } from "./chat-send-dispatch-errors.js";
 import type { ChatSendExternalAuthorityAdmission } from "./chat-send-external-authority-contract.js";
 import {
@@ -81,7 +79,7 @@ async function handleChatSendWithOptions(
   let preparedMediaRecorder: { hasPersisted: () => boolean } | undefined;
   admitted.value.setDiscardAbandonedPreparedMedia(() => {
     if (!preparedMediaRecorder?.hasPersisted()) {
-      void discardPreparedChatSendAttachments(preparedAttachments.value.offloadedRefs);
+      void discardPreparedInboundMedia(preparedAttachments.value.offloadedRefs);
     }
   });
   if (activeRunAbort.controller.signal.aborted) {

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -1,6 +1,8 @@
 /**
  * Gateway server-agent integration tests for agent startup and session dispatch.
  */
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   getAdmittedRunDelegatedAuthority,
@@ -14,6 +16,7 @@ import {
   type AgentRunDelegatedAuthority,
   validateAgentRunDelegatedAuthority,
 } from "../infra/agent-run-registry.js";
+import { getMediaDir } from "../media/store.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -158,6 +161,18 @@ const offloadedImageAttachment = () => ({
     "base64",
   ),
 });
+
+async function listInboundMedia(): Promise<Set<string>> {
+  const entries = await fs.readdir(path.join(getMediaDir(), "inbound")).catch(() => []);
+  return new Set(entries);
+}
+
+async function expectNoNewInboundMedia(before: Set<string>): Promise<void> {
+  await vi.waitFor(async () => {
+    const after = await listInboundMedia();
+    expect([...after].filter((entry) => !before.has(entry))).toEqual([]);
+  });
+}
 
 async function runAgentImageRequest(params: {
   idempotencyKey: string;
@@ -588,13 +603,16 @@ describe("gateway server agent", () => {
   );
 
   test("agent rejects unknown reply channel", async () => {
+    const inboundBefore = await listInboundMedia();
     const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       replyChannel: "unknown-channel",
+      attachments: [offloadedImageAttachment()],
       idempotencyKey: "idem-agent-reply-unknown",
     });
     expect(res.ok).toBe(false);
     expect(res.error?.message).toContain("unknown channel");
+    await expectNoNewInboundMedia(inboundBefore);
 
     const spy = vi.mocked(agentCommandMock);
     expect(spy).not.toHaveBeenCalled();
@@ -741,6 +759,9 @@ describe("gateway server agent", () => {
     expect(media?.[0]?.path).toMatch(/\/media\/inbound\//);
     expect(media?.[0]?.url).toMatch(/^media:\/\/inbound\//);
     expect(call.message).toBe(`what is in the image?\n[media attached: ${media?.[0]?.url}]`);
+    await expect(fs.stat(media?.[0]?.path ?? "")).resolves.toMatchObject({
+      isFile: expect.any(Function),
+    });
   });
 
   test("agent validates first image attachment against per-agent model for fresh sessions", async () => {
@@ -768,6 +789,8 @@ describe("gateway server agent", () => {
   test("agent errors when delivery requested and no last channel exists", async () => {
     testState.allowFrom = ["+1555"];
     try {
+      testState.agentConfig = { model: { primary: "ollama-cloud/gemma4:31b" } };
+      await setGatewayModelCatalogForTest([VISION_AGENT_MODEL]);
       await setTestSessionStore({
         entries: {
           main: {
@@ -776,11 +799,13 @@ describe("gateway server agent", () => {
           },
         },
       });
+      const inboundBefore = await listInboundMedia();
       const res = await rpcReq(gatewaySuite.ws, "agent", {
         message: "hi",
         sessionKey: "main",
         deliver: true,
         bestEffortDeliver: false,
+        attachments: [offloadedImageAttachment()],
         idempotencyKey: "idem-agent-missing-provider",
       });
       expect(res.ok).toBe(false);
@@ -788,6 +813,7 @@ describe("gateway server agent", () => {
       expect(res.error?.message).toContain("Channel is required");
       expect(res.error?.message).not.toMatch(/^Error:/u);
       expect(vi.mocked(agentCommandMock)).not.toHaveBeenCalled();
+      await expectNoNewInboundMedia(inboundBefore);
     } finally {
       testState.allowFrom = undefined;
     }

--- a/src/media/store.cleanup.test.ts
+++ b/src/media/store.cleanup.test.ts
@@ -1,4 +1,5 @@
-// cleanOldMedia must stay out of the SQLite-managed outgoing tree.
+// Media cleanup must respect ownership boundaries between transient staging,
+// replayable inbound media, playback cache, and SQLite-managed outgoing media.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -8,8 +9,14 @@ import {
   MANAGED_OUTGOING_ORIGINALS_SUBDIR,
   readManagedImageRecord,
 } from "../gateway/managed-image-record-store.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { markTrustedGeneratedHtmlPath } from "./web-media.js";
 
 describe("cleanOldMedia managed-subtree retention", () => {
   let store: typeof import("./store.js");
@@ -91,5 +98,61 @@ describe("cleanOldMedia managed-subtree retention", () => {
 
     expect(cleanup.deletedFileCount).toBe(0);
     await expect(fs.stat(legacyOrphanPath)).resolves.toMatchObject({ size: 15 });
+  });
+
+  it("retires only stale outbound staging and its trusted HTML provenance", async () => {
+    const staleInbound = await store.saveMediaBuffer(Buffer.from("inbound"), "image/png");
+    const staleOutbound = await store.saveMediaBuffer(
+      Buffer.from("<!doctype html><h1>stale</h1>"),
+      "text/html",
+      "outbound",
+      undefined,
+      "stale.html",
+    );
+    const freshOutbound = await store.saveMediaBuffer(
+      Buffer.from("fresh outbound"),
+      "text/plain",
+      "outbound",
+    );
+    const stalePlayback = await store.saveMediaBuffer(
+      Buffer.from("playback"),
+      "audio/mpeg",
+      store.PLAYBACK_TRANSCODE_SUBDIR,
+    );
+    const staleManagedOutgoing = await store.saveMediaBuffer(
+      Buffer.from("managed outgoing"),
+      "image/png",
+      MANAGED_OUTGOING_ORIGINALS_SUBDIR,
+    );
+    await markTrustedGeneratedHtmlPath(
+      staleOutbound.path,
+      Buffer.from("<!doctype html><h1>stale</h1>"),
+    );
+    const stale = Date.now() - 25 * 60 * 60_000;
+    await Promise.all(
+      [staleInbound.path, staleOutbound.path, stalePlayback.path, staleManagedOutgoing.path].map(
+        (filePath) => fs.utimes(filePath, stale / 1000, stale / 1000),
+      ),
+    );
+
+    await store.pruneOutboundMedia();
+
+    await expect(fs.stat(staleOutbound.path)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(staleInbound.path)).resolves.toMatchObject({ size: staleInbound.size });
+    await expect(fs.stat(freshOutbound.path)).resolves.toMatchObject({ size: freshOutbound.size });
+    await expect(fs.stat(stalePlayback.path)).resolves.toMatchObject({ size: stalePlayback.size });
+    await expect(fs.stat(staleManagedOutgoing.path)).resolves.toMatchObject({
+      size: staleManagedOutgoing.size,
+    });
+
+    const { db } = openOpenClawStateDatabase();
+    const marker = executeSqliteQueryTakeFirstSync(
+      db,
+      getNodeSqliteKysely<Pick<OpenClawStateKyselyDatabase, "outbound_media_provenance">>(db)
+        .selectFrom("outbound_media_provenance")
+        .select("realpath")
+        .where("realpath", "=", staleOutbound.path),
+    );
+    expect(marker).toBeUndefined();
   });
 });

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -36,6 +36,10 @@ export const PLAYBACK_TRANSCODE_SUBDIR = "playback-transcode";
 // records/*.json files are the pre-SQLite migration barrier. An mtime-only
 // sweep would delete both out from under that reaper.
 const MANAGED_OUTGOING_SUBDIR = "outgoing";
+const OUTBOUND_STAGING_SUBDIR = "outbound";
+// Match delivery-queue orphan grace: staged files get a full day to reach
+// every direct, streamed, fan-out, or queue-owned delivery path.
+const OUTBOUND_STAGING_TTL_MS = 24 * 60 * 60_000;
 /** Fixed disk budget for cached playback renditions; oldest outputs are evicted first. */
 const PLAYBACK_TRANSCODE_MAX_CACHE_BYTES = 512 * 1024 * 1024;
 /** Playback renditions outlive transient media but are still retired after one week. */
@@ -316,6 +320,18 @@ export async function prunePlaybackTranscodeCache(): Promise<void> {
     });
     await prunePlaybackTranscodeCacheToSize();
   });
+}
+
+/** Prunes stale delivery staging without touching inbound replay or SQLite-owned outgoing media. */
+export async function pruneOutboundMedia(): Promise<void> {
+  const outboundDir = resolveMediaScopedDir(OUTBOUND_STAGING_SUBDIR, "pruneOutboundMedia");
+  await openMediaStore(MAX_BYTES, outboundDir).pruneExpired({
+    ttlMs: OUTBOUND_STAGING_TTL_MS,
+    recursive: true,
+    pruneEmptyDirs: true,
+  });
+  const { pruneStaleTrustedGeneratedHtmlMarkers } = await import("./web-media.js");
+  await pruneStaleTrustedGeneratedHtmlMarkers();
 }
 
 /** Prunes expired non-playback media, optionally recursing into scoped subdirectories. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rejected agent requests with attachments could permanently grow `media/inbound`, and where default installations retained every staged outbound transport copy indefinitely.

## Why This Change Was Made

Agent and chat attachment preparation now share one pre-admission discard owner: prepared inbound files are removed unless durable transcript history or an admitted execution has taken custody. Gateway maintenance also applies a fixed outbound-only 24-hour fallback when no general attachment TTL is configured; explicit `attachments.ttlHours` still controls the existing general sweep, and inbound replay retention remains separate.

## User Impact

Hostile or repeated invalid agent requests no longer accumulate orphaned inbound files. Outbound staging is bounded by default to roughly 24–25 hours while Gateway maintenance is running, or is cleaned on the next Gateway startup, without deleting transcript media or SQLite-owned outgoing media.

## Evidence

Before the fix:

- The real Gateway test `agent rejects unknown reply channel` left a new `large---<uuid>.png` file in `media/inbound`.
- The real Gateway test `agent errors when delivery requested and no last channel exists` left the same orphan.
- Outbound prune/default-maintenance regressions failed because there was no `pruneOutboundMedia` owner and the default maintenance call count was zero.

Passing local proof:

- `node scripts/run-vitest.mjs src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server-maintenance.test.ts src/media/store.cleanup.test.ts src/gateway/chat-attachments.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts` — Gateway shard: 4 files, 219 tests passed; media shard: 1 file, 2 tests passed.
- `node scripts/check-changed.mjs -- <12 changed files>` — selected guards, formatting, core/core-test typechecks, lint, database/schema/media/import-cycle/auth boundaries passed.
- `git diff --check` and oxfmt check passed.
- Fresh structured autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --prompt <scope>` — clean, no accepted/actionable findings; patch correct 0.96.
- After rebasing onto current `origin/main`: `node scripts/run-vitest.mjs src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server-maintenance.test.ts src/media/store.cleanup.test.ts` — Gateway: 2 files, 64 tests passed; media: 1 file, 2 tests passed.
- ClawSweeper rank-up proof: `node scripts/run-vitest.mjs src/infra/outbound/delivery-queue-media-directive-durability.test.ts src/infra/outbound/delivery-queue-media-spool.test.ts` — 2 files, 17 tests passed. Write-ahead delivery copies local media into `state/delivery-queue-media`, replays it after producer deletion, and retains pending spool artifacts regardless of age.
- Production LOC: +108/-78 (net +30). Tests: +129/-2 (net +127).
- Exact-head pull-request CI: `node scripts/watch-pr-ci.mjs 125560 e3b2dd0ae25ca42a06f5c08a487cdc84e5dda8bb` attached run https://github.com/openclaw/openclaw/actions/runs/32095285351 and finished `GREEN` with zero pending selected checks; aggregate `openclaw/ci-gate` passed at https://github.com/openclaw/openclaw/actions/runs/32095285351/job/95586367116.
- Repo-native prepare: `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 125560` passed in `hosted_exact_or_recent_parent` mode, verified the remote PR head tree equals the local prep head, and kept the exact head unchanged. No separate Testbox lease was needed because the exact-head hosted result was reusable.

No external provider or live channel is required: both inbound regressions occur before model/channel I/O and are exercised over a real Gateway WebSocket with real filesystem writes; outbound cleanup is exercised against the real filesystem and SQLite provenance store.

Related ownership repairs and history:

- https://github.com/openclaw/openclaw/pull/123983
- https://github.com/openclaw/openclaw/pull/124100
- https://github.com/openclaw/openclaw/pull/124353
- https://github.com/openclaw/openclaw/pull/106741
- https://github.com/openclaw/openclaw/issues/119088
- https://github.com/openclaw/openclaw/pull/119127

AI-assisted: yes; maintainer reviewed and understands the change.
