### PR TITLE
fix(ui): keep shared-worker chat tests isolated

### DIFF
--- a/ui/src/pages/chat/tool-stream-fallback.node.test.ts
+++ b/ui/src/pages/chat/tool-stream-fallback.node.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   agentEvent,
   createHost,
@@ -41,16 +41,21 @@ function requireFallbackStatus(host: ReturnType<typeof createHost>): FallbackSta
 }
 
 describe("app-tool-stream fallback lifecycle handling", () => {
-  beforeEach(() => {
-    vi.useRealTimers();
-  });
+  const globalWithWindow = globalThis as typeof globalThis & {
+    window?: Window & typeof globalThis;
+  };
+  let installedTestWindow = false;
 
   beforeAll(() => {
-    const globalWithWindow = globalThis as typeof globalThis & {
-      window?: Window & typeof globalThis;
-    };
     if (!globalWithWindow.window) {
       globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+      installedTestWindow = true;
+    }
+  });
+
+  afterAll(() => {
+    if (installedTestWindow) {
+      Reflect.deleteProperty(globalWithWindow, "window");
     }
   });
 

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 import {
   agentEvent,
@@ -14,12 +14,21 @@ import {
   type ToolStreamEntry,
 } from "./tool-stream.ts";
 
+const globalWithWindow = globalThis as typeof globalThis & {
+  window?: Window & typeof globalThis;
+};
+let installedTestWindow = false;
+
 beforeAll(() => {
-  const globalWithWindow = globalThis as typeof globalThis & {
-    window?: Window & typeof globalThis;
-  };
   if (!globalWithWindow.window) {
     globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+    installedTestWindow = true;
+  }
+});
+
+afterAll(() => {
+  if (installedTestWindow) {
+    Reflect.deleteProperty(globalWithWindow, "window");
   }
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where shared-worker Control UI test runs could fail intermittently during collection after either Node-environment tool-stream suite ran before another chat suite. Both producers installed `globalThis.window = globalThis` without cleanup; because the UI Vitest lane uses `isolate: false`, a later import of `session-snapshot-invalidation-events.ts` saw a truthy but incomplete `window` and threw `TypeError: window.addEventListener is not a function`.

Related archive and GitHub searches found no existing issue or PR for this specific window-global pollution failure.

## Why This Change Was Made

Each producer suite now records whether it installed the synthetic `window` alias and deletes only its owned alias in `afterAll`, restoring the shared global state at the producer boundary. No guard was added to `session-snapshot-invalidation-events.ts`, because accepting a malformed browser global at the consumer would mask the lifecycle leak. While consolidating the fallback suite's lifecycle hooks, this also removes its duplicate real-timer reset.

The leak was introduced by squash commit 0406e663691612d5dd88584d93de5d371a8141e1 from #113266 on 2026-07-27 and later carried into both current files by the file split. The blamed code and PR author was Peter Lee (@xialonglee); the merger and committer was Peter Steinberger (@steipete). This was a manual maintainer merge, not bot automerge.

AI-assisted. The resulting patch received a fresh Codex autoreview with no accepted or actionable findings and a correctness assessment of 0.99. No agent transcript is included.

## User Impact

There is no user-visible runtime behavior change. This restores deterministic isolation for the Control UI test lane and prevents intermittent local and CI collection failures caused by shared global state.

Production LOC: +0/-0. Tests: +25/-11 (net +14).

## Evidence

Pre-fix deterministic reproduction used one worker with each producer followed by `ui/src/pages/chat/chat-gateway.abort-diagnostic.test.ts`. Both producer orderings independently failed during collection with the exact `TypeError: window.addEventListener is not a function`.

Post-fix exact shared-worker proof:

- `tool-stream.node.test.ts` + `chat-gateway.abort-diagnostic.test.ts`: 27/27 passed
- `tool-stream-fallback.node.test.ts` + `chat-gateway.abort-diagnostic.test.ts`: 31/31 passed
- Both producers + consumer: 52/52 passed

Full Control UI lane:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts`
- 649 files passed, 10 skipped; 9,302 tests passed, 50 skipped; 184.39s

Changed gate and hygiene:

- `node scripts/check-changed.mjs -- ui/src/pages/chat/tool-stream.node.test.ts ui/src/pages/chat/tool-stream-fallback.node.test.ts` passed
- `oxfmt` passed
- `git diff --check` passed
- Fresh Codex autoreview: clean, no accepted/actionable findings; patch correct 0.99
