### PR TITLE
improve(ui): show starter automations only for empty inventories

### DIFF
--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -247,11 +247,29 @@ describe("cron view list pane", () => {
     expect(editing.querySelector('[data-test-id="cron-submit-run"]')).toBeNull();
   });
 
-  it("hides suggestions while any list filter is active", () => {
-    expect(renderView({ jobsQuery: "x" }).querySelector(".cron-suggestion")).toBeNull();
-    const filtered = renderView({ jobsEnabledFilter: "enabled" });
-    expect(filtered.querySelector(".cron-suggestion")).toBeNull();
-    expect(renderView().querySelector(".cron-suggestion")).not.toBeNull();
+  it("shows starter automations only for a loaded empty inventory", () => {
+    const findStarterSection = (container: Element) =>
+      Array.from(container.querySelectorAll(".settings-section")).find(
+        (section) =>
+          section.querySelector(".settings-section__heading")?.textContent?.trim() ===
+          "Starter automations",
+      ) ?? null;
+
+    expect(findStarterSection(renderView({ jobs: [], jobsTotal: 0 }))).not.toBeNull();
+
+    const configuredJobs = [
+      createJob("active"),
+      createJob("paused", { enabled: false }),
+      createJob("failing", { state: { lastRunStatus: "error" } }),
+    ];
+    for (const job of configuredJobs) {
+      expect(findStarterSection(renderView({ jobs: [job], jobsTotal: 1 }))).toBeNull();
+    }
+
+    expect(findStarterSection(renderView({ loading: true }))).toBeNull();
+    expect(findStarterSection(renderView({ error: "Unable to load automations." }))).toBeNull();
+    expect(findStarterSection(renderView({ jobsQuery: "x" }))).toBeNull();
+    expect(findStarterSection(renderView({ jobsEnabledFilter: "enabled" }))).toBeNull();
   });
 
   it("shows a scheduler banner only while the scheduler is off", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -453,6 +453,12 @@ function renderListView(props: CronProps) {
     hasAdvancedJobsFilters ||
     props.jobsQuery.trim().length > 0 ||
     props.jobsEnabledFilter !== "all";
+  const showStarterAutomations =
+    !props.loading &&
+    !props.error &&
+    props.jobsTotal === 0 &&
+    !hasAnyJobsFilters &&
+    props.canManage;
   const children = [
     renderSettingsSection({}, renderCronStats(props)),
     renderAdminRequired(props),
@@ -479,7 +485,7 @@ function renderListView(props: CronProps) {
             )
           : [
               renderSettingsSection({}, renderJobsTable(props, hasAnyJobsFilters)),
-              hasAnyJobsFilters || !props.canManage ? nothing : renderSuggestions(props),
+              showStarterAutomations ? renderSuggestions(props) : nothing,
             ]}
       </div>
     `,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #104746

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Starter automations remained visible beneath the configured automation list, so onboarding content permanently competed with the operator's real automations after setup.

## Why This Change Was Made

The Automations page now treats starter automations as a true empty state. It renders the section only after the unfiltered inventory has loaded with zero configured automations; active, paused, and failing jobs all count as configured, while loading, error, filtered, and read-only states do not expose the starter actions.

## User Impact

Operators with configured automations get a shorter, focused dashboard. New operators still see the full starter catalog until they create their first automation.

## Evidence

### Configured inventory: before and after

| Before | After |
| --- | --- |
| ![Starter automations visible below a configured job](https://github.com/user-attachments/assets/2610a852-0dc0-4eda-8346-91075c34ec78) | ![Configured automation list without the starter section](https://github.com/user-attachments/assets/e0007a4b-29b0-4f0d-a5a7-e9a1a05886b2) |

### Empty inventory retained

![Empty automation inventory with starter automations](https://github.com/user-attachments/assets/3dd12080-6ccd-43dd-a4a6-c03a21dacaab)

- `node scripts/run-vitest.mjs ui/src/pages/cron/view.test.ts` — 39 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/cron/view.ts ui/src/pages/cron/view.test.ts` — passed.
- Source-blind browser validation — empty inventory showed one Starter automations section; configured inventory showed none; both scenarios issued `cron.list` requests.
- Fresh Codex autoreview — no accepted/actionable findings.

AI-assisted: yes. The implementation and proof were inspected and understood before publication.
