### PR TITLE
fix(ci): provide isolated Telegram runtime tmp

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1635,7 +1635,7 @@ jobs:
               }
               set_launcher_stage mask-host-paths
               trap "exit_status=\$?; trap - ERR; printf \"Telegram SUT launcher failed: stage=%s line=%s status=%s\\n\" \"\$launcher_stage\" \"\$LINENO\" \"\$exit_status\" >&2; exit \"\$exit_status\"" ERR
-              for masked_path in "$RUNNER_HOME" /tmp /var/tmp /dev/shm; do
+              for masked_path in "$RUNNER_HOME" /var/tmp /dev/shm; do
                 set_launcher_stage "mask-host-path:${masked_path}"
                 [[ -d "$masked_path" ]]
                 mount \
@@ -1644,6 +1644,14 @@ jobs:
                   openclaw-telegram-mask \
                   "$masked_path"
               done
+              # Keep the host temporary tree hidden while providing the stable
+              # POSIX runtime path used by cross-process lifecycle coordinators.
+              set_launcher_stage mount-private-tmp
+              mount \
+                -t tmpfs \
+                -o "mode=0700,uid=${SUT_UID},gid=${SUT_GID},nosuid,nodev,noexec" \
+                openclaw-telegram-sut-tmp \
+                /tmp
               set_launcher_stage mount-proc
               mount -t proc proc /proc -o nosuid,nodev,noexec,hidepid=2
               if [[ "$boundary_mode" == "true" ]]; then
@@ -1781,6 +1789,9 @@ jobs:
                       "${TMPDIR:?}"; do
                       [[ -d "$writable_path" && -w "$writable_path" ]]
                     done
+                    runtime_stage=verify-private-tmp
+                    [[ "$(stat -c '%F:%a:%u:%g' /tmp)" == "directory:700:${SUT_UID}:${SUT_GID}" &&
+                          -r /tmp && -w /tmp && -x /tmp ]]
                     runtime_stage=verify-host-paths-hidden
                     for protected_path in \
                       "$RUNNER_HOME" \
@@ -1788,7 +1799,6 @@ jobs:
                       "$RUNNER_SENTINEL" \
                       "$TRUSTED_WORKSPACE" \
                       "$EVIDENCE_ROOT" \
-                      /tmp \
                       /var/tmp \
                       /dev/shm; do
                       [[ ! -r "$protected_path" && ! -w "$protected_path" ]]

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -901,9 +901,7 @@ describe("release Telegram QA workflow", () => {
 
     expect(launcher).toContain('for masked_path in "$RUNNER_HOME" /var/tmp /dev/shm; do');
     expect(launcher).toContain("set_launcher_stage mount-private-tmp");
-    expect(launcher).toContain(
-      '-o "mode=0700,uid=${SUT_UID},gid=${SUT_GID},nosuid,nodev,noexec"',
-    );
+    expect(launcher).toContain('-o "mode=0700,uid=${SUT_UID},gid=${SUT_GID},nosuid,nodev,noexec"');
     expect(launcher).toContain("openclaw-telegram-sut-tmp");
     expect(launcher).toContain(
       '"$(stat -c \'%F:%a:%u:%g\' /tmp)" == "directory:700:${SUT_UID}:${SUT_GID}"',

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -891,4 +891,23 @@ describe("release Telegram QA workflow", () => {
     expect(launcher.match(/exec "\$runtime_node_bin"/gu)).toHaveLength(1);
     expect(launcher).toContain('grep -Ev "^(PWD|SHLVL|_)$"');
   });
+
+  it("mounts an isolated SUT-owned tmp without exposing the host tmp tree", () => {
+    const createSut = requireRun(
+      "run_telegram",
+      "Create isolated Telegram SUT identity and launcher",
+    );
+    const launcher = extractHereDocument(createSut, "LAUNCHER");
+
+    expect(launcher).toContain('for masked_path in "$RUNNER_HOME" /var/tmp /dev/shm; do');
+    expect(launcher).toContain("set_launcher_stage mount-private-tmp");
+    expect(launcher).toContain(
+      '-o "mode=0700,uid=${SUT_UID},gid=${SUT_GID},nosuid,nodev,noexec"',
+    );
+    expect(launcher).toContain("openclaw-telegram-sut-tmp");
+    expect(launcher).toContain(
+      '"$(stat -c \'%F:%a:%u:%g\' /tmp)" == "directory:700:${SUT_UID}:${SUT_GID}"',
+    );
+    expect(launcher).not.toContain('for masked_path in "$RUNNER_HOME" /tmp');
+  });
 });


### PR DESCRIPTION
## Summary

- replace the unreadable `/tmp` mask inside the Telegram SUT mount namespace with an empty SUT-owned tmpfs
- retain `nosuid,nodev,noexec` and keep the host temporary tree inaccessible
- attest the private mount ownership, mode, and runtime accessibility before launching the candidate

## Root cause

The trusted Telegram workflow mounted `/tmp` with mode `000`. The exact release candidate added a cross-process lifecycle coordinator under `/tmp/openclaw-state-locks-<uid>`, so the isolated candidate failed before the channel canary with `EACCES`.

The workflow owns this isolation boundary. A private tmpfs preserves host isolation while satisfying the candidate runtime contract; no production fallback or coordinator-path fork is added.

## Validation

- observed failure: release Telegram QA run 32099819292, job 95598826455
- regression assertion covers the mount options and runtime ownership check
- autoreview: clean
- local execution intentionally skipped; GitHub CI is the validation surface for this release task

## Repair accounting

- production runtime LOC: 0
- workflow: +12/-2
- tests: +19/-0
- sibling protected paths (`RUNNER_HOME`, `/var/tmp`, `/dev/shm`) remain unreadable and unwritable
