### PR TITLE
fix(auth-profiles): keep per-model quota buckets usable under an account block

### DIFF
--- a/src/agents/auth-profiles/state.ts
+++ b/src/agents/auth-profiles/state.ts
@@ -101,6 +101,16 @@ function normalizeLastGood(raw: unknown): AuthProfileState["lastGood"] {
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
+function normalizeBlockExemptModels(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const models = [
+    ...new Set(raw.flatMap((value) => normalizeOptionalString(value)?.toLowerCase() ?? [])),
+  ];
+  return models.length > 0 ? models : undefined;
+}
+
 function normalizeUsageStatsEntry(raw: unknown): ProfileUsageStats | undefined {
   if (!isRecord(raw)) {
     return undefined;
@@ -112,6 +122,7 @@ function normalizeUsageStatsEntry(raw: unknown): ProfileUsageStats | undefined {
     blockedSource: normalizeEnumValue(raw.blockedSource, AUTH_BLOCKED_SOURCES),
     blockedModel: normalizeOptionalString(raw.blockedModel),
     blockedScope: raw.blockedScope === "model" ? "model" : undefined,
+    blockExemptModels: normalizeBlockExemptModels(raw.blockExemptModels),
     cooldownUntil: asFiniteNumber(raw.cooldownUntil),
     cooldownReason: normalizeEnumValue(raw.cooldownReason, AUTH_FAILURE_REASONS),
     cooldownModel: normalizeOptionalString(raw.cooldownModel),

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -107,6 +107,13 @@ export type ProfileUsageStats = {
   blockedSource?: AuthProfileBlockedSource;
   blockedModel?: string;
   blockedScope?: "model";
+  /**
+   * Models the usage probe observed with their own unexhausted quota bucket
+   * while the account-wide window was blocked. Without them a per-model
+   * allowance is invisible and the profile-wide block hides capacity the
+   * provider still grants.
+   */
+  blockExemptModels?: string[];
   cooldownUntil?: number;
   cooldownReason?: AuthProfileFailureReason;
   cooldownModel?: string;

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -27,13 +27,16 @@ export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | u
 export function resolveProfileUnusableUntil(
   stats: Pick<
     ProfileUsageStats,
-    "blockedUntil" | "blockedModel" | "blockedScope" | "cooldownUntil" | "disabledUntil"
+    | "blockedUntil"
+    | "blockedModel"
+    | "blockedScope"
+    | "blockExemptModels"
+    | "cooldownUntil"
+    | "disabledUntil"
   >,
   forModel?: string,
 ): number | null {
-  const blockedUntil = isBlockScopedToDifferentModel(stats, forModel)
-    ? undefined
-    : stats.blockedUntil;
+  const blockedUntil = blockedWindowExcludesModel(stats, forModel) ? undefined : stats.blockedUntil;
   const values = [blockedUntil, stats.cooldownUntil, stats.disabledUntil]
     .map((value) => asDateTimestampMs(value))
     .filter((value): value is number => value !== undefined && value > 0);
@@ -50,28 +53,35 @@ export function isActiveUnusableWindow(until: number | undefined, now: number): 
 }
 
 function isBlockedWindowActiveForModel(
-  stats: Pick<ProfileUsageStats, "blockedUntil" | "blockedModel" | "blockedScope">,
+  stats: Pick<
+    ProfileUsageStats,
+    "blockedUntil" | "blockedModel" | "blockedScope" | "blockExemptModels"
+  >,
   now: number,
   forModel?: string,
 ): boolean {
   return (
-    !isBlockScopedToDifferentModel(stats, forModel) &&
-    isActiveUnusableWindow(stats.blockedUntil, now)
+    !blockedWindowExcludesModel(stats, forModel) && isActiveUnusableWindow(stats.blockedUntil, now)
   );
 }
 
-function isBlockScopedToDifferentModel(
-  stats: Pick<ProfileUsageStats, "blockedModel" | "blockedScope">,
+function blockedWindowExcludesModel(
+  stats: Pick<ProfileUsageStats, "blockedModel" | "blockedScope" | "blockExemptModels">,
   forModel?: string,
 ): boolean {
+  if (!forModel) {
+    return false;
+  }
   // Legacy rows carried blockedModel for profile-wide blocks without a scope marker.
   // Only explicit model scope narrows them; unmarked rows stay wide until expiry.
-  return Boolean(
-    forModel &&
+  const scopedToOtherModel =
     stats.blockedScope === "model" &&
-    stats.blockedModel &&
-    stats.blockedModel !== forModel,
-  );
+    Boolean(stats.blockedModel) &&
+    stats.blockedModel !== forModel;
+  // A profile-wide block still leaves models whose own provider-side quota
+  // bucket was observed unexhausted; blocking them would hide granted capacity.
+  const exempt = stats.blockExemptModels?.includes(forModel.toLowerCase()) === true;
+  return scopedToOtherModel || exempt;
 }
 
 function shouldBypassModelScopedCooldown(
@@ -80,6 +90,7 @@ function shouldBypassModelScopedCooldown(
     | "blockedUntil"
     | "blockedModel"
     | "blockedScope"
+    | "blockExemptModels"
     | "cooldownReason"
     | "cooldownModel"
     | "disabledUntil"

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -322,6 +322,21 @@ describe("isProfileInCooldown", () => {
       { blockedUntil: now + 120_000, blockedModel: "gemini-3-flash-preview" },
       [["gemini-3.1-flash-lite", true]],
     ],
+    [
+      "keeps a model with its own unexhausted bucket usable under an account-wide block",
+      "openai:default",
+      {
+        blockedUntil: now + 120_000,
+        blockedReason: "subscription_limit",
+        blockedSource: "wham",
+        blockExemptModels: ["gpt-5.6-luna"],
+      },
+      [
+        ["gpt-5.6-luna", false],
+        ["gpt-5.6-sol", true],
+        [undefined, true],
+      ],
+    ],
   ];
 
   it.each(cases)("%s", (name, profileId, stats, checks) => {
@@ -1456,6 +1471,50 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     } else {
       expect(stats?.cooldownUntil).toBe(now + expectedMs);
     }
+  });
+
+  it("keeps per-model buckets usable when the account-wide window is exhausted", async () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({});
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: 7_200 },
+      },
+      // The provider meters some models separately and still allows them while
+      // the account window is spent; blocking them hides granted capacity.
+      additional_rate_limits: [
+        {
+          limit_name: "GPT-5.6-Luna",
+          rate_limit: { allowed: true, limit_reached: false },
+        },
+        {
+          limit_name: "GPT-5.6-Sol",
+          rate_limit: { allowed: false, limit_reached: true },
+        },
+      ],
+    });
+
+    await markCodexFailureAt({ store, now });
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.blockedUntil).toBe(now + 7_200_000);
+    expect(stats?.blockExemptModels).toEqual(["gpt-5.6-luna"]);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.6-luna")).toBe(false);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.6-sol")).toBe(true);
+  });
+
+  it("records a probe auth rejection as an auth cooldown, not the request's rate limit", async () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({});
+    mockWhamResponse(401);
+
+    await markCodexFailureAt({ store, now });
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.cooldownUntil).toBe(now + 12 * 60 * 60 * 1000);
+    expect(stats?.cooldownReason).toBe("auth");
+    expect(stats?.cooldownModel).toBeUndefined();
   });
 
   it("probes WHAM before recording an OpenAI OAuth detail-less failure", async () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -117,12 +117,21 @@ type WhamUsageWindow = {
   reset_after_seconds?: number;
 };
 
+type WhamAdditionalRateLimit = {
+  limit_name?: string;
+  rate_limit?: {
+    allowed?: boolean;
+    limit_reached?: boolean;
+  };
+};
+
 type WhamUsageResponse = {
   rate_limit?: {
     limit_reached?: boolean;
     primary_window?: WhamUsageWindow;
     secondary_window?: WhamUsageWindow;
   };
+  additional_rate_limits?: WhamAdditionalRateLimit[];
 };
 
 type WhamCooldownProbeResult = {
@@ -131,6 +140,10 @@ type WhamCooldownProbeResult = {
   reason: string;
   blockedUntil?: number;
   blockedSource?: AuthProfileBlockedSource;
+  /** Models the probe saw with their own unexhausted bucket. */
+  exemptModels?: string[];
+  /** Overrides the failure reason when the probe itself identified the fault. */
+  cooldownReason?: AuthProfileFailureReason;
 };
 
 function shouldProbeWhamForFailure(
@@ -202,6 +215,20 @@ function resolveWhamResetMs(window: WhamUsageWindow | undefined, now: number): n
   return null;
 }
 
+/**
+ * Model ids whose own provider-side bucket still allows requests. The provider
+ * names these buckets in display form ("GPT-5.3-Codex-Spark"); model ids are the
+ * same tokens lowercased, so no per-model table is needed here.
+ */
+function resolveWhamExemptModels(data: WhamUsageResponse): string[] {
+  const exempt = (data.additional_rate_limits ?? []).flatMap((entry) => {
+    const limited = entry.rate_limit?.limit_reached === true || entry.rate_limit?.allowed === false;
+    const modelId = entry.limit_name?.trim().toLowerCase().replace(/\s+/g, "-");
+    return limited || !modelId ? [] : [modelId];
+  });
+  return [...new Set(exempt)];
+}
+
 function isWhamWindowExhausted(window: WhamUsageWindow | undefined): boolean {
   return Boolean(
     window &&
@@ -232,6 +259,7 @@ function applyWhamCooldownResult(params: {
       ? existingBlockedUntil
       : 0;
   if (params.whamResult.blockedUntil) {
+    const exemptModels = params.whamResult.exemptModels ?? [];
     return {
       ...params.computed,
       lastProbeAt: params.now,
@@ -240,6 +268,9 @@ function applyWhamCooldownResult(params: {
       blockedSource: params.whamResult.blockedSource ?? "wham",
       blockedModel: undefined,
       blockedScope: undefined,
+      // Only this probe's observation may exempt a model; a stale list would
+      // let a model bypass a block the provider never said it could.
+      blockExemptModels: exemptModels.length > 0 ? exemptModels : undefined,
       cooldownUntil: undefined,
       cooldownReason: undefined,
       cooldownModel: undefined,
@@ -252,6 +283,9 @@ function applyWhamCooldownResult(params: {
       existingActiveCooldownUntil,
       resolveUsageWindowUntil(params.now, params.whamResult.cooldownMs),
     ),
+    ...(params.whamResult.cooldownReason
+      ? { cooldownReason: params.whamResult.cooldownReason, cooldownModel: undefined }
+      : {}),
   };
 }
 
@@ -296,7 +330,14 @@ async function probeWhamForCooldown(
     if (!res.ok) {
       await cancelUnreadResponseBody(res);
       if (res.status === 401) {
-        return { cooldownMs: WHAM_TOKEN_EXPIRED_COOLDOWN_MS, reason: "wham_token_expired" };
+        // The probe, not the model request, is what failed here. Recording it as
+        // the caller's rate_limit would claim a model-scopable quota block while
+        // holding the whole profile down for 12h under a reason that never fits.
+        return {
+          cooldownMs: WHAM_TOKEN_EXPIRED_COOLDOWN_MS,
+          reason: "wham_token_expired",
+          cooldownReason: "auth",
+        };
       }
       if (res.status === 403) {
         return { cooldownMs: WHAM_DEAD_ACCOUNT_COOLDOWN_MS, reason: "wham_account_dead" };
@@ -318,6 +359,7 @@ async function probeWhamForCooldown(
     }
 
     const now = Date.now();
+    const exemptModels = resolveWhamExemptModels(data);
     const primaryResetMs = resolveWhamResetMs(data.rate_limit.primary_window, now);
     const secondaryResetMs = resolveWhamResetMs(data.rate_limit.secondary_window, now);
 
@@ -329,6 +371,7 @@ async function probeWhamForCooldown(
         cooldownMs: WHAM_BURST_COOLDOWN_MS,
         blockedUntil: resolveUsageWindowUntil(now, primaryResetMs),
         blockedSource: "wham",
+        exemptModels,
         reason: "wham_personal_rolling",
       };
     }
@@ -341,6 +384,7 @@ async function probeWhamForCooldown(
         cooldownMs: WHAM_BURST_COOLDOWN_MS,
         blockedUntil: resolveUsageWindowUntil(now, secondaryResetMs),
         blockedSource: "wham",
+        exemptModels,
         reason: "wham_team_weekly",
       };
     }
@@ -353,6 +397,7 @@ async function probeWhamForCooldown(
         cooldownMs: WHAM_BURST_COOLDOWN_MS,
         blockedUntil: resolveUsageWindowUntil(now, primaryResetMs),
         blockedSource: "wham",
+        exemptModels,
         reason: "wham_team_rolling",
       };
     }
@@ -1058,6 +1103,7 @@ function buildBlockedProfileUsageStats(params: {
     blockedSource: params.source,
     blockedModel,
     blockedScope: blockedModel ? "model" : undefined,
+    blockExemptModels: undefined,
     cooldownUntil: undefined,
     cooldownReason: undefined,
     cooldownModel: undefined,


### PR DESCRIPTION
## What Problem This Solves

An OpenAI account can exhaust its account-wide window while individual models keep their own separate, unexhausted allowance. The usage probe already receives those per-model buckets in `additional_rate_limits`, but nothing parsed the field, so a quota block covered every model on the profile.

The result is that the model fallback chain goes dark exactly when it is supposed to take over. Observed on a live gateway: all four OpenAI profiles reported `primary_window.used_percent: 100`, while every one of them also reported

```json
{"limit_name": "GPT-5.3-Codex-Spark", "metered_feature": "codex_bengalfox",
 "rate_limit": {"allowed": true, "limit_reached": false,
                "primary_window": {"used_percent": 0}}}
```

The configured chain was `openai/gpt-5.6-sol` -> `openai/gpt-5.3-codex-spark`. Sol hit the account limit, spark was correctly selected next, and then skipped:

```
[model-fallback/decision] decision=skip_candidate requested=openai/gpt-5.6-sol
candidate=openai/gpt-5.6-sol reason=rate_limit next=openai/gpt-5.3-codex-spark
detail=Provider openai is in cooldown
```

Every agent run on that gateway failed for ~13 hours with capacity sitting unused.

A second, smaller fault sat next to it. A usage probe rejected with HTTP 401 produced a flat 12h profile-wide cooldown that inherited the *caller's* `rate_limit` reason. That left `cooldownReason: "rate_limit"` with no `cooldownModel` — a reason that claims model scope on a record that blocks everything. `isProfileUnusable` can only narrow a model-scoped cooldown when a model is named, so it widened, and no consumer could tell a quota block from a dead token.

## Why This Change Was Made

A block should describe exactly what the provider limited. Anything broader discards capacity the provider still grants, and a fallback chain whose whole purpose is surviving a quota limit must not be disabled by that limit.

The state model already supported narrowing (`blockedModel`, `blockedScope`, `cooldownModel`, `isModelScopedCooldownReason`); it had no way to express "the account window is spent, but these models are still served". `blockExemptModels` records exactly what the probe observed, and only that probe's observation may grant it — a stale list can never unblock a model the provider did not clear.

Model ids come from the reported bucket names by lowercasing, so there is no per-model table to maintain. An unrecognized name simply matches no model and changes nothing.

## User Impact

When an account-wide quota is exhausted, models with their own unexhausted bucket stay usable and the fallback chain keeps working. Behavior is unchanged for providers that report no per-model buckets: absent `additional_rate_limits` means no exemptions and the block stays profile-wide, exactly as before.

A 401 from the probe is now recorded as `auth`. The 12h hold is unchanged and still profile-wide, which is correct for a credential the provider rejects — it is only labelled honestly now, so `openclaw doctor`, logs, and the cooldown predicates agree on what happened.

Persisted state gains one optional field. Older rows lack it and normalize to `undefined`, which is today's behavior; no migration is needed.

## Evidence

Three regression tests, each failing on pre-fix code for its intended reason:

```
FAIL isProfileInCooldown > keeps a model with its own unexhausted bucket usable under an account-wide block
  AssertionError: gpt-5.6-luna: expected true to be false
FAIL WHAM-aware Codex cooldowns > keeps per-model buckets usable when the account-wide window is exhausted
  AssertionError: expected undefined to deeply equal [ 'gpt-5.6-luna' ]
FAIL WHAM-aware Codex cooldowns > records a probe auth rejection as an auth cooldown, not the request's rate limit
  AssertionError: expected 'rate_limit' to be 'auth'
```

Local validation, all green after the fix:

- `node scripts/run-vitest.mjs src/agents/auth-profiles` — 27 files, 381 tests
- `node scripts/run-vitest.mjs src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts src/agents/model-fallback.test.ts src/agents/model-fallback.probe.test.ts src/commands/models/list.status.test.ts src/commands/models/list.auth-overview.test.ts src/commands/doctor-auth.profile-health.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/codex-route-warnings.test.ts` — every suite consuming these predicates
- `pnpm tsgo:core`, `scripts/run-oxlint.mjs` on changed files, `oxfmt --check`

Dependency contract proof: the `additional_rate_limits` shape above was read live from `chatgpt.com/backend-api/codex/usage` across four accounts, each returning an allowed spark bucket beside a 100%-used primary window.

Production delta is +75 lines against +59 test lines. The growth is the capability itself — a provider contract field that was not read, plus the state to carry the observation to the consumer that needs it. No behavior was duplicated and no path was left behind.

Proof gap: this fixes the block that made spark unreachable, but the account this was diagnosed on has no OpenAI capacity left in any window until 20 Aug, so a live end-to-end run of the fallback actually landing on spark is not possible right now. The probe parse is proven against the real payload, and the predicate change is proven by unit tests.
