### PR TITLE
fix(state): register placement move target_machine_class as additive column

### DIFF
--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -179,6 +179,7 @@ describe("OpenClaw database maintenance schema validation", () => {
       "worker_environments.node_device_id TEXT",
       "worker_session_placements.terminal_reason TEXT",
       "worker_session_placements.terminal_at_ms INTEGER",
+      "worker_session_placement_moves.target_machine_class TEXT",
       "worktrees.run_end_cleanup_json TEXT",
       "device_bootstrap_tokens.setup_id TEXT",
       "session_groups.cwd TEXT",

--- a/src/state/openclaw-state-db-additive-columns.ts
+++ b/src/state/openclaw-state-db-additive-columns.ts
@@ -23,6 +23,11 @@ export const CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS = [
   { columnName: "node_device_id", dataType: "TEXT", tableName: "worker_environments" },
   { columnName: "terminal_reason", dataType: "TEXT", tableName: "worker_session_placements" },
   { columnName: "terminal_at_ms", dataType: "INTEGER", tableName: "worker_session_placements" },
+  {
+    columnName: "target_machine_class",
+    dataType: "TEXT",
+    tableName: "worker_session_placement_moves",
+  },
   { columnName: "run_end_cleanup_json", dataType: "TEXT", tableName: "worktrees" },
   { columnName: "setup_id", dataType: "TEXT", tableName: "device_bootstrap_tokens" },
   { columnName: "cwd", dataType: "TEXT", tableName: "session_groups" },

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4444,6 +4444,38 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
   });
 
+  it("repairs target machine class in a pre-column placement move table", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const previousSchema = OPENCLAW_STATE_SCHEMA_SQL.replace(
+      "  -- Keep this nullable column constraint-free so lazy ALTER TABLE produces the\n" +
+        "  -- same shape as fresh databases; placement-move code validates its value.\n" +
+        "  target_machine_class TEXT,\n",
+      "",
+    );
+    const tableStart = previousSchema.indexOf(
+      "CREATE TABLE IF NOT EXISTS worker_session_placement_moves (",
+    );
+    const tableEnd = previousSchema.indexOf("\n) STRICT;", tableStart);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacyDb = new DatabaseSync(databasePath);
+    legacyDb.exec(`
+      DROP TABLE worker_session_placement_moves;
+      ${previousSchema.slice(tableStart, tableEnd + "\n) STRICT;".length)}
+    `);
+    legacyDb.close();
+
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    expect(repairOpenClawStateDatabaseSchemaIfNeeded(options).warnings).toEqual([]);
+    const reopened = openOpenClawStateDatabase(options);
+    const columns = reopened.db
+      .prepare("PRAGMA table_info(worker_session_placement_moves)")
+      .all() as Array<{ name?: string }>;
+
+    expect(columns.map((column) => column.name)).toContain("target_machine_class");
+  });
+
   it("adds staged worker-result refs during the v5 state migration", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };


### PR DESCRIPTION
## Summary
- `worker_session_placement_moves.target_machine_class` was added to the canonical state schema (and to the feature's lazy `ensureColumn` path) but not to `CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS`. A global state database that already contains the lazily-created `worker_session_placement_moves` table (created before the column shipped) therefore fails the strict startup schema check with `SQLite schema is incomplete or noncanonical … column definitions differ for worker_session_placement_moves` → `Failed migrating shared state database schema` → the gateway refuses ready and crash-loops. Databases without the table are unaffected.
- Registers the column as lazy-additive so startup repair adds it in place, matching the sibling `worker_session_placements` / `worker_environments` entries. Behavior otherwise unchanged; the optional table may still be absent.

## Field report
Observed 2026-08-18 on a source-built gateway at `c75d4dc9` after updating from `863f19b7`: state DB had the pre-column table (worker environments had been used); six consecutive startup refusals until the column was added manually with the gateway stopped. Three sibling deployments whose state DBs lacked the table booted cleanly on the same commit.

## Proof
`git diff --check`, format:check, oxlint, `tsgo`, `check:test-types`; focused vitest `src/state/openclaw-state-db.test.ts` + `src/state/openclaw-database-maintenance.test.ts` (170 tests) pass. The new regression test (`repairs target machine class in a pre-column placement move table`) fails without the registry entry and passes with it.

## Review
ClawSweeper local review (gpt-5.6-terra, high) on `915b2acf`: `overallCorrectness: "patch is correct"`, `reviewFindings: []`, security no concerns, no maintainer decision. Its only next step ("refresh the branch and wait for exact-head CI") is a freshness move; per our drift policy the branch is only rebased when CONFLICTING, and merge waits on exact-head `openclaw/ci-gate`. Two runs of the review harness ended with an "invalid structured output" classification while the underlying decision JSON was complete — tooling, not a code issue.
