### PR TITLE
docs(skills): teach current TaskFlow managedFlows runtime

### DIFF
--- a/skills/taskflow-inbox-triage/SKILL.md
+++ b/skills/taskflow-inbox-triage/SKILL.md
@@ -48,7 +48,7 @@ Suggested `waitJson` when blocked on Slack:
 ## Minimal runtime calls
 
 ```ts
-const taskFlow = api.runtime.tasks.flow.fromToolContext(ctx);
+const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
 
 const created = taskFlow.createManaged({
   controllerId: "my-plugin/inbox-triage",

--- a/skills/taskflow/SKILL.md
+++ b/skills/taskflow/SKILL.md
@@ -31,13 +31,13 @@ It does **not** own branching or business logic. Put that in Lobster, acpx, or t
 
 Canonical plugin/runtime entrypoint:
 
-- `api.runtime.tasks.flow`
-- `api.runtime.taskFlow` still exists as an alias, but `api.runtime.tasks.flow` is the canonical shape
+- `api.runtime.tasks.managedFlows` is mutation-capable: create, advance, and cancel Task Flows.
+- `api.runtime.tasks.flows` is the read-only DTO view for listing and status lookups (`get`, `list`, `findLatest`, `resolve`, `getTaskSummary`).
 
 Binding:
 
-- `api.runtime.tasks.flow.fromToolContext(ctx)` when you already have trusted tool context with `sessionKey`
-- `api.runtime.tasks.flow.bindSession({ sessionKey, requesterOrigin })` when your binding layer already resolved the session and delivery context
+- `api.runtime.tasks.managedFlows.fromToolContext(ctx)` when you already have trusted tool context with `sessionKey`
+- `api.runtime.tasks.managedFlows.bindSession({ sessionKey, requesterOrigin })` when your binding layer already resolved the session and delivery context
 
 Managed-flow lifecycle:
 
@@ -59,7 +59,7 @@ Managed-flow lifecycle:
 ## Example shape
 
 ```ts
-const taskFlow = api.runtime.tasks.flow.fromToolContext(ctx);
+const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
 
 const created = taskFlow.createManaged({
   controllerId: "my-plugin/inbox-triage",
@@ -138,7 +138,7 @@ Use the flow runtime for state and task linkage. Keep decisions in the authoring
 
 - Store only the minimum state needed to resume.
 - Put human-readable wait reasons in `blockedSummary` or structured wait metadata in `waitJson`.
-- Use `getTaskSummary(flowId)` when the orchestrator needs a compact health view of child work.
+- Use `getTaskSummary(flowId)` on `api.runtime.tasks.flows` when the orchestrator needs a compact health view of child work.
 - Use `requestCancel(...)` when a caller wants the flow to stop scheduling immediately.
 - Use `cancel(...)` when you also want active linked child tasks cancelled.
 


### PR DESCRIPTION
Closes #119173

[AI-assisted]

## What Problem This Solves

Fixes an issue where users following the bundled TaskFlow skills would call `api.runtime.tasks.flow` / `api.runtime.taskFlow`, a runtime surface that no longer exists on current `main`. That produces a missing-property type error and an undefined runtime object.

## Why This Change Was Made

The public PluginRuntimeTasks contract now exposes `managedFlows` for mutations and `flows` for DTO reads. The two bundled skills were updated to match `docs/plugins/sdk-runtime.md` and `src/plugins/runtime/runtime-tasks.types.ts`. No runtime, CI, or changelog changes. The sdk-migration Before example is left as historical.

## User Impact

Plugin authors and agents following `taskflow` or `taskflow-inbox-triage` now get binding instructions that match the current SDK. Existing when-to-use guidance is unchanged.

## Evidence

- `src/plugins/runtime/runtime-tasks.types.ts` defines `runs`, `flows`, and `managedFlows` only.
- Before: `skills/taskflow/SKILL.md` and `skills/taskflow-inbox-triage/SKILL.md` taught `api.runtime.tasks.flow`.
- After: `rg 'api\.runtime\.tasks\.flow[^s]|api\.runtime\.taskFlow' skills` is clean.
- Remaining `tasks.flow` hits are the sdk-migration Before snippet and a CHANGELOG history line, both left alone.
- `git diff --check` is clean.
- Local `pnpm docs:list` succeeded and listed `plugins/sdk-runtime.md` and `plugins/sdk-migration.md`.
- Exact-head CI `check-docs` and `openclaw/ci-gate` passed on `290e306`.

After-fix real plugin-runtime run on head `290e306` / Node 22.23.2, using a throwaway plugin loaded through the production plugin host (same path as `src/tasks/plugin-managed-flows.e2e.test.ts`). The plugin bound `api.runtime.tasks.managedFlows.fromToolContext`, created and finished a managed flow, then read that same id back through `api.runtime.tasks.flows.fromToolContext` (`get`, `getTaskSummary`, `list`). Observed `api.runtime.tasks` keys were only `flows`, `managedFlows`, and `runs`. Legacy `tasks.flow` / `runtime.taskFlow` aliases were absent.

```text
$ pnpm test src/tasks/pr125647-taskflow-skill-proof.e2e.test.ts
 ✓ src/tasks/pr125647-taskflow-skill-proof.e2e.test.ts > PR 125647 TaskFlow skill bind proof > loads a temporary plugin that mutates through managedFlows and reads through flows 401ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

```json
{
  "ok": true,
  "head": "290e306d2e289f48d191f66951b30a18bd8334b9",
  "node": "22.23.2",
  "pluginStatus": "loaded",
  "taskRuntimeKeys": ["flows", "managedFlows", "runs"],
  "mutation": {
    "surface": "api.runtime.tasks.managedFlows.fromToolContext",
    "createdFlowId": "112cbc04-7487-492a-b08f-9080285f0fca",
    "finishedApplied": true,
    "finishedStatus": "succeeded"
  },
  "dtoRead": {
    "surface": "api.runtime.tasks.flows.fromToolContext",
    "id": "112cbc04-7487-492a-b08f-9080285f0fca",
    "goal": "Prove skill-taught managedFlows plus flows bind",
    "status": "succeeded",
    "state": { "phase": "finished" },
    "listedCount": 1
  }
}
```

The local proof harness was not committed. No product files changed after `290e306`.
