### PR TITLE
fix(test): name Vitest unhandled errors instead of burying them

### DIFF
--- a/scripts/lib/vitest-unhandled-errors.mts
+++ b/scripts/lib/vitest-unhandled-errors.mts
@@ -3,7 +3,7 @@ const ANSI_CSI_SUFFIX_RE = /^[0-?]*[ -/]*[@-~]/u;
 const UNHANDLED_COUNT_RE = /Vitest caught (\d+) unhandled errors? during the test run\./u;
 const UNHANDLED_ORIGIN_RE = /This error originated in "([^"\r\n]+)" test file\./u;
 
-export type VitestUnhandledErrors = {
+type VitestUnhandledErrors = {
   count: number;
   errorFirstLine?: string;
   origin?: string;
@@ -87,7 +87,7 @@ export function createVitestUnhandledErrorDetector() {
   return { observe, finish };
 }
 
-export function formatVitestUnhandledErrorSummary(result: VitestUnhandledErrors): string {
+function formatVitestUnhandledErrorSummary(result: VitestUnhandledErrors): string {
   const details = [result.origin, result.errorFirstLine].filter((value) => value !== undefined);
   const suffix = details.length > 0 ? `: ${details.join(" — ")}` : "";
   return `[vitest] UNHANDLED ERRORS (${result.count})${suffix}`;

--- a/scripts/lib/vitest-unhandled-errors.mts
+++ b/scripts/lib/vitest-unhandled-errors.mts
@@ -1,0 +1,106 @@
+const ANSI_CSI_PREFIX = `${String.fromCharCode(27)}[`;
+const ANSI_CSI_SUFFIX_RE = /^[0-?]*[ -/]*[@-~]/u;
+const UNHANDLED_COUNT_RE = /Vitest caught (\d+) unhandled errors? during the test run\./u;
+const UNHANDLED_ORIGIN_RE = /This error originated in "([^"\r\n]+)" test file\./u;
+
+export type VitestUnhandledErrors = {
+  count: number;
+  errorFirstLine?: string;
+  origin?: string;
+};
+
+export function stripVitestAnsi(value: string): string {
+  return value
+    .split(ANSI_CSI_PREFIX)
+    .map((segment, index) => (index === 0 ? segment : segment.replace(ANSI_CSI_SUFFIX_RE, "")))
+    .join("");
+}
+
+function isVitestErrorBanner(line: string): boolean {
+  if (!line.includes("⎯")) {
+    return false;
+  }
+  const label = line.replaceAll("⎯", "").trim();
+  return label.length > 0 && label !== "Unhandled Errors";
+}
+
+function escapeWorkflowCommandData(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+export function createVitestUnhandledErrorDetector() {
+  let buffered = "";
+  let sawUnhandledBanner = false;
+  let count: number | undefined;
+  let awaitingErrorFirstLine = false;
+  let errorFirstLine: string | undefined;
+  let origin: string | undefined;
+
+  const inspectLine = (rawLine: string) => {
+    const line = stripVitestAnsi(rawLine).trim();
+    if (!sawUnhandledBanner) {
+      sawUnhandledBanner = line.includes("Unhandled Errors");
+      return;
+    }
+
+    if (count === undefined) {
+      const match = UNHANDLED_COUNT_RE.exec(line);
+      const parsed = match?.[1] ? Number(match[1]) : Number.NaN;
+      if (Number.isSafeInteger(parsed) && parsed > 0) {
+        count = parsed;
+      }
+      return;
+    }
+
+    if (errorFirstLine === undefined) {
+      if (isVitestErrorBanner(line)) {
+        awaitingErrorFirstLine = true;
+        return;
+      }
+      if (awaitingErrorFirstLine && line.length > 0) {
+        errorFirstLine = line;
+      }
+    }
+
+    origin ??= UNHANDLED_ORIGIN_RE.exec(line)?.[1];
+  };
+
+  const observe = (output: string): void => {
+    buffered += output;
+    while (true) {
+      const newlineIndex = buffered.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+      inspectLine(buffered.slice(0, newlineIndex));
+      buffered = buffered.slice(newlineIndex + 1);
+    }
+  };
+  const finish = (): VitestUnhandledErrors | null => {
+    if (buffered.length > 0) {
+      inspectLine(buffered);
+      buffered = "";
+    }
+    return count === undefined ? null : { count, errorFirstLine, origin };
+  };
+
+  return { observe, finish };
+}
+
+export function formatVitestUnhandledErrorSummary(result: VitestUnhandledErrors): string {
+  const details = [result.origin, result.errorFirstLine].filter((value) => value !== undefined);
+  const suffix = details.length > 0 ? `: ${details.join(" — ")}` : "";
+  return `[vitest] UNHANDLED ERRORS (${result.count})${suffix}`;
+}
+
+export function writeVitestUnhandledErrorSummary(
+  result: VitestUnhandledErrors,
+  env: NodeJS.ProcessEnv = process.env,
+  log: (message: string) => void = console.error,
+): void {
+  const summary = formatVitestUnhandledErrorSummary(result);
+  if (env.GITHUB_ACTIONS === "true") {
+    log(`::error::${escapeWorkflowCommandData(summary)}`);
+  }
+  log(summary);
+}

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -20,6 +20,11 @@ import { signalExitCode } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { spawnTestProjectsRunner } from "./lib/test-projects-delegation.mts";
 import { resolveVitestProcessEnv } from "./lib/vitest-process-env.mts";
+import {
+  createVitestUnhandledErrorDetector,
+  stripVitestAnsi,
+  writeVitestUnhandledErrorSummary,
+} from "./lib/vitest-unhandled-errors.mts";
 import { spawnPnpmRunner, type PnpmRunnerParams } from "./pnpm-runner.mts";
 import {
   createVitestProcessCompletion,
@@ -48,8 +53,6 @@ type VitestOutputTarget = {
   write(chunk: string): unknown;
 };
 
-const ANSI_CSI_PREFIX = `${String.fromCharCode(27)}[`;
-const ANSI_CSI_SUFFIX_RE = /^[0-?]*[ -/]*[@-~]/u;
 const SUPPRESSED_VITEST_STDERR_PATTERNS = ["[PLUGIN_TIMINGS]"];
 /** Default watchdog timeout for Vitest runs that stop producing output. */
 const DEFAULT_VITEST_NO_OUTPUT_TIMEOUT_MS = 120_000;
@@ -634,10 +637,7 @@ export function resolveVitestSpawnParams(
  * Filters known noisy Vitest stderr lines after stripping ANSI escapes.
  */
 export function shouldSuppressVitestStderrLine(line: string): boolean {
-  const normalizedLine = line
-    .split(ANSI_CSI_PREFIX)
-    .map((segment, index) => (index === 0 ? segment : segment.replace(ANSI_CSI_SUFFIX_RE, "")))
-    .join("");
+  const normalizedLine = stripVitestAnsi(line);
   return SUPPRESSED_VITEST_STDERR_PATTERNS.some((pattern) => normalizedLine.includes(pattern));
 }
 
@@ -1185,12 +1185,20 @@ function forwardVitestOutput(
   stream: VitestOutputStream | null,
   target: VitestOutputTarget,
   shouldSuppressLine: (line: string) => boolean = () => false,
-): void {
+  observeLine: (line: string) => void = () => {},
+): Promise<void> {
   if (!stream) {
-    return;
+    return Promise.resolve();
   }
 
   let buffered = "";
+  const forwardLine = (line: string) => {
+    if (shouldSuppressLine(line)) {
+      return;
+    }
+    observeLine(line);
+    target.write(line);
+  };
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => {
     buffered += chunk;
@@ -1201,15 +1209,16 @@ function forwardVitestOutput(
       }
       const line = buffered.slice(0, newlineIndex + 1);
       buffered = buffered.slice(newlineIndex + 1);
-      if (!shouldSuppressLine(line)) {
-        target.write(line);
-      }
+      forwardLine(line);
     }
   });
-  stream.on("end", () => {
-    if (buffered.length > 0 && !shouldSuppressLine(buffered)) {
-      target.write(buffered);
-    }
+  return new Promise((resolve) => {
+    stream.on("end", () => {
+      if (buffered.length > 0) {
+        forwardLine(buffered);
+      }
+      resolve();
+    });
   });
 }
 
@@ -1266,18 +1275,35 @@ export function spawnWatchedVitestProcess({
       });
     },
   });
-  forwardVitestOutput(child.stdout, process.stdout);
-  forwardVitestOutput(child.stderr, process.stderr, shouldSuppressVitestStderrLine);
+  const unhandledErrors = createVitestUnhandledErrorDetector();
+  const forwardedOutput = Promise.all([
+    forwardVitestOutput(child.stdout, process.stdout, undefined, unhandledErrors.observe),
+    forwardVitestOutput(
+      child.stderr,
+      process.stderr,
+      shouldSuppressVitestStderrLine,
+      unhandledErrors.observe,
+    ),
+  ]);
 
   const teardown = () => {
     teardownChildCleanup();
     teardownNoOutputWatchdog();
   };
-  const completion = createVitestProcessCompletion({
-    child,
-    detached: spawnParams.detached === true,
-  })
-    .then(({ code, signal }) => ({ code, signal: normalizeNodeSignal(signal) }))
+  const completion = Promise.all([
+    createVitestProcessCompletion({
+      child,
+      detached: spawnParams.detached === true,
+    }),
+    forwardedOutput,
+  ])
+    .then(([{ code, signal }]) => {
+      const result = unhandledErrors.finish();
+      if (result) {
+        writeVitestUnhandledErrorSummary(result, env);
+      }
+      return { code, signal: normalizeNodeSignal(signal) };
+    })
     .finally(teardown);
 
   return {

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -11,6 +11,10 @@ import {
   resolveTestProjectsRunnerSpawnParams,
 } from "../../scripts/lib/test-projects-delegation.mts";
 import {
+  createVitestUnhandledErrorDetector,
+  writeVitestUnhandledErrorSummary,
+} from "../../scripts/lib/vitest-unhandled-errors.mts";
+import {
   DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS,
   DEFAULT_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS,
   TOOLING_EXCLUDED_TESTS,
@@ -1035,6 +1039,63 @@ describe("scripts/run-vitest", () => {
       ),
     ).toBe(true);
     expect(shouldSuppressVitestStderrLine("real failure output\n")).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "plain output",
+      output: [
+        "⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯",
+        "Vitest caught 1 unhandled error during the test run.",
+        "⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯",
+        "TypeError: request failed",
+      ].join("\n"),
+      expected: { count: 1, errorFirstLine: "TypeError: request failed", origin: undefined },
+    },
+    {
+      name: "ANSI-colored output with an origin",
+      output: [
+        "\u001b[41m⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯\u001b[0m",
+        "\u001b[31mVitest caught 2 unhandled errors during the test run.\u001b[0m",
+        "\u001b[41m⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯\u001b[0m",
+        "\u001b[31mReferenceError: ResizeObserver is not defined\u001b[0m",
+        'This error originated in "src/app/app-host.dock-suppression.test.ts" test file.',
+      ].join("\n"),
+      expected: {
+        count: 2,
+        errorFirstLine: "ReferenceError: ResizeObserver is not defined",
+        origin: "src/app/app-host.dock-suppression.test.ts",
+      },
+    },
+    {
+      name: "ordinary test output",
+      output: "✓ unit src/app/app-host.dock-suppression.test.ts (1 test)\n",
+      expected: null,
+    },
+  ])("detects unhandled errors in $name", ({ output, expected }) => {
+    const detector = createVitestUnhandledErrorDetector();
+    detector.observe(output);
+
+    expect(detector.finish()).toEqual(expected);
+  });
+
+  it("only emits a workflow annotation under GitHub Actions", () => {
+    const result = {
+      count: 2,
+      origin: "src/app/app-host.dock-suppression.test.ts",
+      errorFirstLine: "ReferenceError: ResizeObserver is not defined",
+    };
+    const localLog = vi.fn();
+    const actionsLog = vi.fn();
+
+    writeVitestUnhandledErrorSummary(result, {}, localLog);
+    writeVitestUnhandledErrorSummary(result, { GITHUB_ACTIONS: "true" }, actionsLog);
+
+    const summary =
+      "[vitest] UNHANDLED ERRORS (2): src/app/app-host.dock-suppression.test.ts — ReferenceError: ResizeObserver is not defined";
+    expect(localLog).toHaveBeenCalledOnce();
+    expect(localLog).toHaveBeenCalledWith(summary);
+    expect(actionsLog.mock.calls).toEqual([[`::error::${summary}`], [summary]]);
   });
 
   it("kills silent vitest runs after the configured idle timeout", () => {


### PR DESCRIPTION
## What Problem This Solves

PR #125480 fixed a real production defect — `browser-panel.ts` constructed its `ResizeObserver` in a
class-field initializer, so the element threw on upgrade in jsdom. It reddened `main`'s `checks-ui` shard
intermittently for days, and to everyone who saw it, it looked like a flaky test. The reason is the shape of
the failure:

```
✓ unit src/app/app-host.dock-suppression.test.ts (1 test)
⎯⎯ Unhandled Errors ⎯⎯
Vitest caught 2 unhandled errors during the test run.
ReferenceError: ResizeObserver is not defined
```

Every test passes; the run fails anyway. In a CI summary that reads as noise, and diagnosing it took pulling
raw job logs through `gh api` because `gh run view --log-failed` returned nothing useful. A defect that
presents as noise gets rerun, not fixed — which is exactly what happened, repeatedly.

## Why This Change Was Made

Vitest already fails these runs; what was missing was legibility. The wrapper now detects the
unhandled-errors section in forwarded output and ends the run with a single line naming the count, the
originating test file, and the error:

```
[vitest] UNHANDLED ERRORS (1): test/scripts/…proof.test.ts — ReferenceError: proofUndefinedGlobal is not defined
[vitest] FAILED (exit 1)
```

Under GitHub Actions it also emits the same text as a `::error::` annotation, so it lands in the job summary
instead of scrollback. That matches the wrapper's established contract that a failing run ends with one
final `[tool] FAILED (exit N)` line, and reuses the existing ANSI stripping rather than adding a second
parser.

Exit codes are deliberately untouched in both directions: this cannot make a passing run fail or a failing
run pass. It only changes what you can see.

## User Impact

None at runtime — tooling only. Maintainers get a named cause instead of a wall of green checkmarks and an
unexplained red run.

## Evidence

Proven end to end, not just against synthetic strings: a throwaway test that triggers a genuine unhandled
error was run through the wrapper, producing the output quoted above, then deleted (the tree is clean and the
file is confirmed absent). Unit coverage exercises the detector against forwarded output with and without an
unhandled-errors section, including ANSI-coloured input.

```
focused wrapper tests: 101 passed
proof run exited 1; normal run exited 0   (exit behavior preserved)
```

`pnpm check:changed` exit 0; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: tooling `+154 / −22` (net **+132**), tests `+61 / −0`. No product
code is touched. The growth is a new `scripts/lib/vitest-unhandled-errors.mts` detector plus its wiring; it
buys a failure mode that currently costs multiple people multiple reruns to identify.

No `CHANGELOG.md` edit — release-only per repo policy; tooling change.
