### PR TITLE
fix(media): surface silent attachment failures

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -123,7 +123,9 @@ function createFixture() {
   };
   const sessionManager = {
     kind: "session-manager",
+    appendMessage: vi.fn((message) => messages.push(message)),
     buildSessionContext: vi.fn(() => ({ messages: [] })),
+    getSessionTarget: vi.fn(() => undefined),
   };
   const hookRunner = { hasHooks: vi.fn(() => false) };
   const cacheTrace = { recordStage: vi.fn() };
@@ -131,6 +133,7 @@ function createFixture() {
   const toolResultPromptProjectionState = { kind: "tool-result-projection" };
   const sessionPromptState = { toolResults: toolResultPromptProjectionState };
   const sessionRuntimeState = {
+    currentTurnImageFailureCount: 0,
     prePromptMessageCount: 2,
     promptCache: undefined,
     systemPromptText: "system prompt",
@@ -319,6 +322,7 @@ function createFixture() {
     order,
     queueHandle,
     result,
+    sessionManager,
     sessionRuntimeState,
     state,
     subscription,
@@ -396,6 +400,29 @@ describe("runEmbeddedAttemptSettledPhase", () => {
       fixture.queueHandle,
       "agent:main",
       "/tmp/session.jsonl",
+    );
+  });
+
+  it("persists image failure notes after after-turn transcript reconciliation", async () => {
+    const fixture = createFixture();
+    fixture.sessionRuntimeState.currentTurnImageFailureCount = 1;
+    await runEmbeddedAttemptSettledPhase(fixture.input);
+
+    expect(fixture.sessionManager.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "openclaw.system-note",
+        display: true,
+        content: expect.stringMatching(/1.*image contents.*unavailable.*resend.*not claim/is),
+      }),
+    );
+    expect(mocks.completeResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({
+          messagesSnapshot: expect.arrayContaining([
+            expect.objectContaining({ customType: "openclaw.system-note", display: true }),
+          ]),
+        }),
+      }),
     );
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -1,6 +1,3 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -18,7 +15,6 @@ const mocks = vi.hoisted(() => ({
   removeTrailingPrecheckError: vi.fn(),
   resolveApiKey: vi.fn(),
   submitPrompt: vi.fn(),
-  useRealPromptExecution: { value: false },
   debug: vi.fn(),
   warn: vi.fn(),
 }));
@@ -44,20 +40,11 @@ vi.mock("./attempt-prompt-build.js", () => ({
   prepareEmbeddedAttemptPromptAssembly: mocks.preparePromptAssembly,
   prepareEmbeddedAttemptPromptContext: mocks.preparePromptContext,
 }));
-vi.mock("./attempt-prompt-submit.js", async (importOriginal) => {
-  const { prepareEmbeddedAttemptPromptExecution } =
-    await importOriginal<typeof import("./attempt-prompt-submit.js")>();
-  return {
-    handleEmbeddedAttemptPromptError: mocks.handlePromptError,
-    prepareEmbeddedAttemptPromptExecution: (
-      input: Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0],
-    ) =>
-      mocks.useRealPromptExecution.value
-        ? prepareEmbeddedAttemptPromptExecution(input)
-        : mocks.preparePromptExecution(input),
-    submitEmbeddedAttemptPrompt: mocks.submitPrompt,
-  };
-});
+vi.mock("./attempt-prompt-submit.js", () => ({
+  handleEmbeddedAttemptPromptError: mocks.handlePromptError,
+  prepareEmbeddedAttemptPromptExecution: mocks.preparePromptExecution,
+  submitEmbeddedAttemptPrompt: mocks.submitPrompt,
+}));
 vi.mock("./attempt-prompt-preflight.js", () => ({
   handleEmbeddedAttemptMidTurnPrecheck: mocks.handleMidTurnPrecheck,
   prepareEmbeddedAttemptPromptPreflight: mocks.preparePromptPreflight,
@@ -103,6 +90,17 @@ function createFixture() {
     yieldDetected: false,
     yieldMessage: null as string | null,
   };
+  const activeSession = {
+    messages: [],
+    agent: {
+      state: { messages: [] },
+      streamFn: vi.fn(),
+    },
+  };
+  const sessionManager = {
+    appendCustomEntry: vi.fn(),
+    getEntries: vi.fn(() => []),
+  };
   let prePromptMessageCount = 1;
 
   const setPrePromptMessageCount = vi.fn((count: number) => {
@@ -129,17 +127,16 @@ function createFixture() {
       transcriptLeafId: "leaf-1",
     };
   });
-  mocks.preparePromptContext.mockImplementation((input: { messages?: unknown[] } = {}) => {
+  mocks.preparePromptContext.mockImplementation(() => {
     order.push("context");
-    const messages = input.messages ?? [];
     return {
       aggregatePressureEngaged: false,
       contextTokenBudget: 32_000,
       currentUserTimestampOverride: { timestamp: 123, text: "hello" },
       effectivePrompt: "hello",
-      hookMessagesForCurrentPrompt: messages,
+      hookMessagesForCurrentPrompt: [],
       llmBoundaryPromptForPrecheck: "hello",
-      prePromptMessageCount: 2 + messages.length,
+      prePromptMessageCount: 2,
       promptForModel: "hello",
       promptForSession: "hello",
       promptSubmission: { prompt: "hello", runtimeOnly: false },
@@ -183,27 +180,6 @@ function createFixture() {
     submissionInput.onSteeringAcknowledged();
   });
   mocks.handlePromptError.mockResolvedValue({});
-
-  const messages: unknown[] = [];
-  const appendCustomMessageEntry = vi.fn();
-  const sessionManager = {
-    appendCustomEntry: vi.fn(),
-    appendCustomMessageEntry,
-    getEntries: vi.fn(() => []),
-  };
-  const sendCustomMessage = vi.fn(async (message: Record<string, unknown>) => {
-    const persisted = { role: "custom", timestamp: Date.now(), ...message };
-    messages.push(persisted);
-    appendCustomMessageEntry(message.customType, message.content, message.display, message.details);
-  });
-  const activeSession = {
-    messages,
-    agent: {
-      state: { messages },
-      streamFn: vi.fn(),
-    },
-    sendCustomMessage,
-  };
   const input = {
     attempt: {
       model: { id: "model-1", provider: "test" },
@@ -292,14 +268,12 @@ function createFixture() {
   } as unknown as PromptPhaseInput;
 
   return {
-    appendCustomMessageEntry,
     input,
     markYieldAborted,
     order,
     setFinalPromptText,
     setPrePromptMessageCount,
     setPromptCacheChangesForTurn,
-    sendCustomMessage,
     state,
     yieldState,
   };
@@ -307,7 +281,6 @@ function createFixture() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.useRealPromptExecution.value = false;
 });
 
 describe("runEmbeddedAttemptPromptPhase", () => {
@@ -399,50 +372,6 @@ describe("runEmbeddedAttemptPromptPhase", () => {
     expect(mocks.submitPrompt).toHaveBeenCalledOnce();
   });
 
-  it("persists an unloadable structured image warning in the same provider context", async () => {
-    const fixture = createFixture();
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-note-"));
-    const sensitiveUrlToken = "sensitive-media-token-1234567890";
-    const missingPath = path.join(workspaceDir, `missing.png?token=${sensitiveUrlToken}`);
-    mocks.useRealPromptExecution.value = true;
-    fixture.input.attempt.config = {};
-    fixture.input.attempt.imageOrder = ["offloaded"];
-    fixture.input.attempt.media = [{ path: missingPath, contentType: "image/png" }];
-    fixture.input.attempt.model.input = ["text", "image"];
-    fixture.input.execution.effectiveFsWorkspaceOnly = true;
-    fixture.input.execution.effectiveWorkspace = workspaceDir;
-
-    try {
-      await runEmbeddedAttemptPromptPhase(fixture.input);
-      await runEmbeddedAttemptPromptPhase(fixture.input);
-
-      const note = expect.objectContaining({
-        role: "custom",
-        customType: "openclaw.system-note",
-        display: true,
-        content: expect.stringMatching(/1.*image contents.*unavailable.*resend.*not claim/is),
-      });
-      expect(fixture.sendCustomMessage).toHaveBeenCalledOnce();
-      expect(fixture.appendCustomMessageEntry).toHaveBeenCalledOnce();
-      expect(fixture.input.activeSession.messages).toContainEqual(note);
-      expect(mocks.preparePromptPreflight).toHaveBeenLastCalledWith(
-        expect.objectContaining({ hookMessagesForCurrentPrompt: expect.arrayContaining([note]) }),
-      );
-      expect(mocks.submitPrompt).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          activeSession: expect.objectContaining({ messages: expect.arrayContaining([note]) }),
-        }),
-      );
-      expect(mocks.warn).toHaveBeenCalledWith(
-        expect.stringMatching(/failed to load.*missing\.png.*file not found/i),
-      );
-      expect(mocks.warn.mock.calls.flat().join("\n")).not.toContain(sensitiveUrlToken);
-      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
-
   it("reads yield state after submission fails and publishes abort state before recovery", async () => {
     const fixture = createFixture();
     const submissionError = new Error("submission failed");
@@ -483,6 +412,14 @@ describe("runEmbeddedAttemptPromptPhase", () => {
   it("releases steering when preflight skips provider submission", async () => {
     const fixture = createFixture();
     const promptError = new Error("preflight rejected");
+    mocks.preparePromptExecution.mockResolvedValueOnce({
+      images: [],
+      imageFactIndexes: [],
+      detectedRefs: [],
+      failedMediaCount: 1,
+      loadedCount: 0,
+      skippedCount: 1,
+    });
     mocks.observePrompt.mockImplementationOnce(() => {
       fixture.order.push("observe");
       return { skipPromptSubmission: true };

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   removeTrailingPrecheckError: vi.fn(),
   resolveApiKey: vi.fn(),
   submitPrompt: vi.fn(),
+  useRealPromptExecution: { value: false },
   debug: vi.fn(),
   warn: vi.fn(),
 }));
@@ -40,11 +44,20 @@ vi.mock("./attempt-prompt-build.js", () => ({
   prepareEmbeddedAttemptPromptAssembly: mocks.preparePromptAssembly,
   prepareEmbeddedAttemptPromptContext: mocks.preparePromptContext,
 }));
-vi.mock("./attempt-prompt-submit.js", () => ({
-  handleEmbeddedAttemptPromptError: mocks.handlePromptError,
-  prepareEmbeddedAttemptPromptExecution: mocks.preparePromptExecution,
-  submitEmbeddedAttemptPrompt: mocks.submitPrompt,
-}));
+vi.mock("./attempt-prompt-submit.js", async (importOriginal) => {
+  const { prepareEmbeddedAttemptPromptExecution } =
+    await importOriginal<typeof import("./attempt-prompt-submit.js")>();
+  return {
+    handleEmbeddedAttemptPromptError: mocks.handlePromptError,
+    prepareEmbeddedAttemptPromptExecution: (
+      input: Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0],
+    ) =>
+      mocks.useRealPromptExecution.value
+        ? prepareEmbeddedAttemptPromptExecution(input)
+        : mocks.preparePromptExecution(input),
+    submitEmbeddedAttemptPrompt: mocks.submitPrompt,
+  };
+});
 vi.mock("./attempt-prompt-preflight.js", () => ({
   handleEmbeddedAttemptMidTurnPrecheck: mocks.handleMidTurnPrecheck,
   prepareEmbeddedAttemptPromptPreflight: mocks.preparePromptPreflight,
@@ -116,16 +129,17 @@ function createFixture() {
       transcriptLeafId: "leaf-1",
     };
   });
-  mocks.preparePromptContext.mockImplementation(() => {
+  mocks.preparePromptContext.mockImplementation((input: { messages?: unknown[] } = {}) => {
     order.push("context");
+    const messages = input.messages ?? [];
     return {
       aggregatePressureEngaged: false,
       contextTokenBudget: 32_000,
       currentUserTimestampOverride: { timestamp: 123, text: "hello" },
       effectivePrompt: "hello",
-      hookMessagesForCurrentPrompt: [],
+      hookMessagesForCurrentPrompt: messages,
       llmBoundaryPromptForPrecheck: "hello",
-      prePromptMessageCount: 2,
+      prePromptMessageCount: 2 + messages.length,
       promptForModel: "hello",
       promptForSession: "hello",
       promptSubmission: { prompt: "hello", runtimeOnly: false },
@@ -170,16 +184,25 @@ function createFixture() {
   });
   mocks.handlePromptError.mockResolvedValue({});
 
-  const activeSession = {
-    messages: [],
-    agent: {
-      state: { messages: [] },
-      streamFn: vi.fn(),
-    },
-  };
+  const messages: unknown[] = [];
+  const appendCustomMessageEntry = vi.fn();
   const sessionManager = {
     appendCustomEntry: vi.fn(),
+    appendCustomMessageEntry,
     getEntries: vi.fn(() => []),
+  };
+  const sendCustomMessage = vi.fn(async (message: Record<string, unknown>) => {
+    const persisted = { role: "custom", timestamp: Date.now(), ...message };
+    messages.push(persisted);
+    appendCustomMessageEntry(message.customType, message.content, message.display, message.details);
+  });
+  const activeSession = {
+    messages,
+    agent: {
+      state: { messages },
+      streamFn: vi.fn(),
+    },
+    sendCustomMessage,
   };
   const input = {
     attempt: {
@@ -213,6 +236,7 @@ function createFixture() {
       toolResultPromptProjectionState: {},
     },
     execution: {
+      mediaOwnerAgentId: "main",
       effectiveFsWorkspaceOnly: false,
       effectiveWorkspace: "/tmp/workspace",
       sandbox: null,
@@ -268,12 +292,14 @@ function createFixture() {
   } as unknown as PromptPhaseInput;
 
   return {
+    appendCustomMessageEntry,
     input,
     markYieldAborted,
     order,
     setFinalPromptText,
     setPrePromptMessageCount,
     setPromptCacheChangesForTurn,
+    sendCustomMessage,
     state,
     yieldState,
   };
@@ -281,6 +307,7 @@ function createFixture() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.useRealPromptExecution.value = false;
 });
 
 describe("runEmbeddedAttemptPromptPhase", () => {
@@ -370,6 +397,50 @@ describe("runEmbeddedAttemptPromptPhase", () => {
       expect.objectContaining({ skipPromptSubmission: false }),
     );
     expect(mocks.submitPrompt).toHaveBeenCalledOnce();
+  });
+
+  it("persists an unloadable structured image warning in the same provider context", async () => {
+    const fixture = createFixture();
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-note-"));
+    const sensitiveUrlToken = "sensitive-media-token-1234567890";
+    const missingPath = path.join(workspaceDir, `missing.png?token=${sensitiveUrlToken}`);
+    mocks.useRealPromptExecution.value = true;
+    fixture.input.attempt.config = {};
+    fixture.input.attempt.imageOrder = ["offloaded"];
+    fixture.input.attempt.media = [{ path: missingPath, contentType: "image/png" }];
+    fixture.input.attempt.model.input = ["text", "image"];
+    fixture.input.execution.effectiveFsWorkspaceOnly = true;
+    fixture.input.execution.effectiveWorkspace = workspaceDir;
+
+    try {
+      await runEmbeddedAttemptPromptPhase(fixture.input);
+      await runEmbeddedAttemptPromptPhase(fixture.input);
+
+      const note = expect.objectContaining({
+        role: "custom",
+        customType: "openclaw.system-note",
+        display: true,
+        content: expect.stringMatching(/1.*image contents.*unavailable.*resend.*not claim/is),
+      });
+      expect(fixture.sendCustomMessage).toHaveBeenCalledOnce();
+      expect(fixture.appendCustomMessageEntry).toHaveBeenCalledOnce();
+      expect(fixture.input.activeSession.messages).toContainEqual(note);
+      expect(mocks.preparePromptPreflight).toHaveBeenLastCalledWith(
+        expect.objectContaining({ hookMessagesForCurrentPrompt: expect.arrayContaining([note]) }),
+      );
+      expect(mocks.submitPrompt).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeSession: expect.objectContaining({ messages: expect.arrayContaining([note]) }),
+        }),
+      );
+      expect(mocks.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/failed to load.*missing\.png.*file not found/i),
+      );
+      expect(mocks.warn.mock.calls.flat().join("\n")).not.toContain(sensitiveUrlToken);
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("reads yield state after submission fails and publishes abort state before recovery", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -1,4 +1,5 @@
 /** Runs prompt assembly, admission, submission, and prompt-local recovery. */
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import {
   buildHeartbeatOutcomeContext,
@@ -99,6 +100,8 @@ type PromptSubmissionPhaseInput = Pick<
   | "trajectoryRecorder"
 >;
 type WithOwnedTranscriptWrite = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+const FAILED_PROMPT_MEDIA_NOTE_TYPE = "openclaw.system-note";
 
 export async function runEmbeddedAttemptPromptPhase(input: {
   attempt: PromptAssemblyInput["attempt"];
@@ -241,16 +244,18 @@ export async function runEmbeddedAttemptPromptPhase(input: {
             }),
           )
         : undefined;
-    const promptContext = prepareEmbeddedAttemptPromptContext({
-      attempt,
-      ...(heartbeatOutcomeContext ? { heartbeatOutcomeContext } : {}),
-      messages: activeSession.messages,
-      prompt: promptAssembly,
-      replaceSessionMessages: (messages) => {
-        activeSession.agent.state.messages = messages;
-      },
-      ...input.context,
-    });
+    const buildPromptContext = () =>
+      prepareEmbeddedAttemptPromptContext({
+        attempt,
+        ...(heartbeatOutcomeContext ? { heartbeatOutcomeContext } : {}),
+        messages: activeSession.messages,
+        prompt: promptAssembly,
+        replaceSessionMessages: (messages) => {
+          activeSession.agent.state.messages = messages;
+        },
+        ...input.context,
+      });
+    let promptContext = buildPromptContext();
     const { hookMessagesForCurrentPrompt, promptForModel, systemPromptForHook } = promptContext;
     input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
     input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);
@@ -312,6 +317,36 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       prompt: promptContext.promptSubmission.prompt,
       skipPromptSubmission,
     });
+    if (
+      imageResult.failedMediaCount > 0 &&
+      !activeSession.messages.some(
+        (message) =>
+          message.role === "custom" &&
+          message.customType === FAILED_PROMPT_MEDIA_NOTE_TYPE &&
+          asOptionalRecord(message.details)?.runId === attempt.runId,
+      )
+    ) {
+      const count = imageResult.failedMediaCount;
+      const content = `System note: ${count} image attachment${count === 1 ? "" : "s"} could not be loaded; their image contents are unavailable. Tell the user and ask them to resend ${count === 1 ? "the image" : "the images"}; do not claim inspection.`;
+      await input.withOwnedTranscriptWrite(() =>
+        activeSession.sendCustomMessage(
+          {
+            customType: FAILED_PROMPT_MEDIA_NOTE_TYPE,
+            content,
+            display: true,
+            details: {
+              source: "prompt-image-hydration",
+              runId: attempt.runId,
+              failedMediaCount: count,
+            },
+          },
+          { triggerTurn: false },
+        ),
+      );
+      promptContext = buildPromptContext();
+      input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
+      input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);
+    }
 
     const reserveTokens = input.getCompactionReserveTokens();
     let state: PromptPreflightInput["state"] = {

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -1,5 +1,4 @@
 /** Runs prompt assembly, admission, submission, and prompt-local recovery. */
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import {
   buildHeartbeatOutcomeContext,
@@ -100,8 +99,6 @@ type PromptSubmissionPhaseInput = Pick<
   | "trajectoryRecorder"
 >;
 type WithOwnedTranscriptWrite = <T>(operation: () => Promise<T> | T) => Promise<T>;
-
-const FAILED_PROMPT_MEDIA_NOTE_TYPE = "openclaw.system-note";
 
 export async function runEmbeddedAttemptPromptPhase(input: {
   attempt: PromptAssemblyInput["attempt"];
@@ -244,18 +241,16 @@ export async function runEmbeddedAttemptPromptPhase(input: {
             }),
           )
         : undefined;
-    const buildPromptContext = () =>
-      prepareEmbeddedAttemptPromptContext({
-        attempt,
-        ...(heartbeatOutcomeContext ? { heartbeatOutcomeContext } : {}),
-        messages: activeSession.messages,
-        prompt: promptAssembly,
-        replaceSessionMessages: (messages) => {
-          activeSession.agent.state.messages = messages;
-        },
-        ...input.context,
-      });
-    let promptContext = buildPromptContext();
+    const promptContext = prepareEmbeddedAttemptPromptContext({
+      attempt,
+      ...(heartbeatOutcomeContext ? { heartbeatOutcomeContext } : {}),
+      messages: activeSession.messages,
+      prompt: promptAssembly,
+      replaceSessionMessages: (messages) => {
+        activeSession.agent.state.messages = messages;
+      },
+      ...input.context,
+    });
     const { hookMessagesForCurrentPrompt, promptForModel, systemPromptForHook } = promptContext;
     input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
     input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);
@@ -317,37 +312,6 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       prompt: promptContext.promptSubmission.prompt,
       skipPromptSubmission,
     });
-    if (
-      imageResult.failedMediaCount > 0 &&
-      !activeSession.messages.some(
-        (message) =>
-          message.role === "custom" &&
-          message.customType === FAILED_PROMPT_MEDIA_NOTE_TYPE &&
-          asOptionalRecord(message.details)?.runId === attempt.runId,
-      )
-    ) {
-      const count = imageResult.failedMediaCount;
-      const content = `System note: ${count} image attachment${count === 1 ? "" : "s"} could not be loaded; their image contents are unavailable. Tell the user and ask them to resend ${count === 1 ? "the image" : "the images"}; do not claim inspection.`;
-      await input.withOwnedTranscriptWrite(() =>
-        activeSession.sendCustomMessage(
-          {
-            customType: FAILED_PROMPT_MEDIA_NOTE_TYPE,
-            content,
-            display: true,
-            details: {
-              source: "prompt-image-hydration",
-              runId: attempt.runId,
-              failedMediaCount: count,
-            },
-          },
-          { triggerTurn: false },
-        ),
-      );
-      promptContext = buildPromptContext();
-      input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
-      input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);
-    }
-
     const reserveTokens = input.getCompactionReserveTokens();
     let state: PromptPreflightInput["state"] = {
       ...input.lifecycle.readState(),

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
@@ -254,6 +254,7 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
       }),
     );
     expect(result.state).toEqual({
+      currentTurnImageFailureCount: 0,
       prePromptMessageCount: 2,
       promptCache: undefined,
       systemPromptText: "runtime prompt",
@@ -283,6 +284,9 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
     expect(guardInput.getPromptCache()).toEqual({ cacheRead: 3 });
     expect(guardInput.getPromptCacheRetention()).toBe("long");
     expect(guardInput.getSystemPrompt()).toBe("updated prompt");
+    guardInput.onCurrentTurnImageFailure(2);
+    guardInput.onCurrentTurnImageFailure(1);
+    expect(result.state.currentTurnImageFailureCount).toBe(2);
   });
 
   it("publishes every cleanup owner before a later transport failure", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -26,12 +26,14 @@ type TrajectoryInput = Parameters<typeof prepareEmbeddedAttemptTrajectory>[0];
 type AttemptSessionManager = ReturnType<typeof guardSessionManager>;
 type SessionSettleTracker = ReturnType<typeof createEmbeddedAttemptSessionSettleTracker>;
 type TrajectoryRecorder = Awaited<ReturnType<typeof prepareEmbeddedAttemptTrajectory>>;
+
 type ExternalAbortController = Pick<
   ReturnType<typeof createEmbeddedAttemptExternalAbortController>,
   "setActiveSessionAbort"
 >;
 
 type EmbeddedAttemptSessionRuntimeState = {
+  currentTurnImageFailureCount: number;
   prePromptMessageCount: number;
   promptCache: EmbeddedRunAttemptResult["promptCache"];
   systemPromptText: string;
@@ -109,6 +111,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     preparedSessionManager;
 
   const state: EmbeddedAttemptSessionRuntimeState = {
+    currentTurnImageFailureCount: 0,
     prePromptMessageCount: 0,
     promptCache: undefined,
     systemPromptText: input.initialSystemPrompt,
@@ -136,6 +139,9 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     sessionManager,
   });
   const { activeSession, setActiveSessionSystemPrompt, settingsManager } = preparedAgentSession;
+  const recordCurrentTurnImageFailure = (count: number) => {
+    state.currentTurnImageFailureCount = Math.max(state.currentTurnImageFailureCount, count);
+  };
   await attempt.userTurnTranscriptRecorder?.waitForRuntimePersistence();
   const boundary = prepareEmbeddedAttemptSessionBoundary({
     activeSession,
@@ -177,6 +183,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     effectiveWorkspace: input.effectiveWorkspace,
     getPrePromptMessageCount: () => state.prePromptMessageCount,
     getPromptCache: () => state.promptCache,
+    onCurrentTurnImageFailure: recordCurrentTurnImageFailure,
     getPromptCacheRetention: () => promptCacheRetentionRef.current,
     getSystemPrompt: () => state.systemPromptText,
     isOpenAIResponsesApi,
@@ -234,6 +241,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     agentDir: input.agentDir,
     abortSignal: input.transport.abortSignal,
     getProviderRuntimeHandle: input.transport.getProviderRuntimeHandle,
+    onCurrentTurnImageFailure: recordCurrentTurnImageFailure,
     sandboxSessionKey: input.transport.sandboxSessionKey,
     ...(input.transport.sandbox !== undefined ? { sandbox: input.transport.sandbox } : {}),
     codeModeControlsEnabled: input.transport.codeModeControlsEnabled,

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -2,6 +2,7 @@
  * Settles prompt dispatch, stream cleanup, and result projection.
  * It may assume stream runtime preparation and session state are ready.
  */
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AssistantMessage } from "../../../llm/types.js";
 import {
   mergeAgentRunAttemptTerminal,
@@ -11,6 +12,7 @@ import {
 } from "../../agent-run-terminal-outcome.js";
 import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import type { AgentMessage } from "../../runtime/index.js";
+import { SessionManager } from "../../sessions/index.js";
 import { settleRequesterAfterSessionSpawns } from "../../subagents/registry/subagent-registry.js";
 import type { NormalizedUsage } from "../../usage.js";
 import { log } from "../logger.js";
@@ -32,6 +34,7 @@ import type { prepareEmbeddedAttemptStream } from "./attempt-stream-prepare.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import type { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import type { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
+import { buildPromptImageFailureNotice } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 /** Runs prompt dispatch, stream settlement, cleanup, and result projection. */
@@ -54,6 +57,9 @@ type PreparedStreamRuntime = {
   stream: ReturnType<typeof prepareEmbeddedAttemptStream>;
   timeout: ReturnType<typeof prepareEmbeddedAttemptTimeout>;
 };
+
+const FAILED_PROMPT_MEDIA_NOTE_TYPE = "openclaw.system-note";
+const FAILED_PROMPT_MEDIA_NOTE_SOURCE = "prompt-image-hydration";
 
 type StreamCleanupInput = {
   attempt: EmbeddedRunAttemptParams;
@@ -507,6 +513,41 @@ export async function runEmbeddedAttemptSettledPhase(
         compactionOccurredThisAttempt: settledStream.compactionOccurredThisAttempt,
       },
     });
+    const noteAlreadyPersisted = activeSession.messages.some(
+      (message) =>
+        message.role === "custom" &&
+        message.customType === FAILED_PROMPT_MEDIA_NOTE_TYPE &&
+        asOptionalRecord(message.details)?.source === FAILED_PROMPT_MEDIA_NOTE_SOURCE &&
+        asOptionalRecord(message.details)?.runId === attempt.runId,
+    );
+    if (sessionRuntimeState.currentTurnImageFailureCount > 0 && !noteAlreadyPersisted) {
+      const note = {
+        role: "custom" as const,
+        customType: FAILED_PROMPT_MEDIA_NOTE_TYPE,
+        content: buildPromptImageFailureNotice(sessionRuntimeState.currentTurnImageFailureCount),
+        display: true,
+        details: {
+          source: FAILED_PROMPT_MEDIA_NOTE_SOURCE,
+          runId: attempt.runId,
+          failedMediaCount: sessionRuntimeState.currentTurnImageFailureCount,
+        },
+        timestamp: Date.now(),
+      };
+      await input.sessionLock.withOwnedTranscriptWrite(() => {
+        const target = sessionManager.getSessionTarget();
+        if (target) {
+          SessionManager.appendMessageToTranscript(
+            target,
+            note,
+            attempt.config ? { config: attempt.config } : undefined,
+          );
+        } else {
+          sessionManager.appendMessage(note);
+        }
+        activeSession.agent.state.messages = [...activeSession.messages, note];
+      });
+      messagesSnapshot = [...messagesSnapshot, note];
+    }
     sessionIdUsed = afterTurn.sessionIdUsed;
     sessionFileUsed = afterTurn.sessionFileUsed;
   } finally {

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -513,14 +513,16 @@ export async function runEmbeddedAttemptSettledPhase(
         compactionOccurredThisAttempt: settledStream.compactionOccurredThisAttempt,
       },
     });
-    const noteAlreadyPersisted = activeSession.messages.some(
-      (message) =>
-        message.role === "custom" &&
-        message.customType === FAILED_PROMPT_MEDIA_NOTE_TYPE &&
-        asOptionalRecord(message.details)?.source === FAILED_PROMPT_MEDIA_NOTE_SOURCE &&
-        asOptionalRecord(message.details)?.runId === attempt.runId,
-    );
-    if (sessionRuntimeState.currentTurnImageFailureCount > 0 && !noteAlreadyPersisted) {
+    if (
+      sessionRuntimeState.currentTurnImageFailureCount > 0 &&
+      !activeSession.messages.some(
+        (message) =>
+          message.role === "custom" &&
+          message.customType === FAILED_PROMPT_MEDIA_NOTE_TYPE &&
+          asOptionalRecord(message.details)?.source === FAILED_PROMPT_MEDIA_NOTE_SOURCE &&
+          asOptionalRecord(message.details)?.runId === attempt.runId,
+      )
+    ) {
       const note = {
         role: "custom" as const,
         customType: FAILED_PROMPT_MEDIA_NOTE_TYPE,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -286,6 +286,7 @@ export function installEmbeddedAttemptContextGuards(input: {
   getPromptCache: () => EmbeddedRunAttemptResult["promptCache"];
   getPromptCacheRetention: () => PromptCacheRetention;
   getSystemPrompt: () => string;
+  onCurrentTurnImageFailure?: (count: number) => void;
   isOpenAIResponsesApi: boolean;
   repairToolUseResultPairing: boolean;
   sessionAgentId: string;
@@ -451,6 +452,7 @@ export function installEmbeddedAttemptContextGuards(input: {
         input.sandbox?.enabled && input.sandbox.fsBridge
           ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }
           : undefined,
+      onCurrentTurnImageFailure: input.onCurrentTurnImageFailure,
     },
   );
   const previousComputerFrameTransform = activeSession.agent.transformContext;

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -261,4 +261,75 @@ describe("prepareEmbeddedAttemptTransport", () => {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
+
+  it("records image hydration failures at the provider handoff", async () => {
+    let providerOptions: ProviderStreamOptions | undefined;
+    const providerStream = vi.fn((_model, _context, options) => {
+      providerOptions = options as ProviderStreamOptions;
+      return {} as never;
+    });
+    bindStreamLlmRuntime(providerStream, {
+      streamSimple: providerStream,
+      registry: { getApiProvider: () => undefined },
+    } as never);
+    const session = {
+      agent: { streamFn: providerStream, transport: "auto" },
+    };
+    const model = { api: "test-api", provider: "test-provider", id: "test-model-image" };
+    const onCurrentTurnImageFailure = vi.fn();
+    registerProviderStreamForModel.mockReturnValue(providerStream);
+    await prepareEmbeddedAttemptTransport({
+      attempt: {
+        config: {},
+        model,
+        modelId: model.id,
+        provider: model.provider,
+        runId: "run-native-image-failure",
+        runtimePlan: {
+          auth: { forwardedAuthProfileId: undefined },
+          transport: { resolveExtraParams: () => ({}) },
+        },
+        sessionId: "session-native-image-failure",
+      },
+      session,
+      settingsManager: {
+        getGlobalSettings: () => ({}),
+        getProjectSettings: () => ({}),
+      },
+      onCurrentTurnImageFailure,
+      sessionAgentId: "main",
+      workspaceDir: "/tmp",
+      workspaceOnly: false,
+      agentDir: "/tmp",
+      abortSignal: new AbortController().signal,
+      getProviderRuntimeHandle: () => ({ provider: model.provider, modelId: model.id }),
+      sandboxSessionKey: "agent:main:test",
+      codeModeControlsEnabled: false,
+      providerPromptState: { state: {}, effectiveContextTokenBudget: 128_000 },
+    } as unknown as PrepareTransportInput);
+    const message = attachRuntimePromptMediaFacts(
+      castAgentMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "inspect" },
+          { type: "image", data: "%%%", mimeType: "image/png" },
+        ],
+      }),
+      [{ kind: "image" }],
+      ["inline"],
+    );
+    const context = { systemPrompt: "system", messages: [message], tools: [] };
+
+    session.agent.streamFn(model as never, context as never, {});
+    const provider = await resolveProviderContext(context as never, providerOptions);
+
+    expect(onCurrentTurnImageFailure).toHaveBeenCalledWith(1);
+    expect(provider.messages[0]?.content).toEqual([
+      { type: "text", text: "inspect" },
+      {
+        type: "text",
+        text: expect.stringMatching(/1.*image contents.*unavailable.*resend.*not claim/is),
+      },
+    ]);
+  });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -452,6 +452,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
   session: AgentSession;
   settingsManager: SettingsManager;
   providerThinkingLevel: ProviderThinkLevel | undefined;
+  onCurrentTurnImageFailure?: (count: number) => void;
   sessionAgentId: string;
   workspaceDir: string;
   workspaceOnly: boolean;
@@ -523,6 +524,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
             localRoots: input.workspaceOnly
               ? undefined
               : getAgentScopedMediaLocalRoots(attempt.config ?? {}, input.sessionAgentId),
+            onCurrentTurnImageFailure: input.onCurrentTurnImageFailure,
             sandbox:
               input.sandbox?.enabled && input.sandbox.fsBridge
                 ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }

--- a/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import type { ImageContent } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   attachRuntimePromptMediaFacts,
   readRuntimePromptMediaFacts,
@@ -703,6 +703,43 @@ describe("installHistoryImagePruneContextTransform", () => {
     } finally {
       restore();
       await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces a failed active image through the installed context transform", async () => {
+    const onCurrentTurnImageFailure = vi.fn();
+    const message = castAgentMessage({
+      role: "user",
+      content: [
+        { type: "text", text: "inspect" },
+        { type: "image", data: "%%%", mimeType: "image/png" },
+      ],
+      __openclaw: {
+        media: [{ kind: "image" }],
+        mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
+      },
+    });
+    const agent: {
+      transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]> | AgentMessage[];
+    } = {};
+    const restore = installHistoryImagePruneContextTransform(agent, {
+      workspaceDir: "/tmp",
+      model: { input: ["text", "image"] },
+      onCurrentTurnImageFailure,
+    });
+
+    try {
+      const replay = await agent.transformContext?.([message]);
+      expect(onCurrentTurnImageFailure).toHaveBeenCalledWith(1);
+      expect(expectArrayMessageContent(replay?.[0], "expected failure notice")).toEqual([
+        { type: "text", text: "inspect" },
+        {
+          type: "text",
+          text: expect.stringMatching(/1.*image contents.*unavailable.*resend.*not claim/is),
+        },
+      ]);
+    } finally {
+      restore();
     }
   });
 

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -492,7 +492,12 @@ type PromptMediaOptions = {
   sandbox?: { root: string; bridge: SandboxFsBridge };
   provider?: boolean;
   signal?: AbortSignal;
+  onCurrentTurnImageFailure?: (count: number) => void;
 };
+
+export function buildPromptImageFailureNotice(count: number): string {
+  return `System note: ${count} image attachment${count === 1 ? "" : "s"} could not be loaded; their image contents are unavailable. Tell the user and ask them to resend ${count === 1 ? "the image" : "the images"}; do not claim inspection.`;
+}
 
 const VIDEO_OMISSION = {
   unsupported: "(video omitted: provider does not support native video)",
@@ -579,6 +584,7 @@ async function materializePromptMediaMessages(
 ): Promise<AgentMessage[]> {
   let hydrated: AgentMessage[] | undefined;
   const videoBudget = { remaining: MAX_VIDEO_BYTES };
+  const activeUserIndex = messages.findLastIndex((message) => message.role === "user");
   for (const [index, message] of messages.entries()) {
     if (message.role !== "user") {
       continue;
@@ -617,6 +623,17 @@ async function materializePromptMediaMessages(
       options,
       budget: videoBudget,
     });
+    if (
+      (options.provider || options.onCurrentTurnImageFailure) &&
+      index === activeUserIndex &&
+      result.failedMediaCount > 0
+    ) {
+      options.onCurrentTurnImageFailure?.(result.failedMediaCount);
+      projectedContent.push({
+        type: "text",
+        text: buildPromptImageFailureNotice(result.failedMediaCount),
+      });
+    }
     hydrated ??= messages.slice();
     if (options.provider) {
       hydrated[index] = {
@@ -669,6 +686,7 @@ export async function materializeProviderContext(params: {
   workspaceOnly?: boolean;
   localRoots?: readonly string[];
   sandbox?: { root: string; bridge: SandboxFsBridge };
+  onCurrentTurnImageFailure?: (count: number) => void;
 }): Promise<ProviderContext> {
   const messages = await materializePromptMediaMessages(params.context.messages as AgentMessage[], {
     workspaceDir: params.workspaceDir,
@@ -678,6 +696,7 @@ export async function materializeProviderContext(params: {
     sandbox: params.sandbox,
     provider: true,
     signal: params.signal,
+    onCurrentTurnImageFailure: params.onCurrentTurnImageFailure,
   });
   params.signal?.throwIfAborted();
   return messages === params.context.messages

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -9,6 +9,7 @@ import type {
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
 import type { Context, ImageContent, TextContent } from "../../../llm/types.js";
+import { redactSensitiveText } from "../../../logging/redact.js";
 import {
   attachRuntimePromptMediaFacts,
   isImageMediaFact,
@@ -220,6 +221,7 @@ async function loadMediaFromRef(
   },
 ): Promise<WebMediaResult | null> {
   options?.signal?.throwIfAborted();
+  const redactedRef = redactSensitiveText(ref.raw || ref.resolved);
   try {
     let targetPath = ref.resolved;
 
@@ -240,8 +242,8 @@ async function loadMediaFromRef(
         });
         targetPath = resolved.resolved;
       } catch (err) {
-        log.debug(
-          `${options?.label ?? "Native media"}: sandbox validation failed: ${formatErrorMessage(err)}`,
+        log.warn(
+          `${options?.label ?? "Native media"}: sandbox validation failed for ${redactedRef}: ${redactSensitiveText(formatErrorMessage(err))}`,
         );
         return null;
       }
@@ -266,7 +268,9 @@ async function loadMediaFromRef(
     return media;
   } catch (err) {
     options?.signal?.throwIfAborted();
-    log.debug(`${options?.label ?? "Native media"}: failed to load: ${formatErrorMessage(err)}`);
+    log.warn(
+      `${options?.label ?? "Native media"}: failed to load ${redactedRef}: ${redactSensitiveText(formatErrorMessage(err))}`,
+    );
     return null;
   }
 }

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1,7 +1,9 @@
 // Media fetch tests cover remote media download limits and validation.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { hasErrnoCode } from "../infra/errors.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -1396,15 +1398,34 @@ describe("readRemoteMediaBuffer", () => {
     },
   );
 
-  it("saves bodyless successful responses without unbounded buffering", async () => {
-    const saved = await saveResponseMedia(new Response(null, { status: 204 }), {
-      sourceUrl: "https://example.com/empty",
-      fallbackContentType: "application/octet-stream",
-      maxBytes: 8,
-    });
+  it("rejects bodyless successful responses without saving an empty file", async () => {
+    const inboundDir = path.join(tempHome.home, ".openclaw", "media", "inbound");
+    const listInboundFiles = async () => {
+      try {
+        return (await fs.readdir(inboundDir)).toSorted();
+      } catch (error) {
+        if (hasErrnoCode(error, "ENOENT")) {
+          return [];
+        }
+        throw error;
+      }
+    };
+    const before = await listInboundFiles();
 
-    expect(saved.size).toBe(0);
-    await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.alloc(0));
+    await expect(
+      saveResponseMedia(new Response(null, { status: 204 }), {
+        sourceUrl: "https://example.com/empty",
+        fallbackContentType: "application/octet-stream",
+        maxBytes: 8,
+      }),
+    ).rejects.toMatchObject({
+      name: "MediaFetchError",
+      code: "http_error",
+      status: 204,
+      message:
+        "Failed to fetch media from https://example.com/empty: HTTP 204; empty response body",
+    });
+    await expect(listInboundFiles()).resolves.toEqual(before);
   });
 
   it("uses caller filename hints for MIME detection without preserving storage basenames", async () => {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -21,7 +21,7 @@ import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
-import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";
+import { saveMediaStream, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
 const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
@@ -393,7 +393,7 @@ async function assertMediaResponseOk(params: {
   readIdleTimeoutMs?: number;
 }): Promise<void> {
   const { res, url, finalUrl, sourceUrl, readIdleTimeoutMs } = params;
-  if (res.ok) {
+  if (res.ok && res.body) {
     return;
   }
   const statusText = res.statusText ? ` ${res.statusText}` : "";
@@ -573,23 +573,15 @@ async function saveOkMediaResponse(params: {
     ? (params.filePathHint ?? fileName)
     : undefined;
   try {
-    const saved = params.res.body
-      ? await saveMediaStream(
-          responseBodyChunks(params.res.body, params.readIdleTimeoutMs),
-          contentType ?? undefined,
-          params.subdir ?? "inbound",
-          params.maxBytes,
-          params.originalFilename,
-          detectionFilePathHint,
-        )
-      : await saveMediaBuffer(
-          Buffer.alloc(0),
-          contentType ?? undefined,
-          params.subdir ?? "inbound",
-          params.maxBytes,
-          params.originalFilename,
-          detectionFilePathHint,
-        );
+    const body = expectDefined(params.res.body, "media response body");
+    const saved = await saveMediaStream(
+      responseBodyChunks(body, params.readIdleTimeoutMs),
+      contentType ?? undefined,
+      params.subdir ?? "inbound",
+      params.maxBytes,
+      params.originalFilename,
+      detectionFilePathHint,
+    );
     return { ...saved, ...(fileName ? { fileName } : {}) };
   } catch (err) {
     if (err instanceof MediaFetchError) {

--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -9,9 +9,14 @@ import {
   waitForPlaybackTranscodeJobsForTest,
 } from "./playback-transcode.test-support.js";
 
-const { probePlaybackMediaFileDescriptor, runFfmpeg } = vi.hoisted(() => ({
+const { playbackWarn, probePlaybackMediaFileDescriptor, runFfmpeg } = vi.hoisted(() => ({
+  playbackWarn: vi.fn(),
   probePlaybackMediaFileDescriptor: vi.fn(),
   runFfmpeg: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: (subsystem: string) => ({ subsystem, warn: playbackWarn }),
 }));
 
 vi.mock("./ffmpeg-exec.js", () => ({
@@ -42,6 +47,7 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
+  playbackWarn.mockReset();
   runFfmpeg.mockReset();
   probePlaybackMediaFileDescriptor.mockReset();
   probePlaybackMediaFileDescriptor.mockImplementation(async (_fd: number, kind: string) =>
@@ -754,6 +760,41 @@ describe("resolvePlaybackTranscode", () => {
           kind: "transcoded",
         });
       });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("warns once when the same transcode operation fails across cooldown retries", async () => {
+    const source = await createSource("warn-failed.caf", "caff-source");
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    runFfmpeg.mockRejectedValue(new Error("ffmpeg unavailable"));
+    const params = {
+      ...source,
+      mimeType: "audio/x-caf",
+      kind: "audio" as const,
+    };
+
+    try {
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await vi.waitFor(() => expect(playbackWarn).toHaveBeenCalledOnce());
+      expect(playbackWarn).toHaveBeenCalledWith(
+        expect.stringContaining(`${source.sourcePath}: ffmpeg unavailable`),
+      );
+
+      nowSpy.mockReturnValue(61_001);
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledTimes(2));
+      await vi.waitFor(async () => {
+        await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+          kind: "fallback",
+        });
+      });
+      expect(playbackWarn).toHaveBeenCalledOnce();
     } finally {
       nowSpy.mockRestore();
     }

--- a/src/media/playback-transcode.ts
+++ b/src/media/playback-transcode.ts
@@ -4,11 +4,13 @@ import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { maxBytesForKind, type MediaKind } from "@openclaw/media-core/constants";
 import { extensionForMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { formatErrorMessage } from "../infra/errors.js";
 import { fileStore } from "../infra/file-store.js";
 import { openLocalFileSafely } from "../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { withTempWorkspace } from "../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { runFfmpeg } from "./ffmpeg-exec.js";
 import { probePlaybackMediaFileDescriptor, type PlaybackMediaProbeResult } from "./media-probe.js";
@@ -139,6 +141,7 @@ const playbackJobs = new Map<string, Promise<void>>();
 const playbackFailures = new Map<string, number>();
 const playbackInspections = new Map<string, PlaybackInspection>();
 const playbackInspectionJobs = new Map<string, Promise<PlaybackInspection>>();
+const log = createSubsystemLogger("media/playback");
 
 /** Hashes the immutable source identity used by playback cache file names. */
 function createPlaybackTranscodeCacheKey(source: PlaybackSourceIdentity): string {
@@ -662,7 +665,6 @@ export async function resolvePlaybackTranscode(
     if (Date.now() - failedAtMs < PLAYBACK_TRANSCODE_FAILURE_COOLDOWN_MS) {
       return { kind: "fallback" };
     }
-    playbackFailures.delete(operationKey);
   }
   if (playbackJobs.size >= MAX_PLAYBACK_TRANSCODE_JOBS) {
     return { kind: "preparing" };
@@ -689,8 +691,13 @@ export async function resolvePlaybackTranscode(
       playbackJobs.delete(operationKey);
       playbackFailures.delete(operationKey);
     },
-    () => {
+    (reason: unknown) => {
       playbackJobs.delete(operationKey);
+      if (!playbackFailures.has(operationKey)) {
+        log.warn(
+          `Playback transcode failed for ${params.sourcePath}: ${formatErrorMessage(reason)}`,
+        );
+      }
       playbackFailures.delete(operationKey);
       playbackFailures.set(operationKey, Date.now());
       pruneMapToMaxSize(playbackFailures, MAX_PLAYBACK_ENTRIES.failures);


### PR DESCRIPTION
## What Problem This Solves

Fixes three silent media failures where work appeared successful even though the media outcome was unusable:

- A current-turn image could fail to hydrate while the model continued without knowing the attachment was unavailable.
- A detached playback transcode could fail without an operator-visible diagnostic.
- An HTTP 204 or other successful null-body response could be stored as a successful zero-byte media file.

## Why This Change Was Made

The repair records each failure at its owning boundary. Current-turn image hydration failures warn with a redacted reference and reason. Both the installed history transform and direct provider materialization report the failed attachment count into one session-owned state field, while provider-visible current-turn content receives an explicit system note that the image contents are unavailable, instructing the model to tell the user, ask for a resend, and not claim inspection.

Durable transcript persistence now happens once at the lifecycle owner: only after `completeEmbeddedAttemptAfterTurn` finishes, the runner appends one canonical displayed `role: "custom"` / `openclaw.system-note` entry through `SessionManager.appendMessageToTranscript` for persistent sessions (or `appendMessage` in memory) and updates `messagesSnapshot`. No prompt-phase or stream-phase persistence path remains, so after-turn reconciliation cannot erase or hide the outcome.

Playback processing warns once per operation while retaining bounded cooldown state. HTTP success responses without a body become typed `http_error` outcomes before storage, so no empty file is written. No compatibility or configuration surface was added.

## User Impact

Users now see that an attachment could not be inspected and are asked to resend it instead of receiving an answer that silently ignored the image. Operators receive one actionable warning when playback processing fails, and invalid empty HTTP media responses no longer enter the media store as successes.

## Evidence

- Source-blind isolated live Control UI/provider proof passed: the provider request contained the unavailable/resend/no-inspection note; public `chat.history` contained the user, assistant, and canonical displayed `role: "custom"` system note; reloading the Control UI rendered that durable note.
- Original focused and sibling Vitest proof passed: 234 tests total (media shard 106; embedded-agent shard 128).
- Exact-head CI repair reproduced [the compact-large failure](https://github.com/openclaw/openclaw/actions/runs/32122906184/job/95667317515): `attempt-stream-finalize.test.ts` failed 6/8 tests at the unconditional message-note lookup, then passed 8/8 after the no-failure short-circuit; the requested sibling set passed 51/51.
- `node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/attempt-settle.ts` passed formatting, core and core-test typechecks, lint, guards, cycle checks, the media-helper guard, and the database-first guard on the new exact head.
- The prior uncommitted Codex autoreview was clean with no accepted/actionable findings; exact-head autoreview will be rerun by the landing lead.
- Production LOC: +101/-25 (net +76). Tests: +231/-22 (net +209). Total: +332/-47. The production growth owns the model-visible and durable failed-image outcome at the session lifecycle boundary while preserving the two sibling materialization paths.

**Before — attachment failure was silent after the assistant response**

![Before: attachment failure was not surfaced](https://github.com/user-attachments/assets/727470ea-b6be-4819-9fc9-4e02eab3634f)

**After — the durable system note is visible after reload**

![After: durable attachment failure note is visible](https://github.com/user-attachments/assets/be166148-2400-47bb-ae08-57ae8e64cdec)

AI-assisted: yes. The maintainer reviewed the code and proof.
