### PR TITLE
fix(browser): keep screenshot sharing hints capability-neutral

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1709,7 +1709,8 @@ describe("browser tool snapshot maxChars", () => {
     expect(imageParams.extraText).toContain(
       JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
     );
-    expect(imageParams.extraText).toContain("message tool");
+    expect(imageParams.extraText).toContain("sanitized outbound copy");
+    expect(imageParams.extraText).not.toContain("message tool");
     expect(imageParams.details?.media).toEqual({ outbound: false });
     expect(toolCommonMocks.stageBrowserScreenshotForSharing).toHaveBeenCalledWith(
       "/tmp/test.png",
@@ -1796,7 +1797,8 @@ describe("browser tool snapshot maxChars", () => {
     expect(joined).toContain("[neutralized] MEDIA:/tmp/secret.png");
     expect(joined).toContain("/tmp/secret.png");
     expect(joined).toContain(JSON.stringify("/tmp/openclaw-media/outbound/share.png"));
-    expect(joined).toContain("message tool");
+    expect(joined).toContain("sanitized outbound copy");
+    expect(joined).not.toContain("message tool");
     // The vision-success path must not surface raw screenshot media via
     // details.media so channel auto-delivery cannot grab the screenshot.
     expect((out?.details as Record<string, unknown>)?.media).toBeUndefined();
@@ -1851,7 +1853,8 @@ describe("browser tool snapshot maxChars", () => {
     expect(imageParams.extraText).toContain(
       JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
     );
-    expect(imageParams.extraText).toContain("message tool");
+    expect(imageParams.extraText).toContain("sanitized outbound copy");
+    expect(imageParams.extraText).not.toContain("message tool");
     expect(imageParams.details?.media).toEqual({ outbound: false });
   });
 

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -115,7 +115,7 @@ function readTargetUrlParam(params: Record<string, unknown>) {
 }
 
 function formatScreenshotShareHint(filePath: string): string {
-  return `[Screenshot saved to ${JSON.stringify(filePath)}. Use this path with the message tool to share the screenshot explicitly.]`;
+  return `[Screenshot saved to ${JSON.stringify(filePath)}. A sanitized outbound copy is ready at this path for explicit sharing.]`;
 }
 
 const SCREENSHOT_SHARE_UNAVAILABLE =
@@ -799,7 +799,7 @@ export function createBrowserTool(opts?: {
             // Screenshot viewing remains useful when optional outbound staging fails.
           }
           // Screenshots stay in the tool result for agent vision, but channel
-          // delivery must remain an explicit message-tool action.
+          // delivery must remain an explicit outbound-delivery action.
           const screenshotDetails = {
             ...(result as Record<string, unknown>),
             media: { outbound: false },
@@ -846,7 +846,7 @@ export function createBrowserTool(opts?: {
                   // a text description as the deliverable output. Exposing the raw
                   // screenshot as media would cause channel delivery to auto-send
                   // potentially sensitive page content. The text block carries the
-                  // staged outbound-copy path for an explicit message-tool send.
+                  // staged outbound-copy path for an explicit outbound-delivery send.
                   vision: {
                     provider: described.provider,
                     model: described.model,


### PR DESCRIPTION
## What Problem This Solves

Every successful browser screenshot result told the model to “Use this path with the message tool,” even when effective policy had independently removed `message` while leaving `browser` available. That result became hallucination bait and a dead end: it named a capability absent from the model’s actual tool surface.

## Why This Change Was Made

Keep the result capability-neutral while preserving the security boundary. The browser still stages a sanitized outbound copy, returns its path, and requires explicit sharing; the hint now says that the sanitized copy is ready at that path instead of naming another gated tool. Comments were updated to describe the outbound-delivery capability rather than a specific tool. Vision-success, vision-fallback, and raw-image result tests now assert the neutral contract.

## User Impact

Agents receive accurate screenshot-sharing guidance under every tool policy and can choose from the outbound capabilities actually present in their context.

## Evidence

- Pre-fix focused regression: screenshot suite failed because the model-visible hint contained `message tool` and omitted the neutral outbound-copy wording.
- Post-fix: `node scripts/run-vitest.mjs run extensions/browser/src/browser-tool.test.ts -t screenshot` → 10 passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` → rc 0.
- `oxlint` + `oxfmt` on touched files → rc 0 / clean.
- Codex autoreview → clean, 0.99, no actionable findings (rerun after rebase).
