### PR TITLE
fix(codex): preserve structured tool results in transcripts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -189,7 +189,6 @@ extensions/codex/src/app-server/config-reviewer.ts	2
 extensions/codex/src/app-server/config-utils.ts	1
 extensions/codex/src/app-server/context-engine-projection.ts	4
 extensions/codex/src/app-server/dynamic-tool-build.ts	1
-extensions/codex/src/app-server/dynamic-tool-response-state.ts	1
 extensions/codex/src/app-server/dynamic-tools.ts	6
 extensions/codex/src/app-server/effective-mcp-catalog.ts	1
 extensions/codex/src/app-server/elicitation-bridge.ts	1

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -340,17 +340,23 @@ export function toCodexDynamicToolProgressResponse(
 ): CodexDynamicToolCallResponse & {
   details?: { async: true; status: "started" } | { mcpAppPreview: unknown };
 } {
-  const transcriptDetails = response.transcriptDetails;
-  if (response.asyncStarted !== true && transcriptDetails === undefined) {
+  const transcriptDetails = isJsonObject(response.transcriptDetails)
+    ? response.transcriptDetails
+    : undefined;
+  const mcpAppPreview = isJsonObject(transcriptDetails?.mcpAppPreview)
+    ? transcriptDetails.mcpAppPreview
+    : undefined;
+  const progressDetails = mcpAppPreview ? { mcpAppPreview } : undefined;
+  if (response.asyncStarted !== true && progressDetails === undefined) {
     return protocolResponse;
   }
   return {
     ...protocolResponse,
-    ...(transcriptDetails ? { details: transcriptDetails } : {}),
+    ...(progressDetails ? { details: progressDetails } : {}),
     ...(response.asyncStarted === true
       ? {
           details: {
-            ...transcriptDetails,
+            ...progressDetails,
             async: true as const,
             status: "started" as const,
           },

--- a/extensions/codex/src/app-server/dynamic-tool-response-state.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-response-state.ts
@@ -8,7 +8,7 @@ import type {
 export type CodexDynamicToolRuntimeResponse = CodexDynamicToolCallResponse & {
   executionStarted?: boolean;
   executedArguments?: Record<string, unknown>;
-  transcriptDetails?: { mcpAppPreview: unknown };
+  transcriptDetails?: unknown;
   terminalResolution?: ReturnType<NonNullable<EmbeddedRunAttemptParams["observeToolTerminal"]>>;
 };
 
@@ -17,17 +17,13 @@ export function withDynamicToolTranscriptDetails<T extends CodexDynamicToolRunti
   response: T,
   details: unknown,
 ): T {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
-    return response;
-  }
-  const mcpAppPreview = (details as Record<string, unknown>).mcpAppPreview;
-  if (!mcpAppPreview || typeof mcpAppPreview !== "object" || Array.isArray(mcpAppPreview)) {
+  if (details === undefined) {
     return response;
   }
   Object.defineProperty(response, "transcriptDetails", {
     configurable: true,
     enumerable: false,
-    value: { mcpAppPreview },
+    value: details,
   });
   return response;
 }

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -987,7 +987,7 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
-  it("retains only MCP App preview details for OpenClaw transcript projection", async () => {
+  it("retains all sanitized details for OpenClaw transcript projection", async () => {
     const mcpAppPreview = {
       kind: "canvas",
       view: { id: "mcp-app-view-1", title: "Nearby food" },
@@ -1017,7 +1017,10 @@ describe("createCodexDynamicToolBridge", () => {
       arguments: { limit: 4 },
     });
 
-    expect(result.transcriptDetails).toEqual({ mcpAppPreview });
+    expect(result.transcriptDetails).toEqual({
+      mcpAppPreview,
+      structuredContent: { privateModelPayload: true },
+    });
     expect(Object.keys(result)).not.toContain("transcriptDetails");
     expect(JSON.stringify(result)).not.toContain("mcpAppPreview");
     expect(JSON.stringify(result)).not.toContain("privateModelPayload");

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -825,7 +825,10 @@ export function createCodexDynamicToolBridge(params: {
           },
           terminalType,
         );
-        withDynamicToolTranscriptDetails(response, result.details);
+        withDynamicToolTranscriptDetails(
+          response,
+          asOptionalRecord(sanitizeToolResult(result))?.details,
+        );
         withDiagnosticFailureDisposition(response, resultFailureKind);
         const blocksSourceReplyTermination = hasExplicitNonSourceMessageRoute(
           executedArgs,

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -1,3 +1,5 @@
+import { withDynamicToolTranscriptDetails } from "./dynamic-tool-response-state.js";
+import { recordCodexDynamicToolResult } from "./dynamic-tool-result-projection.js";
 import {
   describe,
   registerCodexEventProjectorTestLifecycle,
@@ -18,6 +20,39 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector dynamic tool projection", () => {
+  it.each([
+    ["gateway", { ok: true, result: { path: "gateway.port", config: 19_801 } }],
+    ["dashboard", { ok: true, delivered: 0 }],
+    ["memory_search", { ok: true, results: [{ id: "memory-1" }] }],
+  ])("retains structured %s transcript details", async (tool, details) => {
+    const projector = await createProjector();
+    const call = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: `call-${tool}`,
+      namespace: null,
+      tool,
+      arguments: {},
+    };
+    const protocolResponse = {
+      success: true,
+      contentItems: [{ type: "inputText" as const, text: `${tool} done` }],
+    };
+
+    projector.recordDynamicToolCall({ callId: call.callId, tool, arguments: {} });
+    recordCodexDynamicToolResult(
+      projector,
+      call,
+      withDynamicToolTranscriptDetails({ ...protocolResponse }, details),
+      protocolResponse,
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    expect(toolResultMessage).toMatchObject({ role: "toolResult", toolName: tool, details });
+    expect(protocolResponse).not.toHaveProperty("details");
+  });
+
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
     const projector = await createProjector(undefined, {
       resolveDynamicToolResultContentSource: (toolName) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the default Codex harness would silently lose ordinary structured tool-result facts from stored transcripts. The human-readable tool text survived, so audits, UI surfaces, later transcript readers, analytics, and doctor checks could see no structured result even though the same tool retained it under the embedded runtime.

## Why This Change Was Made

Codex app-server intentionally accepts only `contentItems` and `success`; OpenClaw therefore owns transcript-only facts locally. This change retains the complete sanitized `result.details` value in the private runtime response and projects it into the durable `toolResult`, instead of allowlisting only `mcpAppPreview`.

Codex wire bytes and live progress-event bytes remain unchanged: transcript details stay non-enumerable on the app-server response, and progress events still expose only validated MCP App preview/async metadata. Model prompt/cache bytes also remain unchanged because every replay and compaction boundary strips `toolResult.details` before model input.

I considered sharing the embedded `packages/agent-core` tool-result builder. That is the durable long-term shape, but it is not bounded here: embedded owns normal content blocks while Codex deliberately emits a compatibility-shaped content item across the plugin SDK boundary. Follow-up: expose one shared transcript tool-result builder/contract through agent-core + Plugin SDK, migrate both paths, and prove existing content bytes before deleting the Codex-local constructor.

## User Impact

Structured results now survive in Codex transcripts across tool owners, matching the embedded runtime. Operators can reliably inspect facts such as success and delivery counts without parsing prose.

## Evidence

- Pre-fix isolated live gateway, exact `toolResult` SQL:
  - `gateway`: Codex `details_type=NULL, details.ok=NULL`; embedded `details_type=object, details.ok=1`.
  - `dashboard`: identical text `Dashboard command sent to 0 client(s)`; Codex `details_type=NULL`; embedded `details_type=object, ok=1, delivered=0`.
- Post-fix on the same isolated gateway:
  - `gateway`: Codex and embedded both `details_type=object, details.ok=1`.
  - `dashboard`: Codex and embedded both `details_type=object, details.ok=1, delivered=0`, with identical tool-result text.
- Regression proof: the new boundary table failed on pre-fix code for gateway, dashboard, and untouched `memory_search`, each because `message.details` was absent; it passes after the fix.
- `199` focused Codex tests pass across dynamic execution, owner result construction, and transcript projection.
- `12` replay/compaction tests pass, proving details stay outside model-visible prompt/cache input.
- `node scripts/check-changed.mjs` passes.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: `+17/-12` (net `+5`); tests `+40/-2`; assertion-safety baseline `-1`.

Upstream Codex contract checked directly:

- [`DynamicToolCallResponse` contains only `contentItems` and `success`](https://github.com/openai/codex/blob/02e9bfaac7577a3ab77a40de6b0c3cc37b934576/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1560-L1578).
- [app-server forwards exactly those two fields into core](https://github.com/openai/codex/blob/02e9bfaac7577a3ab77a40de6b0c3cc37b934576/codex-rs/app-server/src/dynamic_tools.rs#L37-L52).

Provenance: the MCP-preview-only projection was introduced by @fuller-stack-dev in #113224 (squash `aee46707ba10`, 2026-07-24). That feature correctly preserved MCP previews but made ordinary details loss visible as the broader tool-result contract evolved.
