### PR TITLE
improve(ui): defer offscreen plugin row rendering

### DIFF
--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -175,6 +175,8 @@
    row-local messages can break onto a full-width line below the controls. */
 .plugins-item {
   flex-wrap: wrap;
+  content-visibility: auto;
+  contain-intrinsic-block-size: auto 73px;
 }
 
 .plugins-item--clickable {


### PR DESCRIPTION
## Summary

- defer layout and paint work for offscreen plugin rows with `content-visibility: auto`
- provide a 73 px remembered intrinsic block size so the full catalog keeps stable scroll geometry before rows become visible
- preserve the complete installed catalog in the DOM, including existing search, grouping, details, and mutation behavior

## Performance

Matched production Chromium benchmark on current `main` (`916aca13f34`), using 1,000 realistic installed plugin records (251,611-byte Gateway payload), seven fresh browser contexts per variant, and a cold direct navigation to `/settings/plugins`:

| Median | Current main | This PR | Change |
| --- | ---: | ---: | ---: |
| Ready | 854.4 ms | 713.2 ms | **-16.5%** |
| Startup long-task total | 389 ms | 224 ms | **-42.4%** |
| Longest startup task | 215 ms | 120 ms | **-44.2%** |
| Rendered plugin rows | 1,000 | 1,000 | unchanged |
| DOM elements | 11,310 | 11,313 | unchanged |

The benchmark also searched to one exact result, restored the full catalog, scrolled to plugin 1,000, and opened its detail view successfully in both variants.

Scaling checks on the same builds were intentionally more modest: at 250 plugins, ready changed 581.9 → 571.7 ms while startup long-task time fell 122 → 59 ms; at 100 plugins, ready changed 534.0 → 520.1 ms and long-task time was neutral at 50 → 52 ms. This PR claims the large-catalog improvement, not a latency win for ordinary small catalogs.

## Validation

- `pnpm --dir ui exec vitest run --config vitest.config.ts src/pages/plugins/view.test.ts src/pages/plugins/plugins-page.test.ts src/pages/plugins/plugins-page.routing.test.ts src/pages/plugins/route-data.test.ts` — 70/70 passed
- Plugins production Chromium E2E — 6/6 passed, including browse, search, install, enable, policy warning, read-only, failure, and retry flows
- `pnpm ui:build` — passed, including Control UI bundle/performance budgets
- `pnpm exec stylelint --config config/stylelint.config.mjs ui/src/styles/plugins.css` — passed
- branch autoreview — clean, correctness 0.99
- TruffleHog filesystem scan — 0 verified or unverified secrets
