### PR TITLE
refactor(realtime): share audio duration calculation

### DIFF
--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -42,6 +42,7 @@ import {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  realtimeVoiceAudioDurationMs,
   resamplePcm,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { warn } from "openclaw/plugin-sdk/runtime-env";
@@ -693,9 +694,8 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       typeof this.config.silenceDurationMs === "number"
         ? Math.max(0, Math.floor(this.config.silenceDurationMs))
         : DEFAULT_AUDIO_STREAM_END_SILENCE_MS;
-    const bytesPerSample = this.audioFormat.encoding === "pcm16" ? 2 : 1;
     this.consecutiveSilenceMs += Math.round(
-      (audio.length / bytesPerSample / this.audioFormat.sampleRateHz) * 1000,
+      realtimeVoiceAudioDurationMs(this.audioFormat, audio.length),
     );
     if (!this.audioStreamEnded && this.consecutiveSilenceMs >= silenceThresholdMs) {
       this.session.sendRealtimeInput({ audioStreamEnd: true });

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -4,7 +4,10 @@ import type {
   RealtimeVoiceBargeInOptions,
   RealtimeVoiceToolResultOptions,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import {
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+  realtimeVoiceAudioDurationMs,
+} from "openclaw/plugin-sdk/realtime-voice";
 import {
   AZURE_OPENAI_REALTIME_TOOL_NAME_MAX_LENGTH,
   OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS,
@@ -239,14 +242,10 @@ export abstract class OpenAIRealtimeProtocol {
       (this.oldestOutstandingMarkSequence !== null ||
         options?.audioPlaybackActive === true ||
         force);
-    const bytesPerSample = this.audioFormat.encoding === "pcm16" ? 2 : 1;
     const audioEndMs =
       shouldInterruptProvider && assistantAudioItem
         ? Math.min(
-            Math.floor(
-              (assistantAudioItem.bytes * 1000) /
-                (this.audioFormat.sampleRateHz * this.audioFormat.channels * bytesPerSample),
-            ),
+            Math.floor(realtimeVoiceAudioDurationMs(this.audioFormat, assistantAudioItem.bytes)),
             Math.max(0, this.latestMediaTimestamp - assistantAudioItem.startTimestamp),
           )
         : null;

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -72,8 +72,7 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         this.responseActive = true;
         this.responseCreateInFlight = false;
         this.markQueue = [];
-        this.lastAssistantItemId = null;
-        this.responseStartTimestamp = null;
+        this.assistantAudioItem = null;
         this.resetAssistantTranscript();
         return;
       case "response.output_audio.delta": {
@@ -87,12 +86,17 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
             "xAI realtime voice stream returned malformed base64 audio data",
           );
         }
-        this.emitAudioWithPlaybackMark(Buffer.from(canonicalAudio, "base64"));
-        if (event.item_id && event.item_id !== this.lastAssistantItemId) {
-          this.lastAssistantItemId = event.item_id;
-          this.responseStartTimestamp = this.latestMediaTimestamp;
-        } else if (this.responseStartTimestamp === null) {
-          this.responseStartTimestamp = this.latestMediaTimestamp;
+        const audio = Buffer.from(canonicalAudio, "base64");
+        this.emitAudioWithPlaybackMark(audio);
+        if (event.item_id && event.item_id !== this.assistantAudioItem?.itemId) {
+          this.assistantAudioItem = {
+            itemId: event.item_id,
+            bytes: 0,
+            startTimestamp: this.latestMediaTimestamp,
+          };
+        }
+        if (this.assistantAudioItem) {
+          this.assistantAudioItem.bytes += audio.byteLength;
         }
         this.responseActive = true;
         return;

--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -5,7 +5,10 @@ import type {
   RealtimeVoiceSessionConnection,
   RealtimeVoiceToolResultOptions,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import {
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+  realtimeVoiceAudioDurationMs,
+} from "openclaw/plugin-sdk/realtime-voice";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   XAI_REALTIME_DEFAULT_PREFIX_PADDING_MS,
@@ -22,10 +25,15 @@ import {
 
 export class XaiRealtimePlaybackMarkOverflowError extends Error {}
 
+type XaiAssistantAudioItem = {
+  itemId: string;
+  bytes: number;
+  startTimestamp: number;
+};
+
 export abstract class XaiRealtimeVoiceProtocol {
   protected readonly audioFormat: RealtimeVoiceAudioFormat;
   protected markQueue: string[] = [];
-  protected responseStartTimestamp: number | null = null;
   protected responseActive = false;
   protected responseCreateInFlight = false;
   protected responseCancelInFlight = false;
@@ -33,7 +41,7 @@ export abstract class XaiRealtimeVoiceProtocol {
   protected continuingToolCallIds = new Set<string>();
   protected pendingToolCallIds = new Set<string>();
   protected latestMediaTimestamp = 0;
-  protected lastAssistantItemId: string | null = null;
+  protected assistantAudioItem: XaiAssistantAudioItem | null = null;
   protected toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
   protected deliveredToolCallKeys = new Set<string>();
   protected pendingToolResultAcks = new Set<string>();
@@ -101,20 +109,11 @@ export abstract class XaiRealtimeVoiceProtocol {
   }
 
   handleBargeIn(options?: RealtimeVoiceBargeInOptions): void {
-    const assistantItemId = this.lastAssistantItemId;
-    const responseStartTimestamp = this.responseStartTimestamp;
-    const outputInterruptible =
-      responseStartTimestamp !== null &&
+    const assistantAudioItem = this.assistantAudioItem;
+    const shouldInterruptProvider =
+      assistantAudioItem !== null &&
       (this.responseActive || this.markQueue.length > 0 || options?.audioPlaybackActive === true);
-    const shouldInterruptProvider = assistantItemId !== null && outputInterruptible;
-    const audioEndMs = shouldInterruptProvider
-      ? Math.max(
-          0,
-          responseStartTimestamp === null
-            ? this.latestMediaTimestamp
-            : this.latestMediaTimestamp - responseStartTimestamp,
-        )
-      : null;
+    const audioEndMs = shouldInterruptProvider ? this.audioEndMs(assistantAudioItem) : null;
     if (this.responseActive && !this.responseCancelInFlight) {
       this.sendEvent({ type: "response.cancel" }, "reason=barge-in");
       this.responseCancelInFlight = true;
@@ -123,7 +122,7 @@ export abstract class XaiRealtimeVoiceProtocol {
       this.sendEvent(
         {
           type: "conversation.item.truncate",
-          item_id: assistantItemId,
+          item_id: assistantAudioItem.itemId,
           content_index: 0,
           audio_end_ms: audioEndMs,
         },
@@ -131,8 +130,7 @@ export abstract class XaiRealtimeVoiceProtocol {
       );
       this.config.onClearAudio("barge-in");
       this.markQueue = [];
-      this.lastAssistantItemId = null;
-      this.responseStartTimestamp = null;
+      this.assistantAudioItem = null;
       return;
     }
     this.config.onClearAudio("barge-in");
@@ -142,16 +140,13 @@ export abstract class XaiRealtimeVoiceProtocol {
   protected handleServerVadBargeIn(): void {
     // xAI owns server-VAD cancellation, but only the relay knows how much
     // queued audio actually played. Trim provider history to that boundary.
-    if (
-      this.lastAssistantItemId !== null &&
-      this.responseStartTimestamp !== null &&
-      this.markQueue.length > 0
-    ) {
-      const audioEndMs = Math.max(0, this.latestMediaTimestamp - this.responseStartTimestamp);
+    const assistantAudioItem = this.assistantAudioItem;
+    if (assistantAudioItem !== null && this.markQueue.length > 0) {
+      const audioEndMs = this.audioEndMs(assistantAudioItem);
       this.sendEvent(
         {
           type: "conversation.item.truncate",
-          item_id: this.lastAssistantItemId,
+          item_id: assistantAudioItem.itemId,
           content_index: 0,
           audio_end_ms: audioEndMs,
         },
@@ -160,8 +155,13 @@ export abstract class XaiRealtimeVoiceProtocol {
     }
     this.config.onClearAudio("barge-in");
     this.markQueue = [];
-    this.lastAssistantItemId = null;
-    this.responseStartTimestamp = null;
+    this.assistantAudioItem = null;
+  }
+
+  private audioEndMs(item: XaiAssistantAudioItem): number {
+    const producedAudioMs = Math.floor(realtimeVoiceAudioDurationMs(this.audioFormat, item.bytes));
+    const playbackAudioMs = Math.max(0, this.latestMediaTimestamp - item.startTimestamp);
+    return Math.min(producedAudioMs, playbackAudioMs);
   }
 
   protected buildSessionUpdate(): XaiRealtimeSessionUpdate {
@@ -300,12 +300,11 @@ export abstract class XaiRealtimeVoiceProtocol {
 
   protected resetRealtimeSessionState(options: { preserveToolCallState?: boolean } = {}): void {
     this.markQueue = [];
-    this.responseStartTimestamp = null;
     this.responseActive = false;
     this.responseCreateInFlight = false;
     this.responseCancelInFlight = false;
     this.responseCreatePending = false;
-    this.lastAssistantItemId = null;
+    this.assistantAudioItem = null;
     this.resetInputTranscripts();
     if (!options.preserveToolCallState) {
       this.continuingToolCallIds.clear();

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1,5 +1,8 @@
 // Xai tests cover realtime voice provider plugin behavior.
-import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import {
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+  REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+} from "openclaw/plugin-sdk/realtime-voice";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { XAI_REALTIME_MAX_PENDING_PLAYBACK_MARKS } from "./realtime-voice-config.js";
 import { buildXaiRealtimeVoiceProvider } from "./realtime-voice-provider.js";
@@ -892,30 +895,34 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       expectedActions: [],
     },
     {
-      name: "cancels and truncates active response audio on barge-in",
+      name: "clamps manual barge-in to produced G.711 audio",
       hasAudio: true,
       manual: true,
-      timestamp: 1300,
+      audioBytes: 3_700 * 8,
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+      timestamp: 4760,
       expectedActions: [
         { type: "response.cancel" },
         {
           type: "conversation.item.truncate",
           item_id: "item_1",
           content_index: 0,
-          audio_end_ms: 300,
+          audio_end_ms: 3_700,
         },
       ],
     },
     {
-      name: "truncates queued playback on server-VAD barge-in without cancelling xAI",
+      name: "clamps server-VAD barge-in to produced PCM16 audio without cancelling xAI",
       hasAudio: true,
-      timestamp: 1250,
+      audioBytes: 3_700 * 48,
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      timestamp: 4760,
       expectedActions: [
         {
           type: "conversation.item.truncate",
           item_id: "item_1",
           content_index: 0,
-          audio_end_ms: 250,
+          audio_end_ms: 3_700,
         },
       ],
     },
@@ -940,6 +947,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       acknowledged: true,
       completed: true,
       manual: true,
+      audioBytes: 300 * 8,
       timestamp: 1300,
       expectedActions: [
         {
@@ -967,6 +975,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       completed,
       startNewResponse,
       manual,
+      audioBytes,
+      audioFormat,
       timestamp,
       expectedActions,
     }) => {
@@ -974,7 +984,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       const onAudio = vi.fn();
       const onClearAudio = vi.fn();
       const bridge = createTestBridge({
-        audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+        ...(audioFormat ? { audioFormat } : {}),
         onAudio,
         onClearAudio,
       });
@@ -986,7 +996,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
         socket.emitServer({
           type: "response.output_audio.delta",
           item_id: "item_1",
-          delta: Buffer.from("assistant audio").toString("base64"),
+          delta: Buffer.alloc(audioBytes ?? 16).toString("base64"),
         });
       }
       if (acknowledged) {

--- a/src/plugin-sdk/realtime-voice.test.ts
+++ b/src/plugin-sdk/realtime-voice.test.ts
@@ -2,9 +2,37 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createRealtimeVoiceAudioQueue,
   normalizeRealtimeVoiceResponseOutcome,
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+  REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+  realtimeVoiceAudioDurationMs,
   RealtimeVoiceSessionLifecycle,
   type RealtimeVoiceSessionConnection,
 } from "./realtime-voice.js";
+
+describe("realtimeVoiceAudioDurationMs", () => {
+  it.each([
+    {
+      name: "G.711 μ-law 8 kHz mono",
+      format: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+      byteLength: 8_000,
+      durationMs: 1_000,
+    },
+    {
+      name: "PCM16 24 kHz mono",
+      format: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      byteLength: 48_000,
+      durationMs: 1_000,
+    },
+    {
+      name: "one G.711 μ-law sample without rounding",
+      format: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+      byteLength: 1,
+      durationMs: 0.125,
+    },
+  ])("calculates $name", ({ format, byteLength, durationMs }) => {
+    expect(realtimeVoiceAudioDurationMs(format, byteLength)).toBe(durationMs);
+  });
+});
 
 function connectLifecycle(
   lifecycle: RealtimeVoiceSessionLifecycle,

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -28,6 +28,7 @@ export {
   normalizeRealtimeVoiceResponseOutcome,
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+  realtimeVoiceAudioDurationMs,
 } from "../talk/provider-types.js";
 export {
   createTalkEventSequencer,

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -22,6 +22,14 @@ export type RealtimeVoiceAudioFormat =
       channels: 1;
     };
 
+export function realtimeVoiceAudioDurationMs(
+  format: RealtimeVoiceAudioFormat,
+  byteLength: number,
+): number {
+  const bytesPerSample = format.encoding === "pcm16" ? 2 : 1;
+  return (byteLength * 1000) / (format.sampleRateHz * format.channels * bytesPerSample);
+}
+
 export const REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ: RealtimeVoiceAudioFormat = {
   encoding: "g711_ulaw",
   sampleRateHz: 8000,


### PR DESCRIPTION
Historical context: #79980, reported by @rparikh1019.

## What Problem This Solves

Fixes an issue where xAI realtime voice users interrupting assistant audio could send an `audio_end_ms` later than the audio the provider had actually produced. In the captured regression, both manual G.711 interruption and server-VAD PCM16 interruption reported 3760 ms even though only 3700 ms of decoded audio existed. That can make provider conversation history retain an invalid playback boundary.

## Why This Change Was Made

The xAI owner now tracks the active assistant item as its item ID, decoded byte count, and relay start timestamp. Manual and server-VAD interruption clamp the truncation point to the smaller of produced audio duration and elapsed relay playback, while xAI lifecycle, playback-mark, cancellation, and error semantics remain local to that provider.

The exact byte/format duration primitive now lives beside `RealtimeVoiceAudioFormat` and is exported through the existing `openclaw/plugin-sdk/realtime-voice` seam. It returns fractional milliseconds without rounding. OpenAI and xAI apply caller-owned `Math.floor` truncation for provider-safe upper bounds; Google applies caller-owned `Math.round` for silence accumulation. This public helper pays rent immediately across three current providers and removes duplicated codec arithmetic without adding a new SDK subpath.

External contract checks support this boundary: xAI and OpenAI define `audio_end_ms` as milliseconds actually played and accept `conversation.item.truncate`; output deltas carry base64 codec bytes, while completion events carry no duration. Google uses the same byte/format duration primitive for input-silence accounting but retains server-owned interruption behavior.

This does not change voice-call disconnect grace, generalize provider interruption state, or move Google/GPT-Live interruption ownership into the shared helper.

Provenance: the xAI clock-only truncation was introduced/carried by #106267 (`6c5084f1adb39088c19788b8fbe200b9c3c382d9`), authored and merged by @steipete on 2026-07-13 with Vitor Cepeda Lopes as co-author. The equivalent OpenAI invariant was repaired in #125502; this change reuses that invariant and removes duplicated duration math. Current PR author: @steipete.

Production LOC: +57/-46 (net +11). Tests: +47/-9 (net +38). Roughly +4 production lines are the xAI owner repair; the remaining growth establishes and adopts the shared three-consumer SDK contract. No generated tracked file or changelog changed.

## User Impact

xAI realtime voice interruptions now truncate provider history only to audio that could actually have played, avoiding the 3700/3760 mismatch. OpenAI retains its existing safe truncation behavior, and Google retains its existing silence and interruption behavior while all three providers share one exact duration calculation.

## Evidence

- Pre-fix owner regression: 2 failed, 71 passed. Manual G.711 and server-VAD PCM16 both emitted 3760 ms instead of the expected 3700 ms.
- Post-fix lead focused proof: 244 tests passed across Plugin SDK, OpenAI, xAI, and Google. After rebasing onto current `origin/main`, the same seven-file suite passed 245 tests; one routed test was added by intervening main history.
- `node scripts/check-changed.mjs`: passed for core, coreTests, extensions, and extensionTests.
- `pnpm plugin-sdk:surface:check`: passed; 146 public Plugin SDK subpaths verified.
- `pnpm build`: passed; 146 Plugin SDK subpaths verified and no ineffective dynamic imports reported. Only existing dependency EVAL warnings appeared.
- Formatting and `git diff --check` passed before publication; `git diff --check origin/main...HEAD` passed after rebase.
- Authenticated live proof: temporary OpenAI and xAI mid-response probes advanced the transport clock 60 ms beyond decoded G.711 duration and each received `conversation.item.truncated` (2/2 passed). Temporary files were removed and no secret was printed.
- Final integrated Codex-backed autoreview of the eight-file diff: clean, with no accepted/actionable findings. A fresh pre-commit staged-diff autoreview also passed cleanly.
- Rebase was conflict-free and patch-equivalent: stable patch ID remained `7afa5a8be9dae380dd6149eb164436179487f5c8`.

AI-assisted: yes. The author reviewed the implementation, understands the provider ownership boundaries, and verified the change with deterministic and authenticated live evidence.
