### PR TITLE
fix(agents): reap the MCP stdio process group when the leader exits on its own

### DIFF
--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -145,6 +145,45 @@ describe("OpenClawStdioClientTransport", () => {
     await closing;
   });
 
+  it("reaps the process group when the leader exits on its own", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+    const started = transport.start();
+    child.emit("spawn");
+    await started;
+
+    // Leader exits spontaneously: close() never ran, so the group was never
+    // killed, and same-group descendants would leak without the reap.
+    child.exitCode = 1;
+    child.emit("close", 1);
+
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
+  });
+
+  it("does not double-kill the group when close() already reaped it", async () => {
+    vi.useFakeTimers();
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+    const started = transport.start();
+    child.emit("spawn");
+    await started;
+
+    const closing = transport.close();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { detached: true });
+
+    child.exitCode = 0;
+    child.emit("close", 0);
+    await closing;
+
+    // close()'s tree kill already ran; the close event must not fire another.
+    expect(signalProcessTreeMock).not.toHaveBeenCalled();
+  });
+
   it("force-closes an in-flight repeated graceful shutdown before returning", async () => {
     vi.useFakeTimers();
     const child = new MockChildProcess();

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -41,6 +41,7 @@ export class OpenClawStdioClientTransport implements Transport {
   private readonly stderrStream: PassThrough | null = null;
   private process?: ChildProcess;
   private closingProcess?: ChildProcess;
+  private treeReaped = false;
 
   constructor(private readonly serverParams: OpenClawStdioServerParameters) {
     if (serverParams.stderr === "pipe" || serverParams.stderr === "overlapped") {
@@ -91,6 +92,13 @@ export class OpenClawStdioClientTransport implements Transport {
       child.on("spawn", () => resolve());
       child.on("close", () => {
         this.process = undefined;
+        // A leader that exits on its own leaves same-process-group descendants
+        // orphaned and running; reap the group once (close()/forceClose() mark
+        // treeReaped when they already killed it, so this never double-kills).
+        if (child.pid && !this.treeReaped) {
+          this.treeReaped = true;
+          signalProcessTree(child.pid, "SIGKILL", { detached: true });
+        }
         this.onclose?.();
       });
       child.stdin?.on("error", (error: Error) => this.onerror?.(error));
@@ -151,6 +159,7 @@ export class OpenClawStdioClientTransport implements Transport {
       }
       await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
       if (processToClose.exitCode === null && processToClose.pid) {
+        this.treeReaped = true;
         killProcessTree(processToClose.pid, { detached: true });
         await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
         if (processToClose.exitCode === null && processToClose.pid) {
@@ -173,6 +182,7 @@ export class OpenClawStdioClientTransport implements Transport {
       const closePromise = new Promise<void>((resolve) => {
         processToClose.once("close", () => resolve());
       });
+      this.treeReaped = true;
       signalProcessTree(processToClose.pid, "SIGKILL", { detached: true });
       await Promise.race([closePromise, delay(SIGKILL_REAP_TIMEOUT_MS)]);
     }


### PR DESCRIPTION
## What

Fixes the stdio half of #125544: when a detached stdio MCP leader exits on its own (crash, OOM kill), the transport's close handler just dropped state, so same-process-group descendants kept running with nobody owning them.

## How

The server is spawned with `detached: true` on POSIX, making the child its own process-group leader. The close event now reaps the group once with `signalProcessTree(pid, "SIGKILL", { detached: true })` — the same path close() already uses. A `treeReaped` flag set by close()/forceClose() keeps the handler from double-killing after a transport-initiated shutdown, and a graceful self-exit also gets its leftovers reaped (they belong to the server's lifecycle by this transport's contract).

## Verification

Two new tests in mcp-stdio-transport.test.ts: a spontaneous close fires exactly one group SIGKILL, and a close() that already killed the tree does not fire a second one. 13/13 in both vitest projects (agents-core, agents-support) pass; oxlint/oxfmt clean; tsc shows no errors in the touched files.

Not covered here (kept out on purpose): the Streamable HTTP half of the issue, where the SDK auto-closes before the later DELETE — that behavior lives in the MCP SDK and wants its own look.
