### PR TITLE
refactor(agents): unify exec approval routing

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -27,7 +27,7 @@ advances a milestone.
 | 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280, #123612, #123641, #123665, #123673, #123700, #123696, #123785, #123859, #123889, #123901 |
 | 7   | Bundle push consent + runner updates                       | in progress | #123985, #124037, #124356, #124590                                                                                                                                        |
 | 8   | Stop-and-continue moves                                    | landed      | #125036                                                                                                                                                                   |
-| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | in progress | #125503, #125524                                                                                                                                                          |
+| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | in progress | #125503, #125524, #125587                                                                                                                                                 |
 | 10  | Cloud convergence (provisioners run `openclaw connect`)    | landed      | #125288, #125384, #125465                                                                                                                                                 |
 
 Revision history: revision 1 (2026-08-08) established the session/runner

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -50,8 +50,6 @@ type SendExecApprovalFollowupResult =
 type BuildExecApprovalFollowupTarget =
   typeof import("./bash-tools.exec-host-shared.js").buildExecApprovalFollowupTarget;
 type ExecApprovalFollowupTarget = Parameters<BuildExecApprovalFollowupTarget>[0];
-type ShouldResolveExecApprovalUnavailableInline =
-  typeof import("./bash-tools.exec-host-shared.js").shouldResolveExecApprovalUnavailableInline;
 type ExecAutoReviewer = typeof import("../infra/exec-auto-review.js").defaultExecAutoReviewer;
 type BuildExecApprovalFollowupTargetMock = (
   value: ExecApprovalFollowupTarget,
@@ -66,6 +64,17 @@ type MockAllowlistResult = {
   segmentSatisfiedBy?: ExecSegmentSatisfiedBy[];
   authorizationPlan?: ExecAuthorizationPlan;
 };
+type MockRegisteredExecApprovalRequest = {
+  approvalId: string;
+  approvalSlug: string;
+  warningText: string;
+  expiresAtMs: number;
+  preResolvedDecision: string | null | undefined;
+  initiatingSurface: unknown;
+  sentApproverDms: boolean;
+  unavailableReason: string | null;
+};
+
 type MockExecHostApprovalContext = {
   approvals: {
     allowlist: ExecAllowlistEntry[];
@@ -88,7 +97,14 @@ function exactCommandMarker(command: string): string {
   return `=command:${crypto.createHash("sha256").update(command.trim()).digest("hex").slice(0, 16)}`;
 }
 
-const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() => vi.fn());
+const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _params?: unknown,
+    ): MockRegisteredExecApprovalRequest | Promise<MockRegisteredExecApprovalRequest> | undefined =>
+      undefined,
+  ),
+);
 const buildExecApprovalPendingToolResultMock = vi.hoisted(() => vi.fn());
 const buildExecApprovalFollowupTargetMock = vi.hoisted(() =>
   vi.fn<BuildExecApprovalFollowupTargetMock>(() => null),
@@ -183,7 +199,12 @@ const sendExecApprovalFollowupResultMock = vi.hoisted(() =>
   vi.fn<SendExecApprovalFollowupResult>(async () => undefined),
 );
 const shouldResolveExecApprovalUnavailableInlineMock = vi.hoisted(() =>
-  vi.fn<ShouldResolveExecApprovalUnavailableInline>(() => false),
+  vi.fn(
+    (_params: {
+      unavailableReason: string | null;
+      preResolvedDecision: string | null | undefined;
+    }) => false,
+  ),
 );
 const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
   vi.fn(
@@ -240,6 +261,41 @@ const resolveExecApprovalDecisionStateMock = vi.hoisted(() =>
           : {}),
       });
       return { ...initial, ...strict, timeoutContext };
+    },
+  ),
+);
+const createExecApprovalRequestRouteMock = vi.hoisted(() =>
+  vi.fn(
+    async (
+      params: Record<string, unknown> & {
+        askFallback: ExecSecurity;
+        resolveTimedOut?: (state: {
+          baseDecision: { timedOut: boolean };
+          approvedByAsk: boolean;
+          deniedReason: string | null;
+        }) =>
+          | Promise<{ approvedByAsk: boolean; deniedReason: string | null; context?: unknown }>
+          | { approvedByAsk: boolean; deniedReason: string | null; context?: unknown };
+        requiresExplicitApproval: boolean | ((context: unknown) => boolean);
+        requiresAutoReviewHumanApproval?: boolean;
+      },
+    ) => {
+      const request = await createAndRegisterDefaultExecApprovalRequestMock(params);
+      if (!request) {
+        throw new Error("missing test approval request");
+      }
+      const inline = shouldResolveExecApprovalUnavailableInlineMock({
+        unavailableReason: request.unavailableReason,
+        preResolvedDecision: request.preResolvedDecision,
+      });
+      if (!inline) {
+        return { ...request, kind: "wait" as const };
+      }
+      const state = await resolveExecApprovalDecisionStateMock({
+        ...params,
+        decision: request.preResolvedDecision ?? null,
+      });
+      return { ...request, kind: "inline" as const, preResolvedDecision: null, state };
     },
   ),
 );
@@ -330,6 +386,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   buildExecApprovalPendingToolResult: buildExecApprovalPendingToolResultMock,
   createExecApprovalDecisionState: createExecApprovalDecisionStateMock,
   createAndRegisterDefaultExecApprovalRequest: createAndRegisterDefaultExecApprovalRequestMock,
+  createExecApprovalRequestRoute: createExecApprovalRequestRouteMock,
   enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
   resolveExecApprovalDecisionState: resolveExecApprovalDecisionStateMock,
@@ -553,12 +610,10 @@ describe("processGatewayAllowlist", () => {
     buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
   }
 
-  async function useRealUnavailableApprovalGate() {
-    const actualShared = await vi.importActual<typeof import("./bash-tools.exec-host-shared.js")>(
-      "./bash-tools.exec-host-shared.js",
-    );
+  function useRealUnavailableApprovalGate() {
     shouldResolveExecApprovalUnavailableInlineMock.mockImplementation(
-      actualShared.shouldResolveExecApprovalUnavailableInline,
+      ({ unavailableReason, preResolvedDecision }) =>
+        unavailableReason === "no-approval-route" && preResolvedDecision === null,
     );
   }
 
@@ -831,7 +886,7 @@ describe("processGatewayAllowlist", () => {
   });
 
   it("resolves a triggerless CLI no-route approval through the real gate", async () => {
-    await useRealUnavailableApprovalGate();
+    useRealUnavailableApprovalGate();
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
       approvalId: "approval-cli-no-route",
       approvalSlug: "slug",
@@ -878,7 +933,7 @@ describe("processGatewayAllowlist", () => {
   });
 
   it("preserves a routed approval through the real gate", async () => {
-    await useRealUnavailableApprovalGate();
+    useRealUnavailableApprovalGate();
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
       approvalId: "approval-routed",
       approvalSlug: "slug",

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -63,12 +63,10 @@ import {
   buildHeadlessExecApprovalDeniedMessage,
   buildExecApprovalFollowupTarget,
   buildExecApprovalPendingToolResult,
-  createAndRegisterDefaultExecApprovalRequest,
-  resolveExecApprovalDecisionState,
+  createExecApprovalRequestRoute,
   resolveExecApprovalWaitOutcome,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
-  shouldResolveExecApprovalUnavailableInline,
 } from "./bash-tools.exec-host-shared.js";
 import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
 import {
@@ -994,6 +992,27 @@ export async function processGatewayAllowlist(
         ),
         ...buildExecApprovalTurnSourceContext(params),
       });
+    const approvalRoute = await createExecApprovalRequestRoute({
+      warnings: params.warnings,
+      approvalRunningNoticeMs: params.approvalRunningNoticeMs,
+      createApprovalSlug,
+      turnSourceChannel: params.turnSourceChannel,
+      turnSourceAccountId: params.turnSourceAccountId,
+      register: registerGatewayApproval,
+      askFallback,
+      resolveTimedOut: (state) => {
+        const adjusted = applyTimedOutAllowlistFallback(state);
+        return {
+          approvedByAsk: adjusted.approvedByAsk,
+          deniedReason: adjusted.deniedReason,
+        };
+      },
+      requiresExplicitApproval: requiresInlineEvalApproval,
+      requiresAutoReviewHumanApproval:
+        autoReviewRequiresHumanApproval ||
+        requiresHeredocApproval ||
+        timedOutFallbackRequiresHeredocApproval,
+    });
     const {
       approvalId,
       approvalSlug,
@@ -1003,14 +1022,7 @@ export async function processGatewayAllowlist(
       initiatingSurface,
       sentApproverDms,
       unavailableReason,
-    } = await createAndRegisterDefaultExecApprovalRequest({
-      warnings: params.warnings,
-      approvalRunningNoticeMs: params.approvalRunningNoticeMs,
-      createApprovalSlug,
-      turnSourceChannel: params.turnSourceChannel,
-      turnSourceAccountId: params.turnSourceAccountId,
-      register: registerGatewayApproval,
-    });
+    } = approvalRoute;
     emitGatewayExecApprovalSecurityEvent({
       action: "exec.approval.requested",
       outcome: "success",
@@ -1022,28 +1034,8 @@ export async function processGatewayAllowlist(
       segmentCount: allowlistEval.segments.length,
       trigger: params.trigger,
     });
-    if (
-      shouldResolveExecApprovalUnavailableInline({
-        unavailableReason,
-        preResolvedDecision,
-      })
-    ) {
-      const strictInlineEvalDecision = await resolveExecApprovalDecisionState({
-        decision: preResolvedDecision ?? null,
-        askFallback,
-        resolveTimedOut: (state) => {
-          const adjusted = applyTimedOutAllowlistFallback(state);
-          return {
-            approvedByAsk: adjusted.approvedByAsk,
-            deniedReason: adjusted.deniedReason,
-          };
-        },
-        requiresExplicitApproval: requiresInlineEvalApproval,
-        requiresAutoReviewHumanApproval:
-          autoReviewRequiresHumanApproval ||
-          requiresHeredocApproval ||
-          timedOutFallbackRequiresHeredocApproval,
-      });
+    if (approvalRoute.kind === "inline") {
+      const strictInlineEvalDecision = approvalRoute.state;
 
       if (strictInlineEvalDecision.deniedReason || !strictInlineEvalDecision.approvedByAsk) {
         const inlineDeniedReason = strictInlineEvalDecision.deniedReason ?? "approval-required";
@@ -1096,22 +1088,17 @@ export async function processGatewayAllowlist(
         host: "gateway",
         segmentCount: allowlistEval.segments.length,
         trigger: params.trigger,
-        decision: preResolvedDecision,
+        decision: null,
       });
       await commitExecutionAuthorization({
-        source: preResolvedDecision === null ? "ask-fallback" : "explicit-approval",
+        source: "ask-fallback",
         resolvedPath: resolveApprovalAuditTrustPath(
           allowlistEval.segments[0]?.resolution ?? null,
           params.workdir,
         ),
-        ...(preResolvedDecision === "allow-always"
-          ? { allowAlwaysDecision: approvalAllowAlwaysPersistence }
-          : {}),
       });
       const execCommandOverride =
-        preResolvedDecision === null && fallbackSecurity === "allowlist"
-          ? fallbackEnforcedCommand
-          : enforcedCommand;
+        fallbackSecurity === "allowlist" ? fallbackEnforcedCommand : enforcedCommand;
       return {
         execCommandOverride,
         allowWithoutEnforcedCommand: execCommandOverride === undefined,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -43,6 +43,17 @@ type MockExecAllowlistEntry = {
   source?: "allow-always";
   commandText?: string;
 };
+type MockRegisteredExecApprovalRequest = {
+  approvalId: string;
+  approvalSlug: string;
+  warningText: string;
+  expiresAtMs: number;
+  preResolvedDecision: string | null | undefined;
+  initiatingSurface: unknown;
+  sentApproverDms: boolean;
+  unavailableReason: string | null;
+};
+
 type MockExecApprovalsResolved = {
   allowlist: MockExecAllowlistEntry[];
   file: { version: 1; agents: Record<string, unknown> };
@@ -182,7 +193,14 @@ const resolveExecHostApprovalContextMock = vi.hoisted(() =>
     askFallback: "deny",
   })),
 );
-const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() => vi.fn());
+const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _params?: unknown,
+    ): MockRegisteredExecApprovalRequest | Promise<MockRegisteredExecApprovalRequest> | undefined =>
+      undefined,
+  ),
+);
 const runAbortedApprovalError = vi.hoisted(() => new Error("approval owning run aborted"));
 const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() =>
   vi.fn(
@@ -206,7 +224,14 @@ const createExecApprovalDecisionStateMock = vi.hoisted(() =>
     }),
   ),
 );
-const shouldResolveExecApprovalUnavailableInlineMock = vi.hoisted(() => vi.fn(() => false));
+const shouldResolveExecApprovalUnavailableInlineMock = vi.hoisted(() =>
+  vi.fn(
+    (_params: {
+      unavailableReason: string | null;
+      preResolvedDecision: string | null | undefined;
+    }) => false,
+  ),
+);
 const buildExecApprovalPendingToolResultMock = vi.hoisted(() => vi.fn());
 const sendExecApprovalFollowupResultMock = vi.hoisted(() =>
   vi.fn(async (_target: unknown, _resultText: string) => undefined),
@@ -266,6 +291,41 @@ const resolveExecApprovalDecisionStateMock = vi.hoisted(() =>
           : {}),
       });
       return { ...initial, ...strict, timeoutContext };
+    },
+  ),
+);
+const createExecApprovalRequestRouteMock = vi.hoisted(() =>
+  vi.fn(
+    async (
+      params: Record<string, unknown> & {
+        askFallback: ExecSecurity;
+        resolveTimedOut?: (state: {
+          baseDecision: { timedOut: boolean };
+          approvedByAsk: boolean;
+          deniedReason: string | null;
+        }) =>
+          | Promise<{ approvedByAsk: boolean; deniedReason: string | null; context?: unknown }>
+          | { approvedByAsk: boolean; deniedReason: string | null; context?: unknown };
+        requiresExplicitApproval: boolean | ((context: unknown) => boolean);
+        requiresAutoReviewHumanApproval?: boolean;
+      },
+    ) => {
+      const request = await createAndRegisterDefaultExecApprovalRequestMock(params);
+      if (!request) {
+        throw new Error("missing test approval request");
+      }
+      const inline = shouldResolveExecApprovalUnavailableInlineMock({
+        unavailableReason: request.unavailableReason,
+        preResolvedDecision: request.preResolvedDecision,
+      });
+      if (!inline) {
+        return { ...request, kind: "wait" as const };
+      }
+      const state = await resolveExecApprovalDecisionStateMock({
+        ...params,
+        decision: request.preResolvedDecision ?? null,
+      });
+      return { ...request, kind: "inline" as const, preResolvedDecision: null, state };
     },
   ),
 );
@@ -372,6 +432,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   resolveExecHostApprovalContext: resolveExecHostApprovalContextMock,
   buildDefaultExecApprovalRequestArgs: vi.fn(() => ({})),
   createAndRegisterDefaultExecApprovalRequest: createAndRegisterDefaultExecApprovalRequestMock,
+  createExecApprovalRequestRoute: createExecApprovalRequestRouteMock,
   shouldResolveExecApprovalUnavailableInline: shouldResolveExecApprovalUnavailableInlineMock,
   buildExecApprovalFollowupTarget: vi.fn((value) => value),
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -393,6 +393,26 @@ export async function executeNodeHostCommand(
 
     if (!inlineApprovedByAsk) {
       // Human approval may complete after this tool call returns, so follow-up delivery owns invocation.
+      const approvalRoute = await execHostShared.createExecApprovalRequestRoute({
+        warnings: params.warnings,
+        approvalRunningNoticeMs: params.approvalRunningNoticeMs,
+        createApprovalSlug,
+        turnSourceChannel: params.turnSourceChannel,
+        turnSourceAccountId: params.turnSourceAccountId,
+        register: registerNodeApproval,
+        askFallback,
+        resolveTimedOut: async () => {
+          const fallback = await resolveCurrentTimeoutFallback();
+          return {
+            approvedByAsk: fallback.approvedByAsk,
+            deniedReason: fallback.deniedReason,
+            context: fallback,
+          };
+        },
+        requiresExplicitApproval: (fallback) =>
+          fallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
+        requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
+      });
       const {
         approvalId,
         approvalSlug,
@@ -402,35 +422,9 @@ export async function executeNodeHostCommand(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
-      } = await execHostShared.createAndRegisterDefaultExecApprovalRequest({
-        warnings: params.warnings,
-        approvalRunningNoticeMs: params.approvalRunningNoticeMs,
-        createApprovalSlug,
-        turnSourceChannel: params.turnSourceChannel,
-        turnSourceAccountId: params.turnSourceAccountId,
-        register: registerNodeApproval,
-      });
-      if (
-        execHostShared.shouldResolveExecApprovalUnavailableInline({
-          unavailableReason,
-          preResolvedDecision,
-        })
-      ) {
-        const inlineDecision = await execHostShared.resolveExecApprovalDecisionState({
-          decision: preResolvedDecision ?? null,
-          askFallback,
-          resolveTimedOut: async () => {
-            const fallback = await resolveCurrentTimeoutFallback();
-            return {
-              approvedByAsk: fallback.approvedByAsk,
-              deniedReason: fallback.deniedReason,
-              context: fallback,
-            };
-          },
-          requiresExplicitApproval: (fallback) =>
-            fallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
-          requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
-        });
+      } = approvalRoute;
+      if (approvalRoute.kind === "inline") {
+        const inlineDecision = approvalRoute.state;
         const currentFallback = inlineDecision.timeoutContext;
         if (inlineDecision.deniedReason || !inlineDecision.approvedByAsk) {
           throw new Error(
@@ -444,14 +438,10 @@ export async function executeNodeHostCommand(
           );
         }
         inlineApprovedByAsk = inlineDecision.approvedByAsk;
-        inlineApprovalSource = preResolvedDecision === null ? "ask-fallback" : undefined;
-        if (inlineApprovalSource) {
-          inlineDispatchAuthority = "ask-fallback";
-          inlineFallbackPolicy = currentFallback;
-        } else {
-          inlineDispatchAuthority = "human-approval";
-        }
-        inlineApprovalDecision = inlineApprovalSource ? null : "allow-once";
+        inlineApprovalSource = "ask-fallback";
+        inlineDispatchAuthority = "ask-fallback";
+        inlineFallbackPolicy = currentFallback;
+        inlineApprovalDecision = null;
         inlineApprovalId = approvalId;
       } else {
         const followupTarget = execHostShared.buildExecApprovalFollowupTarget({

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -12,12 +12,10 @@ import {
 } from "./bash-tools.exec-approval-followup-state.js";
 import {
   buildExecApprovalPendingToolResult,
-  createAndRegisterDefaultExecApprovalRequest,
-  resolveExecApprovalDecisionState,
+  createExecApprovalRequestRoute,
   resolveExecApprovalWaitOutcome,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
-  shouldResolveExecApprovalUnavailableInline,
 } from "./bash-tools.exec-host-shared.js";
 
 const mocks = vi.hoisted(() => ({
@@ -498,55 +496,6 @@ describe("resolveExecHostApprovalContext", () => {
   });
 });
 
-describe("resolveExecApprovalDecisionState", () => {
-  it.each([
-    {
-      name: "keeps fail-closed timeout denial",
-      decision: null,
-      askFallback: "deny" as const,
-      requiresExplicitApproval: false,
-      expected: { approvedByAsk: false, deniedReason: "approval-timeout" },
-    },
-    {
-      name: "accepts explicit approval across strict boundaries",
-      decision: "allow-once",
-      askFallback: "deny" as const,
-      requiresExplicitApproval: true,
-      expected: { approvedByAsk: true, deniedReason: null },
-    },
-  ])("$name", async ({ decision, askFallback, requiresExplicitApproval, expected }) => {
-    await expect(
-      resolveExecApprovalDecisionState({
-        decision,
-        askFallback,
-        requiresExplicitApproval,
-      }),
-    ).resolves.toMatchObject(expected);
-  });
-
-  it("applies current timeout policy before enforcing human-only approval", async () => {
-    const timeoutContext = { requiresExplicitApproval: true, policy: "current" };
-
-    await expect(
-      resolveExecApprovalDecisionState({
-        decision: null,
-        askFallback: "full",
-        resolveTimedOut: async () => ({
-          approvedByAsk: true,
-          deniedReason: null,
-          context: timeoutContext,
-        }),
-        requiresExplicitApproval: (context) => context?.requiresExplicitApproval === true,
-      }),
-    ).resolves.toEqual({
-      baseDecision: { approvedByAsk: true, deniedReason: null, timedOut: true },
-      approvedByAsk: false,
-      deniedReason: "approval-timeout",
-      timeoutContext,
-    });
-  });
-});
-
 describe("resolveExecApprovalWaitOutcome", () => {
   beforeEach(() => {
     mocks.resolveRegisteredExecApprovalDecision.mockReset();
@@ -665,7 +614,7 @@ describe("buildExecApprovalPendingToolResult", () => {
   }
 
   it("does not infer approver DM delivery from unavailable approval state", async () => {
-    const state = await createAndRegisterDefaultExecApprovalRequest({
+    const state = await createExecApprovalRequestRoute({
       warnings: [],
       approvalRunningNoticeMs: 1_000,
       createApprovalSlug: (approvalId) => approvalId,
@@ -676,45 +625,58 @@ describe("buildExecApprovalPendingToolResult", () => {
         expiresAtMs: Date.now() + 60_000,
         finalDecision: null,
       }),
+      askFallback: "deny",
+      requiresExplicitApproval: false,
     });
     expect(state.sentApproverDms).toBe(false);
     expect(state.unavailableReason).toBe("no-approval-route");
   });
 
-  it("resolves terminal no-route approvals inline", () => {
-    expect(
-      shouldResolveExecApprovalUnavailableInline({
-        unavailableReason: "no-approval-route",
-        preResolvedDecision: null,
-      }),
-    ).toBe(true);
+  const createRoute = (finalDecision: string | null | undefined, turnSourceChannel?: string) =>
+    createExecApprovalRequestRoute({
+      warnings: [],
+      approvalRunningNoticeMs: 1_000,
+      createApprovalSlug: (approvalId) => approvalId,
+      turnSourceChannel,
+      register: async (approvalId) => ({ id: approvalId, expiresAtMs: 60_000, finalDecision }),
+      askFallback: "deny",
+      requiresExplicitApproval: false,
+    });
+
+  it("resolves terminal no-route approvals inline", async () => {
+    await expect(createRoute(null)).resolves.toMatchObject({
+      kind: "inline",
+      preResolvedDecision: null,
+      state: { approvedByAsk: false, deniedReason: "approval-timeout" },
+    });
   });
 
-  it("keeps waiting when a route exists or a decision arrived", () => {
-    expect(
-      shouldResolveExecApprovalUnavailableInline({
-        unavailableReason: null,
-        preResolvedDecision: null,
+  it.each([
+    ["a live route", undefined, "webchat"],
+    ["an explicit decision", "allow-once", undefined],
+    ["a disabled initiating platform without a terminal decision", undefined, "discord"],
+  ])("keeps waiting for %s", async (_name, finalDecision, channel) => {
+    await expect(createRoute(finalDecision, channel)).resolves.toMatchObject({ kind: "wait" });
+  });
+
+  it("applies strict approval ordering to an inline route", async () => {
+    await expect(
+      createExecApprovalRequestRoute({
+        warnings: [],
+        approvalRunningNoticeMs: 1_000,
+        createApprovalSlug: (approvalId) => approvalId,
+        register: async (approvalId) => ({
+          id: approvalId,
+          expiresAtMs: 60_000,
+          finalDecision: null,
+        }),
+        askFallback: "full",
+        requiresExplicitApproval: true,
       }),
-    ).toBe(false);
-    expect(
-      shouldResolveExecApprovalUnavailableInline({
-        unavailableReason: "no-approval-route",
-        preResolvedDecision: "allow-once",
-      }),
-    ).toBe(false);
-    expect(
-      shouldResolveExecApprovalUnavailableInline({
-        unavailableReason: "no-approval-route",
-        preResolvedDecision: undefined,
-      }),
-    ).toBe(false);
-    expect(
-      shouldResolveExecApprovalUnavailableInline({
-        unavailableReason: "initiating-platform-disabled",
-        preResolvedDecision: null,
-      }),
-    ).toBe(false);
+    ).resolves.toMatchObject({
+      kind: "inline",
+      state: { approvedByAsk: false, deniedReason: "approval-timeout" },
+    });
   });
 
   it("keeps a local /approve prompt when the initiating Discord surface is disabled", () => {

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -270,15 +270,19 @@ function resolveExecApprovalUnavailableState(params: {
   };
 }
 
-/** Creates, registers, and normalizes a default approval request context. */
-export async function createAndRegisterDefaultExecApprovalRequest(params: {
+type DefaultExecApprovalRequestParams = {
   warnings: string[];
   approvalRunningNoticeMs: number;
   createApprovalSlug: (approvalId: string) => string;
   turnSourceChannel?: string;
   turnSourceAccountId?: string;
   register: (approvalId: string) => Promise<ExecApprovalRegistration>;
-}): Promise<RegisteredExecApprovalRequestContext> {
+};
+
+/** Creates, registers, and normalizes a default approval request context. */
+async function createAndRegisterDefaultExecApprovalRequest(
+  params: DefaultExecApprovalRequestParams,
+): Promise<RegisteredExecApprovalRequestContext> {
   const {
     approvalId,
     approvalSlug,
@@ -403,7 +407,7 @@ type ExecApprovalDecisionState<TTimeoutContext> = ReturnType<
 > & { timeoutContext: TTimeoutContext | undefined };
 
 /** Resolves explicit, timeout-fallback, and strict-human approval policy in one owner. */
-export async function resolveExecApprovalDecisionState<TTimeoutContext = undefined>(
+async function resolveExecApprovalDecisionState<TTimeoutContext = undefined>(
   params: ExecApprovalDecisionParams<TTimeoutContext>,
 ): Promise<ExecApprovalDecisionState<TTimeoutContext>> {
   const initial = createExecApprovalDecisionState({
@@ -442,6 +446,27 @@ export async function resolveExecApprovalDecisionState<TTimeoutContext = undefin
   };
 }
 
+type ExecApprovalRequestRoute<TTimeoutContext> =
+  | (Omit<RegisteredExecApprovalRequestContext, "preResolvedDecision"> & {
+      kind: "inline";
+      preResolvedDecision: null;
+      state: ExecApprovalDecisionState<TTimeoutContext>;
+    })
+  | (RegisteredExecApprovalRequestContext & { kind: "wait" });
+
+/** Registers an approval and resolves terminal no-route fallback through the shared policy owner. */
+export async function createExecApprovalRequestRoute<TTimeoutContext = undefined>(
+  params: DefaultExecApprovalRequestParams &
+    Omit<ExecApprovalDecisionParams<TTimeoutContext>, "decision">,
+): Promise<ExecApprovalRequestRoute<TTimeoutContext>> {
+  const request = await createAndRegisterDefaultExecApprovalRequest(params);
+  if (request.unavailableReason !== "no-approval-route" || request.preResolvedDecision !== null) {
+    return { ...request, kind: "wait" };
+  }
+  const state = await resolveExecApprovalDecisionState({ ...params, decision: null });
+  return { ...request, kind: "inline", preResolvedDecision: null, state };
+}
+
 /** Waits for an approval and normalizes cancellation, request failure, and resolved policy. */
 export async function resolveExecApprovalWaitOutcome<TTimeoutContext = undefined>(
   params: Omit<ExecApprovalDecisionParams<TTimeoutContext>, "decision"> & {
@@ -472,16 +497,6 @@ export async function resolveExecApprovalWaitOutcome<TTimeoutContext = undefined
   }
   const state = await resolveExecApprovalDecisionState({ ...params, decision });
   return params.signal?.aborted ? { kind: "run-aborted" } : { kind: "resolved", decision, state };
-}
-
-/** Returns true when registration proved no approval decision can arrive later. */
-export function shouldResolveExecApprovalUnavailableInline(params: {
-  unavailableReason: ExecApprovalUnavailableReason | null;
-  preResolvedDecision: string | null | undefined;
-}): boolean {
-  // finalDecision:null is emitted only after the gateway expires a no-route record.
-  // Resolve fallback inline; an async wait can never observe a later decision.
-  return params.unavailableReason === "no-approval-route" && params.preResolvedDecision === null;
 }
 
 /** Builds the denial copy for headless runs that cannot wait for approval. */


### PR DESCRIPTION
## What Problem This Solves

Gateway and node exec hosts still independently composed default approval registration, terminal no-route detection, and inline timeout/strict-policy resolution. That duplicated the final shared approval-lifecycle sequence before host-specific authorization work begins.

## Why This Change Was Made

This adds one shared approval-route owner with a closed `inline` or `wait` result. Terminal no-route requests resolve through the existing shared decision policy; routed and explicit pre-resolved requests remain waiting. Gateway and node keep all security events, denial copy, mutable-file/current-policy revalidation, authorization commits, follow-ups, and dispatch.

The standalone route predicate and now-internal low-level registration/decision exports are removed.

## User Impact

No intended user-visible behavior change. Gateway and node exec approvals now share registration normalization and route selection by construction.

Production LOC: +84 / -92 (net -8). Tests: +175 / -97.

AI-assisted: yes. I understand and reviewed the approval registration/routing boundary.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts` — 211 tests passed.
- `node scripts/check-changed.mjs` — passed, including core/test typechecks, lint, dead-export scans, import-cycle checks, and auth/storage guards.
- `pnpm tsgo` and `pnpm tsgo:core:test` — passed.
- `pnpm docs:check-links` — 6,520 internal links checked, 0 broken.
- Autoreview — clean, no accepted/actionable findings, including the milestone ledger update.
- Shared coverage proves terminal no-route inline fallback, live/explicit/disabled routes remain waiting, and strict human-review ordering is preserved. Existing host suites retain security events, policy refresh, authorization commits, follow-ups, and dispatch parity.
