### PR TITLE
fix(node-cli): treat an empty --tls-fingerprint as unset, not as no pinning

### DIFF
--- a/src/cli/node-cli/gateway-options.test.ts
+++ b/src/cli/node-cli/gateway-options.test.ts
@@ -71,4 +71,18 @@ describe("node gateway options", () => {
       "Invalid TLS fingerprint",
     );
   });
+
+  it("treats an empty --tls-fingerprint as unset instead of disabling pinning", () => {
+    const config = {
+      gateway: { tlsFingerprint: TLS_FINGERPRINT },
+    } as Parameters<typeof resolveNodeGatewayOptions>[1];
+    expect(resolveNodeGatewayOptions({ tlsFingerprint: "" }, config)).toMatchObject({
+      tls: true,
+      tlsFingerprint: TLS_FINGERPRINT,
+    });
+    expect(resolveNodeGatewayOptions({ tlsFingerprint: "   " }, config)).toMatchObject({
+      tls: true,
+      tlsFingerprint: TLS_FINGERPRINT,
+    });
+  });
 });

--- a/src/cli/node-cli/gateway-options.ts
+++ b/src/cli/node-cli/gateway-options.ts
@@ -75,14 +75,13 @@ export function resolveNodeGatewayOptions(
   const port = options.port === undefined ? baselinePort : parsePort(options.port);
   const endpointChanged = host !== baselineHost || (port !== null && port !== baselinePort);
   const baselineTlsFingerprint = pair?.tlsFingerprint ?? config?.gateway?.tlsFingerprint;
+  // An explicit-but-empty --tls-fingerprint must not silently disable pinning:
+  // treat it as unset and fall back to the configured baseline fingerprint.
   const selectedTlsFingerprint =
     options.tls === false
       ? undefined
-      : options.tlsFingerprint !== undefined
-        ? options.tlsFingerprint
-        : endpointChanged
-          ? undefined
-          : baselineTlsFingerprint;
+      : (normalizeOptionalString(options.tlsFingerprint) ??
+        (endpointChanged ? undefined : baselineTlsFingerprint));
   const baselineTls = pair?.tls ?? config?.gateway?.tls;
   const tlsFingerprint = selectedTlsFingerprint
     ? requireTlsFingerprint(selectedTlsFingerprint)


### PR DESCRIPTION
## Summary

fix(node-cli): treat an explicit-but-empty `--tls-fingerprint` as unset so it falls back to the configured baseline fingerprint, instead of silently disabling certificate pinning

## What Problem This Solves

The recent TLS pin normalization (`11ebdfc9c32`, #125276) rewrote fingerprint selection in `resolveNodeGatewayOptions` to take any explicitly passed value verbatim:

```ts
const selectedTlsFingerprint =
  options.tls === false
    ? undefined
    : options.tlsFingerprint !== undefined
      ? options.tlsFingerprint
      : endpointChanged ? undefined : baselineTlsFingerprint;
const tlsFingerprint = selectedTlsFingerprint
  ? requireTlsFingerprint(selectedTlsFingerprint)
  : undefined;
```

Two regressions versus the previous behavior (which ran the value through `normalizeOptionalString` first):

1. **`--tls-fingerprint ""` silently disables pinning.** `""` is not `undefined`, so it is selected; being falsy, `tlsFingerprint` becomes `undefined` and the node connects with **no certificate pinning at all** — even though a baseline fingerprint is configured. Previously, the empty string normalized to "unset" and the baseline fingerprint stayed active.
2. **Whitespace-only values hard-fail.** `"   "` is truthy, so it goes to `requireTlsFingerprint`, which throws `Invalid TLS fingerprint` — the node command fails outright instead of falling back.

**代码证据**: `src/cli/node-cli/gateway-options.ts:78-89` — the selection no longer normalizes the option before deciding whether a baseline fallback applies.

Trigger condition: `openclaw node --tls-fingerprint ""` (or a whitespace-only value), or any tooling that forwards an empty value for the flag.

## Root Cause

- Introduced by commit `11ebdfc9c32` (2026-08-17, #125276, "normalize TLS certificate pins"), which made validation strict but dropped the empty-input normalization from the selection path.
- Violated invariant: "explicitly provided" must mean "provided with a non-empty value". An empty override should behave like no override — especially for a security control, where the wrong direction is a silent downgrade.

## Why This Fix

- Option A (chosen): run the option through `normalizeOptionalString` before selection, restoring the pre-strictness semantics for empty/blank input while keeping `requireTlsFingerprint` strict validation for real values. One line; matches the old behavior exactly for this case.
- Option B: special-case `""` only. Leaves whitespace-only input as a crash; normalizing covers both with the same established helper.
- Not chosen: making `requireTlsFingerprint` lenient — strict validation of actual fingerprints is the point of the referenced change and stays untouched.

## User Impact

- Affected scenarios: node startup with an empty or whitespace `--tls-fingerprint` value (scripts that always pass the flag, config templates with an empty field).
- Before: empty value → connection without certificate pinning (silent security downgrade); whitespace value → startup crash.
- After: both fall back to the configured baseline fingerprint; genuine fingerprints still validated strictly.
- Behavior change: restores the pre-#125276 fallback semantics for empty input only.

## Evidence

Runs the real `resolveNodeGatewayOptions` with a baseline fingerprint configured (Node v24, tsx) — no mocks.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-tls-fingerprint-empty.mjs
FAIL tlsFingerprint: "" -> tls=undefined tlsFingerprint=<none> (expected pinned abababababab...)
Error: Invalid TLS fingerprint; expected a SHA-256 certificate fingerprint.
    at requireTlsFingerprint (packages/gateway-client/src/client-address-utils.ts:29:11)
    at resolveNodeGatewayOptions (src/cli/node-cli/gateway-options.ts:88:7)
```

(`--tls-fingerprint ""` connects unpinned; `"   "` crashes startup.)

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-tls-fingerprint-empty.mjs
PASS tlsFingerprint: "" -> tls=true tlsFingerprint=abab… (expected pinned)
PASS tlsFingerprint: "   " -> tls=true tlsFingerprint=abab… (expected pinned)
PASS control: no override -> tls=true tlsFingerprint=abab… (expected pinned)
RESULT: ALL PASS
```

## Tests and Validation

- `npx vitest run src/cli/node-cli/gateway-options.test.ts` — 5/5 passed, including the new regression test `treats an empty --tls-fingerprint as unset instead of disabling pinning` (both `""` and whitespace-only fall back to the baseline fingerprint; strict rejection of invalid real values unchanged).
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
