### PR TITLE
fix(agents): warn when session search results are incomplete

### DIFF
--- a/src/agents/tools/sessions-search-tool.test.ts
+++ b/src/agents/tools/sessions-search-tool.test.ts
@@ -39,6 +39,7 @@ function createTool(params: {
   sandboxed?: boolean;
   requests?: CallGatewayRequest[];
   sessionLinkBase?: string;
+  indexing?: boolean;
   truncated?: boolean;
 }) {
   const config = params.config ?? { tools: { sessions: { visibility: "self" } } };
@@ -92,6 +93,7 @@ function createTool(params: {
         results: results.filter(
           (row) => Array.isArray(sessionKeys) && sessionKeys.includes(row.sessionKey),
         ),
+        ...(params.indexing ? { indexing: true } : {}),
         ...(params.truncated ? { truncated: true } : {}),
       } as T;
     },
@@ -147,8 +149,21 @@ describe("sessions_search tool", () => {
     expect(error.details).toMatchObject({ status: "error", error: expect.any(String) });
     expect(Value.Check(tool.outputSchema!, error.details)).toBe(true);
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ results: Array<{ role: "assistant" | "user"; score: number; sessionKey: string; snippet: string; timestamp: number; messageId?: string; sessionId?: string }>; indexing?: true; sessionLinkRule?: string; truncated?: true } | { error: string; status: "error" | "forbidden" }',
+      '{ results: Array<{ role: "assistant" | "user"; score: number; sessionKey: string; snippet: string; timestamp: number; messageId?: string; sessionId?: string }>; indexing?: true; sessionLinkRule?: string; truncated?: true; warning?: string } | { error: string; status: "error" | "forbidden" }',
     );
+  });
+
+  it("warns that indexing makes search results incomplete", async () => {
+    const result = await createTool({
+      results: [hit()],
+      indexing: true,
+    }).execute("indexing-warning", { query: "text" });
+
+    expect(result.details).toMatchObject({
+      indexing: true,
+      warning:
+        "Transcript indexing is in progress; results may be incomplete. Retry sessions_search shortly.",
+    });
   });
 
   it("rejects empty queries and invalid limits", async () => {

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -50,6 +50,8 @@ const SESSIONS_SEARCH_MAX_SESSION_KEYS = 200;
 const SESSIONS_SEARCH_MAX_QUERY_CHARS = 4096;
 const SESSIONS_SEARCH_MAX_BYTES = 32 * 1024;
 const SESSIONS_SEARCH_SNIPPET_MAX_CHARS = 300;
+const SESSIONS_SEARCH_INDEXING_WARNING =
+  "Transcript indexing is in progress; results may be incomplete. Retry sessions_search shortly.";
 
 const SessionsSearchToolSchema = Type.Object({
   query: Type.String({ maxLength: SESSIONS_SEARCH_MAX_QUERY_CHARS }),
@@ -80,6 +82,7 @@ const SessionsSearchOutputSchema = Type.Union([
         }),
       ),
       indexing: Type.Optional(Type.Literal(true)),
+      warning: Type.Optional(Type.String()),
       truncated: Type.Optional(Type.Literal(true)),
     },
     { additionalProperties: false },
@@ -600,7 +603,7 @@ export function createSessionsSearchTool(opts?: {
         ...(opts?.sessionLinkBase
           ? { sessionLinkRule: describeSessionLinkRule(opts.sessionLinkBase) }
           : {}),
-        ...(indexing ? { indexing: true } : {}),
+        ...(indexing ? { indexing: true, warning: SESSIONS_SEARCH_INDEXING_WARNING } : {}),
         ...(backendTruncated || visibleHits.length > limit || capped.truncated
           ? { truncated: true }
           : {}),


### PR DESCRIPTION
## What Problem This Solves

`sessions_search` can return false-negative/incomplete results while transcript indexes are rebuilding. The SQLite search owner intentionally excludes dirty sessions and sets `indexing: true` so callers retry, but the model-facing tool passed through only the opaque boolean. The model could reasonably conclude “no matches” and continue with incomplete history — a silent failure.

## Why This Change Was Made

Keep the existing indexing contract and make it actionable at the model boundary. Whenever any search chunk reports `indexing: true`, the tool now returns a bounded warning: `Transcript indexing is in progress; results may be incomplete. Retry sessions_search shortly.` The output schema admits the warning. No gateway/protocol/config behavior changes.

## User Impact

Agents no longer treat in-progress transcript reconciliation as a definitive empty search. They are explicitly told the result may be incomplete and what to do next.

## Evidence

- Pre-fix regression: focused test failed (1 failed, 15 passed) because the indexing response had no warning.
- Post-fix: `node scripts/run-vitest.mjs run src/agents/tools/sessions-search-tool.test.ts` → 16/16 pass on rebased head.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` → rc 0.
- `oxlint` + `oxfmt` on touched files → rc 0 / clean.
- Codex autoreview → clean, 0.99, no actionable findings (rerun after rebase).
