### PR TITLE
fix(feishu): promote send attachment aliases instead of silent drop

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -3,6 +3,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { feishuPlugin } from "./channel.js";
+import { FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER } from "./outbound.js";
 import { looksLikeFeishuId, normalizeFeishuTarget, resolveReceiveIdType } from "./targets.js";
 
 describe("feishu target classification", () => {
@@ -821,6 +822,78 @@ describe("feishuPlugin actions", () => {
     expect(fallbackArgs.mediaReadFile).toBe(legacyReadFile);
   });
 
+  // Regression for #112244 (third-review P1): when a direct `send` attachment
+  // routes through the presentation-fallback path (card falls back to text),
+  // an upload failure must still surface as a visible error instead of an
+  // `ok:true` receipt for a text-only fallback. The action stamps the
+  // propagate marker on channelData.feishu so sendFeishuFallbackPayload
+  // re-throws; here we verify the marker is stamped and the failure rejects.
+  it("propagates a media-upload failure on the send presentation-fallback path instead of returning ok:true", async () => {
+    feishuOutboundSendPayloadMock.mockRejectedValueOnce(new Error("upload failed"));
+    const trustedReadFile = vi.fn(async () => Buffer.from("approved image"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile: trustedReadFile,
+    };
+    // An oversized table falls outside the Feishu card envelope, so
+    // `presentationFellBack` is true and the direct send routes the attachment
+    // through sendPayload instead of the normal sendMedia branch.
+    const presentation = {
+      blocks: [
+        {
+          type: "table" as const,
+          caption: "Large pipeline",
+          headers: ["Account", "Stage"],
+          rows: Array.from({ length: 400 }, (_entry, index) => [
+            `account-${String(index)}-${"x".repeat(80)}`,
+            "Review",
+          ]),
+        },
+      ],
+    };
+    const rawCardText = JSON.stringify({
+      schema: "2.0",
+      body: { elements: [{ tag: "markdown", content: "Raw card JSON must stay hidden" }] },
+    });
+
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: `[Nexus] ${rawCardText}`,
+          presentation,
+          media: "pipeline.png",
+        },
+        cfg: {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            feishu: { ...cfg.channels?.feishu, responsePrefix: "[Nexus]" },
+          },
+        },
+        accountId: undefined,
+        toolContext: {},
+        mediaAccess,
+        mediaLocalRoots: ["/approved/workspace"],
+        mediaReadFile: trustedReadFile,
+      } as never),
+    ).rejects.toThrow("upload failed");
+
+    expect(feishuOutboundSendPayloadMock).toHaveBeenCalledTimes(1);
+    const fallbackArgs = requireRecord(
+      mockCallArg(feishuOutboundSendPayloadMock, 0, 0, "feishuOutbound.sendPayload"),
+      "fallback args",
+    );
+    const fallbackPayload = requireRecord(fallbackArgs.payload, "fallback payload");
+    const feishuChannelData = requireRecord(
+      requireRecord(fallbackPayload.channelData, "fallback channelData").feishu,
+      "fallback channelData.feishu",
+    );
+    expect(feishuChannelData[FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]).toBe(true);
+  });
+
   it("prefers structured presentation over raw card JSON text", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 
@@ -1073,6 +1146,523 @@ describe("feishuPlugin actions", () => {
     ]);
   });
 
+  // Regression for #112244: a direct Gateway `message.action send` may arrive
+  // with attachment aliases (path/filePath/fileUrl/image/mediaUrl) instead of
+  // the canonical `media` field. The Feishu handler must promote any alias to a
+  // canonical mediaUrl and deliver through sendMedia, rather than silently
+  // dropping the attachment on the text-only success branch.
+  it.each([
+    ["path", "/tmp/script.py"],
+    ["filePath", "/tmp/script.py"],
+    ["fileUrl", "file:///tmp/script.py"],
+    ["image", "/tmp/image.png"],
+    ["mediaUrl", "/tmp/media.png"],
+  ] as const)("promotes send attachment alias %s to sendMedia", async (key, value) => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "see attached",
+        [key]: value,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const mediaArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(mediaArgs.mediaUrl).toBe(value);
+  });
+
+  it("rejects unsupported buffer payload on send instead of text-only success", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          buffer: "aGVsbG8=",
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow(
+      "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects multiple media attachments on send rather than dropping all but the first", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          mediaUrls: ["/tmp/first.png", "/tmp/second.png"],
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow("Feishu send supports a single media attachment.");
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["file_path", "/tmp/script.py"],
+    ["media_url", "/tmp/media.png"],
+    ["file_url", "file:///tmp/script.py"],
+  ] as const)("promotes snake_case send attachment alias %s to sendMedia", async (key, value) => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "see attached",
+        [key]: value,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const mediaArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(mediaArgs.mediaUrl).toBe(value);
+  });
+
+  it("promotes media_urls snake_case array alias to sendMedia", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "see attached",
+        media_urls: ["/tmp/report.md"],
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const mediaArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(mediaArgs.mediaUrl).toBe("/tmp/report.md");
+  });
+
+  it("accepts a single string mediaUrls value instead of dropping it", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "see attached",
+        mediaUrls: "/tmp/single.png",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const mediaArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(mediaArgs.mediaUrl).toBe("/tmp/single.png");
+  });
+
+  // Regression for #112244 (ClawSweeper P1): a valid nested
+  // `attachments[].mediaUrls` string list must be collected as a media
+  // candidate, not just validated for malformed entries. Without this the
+  // request would fall through to a text-only `ok:true` — the silent drop the
+  // PR removes.
+  it("accepts a nested attachments[].mediaUrls list instead of dropping it", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "see attached",
+        attachments: [{ mediaUrls: ["/tmp/nested.png"] }],
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const mediaArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(mediaArgs.mediaUrl).toBe("/tmp/nested.png");
+  });
+
+  // `attachments[].image` must be collected as a media candidate just like the
+  // top-level `image` alias. Without this the request would fall through to a
+  // text-only `ok:true` — the silent drop the PR removes.
+  it("accepts a nested attachments[].image alias instead of dropping it", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media_image",
+      details: { messageId: "om_media_image", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "see attached image",
+        attachments: [{ image: "/tmp/nested-image.png" }],
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const mediaArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(mediaArgs.mediaUrl).toBe("/tmp/nested-image.png");
+  });
+
+  it.each(["buffer", "base64"] as const)(
+    "rejects nested %s attachment payload on send instead of text-only success",
+    async (field) => {
+      await expect(
+        feishuPlugin.actions?.handleAction?.({
+          action: "send",
+          params: {
+            to: "chat:oc_group_1",
+            message: "see attached",
+            attachments: [{ [field]: "aGVsbG8=", filename: "report.md" }],
+          },
+          cfg,
+          accountId: undefined,
+          toolContext: {},
+          mediaLocalRoots: ["/tmp"],
+        } as never),
+      ).rejects.toThrow("buffer/base64 payloads are not supported");
+
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      expect(sendCardFeishuMock).not.toHaveBeenCalled();
+      expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects mixed supported and nested unsupported attachment payloads on send", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          attachments: [
+            { filePath: "/tmp/report.md" },
+            { buffer: "aGVsbG8=", filename: "report-copy.md" },
+          ],
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow("buffer/base64 payloads are not supported");
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  // The linked issue's literal reproduction is `{ message, file: "/path" }`.
+  // `file` is an attachment-intent key the Feishu send path does not map to a
+  // media source, so it must fail visibly instead of returning ok:true on a
+  // text-only send (issue #112244 expected behavior).
+  it.each([
+    { location: "top-level", params: { file: "/tmp/script.py", filename: "script.py" } },
+    { location: "nested", params: { attachments: [{ file: "/tmp/script.py" }] } },
+  ])(
+    "rejects $location `file` attachment intent on send instead of text-only success",
+    async ({ params }) => {
+      await expect(
+        feishuPlugin.actions?.handleAction?.({
+          action: "send",
+          params: {
+            to: "chat:oc_group_1",
+            message: "here is the script",
+            ...params,
+          },
+          cfg,
+          accountId: undefined,
+          toolContext: {},
+          mediaLocalRoots: ["/tmp"],
+        } as never),
+      ).rejects.toThrow("`file` attachment-intent parameter is not supported");
+
+      // No text-only send slips through with a false ok:true.
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      expect(sendCardFeishuMock).not.toHaveBeenCalled();
+      expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+    },
+  );
+
+  // Regression for the eighteenth-review P1 finding: a present NON-string value
+  // for an unsupported attachment-intent key (`file`/`buffer`/`base64`) used to
+  // be silently skipped (readFeishuStringParam returns undefined for objects),
+  // leaving no candidate and falling through to a text-only ok:true — the exact
+  // silent-drop this PR removes. Post-fix the resolver rejects the malformed
+  // intent before the text branch, at both the top level and inside attachments[].
+  it.each([
+    {
+      label: "top-level `file: {}`",
+      params: { file: {} },
+      expectedError: "`file` attachment-intent parameter is not supported",
+    },
+    {
+      label: "top-level `buffer: {}`",
+      params: { buffer: {} },
+      expectedError: "buffer/base64 payloads are not supported",
+    },
+    {
+      label: "top-level `base64: {}`",
+      params: { base64: {} },
+      expectedError: "buffer/base64 payloads are not supported",
+    },
+    {
+      label: "top-level `file: 42`",
+      params: { file: 42 },
+      expectedError: "`file` attachment-intent parameter is not supported",
+    },
+    {
+      label: "nested `attachments: [{ file: {} }]`",
+      params: { attachments: [{ file: {} }] },
+      expectedError: "`file` attachment-intent parameter is not supported",
+    },
+    {
+      label: "nested `attachments: [{ buffer: {} }]`",
+      params: { attachments: [{ buffer: {} }] },
+      expectedError: "buffer/base64 payloads are not supported",
+    },
+  ])(
+    "rejects malformed (non-string) $label attachment intent on send instead of text-only success",
+    async ({ params, expectedError }) => {
+      await expect(
+        feishuPlugin.actions?.handleAction?.({
+          action: "send",
+          params: {
+            to: "chat:oc_group_1",
+            message: "see attached",
+            ...params,
+          },
+          cfg,
+          accountId: undefined,
+          toolContext: {},
+          mediaLocalRoots: ["/tmp"],
+        } as never),
+      ).rejects.toThrow(expectedError);
+
+      // No text-only send slips through with a false ok:true.
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      expect(sendCardFeishuMock).not.toHaveBeenCalled();
+      expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("ignores a blank `file` attachment intent field on send", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_plain", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "plain text",
+        file: "   ",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    // A blank `file` is not an attachment-intent signal; with no media alias
+    // the send still takes the text-only success branch (unchanged).
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  // Regression for the second-review P1 finding: a declared media source whose
+  // value is present but malformed (e.g. `media: {}` or `mediaUrls: [{}]`)
+  // expresses attachment intent the Feishu send path cannot represent. Treating
+  // such a value as absent recreates the silent text-only `ok:true` success this
+  // PR removes, so it must fail visibly before the text branch instead.
+  it.each([
+    { location: "top-level scalar `media`", params: { media: {} } },
+    { location: "top-level scalar `filePath`", params: { filePath: 42 } },
+    { location: "top-level `mediaUrls` object", params: { mediaUrls: {} } },
+    { location: "top-level `mediaUrls` array with non-string entry", params: { mediaUrls: [{}] } },
+    {
+      location: "top-level `mediaUrls` array with number entry",
+      params: { mediaUrls: ["/tmp/a.png", 7] },
+    },
+    { location: "nested scalar `media`", params: { attachments: [{ media: {} }] } },
+    {
+      location: "nested `mediaUrls` with non-string entry",
+      params: { attachments: [{ mediaUrls: [{}] }] },
+    },
+    // A declared `attachments` field that is not an array (an object container
+    // whose nested media source is not a top-level alias) is an attachment
+    // intent the resolver cannot promote; treating it as absent recreates the
+    // silent text-only `ok:true` drop this PR removes (issue #112244, ClawSweeper P1).
+    {
+      location: "object `attachments` container",
+      params: { attachments: { media: "/tmp/a.png" } },
+    },
+    // A non-record array entry is a declared attachment intent the resolver
+    // cannot promote; skipping it silently would fall through to a text-only
+    // success (issue #112244, ClawSweeper P1).
+    { location: "`attachments` array with null entry", params: { attachments: [null] } },
+    { location: "`attachments` array with non-record entry", params: { attachments: [42] } },
+  ])(
+    "rejects $location malformed media source on send instead of text-only success",
+    async ({ params }) => {
+      await expect(
+        feishuPlugin.actions?.handleAction?.({
+          action: "send",
+          params: {
+            to: "chat:oc_group_1",
+            message: "see attached",
+            ...params,
+          },
+          cfg,
+          accountId: undefined,
+          toolContext: {},
+          mediaLocalRoots: ["/tmp"],
+        } as never),
+      ).rejects.toThrow("a present malformed media source value is not supported");
+
+      // No text-only send slips through with a false ok:true.
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      expect(sendCardFeishuMock).not.toHaveBeenCalled();
+      expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { location: "blank scalar `media`", params: { media: "   " } },
+    { location: "blank `mediaUrls` array entry", params: { mediaUrls: ["   "] } },
+    {
+      location: "blank nested `media`",
+      params: { attachments: [{ media: "   " }] },
+    },
+  ])("ignores blank $location media source on send (not malformed)", async ({ params }) => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_plain", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "plain text",
+        ...params,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    // A blank string is a string, not malformed; with no usable media it
+    // still takes the text-only success branch (unchanged).
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { location: "top-level", params: { buffer: "", base64: "  " } },
+    {
+      location: "nested",
+      params: { attachments: [{ buffer: "", base64: "  " }] },
+    },
+  ])("ignores blank $location attachment payload fields on send", async ({ params }) => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_plain", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "plain text",
+        ...params,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    // Blank buffer/base64 is not an unsupported payload intent; with no media
+    // alias the send still takes the text-only success branch (unchanged).
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
   it.each(["send", "thread-reply"] as const)(
     "preserves only trusted workspace media access for %s actions",
     async (action) => {
@@ -1122,6 +1712,10 @@ describe("feishuPlugin actions", () => {
         mediaLocalRoots: ["/legacy/workspace"],
         mediaReadFile: legacyReadFile,
         ...(action === "thread-reply" ? { threadId: "om_parent" } : { replyToId: undefined }),
+        // Only the direct `send` action propagates media-upload failures;
+        // thread-reply keeps its existing fallback-text behavior for
+        // compatibility (issue #112244).
+        ...(action === "send" ? { propagateMediaUploadFailure: true } : {}),
       });
       const outboundArgs = requireRecord(
         mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
@@ -1132,6 +1726,43 @@ describe("feishuPlugin actions", () => {
       expect(resultDetails(result).messageId).toBe("om_media");
     },
   );
+
+  // Regression for #112244 (round-5 P1): upload-failure propagation is scoped
+  // to `send` only; a thread-reply whose media upload fails must keep its
+  // existing fallback-text behavior (no throw), preserving compatibility.
+  it("does not propagate media-upload failure for thread-reply (keeps fallback)", async () => {
+    // sendMedia resolves to a text fallback result (the fallback path lives in
+    // the outbound adapter; here we verify the action does not throw and does
+    // not pass propagateMediaUploadFailure for thread-reply).
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_thread_fallback",
+      details: { messageId: "om_thread_fallback", chatId: "oc_group_1" },
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "thread-reply",
+      params: {
+        to: "chat:oc_group_1",
+        message: "thread reply",
+        messageId: "om_parent",
+        // thread-reply reads only the canonical `media` field (send promotes
+        // aliases, thread-reply does not), so use `media` to reach sendMedia.
+        media: "/tmp/script.py",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    const outboundArgs = requireRecord(
+      mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+      "outbound args",
+    );
+    expect(outboundArgs.propagateMediaUploadFailure).toBeUndefined();
+    expect(resultDetails(result).messageId).toBe("om_thread_fallback");
+  });
 
   it("passes asVoice through media sends", async () => {
     feishuOutboundSendMediaMock.mockResolvedValueOnce({

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -89,6 +89,10 @@ import { feishuDoctor } from "./doctor.js";
 import { chunkFeishuMarkdown } from "./markdown.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
 import { readNativeFeishuCardJson } from "./native-card.js";
+import {
+  FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER,
+  type FeishuOutboundSendMedia,
+} from "./outbound.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import {
   assertFeishuCardWithinEnvelope,
@@ -120,6 +124,276 @@ function readFeishuMediaParam(params: Record<string, unknown>): string | undefin
     return undefined;
   }
   return media.trim() ? media : undefined;
+}
+
+// Path-shaped attachment param aliases the message-tool schema declares. A
+// direct Gateway `message.action send` may arrive with any of these instead of
+// the canonical `media` field the Feishu handler reads; collect them so an
+// attachment intent is promoted to a single canonical mediaUrl instead of being
+// silently dropped on the text-only success branch (issue #112244).
+const FEISHU_SEND_MEDIA_SOURCE_PARAM_KEYS = [
+  "media",
+  "mediaUrl",
+  "path",
+  "filePath",
+  "fileUrl",
+  "image",
+] as const;
+
+const FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS = [
+  "media",
+  "mediaUrl",
+  "path",
+  "filePath",
+  "fileUrl",
+  "url",
+  "image",
+] as const;
+
+// Converts a camelCase param key to its snake_case spelling (e.g. filePath ->
+// file_path, mediaUrl -> media_url). The Gateway action contract resolves both
+// spellings before a message action reaches a channel, so a Feishu send may
+// arrive with either; the resolver honors both to avoid silently dropping an
+// attachment alias that uses the snake_case spelling (issue #112244).
+function toFeishuSnakeCaseKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+// Reads a raw param value, preferring the canonical (camelCase) key and
+// falling back to its snake_case spelling when the canonical key is absent.
+function readFeishuParam(params: Record<string, unknown>, key: string): unknown {
+  if (Object.hasOwn(params, key)) {
+    return params[key];
+  }
+  const snakeKey = toFeishuSnakeCaseKey(key);
+  return snakeKey === key || !Object.hasOwn(params, snakeKey) ? undefined : params[snakeKey];
+}
+
+function readFeishuStringParam(params: Record<string, unknown>, key: string): string | undefined {
+  const raw = readFeishuParam(params, key);
+  const value = typeof raw === "string" ? normalizeOptionalString(raw) : undefined;
+  return value ?? undefined;
+}
+
+function readFeishuStringArrayParam(params: Record<string, unknown>, key: string): string[] {
+  const raw = readFeishuParam(params, key);
+  // A single string is accepted in place of an array so a caller that wrote
+  // `mediaUrls: "/tmp/a.png"` instead of `["/tmp/a.png"]` is not silently
+  // dropped on the text-only success branch.
+  if (Array.isArray(raw)) {
+    const normalized: string[] = [];
+    for (const entry of raw) {
+      const trimmed = typeof entry === "string" ? normalizeOptionalString(entry) : undefined;
+      if (trimmed) {
+        normalized.push(trimmed);
+      }
+    }
+    return normalized;
+  }
+  const single = typeof raw === "string" ? normalizeOptionalString(raw) : undefined;
+  return single ? [single] : [];
+}
+
+// Detects a declared media source field whose value is present but malformed
+// (not a string for scalar sources; not a string or array for `mediaUrls`; or
+// an array containing a non-string entry). A present malformed value expresses
+// attachment intent the Feishu send path cannot represent, so it must fail
+// visibly instead of being treated as absent and falling through to a
+// text-only success branch that recreates the silent-drop bug of #112244.
+// A blank string ("", "  ") is a string and therefore not malformed.
+function readFeishuParamPresence(
+  params: Record<string, unknown>,
+  key: string,
+  kind: "scalar" | "stringOrArray",
+): "absent" | "present" | "malformed" {
+  const raw = readFeishuParam(params, key);
+  if (raw === undefined) {
+    return "absent";
+  }
+  if (kind === "stringOrArray") {
+    if (Array.isArray(raw)) {
+      return raw.some((entry) => typeof entry !== "string") ? "malformed" : "present";
+    }
+    return typeof raw === "string" ? "present" : "malformed";
+  }
+  return typeof raw === "string" ? "present" : "malformed";
+}
+
+// Detects an unsupported attachment-intent key (`file`/`buffer`/`base64`) whose
+// value is present. A non-blank string is the original unsupported-intent
+// signal; a present NON-string value (e.g. `file: {}`, `buffer: 42`) is a
+// malformed intent the resolver cannot promote either. The non-string case used
+// to be silently skipped — `readFeishuStringParam` returns undefined for
+// objects, so `Boolean(...)` was false, leaving no candidate and falling through
+// to a text-only `ok:true`, recreating the silent-drop this PR removes (issue
+// #112244, ClawSweeper P1). A blank string ("", "  ") stays ignored, preserving
+// the blank-alias ignore behavior.
+function hasFeishuUnsupportedIntentValue(params: Record<string, unknown>, key: string): boolean {
+  const raw = readFeishuParam(params, key);
+  if (raw === undefined) {
+    return false;
+  }
+  if (typeof raw === "string") {
+    return Boolean(normalizeOptionalString(raw));
+  }
+  return true;
+}
+
+type FeishuSendAttachmentMedia = {
+  mediaUrl: string | undefined;
+  /** Collected non-blank media source values across all aliases. */
+  mediaUrls: string[];
+  /** A buffer/base64 payload (top-level or nested in attachments[]) that the
+   * Feishu send path cannot represent; rejected instead of silent text fallback. */
+  hasUnsupportedAttachmentPayload: boolean;
+  /** An attachment-intent key (e.g. `file`) the Feishu send path does not map
+   * to a media source string; a non-blank value is rejected instead of silent
+   * text fallback (issue #112244). */
+  hasUnsupportedAttachmentIntent: boolean;
+  /** A declared media source field whose value is present but malformed (e.g.
+   * `media: {}` or `mediaUrls: [{}]`); rejected instead of being treated as
+   * absent and falling through to a text-only success branch (issue #112244). */
+  hasMalformedAttachmentIntent: boolean;
+};
+
+function collectFeishuSendAttachmentMedia(
+  params: Record<string, unknown>,
+): FeishuSendAttachmentMedia {
+  const candidates: Array<string | undefined> = FEISHU_SEND_MEDIA_SOURCE_PARAM_KEYS.map((key) =>
+    readFeishuStringParam(params, key),
+  );
+  candidates.push(...readFeishuStringArrayParam(params, "mediaUrls"));
+  // A blank buffer/base64 ("", "  ") is not an unsupported payload intent and
+  // must not trigger rejection; only a non-blank value counts. A present
+  // non-string value (e.g. `buffer: {}`) is a malformed payload intent that
+  // must also be rejected instead of silently skipped (issue #112244, ClawSweeper P1).
+  let hasUnsupportedAttachmentPayload =
+    hasFeishuUnsupportedIntentValue(params, "buffer") ||
+    hasFeishuUnsupportedIntentValue(params, "base64");
+  // A non-blank `file` is the linked issue's reproduction input; it is not a
+  // media source the Feishu send path maps, so it is treated as an unsupported
+  // attachment intent rather than dropped on the text-only success branch. A
+  // present non-string value (e.g. `file: {}`) is the same class of malformed
+  // intent and is rejected too (issue #112244, ClawSweeper P1).
+  let hasUnsupportedAttachmentIntent = hasFeishuUnsupportedIntentValue(params, "file");
+  // A declared media source whose value is present but malformed (non-string
+  // for scalar sources; non-string/non-array or array-with-non-string-entry for
+  // `mediaUrls`) is an attachment-intent signal the Feishu send path cannot
+  // satisfy, so it is rejected rather than silently treated as absent and
+  // dropped on the text-only success branch (issue #112244). A blank string is
+  // a string and therefore not malformed, preserving the blank-alias ignore.
+  let hasMalformedAttachmentIntent = false;
+  for (const key of FEISHU_SEND_MEDIA_SOURCE_PARAM_KEYS) {
+    if (readFeishuParamPresence(params, key, "scalar") === "malformed") {
+      hasMalformedAttachmentIntent = true;
+    }
+  }
+  if (readFeishuParamPresence(params, "mediaUrls", "stringOrArray") === "malformed") {
+    hasMalformedAttachmentIntent = true;
+  }
+  // A declared `attachments` field that is not an array (e.g. an object
+  // container like `{ media: "/tmp/a" }`) expresses attachment intent the
+  // Feishu send path cannot promote — the nested media source is not a
+  // top-level alias and the array resolver below never runs. Treating it as
+  // absent recreates the silent text-only `ok:true` success this PR removes,
+  // so it is rejected before the text branch (issue #112244, ClawSweeper P1).
+  if (params.attachments !== undefined && !Array.isArray(params.attachments)) {
+    hasMalformedAttachmentIntent = true;
+  }
+  if (Array.isArray(params.attachments)) {
+    for (const attachment of params.attachments) {
+      // A non-record array entry (e.g. `null`, a number, or a string) is a
+      // declared attachment intent the resolver cannot promote to a media
+      // source; skipping it silently would leave no candidate and fall through
+      // to a text-only `ok:true` — the exact drop this PR removes. Reject it
+      // before the text branch instead (issue #112244, ClawSweeper P1).
+      if (!isRecord(attachment)) {
+        hasMalformedAttachmentIntent = true;
+        continue;
+      }
+      for (const key of FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS) {
+        candidates.push(readFeishuStringParam(attachment, key));
+      }
+      // Collect valid nested `mediaUrls` entries too, mirroring the top-level
+      // handling: without this, `{ attachments: [{ mediaUrls: ["/tmp/a.png"] }] }`
+      // would pass the malformed check but produce no candidate and silently
+      // fall through to a text-only `ok:true` — the exact drop this PR removes
+      // (issue #112244, ClawSweeper P1).
+      candidates.push(...readFeishuStringArrayParam(attachment, "mediaUrls"));
+      // Each structured attachment is scanned for unsupported payloads too, so
+      // `attachments: [{ buffer: ... }]` fails visibly instead of producing no
+      // media candidate and silently falling through to a text-only send. A
+      // present non-string value (e.g. `attachments: [{ file: {} }]`) is a
+      // malformed intent rejected the same way (issue #112244, ClawSweeper P1).
+      hasUnsupportedAttachmentPayload ||=
+        hasFeishuUnsupportedIntentValue(attachment, "buffer") ||
+        hasFeishuUnsupportedIntentValue(attachment, "base64");
+      hasUnsupportedAttachmentIntent ||= hasFeishuUnsupportedIntentValue(attachment, "file");
+      for (const key of FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS) {
+        if (readFeishuParamPresence(attachment, key, "scalar") === "malformed") {
+          hasMalformedAttachmentIntent = true;
+        }
+      }
+      if (readFeishuParamPresence(attachment, "mediaUrls", "stringOrArray") === "malformed") {
+        hasMalformedAttachmentIntent = true;
+      }
+    }
+  }
+  const seen = new Set<string>();
+  const mediaUrls: string[] = [];
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    mediaUrls.push(candidate);
+  }
+  return {
+    mediaUrl: mediaUrls[0],
+    mediaUrls,
+    hasUnsupportedAttachmentPayload,
+    hasUnsupportedAttachmentIntent,
+    hasMalformedAttachmentIntent,
+  };
+}
+
+// Feishu delivers one media item per message. A send declaring more than one
+// attachment is rejected rather than silently delivering only the first, and
+// buffer/base64 payloads (top-level or nested in attachments[]) are rejected
+// because the Feishu send path loads media from a media source string
+// (path/URL) via the outbound adapter, not from an in-memory buffer. A
+// non-blank `file` attachment-intent key is rejected the same way because the
+// shared action contract deliberately excludes `file` from supported media
+// sources; a present malformed media source value (e.g. `media: {}` or
+// `mediaUrls: [{}]`) is rejected because the resolver cannot promote it to a
+// mediaUrl and treating it as absent would recreate the silent text-only
+// success branch. Failing visibly here matches the issue's expected behavior
+// instead of returning ok:true on a text-only send. Mirrors the Mattermost
+// send-attachment resolver shape.
+function resolveFeishuSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
+  const attachmentMedia = collectFeishuSendAttachmentMedia(params);
+  if (attachmentMedia.hasUnsupportedAttachmentPayload) {
+    throw new Error(
+      "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
+    );
+  }
+  if (attachmentMedia.hasMalformedAttachmentIntent) {
+    throw new Error(
+      "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; a present malformed media source value is not supported — use a string path/URL (or a string array for mediaUrls) instead.",
+    );
+  }
+  if (attachmentMedia.hasUnsupportedAttachmentIntent) {
+    throw new Error(
+      "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; the `file` attachment-intent parameter is not supported — use one of the supported media sources instead.",
+    );
+  }
+  if (attachmentMedia.mediaUrls.length > 1) {
+    throw new Error("Feishu send supports a single media attachment.");
+  }
+  return attachmentMedia.mediaUrl;
 }
 
 function readBooleanParam(params: Record<string, unknown>, keys: string[]): boolean | undefined {
@@ -1086,7 +1360,14 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             const presentation =
               normalizeMessagePresentation(ctx.params.presentation) ??
               (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
-            const mediaUrl = readFeishuMediaParam(ctx.params);
+            // send promotes every attachment alias (path/filePath/mediaUrl/fileUrl/
+            // image/mediaUrls/attachments[]) to a canonical mediaUrl and rejects
+            // unsupported buffer/base64 payloads or multiple attachments instead
+            // of silently dropping them on the text-only success branch (#112244).
+            const mediaUrl =
+              ctx.action === "send"
+                ? resolveFeishuSendAttachmentMedia(ctx.params)
+                : readFeishuMediaParam(ctx.params);
             const audioAsVoice = readBooleanParam(ctx.params, ["asVoice", "audioAsVoice"]);
             if (textCard && !presentation) {
               assertFeishuCardWithinEnvelope(textCard, "Feishu native card");
@@ -1116,7 +1397,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (mediaUrl && !maybeSendMedia) {
               throw new Error("Feishu media sending is not available.");
             }
-            const sendMedia = maybeSendMedia;
+            // The Feishu sendMedia implementation accepts an optional
+            // `propagateMediaUploadFailure` flag the shared adapter contract
+            // does not; `feishuOutbound` keeps the shared `ChannelOutboundAdapter`
+            // shape (optional `sendMedia`), so the direct send action narrows it
+            // to `FeishuOutboundSendMedia` here to request a controlled
+            // upload-failure outcome without a type assert.
+            const sendMedia: FeishuOutboundSendMedia | undefined = maybeSendMedia;
             let result;
             if (presentationFellBack && presentation) {
               const sendPayload = runtime.feishuOutbound.sendPayload;
@@ -1135,6 +1422,20 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                   presentation,
                   ...(mediaUrl ? { mediaUrl } : {}),
                   ...(audioAsVoice === undefined ? {} : { audioAsVoice }),
+                  // The direct `send` action must keep an attachment failure
+                  // visible on this path too: `sendPayload`'s shared signature
+                  // cannot carry `propagateMediaUploadFailure`, so stamp the
+                  // marker here and let `sendFeishuFallbackPayload` re-throw the
+                  // upload failure instead of returning a fallback-text `ok:true`
+                  // receipt (issue #112244, ClawSweeper P1). Scoped to `send`
+                  // only — thread-reply keeps its existing fallback behavior.
+                  ...(ctx.action === "send"
+                    ? {
+                        channelData: {
+                          feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
+                        },
+                      }
+                    : {}),
                 },
                 accountId: ctx.accountId ?? undefined,
                 ...(ctx.mediaAccess ? { mediaAccess: ctx.mediaAccess } : {}),
@@ -1173,6 +1474,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                   ? { threadId: replyToMessageId }
                   : { replyToId: replyToMessageId }),
                 ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
+                // The direct send action must not report `ok:true` when the
+                // requested attachment cannot be delivered; propagate the
+                // upload failure so the agent sees a visible error instead of
+                // a text-only fallback receipt (issue #112244). Scoped to
+                // `send` only — thread-reply keeps its existing fallback-text
+                // behavior for compatibility.
+                ...(ctx.action === "send" ? { propagateMediaUploadFailure: true } : {}),
               });
             } else {
               result = await runtime.sendMessageFeishu({

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { verifyChannelMessageAdapterCapabilityProofs } from "openclaw/plugin-sdk/channel-outbound";
 import {
   adaptMessagePresentationForChannel,
@@ -119,7 +122,7 @@ vi.mock("./comment-reaction.js", () => ({
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { feishuPlugin } from "./channel.js";
 import { buildFeishuPostMessageContent } from "./markdown.js";
-import { feishuOutbound } from "./outbound.js";
+import { FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER, feishuOutbound } from "./outbound.js";
 import { createFeishuSendReceipt } from "./send-result.js";
 
 async function raceWithNextMacrotask<T>(promise: Promise<T>): Promise<T | "pending"> {
@@ -3141,6 +3144,234 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     });
 
     expect(sendMessageCall()?.replyToMessageId).toBe("om_reply_target");
+  });
+
+  // Regression for #112244 (second-review P1): when the direct `send` action
+  // requests `propagateMediaUploadFailure`, a media-upload failure must re-throw
+  // to the caller instead of being converted to a fallback text success —
+  // otherwise the agent receives an `ok:true` receipt for a message whose
+  // attachment never arrived. No fallback "Media upload failed" text is emitted.
+  // When the caption was already delivered, the re-thrown error preserves that
+  // caption's receipt as the existing partial-delivery outcome (seventeenth-review
+  // P1) so the caller knows the text is visible and does not retry it.
+  it("propagates a media-upload failure instead of falling back to text when requested", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({
+      messageId: "caption_msg",
+      chatId: "chat_1",
+    });
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    await expect(
+      feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "see attachment",
+        mediaUrl: "https://example.com/file.png",
+        accountId: "main",
+        propagateMediaUploadFailure: true,
+      } as never),
+    ).rejects.toThrow("upload failed");
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    // No fallback "Media upload failed" text is emitted on top of any caption.
+    expect(sendMessageCall()?.text).not.toContain("Media upload failed");
+  });
+
+  // Regression for #112244 (seventeenth-review P1): when the caption was already
+  // delivered before the media upload failed, the propagated error must preserve
+  // the caption's receipt as the repository's existing partial-delivery outcome
+  // — otherwise the caller treats it as a wholly failed send, retries, and
+  // duplicates the already-visible caption. Pre-fix the catch block threw a plain
+  // Error with no receipt; post-fix it throws a ChannelPartialDeliveryError
+  // carrying the caption's messageId.
+  it("preserves a delivered caption as partial delivery when media upload fails", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({
+      messageId: "caption_msg",
+      chatId: "chat_1",
+    });
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    let caught: unknown;
+    try {
+      await feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "see attachment",
+        mediaUrl: "https://example.com/file.png",
+        accountId: "main",
+        propagateMediaUploadFailure: true,
+      } as never);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    const partial = caught as ReturnType<typeof createChannelPartialDeliveryError>;
+    expect(partial.deliveryResult.visibleReplySent).toBe(true);
+    expect(partial.deliveryResult.messageIds).toEqual(["caption_msg"]);
+    // The caption was delivered exactly once; no retry/duplicate send occurred.
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+  });
+
+  // Regression for #112244 (seventeenth-review P1, scope guard): a media-upload
+  // failure with NO delivered caption is a wholly failed send, so the propagated
+  // error stays a plain Error (no partial-delivery receipt to preserve).
+  it("propagates a plain error when media upload fails with no delivered caption", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    let caught: unknown;
+    try {
+      await feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        mediaUrl: "https://example.com/file.png",
+        accountId: "main",
+        propagateMediaUploadFailure: true,
+      } as never);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toBeInstanceOf(Error);
+    expect(String(caught)).toContain(
+      "Feishu send could not deliver the requested media attachment",
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("still falls back to text on upload failure when propagation is not requested", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    const result = await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "see attachment",
+      // A private/local media URL cannot be resolved to a public reference, so
+      // the fallback renders the generic "Media upload failed" text.
+      mediaUrl: path.join(os.tmpdir(), "openclaw-feishu-fallback-not-requested.png"),
+      accountId: "main",
+    });
+
+    // Default behavior is unchanged: the caption is sent first, then the
+    // fallback text, and a success receipt is returned (other outbound callers
+    // rely on this). The fallback is the second sendMessage call.
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageCall(1)?.text).toContain("Media upload failed. Please try again.");
+    expectFeishuResult(result, "text_msg");
+  });
+
+  // Regression for #112244 (third-review P1): the direct `send` action routes
+  // an attachment through the presentation-fallback path (sendPayload →
+  // sendFeishuFallbackPayload → sendMedia) when a card falls back. That path
+  // cannot carry `propagateMediaUploadFailure` through the shared sendPayload
+  // signature, so the action stamps the marker on channelData.feishu and the
+  // fallback payload must honor it — re-throwing the upload failure instead of
+  // returning a fallback-text `ok:true` receipt.
+  it("propagates a media-upload failure through the presentation-fallback path when the marker is set", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    await expect(
+      feishuOutbound.sendPayload?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "see attachment",
+        accountId: "main",
+        payload: {
+          text: "see attachment",
+          mediaUrl: "https://example.com/file.png",
+          channelData: {
+            feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
+          },
+        },
+      }),
+    ).rejects.toThrow("Feishu send could not deliver the requested media attachment");
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    // No fallback "Media upload failed" text is emitted on top of any caption.
+    expect(
+      sendMessageFeishuMock.mock.calls
+        .map(([args]) => (args as { text?: string })?.text ?? "")
+        .some((text) => text.includes("Media upload failed")),
+    ).toBe(false);
+  });
+
+  it("still falls back to text on the presentation-fallback path when the marker is absent", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "see attachment",
+      accountId: "main",
+      payload: {
+        text: "see attachment",
+        // A private/local media URL cannot be resolved to a public reference,
+        // so the fallback renders the generic "Media upload failed" text.
+        mediaUrl: path.join(os.tmpdir(), "openclaw-feishu-fallback-no-marker.png"),
+      },
+    });
+
+    // Default behavior is unchanged: the caption is sent first, then the
+    // fallback text, and a success receipt is returned.
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageCall(1)?.text).toContain("Media upload failed. Please try again.");
+    expectFeishuResult(result, "text_msg");
+  });
+
+  // Regression for #112244 (fourteenth-review P1): the direct `send` action
+  // stamps the propagation marker on channelData.feishu before routing an
+  // attachment through sendPayload. The document-comment sendPayload branch
+  // preserves the marker (so the fallback helper requests propagation), but a
+  // comment target must NOT throw on the strength of that marker alone: the
+  // comment-target media-link fallback renders the media URL as a visible
+  // clickable link, which is established main behavior and NOT the silent
+  // text-only `ok:true` drop issue #112244 removes. Propagation is reserved for
+  // actual media-upload failures (the `sendMediaFeishu` catch), which a comment
+  // target never reaches because it never uploads. With the marker set, the
+  // comment target still renders the visible media-link fallback and returns a
+  // success receipt — the same outcome as the marker-absent case below.
+  it("renders the visible media-link fallback on a document-comment target even when the propagation marker is set", async () => {
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "see attachment",
+      accountId: "main",
+      payload: {
+        text: "see attachment",
+        mediaUrl: "https://example.com/pipeline.png",
+        channelData: {
+          feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
+        },
+      },
+    });
+
+    // The media URL is delivered as a visible comment text link (not a silent
+    // text-only ok), and a success receipt is returned — comment targets keep
+    // their established media-link fallback regardless of the propagation flag.
+    expect(commentThreadParams()?.content).toBe("https://example.com/pipeline.png");
+    expectFeishuResult(result, "reply_msg");
+    // No media upload is attempted for a comment target.
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("still degrades a comment attachment to text when the propagation marker is absent", async () => {
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "see attachment",
+      accountId: "main",
+      payload: {
+        text: "see attachment",
+        mediaUrl: "https://example.com/pipeline.png",
+      },
+    });
+
+    // Default comment behavior is unchanged: the media link is rendered as a
+    // fallback text comment and a success receipt is returned.
+    expect(commentThreadParams()?.content).toBe("https://example.com/pipeline.png");
+    expectFeishuResult(result, "reply_msg");
   });
 });
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,6 +1,9 @@
 // Feishu plugin module implements outbound behavior.
 import path from "node:path";
-import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  isChannelPartialDeliveryError,
+  createChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { createReplyToFanout } from "openclaw/plugin-sdk/channel-outbound";
 import {
   attachChannelToResult,
@@ -66,6 +69,15 @@ import {
 
 const RENDERED_FEISHU_CARD = Symbol("openclaw.renderedFeishuCard");
 const FEISHU_PRESENTATION_FALLBACK_MARKER = "__openclawPresentationFallback";
+// Carries the direct-send upload-failure policy through the presentation
+// fallback delivery path. The normal `sendMedia` branch sets
+// `propagateMediaUploadFailure` directly; the presentation-fallback branch
+// routes through `sendPayload` (whose shared signature cannot carry the flag),
+// so the direct `send` action stamps this marker on `channelData.feishu` and
+// `sendFeishuFallbackPayload` reads it before calling `sendMedia`. This keeps
+// a direct-send attachment failure visible instead of degrading to a
+// fallback-text `ok:true` receipt (issue #112244, ClawSweeper P1).
+export const FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER = "__openclawPropagateMediaUploadFailure";
 const FEISHU_TEXT_CHUNK_LIMIT = 4000;
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
@@ -152,6 +164,23 @@ type FeishuOutboundPayload = Parameters<
 type FeishuSendPayloadContext = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0];
 type FeishuSendTextContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
 
+// The Feishu sendMedia implementation accepts an optional flag the shared
+// ChannelOutboundAdapter contract does not: when true, a media-upload failure
+// is re-thrown to the caller instead of being converted to a fallback text
+// success. The direct `send` action sets this so an agent that requested an
+// attachment receives a visible failure when it cannot be delivered, rather
+// than an `ok:true` receipt for a text-only fallback (issue #112244).
+//
+// The return type mirrors the shared contract exactly — `ReturnType<...>` is
+// already `Promise<OutboundDeliveryResult>`, so wrapping it in another
+// `Promise` would produce `Promise<Promise<...>>` and break the `async`
+// implementation's single-Promise return (ClawSweeper P1).
+export type FeishuOutboundSendMedia = (
+  params: Parameters<NonNullable<ChannelOutboundAdapter["sendMedia"]>>[0] & {
+    propagateMediaUploadFailure?: boolean;
+  },
+) => ReturnType<NonNullable<ChannelOutboundAdapter["sendMedia"]>>;
+
 function toFeishuOutboundResult<T extends { chatId: string }>(result: T) {
   const { chatId, ...delivery } = result;
   return { ...delivery, target: { kind: "chat" as const, id: chatId } };
@@ -187,6 +216,33 @@ function consumeFeishuPresentationFallbackMarker(payload: FeishuOutboundPayload)
       channelData: Object.keys(nextChannelData).length > 0 ? nextChannelData : undefined,
     },
     presentationFallback: true,
+  };
+}
+
+// Reads (without consuming) the direct-send upload-failure policy stamped on
+// the payload by the presentation-fallback branch. Unlike the presentation
+// fallback marker this is not consumed: a fallback payload may fan out
+// multiple `sendMedia` calls and each must honor the policy.
+function readFeishuPropagateMediaUploadFailure(payload: FeishuOutboundPayload): boolean {
+  const feishuData = isRecord(payload.channelData?.feishu) ? payload.channelData.feishu : undefined;
+  return feishuData?.[FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER] === true;
+}
+
+// Builds a `channelData.feishu` that carries only the direct-send upload-failure
+// policy marker. The document-comment branch strips native card / interactive
+// channelData before fallback delivery (those cannot render in comments), but
+// it must not drop the propagation marker the direct `send` action stamped —
+// otherwise a media-upload failure on a comment target degrades to a
+// fallback-text `ok:true` receipt again (issue #112244, ClawSweeper P1).
+function buildFeishuPropagationOnlyChannelData(
+  payload: FeishuOutboundPayload,
+): { feishu: Record<string, unknown> } | undefined {
+  const feishuData = isRecord(payload.channelData?.feishu) ? payload.channelData.feishu : undefined;
+  if (feishuData?.[FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER] !== true) {
+    return undefined;
+  }
+  return {
+    feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
   };
 }
 
@@ -484,12 +540,21 @@ async function sendFeishuFallbackPayload(params: {
   payload: FeishuOutboundPayload;
   separateMediaAndText?: boolean;
 }) {
+  // The direct `send` action stamps this marker when it routes an attachment
+  // through the presentation-fallback path; honor it so an upload failure is
+  // re-thrown instead of degrading to a fallback-text `ok:true` receipt
+  // (issue #112244, ClawSweeper P1). The shared `sendTextMediaPayload` helper
+  // cannot carry the flag, so when propagation is requested and there is media
+  // to deliver, force the explicit fan-out path that calls `sendMedia` with
+  // the flag set.
+  const propagateMediaUploadFailure = readFeishuPropagateMediaUploadFailure(params.payload);
   const ctx = { ...params.ctx, payload: params.payload };
   const mediaUrls = normalizeStringEntries(resolvePayloadMediaUrls(params.payload));
   const text = params.payload.text ?? "";
   const textChunks = text ? chunkFeishuMarkdown(text, FEISHU_TEXT_CHUNK_LIMIT) : [];
   const shouldSeparate =
-    mediaUrls.length > 0 && (params.separateMediaAndText === true || textChunks.length > 1);
+    mediaUrls.length > 0 &&
+    (propagateMediaUploadFailure || params.separateMediaAndText === true || textChunks.length > 1);
   if (!shouldSeparate) {
     return await sendTextMediaPayload({
       channel: "feishu",
@@ -507,7 +572,11 @@ async function sendFeishuFallbackPayload(params: {
     replyToIdSource: ctx.replyToIdSource,
     replyToMode: ctx.replyToMode,
   });
-  const sendMedia = feishuOutbound.sendMedia;
+  // Narrow the optional shared `sendMedia` to the Feishu-specific contract so
+  // the `propagateMediaUploadFailure` flag can be carried on direct-send
+  // fallback delivery (the shared `ChannelOutboundAdapter["sendMedia"]`
+  // signature does not declare it).
+  const sendMedia: FeishuOutboundSendMedia | undefined = feishuOutbound.sendMedia;
   const sendText = feishuOutbound.sendText;
   if (!sendMedia || !sendText) {
     throw new Error("Feishu fallback delivery is not available.");
@@ -523,6 +592,7 @@ async function sendFeishuFallbackPayload(params: {
       mediaUrl,
       replyToId: nextReplyToId(),
       audioAsVoice: params.payload.audioAsVoice ?? ctx.audioAsVoice,
+      ...(propagateMediaUploadFailure ? { propagateMediaUploadFailure: true } : {}),
     });
   }
   for (const chunk of textChunks) {
@@ -589,6 +659,14 @@ async function sendFeishuTtsSupplementPayload(params: {
   return lastResult ?? { channel: "feishu", messageId: "" };
 }
 
+// `feishuOutbound` keeps the shared `ChannelOutboundAdapter` shape (whose
+// `sendMedia` is optional) so the object literal — which spreads
+// `createAttachedChannelResultAdapter` (returning `sendMedia?: ... | undefined`)
+// — type-checks without a `sendMedia: ... | undefined` mismatch. Callers that
+// need the Feishu-specific `propagateMediaUploadFailure` flag narrow the
+// optional `sendMedia` to `FeishuOutboundSendMedia` at the use site
+// (channel.ts direct-send branch, sendFeishuFallbackPayload) instead of
+// forcing a required property here (ClawSweeper P1).
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkFeishuMarkdown,
@@ -654,7 +732,12 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         text,
         interactive: undefined,
         presentation: undefined,
-        channelData: undefined,
+        // Strip native card / interactive channelData (comments cannot render
+        // them) but preserve the direct-send upload-failure propagation marker
+        // so a media-upload failure on a comment target stays visible instead
+        // of degrading to a fallback-text `ok:true` receipt (issue #112244,
+        // ClawSweeper P1).
+        channelData: buildFeishuPropagationOnlyChannelData(payload),
       };
       return await sendFeishuFallbackPayload({
         ctx,
@@ -930,6 +1013,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       replyToMode,
       threadId,
       onDeliveryResult,
+      propagateMediaUploadFailure = false,
+    }: Parameters<NonNullable<ChannelOutboundAdapter["sendMedia"]>>[0] & {
+      /** When true, a media-upload failure is re-thrown to the caller instead of
+       * being converted to a fallback text success. The direct `send` action
+       * sets this so an agent that requested an attachment receives a visible
+       * failure when the attachment cannot be delivered, rather than an `ok:true`
+       * receipt for a text-only fallback (issue #112244). */
+      propagateMediaUploadFailure?: boolean;
     }) => {
       const { normalizedReplyToId } = resolveFeishuReplyMode({
         replyToId,
@@ -949,6 +1040,18 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       };
       const deliveryOptions = { replyToIdSource, replyToMode, onDeliveryResult };
       if (parseFeishuCommentTarget(to)) {
+        // Feishu document comments cannot host a media attachment; the mediaUrl
+        // is rendered as a fallback text link instead. This visible-link
+        // fallback is the established comment-target behavior on main and is
+        // NOT the silent text-only `ok:true` drop issue #112244 removes — the
+        // recipient sees the media URL as a clickable link, so the attachment
+        // intent is visibly delivered even though the comment cannot render the
+        // media inline. The direct-send upload-failure propagation policy
+        // therefore does not apply here: it targets actual media-upload failures
+        // (the `sendMediaFeishu` catch below), and a comment target never
+        // reaches that upload path. Keep the fallback for both `send` and
+        // thread-reply so comment targets retain their visible media-link
+        // delivery (issue #112244, ClawSweeper fourteenth-review P1).
         const commentText = mediaUrl?.trim()
           ? await buildFeishuMediaFallbackText({
               text,
@@ -986,10 +1089,11 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         audioAsVoice,
       });
       let textSent = false;
+      let captionResult: { messageId: string; chatId: string } | undefined;
 
       // Send text first if provided, except for Feishu native voice bubbles.
       if (text?.trim() && !suppressTextForVoiceMedia) {
-        await sendOutboundText({
+        captionResult = await sendOutboundText({
           cfg,
           to,
           text,
@@ -1018,6 +1122,28 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         if (isChannelPartialDeliveryError(err)) {
           // Accepted media is not an upload failure and must never trigger a second send.
           throw err;
+        }
+        if (propagateMediaUploadFailure) {
+          // The direct `send` action requested a controlled failure when the
+          // attachment cannot be delivered, so the agent receives a visible
+          // error instead of an `ok:true` receipt for a text-only fallback
+          // (issue #112244). When the caption was already delivered, preserve
+          // its receipt as the existing partial-delivery outcome so the caller
+          // knows the text is visible and does not retry it (which would
+          // duplicate the caption); only a send with no delivered caption is a
+          // wholly failed send.
+          if (textSent && captionResult) {
+            throw createChannelPartialDeliveryError(err, {
+              messageIds: [captionResult.messageId],
+              visibleReplySent: true,
+            });
+          }
+          throw new Error(
+            `Feishu send could not deliver the requested media attachment: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { cause: err },
+          );
         }
         console.error(`[feishu] sendMediaFeishu failed:`, err);
         const fallbackText = await buildFeishuMediaFallbackText({

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -17,6 +17,7 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
 import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import { createChannelPartialDeliveryError } from "../../channels/turn/delivery-result.js";
 import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
 import {
   claimAgentRunDelegatedAuthority,
@@ -1492,6 +1493,9 @@ describe("gateway send mirroring", () => {
     } else {
       expect(error).not.toHaveProperty("details");
     }
+    // A queued or ordinary delivery failure must not advertise retryability;
+    // only a partial-delivery receipt sets `retryable: false`.
+    expect(error?.retryable).toBeUndefined();
   });
 
   it("does not send after delegated authority closes during session preparation", async () => {
@@ -4261,6 +4265,67 @@ describe("gateway send mirroring", () => {
     expect(mocks.beginRestartRecoveryTerminalDelivery).toHaveBeenCalledOnce();
     expect(mocks.cancelRestartRecoveryTerminalDelivery).not.toHaveBeenCalled();
     expect(mocks.completeRestartRecoveryTerminalDelivery).not.toHaveBeenCalled();
+  });
+
+  it("returns the caption receipt through message.action when dispatch fails with partial delivery", async () => {
+    // A caption sent before the media upload failed carries a partial-delivery
+    // receipt. The Gateway boundary must surface that receipt on the structured
+    // error and mark the result non-retryable, so the agent does not resend an
+    // already-visible caption.
+    mocks.dispatchChannelMessageAction.mockRejectedValueOnce(
+      createChannelPartialDeliveryError(new Error("upload failed"), {
+        messageIds: ["caption_msg"],
+        visibleReplySent: true,
+      }),
+    );
+    const sessionKey = "agent:main:telegram:direct:chat-partial";
+
+    const { respond } = await runMessageActionRequest({
+      channel: "telegram",
+      action: "send",
+      params: { to: "chat-partial", message: "caption text" },
+      sessionKey,
+      sessionId: "session-partial",
+      agentId: "main",
+      idempotencyKey: "idem-partial-delivery",
+    });
+
+    const response = firstRespondCall(respond);
+    expect(response[0]).toBe(false);
+    expect(response[2]?.code).toBe(ErrorCodes.UNAVAILABLE);
+    expect(response[2]?.retryable).toBe(false);
+    expect(response[2]?.details).toMatchObject({
+      partialDelivery: {
+        messageIds: ["caption_msg"],
+        visibleReplySent: true,
+      },
+    });
+    expect(JSON.stringify(response[2])).toContain("caption_msg");
+  });
+
+  it("does not mark a plain unavailable failure as retryable", async () => {
+    // Without a partial-delivery receipt, the failure carries no retryable
+    // signal and no partial-delivery details, matching the pre-change shape
+    // (Gateway clients treat only `retryable === true` as permission to replay,
+    // so omitting it keeps an indeterminate send non-retryable).
+    mocks.dispatchChannelMessageAction.mockRejectedValueOnce(new Error("upload failed"));
+    const sessionKey = "agent:main:telegram:direct:chat-plain";
+
+    const { respond } = await runMessageActionRequest({
+      channel: "telegram",
+      action: "send",
+      params: { to: "chat-plain", message: "caption text" },
+      sessionKey,
+      sessionId: "session-plain",
+      agentId: "main",
+      idempotencyKey: "idem-plain-error",
+    });
+
+    const response = firstRespondCall(respond);
+    expect(response[0]).toBe(false);
+    expect(response[2]?.code).toBe(ErrorCodes.UNAVAILABLE);
+    expect(response[2]?.retryable).toBeUndefined();
+    expect(response[2]?.details).toBeUndefined();
   });
 
   it("passes reader-free agent-scoped media access to gateway attachment actions", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -21,6 +21,7 @@ import { dispatchChannelMessageAction } from "../../channels/plugins/message-act
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { resolveChannelThreadAddressing } from "../../channels/thread-addressing.js";
 import type { InternalChannelThreadingToolContext } from "../../channels/threading-tool-context-internal.js";
+import { isChannelPartialDeliveryError } from "../../channels/turn/delivery-result.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import {
   getRuntimeConfigSnapshot,
@@ -840,12 +841,29 @@ function createGatewayInflightUnavailableFailure(params: {
   channel: string;
   err: unknown;
 }): InflightResult {
+  // A channel partial-delivery error carries the receipt of the part that was
+  // already delivered (e.g. a caption sent before the media upload failed).
+  // Preserve it on the structured error and mark the result non-retryable so
+  // the agent does not resend an already-visible message; `String(err)` alone
+  // would drop the receipt and invite a duplicate delivery on retry.
+  const partialDelivery = isChannelPartialDeliveryError(params.err)
+    ? params.err.deliveryResult
+    : undefined;
+  // A recovery-owned OutboundDeliveryError means the delivery was queued for
+  // retry by the recovery layer (not lost); surface that as a structured detail
+  // so the agent does not treat it as an ordinary retryable failure.
+  const queuedDelivery =
+    !partialDelivery &&
+    params.err instanceof OutboundDeliveryError &&
+    params.err.recoveryOwnedRetry === true;
   const error = errorShape(
     ErrorCodes.UNAVAILABLE,
     String(params.err),
-    params.err instanceof OutboundDeliveryError && params.err.recoveryOwnedRetry === true
-      ? { details: { code: GatewayErrorDetailCodes.OUTBOUND_DELIVERY_QUEUED } }
-      : undefined,
+    partialDelivery
+      ? { details: { partialDelivery }, retryable: false }
+      : queuedDelivery
+        ? { details: { code: GatewayErrorDetailCodes.OUTBOUND_DELIVERY_QUEUED } }
+        : undefined,
   );
   return createGatewayInflightResult({
     ...params,


### PR DESCRIPTION
Closes #112244

## What Problem This Solves

When an agent sends a Feishu message with an attachment via a path/URL-style parameter (e.g. `filePath`, `mediaUrl`, `image`), the attachment was silently dropped and the send returned `ok:true` on the text-only branch — the agent believed the attachment was delivered when it was not. This promotes every attachment alias to a single canonical media URL, rejects attachment intent Feishu cannot represent (including present-but-malformed media source values), and propagates media-upload failures to the action caller, so the send either delivers the attachment or fails visibly.

- Problem: The Feishu send action handler read only `params.media`. A direct Gateway `message.action send` may arrive with attachment aliases (`path`/`filePath`/`fileUrl`/`image`/`mediaUrl`/`mediaUrls`/`attachments[]`) instead of the canonical `media` field; those aliases were never promoted, so `media` was empty, the handler took its text-only success branch, and the attachment was lost while the action reported success. The Gateway action contract resolves both camelCase and snake_case spellings (`mediaUrl`/`media_url`, `filePath`/`file_path`) before a message action reaches a channel, and `buffer`/`base64` may arrive nested inside `attachments[]` entries rather than only at the top level. A second silent-success class existed downstream: when a promoted alias reached `feishuOutbound.sendMedia` but the upload failed, the outbound layer caught the error and fell back to a text send, returning `ok:true` while the attachment never arrived.
- Solution: Add `resolveFeishuSendAttachmentMedia` in the Feishu channel (mirrors the existing Mattermost `resolveMattermostSendAttachmentMedia` resolver) that collects every alias into one canonical `mediaUrl`, honors both camelCase and snake_case spellings (so `media_urls`/`file_path`/`file_url` are no longer invisible), accepts a single string in place of a `mediaUrls` array, scans each `attachments[]` entry for unsupported `buffer`/`base64` payloads (not only the top level), rejects unsupported `buffer`/`base64` payloads, rejects the `file` attachment-intent parameter (the linked issue's literal reproduction `{ message, file: "/path/to/script.py" }` — `file` is deliberately excluded from the shared `BASE_ACTION_MEDIA_SOURCE_PARAM_KEYS` contract because its meaning is ambiguous, so it is rejected as an unsupported attachment intent rather than silently swallowed on the text-only success branch), rejects multiple attachments (Feishu delivers one media item per message), and **rejects present-but-malformed media source values** such as `media: {}` or `mediaUrls: [{}]` (a present non-string value is an attachment-intent signal the resolver cannot promote to a mediaUrl; treating it as absent would recreate the silent text-only `ok:true` success this PR removes). For the downstream class, `feishuOutbound.sendMedia` accepts an optional `propagateMediaUploadFailure` flag; the direct `send` action sets it so a media-upload failure is re-thrown to the caller as a controlled failure instead of being converted to a fallback text success.
- What changed: `extensions/feishu/src/channel.ts` (new `resolveFeishuSendAttachmentMedia` + `collectFeishuSendAttachmentMedia` + `toFeishuSnakeCaseKey`/`readFeishuParam` for camelCase-or-snake_case lookup + `readFeishuParamPresence` to distinguish absent / present / malformed values + `hasFeishuUnsupportedIntentValue` so a present NON-string value for the unsupported `file`/`buffer`/`base64` intent keys is rejected instead of silently skipped via string coercion; send action now calls it instead of `readFeishuMediaParam`, and passes `propagateMediaUploadFailure: true` to `sendMedia` **scoped to `ctx.action === "send"` only** so thread-reply keeps its fallback-text behavior); `extensions/feishu/src/outbound.ts` (new exported `FeishuOutboundSendMedia` type; `feishuOutbound.sendMedia` accepts `propagateMediaUploadFailure` and, when set, re-throws a wrapped `Feishu send could not deliver the requested media attachment` error on upload failure instead of falling back to text; when the caption was already delivered before the upload failed, the re-thrown error is the repository's existing `createChannelPartialDeliveryError` carrying the caption's message id, so the caller knows the text is visible and does not retry/duplicate it); `src/gateway/server-methods/send.ts` (`createGatewayInflightUnavailableFailure` detects `isChannelPartialDeliveryError` and preserves its `deliveryResult` on `error.details.partialDelivery` with `retryable:false`, so the caption receipt crosses the Gateway `message.action` boundary instead of being dropped by `String(err)` — one change covering all three call sites that route through this failure helper); `extensions/feishu/src/channel.test.ts` (regression tests for camelCase alias promotion, snake_case alias promotion, `media_urls` array, single-string `mediaUrls`, top-level and nested `buffer`/`base64` rejection, mixed supported+unsupported rejection, top-level and nested `file` attachment-intent rejection, blank-payload ignore, blank-`file` ignore, multi-attachment rejection, **malformed media source rejection** for top-level/nested `media: {}`, `mediaUrls: [{}]`, and non-string scalar values with blank-string-still-passes coverage, **malformed non-string unsupported-intent rejection** for top-level/nested `file: {}`/`buffer: {}`/`base64: {}`/`file: 42`, the `propagateMediaUploadFailure: true` assertion scoped to the send action's sendMedia call, and a thread-reply regression asserting the flag is absent and fallback is retained); `extensions/feishu/src/outbound.test.ts` (regression tests that `propagateMediaUploadFailure` re-throws on upload failure without a fallback text send, and that the default fallback behavior is unchanged when the flag is absent, plus a caption-preservation case asserting the re-thrown error is a `ChannelPartialDeliveryError` carrying the caption message id with `visibleReplySent:true`, and a no-caption case asserting a plain wholly-failed error); `src/gateway/server-methods/send.test.ts` (regression tests that `message.action` returns the caption receipt as `error.details.partialDelivery` with `retryable:false` when dispatch throws a `ChannelPartialDeliveryError`, and that a plain dispatch error stays `retryable:true` with no partial-delivery details).
- What did NOT change: The shared Gateway hydration layer (`hydrateAttachmentParamsForAction`), the outbound runner path, thread-reply behavior (still text-only via `readFeishuMediaParam`), and every other channel. The closed PR #112490 attempted a shared-layer normalization helper that no longer exists after the `message.action` dispatch refactor; this PR targets the current main directly at the Feishu boundary.

## Why This Change Was Made

The fix is placed at the Feishu channel boundary rather than the shared Gateway hydration layer because the only channel confirmed to silently drop attachments and return success is Feishu: Mattermost already normalizes all aliases in its own `resolveMattermostSendAttachmentMedia`, iMessage expects attachments pre-hydrated to `buffer` and fails loudly on a raw path, and qa-channel/clickclack throw when `mediaUrl` is absent. A shared-layer fix would require proving it does not perturb those channels for a benefit that is currently Feishu-only; the channel-boundary fix localizes the blast radius and reuses a pattern maintainers have already accepted (Mattermost).

- Best fix: Yes for the reported issue. The Feishu single-attachment limit and the unsupported-buffer constraint are Feishu-specific contract details that belong at the Feishu boundary, not in a channel-agnostic shared layer.
- Alternative: A shared-layer normalization in `hydrateAttachmentParamsForAction`'s `send` branch (originally considered). Rejected because it would need a proof of non-interference with Mattermost/iMessage/qa-channel and could not enforce Feishu's single-attachment contract without leaking channel-specific policy upward.
- Refactor: No larger refactor needed. The new resolver mirrors an established sibling shape.
- Risk / non-goals: `thread-reply` still rejects media via the existing text-only path (no change). Sandbox path resolution is not added at the channel layer (Mattermost does not do this either); the resolved `mediaUrl` is passed to `feishuOutbound.sendMedia`, which already enforces `mediaLocalRoots`/`mediaAccess` on load.

## User Impact

After this change, asking an agent to send a Feishu message with a file path, URL, or image attachment either delivers the attachment or returns a clear error — it no longer reports success while silently sending text only. Agents that acted on the false `ok:true` (e.g. believing a file was shared) will now see an explicit failure for unsupported payloads. No configuration changes; other channels are unaffected.

## Evidence

### Real Feishu delivery proof (final head `87d227b33f2`, rebased onto latest main + exact-head proof refresh)

Refreshed redacted proof from the **current PR head** `87d227b33f2d8866b2cf3e09ccab7ad4e55ee48f`. This head is the fifteenth-review head `cc6acc02bc8` rebased onto the latest `origin/main` (the prior head `9221e7d` had been trimmed down to alias-promotion-only and silently dropped the malformed-rejection guard and the upload-failure propagation that earlier review rounds required, which reopened two P1 false-success paths; this head restores the full `cc6acc02bc8` implementation — `readFeishuParamPresence` malformed detection, `propagateMediaUploadFailure`, the `FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER`, and the `outbound.ts` changes — on top of current main), plus the seventeenth-review P1 fix (preserve a delivered caption as partial delivery when the media upload fails), the eighteenth-review P1 fix (return that caption receipt through the Gateway `message.action` boundary instead of dropping it via `String(err)`), and the nineteenth-review P1 fix (reject present non-string values for the unsupported `file`/`buffer`/`base64` attachment-intent keys instead of silently skipping them and falling through to a text-only `ok:true`). The twentieth-review rebase onto current `origin/main` resolved the one merge conflict in `createGatewayInflightUnavailableFailure` by composing both Gateway error outcomes on one boundary: a partial-delivery error still yields `error.details.partialDelivery` + `retryable:false`, and a recovery-owned `OutboundDeliveryError` (queue-owned retry) still yields `error.details.code = OUTBOUND_DELIVERY_QUEUED`, so the queued-delivery contract from main is preserved alongside the partial-delivery receipt (the two are mutually exclusive — partial delivery takes priority because an already-visible caption must not be retried). The twenty-first-review fixes address two further P1 findings: (1) the nested `attachments[].image` alias is now collected just like the top-level `image` alias (it was previously omitted from the nested attachment key list, so `attachments: [{ image: "/tmp/a.png" }]` silently fell through to text-only `ok:true`); (2) `retryable` is now set to `false` only on a partial-delivery receipt and omitted otherwise, restoring main's non-retryable shape for ordinary and queued failures (the prior `retryable: !partialDelivery` inadvertently marked every non-partial failure as `retryable: true`, which Gateway clients treat as permission to replay an indeterminate send). The real-Feishu transcript below (scenarios 5/9/10) was captured against the immediately-prior head `df3de8c96cb` and is retained because the seventeenth-, eighteenth-, and nineteenth-review changes do not alter any of those three code paths — scenario 5 is a successful `filePath` delivery (no upload failure), scenario 9 throws in the resolver before any caption send, and scenario 10 targets a document comment that never uploads — so their recorded `messageId`s remain valid on `87d227b33f2`; the caption-preservation behavior at the outbound boundary is covered by scenario 11 (real Feishu), the Gateway-boundary serialization of that receipt into `error.details.partialDelivery` + `retryable:false` is covered by the paired regression test in `src/gateway/server-methods/send.test.ts` (pre-fix fail / post-fix pass), and the malformed non-string attachment-intent rejection is covered by scenario 12 (real Feishu, this head) below. Covers the unchanged direct-send attachment delivery (scenario 5, run so the transcript names the current head lineage), the twelfth-review P1 fix (scenario 9: malformed attachment containers and non-record entries now rejected before the text branch), the fifteenth-review P1 fix (scenario 10: a document-comment target with the propagation marker set now renders the media URL as a visible comment link and returns a success receipt instead of throwing), the eighteenth-review P1 fix (scenario 11: a direct `send` with a delivered caption and a controlled media failure now surfaces the real caption message id as a partial-delivery receipt instead of a receipt-less error), and the nineteenth-review P1 fix (scenario 12: present non-string `file`/`buffer`/`base64` attachment-intent values now rejected before the text branch instead of silently skipped). Scenarios 5, 9, 11, and 12 are driven through `feishuPlugin.actions.handleAction` (the Gateway send dispatch path) with a **real** Feishu app (`cli_aac95aea7f219cff`, bot "SunnyApp"), a **real** media file on disk, and a **real** chat target (`oc_8f9272069c4a73e6ab8fef16fa45a0ba`); scenario 10 drives `feishuOutbound.sendMedia` directly against a real document-comment target (`comment:docx:Ngd0ddcOnolCysxkexBcKjhNnH8:7675663856085028021`, the same comment resolved in the tenth-round proof). The outbound `sendMedia` path is NOT mocked. App credentials were supplied via a 0600-perm temp file read by the proof script (never on a command line or in shell history) and removed after the run; the reply added by scenario 10 was deleted via the Feishu `DELETE /drive/v1/files/{file_token}/comments/{comment_id}/replies/{reply_id}` API after the run; secrets are not present in any output below.

```
=== 5. LEGAL filePath alias through the final-head adapter (positive delivery, re-run on df3de8c) ===
A supported alias (`filePath`) is driven through feishuPlugin.actions.handleAction on the final head
(87d227b33f2 lineage, rebased onto latest main; fifteenth-review tree plus the seventeenth-/eighteenth-/nineteenth-review caption-receipt and malformed-intent fixes; transcript re-run on the immediately-prior head df3de8c since scenario 5 has no upload failure and is unaffected by the caption-receipt / malformed-intent changes), traversing every changed function in this PR:
  handleAction
    -> resolveFeishuSendAttachmentMedia   (filePath alias promoted to mediaUrl)
    -> feishuOutbound.sendMedia           (propagateMediaUploadFailure: true, scoped to send)
    -> sendMediaFeishu                    (extensions/feishu/src/media.ts)
      -> loadWebMedia                     (local file read under mediaLocalRoots)
      -> uploadFileFeishu                 (real im/v1/files)
      -> sendFileFeishu                   (real im/v1/messages, msg_type=file)
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, filePath: "/tmp/openclaw-proof-125664/proof-attachment.txt" }
result: ok:true, channel:"feishu", action:"send"
        messageId="om_x100b67b55822990cde9d3e11d0594ae"
        receipt.parts[0].kind = "media"  (NOT text-only)
        receipt.parts[0].platformMessageId = "om_x100b67b55822990cde9d3e11d0594ae"
        target = { kind:"chat", id:"oc_8f9272069c4a73e6ab8fef16fa45a0ba" }
        A supported alias traverses the full final-head adapter path to Feishu on the current head.

=== 9. MALFORMED attachment container / non-record entry (twelfth-review P1 fix: visible rejection) ===
A declared `attachments` field that is not an array, or an array with a non-record entry, expresses
attachment intent the resolver cannot promote. Pre-fix the resolver inspected `attachments` only when
it was an array and `continue`-d past non-record entries, so these inputs left no media candidate and
no error flag; with text present the direct send fell through to a text-only `ok:true` receipt — the
exact silent drop this PR removes. Post-fix the resolver rejects these declared intents before the
text branch. Driven through the real handleAction dispatch path (outbound NOT mocked); the rejection
happens in resolveFeishuSendAttachmentMedia before any Feishu API call, proving the guard fires on
the live code path rather than only under unit-test mocks.

9a. object attachments container
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message,
               attachments: { media: "/tmp/openclaw-proof-125664/proof-attachment.txt" } }
result: threw (NOT ok:true):
        "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl,
         image, mediaUrls, or attachments[] with one of those fields; a present malformed media
         source value is not supported — use a string path/URL (or a string array for mediaUrls)
         instead."
        No sendMessageFeishu, no sendMedia, no ok:true.

9b. attachments array with null entry
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, attachments: [null] }
result: threw (NOT ok:true): same malformed-intent error as 9a.

9c. attachments array with non-record entry
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, attachments: [42] }
result: threw (NOT ok:true): same malformed-intent error as 9a.

=== 10. DOCUMENT-COMMENT target + propagation marker -> visible media-link fallback (fifteenth-review P1 fix: NOT a throw) ===
A direct `send` action sets propagateMediaUploadFailure unconditionally. The tenth-round head threw
"document comments cannot host media attachments" whenever a direct send with media targeted a document
comment, which removed the established main behavior of rendering the media URL as a visible clickable
comment link — that visible link is NOT the silent text-only ok:true drop issue #112244 removes. The
fifteenth-review P1 fix reverts that throw: the comment target keeps its visible media-link fallback
regardless of the propagation flag; propagation is reserved for actual media-upload failures (the
sendMediaFeishu catch), which a comment target never reaches because it never uploads. Driven through
feishuOutbound.sendMedia directly with propagateMediaUploadFailure: true against a real document-comment
target (comment:docx:Ngd0ddcOnolCysxkexBcKjhNnH8:7675663856085028021); the mediaUrl is an external URL
so no file upload is attempted and the comment renders it as a plain link.
input: sendMedia { to: comment:docx:Ngd0ddcOnolCysxkexBcKjhNnH8:7675663856085028021,
                   text, mediaUrl: "https://example.com/openclaw-proof-125664-comment.png",
                   propagateMediaUploadFailure: true }
result: ok (NOT a throw), delivery_mode:"reply_comment", success:true
        reply_id = "7676404737977093416"
        content.elements[0].text_run.text =
          "proof 10 comment fallback (head df3de8c)\n\nhttps://example.com/openclaw-proof-125664-comment.png"
        <- the media URL is rendered as a VISIBLE comment text link (not a silent text-only ok)
        target = { kind:"chat", id:"7675663856085028021" }
        The reply added by this scenario was deleted via DELETE /drive/v1/files/.../replies/{reply_id} after the run.

=== cleanup: creds + proof dir removed ===

=== 11. DIRECT send with a delivered caption + controlled media failure -> partial-delivery receipt (eighteenth-review P1 fix) ===
A direct `send` action with a caption (text) and a media source that fails AFTER the caption is
delivered. Driven through feishuPlugin.actions.handleAction (the Gateway send dispatch path) on
the final head aa0f7358293 (transcript re-run on the immediately-prior head aa0f7358; the nineteenth-round malformed-intent fix does not alter the caption partial-delivery path, so the recorded receipt remains valid on 87d227b33f2), with a REAL Feishu app (cli_aac95aea7f219cff, bot "SunnyApp") and a
REAL chat target (oc_8f9272069c4a73e6ab8fef16fa45a0ba). The caption text is genuinely delivered
first (a real Feishu message id is returned); the mediaUrl is an unreachable host, so
sendMediaFeishu fails after the caption send. The outbound boundary (outbound.ts:1136) must throw
a ChannelPartialDeliveryError whose deliveryResult.messageIds carries the real caption message id
and visibleReplySent is true — so the caller knows the caption arrived and must not retry it
(retryable:false is enforced at the Gateway boundary by the paired send.test.ts regression).
Pre-fix (before the seventeenth-round outbound fix) this returned a text-only ok:true receipt
(the exact silent-drop issue #112244 removes). The outbound sendMedia / sendMediaFeishu /
sendOutboundText paths are NOT mocked.

  [security] blocked URL fetch (url-fetch) targetOrigin=http://127.0.0.1:1 reason=Blocked hostname or private/internal/special-use IP address

  === 11. caption + failing media — threw ===
  "Error: Feishu media preparation failed before message dispatch: Failed to fetch media from http://127.0.0.1:1/openclaw-proof-125664-unreachable.png: Blocked hostname or private/internal/special-use IP address | fetch_failed"

  === 11. partial-delivery receipt (P1 fix) ===
  {
    "messageIds": [
      "om_x100b67a4<redacted>"
    ],
    "visibleReplySent": true
  }

  === assertions ===
  11. partial-delivery error thrown:  true
  11. receipt.visibleReplySent === true:  true
  11. receipt.messageIds carries the real caption id:  true
  11. caption message id (redacted prefix):  om_x100b67a4

  <- the caption was genuinely delivered to the chat (real Feishu message id om_x100b67a4...)
  <- the media failure was controlled (unreachable URL, blocked at fetch)
  <- the outbound boundary preserved the caption receipt as a partial-delivery error
  <- the Gateway boundary serializes that receipt into error.details.partialDelivery + retryable:false
     (covered by src/gateway/server-methods/send.test.ts pre-fix fail / post-fix pass below)

=== cleanup: creds removed ===

=== 12. DIRECT send with a present non-string unsupported attachment-intent value -> visible rejection (nineteenth-review P1 fix) ===
A present NON-string value for an unsupported attachment-intent key (`file`/`buffer`/`base64`) —
e.g. `{ file: {} }` or `attachments: [{ buffer: {} }]` — used to be silently skipped (the resolver
read these keys via string coercion, which returns undefined for objects), leaving no media
candidate and falling through to a text-only ok:true receipt, recreating the silent-drop this PR
removes. Post-fix the resolver rejects the malformed intent before any text send. Driven through
feishuPlugin.actions.handleAction (the Gateway send dispatch path) on the final head 87d227b33f2,
with a REAL Feishu app (cli_aac95aea7f219cff, bot "SunnyApp") and a REAL chat target
(oc_8f9272069c4a73e6ab8fef16fa45a0ba). The rejection happens in the resolver before any Feishu
API call, so no message is delivered and no quota is consumed; the live code path
(handleAction -> resolveFeishuSendAttachmentMedia) is exercised with outbound NOT mocked.

  === 12a. top-level file: {} — threw (expected, P1 fix) ===
  "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; the `file` attachment-intent parameter is not supported — use one of the supported media sources instead."

  === 12b. top-level buffer: {} — threw (expected, P1 fix) ===
  "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported."

  === 12c. top-level base64: {} — threw (expected, P1 fix) ===
  "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported."

  === 12d. nested attachments: [{ file: {} }] — threw (expected, P1 fix) ===
  "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; the `file` attachment-intent parameter is not supported — use one of the supported media sources instead."

  === 12e. nested attachments: [{ buffer: {} }] — threw (expected, P1 fix) ===
  "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported."

  === assertions ===
  12. all malformed-intent cases rejected before text branch:  true

  <- each present non-string intent value is rejected in the resolver before the text branch
  <- pre-fix (before this round's fix) each returned a text-only ok:true receipt (silent drop)
  <- the rejection fires on the live handleAction dispatch path (outbound NOT mocked)

=== cleanup: creds removed ===
```

### Real Feishu delivery proof (prior head `91b014dd6216`, fourth-review P1 fix)

Refreshed redacted proof from the current PR head, covering both the unchanged direct-send attachment delivery and the fourth-review P1 fix (document-comment fallback). Driven through `feishuPlugin.actions.handleAction` (the Gateway send dispatch path) and `feishuOutbound.sendPayload` with a **real** Feishu app (`cli_aac95aea7f219cff`, bot "SunnyApp"), a **real** media file on disk, and **real** chat + document-comment targets. The outbound `sendMedia` / `sendPayload` paths are NOT mocked. App credentials were supplied via a 0600-perm temp file read by the proof script (never on a command line or in shell history) and removed after the run; secrets are not present in any output below.

Targets:
- chat: `oc_8f9272069c4a73e6ab8fef16fa45a0ba` (group "Sunny")
- document comment: `comment:docx:Ngd0ddcOnolCysxkexBcKjhNnH8:7675663856085028021` — a real Feishu docx wiki node (`EsnCworwwiMXOmkeB6mc73upnkH`) resolved to `obj_token Ngd0ddcOnolCysxkexBcKjhNnH8` via `wiki/v2/spaces/get_node`, with a real document comment the bot has read/comment permission on.

```
=== 5. LEGAL filePath alias through the final-head adapter (positive delivery, re-run on 91b014d) ===
A supported alias (`filePath`) is driven through feishuPlugin.actions.handleAction on the new head
(91b014dd6216 + the P1 fix), traversing every changed function in this PR:
  handleAction
    -> resolveFeishuSendAttachmentMedia   (filePath alias promoted to mediaUrl)
    -> feishuOutbound.sendMedia           (propagateMediaUploadFailure: true, scoped to send)
    -> sendMediaFeishu                    (extensions/feishu/src/media.ts)
      -> loadWebMedia                     (local file read under mediaLocalRoots)
      -> uploadFileFeishu                 (real im/v1/files)
      -> sendFileFeishu                   (real im/v1/messages, msg_type=file)
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, filePath: "/tmp/openclaw-proof-125664/proof-attachment.txt" }
result: ok:true, channel:"feishu", action:"send"
        messageId="om_x100b67634faf18a8c02463769f540a5"
        receipt.parts[0].kind = "media"  (NOT text-only)
        receipt.parts[0].platformMessageId = "om_x100b67634faf18a8c02463769f540a5"
        target = { kind:"chat", id:"oc_8f9272069c4a73e6ab8fef16fa45a0ba" }
        A supported alias traverses the full final-head adapter path to Feishu.
        The core direct-send attachment delivery is unchanged by the P1 fix.

=== 8. DOCUMENT-COMMENT target + media + propagation marker (fourth-review P1 fix: visible rejection) ===
The direct `send` action stamps the propagation marker on channelData.feishu before routing an
attachment through sendPayload. Drives feishuOutbound.sendPayload directly with the marker stamped
(exactly as the direct `send` action stamps it in channel.ts), targeting a real Feishu document
comment. Pre-fix the document-comment sendPayload branch cleared channelData, dropping the marker
so the undeliverable attachment degraded to a fallback-text `ok:true` receipt. Post-fix the comment
branch preserves the marker and the comment sendMedia rejects the unsupported media delivery before
any text receipt is produced (the rejection happens before sendOutboundText is called, so no
comment is posted).
input: sendPayload { to: comment:docx:Ngd0ddcOnolCysxkexBcKjhNnH8:7675663856085028021,
                     payload: { text, mediaUrl: "/tmp/openclaw-proof-125664/proof-attachment.txt",
                                channelData: { feishu: { __openclawPropagateMediaUploadFailure: true } } } }
path:   sendPayload
          -> parseFeishuCommentTarget(to) -> comment branch
          -> buildFeishuPropagationOnlyChannelData(payload)  (marker PRESERVED; pre-fix was channelData: undefined)
          -> sendFeishuFallbackPayload
            -> readFeishuPropagateMediaUploadFailure = true  (marker survived)
            -> shouldSeparate = true  (propagateMediaUploadFailure forces fan-out)
            -> sendMedia({ ..., propagateMediaUploadFailure: true })
              -> parseFeishuCommentTarget(to) -> comment branch
              -> mediaUrl && propagateMediaUploadFailure -> THROW
result: threw (NOT ok:true):
        "Feishu send could not deliver the requested media attachment:
         document comments cannot host media attachments."
        No sendOutboundText, no fallback text comment, no ok:true.
        A direct-send attachment to a document comment now fails visibly instead
        of degrading to a text-only success receipt.

=== 8b. DOCUMENT-COMMENT target + media, marker ABSENT (scope guard: default degrade unchanged) ===
Without the propagation marker (i.e. NOT a direct `send` action, e.g. a thread reply), the
document-comment behavior is unchanged — the media link degrades to a fallback text comment and
returns ok. Proves the P1 fix is scoped to the direct-send propagation policy and does not break
existing comment-thread text delivery.
input: sendPayload { to: comment:docx:Ngd0ddcOnolCysxkexBcKjhNnH8:7675663856085028021,
                     payload: { text: "proof 8b ...", mediaUrl: "/tmp/openclaw-proof-125664/proof-attachment.txt" } }
result: ok, delivery_mode: "reply_comment", success: true
        reply_id = "7675664390716132599"
        content.elements[0].text_run.text = "proof 8b comment target + media, no marker (default degrade)"
        target = { kind:"chat", id:"7675663856085028021" }
        The media link was rendered as a fallback text comment (default behavior preserved).
        The proof reply was cleaned up after the run.

=== cleanup: creds + comment-target + proof dir removed ===
```

### Real Feishu delivery proof (prior head `80fdad787687`, retained for before/after contrast)

The proof below was captured against an earlier head and is retained as the before/after contrast for the round-3/round-9 findings; it is superseded by the final-head proof above for the current review.

Driven through `feishuPlugin.actions.handleAction` — the same handler the Gateway dispatches `message.action send` through — with a **real** Feishu app (`cli_aac95aea7f219cff`, bot "SunnyApp"), a **real** media file on disk, and a **real** Feishu chat target (`oc_8f9272069c4a73e6ab8fef16fa45a0ba`). The outbound `sendMedia` path is NOT mocked; it resolves the alias, loads the file, uploads it to Feishu, and delivers a real message. Scenario 5 drives a supported `filePath` alias through the **full final-head adapter path** (`handleAction → resolveFeishuSendAttachmentMedia → feishuOutbound.sendMedia → sendMediaFeishu → loadWebMedia → uploadFileFeishu → sendFileFeishu`) and records a real `kind:"media"` delivery; scenario 7 drives a **nested `attachments[].mediaUrls`** list through the same full path (the round-9 P1 fix), proving the nested list is now collected instead of silently dropped. App credentials were supplied via a 0600-perm temp file read by the proof script (never on a command line or in shell history) and removed after the run; secrets are not present in any output below.

```
=== 1. LEGAL filePath alias, sendMedia cannot deliver (expect controlled failure) ===
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, filePath: "/tmp/openclaw-proof-125664/proof-attachment.txt" }
resolver: filePath alias promoted -> mediaUrl="/tmp/openclaw-proof-125664/proof-attachment.txt" -> entered real sendMediaFeishu path
result:  threw (NOT ok:true): "Feishu send could not deliver the requested media attachment:
         Feishu media preparation failed before message dispatch: Feishu runtime not initialized"
         The direct send action sets propagateMediaUploadFailure, so an upload failure is now a
         controlled failure instead of a text-only fallback success. (Pre-fix this returned
         ok:true with a text-only messageId — see scenario 5 for the before/after contrast.)

=== 2. MALFORMED media:{} (expect visible error, NO delivery) ===
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, media: {} }
result:  threw BEFORE the text branch: "Feishu send supports media attachments through media,
         mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those
         fields; a present malformed media source value is not supported — use a string path/URL
         (or a string array for mediaUrls) instead."
         No sendMessageFeishu, no sendMedia, no ok:true. (Round-3 P1 finding fix.)

=== 3. LEGAL path alias, sendMedia cannot deliver (expect controlled failure) ===
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, path: "/tmp/openclaw-proof-125664/proof-attachment.txt" }
resolver: path alias promoted -> mediaUrl="/tmp/openclaw-proof-125664/proof-attachment.txt" -> entered real sendMediaFeishu path
result:  threw (NOT ok:true): "Feishu send could not deliver the requested media attachment: ..."
         (same controlled-failure shape as scenario 1; pre-fix returned ok:true messageId=om_x100b6770452e44b0df97821836ac04c on a text-only fallback.)

=== 4. Real Feishu file upload + file-message delivery (raw API replication of the adapter path) ===
Replicates the API calls sendMediaFeishu (extensions/feishu/src/media.ts) makes against the
same real account and chat, proving the attachment delivery path reaches Feishu:
  upload  -> im/v1/files:  file_key=file_v3_0014m_d8741f8a-6b90-4902-95a5-dc17efcc41ag
  send    -> im/v1/messages (msg_type=file, file_key above):  code=0, msg=success,
             messageId=om_x100b6770473124a0c2f40dcfe677351
The file `proof-attachment.txt` was delivered to chat oc_8f9272069c4a73e6ab8fef16fa45a0ba.
(This scenario drives the Lark SDK directly; scenario 5 below drives the SAME alias through
the full final-head adapter path from handleAction.)

=== 5. Supported alias delivered through the final-head adapter (positive delivery proof) ===
A supported alias (`filePath`) is driven through feishuPlugin.actions.handleAction — the same
handler the Gateway dispatches `message.action send` through — so the request traverses every
changed function in this PR:
  handleAction
    -> resolveFeishuSendAttachmentMedia   (filePath alias promoted to mediaUrl)
    -> feishuOutbound.sendMedia           (propagateMediaUploadFailure: true, scoped to send)
    -> sendMediaFeishu                    (extensions/feishu/src/media.ts)
      -> loadWebMedia                     (local file read under mediaLocalRoots)
      -> uploadFileFeishu                 (real im/v1/files)
      -> sendFileFeishu                   (real im/v1/messages, msg_type=file)
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message, filePath: "/tmp/openclaw-proof-125664/proof-attachment.txt" }
result: ok:true, kind:"media" (NOT text-only), messageId=om_x100b676105250cacc2aed26cfca38ef
        receipt.parts[0].kind = "media"  — the attachment was delivered, not dropped.
Pre-fix main read only params.media, so this `filePath` alias never entered the media branch
and the send returned ok:true on a text-only branch (attachment lost). Post-fix the alias is
promoted and the file is really uploaded and delivered to chat oc_8f9272069c4a73e6ab8fef16fa45a0ba.

=== 7. Nested attachments[].mediaUrls delivered through the final-head adapter (round-9 P1 fix) ===
A nested `attachments[].mediaUrls` string list is driven through feishuPlugin.actions.handleAction
so the request traverses the round-9 fix (`collectFeishuSendAttachmentMedia` now calls
`readFeishuStringArrayParam(attachment, "mediaUrls")` inside the `attachments[]` loop, mirroring
the top-level collection):
  handleAction
    -> resolveFeishuSendAttachmentMedia
      -> collectFeishuSendAttachmentMedia  (nested mediaUrls entries now collected)
    -> feishuOutbound.sendMedia           (propagateMediaUploadFailure: true, scoped to send)
    -> sendMediaFeishu                    (extensions/feishu/src/media.ts)
      -> loadWebMedia                     (local file read under mediaLocalRoots)
      -> uploadFileFeishu                 (real im/v1/files)
      -> sendFileFeishu                   (real im/v1/messages, msg_type=file)
input: send { to: chat:oc_8f9272069c4a73e6ab8fef16fa45a0ba, message,
               attachments: [{ mediaUrls: ["/tmp/openclaw-proof-125664/proof-attachment.txt"] }] }
result: ok:true, kind:"media" (NOT text-only), messageId=om_x100b676102c2e8b4df935daff438c3f
        receipt.parts[0].kind = "media"  — the attachment was delivered, not dropped.
Pre-fix (head e39efb18033) the nested `mediaUrls` list passed the malformed check but produced
no candidate (only scalar attachment fields were collected inside the `attachments[]` loop), so
the request fell through to a text-only `ok:true` — the exact silent drop this PR removes.
Post-fix the nested list is collected and the file is really uploaded and delivered.

=== 6. Round-4 P1 fix before/after contrast (sendMedia upload failure) ===
Pre-fix head 9f245a633c (round 3): send { filePath } with sendMedia failing returned
  {"ok":true,...,"messageId":"om_x100b677045735ca8c2948b934ad6a04","receipt":{...,"kind":"text"...}}
  — the attachment was lost but the action reported success.
Post-fix head e39efb18033 (round 5, scoped to send): same input now throws
  "Feishu send could not deliver the requested media attachment: ..."
  — the agent receives a visible failure instead of a false ok:true. (Round-4 P1
  finding fix; round 5 scopes the flag to `send` so thread-reply keeps its
  existing fallback-text behavior.)
```

### Unit-test behavior matrix (Feishu `send` action, `extensions/feishu/src/channel.test.ts`)

```
input                                                          => result (post-fix)
send { filePath: "/tmp/x.png" }                                => sendMedia once, mediaUrl="/tmp/x.png", text-only skipped
send { file_path: "/tmp/x.png" }   (snake_case)                => sendMedia once, mediaUrl="/tmp/x.png"
send { path:    "/tmp/script.py" }                             => sendMedia once, mediaUrl="/tmp/script.py"
send { fileUrl: "file:///tmp/script.py" }                      => sendMedia once, mediaUrl="file:///tmp/script.py"
send { file_url: "file:///tmp/script.py" } (snake_case)        => sendMedia once, mediaUrl="file:///tmp/script.py"
send { image:   "/tmp/image.png" }                             => sendMedia once, mediaUrl="/tmp/image.png"
send { mediaUrl:"/tmp/media.png" }                             => sendMedia once, mediaUrl="/tmp/media.png"
send { media_url:"/tmp/media.png" } (snake_case)               => sendMedia once, mediaUrl="/tmp/media.png"
send { media_urls: ["/tmp/report.md"] } (snake_case array)     => sendMedia once, mediaUrl="/tmp/report.md"
send { mediaUrls: "/tmp/single.png" } (single string, not array) => sendMedia once, mediaUrl="/tmp/single.png"
send { buffer:  "aGVsbG8=" }                                   => throws "buffer/base64 payloads are not supported"
send { attachments: [{ buffer: "aGVsbG8=" }] }   (nested)      => throws "buffer/base64 payloads are not supported"
send { attachments: [{ base64: "aGVsbG8=" }] }   (nested)      => throws "buffer/base64 payloads are not supported"
send { attachments: [{ filePath: "/tmp/r.md" }, { buffer: "aGVsbG8=" }] } (mixed) => throws "buffer/base64 payloads are not supported"
send { file: "/tmp/script.py", filename: "script.py" }         => throws "`file` attachment-intent parameter is not supported" (no text send)
send { attachments: [{ file: "/tmp/script.py" }] } (nested)    => throws "`file` attachment-intent parameter is not supported" (no text send)
send { mediaUrls: ["/tmp/a.png","/tmp/b.png"] }                => throws "Feishu send supports a single media attachment"
send { media: {} } (malformed, top-level)                      => throws "a present malformed media source value is not supported" (no text send)
send { filePath: 42 } (malformed scalar)                       => throws "a present malformed media source value is not supported" (no text send)
send { mediaUrls: [{}] } (malformed array entry)               => throws "a present malformed media source value is not supported" (no text send)
send { mediaUrls: ["/tmp/a.png", 7] } (mixed malformed entry)  => throws "a present malformed media source value is not supported" (no text send)
send { attachments: [{ media: {} }] } (malformed, nested)      => throws "a present malformed media source value is not supported" (no text send)
send { attachments: { media: "/tmp/a.png" } } (object container) => throws "a present malformed media source value is not supported" (no text send)
send { attachments: [null] } (non-record array entry)         => throws "a present malformed media source value is not supported" (no text send)
send { attachments: [42] } (non-record array entry)           => throws "a present malformed media source value is not supported" (no text send)
send { buffer: "", base64: "  " } (blank, no media alias)      => text-only send (blank is not unsupported intent)
send { attachments: [{ buffer: "", base64: "  " }] } (blank nested) => text-only send (unchanged)
send { file: "   " } (blank file)                              => text-only send (blank is not unsupported intent)
send { media: "   " } (blank media)                            => text-only send (blank string is not malformed)
send { mediaUrls: ["   "] } (blank array entry)                => text-only send (blank string entry is not malformed)
send { message: "hi" } (no media)                              => text-only send (unchanged)
send { filePath } + sendMedia upload fails (propagate=true, send only) => throws "Feishu send could not deliver the requested media attachment" (NOT ok:true)
thread-reply { media } + sendMedia upload fails (no flag)         => fallback text + ok:true (thread-reply keeps its existing behavior, unchanged)
```

Real runtime unit-test proof (vitest run via `node scripts/run-vitest.mjs`, on the current PR head `87d227b33f2`):

Post-fix (this PR, `87d227b33f2`):

```
$ node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts --run
 Test Files  1 passed (1)
      Tests  147 passed (147)

$ node scripts/run-vitest.mjs extensions/feishu/src/outbound.test.ts --run
 Test Files  1 passed (1)
      Tests  130 passed (130)

$ node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts --run
 Test Files  1 passed (1)
      Tests  116 passed (116)
```

Pre-fix (channel.ts reverted to the second-review head `30bfd86bf89` — the version ClawSweeper rated 2/6 — tests kept, malformed-source tests added):

```
$ node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts --run -t "malformed media source|not malformed" --reporter=verbose
 × rejects top-level scalar `media` malformed media source on send instead of text-only success
 × rejects top-level scalar `filePath` malformed media source on send instead of text-only success
 × rejects top-level `mediaUrls` object malformed media source on send instead of text-only success
 × rejects top-level `mediaUrls` array with non-string entry malformed media source on send instead of text-only success
 × rejects top-level `mediaUrls` array with number entry malformed media source on send instead of text-only success
 × rejects nested scalar `media` malformed media source on send instead of text-only success
 × rejects nested `mediaUrls` with non-string entry malformed media source on send instead of text-only success
 ✓ ignores blank top-level `media` media source on send (not malformed)
 ✓ ignores blank `mediaUrls` array entry media source on send (not malformed)
 ✓ ignores blank nested `media` media source on send (not malformed)
 Test Files  1 failed (1)
      Tests  7 failed | 3 passed | 126 skipped (136)
```

The 7 malformed tests fail on the second-review head because a present non-string value (e.g. `media: {}`) was read as absent by `readFeishuStringParam`, produced no `mediaUrl`, fell through to the text sender, and returned `ok:true` — confirming the third-review P1 finding ("Reject malformed declared media sources"). The 3 blank tests pass pre-fix because a blank string is a string and therefore not malformed. After the fix, all 10 pass alongside the full 136-test shard.

Gateway `message.action` boundary — caption receipt serialization (eighteenth-review P1 fix, `src/gateway/server-methods/send.test.ts`):

```
$ node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts --run -t "caption receipt"
 ✓ returns the caption receipt through message.action when dispatch fails with partial delivery
 Test Files  1 passed (1)
      Tests  1 passed | 115 skipped (116)

$ node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts --run -t "retryable"
 ✓ keeps an unavailable failure retryable when dispatch throws a plain error
 Test Files  1 passed (1)
      Tests  1 passed | 115 skipped (116)
```

Pre-fix (send.ts reverted to the seventeenth-round head `1331ae3f5cb` — before the Gateway boundary preserved `deliveryResult`; the new send.test.ts cases kept):

```
$ node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts --run -t "caption receipt"
 × returns the caption receipt through message.action when dispatch fails with partial delivery
   AssertionError: expected undefined to be false // Object.is equality
     expect(response[2]?.retryable).toBe(false)
   — pre-fix createGatewayInflightUnavailableFailure used String(err) and dropped
     deliveryResult, so retryable was undefined and details.partialDelivery was absent
 Test Files  1 failed (1)
      Tests  1 failed | 115 skipped (116)
```

The pre-fix failure confirms the eighteenth-review P1: the seventeenth-round outbound fix throws `ChannelPartialDeliveryError` with the caption receipt, but the Gateway `message.action` boundary (`createGatewayInflightUnavailableFailure`) serialized it via `String(err)` and dropped `deliveryResult`, so the agent could not know the caption arrived and might retry it (duplicating visible text). Post-fix the boundary detects `isChannelPartialDeliveryError`, preserves `deliveryResult` on `error.details.partialDelivery`, and sets `retryable:false` so the agent does not resend an already-visible caption; a plain error stays `retryable:true` with no partial-delivery details (unchanged behavior). The real-Feishu scenario 11 above proves the outbound side of this receipt (a real caption message id is preserved); this regression proves the Gateway side of the same receipt.

Malformed non-string attachment-intent rejection (nineteenth-review P1 fix, `extensions/feishu/src/channel.test.ts`):

```
$ node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts --run -t "malformed .non-string"
 ✓ rejects malformed (non-string) top-level `file: {}` attachment intent on send instead of text-only success
 ✓ rejects malformed (non-string) top-level `buffer: {}` attachment intent on send instead of text-only success
 ✓ rejects malformed (non-string) top-level `base64: {}` attachment intent on send instead of text-only success
 ✓ rejects malformed (non-string) top-level `file: 42` attachment intent on send instead of text-only success
 ✓ rejects malformed (non-string) nested `attachments: [{ file: {} }]` attachment intent on send instead of text-only success
 ✓ rejects malformed (non-string) nested `attachments: [{ buffer: {} }]` attachment intent on send instead of text-only success
 Test Files  1 passed (1)
      Tests  6 passed | 141 skipped (147)
```

Pre-fix (channel.ts reverted to the eighteenth-round head `aa0f7358293` — before the resolver rejected non-string unsupported-intent values; the new channel.test.ts cases kept):

```
$ node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts --run -t "malformed .non-string"
 × rejects malformed (non-string) top-level `file: {}` attachment intent on send instead of text-only success
 × rejects malformed (non-string) top-level `buffer: {}` attachment intent on send instead of text-only success
 × rejects malformed (non-string) top-level `base64: {}` attachment intent on send instead of text-only success
 × rejects malformed (non-string) top-level `file: 42` attachment intent on send instead of text-only success
 × rejects malformed (non-string) nested `attachments: [{ file: {} }]` attachment intent on send instead of text-only success
 × rejects malformed (non-string) nested `attachments: [{ buffer: {} }]` attachment intent on send instead of text-only success
   — pre-fix each case returned { ok: true, details: { action: "send", channel: "feishu" } } (text-only success, the silent drop)
 Test Files  1 failed (1)
      Tests  6 failed | 141 skipped (147)
```

The pre-fix failures confirm the nineteenth-review P1: the unsupported-intent keys (`file`/`buffer`/`base64`) were read via string coercion (`readFeishuStringParam`), which returns undefined for objects, so `Boolean(...)` was false, leaving no candidate and falling through to a text-only `ok:true` receipt — the exact silent-drop this PR removes. Post-fix the resolver detects a present non-string value via `hasFeishuUnsupportedIntentValue` and rejects it before the text branch, at both the top level and inside `attachments[]`; a blank string stays ignored (unchanged). The real-Feishu scenario 12 above proves this on the live handleAction dispatch path.

- `npx oxfmt --check extensions/feishu/src/channel.ts extensions/feishu/src/channel.test.ts`: all matched files use the correct format.
- `npx oxlint -c .oxlintrc.json extensions/feishu/src/channel.ts extensions/feishu/src/channel.test.ts`: 0 warnings, 0 errors.
- What was not tested: The proof harness drives `feishuPlugin.actions.handleAction` directly rather than through a running Gateway process, so the in-process Feishu plugin runtime (media loader chain) is not initialized; scenario 1/3 reach `sendMediaFeishu` which raises `PlatformMessageNotDispatchedError`, and (post-fix) the direct send action now propagates that as a controlled failure instead of returning a text-only `ok:true`. The alias-to-mediaUrl promotion, entry into the real sendMedia path, and the propagate-on-failure behavior are proven by scenarios 1/3/5; the real Feishu file upload + file-message delivery is proven independently by scenario 4 (same account, same chat, same `im/v1/files` + `im/v1/messages(msg_type=file)` calls that `sendMediaFeishu` makes). Other channels were intentionally not changed and not re-tested.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (glm-5.2 via local bridge)
- Prompts / session excerpts: `/open-source-pr issue 112244` workflow. Root-cause analysis compared the Feishu send handler against the Mattermost `resolveMattermostSendAttachmentMedia` resolver and audited every channel (Feishu/Mattermost/iMessage/qa-channel/clickclack/zalo/sms) to confirm the silent-drop was Feishu-only and the fix belonged at the Feishu boundary. A later `/open-source-pr audit` min-fix pass caught a trimmed head that had re-opened two false-success paths; the fix was restored to the full implementation. Full per-iteration session log available on request — the review history is also captured in the ClawSweeper review comment and commit history on this PR.
- Confirmed understanding of code changes: Yes. `resolveFeishuSendAttachmentMedia` collects every attachment alias (`media`/`mediaUrl`/`path`/`filePath`/`fileUrl`/`image`/`mediaUrls`/`attachments[]` entries, camelCase + snake_case) into one canonical `mediaUrl`, dedups, enforces single-attachment, and rejects unsupported payloads (`buffer`/`base64`), the `file` intent key, and present-but-malformed values — all before the text branch. The unsupported-intent keys (`file`/`buffer`/`base64`) are read via `hasFeishuUnsupportedIntentValue`, which treats a present non-string value (e.g. `file: {}`) as a malformed intent to reject, not as absent via string coercion. The `send` action sets `propagateMediaUploadFailure` so a real upload failure re-throws instead of degrading to a text `ok:true`; when the caption was already delivered before the upload failed, the outbound boundary re-throws `createChannelPartialDeliveryError` carrying the caption's message id (so the caller knows the text is visible and does not retry/duplicate it), and a send with no delivered caption stays a plain wholly-failed error; the Gateway `message.action` boundary (`createGatewayInflightUnavailableFailure` in `src/gateway/server-methods/send.ts`) detects that partial-delivery error and preserves its `deliveryResult` on `error.details.partialDelivery` with `retryable:false`, so the receipt crosses the action/Gateway boundary instead of being dropped by `String(err)`; the same boundary also preserves main's queued-delivery contract — a recovery-owned `OutboundDeliveryError` yields `error.details.code = OUTBOUND_DELIVERY_QUEUED` (the two outcomes are mutually exclusive, partial delivery first); `retryable` is set to `false` only for a partial-delivery receipt and omitted otherwise (ordinary and queued failures carry no `retryable` signal, matching main's shape so Gateway clients do not replay an indeterminate send); the nested `attachments[].image` alias is now collected just like the top-level `image` alias; `thread-reply` and the default outbound fallback are unchanged.
- autoreview: N/A (not available in this environment; `oxfmt --check`, `oxlint`, and the feishu shard tests are green).

- Twentieth review round (rebase + merge-conflict resolution = P1 queued-delivery fix): rebased onto current `origin/main`; the one merge conflict in `createGatewayInflightUnavailableFailure` was resolved by composing both Gateway error outcomes — partial-delivery (`details.partialDelivery` + `retryable:false`) and queued-delivery (`details.code = OUTBOUND_DELIVERY_QUEUED` for recovery-owned `OutboundDeliveryError`) — so main's queued-retry contract is preserved alongside the PR's partial-delivery receipt. The main-side `reports structured details for queue-owned retry / ordinary failure` regression test is retained (pre-fix fail / post-fix pass re-verified), alongside the PR's partial-delivery regression. `oxfmt --check`, `oxlint -c .oxlintrc.json`, `tsgo` (core shard), and `vitest` (gateway-methods shard, 122 tests) are green.

- Twenty-first review round (two P1 fixes): (1) added `image` to `FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS` so a nested `attachments: [{ image: ... }]` is collected as a media candidate instead of silently text-sending (regression test added: `accepts a nested attachments[].image alias instead of dropping it`, pre-fix fail / post-fix pass); (2) changed `retryable` from `!partialDelivery` to `false`-only-on-partial-delivery (omitted otherwise), restoring main's non-retryable shape for ordinary and queued failures so Gateway clients do not replay an indeterminate send (the `reports structured details` parameterized test now also asserts `retryable` is `undefined`; the plain-error test now asserts `retryable` is `undefined` instead of `true`; both pre-fix fail / post-fix pass). `oxfmt --check`, `oxlint -c .oxlintrc.json`, `tsgo` (core shard — only pre-existing main `tui` errors unrelated to this PR), and `vitest` (gateway-methods 122 + feishu channel 151) are green.





