### PR TITLE
fix(exec): seed trusted shell snapshot prompt

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -166,6 +166,14 @@ Env var equivalents:
 - `OPENCLAW_LOAD_SHELL_ENV=1`
 - `OPENCLAW_SHELL_ENV_TIMEOUT_MS=15000` (default `15000`)
 
+For Bash, the import uses an interactive login shell (`bash -lic`) so `PS1` is initialized
+before login startup files run. Bash reads `/etc/profile` and the first available user login
+profile (`~/.bash_profile`, `~/.bash_login`, or `~/.profile`); many login profiles also source
+`~/.bashrc`. Keep those files quiet and bounded because their output, long-running work, or
+failures can affect OpenClaw startup. Other shells use noninteractive login startup (`-l -c`).
+This interactive Bash mode is limited to explicit shell env imports; automatic executable PATH
+discovery during ordinary Gateway commands remains noninteractive.
+
 ## Exec shell snapshots
 
 On non-Windows Gateway hosts, bash and zsh `exec` commands use a startup snapshot by default.

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -96,7 +96,7 @@ export type OpenClawConfig = {
   /** ACP integration settings. */
   acp?: AcpConfig;
   env?: {
-    /** Opt-in: import missing secrets from a login shell environment (exec `$SHELL -l -c 'env -0'`). */
+    /** Opt-in: import missing secrets from a login shell environment (interactive for Bash). */
     shellEnv?: {
       enabled?: boolean;
       /** Timeout for the login shell exec (ms). Default: 15000. */

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -1,4 +1,5 @@
 // Covers shell environment fallback loading.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -34,6 +35,10 @@ beforeEach(async () => {
 });
 
 describe("shell env fallback", () => {
+  function framedShellEnv(output: string): Buffer {
+    return Buffer.from(`\0${output}`);
+  }
+
   function getShellPathTwice(params: {
     exec: Parameters<typeof getShellPathFromLoginShell>[0]["exec"];
     platform: NodeJS.Platform;
@@ -53,7 +58,7 @@ describe("shell env fallback", () => {
 
   function runShellEnvFallbackForShell(shell: string) {
     const env: NodeJS.ProcessEnv = { SHELL: shell };
-    const exec = vi.fn(() => Buffer.from("OPENAI_API_KEY=from-shell\0"));
+    const exec = vi.fn(() => framedShellEnv("OPENAI_API_KEY=from-shell\0"));
     const res = runShellEnvFallback({
       enabled: true,
       env,
@@ -119,8 +124,8 @@ describe("shell env fallback", () => {
     }
   }
 
-  function requireExecCall(exec: ReturnType<typeof vi.fn>): unknown[] {
-    const call = exec.mock.calls[0];
+  function requireExecCall(exec: ReturnType<typeof vi.fn>, index = 0): unknown[] {
+    const call = (exec.mock.calls as unknown[][])[index];
     if (!call) {
       throw new Error("expected shell env exec call");
     }
@@ -148,7 +153,7 @@ describe("shell env fallback", () => {
     expect(exec).toHaveBeenCalledTimes(1);
     const [shell, args, options] = requireExecCall(exec);
     expect(shell).toBe("/bin/sh");
-    expect(args).toStrictEqual(["-l", "-c", "env -0"]);
+    expect(args).toStrictEqual(["-l", "-c", "printf '\\0'; env -0"]);
     expect((options as { windowsHide?: unknown } | undefined)?.windowsHide).toBe(true);
   }
 
@@ -189,7 +194,7 @@ describe("shell env fallback", () => {
     let receivedTimeout: number | undefined;
     const exec = vi.fn((_shell: string, _args: string[], options: { timeout?: number }) => {
       receivedTimeout = options.timeout;
-      return Buffer.from("OPENAI_API_KEY=from-shell\0");
+      return framedShellEnv("OPENAI_API_KEY=from-shell\0");
     });
 
     const res = loadShellEnvFallback({
@@ -224,7 +229,7 @@ describe("shell env fallback", () => {
   it("imports missing expected keys even when another expected key already exists", () => {
     const env: NodeJS.ProcessEnv = { OPENCLAW_GATEWAY_TOKEN: "set" };
     const exec = vi.fn(() =>
-      Buffer.from(
+      framedShellEnv(
         "OPENCLAW_GATEWAY_TOKEN=from-shell\0TWILIO_ACCOUNT_SID=AC123\0TWILIO_AUTH_TOKEN=secret\0TWILIO_FROM_NUMBER=+15550001234\0",
       ),
     );
@@ -254,7 +259,7 @@ describe("shell env fallback", () => {
 
   it("treats explicitly empty env vars as intentional overrides", () => {
     const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: "" };
-    const exec = vi.fn(() => Buffer.from("OPENAI_API_KEY=from-shell\0"));
+    const exec = vi.fn(() => framedShellEnv("OPENAI_API_KEY=from-shell\0"));
 
     const res = runShellEnvFallback({
       enabled: true,
@@ -272,7 +277,9 @@ describe("shell env fallback", () => {
 
   it("imports expected keys without overriding existing env", () => {
     const env: NodeJS.ProcessEnv = {};
-    const exec = vi.fn(() => Buffer.from("OPENAI_API_KEY=from-shell\0DISCORD_BOT_TOKEN=discord\0"));
+    const exec = vi.fn(() =>
+      framedShellEnv("OPENAI_API_KEY=from-shell\0DISCORD_BOT_TOKEN=discord\0"),
+    );
 
     const res1 = runShellEnvFallback({
       enabled: true,
@@ -288,7 +295,7 @@ describe("shell env fallback", () => {
 
     env.OPENAI_API_KEY = "from-parent";
     const exec2 = vi.fn(() =>
-      Buffer.from("OPENAI_API_KEY=from-shell\0DISCORD_BOT_TOKEN=discord2\0"),
+      framedShellEnv("OPENAI_API_KEY=from-shell\0DISCORD_BOT_TOKEN=discord2\0"),
     );
     const res2 = runShellEnvFallback({
       enabled: true,
@@ -306,7 +313,7 @@ describe("shell env fallback", () => {
   it("reuses the cached login-shell env probe across repeated fallback reads", () => {
     const env: NodeJS.ProcessEnv = {};
     const exec = vi.fn(() =>
-      Buffer.from("OPENAI_API_KEY=from-shell\0ANTHROPIC_API_KEY=from-shell-anthropic\0"),
+      framedShellEnv("OPENAI_API_KEY=from-shell\0ANTHROPIC_API_KEY=from-shell-anthropic\0"),
     );
 
     expect(
@@ -365,26 +372,26 @@ describe("shell env fallback", () => {
   it.each([
     {
       name: "successful",
-      oldest: Buffer.from("PROBE_RESULT=oldest\0"),
+      oldest: framedShellEnv("PROBE_RESULT=oldest\0"),
       newest: new Error("newest failure"),
       refreshOldest: false,
     },
     {
       name: "failed",
       oldest: new Error("oldest failure"),
-      newest: Buffer.from("PROBE_RESULT=newest\0"),
+      newest: framedShellEnv("PROBE_RESULT=newest\0"),
       refreshOldest: false,
     },
     {
       name: "recent successful",
-      oldest: Buffer.from("PROBE_RESULT=oldest\0"),
+      oldest: framedShellEnv("PROBE_RESULT=oldest\0"),
       newest: new Error("newest failure"),
       refreshOldest: true,
     },
     {
       name: "recent failed",
       oldest: new Error("oldest failure"),
-      newest: Buffer.from("PROBE_RESULT=newest\0"),
+      newest: framedShellEnv("PROBE_RESULT=newest\0"),
       refreshOldest: true,
     },
   ])("bounds $name probe entries with LRU eviction", ({ oldest, newest, refreshOldest }) => {
@@ -405,11 +412,11 @@ describe("shell env fallback", () => {
         logger,
       });
     const oldestExec = makeExec(oldest);
-    const oldestFillerExec = makeExec(Buffer.from("PROBE_RESULT=filler-0\0"));
+    const oldestFillerExec = makeExec(framedShellEnv("PROBE_RESULT=filler-0\0"));
     const fillerExecs = [
       oldestFillerExec,
       ...Array.from({ length: 62 }, (_, index) =>
-        makeExec(Buffer.from(`PROBE_RESULT=filler-${index + 1}\0`)),
+        makeExec(framedShellEnv(`PROBE_RESULT=filler-${index + 1}\0`)),
       ),
     ];
     const newestExec = makeExec(newest);
@@ -435,7 +442,7 @@ describe("shell env fallback", () => {
   it("tracks last applied keys across success, skip, and failure paths", () => {
     const successEnv: NodeJS.ProcessEnv = {};
     const successExec = vi.fn(() =>
-      Buffer.from("OPENAI_API_KEY=from-shell\0DISCORD_BOT_TOKEN=\0EXTRA=ignored\0"),
+      framedShellEnv("OPENAI_API_KEY=from-shell\0DISCORD_BOT_TOKEN=\0EXTRA=ignored\0"),
     );
     expect(
       loadShellEnvFallback({
@@ -489,7 +496,7 @@ describe("shell env fallback", () => {
       env: {},
       expectedKeys: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
       exec: (() =>
-        Buffer.from(
+        framedShellEnv(
           "OPENAI_API_KEY=openai-shell\0ANTHROPIC_API_KEY=anthropic-shell\0",
         )) as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
     });
@@ -500,7 +507,7 @@ describe("shell env fallback", () => {
   });
 
   it("resolves PATH via login shell and caches it", () => {
-    const exec = vi.fn(() => Buffer.from("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
+    const exec = vi.fn(() => framedShellEnv("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
 
     const { first, second } = probeShellPathWithFreshCache({
       exec,
@@ -528,7 +535,7 @@ describe("shell env fallback", () => {
   });
 
   it("returns null when login shell PATH is blank", () => {
-    const exec = vi.fn(() => Buffer.from("PATH=   \0HOME=/tmp\0"));
+    const exec = vi.fn(() => framedShellEnv("PATH=   \0HOME=/tmp\0"));
 
     const { first, second } = probeShellPathWithFreshCache({
       exec,
@@ -575,7 +582,7 @@ describe("shell env fallback", () => {
       expect(exec).toHaveBeenCalledTimes(1);
       const [shell, args, options] = requireExecCall(exec);
       expect(shell).toBe(trustedShell);
-      expect(args).toStrictEqual(["-l", "-c", "env -0"]);
+      expect(args).toStrictEqual(["-l", "-c", "printf '\\0'; env -0"]);
       expect((options as { windowsHide?: unknown } | undefined)?.windowsHide).toBe(true);
     });
   });
@@ -607,7 +614,7 @@ describe("shell env fallback", () => {
     let receivedEnv: NodeJS.ProcessEnv | undefined;
     const exec = vi.fn((_shell: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
       receivedEnv = options.env;
-      return Buffer.from("OPENAI_API_KEY=from-shell\0");
+      return framedShellEnv("OPENAI_API_KEY=from-shell\0");
     });
 
     const res = runShellEnvFallback({
@@ -622,12 +629,86 @@ describe("shell env fallback", () => {
     expectSanitizedStartupEnv(receivedEnv);
   });
 
+  it("ignores startup output before the framed environment payload", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const exec = vi.fn((_shell: string, args: string[]) => {
+      const frame = args.at(-1) === "printf '\\0'; env -0" ? "\0" : "";
+      return Buffer.from(`NOTICE=startup output\n${frame}OPENAI_API_KEY=from-shell\0`);
+    });
+
+    expect(
+      loadShellEnvFallback({
+        enabled: true,
+        env,
+        expectedKeys: ["OPENAI_API_KEY"],
+        exec: exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+      }),
+    ).toEqual({ ok: true, applied: ["OPENAI_API_KEY"] });
+    expect(env.OPENAI_API_KEY).toBe("from-shell");
+  });
+
+  it("uses interactive Bash login startup before nounset reads PS1", () => {
+    if (process.platform === "win32" || !fs.existsSync("/bin/bash")) {
+      return;
+    }
+    const shell = "/bin/bash";
+    const env: NodeJS.ProcessEnv = { SHELL: shell };
+    const exec = vi.fn(
+      (file: string, args: string[], options: Parameters<typeof execFileSync>[2]) => {
+        expect(args).toStrictEqual(["-lic", "printf '\\0'; env -0"]);
+        return execFileSync(file, ["-lic", "set -u; : \"$PS1\"; printf '\\0'; env -0"], options);
+      },
+    );
+
+    withEtcShells([shell], () => {
+      expect(
+        loadShellEnvFallback({
+          enabled: true,
+          env,
+          expectedKeys: ["PATH"],
+          exec: exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+        }),
+      ).toMatchObject({ ok: true });
+    });
+    expect(exec).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Bash PATH discovery noninteractive and cached separately from env imports", () => {
+    const shell = "/bin/bash";
+    const env: NodeJS.ProcessEnv = { SHELL: shell };
+    const exec = vi.fn(() =>
+      framedShellEnv("OPENAI_API_KEY=from-shell\0PATH=/usr/local/bin:/usr/bin\0"),
+    );
+
+    withEtcShells([shell], () => {
+      expect(
+        loadShellEnvFallback({
+          enabled: true,
+          env,
+          expectedKeys: ["OPENAI_API_KEY"],
+          exec: exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+        }),
+      ).toEqual({ ok: true, applied: ["OPENAI_API_KEY"] });
+      expect(
+        getShellPathFromLoginShell({
+          env,
+          exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
+          platform: "linux",
+        }),
+      ).toBe("/usr/local/bin:/usr/bin");
+    });
+
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(requireExecCall(exec)[1]).toStrictEqual(["-lic", "printf '\\0'; env -0"]);
+    expect(requireExecCall(exec, 1)[1]).toStrictEqual(["-l", "-c", "printf '\\0'; env -0"]);
+  });
+
   it("sanitizes startup-related env vars before login-shell PATH probe", () => {
     const env = makeUnsafeStartupEnv();
     let receivedEnv: NodeJS.ProcessEnv | undefined;
     const exec = vi.fn((_shell: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
       receivedEnv = options.env;
-      return Buffer.from("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0");
+      return framedShellEnv("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0");
     });
 
     const result = getShellPathFromLoginShell({
@@ -642,7 +723,7 @@ describe("shell env fallback", () => {
   });
 
   it("resolves from the daemon PATH without probing the login shell", () => {
-    const exec = vi.fn(() => Buffer.from("PATH=/bin\0"));
+    const exec = vi.fn(() => framedShellEnv("PATH=/bin\0"));
 
     const result = resolveExecutableFromUserShellPath("sh", {
       env: { PATH: "/bin" },
@@ -655,7 +736,7 @@ describe("shell env fallback", () => {
   });
 
   it("resolves from the login-shell PATH when the daemon PATH misses the executable", () => {
-    const exec = vi.fn(() => Buffer.from("PATH=/bin\0"));
+    const exec = vi.fn(() => framedShellEnv("PATH=/bin\0"));
 
     const result = resolveExecutableFromUserShellPath("sh", {
       env: { PATH: "/missing", SHELL: "/bin/sh" },
@@ -680,7 +761,7 @@ describe("shell env fallback", () => {
     const shellTool = path.join(shellBin, "tool");
     fs.writeFileSync(daemonTool, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
     fs.writeFileSync(shellTool, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-    const exec = vi.fn(() => Buffer.from(`PATH=${shellBin}\0`));
+    const exec = vi.fn(() => framedShellEnv(`PATH=${shellBin}\0`));
 
     const result = resolveExecutableFromUserShellPath("tool", {
       env: { PATH: daemonBin, SHELL: "/bin/sh" },
@@ -693,7 +774,7 @@ describe("shell env fallback", () => {
   });
 
   it("returns the login-shell PATH needed by env-based executable launchers", () => {
-    const exec = vi.fn(() => Buffer.from("PATH=/bin\0"));
+    const exec = vi.fn(() => framedShellEnv("PATH=/bin\0"));
 
     const result = resolveExecutableFromUserShellPath("sh", {
       env: { PATH: "/missing", SHELL: "/bin/sh" },
@@ -705,7 +786,7 @@ describe("shell env fallback", () => {
   });
 
   it("returns null without invoking shell on win32", () => {
-    const exec = vi.fn(() => Buffer.from("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
+    const exec = vi.fn(() => framedShellEnv("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
 
     const { first, second } = probeShellPathWithFreshCache({
       exec,

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -16,6 +16,7 @@ import { pruneMapToMaxSize } from "./map-size.js";
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BUFFER_BYTES = 2 * 1024 * 1024;
 const DEFAULT_SHELL = "/bin/sh";
+const LOGIN_SHELL_ENV_COMMAND = "printf '\\0'; env -0";
 let lastAppliedKeys: string[] = [];
 let cachedShellPath: string | null | undefined;
 let cachedEtcShells: Set<string> | null | undefined;
@@ -26,6 +27,7 @@ type CachedLoginShellEnvProbeResult =
 const loginShellEnvProbeCache = new Map<string, CachedLoginShellEnvProbeResult>();
 const LOGIN_SHELL_ENV_CACHE_LIMIT = 64;
 const execCacheIds = new WeakMap<object, number>();
+type LoginShellEnvProbePurpose = "environment-import" | "path";
 
 function resolveShellExecEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const execEnv = sanitizeHostExecEnv({ baseEnv: env });
@@ -91,8 +93,16 @@ function execLoginShellEnvZero(params: {
   env: NodeJS.ProcessEnv;
   exec: typeof execFileSync;
   timeoutMs: number;
+  purpose: LoginShellEnvProbePurpose;
 }): Buffer {
-  return params.exec(params.shell, ["-l", "-c", "env -0"], {
+  // Explicit imports reproduce the user's interactive Bash startup; PATH discovery must not run
+  // interactive startup files during ordinary command execution.
+  const useInteractiveBash =
+    params.purpose === "environment-import" && path.basename(params.shell) === "bash";
+  const args = useInteractiveBash
+    ? ["-lic", LOGIN_SHELL_ENV_COMMAND]
+    : ["-l", "-c", LOGIN_SHELL_ENV_COMMAND];
+  return params.exec(params.shell, args, {
     encoding: "buffer",
     timeout: params.timeoutMs,
     maxBuffer: DEFAULT_MAX_BUFFER_BYTES,
@@ -104,7 +114,16 @@ function execLoginShellEnvZero(params: {
 
 function parseShellEnv(stdout: Buffer): Map<string, string> {
   const shellEnv = new Map<string, string>();
-  const parts = stdout.toString("utf8").split("\0");
+  // Startup files may write banners before our command. The leading NUL frames the env payload
+  // so that banner text cannot become part of its first key.
+  const frameEnd = stdout.indexOf(0);
+  if (frameEnd < 0) {
+    return shellEnv;
+  }
+  const parts = stdout
+    .subarray(frameEnd + 1)
+    .toString("utf8")
+    .split("\0");
   for (const part of parts) {
     if (!part) {
       continue;
@@ -142,6 +161,7 @@ function createLoginShellEnvCacheKey(params: {
   timeoutMs: number;
   exec?: typeof execFileSync;
   execEnv: NodeJS.ProcessEnv;
+  purpose: LoginShellEnvProbePurpose;
 }): string {
   const startupEnvEntries = Object.entries(params.execEnv)
     .filter(([key]) => {
@@ -164,6 +184,7 @@ function createLoginShellEnvCacheKey(params: {
   return JSON.stringify([
     params.shell,
     params.timeoutMs,
+    params.purpose,
     resolveExecCacheId(params.exec),
     startupEnvEntries,
   ]);
@@ -183,6 +204,7 @@ function probeLoginShellEnv(params: {
   timeoutMs?: number;
   exec?: typeof execFileSync;
   platform?: NodeJS.Platform;
+  purpose: LoginShellEnvProbePurpose;
 }): LoginShellEnvProbeResult {
   const platform = params.platform ?? process.platform;
   if (platform === "win32") {
@@ -198,6 +220,7 @@ function probeLoginShellEnv(params: {
     timeoutMs,
     exec: params.exec,
     execEnv,
+    purpose: params.purpose,
   });
   const cached = loginShellEnvProbeCache.get(cacheKey);
   if (cached) {
@@ -209,7 +232,13 @@ function probeLoginShellEnv(params: {
   }
 
   try {
-    const stdout = execLoginShellEnvZero({ shell, env: execEnv, exec, timeoutMs });
+    const stdout = execLoginShellEnvZero({
+      shell,
+      env: execEnv,
+      exec,
+      timeoutMs,
+      purpose: params.purpose,
+    });
     const shellEnv = parseShellEnv(stdout);
     cacheLoginShellEnvProbe(cacheKey, { ok: true, entries: [...shellEnv.entries()] });
     return { ok: true, shellEnv };
@@ -260,6 +289,7 @@ export function loadShellEnvFallback(opts: ShellEnvFallbackOptions): ShellEnvFal
     timeoutMs: opts.timeoutMs,
     exec: opts.exec,
     platform: opts.platform,
+    purpose: "environment-import",
   });
   if (!probe.ok) {
     logger.warn(`[openclaw] shell env fallback failed: ${probe.error}`);
@@ -321,6 +351,7 @@ export function getShellPathFromLoginShell(opts: {
     timeoutMs: opts.timeoutMs,
     exec: opts.exec,
     platform,
+    purpose: "path",
   });
   if (!probe.ok) {
     cachedShellPath = null;


### PR DESCRIPTION
## Summary

- use interactive Bash startup only for explicit `env.shellEnv` imports; keep ordinary executable PATH discovery noninteractive
- key the shared login-shell cache by probe purpose so the two contracts cannot reuse each other's result
- frame the environment payload with a leading NUL so startup banners cannot corrupt its first key
- document the operator-visible Bash startup contract and add real-Bash, banner, and purpose-isolation regressions

## Root cause

The failing Telegram release runner used `src/infra/shell-env.ts` to launch `bash -l -c env -0`. Bash clears an imported `PS1` before noninteractive startup, so seeding the child environment could not repair the failure. On the affected runner, nounset startup policy dereferenced the absent prompt and aborted the opt-in shell environment import before provider bootstrap.

The first repair correctly identified the command builder but treated every consumer as environment import. The shared probe also serves automatic login-shell PATH discovery for ordinary Gateway `exec`; making that default path interactive would execute user `.bashrc` side effects during commands. The cache likewise lacked the probe purpose, so an interactive import result could satisfy a later noninteractive PATH read.

The architectural owner is now explicit in the shared probe contract. `loadShellEnvFallback` requests `environment-import`, which uses `bash -lic`; `getShellPathFromLoginShell` requests `path`, which remains `bash -l -c`. Purpose participates in the cache key. All shell probes emit a NUL before `env -0`, and parsing starts after that frame so startup stdout cannot merge into the first environment key. Existing host-environment security filtering remains unchanged.

The source contract and [public environment guidance](https://docs.openclaw.ai/help/environment#shell-env-import) describe the Bash-only, opt-in behavior and explicitly distinguish automatic noninteractive PATH discovery. This matches the [GNU Bash startup-file contract](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files).

## Validation

- observed failure: [release Telegram QA run 32099819292, job 95598826455](https://github.com/openclaw/openclaw/actions/runs/32099819292/job/95598826455)
- exact GitHub regression disproving environment seeding (`PS1: unbound variable`): [run 32150297756, job 95754632809](https://github.com/openclaw/openclaw/actions/runs/32150297756/job/95754632809)
- prior exact-head CI before the probe-purpose follow-up: [run 32155005792](https://github.com/openclaw/openclaw/actions/runs/32155005792)
- GitHub-only canonical formatter passed on the exact source patch; the diagnostic workflow's aggregate gate is red only because its normal preflight is intentionally skipped: [run 32159463038, job 95784581902](https://github.com/openclaw/openclaw/actions/runs/32159463038/job/95784581902)
- source-identical GitHub focused proof for real Bash, startup-banner framing, cache isolation, and noninteractive PATH behavior: [run 32159770724, job 95785588244](https://github.com/openclaw/openclaw/actions/runs/32159770724/job/95785588244) — 34/34 tests passed and canonical formatting stayed unchanged; its aggregate gate is red only because normal preflight is intentionally skipped
- pre-rebase exact source-identical proof after the test-type-only follow-up: [run 32160130106, job 95786784500](https://github.com/openclaw/openclaw/actions/runs/32160130106/job/95786784500) — canonical formatting unchanged and 34/34 tests passed; its aggregate gate is red only because normal preflight is intentionally skipped
- pre-rebase exact PR-head CI: [run 32160109713](https://github.com/openclaw/openclaw/actions/runs/32160109713) — passed with zero failed checks
- the final repair was rebuilt as one commit on current main `d8c1d90edb49`; its four PR files are byte-identical to the previously proven head, while earlier disproven iteration commits were removed
- current-main exact source-identical focused proof: [run 32161189813, job 95790231311](https://github.com/openclaw/openclaw/actions/runs/32161189813/job/95790231311) — canonical formatting unchanged and 34/34 tests passed; its aggregate gate is red only because normal preflight is intentionally skipped
- current-main exact PR-head CI for `86d1af0af266`: [run 32161137144](https://github.com/openclaw/openclaw/actions/runs/32161137144) — passed with zero failed checks
- `pnpm docs:list` was not run because this task forbids local execution; docs routing used `docs/docs.json`, `docs/AGENTS.md`, and the existing `/help/environment` shell-env section
- no local tests or validation were run

## Repair accounting

- executable production source: +31 net, covering the explicit probe-purpose boundary, purpose-aware cache identity, and framed payload parser
- config type contract: net zero; public docs +8; focused tests +81 net
- all production callers were traced: opt-in config loading uses environment import; Gateway exec and executable resolution use noninteractive PATH discovery
- non-Bash login startup behavior and the shared host-environment security policy remain unchanged
