### PR TITLE
fix(ui): stop composer mic hover shift and stray red hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1988,6 +1988,7 @@
     "ui:i18n:report": "node --import tsx scripts/control-ui-i18n-report.ts",
     "ui:i18n:sync": "node --import tsx scripts/control-ui-i18n.ts sync --write",
     "ui:i18n:verify": "node --import tsx scripts/control-ui-i18n-verify.ts verify",
+    "ui:proof:composer-mic-hover": "node --import tsx scripts/capture-composer-mic-hover-proof.mts",
     "ui:proof:workboard": "node --import tsx scripts/capture-workboard-ui-proof.mts",
     "native:i18n:baseline": "node --import tsx scripts/native-app-i18n.ts baseline --write",
     "native:i18n:check": "node --import tsx scripts/native-app-i18n.ts check",

--- a/scripts/capture-composer-mic-hover-proof.mts
+++ b/scripts/capture-composer-mic-hover-proof.mts
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Captures composer mic-hover proof shots: idle vs hovered talk control, plus
+// the mic button's x position in both states (the hover-shift regression).
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "playwright";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+} from "../ui/src/test-helpers/control-ui-e2e.ts";
+
+function readOption(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inline = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const outputDir = path.resolve(
+  readOption("output-dir") ?? ".artifacts/control-ui-e2e/composer-mic-hover-proof",
+);
+const label = readOption("label") ?? "after";
+const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+if (!canRunPlaywrightChromium(executablePath)) {
+  throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
+}
+
+await mkdir(outputDir, { recursive: true });
+const server = await startControlUiE2eServer(undefined, { source: true });
+const browser = await chromium.launch({ executablePath });
+const context = await browser.newContext({
+  colorScheme: "dark",
+  viewport: { width: 1280, height: 800 },
+});
+const page = await context.newPage();
+page.setDefaultTimeout(30_000);
+
+try {
+  await installMockGateway(page);
+  await page.goto(`${server.baseUrl}chat`);
+  const composer = page.locator(".agent-chat__input");
+  await composer.waitFor({ state: "visible" });
+  const voice = page.getByRole("button", { name: "Start voice input" });
+  await voice.waitFor({ state: "visible" });
+
+  await page.mouse.move(10, 10);
+  await page.waitForTimeout(400);
+  const composerBox = await composer.boundingBox();
+  if (!composerBox) {
+    throw new Error("composer has no layout box");
+  }
+  const clip = {
+    x: Math.max(0, composerBox.x - 12),
+    y: Math.max(0, composerBox.y - 12),
+    width: Math.min(1280, composerBox.width + 24),
+    height: composerBox.height + 24,
+  };
+  const idleVoiceBox = await voice.boundingBox();
+  await page.screenshot({ clip, path: path.join(outputDir, `${label}-idle.png`) });
+
+  await voice.hover();
+  await page.waitForTimeout(400);
+  const hoverVoiceBox = await voice.boundingBox();
+  await page.screenshot({ clip, path: path.join(outputDir, `${label}-hover.png`) });
+
+  const picker = page.getByRole("button", { name: "Microphone input" });
+  if (await picker.count()) {
+    await picker.hover();
+    await page.waitForTimeout(400);
+    await page.screenshot({ clip, path: path.join(outputDir, `${label}-hover-chevron.png`) });
+    await picker.click();
+    await page.waitForTimeout(500);
+    await page.screenshot({
+      path: path.join(outputDir, `${label}-picker-open.png`),
+      clip: { ...clip, y: Math.max(0, clip.y - 260), height: clip.height + 260 },
+    });
+    await page.keyboard.press("Escape");
+  }
+
+  if (!idleVoiceBox || !hoverVoiceBox) {
+    throw new Error("voice button has no layout box");
+  }
+  console.log(
+    JSON.stringify(
+      {
+        label,
+        idleVoiceX: idleVoiceBox.x,
+        hoverVoiceX: hoverVoiceBox.x,
+        hoverShiftPx: hoverVoiceBox.x - idleVoiceBox.x,
+        outputDir,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await context.close();
+  await browser.close();
+  await server.close();
+}

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -517,8 +517,8 @@ suite.define(() => {
       await expect.poll(() => camera.count()).toBe(0);
       expect(await page.evaluate(() => matchMedia("(pointer: coarse)").matches)).toBe(false);
       await expect
-        .poll(() => microphonePickerShell.evaluate((node) => node.getBoundingClientRect().width))
-        .toBe(0);
+        .poll(() => microphonePickerShell.evaluate((node) => getComputedStyle(node).opacity))
+        .toBe("0");
       // Resize re-layout is async; wait for the header controls to adopt the
       // mobile width before sampling one-shot bounding boxes below.
       await expect
@@ -611,18 +611,31 @@ suite.define(() => {
       await expect.poll(() => voice.isDisabled()).toBe(true);
       await page.mouse.move(0, 0);
       await expect.poll(() => page.locator("wa-tooltip[open]").count()).toBe(0);
+      // The picker reserves its width while hidden; only opacity reveals it, so
+      // hovering never shifts the right-aligned mic/send cluster sideways.
       await expect
         .poll(() => microphonePickerShell.evaluate((node) => node.getBoundingClientRect().width))
-        .toBe(0);
+        .toBe(22);
+      await expect
+        .poll(() => microphonePickerShell.evaluate((node) => getComputedStyle(node).opacity))
+        .toBe("0");
       await expect.poll(() => voice.evaluate((node) => getComputedStyle(node).opacity)).toBe("0.4");
+      const idleVoiceBox = await voice.boundingBox();
+      expect(idleVoiceBox).not.toBeNull();
 
       await voice.hover();
       await expect
-        .poll(() => microphonePickerShell.evaluate((node) => node.getBoundingClientRect().width))
-        .toBe(20);
-      await expect
         .poll(() => microphonePickerShell.evaluate((node) => getComputedStyle(node).opacity))
         .toBe("1");
+      await expect
+        .poll(() => microphonePickerShell.evaluate((node) => node.getBoundingClientRect().width))
+        .toBe(22);
+      const hoveredVoiceBox = await voice.boundingBox();
+      expect(hoveredVoiceBox).not.toBeNull();
+      if (!idleVoiceBox || !hoveredVoiceBox) {
+        throw new Error("expected voice button layout boxes around hover");
+      }
+      expect(hoveredVoiceBox.x).toBe(idleVoiceBox.x);
       await microphonePicker.click();
       await expect.poll(() => microphonePicker.getAttribute("aria-expanded")).toBe("true");
       await expect.poll(() => page.locator(".chat-talk-input-picker[open]").count()).toBe(1);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3503,17 +3503,21 @@ button.chat-pr__diff {
   stroke-linejoin: round;
 }
 
+/* Theme overrides adjust the hover fill via this variable instead of their own
+   :hover rules: a :root[data-theme] selector outranks every variant's hover
+   (--voice, --stop), which painted the idle mic with the send button's loud
+   accent hover in dark themes. */
 .chat-send-btn:hover:not(:disabled) {
-  background: var(--accent-hover);
+  background: var(--chat-send-hover-background, var(--accent-hover));
   box-shadow: 0 2px 12px var(--accent-glow);
 }
 
-:root[data-theme="dark"] .chat-send-btn:hover:not(:disabled) {
-  background: var(--primary-hover);
+:root[data-theme="dark"] .chat-send-btn {
+  --chat-send-hover-background: var(--primary-hover);
 }
 
-:root[data-theme="openknot"] .chat-send-btn:hover:not(:disabled) {
-  background: var(--primary-hover);
+:root[data-theme="openknot"] .chat-send-btn {
+  --chat-send-hover-background: var(--primary-hover);
 }
 
 /* Outline (not box-shadow) so the hover rules' higher-specificity box-shadow
@@ -3561,11 +3565,11 @@ button.chat-pr__diff {
   --chat-voice-hover-color: var(--text);
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   flex: 0 0 auto;
 }
 
 .chat-talk-control--active {
-  --chat-picker-border: color-mix(in srgb, var(--accent) 24%, transparent);
   --chat-picker-background: color-mix(in srgb, var(--accent) 14%, transparent);
   --chat-picker-color: var(--accent);
   --chat-picker-hover-background: color-mix(in srgb, var(--accent) 20%, transparent);
@@ -3576,24 +3580,20 @@ button.chat-pr__diff {
   display: inline-flex;
 }
 
-.chat-talk-control .chat-send-btn {
-  border-radius: var(--radius-full) 0 0 var(--radius-full);
-}
-
+/* The device picker is a detached round ghost button beside the mic — the mic
+   itself never changes shape. It reserves its width at all times and hover
+   only fades it in; collapsing the width instead shifts the whole
+   right-aligned mic/send cluster sideways under the cursor on mouse-over. */
 .chat-talk-input-picker {
   display: inline-flex;
-  align-self: stretch;
-  width: 20px;
-  transition:
-    width 120ms ease,
-    opacity 100ms ease;
+  align-self: center;
+  width: 22px;
+  transition: opacity var(--duration-fast) ease;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .chat-talk-control:not(.chat-talk-control--active, :hover, :focus-within)
     .chat-talk-input-picker:not([open]) {
-    width: 0;
-    min-width: 0;
     opacity: 0;
   }
 }
@@ -3602,12 +3602,11 @@ button.chat-pr__diff {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
-  height: 100%;
+  width: 22px;
+  height: 22px;
   padding: 0;
   border: 0;
-  border-left: 1px solid var(--chat-picker-border, var(--border));
-  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  border-radius: var(--radius-full);
   background: var(--chat-picker-background, transparent);
   color: var(--chat-picker-color, var(--muted));
   transition: background var(--duration-fast) ease;


### PR DESCRIPTION
## What Problem This Solves

The composer's talk (microphone) button shifted 20px left every time you hovered it, because the device-picker chevron next to it animated its own `width` from 0 to 20px on hover instead of just fading in. The mic button also picked up the send button's loud accent-red hover fill in dark and openknot themes instead of the quiet neutral hover it was actually styled for.

## Why This Change Was Made

Peter flagged the hover-driven layout shift as confusing, then asked for alternatives to the split-pill shape morph and the red hover once the shift was fixed. Four options were mocked with the visualizer tool; option C ("detached chevron — no shape morph") was picked: the mic stays a plain circle in every state, and the device picker renders as its own small round ghost button beside it that only fades in on hover/focus, with its width always reserved so nothing in the right-aligned action cluster ever moves.

The red hover turned out to be a real specificity bug: `:root[data-theme="dark"] .chat-send-btn:hover` and the `openknot` equivalent outranked every button variant's own `:hover` rule (voice, stop), so dark-theme users always saw the send button's accent-red hover on the idle mic regardless of what the voice variant declared. Fixed by having those theme overrides set a `--chat-send-hover-background` variable instead of their own `:hover` rule, so each variant's hover styling can still win.

## User Impact

- Hovering the composer mic button no longer shifts it (or the send button next to it) sideways.
- The device-picker chevron is a separate, always-circular control instead of morphing the mic into a split pill.
- The idle mic button's hover is a quiet neutral tint in dark/openknot themes instead of the send button's accent-red fill; red stays reserved for actively recording/live voice states.
- Active talk-session and touch-device layouts are unchanged (chevron stays visible there, as before).

## Evidence

- Real rendered before/after screenshots captured from the mocked Control UI dev server, confirming zero pixel shift on hover (idle x == hover x) and the corrected shape/hover treatment.
- `ui/src/e2e/chat-composer-redesign.e2e.test.ts` updated to assert the new invariant: the picker reserves its 22px width at all times (only opacity changes), and the mic button's x-position is identical before and after hover. This assertion fails against the pre-fix stylesheet (verified locally) and passes with the fix.
- `node scripts/check-changed.mjs` (stylelint + UI typecheck) green.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.

Added `scripts/capture-composer-mic-hover-proof.mts`, a small Playwright helper (same pattern as `scripts/capture-workboard-ui-proof.mts`) that screenshots the composer mic button idle/hover/chevron-hover/picker-open states and prints the measured hover x-shift, for future visual regression checks on this control.
