### PR TITLE
docs(skills): add interrupted-run recovery to openclaw-debugging

### DIFF
--- a/.agents/skills/openclaw-debugging/SKILL.md
+++ b/.agents/skills/openclaw-debugging/SKILL.md
@@ -28,6 +28,15 @@ debug signal rather than a guess.
 5. Patch the root cause.
 6. Rerun the exact failing probe, then broaden only if the contract requires it.
 
+## Interrupted-Run Recovery
+
+When a gateway restart, upgrade, or handoff interrupts debugging:
+
+1. Inspect the branch, worktree status, current head, and relevant file history before acting. Confirm which changes and destructive steps already completed.
+2. Compare the original evidence with current-head owners and tests. Confirm the suspected gap still exists before editing code.
+3. If a focused test fails in shared temporary state, rerun the same probe under a fresh private temporary root. Treat it as a product failure only when the isolated rerun reproduces it.
+4. Verify the smallest relevant current-head test set and the production diff. Finish with either a grounded patch or an explicit no-op when the repair is already present.
+
 ## Model Transport Logs
 
 Use targeted env flags instead of global debug when the model request shape or


### PR DESCRIPTION
Adds an **Interrupted-Run Recovery** section to the `openclaw-debugging` skill, covering how to resume a debugging run after a gateway restart, upgrade, or handoff: re-establish branch and worktree state before acting, reconfirm the suspected gap against current head, rerun shared-temp failures under a private temporary root before calling them product bugs, and finish with either a grounded patch or an explicit no-op when the repair already landed.

## Provenance

Recovered from uncommitted work in the `session-stall-recovery` worktree, which sat 1,844 commits behind `main`.

That worktree also rewrote the skill's `description:` frontmatter, truncating it mid-sentence — "before changing" instead of "before changing code…". Current `main` has since extended that line to mention fetching stored sessions, transcripts and attachments as evidence, so the truncation was dropped and only the new section applied.

## Status

Draft for handoff. Documentation only; no code paths touched. No `code-review` has been run.
