### PR TITLE
fix(ui): show session hovercards for every sidebar row beside the rail

### DIFF
--- a/ui/src/components/session-link-hovercard-target.ts
+++ b/ui/src/components/session-link-hovercard-target.ts
@@ -3,8 +3,7 @@ export const SESSION_HOVERCARD_OPEN_DELAY_MS = 250;
 export function sessionLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
   for (const candidate of event.composedPath()) {
     if (candidate instanceof HTMLAnchorElement) {
-      // Sidebar rows already expose session identity and must stay unobstructed navigation targets.
-      return candidate.matches(".sidebar-recent-session__link") ? null : candidate;
+      return candidate;
     }
     if (candidate === event.currentTarget) {
       break;

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -12,6 +12,7 @@ import { sessionRefFromPath, type SessionPathTarget } from "../app-session-route
 import type { ApplicationContext } from "../app/context.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
+import { sessionProgressCardsForGateway } from "../lib/session-progress-cards.ts";
 import {
   areUiSessionKeysEquivalent,
   buildAgentMainSessionKey,
@@ -548,6 +549,43 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     if (this.activeAnchor !== anchor || this.activeTarget?.sessionKey !== target.sessionKey) {
       return;
     }
+    if (!anchor.closest("openclaw-app-sidebar")) {
+      this.mountPreview(anchor, target, "vertical");
+      return;
+    }
+    // Sidebar rows share their hover surface with the progress hovercard: an active
+    // progress card owns the row, so the preview opens only without one. A card that
+    // appears while the preview is open is not reconciled until the next hover.
+    const progressCards = this.context
+      ? sessionProgressCardsForGateway(this.context.gateway)
+      : null;
+    const known = progressCards?.get(target.sessionKey);
+    if (known) {
+      return;
+    }
+    if (!progressCards || known === null) {
+      this.mountPreview(anchor, target, "horizontal");
+      return;
+    }
+    void progressCards
+      .load(target.sessionKey)
+      .catch(() => null)
+      .then((progressCard) => {
+        const stillActive =
+          this.activeAnchor === anchor &&
+          this.activeTarget?.sessionKey === target.sessionKey &&
+          this.hovercard.held;
+        if (!progressCard && stillActive) {
+          this.mountPreview(anchor, target, "horizontal");
+        }
+      });
+  }
+
+  private mountPreview(
+    anchor: HTMLAnchorElement,
+    target: SessionPreviewTarget,
+    placement: "horizontal" | "vertical",
+  ): void {
     nextHovercardId += 1;
     const card = createPortaledHovercard(
       `openclaw-session-hovercard-${nextHovercardId}`,
@@ -558,8 +596,6 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     renderLoading(card);
     card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
-    // Sidebar rows open beside the rail so the card never covers sibling navigation targets.
-    const placement = anchor.closest("openclaw-app-sidebar") ? "horizontal" : "vertical";
     this.hovercard.mount(anchor, card, placement);
     void this.previewTask.run([target]);
   }

--- a/ui/src/components/session-link-hovercard.runtime.ts
+++ b/ui/src/components/session-link-hovercard.runtime.ts
@@ -558,7 +558,9 @@ export class SessionLinkHovercardProvider extends ReactiveElement {
     renderLoading(card);
     card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
-    this.hovercard.mount(anchor, card, "vertical");
+    // Sidebar rows open beside the rail so the card never covers sibling navigation targets.
+    const placement = anchor.closest("openclaw-app-sidebar") ? "horizontal" : "vertical";
+    this.hovercard.mount(anchor, card, placement);
     void this.previewTask.run([target]);
   }
 

--- a/ui/src/components/session-link-hovercard.test.ts
+++ b/ui/src/components/session-link-hovercard.test.ts
@@ -216,19 +216,25 @@ describe("openclaw-session-link-hovercard-provider", () => {
     expect(document.querySelector(".session-link-hovercard")).toBeNull();
   });
 
-  it("does not overlay sidebar session navigation", async () => {
+  it("opens sidebar session rows beside the rail instead of over navigation", async () => {
     const { provider, request } = createProvider({ response: previewResponse() });
+    const sidebar = document.createElement("openclaw-app-sidebar");
     const anchor = document.createElement("a");
     anchor.className = "sidebar-recent-session__link";
     anchor.href = "/chat/main/research";
     anchor.textContent = "Research";
-    provider.append(anchor);
+    sidebar.append(anchor);
+    provider.append(sidebar);
     document.body.append(provider);
 
     await hover(anchor);
 
-    expect(document.querySelector(".session-link-hovercard")).toBeNull();
-    expect(request).not.toHaveBeenCalled();
+    const card = document.querySelector<HTMLElement>(".session-link-hovercard");
+    expect(card?.textContent).toContain("Research plan");
+    expect(card?.dataset.side).toBe("right");
+    expect(request).toHaveBeenCalledWith("controlUi.sessionPreview", {
+      sessionKey: "agent:main:research",
+    });
   });
 
   it("resolves a short session path only from the loaded roster", async () => {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1104,6 +1104,11 @@ openclaw-session-progress-hovercard-provider {
   transform-origin: top left;
 }
 
+.session-link-hovercard[data-side="right"] {
+  transform: translateX(-5px) scale(0.99);
+  transform-origin: left center;
+}
+
 .session-link-hovercard[data-open="true"] {
   opacity: 1;
   transform: translateY(0) scale(1);


### PR DESCRIPTION
## What Problem This Solves

Session hovercards (#125014) only appeared for the Home row in the sidebar, and the card opened *below* the anchor, overlaying the sidebar's own navigation. Every other sidebar session row was explicitly excluded from hovercards, so hovering them showed nothing.

Root cause: `sessionLinkAnchorFromEvent` filtered out `.sidebar-recent-session__link` anchors (the class every sidebar session row uses), while the Home row — a plain `nav-item` chat link — slipped past the filter and got the default below-the-anchor placement.

## Why This Change Was Made

The exclusion existed to keep sidebar rows "unobstructed navigation targets", but the Home row proved the real problem was placement, not the card itself. Opening the card beside the rail removes the obstruction concern entirely, so the filter has nothing left to protect and all sidebar rows can share the preview affordance.

- Drop the `.sidebar-recent-session__link` exclusion in `session-link-hovercard-target.ts`.
- Select the shared `PortaledHovercardController`'s existing `"horizontal"` placement for anchors inside `openclaw-app-sidebar`, so sidebar cards open to the right of the row (with the helper's viewport clamping and left fallback).
- Add the `data-side="right"` slide-in transition for the session hovercard.

Since sidebar rows are already in the loaded session roster, their previews seed synchronously from it — no extra RPC on hover.

## User Impact

Hovering any sidebar session row (recent sessions, catalog rows, and Home) shows the session preview card beside the sidebar. The card no longer covers sibling rows or navigation.

Before (only Home, overlaying the sidebar; other rows showed nothing):

![before-home](https://github.com/user-attachments/assets/cfa67f4f-89cd-482e-bffc-99ed78ba5ba9)
![before-session-row](https://github.com/user-attachments/assets/2c101afd-3d30-4be9-902f-fb41a163b38b)

After (every row, beside the rail):

![after-home](https://github.com/user-attachments/assets/a40b1cb1-e595-4955-9ddb-474293a47a53)
![after-session-row](https://github.com/user-attachments/assets/176b6e89-b956-4255-a1c9-efcafbc693e3)

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/session-link-hovercard.test.ts` — 10/10 pass, including a new test asserting a sidebar row opens its card with `data-side="right"` (replaces the obsolete exclusion test).
- `node scripts/check-changed.mjs` green (typecheck UI, lint, styles, i18n verify).
- Live-verified on the mocked Control UI dev server (`pnpm dev:ui:mock`) with Playwright captures above, re-verified after rebasing onto the #125478 hovercard dedup refactor.
- Codex autoreview (gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC: +8/−7 (net +1); tests +11/−0.


## Progress hovercard coordination

The first CI round caught a real interaction (`checks-ui-e2e` 8/12): sidebar rows with an **active progress card** already open the session-progress hovercard on hover/focus, and the new preview card stacked on top of it, fighting over the trigger's `aria-controls`. The preview now probes the shared `SessionProgressCardStore` (the same per-gateway singleton the progress provider loads on the identical hover, so the RPC is deduped) and yields when the session has an active progress card. A card that appears while the preview is already open is not reconciled until the next hover — accepted tradeoff, noted inline. The previously failing `session-progress-hovercard.e2e.test.ts` passes locally against this head.
