### PR TITLE
fix: session archive completes after forced stop

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -102,6 +102,8 @@ const embeddedRunState = resolveGlobalSingleton(EMBEDDED_RUN_STATE_KEY, () => ({
   abandonedRunsBySessionId: new Map<string, AbandonedEmbeddedRun>(),
   abandonedRunSessionIdsByKey: new Map<string, string>(),
   abandonedRunSessionIdsByFile: new Map<string, string>(),
+  // The exact handle owns forced cleanup so a stale session id cannot release a replacement turn.
+  forcedTerminalSettlements: new WeakMap<EmbeddedAgentQueueHandle, () => Promise<void>>(),
   waiters: new Map<string, Set<EmbeddedRunWaiter>>(),
 }));
 
@@ -138,6 +140,12 @@ export const ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_KEY =
 export const ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_FILE =
   embeddedRunState.abandonedRunSessionIdsByFile ??
   (embeddedRunState.abandonedRunSessionIdsByFile = new Map<string, string>());
+export const EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS =
+  embeddedRunState.forcedTerminalSettlements ??
+  (embeddedRunState.forcedTerminalSettlements = new WeakMap<
+    EmbeddedAgentQueueHandle,
+    () => Promise<void>
+  >());
 export const EMBEDDED_RUN_WAITERS =
   embeddedRunState.waiters ??
   (embeddedRunState.waiters = new Map<string, Set<EmbeddedRunWaiter>>());

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -43,6 +43,7 @@ import {
 import { logMessageQueuedWithBacklogPolicy } from "../../logging/diagnostic-runtime.js";
 import { diagnosticLogger as diag, logSessionStateChange } from "../../logging/diagnostic.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
+import { resolveSessionPlacementForcedTerminalSettlement } from "../session-placement-admission.js";
 import {
   ACTIVE_EMBEDDED_RUNS,
   ACTIVE_EMBEDDED_RUNS_BY_RUN_ID,
@@ -52,6 +53,7 @@ import {
   ABANDONED_EMBEDDED_RUNS_BY_SESSION_ID,
   ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_FILE,
   ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_KEY,
+  EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS,
   EMBEDDED_RUN_WAITERS,
   getActiveEmbeddedRunCount,
   RETAINED_EMBEDDED_RUN_ABORTABILITY_RUN_IDS,
@@ -1029,7 +1031,7 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
     const forceCleared =
       params.forceClear === true &&
       ((!expiredReplyRun && stampedStaleReplyRun && !ownerSettled) || !aborted || !drained)
-        ? forceClearEmbeddedAgentRun(
+        ? await forceClearEmbeddedAgentRun(
             params.sessionId,
             embeddedRunHandle,
             replyOperation,
@@ -1191,9 +1193,14 @@ export function setActiveEmbeddedRun(
   if (previousHandle) {
     previousHandle.closeDiagnostics?.();
     clearEmbeddedRunAbortability(previousHandle, { retainFinalizing: true });
+    EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS.delete(previousHandle);
   }
   clearEmbeddedRunAbandonment({ sessionId, sessionKey, sessionFile });
   ACTIVE_EMBEDDED_RUNS.set(sessionId, handle);
+  const forcedTerminalSettlement = resolveSessionPlacementForcedTerminalSettlement();
+  if (forcedTerminalSettlement) {
+    EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS.set(handle, forcedTerminalSettlement);
+  }
   if (handle.runId) {
     ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.set(handle.runId, handle);
   }
@@ -1260,20 +1267,24 @@ export function clearActiveEmbeddedRun(
   } else if (activeHandle !== undefined) {
     diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
   }
+  EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS.delete(handle);
   // Exact-handle waiters own teardown even after another run takes the session slot.
   notifyEmbeddedRunEnded(sessionId, handle);
 }
 
-function forceClearEmbeddedAgentRun(
+async function forceClearEmbeddedAgentRun(
   sessionId: string,
   expectedHandle: EmbeddedAgentQueueHandle | undefined,
   expectedReplyOperation: ReplyOperation | undefined,
   sessionKey?: string,
   reason = "stuck_recovery",
-): boolean {
+): Promise<boolean> {
   let cleared = false;
+  let forcedTerminalSettlement: (() => Promise<void>) | undefined;
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (handle && handle === expectedHandle) {
+    forcedTerminalSettlement = EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS.get(handle);
+    EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS.delete(handle);
     handle.closeDiagnostics?.();
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
     clearEmbeddedRunAbortability(handle);
@@ -1288,15 +1299,22 @@ function forceClearEmbeddedAgentRun(
     cleared = true;
   }
   const cause = new Error(`Embedded run force-cleared by ${reason}`);
-  return (
-    (expectedReplyOperation ? forceClearReplyOperation(expectedReplyOperation, cause) : false) ||
-    cleared
-  );
+  try {
+    return (
+      (expectedReplyOperation ? forceClearReplyOperation(expectedReplyOperation, cause) : false) ||
+      cleared
+    );
+  } finally {
+    await forcedTerminalSettlement?.();
+  }
 }
 
 const testing = {
   persistForceClearedEmbeddedRunTerminalState,
   resetActiveEmbeddedRuns() {
+    for (const handle of ACTIVE_EMBEDDED_RUNS.values()) {
+      EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS.delete(handle);
+    }
     for (const waiters of EMBEDDED_RUN_WAITERS.values()) {
       for (const waiter of waiters) {
         if (waiter.timer) {

--- a/src/agents/session-placement-admission.ts
+++ b/src/agents/session-placement-admission.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { RunEmbeddedAgentParams } from "./embedded-agent-runner/run/params.js";
@@ -45,6 +46,24 @@ const state = resolveGlobalSingleton(
   Symbol.for("openclaw.sessionPlacementAdmissionState"),
   (): SessionPlacementAdmissionState => ({}),
 );
+// Carry exact local-turn cleanup until the embedded handle captures it; never recover by session id.
+const forcedTerminalSettlement = resolveGlobalSingleton(
+  Symbol.for("openclaw.sessionPlacementForcedTerminalSettlement"),
+  () => new AsyncLocalStorage<() => Promise<void>>(),
+);
+
+export function withSessionPlacementForcedTerminalSettlement<T>(
+  settle: () => Promise<void>,
+  task: () => Promise<T>,
+): Promise<T> {
+  return forcedTerminalSettlement.run(settle, task);
+}
+
+export function resolveSessionPlacementForcedTerminalSettlement():
+  | (() => Promise<void>)
+  | undefined {
+  return forcedTerminalSettlement.getStore();
+}
 
 export function installSessionPlacementAdmissionProvider(
   provider: SessionPlacementAdmissionProvider,

--- a/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
@@ -6,6 +6,7 @@ import {
   prepareAgentRunAdmission,
 } from "../../agents/admitted-run-context.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { clearRuntimeConfigSnapshot } from "../../config/io.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import {
@@ -78,6 +79,7 @@ export async function setupWorkerTurnLauncherTest(): Promise<void> {
 export async function cleanupWorkerTurnLauncherTest(): Promise<void> {
   cleanupAdmissionSink?.();
   cleanupAdmissionSink = undefined;
+  clearRuntimeConfigSnapshot();
   closeOpenClawStateDatabaseForTest();
   resetAgentEventsForTest();
   await testState.cleanup();

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -1,7 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WORKER_LAUNCH_V2_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
-import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import {
+  abortAndDrainEmbeddedAgentRun,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
+import { setRuntimeConfigSnapshot } from "../../config/io.js";
+import {
+  loadSessionEntry,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { createChatRunState } from "../server-chat-state.js";
+import { prepareSessionArchiveLifecycle } from "../server-methods/sessions-archive-lifecycle.js";
+import type { GatewayRequestContext } from "../server-methods/types.js";
 import type { WorkerTunnelHandle } from "./tunnel-contract.js";
 import {
   ENVIRONMENT_ID,
@@ -207,6 +218,126 @@ describe("worker turn launcher local placement", () => {
 
     releaseSecond.resolve();
     await second;
+    expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+  });
+
+  it("releases a force-cleared embedded turn for archive without clearing its replacement", async () => {
+    const startedAt = Date.now() - 60_000;
+    setRuntimeConfigSnapshot({ session: { store: sessionTarget.storePath } });
+    await upsertSessionEntryCore(sessionTarget, {
+      sessionId: SESSION_ID,
+      startedAt,
+      status: "running",
+      updatedAt: startedAt,
+    });
+    const runningEntry = loadSessionEntry(sessionTarget);
+    expect(runningEntry).toMatchObject({
+      sessionId: SESSION_ID,
+      startedAt,
+      status: "running",
+      updatedAt: expect.any(Number),
+    });
+    if (!runningEntry) {
+      throw new Error("expected running session entry");
+    }
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments: unusedEnvironments(),
+      placements,
+    });
+    const oldRunStarted = createDeferred();
+    const finishOldRun = createDeferred();
+    const replacementStarted = createDeferred();
+    const finishReplacement = createDeferred();
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    };
+
+    const oldRun = provider.executeLocalTurn(
+      {
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        agentId: "main",
+        runId: "run-force-cleared",
+      },
+      async () => {
+        setActiveEmbeddedRun(SESSION_ID, handle, SESSION_KEY);
+        oldRunStarted.resolve();
+        await finishOldRun.promise;
+      },
+    );
+    await oldRunStarted.promise;
+    const oldClaimId = placements.get(SESSION_ID)?.turnClaim?.claimId;
+    expect(oldClaimId).toBeTruthy();
+
+    await expect(
+      abortAndDrainEmbeddedAgentRun({
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        settleMs: 100,
+        forceClear: true,
+        reason: "stuck_recovery",
+      }),
+    ).resolves.toMatchObject({ forceCleared: true });
+    const killedEntry = loadSessionEntry(sessionTarget);
+    expect(killedEntry).toMatchObject({
+      sessionId: SESSION_ID,
+      status: "killed",
+      abortedLastRun: true,
+    });
+    expect(killedEntry?.updatedAt).toBeGreaterThan(runningEntry.updatedAt);
+
+    const context = {
+      agentRunSeq: new Map(),
+      broadcast: vi.fn(),
+      cancelRunBoundApprovals: vi.fn(),
+      chatAbortControllers: new Map(),
+      chatQueuedTurns: new Map(),
+      chatRunState: createChatRunState(),
+      dedupe: new Map(),
+      getRuntimeConfig: () => ({}),
+      logGateway: { warn: vi.fn() },
+      nodeSendToSession: vi.fn(),
+      removeChatRun: vi.fn(),
+      workerSessionPlacementService: placements,
+    } as unknown as GatewayRequestContext;
+    const archiveDrain = await prepareSessionArchiveLifecycle({
+      context,
+      storePath: sessionTarget.storePath,
+      sessionKeys: [SESSION_KEY],
+      sessionId: SESSION_ID,
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+      lifecycleIdentities: [SESSION_KEY, SESSION_ID],
+    });
+    expect(archiveDrain.hasAuthoritativeWork()).toBe(false);
+    archiveDrain.release();
+
+    const replacement = provider.executeLocalTurn(
+      {
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        agentId: "main",
+        runId: "run-replacement",
+      },
+      async () => {
+        replacementStarted.resolve();
+        await finishReplacement.promise;
+      },
+    );
+    await replacementStarted.promise;
+    const replacementClaimId = placements.get(SESSION_ID)?.turnClaim?.claimId;
+    expect(replacementClaimId).toBeTruthy();
+    expect(replacementClaimId).not.toBe(oldClaimId);
+
+    finishOldRun.resolve();
+    await oldRun;
+    expect(placements.get(SESSION_ID)?.turnClaim?.claimId).toBe(replacementClaimId);
+
+    finishReplacement.resolve();
+    await replacement;
     expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
   });
 

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -2,10 +2,11 @@ import { randomUUID } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { mapThinkingLevelForProvider } from "../../agents/embedded-agent-runner/utils.js";
 import type { SandboxContext } from "../../agents/sandbox/types.js";
-import type {
-  LocalTurnPlacementClaim,
-  SessionPlacementAdmissionProvider,
-  SessionPlacementTurnParams,
+import {
+  withSessionPlacementForcedTerminalSettlement,
+  type LocalTurnPlacementClaim,
+  type SessionPlacementAdmissionProvider,
+  type SessionPlacementTurnParams,
 } from "../../agents/session-placement-admission.js";
 import { convertToLlm } from "../../agents/sessions/messages.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
@@ -84,10 +85,13 @@ async function executeLocalTurn<T>(params: {
     runId: params.claim.runId,
     owner: { kind: "local" },
   });
+  // Forced terminalization and ordinary completion share this exact-claim closure.
+  // Replacement fencing makes a late finally harmless after recovery settles it.
+  const settle = () => releaseClaimIfOwned(params.placements, turnClaim);
   try {
-    return await params.runLocal();
+    return await withSessionPlacementForcedTerminalSettlement(settle, params.runLocal);
   } finally {
-    await releaseClaimIfOwned(params.placements, turnClaim);
+    await settle();
   }
 }
 


### PR DESCRIPTION
Closes #125555

## What Problem This Solves

Fixes an issue where operators stopping a workspace-backed session could be unable to archive it when the embedded run required forced terminalization. The session appeared killed and had no remaining process, but its durable local turn claim remained active, so every archive attempt returned “did not finish stopping; retry the archive.”

## Why This Change Was Made

Forced terminalization now invokes the exact claim-settlement closure captured by the local turn owner and bound to the authoritative embedded-run handle. Normal completion and forced recovery share that idempotent, replacement-fenced cleanup path; archive remains a consumer of authoritative lifecycle state and does not gain a stale-claim bypass.

The regression composes the real SQLite placement store, a deliberately unresolved local run, forced killed-state persistence, archive drain, replacement claim acquisition, and late completion of the old run.

AI-assisted implementation; maintainer reviewed the complete diff and behavior.

## User Impact

Stopped sessions no longer remain permanently unarchivable after a forced stop. Transcripts and worktrees keep their existing preservation behavior, while stale local execution authority is released at its owning lifecycle boundary.

## Evidence

Before (live managed Gateway, redacted):
- `chat.abort` succeeded.
- `sessions.patch` failed twice with `Timed out waiting for session <id> turn claim release` and the user-visible retry error.
- The lane exceeded its abort grace and the session persisted as killed.
- Later inspection showed no process in the worktree and a clean tree, but the original local placement claim was still durable.

Regression proof:
- The new composed regression failed on pre-fix `main` for the intended reason: `Timed out waiting for session session-worker-turn turn claim release`.
- `node scripts/run-vitest.mjs` across 11 lifecycle/worker-turn files: 108 tests passed.
- Focused source-blind behavior validation ran the composed scenario twice: both runs passed.
- `node scripts/check-changed.mjs -- <six changed paths>` passed core and core-test lanes, including typecheck, lint, import cycles, and database guards.
- `pnpm build` passed; no ineffective dynamic-import warning was introduced.
- Fresh Codex autoreview at P0/P1: no accepted/actionable findings.
- `git diff --check` passed.

Proof boundary:
- The original failure was observed live. Post-fix live Gateway reproduction was not repeated because deterministically triggering it requires intentionally wedging an internal run beyond abort grace; the after-proof uses the real SQLite placement/archive owner boundary rather than a mocked claim.

LOC classification:
- Production: +62/-13 (net +49), required for the closure-bound exact-authority seam across the local-turn and embedded-run owners.
- Tests/test support: +134/-1 (net +133).
