### PR TITLE
fix(ui): separate stop action from microphone controls

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -572,6 +572,25 @@ suite.define(() => {
       await textarea.fill("");
       const stop = page.getByRole("button", { name: "Stop generating" });
       await expect.poll(() => stop.isVisible()).toBe(true);
+      await voice.hover();
+      await expect
+        .poll(() => microphonePickerShell.evaluate((node) => getComputedStyle(node).opacity))
+        .toBe("1");
+      const [runningVoiceBox, runningPickerBox, runningStopBox] = await Promise.all([
+        voice.boundingBox(),
+        microphonePicker.boundingBox(),
+        stop.boundingBox(),
+      ]);
+      expect(runningVoiceBox).not.toBeNull();
+      expect(runningPickerBox).not.toBeNull();
+      expect(runningStopBox).not.toBeNull();
+      if (!runningVoiceBox || !runningPickerBox || !runningStopBox) {
+        throw new Error("expected running composer action layout boxes");
+      }
+      const microphonePickerGap = runningPickerBox.x - (runningVoiceBox.x + runningVoiceBox.width);
+      const stopGap = runningStopBox.x - (runningPickerBox.x + runningPickerBox.width);
+      expect(microphonePickerGap).toBeLessThanOrEqual(1);
+      expect(stopGap).toBeGreaterThanOrEqual(8);
       await textarea.press("Escape");
       const abortRequest = await gateway.waitForRequest("chat.abort");
       expect(abortRequest.params).toMatchObject({

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3040,7 +3040,7 @@ button.chat-pr__diff {
 .agent-chat__composer-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   flex: 0 0 auto;
 }
 
@@ -3633,7 +3633,7 @@ button.chat-pr__diff {
   --chat-voice-hover-color: var(--text);
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 0;
   flex: 0 0 auto;
 }
 
@@ -4053,7 +4053,8 @@ button.chat-pr__diff {
 
   .agent-chat__composer-actions {
     flex-direction: column;
-    gap: 4px;
+    row-gap: 4px;
+    column-gap: 8px;
     margin-left: var(--chat-box-inset);
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the microphone input chevron sat equally far from the microphone and the stop button, making the picker read as a separate action instead of part of the microphone control.

## Why This Change Was Made

The composer now keeps the microphone and its input picker as one tight visual cluster, while horizontal primary actions use a wider separation. The responsive column layout retains its compact vertical spacing.

## User Impact

The microphone picker is easier to associate with voice input, and the stop button is more clearly separated as the primary run action.

## Evidence

AI-assisted.

| Before | After |
| --- | --- |
| ![Before: composer controls with equal spacing](https://github.com/user-attachments/assets/5642ed59-6a93-48ca-bf07-ee61c11b5284) | ![After: microphone and picker grouped with stop action separated](https://github.com/user-attachments/assets/a8ffada9-3c89-4b15-adbc-9636c6b52564) |

- Pre-fix focused E2E regression: failed with a measured 4px microphone-to-picker gap against the <=1px contract.
- Post-fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 3 tests passed.
- `node scripts/check-changed.mjs -- ui/src/styles/chat/layout.css ui/src/e2e/chat-composer-redesign.e2e.test.ts` — passed.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
