### PR TITLE
fix(control-ui): only rewrite the dev Gateway URL on loopback

### DIFF
--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -145,6 +145,23 @@ describe("loadSettings default gateway URL derivation", () => {
     }
   });
 
+  it("keeps a remotely served dev page on its own origin", () => {
+    // A dev page reached over a tunnel must not redirect the Gateway to port
+    // 18789 on that public host: there is no Gateway there, and the rewrite
+    // would advertise a local port to a remote viewer.
+    setTestLocation({ protocol: "https:", host: "preview.example.com", pathname: "/" });
+    vi.stubGlobal("document", {
+      querySelector: (selector: string) => (selector.includes("@vite/client") ? {} : null),
+      documentElement: { getAttribute: () => null },
+    } as unknown as Document);
+
+    try {
+      expect(loadSettings().gatewayUrl).toBe("wss://preview.example.com");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("uses configured base path and normalizes trailing slash", () => {
     setTestLocation({
       protocol: "https:",

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -247,6 +247,17 @@ function isViteDevPage(): boolean {
   return Boolean(document.querySelector('script[src*="/@vite/client"]'));
 }
 
+function isLocalViteDevPage(): boolean {
+  const hostname = location.hostname;
+  return (
+    isViteDevPage() &&
+    (hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]")
+  );
+}
+
 function formatHostWithPort(hostname: string, port: string): string {
   // location.hostname already carries brackets for IPv6 literals; wrapping
   // again would produce an undialable ws://[[::1]]:port default.
@@ -259,7 +270,7 @@ function deriveDefaultGatewayUrl(): { pageUrl: string; effectiveUrl: string } {
   const proto = location.protocol === "https:" ? "wss" : "ws";
   const basePath = resolveControlUiBasePath(location.pathname);
   const pageUrl = `${proto}://${location.host}${basePath}`;
-  if (!isViteDevPage()) {
+  if (!isLocalViteDevPage()) {
     return { pageUrl, effectiveUrl: pageUrl };
   }
   const effectiveUrl = `${proto}://${formatHostWithPort(location.hostname, "18789")}`;


### PR DESCRIPTION
A Vite dev page rewrites its default Gateway URL to port `18789` on whatever host served the page. That is correct on loopback and wrong anywhere else: served through a tunnel, it advertises a local port to a remote viewer and points at a Gateway that is not there. This restricts the rewrite to pages actually served from loopback.

## Provenance

Recovered from an uncommitted worktree that was **15,410 commits behind** `main`. That worktree held three fixes; the other two are already implemented upstream and were dropped rather than re-litigated:

- the `expectedSessionId` guard on `sessions.patch` — upstream now sends it from the session menu, organizer, batch mutations and chat pane
- a stale thinking-label fix — the code it targeted no longer exists

Rather than rebase across that much drift, this fix was applied directly onto current `main`.

## Validation

`ui/src/app/settings.node.test.ts` — 45 tests pass, including a new case asserting a remotely served dev page keeps its own origin. The existing IPv6 loopback case (`[::1]`) still routes to `18789`.

## Status

Draft for handoff. No `code-review` has been run.
