### PR TITLE
fix(tts): avoid mislabeled local and ElevenLabs audio

### DIFF
--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -35,6 +35,16 @@ function parseRequestBody(init: RequestInit | undefined): Record<string, unknown
   return body as Record<string, unknown>;
 }
 
+const OUTPUT_FORMAT_CASES = [
+  { outputFormat: "pcm_44100", fileExtension: ".pcm", voiceCompatible: false },
+  { outputFormat: "OPUS_48000_64", fileExtension: ".opus", voiceCompatible: true },
+  { outputFormat: "mp3_44100_128", fileExtension: ".mp3", voiceCompatible: false },
+  { outputFormat: "ulaw_8000", fileExtension: ".ulaw", voiceCompatible: false },
+  { outputFormat: "alaw_8000", fileExtension: ".alaw", voiceCompatible: false },
+  { outputFormat: "wav_44100", fileExtension: ".wav", voiceCompatible: false },
+  { outputFormat: "future_123", fileExtension: ".bin", voiceCompatible: false },
+] as const;
+
 describe("elevenlabs speech provider", () => {
   const originalFetch = globalThis.fetch;
 
@@ -309,6 +319,79 @@ describe("elevenlabs speech provider", () => {
       timeoutMs: 1_000,
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(OUTPUT_FORMAT_CASES)(
+    "returns truthful $outputFormat metadata for a voice-note override",
+    async ({ outputFormat, fileExtension, voiceCompatible }) => {
+      const fetchMock = vi.fn(async (url: string) => {
+        expect(new URL(url).searchParams.get("output_format")).toBe(outputFormat);
+        return new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-type": "audio/mpeg" },
+        });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await buildElevenLabsSpeechProvider().synthesize({
+        text: "hello",
+        target: "voice-note",
+        cfg: {} as never,
+        providerConfig: { apiKey: "xi-test" },
+        providerOverrides: { outputFormat },
+        timeoutMs: 1_000,
+      });
+
+      expect(result).toEqual({
+        audioBuffer: Buffer.from([1, 2, 3]),
+        outputFormat,
+        fileExtension,
+        voiceCompatible,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("returns truthful stream metadata for an output override and releases the stream once", async () => {
+    const cancel = vi.fn();
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(new URL(url).searchParams.get("output_format")).toBe("pcm_44100");
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1, 2, 3]));
+          },
+          cancel,
+        }),
+        { headers: { "content-type": "audio/mpeg" } },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await buildElevenLabsSpeechProvider().streamSynthesize?.({
+      text: "hello",
+      target: "voice-note",
+      cfg: {} as never,
+      providerConfig: { apiKey: "xi-test" },
+      providerOverrides: { outputFormat: "pcm_44100" },
+      timeoutMs: 1_000,
+    });
+    if (!result) {
+      throw new Error("streamSynthesize is unavailable");
+    }
+
+    expect(result).toMatchObject({
+      outputFormat: "pcm_44100",
+      fileExtension: ".pcm",
+      voiceCompatible: false,
+    });
+    if (!result.release) {
+      throw new Error("stream release is unavailable");
+    }
+    expect(cancel).not.toHaveBeenCalled();
+    await result.release();
+    await result.release();
+    expect(cancel).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -109,6 +109,24 @@ function normalizeElevenLabsLatencyTier(value: unknown): number | undefined {
     : undefined;
 }
 
+const ELEVENLABS_OUTPUT_FAMILIES = new Set(["opus", "mp3", "pcm", "ulaw", "alaw", "wav"]);
+
+function resolveElevenLabsOutputPlan(req: SpeechSynthesisRequest): {
+  outputFormat: string;
+  fileExtension: string;
+  voiceCompatible: boolean;
+} {
+  const outputFormat =
+    trimToUndefined(req.providerOverrides?.outputFormat) ??
+    (req.target === "voice-note" ? "opus_48000_64" : "mp3_44100_128");
+  const family = outputFormat.trim().toLowerCase().split("_", 1)[0];
+  return {
+    outputFormat,
+    fileExtension: family && ELEVENLABS_OUTPUT_FAMILIES.has(family) ? `.${family}` : ".bin",
+    voiceCompatible: family === "opus",
+  };
+}
+
 function normalizeVoiceSettings(
   rawVoiceSettings: Record<string, unknown> | undefined,
 ): Partial<ElevenLabsProviderConfig["voiceSettings"]> {
@@ -549,38 +567,30 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
       Boolean(resolveElevenLabsApiKey(readElevenLabsProviderConfig(providerConfig).apiKey)),
     synthesize: async (req) => {
       const overrides = req.providerOverrides ?? {};
-      const outputFormat =
-        trimToUndefined(overrides.outputFormat) ??
-        (req.target === "voice-note" ? "opus_48000_64" : "mp3_44100_128");
+      const outputPlan = resolveElevenLabsOutputPlan(req);
       const audioBuffer = await elevenLabsTTS(
         resolveElevenLabsTtsRequest(req, {
-          outputFormat,
+          outputFormat: outputPlan.outputFormat,
           latencyTier: normalizeElevenLabsLatencyTier(overrides.latencyTier),
         }),
       );
       return {
         audioBuffer,
-        outputFormat,
-        fileExtension: req.target === "voice-note" ? ".opus" : ".mp3",
-        voiceCompatible: req.target === "voice-note",
+        ...outputPlan,
       };
     },
     streamSynthesize: async (req) => {
       const overrides = req.providerOverrides ?? {};
-      const outputFormat =
-        trimToUndefined(overrides.outputFormat) ??
-        (req.target === "voice-note" ? "opus_48000_64" : "mp3_44100_128");
+      const outputPlan = resolveElevenLabsOutputPlan(req);
       const stream = await elevenLabsTTSStream(
         resolveElevenLabsTtsRequest(req, {
-          outputFormat,
+          outputFormat: outputPlan.outputFormat,
           latencyTier: normalizeElevenLabsLatencyTier(overrides.latencyTier),
         }),
       );
       return {
         audioStream: stream.audioStream,
-        outputFormat,
-        fileExtension: req.target === "voice-note" ? ".opus" : ".mp3",
-        voiceCompatible: req.target === "voice-note",
+        ...outputPlan,
         release: stream.release,
       };
     },

--- a/extensions/tts-local-cli/speech-provider-stream-error.test.ts
+++ b/extensions/tts-local-cli/speech-provider-stream-error.test.ts
@@ -17,6 +17,7 @@ import { buildCliSpeechProvider } from "./speech-provider.js";
 
 const TEST_CFG = {} as OpenClawConfig;
 const MIB = 1024 * 1024;
+const WAV_AUDIO = Buffer.concat([Buffer.from("RIFF"), Buffer.alloc(4), Buffer.from("WAVEaudio")]);
 
 function commandResult(overrides: Record<string, unknown> = {}) {
   return {
@@ -24,7 +25,7 @@ function commandResult(overrides: Record<string, unknown> = {}) {
     signal: null,
     killed: false,
     termination: "exit",
-    stdout: Buffer.from("audio"),
+    stdout: WAV_AUDIO,
     stderr: Buffer.alloc(0),
     ...overrides,
   };
@@ -53,7 +54,7 @@ describe("CLI TTS process wrapper", () => {
   });
 
   it("uses Execa input, timeout, escalation, and asymmetric byte caps", async () => {
-    await expect(synthesize()).resolves.toMatchObject({ audioBuffer: Buffer.from("audio") });
+    await expect(synthesize()).resolves.toMatchObject({ audioBuffer: WAV_AUDIO });
 
     expect(runCommandBufferedMock).toHaveBeenCalledWith(
       ["/fake/tts", "--voice", "test"],
@@ -120,12 +121,12 @@ describe("CLI TTS process wrapper", () => {
         code: 0,
         error: new Error("stderr stream failed"),
         errorStream: "stderr",
-        stdout: Buffer.from("stdout-audio"),
+        stdout: WAV_AUDIO,
         termination: "error",
       }),
     );
     await expect(synthesize()).resolves.toMatchObject({
-      audioBuffer: Buffer.from("stdout-audio"),
+      audioBuffer: WAV_AUDIO,
     });
   });
 });

--- a/extensions/tts-local-cli/speech-provider-stream-error.test.ts
+++ b/extensions/tts-local-cli/speech-provider-stream-error.test.ts
@@ -104,7 +104,7 @@ describe("CLI TTS process wrapper", () => {
     await expect(synthesize()).rejects.toThrow("CLI TTS failed: stdout stream failed");
 
     runCommandBufferedMock.mockImplementationOnce(async (argv: string[]) => {
-      writeFileSync(argv[1]!, Buffer.from("file-audio"));
+      writeFileSync(argv[1]!, WAV_AUDIO);
       return commandResult({
         code: 0,
         error: streamError,
@@ -113,7 +113,7 @@ describe("CLI TTS process wrapper", () => {
       });
     });
     await expect(synthesize(["{{OutputPath}}"])).resolves.toMatchObject({
-      audioBuffer: Buffer.from("file-audio"),
+      audioBuffer: WAV_AUDIO,
     });
 
     runCommandBufferedMock.mockResolvedValueOnce(

--- a/extensions/tts-local-cli/speech-provider.live.test.ts
+++ b/extensions/tts-local-cli/speech-provider.live.test.ts
@@ -2,7 +2,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
+import { resolveFfmpegBin, runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import type { SpeechProviderConfig } from "openclaw/plugin-sdk/speech-core";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
@@ -55,5 +55,43 @@ copyFileSync(${JSON.stringify(wavPath)}, process.argv[outIndex + 1]);
       expect(result.audioBuffer.byteLength).toBeGreaterThan(0);
       expect(readFileSync(wavPath).byteLength).toBeGreaterThan(0);
     });
+  }, 30_000);
+
+  it("detects MP3 stdout and converts it to configured WAV", async () => {
+    const providerConfig: SpeechProviderConfig = {
+      command: resolveFfmpegBin(),
+      args: [
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=660:duration=0.1",
+        "-c:a",
+        "libmp3lame",
+        "-f",
+        "mp3",
+        "pipe:1",
+      ],
+      outputFormat: "wav",
+      timeoutMs: 30_000,
+    };
+
+    const result = await buildCliSpeechProvider().synthesize({
+      text: "hello world",
+      cfg: {} as OpenClawConfig,
+      providerConfig,
+      providerOverrides: {},
+      timeoutMs: 30_000,
+      target: "audio-file",
+    });
+
+    expect(result.outputFormat).toBe("wav");
+    expect(result.fileExtension).toBe(".wav");
+    expect(result.voiceCompatible).toBe(false);
+    expect(result.audioBuffer.subarray(0, 4).toString("ascii")).toBe("RIFF");
+    expect(result.audioBuffer.subarray(8, 12).toString("ascii")).toBe("WAVE");
   }, 30_000);
 });

--- a/extensions/tts-local-cli/speech-provider.live.test.ts
+++ b/extensions/tts-local-cli/speech-provider.live.test.ts
@@ -10,6 +10,11 @@ import { buildCliSpeechProvider } from "./speech-provider.js";
 
 const describeLive = process.env.OPENCLAW_LIVE_TEST === "1" ? describe : describe.skip;
 
+function firstOggPacketPrefix(buffer: Buffer, length: number): string {
+  const segmentCount = buffer[26] ?? 0;
+  return buffer.subarray(27 + segmentCount, 27 + segmentCount + length).toString("ascii");
+}
+
 describeLive("buildCliSpeechProvider live", () => {
   it("synthesizes through a real local CLI fixture and ffmpeg", async () => {
     await withTempDir("openclaw-cli-tts-live-", async (dir) => {
@@ -93,5 +98,47 @@ copyFileSync(${JSON.stringify(wavPath)}, process.argv[outIndex + 1]);
     expect(result.voiceCompatible).toBe(false);
     expect(result.audioBuffer.subarray(0, 4).toString("ascii")).toBe("RIFF");
     expect(result.audioBuffer.subarray(8, 12).toString("ascii")).toBe("WAVE");
+  }, 30_000);
+
+  it("detects Ogg Vorbis stdout and converts it to Ogg Opus for voice notes", async () => {
+    const providerConfig: SpeechProviderConfig = {
+      command: resolveFfmpegBin(),
+      args: [
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=660:duration=0.1",
+        "-ac",
+        "2",
+        "-c:a",
+        "vorbis",
+        "-strict",
+        "-2",
+        "-f",
+        "ogg",
+        "pipe:1",
+      ],
+      outputFormat: "opus",
+      timeoutMs: 30_000,
+    };
+
+    const result = await buildCliSpeechProvider().synthesize({
+      text: "hello world",
+      cfg: {} as OpenClawConfig,
+      providerConfig,
+      providerOverrides: {},
+      timeoutMs: 30_000,
+      target: "voice-note",
+    });
+
+    expect(result.outputFormat).toBe("opus");
+    expect(result.fileExtension).toBe(".ogg");
+    expect(result.voiceCompatible).toBe(true);
+    expect(result.audioBuffer.subarray(0, 4).toString("ascii")).toBe("OggS");
+    expect(firstOggPacketPrefix(result.audioBuffer, 8)).toBe("OpusHead");
   }, 30_000);
 });

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -23,6 +23,8 @@ import { buildCliSpeechProvider } from "./speech-provider.js";
 
 const TEST_CFG = {} as OpenClawConfig;
 const MAX_AUDIO_OUTPUT_BYTES = 50 * 1024 * 1024;
+const VALID_MPEG_FRAME_HEADER = [0xff, 0xfb, 0x90, 0x64] as const;
+const EMPTY_ID3V2_HEADER = [...Buffer.from("ID3"), 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
 function createCliFixture(): { dir: string; script: string } {
   const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-tts-test-"));
@@ -271,8 +273,12 @@ describe("buildCliSpeechProvider", () => {
   });
 
   it.each([
-    { transport: "stdout", audio: [...Buffer.from("ID3audio")], writeFile: false },
-    { transport: "templated file", audio: [0xff, 0xfb, 0x90, 0x64], writeFile: true },
+    {
+      transport: "stdout",
+      audio: [...EMPTY_ID3V2_HEADER, ...VALID_MPEG_FRAME_HEADER],
+      writeFile: false,
+    },
+    { transport: "templated file", audio: VALID_MPEG_FRAME_HEADER, writeFile: true },
   ])("converts detected MP3 bytes from $transport to configured WAV", async (testCase) => {
     const fixture = createRawAudioFixture(testCase.audio);
     try {
@@ -383,6 +389,25 @@ describe("buildCliSpeechProvider", () => {
   it.each([
     { label: "plain bytes", audio: [...Buffer.from("not audio")] },
     { label: "reserved MP3 layer", audio: [0xff, 0xf1, 0x90, 0x64] },
+    { label: "bare ID3 prefix", audio: [...Buffer.from("ID3audio")] },
+    {
+      label: "ID3 tag with a non-sync-safe size",
+      audio: [
+        ...Buffer.from("ID3"),
+        0x04,
+        0x00,
+        0x00,
+        0x80,
+        0x00,
+        0x00,
+        0x00,
+        ...VALID_MPEG_FRAME_HEADER,
+      ],
+    },
+    {
+      label: "ID3 tag followed by a reserved MP3 layer",
+      audio: [...EMPTY_ID3V2_HEADER, 0xff, 0xf1, 0x90, 0x64],
+    },
   ])("rejects $label on stdout with supported-format guidance", async ({ audio }) => {
     const fixture = createRawAudioFixture(audio);
     try {
@@ -394,6 +419,22 @@ describe("buildCliSpeechProvider", () => {
           }),
         }),
       ).rejects.toThrow("stdout audio format is not recognized");
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unrecognized bytes written to a recognized audio extension", async () => {
+    const fixture = createRawAudioFixture([...Buffer.from("not audio")]);
+    try {
+      await expect(
+        synthesize({
+          providerConfig: baseProviderConfig(fixture.script, {
+            args: [fixture.script, "--out", "{{OutputPath}}"],
+            outputFormat: "mp3",
+          }),
+        }),
+      ).rejects.toThrow("unknown format");
     } finally {
       rmSync(fixture.dir, { recursive: true, force: true });
     }

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -328,38 +328,21 @@ describe("buildCliSpeechProvider", () => {
     }
   });
 
-  it("keeps Ogg Opus native for voice-note targets", async () => {
-    const audio = createOggFirstPage(Buffer.from("OpusHeadnative-audio"));
-    const fixture = createRawAudioFixture([...audio]);
-    try {
-      const result = await synthesize({
-        providerConfig: baseProviderConfig(fixture.script, {
-          args: [fixture.script, "--text", "{{Text}}"],
-          outputFormat: "opus",
-        }),
-        target: "voice-note",
-      });
-
-      expect(result).toEqual({
-        audioBuffer: audio,
-        outputFormat: "opus",
-        fileExtension: ".ogg",
-        voiceCompatible: true,
-      });
-      expect(runFfmpegMock).not.toHaveBeenCalled();
-    } finally {
-      rmSync(fixture.dir, { recursive: true, force: true });
-    }
-  });
-
   it.each([
-    { transport: "stdout", outputArgs: [] },
     {
+      codec: "OpusHead",
+      packet: Buffer.from("OpusHeadnative-audio"),
+      transport: "stdout",
+      outputArgs: [],
+    },
+    {
+      codec: "Vorbis",
+      packet: Buffer.from("\x01vorbis-not-OpusHead"),
       transport: "templated file",
       outputArgs: ["--out", "{{OutputDir}}/{{OutputBase}}.ogg"],
     },
-  ])("converts Ogg Vorbis from $transport to Opus for voice notes", async (testCase) => {
-    const audio = createOggFirstPage(Buffer.from("\x01vorbis-not-OpusHead"));
+  ])("converts Ogg $codec from $transport to Opus for voice notes", async (testCase) => {
+    const audio = createOggFirstPage(testCase.packet);
     const fixture = createRawAudioFixture([...audio]);
     try {
       const result = await synthesize({

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -24,7 +24,19 @@ import { buildCliSpeechProvider } from "./speech-provider.js";
 const TEST_CFG = {} as OpenClawConfig;
 const MAX_AUDIO_OUTPUT_BYTES = 50 * 1024 * 1024;
 const VALID_MPEG_FRAME_HEADER = [0xff, 0xfb, 0x90, 0x64] as const;
+const FREE_FORMAT_MPEG_FRAME_HEADER = [0xff, 0xfb, 0x00, 0x64] as const;
 const EMPTY_ID3V2_HEADER = [...Buffer.from("ID3"), 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+const EMPTY_ID3V24_HEADER_WITH_FOOTER = [
+  ...Buffer.from("ID3"),
+  0x04,
+  0x00,
+  0x10,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+];
+const EMPTY_ID3V24_FOOTER = [...Buffer.from("3DI"), ...EMPTY_ID3V24_HEADER_WITH_FOOTER.slice(3)];
 
 function createCliFixture(): { dir: string; script: string } {
   const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-tts-test-"));
@@ -274,12 +286,22 @@ describe("buildCliSpeechProvider", () => {
 
   it.each([
     {
-      transport: "stdout",
+      source: "ID3-tagged stdout",
       audio: [...EMPTY_ID3V2_HEADER, ...VALID_MPEG_FRAME_HEADER],
       writeFile: false,
     },
-    { transport: "templated file", audio: VALID_MPEG_FRAME_HEADER, writeFile: true },
-  ])("converts detected MP3 bytes from $transport to configured WAV", async (testCase) => {
+    {
+      source: "ID3v2.4 footer stdout",
+      audio: [
+        ...EMPTY_ID3V24_HEADER_WITH_FOOTER,
+        ...EMPTY_ID3V24_FOOTER,
+        ...VALID_MPEG_FRAME_HEADER,
+      ],
+      writeFile: false,
+    },
+    { source: "free-format stdout", audio: FREE_FORMAT_MPEG_FRAME_HEADER, writeFile: false },
+    { source: "untagged frame file", audio: VALID_MPEG_FRAME_HEADER, writeFile: true },
+  ])("converts detected MP3 bytes from $source to configured WAV", async (testCase) => {
     const fixture = createRawAudioFixture(testCase.audio);
     try {
       const result = await synthesize({

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -272,7 +272,7 @@ describe("buildCliSpeechProvider", () => {
 
   it.each([
     { transport: "stdout", audio: [...Buffer.from("ID3audio")], writeFile: false },
-    { transport: "templated file", audio: [0xff, 0xfb], writeFile: true },
+    { transport: "templated file", audio: [0xff, 0xfb, 0x90, 0x64], writeFile: true },
   ])("converts detected MP3 bytes from $transport to configured WAV", async (testCase) => {
     const fixture = createRawAudioFixture(testCase.audio);
     try {
@@ -380,8 +380,11 @@ describe("buildCliSpeechProvider", () => {
     }
   });
 
-  it("rejects unrecognized stdout with supported-format guidance", async () => {
-    const fixture = createRawAudioFixture([...Buffer.from("not audio")]);
+  it.each([
+    { label: "plain bytes", audio: [...Buffer.from("not audio")] },
+    { label: "reserved MP3 layer", audio: [0xff, 0xf1, 0x90, 0x64] },
+  ])("rejects $label on stdout with supported-format guidance", async ({ audio }) => {
+    const fixture = createRawAudioFixture(audio);
     try {
       await expect(
         synthesize({

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -42,11 +42,36 @@ const stdin = await new Promise((resolve) => {
   process.stdin.on("data", (chunk) => { data += chunk; });
   process.stdin.on("end", () => resolve(data));
 });
-const payload = Buffer.from(JSON.stringify({ args: process.argv.slice(2), stdin, textArg }));
+const payload = Buffer.concat([
+  Buffer.from("RIFF"),
+  Buffer.alloc(4),
+  Buffer.from("WAVE"),
+  Buffer.from(JSON.stringify({ args: process.argv.slice(2), stdin, textArg })),
+]);
 if (outputPath) {
   writeFileSync(outputPath, payload);
 } else {
   process.stdout.write(payload);
+}
+`,
+  );
+  return { dir, script };
+}
+
+function createRawAudioFixture(audio: readonly number[]): { dir: string; script: string } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-tts-raw-test-"));
+  const script = path.join(dir, "emit-audio.mjs");
+  writeFileSync(
+    script,
+    `
+import { writeFileSync } from "node:fs";
+const outIndex = process.argv.indexOf("--out");
+const outputPath = outIndex >= 0 ? process.argv[outIndex + 1] : "";
+const audio = Buffer.from(${JSON.stringify(audio)});
+if (outputPath) {
+  writeFileSync(outputPath, audio);
+} else {
+  process.stdout.write(audio);
 }
 `,
   );
@@ -81,7 +106,8 @@ async function synthesize(params: {
 }
 
 function parseAudioPayload(result: { audioBuffer: Buffer }) {
-  return JSON.parse(result.audioBuffer.toString("utf8")) as {
+  const jsonStart = result.audioBuffer.indexOf("{");
+  return JSON.parse(result.audioBuffer.subarray(jsonStart).toString("utf8")) as {
     stdin?: string;
     textArg?: string;
   };
@@ -154,13 +180,13 @@ describe("buildCliSpeechProvider", () => {
       const result = await synthesize({
         providerConfig: baseProviderConfig(fixture.script, {
           args: [fixture.script, "--out", "{{OutputPath}}"],
-          outputFormat: "mp3",
+          outputFormat: "wav",
         }),
         text: "hello 😀 world",
       });
 
-      expect(result.outputFormat).toBe("mp3");
-      expect(result.fileExtension).toBe(".mp3");
+      expect(result.outputFormat).toBe("wav");
+      expect(result.fileExtension).toBe(".wav");
       expect(result.voiceCompatible).toBe(false);
       const audioPayload = parseAudioPayload(result);
       expect(audioPayload.stdin).toBe("hello world");
@@ -233,6 +259,52 @@ describe("buildCliSpeechProvider", () => {
         voiceCompatible: false,
       });
       expectArgsContainSequence(requireFfmpegArgs(), ["-c:a", "libmp3lame", "-b:a", "128k"]);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { transport: "stdout", audio: [...Buffer.from("ID3audio")], writeFile: false },
+    { transport: "templated file", audio: [0xff, 0xfb], writeFile: true },
+  ])("converts detected MP3 bytes from $transport to configured WAV", async (testCase) => {
+    const fixture = createRawAudioFixture(testCase.audio);
+    try {
+      const result = await synthesize({
+        providerConfig: baseProviderConfig(fixture.script, {
+          args: [
+            fixture.script,
+            "--text",
+            "{{Text}}",
+            ...(testCase.writeFile ? ["--out", "{{OutputPath}}"] : []),
+          ],
+          outputFormat: "wav",
+        }),
+      });
+
+      expect(result).toEqual({
+        audioBuffer: Buffer.from("converted:.wav"),
+        outputFormat: "wav",
+        fileExtension: ".wav",
+        voiceCompatible: false,
+      });
+      expectArgsContainSequence(requireFfmpegArgs(), ["-f", "wav"]);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unrecognized stdout with supported-format guidance", async () => {
+    const fixture = createRawAudioFixture([...Buffer.from("not audio")]);
+    try {
+      await expect(
+        synthesize({
+          providerConfig: baseProviderConfig(fixture.script, {
+            args: [fixture.script, "--text", "{{Text}}"],
+            outputFormat: "wav",
+          }),
+        }),
+      ).rejects.toThrow("stdout audio format is not recognized");
     } finally {
       rmSync(fixture.dir, { recursive: true, force: true });
     }

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -59,10 +59,9 @@ if (outputPath) {
 }
 
 function createRawAudioFixture(audio: readonly number[]): { dir: string; script: string } {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-tts-raw-test-"));
-  const script = path.join(dir, "emit-audio.mjs");
+  const fixture = createCliFixture();
   writeFileSync(
-    script,
+    fixture.script,
     `
 import { writeFileSync } from "node:fs";
 const outIndex = process.argv.indexOf("--out");
@@ -75,7 +74,14 @@ if (outputPath) {
 }
 `,
   );
-  return { dir, script };
+  return fixture;
+}
+
+function createOggFirstPage(firstPacket: Buffer): Buffer {
+  const header = Buffer.alloc(27);
+  header.write("OggS");
+  header[26] = 1;
+  return Buffer.concat([header, Buffer.from([firstPacket.length]), firstPacket]);
 }
 
 function baseProviderConfig(
@@ -289,6 +295,86 @@ describe("buildCliSpeechProvider", () => {
         voiceCompatible: false,
       });
       expectArgsContainSequence(requireFfmpegArgs(), ["-f", "wav"]);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Ogg Opus native for voice-note targets", async () => {
+    const audio = createOggFirstPage(Buffer.from("OpusHeadnative-audio"));
+    const fixture = createRawAudioFixture([...audio]);
+    try {
+      const result = await synthesize({
+        providerConfig: baseProviderConfig(fixture.script, {
+          args: [fixture.script, "--text", "{{Text}}"],
+          outputFormat: "opus",
+        }),
+        target: "voice-note",
+      });
+
+      expect(result).toEqual({
+        audioBuffer: audio,
+        outputFormat: "opus",
+        fileExtension: ".ogg",
+        voiceCompatible: true,
+      });
+      expect(runFfmpegMock).not.toHaveBeenCalled();
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { transport: "stdout", outputArgs: [] },
+    {
+      transport: "templated file",
+      outputArgs: ["--out", "{{OutputDir}}/{{OutputBase}}.ogg"],
+    },
+  ])("converts Ogg Vorbis from $transport to Opus for voice notes", async (testCase) => {
+    const audio = createOggFirstPage(Buffer.from("\x01vorbis-not-OpusHead"));
+    const fixture = createRawAudioFixture([...audio]);
+    try {
+      const result = await synthesize({
+        providerConfig: baseProviderConfig(fixture.script, {
+          args: [fixture.script, "--text", "{{Text}}", ...testCase.outputArgs],
+          outputFormat: "opus",
+        }),
+        target: "voice-note",
+      });
+
+      expect(result).toEqual({
+        audioBuffer: Buffer.from("converted:.opus"),
+        outputFormat: "opus",
+        fileExtension: ".ogg",
+        voiceCompatible: true,
+      });
+      const ffmpegArgs = requireFfmpegArgs();
+      expectArgsContainSequence(ffmpegArgs, ["-c:a", "libopus", "-b:a", "64k"]);
+      expect(ffmpegArgs[ffmpegArgs.indexOf("-i") + 1]).toMatch(/\.ogg$/);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("converts an M4A file to the configured MP3 target", async () => {
+    const fixture = createRawAudioFixture([...Buffer.from("m4a fixture")]);
+    try {
+      const result = await synthesize({
+        providerConfig: baseProviderConfig(fixture.script, {
+          args: [fixture.script, "--out", "{{OutputDir}}/{{OutputBase}}.m4a"],
+          outputFormat: "mp3",
+        }),
+      });
+
+      expect(result).toEqual({
+        audioBuffer: Buffer.from("converted:.mp3"),
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: false,
+      });
+      const ffmpegArgs = requireFfmpegArgs();
+      expectArgsContainSequence(ffmpegArgs, ["-c:a", "libmp3lame", "-b:a", "128k"]);
+      expect(ffmpegArgs[ffmpegArgs.indexOf("-i") + 1]).toMatch(/\.m4a$/);
     } finally {
       rmSync(fixture.dir, { recursive: true, force: true });
     }

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -134,7 +134,7 @@ function findAudioFile(dir: string, baseName: string): string | null {
   return null;
 }
 
-function detectFormat(filePath: string): "mp3" | "opus" | "wav" | null {
+function detectFormatFromExtension(filePath: string): OutputFormat | null {
   const ext = path.extname(filePath).toLowerCase();
   if (ext === ".opus" || ext === ".ogg") {
     return "opus";
@@ -146,6 +146,17 @@ function detectFormat(filePath: string): "mp3" | "opus" | "wav" | null {
     return "mp3";
   }
   return null;
+}
+
+function detectAudioFormat(buffer: Buffer): OutputFormat | null {
+  const prefix = buffer.toString("ascii", 0, 12);
+  if (prefix.startsWith("RIFF") && prefix.slice(8, 12) === "WAVE") {
+    return "wav";
+  }
+  if (prefix.startsWith("ID3") || (buffer[0] === 0xff && ((buffer[1] ?? 0) & 0xe0) === 0xe0)) {
+    return "mp3";
+  }
+  return prefix.startsWith("OggS") ? "opus" : null;
 }
 
 function getFileExt(format: string): string {
@@ -224,12 +235,13 @@ async function runCli(params: {
 
   const audioFile = findAudioFile(params.outputDir, params.filePrefix);
   if (audioFile) {
-    const format = detectFormat(audioFile);
+    const buffer = readAudioFile(audioFile);
+    const format = detectAudioFormat(buffer) ?? detectFormatFromExtension(audioFile);
     if (!format) {
       throw new Error(`CLI TTS: unknown format for ${audioFile}`);
     }
     return {
-      buffer: readAudioFile(audioFile),
+      buffer,
       actualFormat: format,
       audioPath: audioFile,
     };
@@ -240,8 +252,13 @@ async function runCli(params: {
 
   const stdout = result.stdout;
   if (stdout.length > 0) {
-    // Assume WAV for stdout output; could be MP3 but caller should convert if needed
-    return { buffer: stdout, actualFormat: "wav" };
+    const actualFormat = detectAudioFormat(stdout);
+    if (!actualFormat) {
+      throw new Error(
+        "CLI TTS stdout audio format is not recognized; emit WAV, MP3, or Ogg Opus bytes, or write a supported audio file",
+      );
+    }
+    return { buffer: stdout, actualFormat };
   }
   if (result.termination === "error") {
     throw new Error(`CLI TTS failed: ${result.error?.message ?? result.termination}`);

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -23,6 +23,7 @@ const log = createSubsystemLogger("tts-local-cli");
 const VALID_OUTPUT_FORMATS = ["mp3", "opus", "wav"] as const;
 const AUDIO_EXTENSIONS = new Set([".wav", ".mp3", ".opus", ".ogg", ".m4a"]);
 type OutputFormat = (typeof VALID_OUTPUT_FORMATS)[number];
+type SourceFormat = OutputFormat | "ogg" | "m4a";
 
 type CliConfig = {
   command: string;
@@ -134,21 +135,27 @@ function findAudioFile(dir: string, baseName: string): string | null {
   return null;
 }
 
-function detectFormatFromExtension(filePath: string): OutputFormat | null {
+function detectFormatFromExtension(filePath: string): SourceFormat | null {
   const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".opus" || ext === ".ogg") {
+  if (ext === ".opus") {
     return "opus";
+  }
+  if (ext === ".ogg") {
+    return "ogg";
   }
   if (ext === ".wav") {
     return "wav";
   }
-  if (ext === ".mp3" || ext === ".m4a") {
+  if (ext === ".mp3") {
     return "mp3";
+  }
+  if (ext === ".m4a") {
+    return "m4a";
   }
   return null;
 }
 
-function detectAudioFormat(buffer: Buffer): OutputFormat | null {
+function detectAudioFormat(buffer: Buffer): SourceFormat | null {
   const prefix = buffer.toString("ascii", 0, 12);
   if (prefix.startsWith("RIFF") && prefix.slice(8, 12) === "WAVE") {
     return "wav";
@@ -156,12 +163,27 @@ function detectAudioFormat(buffer: Buffer): OutputFormat | null {
   if (prefix.startsWith("ID3") || (buffer[0] === 0xff && ((buffer[1] ?? 0) & 0xe0) === 0xe0)) {
     return "mp3";
   }
-  return prefix.startsWith("OggS") ? "opus" : null;
+  if (!prefix.startsWith("OggS")) {
+    return null;
+  }
+  const segmentCount = buffer[26] ?? 0;
+  const firstSegmentLength = buffer[27] ?? 0;
+  const firstPacketOffset = 27 + segmentCount;
+  const firstPacketPrefix = buffer.toString("ascii", firstPacketOffset, firstPacketOffset + 8);
+  return segmentCount > 0 && firstSegmentLength >= 8 && firstPacketPrefix === "OpusHead"
+    ? "opus"
+    : "ogg";
 }
 
-function getFileExt(format: string): string {
+function getFileExt(format: SourceFormat): string {
   if (format === "opus") {
     return ".opus";
+  }
+  if (format === "ogg") {
+    return ".ogg";
+  }
+  if (format === "m4a") {
+    return ".m4a";
   }
   if (format === "wav") {
     return ".wav";
@@ -183,7 +205,7 @@ async function runCli(params: {
   outputDir: string;
   filePrefix: string;
   outputFormat?: OutputFormat;
-}): Promise<{ buffer: Buffer; actualFormat: "mp3" | "opus" | "wav"; audioPath?: string }> {
+}): Promise<{ buffer: Buffer; actualFormat: SourceFormat; audioPath?: string }> {
   const cleanText = stripEmojis(params.text);
   if (!cleanText) {
     throw new Error("CLI TTS: text is empty after removing emojis");

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -136,23 +136,49 @@ function findAudioFile(dir: string, baseName: string): string | null {
 }
 
 function detectFormatFromExtension(filePath: string): SourceFormat | null {
-  const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".opus") {
-    return "opus";
+  return path.extname(filePath).toLowerCase() === ".m4a" ? "m4a" : null;
+}
+
+function hasMpegFrameHeader(buffer: Buffer, offset: number): boolean {
+  const mpegHeader = buffer[offset + 1] ?? 0;
+  const mpegFormat = buffer[offset + 2] ?? 0;
+  return (
+    buffer.length >= offset + 4 &&
+    buffer[offset] === 0xff &&
+    (mpegHeader & 0xe0) === 0xe0 &&
+    (mpegHeader & 0x18) !== 0x08 &&
+    (mpegHeader & 0x06) !== 0 &&
+    (mpegFormat & 0xf0) !== 0 &&
+    (mpegFormat & 0xf0) !== 0xf0 &&
+    (mpegFormat & 0x0c) !== 0x0c
+  );
+}
+
+function hasId3v2MpegFrame(buffer: Buffer): boolean {
+  if (buffer.length < 10) {
+    return false;
   }
-  if (ext === ".ogg") {
-    return "ogg";
+  const majorVersion = buffer[3] ?? 0;
+  const revision = buffer[4] ?? 0;
+  const flags = buffer[5] ?? 0;
+  if (majorVersion < 2 || majorVersion > 4 || revision === 0xff) {
+    return false;
   }
-  if (ext === ".wav") {
-    return "wav";
+  const allowedFlags = majorVersion === 2 ? 0xc0 : majorVersion === 3 ? 0xe0 : 0xf0;
+  if ((flags & (0xff ^ allowedFlags)) !== 0) {
+    return false;
   }
-  if (ext === ".mp3") {
-    return "mp3";
+  const size0 = buffer[6] ?? 0;
+  const size1 = buffer[7] ?? 0;
+  const size2 = buffer[8] ?? 0;
+  const size3 = buffer[9] ?? 0;
+  if ((size0 | size1 | size2 | size3) & 0x80) {
+    return false;
   }
-  if (ext === ".m4a") {
-    return "m4a";
-  }
-  return null;
+  const tagSize = (size0 << 21) | (size1 << 14) | (size2 << 7) | size3;
+  const footerSize = majorVersion === 4 && (flags & 0x10) !== 0 ? 10 : 0;
+  const audioOffset = 10 + tagSize + footerSize;
+  return audioOffset < buffer.length && hasMpegFrameHeader(buffer, audioOffset);
 }
 
 function detectAudioFormat(buffer: Buffer): SourceFormat | null {
@@ -160,18 +186,7 @@ function detectAudioFormat(buffer: Buffer): SourceFormat | null {
   if (prefix.startsWith("RIFF") && prefix.slice(8, 12) === "WAVE") {
     return "wav";
   }
-  const mpegHeader = buffer[1] ?? 0;
-  const mpegFormat = buffer[2] ?? 0;
-  const hasMp3FrameHeader =
-    buffer.length >= 4 &&
-    buffer[0] === 0xff &&
-    (mpegHeader & 0xe0) === 0xe0 &&
-    (mpegHeader & 0x18) !== 0x08 &&
-    (mpegHeader & 0x06) !== 0 &&
-    (mpegFormat & 0xf0) !== 0 &&
-    (mpegFormat & 0xf0) !== 0xf0 &&
-    (mpegFormat & 0x0c) !== 0x0c;
-  if (prefix.startsWith("ID3") || hasMp3FrameHeader) {
+  if (hasMpegFrameHeader(buffer, 0) || (prefix.startsWith("ID3") && hasId3v2MpegFrame(buffer))) {
     return "mp3";
   }
   if (!prefix.startsWith("OggS")) {

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -148,7 +148,7 @@ function hasMpegFrameHeader(buffer: Buffer, offset: number): boolean {
     (mpegHeader & 0xe0) === 0xe0 &&
     (mpegHeader & 0x18) !== 0x08 &&
     (mpegHeader & 0x06) !== 0 &&
-    (mpegFormat & 0xf0) !== 0 &&
+    // Bitrate index zero is valid MPEG free format; only 0xf is forbidden.
     (mpegFormat & 0xf0) !== 0xf0 &&
     (mpegFormat & 0x0c) !== 0x0c
   );

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -189,16 +189,7 @@ function detectAudioFormat(buffer: Buffer): SourceFormat | null {
   if (hasMpegFrameHeader(buffer, 0) || (prefix.startsWith("ID3") && hasId3v2MpegFrame(buffer))) {
     return "mp3";
   }
-  if (!prefix.startsWith("OggS")) {
-    return null;
-  }
-  const segmentCount = buffer[26] ?? 0;
-  const firstSegmentLength = buffer[27] ?? 0;
-  const firstPacketOffset = 27 + segmentCount;
-  const firstPacketPrefix = buffer.toString("ascii", firstPacketOffset, firstPacketOffset + 8);
-  return segmentCount > 0 && firstSegmentLength >= 8 && firstPacketPrefix === "OpusHead"
-    ? "opus"
-    : "ogg";
+  return prefix.startsWith("OggS") ? "ogg" : null;
 }
 
 function getFileExt(format: SourceFormat): string {

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -160,7 +160,18 @@ function detectAudioFormat(buffer: Buffer): SourceFormat | null {
   if (prefix.startsWith("RIFF") && prefix.slice(8, 12) === "WAVE") {
     return "wav";
   }
-  if (prefix.startsWith("ID3") || (buffer[0] === 0xff && ((buffer[1] ?? 0) & 0xe0) === 0xe0)) {
+  const mpegHeader = buffer[1] ?? 0;
+  const mpegFormat = buffer[2] ?? 0;
+  const hasMp3FrameHeader =
+    buffer.length >= 4 &&
+    buffer[0] === 0xff &&
+    (mpegHeader & 0xe0) === 0xe0 &&
+    (mpegHeader & 0x18) !== 0x08 &&
+    (mpegHeader & 0x06) !== 0 &&
+    (mpegFormat & 0xf0) !== 0 &&
+    (mpegFormat & 0xf0) !== 0xf0 &&
+    (mpegFormat & 0x0c) !== 0x0c;
+  if (prefix.startsWith("ID3") || hasMp3FrameHeader) {
     return "mp3";
   }
   if (!prefix.startsWith("OggS")) {


### PR DESCRIPTION
## What Problem This Solves

Fixes two cases where successful TTS synthesis could return audio bytes under false format metadata:

- a local CLI emitting MP3, Ogg, or other supported file output could be treated as the configured target without checking the produced container/codec, skipping required conversion and persisting an incorrect MIME/extension;
- an ElevenLabs `outputFormat` override could reach the API while the provider still reported the target's default `.opus`/`.mp3` extension and voice compatibility.

The latter could approve PCM or telephony bytes for voice-note delivery even though the resulting file was not voice-compatible.

## Why This Change Was Made

The local CLI provider now distinguishes requested target formats from detected source formats. It identifies WAV directly, accepts untagged MP3 only with a valid MPEG frame header, and accepts ID3v2-tagged MP3 only after validating the tag version, flags, sync-safe length, optional footer, bounds, and the MPEG frame at the computed audio offset. It treats every `OggS` result as a source container and routes it through the existing ffmpeg conversion path, so neither malformed Ogg nor already-Opus Ogg can bypass normalization as native voice audio. M4A is likewise retained only as a source format that must be converted to the configured target. Recognizable file bytes take precedence over a misleading filename, while extension fallback remains for supported containers outside the byte detector.

ElevenLabs now resolves one canonical output plan from the effective API format. Buffered and streaming synthesis share that plan, mapping the documented MP3, Opus, PCM, μ-law, A-law, and WAV families to truthful extensions and marking only Opus as voice-compatible.

Production LOC: +93/-27 (net +66) | Tests: +388/-12

The production growth is the source-format boundary needed to distinguish target formats from Ogg/M4A inputs and to validate complete MPEG-frame and ID3v2 evidence before MP3 conversion can be skipped. Ogg never skips conversion.

## User Impact

Operators can rely on TTS output metadata matching the audio that was actually produced. Misconfigured local CLIs are converted instead of silently shipping mislabeled files; Ogg Vorbis cannot masquerade as native Opus; and ElevenLabs overrides no longer cause raw PCM or telephony audio to be persisted as Opus or delivered as a voice note.

## Evidence

- Regression-first proof on the old production code:
  - MP3 stdout/file cases returned unconverted MP3 bytes as WAV, and unknown stdout resolved instead of failing;
  - Ogg Vorbis from stdout and file output was accepted as Opus and skipped conversion;
  - reserved MPEG headers such as `FF F1`, bare `ID3` prefixes, malformed sync-safe ID3 lengths, and tagged invalid frames were accepted as MP3 and skipped conversion;
  - file extensions could still override unrecognized bytes, while M4A file output was treated as MP3 and skipped conversion;
  - ElevenLabs buffered and streaming voice-note overrides returned target-default extensions/compatibility instead of effective-format facts.
- Focused unit regressions:
  - `node scripts/run-vitest.mjs extensions/tts-local-cli/speech-provider.test.ts extensions/tts-local-cli/speech-provider-stream-error.test.ts`
  - 29 tests passed across provider and stream-error coverage, including ordinary and free-format MPEG headers, ID3v2 and ID3v2.4-footer-tagged MP3, malformed ID3 rejection, invalid-extension rejection, Ogg Opus/Vorbis normalization across stdout and file output, and M4A conversion.
  - `node scripts/run-vitest.mjs extensions/elevenlabs/speech-provider.test.ts`
  - 18 tests passed across effective format families and streaming release behavior.
- Real local process + ffmpeg proof:
  - `OPENCLAW_LIVE_TEST=1 pnpm test:live extensions/tts-local-cli/speech-provider.live.test.ts`
  - 3 tests passed: WAV-file→Opus, MP3-stdout→WAV with RIFF/WAVE output, and Ogg-Vorbis-stdout→Ogg-Opus with first-packet `OpusHead` output.
- Authenticated ElevenLabs live proof using `pcm_24000` on a voice-note target:
  - buffered synthesis: `.pcm`, `voiceCompatible=false`, 115,914 bytes;
  - streaming synthesis: `.pcm`, `voiceCompatible=false`, 118,144 bytes.
- Changed-surface gate:
  - `node scripts/check-changed.mjs -- extensions/tts-local-cli/speech-provider.ts extensions/tts-local-cli/speech-provider.test.ts extensions/tts-local-cli/speech-provider-stream-error.test.ts extensions/tts-local-cli/speech-provider.live.test.ts`
  - formatting, extension types/tests, lint, dependency, dead-code, database-first, sidecar, media, and import-cycle guards passed.
- `git diff --check`
- Widened `autoreview --mode uncommitted --max-priority P2` after the Ogg always-convert simplification: clean, no accepted/actionable findings.

AI-assisted: yes. The implementation was reviewed and validated by the maintainer before publication.
