### PR TITLE
fix(ui): stop session tooltips covering progress cards

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -402,8 +402,6 @@ function renderCatalogSessionRow(
     const label = session.name || session.threadId;
     return params.renderLiveRow(adoptedRow, {
       label,
-      meta: formatSidebarTimestamp(timestamp),
-      title: `${label} · ${host.label}`,
       ...(session.pullRequest ? { pullRequest: session.pullRequest } : {}),
     });
   }
@@ -467,7 +465,6 @@ function renderCatalogSessionRow(
       <a
         href=${href}
         class="sidebar-recent-session__link"
-        title=${[`${label} · ${host.label}`, stateDescription].filter(Boolean).join(" · ")}
         aria-current=${active ? "page" : nothing}
         aria-describedby=${stateId ?? nothing}
         @click=${(event: MouseEvent) => {

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -74,8 +74,6 @@ export function visibleCatalogHosts(
 export type CatalogBackingSessionDisplay = {
   label: string;
   subtitle?: string;
-  meta: string;
-  title: string;
   pullRequest?: SessionCatalogSession["pullRequest"];
 };
 

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -18,7 +18,6 @@ import type {
   CatalogBackingSessionDisplay,
   CatalogSessionMenuRequest,
 } from "./app-sidebar-session-catalogs.ts";
-import { formatSidebarTimestamp } from "./app-sidebar-session-catalogs.ts";
 import {
   rowDemandsVisibility,
   sidebarSessionMetaId,
@@ -207,8 +206,6 @@ export function renderRecentSession(params: {
   const trailingDescription = session.isChild
     ? ""
     : describeSessionTrailingState(session, pullRequestState);
-  const meta = display?.meta ?? formatSidebarTimestamp(session.updatedAt);
-  const rowMeta = session.pinned ? "" : meta;
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
   const stateId = trailingIndicator === nothing ? undefined : sidebarSessionStateId(session.key);
@@ -218,12 +215,6 @@ export function renderRecentSession(params: {
       (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
       (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
     );
-  const title = [
-    display?.title ?? [label, narration, rowMeta].filter(Boolean).join(" · "),
-    trailingDescription,
-  ]
-    .filter(Boolean)
-    .join(" · ");
   const pinLabel = `${t(session.pinned ? "sessionsView.unpinSession" : "sessionsView.pinSession")}: ${label}`;
   const menuLabel = `${t("chat.sidebar.openSessionMenu")}: ${label}`;
   const rowClass = [
@@ -288,7 +279,6 @@ export function renderRecentSession(params: {
         href=${session.href}
         class="sidebar-recent-session__link"
         draggable="false"
-        title=${title}
         aria-current=${session.visuallyActive ? "page" : nothing}
         aria-describedby=${[stateId, metaId].filter(Boolean).join(" ") || nothing}
         @click=${(event: MouseEvent) => host.handleSessionRowClick(event, session)}

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -256,7 +256,6 @@ export function renderRecentSession(params: {
       data-session-key=${session.key}
       role=${ifDefined(listItem ? "listitem" : undefined)}
       draggable=${rowDraggable ? "true" : "false"}
-      title=${!session.isChild && !groupWriteAccess.allowed ? groupWriteAccess.reason : nothing}
       @dragstart=${!rowDraggable
         ? nothing
         : (event: DragEvent) => {

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -479,6 +479,7 @@ suite.define(() => {
         '[data-session-section="ungrouped"] .sidebar-recent-session, [data-session-section="catalog:codex"] .sidebar-recent-session--catalog-project-child',
       );
       await expect.poll(() => threadRows.count()).toBe(4);
+      expect(await threadRows.locator(".sidebar-recent-session__link[title]").count()).toBe(0);
       const threadRowMetrics = await threadRows.evaluateAll((rows) =>
         rows.map((row) => {
           const link = row.querySelector(".sidebar-recent-session__link");

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -270,7 +270,7 @@ suite.define(() => {
     );
   });
 
-  it("keeps the hover surface closed when the session has no progress card", async () => {
+  it("does not fall back to a native tooltip when the session has no progress card", async () => {
     const sessionKey = "agent:main:no-progress-card";
 
     await suite.withPage(
@@ -300,6 +300,7 @@ suite.define(() => {
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
         const row = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
         await row.waitFor({ state: "visible" });
+        expect(await row.locator(".sidebar-recent-session__link").getAttribute("title")).toBeNull();
         await row.hover();
 
         await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -300,6 +300,7 @@ suite.define(() => {
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
         const row = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
         await row.waitFor({ state: "visible" });
+        expect(await row.getAttribute("title")).toBeNull();
         expect(await row.locator(".sidebar-recent-session__link").getAttribute("title")).toBeNull();
         await row.hover();
 

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -614,7 +614,7 @@ describe("AppSidebar catalog session rows", () => {
       const state = row?.querySelector(".session-row-state");
 
       expect(link?.getAttribute("aria-describedby")).toBe(state?.id);
-      expect(link?.getAttribute("title")).toBe("Running catalog · Local Codex · Active run");
+      expect(link?.hasAttribute("title")).toBe(false);
       expect(state?.querySelector('.session-run-spinner[aria-label="Active run"]')).not.toBeNull();
       expect(state?.querySelector(".session-run-spinner")?.hasAttribute("title")).toBe(false);
     } finally {

--- a/ui/src/test-helpers/app-sidebar-cases/narration.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/narration.ts
@@ -69,7 +69,7 @@ describe("AppSidebar live narration", () => {
     const link = sidebar.querySelector<HTMLAnchorElement>(
       `[data-session-key="${key}"] .sidebar-recent-session__link`,
     );
-    expect(link?.title).toContain("Final verification is running.");
+    expect(link?.hasAttribute("title")).toBe(false);
     expect(link?.querySelector("[aria-live]")).toBeNull();
 
     sessions.publishList({
@@ -129,8 +129,8 @@ describe("AppSidebar live narration", () => {
     );
     expect(row?.textContent).not.toContain("Checking the remaining files.");
     expect(
-      row?.querySelector<HTMLAnchorElement>(".sidebar-recent-session__link")?.title,
-    ).not.toContain("Checking the remaining files.");
+      row?.querySelector<HTMLAnchorElement>(".sidebar-recent-session__link")?.hasAttribute("title"),
+    ).toBe(false);
   });
 
   it("keeps only the six newest running subscriptions and evicts the old boundary", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
@@ -150,7 +150,7 @@ describe("AppSidebar section reordering", () => {
     expect(header.getAttribute("draggable")).toBe("false");
     expect(header.getAttribute("title")).toBeTruthy();
     expect(row?.getAttribute("draggable")).toBe("false");
-    expect(row?.getAttribute("title")).toBeTruthy();
+    expect(row?.hasAttribute("title")).toBe(false);
 
     const dataTransfer = createDataTransferStub();
     dispatchDragEvent(header, "dragstart", dataTransfer);

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -302,10 +302,9 @@ describe("AppSidebar session indicators", () => {
       expect(descriptionId).toBe(`sidebar-session-state-${encodeURIComponent(key)}`);
       expect(sidebar.querySelector(`[id="${descriptionId}"]`)).not.toBeNull();
     }
-    expect(forked?.querySelector("a")?.getAttribute("title")).toContain("Forked session");
-    expect(unread?.querySelector("a")?.getAttribute("title")).toContain("Unread");
-    expect(runningUnread?.querySelector("a")?.getAttribute("title")).toContain("Active run");
-    expect(runningUnread?.querySelector("a")?.getAttribute("title")).toContain("Unread");
+    for (const row of [forked, unread, runningUnread]) {
+      expect(row?.querySelector("a")?.hasAttribute("title")).toBe(false);
+    }
     expect(runningUnread?.querySelector(".session-row-state")?.getAttribute("aria-label")).toBe(
       "Active run · Unread",
     );
@@ -324,9 +323,7 @@ describe("AppSidebar session indicators", () => {
       const row = sidebar.querySelector(`[data-session-key="${key}"]`);
       expectEmptyLead(row);
       expect(row?.querySelector(".session-row-state [data-session-pr-state]")).not.toBeNull();
-      expect(row?.querySelector("a")?.getAttribute("title")).toContain(
-        key === keys.openPullRequest ? "Open PR" : "Merged",
-      );
+      expect(row?.querySelector("a")?.hasAttribute("title")).toBe(false);
       expect(row?.querySelector("[data-session-pr-state]")?.hasAttribute("title")).toBe(false);
     }
 

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -403,7 +403,7 @@ describe("AppSidebar session accessibility", () => {
     expect(link?.querySelector(".sidebar-recent-session__name")?.textContent).toBe(
       "Quarterly launch plan",
     );
-    expect(link?.getAttribute("title")).toBe("Quarterly launch plan · now · Unread");
+    expect(link?.hasAttribute("title")).toBe(false);
     expect(link?.getAttribute("aria-describedby")).toBe(
       `sidebar-session-state-${encodeURIComponent(key)}`,
     );


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves

Fixes an issue where users hovering sidebar sessions could see the browser-native session title tooltip overlap the rich progress card; the tooltip also appeared on rows without progress cards and could be inherited from a denied-access row container.

## Why This Change Was Made

Session rows now rely on visible native link content and existing ARIA state descriptions. All live, adopted-catalog, and native-catalog session-link `title` attributes, the denied-group-write row `title`, and the dead tooltip-only display fields are removed; the rich progress card remains the canonical rich hover surface. The disabled section header retains the group-reordering access explanation, while the session row remains an unobstructed navigation target.

## User Impact

Users get one unobstructed session hover surface, including when group-write access is unavailable, with visible link text, keyboard navigation, native list/listitem structure, `aria-current`, and `aria-describedby` semantics preserved.

## Evidence

- Pre-fix live-row regression failed as intended: expected `title` to be null, received `No progress card · 20,683d`.
- Pre-fix catalog regression failed as intended: expected zero titled links, received 3.
- Pre-fix denied-access regression failed as intended: expected the row to have no `title`, received a native access-reason title.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 1 file passed, 268 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-hovercard.e2e.test.ts` — 1 file passed, 3 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/codex-sessions.e2e.test.ts -t "groups sessions by host"` — 1 file passed, 1 test passed, 6 skipped.
- `pnpm ui:build` — passed, including sidecar/performance verification.
- `node scripts/check-changed.mjs -- ui/src/components/app-sidebar-session-row-render.ts ui/src/components/app-sidebar-session-catalogs.ts ui/src/components/app-sidebar-session-catalog-render.ts ui/src/e2e/session-progress-hovercard.e2e.test.ts ui/src/e2e/codex-sessions.e2e.test.ts ui/src/test-helpers/app-sidebar-cases/interactions.ts ui/src/test-helpers/app-sidebar-cases/narration.ts ui/src/test-helpers/app-sidebar-cases/section-reordering.ts ui/src/test-helpers/app-sidebar-cases/session-indicators.ts ui/src/test-helpers/app-sidebar-cases/sessions.ts` — all selected lanes passed.
- Fresh uncommitted autoreview on the ClawSweeper repair — clean, with no accepted/actionable findings (`overall: patch is correct`, confidence 0.99).
- Source-blind behavior validation — all three original clauses passed; PNG inspection cannot itself prove DOM attribute absence.
- ClawSweeper disposition: the denied-access row finding and both focused Rank-up moves were applied. No separate row-level replacement was added because the row exposes navigation, not a disabled reorder action; the disabled section header continues to explain unavailable section reordering. Per repository policy, the branch is not rebased solely for behind-main drift; exact-head CI and `scripts/pr prepare-run` validate the current merge.
- Production LOC: +0/-16. Tests/test support: +14/-14.

### After

![Control UI sidebar showing the unobstructed rich session progress hovercard](https://github.com/user-attachments/assets/7e8171f4-1c26-4d44-a6ab-2c2e0ce7326a)

Browser-native title tooltips are browser chrome and are omitted from Playwright page screenshots, while the reporter-provided screenshot exists only as a chat attachment not exposed as a local upload file. The failing DOM assertions are the reproducible before proof. No before image was fabricated.
