### PR TITLE
fix: keep main session aware of isolated groups

### DIFF
--- a/docs/concepts/main-session.md
+++ b/docs/concepts/main-session.md
@@ -33,8 +33,8 @@ coding/CLI sessions under **Coding**.
 The main session is not just a chat log; it is the place where your agent's
 world converges:
 
-- **Group activity.** Group and room sessions stay isolated by default (see
-  below), but under the default DM scope the main session automatically watches them.
+- **Group activity.** Under `session.groupScope: "per-group"` (the default),
+  group and room sessions stay isolated while the main session automatically watches them.
   Activity queues up as compact notices — coalesced per conversation, never
   one wake-up per message — and the agent sees them the next time it runs: on
   your next message or on a scheduled heartbeat. Under the default `tree`
@@ -97,12 +97,13 @@ to. If several people can message your agent, isolate DMs:
 }
 ```
 
-With an isolating scope, each sender gets their own session, group watching
-from the main session is disabled, and cross-conversation memory recall
-defaults off. `openclaw security audit` recommends isolation when it detects
-multiple DM senders. The full scope matrix, identity linking, and per-route
-overrides are covered in [Session management](/concepts/session) and
-[Channel routing](/channels/channel-routing).
+With an isolating scope, each sender gets their own session and
+cross-conversation memory recall defaults off. Group watching remains controlled
+independently by `session.groupScope`: `per-group` keeps ambient main-session
+visibility, while `main` puts the room in the main conversation directly.
+`openclaw security audit` recommends DM isolation when it detects multiple
+senders. The full scope matrix, identity linking, and per-route overrides are
+covered in [Session management](/concepts/session) and [Channel routing](/channels/channel-routing).
 
 Groups and rooms use separate sessions by default. To make selected trusted
 team rooms part of the rolling main conversation, set

--- a/docs/concepts/session-state.md
+++ b/docs/concepts/session-state.md
@@ -39,9 +39,10 @@ Log-only kinds exist for reconciliation history, not notification: ordinary chil
 
 ## Watchers
 
-A watcher is a session that holds a cursor (`session_watch_cursors`) on a target. Cursors come from two places:
+A watcher is a session that holds a cursor (`session_watch_cursors`) on a target. Cursors come from three places:
 
 - **Implicit (spawn edges).** When a session spawns a sub-agent or ACP child, the parent's cursor is seeded automatically at the child's spawn version. Parents never subscribe manually.
+- **Ambient groups.** Under `session.groupScope: "per-group"`, the agent's main session watches its isolated group, room, and channel sessions after their first human turn. This is independent of `session.dmScope`; routing a room into main needs no watch because it already shares the main conversation.
 - **Explicit (`sessions_send watch: true`).** Any coordinator can watch a non-spawned target: pass `watch: true` on `sessions_send`, and after the send dispatches successfully the sender is registered as a watcher of the session that actually received the message. Registration starts at the target's current state version — prior history never produces notices. The tool result reports `watched: true|false` when the parameter was set.
 
 Watcher identity must be an agent-qualified session key. Under `session.scope="global"` the shared `global` key is ambiguous across agents, so such sessions get the durable log and `changesSince` but no proactive notices.

--- a/src/agents/watched-sessions-prompt.test.ts
+++ b/src/agents/watched-sessions-prompt.test.ts
@@ -17,9 +17,7 @@ function stubStateDir() {
 }
 
 function watchGroup(sessionKey: string) {
-  expect(registerMainSessionGroupWatch({ sessionKey, agentId: "main", dmScope: "main" })).toBe(
-    true,
-  );
+  expect(registerMainSessionGroupWatch({ sessionKey, agentId: "main" })).toBe(true);
 }
 
 afterEach(() => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -37,7 +37,10 @@ import {
   isSessionLifecycleMutationActive,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
-import { listSessionStateEventsSince } from "../../sessions/session-state-events.js";
+import {
+  listAmbientGroupWatchTargets,
+  listSessionStateEventsSince,
+} from "../../sessions/session-state-events.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   resolveIncognitoOpenClawAgentSqlitePath,
@@ -434,6 +437,34 @@ afterEach(async () => {
   await sessionMcpTesting.resetSessionMcpRuntimeManager();
 });
 describe("initSessionState guarded initialization", () => {
+  it("registers per-group ambient visibility when direct messages use isolated sessions", async () => {
+    const stateDir = await makeCaseDir("openclaw-per-group-main-watch-");
+    const storePath = path.join(stateDir, "sessions.json");
+    const groupSessionKey = "agent:main:telegram:group:family";
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await initSessionState({
+        ctx: {
+          Body: "hello group",
+          ChatType: "group",
+          DmScope: "per-channel-peer",
+          From: "telegram:group:family",
+          Provider: "telegram",
+          SessionKey: groupSessionKey,
+        },
+        cfg: {
+          session: {
+            store: storePath,
+            dmScope: "per-channel-peer",
+            groupScope: "per-group",
+          },
+        } as OpenClawConfig,
+      });
+
+      expect(listAmbientGroupWatchTargets("agent:main:main")).toEqual(new Set([groupSessionKey]));
+    });
+  });
+
   it("pins an admitted non-default-agent incognito session to its process-local store", async () => {
     const stateDir = await makeCaseDir("openclaw-session-incognito-init-");
     await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1083,7 +1083,6 @@ async function initSessionStateAttemptLocked(
       sessionKey,
       agentId,
       entry: sessionEntry,
-      dmScope: ctx.DmScope ?? sessionCfg?.dmScope ?? "main",
       mainKey,
     });
   }

--- a/src/config/schema.help.automation.ts
+++ b/src/config/schema.help.automation.ts
@@ -7,7 +7,7 @@ export const AUTOMATION_FIELD_HELP: Record<string, string> = {
   "session.dmScope":
     'DM session scoping: "main" keeps continuity, while "per-peer", "per-channel-peer", and "per-account-channel-peer" increase isolation. Use isolated modes for shared inboxes or multi-account deployments.',
   "session.groupScope":
-    'Group/channel session scoping: "per-group" keeps rooms isolated by default, while "main" shares the agent main session. Use "main" only for rooms whose context should join the agent\'s primary conversation.',
+    'Group/channel session scoping: "per-group" keeps rooms separate while the agent main session ambiently watches them, independently of dmScope; "main" merges room context into main and needs no watch. Use "main" only for trusted rooms.',
   "session.identityLinks":
     "Maps canonical identities to provider-prefixed peer IDs so equivalent users resolve to one DM thread (example: telegram:123456). Use this when the same human appears across multiple channels or accounts.",
   "session.resetTriggers":

--- a/src/config/schema.help.runtime.ts
+++ b/src/config/schema.help.runtime.ts
@@ -303,7 +303,7 @@ export const RUNTIME_FIELD_HELP: Record<string, string> = {
   "bindings[].session.dmScope":
     'Optional DM session scope override for this route binding. For example, keep global session.dmScope="main" while using "per-account-channel-peer" for selected direct peers.',
   "bindings[].session.groupScope":
-    'Optional group/channel session scope override for this route binding. Use "main" to merge only selected rooms into the agent main session while other rooms keep the global "per-group" default.',
+    'Optional group/channel session scope override for this route binding. "per-group" keeps matched rooms separate and ambiently watched by the agent main session regardless of dmScope; "main" merges their context into main and needs no watch.',
   "bindings[].match":
     "Match rule object for deciding when a binding applies, including channel and optional account/peer constraints. Keep rules narrow to avoid accidental agent takeover across contexts.",
   "bindings[].match.channel":

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -534,31 +534,20 @@ describe("session state events", () => {
     });
   });
 
-  it("registers the main watcher once only under dmScope main", () => {
+  it("registers one ambient main watcher for a distinct group session", () => {
     const database = createDatabaseOptions();
     expect(
       registerMainSessionGroupWatch(
-        { sessionKey: group, agentId: "main", dmScope: "main" },
+        { sessionKey: group, agentId: "main" },
         { ...database, now: 100 },
       ),
     ).toBe(true);
     expect(
       registerMainSessionGroupWatch(
-        { sessionKey: group, agentId: "main", dmScope: "main" },
+        { sessionKey: group, agentId: "main" },
         { ...database, now: 200 },
       ),
     ).toBe(true);
-    expect(
-      registerMainSessionGroupWatch(
-        {
-          sessionKey: "agent:main:slack:channel:room-2",
-          agentId: "main",
-          dmScope: "per-channel-peer",
-        },
-        database,
-      ),
-    ).toBe(false);
-
     const rows = openOpenClawStateDatabase(database)
       .db.prepare(
         `SELECT watcher_session_key, target_session_key, provenance, updated_at
@@ -595,37 +584,11 @@ describe("session state events", () => {
           agentId: "main",
           mainKey: "work",
           entry: { sessionId: "session-main", updatedAt: 100, chatType: "group" },
-          dmScope: "main",
         },
         database,
       ),
     ).toBe(false);
     expect(listAmbientGroupWatchTargets(mainSessionKey, database)).toEqual(new Set());
-  });
-
-  it("revokes ambient watches outside main scope but preserves explicit watches", () => {
-    const database = createDatabaseOptions();
-    registerMainSessionGroupWatch(
-      { sessionKey: group, agentId: "main", dmScope: "main" },
-      database,
-    );
-    expect(
-      registerMainSessionGroupWatch(
-        { sessionKey: group, agentId: "main", dmScope: "per-channel-peer" },
-        database,
-      ),
-    ).toBe(false);
-    expect(listAmbientGroupWatchTargets(watcher, database)).toEqual(new Set());
-    expect(readCursor(database, watcher, group)).toBeUndefined();
-
-    registerSessionStateWatch({ watcherSessionKey: watcher, targetSessionKey: group }, database);
-    expect(
-      registerMainSessionGroupWatch(
-        { sessionKey: group, agentId: "main", dmScope: "per-channel-peer" },
-        database,
-      ),
-    ).toBe(false);
-    expect(readCursor(database, watcher, group)).toBeDefined();
   });
 
   it("records and coalesces group activity without an immediate wake", async () => {
@@ -635,10 +598,7 @@ describe("session state events", () => {
     await vi.advanceTimersByTimeAsync(300);
     wakes.mockClear();
     const database = createDatabaseOptions();
-    registerMainSessionGroupWatch(
-      { sessionKey: group, agentId: "main", dmScope: "main" },
-      database,
-    );
+    registerMainSessionGroupWatch({ sessionKey: group, agentId: "main" }, database);
 
     for (const actorId of ["human-1", "human-2"]) {
       recordSessionHumanDirectMessage(
@@ -667,11 +627,11 @@ describe("session state events", () => {
     const dormantGroup = "agent:main:slack:channel:dormant";
     const registeredAt = 100;
     registerMainSessionGroupWatch(
-      { sessionKey: group, agentId: "main", dmScope: "main" },
+      { sessionKey: group, agentId: "main" },
       { ...database, now: registeredAt },
     );
     registerMainSessionGroupWatch(
-      { sessionKey: dormantGroup, agentId: "main", dmScope: "main" },
+      { sessionKey: dormantGroup, agentId: "main" },
       { ...database, now: registeredAt },
     );
 
@@ -731,10 +691,7 @@ describe("session state events", () => {
     await vi.advanceTimersByTimeAsync(300);
     wakes.mockClear();
     const database = createDatabaseOptions();
-    registerMainSessionGroupWatch(
-      { sessionKey: group, agentId: "main", dmScope: "main" },
-      database,
-    );
+    registerMainSessionGroupWatch({ sessionKey: group, agentId: "main" }, database);
     expect(listAmbientGroupWatchTargets(watcher, database)).toEqual(new Set([group]));
 
     registerSessionStateWatch({ watcherSessionKey: watcher, targetSessionKey: group }, database);
@@ -748,10 +705,7 @@ describe("session state events", () => {
         .get(watcher, group),
     ).toEqual({ provenance: "explicit" });
     // Later inbound group registration must not downgrade the explicit watch.
-    registerMainSessionGroupWatch(
-      { sessionKey: group, agentId: "main", dmScope: "main" },
-      database,
-    );
+    registerMainSessionGroupWatch({ sessionKey: group, agentId: "main" }, database);
 
     recordSessionHumanDirectMessage(
       {

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -4,7 +4,6 @@ import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion"
 import type { Insertable, Selectable } from "kysely";
 import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import type { DmScope } from "../config/types.base.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -901,13 +900,12 @@ export function registerSessionStateWatch(
   }
 }
 
-/** Register the personal agent's main session to observe one routed group session. */
+/** Register the agent's main session to observe one routed group session. */
 export function registerMainSessionGroupWatch(
   params: {
     sessionKey: string;
     agentId: string;
     entry?: SessionEntry;
-    dmScope: DmScope;
     mainKey?: string;
   },
   options: OpenClawStateDatabaseOptions & { now?: number } = {},
@@ -919,33 +917,14 @@ export function registerMainSessionGroupWatch(
     agentId: params.agentId,
     mainKey: params.mainKey,
   });
+  // groupScope already chose the routed key: "main" is the watcher itself,
+  // while every distinct group key is a per-group target. dmScope is orthogonal.
   if (params.sessionKey === watcherSessionKey) {
     return false;
   }
   const now = options.now ?? Date.now();
   try {
     const { db: readDb } = openOpenClawStateDatabase(options);
-    if (params.dmScope !== "main") {
-      if (!isAmbientGroupWatchCursor(readCursor(readDb, watcherSessionKey, params.sessionKey))) {
-        return false;
-      }
-      runOpenClawStateWriteTransaction(({ db }) => {
-        // Recheck provenance in the write transaction: an explicit registration
-        // may have promoted this pair after the read-only preflight.
-        if (!isAmbientGroupWatchCursor(readCursor(db, watcherSessionKey, params.sessionKey))) {
-          return;
-        }
-        executeSqliteQuerySync(
-          db,
-          getSessionStateKysely(db)
-            .deleteFrom("session_watch_cursors")
-            .where("target_session_key", "=", params.sessionKey)
-            .where("watcher_session_key", "=", watcherSessionKey)
-            .where("provenance", "=", SESSION_WATCH_PROVENANCE_AMBIENT_GROUP),
-        );
-      }, options);
-      return false;
-    }
     // This runs on every human group turn. Keep the steady-state path read-only;
     // the transaction below is only for first registration and its race recheck.
     if (readCursor(readDb, watcherSessionKey, params.sessionKey)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deployments using isolated DMs (`session.dmScope: "per-channel-peer"`) together with per-group sessions could leave the main session with zero ambient group visibility. Operators then had to serialize group conversations into main to keep the primary agent aware of room activity.

## Why This Change Was Made

Routed group topology and `session.groupScope` own whether a group is a distinct watch target; `session.dmScope` is orthogonal. A distinct group key is now registered as an ambient target, while a `groupScope: "main"` route already equals the main watcher and needs no cursor. The obsolete DM-scope revocation path was removed, explicit watches remain promoted and preserved, and no new configuration or migration is introduced.

## User Impact

Multi-user front doors can isolate DMs and groups while the main session still receives compact group notices and the Watched Sessions prompt section. Existing provenance rows keep their meaning, and missing ambient rows seed on future human group turns.

## Evidence

- Pre-fix regression reproduced an empty ambient watch target set for `dmScope: "per-channel-peer"` plus `groupScope: "per-group"`; the repaired `initSessionState` boundary registers the isolated group.
- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts src/sessions/session-state-events.test.ts src/agents/watched-sessions-prompt.test.ts src/config/schema.help.quality.test.ts` — 225 passed.
- `pnpm docs:check-mdx` — passed for 776 files.
- Targeted `oxfmt --check`, `git diff --check`, and the actual `node scripts/check-changed.mjs` selected gate passed; dry-run lanes were `core`, `coreTests`, and `docs`.
- Fresh Codex autoreview on the final patch reported no accepted/actionable findings (`overall 0.96`).
- LOC: production `+5/-27` (net `-22`); tests `+41/-58` (net `-17`); docs `+11/-9` (net `+2`); total `+57/-94` (net `-37`).
- No live provider or channel run was used. This is not live proof: the deterministic SQLite cursor owner, `initSessionState` routing boundary, and prompt projection are covered directly.

AI-assisted with Codex. I understand and reviewed the resulting code and behavior.
