### PR TITLE
test(release): preserve Codex follow-through finality

### DIFF
--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -59,6 +59,14 @@ if [[ -z "$BINDING_STORE_CONTRACT" ]]; then
     BINDING_STORE_CONTRACT="legacy-sidecar"
   fi
 fi
+if grep -q \
+  'continuesSourceReplyProgress' \
+  "$CANDIDATE_ROOT/extensions/codex/src/app-server/dynamic-tools.ts" 2>/dev/null; then
+  FOLLOWTHROUGH_PROGRESS_FINAL_MODE="explicit"
+else
+  # Frozen candidates continue after omitted finality; current candidates require false.
+  FOLLOWTHROUGH_PROGRESS_FINAL_MODE="legacy"
+fi
 run_log=""
 
 cleanup() {
@@ -197,6 +205,7 @@ if ! docker_e2e_run_with_harness \
   -e OPENCLAW_CODEX_NPM_PLUGIN_REGISTRY_TARBALL="$CODEX_PLUGIN_REGISTRY_TARBALL" \
   -e OPENCLAW_CODEX_NPM_PLUGIN_REGISTRY_VERSION="$CODEX_PLUGIN_REGISTRY_VERSION" \
   -e OPENCLAW_CODEX_NPM_PLUGIN_BINDING_STORE_CONTRACT="$BINDING_STORE_CONTRACT" \
+  -e OPENCLAW_CODEX_NPM_PLUGIN_FOLLOWTHROUGH_PROGRESS_FINAL_MODE="$FOLLOWTHROUGH_PROGRESS_FINAL_MODE" \
   -e OPENCLAW_CODEX_NPM_PLUGIN_SESSION_STORE_CONTRACT="$SESSION_STORE_CONTRACT" \
   -e "OPENCLAW_CODEX_NPM_PLUGIN_ASSERT_MAX_TEXT_FILE_BYTES=$ASSERT_MAX_TEXT_FILE_BYTES" \
   -e "OPENCLAW_CODEX_NPM_PLUGIN_ASSERT_MAX_ERROR_TAIL_BYTES=$ASSERT_MAX_ERROR_TAIL_BYTES" \
@@ -446,10 +455,23 @@ printf 'qa_beta=violet-%s\n' "$FOLLOWTHROUGH_SUFFIX" >"$FOLLOWTHROUGH_WORKSPACE/
 printf 'qa_gamma=silver-%s\n' "$FOLLOWTHROUGH_SUFFIX" >"$FOLLOWTHROUGH_WORKSPACE/FOLLOWTHROUGH_GAMMA.md"
 rm -f "$FOLLOWTHROUGH_ARTIFACT"
 
+case "${OPENCLAW_CODEX_NPM_PLUGIN_FOLLOWTHROUGH_PROGRESS_FINAL_MODE:?missing follow-through final mode}" in
+  explicit)
+    FOLLOWTHROUGH_PROGRESS_INSTRUCTION="with final=false"
+    ;;
+  legacy)
+    FOLLOWTHROUGH_PROGRESS_INSTRUCTION="without passing final"
+    ;;
+  *)
+    echo "invalid follow-through final mode: $OPENCLAW_CODEX_NPM_PLUGIN_FOLLOWTHROUGH_PROGRESS_FINAL_MODE" >&2
+    exit 1
+    ;;
+esac
+
 FOLLOWTHROUGH_PROMPT="$(cat <<PROMPT
 Live release follow-through check.
 
-First call message(action=send) with final=false and send exactly
+First call message(action=send) $FOLLOWTHROUGH_PROGRESS_INSTRUCTION and send exactly
 $FOLLOWTHROUGH_PROGRESS_MARKER to this conversation. Make this progress send
 your only tool call in this step,
 and wait for its result before calling any other tool.

--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -449,9 +449,9 @@ rm -f "$FOLLOWTHROUGH_ARTIFACT"
 FOLLOWTHROUGH_PROMPT="$(cat <<PROMPT
 Live release follow-through check.
 
-First call message(action=send) without passing final and send exactly
-$FOLLOWTHROUGH_PROGRESS_MARKER to this conversation. The final field must be
-omitted, not false. Make this progress send your only tool call in this step,
+First call message(action=send) with final=false and send exactly
+$FOLLOWTHROUGH_PROGRESS_MARKER to this conversation. Make this progress send
+your only tool call in this step,
 and wait for its result before calling any other tool.
 
 Only after that send succeeds, read FOLLOWTHROUGH_ALPHA.md,

--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -662,9 +662,9 @@ function assertFollowthroughTranscript({ transcriptEvents, progressMarker, compl
         call.text !== expected[index] ||
         call.args.action !== "send" ||
         // Extended-stable candidates can predate this optional Codex control.
-        // A successful ordered completion send is valid evidence; `false` is not.
+        // Current progress sends use `false`; completion may omit it or use `true`.
         (index === 0
-          ? call.args.final !== undefined
+          ? call.args.final !== undefined && call.args.final !== false
           : call.args.final !== undefined && call.args.final !== true),
     )
   ) {

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -893,8 +893,21 @@ describe("Codex install helpers", () => {
     expect(result.stderr).toBe("");
   });
 
+  it("accepts explicit progress and completion final controls", () => {
+    const root = makeTempDir(tempDirs, "openclaw-codex-npm-followthrough-explicit-finals-");
+    const fixture = createCodexNpmPluginLiveFollowthroughFixture({
+      root,
+      messageFinals: [false, true],
+    });
+
+    const result = runCodexNpmPluginLiveFollowthroughAssertions(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
   it.each([
-    ["explicit progress", [false, true]],
+    ["terminal progress", [true, true]],
     ["nonfinal completion", [undefined, false]],
   ] as const)("rejects %s Codex message final controls", (_label, messageFinals) => {
     const root = makeTempDir(tempDirs, "openclaw-codex-npm-followthrough-final-controls-");

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3570,7 +3570,12 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expect(runner).not.toContain('CODEX_PLUGIN_SPEC="npm-pack:$container_path"');
     expect(runner).not.toContain("trap 'openclaw_e2e_stop_process \"${registry_pid:-}\"' EXIT");
     expectTextToIncludeAll(runner, [
-      "message(action=send) with final=false",
+      "'continuesSourceReplyProgress'",
+      'FOLLOWTHROUGH_PROGRESS_FINAL_MODE="explicit"',
+      'FOLLOWTHROUGH_PROGRESS_FINAL_MODE="legacy"',
+      'FOLLOWTHROUGH_PROGRESS_INSTRUCTION="with final=false"',
+      'FOLLOWTHROUGH_PROGRESS_INSTRUCTION="without passing final"',
+      "message(action=send) $FOLLOWTHROUGH_PROGRESS_INSTRUCTION",
       "final=true and send exactly",
     ]);
     expect(runner).not.toContain("--timeout 420");

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3571,7 +3571,7 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expect(runner).not.toContain("trap 'openclaw_e2e_stop_process \"${registry_pid:-}\"' EXIT");
     expectTextToIncludeAll(runner, [
       "message(action=send) with final=false",
-      "message(action=send) with final=true",
+      "final=true and send exactly",
     ]);
     expect(runner).not.toContain("--timeout 420");
     expectTextToIncludeAll(assertions, [

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3569,7 +3569,10 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expect(runner).not.toContain("cat /tmp/openclaw-codex-plugin-pack.log");
     expect(runner).not.toContain('CODEX_PLUGIN_SPEC="npm-pack:$container_path"');
     expect(runner).not.toContain("trap 'openclaw_e2e_stop_process \"${registry_pid:-}\"' EXIT");
-    expect(runner).not.toContain("final=false");
+    expectTextToIncludeAll(runner, [
+      "message(action=send) with final=false",
+      "message(action=send) with final=true",
+    ]);
     expect(runner).not.toContain("--timeout 420");
     expectTextToIncludeAll(assertions, [
       'Requested agent harness "codex" is not registered',


### PR DESCRIPTION
## Summary

- request `final=false` for progress on current Codex candidates
- retain omitted-final progress for frozen candidates whose owner path continues that legacy form
- accept both transcript contracts while rejecting terminal progress and non-final completion

## Root cause

The current probe instructed Codex to omit `final` for the progress send. Current OpenClaw treats an omitted source-reply final value as terminal and continues only when it is explicitly false, so the turn ended before the file reads, artifact write, and completion send.

The trusted harness also validates frozen extended-stable candidates. It now selects the prompt from the candidate-owned behavior marker: current `continuesSourceReplyProgress` candidates receive `final=false`; older candidates retain the omitted-final instruction that their `source-reply-finality.ts` path supports.

Pinned Codex 0.147.0 does not reinterpret this argument. `../codex/codex-rs/app-server/src/bespoke_event_handling.rs:785` clones the dynamic tool request arguments directly into `DynamicToolCallParams`; OpenClaw's projected message schema and dynamic-tool bridge own the `final` contract. The same pass-through was inspected at tag `rust-v0.147.0`.

## Evidence

- original package/update failure: https://github.com/openclaw/openclaw/actions/runs/32099770866/job/95598878111
- exact-head PR CI: https://github.com/openclaw/openclaw/actions/runs/32147985733
- focused exact-head Codex npm release lane: https://github.com/openclaw/openclaw/actions/runs/32149359350

No local tests or validation were run, per release-validation instruction. Production delta is +0/-0; all changes are release harness and tests.

Agent transcript omitted.