### PR TITLE
fix(ui): restore new-session drafts after reload

### DIFF
--- a/ui/src/pages/new-session/draft-persistence.ts
+++ b/ui/src/pages/new-session/draft-persistence.ts
@@ -69,6 +69,7 @@ export class NewSessionDraftPersistence {
     if (currentOwner === nextOwner) {
       return;
     }
+    const routeKey = this.routeKey;
     this.persistNow();
     this.restoreGeneration += 1;
     this.restoredIdentity = "";
@@ -77,6 +78,10 @@ export class NewSessionDraftPersistence {
     this.recoveryScope = recoveryScope;
     if (currentOwner && !preserveCurrent) {
       this.apply("", [], true);
+    }
+    // The route may win the startup race; activate it as soon as its owner exists.
+    if (!preserveCurrent) {
+      this.activateRoute(routeKey);
     }
   }
 
@@ -98,7 +103,7 @@ export class NewSessionDraftPersistence {
   }
 
   selectRoute(routeKey: string) {
-    if (!this.gatewayOwner || !this.recoveryScope || !routeKey) {
+    if (!routeKey) {
       return;
     }
     if (this.routeKey !== routeKey) {


### PR DESCRIPTION
## Summary

- retain the selected New Session route while Gateway recovery ownership is still loading
- activate the retained route as soon as its durable draft owner becomes available
- preserve pending-cloud recovery as the higher-priority restore path

## Root cause

The route and Gateway credential scope initialize independently. When the route initialized first, draft persistence ignored it because no owner existed yet. Owner discovery then had no route to activate, leaving a persisted text-only draft invisible after reload. Attachment-bearing drafts could mask the race by causing a later render.

The architectural owner is `NewSessionDraftPersistence`, which now records the route fact where it occurs and activates it when ownership arrives.

## Validation

- pre-fix exact-SHA Control UI E2E failed twice at `new-session-page.prompt-attachments.e2e.test.ts:53`: [run 32098888723](https://github.com/openclaw/openclaw/actions/runs/32098888723)
- exact PR-head merge-result CI passed all 12 Control UI E2E shards and the real-Gateway lane: [run 32104037357](https://github.com/openclaw/openclaw/actions/runs/32104037357)
- current-main composition proof uses main `1ed682f883ec448599e7085ffafaddc4e70f1a1e` plus the unchanged PR patch; the workflow verified the original and composed stable patch-id are both `76ee04f3c72532409a0141408efb4ddeea34ba60`
- focused browser reload passed 5/5 times on that composition: [proof job 95762235172](https://github.com/openclaw/openclaw/actions/runs/32152689714/job/95762235172)
- sanitized after-reload screenshot visibly shows the restored text-only draft: [visual artifact](https://github.com/openclaw/openclaw/actions/runs/32152689714/artifacts/9330442370)
- a direct old-head diagnostic intermittently reloaded before the store was settled because that head predates current main’s committed-state/render-boundary test helper; the merge composition above includes that harness repair
- no local tests were run

## Scope

Production delta: +6/-1 lines. No test, config, protocol, dependency, or storage-schema changes.