### PR TITLE
docs(apps): time-box the progress-card legacy plan fallback to 2026-10-18

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -5885,9 +5885,10 @@ class ChatController internal constructor(
         }
       }
       "plan" -> {
-        // Released Gateways through v2026.7.x only emit stream:"plan" and lack progressCard.get.
-        // Remove this fallback with the Gateway's legacy dual-emit once the minimum supported
-        // Gateway ships the store (tracked follow-up).
+        // Released Gateways through v2026.8.x only emit stream:"plan" and lack progressCard.get.
+        // SUNSET 2026-10-18: this fallback is a fixed cutover window, not a permanent contract.
+        // On that date delete it together with the Gateway's legacy stream:"plan" dual-emit and
+        // the Apple twin in ChatViewModel+TransportEvents.swift. Tracked: #125639.
         if (gatewayAdvertisesProgressCard() != false) return
         val planData = data ?: return
         if (planData["phase"].asStringOrNull() != "update") return

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -650,8 +650,9 @@ extension OpenClawChatViewModel {
         case "plan":
             // Released Gateways through v2026.8.x lack progressCard.get and only emit stream:"plan".
             // Rendering these only when the store is known-absent keeps a dual-emitting Gateway from
-            // fighting the durable card. Remove with the Gateway's legacy dual-emit once the minimum
-            // supported Gateway ships the store.
+            // fighting the durable card. SUNSET 2026-10-18: this fallback is a fixed cutover window,
+            // not a permanent contract. On that date delete it together with the Gateway's legacy
+            // stream:"plan" dual-emit and the Android twin in ChatController.kt. Tracked: #125639.
             guard self.progressCardStoreAvailable == false else { return }
             guard evt.data["phase"]?.value as? String == "update" else { return }
             let steps = Self.parseLegacyProgressCardSteps(evt.data["steps"])


### PR DESCRIPTION
# What Problem This Solves

The native `stream:"plan"` fallback (#125442 → #125588 on Apple, #125444 on Android) is deliberate compatibility debt, but its removal condition was open-ended: "once the minimum supported Gateway ships the store." Open-ended conditions rot — nobody re-evaluates them, and the fallback quietly becomes permanent architecture and a second source of truth for the same surface.

Maintainer decision: give operators a fixed cutover window and delete it on a date.

# Why This Change Was Made

Comment-only, both platforms, no runtime change:

- **Fixed sunset date: 2026-10-18** (~2 months), replacing the open-ended condition.
- **Each platform points at its twin.** The Apple note names `ChatController.kt` and the Android note names `ChatViewModel+TransportEvents.swift`, so neither half can be deleted alone and leave the platforms inconsistent.
- **Both point at the tracker**, #125639, which carries the full removal checklist: both `case "plan"` branches, the capability plumbing (`gatewayAdvertisesProgressCardStore()` + both transports, `progressCardStoreAvailable` and its `.routeChanged` invalidation, the legacy step parser, Android's `gatewayProgressCardAdvertised` / `legacyProgressCardRevision`), the Gateway's three legacy `stream:"plan"` emit sites, and deleting the fallback-only tests rather than updating them.
- **Corrects the Android version note** from "through v2026.7.x" to "through v2026.8.x": `v2026.8.1-beta.2` is released and also lacks `progressCard.get`, so the older bound understated the affected range.

# User Impact

None today — comments only. At the sunset date, users still on a Gateway older than the progress-card release lose the plan surface; that is the intended, now-dated end of the cutover window.

# Evidence

- `git diff` is two comment blocks; no executable lines changed.
- `pnpm native:i18n:verify` — `changed=false` (no inventory drift).
- `git diff --check` clean. Line lengths within limits: Android `max_line_length = off`; longest added Swift line is 101 chars against a 140 warning threshold, in a file that already has 27 lines over 100.
- Shared-kit suite run: 1375 of 1376 passed. The one failure, `send reapplies thinking gate after model patch rollback`, is an unrelated load-sensitive flake — it passed 6/6 in isolation (0.07–0.27s each) and failed only under full parallel load on a busy machine with `Timeout waiting for: reasoning model patch started` after 15s. A two-comment diff cannot affect it; recorded as a separate follow-up.
- Structured autoreview (Codex): clean.
