### PR TITLE
fix: reclaim locks held by Linux zombie processes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3321,7 +3321,7 @@ src/infra/retry-policy.ts	3
 src/infra/retryable-network-errors.ts	1
 src/infra/session-cost-usage-aggregation.ts	5
 src/infra/session-cost-usage-cache-runtime.ts	1
-src/infra/session-cost-usage-cache.sqlite.ts	2
+src/infra/session-cost-usage-cache.sqlite.ts	1
 src/infra/session-cost-usage-collection.ts	4
 src/infra/session-cost-usage-pricing.ts	6
 src/infra/session-cost-usage-reporting.ts	9

--- a/extensions/memory-core/src/short-term-promotion-artifacts.ts
+++ b/extensions/memory-core/src/short-term-promotion-artifacts.ts
@@ -14,6 +14,7 @@ import {
 import { filterLiveShortTermRecallEntries } from "./short-term-promotion-record.js";
 import {
   SHORT_TERM_LOCK_STALE_MS,
+  deleteShortTermLockEntryIfCurrent,
   isProcessLikelyAlive,
   parseLockOwnerPid,
   readPhaseSignalStore,
@@ -186,7 +187,7 @@ export async function repairShortTermPromotionArtifacts(params: {
   if (lockEntry && Date.now() - lockEntry.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
     const ownerPid = parseLockOwnerPid(lockEntry.owner);
     if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
-      removedStaleLock = await lockStore.delete(lockKey);
+      removedStaleLock = await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry);
     }
   }
 

--- a/extensions/memory-core/src/short-term-promotion-store.ts
+++ b/extensions/memory-core/src/short-term-promotion-store.ts
@@ -1,4 +1,6 @@
+import fsSync from "node:fs";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -61,15 +63,38 @@ export function parseLockOwnerPid(raw: string): number | null {
 export function isProcessLikelyAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
-    return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ESRCH") {
       return false;
     }
-    // EPERM and unknown errors are treated as alive to avoid stealing active locks.
+    // EPERM and unknown errors remain potentially alive unless procfs proves a zombie.
+  }
+  if (process.platform !== "linux") {
     return true;
   }
+  try {
+    const status = fsSync.readFileSync(`/proc/${pid}/status`, "utf8");
+    const state = status.match(/^State:\s+(\S)/m)?.[1];
+    return state !== "Z" && state !== "X";
+  } catch {
+    // An unreadable proc entry is not enough evidence to steal an active lock.
+    return true;
+  }
+}
+
+export async function deleteShortTermLockEntryIfCurrent(
+  lockStore: PluginStateKeyedStore<ShortTermLockEntry>,
+  lockKey: string,
+  expected: ShortTermLockEntry,
+): Promise<boolean> {
+  if (!lockStore.deleteIf) {
+    throw new Error("memory-core short-term lock store requires conditional deletion");
+  }
+  return await lockStore.deleteIf(
+    lockKey,
+    (current) => current.owner === expected.owner && current.acquiredAt === expected.acquiredAt,
+  );
 }
 
 async function withInProcessShortTermLock<T>(lockPath: string, task: () => Promise<T>): Promise<T> {
@@ -90,19 +115,16 @@ export async function withShortTermLock<T>(
     const startedAt = Date.now();
 
     while (true) {
-      const owner = `${process.pid}:${Date.now()}`;
-      const acquired = await lockStore.registerIfAbsent(lockKey, {
-        owner,
+      const lockEntry: ShortTermLockEntry = {
+        owner: `${process.pid}:${Date.now()}`,
         acquiredAt: Date.now(),
-      });
+      };
+      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry);
       if (acquired) {
         try {
           return await task();
         } finally {
-          const current = await lockStore.lookup(lockKey).catch(() => undefined);
-          if (current?.owner === owner) {
-            await lockStore.delete(lockKey).catch(() => false);
-          }
+          await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry).catch(() => false);
         }
       }
 
@@ -110,8 +132,9 @@ export async function withShortTermLock<T>(
       if (existing && Date.now() - existing.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
         const ownerPid = parseLockOwnerPid(existing.owner);
         if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
-          await lockStore.delete(lockKey);
-          continue;
+          if (await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, existing)) {
+            continue;
+          }
         }
       }
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1,5 +1,6 @@
 // Memory Core tests cover short term promotion plugin behavior.
 import { createHash } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -17,10 +18,15 @@ vi.mock("openclaw/plugin-sdk/memory-host-events", () => ({
 import {
   configureMemoryCoreDreamingState,
   DREAMING_DAILY_PROVENANCE_NAMESPACE,
+  memoryCoreWorkspaceStateKey,
+  openMemoryCoreStateStore,
+  SHORT_TERM_LOCK_MAX_ENTRIES,
+  SHORT_TERM_LOCK_NAMESPACE,
   SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
   SHORT_TERM_RECALL_NAMESPACE,
   writeMemoryCoreWorkspaceEntry,
 } from "./dreaming-state.js";
+import { deleteShortTermLockEntryIfCurrent } from "./short-term-promotion-store.js";
 import {
   applyShortTermPromotions,
   auditShortTermPromotionArtifacts,
@@ -3736,6 +3742,59 @@ describe("short-term promotion", () => {
         message: "Short-term promotion lock appears stale.",
         fixable: true,
       });
+    });
+  });
+
+  it("reclaims a stale sqlite lock owned by a Linux zombie", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const ownerPid = 4242;
+      await testing.writeShortTermLock(workspaceDir, {
+        owner: `${ownerPid}:0`,
+        acquiredAt: Date.now() - 120_000,
+      });
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(process, "kill").mockImplementation(() => true);
+      vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath) => {
+        if (String(filePath) === `/proc/${ownerPid}/status`) {
+          return `Name:\tmemory worker\nState:\tZ (zombie)\nPid:\t${ownerPid}\n`;
+        }
+        throw new Error(`unexpected read: ${String(filePath)}`);
+      });
+
+      const audit = await auditShortTermPromotionArtifacts({ workspaceDir });
+      expect(audit.issues.map((issue) => issue.code)).toContain("recall-lock-stale");
+
+      await expect(repairShortTermPromotionArtifacts({ workspaceDir })).resolves.toMatchObject({
+        changed: true,
+        removedStaleLock: true,
+      });
+    });
+  });
+
+  it("preserves a replacement lock when the expected stale entry is no longer current", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const expected = {
+        owner: "4243:stale",
+        acquiredAt: Date.now() - 120_000,
+      };
+      const replacement = {
+        owner: `${process.pid}:replacement`,
+        acquiredAt: Date.now(),
+      };
+      const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
+      const lockStore = openMemoryCoreStateStore<typeof expected>({
+        namespace: SHORT_TERM_LOCK_NAMESPACE,
+        maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+      });
+      try {
+        await lockStore.register(lockKey, replacement);
+        await expect(deleteShortTermLockEntryIfCurrent(lockStore, lockKey, expected)).resolves.toBe(
+          false,
+        );
+        await expect(lockStore.lookup(lockKey)).resolves.toEqual(replacement);
+      } finally {
+        await lockStore.delete(lockKey);
+      }
     });
   });
 

--- a/src/infra/session-cost-usage-cache.sqlite.test.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -31,12 +31,46 @@ function countRegisteredAgentDatabases(): number {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
   cleanupTempDirs(tempDirs);
 });
 
 describe("session cost usage SQLite cache", () => {
+  it("removes a persisted refresh lock owned by a Linux zombie", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-zombie-lock-");
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const agentId = "worker-1";
+      const zombiePid = 4242;
+      const database = openOpenClawAgentDatabase({ agentId });
+      database.db
+        .prepare(
+          "INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at) VALUES (?, ?, ?, NULL, NULL, ?)",
+        )
+        .run(
+          "session-cost-usage",
+          "refresh-lock",
+          JSON.stringify({ pid: zombiePid, startedAt: 1, ownerNonce: "zombie-owner" }),
+          1,
+        );
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(process, "kill").mockImplementation(() => true);
+      vi.spyOn(fs, "readFileSync").mockImplementation((filePath) => {
+        expect(String(filePath)).toBe(`/proc/${zombiePid}/status`);
+        return `Name:\tworker\nState:\tZ (zombie)\nPid:\t${zombiePid}\n`;
+      });
+
+      expect(isSessionCostUsageRefreshRunning(agentId, database.path)).toBe(false);
+      expect(
+        database.db
+          .prepare("SELECT value_json FROM cache_entries WHERE scope = ? AND key = ?")
+          .get("session-cost-usage", "refresh-lock"),
+      ).toBeUndefined();
+    });
+  });
+
   it("returns empty values without creating a missing agent database", () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-missing-");
 

--- a/src/infra/session-cost-usage-cache.sqlite.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { isPidAlive } from "../shared/pid-alive.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
@@ -241,19 +242,10 @@ function parseRefreshLock(raw: string | null): SessionCostUsageRefreshLock | nul
   }
 }
 
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
-  }
-}
-
 export function isSessionCostUsageRefreshRunning(agentId?: string, databasePath?: string): boolean {
   const raw = readCacheValue(agentId, LEGACY_CACHE_SCOPE, REFRESH_LOCK_KEY, databasePath);
   const lock = parseRefreshLock(raw);
-  if (lock && isProcessRunning(lock.pid)) {
+  if (lock && isPidAlive(lock.pid)) {
     return true;
   }
   if (raw !== null) {
@@ -276,7 +268,7 @@ export function acquireSessionCostUsageRefreshLock(
   const previousLock = parseRefreshLock(previousRaw);
   // Process liveness is resolved before BEGIN. The transaction only compares
   // the authoritative row and commits the prepared replacement synchronously.
-  const previousOwnerIsRunning = previousLock ? isProcessRunning(previousLock.pid) : false;
+  const previousOwnerIsRunning = previousLock ? isPidAlive(previousLock.pid) : false;
   const lock: SessionCostUsageRefreshLock = {
     pid: process.pid,
     startedAt: Date.now(),

--- a/src/test-utils/process-tree.ts
+++ b/src/test-utils/process-tree.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isPidAlive } from "../shared/pid-alive.js";
 
 export async function writeForkingNoOutputScript(dir: string): Promise<string> {
   const scriptPath = path.join(dir, "fork-no-output.sh");
@@ -20,15 +21,6 @@ export async function writeForkingNoOutputScript(dir: string): Promise<string> {
   );
   await fs.chmod(scriptPath, 0o700);
   return scriptPath;
-}
-
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export async function waitForPidToExit(pid: number, timeoutMs = 2000): Promise<boolean> {

--- a/test/helpers/process-wait.test.ts
+++ b/test/helpers/process-wait.test.ts
@@ -1,0 +1,20 @@
+import fsSync from "node:fs";
+import { afterEach, expect, it, vi } from "vitest";
+import { waitForDead } from "./process-wait.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it("stops waiting when a Linux process is a zombie", async () => {
+  vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+  vi.spyOn(process, "kill").mockImplementation(() => true);
+  vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath) => {
+    if (String(filePath) === "/proc/42/status") {
+      return "Name:\tworker\nState:\tZ (zombie)\nPid:\t42\n";
+    }
+    throw new Error(`unexpected read: ${String(filePath)}`);
+  });
+
+  await expect(waitForDead(42, 20)).resolves.toBeUndefined();
+});

--- a/test/helpers/process-wait.ts
+++ b/test/helpers/process-wait.ts
@@ -1,14 +1,8 @@
 import type { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { isPidAlive } from "../../src/shared/pid-alive.js";
 
-export function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
+export { isPidAlive as isProcessAlive };
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => {
@@ -45,7 +39,7 @@ export async function waitForPidFile(filePath: string, timeoutMs: number): Promi
 export async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
   const deadlineAt = Date.now() + timeoutMs;
   while (Date.now() < deadlineAt) {
-    if (!isProcessAlive(pid)) {
+    if (!isPidAlive(pid)) {
       return;
     }
     await sleep(5);


### PR DESCRIPTION
Related: #125495

## What Problem This Solves

Fixes an issue where Linux processes that had exited but were still awaiting reaping could keep OpenClaw-owned locks and test waits alive. Because POSIX signal-zero succeeds for a zombie PID, short-term memory promotion could repeatedly time out on a stale lock, session-cost refresh could remain permanently busy, and shared process-wait helpers could stall until their deadlines.

## Why This Change Was Made

The affected lock owners now distinguish Linux zombie/dead states from live processes while keeping conservative behavior for `EPERM`, unknown probe errors, and unreadable procfs state. Memory promotion lock deletion is also conditional on the exact `owner` and `acquiredAt` value, so a newly acquired replacement lock cannot be deleted by a stale observer.

Core session-cost refresh and shared test helpers reuse the existing canonical zombie-aware PID helper instead of maintaining local signal-zero predicates. The agent-core kill-tree was investigated and deliberately left unchanged: it returns immediately and only uses its unref'd timer to decide conservative escalation, so a zombie does not block a caller; adding a synchronous process-group scan would add event-loop cost and could suppress SIGKILL while a live descendant remains.

## User Impact

Linux operators recover automatically from memory-promotion and session-cost locks whose owners are dead zombies. Session usage refresh no longer remains falsely busy, and process-cleanup tests no longer wait out their timeout for a terminated PID.

## Evidence

- Regression coverage:
  - `extensions/memory-core/src/short-term-promotion.test.ts` covers zombie-owned stale-lock reclamation and exact-owner replacement safety.
  - `src/infra/session-cost-usage-cache.sqlite.test.ts` covers removal of a persisted zombie-owned refresh lock.
  - `test/helpers/process-wait.test.ts` covers a shared wait completing for a Linux zombie.
  - Each zombie regression fails against the pre-fix signal-zero-only behavior for the intended reason.
- Focused Vitest: 141 tests passed across memory-core, session-cost SQLite, process-wait, canonical PID liveness, shared process-tree helpers, and unchanged kill-tree coverage.
- Linux Docker (`node:24-bookworm`, `--init`): a deliberate child remained in `/proc` state `Z`; `process.kill(pid, 0)` succeeded while `isPidAlive(pid)` returned `false` and `isPidDefinitelyDead(pid)` returned `true`.
- `node scripts/check-changed.mjs` — passed.
- `git diff --check` — passed.
- Fresh Codex autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings; patch-correct score 0.97.

Production LOC: +40/-24 (net +16). Tests: +114/-1. Shared test support: +4/-18 (net -14). The production growth is the Linux zombie classification plus atomic lock-owner deletion; duplicate core/test liveness predicates were removed.

AI-assisted; implementation and final diff were manually reviewed and behavior-verified.
