### PR TITLE
fix: tools report terminal no-delivery outcomes

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -87,6 +87,8 @@ In Code Mode, the conversation tools reuse their exact Gateway output contracts.
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return immediately.
 - **Wait for reply:** set a timeout and get the response inline.
 
+A waited send that finishes without visible assistant text returns `status: "no_reply"`. That is a terminal, intentional non-outcome: no announcement remains pending. Continue without waiting, or send a new message if a response is required.
+
 Thread-scoped chat sessions, such as keys ending in `:thread:<id>`, are not valid `sessions_send` targets. Use the parent channel session key for inter-agent coordination so tool-routed messages do not appear inside an active human-facing thread.
 
 Messages and A2A follow-up replies are marked as inter-session data in the receiving prompt (`[Inter-session message ... isUser=false]`) and in transcript provenance. The receiving agent should treat them as tool-routed data, not as a direct end-user-authored instruction.

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -71,6 +71,9 @@ never needs the agent.
   tabs, switch the visible tab, and move or hide the chat dock. Ask "put the
   chat on the left and show the finance tab" and watch it happen.
 
+  Switching the visible tab or chat dock requires a connected Control UI. If
+  none is connected, the command returns `UNAVAILABLE`; open the Control UI and retry.
+
 ## What widgets are allowed to do
 
 A widget that only renders needs no approval — it appears instantly, exactly

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1086,6 +1086,22 @@ describe("sessions tools", () => {
     expect(Value.Check(tool.outputSchema!, waited.details)).toBe(true);
     expect(
       Value.Check(tool.outputSchema!, {
+        runId: "run-no-reply",
+        status: "no_reply",
+        sessionKey: "agent:main:other",
+        message: "Target session completed without a visible reply.",
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(tool.outputSchema!, {
+        runId: "run-invalid-ok",
+        status: "ok",
+        sessionKey: "agent:main:other",
+        delivery: { status: "pending", mode: "announce" },
+      }),
+    ).toBe(false);
+    expect(
+      Value.Check(tool.outputSchema!, {
         runId: "run-error",
         status: "forbidden",
         error: "hidden",
@@ -1099,9 +1115,7 @@ describe("sessions tools", () => {
         extra: true,
       }),
     ).toBe(false);
-    expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ error: string; runId: string; status: "error" | "forbidden"; sentBeforeError?: true; sessionKey?: string; watched?: boolean } | { delivery: { mode: "announce"; status: "pending" | "skipped" }; runId: string; sessionKey: string; status: "accepted"; watched?: boolean } | { error: string; runId: string; sentBeforeError: true; sessionKey: string; status: "timeout"; delivery?: { mode: "announce"; status: "pending" | "skipped" }; watched?: boolean } | { delivery: { mode: "announce"; status: "pending" | "skipped" }; runId: string; sessionKey: string; status: "ok"; reply?: string; watched?: boolean }',
-    );
+    expect(compactToolOutputHint(tool.outputSchema)).toBeUndefined();
     await waitForCalls(() => agentCallCount, 6);
     await waitForCalls(() => waitCallCount, 6);
     await waitForCalls(() => historyCallCount, 7);

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -615,20 +615,6 @@ describe("waitForAgentRunAndReadUpdatedAssistantReply", () => {
       expected: { status: "ok", replyText: undefined },
     },
     {
-      name: "prefers an authoritative visible terminal reply over suppressed history",
-      runId: "run-visible-terminal-reply",
-      messages: [forwardedRequest, messageToolMirror("suppressed mirror", {})],
-      wait: {
-        status: "ok",
-        terminalReply: { disposition: "visible", text: "authoritative reply" },
-      },
-      expected: {
-        status: "ok",
-        terminalReply: { disposition: "visible", text: "authoritative reply" },
-        replyText: "authoritative reply",
-      },
-    },
-    {
       name: "does not let an older turn's message-tool mirror suppress a fresh reply",
       runId: "run-after-older-source-reply",
       messages: [
@@ -704,6 +690,31 @@ describe("waitForAgentRunAndReadUpdatedAssistantReply", () => {
       "agent.wait",
       "chat.history",
     ]);
+  });
+
+  it("returns an authoritative visible terminal reply without reading history", async () => {
+    callGatewayMock.mockImplementation(async (request) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          terminalReply: { disposition: "visible", text: "authoritative reply" },
+        };
+      }
+      throw new Error("history unavailable");
+    });
+
+    const result = await waitForAgentRunAndReadUpdatedAssistantReply({
+      runId: "run-visible-terminal-reply",
+      sessionKey: "agent:main:child",
+      timeoutMs: 1_000,
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      terminalReply: { disposition: "visible", text: "authoritative reply" },
+      replyText: "authoritative reply",
+    });
+    expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual(["agent.wait"]);
   });
 });
 

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -615,6 +615,20 @@ describe("waitForAgentRunAndReadUpdatedAssistantReply", () => {
       expected: { status: "ok", replyText: undefined },
     },
     {
+      name: "prefers an authoritative visible terminal reply over suppressed history",
+      runId: "run-visible-terminal-reply",
+      messages: [forwardedRequest, messageToolMirror("suppressed mirror", {})],
+      wait: {
+        status: "ok",
+        terminalReply: { disposition: "visible", text: "authoritative reply" },
+      },
+      expected: {
+        status: "ok",
+        terminalReply: { disposition: "visible", text: "authoritative reply" },
+        replyText: "authoritative reply",
+      },
+    },
+    {
       name: "does not let an older turn's message-tool mirror suppress a fresh reply",
       runId: "run-after-older-source-reply",
       messages: [

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -428,6 +428,9 @@ export async function waitForAgentRunAndReadUpdatedAssistantReply(params: {
   if (wait.status !== "ok") {
     return wait;
   }
+  if (wait.terminalReply?.disposition === "visible") {
+    return { ...wait, replyText: wait.terminalReply.text };
+  }
 
   const latestReply = await readLatestAssistantReplySnapshot({
     sessionKey: params.sessionKey,
@@ -436,9 +439,9 @@ export async function waitForAgentRunAndReadUpdatedAssistantReply(params: {
     stopAtTranscriptArtifact: true,
     callGateway: params.callGateway,
   });
-  const replyText =
-    (wait.terminalReply?.disposition === "visible" ? wait.terminalReply.text : undefined) ??
-    (hasUpdatedAssistantReplySnapshot(latestReply, params.baseline) ? latestReply.text : undefined);
+  const replyText = hasUpdatedAssistantReplySnapshot(latestReply, params.baseline)
+    ? latestReply.text
+    : undefined;
   return {
     ...wait,
     replyText,

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -436,9 +436,9 @@ export async function waitForAgentRunAndReadUpdatedAssistantReply(params: {
     stopAtTranscriptArtifact: true,
     callGateway: params.callGateway,
   });
-  const replyText = hasUpdatedAssistantReplySnapshot(latestReply, params.baseline)
-    ? latestReply.text
-    : undefined;
+  const replyText =
+    (wait.terminalReply?.disposition === "visible" ? wait.terminalReply.text : undefined) ??
+    (hasUpdatedAssistantReplySnapshot(latestReply, params.baseline) ? latestReply.text : undefined);
   return {
     ...wait,
     replyText,

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -94,7 +94,7 @@ export function describeSessionsSendTool(): string {
     "Run a visible session on this Gateway by sessionKey/label, or a configured local agent by agentId; sessionKey wins redundant label.",
     "A session identifies model context, not an external address; its reply may still announce through established delivery context.",
     "For an exact external destination, use `conversations_list` plus `conversations_send`/`conversations_turn`.",
-    "Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
+    'Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available; status "no_reply" is terminal, so do not wait for an announcement.',
     "watch:true: notice arrives when others later change target session.",
   ].join(" ");
 }

--- a/src/agents/tools/dashboard-tool.test.ts
+++ b/src/agents/tools/dashboard-tool.test.ts
@@ -201,7 +201,11 @@ describe("dashboard tool", () => {
       expect(result.content[0]).toMatchObject({
         text: expect.stringMatching(/Control UI.*retry/i),
       });
-      expect(broadcastToConnIds).not.toHaveBeenCalled();
+      expect(broadcastToConnIds).toHaveBeenCalledWith(
+        "board.command",
+        expect.any(Object),
+        new Set(),
+      );
     } finally {
       clearContext();
     }

--- a/src/agents/tools/dashboard-tool.test.ts
+++ b/src/agents/tools/dashboard-tool.test.ts
@@ -1,6 +1,7 @@
 import { Value } from "typebox/value";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { BoardCommand, BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { setFallbackGatewayContext } from "../../gateway/server-plugin-fallback-context.js";
 import { createDashboardTool } from "./dashboard-tool.js";
 import type { InProcessGatewayCaller } from "./in-process-gateway.js";
 
@@ -178,5 +179,31 @@ describe("dashboard tool", () => {
     expect(harness.calls).toEqual([]);
     expect(harness.commands).toEqual([{ sessionKey: "agent:main:main", command }]);
     expect(result.details).toEqual({ ok: true, delivered: 2 });
+  });
+
+  it.each([
+    ["focus_tab", { tabId: "notes" }],
+    ["set_chat_dock", { dock: "left" }],
+  ])("reports %s as unavailable when no Control UI is connected", async (action, args) => {
+    const broadcastToConnIds = vi.fn();
+    const clearContext = setFallbackGatewayContext({
+      broadcastToConnIds,
+      getClientConnIds: () => new Set(),
+    } as never);
+    try {
+      const tool = createDashboardTool({ agentSessionKey: "agent:main:main" });
+      const result = await tool.execute("command", { action, ...args });
+      expect(result.details).toEqual({
+        status: "unavailable",
+        code: "UNAVAILABLE",
+        message: "Connect Control UI and retry.",
+      });
+      expect(result.content[0]).toMatchObject({
+        text: expect.stringMatching(/Control UI.*retry/i),
+      });
+      expect(broadcastToConnIds).not.toHaveBeenCalled();
+    } finally {
+      clearContext();
+    }
   });
 });

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -239,9 +239,7 @@ function emitBoardCommand(params: {
     context.getClientConnIds?.(
       (client) => client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI,
     ) ?? new Set<string>();
-  if (connIds.size > 0) {
-    context.broadcastToConnIds("board.command", params, connIds);
-  }
+  context.broadcastToConnIds("board.command", params, connIds);
   return connIds.size;
 }
 

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -239,7 +239,9 @@ function emitBoardCommand(params: {
     context.getClientConnIds?.(
       (client) => client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI,
     ) ?? new Set<string>();
-  context.broadcastToConnIds("board.command", params, connIds);
+  if (connIds.size > 0) {
+    context.broadcastToConnIds("board.command", params, connIds);
+  }
   return connIds.size;
 }
 
@@ -250,6 +252,16 @@ function snapshotResult(snapshot: BoardSnapshot) {
   );
 }
 
+function commandResult(delivered: number) {
+  return delivered === 0
+    ? textResult("Dashboard unavailable. Connect Control UI and retry.", {
+        status: "unavailable",
+        code: "UNAVAILABLE",
+        message: "Connect Control UI and retry.",
+      })
+    : textResult(`Dashboard command sent to ${delivered} client(s)`, { ok: true, delivered });
+}
+
 export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTool {
   const gatewayCall = opts.callGateway ?? callInProcessGatewayTool;
   const emitCommand = opts.emitCommand ?? emitBoardCommand;
@@ -257,7 +269,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
     label: "Dashboard",
     name: "dashboard",
     description:
-      "Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab; set_chat_dock moves or hides the chat dock (left/right/bottom/hidden). Widgets use stable names. Create trusted plugin widgets with widget_put; examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
+      "Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab; set_chat_dock moves or hides the chat dock (left/right/bottom/hidden). focus_tab and set_chat_dock require a connected Control UI. Widgets use stable names. Create trusted plugin widgets with widget_put; examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
     parameters: DashboardToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;
@@ -280,10 +292,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
             tabId: readTabId(params),
           },
         });
-        return textResult(`Dashboard command sent to ${delivered} client(s)`, {
-          ok: true,
-          delivered,
-        });
+        return commandResult(delivered);
       }
       if (action === "set_chat_dock") {
         const dock = readDock(params, "dock");
@@ -295,10 +304,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
           agentId: opts.agentId,
           command: { kind: "set_chat_dock", dock },
         });
-        return textResult(`Dashboard command sent to ${delivered} client(s)`, {
-          ok: true,
-          delivered,
-        });
+        return commandResult(delivered);
       }
       if (action === "widget_put") {
         const pluginKind = readToolStringParam(params, "pluginKind", { required: true });

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -166,10 +166,20 @@ const SessionsSendOutputSchema = Type.Union([
   Type.Object(
     {
       runId: Type.String(),
+      status: Type.Literal("no_reply"),
+      sessionKey: Type.String(),
+      message: Type.String(),
+      watched: Type.Optional(Type.Boolean()),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      runId: Type.String(),
       status: Type.Literal("ok"),
       sessionKey: Type.String(),
       delivery: SessionsSendDeliverySchema,
-      reply: Type.Optional(Type.String()),
+      reply: Type.String(),
       watched: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
@@ -179,6 +189,7 @@ const SessionsSendOutputSchema = Type.Union([
 type GatewayCaller = AgentToolGatewayRequestCaller;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
 const SESSIONS_SEND_MESSAGE_ALIASES = ["SendMessage", "content", "text"] as const;
+const NO_REPLY_MESSAGE = "No visible reply or pending announcement. Continue or retry if needed.";
 
 function normalizeSessionsSendArguments(args: unknown): Record<string, unknown> {
   const params =
@@ -1229,16 +1240,13 @@ export function createSessionsSendTool(opts?: {
             });
           }
           const reply = result.replyText;
-          startA2AFlow(reply ?? undefined);
-
-          return jsonResult({
-            runId,
-            status: "ok",
-            sessionKey: displayKey,
-            delivery,
-            ...(typeof reply === "string" ? { reply } : {}),
-            ...watchField,
-          });
+          const response = reply
+            ? { status: "ok" as const, delivery, reply }
+            : { status: "no_reply" as const, message: NO_REPLY_MESSAGE };
+          if (reply) {
+            startA2AFlow(reply);
+          }
+          return jsonResult({ runId, sessionKey: displayKey, ...response, ...watchField });
         },
       });
     },

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1460,59 +1460,71 @@ describe("sessions_send gating", () => {
     ]);
   });
 
-  it("keeps synchronous distinct-target sends unchanged", async () => {
-    const targetSessionKey = "agent:main:other";
-    const tool = createSessionsSendTool({
-      agentSessionKey: MAIN_AGENT_SESSION_KEY,
-      agentChannel: MAIN_AGENT_CHANNEL,
-      config: {
-        session: { scope: "per-sender", mainKey: "main" },
-        tools: {
-          agentToAgent: { enabled: false },
-          sessions: { visibility: "all" },
-        },
-      } as never,
-    });
-    let historyCalls = 0;
-    const staleAssistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "older reply from a previous run" }],
-      timestamp: 20,
-    };
+  it.each(["silent", "empty"] as const)(
+    "reports a terminal %s target without leaving an announcement pending",
+    async (disposition) => {
+      const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+      vi.mocked(runSessionsSendA2AFlow).mockClear();
+      const targetSessionKey = "agent:main:other";
+      const tool = createSessionsSendTool({
+        agentSessionKey: MAIN_AGENT_SESSION_KEY,
+        agentChannel: MAIN_AGENT_CHANNEL,
+        config: {
+          session: { scope: "per-sender", mainKey: "main" },
+          tools: {
+            agentToAgent: { enabled: false },
+            sessions: { visibility: "all" },
+          },
+        } as never,
+      });
+      let historyCalls = 0;
+      const staleAssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "older reply from a previous run" }],
+        timestamp: 20,
+      };
 
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string; params?: Record<string, unknown> };
-      if (request.method === "sessions.list") {
-        return {
-          path: "/tmp/sessions.json",
-          sessions: [{ key: targetSessionKey, kind: "direct" }],
-        };
-      }
-      if (request.method === "agent") {
-        return { runId: "run-stale-send", acceptedAt: 123 };
-      }
-      if (request.method === "agent.wait") {
-        return { runId: "run-stale-send", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        historyCalls += 1;
-        return { messages: [staleAssistantMessage] };
-      }
-      return {};
-    });
+      callGatewayMock.mockImplementation(async (opts: unknown) => {
+        const request = opts as { method?: string; params?: Record<string, unknown> };
+        if (request.method === "sessions.list") {
+          return {
+            path: "/tmp/sessions.json",
+            sessions: [{ key: targetSessionKey, kind: "direct" }],
+          };
+        }
+        if (request.method === "agent") {
+          return { runId: "run-stale-send", acceptedAt: 123 };
+        }
+        if (request.method === "agent.wait") {
+          return {
+            runId: "run-stale-send",
+            status: "ok",
+            terminalReply: { disposition },
+          };
+        }
+        if (request.method === "chat.history") {
+          historyCalls += 1;
+          return { messages: [staleAssistantMessage] };
+        }
+        return {};
+      });
 
-    const result = await tool.execute("call-stale-send", {
-      sessionKey: targetSessionKey,
-      message: "ping",
-      timeoutSeconds: 1,
-    });
+      const result = await tool.execute("call-stale-send", {
+        sessionKey: targetSessionKey,
+        message: "ping",
+        timeoutSeconds: 1,
+      });
 
-    expect(historyCalls).toBe(2);
-    const details = requireDetails(result);
-    expect(details.status).toBe("ok");
-    expect(details.reply).toBeUndefined();
-    expect(details.sessionKey).toBe(targetSessionKey);
-  });
+      expect(historyCalls).toBe(2);
+      const details = requireDetails(result);
+      expect(details.status).toBe("no_reply");
+      expect(details.reply).toBeUndefined();
+      expect(details.delivery).toBeUndefined();
+      expect(details.message).toContain("pending announcement");
+      expect(details.sessionKey).toBe(targetSessionKey);
+      expect(runSessionsSendA2AFlow).not.toHaveBeenCalled();
+    },
+  );
 
   it("passes a baseline into fire-and-forget same-session A2A delivery", async () => {
     const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
@@ -1935,7 +1947,7 @@ describe("sessions_send gating", () => {
       timeoutSeconds: Number.MAX_SAFE_INTEGER,
     });
 
-    expect(requireDetails(result).status).toBe("ok");
+    expect(requireDetails(result).status).toBe("no_reply");
     expect(waitTimeouts).toEqual([MAX_TIMER_TIMEOUT_MS]);
   });
 });

--- a/src/worker/worker-session-tools.ts
+++ b/src/worker/worker-session-tools.ts
@@ -61,7 +61,7 @@ export function createWorkerSessionTools(client: WorkerSessionRpcClient): AnyAge
       label: "Session Send",
       name: "sessions_send",
       description:
-        "Send a message to an authorized parent, child, or sibling cloud session. Cross-tree and stale-incarnation targets are denied by the Gateway.",
+        'Send a message to an authorized parent, child, or sibling cloud session. Cross-tree and stale-incarnation targets are denied by the Gateway. Status "no_reply" is terminal; do not wait for another result.',
       parameters: Type.Object({
         sessionKey: Type.String({ minLength: 1, maxLength: 1_024 }),
         message: Type.String({ minLength: 1, maxLength: WORKER_SESSION_TOOL_MAX_TEXT_LENGTH }),

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1167,7 +1167,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Run a visible session on this Gateway by sessionKey/label, or a configured local agent by agentId; sessionKey wins redundant label. A session identifies model context, not an external address; its reply may still announce through established delivery context. For an exact external destination, use `conversations_list` plus `conversations_send`/`conversations_turn`. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Run a visible session on this Gateway by sessionKey/label, or a configured local agent by agentId; sessionKey wins redundant label. A session identifies model context, not an external address; its reply may still announce through established delivery context. For an exact external destination, use `conversations_list` plus `conversations_send`/`conversations_turn`. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available; status \"no_reply\" is terminal, so do not wait for an announcement. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53365,
-    "roughTokens": 13342
+    "chars": 53434,
+    "roughTokens": 13359
   },
   "openClawDeveloperInstructions": {
     "chars": 4479,
@@ -241,8 +241,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82229,
-    "roughTokens": 20558
+    "chars": 82298,
+    "roughTokens": 20575
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53057,
-    "roughTokens": 13265
+    "chars": 53126,
+    "roughTokens": 13282
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -241,8 +241,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80441,
-    "roughTokens": 20111
+    "chars": 80510,
+    "roughTokens": 20128
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54614,
-    "roughTokens": 13654
+    "chars": 54683,
+    "roughTokens": 13671
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82414,
-    "roughTokens": 20604
+    "chars": 82483,
+    "roughTokens": 20621
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

Fixes two false-success tool outcomes. A waited `sessions_send` could report an announcement as pending after the target had already completed without a visible reply, while UI-only dashboard commands reported success when no Control UI client was connected.

## Why This Change Was Made

`sessions_send` now returns a closed terminal `no_reply` variant with actionable guidance and no delivery field; its `ok` variant requires a reply. The shared wait boundary returns the Gateway's authoritative visible terminal reply before any transcript read and uses transcript extraction only as a fallback. Dashboard commands now return an `UNAVAILABLE`-coded result for empty fanout. Model-facing descriptions, worker guidance, public docs, and prompt fixtures were updated with the same contract.

The exact result shapes are not exported through the plugin SDK or documented as a stable public contract. This change is AI-assisted; I reviewed the affected owners, consumers, sibling Gateway behavior, and runtime bridge directly.

## User Impact

Agents no longer wait forever or invent follow-ups after a completed no-reply session send. Dashboard commands now tell the agent to connect the Control UI and retry instead of claiming delivery to zero clients.

## Evidence

Pre-fix isolated dev Gateway, local mock provider, two completed session windows:

- `sessions_send`: `status: "ok"`, `delivery.status: "pending"`, no `reply`
- dashboard: `ok: true`, `delivered: 0`

Post-fix, same real Gateway flow:

- `sessions_send`: `status: "no_reply"`, message `No visible reply or pending announcement. Continue or retry if needed.`, no `delivery`
- dashboard: `status: "unavailable"`, `code: "UNAVAILABLE"`, message `Connect Control UI and retry.`

Validation:

- Focused Vitest: ClawSweeper acceptance set, 200 tests passed; broader focused set also passed
- `pnpm build`
- `node scripts/check-changed.mjs`
- Codex autoreview: clean, no accepted/actionable findings

Production LOC: +40/-25 (net +15). Tests/test support: +150/-68 (net +82). Docs: +5/-0.
