### PR TITLE
fix(doctor): point legacy model refs at doctor --fix

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -33,7 +33,11 @@ import {
   collectDisabledCodexPluginRouteIssues,
   enableCodexPluginForRequiredRoutes,
 } from "./codex-route-config-scan.js";
-import { parseCodexRouteModelRef } from "./codex-route-model-ref.js";
+import {
+  isBlockedLegacyCodexModelRef,
+  parseCodexRouteModelRef,
+  toCanonicalOpenAIModelRef,
+} from "./codex-route-model-ref.js";
 import { maybeRepairCodexSessionRoutes } from "./codex-route-session-repair.js";
 import type {
   CodexRouteHit,
@@ -45,6 +49,24 @@ import {
   collectBlockedLegacyOpenAICodexProviderPlan,
   type BlockedLegacyOpenAICodexProviderPlan,
 } from "./legacy-config-migrations.runtime.models.js";
+import { rewriteKnownModelRefs } from "./legacy-config-migrations.runtime.models.refs.js";
+import { migrateLegacyRuntimeModelRef } from "./legacy-runtime-model-providers.js";
+
+export function resolveKnownModelRefMigrationTarget(
+  cfg: OpenClawConfig,
+  ref: string,
+): string | undefined {
+  const blockedModelIdentities = new Set(
+    collectBlockedLegacyOpenAICodexProviderPlan(cfg).blockedModelIdentities,
+  );
+  if (isBlockedLegacyCodexModelRef({ modelRef: ref, blockedModelIdentities })) {
+    return undefined;
+  }
+  const providerRef =
+    migrateLegacyRuntimeModelRef(ref)?.ref ?? toCanonicalOpenAIModelRef(ref) ?? ref;
+  const migrated = rewriteKnownModelRefs(providerRef, "model", []).value;
+  return typeof migrated === "string" && migrated !== ref ? migrated : undefined;
+}
 
 function formatCodexRouteChange(hit: CodexRouteHit): string {
   return `${hit.path}: ${hit.model} -> ${hit.canonicalModel}.`;

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -984,33 +984,62 @@ describe("CORE_HEALTH_CHECKS", () => {
     );
   });
 
-  it("distinguishes unknown model providers from unconfirmed models", async () => {
+  it("distinguishes migratable model refs from unknown providers and unconfirmed models", async () => {
     const check = getCheck(createCoreHealthChecks(), "core/doctor/model-references");
 
-    await expect(
-      check.detect({
-        mode: "doctor",
-        runtime,
-        cfg: {
-          agents: {
-            defaults: {
-              model: { primary: "openai/not-in-the-local-catalog" },
-              imageModel: { primary: "no-such-provider/no-such-model" },
+    const findings = await check.detect({
+      mode: "doctor",
+      runtime,
+      cfg: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.6-sol",
+              fallbacks: [
+                "codex-cli/gpt-5.6-sol",
+                "groq/llama3-70b-8192",
+                "groq/llama-3.3-70b-versatile",
+                "openai/not-in-the-local-catalog",
+              ],
             },
+            imageModel: { primary: "no-such-provider/no-such-model" },
           },
         },
-      }),
-    ).resolves.toEqual(
+      },
+    });
+
+    for (const [source, target, severity] of [
+      ["openai-codex/gpt-5.6-sol", "openai/gpt-5.6-sol", "warning"],
+      ["codex-cli/gpt-5.6-sol", "openai/gpt-5.6-sol", "warning"],
+      ["groq/llama3-70b-8192", "groq/llama-3.3-70b-versatile", "info"],
+    ] as const) {
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          severity,
+          target: source,
+          message: `Configured model "${source}" is a legacy reference. Doctor can migrate it to "${target}".`,
+          fixHint: `Run \`openclaw doctor --fix\` to migrate this model reference to "${target}".`,
+        }),
+      );
+    }
+    expect(findings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           severity: "info",
           target: "openai/not-in-the-local-catalog",
+          fixHint:
+            "Verify the model id with the provider, or rerun with --severity-min info after refreshing the local catalog.",
         }),
         expect.objectContaining({
           severity: "warning",
           target: "no-such-provider/no-such-model",
+          fixHint:
+            "Install a plugin that declares this provider, configure it under models.providers, or remove the model reference.",
         }),
       ]),
+    );
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({ target: "groq/llama-3.3-70b-versatile" }),
     );
   });
 });

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -27,6 +27,7 @@ import {
 import {
   collectCodexRuntimeCompatibilityWarnings,
   collectDisabledCodexPluginRouteIssues,
+  resolveKnownModelRefMigrationTarget,
 } from "../commands/doctor/shared/codex-route-warnings.js";
 import { isDefaultInstallIdentity } from "../config/paths.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
@@ -676,6 +677,14 @@ function createModelReferenceCheck(): HealthCheck {
         env: ctx.env,
         workspaceDir: ctx.cwd,
       }).flatMap((inspection): HealthFinding[] => {
+        const migrationTarget = resolveKnownModelRefMigrationTarget(ctx.cfg, inspection.ref);
+        const migrationFinding = migrationTarget
+          ? {
+              message: `Configured model "${inspection.ref}" is a legacy reference. Doctor can migrate it to "${migrationTarget}".`,
+              requirement: `canonical model reference "${migrationTarget}"`,
+              fixHint: `Run \`openclaw doctor --fix\` to migrate this model reference to "${migrationTarget}".`,
+            }
+          : undefined;
         if (inspection.status === "unknown-provider") {
           return [
             {
@@ -683,10 +692,12 @@ function createModelReferenceCheck(): HealthCheck {
               severity: "warning",
               source: "doctor",
               target: inspection.ref,
-              message: `Configured model "${inspection.ref}" uses unknown provider "${inspection.provider}". No installed plugin manifest or models.providers entry declares it.`,
-              requirement: "an installed plugin manifest or models.providers configuration",
-              fixHint:
-                "Install a plugin that declares this provider, configure it under models.providers, or remove the model reference.",
+              ...(migrationFinding ?? {
+                message: `Configured model "${inspection.ref}" uses unknown provider "${inspection.provider}". No installed plugin manifest or models.providers entry declares it.`,
+                requirement: "an installed plugin manifest or models.providers configuration",
+                fixHint:
+                  "Install a plugin that declares this provider, configure it under models.providers, or remove the model reference.",
+              }),
             },
           ];
         }
@@ -697,10 +708,12 @@ function createModelReferenceCheck(): HealthCheck {
               severity: "info",
               source: "doctor",
               target: inspection.ref,
-              message: `Configured model "${inspection.ref}" uses a known provider but is not in the local model catalog. It may be newly released or self-hosted.`,
-              requirement: "a provider-supported model id",
-              fixHint:
-                "Verify the model id with the provider, or rerun with --severity-min info after refreshing the local catalog.",
+              ...(migrationFinding ?? {
+                message: `Configured model "${inspection.ref}" uses a known provider but is not in the local model catalog. It may be newly released or self-hosted.`,
+                requirement: "a provider-supported model id",
+                fixHint:
+                  "Verify the model id with the provider, or rerun with --severity-min info after refreshing the local catalog.",
+              }),
             },
           ];
         }


### PR DESCRIPTION
## What Problem This Solves

Doctor's model-reference check advised operators to do the one thing the architecture forbids, for a condition doctor already repairs itself.

With a retired provider ref in config:

```
$ openclaw doctor --json
{
  "checkId": "core/doctor/model-references",
  "severity": "warning",
  "message": "Configured model \"openai-codex/gpt-5.6-sol\" uses unknown provider \"openai-codex\".
              No installed plugin manifest or models.providers entry declares it.",
  "fixHint": "Install a plugin that declares this provider, configure it under models.providers,
              or remove the model reference."
}
```

On the very same config:

```
$ openclaw doctor --fix
Repaired Codex model routes:
- agents.defaults.model.primary: openai-codex/gpt-5.6-sol -> openai/gpt-5.6-sol.
  Set agents.defaults.models.openai/gpt-5.6-sol.agentRuntime.id to "codex" so repaired OpenAI refs
  keep Codex auth routing.
```

Every branch of that hint is wrong for this case. Nothing declares `openai-codex` anymore — it was folded into `openai`. Configuring it under `models.providers` would recreate a retired route, which root `AGENTS.md` explicitly prohibits ("No new/live `openai-codex` provider/plugin/auth/model routes; treat them as legacy input only"). And removing the reference throws away the operator's model choice when `--fix` migrates it losslessly *and* preserves Codex auth routing.

Measured on two retired provider ids, both flagged with the same wrong hint and both migrated correctly:

| ref | before | after `doctor --fix` |
| --- | --- | --- |
| `openai-codex/gpt-5.6-sol` | "install a plugin…" | `openai/gpt-5.6-sol` |
| `codex-cli/gpt-5.6-sol` | "install a plugin…" | `openai/gpt-5.6-sol` |

## Why This Change Was Made

This is a defect in the check added in #125558, so it is fixed at the source.

The check had no notion of "retired but migratable" — it only asked whether a provider is currently declared. The knowledge it was missing already exists: `rewriteKnownModelRefs` and the retired-model tables in `legacy-config-migrations.runtime.models.refs.ts` are what `doctor --fix` itself uses.

So rather than hardcoding a list of retired provider ids into the check, `resolveKnownModelRefMigrationTarget` asks that owner whether it would rewrite the ref. If it would, the finding names the concrete target and points at `openclaw doctor --fix`; if it would not, the existing message is emitted unchanged. Retired-ref knowledge stays in the migration module, and the check consults it.

Two details worth noting. Refs that are *blocked* rather than migratable (`isBlockedLegacyCodexModelRef`) are excluded, so they keep the original guidance. And the migration hint applies to both the unknown-provider and unknown-model branches, since a retired model id under a live provider is equally migratable.

## User Impact

An operator with a legacy model ref is now told the concrete canonical target and the one command that performs the migration, instead of being pushed toward resurrecting a removed provider or discarding their model choice. Guidance for genuinely unknown providers is unchanged, and what `doctor --fix` actually migrates is untouched — this changes only the read-only check's advice.

## Evidence

- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.test.ts` — 24 pass.
- Verified independently on a built CLI by applying the change to a clean checkout and rebuilding, across four configs:
  - `openai-codex/gpt-5.6-sol` → ``Run `openclaw doctor --fix` to migrate this model reference to "openai/gpt-5.6-sol".``
  - `codex-cli/gpt-5.6-sol` → same target
  - `totally-fake-provider/some-model` → original "install a plugin…" guidance preserved
  - `openai/gpt-5.6-sol` → no finding
