### PR TITLE
fix(ui): keep unsent draft indicators visible

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -168,7 +168,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
   const active =
     isSessionRouteId(host.activeRouteId) &&
     areUiSessionKeysEquivalent(host.getRouteSessionKey(), mainKey);
-  const hasComposerDraft = !active && host.hasSessionDraft(mainKey);
+  const hasComposerDraft = host.hasSessionDraft(mainKey);
   const running = mainRow?.hasActiveRun === true;
   const unread = mainRow?.unread === true && !active;
   // Home keeps its page/attention glyph leading and shares trailing activity with session rows.

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -331,7 +331,7 @@ export function renderRecentSession(params: {
               ></openclaw-viewer-facepile>
               ${renderSessionRowBadges({
                 ...session,
-                hasComposerDraft: session.hasComposerDraft === true && !session.visuallyActive,
+                hasComposerDraft: session.hasComposerDraft === true,
                 pullRequest: session.pullRequest ?? display?.pullRequest,
                 hasApproval: sessionHasPendingApproval(
                   host.sessionData.approvalBadgeSnapshot(),

--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -136,9 +136,8 @@ describe("Markdown table interactions", () => {
     const { owner } = interactiveOwner();
     const copy = owner.querySelector<HTMLButtonElement>(".markdown-table__copy")!;
     copy.click();
-    await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith("Name\tValue\nAlpha\tOne");
-    });
+    expect(copyToClipboard).toHaveBeenCalledWith("Name\tValue\nAlpha\tOne");
+    await vi.advanceTimersByTimeAsync(0);
     expect(copy.getAttribute("aria-label")).toBe("Copied!");
 
     const expand = owner.querySelector<HTMLButtonElement>(".markdown-table__expand")!;

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -119,7 +119,8 @@ suite.define(() => {
       await expect
         .poll(() => activeComposer(restoredPage).inputValue())
         .toBe("restart draft A with image");
-      await expect.poll(() => activeAttachments(restoredPage).count()).toBe(1);
+      await activeAttachments(restoredPage).first().waitFor();
+      expect(await activeAttachments(restoredPage).count()).toBe(1);
       if (artifactDir) {
         await restoredPage.screenshot({
           path: path.join(artifactDir, "existing-session-restart-draft-restored.png"),
@@ -130,7 +131,8 @@ suite.define(() => {
       await expect
         .poll(() => activeComposer(restoredPage).inputValue())
         .toBe("restart draft B with removable file");
-      await expect.poll(() => activeAttachments(restoredPage).count()).toBe(1);
+      await activeAttachments(restoredPage).first().waitFor();
+      expect(await activeAttachments(restoredPage).count()).toBe(1);
       await restoredPage
         .locator('openclaw-chat-pane[aria-hidden="false"] .chat-attachment-remove')
         .click();

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -25,8 +25,8 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
-  it("shows an unsent-draft pencil after switching sessions and removes it after clearing", async () => {
-    const firstKey = "agent:main:draft-first";
+  it("keeps the browser-local draft pencil visible on active Home beside activity", async () => {
+    const mainKey = "agent:main:main";
     const secondKey = "agent:main:draft-second";
     const context = await suite.browser.newContext({
       colorScheme: "dark",
@@ -38,39 +38,54 @@ suite.define(() => {
     await installMockGateway(page, {
       methodResponses: {
         "sessions.list": sessionsListResponse([
-          sessionRow(firstKey, "Draft first", 2),
+          sessionRow(mainKey, "Main", 2, {
+            hasActiveRun: true,
+            startedAt: 1,
+            status: "running",
+          }),
           sessionRow(secondKey, "Draft second", 1),
         ]),
       },
-      sessionKey: firstKey,
+      sessionKey: mainKey,
     });
 
     try {
-      await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstKey));
-      const firstRow = page.locator(`[data-session-key="${firstKey}"]`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, mainKey));
+      const homeRow = page.locator(".nav-item--home");
       const secondRow = page.locator(`[data-session-key="${secondKey}"]`);
       const composer = page.locator(
         'openclaw-chat-pane[aria-hidden="false"] .agent-chat__composer-combobox > textarea',
       );
-      await firstRow.waitFor({ state: "visible", timeout: 10_000 });
+      await homeRow.waitFor({ state: "visible", timeout: 10_000 });
       await secondRow.waitFor({ state: "visible" });
       await composer.waitFor({ state: "visible" });
       await captureUiProof(page, "draft-indicator-before.png");
 
       await composer.fill("Keep this unsent");
+      const activity = homeRow.getByRole("img", { name: "Active run" });
+      const draft = homeRow.getByRole("img", { name: "Unsent draft" });
+      await activity.waitFor();
+      await draft.waitFor();
+      const activityBox = await activity.boundingBox();
+      const draftBox = await draft.boundingBox();
+      if (!activityBox || !draftBox) {
+        throw new Error("expected activity and draft icon bounds");
+      }
+      expect(draftBox.x).toBeGreaterThanOrEqual(activityBox.x + activityBox.width);
+      await captureUiProof(page, "draft-indicator-active.png");
+
       await secondRow.getByRole("link").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));
-      await firstRow.getByRole("img", { name: "Unsent draft" }).waitFor();
-      await captureUiProof(page, "draft-indicator-after.png");
+      await draft.waitFor();
 
-      await firstRow.getByRole("link").click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(firstKey));
-      expect(await firstRow.getByRole("img", { name: "Unsent draft" }).count()).toBe(0);
+      await homeRow.click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(mainKey));
+      await draft.waitFor();
 
       await composer.fill("");
       await secondRow.getByRole("link").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));
-      await expect.poll(() => firstRow.getByRole("img", { name: "Unsent draft" }).count()).toBe(0);
+      await expect.poll(() => draft.count()).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/test-helpers/app-sidebar-cases/outbox-badges.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/outbox-badges.ts
@@ -4,7 +4,7 @@ import "../../components/app-sidebar.ts";
 import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
 
 describe("AppSidebar outbox attention badges", () => {
-  it("shows draft pencils only for inactive sessions with stored composer text", async () => {
+  it("shows draft pencils for active and inactive sessions with stored composer text", async () => {
     const draftKey = "agent:main:draft-thread";
     const activeDraftKey = "agent:main:active-draft-thread";
     const plainKey = "agent:main:plain-thread";
@@ -25,7 +25,7 @@ describe("AppSidebar outbox attention badges", () => {
     expect(draftBadge?.getAttribute("aria-label")).toBe("Unsent draft");
     expect(
       sidebar.querySelector(`[data-session-key="${activeDraftKey}"] .session-row-badge--draft`),
-    ).toBeNull();
+    ).not.toBeNull();
     expect(
       sidebar.querySelector(`[data-session-key="${plainKey}"] .session-row-badge--draft`),
     ).toBeNull();

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -42,7 +42,7 @@ describe("AppSidebar session indicators", () => {
     expect(emojiRow?.querySelector(".session-glyph__icon")).toBeNull();
   });
 
-  it("places Home activity in the same trailing endcap as session activity", async () => {
+  it("keeps Home activity and its active composer draft in the trailing endcap", async () => {
     const mainKey = "agent:main:main";
     const workingKey = "agent:main:working";
     const sessions = createSessionsHarness("main", [mainKey, workingKey]);
@@ -58,6 +58,8 @@ describe("AppSidebar session indicators", () => {
       createGatewayHarness({} as GatewayBrowserClient).gateway,
       sessions.sessions,
     );
+    sidebar.activeRouteId = "chat";
+    sidebar.sessionKey = mainKey;
     sidebar.outboxAttentionCountForSession = (sessionKey) => (sessionKey === mainKey ? 2 : 0);
     sidebar.hasSessionDraft = (sessionKey) => sessionKey === mainKey;
     sidebar.requestUpdate();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with browser-local unsent composer text would lose the draft pencil while the owning Home or session row was active. When an active run was present, the activity indicator could occupy the only visible trailing state, making the retained draft undiscoverable.

## Why This Change Was Made

Draft presence is persistent row state, not an inactive-session notification. The sidebar now renders it for active and inactive rows alike, while keeping run activity and the pencil as separate trailing indicators. The draft remains browser-local: the durable payload lives in IndexedDB and its live presence projection is held in session storage; no Gateway or server persistence contract changes.

## User Impact

The unsent-draft pencil remains visible while users are in the session, after they switch away and back, and alongside active-run activity. Clearing the composer removes it as before.

## Evidence

Before typing — active run only:
![Active Home before draft](https://github.com/user-attachments/assets/d3f61d30-9a11-48db-a01a-fea743361385)

After typing — active run and draft are both visible without overlap:
![Active Home with separate activity and draft indicators](https://github.com/user-attachments/assets/eb7b07ad-9e54-4004-8bf6-2cbaa6f90513)

- Regression test failed before the fix with the active Home and active session draft pencils missing, then passed after the two owner-boundary changes.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 268 passed.
- Focused mocked Gateway browser flow — passed; verifies active visibility, non-overlapping icon bounds, switch-away/back persistence, and removal after clearing.
- `node scripts/check-changed.mjs -- <five changed paths>` — passed.
- Codex autoreview — clean, no accepted/actionable findings.
- Source-blind behavior validation — all four user-visible clauses passed.
- Exact-head CI exposed two unrelated timing defects in existing UI coverage. The Markdown table copy test now checks synchronous clipboard dispatch before explicitly advancing its pending promise (one focused pass plus five bounded stress runs). The attachment restart E2E now waits for the asynchronously hydrated attachment itself instead of treating synchronously restored text as attachment readiness (one focused pass plus three bounded stress runs). Both follow-up changed gates and autoreviews are clean.

AI-assisted: yes. The implementation and behavior were independently reviewed and validated.
