### PR TITLE
fix(codex): enforce hosted search domains for web fetch

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -294,8 +294,10 @@ namespace.
   search; other managed providers remain available
 - Restricting the Codex native tool surface also keeps managed `web_search`
   available
-- When `allowedDomains` is set, automatic managed fallback fails closed if
-  hosted search is unavailable so the native allowlist cannot be bypassed
+- When `allowedDomains` is set, it restricts both hosted `web_search` and
+  managed `web_fetch` on turns where native hosted search is active. Turns
+  using a managed search provider are unchanged. Automatic managed search
+  fallback also fails closed if hosted search is unavailable.
 - Tool-disabled LLM-only runs disable both native and managed search
 - `tools.web.search.enabled: false` disables both managed and native search
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -492,10 +492,15 @@ describe("Codex app-server dynamic tool build", () => {
         },
       },
     } as never;
-    setOpenClawCodingToolsFactoryForTests(() => [
-      createRuntimeDynamicTool("web_search"),
-      createRuntimeDynamicTool("message"),
-    ]);
+    let receivedOptions: Record<string, unknown> | undefined;
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      receivedOptions = options as Record<string, unknown>;
+      return [
+        createRuntimeDynamicTool("web_search"),
+        createRuntimeDynamicTool("web_fetch"),
+        createRuntimeDynamicTool("message"),
+      ];
+    });
     let webSearchAllowed = false;
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
@@ -504,8 +509,47 @@ describe("Codex app-server dynamic tool build", () => {
       },
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(["message"]);
+    expect(tools.map((tool) => tool.name)).toEqual(["web_fetch", "message"]);
+    expect(
+      (receivedOptions?.webFetchHostnameAllowlistRef as { value?: string[] } | undefined)?.value,
+    ).toEqual(["example.com", "*.example.com"]);
     expect(webSearchAllowed).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "a managed search provider is selected",
+      search: { provider: "brave", openaiCodex: { allowedDomains: ["example.com"] } },
+      toolsAllow: undefined,
+    },
+    {
+      name: "the native search allowlist is empty",
+      search: { openaiCodex: { allowedDomains: [] } },
+      toolsAllow: undefined,
+    },
+    {
+      name: "effective tool policy disables hosted search",
+      search: { openaiCodex: { allowedDomains: ["example.com"] } },
+      toolsAllow: ["web_fetch"],
+    },
+  ])("leaves web_fetch unrestricted when $name", async ({ search, toolsAllow }) => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = toolsAllow;
+    params.config = { tools: { web: { search } } } as never;
+    let receivedOptions: Record<string, unknown> | undefined;
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      receivedOptions = options as Record<string, unknown>;
+      return [createRuntimeDynamicTool("web_search"), createRuntimeDynamicTool("web_fetch")];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir);
+
+    expect(
+      (receivedOptions?.webFetchHostnameAllowlistRef as { value?: string[] } | undefined)?.value,
+    ).toBeUndefined();
   });
 
   it("forwards client caps alongside channel authority context", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -21,6 +21,7 @@ import {
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { runWithCronCreatorAuthorityCapabilityResolver } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
+import { buildHostnameAllowlistPolicyFromSuffixAllowlist } from "openclaw/plugin-sdk/ssrf-policy";
 import {
   isCodexRemoteExecPlacementSandbox,
   readCodexPluginConfig,
@@ -247,6 +248,13 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   toolBuildStages.mark("load-agent-harness-tools");
   const sessionKeys = resolveOpenClawCodingToolsSessionKeys(params, input.sandboxSessionKey);
   const nativeExecutionPolicy = resolveCodexNativeExecutionPolicyForDynamicTools(input);
+  const webSearchPlan = resolveCodexWebSearchPlan({
+    config: params.config,
+    disableTools: params.disableTools,
+    nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled,
+    nativeProviderWebSearchSupport: input.nativeProviderWebSearchSupport,
+  });
+  const webFetchHostnameAllowlistRef: { value?: string[] } = {};
   const buildOpenClawCodingTools = () =>
     params.hostCapabilities.bindToolSurface(
       createOpenClawCodingTools({
@@ -321,6 +329,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
           },
         ),
         suppressManagedWebSearch: false,
+        webFetchHostnameAllowlistRef,
         currentChannelId: params.currentChannelId,
         currentMessagingTarget: params.currentMessagingTarget,
         hookChannelId: resolveCodexAppServerHookChannelId(params, input.sandboxSessionKey),
@@ -371,12 +380,6 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const readableAllToolProjection = filterProviderNormalizableTools(allTools);
   preNormalizationDiagnostics.push(...readableAllToolProjection.diagnostics);
-  const webSearchPlan = resolveCodexWebSearchPlan({
-    config: params.config,
-    disableTools: params.disableTools,
-    nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled,
-    nativeProviderWebSearchSupport: input.nativeProviderWebSearchSupport,
-  });
   const readableAllTools = [...readableAllToolProjection.tools];
   const normallyProfiledTools =
     input.nativeToolSurfaceEnabled === false
@@ -472,7 +475,14 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   toolBuildStages.mark("runtime-normalization");
   // Resolve policy before hiding the managed tool. Hosted search follows the
   // same effective policy, while only one search implementation is exposed.
-  input.onWebSearchPolicyResolved?.(normalizedTools.some((tool) => tool.name === "web_search"));
+  const webSearchAllowed = normalizedTools.some((tool) => tool.name === "web_search");
+  webFetchHostnameAllowlistRef.value =
+    webSearchPlan.kind === "native-hosted" && webSearchAllowed
+      ? buildHostnameAllowlistPolicyFromSuffixAllowlist(
+          params.config?.tools?.web?.search?.openaiCodex?.allowedDomains,
+        )?.hostnameAllowlist
+      : undefined;
+  input.onWebSearchPolicyResolved?.(webSearchAllowed);
   const exposedTools = webSearchPlan.suppressManagedWebSearch
     ? normalizedTools.filter((tool) => tool.name !== "web_search")
     : normalizedTools;

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -21,7 +21,6 @@ import {
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { runWithCronCreatorAuthorityCapabilityResolver } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
-import { buildHostnameAllowlistPolicyFromSuffixAllowlist } from "openclaw/plugin-sdk/ssrf-policy";
 import {
   isCodexRemoteExecPlacementSandbox,
   readCodexPluginConfig,
@@ -476,12 +475,9 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   // Resolve policy before hiding the managed tool. Hosted search follows the
   // same effective policy, while only one search implementation is exposed.
   const webSearchAllowed = normalizedTools.some((tool) => tool.name === "web_search");
-  webFetchHostnameAllowlistRef.value =
-    webSearchPlan.kind === "native-hosted" && webSearchAllowed
-      ? buildHostnameAllowlistPolicyFromSuffixAllowlist(
-          params.config?.tools?.web?.search?.openaiCodex?.allowedDomains,
-        )?.hostnameAllowlist
-      : undefined;
+  webFetchHostnameAllowlistRef.value = webSearchAllowed
+    ? webSearchPlan.webFetchHostnameAllowlist
+    : undefined;
   input.onWebSearchPolicyResolved?.(webSearchAllowed);
   const exposedTools = webSearchPlan.suppressManagedWebSearch
     ? normalizedTools.filter((tool) => tool.name !== "web_search")

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -468,7 +468,11 @@ function platformPreparedRuntimeAuth(resolvedApiKey?: string) {
 
 async function runSideQuestionWithManagedWebSearchCall(
   params: Parameters<typeof runCodexAppServerSideQuestion>[0] = sideParams(),
-  options: { preserveToolFactory?: boolean } = {},
+  options: {
+    preserveToolFactory?: boolean;
+    toolName?: string;
+    toolArguments?: JsonObject;
+  } = {},
 ) {
   const client = createFakeClient();
   if (!options.preserveToolFactory) {
@@ -505,8 +509,8 @@ async function runSideQuestionWithManagedWebSearchCall(
     params: {
       ...codexTestTurnIds("side-thread"),
       callId: "tool-1",
-      tool: "web_search",
-      arguments: { query: "service providers" },
+      tool: options.toolName ?? "web_search",
+      arguments: options.toolArguments ?? { query: "service providers" },
     },
   });
   client.emit(turnCompleted("side-thread", "turn-1", "Search answer."));
@@ -580,6 +584,7 @@ describe("runCodexAppServerSideQuestion", () => {
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
     resetDiagnosticEventsForTest();
     resetGlobalHookRunner();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -1255,6 +1260,67 @@ describe("runCodexAppServerSideQuestion", () => {
       contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: web_search" }],
     });
     expect(toolExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "blocks an outside host",
+      allowedDomains: ["1.1.1.1"],
+      url: "http://8.8.8.8/",
+      success: false,
+    },
+    {
+      name: "allows a permitted host",
+      allowedDomains: ["1.1.1.1"],
+      url: "http://1.1.1.1/",
+      success: true,
+    },
+  ])("applies native search domains to side-question web_fetch and $name", async (testCase) => {
+    const actualAgentHarness = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/agent-harness")
+    >("openclaw/plugin-sdk/agent-harness");
+    createOpenClawCodingToolsMock.mockImplementation((options) =>
+      actualAgentHarness
+        .createOpenClawCodingTools(options as never)
+        .filter((tool) => tool.name === "web_search" || tool.name === "web_fetch"),
+    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("permitted", { status: 200, headers: { "content-type": "text/plain" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { toolResponse } = await runSideQuestionWithManagedWebSearchCall(
+      sideParams({
+        cfg: {
+          tools: {
+            web: {
+              search: { openaiCodex: { allowedDomains: testCase.allowedDomains } },
+              fetch: { cacheTtlMinutes: 0 },
+            },
+          },
+        } as never,
+      }),
+      {
+        preserveToolFactory: true,
+        toolName: "web_fetch",
+        toolArguments: { url: testCase.url },
+      },
+    );
+
+    expect(toolResponse).toMatchObject({ success: testCase.success });
+    expect(fetchMock).toHaveBeenCalledTimes(testCase.success ? 1 : 0);
+    if (!testCase.success) {
+      expect(toolResponse).toEqual({
+        success: false,
+        contentItems: [
+          {
+            type: "inputText",
+            text: expect.stringMatching(/Domain policy: Blocked hostname.*1\.1\.1\.1/),
+          },
+        ],
+      });
+    }
   });
 
   it("preserves managed web_search while planning hosted search for Responses side questions", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -1017,6 +1017,7 @@ async function createCodexSideToolBridge(input: {
     ({ id: input.params.model, provider: input.params.provider } as never);
   const messageToolProvider = resolveCodexMessageToolProvider(input.params);
   let tools: AnyAgentTool[] = [];
+  const webFetchHostnameAllowlistRef: { value?: string[] } = {};
   if (supportsModelTools(runtimeModel)) {
     const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
       .createOpenClawCodingTools;
@@ -1064,6 +1065,7 @@ async function createCodexSideToolBridge(input: {
         workspaceDir: input.cwd,
       }),
       suppressManagedWebSearch: false,
+      webFetchHostnameAllowlistRef,
       ...(input.params.messageProvider || input.params.messageChannel
         ? {
             messageProvider: messageToolProvider,
@@ -1120,6 +1122,7 @@ async function createCodexSideToolBridge(input: {
     nativeProviderWebSearchSupport: input.nativeProviderWebSearchSupport,
     webSearchAllowed: tools.some((tool) => tool.name === "web_search"),
   });
+  webFetchHostnameAllowlistRef.value = requestedWebSearchPlan.webFetchHostnameAllowlist;
   // Codex forks do not accept dynamicTools, so managed web_search cannot be
   // registered on a side thread. Keep it only as the native-search policy signal.
   const webSearchPlan =

--- a/extensions/codex/src/app-server/web-search.test.ts
+++ b/extensions/codex/src/app-server/web-search.test.ts
@@ -50,6 +50,7 @@ describe("resolveCodexWebSearchPlan", () => {
         "tools.web_search.location.city": "Edmonton",
         "tools.web_search.location.timezone": "America/Edmonton",
       },
+      webFetchHostnameAllowlist: ["example.com", "*.example.com"],
     });
   });
 

--- a/extensions/codex/src/app-server/web-search.ts
+++ b/extensions/codex/src/app-server/web-search.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { buildHostnameAllowlistPolicyFromSuffixAllowlist } from "openclaw/plugin-sdk/ssrf-policy";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { JsonObject } from "./protocol.js";
 
@@ -6,6 +7,7 @@ export type CodexWebSearchPlan = {
   kind: "native-hosted" | "managed" | "disabled";
   suppressManagedWebSearch: boolean;
   threadConfig: JsonObject;
+  webFetchHostnameAllowlist?: string[];
 };
 
 export type CodexNativeWebSearchSupport = "supported" | "unsupported" | "unknown";
@@ -125,5 +127,8 @@ export function resolveCodexWebSearchPlan(params: {
     // exposing managed web_search here could bypass native allowed_domains.
     suppressManagedWebSearch: true,
     threadConfig: buildCodexNativeWebSearchThreadConfig(params.config),
+    webFetchHostnameAllowlist: buildHostnameAllowlistPolicyFromSuffixAllowlist(
+      nativeConfig?.allowedDomains,
+    )?.hostnameAllowlist,
   };
 }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -255,6 +255,7 @@ type OpenClawCodingToolsOptions = {
   modelCompat?: ModelCompatConfig;
   /** If false, keep OpenClaw web_search even when a provider-native search tool is active. */
   suppressManagedWebSearch?: boolean;
+  webFetchHostnameAllowlistRef?: { value?: string[] };
   webSearchEnabled?: boolean;
   /**
    * Auth mode for the current provider. We only need this for Anthropic OAuth
@@ -811,6 +812,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
               : runtimeRoot,
             sandboxed: Boolean(sandbox),
             config: options?.config,
+            webFetchHostnameAllowlistRef: options?.webFetchHostnameAllowlistRef,
             webSearchEnabled: options?.webSearchEnabled,
             clientCaps: options?.clientCaps,
             toolBindings: options?.toolBindings,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -133,6 +133,7 @@ export function createOpenClawTools(
     fsPolicy?: ToolFsPolicy;
     sandboxed?: boolean;
     config?: OpenClawConfig;
+    webFetchHostnameAllowlistRef?: { value?: string[] };
     webSearchEnabled?: boolean;
     /** Capabilities declared by the gateway client that originated this run. */
     clientCaps?: string[];
@@ -374,6 +375,7 @@ export function createOpenClawTools(
     sandboxed: options?.sandboxed,
     runtimeWebFetch: runtimeWebTools?.fetch,
     lateBindRuntimeConfig: true,
+    hostnameAllowlistRef: options?.webFetchHostnameAllowlistRef,
   });
   options?.recordToolPrepStage?.("openclaw-tools:web-fetch-tool");
   const messageTool = options?.disableMessageTool

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -55,6 +55,7 @@ function createWebFetchToolForTest(params?: {
   firecrawlApiKey?: string;
   useTrustedEnvProxy?: boolean;
   ssrfPolicy?: ssrf.SsrFPolicy;
+  hostnameAllowlist?: string[];
   cacheTtlMinutes?: number;
 }) {
   return createWebFetchTool({
@@ -84,6 +85,7 @@ function createWebFetchToolForTest(params?: {
       },
     },
     lookupFn: lookupMock,
+    hostnameAllowlistRef: { value: params?.hostnameAllowlist },
   });
 }
 
@@ -193,6 +195,54 @@ describe("web_fetch SSRF protection", () => {
 
     const result = await tool?.execute?.("call", { url: "https://example.com" });
     expectRawFetchSuccessDetails(result?.details);
+  });
+
+  it("blocks a turn-scoped domain-policy miss with recovery guidance", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("not permitted"));
+    const tool = createWebFetchToolForTest({
+      hostnameAllowlist: ["example.com", "*.example.com"],
+    });
+
+    await expectBlockedUrl(
+      tool,
+      "https://www.nytimes.com/",
+      /domain policy blocked.*example\.com.*Try a URL on a permitted domain/i,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a turn-scoped domain-policy match", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("permitted"));
+    const tool = createWebFetchToolForTest({
+      hostnameAllowlist: ["example.com", "*.example.com"],
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/" });
+
+    expectRawFetchSuccessDetails(result?.details);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not reuse an unrestricted cache entry across a domain policy", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("cached outside content"));
+    const url = "https://outside.test/cached-policy-boundary";
+    const unrestricted = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
+    await unrestricted?.execute?.("call", { url });
+    const restricted = createWebFetchToolForTest({
+      ssrfPolicy: { hostnameAllowlist: ["example.com", "*.example.com"] },
+      cacheTtlMinutes: 1,
+    });
+
+    await expectBlockedUrl(
+      restricted,
+      url,
+      /domain policy.*example\.com.*Try a URL on a permitted domain/i,
+    );
+    expect(fetchSpy).toHaveBeenCalledOnce();
   });
 
   it("preserves trailing Unicode URL text through tool argument parsing", async () => {

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -207,7 +207,7 @@ describe("web_fetch SSRF protection", () => {
     await expectBlockedUrl(
       tool,
       "https://www.nytimes.com/",
-      /domain policy blocked.*example\.com.*Try a URL on a permitted domain/i,
+      /domain policy: blocked hostname.*example\.com.*Try a URL on a permitted domain/i,
     );
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(lookupMock).not.toHaveBeenCalled();
@@ -240,7 +240,7 @@ describe("web_fetch SSRF protection", () => {
     await expectBlockedUrl(
       restricted,
       url,
-      /domain policy.*example\.com.*Try a URL on a permitted domain/i,
+      /domain policy: blocked hostname.*example\.com.*Try a URL on a permitted domain/i,
     );
     expect(fetchSpy).toHaveBeenCalledOnce();
   });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -13,12 +13,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import {
-  mergeSsrFPolicies,
-  SsrFBlockedError,
-  type LookupFn,
-  type SsrFPolicy,
-} from "../../infra/net/ssrf.js";
+import { SsrFBlockedError, type LookupFn, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug, logWarn } from "../../logger.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
@@ -688,10 +683,7 @@ async function maybeFetchProviderWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
-  const ssrfPolicy = mergeSsrFPolicies(params.ssrfPolicy);
-  const dangerouslyAllowPrivateNetwork = ssrfPolicy?.dangerouslyAllowPrivateNetwork === true;
-  const allowRfc2544BenchmarkRange = ssrfPolicy?.allowRfc2544BenchmarkRange === true;
-  const allowIpv6UniqueLocalRange = ssrfPolicy?.allowIpv6UniqueLocalRange === true;
+  const ssrfPolicy = params.ssrfPolicy;
   const useTrustedEnvProxy = params.useTrustedEnvProxy;
   let parsedUrl: URL;
   try {
@@ -708,12 +700,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   const cacheDiscriminators = [
     `user-agent:${sha256Hex(params.userAgent)}`,
     params.providerCacheKey ? `provider:${params.providerCacheKey}` : "",
-    dangerouslyAllowPrivateNetwork ? "allow-private-network" : "",
-    allowRfc2544BenchmarkRange ? "allow-rfc2544" : "",
-    allowIpv6UniqueLocalRange ? "allow-ipv6-ula" : "",
-    ssrfPolicy?.allowedHostnames?.length
-      ? `allowed-hostnames:${sha256Hex(ssrfPolicy.allowedHostnames.join("\n"))}`
-      : "",
+    ssrfPolicy ? `ssrf-policy:${sha256Hex(JSON.stringify(ssrfPolicy))}` : "",
     useTrustedEnvProxy ? "trusted-env-proxy" : "",
     headersCacheKey ? `headers:${headersCacheKey}` : "",
   ].filter(Boolean);
@@ -944,6 +931,7 @@ export function createWebFetchTool(options?: {
   runtimeWebFetch?: RuntimeWebFetchMetadata;
   lateBindRuntimeConfig?: boolean;
   lookupFn?: LookupFn;
+  hostnameAllowlistRef?: { value?: string[] };
 }): AnyAgentTool | null {
   const fetch = resolveFetchConfig(options?.config);
   if (!resolveFetchEnabled({ fetch, sandboxed: options?.sandboxed })) {
@@ -1010,6 +998,7 @@ export function createWebFetchTool(options?: {
         readToolStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readPositiveIntegerParam(params, "maxChars");
       const maxCharsCap = resolveFetchMaxCharsCap(executionFetch);
+      const hostnameAllowlist = options?.hostnameAllowlistRef?.value;
       // The progress line is emitted only if the fetch is still pending after
       // the threshold; fast cache/network hits clear the timer before it fires.
       const clearProgressTimer = scheduleToolProgress(
@@ -1042,7 +1031,9 @@ export function createWebFetchTool(options?: {
           readabilityEnabled,
           config,
           useTrustedEnvProxy: resolveFetchUseTrustedEnvProxy(executionFetch),
-          ssrfPolicy: executionFetch?.ssrfPolicy,
+          ssrfPolicy: hostnameAllowlist
+            ? { ...executionFetch?.ssrfPolicy, hostnameAllowlist }
+            : executionFetch?.ssrfPolicy,
           ...(providerCacheKey ? { providerCacheKey } : {}),
           lookupFn: options?.lookupFn,
           signal,

--- a/src/config/schema.help.runtime.ts
+++ b/src/config/schema.help.runtime.ts
@@ -549,7 +549,7 @@ export const RUNTIME_FIELD_HELP: Record<string, string> = {
   "tools.web.search.openaiCodex.mode":
     'Native Codex web search preference: "cached" (default; unrestricted Codex turns resolve it to live) or "live".',
   "tools.web.search.openaiCodex.allowedDomains":
-    "Optional domain allowlist passed to the native Codex web_search tool.",
+    "Domain allowlist for native Codex web_search. On native-hosted-search turns, it also gates managed web_fetch; managed-provider turns are unchanged.",
   "tools.web.search.openaiCodex.contextSize":
     'Native Codex search context size hint: "low", "medium", or "high".',
   "tools.web.search.openaiCodex.userLocation.country":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -446,7 +446,7 @@ export type ToolsConfig = {
         enabled?: boolean;
         /** Prefer cached or explicitly request live access. Unrestricted Codex turns resolve cached to live. */
         mode?: "cached" | "live";
-        /** Optional allowlist of domains passed to the native Codex tool. */
+        /** Native Codex search allowlist; also gates web_fetch on native-hosted-search turns. */
         allowedDomains?: string[];
         /** Optional Codex native search context size hint. */
         contextSize?: "low" | "medium" | "high";

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -390,7 +390,7 @@ function resolveHostnamePolicyChecks(
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
     throw new SsrFBlockedError(
-      `Domain policy blocked ${hostname}. Permitted hostname patterns: ${hostnameAllowlist.join(", ")}. Try a URL on a permitted domain.`,
+      `Domain policy: Blocked hostname (not in allowlist): ${hostname}. Permitted hostname patterns: ${hostnameAllowlist.join(", ")}. Try a URL on a permitted domain.`,
     );
   }
 

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -389,7 +389,9 @@ function resolveHostnamePolicyChecks(
   const skipPrivateNetworkChecks = shouldSkipPrivateNetworkChecks(normalized, policy);
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
-    throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
+    throw new SsrFBlockedError(
+      `Domain policy blocked ${hostname}. Permitted hostname patterns: ${hostnameAllowlist.join(", ")}. Try a URL on a permitted domain.`,
+    );
   }
 
   if (!skipPrivateNetworkChecks) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using Codex native hosted search with `tools.web.search.openaiCodex.allowedDomains` could have that policy silently bypassed by the still-available managed `web_fetch` tool. A blocked native search could fetch the same disallowed site directly and return its live content.

## Why This Change Was Made

The Codex turn builder now carries the configured domains into the managed fetch pipeline only after native hosted search is confirmed active for that effective turn. The existing managed SSRF `hostnameAllowlist` owns initial URL and redirect enforcement; the shared suffix-policy helper preserves apex/subdomain semantics, and the complete effective SSRF policy now partitions the process fetch cache.

No config key or config shape changed. This deliberately widens the meaning of the existing `allowedDomains` key and is fail-closed only for native-hosted-search turns. Managed-provider turns, no-allowlist turns, and turns whose effective tool policy disables hosted search keep their prior behavior.

Upstream Codex contract inspected at `openai/codex@936f5eb3`: `codex-rs/protocol/src/config_types.rs:407-490` maps `allowed_domains` into web-search filters; `codex-rs/core/src/tools/hosted_spec.rs:14-45` serializes those filters into the hosted tool; `codex-rs/core/tests/suite/web_search.rs:374-429` proves request serialization, not upstream enforcement.

## User Impact

Operators who set `tools.web.search.openaiCodex.allowedDomains` can now rely on the same domains constraining managed `web_fetch` during turns where Codex native hosted search is active. A disallowed fetch returns an actionable domain-policy refusal that names the permitted hostname patterns and tells the agent to try a permitted domain. Operators using a managed search provider, or no allowlist, see no behavior change.

Compatibility-sensitive config metric: 0 keys added, changed, or removed; one existing key has intentionally broader fail-closed semantics on native-hosted-search turns.

Production LOC: +38/-27 (net +11) | Tests: +169/-8 | Docs: +4/-2

## Evidence

Pre-fix regression evidence on current `origin/main`:

- `node scripts/run-vitest.mjs src/agents/tools/web-fetch.ssrf.test.ts --reporter=verbose` failed only the two new policy cases: the disallowed NYTimes fetch resolved successfully, and a restricted turn reused an unrestricted cached response.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts --reporter=verbose` failed only the new native-hosted case because no fetch hostname policy was forwarded.

Post-fix focused proof:

- managed fetch SSRF/domain/cache suite: 16/16 passed
- Codex dynamic-tool suite: 74/74 passed, including managed-provider, no-allowlist, and effective-search-denied controls
- Codex side-question suite: 67/67 passed, including real managed `web_fetch` blocked/permitted controls
- Codex search-plan suite: 11/11 passed
- `node scripts/check-changed.mjs`
- `pnpm check:docs`
- `pnpm build`
- structured Codex autoreview: clean, no accepted/actionable findings

Live isolated Gateway proof used its own state directory and free loopback port 64482. Hosted search could not open NYTimes; the requested RSS fallback ended visibly with:

> Domain policy blocked rss.nytimes.com. Permitted hostname patterns: example.com, *.example.com. Try a URL on a permitted domain.

The model declined to identify a headline. A separate positive-control turn fetched `https://example.com/`, observed HTTP 200, and reported the title “Example Domain.” The probe-owned Gateway was stopped after capture.

The final wording additionally preserves the established `Blocked hostname (not in allowlist)` substring; core network, Teams redirect, and OpenAI OAuth fake-IP compatibility suites all pass with that form. ClawSweeper's side-question P1 is addressed by making the native search plan own the normalized fetch patterns and sharing that prepared fact across both builders.
