### PR TITLE
fix(ci): resolve performance targets from checkout

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -94,11 +94,21 @@ jobs:
       kova_config_contract: ${{ steps.resolve.outputs.kova_config_contract }}
       kova_ref_trusted_for_live: ${{ steps.resolve.outputs.kova_ref_trusted_for_live }}
     steps:
+      - name: Checkout target metadata
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.target_ref || github.sha }}
+          path: .artifacts/performance-target
+          sparse-checkout: src/config/zod-schema.agent-defaults.ts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Resolve OpenClaw target ref
         id: resolve
         env:
-          GH_TOKEN: ${{ github.token }}
           TARGET_REF_INPUT: ${{ inputs.target_ref }}
+          TARGET_CHECKOUT_DIR: ${{ github.workspace }}/.artifacts/performance-target
           KOVA_REF_INPUT: ${{ inputs.kova_ref }}
           KOVA_CONFIG_CONTRACT_INPUT: ${{ inputs.kova_config_contract }}
         shell: bash
@@ -109,17 +119,8 @@ jobs:
             echo "::error::target_ref must be a single line."
             exit 1
           fi
-          if [[ -z "$requested" ]]; then
-            resolved_sha="$GITHUB_SHA"
-            tested_ref="$GITHUB_REF_NAME"
-          else
-            encoded_ref="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$requested")"
-            if ! resolved_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq '.sha')"; then
-              echo "::error::Unable to resolve OpenClaw target_ref '${requested}'."
-              exit 1
-            fi
-            tested_ref="$requested"
-          fi
+          resolved_sha="$(git -C "$TARGET_CHECKOUT_DIR" rev-parse HEAD)"
+          tested_ref="${requested:-$GITHUB_REF_NAME}"
           if [[ ! "$resolved_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::OpenClaw target ref resolved to invalid SHA '${resolved_sha}'."
             exit 1
@@ -137,11 +138,9 @@ jobs:
           fi
 
           if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then
-            if schema_content="$({
-              gh api "repos/${GITHUB_REPOSITORY}/contents/src/config/zod-schema.agent-defaults.ts?ref=${resolved_sha}" --jq '.content' |
-                base64 --decode
-            })"; then
-              :
+            schema_path="${TARGET_CHECKOUT_DIR}/src/config/zod-schema.agent-defaults.ts"
+            if [[ -f "$schema_path" ]]; then
+              schema_content="$(cat "$schema_path")"
             elif [[ -z "$kova_ref" ]]; then
               echo "::error::Unable to inspect the Kova config-fixture contract for target ${resolved_sha}. Supply kova_ref explicitly and optionally set kova_config_contract for that producer."
               exit 1

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -91,6 +91,7 @@ describe("OpenClaw performance workflow", () => {
     const legacyKovaRef = "0f9e678e239b45db46d2bd930b7983203580df78";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
+    const targetCheckout = findStep("Checkout target metadata", "resolve_target");
     const resolveTarget = findStep("Resolve OpenClaw target ref", "resolve_target");
 
     expect(workflow).toContain(`KOVA_CANONICAL_CONFIG_REF: ${canonicalKovaRef}`);
@@ -110,7 +111,12 @@ describe("OpenClaw performance workflow", () => {
     expect(resolveTarget.env?.KOVA_CONFIG_CONTRACT_INPUT).toBe(
       "${{ inputs.kova_config_contract }}",
     );
-    expect(resolveTarget.run).toContain("zod-schema.agent-defaults.ts?ref=${resolved_sha}");
+    expect(targetCheckout.with?.["sparse-checkout"]).toBe(
+      "src/config/zod-schema.agent-defaults.ts",
+    );
+    expect(resolveTarget.run).toContain(
+      'schema_path="${TARGET_CHECKOUT_DIR}/src/config/zod-schema.agent-defaults.ts"',
+    );
     expect(resolveTarget.run).toContain("KOVA_CANONICAL_CONFIG_REF");
     expect(resolveTarget.run).toContain("KOVA_LEGACY_LIST_CONFIG_REF");
     expect(resolveTarget.run).toContain('detected_kova_config_contract="canonical"');
@@ -120,13 +126,14 @@ describe("OpenClaw performance workflow", () => {
     expect(resolveTarget.run).toContain(
       'if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then',
     );
-    expect(resolveTarget.run).toContain('if schema_content="$({');
+    expect(resolveTarget.run).toContain('if [[ -f "$schema_path" ]]; then');
+    expect(resolveTarget.run).toContain('schema_content="$(cat "$schema_path")"');
     expect(resolveTarget.run).toContain('elif [[ -z "$kova_ref" ]]; then');
     expect(resolveTarget.run).toContain('schema_content=""');
     expect(resolveTarget.run).toContain("Supply kova_ref explicitly");
     expect(
       resolveTarget.run?.indexOf('if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then'),
-    ).toBeLessThan(resolveTarget.run?.indexOf('schema_content="$({') ?? -1);
+    ).toBeLessThan(resolveTarget.run?.indexOf('schema_path="${TARGET_CHECKOUT_DIR}') ?? -1);
     expect(resolveTarget.run).toContain(
       'echo "kova_config_contract=$kova_config_contract" >> "$GITHUB_OUTPUT"',
     );
@@ -248,6 +255,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("resolves each target once before benchmark and publication fan out", () => {
     const workflow = readWorkflow();
+    const targetCheckout = findStep("Checkout target metadata", "resolve_target");
     const resolveTarget = findStep("Resolve OpenClaw target ref", "resolve_target");
     const checkout = findStep("Checkout OpenClaw");
     const record = findStep("Record tested revision");
@@ -256,13 +264,19 @@ describe("OpenClaw performance workflow", () => {
 
     expect(workflow.jobs?.kova?.needs).toBe("resolve_target");
     expect(workflow.jobs?.source_performance?.needs).toBe("resolve_target");
+    expect(targetCheckout.uses).toBe("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10");
+    expect(targetCheckout.with?.ref).toBe("${{ inputs.target_ref || github.sha }}");
+    expect(targetCheckout.with?.path).toBe(".artifacts/performance-target");
+    expect(targetCheckout.with?.["sparse-checkout-cone-mode"]).toBe(false);
+    expect(targetCheckout.with?.["persist-credentials"]).toBe(false);
     expect(resolveTarget.id).toBe("resolve");
-    expect(resolveTarget.env?.GH_TOKEN).toBe("${{ github.token }}");
+    expect(resolveTarget.env?.GH_TOKEN).toBeUndefined();
     expect(resolveTarget.env?.TARGET_REF_INPUT).toBe("${{ inputs.target_ref }}");
-    expect(resolveTarget.run).toContain("encodeURIComponent");
-    expect(resolveTarget.run).toContain(
-      'gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}"',
+    expect(resolveTarget.env?.TARGET_CHECKOUT_DIR).toBe(
+      "${{ github.workspace }}/.artifacts/performance-target",
     );
+    expect(resolveTarget.run).toContain('git -C "$TARGET_CHECKOUT_DIR" rev-parse HEAD');
+    expect(resolveTarget.run).not.toContain("gh api");
     expect(resolveTarget.run).toContain("checkout_ref=$resolved_sha");
     expect(resolveTarget.run).toContain("tested_sha=$resolved_sha");
     expect(checkout.with?.ref).toBe("${{ needs.resolve_target.outputs.checkout_ref }}");


### PR DESCRIPTION
## Summary

- sparse-checkout the selected performance target metadata before resolution
- derive the immutable target SHA and Kova config contract from that checkout
- remove target-resolution REST calls that can fail under GitHub secondary throttling

## Root cause

Full Release Validation child run https://github.com/openclaw/openclaw/actions/runs/32097655871 failed before performance work began because GitHub returned HTTP 429 while `Resolve target ref` fetched the target schema through the contents API. The resolver treated the transient API throttle as a missing contract.

## Evidence

- failing job: https://github.com/openclaw/openclaw/actions/runs/32097655871/job/95592025377
- regression test now requires one sparse target checkout and forbids `gh api` in target resolution
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
- GitHub-hosted PR checks are the validation path; no local release/test workload was run

## Scope

Workflow tooling only. No product behavior, config, protocol, or release candidate changes.