### PR TITLE
fix(mcp): explain an empty probe instead of printing a bare header

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -297,6 +297,22 @@ describe("mcp cli", () => {
     });
   });
 
+  it("tells the operator how to add a server when probing with none configured", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      mockLog.mockClear();
+
+      await runMcpCommand(["mcp", "probe"]);
+
+      const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(output).toContain("No MCP servers configured in");
+      expect(output).toContain("openclaw mcp add <name> --command <command>");
+      // A bare "MCP probe (<path>):" header was the whole output before this guard.
+      expect(output).not.toMatch(/^MCP probe \(.*\):$/m);
+    });
+  });
+
   it("updates per-server MCP tool filters", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -830,6 +830,15 @@ export function registerMcpCli(program: Command) {
           `MCP server "${name}" is disabled in ${loaded.path}. Run ${formatCliCommand(`openclaw mcp configure ${name} --enable`)} before probing it.`,
         );
       }
+      // Without this the human output is a bare header: both probe loops are empty,
+      // so an operator with no servers sees no outcome and no next step. JSON keeps
+      // emitting its empty envelope so machine consumers see a stable shape.
+      if (!opts.json && Object.keys(servers).length === 0) {
+        defaultRuntime.log(
+          `No MCP servers configured in ${loaded.path}. Add one with ${formatCliCommand("openclaw mcp add <name> --command <command>")}.`,
+        );
+        return;
+      }
       const runtime = createSessionMcpRuntime({
         sessionId: "openclaw-cli-mcp-probe",
         workspaceDir: process.cwd(),


### PR DESCRIPTION
## What Problem This Solves

`openclaw mcp probe` with no MCP servers configured printed one line and stopped:

```
$ openclaw mcp probe
MCP probe (/tmp/ocp-r29/openclaw.json):
# exit 0
```

That is the whole output. Both sibling commands handle the same state by naming the condition and the command that resolves it:

```
$ openclaw mcp list
No OpenClaw-managed MCP servers configured in /tmp/ocp-r29/openclaw.json. Add one with openclaw mcp set <name> '{"command":"uvx","args":["context7-mcp"]}'.

$ openclaw mcp doctor
No MCP servers configured in /tmp/ocp-r29/openclaw.json. Add one with openclaw mcp add <name> --command <command>.
```

An operator who runs `probe` first — a reasonable thing to do when checking whether MCP is working — gets a header, no outcome, and no next step.

## Why This Change Was Made

The header is printed unconditionally, then two loops render servers and diagnostics. With zero servers both loops are empty, so the header is the entire result. There was no bug in the probing logic; the empty case simply had no branch.

This is the doctrine's "every action ends in a visible outcome or a recorded, intentional non-outcome" case, so the fix reuses `mcp doctor`'s exact wording rather than inventing a third phrasing for one condition.

The guard sits before `createSessionMcpRuntime`, so the command also stops constructing a probe runtime and disposing it again to inspect nothing.

`--json` is deliberately untouched: it already emits a well-formed empty envelope (`{"servers":{},"tools":[],"diagnostics":[]}`), and machine consumers should keep seeing a stable shape rather than a message.

## User Impact

`openclaw mcp probe` on a config with no MCP servers now says so and points at `openclaw mcp add`, matching `list` and `doctor`. Exit code stays 0 — this is an empty result, not a failure. Output for configs that do have servers, including the non-zero exit when a probe fails, is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/cli/mcp-cli.test.ts` — 26 pass, including a new case asserting the guidance appears and that the bare `MCP probe (<path>):` header is no longer the whole output.
- I confirmed the test fails without the production change: it reports `expected 'MCP probe (/var/folders/...' to contain 'No MCP servers configured in'`, which is exactly the output I measured on the built CLI.
- Behavior with servers configured re-checked on the built CLI: a broken server still reports `! <name>: spawn ... ENOENT` and exits 1.
