### PR TITLE
fix: keep non-person principals out of session owners

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5201,6 +5201,7 @@ public struct SessionsListParams: Codable, Sendable {
     public let label: String?
     public let boardface: AnyCodable?
     public let creatorid: String?
+    public let ownerid: String?
     public let involvingme: Bool?
     public let spawnedby: String?
     public let agentid: String?
@@ -5221,6 +5222,7 @@ public struct SessionsListParams: Codable, Sendable {
         label: String? = nil,
         boardface: AnyCodable? = nil,
         creatorid: String? = nil,
+        ownerid: String? = nil,
         involvingme: Bool? = nil,
         spawnedby: String? = nil,
         agentid: String? = nil,
@@ -5240,6 +5242,7 @@ public struct SessionsListParams: Codable, Sendable {
         self.label = label
         self.boardface = boardface
         self.creatorid = creatorid
+        self.ownerid = ownerid
         self.involvingme = involvingme
         self.spawnedby = spawnedby
         self.agentid = agentid
@@ -5261,6 +5264,7 @@ public struct SessionsListParams: Codable, Sendable {
         case label
         case boardface = "boardFace"
         case creatorid = "creatorId"
+        case ownerid = "ownerId"
         case involvingme = "involvingMe"
         case spawnedby = "spawnedBy"
         case agentid = "agentId"

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -406,6 +406,8 @@ export const SessionsListParamsSchema = closedObject({
   boardFace: Type.Optional(Type.Union([Type.Literal("chat"), Type.Literal("dashboard")])),
   /** Filter rows by their permanent creator identity. */
   creatorId: Type.Optional(NonEmptyString),
+  /** Filter rows by their current assignable owner identity. */
+  ownerId: Type.Optional(NonEmptyString),
   /** Limit rows to sessions owned by or previously prompted by the authenticated viewer. */
   involvingMe: Type.Optional(Type.Boolean()),
   spawnedBy: Type.Optional(NonEmptyString),

--- a/src/gateway/server-methods/sessions-mutations.owner.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.owner.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { dispatchGatewayMethodInProcess, setFallbackGatewayContext } from "../server-plugins.js";
 import {
@@ -192,15 +193,30 @@ describe("sessions.assignOwner", () => {
         assignedBy: { type: "human", id: "profile-viewer" },
         assignedAt: 4242,
       });
-      expect(result.requestContext.broadcastToConnIds).toHaveBeenCalledWith(
-        "sessions.changed",
-        expect.objectContaining({
-          reason: "owner",
-          owner: expect.objectContaining({ actor: expect.objectContaining({ id: "research" }) }),
-        }),
-        expect.any(Set),
-        expect.any(Object),
-      );
+      const durableOwner = ensureProfileForEmail("next-owner@example.test");
+      const reassigned = await invoke({
+        cfg,
+        client: client("profile-viewer"),
+        request: {
+          key: sessionKey,
+          owner: { type: "human", id: durableOwner.id },
+        },
+      });
+      expect(reassigned.responses).toMatchObject([
+        [
+          true,
+          {
+            owner: {
+              actor: { type: "human", id: durableOwner.id },
+              assignedBy: { type: "human", id: "profile-viewer" },
+            },
+          },
+          undefined,
+        ],
+      ]);
+      expect(
+        loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.owner?.actor,
+      ).toEqual({ type: "human", id: durableOwner.id });
 
       const target = resolveSessionSharingTarget({ cfg, sessionKey, agentId: "main" });
       if (!target) {
@@ -213,7 +229,7 @@ describe("sessions.assignOwner", () => {
     });
   });
 
-  it("rejects hidden viewers, unidentified callers, and unknown agent targets", async () => {
+  it("rejects hidden viewers, unidentified callers, and unknown owner targets", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       const sessionKey = "agent:main:private-handoff";
       await upsertSessionEntryCore(
@@ -292,15 +308,24 @@ describe("sessions.assignOwner", () => {
           createdActor: { type: "human", id: "profile-creator" },
         },
       );
-      const unknown = await invoke({
-        cfg,
-        client: client("profile-viewer"),
-        request: { key: sessionKey, owner: { type: "agent", id: "missing" } },
-      });
-      expect(unknown.responses[0]?.[2]).toMatchObject({
-        code: "INVALID_REQUEST",
-        message: 'unknown agent id "missing"',
-      });
+      for (const owner of [
+        { type: "human" as const, id: "unknown-profile" },
+        { type: "human" as const, id: "discord:channel:123" },
+        { type: "agent" as const, id: "missing" },
+      ]) {
+        const unknown = await invoke({
+          cfg,
+          client: client("profile-viewer"),
+          request: { key: sessionKey, owner },
+        });
+        expect(unknown.responses[0]?.[2]).toMatchObject({
+          code: "INVALID_REQUEST",
+          message: `unknown session owner "${owner.id}"`,
+        });
+      }
+      expect(
+        loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.owner,
+      ).toBeUndefined();
     });
   });
 });

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -10,11 +10,9 @@ import {
   validateSessionsPluginPatchParams,
   validateSessionsResetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { listAgentIds } from "../../agents/agent-scope.js";
 import { assignSessionOwner } from "../../config/sessions/session-accessor.js";
 import { patchPluginSessionExtension } from "../../plugins/host-hook-state.js";
 import { isPluginJsonValue } from "../../plugins/host-hooks.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import {
@@ -24,7 +22,8 @@ import {
   SessionMutationAuthorizationChangedError,
 } from "../session-sharing.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
-import { projectSessionActor } from "../session-utils-row.js";
+import type { SessionActorProfileIdentity } from "../session-utils-contracts.js";
+import { projectAssignableSessionOwner, projectSessionActor } from "../session-utils-row.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
@@ -108,26 +107,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       return;
     }
     const key = requireSessionKey(params.key, respond);
-    const ownerId = normalizeOptionalString(params.owner.id);
-    if (!key || !ownerId) {
-      return;
-    }
-    const cfg = context.getRuntimeConfig();
-    const owner =
-      params.owner.type === "agent"
-        ? (() => {
-            const normalizedId = normalizeAgentId(ownerId);
-            return normalizedId && listAgentIds(cfg).includes(normalizedId)
-              ? ({ type: "agent", id: normalizedId } as const)
-              : null;
-          })()
-        : ({ type: "human", id: ownerId } as const);
-    if (!owner) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unknown agent id "${ownerId}"`),
-      );
+    if (!key) {
       return;
     }
     const runtimeAgentId = normalizeOptionalString(client?.internal?.agentRuntimeIdentity?.agentId);
@@ -150,6 +130,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const cfg = context.getRuntimeConfig();
     const requestedAgent = resolveRequestedSessionAgentId(cfg, key, params.agentId);
     if (!requestedAgent.ok) {
       respond(false, undefined, requestedAgent.error);
@@ -174,6 +155,17 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       respond(false, undefined, visibilityError);
       return;
     }
+    const ownerIdentityById = new Map<string, SessionActorProfileIdentity | undefined>();
+    const projectedOwner = projectAssignableSessionOwner(params.owner, ownerIdentityById, cfg);
+    if (!projectedOwner) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `unknown session owner "${params.owner.id}"`),
+      );
+      return;
+    }
+    const owner = { type: projectedOwner.type, id: projectedOwner.id };
     const assignment = assignSessionOwner(
       {
         agentId: target.agentId,
@@ -208,7 +200,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       },
     );
     const projectedActor = assignment
-      ? projectSessionActor(assignment.actor, new Map(), cfg)
+      ? projectAssignableSessionOwner(assignment.actor, ownerIdentityById, cfg)
       : null;
     const projectedAssignedBy = assignment?.assignedBy
       ? projectSessionActor(assignment.assignedBy, new Map(), cfg)

--- a/src/gateway/server-methods/sessions-sharing.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.test.ts
@@ -428,7 +428,7 @@ describe("session sharing handlers", () => {
               totalCount: number;
               nextOffset: number | null;
               hasMore: boolean;
-              creators: Array<{ id: string }>;
+              creators: Array<{ type: "human" | "agent"; id: string }>;
               sessions: Array<{ key: string }>;
             }
           | undefined;
@@ -506,7 +506,7 @@ describe("session sharing handlers", () => {
         limitApplied: 1,
         nextOffset: null,
         hasMore: false,
-        creators: [{ id: "visible-owner@example.com" }],
+        creators: [],
         sessions: [{ key: visibleKey }],
       });
     });

--- a/src/gateway/session-utils-creators.test.ts
+++ b/src/gateway/session-utils-creators.test.ts
@@ -5,40 +5,30 @@ import type { GatewayClient } from "./server-methods/types.js";
 import { createSessionListEntryFilter } from "./session-sharing.js";
 
 const getUserProfileDisplay = vi.hoisted(() =>
-  vi.fn((profileId: string) => ({
-    id: profileId,
-    displayName: profileId === "profile-ada" ? "Ada" : "Bob",
-    avatarRevision: profileId === "profile-ada" ? "ada-hash-png" : "42",
-    hasAvatar: profileId === "profile-ada",
-  })),
+  vi.fn((profileId: string) => {
+    const displayNames: Record<string, string> = {
+      "profile-ada": "Ada",
+      "profile-bob": "Bob",
+      "profile-carol": "Bob",
+      "profile-dana": "Bob",
+      "profile-erin": "Bob",
+      "profile:channel:opaque": "Channel Keeper",
+      "shared-id": "Shared",
+    };
+    const displayName = displayNames[profileId];
+    if (!displayName) {
+      throw new Error(`unknown profile: ${profileId}`);
+    }
+    return {
+      id: profileId,
+      displayName,
+      avatarRevision: profileId === "profile-ada" ? "ada-hash-png" : "42",
+      hasAvatar: profileId === "profile-ada",
+    };
+  }),
 );
 
 vi.mock("../state/user-profiles.js", () => ({ getUserProfileDisplay }));
-vi.mock("./session-utils-row.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./session-utils-row.js")>();
-  return {
-    ...actual,
-    projectSessionActor: (
-      actor: Parameters<typeof actual.projectSessionActor>[0],
-      identities: Parameters<typeof actual.projectSessionActor>[1],
-      cfg: Parameters<typeof actual.projectSessionActor>[2],
-    ) => {
-      if (actor?.id === "shared-id") {
-        return actor.type === "human"
-          ? { type: actor.type, id: actor.id, label: "Alpha" }
-          : { type: actor.type, id: actor.id, label: "Zulu", avatarUrl: "/avatar" };
-      }
-      if (actor?.id === "unicode-id") {
-        return {
-          type: actor.type,
-          id: actor.id,
-          label: actor.type === "human" ? "é" : "e\u0301",
-        };
-      }
-      return actual.projectSessionActor(actor, identities, cfg);
-    },
-  };
-});
 
 import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
 
@@ -47,7 +37,7 @@ afterEach(() => {
   getUserProfileDisplay.mockClear();
 });
 
-it("keeps creator labels and avatars stable across actor order", () => {
+it("lets configured agents win id-only owner facet collisions", () => {
   const actorOrders = [
     ["human", "agent"],
     ["agent", "human"],
@@ -64,43 +54,19 @@ it("keeps creator labels and avatars stable across actor order", () => {
       ]),
     );
     const result = listSessionsFromStore({
-      cfg: {} as OpenClawConfig,
+      cfg: {
+        agents: { list: [{ id: "shared-id", identity: { name: "Shared agent" } }] },
+      } as OpenClawConfig,
       storePath: "/tmp/openclaw-session-creator-order",
       store,
       opts: { archived: "all" },
     });
 
-    expect(result.creators).toEqual([{ id: "shared-id", label: "Alpha", avatarUrl: "/avatar" }]);
+    expect(result.creators).toEqual([{ type: "agent", id: "shared-id", label: "Shared agent" }]);
   }
 });
 
-it("breaks locale-equivalent creator label ties deterministically", () => {
-  for (const actorOrder of [
-    ["human", "agent"],
-    ["agent", "human"],
-  ] as const) {
-    const store = Object.fromEntries(
-      actorOrder.map((type, index) => [
-        `agent:main:unicode-${index}`,
-        {
-          createdActor: { type, id: "unicode-id" },
-          sessionId: `unicode-session-${index}`,
-          updatedAt: 2 - index,
-        } satisfies SessionEntry,
-      ]),
-    );
-    const result = listSessionsFromStore({
-      cfg: {} as OpenClawConfig,
-      storePath: "/tmp/openclaw-session-creator-unicode-order",
-      store,
-      opts: { archived: "all" },
-    });
-
-    expect(result.creators).toEqual([{ id: "unicode-id", label: "e\u0301" }]);
-  }
-});
-
-it("returns the complete deterministic creator facet independently of pagination", () => {
+it("returns the complete deterministic owner facet independently of pagination", () => {
   const store: Record<string, SessionEntry> = {
     "agent:main:ada": {
       archivedAt: 3,
@@ -127,11 +93,12 @@ it("returns the complete deterministic creator facet independently of pagination
   expect(result.totalCount).toBe(2);
   expect(result.creators).toEqual([
     {
+      type: "human",
       id: "profile-ada",
       label: "Ada",
       avatarUrl: "/api/users/profile-ada/avatar?v=ada-hash-png",
     },
-    { id: "profile-bob", label: "Bob" },
+    { type: "human", id: "profile-bob", label: "Bob" },
   ]);
   expect(result.sessions[0]?.createdActor).toEqual({
     type: "human",
@@ -154,6 +121,78 @@ it("returns the complete deterministic creator facet independently of pagination
   });
   expect(filtered.sessions.map((row) => row.key)).toEqual(["agent:main:bob"]);
   expect(filtered.creators).toEqual(result.creators);
+});
+
+it("projects only durable profiles and configured agents as effective owners", () => {
+  const cases = [
+    { createdActor: { type: "human" as const, id: "profile-ada" }, ownerId: "profile-ada" },
+    {
+      createdActor: { type: "human" as const, id: "profile:channel:opaque" },
+      ownerId: "profile:channel:opaque",
+    },
+    { createdActor: { type: "agent" as const, id: "research" }, ownerId: "research" },
+    { createdActor: { type: "human" as const, id: "discord:channel:123" } },
+    { createdActor: { type: "agent" as const, id: "agent:roboclaw:discord:channel:456" } },
+    { createdActor: { type: "system" as const, id: "system-import" } },
+    {
+      createdActor: { type: "human" as const, id: "profile-ada" },
+      owner: { actor: { type: "human" as const, id: "slack:channel:789" } },
+    },
+  ];
+  const store = Object.fromEntries(
+    cases.map(({ createdActor, owner }, index) => [
+      `agent:main:owner-${index}`,
+      {
+        createdActor,
+        owner,
+        sessionId: `session-owner-${index}`,
+        updatedAt: cases.length - index,
+      } satisfies SessionEntry,
+    ]),
+  );
+  const result = listSessionsFromStore({
+    cfg: {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "research", identity: { name: "Research" } },
+        ],
+      },
+    } as OpenClawConfig,
+    storePath: "/tmp/openclaw-session-owner-candidates",
+    store,
+    opts: { archived: "all" },
+  });
+
+  expect(result.creators).toEqual([
+    {
+      type: "human",
+      id: "profile-ada",
+      label: "Ada",
+      avatarUrl: "/api/users/profile-ada/avatar?v=ada-hash-png",
+    },
+    { type: "human", id: "profile:channel:opaque", label: "Channel Keeper" },
+    { type: "agent", id: "research", label: "Research" },
+  ]);
+  expect(
+    result.sessions.map((row) => ({
+      key: row.key,
+      createdActor: row.createdActor && {
+        type: row.createdActor.type,
+        id: row.createdActor.id,
+      },
+      owner: row.owner && {
+        type: row.owner.actor.type,
+        id: row.owner.actor.id,
+      },
+    })),
+  ).toEqual(
+    cases.map(({ createdActor, ownerId }, index) => ({
+      key: `agent:main:owner-${index}`,
+      createdActor,
+      owner: ownerId ? { type: createdActor.type, id: ownerId } : undefined,
+    })),
+  );
 });
 
 it("projects and filters the effective owner while preserving creator provenance", () => {
@@ -195,11 +234,12 @@ it("projects and filters the effective owner while preserving creator provenance
   });
   expect(result.creators).toEqual([
     {
+      type: "human",
       id: "profile-ada",
       label: "Ada",
       avatarUrl: "/api/users/profile-ada/avatar?v=ada-hash-png",
     },
-    { id: "profile-bob", label: "Bob" },
+    { type: "human", id: "profile-bob", label: "Bob" },
   ]);
   const filtered = listSessionsFromStore({
     cfg: {} as OpenClawConfig,
@@ -408,9 +448,8 @@ it("preserves legacy list output across visibility, scope, creator, and search f
     JSON.stringify({
       count: 5,
       creators: [
-        { id: "profile-ada", label: "Ada" },
-        { id: "profile-bob", label: "Bob" },
-        { id: "system-import" },
+        { type: "human", id: "profile-ada", label: "Ada" },
+        { type: "human", id: "profile-bob", label: "Bob" },
       ],
       hasMore: false,
       keys: ["global", "unknown", "agent:main:shared", "agent:work:shared", "agent:main:archived"],
@@ -433,8 +472,8 @@ it("preserves legacy list output across visibility, scope, creator, and search f
     JSON.stringify({
       count: 2,
       creators: [
-        { id: "profile-ada", label: "Ada" },
-        { id: "profile-bob", label: "Bob" },
+        { type: "human", id: "profile-ada", label: "Ada" },
+        { type: "human", id: "profile-bob", label: "Bob" },
       ],
       hasMore: false,
       keys: ["global", "agent:main:archived"],
@@ -472,9 +511,9 @@ it("keeps the serialized list response deterministic for the current filter path
     storePath: "/tmp/openclaw-session-byte-parity",
   });
   const expectedSerializedResponse = [
-    '{"ts":1000000,"path":"/tmp/openclaw-session-byte-parity","count":1,"totalCount":1,"limitApplied":100,"nextOffset":null,"hasMore":false,"creators":[{"id":"creator-b"}]',
+    '{"ts":1000000,"path":"/tmp/openclaw-session-byte-parity","count":1,"totalCount":1,"limitApplied":100,"nextOffset":null,"hasMore":false,"creators":[]',
     ',"defaults":{"modelProvider":"openai","model":"gpt-5.4","contextTokens":200000,"agentRuntime":{"id":"codex","cloudPlacementSupported":false,"source":"implicit"},"thinkingLevels":[{"id":"off","label":"off"},{"id":"minimal","label":"minimal"},{"id":"low","label":"low"},{"id":"medium","label":"medium"},{"id":"high","label":"high"},{"id":"xhigh","label":"xhigh"}],"thinkingOptions":["off","minimal","low","medium","high","xhigh"],"thinkingDefault":"off"}',
-    ',"sessions":[{"key":"global","visibility":"shared","createdActor":{"type":"system","id":"creator-b"},"owner":{"actor":{"type":"system","id":"creator-b"}},"kind":"global","classification":"global","agentId":"main","isMain":false,"isBackground":false,"subject":"needle global","updatedAt":999999,"archived":false,"pinned":false,"unread":false,"sessionId":"session-global","thinkingLevels":[{"id":"off","label":"off"},{"id":"minimal","label":"minimal"},{"id":"low","label":"low"},{"id":"medium","label":"medium"},{"id":"high","label":"high"},{"id":"xhigh","label":"xhigh"}],"thinkingOptions":["off","minimal","low","medium","high","xhigh"],"thinkingDefault":"off","effectiveFastMode":false,"effectiveFastModeSource":"default","fastAutoOnSeconds":60,"totalTokens":1,"totalTokensFresh":true,"estimatedCostUsd":0,"effectiveResponseUsage":"off","effectiveQueueMode":"steer","modelProvider":"openai","model":"gpt-5.4","agentRuntime":{"id":"codex","source":"implicit"},"contextTokens":100}]}',
+    ',"sessions":[{"key":"global","visibility":"shared","createdActor":{"type":"system","id":"creator-b"},"kind":"global","classification":"global","agentId":"main","isMain":false,"isBackground":false,"subject":"needle global","updatedAt":999999,"archived":false,"pinned":false,"unread":false,"sessionId":"session-global","thinkingLevels":[{"id":"off","label":"off"},{"id":"minimal","label":"minimal"},{"id":"low","label":"low"},{"id":"medium","label":"medium"},{"id":"high","label":"high"},{"id":"xhigh","label":"xhigh"}],"thinkingOptions":["off","minimal","low","medium","high","xhigh"],"thinkingDefault":"off","effectiveFastMode":false,"effectiveFastModeSource":"default","fastAutoOnSeconds":60,"totalTokens":1,"totalTokensFresh":true,"estimatedCostUsd":0,"effectiveResponseUsage":"off","effectiveQueueMode":"steer","modelProvider":"openai","model":"gpt-5.4","agentRuntime":{"id":"codex","source":"implicit"},"contextTokens":100}]}',
   ].join("");
 
   expect(JSON.stringify(result)).toBe(expectedSerializedResponse);

--- a/src/gateway/session-utils-creators.test.ts
+++ b/src/gateway/session-utils-creators.test.ts
@@ -241,13 +241,23 @@ it("projects and filters the effective owner while preserving creator provenance
     },
     { type: "human", id: "profile-bob", label: "Bob" },
   ]);
-  const filtered = listSessionsFromStore({
+  const creatorFiltered = listSessionsFromStore({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
-    opts: { archived: "all", creatorId: "profile-bob" },
+    opts: { archived: "all", creatorId: "profile-ada" },
   });
-  expect(filtered.sessions.map((row) => row.key)).toEqual(["agent:main:assigned-owner"]);
+  expect(creatorFiltered.sessions.map((row) => row.key)).toEqual([
+    "agent:main:default-owner",
+    "agent:main:assigned-owner",
+  ]);
+  const ownerFiltered = listSessionsFromStore({
+    cfg: {} as OpenClawConfig,
+    storePath: "/tmp/openclaw-session-owners",
+    store,
+    opts: { archived: "all", ownerId: "profile-bob" },
+  });
+  expect(ownerFiltered.sessions.map((row) => row.key)).toEqual(["agent:main:assigned-owner"]);
 });
 
 it("projects participant identities and filters sessions involving the viewer", () => {

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
+import { listAgentIds } from "../agents/agent-scope-config.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   countActiveDescendantRuns,
@@ -20,6 +21,7 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
 import {
   resolveSessionStoreAgentId,
@@ -43,7 +45,7 @@ import {
   buildSessionListRowMetadataContext,
   buildSingleRowStoreChildSessionsByKey,
 } from "./session-utils-projection.js";
-import { buildGatewaySessionRow, projectSessionActor } from "./session-utils-row.js";
+import { buildGatewaySessionRow, projectAssignableSessionOwner } from "./session-utils-row.js";
 import {
   appendStoredSessionModelSearchFields,
   matchesSessionListSearch,
@@ -79,7 +81,7 @@ type ListSessionsFromStoreParams = {
 
 type SessionEntrySelection = {
   entries: SessionEntryPair[];
-  creators: Array<{ id: string; label?: string; avatarUrl?: string }>;
+  ownerFacet: SessionOwnerFacetIdentity[];
   totalCount: number;
   limitApplied?: number;
   offset: number;
@@ -87,49 +89,21 @@ type SessionEntrySelection = {
   hasMore: boolean;
 };
 
-function preferredCreatorIdentityValue(
-  current: string | undefined,
-  candidate: string | undefined,
-): string | undefined {
-  if (!current || !candidate) {
-    return current ?? candidate;
-  }
-  return candidate < current ? candidate : current;
-}
-
-function addSessionCreatorIdentity(
-  creators: Map<string, { id: string; label?: string; avatarUrl?: string }>,
-  entry: SessionEntry,
-  userProfileIdentityById: Map<string, SessionActorProfileIdentity | undefined>,
-  cfg: OpenClawConfig,
+function addSessionOwnerFacetIdentity(
+  ownerFacet: Map<string, SessionOwnerFacetIdentity>,
+  actor: SessionOwnerFacetIdentity,
 ): void {
-  const actor = projectSessionActor(
-    entry.owner?.actor ?? entry.createdActor,
-    userProfileIdentityById,
-    cfg,
-  );
-  const id = normalizeOptionalString(actor?.id);
-  if (!id) {
-    return;
-  }
-  const label = normalizeOptionalString(actor?.label);
-  const avatarUrl = normalizeOptionalString(actor?.avatarUrl);
-  const existing = creators.get(id);
-  const preferredLabel = preferredCreatorIdentityValue(existing?.label, label);
-  const preferredAvatarUrl = preferredCreatorIdentityValue(existing?.avatarUrl, avatarUrl);
-  if (!existing || preferredLabel !== existing.label || preferredAvatarUrl !== existing.avatarUrl) {
-    creators.set(id, {
-      id,
-      ...(preferredLabel ? { label: preferredLabel } : {}),
-      ...(preferredAvatarUrl ? { avatarUrl: preferredAvatarUrl } : {}),
-    });
+  const existing = ownerFacet.get(actor.id);
+  // The wire filter is id-only; a configured agent wins an authoritative namespace collision.
+  if (!existing || (existing.type === "human" && actor.type === "agent")) {
+    ownerFacet.set(actor.id, actor);
   }
 }
 
-function sortSessionCreatorIdentities(
-  creators: Map<string, { id: string; label?: string; avatarUrl?: string }>,
-): Array<{ id: string; label?: string; avatarUrl?: string }> {
-  return [...creators.values()].toSorted((a, b) => {
+function sortSessionOwnerFacet(
+  ownerFacet: Map<string, SessionOwnerFacetIdentity>,
+): SessionOwnerFacetIdentity[] {
+  return [...ownerFacet.values()].toSorted((a, b) => {
     const byLabel = (a.label ?? a.id).localeCompare(b.label ?? b.id);
     return byLabel || a.id.localeCompare(b.id);
   });
@@ -196,10 +170,11 @@ function filterSessionEntries(params: {
   opts: SessionsListParams;
   now: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
+  configuredAgentIds?: ReadonlySet<string>;
   getRowContext?: SessionListRowContextProvider;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
   involvingActorId?: string;
-}): Pick<SessionEntrySelection, "creators" | "entries"> {
+}): Pick<SessionEntrySelection, "ownerFacet" | "entries"> {
   const { cfg, store, opts, now } = params;
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
@@ -216,7 +191,9 @@ function filterSessionEntries(params: {
   const involvingActorId = normalizeOptionalString(params.involvingActorId);
   const activeCutoff = activeMinutes === undefined ? undefined : now - activeMinutes * 60_000;
   const entries: SessionEntryPair[] = [];
-  const creators = new Map<string, { id: string; label?: string; avatarUrl?: string }>();
+  const ownerFacet = new Map<string, SessionOwnerFacetIdentity>();
+  let configuredAgentIds = params.configuredAgentIds;
+  let filterOwnerIdentityById: Map<string, SessionActorProfileIdentity | undefined> | undefined;
 
   for (const [key, entry] of Object.entries(store)) {
     if (params.entryFilter && !params.entryFilter(key, entry)) {
@@ -320,15 +297,31 @@ function filterSessionEntries(params: {
     if (activeCutoff !== undefined && (entry.updatedAt ?? 0) < activeCutoff) {
       continue;
     }
+    let effectiveOwner: SessionOwnerFacetIdentity | undefined;
     if (params.userProfileIdentityById) {
-      addSessionCreatorIdentity(creators, entry, params.userProfileIdentityById, cfg);
+      configuredAgentIds ??= new Set(listAgentIds(cfg));
+      effectiveOwner = projectAssignableSessionOwner(
+        entry.owner?.actor ?? entry.createdActor,
+        params.userProfileIdentityById,
+        cfg,
+        configuredAgentIds,
+      );
+      if (effectiveOwner) {
+        addSessionOwnerFacetIdentity(ownerFacet, effectiveOwner);
+      }
+    } else if (creatorId || involvingActorId) {
+      filterOwnerIdentityById ??= new Map();
+      effectiveOwner = projectAssignableSessionOwner(
+        entry.owner?.actor ?? entry.createdActor,
+        filterOwnerIdentityById,
+        cfg,
+      );
     }
-    if (creatorId && (entry.owner?.actor ?? entry.createdActor)?.id !== creatorId) {
+    if (creatorId && effectiveOwner?.id !== creatorId) {
       continue;
     }
     if (involvingActorId) {
-      const owner = entry.owner?.actor ?? entry.createdActor;
-      const viewerOwns = owner?.type === "human" && owner.id === involvingActorId;
+      const viewerOwns = effectiveOwner?.type === "human" && effectiveOwner.id === involvingActorId;
       // Only profile-backed ids share the authenticated viewer namespace.
       // Channel-native and legacy unknown ids remain display-only.
       const viewerParticipates = entry.participants?.some(
@@ -344,7 +337,7 @@ function filterSessionEntries(params: {
     entries.push([key, entry]);
   }
 
-  return { entries, creators: sortSessionCreatorIdentities(creators) };
+  return { entries, ownerFacet: sortSessionOwnerFacet(ownerFacet) };
 }
 
 function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefined): boolean {
@@ -364,10 +357,11 @@ function selectSessionEntries(params: {
   getRowContext?: SessionListRowContextProvider;
   defaultLimit?: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
+  configuredAgentIds?: ReadonlySet<string>;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
   involvingActorId?: string;
 }): SessionEntrySelection {
-  const { creators, entries: filtered } = filterSessionEntries(params);
+  const { ownerFacet, entries: filtered } = filterSessionEntries(params);
   const limit = resolveSessionsListLimit(params.opts, params.defaultLimit);
   const offset = resolveSessionsListOffset(params.opts);
   const windowLimit = resolveSessionsListWindowLimit(limit, offset);
@@ -378,7 +372,7 @@ function selectSessionEntries(params: {
   const hasMore = nextOffset < filtered.length;
   return {
     entries,
-    creators,
+    ownerFacet,
     totalCount: filtered.length,
     limitApplied: limit,
     offset,
@@ -391,6 +385,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   const { cfg, store, opts } = params;
   const now = Date.now();
   const userProfileIdentityById = new Map<string, SessionActorProfileIdentity | undefined>();
+  const configuredAgentIds = new Set(listAgentIds(cfg));
   let rowContext: SessionListRowContext | undefined;
   const getRowContext = () => {
     rowContext ??= buildSessionListRowContext({ store, now, userProfileIdentityById });
@@ -419,6 +414,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
         : undefined,
     defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
     userProfileIdentityById,
+    configuredAgentIds,
     involvingActorId: params.involvingActorId,
   });
   const fullRowContext =
@@ -453,6 +449,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     includeDerivedTitles: opts.includeDerivedTitles === true,
     includeLastMessage: opts.includeLastMessage === true,
     now,
+    configuredAgentIds,
     rowContext: sharedRowContext,
     storeChildSessionsByKey: fullRowContext?.storeChildSessionsByKey,
     storePath: hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath),
@@ -476,7 +473,7 @@ function buildSessionsListResult(params: {
     offset: list.offset > 0 ? list.offset : undefined,
     nextOffset: list.nextOffset,
     hasMore: list.hasMore,
-    creators: list.creators,
+    creators: list.ownerFacet,
     defaults: getSessionDefaults(params.cfg, params.modelCatalog, {
       ...(params.agentId ? { agentId: params.agentId } : {}),
       allowPluginNormalization: false,
@@ -526,6 +523,7 @@ export function listSessionsFromStore(params: ListSessionsFromStoreParams): Sess
       transcriptUsageMaxBytes: SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES,
       storeChildSessionsByKey,
       rowContext: list.rowContext,
+      configuredAgentIds: list.configuredAgentIds,
       skipTranscriptUsageFallback: params.lightweightListRows === true,
       lightweightListRow: params.lightweightListRows === true,
     });

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -188,6 +188,7 @@ function filterSessionEntries(params: {
       ? Math.max(1, Math.floor(opts.activeMinutes))
       : undefined;
   const creatorId = normalizeOptionalString(opts.creatorId);
+  const ownerId = normalizeOptionalString(opts.ownerId);
   const involvingActorId = normalizeOptionalString(params.involvingActorId);
   const activeCutoff = activeMinutes === undefined ? undefined : now - activeMinutes * 60_000;
   const entries: SessionEntryPair[] = [];
@@ -309,15 +310,20 @@ function filterSessionEntries(params: {
       if (effectiveOwner) {
         addSessionOwnerFacetIdentity(ownerFacet, effectiveOwner);
       }
-    } else if (creatorId || involvingActorId) {
+    } else if (ownerId || involvingActorId) {
       filterOwnerIdentityById ??= new Map();
+      configuredAgentIds ??= new Set(listAgentIds(cfg));
       effectiveOwner = projectAssignableSessionOwner(
         entry.owner?.actor ?? entry.createdActor,
         filterOwnerIdentityById,
         cfg,
+        configuredAgentIds,
       );
     }
-    if (creatorId && effectiveOwner?.id !== creatorId) {
+    if (creatorId && entry.createdActor?.id !== creatorId) {
+      continue;
+    }
+    if (ownerId && effectiveOwner?.id !== ownerId) {
       continue;
     }
     if (involvingActorId) {

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -4,6 +4,7 @@ import type {
   SessionCreatedActor,
   SessionOwner,
 } from "../../packages/gateway-protocol/src/index.js";
+import { listAgentIds } from "../agents/agent-scope-config.js";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
@@ -36,6 +37,7 @@ import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.j
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveActiveSessionAgentStatus } from "../sessions/session-agent-status.js";
 import { looksLikeAvatarPath } from "../shared/avatar-policy.js";
+import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
 import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { buildControlUiAvatarUrl, normalizeControlUiBasePath } from "./control-ui-shared.js";
@@ -117,21 +119,54 @@ export function projectSessionActor(
   return { type: actor.type, id, ...identity };
 }
 
+/** Projects an identity only when it can own a session durably. */
+export function projectAssignableSessionOwner(
+  actor: SessionEntry["createdActor"],
+  userProfileIdentityById: Map<string, SessionActorProfileIdentity | undefined>,
+  cfg: OpenClawConfig,
+  configuredAgentIds?: ReadonlySet<string>,
+): SessionOwnerFacetIdentity | undefined {
+  if (!actor || (actor.type !== "human" && actor.type !== "agent")) {
+    return undefined;
+  }
+  const rawId = normalizeOptionalString(actor.id);
+  if (!rawId) {
+    return undefined;
+  }
+  const id = actor.type === "agent" ? normalizeAgentId(rawId) : rawId;
+  if (actor.type === "agent" && !(configuredAgentIds ?? new Set(listAgentIds(cfg))).has(id)) {
+    return undefined;
+  }
+  const projected = projectSessionActor({ type: actor.type, id }, userProfileIdentityById, cfg);
+  if (!projected?.id || (actor.type === "human" && userProfileIdentityById.get(id) === undefined)) {
+    return undefined;
+  }
+  return {
+    type: actor.type,
+    id,
+    ...(projected.label ? { label: projected.label } : {}),
+    ...(projected.avatarUrl ? { avatarUrl: projected.avatarUrl } : {}),
+  };
+}
+
 function projectSessionOwner(
   entry: SessionEntry | undefined,
   userProfileIdentityById: Map<string, SessionActorProfileIdentity | undefined> | undefined,
   cfg: OpenClawConfig,
+  configuredAgentIds?: ReadonlySet<string>,
 ): SessionOwner | undefined {
   const persisted = entry?.owner;
-  const actor = projectSessionActor(
+  const identities = userProfileIdentityById ?? new Map();
+  const actor = projectAssignableSessionOwner(
     persisted?.actor ?? entry?.createdActor,
-    userProfileIdentityById,
+    identities,
     cfg,
+    configuredAgentIds,
   );
   if (!actor) {
     return undefined;
   }
-  const assignedBy = projectSessionActor(persisted?.assignedBy, userProfileIdentityById, cfg);
+  const assignedBy = projectSessionActor(persisted?.assignedBy, identities, cfg);
   return {
     actor,
     ...(assignedBy ? { assignedBy } : {}),
@@ -164,6 +199,7 @@ export function buildGatewaySessionRow(params: {
   transcriptUsageMaxBytes?: number;
   storeChildSessionsByKey?: Map<string, string[]>;
   rowContext?: SessionListRowContext;
+  configuredAgentIds?: ReadonlySet<string>;
   agentId?: string;
   skipTranscriptUsageFallback?: boolean;
   lightweightListRow?: boolean;
@@ -476,7 +512,12 @@ export function buildGatewaySessionRow(params: {
       rowContext?.userProfileIdentityById,
       cfg,
     ),
-    owner: projectSessionOwner(entry, rowContext?.userProfileIdentityById, cfg),
+    owner: projectSessionOwner(
+      entry,
+      rowContext?.userProfileIdentityById,
+      cfg,
+      params.configuredAgentIds,
+    ),
     participants: projectSessionParticipants(entry, rowContext?.userProfileIdentityById, cfg),
     participantCount: entry?.participantCount,
     createdAt: entry?.createdAt,

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -1,3 +1,8 @@
+import type {
+  SessionCreatedActor,
+  SessionsAssignOwnerParams,
+} from "../../packages/gateway-protocol/src/index.js";
+
 /** Agent identity fields returned by gateway session listing APIs. */
 type GatewayAgentIdentity = {
   name?: string;
@@ -37,6 +42,10 @@ export type GatewayThinkingLevelOption = {
 
 export type GatewayAgentKind = "agent" | "system";
 
+/** Assignable identity returned by the complete session-owner facet. */
+export type SessionOwnerFacetIdentity = SessionsAssignOwnerParams["owner"] &
+  Pick<SessionCreatedActor, "label" | "avatarUrl">;
+
 /** Per-session Control UI face preference carried by session list rows. */
 export type SessionBoardFace = "chat" | "dashboard";
 
@@ -66,7 +75,7 @@ export type SessionsListResultBase<TDefaults, TRow> = {
   nextOffset?: number | null;
   hasMore?: boolean;
   /** Complete owner facet for the filtered result, independent of pagination. */
-  creators?: Array<{ id: string; label?: string; avatarUrl?: string }>;
+  creators?: SessionOwnerFacetIdentity[];
   defaults: TDefaults;
   sessions: TRow[];
 };

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -43,7 +43,7 @@ type SessionCatalogGroupsParams = {
   loadingMoreCatalogIds: ReadonlySet<string>;
   projectGrouping: CatalogProjectGrouping;
   liveRows: readonly GatewaySessionRow[];
-  creatorId?: string | null;
+  ownerId?: string | null;
   renderLiveRow: (row: GatewaySessionRow, display: CatalogBackingSessionDisplay) => unknown;
   onToggleSection: (sectionId: string) => void;
   draggingSectionId: string | null;
@@ -120,9 +120,11 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
   // Adopted rows reuse the live session row so activity, unread state, and
   // the session menu behave exactly like the regular list.
   const liveRowsByKey = new Map<string, GatewaySessionRow>();
+  const liveOwnerIdBySessionKey = new Map<string, string | undefined>();
   for (const row of params.liveRows) {
     if (!liveRowsByKey.has(row.key)) {
       liveRowsByKey.set(row.key, row);
+      liveOwnerIdBySessionKey.set(row.key, row.owner?.actor.id);
     }
   }
   return params.catalogs.map((catalog) => {
@@ -130,7 +132,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const collapsed = params.collapsedSections.has(sectionId);
     const hosts = catalog.hosts;
     // Catalog providers own host identity; the sidebar only removes hosts with no visible rows.
-    const visibleHosts = visibleCatalogHosts(hosts, params.creatorId);
+    const visibleHosts = visibleCatalogHosts(hosts, params.ownerId, liveOwnerIdBySessionKey);
     const rows = visibleHosts.flatMap((host) =>
       host.sessions.map((session) => ({ host, session })),
     );

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -88,4 +88,27 @@ describe("visibleCatalogHosts", () => {
       { ...hosts[0]!, sessions: [hosts[0]!.sessions[0]!] },
     ]);
   });
+
+  it("uses a live adopted session owner before catalog creator provenance", () => {
+    const adoptedKey = "agent:main:adopted";
+    const hosts: SessionCatalogHost[] = [
+      {
+        hostId: "node:remote",
+        label: "Remote node",
+        kind: "node",
+        connected: true,
+        sessions: [
+          {
+            ...session("adopted", "Adopted"),
+            sessionKey: adoptedKey,
+            createdActor: { id: "operator:creator", type: "human" },
+          },
+        ],
+      },
+    ];
+
+    expect(
+      visibleCatalogHosts(hosts, "operator:owner", new Map([[adoptedKey, "operator:owner"]])),
+    ).toEqual(hosts);
+  });
 });

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -57,13 +57,21 @@ export function visibleSessionCatalogProjection(
 
 export function visibleCatalogHosts(
   hosts: readonly SessionCatalogHost[],
-  creatorId?: string | null,
+  ownerId?: string | null,
+  liveOwnerIdBySessionKey: ReadonlyMap<string, string | undefined> = new Map(),
 ): SessionCatalogHost[] {
   const visible: SessionCatalogHost[] = [];
   for (const host of hosts) {
-    const sessions = host.sessions.filter(
-      (session) => !creatorId || session.createdActor?.id === creatorId,
-    );
+    const sessions = host.sessions.filter((session) => {
+      if (!ownerId) {
+        return true;
+      }
+      const sessionKey = session.sessionKey;
+      const adopted = Boolean(sessionKey && liveOwnerIdBySessionKey.has(sessionKey));
+      const effectiveOwnerId =
+        adopted && sessionKey ? liveOwnerIdBySessionKey.get(sessionKey) : session.createdActor?.id;
+      return effectiveOwnerId === ownerId;
+    });
     if (sessions.length > 0) {
       visible.push(sessions.length === host.sessions.length ? host : { ...host, sessions });
     }

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -45,7 +45,7 @@ type SessionCatalogRenderSnapshot = {
   projectGrouping: CatalogProjectGrouping;
   liveRows: readonly GatewaySessionRow[];
   toSidebarSession: (row: GatewaySessionRow) => SidebarRecentSession;
-  creatorId: string | null;
+  ownerId: string | null;
   catalogOpenTarget: CatalogOpenTarget;
   terminalAvailable: boolean;
 };
@@ -330,7 +330,7 @@ function renderSessionCatalog(params: {
       loadingMoreCatalogIds: snapshot.loadingMoreCatalogIds,
       projectGrouping: snapshot.projectGrouping,
       liveRows: snapshot.liveRows,
-      creatorId: snapshot.creatorId,
+      ownerId: snapshot.ownerId,
       renderLiveRow: (row, display) =>
         renderRecentSession({
           host,

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GatewaySessionRow } from "../api/types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import { fetchSessionLineage } from "./app-sidebar-child-session-data.ts";
 import {
   buildSidebarSessionNavigationState,
@@ -64,7 +64,7 @@ function sortSidebarRows(
   rows: GatewaySessionRow[],
   sortMode: "created" | "updated" | "people",
   createdOrder: ReadonlyMap<string, number>,
-  creators?: Array<{ id: string; label: string }>,
+  creators?: SessionsListResult["creators"],
 ) {
   return rows.toSorted((a, b) =>
     compareSidebarSessionRowsByMode({ a, b, sortMode, createdOrder, creators }),
@@ -83,6 +83,7 @@ describe("sidebar session sort modes", () => {
     updatedAt,
     createdAt,
     createdActor: creatorId ? { type: "human", id: creatorId } : undefined,
+    owner: creatorId ? { actor: { type: "human", id: creatorId } } : undefined,
   });
 
   it("sorts timestamped sessions newest-first ahead of legacy sessions", () => {
@@ -134,8 +135,8 @@ describe("sidebar session sort modes", () => {
 
     expect(
       sortSidebarRows(rows, "people", observed, [
-        { id: "alex", label: "Alex" },
-        { id: "sam", label: "Sam" },
+        { type: "human", id: "alex", label: "Alex" },
+        { type: "human", id: "sam", label: "Sam" },
       ]).map((entry) => entry.key),
     ).toEqual(["alex-new", "alex-old", "sam-new"]);
   });

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -51,11 +51,7 @@ import {
 import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
 import { resolveCloudWorkerStopAction } from "./cloud-worker-stop.ts";
 import type { SessionAttentionController } from "./session-attention-controller.ts";
-import {
-  listSessionOwners,
-  type SessionCreatedActor,
-  type SessionOwnerOption,
-} from "./session-owner-chip.ts";
+import type { SessionOwnerOption } from "./session-owner-chip.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
@@ -87,8 +83,8 @@ export function compareSidebarSessionRowsByMode(input: {
       : compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
   }
   const creators = input.creators ?? [];
-  const ownerA = a.owner?.actor ?? a.createdActor;
-  const ownerB = b.owner?.actor ?? b.createdActor;
+  const ownerA = a.owner?.actor;
+  const ownerB = b.owner?.actor;
   const idA = ownerA?.id?.trim() ?? "";
   const idB = ownerB?.id?.trim() ?? "";
   if (idA !== idB) {
@@ -427,14 +423,14 @@ function latestVisibleAgentSessionRow(input: {
   agentId: string;
   sessionsAgentId: string | null;
   sessionsResult: SessionsListResult | null;
-  sessionRowsByAgent: Readonly<Record<string, SessionsListResult["sessions"]>>;
+  sessionResultsByAgent: Readonly<Record<string, SessionsListResult>>;
   defaultAgentId: string;
 }): SessionRow | null {
   const normalized = normalizeAgentId(input.agentId);
   const rows =
     normalized === normalizeAgentId(input.sessionsAgentId ?? "")
       ? (input.sessionsResult?.sessions ?? [])
-      : (input.sessionRowsByAgent[normalized] ?? []);
+      : (input.sessionResultsByAgent[normalized]?.sessions ?? []);
   // Unprefixed keys belong to the system default agent. Keeping them for
   // another agent would resume the wrong conversation with the raw key.
   const visible = filterVisibleSessionRows(rows, {
@@ -468,7 +464,7 @@ export function resolveLatestSidebarAgentSession(input: {
   sessionData: {
     sessionsAgentId: string | null;
     sessionsResult: SessionsListResult | null;
-    sessionRowsByAgent: Readonly<Record<string, SessionsListResult["sessions"]>>;
+    sessionResultsByAgent: Readonly<Record<string, SessionsListResult>>;
   };
   context: ApplicationContext<RouteId> | undefined;
 }): SessionRow | null {
@@ -476,7 +472,7 @@ export function resolveLatestSidebarAgentSession(input: {
     agentId: input.agentId,
     sessionsAgentId: input.sessionData.sessionsAgentId,
     sessionsResult: input.sessionData.sessionsResult,
-    sessionRowsByAgent: input.sessionData.sessionRowsByAgent,
+    sessionResultsByAgent: input.sessionData.sessionResultsByAgent,
     defaultAgentId: resolveUiDefaultAgentId({
       agentsList: input.context?.agents.state.agentsList,
       hello: input.context?.gateway.snapshot.hello,
@@ -580,7 +576,7 @@ export function collectKnownSidebarSessionGroups(
 export function findProjectedSidebarSession(input: {
   sessionKey: string;
   navigationState: SidebarSessionNavigationState;
-  sessionRowsByAgent: Readonly<Record<string, SessionsListResult["sessions"]>>;
+  sessionResultsByAgent: Readonly<Record<string, SessionsListResult>>;
 }): SidebarRecentSession | undefined {
   const active = input.navigationState.visibleSessionRows.find(
     (candidate) => candidate.key === input.sessionKey,
@@ -588,8 +584,8 @@ export function findProjectedSidebarSession(input: {
   if (active) {
     return input.navigationState.toSidebarSession(active);
   }
-  for (const rows of Object.values(input.sessionRowsByAgent)) {
-    const row = rows.find((candidate) => candidate.key === input.sessionKey);
+  for (const result of Object.values(input.sessionResultsByAgent)) {
+    const row = result.sessions.find((candidate) => candidate.key === input.sessionKey);
     if (row) {
       return input.navigationState.toSidebarSession(row);
     }
@@ -615,40 +611,34 @@ export function promoteSidebarSessionCreatedOrder(
 }
 
 export function applySidebarSessionCreatorFilter(input: {
-  projected: readonly SidebarRecentSession[];
-  creatorRows: readonly {
-    createdActor?: SessionCreatedActor;
-    owner?: { actor: SessionCreatedActor };
-  }[];
-  creatorFacet: readonly { id: string; label?: string; avatarUrl?: string }[] | undefined;
+  projected: SidebarRecentSession[];
+  creatorFacet: SessionsListResult["creators"];
   selectedCreatorId: string | null;
-  involvingActorId?: string;
 }): {
   rows: SidebarRecentSession[];
   creatorOptions: readonly SessionOwnerOption[];
   ownershipVisible: boolean;
   activeCreatorId: string | null;
-  involvingMeActive: boolean;
 } {
-  const flattened: SidebarRecentSession[] = [];
-  const pending = [...input.projected];
-  while (pending.length > 0) {
-    const row = pending.shift();
-    if (row) {
-      flattened.push(row);
+  const creatorOptions = input.creatorFacet ?? [];
+  let hasParticipants = false;
+  if (creatorOptions.length < 2) {
+    const pending = [...input.projected];
+    let index = 0;
+    while (index < pending.length) {
+      const row = pending[index];
+      index += 1;
+      if (!row) {
+        continue;
+      }
+      if ((row.participantCount ?? 0) > 0) {
+        hasParticipants = true;
+        break;
+      }
       pending.push(...row.children);
     }
   }
-  const creatorOptions = listSessionOwners([
-    ...(input.creatorFacet ?? []).map((creator) => ({
-      createdActor: { type: "human" as const, ...creator },
-    })),
-    ...flattened,
-    ...input.creatorRows,
-  ]);
-  const ownershipVisible =
-    creatorOptions.length >= 2 || flattened.some((row) => (row.participantCount ?? 0) > 0);
-  const involvingMeActive = Boolean(input.involvingActorId);
+  const ownershipVisible = creatorOptions.length >= 2 || hasParticipants;
   const activeCreatorId = ownershipVisible
     ? creatorOptions.some((creator) => creator.id === input.selectedCreatorId)
       ? input.selectedCreatorId
@@ -658,18 +648,17 @@ export function applySidebarSessionCreatorFilter(input: {
     // Involving-me is evaluated by the Gateway against the complete participant table.
     // The bounded display projection cannot safely repeat that predicate client-side.
     return {
-      rows: [...input.projected],
+      rows: input.projected,
       creatorOptions,
       ownershipVisible,
       activeCreatorId,
-      involvingMeActive,
     };
   }
   const filterTree = (treeRows: readonly SidebarRecentSession[]): SidebarRecentSession[] => {
     const filtered: SidebarRecentSession[] = [];
     for (const row of treeRows) {
       const children = filterTree(row.children);
-      const ownerId = (row.owner?.actor ?? row.createdActor)?.id;
+      const ownerId = row.owner?.actor.id;
       if (activeCreatorId && ownerId === activeCreatorId) {
         filtered.push({ ...row, children });
       } else {
@@ -685,7 +674,6 @@ export function applySidebarSessionCreatorFilter(input: {
     creatorOptions,
     ownershipVisible,
     activeCreatorId,
-    involvingMeActive,
   };
 }
 
@@ -695,7 +683,7 @@ export function mergeAdoptedSessionPullRequestRows(input: {
   rows: SidebarRecentSession[];
   adopted: ReadonlySet<string>;
   sessionsResult: SessionsListResult | null;
-  sessionRowsByAgent: Record<string, GatewaySessionRow[]>;
+  sessionResultsByAgent: Record<string, SessionsListResult>;
   navigationState: SidebarSessionNavigationState;
 }): SidebarRecentSession[] {
   if (input.adopted.size === 0) {
@@ -704,7 +692,7 @@ export function mergeAdoptedSessionPullRequestRows(input: {
   const byKey = new Map(input.rows.map((row) => [row.key, row]));
   const liveRows = [
     ...(input.sessionsResult?.sessions ?? []),
-    ...Object.values(input.sessionRowsByAgent).flat(),
+    ...Object.values(input.sessionResultsByAgent).flatMap((result) => result.sessions),
   ];
   for (const row of liveRows) {
     if (input.adopted.has(row.key) && !byKey.has(row.key)) {

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -67,7 +67,7 @@ import {
 import { SessionAttentionController } from "./session-attention-controller.ts";
 import { SessionDataController } from "./session-data-controller.ts";
 import type { SessionOrganizerController } from "./session-organizer-controller.ts";
-import type { SessionCreatedActor, SessionOwnerOption } from "./session-owner-chip.ts";
+import type { SessionOwnerOption } from "./session-owner-chip.ts";
 import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
 
 /** Session-row projection, selection, sorting, and agent scope navigation. */
@@ -82,7 +82,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
         rows: this.visibleSessionRowsInOrder(),
         adopted: adoptedCatalogSessionKeys(this.visibleSessionCatalogs()),
         sessionsResult: this.sessionData.sessionsResult,
-        sessionRowsByAgent: this.sessionData.sessionRowsByAgent,
+        sessionResultsByAgent: this.sessionData.sessionResultsByAgent,
         navigationState: this.getSessionNavigationState(),
       }),
     getSelectedAgentId: () => this.selectedAgentIdForSessions(),
@@ -97,7 +97,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       a,
       b,
       sortMode: this.effectiveSessionSortMode(),
-      creators: this.sessionData.sessionsResult?.creators,
+      creators: this.selectedAgentSessionResult()?.creators,
       createdOrder: this.sessionData.sessionCreatedOrder,
     });
 
@@ -124,7 +124,9 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
 
   sessionCreatorOptions: readonly SessionOwnerOption[] = [];
   protected activeSessionCreatorId: string | null = null;
-  sessionCreatorFilterActive = false;
+  get sessionCreatorFilterActive() {
+    return this.activeSessionCreatorId !== null;
+  }
   sessionOwnershipVisible = false;
 
   @state() selectedSessionKeys: ReadonlySet<string> = new Set();
@@ -186,8 +188,9 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   override updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
     const selectedId = this.sessionCreatorFilterId;
-    const creators = this.sessionData.sessionsResult?.creators;
-    const hasParticipants = this.sessionData.sessionsResult?.sessions.some(
+    const selectedResult = this.selectedAgentSessionResult();
+    const creators = selectedResult?.creators;
+    const hasParticipants = selectedResult?.sessions.some(
       (session) => (session.participantCount ?? 0) > 0,
     );
     if (this.sessionSortMode === "people" && this.sessionPeopleSortCapability() === false) {
@@ -242,27 +245,17 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   }
 
   protected applySessionCreatorFilter(
-    projected: readonly SidebarRecentSession[],
-    creatorRows: readonly {
-      createdActor?: SessionCreatedActor;
-      owner?: { actor: SessionCreatedActor };
-    }[] = [],
-    creatorFacet?: readonly { id: string; label?: string }[],
+    projected: SidebarRecentSession[],
+    creatorFacet: SessionsListResult["creators"],
   ): SidebarRecentSession[] {
     const result = applySidebarSessionCreatorFilter({
       projected,
-      creatorRows,
-      creatorFacet: creatorFacet ?? this.sessionData.sessionsResult?.creators,
+      creatorFacet,
       selectedCreatorId: this.sessionCreatorFilterId,
-      involvingActorId: this.sessionInvolvingMeFilterActive
-        ? this.sessionDataContext?.gateway.snapshot.selfUser?.id
-        : undefined,
     });
     this.sessionCreatorOptions = result.creatorOptions;
     this.sessionOwnershipVisible = result.ownershipVisible;
-    this.sessionCreatorFilterActive = result.activeCreatorId !== null;
     this.activeSessionCreatorId = result.activeCreatorId;
-    this.sessionInvolvingMeFilterActive = result.involvingMeActive;
     return result.rows;
   }
 
@@ -583,7 +576,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return findProjectedSidebarSession({
       sessionKey,
       navigationState,
-      sessionRowsByAgent: this.sessionData.sessionRowsByAgent,
+      sessionResultsByAgent: this.sessionData.sessionResultsByAgent,
     });
   }
 
@@ -598,7 +591,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const rows =
       selected === loadedAgentId
         ? (this.sessionData.sessionsResult?.sessions ?? [])
-        : (this.sessionData.sessionRowsByAgent[selected] ?? []);
+        : (this.sessionData.sessionResultsByAgent[selected]?.sessions ?? []);
     const rowsByKey = new Map(rows.map((row) => [row.key, row]));
     const rootRows =
       selected === routeAgentId && selected === loadedAgentId
@@ -704,10 +697,17 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       }
     }
     const creatorFacet =
-      rows === this.sessionData.sessionsResult?.sessions
-        ? this.sessionData.sessionsResult.creators
-        : undefined;
-    return this.applySessionCreatorFilter(projected, rows, creatorFacet);
+      selected === loadedAgentId
+        ? this.sessionData.sessionsResult?.creators
+        : this.sessionData.sessionResultsByAgent[selected]?.creators;
+    return this.applySessionCreatorFilter(projected, creatorFacet);
+  }
+
+  private selectedAgentSessionResult(): SessionsListResult | null {
+    const selected = this.expandedAgentId();
+    return selected === normalizeAgentId(this.sessionData.sessionsAgentId ?? "")
+      ? this.sessionData.sessionsResult
+      : (this.sessionData.sessionResultsByAgent[selected] ?? null);
   }
 
   /** Canonical main-session key for the selected (or given) agent. */
@@ -730,7 +730,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const rows =
       normalized === normalizeAgentId(this.sessionData.sessionsAgentId ?? "")
         ? (this.sessionData.sessionsResult?.sessions ?? [])
-        : (this.sessionData.sessionRowsByAgent[normalized] ?? []);
+        : (this.sessionData.sessionResultsByAgent[normalized]?.sessions ?? []);
     return findSidebarMainSessionRow(rows, mainKey);
   }
 
@@ -777,7 +777,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   }
 
   agentUnreadCount(agentId: string): number {
-    const rows = this.sessionData.sessionRowsByAgent[normalizeAgentId(agentId)] ?? [];
+    const rows = this.sessionData.sessionResultsByAgent[normalizeAgentId(agentId)]?.sessions ?? [];
     return rows.filter((row) => row.unread === true && row.archived !== true).length;
   }
 }

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -184,7 +184,7 @@ export function renderRecentSession(params: {
   const ownerActor = host.sessionOwnershipVisible
     ? host.sessionsStatusFilter === "archived"
       ? session.archivedBy
-      : (session.owner?.actor ?? session.createdActor)
+      : session.owner?.actor
     : undefined;
   const ownerId = ownerActor?.id?.trim();
   const ownerViewing = ownerId

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -466,7 +466,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         projectGrouping: this.catalogProjectGrouping,
         liveRows,
         toSidebarSession: navigationState.toSidebarSession,
-        creatorId: this.activeSessionCreatorId,
+        ownerId: this.activeSessionCreatorId,
         catalogOpenTarget: this.catalogOpenTarget,
         terminalAvailable: this.terminalAvailable,
       },

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -435,7 +435,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     const expandedAgentId = this.expandedAgentId();
     const liveRows = [
       ...(this.sessionData.sessionsResult?.sessions ?? []),
-      ...Object.values(this.sessionData.sessionRowsByAgent).flat(),
+      ...Object.values(this.sessionData.sessionResultsByAgent).flatMap((result) => result.sessions),
     ];
     const { sections: allSections } = this.zonedVisibleSections(visibleSessions);
     const catalogs = this.visibleSessionCatalogs();

--- a/ui/src/components/session-data-controller-events.ts
+++ b/ui/src/components/session-data-controller-events.ts
@@ -11,7 +11,7 @@ import {
 type SidebarSessionListOwner = {
   readonly context: ApplicationContext<RouteId> | undefined;
   readonly sessionCreatedOrder: Map<string, number>;
-  sessionRowsByAgent: Record<string, NonNullable<SessionListSnapshot["result"]>["sessions"]>;
+  sessionResultsByAgent: Record<string, NonNullable<SessionListSnapshot["result"]>>;
   sessionsResult: SessionListSnapshot["result"];
   sessionsAgentId: SessionListSnapshot["agentId"];
   sessionsLoading: boolean;
@@ -42,7 +42,7 @@ export function publishSidebarSessionList(
     }
   }
   if (snapshot.result && snapshot.agentId) {
-    owner.sessionRowsByAgent[normalizeAgentId(snapshot.agentId)] = snapshot.result.sessions;
+    owner.sessionResultsByAgent[normalizeAgentId(snapshot.agentId)] = snapshot.result;
   }
 }
 

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -72,7 +72,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   presenceInstanceId?: string;
 
   // These caches were not Lit state on the element and stay non-reactive here.
-  sessionRowsByAgent: Record<string, SessionsListResult["sessions"]> = {};
+  sessionResultsByAgent: Record<string, SessionsListResult> = {};
   sessionCreatedOrder = new Map<string, number>();
 
   private readonly subscriptions: SubscriptionsController;
@@ -499,7 +499,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.reconnectListRevision = null;
     this.sessionsResult = null;
     this.sessionsAgentId = null;
-    this.sessionRowsByAgent = {};
+    this.sessionResultsByAgent = {};
     this.resetChildSessionState();
     this.sessionCreatedOrder.clear();
     this.visibleSessionLimits.clear();
@@ -691,7 +691,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     // A filter transition owns a new child/lineage generation; otherwise a
     // pending request from the retired view can repopulate its cleared rows.
     this.resetChildSessionState();
-    this.sessionRowsByAgent = {};
+    this.sessionResultsByAgent = {};
     if (statusFilter === "active" && this.context) {
       this.sessionsResult = this.context.sessions.state.result;
       this.sessionsAgentId = this.context.sessions.state.agentId;

--- a/ui/src/components/session-owner-chip.test.ts
+++ b/ui/src/components/session-owner-chip.test.ts
@@ -1,8 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, expect, it, vi } from "vitest";
-import type { SessionCreatedActor } from "./session-owner-chip.ts";
-import "./session-owner-chip.ts";
+import { listAssignableSessionOwners, type SessionCreatedActor } from "./session-owner-chip.ts";
 
 type OwnerChipElement = HTMLElement & {
   createdActor: SessionCreatedActor | null;
@@ -66,4 +65,32 @@ it("renders the total participant count in the back slot for three identities", 
   expect(chip.querySelector(".session-owner-stack")?.getAttribute("aria-label")).toBe(
     "Owned by Ada · +2 more",
   );
+});
+
+it("treats a present owner facet as authoritative before adding self and configured agents", () => {
+  const facet = [
+    { type: "human" as const, id: "profile:channel:opaque", label: "Opaque Person" },
+    { type: "agent" as const, id: "facet-agent", label: "Facet Agent" },
+  ];
+
+  expect(
+    listAssignableSessionOwners({
+      facet,
+      agents: [{ id: "configured-agent", name: "Configured Agent" }],
+      self: { id: "profile-self", name: "Self" },
+    }),
+  ).toEqual([
+    { type: "agent", id: "configured-agent", label: "Configured Agent" },
+    { type: "agent", id: "facet-agent", label: "Facet Agent" },
+    { type: "human", id: "profile:channel:opaque", label: "Opaque Person" },
+    { type: "human", id: "profile-self", label: "Self" },
+  ]);
+});
+
+it("does not reconstruct assignment candidates when the owner facet is absent", () => {
+  expect(
+    listAssignableSessionOwners({
+      facet: undefined,
+    }),
+  ).toEqual([]);
 });

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import type { SessionCreatedActor as ProtocolSessionCreatedActor } from "../../../packages/gateway-protocol/src/schema/sessions.js";
+import type { SessionsListResult } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
 import { takeGraphemes } from "../lib/graphemes.ts";
 import { resolveAvatar } from "../lib/identity-avatar.ts";
@@ -8,78 +9,15 @@ import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import "./viewer-facepile.ts";
 
 export type SessionCreatedActor = ProtocolSessionCreatedActor;
-export type SessionOwnerOption = SessionCreatedActor & {
-  type: "human" | "agent";
-  id: string;
-};
-
-export function listSessionOwners(
-  sessions: readonly {
-    createdActor?: SessionCreatedActor;
-    owner?: { actor: SessionCreatedActor };
-  }[],
-): SessionOwnerOption[] {
-  const owners = new Map<string, SessionOwnerOption>();
-  for (const session of sessions) {
-    const actor = session.owner?.actor ?? session.createdActor;
-    const id = actor?.id?.trim();
-    if (!actor || !id || (actor.type !== "human" && actor.type !== "agent")) {
-      continue;
-    }
-    const label = actor.label?.trim();
-    const avatarUrl = actor.avatarUrl?.trim();
-    const existing = owners.get(id);
-    const nextLabel =
-      label && (!existing?.label || label.localeCompare(existing.label) < 0)
-        ? label
-        : existing?.label;
-    const nextAvatarUrl = [existing?.avatarUrl, avatarUrl]
-      .filter((value): value is string => Boolean(value))
-      .toSorted()[0];
-    if (
-      !existing ||
-      actor.type !== existing.type ||
-      nextLabel !== existing.label ||
-      nextAvatarUrl !== existing.avatarUrl
-    ) {
-      owners.set(id, {
-        type: actor.type,
-        id,
-        ...(nextLabel ? { label: nextLabel } : {}),
-        ...(nextAvatarUrl ? { avatarUrl: nextAvatarUrl } : {}),
-      });
-    }
-  }
-  return [...owners.values()].toSorted((a, b) => {
-    const byLabel = (a.label ?? a.id).localeCompare(b.label ?? b.id);
-    return byLabel || a.id.localeCompare(b.id);
-  });
-}
+export type SessionOwnerOption = NonNullable<SessionsListResult["creators"]>[number];
 
 export function listAssignableSessionOwners(params: {
-  sessions: readonly {
-    createdActor?: SessionCreatedActor;
-    owner?: { actor: SessionCreatedActor };
-  }[];
-  facet?: readonly { id: string; label?: string; avatarUrl?: string }[];
+  facet?: SessionsListResult["creators"];
   agents?: readonly { id: string; name?: string }[];
   self?: { id: string; name?: string; avatarUrl?: string } | null;
 }): SessionOwnerOption[] {
-  const agents = new Map((params.agents ?? []).map((agent) => [agent.id, agent] as const));
-  const owners = new Map(listSessionOwners(params.sessions).map((owner) => [owner.id, owner]));
-  for (const identity of params.facet ?? []) {
-    const existing = owners.get(identity.id);
-    const agent = agents.get(identity.id);
-    owners.set(identity.id, {
-      type: existing?.type ?? (agent ? "agent" : "human"),
-      id: identity.id,
-      ...((identity.label ?? existing?.label) ? { label: identity.label ?? existing?.label } : {}),
-      ...((identity.avatarUrl ?? existing?.avatarUrl)
-        ? { avatarUrl: identity.avatarUrl ?? existing?.avatarUrl }
-        : {}),
-    });
-  }
-  if (params.self?.id) {
+  const owners = new Map((params.facet ?? []).map((owner) => [owner.id, owner]));
+  if (params.self?.id && owners.get(params.self.id)?.type !== "agent") {
     owners.set(params.self.id, {
       type: "human",
       id: params.self.id,
@@ -87,7 +25,7 @@ export function listAssignableSessionOwners(params: {
       ...(params.self.avatarUrl ? { avatarUrl: params.self.avatarUrl } : {}),
     });
   }
-  for (const agent of agents.values()) {
+  for (const agent of params.agents ?? []) {
     owners.set(agent.id, {
       type: "agent",
       id: agent.id,
@@ -162,9 +100,9 @@ export function renderSessionOwnerMenuAvatar(owner: SessionOwnerOption) {
 }
 
 /**
- * Permanent session-owner avatar. Ownership is provenance, so the chip remains
- * when its owner leaves; live viewing only changes avatar saturation. Render
- * only when the gateway has 2+ distinct creator identities (solo mode shows no
+ * Permanent session-owner avatar. Ownership remains visible when its owner
+ * leaves; live viewing only changes avatar saturation. Render only when the
+ * Gateway's complete owner facet has 2+ identities (solo mode shows no
  * attribution chrome). Human actors use the durable profile projection carried
  * by the session record; actors without it keep stable initials.
  */

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -91,7 +91,12 @@ export interface SidebarMenusControllerHost
   readonly sessionData: SessionOrganizerControllerHost["sessionData"] &
     Pick<
       SessionDataController,
-      "approvalBadgeSnapshot" | "presenceInstanceId" | "presencePayload" | "sessionsLoading"
+      | "approvalBadgeSnapshot"
+      | "presenceInstanceId"
+      | "presencePayload"
+      | "sessionResultsByAgent"
+      | "sessionsLoading"
+      | "sessionsResult"
     >;
   readonly sessionDataContext: ApplicationContext<RouteId> | undefined;
   readonly sessionOrganizer: SessionOrganizerController;

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -173,9 +173,11 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
     isGatewayMethodAdvertised(context.gateway.snapshot, cloudWorkerStopAction.method) === true,
   );
   const selfUser = context?.gateway.snapshot.selfUser ?? null;
-  const sessionsResult = context?.sessions.state.result;
+  const sessionsResult = [
+    host.sessionData.sessionsResult,
+    ...Object.values(host.sessionData.sessionResultsByAgent),
+  ].find((result) => result?.sessions.some((row) => row.key === session.key));
   const ownerOptions = listAssignableSessionOwners({
-    sessions: sessionsResult?.sessions ?? [session],
     facet: sessionsResult?.creators,
     agents: context?.agents.state.agentsList?.agents,
     self: selfUser,
@@ -227,7 +229,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
         .groups=${host.knownSessionGroups()}
         .ownerOptions=${ownerOptions}
         .selfOwner=${selfOwner}
-        .currentOwnerId=${(session.owner?.actor ?? session.createdActor)?.id ?? null}
+        .currentOwnerId=${session.owner?.actor.id ?? null}
         .work=${batchRows ? null : controller.sessionMenuWork}
         .workboard=${null}
         .onClose=${() => {

--- a/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
+++ b/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
@@ -46,8 +46,8 @@ suite.define(() => {
             "sessions.list": {
               count: 1,
               creators: [
-                { id: "profile-ada", label: "Ada" },
-                { id: "profile-zoe", label: "Zoe" },
+                { type: "human", id: "profile-ada", label: "Ada" },
+                { type: "human", id: "profile-zoe", label: "Zoe" },
               ],
               defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
               path: "",
@@ -55,6 +55,9 @@ suite.define(() => {
                 {
                   contextTokens: null,
                   createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+                  owner: {
+                    actor: { type: "human", id: "profile-ada", label: "Ada" },
+                  },
                   displayName: "Owner presence",
                   hasActiveRun: false,
                   key: sessionKey,

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -168,7 +168,7 @@ suite.define(() => {
       .poll(async () =>
         (await gateway.getRequests("sessions.list")).some(
           (request) =>
-            (request.params as { creatorId?: unknown } | undefined)?.creatorId === "profile-ada",
+            (request.params as { ownerId?: unknown } | undefined)?.ownerId === "profile-ada",
         ),
       )
       .toBe(true);

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -17,8 +17,10 @@ const uiProofArtifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2
 let page: Page | undefined;
 function sessionsList(creators: [string, string]) {
   const creatorFacet = [
-    { id: creators[0], label: "Ada" },
-    ...(creators[1] === creators[0] ? [] : [{ id: creators[1], label: "Bob" }]),
+    { type: "human" as const, id: creators[0], label: "Ada" },
+    ...(creators[1] === creators[0]
+      ? []
+      : [{ type: "human" as const, id: creators[1], label: "Bob" }]),
   ];
   return {
     count: 2,
@@ -32,6 +34,7 @@ function sessionsList(creators: [string, string]) {
         label: "Ada research",
         category: "Research",
         createdActor: { type: "human", id: creators[0], label: "Ada" },
+        owner: { actor: { type: "human", id: creators[0], label: "Ada" } },
         updatedAt: 2,
       },
       {
@@ -43,6 +46,13 @@ function sessionsList(creators: [string, string]) {
           type: "human",
           id: creators[1],
           label: creators[1] === creators[0] ? "Ada" : "Bob",
+        },
+        owner: {
+          actor: {
+            type: "human",
+            id: creators[1],
+            label: creators[1] === creators[0] ? "Ada" : "Bob",
+          },
         },
         updatedAt: 1,
       },
@@ -479,7 +489,7 @@ suite.define(() => {
     }
     Object.assign(activeSession, { visibility: "shared", sharingRole: "owner" });
     sessions.count = 1;
-    sessions.creators = [{ id: "profile-ada", label: "Ada" }];
+    sessions.creators = [{ type: "human", id: "profile-ada", label: "Ada" }];
     sessions.sessions = [activeSession];
     const longMemberLabel =
       "Alexandria Montgomery-Santiago from the International Collaboration Working Group";

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -163,7 +163,7 @@ test("sessions.changed deletes every null-tombstoned field, not a hand-kept list
   expect(row?.updatedAt).toBe(2);
 });
 
-test("sessions.changed invalidates the complete creator facet until canonical refresh", () => {
+test("sessions.changed invalidates the complete owner facet until canonical refresh", () => {
   const key = "agent:main:main";
   const result = buildResult([
     {
@@ -171,42 +171,51 @@ test("sessions.changed invalidates the complete creator facet until canonical re
       kind: "global",
       updatedAt: 1,
       createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+      owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
     },
   ]);
-  result.creators = [{ id: "profile-ada", label: "Ada" }];
+  result.creators = [{ type: "human", id: "profile-ada", label: "Ada" }];
 
   const reconciled = reconcileSessionChanged(result, {
     sessionKey: key,
     reason: "reset",
     updatedAt: 2,
     createdActor: { type: "human", id: "profile-bob", label: "Bob" },
+    owner: { actor: { type: "human", id: "profile-bob", label: "Bob" } },
   });
 
   expect(reconciled.result?.sessions[0]?.createdActor?.id).toBe("profile-bob");
   expect(reconciled.result?.creators).toBeUndefined();
 });
 
-test("sessions.changed preserves the creator facet when ownership is unchanged", () => {
+test("sessions.changed preserves the owner facet when ownership is unchanged", () => {
   const key = "agent:main:main";
   const createdActor = { type: "human" as const, id: "profile-ada", label: "Ada" };
-  const result = buildResult([{ key, kind: "global", updatedAt: 1, createdActor }]);
-  result.creators = [{ id: createdActor.id, label: createdActor.label }];
+  const result = buildResult([
+    { key, kind: "global", updatedAt: 1, createdActor, owner: { actor: createdActor } },
+  ]);
+  result.creators = [{ type: createdActor.type, id: createdActor.id, label: createdActor.label }];
 
   const reconciled = reconcileSessionChanged(result, {
     sessionKey: key,
     reason: "send",
     updatedAt: 2,
     createdActor,
+    owner: { actor: createdActor },
   });
 
-  expect(reconciled.result?.creators).toEqual([{ id: createdActor.id, label: createdActor.label }]);
+  expect(reconciled.result?.creators).toEqual([
+    { type: createdActor.type, id: createdActor.id, label: createdActor.label },
+  ]);
 });
 
 test("sessions.changed applies reassignment and invalidates the complete owner facet", () => {
   const key = "agent:main:main";
   const createdActor = { type: "human" as const, id: "profile-ada", label: "Ada" };
-  const result = buildResult([{ key, kind: "global", updatedAt: 1, createdActor }]);
-  result.creators = [{ id: createdActor.id, label: createdActor.label }];
+  const result = buildResult([
+    { key, kind: "global", updatedAt: 1, createdActor, owner: { actor: createdActor } },
+  ]);
+  result.creators = [{ type: createdActor.type, id: createdActor.id, label: createdActor.label }];
 
   const reconciled = reconcileSessionChanged(result, {
     sessionKey: key,

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -477,8 +477,8 @@ export function reconcileSessionChanged(
   }
   const eventTs = typeof event.ts === "number" && Number.isFinite(event.ts) ? event.ts : null;
   const timestamped = eventTs === null ? next : { ...next, ts: Math.max(next.ts, eventTs) };
-  const previousOwner = existing?.owner?.actor ?? existing?.createdActor;
-  const nextOwner = row.owner?.actor ?? row.createdActor;
+  const previousOwner = existing?.owner?.actor;
+  const nextOwner = row.owner?.actor;
   const ownershipChanged =
     (Object.hasOwn(rowFields, "owner") || Object.hasOwn(rowFields, "createdActor")) &&
     (previousOwner?.type !== nextOwner?.type ||

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -57,6 +57,7 @@ export type SessionListOptions = {
   activeMinutes?: number;
   search?: string;
   creatorId?: string;
+  ownerId?: string;
   involvingMe?: boolean;
   offset?: number;
   limit?: number;

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -100,6 +100,7 @@ export function buildSessionListParams(options: SessionListOptions = {}): Record
   const spawnedBy = options.spawnedBy?.trim();
   const search = options.search?.trim();
   const creatorId = options.creatorId?.trim();
+  const ownerId = options.ownerId?.trim();
   if (options.involvingMe === true) {
     params.involvingMe = true;
   }
@@ -117,6 +118,9 @@ export function buildSessionListParams(options: SessionListOptions = {}): Record
   }
   if (creatorId) {
     params.creatorId = creatorId;
+  }
+  if (ownerId) {
+    params.ownerId = ownerId;
   }
   if (typeof options.offset === "number" && options.offset > 0) {
     params.offset = Math.floor(options.offset);

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -79,6 +79,7 @@ function isPrimarySessionListQuery(options: SessionListScope): boolean {
     !query.activeMinutes &&
     !query.search &&
     !query.creatorId &&
+    !query.ownerId &&
     query.involvingMe !== true &&
     query.includeGlobal === true &&
     query.includeUnknown === true &&
@@ -536,7 +537,8 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     setCreatorFilter(creatorId: string | null) {
       const options = {
         ...lastListOptions,
-        creatorId: creatorId?.trim() || undefined,
+        creatorId: undefined,
+        ownerId: creatorId?.trim() || undefined,
         involvingMe: undefined,
       };
       delete options.offset;
@@ -546,6 +548,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       const options = {
         ...lastListOptions,
         creatorId: undefined,
+        ownerId: undefined,
         involvingMe: enabled || undefined,
       };
       delete options.offset;

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -6,10 +6,7 @@ import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { icons } from "../../components/icons.ts";
 import { sessionMenuReasons } from "../../components/session-menu-access.ts";
-import {
-  listAssignableSessionOwners,
-  listSessionOwners,
-} from "../../components/session-owner-chip.ts";
+import { listAssignableSessionOwners } from "../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import {
   hasSessionPresenceViewers,
@@ -340,18 +337,13 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     const selfId = sharingSnapshot.selfUser?.id;
     const instanceId = sharingSnapshot.client?.instanceId;
     const result = this.state?.sessionsResult;
-    const showOwnerChip =
-      (result?.creators ?? listSessionOwners(result?.sessions ?? [])).length >= 2 ||
-      (row?.participantCount ?? 0) > 0;
-    const renderedOwnerId = showOwnerChip
-      ? (row?.owner?.actor ?? row?.createdActor)?.id
-      : undefined;
+    const showOwnerChip = (result?.creators?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
+    const renderedOwnerId = showOwnerChip ? row?.owner?.actor.id : undefined;
     const presence = projectPresencePayload(this.presencePayload, selfId, instanceId);
     const ownerViewing = presence.users.some(
       (user) => user.id === renderedOwnerId && user.watchedSessions.includes(key),
     );
     const ownerOptions = listAssignableSessionOwners({
-      sessions: result?.sessions ?? (row ? [row] : []),
       facet: result?.creators,
       agents: this.context.agents.state.agentsList?.agents,
       self: sharingSnapshot.selfUser ?? null,
@@ -476,7 +468,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .layoutActions=${layoutMenuActions}
               .ownerOptions=${ownerOptions}
               .selfOwner=${selfOwner}
-              .currentOwnerId=${(row.owner?.actor ?? row.createdActor)?.id ?? null}
+              .currentOwnerId=${row.owner?.actor.id ?? null}
               .actionDisabledReasons=${actionDisabledReasons}
               .forkDisabled=${this.state.sessionsLoading || row.modelSelectionLocked === true}
               .forkFromLastCompleted=${row.hasActiveRun === true}

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -126,6 +126,7 @@ function mountIntegratedPresenceHeader(params: {
   const session = row({
     key: state.sessionKey,
     createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+    owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
   });
   state.settings = {} as ChatPageHost["settings"];
   state.sessionsResult = {
@@ -493,7 +494,10 @@ describe("chat pane header", () => {
   it("renders the permanent owner chip only when attribution chrome is enabled", () => {
     const shown = mount({
       showOwnerChip: true,
-      session: row({ createdActor: { type: "human", id: "profile-ada", label: "Ada" } }),
+      session: row({
+        createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+        owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
+      }),
     });
     expect(shown.container.querySelector("openclaw-session-owner-chip")).not.toBeNull();
 
@@ -509,6 +513,7 @@ describe("chat pane header", () => {
       showOwnerChip: true,
       session: row({
         createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+        owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
         participants: [
           { type: "human", id: "profile-bob", label: "Bob" },
           { type: "agent", id: "research", label: "Research" },
@@ -533,8 +538,8 @@ describe("chat pane header", () => {
     {
       name: "excludes the creator when the owner chip is shown",
       creators: [
-        { type: "human", id: "profile-ada", label: "Ada" },
-        { type: "human", id: "profile-zoe", label: "Zoe" },
+        { type: "human" as const, id: "profile-ada", label: "Ada" },
+        { type: "human" as const, id: "profile-zoe", label: "Zoe" },
       ],
       viewers: ["profile-ada", "profile-zoe"],
       expectedChip: true,
@@ -542,7 +547,7 @@ describe("chat pane header", () => {
     },
     {
       name: "keeps the creator when the owner chip is hidden",
-      creators: [{ type: "human", id: "profile-ada", label: "Ada" }],
+      creators: [{ type: "human" as const, id: "profile-ada", label: "Ada" }],
       viewers: ["profile-ada", "profile-zoe"],
       expectedChip: false,
       expectedViewers: ["profile-ada", "profile-zoe"],
@@ -550,8 +555,8 @@ describe("chat pane header", () => {
     {
       name: "omits the facepile when the shown owner is the only viewer",
       creators: [
-        { type: "human", id: "profile-ada", label: "Ada" },
-        { type: "human", id: "profile-zoe", label: "Zoe" },
+        { type: "human" as const, id: "profile-ada", label: "Ada" },
+        { type: "human" as const, id: "profile-zoe", label: "Zoe" },
       ],
       viewers: ["profile-ada"],
       expectedChip: true,
@@ -633,6 +638,14 @@ describe("chat pane header", () => {
           id: "profile-ada",
           label: "Ada",
           avatarUrl: "/api/users/profile-ada/avatar?v=7",
+        },
+        owner: {
+          actor: {
+            type: "human",
+            id: "profile-ada",
+            label: "Ada",
+            avatarUrl: "/api/users/profile-ada/avatar?v=7",
+          },
         },
       }),
     });

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -446,9 +446,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         : nothing}
       ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
       ${renderSessionOwnerChip(
-        props.showOwnerChip
-          ? (props.session?.owner?.actor ?? props.session?.createdActor)
-          : undefined,
+        props.showOwnerChip ? props.session?.owner?.actor : undefined,
         "header",
         props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
         props.ownerViewing,

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -65,7 +65,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
   }
   const result = props.state?.result;
   const members = new Set(result?.members.map((member) => member.identityId) ?? []);
-  // The shared header owner chip presents createdActor; this picker only manages mutable members.
+  // The shared header owner chip presents effective ownership; this picker manages mutable members.
   const identities =
     result?.identities.filter((identity) => identity.id !== result.owner?.id) ?? [];
   const allowed = result?.allowedVisibilities ?? props.allowedVisibilities ?? [visibility];

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -303,11 +303,12 @@ describe("AppSidebar session catalog pagination", () => {
     const backingRows = (sidebar.sessionData.sessionsResult?.sessions ?? []).map((row) =>
       row.key === backingSessionKey ? Object.assign({}, row, { unread: true }) : row,
     );
-    sidebar.sessionData.sessionsResult = {
+    const backingResult = {
       ...sidebar.sessionData.sessionsResult!,
       sessions: backingRows,
     };
-    sidebar.sessionData.sessionRowsByAgent = { main: backingRows };
+    sidebar.sessionData.sessionsResult = backingResult;
+    sidebar.sessionData.sessionResultsByAgent = { main: backingResult };
     sidebar.sessionData.requestSessionDataUpdate();
     await sidebar.updateComplete;
 
@@ -355,11 +356,12 @@ describe("AppSidebar session catalog pagination", () => {
         ? Object.assign({}, row, { unread: false, hasActiveRun: true })
         : row,
     );
-    sidebar.sessionData.sessionsResult = {
+    const runningResult = {
       ...sidebar.sessionData.sessionsResult,
       sessions: runningRows,
     };
-    sidebar.sessionData.sessionRowsByAgent = { main: runningRows };
+    sidebar.sessionData.sessionsResult = runningResult;
+    sidebar.sessionData.sessionResultsByAgent = { main: runningResult };
     sidebar.sessionData.requestSessionDataUpdate();
     await sidebar.updateComplete;
 

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -181,9 +181,10 @@ describe("AppSidebar session mutation feedback", () => {
       throw new Error("expected session owner fixture");
     }
     row.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
+    row.owner = { actor: row.createdActor };
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
     harness.publishList({ result, agentId: "main" });
     await sidebar.updateComplete;

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership-filtering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership-filtering.ts
@@ -150,7 +150,7 @@ describe("AppSidebar session ownership filtering", () => {
     expect(sidebar.querySelector(".sidebar-session-sort--filtered")).not.toBeNull();
   });
 
-  it("filters catalog rows by authoritative creator ownership", async () => {
+  it("filters adopted catalog rows by authoritative live ownership", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const backingSessionKey = "agent:main:claude-bound";
     const harness = createSessionsHarness("main", [
@@ -168,7 +168,12 @@ describe("AppSidebar session ownership filtering", () => {
       throw new Error("expected ownership rows");
     }
     ada.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
-    adopted.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
+    adopted.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
+    adopted.owner = {
+      actor: { type: "human", id: "profile-bob", label: "Bob" },
+      assignedBy: { type: "human", id: "profile-ada", label: "Ada" },
+      assignedAt: 10,
+    };
     result.creators = [
       { type: "human", id: "profile-ada", label: "Ada" },
       { type: "human", id: "profile-bob", label: "Bob" },
@@ -193,7 +198,7 @@ describe("AppSidebar session ownership filtering", () => {
                 status: "stored",
                 archived: false,
                 sessionKey: backingSessionKey,
-                createdActor: { type: "human", id: "profile-bob", label: "Bob" },
+                createdActor: { type: "human", id: "profile-ada", label: "Ada" },
                 canContinue: true,
                 canArchive: false,
               },
@@ -216,9 +221,9 @@ describe("AppSidebar session ownership filtering", () => {
 
     expect(sidebar.querySelector(`[data-session-key="${backingSessionKey}"]`)).not.toBeNull();
     expect(sidebar.textContent).toContain("External unowned session");
-    await selectCreator(sidebar, "profile-ada");
+    await selectCreator(sidebar, "profile-bob");
 
-    expect(sidebar.querySelector(`[data-session-key="${backingSessionKey}"]`)).toBeNull();
+    expect(sidebar.querySelector(`[data-session-key="${backingSessionKey}"]`)).not.toBeNull();
     expect(sidebar.textContent).not.toContain("External unowned session");
 
     harness.publishList({

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership-filtering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership-filtering.ts
@@ -30,6 +30,77 @@ async function selectCreator(sidebar: SidebarLifecycleState, creatorId: string) 
 }
 
 describe("AppSidebar session ownership filtering", () => {
+  it("uses the complete owner facet instead of raw loaded-row principals", async () => {
+    const harness = createSessionsHarness("main", [
+      "agent:main:opaque-profile",
+      "agent:main:discord-channel",
+      "agent:main:session-principal",
+    ]);
+    const result = harness.sessions.state.result;
+    if (!result) {
+      throw new Error("expected session list");
+    }
+    const opaqueProfile = result.sessions.find((row) => row.key.endsWith(":opaque-profile"));
+    const discordChannel = result.sessions.find((row) => row.key.endsWith(":discord-channel"));
+    const sessionPrincipal = result.sessions.find((row) => row.key.endsWith(":session-principal"));
+    if (!opaqueProfile || !discordChannel || !sessionPrincipal) {
+      throw new Error("expected owner rows");
+    }
+    opaqueProfile.createdActor = {
+      type: "human",
+      id: "profile:channel:opaque",
+      label: "Channel Keeper",
+    };
+    opaqueProfile.owner = { actor: opaqueProfile.createdActor };
+    discordChannel.createdActor = { type: "human", id: "discord:channel:123" };
+    sessionPrincipal.createdActor = {
+      type: "agent",
+      id: "agent:roboclaw:discord:channel:456",
+    };
+    result.creators = [
+      { type: "human", id: "profile:channel:opaque", label: "Channel Keeper" },
+      { type: "agent", id: "research", label: "Research" },
+    ];
+
+    const { sidebar } = await mountSidebar(
+      createGateway({} as GatewayBrowserClient),
+      harness.sessions,
+    );
+    harness.publishList({ result, agentId: "main" });
+    await sidebar.updateComplete;
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort")?.click();
+    await sidebar.updateComplete;
+
+    const menu = sidebar.querySelector(".sidebar-session-sort-menu");
+    expect(menu?.querySelector('[value="creator:profile:channel:opaque"]')).not.toBeNull();
+    expect(menu?.textContent).toContain("Channel Keeper");
+    expect(
+      sidebar.querySelector(
+        '[data-session-key="agent:main:opaque-profile"] openclaw-session-owner-chip',
+      ),
+    ).not.toBeNull();
+    expect(
+      sidebar.querySelector(
+        '[data-session-key="agent:main:discord-channel"] openclaw-session-owner-chip',
+      ),
+    ).toBeNull();
+    expect(
+      sidebar.querySelector(
+        '[data-session-key="agent:main:session-principal"] openclaw-session-owner-chip',
+      ),
+    ).toBeNull();
+    expect(menu?.querySelector('[value="creator:discord:channel:123"]')).toBeNull();
+    expect(menu?.querySelector('[value="creator:agent:roboclaw:discord:channel:456"]')).toBeNull();
+
+    result.creators = undefined;
+    harness.publishList({ result, agentId: "main" });
+    await sidebar.updateComplete;
+
+    const unavailableMenu = sidebar.querySelector(".sidebar-session-sort-menu");
+    expect(unavailableMenu?.querySelector('[value^="creator:"]') ?? null).toBeNull();
+    expect(unavailableMenu?.textContent ?? "").not.toContain("Channel Keeper");
+  });
+
   it("filters by effective owner and hides custom groups without matching sessions", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", [
@@ -60,6 +131,10 @@ describe("AppSidebar session ownership filtering", () => {
       assignedAt: 11,
     };
     bob.category = "Operations";
+    result.creators = [
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
+    ];
     harness.publish({ groups: ["Research", "Operations"] });
     const { sidebar } = await mountSidebar(gateway, harness.sessions);
     harness.publishList({ result, agentId: "main" });
@@ -95,8 +170,8 @@ describe("AppSidebar session ownership filtering", () => {
     ada.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
     adopted.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
 
     const { sidebar } = await mountSidebar(gateway, harness.sessions);
@@ -174,8 +249,8 @@ describe("AppSidebar session ownership filtering", () => {
     ada.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
     bob.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
 
     const unloadedSessionKey = "agent:main:beyond-loaded-page";
@@ -228,11 +303,13 @@ describe("AppSidebar session ownership filtering", () => {
       throw new Error("expected ownership rows");
     }
     unread.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
+    unread.owner = { actor: unread.createdActor };
     unread.unread = true;
     other.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
+    other.owner = { actor: other.createdActor };
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
 
     const { sidebar } = await mountSidebar(
@@ -264,11 +341,12 @@ describe("AppSidebar session ownership filtering", () => {
       ...parentRow,
       key: parentKey,
       createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+      owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
       childSessions: [childKey],
     };
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
     harness.list.mockResolvedValue({
       ts: 2,
@@ -284,6 +362,7 @@ describe("AppSidebar session ownership filtering", () => {
           updatedAt: 2,
           status: "done",
           createdActor: { type: "human", id: "profile-bob", label: "Bob" },
+          owner: { actor: { type: "human", id: "profile-bob", label: "Bob" } },
         },
       ],
     });

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
   createGateway,
@@ -58,6 +59,14 @@ function visibleSessionKeys(sidebar: SidebarLifecycleState): string[] {
     .map((row) => row.dataset.sessionKey ?? "");
 }
 
+function setEffectiveOwner(
+  row: GatewaySessionRow,
+  actor: NonNullable<GatewaySessionRow["createdActor"]>,
+) {
+  row.createdActor = actor;
+  row.owner = { actor };
+}
+
 describe("AppSidebar session ownership", () => {
   it("renders durable actor avatars identically regardless of live presence", async () => {
     const gateway = createGatewayHarness({} as GatewayBrowserClient);
@@ -84,23 +93,23 @@ describe("AppSidebar session ownership", () => {
     if (!ada || !bob || !carol) {
       throw new Error("expected creator rows");
     }
-    ada.createdActor = {
+    setEffectiveOwner(ada, {
       type: "human",
       id: "profile-ada",
       label: "Ada",
       avatarUrl: "/api/users/profile-ada/avatar?v=1",
-    };
-    bob.createdActor = {
+    });
+    setEffectiveOwner(bob, {
       type: "human",
       id: "profile-bob",
       label: "Bob",
       avatarUrl: "/api/users/profile-bob/avatar?v=2",
-    };
-    carol.createdActor = { type: "human", id: "profile-carol", label: "Carol" };
+    });
+    setEffectiveOwner(carol, { type: "human", id: "profile-carol", label: "Carol" });
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
-      { id: "profile-carol", label: "Carol" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-carol", label: "Carol" },
     ];
 
     const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
@@ -180,10 +189,10 @@ describe("AppSidebar session ownership", () => {
       if (!lobster) {
         throw new Error("expected creator row");
       }
-      lobster.createdActor = { type, id: "profile-lobster", label };
+      setEffectiveOwner(lobster, { type, id: "profile-lobster", label });
       result.creators = [
-        { id: "profile-lobster", label },
-        { id: "profile-ada", label: "Ada" },
+        { type, id: "profile-lobster", label },
+        { type: "human", id: "profile-ada", label: "Ada" },
       ];
 
       const { sidebar } = await mountSidebar(gateway, harness.sessions);
@@ -208,10 +217,10 @@ describe("AppSidebar session ownership", () => {
     if (!ada) {
       throw new Error("expected creator row");
     }
-    ada.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
+    setEffectiveOwner(ada, { type: "human", id: "profile-ada", label: "Ada" });
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
 
     const { sidebar } = await mountSidebar(gateway, harness.sessions);
@@ -235,7 +244,7 @@ describe("AppSidebar session ownership", () => {
     await sidebar.updateComplete;
     expect(harness.setCreatorFilter).toHaveBeenCalledWith("profile-bob");
 
-    result.creators = [{ id: "profile-bob", label: "Bob" }];
+    result.creators = [{ type: "human", id: "profile-bob", label: "Bob" }];
     harness.publishList({ result, agentId: "main" });
     await sidebar.updateComplete;
     await sidebar.updateComplete;
@@ -252,10 +261,10 @@ describe("AppSidebar session ownership", () => {
     if (!result || !collab) {
       throw new Error("expected participant row");
     }
-    collab.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
+    setEffectiveOwner(collab, { type: "human", id: "profile-bob", label: "Bob" });
     collab.participants = [{ type: "human", id: "profile-ada", label: "Ada" }];
     collab.participantCount = 1;
-    result.creators = [{ id: "profile-bob", label: "Bob" }];
+    result.creators = [{ type: "human", id: "profile-bob", label: "Bob" }];
 
     const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
     harness.publishList({ result, agentId: "main" });
@@ -295,7 +304,7 @@ describe("AppSidebar session ownership", () => {
       throw new Error("expected session list");
     }
     for (const row of result.sessions) {
-      row.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
+      setEffectiveOwner(row, { type: "human", id: "profile-ada", label: "Ada" });
     }
     const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
     harness.publishList({ result, agentId: "main" });
@@ -327,10 +336,11 @@ describe("AppSidebar session ownership", () => {
     ] as const) {
       Object.assign(result.sessions[index]!, {
         createdActor: { type: "human", id, label },
+        owner: { actor: { type: "human", id, label } },
         updatedAt,
       });
     }
-    result.creators = [{ id: "profile-bob", label: "Bob" }];
+    result.creators = [{ type: "human", id: "profile-bob", label: "Bob" }];
     const createdOrder = keys.slice(1);
     // b1 and a1 tie at updatedAt 40; the ascending-key tie-break (mirroring
     // the gateway list order) puts a1 first.
@@ -367,8 +377,8 @@ describe("AppSidebar session ownership", () => {
     await expectSort(sidebar, "created", createdOrder);
     await expectSort(sidebar, "people", peopleOrder);
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
     harness.publishList({ result, agentId: "main" });
     gateway.publish({ hello: sessionSharingHello(false) });
@@ -404,11 +414,11 @@ describe("AppSidebar session ownership", () => {
     }
     archived.archived = true;
     archived.archivedBy = { type: "human", id: "profile-bob", label: "Bob" };
-    archived.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
-    collaborator.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
+    setEffectiveOwner(archived, { type: "human", id: "profile-ada", label: "Ada" });
+    setEffectiveOwner(collaborator, { type: "human", id: "profile-bob", label: "Bob" });
     result.creators = [
-      { id: "profile-ada", label: "Ada" },
-      { id: "profile-bob", label: "Bob" },
+      { type: "human", id: "profile-ada", label: "Ada" },
+      { type: "human", id: "profile-bob", label: "Bob" },
     ];
 
     const { sidebar } = await mountSidebar(gateway, harness.sessions);
@@ -427,8 +437,8 @@ describe("AppSidebar session ownership", () => {
     ) as (HTMLElement & { excludeUserId?: string }) | null;
     expect(archivedFacepile?.excludeUserId).toBe("profile-bob");
 
-    collaborator.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
-    result.creators = [{ id: "profile-ada", label: "Ada" }];
+    setEffectiveOwner(collaborator, { type: "human", id: "profile-ada", label: "Ada" });
+    result.creators = [{ type: "human", id: "profile-ada", label: "Ada" }];
     harness.publishList({ result, agentId: "main" });
     await sidebar.updateComplete;
 

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -244,7 +244,7 @@ describe("AppSidebar session source lifecycle", () => {
     );
   });
 
-  it("resets cached rows and creation order when the sessions source changes", async () => {
+  it("resets per-agent cached results and creation order when the sessions source changes", async () => {
     const client = {} as GatewayBrowserClient;
     const gateway = createGateway(client);
     const { provider, sidebar } = await mountSidebar(
@@ -252,7 +252,7 @@ describe("AppSidebar session source lifecycle", () => {
       createSessions("first", ["first-a", "first-b"]),
     );
 
-    expect(Object.keys(sidebar.sessionData.sessionRowsByAgent)).toEqual(["first"]);
+    expect(Object.keys(sidebar.sessionData.sessionResultsByAgent)).toEqual(["first"]);
     expect([...sidebar.sessionData.sessionCreatedOrder]).toEqual([
       ["first-a", 0],
       ["first-b", 1],
@@ -262,7 +262,7 @@ describe("AppSidebar session source lifecycle", () => {
     provider.setContext(createContext(gateway, createSessions("second", ["second-b", "second-a"])));
     await sidebar.updateComplete;
 
-    expect(Object.keys(sidebar.sessionData.sessionRowsByAgent)).toEqual(["second"]);
+    expect(Object.keys(sidebar.sessionData.sessionResultsByAgent)).toEqual(["second"]);
     expect([...sidebar.sessionData.sessionCreatedOrder]).toEqual([
       ["second-b", 0],
       ["second-a", 1],
@@ -278,6 +278,11 @@ describe("AppSidebar session source lifecycle", () => {
     const client = {} as GatewayBrowserClient;
     const gateway = createGatewayHarness(client);
     const sessions = createSessionsHarness("main", ["main-a", "main-b"]);
+    if (sessions.sessions.state.result) {
+      sessions.sessions.state.result.creators = [
+        { type: "human", id: "profile-ada", label: "Ada" },
+      ];
+    }
     const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
     const cachedResult = sidebar.sessionData.sessionsResult;
 
@@ -287,7 +292,10 @@ describe("AppSidebar session source lifecycle", () => {
 
     expect(sidebar.sessionData.sessionsResult).toBe(cachedResult);
     expect(sidebar.sessionData.sessionsAgentId).toBe("main");
-    expect(Object.keys(sidebar.sessionData.sessionRowsByAgent)).toEqual(["main"]);
+    expect(Object.keys(sidebar.sessionData.sessionResultsByAgent)).toEqual(["main"]);
+    expect(sidebar.sessionData.sessionResultsByAgent.main?.creators).toEqual([
+      { type: "human", id: "profile-ada", label: "Ada" },
+    ]);
     expect([...sidebar.sessionData.sessionCreatedOrder.keys()]).toEqual(["main-a", "main-b"]);
 
     gateway.publish({ phase: "connected" });
@@ -300,7 +308,7 @@ describe("AppSidebar session source lifecycle", () => {
       "main-a",
       "main-b",
     ]);
-    expect(sidebar.sessionData.sessionRowsByAgent.main?.map((row) => row.key)).toEqual([
+    expect(sidebar.sessionData.sessionResultsByAgent.main?.sessions.map((row) => row.key)).toEqual([
       "main-a",
       "main-b",
     ]);
@@ -327,7 +335,7 @@ describe("AppSidebar session source lifecycle", () => {
 
     expect(sidebar.sessionData.sessionsResult).toBeNull();
     expect(sidebar.sessionData.sessionsAgentId).toBeNull();
-    expect(sidebar.sessionData.sessionRowsByAgent).toEqual({});
+    expect(sidebar.sessionData.sessionResultsByAgent).toEqual({});
     expect(sidebar.sessionData.sessionCreatedOrder.size).toBe(0);
   });
 
@@ -343,7 +351,7 @@ describe("AppSidebar session source lifecycle", () => {
 
     expect(sidebar.sessionData.sessionsResult).toBeNull();
     expect(sidebar.sessionData.sessionsAgentId).toBeNull();
-    expect(sidebar.sessionData.sessionRowsByAgent).toEqual({});
+    expect(sidebar.sessionData.sessionResultsByAgent).toEqual({});
     expect(sidebar.sessionData.sessionCreatedOrder.size).toBe(0);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI's **Owners** filter could list Discord channel routes, session-key principals, and other non-person provenance as if they were assignable people. The same raw identities could also appear as owner chips or be accepted as arbitrary human assignment targets.

The regression became visible when effective ownership began falling back to immutable creator provenance in [#125057](https://github.com/openclaw/openclaw/pull/125057), on top of the complete creator facet introduced in [#114842](https://github.com/openclaw/openclaw/pull/114842).

## Why This Change Was Made

The Gateway now has one canonical assignable-owner projection used by session rows, complete owner facets, owner filtering, and `sessions.assignOwner`. Durable user profiles and configured agents can own sessions; channel routes, session-key principals, system actors, and unresolved identities remain creator provenance without becoming ownership.

The established `creatorId` list filter remains bound to permanent creator provenance. Current ownership uses the additive `ownerId` filter, which the Control UI sends for its Owners menu. Adopted catalog rows prefer their mapped live session owner and fall back to catalog creator provenance only when no live row exists.

The Control UI consumes the authoritative owner facet, caches the complete result per agent, and no longer reconstructs owner candidates from raw rows during cache or event transitions.

Production LOC: +250/-261 (net -11) | Tests and test support: +438/-173 | Generated Swift: +4/-0

AI-assisted; the complete diff and behavior were reviewed and verified by the maintainer.

## User Impact

The Owners menu now contains only real durable people and configured agents. Sessions created through Discord routes or agent/session principals remain visible, but those identities no longer appear as people, owner chips, or assignment targets.

Opaque profile IDs remain valid even when they contain text such as `channel:`; the repair uses authoritative identity resolution rather than string-prefix heuristics. Existing clients using `creatorId` keep their permanent-creator behavior, while owner-aware clients can use `ownerId`.

## Evidence

### Before

The old payload promoted a Discord route and a session principal into the Owners menu and rendered them with owner avatars:

![Before: Discord and session principals appear as owners](https://github.com/user-attachments/assets/c988ab7d-0b5c-47ce-b3d8-2324ee694a32)

### After

All four sessions remain visible, while only the durable profile and configured agent appear under Owners. The two provenance-only rows have no owner chips:

![After: only durable people and configured agents appear as owners](https://github.com/user-attachments/assets/1f34d9ee-2199-444b-a663-845d461eaa54)

### Focused validation

- Pre-fix creator compatibility and adopted-catalog regressions failed for the intended reasons
- `node scripts/run-vitest.mjs src/gateway/session-utils-creators.test.ts src/gateway/server-methods/sessions-mutations.owner.test.ts` — 10/10 passed
- Full Control UI unit suite — 9,293 passed, 50 skipped
- Control UI ownership E2E — 11/11 passed
- Source-blind rendered behavior contract — 6/6 passed
- Protocol registry and generated Swift checks — passed
- Fresh Codex autoreview — clean, no actionable findings; correctness 0.99
- Changed gate passed format, ratchets, dead-code, i18n, core/UI typechecks, core/UI/app lint, and every resumed post-tooling architecture guard. The selected macOS tooling shard emitted only heartbeats for 10.5 minutes on a loaded host and was interrupted; exact-head CI/Testbox is the landing authority.
