### PR TITLE
fix(doctor): classify critical disk exhaustion as error

### DIFF
--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -181,7 +181,7 @@ describe("collectDiskSpaceHealthFindings", () => {
     ]);
   });
 
-  it("returns a critical-space warning finding", () => {
+  it("returns a critical-space error finding", () => {
     const findings = collectDiskSpaceHealthFindings({ gateway: { mode: "local" } } as never, {
       env: { HOME: "/home/test" },
       readDiskSpace: () => ({ availableBytes: 50 * 1024 * 1024 }),
@@ -190,7 +190,7 @@ describe("collectDiskSpaceHealthFindings", () => {
     expect(findings).toEqual([
       expect.objectContaining({
         checkId: "core/doctor/disk-space",
-        severity: "warning",
+        severity: "error",
         message: "CRITICAL: only 50 MB free on the partition containing /home/test/.openclaw.",
         path: "/home/test/.openclaw",
         target: "50 MB",

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -112,15 +112,15 @@ export function collectDiskSpaceHealthFindings(
   }
 
   const [message, ...details] = result.warnings;
+  const critical = result.availableBytes < CRITICAL_BYTES;
   return [
     {
       checkId: DISK_SPACE_CHECK_ID,
-      severity: "warning",
+      severity: critical ? "error" : "warning",
       message: expectDefined(message, "disk-space warning message").replace(/^- /, ""),
       path: result.stateDir,
       target: formatBytes(result.availableBytes),
-      requirement:
-        result.availableBytes < CRITICAL_BYTES ? "critical-free-space" : "low-free-space",
+      requirement: critical ? "critical-free-space" : "low-free-space",
       fixHint: details.map((line) => line.replace(/^- /, "")).join(" "),
     },
   ];


### PR DESCRIPTION
## What Problem This Solves

Doctor’s human output calls less than 100 MB free **CRITICAL** because config writes, session transcripts, and log rotation may fail silently and cause data loss. The structured health finding nevertheless used `severity: "warning"`. As a result, `openclaw doctor --lint --all --severity-min error --json` filtered the critical disk condition out, returned `ok: true`, and exited successfully.

## Why This Change Was Made

Reuse the existing critical threshold for both the structured finding severity and requirement. Below 100 MB is now `error` / `critical-free-space`; 100–500 MB remains `warning` / `low-free-space`. Human output and thresholds are unchanged.

## User Impact

Automation and operators relying on Doctor’s error gate can no longer miss imminent write failures and data-loss risk due to critically low disk space.

## Evidence

- Pre-fix focused regression: 1 failed / 23 passed because 50 MB was classified as warning.
- Post-fix: `node scripts/run-vitest.mjs run src/commands/doctor-disk-space.test.ts` → 24/24 pass on rebased head.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` → rc 0.
- `oxlint` + `oxfmt` on touched files → rc 0 / clean.
- Codex autoreview → clean, 0.99, no actionable findings (rerun after rebase).
