### PR TITLE
improve(ui): paginate grouped sessions

### DIFF
--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -928,6 +928,7 @@ class SessionsPage extends OpenClawLightDomElement {
 
   private setGroupBy(mode: SessionsGroupBy) {
     this.groupBy = mode;
+    this.page = 0;
     saveStoredGroupBy(mode);
   }
 

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -423,18 +423,20 @@ describe("sessions view", () => {
     expect(container.querySelectorAll(".session-data-row--archived")).toHaveLength(1);
   });
 
-  it("groups sessions by channel with section headers and no pagination", async () => {
+  it("paginates grouped sessions while preserving full group counts", async () => {
     const container = document.createElement("div");
+    const onPageChange = vi.fn();
+    const result = buildMultiResult([
+      { key: "agent:main:discord:channel:1", kind: "group", updatedAt: 3 },
+      { key: "agent:main:telegram:direct:2", kind: "direct", updatedAt: 2 },
+      { key: "agent:main:discord:channel:3", kind: "group", updatedAt: 1 },
+    ]);
     render(
       renderSessions({
-        ...buildProps(
-          buildMultiResult([
-            { key: "agent:main:discord:channel:1", kind: "group", updatedAt: 3 },
-            { key: "agent:main:telegram:direct:2", kind: "direct", updatedAt: 2 },
-            { key: "agent:main:discord:channel:3", kind: "group", updatedAt: 1 },
-          ]),
-        ),
+        ...buildProps(result),
         groupBy: "channel",
+        pageSize: 2,
+        onPageChange,
       }),
       container,
     );
@@ -443,12 +445,41 @@ describe("sessions view", () => {
     const headers = Array.from(container.querySelectorAll(".session-group-row__label")).map((el) =>
       el.textContent?.trim(),
     );
-    expect(headers).toEqual(["discord", "telegram"]);
+    expect(headers).toEqual(["discord"]);
     const counts = Array.from(container.querySelectorAll(".session-group-row__count")).map((el) =>
       el.textContent?.trim(),
     );
-    expect(counts).toEqual(["2 sessions", "1 session"]);
-    expect(container.querySelector(".data-table-pagination")).toBeNull();
+    expect(counts).toEqual(["2 sessions"]);
+    expect(container.querySelectorAll(".session-data-row")).toHaveLength(2);
+    expect(container.querySelector(".data-table-pagination")?.textContent).toContain(
+      "1-2 of 3 rows",
+    );
+
+    const next = Array.from(container.querySelectorAll(".data-table-pagination button")).find(
+      (button) => button.textContent?.trim() === "Next",
+    );
+    expect(next).toBeInstanceOf(HTMLButtonElement);
+    next!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+
+    render(
+      renderSessions({
+        ...buildProps(result),
+        groupBy: "channel",
+        page: 1,
+        pageSize: 2,
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(container.querySelector(".session-group-row__label")?.textContent?.trim()).toBe(
+      "telegram",
+    );
+    expect(container.querySelector(".session-group-row__count")?.textContent?.trim()).toBe(
+      "1 session",
+    );
+    expect(container.querySelectorAll(".session-data-row")).toHaveLength(1);
   });
 
   it("selects and names the current page size on first render", async () => {

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -981,16 +981,16 @@ export function renderSessions(props: SessionsProps) {
   const totalRows = sorted.length;
   const totalPages = Math.max(1, Math.ceil(totalRows / props.pageSize));
   const page = Math.min(props.page, totalPages - 1);
-  // Grouping shows all rows in their sections; pagination would split groups confusingly.
-  const groupingActive = props.groupBy !== "none";
-  const groups = groupingActive
-    ? groupSessionRows({
-        rows: sorted,
-        mode: props.groupBy,
-        knownCategories: props.knownCategories,
-      })
-    : null;
-  const paginated = groupingActive ? sorted : paginateRows(sorted, page, props.pageSize);
+  const groups =
+    props.groupBy !== "none"
+      ? groupSessionRows({
+          rows: sorted,
+          mode: props.groupBy,
+          knownCategories: props.knownCategories,
+        })
+      : null;
+  const displayRows = groups ? groups.flatMap((group) => group.rows) : sorted;
+  const paginated = paginateRows(displayRows, page, props.pageSize);
   const emptyBecauseFiltered =
     rawRows.length === 0 ? hasActiveFilters(props) : filtered.length === 0;
   const liveCount = rawRows.filter((row) => isSessionRunActive(row)).length;
@@ -1077,7 +1077,6 @@ export function renderSessions(props: SessionsProps) {
       renderSessionsTable(props, {
         paginated,
         groups,
-        groupingActive,
         emptyBecauseFiltered,
         emptyMessage,
         totalRows,
@@ -1093,7 +1092,6 @@ export function renderSessions(props: SessionsProps) {
 type SessionsTableContext = {
   paginated: GatewaySessionRow[];
   groups: SessionRowGroup[] | null;
-  groupingActive: boolean;
   emptyBecauseFiltered: boolean;
   emptyMessage: string;
   totalRows: number;
@@ -1107,16 +1105,8 @@ type SessionsTableContext = {
 };
 
 function renderSessionsTable(props: SessionsProps, ctx: SessionsTableContext) {
-  const {
-    paginated,
-    groups,
-    groupingActive,
-    emptyBecauseFiltered,
-    emptyMessage,
-    totalRows,
-    totalPages,
-    page,
-  } = ctx;
+  const { paginated, groups, emptyBecauseFiltered, emptyMessage, totalRows, totalPages, page } =
+    ctx;
   const sortHeader = ctx.sortHeader;
   const emptyStateMessage = emptyBecauseFiltered
     ? t("sessionsView.noSessionsMatchFilters")
@@ -1142,6 +1132,7 @@ function renderSessionsTable(props: SessionsProps, ctx: SessionsTableContext) {
     key: keyof Parameters<SessionsProps["onFiltersChange"]>[0],
     value: string | boolean,
   ) => props.onFiltersChange({ activeMinutes, limit, includeGlobal, includeUnknown, [key]: value });
+  const paginatedKeys = groups ? new Set(paginated.map((row) => row.key)) : null;
   return html`
     <div
       class="sessions-toolbar sessions-filter-bar"
@@ -1314,7 +1305,11 @@ function renderSessionsTable(props: SessionsProps, ctx: SessionsTableContext) {
                 `
               : groups
                 ? groups.flatMap((group) => {
-                    const section = group.rows.flatMap((row) => renderRows(row, props));
+                    const visibleRows = group.rows.filter((row) => paginatedKeys?.has(row.key));
+                    if (visibleRows.length === 0 && group.rows.length > 0) {
+                      return [];
+                    }
+                    const section = visibleRows.flatMap((row) => renderRows(row, props));
                     section.unshift(renderGroupHeaderRow(group, props));
                     return section;
                   })
@@ -1323,7 +1318,7 @@ function renderSessionsTable(props: SessionsProps, ctx: SessionsTableContext) {
       </table>
     </div>
 
-    ${totalRows > 0 && !groupingActive
+    ${totalRows > 0
       ? html`
           <div class="data-table-pagination">
             <div class="data-table-pagination__info">


### PR DESCRIPTION
## What Problem This Solves

The Sessions page capped ungrouped results at the selected page size, but enabling any grouping bypassed the pager and rendered every fetched session. With 650 sessions, grouping by channel put 650 rows in the DOM and took a 967.0 ms median in production Chromium.

## Why This Change Was Made

Build the complete filtered/sorted group order first, flatten that order, and apply the existing page and page-size bounds before rendering. Group headers appear only for groups represented on the current page, while their counts continue to describe the full filtered group.

Changing the grouping resets to page 1. The existing pager and page-size controls remain available, so every session is reachable without changing filter, sort, grouping, or group-count semantics. Bulk selection continues to target the visible page, matching ungrouped behavior.

## User Impact

Large grouped session lists render only one page of rows instead of the entire result set. On a 650-session profile with the default 25-row page, channel grouping renders 25 rows and becomes responsive in about 34 ms instead of about 967 ms.

## Evidence

Seven fresh-profile runs against matched production builds from current `main` (`ca8bd59df50`) and this head in headless Chromium with a mocked Gateway serving 650 sessions:

- Group-by-channel median: **967.0 → 34.4 ms** (**−96.4%**)
- Grouped DOM rows: **650 → 25** (**−96.2%**)
- Grouped search median: **160.7 → 20.8 ms** (**−87.1%**)
- Accumulated long-task time: **1,466 → 367 ms** (**−75.0%**)
- Initial ready median: 838.9 → 848.9 ms; no startup-latency improvement is claimed

Validation:

- `pnpm check:changed`
- Production UI build and Control UI performance budget
- Broad Control UI suite: **9,185 passing** across the regular and isolated shards
- Sessions group mocked-Gateway Chromium E2E: **11/11 passing**
- Focused Sessions view/page tests: **85/85 passing**
- Autoreview: clean, no accepted/actionable findings
- Visual proof at 650 rows: full group count retained, 10 visible rows at selected page size, and coherent `1-10 of 650 rows` / Previous / Next controls
