### PR TITLE
fix: defer aborted delivery recovery

### DIFF
--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../channels/message/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { isAbortError } from "../abort-signal.js";
 import {
   createDeliveryRecoveryCoordinator,
   createEmptyDeliveryRecoverySummary,
@@ -742,7 +743,7 @@ async function drainQueuedEntry(opts: {
   stateDir?: string;
   onRecovered?: (entry: QueuedDelivery) => void;
   onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
-}): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone"> {
+}): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone" | "deferred"> {
   const { entry } = opts;
   const maxRetries = resolveMaxRetries(entry);
   const attemptBudgetExhausted = resolveAttemptCount(entry) >= maxRetries;
@@ -1109,7 +1110,6 @@ async function drainQueuedEntry(opts: {
     return "recovered";
   } catch (err) {
     const errMsg = formatErrorMessage(err);
-    opts.onFailed?.(entry, errMsg);
     if (isOutboundDeliveryError(err) && err.results.length > 0) {
       deliveredResults = [...err.results];
     }
@@ -1118,6 +1118,7 @@ async function drainQueuedEntry(opts: {
       postSendState !== undefined ||
       (isOutboundDeliveryError(err) && err.sentBeforeError);
     if (hasSendEvidence) {
+      opts.onFailed?.(entry, errMsg);
       // A rejected batch can still contain successful earlier sends. Preserve
       // that concrete evidence so reconnect recovery never replays the batch.
       try {
@@ -1152,6 +1153,7 @@ async function drainQueuedEntry(opts: {
     if (!(await loadPendingDelivery(entry.id, opts.stateDir))) {
       // A best-effort pre-send marker fallback may ack the row before provider
       // I/O. Recovery then owns the stable queue terminal on provider rejection.
+      opts.onFailed?.(entry, errMsg);
       emitQueuedAuditTerminals(entry, () =>
         failedOutboundAuditTerminals({
           payloadCount: queuedPayloadCount(entry),
@@ -1162,6 +1164,11 @@ async function drainQueuedEntry(opts: {
       );
       return "failed";
     }
+    if (isAbortError(err)) {
+      opts.log.info(`Delivery entry ${entry.id} recovery aborted; leaving pending`);
+      return "deferred";
+    }
+    opts.onFailed?.(entry, errMsg);
     const permanentPlatformRejection = findPlatformMessageRejectedError(err);
     if (permanentPlatformRejection || isPermanentDeliveryError(errMsg)) {
       try {

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -710,6 +710,22 @@ describe("delivery-queue recovery", () => {
     await expectPendingEntry({ retryCount: 1, attemptCount: 1, lastError: "network down" });
     expect(auditEvents).toEqual([]);
   });
+  it("leaves an aborted recovery pending without consuming retry budget", async () => {
+    const { auditEvents, unsubscribe } = captureAuditEvents();
+    const id = await enqueueDemoRecoveryDelivery();
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+
+    const { result, log } = await runRecovery({
+      deliver: vi.fn().mockRejectedValue(abortError),
+    });
+    unsubscribe();
+
+    expect(result).toMatchObject({ recovered: 0, failed: 0 });
+    await expectPendingEntry({ id, retryCount: 0, lastError: undefined });
+    expect(auditEvents).toEqual([]);
+    expectMockMessageContaining(log.info, "recovery aborted; leaving pending");
+  });
   it.each([
     {
       name: "keeps a repeated pre-connect recovery failure replayable",


### PR DESCRIPTION
## Summary

- leave an aborted delivery recovery pending instead of recording a failed attempt
- preserve existing failure accounting whenever send evidence exists or the queue row was already finalized
- cover retry budget, queue state, audit events, and recovery logging with a regression test

## Root cause

The recovery catch path invoked `onFailed` and persisted a queue failure for every thrown error. An `AbortError` commonly represents shutdown or cancellation rather than a provider delivery failure, so it consumed retry budget and stored a misleading `lastError`.

## Impact

Cancelled recovery work remains eligible for a later recovery pass without incrementing `retryCount`. Errors with send evidence keep the existing unknown-send safeguards, and ordinary or permanent failures retain their current behavior.

## Validation

- `pnpm exec vitest run src/infra/outbound/delivery-queue.recovery.test.ts` (59 tests)
- `pnpm tsgo:core`
- `pnpm exec oxlint src/infra/outbound/delivery-queue-recovery.ts src/infra/outbound/delivery-queue.recovery.test.ts`
- `pnpm exec oxfmt --check src/infra/outbound/delivery-queue-recovery.ts src/infra/outbound/delivery-queue.recovery.test.ts`
