### PR TITLE
fix(apps): render legacy plan events when the Gateway lacks the progress-card store

### DIFF
--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -551,6 +551,13 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         try await self.requestHistory(sessionKey: sessionKey, agentID: nil, ifCurrentRoute: nil)
     }
 
+    func gatewayAdvertisesProgressCardStore() async -> Bool? {
+        guard let route = await self.currentSessionMutationRoute() else { return nil }
+        return await self.gateway.supportsServerMethod(
+            "progressCard.get",
+            ifCurrentRoute: route)
+    }
+
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard? {
         let target = self.sessionTarget(for: sessionKey)
         let request = OpenClawChatGatewayRequests.progressCardGet(sessionKey: target.sessionKey)

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -144,6 +144,13 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             agentID: target.agentID)
     }
 
+    func gatewayAdvertisesProgressCardStore() async -> Bool? {
+        guard let lease = await self.connection.captureServerLease() else { return nil }
+        return await self.connection.supportsServerMethod(
+            "progressCard.get",
+            ifCurrentServerLease: lease)
+    }
+
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard? {
         let target = self.sessionTarget(for: sessionKey)
         let request = OpenClawChatGatewayRequests.progressCardGet(sessionKey: target.sessionKey)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -696,6 +696,7 @@ public protocol OpenClawChatTransport: Sendable {
         worktreeBaseRef: String?) async throws -> OpenClawChatCreateSessionResponse
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload
+    func gatewayAdvertisesProgressCardStore() async -> Bool?
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard?
     func requestFullMessage(sessionKey: String, messageID: String) async throws -> OpenClawChatMessage?
     func listModels() async throws -> [OpenClawChatModelChoice]
@@ -794,6 +795,10 @@ public protocol OpenClawChatTransport: Sendable {
 }
 
 extension OpenClawChatTransport {
+    public func gatewayAdvertisesProgressCardStore() async -> Bool? {
+        nil
+    }
+
     public func fetchProgressCard(sessionKey _: String) async throws -> ProgressCard? {
         nil
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ProgressCard.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ProgressCard.swift
@@ -21,6 +21,10 @@ extension OpenClawChatViewModel {
     func scheduleProgressCardFetch(for session: SessionSnapshot? = nil) {
         let session = session ?? self.currentSessionSnapshot()
         guard self.isCurrentSession(session) else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            self.progressCardStoreAvailable = await self.transport.gatewayAdvertisesProgressCardStore()
+        }
         self.lastIssuedProgressCardRequestID &+= 1
         let requestID = self.lastIssuedProgressCardRequestID
         let generation = self.progressCardGeneration
@@ -75,7 +79,7 @@ extension OpenClawChatViewModel {
             self.isCurrentSession(session)
     }
 
-    private func applyProgressCard(_ card: ProgressCard?) {
+    func applyProgressCard(_ card: ProgressCard?) {
         let normalized = Self.normalizedProgressCard(card)
         let previousPresentation = Self.progressCardPresentation(self.progressCard)
         let presentation = Self.progressCardPresentation(normalized)
@@ -100,6 +104,71 @@ extension OpenClawChatViewModel {
         guard let card else { return nil }
         return [card.markdown == nil ? "0" : "1", card.markdown ?? ""] +
             (card.steps ?? []).flatMap { [$0.step, $0.status.rawValue] }
+    }
+
+    static func parseLegacyProgressCardSteps(_ value: AnyCodable?) -> [ProgressCardStep] {
+        guard let value else { return [] }
+        let rawItems: [Any]
+        switch value.value {
+        case let items as [AnyCodable]:
+            rawItems = items.map(\.value)
+        case let items as [Any]:
+            rawItems = items
+        case let items as NSArray:
+            rawItems = items.map(\.self)
+        default:
+            return []
+        }
+        var hasInProgressStep = false
+        return rawItems.compactMap { rawItem in
+            guard let step = Self.parseLegacyProgressCardStep(rawItem) else { return nil }
+            if case .inProgress = step.status {
+                guard !hasInProgressStep else { return nil }
+                hasInProgressStep = true
+            }
+            return step
+        }
+    }
+
+    private static func parseLegacyProgressCardStep(_ rawValue: Any) -> ProgressCardStep? {
+        let value = (rawValue as? AnyCodable)?.value ?? rawValue
+        if let legacyStep = value as? String {
+            return self.makeLegacyProgressCardStep(text: legacyStep, status: .pending)
+        }
+
+        let fields: [String: Any]
+        switch value {
+        case let dictionary as [String: AnyCodable]:
+            fields = dictionary.mapValues(\.value)
+        case let dictionary as [String: String]:
+            fields = dictionary
+        case let dictionary as [String: Any]:
+            fields = dictionary
+        case let dictionary as NSDictionary:
+            fields = dictionary.reduce(into: [:]) { result, entry in
+                guard let key = entry.key as? String else { return }
+                result[key] = (entry.value as? AnyCodable)?.value ?? entry.value
+            }
+        default:
+            return nil
+        }
+
+        guard let text = fields["step"] as? String,
+              let rawStatus = fields["status"] as? String,
+              let status = ProgressCardStepStatus(rawValue: rawStatus)
+        else {
+            return nil
+        }
+        return self.makeLegacyProgressCardStep(text: text, status: status)
+    }
+
+    private static func makeLegacyProgressCardStep(
+        text: String,
+        status: ProgressCardStepStatus) -> ProgressCardStep?
+    {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return ProgressCardStep(step: trimmed, status: status)
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawKit
+import OpenClawProtocol
 import OSLog
 
 private let transportEventsLogger = Logger(subsystem: "ai.openclaw", category: "OpenClawChatUI")
@@ -642,6 +643,27 @@ extension OpenClawChatViewModel {
                 self.updateActiveSessionRunWithoutChatSnapshot(false)
                 self.updateStreamingAssistantText(text)
             }
+        case "plan":
+            // Released Gateways through v2026.8.x lack progressCard.get and only emit stream:"plan".
+            // Rendering these only when the store is known-absent keeps a dual-emitting Gateway from
+            // fighting the durable card. Remove with the Gateway's legacy dual-emit once the minimum
+            // supported Gateway ships the store.
+            guard self.progressCardStoreAvailable == false else { return }
+            guard evt.data["phase"]?.value as? String == "update" else { return }
+            let steps = Self.parseLegacyProgressCardSteps(evt.data["steps"])
+            guard !steps.isEmpty else {
+                self.clearProgressCard()
+                return
+            }
+            self.legacyProgressCardRevision &+= 1
+            let explanation = (evt.data["explanation"]?.value as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            self.applyProgressCard(ProgressCard(
+                sessionkey: self.sessionKey,
+                revision: self.legacyProgressCardRevision,
+                updatedat: evt.ts ?? 0,
+                markdown: explanation?.isEmpty == false ? explanation : nil,
+                steps: steps))
         case "tool":
             guard let phase = evt.data["phase"]?.value as? String else { return }
             guard let name = evt.data["name"]?.value as? String else { return }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -59,6 +59,10 @@ extension OpenClawChatViewModel {
             self.resolveQuestionEvent(resolved)
             self.reconcileQuestionsAfterEvent()
         case .routeChanged:
+            // A replacement route may be a different Gateway, so a cached
+            // known-absent store must not authorize the legacy plan fallback
+            // against a new Gateway that dual-emits both sources.
+            self.progressCardStoreAvailable = nil
             self.clearProgressCard()
             self.swarmEnabled = false
             self.resetSwarmProgress()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -101,10 +101,13 @@ public final class OpenClawChatViewModel {
     var activeSessionRunIDs: [String] = []
     var liveRunStateByRunID: [String: ChatLiveRunState] = [:]
     public internal(set) var progressCard: ProgressCard?
+    var progressCardStoreAvailable: Bool?
     @ObservationIgnored
     var progressCardGeneration: UInt64 = 0
     @ObservationIgnored
     var lastIssuedProgressCardRequestID: UInt64 = 0
+    @ObservationIgnored
+    var legacyProgressCardRevision = 0
 
     public private(set) var sessionKey: String {
         didSet {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -101,6 +101,13 @@ private func progressCard(
         steps: steps)
 }
 
+private func legacyPlanStep(_ step: String, status: String) -> AnyCodable {
+    AnyCodable([
+        "step": AnyCodable(step),
+        "status": AnyCodable(status),
+    ])
+}
+
 private func usageEvent(runId: String, outputTokens: Int, seq: Int) -> OpenClawAgentEventPayload {
     OpenClawAgentEventPayload(
         runId: runId,
@@ -344,6 +351,7 @@ private func makeViewModel(
     commandResponses: [[OpenClawChatCommandChoice]] = [],
     requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
     fetchProgressCardHook: (@Sendable (String) async throws -> ProgressCard?)? = nil,
+    progressCardStoreAvailable: Bool? = nil,
     historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
     setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
     createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
@@ -395,6 +403,7 @@ private func makeViewModel(
         commandResponses: commandResponses,
         requestHistoryHook: requestHistoryHook,
         fetchProgressCardHook: fetchProgressCardHook,
+        progressCardStoreAvailable: progressCardStoreAvailable,
         historyResponseHook: historyResponseHook,
         setActiveSessionHook: setActiveSessionHook,
         createSessionHook: createSessionHook,
@@ -540,6 +549,28 @@ private func emitAgentLifecycleEnd(
                 stream: "lifecycle",
                 ts: Int(Date().timeIntervalSince1970 * 1000),
                 data: ["phase": AnyCodable("end")])))
+}
+
+private func legacyPlanEvent(
+    runId: String = "sess-main",
+    steps: [AnyCodable],
+    explanation: String? = nil,
+    seq: Int = 1,
+    timestamp: Int? = 1000) -> OpenClawChatTransportEvent
+{
+    var data: [String: AnyCodable] = [
+        "phase": AnyCodable("update"),
+        "steps": AnyCodable(steps),
+    ]
+    if let explanation {
+        data["explanation"] = AnyCodable(explanation)
+    }
+    return .agent(OpenClawAgentEventPayload(
+        runId: runId,
+        seq: seq,
+        stream: "plan",
+        ts: timestamp,
+        data: data))
 }
 
 private func emitExternalFinal(
@@ -692,6 +723,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let commandResponses: [[OpenClawChatCommandChoice]]
     private let requestHistoryHook: (@Sendable (String) async throws -> Void)?
     private let fetchProgressCardHook: (@Sendable (String) async throws -> ProgressCard?)?
+    private let progressCardStoreAvailable: Bool?
     private let historyResponseHook:
         (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)?
     private let setActiveSessionHook: (@Sendable (String) async throws -> Void)?
@@ -732,6 +764,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         commandResponses: [[OpenClawChatCommandChoice]] = [],
         requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
         fetchProgressCardHook: (@Sendable (String) async throws -> ProgressCard?)? = nil,
+        progressCardStoreAvailable: Bool? = nil,
         historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
         setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
         createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
@@ -766,6 +799,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.commandResponses = commandResponses
         self.requestHistoryHook = requestHistoryHook
         self.fetchProgressCardHook = fetchProgressCardHook
+        self.progressCardStoreAvailable = progressCardStoreAvailable
         self.historyResponseHook = historyResponseHook
         self.setActiveSessionHook = setActiveSessionHook
         self.createSessionHook = createSessionHook
@@ -844,6 +878,10 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
 
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard? {
         try await self.fetchProgressCardHook?(sessionKey)
+    }
+
+    func gatewayAdvertisesProgressCardStore() async -> Bool? {
+        self.progressCardStoreAvailable
     }
 
     func sendMessage(
@@ -1458,6 +1496,116 @@ private actor SwarmCapabilityScript {
 
 @Suite(.serialized)
 struct ChatViewModelTests {
+    @Test func `legacy plan renders only when progress card store is unavailable`() async throws {
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            progressCardStoreAvailable: false)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("progress card capability resolves unavailable") {
+            await MainActor.run { vm.progressCardStoreAvailable == false }
+        }
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [
+                    legacyPlanStep("  Inspect state  ", status: "in_progress"),
+                    AnyCodable("Write fix"),
+                    legacyPlanStep("Verify", status: "completed"),
+                    legacyPlanStep("Duplicate active", status: "in_progress"),
+                    legacyPlanStep("   ", status: "pending"),
+                    legacyPlanStep("Invalid status", status: "blocked"),
+                    AnyCodable(42),
+                ],
+                explanation: "  Working through the change  ",
+                timestamp: 4321))
+        }
+
+        let card = try #require(await MainActor.run { vm.progressCard })
+        #expect(card.sessionkey == "main")
+        #expect(card.updatedat == 4321)
+        #expect(card.markdown == "Working through the change")
+        #expect(card.steps?.map(\.step) == ["Inspect state", "Write fix", "Verify"])
+        #expect(card.steps?.map(\.status.rawValue) == ["in_progress", "pending", "completed"])
+    }
+
+    @Test func `legacy plan is ignored when progress card store is available`() async throws {
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            progressCardStoreAvailable: true)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("progress card capability resolves available") {
+            await MainActor.run { vm.progressCardStoreAvailable == true }
+        }
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [legacyPlanStep("Ignored", status: "in_progress")]))
+        }
+
+        #expect(await MainActor.run { vm.progressCard == nil })
+    }
+
+    @Test func `legacy plan is ignored while progress card capability is unknown`() async throws {
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            progressCardStoreAvailable: nil)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [legacyPlanStep("Ignored", status: "in_progress")]))
+        }
+
+        #expect(await MainActor.run { vm.progressCard == nil })
+        #expect(await MainActor.run { vm.progressCardStoreAvailable == nil })
+    }
+
+    @Test func `empty legacy plan clears progress card`() async throws {
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            fetchProgressCardHook: { _ in progressCard(revision: 9, markdown: "Existing") },
+            progressCardStoreAvailable: false)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("initial progress card and legacy capability apply") {
+            await MainActor.run {
+                vm.progressCard?.revision == 9 && vm.progressCardStoreAvailable == false
+            }
+        }
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(steps: []))
+        }
+
+        #expect(await MainActor.run { vm.progressCard == nil })
+    }
+
+    @Test func `successive legacy plan snapshots use distinct revisions`() async throws {
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            progressCardStoreAvailable: false)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("progress card capability resolves unavailable") {
+            await MainActor.run { vm.progressCardStoreAvailable == false }
+        }
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [AnyCodable("First")],
+                seq: 1))
+        }
+        let firstRevision = try #require(await MainActor.run { vm.progressCard?.revision })
+        #expect(await MainActor.run { vm.progressCard?.steps?.first?.status.rawValue } == "pending")
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [AnyCodable("Second")],
+                seq: 2))
+        }
+
+        #expect(await MainActor.run { vm.progressCard?.steps?.first?.step } == "Second")
+        #expect(await MainActor.run { vm.progressCard?.revision } == firstRevision + 1)
+    }
+
     @Test func `progress card change fetches durable card beyond run completion`() async throws {
         let fetchCalls = AsyncCounter()
         let card = progressCard(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -1528,6 +1528,32 @@ struct ChatViewModelTests {
         #expect(card.steps?.map(\.status.rawValue) == ["in_progress", "pending", "completed"])
     }
 
+    @Test func `route replacement invalidates a stale known-absent capability`() async throws {
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            progressCardStoreAvailable: false)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("progress card capability resolves unavailable") {
+            await MainActor.run { vm.progressCardStoreAvailable == false }
+        }
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [legacyPlanStep("Old gateway step", status: "in_progress")]))
+        }
+        #expect(await MainActor.run { vm.progressCard } != nil)
+
+        // A replacement route may be a different Gateway; the stale known-absent
+        // value must not authorize the legacy path against a dual-emitting one.
+        await MainActor.run { vm.handleTransportEvent(.routeChanged) }
+        #expect(await MainActor.run { vm.progressCardStoreAvailable } == nil)
+
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [legacyPlanStep("New gateway step", status: "in_progress")]))
+        }
+        #expect(await MainActor.run { vm.progressCard } == nil)
+    }
+
     @Test func `legacy plan is ignored when progress card store is available`() async throws {
         let (_, vm) = await makeViewModel(
             historyResponses: [historyPayload()],


### PR DESCRIPTION
# What Problem This Solves

`progressCard.get` ships in **no released Gateway tag**. The progress-card merge `7170a6231a4` is not an ancestor of any `v2026.*` tag — not the newest `v2026.8.1-beta.2`, not stable `v2026.7.1-2`. App Store and TestFlight builds routinely connect to older Gateways.

After #125442 migrated the Apple plan surface to the durable store and deleted all legacy `stream:"plan"` consumption, iOS/macOS against **any currently released Gateway** calls `progressCard.get`, gets `INVALID_REQUEST: unknown method`, swallows it, and renders no status card at all — where the plan pill used to work. That is the repo's worst bug class: an action that ends in no visible outcome, on the default path.

The sibling Android PR #125444 hit the identical bug and landed the fix first (merge `af599f2cf757`). This mirrors that canonical design on Apple rather than inventing a second answer.

# Why This Change Was Made

- **Tri-state capability probe.** `OpenClawChatTransport.gatewayAdvertisesProgressCardStore() -> Bool?` (`nil` = unknown, `false` = known-absent). Both real transports answer from the **existing** advertised-methods accessors — `GatewayNodeSession.supportsServerMethod(_:ifCurrentRoute:)` on iOS, `GatewayConnection.supportsServerMethod(_:ifCurrentServerLease:)` on macOS. No new plumbing; `HelloOk.advertisedServerMethods()` already existed.
- **Cached on the view model**, refreshed wherever the card fetch is already scheduled (history load, session switch, reconnect). The capability is gateway-scoped, so it deliberately survives session switches.
- **Legacy `case "plan"` restored, gated on `== false`.** Only a *known-absent* store activates it: `true` and `nil` both return. That is what keeps a new, dual-emitting Gateway from fighting the durable card. Legacy snapshots synthesize a `ProgressCard` with a locally-incremented revision so the revision-dedupe path can't collapse two distinct snapshots.
- **Legacy step parser restored**, retargeted from the deleted `OpenClawChatPlanStep` to the generated `ProgressCardStep` — same semantics as before #125442, including bare-string legacy steps and keeping only the first `in_progress`.

This is a compatibility fallback, so it is named per the Architecture rules: **shipped contract** — every released Gateway tag lacks `progressCard.get`; **failure mode** — silent empty status card; **removal plan** — delete together with the Gateway's legacy `stream:"plan"` dual-emit once the minimum supported Gateway ships the store (the inline comment says exactly this); **why doctor cannot solve it** — the skew is a remote Gateway's shipped version, not local config.

Correcting my own record: #125442's body argued "the app ships with its gateway era." That is wrong for an App Store app, and it is why this regression shipped.

# User Impact

iOS/macOS users on any current Gateway release get their plan/status card back. Users on a Gateway with the store are unaffected — that path is untouched and the legacy branch is inert.

# Evidence

**Live A/B on a real released Gateway.** Rig: `v2026.8.1-beta.2` checked out and run as a real Gateway (isolated `OPENCLAW_STATE_DIR`, port 19833), real iOS app on iPhone 17 Pro, paired through the normal setup-code flow, plan driven by asking the agent to call `update_plan`. That Gateway genuinely rejects the method:

```
$ openclaw gateway call progressCard.get --url ws://127.0.0.1:19833 ...
{"ok":false,"error":{"code":"INVALID_REQUEST","message":"unknown method: progressCard.get"}}
```

Both builds were verified by symbol inspection before installing (fixed build: 38 `gatewayAdvertisesProgressCard*` symbols + the legacy parser; pre-fix build: 0 of each).

| Before — merged `main` (`a0c5937fd19`) | After — this branch |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/04cf87be-73e7-4d55-b167-8ac853a2f0eb) | ![after](https://github.com/user-attachments/assets/2cba6815-cfb4-4e7d-97f4-2afcd3f64aa5) |
| Live `update_plan` run completes — **no card at all** | Same Gateway, same tool — card renders with typed steps ✓ ✓ ▸ ▢ and `2/4` |

Both shots are live runs with the plan events arriving in real time, not history replay (legacy card state is in-memory, so a relaunch comparison would not have been apples-to-apples).

- `swift test --package-path apps/shared/OpenClawKit` — **1375 tests / 106 suites green**, run by the coordinator. New coverage: renders only when the store is known-absent; ignored when available; ignored while unknown; empty steps clear; successive snapshots keep distinct revisions.
- Flake check: full suite 4 green runs, progress-card filter 5/5 green. One unrelated one-off failure was seen in an early full run and did not reproduce in 4 subsequent full runs; it was not in the new tests.
- `swift build --package-path apps/macos` — green. iOS simulator app build — `** BUILD SUCCEEDED **`, SwiftLint clean.
- `pnpm check:protocol-coverage` — green.
- Structured autoreview (Codex) — clean.

Production LOC is intentionally positive (+113/−1); it buys back a deleted capability against a named shipped contract, with the removal plan recorded at the code site. Tests +148.
