### PR TITLE
fix(commands): preserve approval reviewer custody

### DIFF
--- a/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
+++ b/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
@@ -9,10 +9,12 @@ import path from "node:path";
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
+import { resolveCommandExecApprovalRoute } from "../auto-reply/reply/commands-private-route.js";
+import type { HandleCommandsParams } from "../auto-reply/reply/commands-types.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
+import { ADMIN_SCOPE, APPROVALS_SCOPE } from "../gateway/method-scopes.js";
 import { startGatewayServer } from "../gateway/server.js";
 import {
   connectGatewayClient,
@@ -20,6 +22,7 @@ import {
   getGatewayE2ePortBlock,
 } from "../gateway/test-helpers.e2e.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../gateway/test-helpers.env.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { withTimeout } from "../utils/with-timeout.js";
@@ -27,6 +30,7 @@ import { createOpenClawCodingTools } from "./agent-tools.js";
 import { getFinishedSession } from "./bash-process-registry.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import type { ExecApprovalFollowupOutcome } from "./bash-tools.exec-types.js";
+import { createExecTool } from "./bash-tools.js";
 
 const TEST_ENV_KEYS = [
   "HOME",
@@ -143,6 +147,39 @@ describe("gateway-hosted exec approvals", () => {
       });
       cleanup.push(() => disconnectGatewayClient(operator));
 
+      const originReviewerIdentity = loadOrCreateDeviceIdentity({
+        path: path.join(stateDir, "test-device-identities", "origin-reviewer.sqlite"),
+      });
+      const otherReviewerIdentity = loadOrCreateDeviceIdentity({
+        path: path.join(stateDir, "test-device-identities", "other-reviewer.sqlite"),
+      });
+      const originReviewer = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        clientName: GATEWAY_CLIENT_NAMES.TEST,
+        clientDisplayName: "origin approval reviewer",
+        mode: GATEWAY_CLIENT_MODES.TEST,
+        scopes: [APPROVALS_SCOPE],
+        caps: [GATEWAY_CLIENT_CAPS.EXEC_APPROVALS],
+        deviceIdentity: originReviewerIdentity,
+        requestTimeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+        timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+      });
+      cleanup.push(() => disconnectGatewayClient(originReviewer));
+      const otherReviewer = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        clientName: GATEWAY_CLIENT_NAMES.TEST,
+        clientDisplayName: "other approval reviewer",
+        mode: GATEWAY_CLIENT_MODES.TEST,
+        scopes: [APPROVALS_SCOPE],
+        caps: [GATEWAY_CLIENT_CAPS.EXEC_APPROVALS],
+        deviceIdentity: otherReviewerIdentity,
+        requestTimeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+        timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+      });
+      cleanup.push(() => disconnectGatewayClient(otherReviewer));
+
       let resolveOutcome: (outcome: ExecApprovalFollowupOutcome) => void = () => {};
       let approvedProcessId: string | undefined;
 
@@ -224,6 +261,63 @@ describe("gateway-hosted exec approvals", () => {
         throw new Error("expected retained approved process output");
       }
       expect(finished.expiresAt - finished.endedAt).toBe(180_000);
+
+      const commandRoute = resolveCommandExecApprovalRoute({
+        commandParams: {
+          command: { channel: "webchat", from: "owner", to: "owner" },
+          ctx: {
+            ApprovalReviewerDeviceId: originReviewerIdentity.deviceId,
+            OriginatingTo: "owner",
+          },
+        } as HandleCommandsParams,
+      });
+      let resolveRoutedOutcome: (outcome: ExecApprovalFollowupOutcome) => void = () => {};
+      const routedOutcomePromise = new Promise<ExecApprovalFollowupOutcome>((resolve) => {
+        resolveRoutedOutcome = resolve;
+      });
+      const routedTool = createExecTool({
+        host: "gateway",
+        security: "allowlist",
+        ask: "always",
+        allowBackground: true,
+        approvalRunningNoticeMs: 0,
+        approvalFollowupMode: "direct",
+        approvalFollowup: ({ outcome: routedOutcome }) => {
+          resolveRoutedOutcome(routedOutcome);
+          return undefined;
+        },
+        cwd: workspaceDir,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        ...commandRoute,
+      });
+      const routedPending = await routedTool.execute("exec-approval-device-custody", {
+        command: "printf 'device-bound-smoke\\n'",
+        workdir: workspaceDir,
+        background: true,
+        timeoutSeconds: 5,
+      });
+      const routedApprovalId = requireApprovalId(routedPending.details);
+
+      await expect(
+        otherReviewer.request(
+          "exec.approval.resolve",
+          { id: routedApprovalId, decision: "allow-once" },
+          { timeoutMs: 10_000 },
+        ),
+      ).rejects.toThrow("unknown or expired approval id");
+      await originReviewer.request(
+        "exec.approval.resolve",
+        { id: routedApprovalId, decision: "allow-once" },
+        { timeoutMs: 10_000 },
+      );
+
+      const routedOutcome = await withTimeout(routedOutcomePromise, 15_000, {
+        message: "timed out waiting for device-bound exec outcome",
+      });
+      expect(routedOutcome.status).toBe("completed");
+      expect(routedOutcome.exitCode).toBe(0);
+      expect(routedOutcome.aggregated).toBe("device-bound-smoke");
     },
     EXEC_APPROVAL_E2E_TIMEOUT_MS,
   );

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -48,6 +48,7 @@ type ExecCall = {
 
 type ExecDefaults = {
   accountId?: string;
+  approvalReviewerDeviceId?: string;
   approvalFollowup?: () => Promise<string | undefined>;
   approvalFollowupMode?: string;
   approvalFollowupText?: string;
@@ -302,7 +303,9 @@ afterEach(() => {
 describe("diagnostics command", () => {
   it("requests Gateway diagnostics approval without a duplicate pending chat reply", async () => {
     const { execCalls, handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
-    const result = await handleDiagnosticsCommand(buildDiagnosticsParams("/diagnostics"), true);
+    const params = buildDiagnosticsParams("/diagnostics");
+    params.ctx.ApprovalReviewerDeviceId = "device-diagnostics-reviewer";
+    const result = await handleDiagnosticsCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply).toBeUndefined();
@@ -312,6 +315,7 @@ describe("diagnostics command", () => {
     expect(execCall.defaults.security).toBe("allowlist");
     expect(execCall.defaults.ask).toBe("always");
     expect(execCall.defaults.trigger).toBe("diagnostics");
+    expect(execCall.defaults.approvalReviewerDeviceId).toBe("device-diagnostics-reviewer");
     expect(execCall.defaults.approvalFollowupMode).toBe("direct");
     expect(execCall.defaults.approvalWarningText).toContain(
       "Diagnostics can include sensitive local logs and host-level runtime metadata.",

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -58,6 +58,7 @@ type ExecCall = {
 
 type ExecDefaults = {
   accountId?: string;
+  approvalReviewerDeviceId?: string;
   approvalFollowup?: () => Promise<string | undefined>;
   approvalFollowupMode?: string;
   approvalFollowupText?: string;
@@ -314,7 +315,9 @@ afterEach(() => {
 describe("diagnostics command", () => {
   it("requests Gateway diagnostics approval without a duplicate pending chat reply", async () => {
     const { execCalls, handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
-    const result = await handleDiagnosticsCommand(buildDiagnosticsParams("/diagnostics"), true);
+    const params = buildDiagnosticsParams("/diagnostics");
+    params.ctx.ApprovalReviewerDeviceId = "device-diagnostics-reviewer";
+    const result = await handleDiagnosticsCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply).toBeUndefined();
@@ -324,6 +327,7 @@ describe("diagnostics command", () => {
     expect(execCall.defaults.security).toBe("allowlist");
     expect(execCall.defaults.ask).toBe("always");
     expect(execCall.defaults.trigger).toBe("diagnostics");
+    expect(execCall.defaults.approvalReviewerDeviceId).toBe("device-diagnostics-reviewer");
     expect(execCall.defaults.approvalFollowupMode).toBe("direct");
     expect(execCall.defaults.approvalWarningText).toContain(
       "Diagnostics can include sensitive local logs and host-level runtime metadata.",

--- a/src/auto-reply/reply/commands-export-trajectory.test-support.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.test-support.ts
@@ -131,6 +131,7 @@ describe("buildExportTrajectoryCommandReply", () => {
   it("requests per-run exec approval for trajectory exports", async () => {
     const { execCalls, deps } = createExecDeps();
     const params = makeParams();
+    params.ctx.ApprovalReviewerDeviceId = "device-trajectory-reviewer";
 
     const reply = await buildExportTrajectoryCommandReply(params, deps);
 
@@ -151,6 +152,7 @@ describe("buildExportTrajectoryCommandReply", () => {
     expect(execCall.defaults.sessionStore).toBe("/tmp/openclaw-sessions.json");
     expect(execCall.defaults.currentChannelId).toBe("bot");
     expect(execCall.defaults.accountId).toBe("account-1");
+    expect(execCall.defaults.approvalReviewerDeviceId).toBe("device-trajectory-reviewer");
     expect(execCall.params.security).toBe("allowlist");
     expect(execCall.params.ask).toBe("always");
     expect(execCall.params.background).toBe(true);

--- a/src/auto-reply/reply/commands-export-trajectory.test-support.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.test-support.ts
@@ -175,7 +175,6 @@ describe("buildExportTrajectoryCommandReply", () => {
     expect(execCall.defaults.currentChannelId).toBe("bot");
     expect(execCall.defaults.accountId).toBe("account-1");
     expect(execCall.defaults.approvalReviewerDeviceId).toBe("device-trajectory-reviewer");
-    expect(execCall.params.security).toBe("allowlist");
     expect(execCall.params.ask).toBe("always");
     expect(execCall.params.background).toBe(true);
     const command = typeof execCall.params.command === "string" ? execCall.params.command : "";

--- a/src/auto-reply/reply/commands-export-trajectory.test-support.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.test-support.ts
@@ -153,6 +153,7 @@ describe("buildExportTrajectoryCommandReply", () => {
   it("requests per-run exec approval for trajectory exports", async () => {
     const { execCalls } = mockCommandBoundaries();
     const params = makeParams();
+    params.ctx.ApprovalReviewerDeviceId = "device-trajectory-reviewer";
 
     const reply = await buildExportTrajectoryCommandReply(params);
 
@@ -173,6 +174,8 @@ describe("buildExportTrajectoryCommandReply", () => {
     expect(execCall.defaults.sessionStore).toBe("/tmp/openclaw-sessions.json");
     expect(execCall.defaults.currentChannelId).toBe("bot");
     expect(execCall.defaults.accountId).toBe("account-1");
+    expect(execCall.defaults.approvalReviewerDeviceId).toBe("device-trajectory-reviewer");
+    expect(execCall.params.security).toBe("allowlist");
     expect(execCall.params.ask).toBe("always");
     expect(execCall.params.background).toBe(true);
     const command = typeof execCall.params.command === "string" ? execCall.params.command : "";

--- a/src/auto-reply/reply/commands-private-route.test.ts
+++ b/src/auto-reply/reply/commands-private-route.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import type { MsgContext } from "../templating.js";
 import {
+  resolveCommandExecApprovalRoute,
   resolvePrivateCommandApprovalRouteExpiresAtMs,
   resolvePrivateCommandRouteTargets,
 } from "./commands-private-route.js";
@@ -148,6 +149,31 @@ function buildApprovalRequest(): ExecApprovalRequest {
 
 afterEach(() => {
   resetPluginRuntimeStateForTest();
+});
+
+describe("resolveCommandExecApprovalRoute", () => {
+  it("preserves origin reviewer custody when delivery moves to a private target", () => {
+    const commandParams = buildCommandParams({} as OpenClawConfig);
+    commandParams.ctx.ApprovalReviewerDeviceId = "  device-origin-reviewer  ";
+
+    expect(
+      resolveCommandExecApprovalRoute({
+        commandParams,
+        privateApprovalTarget: {
+          channel: "telegram",
+          to: "849985193",
+          accountId: "telegram-owner-account",
+          threadId: 42,
+        },
+      }),
+    ).toEqual({
+      messageProvider: "telegram",
+      currentChannelId: "849985193",
+      currentThreadTs: "42",
+      accountId: "telegram-owner-account",
+      approvalReviewerDeviceId: "device-origin-reviewer",
+    });
+  });
 });
 
 describe("resolvePrivateCommandApprovalRouteExpiresAtMs", () => {

--- a/src/auto-reply/reply/commands-private-route.test.ts
+++ b/src/auto-reply/reply/commands-private-route.test.ts
@@ -12,6 +12,7 @@ import {
 import type { MsgContext } from "../templating.js";
 import {
   buildPrivateCommandApprovalRequest,
+  resolveCommandExecApprovalRoute,
   resolvePrivateCommandRouteTargets,
 } from "./commands-private-route.js";
 import type { HandleCommandsParams } from "./commands-types.js";
@@ -164,6 +165,31 @@ describe("buildPrivateCommandApprovalRequest", () => {
       createdAtMs,
     });
     expect(request.expiresAtMs).toBe(expiresAtMs);
+  });
+});
+
+describe("resolveCommandExecApprovalRoute", () => {
+  it("preserves origin reviewer custody when delivery moves to a private target", () => {
+    const commandParams = buildCommandParams({} as OpenClawConfig);
+    commandParams.ctx.ApprovalReviewerDeviceId = "  device-origin-reviewer  ";
+
+    expect(
+      resolveCommandExecApprovalRoute({
+        commandParams,
+        privateApprovalTarget: {
+          channel: "telegram",
+          to: "849985193",
+          accountId: "telegram-owner-account",
+          threadId: 42,
+        },
+      }),
+    ).toEqual({
+      messageProvider: "telegram",
+      currentChannelId: "849985193",
+      currentThreadTs: "42",
+      accountId: "telegram-owner-account",
+      approvalReviewerDeviceId: "device-origin-reviewer",
+    });
   });
 });
 

--- a/src/auto-reply/reply/commands-private-route.ts
+++ b/src/auto-reply/reply/commands-private-route.ts
@@ -133,8 +133,8 @@ export function readCommandDeliveryTarget(params: HandleCommandsParams): string 
 /**
  * Resolves where an exec approval prompt for a command should be delivered:
  * the private owner-DM target when one was resolved, else the originating
- * command surface. Keeps the fallback ternaries in one place so private and
- * origin routing cannot drift between command handlers.
+ * command surface. The originating reviewer device stays separate from a
+ * private delivery target so command handlers cannot drop approval custody.
  */
 export function resolveCommandExecApprovalRoute(params: {
   commandParams: HandleCommandsParams;
@@ -144,6 +144,7 @@ export function resolveCommandExecApprovalRoute(params: {
   currentChannelId: string | undefined;
   currentThreadTs: string | undefined;
   accountId: string | undefined;
+  approvalReviewerDeviceId: string | undefined;
 } {
   const target = params.privateApprovalTarget;
   return {
@@ -157,6 +158,9 @@ export function resolveCommandExecApprovalRoute(params: {
     accountId: target
       ? (target.accountId ?? undefined)
       : (params.commandParams.ctx.AccountId ?? undefined),
+    approvalReviewerDeviceId: normalizeOptionalString(
+      params.commandParams.ctx.ApprovalReviewerDeviceId,
+    ),
   };
 }
 

--- a/src/auto-reply/reply/commands-private-route.ts
+++ b/src/auto-reply/reply/commands-private-route.ts
@@ -164,8 +164,8 @@ function readCommandDeliveryTarget(params: HandleCommandsParams): string | undef
 /**
  * Resolves where an exec approval prompt for a command should be delivered:
  * the private owner-DM target when one was resolved, else the originating
- * command surface. Keeps the fallback ternaries in one place so private and
- * origin routing cannot drift between command handlers.
+ * command surface. The originating reviewer device stays separate from a
+ * private delivery target so command handlers cannot drop approval custody.
  */
 export function resolveCommandExecApprovalRoute(params: {
   commandParams: HandleCommandsParams;
@@ -175,6 +175,7 @@ export function resolveCommandExecApprovalRoute(params: {
   currentChannelId: string | undefined;
   currentThreadTs: string | undefined;
   accountId: string | undefined;
+  approvalReviewerDeviceId: string | undefined;
 } {
   const target = params.privateApprovalTarget;
   return {
@@ -188,6 +189,9 @@ export function resolveCommandExecApprovalRoute(params: {
     accountId: target
       ? (target.accountId ?? undefined)
       : (params.commandParams.ctx.AccountId ?? undefined),
+    approvalReviewerDeviceId: normalizeOptionalString(
+      params.commandParams.ctx.ApprovalReviewerDeviceId,
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- preserve the originating approval-reviewer device when a sensitive command redirects delivery to a private owner target
- keep delivery routing and reviewer custody as separate facts at the shared command-route owner
- cover diagnostics and trajectory-export callers plus a real Gateway final-effect flow

## Root cause and fix

`resolveCommandExecApprovalRoute` owned the split between the originating command surface and a redirected private delivery target, but it returned only delivery fields. Both callers spread that result into `createExecTool`, so redirecting the prompt silently dropped `ApprovalReviewerDeviceId` before the exec runtime registered the approval.

The shared resolver now returns the normalized originating reviewer device independently from channel/account/thread delivery. The existing exec-host boundary converts that single device into the trusted runtime's `approvalReviewerDeviceIds`; no new authorization path, fallback, config, protocol, or storage surface was added.

## Final-effect proof

`src/agents/bash-tools.exec-gateway-approval.e2e.test.ts` now drives the complete production chain on a real Gateway:

1. resolve the command approval route from the originating device
2. execute the real Gateway-hosted exec tool and register its approval
3. prove a different authenticated approval-only device cannot resolve it (without the administrator bypass)
4. prove the originating device can resolve it and the command completes

The test fails before this patch because the route omits reviewer custody and the other device can resolve the approval.

## Validation

- exact head: `9b64792523f2653fe1b62704019b92b35e83f51f`
- exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34449961826 (success on the exact head)
- exact-head final-effect proof: https://github.com/openclaw/openclaw/actions/runs/33343061765/job/99342198724 (`Run command reviewer custody E2E proof` succeeded; the diagnostic job's later ordinary lint step was cancelled)
- ClawSweeper: Platinum, no findings, proof sufficient on the exact head; https://github.com/openclaw/openclaw/pull/125663#issuecomment-5324596185
- structured autoreview: branch clean at 0.98; final-effect test clean at 0.99; no actionable findings
- production: +6/-2; tests: +128/-2
- no local tests, builds, formatting, or dependency setup; GitHub is authoritative

Agent transcript omitted.