### PR TITLE
test(agents): isolate live session model fixture

### DIFF
--- a/src/agents/sessions/agent-session.live.test.ts
+++ b/src/agents/sessions/agent-session.live.test.ts
@@ -1,19 +1,17 @@
 // Live end-to-end checks for AgentSession turns, compaction, and follow-up delivery.
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
-import { discoverModels } from "../agent-model-discovery.js";
-import { isLiveTestEnabled, readLiveTestConfig } from "../live-test-helpers.js";
-import { ensureOpenClawModelsJson } from "../models-config.js";
+import { isLiveTestEnabled } from "../live-test-helpers.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { AgentSession } from "./agent-session.js";
 import { AuthStorage } from "./auth-storage.js";
 import { createExtensionRuntime } from "./extensions/loader.js";
 import type { LoadExtensionsResult, ToolDefinition } from "./extensions/types.js";
-import type { ModelRegistry } from "./model-registry.js";
+import { ModelRegistry } from "./model-registry.js";
 import type { ResourceLoader } from "./resource-loader.js";
 import { createAgentSession } from "./sdk.js";
 import { SessionManager } from "./session-manager.js";
@@ -69,20 +67,41 @@ function createResourceLoader(handlers: ExtensionHandlers = new Map()): Resource
 }
 
 async function resolveLiveModel(
-  agentDir: string,
+  modelsPath: string,
   authStorage: AuthStorage,
 ): Promise<{ model: Model; modelRegistry: ModelRegistry }> {
-  await ensureOpenClawModelsJson(await readLiveTestConfig(), agentDir, {
-    providerDiscoveryProviderIds: ["anthropic"],
-  });
-  const modelRegistry = discoverModels(authStorage, agentDir, { providerFilter: "anthropic" });
   const requestedModelId =
     process.env.OPENCLAW_LIVE_AGENT_SESSION_MODEL?.trim() || DEFAULT_MODEL_ID;
-  const model =
-    modelRegistry.find("anthropic", requestedModelId) ??
-    modelRegistry
-      .getAll()
-      .find((candidate) => candidate.provider === "anthropic" && /haiku/i.test(candidate.id));
+  // This suite owns AgentSession behavior, so keep its provider fixture independent from the
+  // operator's config and refreshable catalog state. Catalog discovery has dedicated live lanes.
+  await writeFile(
+    modelsPath,
+    `${JSON.stringify(
+      {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            api: "anthropic-messages",
+            models: [
+              {
+                id: requestedModelId,
+                name: requestedModelId,
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200_000,
+                maxTokens: 64_000,
+              },
+            ],
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const modelRegistry = ModelRegistry.create(authStorage, modelsPath);
+  const model = modelRegistry.find("anthropic", requestedModelId);
   if (!model) {
     throw new Error(`No Anthropic Haiku model found for ${requestedModelId}`);
   }
@@ -102,10 +121,11 @@ async function createLiveSession(
   tempRoots.push(root);
   const cwd = join(root, "workspace");
   const agentDir = join(root, "agent");
+  const modelsPath = join(root, "models.json");
   await mkdir(cwd, { recursive: true });
   const authStorage = AuthStorage.inMemory();
   authStorage.setRuntimeApiKey("anthropic", API_KEY);
-  const { model, modelRegistry } = await resolveLiveModel(agentDir, authStorage);
+  const { model, modelRegistry } = await resolveLiveModel(modelsPath, authStorage);
   const sessionManager = SessionManager.inMemory();
   const settingsManager = SettingsManager.inMemory({
     defaultThinkingLevel: "off",


### PR DESCRIPTION
## Summary

Keep the AgentSession live suite focused on session turns, compaction, and follow-up delivery by giving it an isolated Anthropic model fixture. The suite no longer depends on the operator config or refreshable plugin catalog state.

## Root cause

The release lane executed the session suite against a fresh agent directory while resolving its model through mutable config/catalog discovery. All three session cases failed before exercising AgentSession because the registry contained no Anthropic Haiku row. Catalog discovery already has dedicated live coverage; it is not part of this suite's invariant.

## Validation

- Original failure reproduced twice in release run 32099770866: all three `agent-session.live.test.ts` cases failed with `No Anthropic Haiku model found for claude-haiku-4-5`.
- Exact tested head: `0c4a5ce92fc6de62f1587fe1ef208e428c2175ec`.
- Exact-head Anthropic live proof: [run 32107756826, native-live-src-agents job](https://github.com/openclaw/openclaw/actions/runs/32107756826/job/95621313893).
  - `completes a real tool turn`: passed.
  - `manually compacts a completed turn and remains usable`: passed.
  - `drains a follow-up queued by an agent-end handler`: passed.
  - The complete three-case file passed twice: 5.873s initially and 5.947s on the workflow retry.
- The job's overall failure is unrelated to this PR: `src/agents/xai.live.test.ts` timed out after 90 seconds in `sends wrapped grok-4.3 tool payloads live`, including on the automatic retry. This PR changes only the AgentSession Anthropic fixture.
- `git diff --check` passed.
- Structured autoreview passed with no actionable findings.
- No tests were run locally; executable proof ran only on GitHub.
