### PR TITLE
fix(ui): coalesce device refreshes during active loads

### DIFF
--- a/ui/src/lib/nodes/device-token.test.ts
+++ b/ui/src/lib/nodes/device-token.test.ts
@@ -26,6 +26,7 @@ function createState(request: (method: string, params?: unknown) => Promise<unkn
     connected: true,
     requestGeneration: 1,
     devicesLoading: false,
+    devicesQueuedRefresh: "none" as const,
     devicesError: null as string | null,
     devicesList: null,
   };

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -153,8 +153,11 @@ type NodesRequestState = {
   requestGeneration: number;
 };
 
+type QueuedRefresh = "none" | "quiet" | "visible";
+
 type NodesState = NodesRequestState & {
   nodesLoading: boolean;
+  nodesQueuedRefresh: QueuedRefresh;
   nodes: Array<Record<string, unknown>>;
   lastError: string | null;
   chatError?: string | null;
@@ -162,6 +165,7 @@ type NodesState = NodesRequestState & {
 
 type DevicesState = NodesRequestState & {
   devicesLoading: boolean;
+  devicesQueuedRefresh: QueuedRefresh;
   devicesError: string | null;
   devicesList: DevicePairingList | null;
 };
@@ -205,9 +209,11 @@ export function createInitialDevicesState(
     connected: snapshot.connected ?? false,
     requestGeneration: 0,
     nodesLoading: false,
+    nodesQueuedRefresh: "none",
     nodes: [],
     lastError: null,
     devicesLoading: false,
+    devicesQueuedRefresh: "none",
     devicesError: null,
     devicesList: null,
     execApprovalsLoading: false,
@@ -227,9 +233,17 @@ function isCurrentNodesRequest(
   return state.connected && state.client === client && state.requestGeneration === generation;
 }
 
+function queueRefresh(current: QueuedRefresh, quiet: boolean | undefined): QueuedRefresh {
+  return current === "visible" || quiet !== true ? "visible" : "quiet";
+}
+
 export async function loadNodes(state: NodesState, opts?: { quiet?: boolean }) {
   const client = state.client;
-  if (!client || !state.connected || state.nodesLoading) {
+  if (!client || !state.connected) {
+    return;
+  }
+  if (state.nodesLoading) {
+    state.nodesQueuedRefresh = queueRefresh(state.nodesQueuedRefresh, opts?.quiet);
     return;
   }
   state.nodesLoading = true;
@@ -250,13 +264,22 @@ export async function loadNodes(state: NodesState, opts?: { quiet?: boolean }) {
   } finally {
     if (isCurrentNodesRequest(state, client, generation)) {
       state.nodesLoading = false;
+      const queued = state.nodesQueuedRefresh;
+      state.nodesQueuedRefresh = "none";
+      if (queued !== "none") {
+        await loadNodes(state, { quiet: queued === "quiet" });
+      }
     }
   }
 }
 
 export async function loadDevices(state: DevicesState, opts?: { quiet?: boolean }) {
   const client = state.client;
-  if (!client || !state.connected || state.devicesLoading) {
+  if (!client || !state.connected) {
+    return;
+  }
+  if (state.devicesLoading) {
+    state.devicesQueuedRefresh = queueRefresh(state.devicesQueuedRefresh, opts?.quiet);
     return;
   }
   state.devicesLoading = true;
@@ -282,6 +305,11 @@ export async function loadDevices(state: DevicesState, opts?: { quiet?: boolean 
   } finally {
     if (isCurrentNodesRequest(state, client, generation)) {
       state.devicesLoading = false;
+      const queued = state.devicesQueuedRefresh;
+      state.devicesQueuedRefresh = "none";
+      if (queued !== "none") {
+        await loadDevices(state, { quiet: queued === "quiet" });
+      }
     }
   }
 }

--- a/ui/src/pages/devices/devices-page.test.ts
+++ b/ui/src/pages/devices/devices-page.test.ts
@@ -6,7 +6,9 @@ import type { PresenceEntry } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import {
+  approveDevicePairing,
   createInitialDevicesState,
+  loadDevices,
   loadNodes,
   type InventoryRemovalRequest,
 } from "../../lib/nodes/index.ts";
@@ -262,6 +264,62 @@ describe("DevicesPage gateway lifecycle", () => {
 
     await vi.waitFor(() => expect(request).toHaveBeenCalledWith("node.list", {}));
     page.remove();
+  });
+
+  it("coalesces a device refresh requested while an older list is loading", async () => {
+    const stale = deferred<{
+      paired: [];
+      pending: Array<{ requestId: string; deviceId: string }>;
+    }>();
+    const refreshed = deferred<{ paired: []; pending: [] }>();
+    let listCalls = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "device.pair.list") {
+        listCalls += 1;
+        return listCalls === 1 ? stale.promise : refreshed.promise;
+      }
+      return Promise.resolve({});
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const state = createInitialDevicesState({ client, connected: true });
+
+    const initialLoad = loadDevices(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("device.pair.list", {}));
+    const approval = approveDevicePairing(state, "request-1");
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("device.pair.approve", { requestId: "request-1" }),
+    );
+
+    stale.resolve({ paired: [], pending: [{ requestId: "request-1", deviceId: "device-1" }] });
+    await vi.waitFor(() => expect(listCalls).toBe(2));
+    expect(state.devicesLoading).toBe(true);
+
+    refreshed.resolve({ paired: [], pending: [] });
+    await Promise.all([initialLoad, approval]);
+    expect(state.devicesList).toEqual({ paired: [], pending: [] });
+    expect(state.devicesLoading).toBe(false);
+  });
+
+  it("coalesces a node refresh requested while an older list is loading", async () => {
+    const stale = deferred<{ nodes: Array<Record<string, unknown>> }>();
+    const refreshed = deferred<{ nodes: Array<Record<string, unknown>> }>();
+    const request = vi
+      .fn<(method: string, params?: unknown) => Promise<unknown>>()
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(refreshed.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const state = createInitialDevicesState({ client, connected: true });
+
+    const initialLoad = loadNodes(state);
+    void loadNodes(state, { quiet: true });
+    stale.resolve({ nodes: [{ id: "old" }] });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(state.nodesLoading).toBe(true);
+
+    refreshed.resolve({ nodes: [{ id: "new" }] });
+    await initialLoad;
+    expect(state.nodes).toEqual([{ id: "new" }]);
+    expect(state.nodesLoading).toBe(false);
   });
 
   it("retries a node load after a same-client disconnect", async () => {


### PR DESCRIPTION
## What Problem This Solves

Nodes and device list loaders silently dropped every refresh request received while a previous list RPC was in flight. If an operator approved/rejected pairing, removed inventory, rotated/revoked a token, or the Gateway emitted a resolved/inventory event during that window, both the mutation refresh and event refresh could vanish. The older pre-mutation response could then restore the obsolete row until the next 30-second poll; retrying the action produced confusing “unknown requestId” errors.

## Why This Change Was Made

The list owners now coalesce one pending refresh instead of dropping it. A closed `none | quiet | visible` mode preserves whether any queued caller requested visible error handling. When the active request settles, the owner immediately performs the queued reload; repeated requests during that reload coalesce again. Connection-generation guards remain unchanged, so stale connection work still fails closed.

## User Impact

Successful pairing, rejection, removal, rotation, revocation, and inventory events are reflected immediately even when they race an existing list load.

## Evidence

- Pre-fix order-faithful regression: 2/2 coalescing tests failed because no second list request occurred.
- Post-fix: Devices page + device-token suites → 44/44 pass.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` → rc 0.
- `node scripts/run-tsgo-core-test-shards.mjs` → rc 0 (the first CI run identified one direct test fixture missing the new owner state; fixed on current head).
- `oxlint` + `oxfmt` on touched files → rc 0 / clean.
- Codex autoreview → clean, 0.99, no actionable findings (full branch after fixture update).
- Prior head's attachment-restoration E2E failure was unrelated to Nodes/Devices; the updated exact-head run is authoritative.
