### PR TITLE
[AI-assisted] docs(copilot): describe the transcript journal, not the removed dual-write mirror

### DIFF
--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -13,7 +13,7 @@ OpenClaw's built-in harness. The Copilot CLI session owns the low-level
 agent loop: native tool execution, native compaction (`infiniteSessions`), and
 CLI-managed thread state under `copilotHome`. OpenClaw still owns chat
 channels, session files, model selection, dynamic tools (bridged), approvals,
-media delivery, the visible transcript mirror, `/btw` side questions (see
+media delivery, the visible chat transcript, `/btw` side questions (see
 [Side questions (`/btw`)](/plugins/copilot#side-questions-%2Fbtw)), and `openclaw doctor`.
 
 For the broader model/provider/runtime split, start with
@@ -228,22 +228,32 @@ When `harness.compact` runs, the Copilot SDK harness:
 3. Returns the SDK compaction outcome without writing compatibility marker
    files under the workspace.
 
-The OpenClaw-side transcript mirror (below) keeps receiving post-compaction
+The OpenClaw-side transcript journal (below) keeps receiving post-compaction
 messages, so user-facing chat history stays consistent.
 
-## Transcript mirroring
+## Transcript persistence
 
-`runCopilotAttempt` dual-writes each turn's mirrorable messages into the
-OpenClaw audit transcript via
-`extensions/copilot/src/dual-write-transcripts.ts`. The mirror is scoped per
-session (`copilot:${sessionId}`) and keyed per message
-(`${role}:${sha256_16(role,content)}`), so re-emitted prior-turn entries
-collide with existing on-disk keys instead of duplicating.
+`runCopilotAttempt` gives each attempt a transcript journal
+(`createAttemptTranscriptJournal` in
+`extensions/copilot/src/attempt-transcript-journal.ts`) that persists every
+turn's messages into the OpenClaw session transcript. Journal identity is
+turn-scoped, not content-scoped: the initial user turn is keyed
+`${runId}:user` and SDK-sourced events are keyed
+`copilot-sdk:${sdkSessionId}:${eventId}`, with claimed event ids plus an
+idempotency scan at the transcript store, so re-emitted prior-turn entries
+cannot duplicate.
 
-Two layers of failure containment wrap the mirror so a transcript write
-failure never fails the attempt: an internal best-effort wrapper, plus a
-defense-in-depth `.catch(...)` at the attempt level. Failures are logged, not
-surfaced.
+Assistant turns and their tool results are journaled as structurally complete
+groups, so a crash between groups leaves a valid transcript prefix.
+`before_message_write` hooks may redact content but cannot change role or
+tool topology; a structurally destructive rewrite suppresses the whole group
+instead of persisting a false replay.
+
+Persistence failures fail closed. The first write failure marks the journal
+failed, aborts the in-flight SDK session, and flags the attempt's replay as
+unvalidated so the next run revalidates instead of trusting a partial
+transcript. Only the post-append transcript update notification is
+best-effort and logged.
 
 ## Side questions (`/btw`)
 

--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -251,8 +251,8 @@ instead of persisting a false replay.
 
 Persistence failures fail closed. The first write failure marks the journal
 failed, aborts the in-flight SDK session, and flags the attempt's replay as
-unvalidated so the next run revalidates instead of trusting a partial
-transcript. Only the post-append transcript update notification is
+unvalidated so the next run creates a fresh SDK session instead of trusting a
+partial transcript. Only the post-append transcript update notification is
 best-effort and logged.
 
 ## Side questions (`/btw`)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers reading the new Copilot plugin doc would be pointed at a transcript mirroring architecture that no longer exists. The doc (added in #125556) describes `runCopilotAttempt` dual-writing messages via `extensions/copilot/src/dual-write-transcripts.ts`, scoped per session (`copilot:${sessionId}`) with per-message content-fingerprint keys, and claims a transcript write failure "never fails the attempt" because failures are merely logged.

None of that matches current `main`: `dual-write-transcripts.ts` was removed in #114403 (Jul 27) and replaced by the attempt transcript journal.

## Why This Change Was Made

The section now describes the shipped architecture, verified against `extensions/copilot/src/` on current main:

- Each attempt owns a journal (`createAttemptTranscriptJournal`, wired in `attempt-execution.ts`) that persists turn messages into the OpenClaw session transcript.
- Identity is turn-scoped, not content-scoped: the initial user turn is keyed `${runId}:user`, SDK events `copilot-sdk:${sdkSessionId}:${eventId}`, deduped via claimed event ids plus an idempotency scan at the transcript store. The journal itself comments that old mirror keys "can be content fingerprints and are not turn identity".
- Assistant turns and tool results are journaled as structurally complete groups; `before_message_write` hooks may redact content but not role/tool topology.
- Failure containment is the opposite of the old wording: the first write failure marks the journal failed, aborts the in-flight SDK session, and flags the attempt's replay as unvalidated (`journalValidated`/`nativeReplayInvalid` in `attempt-finalize.ts`) so the next run revalidates rather than trusting a partial transcript. Only the post-append transcript update notification is best-effort.

The two "transcript mirror" references that pointed at the section (intro list, compaction lead-in) were updated to match, and the heading renamed to "Transcript persistence". No other doc or anchor references the old heading (repo-wide grep).

## User Impact

Developers extending or debugging the Copilot plugin read an accurate description of transcript persistence, key identity, and failure behavior instead of hunting for a deleted module and wrong invariants (the old text implied transcript write failures are silent, when they now abort the session and invalidate replay).

## Evidence

- `git log`: `dual-write-transcripts.ts` last exists before #114403 (`3dc3370d`), which added `attempt-transcript-journal.ts` (+ tests) and deleted the dual-write files.
- Current main: `attempt-transcript-journal.ts` implements `${runId}:user` / `copilot-sdk:${sdkSessionId}:${eventId}` keys (L473/L521/L681), `captureFailure` aborts the SDK session, `attempt-finalize.ts` sets `journalValidated: false` / `nativeReplayInvalid: true` on journal failure.
- `bash scripts/docs-spellcheck.sh` → exit 0 across the full docs tree.
- Anchor safety for the heading rename: repo-wide grep finds zero references to the old `#transcript-mirroring` anchor; the changed section adds and removes zero links; file parses cleanly under markdown-it (15 headings).
