### PR TITLE
fix(gateway): preserve chat metadata across UI prefs

### DIFF
--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -18,6 +18,12 @@ import {
   createGatewayAgentModelCatalogProjector,
 } from "./server-methods/models-list-result.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
+import { registerGatewayModelCatalogPrivateAccess } from "./server-model-catalog-auth.js";
+import {
+  loadGatewayModelCatalogSnapshot,
+  loadPreparedGatewayModelCatalogSnapshot,
+  readPreparedGatewayModelCatalogOwnerSnapshot,
+} from "./server-model-catalog.js";
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 const mocks = getPreparedModelRuntimeMocks();
@@ -110,16 +116,16 @@ afterEach(async () => {
   }
 });
 
-async function createLifecycle() {
+async function createLifecycle(getConfig: () => OpenClawConfig = () => config) {
   return await createGatewayChatMetadataLifecycle({
-    getConfig: () => config,
+    getConfig,
     minimalTestGateway: false,
     log: { warn: vi.fn() } as never,
   });
 }
 
-async function publishOwner(): Promise<void> {
-  await refreshPreparedModelRuntimeSnapshots(config, {
+async function publishOwner(ownerConfig: OpenClawConfig = config): Promise<void> {
+  await refreshPreparedModelRuntimeSnapshots(ownerConfig, {
     gatewayLifecycle: true,
     catalogMode: "live",
     allowGatewaySubagentBinding: true,
@@ -202,6 +208,51 @@ describe("gateway chat metadata lifecycle composition", () => {
     await lifecycle.attachContext(context, sidecars);
 
     await expectAvailable(lifecycle);
+  });
+
+  it("keeps the published owner across a display-only config publication", async () => {
+    const publishedConfig = {
+      ...config,
+      ui: { prefs: { chatShowThinking: true } },
+    } satisfies OpenClawConfig;
+    const currentConfig = {
+      ...config,
+      ui: { prefs: { chatShowThinking: false } },
+    } satisfies OpenClawConfig;
+    await publishOwner(publishedConfig);
+    const lifecycle = await createLifecycle(() => currentConfig);
+    const loadCatalogSnapshot: GatewayRequestContext["loadGatewayModelCatalogSnapshot"] = (
+      loadParams,
+    ) => loadGatewayModelCatalogSnapshot({ ...loadParams, getConfig: () => currentConfig });
+    registerGatewayModelCatalogPrivateAccess(loadCatalogSnapshot, {
+      loadDeferred: (loadParams) =>
+        loadPreparedGatewayModelCatalogSnapshot({
+          ...loadParams,
+          getConfig: () => currentConfig,
+        }),
+      readPrepared: (loadParams) =>
+        readPreparedGatewayModelCatalogOwnerSnapshot({
+          ...loadParams,
+          getConfig: () => currentConfig,
+        }),
+    });
+    const currentContext = {
+      ...context,
+      getRuntimeConfig: () => currentConfig,
+      loadGatewayModelCatalogSnapshot: loadCatalogSnapshot,
+    } as GatewayRequestContext;
+
+    await lifecycle.attachContext(currentContext, sidecars);
+
+    await expect(lifecycle.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [
+        expect.objectContaining({
+          available: true,
+          id: "gpt-5.4",
+          provider: "openai",
+        }),
+      ],
+    });
   });
 
   it("publishes a successful harness auth binding before the next metadata read", async () => {

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -6,8 +6,8 @@ import {
 } from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import {
-  getPreparedModelCatalogOwnerSnapshot,
-  type LoadPreparedModelCatalogParams,
+  getPublishedPreparedModelCatalogOwnerSnapshot,
+  type GetPublishedPreparedModelCatalogOwnerParams,
 } from "../../agents/prepared-model-catalog.js";
 import { getPreparedModelRuntimeAuthMaterializations } from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
@@ -78,7 +78,7 @@ type ChatMetadataRuntimeDeps = {
   getConfig: () => OpenClawConfig;
   getContext: () => GatewayRequestContext;
   getPreparedOwner: (
-    params: LoadPreparedModelCatalogParams,
+    params: GetPublishedPreparedModelCatalogOwnerParams,
   ) => PreparedModelRuntimeSnapshot | undefined;
   getPreparedAuthStore: (
     agentDir?: string,
@@ -125,9 +125,9 @@ function captureGenerationFacts(deps: ChatMetadataRuntimeDeps): PreparedGenerati
   const config = deps.getConfig();
   const agents = listAgentIds(config).map((rawAgentId): PreparedAgentFacts => {
     const agentId = normalizeAgentId(rawAgentId);
-    // Flagless resolution reaches the configured owner regardless of its
-    // publication-time gateway-binding capability.
-    const owner = deps.getPreparedOwner({ agentId, config, readOnly: true });
+    // Metadata follows the published lifecycle owner while its replacement gate owns turnover;
+    // display-only config publications must not make that still-current owner disappear.
+    const owner = deps.getPreparedOwner({ agentId, config });
     if (!owner) {
       throw new ChatMetadataSnapshotUnavailableError(
         `prepared chat metadata owner is unavailable for agent "${agentId}"`,
@@ -276,7 +276,7 @@ export function createGatewayChatMetadataRuntime(params: {
   const deps: ChatMetadataRuntimeDeps = {
     getConfig: params.getConfig,
     getContext: params.getContext,
-    getPreparedOwner: getPreparedModelCatalogOwnerSnapshot,
+    getPreparedOwner: getPublishedPreparedModelCatalogOwnerSnapshot,
     getPreparedAuthStore: getPreparedRuntimeAuthProfileStoreSnapshot,
     getAuthStoreRevision: getRuntimeAuthProfileStoreSnapshotRevision,
     getSkillsVersion: getSkillsSnapshotVersion,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a display-only synchronized UI preference update could make chat metadata reject the still-current published model owner. New-session model selection then became unavailable even though direct model and command reads remained healthy.

## Why This Change Was Made

Chat metadata now reads the lifecycle-published prepared model owner without requiring full-config equality. The existing replacement gate still fences real model/config owner turnover, so readers continue to fail closed while a genuine replacement is publishing. UI-side suppression and globally weakening prepared config matching were rejected because both would move or broaden the fix beyond the lifecycle owner boundary.

## User Impact

Model selection remains available after changing synchronized display preferences. No Gateway restart or provider reconfiguration is required.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-chat-metadata-lifecycle.integration.test.ts src/gateway/server-methods/chat-metadata-runtime.test.ts` — 30/30 tests passed on the rebased head.
- `node scripts/check-changed.mjs -- src/gateway/server-chat-metadata-lifecycle.integration.test.ts src/gateway/server-methods/chat-metadata-runtime.ts` completed formatting, typechecks, lint, dead-code, dependency, and schema checks before the 10-minute outer harness limit. Its remaining runtime-sidecar-loader, import-cycle, webhook-auth body-order, pairing-store group-auth, and pairing account-scope guards were rerun individually and passed.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- `node --import tsx scripts/build-all.mts qaRuntime` and `pnpm ui:build` passed. A broader local `pnpm build` attempt ended during declaration invocation 8/9 without a compiler diagnostic on a heavily loaded host; exact-head CI provides the authoritative full-build result.
- Real isolated Gateway + Control UI proof: `Proof Model Alpha` was available before a real `config.patch` committed `ui.prefs.chatShowThinking=false`; after `config.get`, one config publication event, and a fresh chat metadata/startup read, the model remained available and `Models unavailable` never appeared. The isolated state and processes were removed afterward.
- Production LOC: +7/-7 (net 0). Tests: +55/-4.
- AI-assisted: yes.

Initial model availability:

![Initial model available](https://github.com/user-attachments/assets/0d6e282e-01a7-4d37-8c4b-d0e09a1a1f77)

Final model availability after the synchronized preference commit:

![Final model available](https://github.com/user-attachments/assets/b88eec35-4964-41e8-b349-df0a4164b15d)

https://github.com/user-attachments/assets/cf7d804e-2469-4ae5-92a6-a3fd04cbaf65
