### PR TITLE
fix(providers): keep discovered image support for configured models

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -286,6 +286,7 @@ Custom providers configured under `models.providers` are written into `models.js
     - SecretRef-managed `apiKey` values refresh from source markers instead of persisting resolved secrets: the env variable name for env refs, `secretref-managed` for file/exec/store refs.
     - SecretRef-managed header values refresh the same way, using `secretref-env:ENV_VAR_NAME` for env refs.
     - Empty or missing `apiKey`/`baseUrl` in `models.json` fall back to config `models.providers`.
+    - Explicit model lists control membership. For matching rows, an explicit `input` wins; when the source row omits `input`, plugin discovery can fill that capability metadata.
     - Other provider fields refresh from config and normalized catalog data.
 
   </Accordion>

--- a/docs/providers/bedrock-mantle.md
+++ b/docs/providers/bedrock-mantle.md
@@ -139,10 +139,11 @@ If you prefer explicit config instead of auto-discovery:
 }
 ```
 
-An explicit non-empty `models` list is authoritative and replaces every
-discovered row, including the Claude rows below. Omit `models` to retain the
-automatic Mantle catalog, or include the complete Claude model entries you
-want to use.
+An explicit non-empty `models` list controls membership and replaces discovered
+rows, including the Claude rows below. For matching rows, an explicit `input`
+wins; when the source row omits `input`, discovery can fill that capability
+metadata. Omit `models` to retain the automatic Mantle catalog, or include the
+complete Claude model entries you want to use.
 
 ## Advanced configuration
 
@@ -198,8 +199,9 @@ want to use.
     Preview accepts a `temperature` override normally.
 
     A non-empty explicit `models.providers["amazon-bedrock-mantle"].models`
-    list replaces the complete discovered catalog. Omit that list when you
-    want these built-in Claude rows.
+    list controls membership and replaces the complete discovered catalog.
+    Matching rows can inherit discovered `input` capability only when the source
+    row omitted it. Omit the list when you want these built-in Claude rows.
 
   </Accordion>
 

--- a/extensions/amazon-bedrock-mantle/index.test.ts
+++ b/extensions/amazon-bedrock-mantle/index.test.ts
@@ -63,7 +63,7 @@ describe("amazon-bedrock-mantle provider plugin", () => {
           providers: {
             "amazon-bedrock-mantle": {
               baseUrl: "https://explicit.example.test/v1",
-              models: [],
+              models: [{ id: "anthropic.claude-opus-4-7", input: ["text"] }],
             },
           },
         },

--- a/extensions/amazon-bedrock-mantle/index.test.ts
+++ b/extensions/amazon-bedrock-mantle/index.test.ts
@@ -40,6 +40,48 @@ describe("amazon-bedrock-mantle provider plugin", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("returns raw discovery for the host to merge with materialized config", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: "anthropic.claude-opus-4-7",
+              object: "model",
+              input_modalities: ["text", "image"],
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const provider = await registerSingleProviderPlugin(bedrockMantlePlugin);
+
+    const result = await provider.catalog?.run({
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock-mantle": {
+              baseUrl: "https://explicit.example.test/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "test-token",
+        AWS_REGION: "us-east-1",
+      },
+    } as never);
+
+    if (!result || !("provider" in result)) {
+      throw new Error("expected single provider catalog result");
+    }
+    expect(result.provider.baseUrl).toBe("https://bedrock-mantle.us-east-1.api.aws/v1");
+    expect(result.provider.models[0]?.input).toEqual(["text", "image"]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("registers with correct provider ID and label", async () => {
     const provider = await registerSingleProviderPlugin(bedrockMantlePlugin);
     expect(provider.id).toBe("amazon-bedrock-mantle");

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -11,7 +11,6 @@ import {
   resolveClaudeSonnet5ModelIdentity,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
-  mergeImplicitMantleProvider,
   resolveImplicitMantleProvider,
   resolveMantleBearerToken,
   resolveMantleRuntimeBearerToken,
@@ -78,10 +77,7 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
           return null;
         }
         return {
-          provider: mergeImplicitMantleProvider({
-            existing: ctx.config.models?.providers?.[providerId],
-            implicit,
-          }),
+          provider: implicit,
         };
       },
     },

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -334,6 +334,54 @@ describe("amazon-bedrock provider plugin", () => {
     ).toBeUndefined();
   });
 
+  it("returns raw discovery for the host to merge with materialized config", async () => {
+    foundationModelResults.push({
+      modelSummaries: [
+        {
+          modelId: "anthropic.claude-opus-4-7",
+          modelName: "Claude Opus 4.7",
+          providerName: "Anthropic",
+          inputModalities: ["TEXT", "IMAGE"],
+          outputModalities: ["TEXT"],
+          responseStreamingSupported: true,
+          modelLifecycle: { status: "ACTIVE" },
+        },
+      ],
+    });
+    inferenceProfileListResults.push({ inferenceProfileSummaries: [] });
+    const provider = await registerWithConfig();
+
+    const result = await provider.catalog?.run({
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              baseUrl: "https://explicit.example.test",
+              models: [
+                {
+                  id: "anthropic.claude-opus-4-7",
+                  name: "Configured Opus",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1,
+                  maxTokens: 1,
+                },
+              ],
+            },
+          },
+        },
+      },
+      env: { AWS_PROFILE: "default", AWS_REGION: "us-east-1" } as NodeJS.ProcessEnv,
+    } as never);
+
+    if (!result || !("provider" in result)) {
+      throw new Error("expected single provider catalog result");
+    }
+    expect(result.provider.baseUrl).toBe("https://bedrock-runtime.us-east-1.amazonaws.com");
+    expect(result.provider.models[0]?.input).toEqual(["text", "image"]);
+  });
+
   it("marks Claude 4.6 Bedrock models as adaptive by default", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
 

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -335,20 +335,6 @@ describe("amazon-bedrock provider plugin", () => {
   });
 
   it("returns raw discovery for the host to merge with materialized config", async () => {
-    foundationModelResults.push({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-opus-4-7",
-          modelName: "Claude Opus 4.7",
-          providerName: "Anthropic",
-          inputModalities: ["TEXT", "IMAGE"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
-    });
-    inferenceProfileListResults.push({ inferenceProfileSummaries: [] });
     const provider = await registerWithConfig();
 
     const result = await provider.catalog?.run({
@@ -356,16 +342,10 @@ describe("amazon-bedrock provider plugin", () => {
         models: {
           providers: {
             "amazon-bedrock": {
-              baseUrl: "https://explicit.example.test",
               models: [
                 {
-                  id: "anthropic.claude-opus-4-7",
-                  name: "Configured Opus",
-                  reasoning: false,
-                  input: ["text"],
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                  contextWindow: 1,
-                  maxTokens: 1,
+                  id: NON_ANTHROPIC_MODEL,
+                  input: ["text", "image"],
                 },
               ],
             },
@@ -379,7 +359,10 @@ describe("amazon-bedrock provider plugin", () => {
       throw new Error("expected single provider catalog result");
     }
     expect(result.provider.baseUrl).toBe("https://bedrock-runtime.us-east-1.amazonaws.com");
-    expect(result.provider.models[0]?.input).toEqual(["text", "image"]);
+    expect(result.provider.models[0]).toMatchObject({
+      id: NON_ANTHROPIC_MODEL,
+      input: ["text"],
+    });
   });
 
   it("marks Claude 4.6 Bedrock models as adaptive by default", async () => {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -23,7 +23,7 @@ import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-st
 import { refreshAwsSharedConfigCacheForBedrock } from "./aws-credential-refresh.js";
 import { supportsBedrockPromptCaching } from "./bedrock-options.js";
 import { loadBedrockControlPlaneSdk, runBedrockControlPlaneRequest } from "./control-plane.js";
-import { mergeImplicitBedrockProvider, resolveBedrockConfigApiKey } from "./discovery-shared.js";
+import { resolveBedrockConfigApiKey } from "./discovery-shared.js";
 import { bedrockMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
 import { streamSimpleBedrock } from "./stream.runtime.js";
 import {
@@ -531,10 +531,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
           return null;
         }
         return {
-          provider: mergeImplicitBedrockProvider({
-            existing: ctx.config.models?.providers?.[providerId],
-            implicit,
-          }),
+          provider: implicit,
         };
       },
     },

--- a/extensions/anthropic-vertex/index.test.ts
+++ b/extensions/anthropic-vertex/index.test.ts
@@ -44,7 +44,7 @@ describe("anthropic-vertex provider plugin", () => {
     ).toBe("gcp-vertex-credentials");
   });
 
-  it("merges the implicit Vertex catalog into explicit provider overrides", async () => {
+  it("returns raw discovery for the host to merge with explicit provider overrides", async () => {
     const provider = await registerSingleProviderPlugin(anthropicVertexPlugin);
 
     const result = await provider.catalog?.run({
@@ -76,8 +76,8 @@ describe("anthropic-vertex provider plugin", () => {
     }
     expect(result.provider.api).toBe("anthropic-messages");
     expect(result.provider.apiKey).toBe("gcp-vertex-credentials");
-    expect(result.provider.baseUrl).toBe("https://europe-west4-aiplatform.googleapis.com");
-    expect(result.provider.headers).toEqual({ "x-test-header": "1" });
+    expect(result.provider.baseUrl).toBe("https://us-east5-aiplatform.googleapis.com");
+    expect(result.provider.headers).toBeUndefined();
     expect(result.provider.models.map((model) => model.id)).toEqual([
       "claude-fable-5",
       "claude-mythos-5",

--- a/extensions/anthropic-vertex/provider-catalog-runtime.ts
+++ b/extensions/anthropic-vertex/provider-catalog-runtime.ts
@@ -3,8 +3,6 @@ import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-sha
 import { buildAnthropicVertexProvider } from "./provider-catalog.js";
 import { hasAnthropicVertexAvailableAuth } from "./region.js";
 
-const PROVIDER_ID = "anthropic-vertex";
-
 /** Merge an implicit Anthropic Vertex provider with explicit user config. */
 export function mergeImplicitAnthropicVertexProvider(params: {
   existing?: ModelProviderConfig;
@@ -43,9 +41,6 @@ export async function runAnthropicVertexCatalog(ctx: ProviderCatalogContext) {
     return null;
   }
   return {
-    provider: mergeImplicitAnthropicVertexProvider({
-      existing: ctx.config.models?.providers?.[PROVIDER_ID],
-      implicit,
-    }),
+    provider: implicit,
   };
 }

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -104,45 +104,40 @@ describe("models-config merge helpers", () => {
     ]);
   });
 
-  it("preserves explicit input modality overrides when implicit metadata has the same model id", () => {
-    const merged = mergeProviderModels(
-      {
-        api: "ollama",
-        models: [
-          {
-            id: "qwen3-vl:latest",
-            name: "Qwen3 VL",
-            input: ["text"],
-            reasoning: true,
-            contextWindow: 128_000,
-            maxTokens: 8192,
-          },
-        ],
-      } as ProviderConfig,
-      {
-        api: "ollama",
-        models: [
-          {
-            id: "qwen3-vl:latest",
-            name: "Qwen3 VL",
-            input: ["text", "image"],
-            contextWindow: 128_000,
-            maxTokens: 8192,
-          },
-        ],
-      } as ProviderConfig,
-    );
+  it("uses source input presence when merging matching model metadata", () => {
+    const implicit = {
+      api: "ollama",
+      models: [
+        {
+          id: "qwen3-vl:latest",
+          name: "Qwen3 VL",
+          input: ["text", "image"],
+          reasoning: true,
+          contextWindow: 128_000,
+          maxTokens: 8192,
+        },
+      ],
+    } as ProviderConfig;
+    const explicit = {
+      api: "ollama",
+      models: [
+        {
+          id: "qwen3-vl:latest",
+          name: "Qwen3 VL",
+          input: ["text"],
+          contextWindow: 128_000,
+          maxTokens: 8192,
+        },
+      ],
+    } as ProviderConfig;
 
-    expect(merged.models).toEqual([
-      {
-        id: "qwen3-vl:latest",
-        name: "Qwen3 VL",
-        input: ["text", "image"],
-        reasoning: true,
-        contextWindow: 128_000,
-        maxTokens: 8192,
-      },
-    ]);
+    expect(mergeProviderModels(implicit, explicit).models?.[0]?.input).toEqual(["text"]);
+    expect(
+      mergeProviderModels(implicit, explicit, {
+        providerId: "ollama",
+        sourceModelInputOmissions: new Set(["ollama/qwen3-vl:latest"]),
+      }).models?.[0]?.input,
+    ).toEqual(["text", "image"]);
   });
 
   it("keeps compat catalog-owned for a configured model on the catalog route", () => {

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -8,12 +8,12 @@ import { asPositiveFiniteNumber } from "@openclaw/normalization-core/number-coer
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
+import {
+  modelKey,
+  normalizeConfiguredProviderCatalogModelId,
+  type ModelManifestNormalizationContext,
+} from "./model-ref-shared.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
-
-export type ProviderCatalogModelInputPresenceResolver = (
-  providerId: string,
-  modelId: string,
-) => boolean | undefined;
 
 export function normalizeProviderMapKeys<T>(
   providers: Record<string, T> | null | undefined,
@@ -63,28 +63,25 @@ export function mergeProviderModels(
   explicit: ProviderConfig,
   options?: {
     providerId: string;
-    resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+    sourceModelInputOmissions?: ReadonlySet<string>;
+    manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
+    preserveConfiguredModelMembership?: boolean;
   },
 ): ProviderConfig {
-  const explicitProvider = options
-    ? inheritDiscoveredModelInput({ implicit, explicit, ...options })
-    : explicit;
   const implicitModels = Array.isArray(implicit.models) ? implicit.models : [];
-  const explicitModels = Array.isArray(explicitProvider.models) ? explicitProvider.models : [];
+  const explicitModels = Array.isArray(explicit.models) ? explicit.models : [];
   const implicitHeaders =
     implicit.headers && typeof implicit.headers === "object" && !Array.isArray(implicit.headers)
       ? implicit.headers
       : undefined;
   const explicitHeaders =
-    explicitProvider.headers &&
-    typeof explicitProvider.headers === "object" &&
-    !Array.isArray(explicitProvider.headers)
-      ? explicitProvider.headers
+    explicit.headers && typeof explicit.headers === "object" && !Array.isArray(explicit.headers)
+      ? explicit.headers
       : undefined;
   if (implicitModels.length === 0) {
     return {
       ...implicit,
-      ...explicitProvider,
+      ...explicit,
       ...(implicitHeaders || explicitHeaders
         ? {
             headers: {
@@ -113,6 +110,19 @@ export function mergeProviderModels(
     if (!implicitModel) {
       return explicitModel;
     }
+    const sourceOmittedInput =
+      options &&
+      options.sourceModelInputOmissions?.has(
+        modelKey(
+          normalizeProviderId(options.providerId),
+          normalizeConfiguredProviderCatalogModelId(options.providerId, id, options),
+        ),
+      ) === true;
+    if (options?.preserveConfiguredModelMembership) {
+      return sourceOmittedInput && implicitModel.input !== undefined
+        ? Object.assign({}, explicitModel, { input: implicitModel.input })
+        : explicitModel;
+    }
 
     const contextWindow =
       asPositiveFiniteNumber(explicitModel.contextWindow) ??
@@ -130,12 +140,9 @@ export function mergeProviderModels(
       },
       catalogCompat: implicitModel.compat,
       configuredRoute: {
-        api: explicitModel.api ?? explicitProvider.api ?? implicitModel.api ?? implicit.api,
+        api: explicitModel.api ?? explicit.api ?? implicitModel.api ?? implicit.api,
         baseUrl:
-          explicitModel.baseUrl ??
-          explicitProvider.baseUrl ??
-          implicitModel.baseUrl ??
-          implicit.baseUrl,
+          explicitModel.baseUrl ?? explicit.baseUrl ?? implicitModel.baseUrl ?? implicit.baseUrl,
       },
       configuredCompat: explicitModel.compat,
     });
@@ -144,7 +151,12 @@ export function mergeProviderModels(
       {},
       explicitModel,
       {
-        input: "input" in explicitModel ? explicitModel.input : implicitModel.input,
+        input:
+          sourceOmittedInput && implicitModel.input !== undefined
+            ? implicitModel.input
+            : "input" in explicitModel
+              ? explicitModel.input
+              : implicitModel.input,
         reasoning: `reasoning` in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       },
       contextWindow === undefined ? {} : { contextWindow },
@@ -154,18 +166,20 @@ export function mergeProviderModels(
     );
   });
 
-  for (const implicitModel of implicitModels) {
-    const id = getProviderModelId(implicitModel);
-    if (!id || seen.has(id)) {
-      continue;
+  if (!options?.preserveConfiguredModelMembership) {
+    for (const implicitModel of implicitModels) {
+      const id = getProviderModelId(implicitModel);
+      if (!id || seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      mergedModels.push(implicitModel);
     }
-    seen.add(id);
-    mergedModels.push(implicitModel);
   }
 
   return {
     ...implicit,
-    ...explicitProvider,
+    ...explicit,
     ...(implicitHeaders || explicitHeaders
       ? {
           headers: {
@@ -178,49 +192,12 @@ export function mergeProviderModels(
   };
 }
 
-/** Restores discovered input only when the source model row omitted that field. */
-export function inheritDiscoveredModelInput(params: {
-  providerId: string;
-  implicit: ProviderConfig;
-  explicit: ProviderConfig;
-  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
-}): ProviderConfig {
-  const { resolveModelInputConfigured } = params;
-  const explicitModels = Array.isArray(params.explicit.models) ? params.explicit.models : [];
-  const implicitModels = Array.isArray(params.implicit.models) ? params.implicit.models : [];
-  if (!resolveModelInputConfigured || explicitModels.length === 0 || implicitModels.length === 0) {
-    return params.explicit;
-  }
-
-  const implicitById = new Map(
-    implicitModels
-      .map((model) => [getProviderModelId(model), model] as const)
-      .filter(([id]) => Boolean(id)),
-  );
-  let mutated = false;
-  const models = explicitModels.map((explicitModel) => {
-    const id = getProviderModelId(explicitModel);
-    const implicitModel = implicitById.get(id);
-    if (
-      !id ||
-      !implicitModel ||
-      implicitModel.input === undefined ||
-      resolveModelInputConfigured(params.providerId, id) !== false
-    ) {
-      return explicitModel;
-    }
-    mutated = true;
-    return Object.assign({}, explicitModel, { input: implicitModel.input });
-  });
-
-  return mutated ? { ...params.explicit, models } : params.explicit;
-}
-
 /** Merges implicit and explicit provider config maps by provider id. */
 export function mergeProviders(params: {
   implicit?: Record<string, ProviderConfig> | null;
   explicit?: Record<string, ProviderConfig> | null;
-  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+  sourceModelInputOmissions?: ReadonlySet<string>;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 }): Record<string, ProviderConfig> {
   const out = normalizeProviderMapKeys(params.implicit);
   for (const [providerKey, explicit] of Object.entries(normalizeProviderMapKeys(params.explicit))) {
@@ -228,7 +205,8 @@ export function mergeProviders(params: {
     out[providerKey] = implicit
       ? mergeProviderModels(implicit, explicit, {
           providerId: providerKey,
-          resolveModelInputConfigured: params.resolveModelInputConfigured,
+          sourceModelInputOmissions: params.sourceModelInputOmissions,
+          manifestPlugins: params.manifestPlugins,
         })
       : explicit;
   }

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -10,6 +10,11 @@ import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 
+export type ProviderCatalogModelInputPresenceResolver = (
+  providerId: string,
+  modelId: string,
+) => boolean | undefined;
+
 export function normalizeProviderMapKeys<T>(
   providers: Record<string, T> | null | undefined,
 ): Record<string, T> {
@@ -56,21 +61,30 @@ function getProviderModelId(model: unknown): string {
 export function mergeProviderModels(
   implicit: ProviderConfig,
   explicit: ProviderConfig,
+  options?: {
+    providerId: string;
+    resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+  },
 ): ProviderConfig {
+  const explicitProvider = options
+    ? inheritDiscoveredModelInput({ implicit, explicit, ...options })
+    : explicit;
   const implicitModels = Array.isArray(implicit.models) ? implicit.models : [];
-  const explicitModels = Array.isArray(explicit.models) ? explicit.models : [];
+  const explicitModels = Array.isArray(explicitProvider.models) ? explicitProvider.models : [];
   const implicitHeaders =
     implicit.headers && typeof implicit.headers === "object" && !Array.isArray(implicit.headers)
       ? implicit.headers
       : undefined;
   const explicitHeaders =
-    explicit.headers && typeof explicit.headers === "object" && !Array.isArray(explicit.headers)
-      ? explicit.headers
+    explicitProvider.headers &&
+    typeof explicitProvider.headers === "object" &&
+    !Array.isArray(explicitProvider.headers)
+      ? explicitProvider.headers
       : undefined;
   if (implicitModels.length === 0) {
     return {
       ...implicit,
-      ...explicit,
+      ...explicitProvider,
       ...(implicitHeaders || explicitHeaders
         ? {
             headers: {
@@ -116,9 +130,12 @@ export function mergeProviderModels(
       },
       catalogCompat: implicitModel.compat,
       configuredRoute: {
-        api: explicitModel.api ?? explicit.api ?? implicitModel.api ?? implicit.api,
+        api: explicitModel.api ?? explicitProvider.api ?? implicitModel.api ?? implicit.api,
         baseUrl:
-          explicitModel.baseUrl ?? explicit.baseUrl ?? implicitModel.baseUrl ?? implicit.baseUrl,
+          explicitModel.baseUrl ??
+          explicitProvider.baseUrl ??
+          implicitModel.baseUrl ??
+          implicit.baseUrl,
       },
       configuredCompat: explicitModel.compat,
     });
@@ -148,7 +165,7 @@ export function mergeProviderModels(
 
   return {
     ...implicit,
-    ...explicit,
+    ...explicitProvider,
     ...(implicitHeaders || explicitHeaders
       ? {
           headers: {
@@ -161,15 +178,59 @@ export function mergeProviderModels(
   };
 }
 
+/** Restores discovered input only when the source model row omitted that field. */
+export function inheritDiscoveredModelInput(params: {
+  providerId: string;
+  implicit: ProviderConfig;
+  explicit: ProviderConfig;
+  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+}): ProviderConfig {
+  const { resolveModelInputConfigured } = params;
+  const explicitModels = Array.isArray(params.explicit.models) ? params.explicit.models : [];
+  const implicitModels = Array.isArray(params.implicit.models) ? params.implicit.models : [];
+  if (!resolveModelInputConfigured || explicitModels.length === 0 || implicitModels.length === 0) {
+    return params.explicit;
+  }
+
+  const implicitById = new Map(
+    implicitModels
+      .map((model) => [getProviderModelId(model), model] as const)
+      .filter(([id]) => Boolean(id)),
+  );
+  let mutated = false;
+  const models = explicitModels.map((explicitModel) => {
+    const id = getProviderModelId(explicitModel);
+    const implicitModel = implicitById.get(id);
+    if (
+      !id ||
+      !implicitModel ||
+      implicitModel.input === undefined ||
+      resolveModelInputConfigured(params.providerId, id) !== false
+    ) {
+      return explicitModel;
+    }
+    mutated = true;
+    return Object.assign({}, explicitModel, { input: implicitModel.input });
+  });
+
+  return mutated ? { ...params.explicit, models } : params.explicit;
+}
+
 /** Merges implicit and explicit provider config maps by provider id. */
 export function mergeProviders(params: {
   implicit?: Record<string, ProviderConfig> | null;
   explicit?: Record<string, ProviderConfig> | null;
+  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
 }): Record<string, ProviderConfig> {
   const out = normalizeProviderMapKeys(params.implicit);
   for (const [providerKey, explicit] of Object.entries(normalizeProviderMapKeys(params.explicit))) {
     const implicit = out[providerKey];
-    out[providerKey] = implicit ? mergeProviderModels(implicit, explicit) : explicit;
+    out[providerKey] = implicit
+      ? mergeProviderModels(implicit, explicit, {
+          providerId: providerKey,
+          resolveModelInputConfigured: params.resolveModelInputConfigured,
+        })
+      : explicit;
   }
   return out;
 }

--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  planOpenClawModelsJsonWithDeps,
+  resolveProvidersForModelsJsonWithDeps,
+} from "./models-config.plan.test-support.js";
+
+type ResolveImplicitProviders = NonNullable<
+  NonNullable<
+    Parameters<typeof resolveProvidersForModelsJsonWithDeps>[1]
+  >["resolveImplicitProviders"]
+>;
+
+function model(id: string, input: Array<"text" | "image"> = ["text"]) {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1024,
+    maxTokens: 1024,
+  };
+}
+
+describe("models config input presence", () => {
+  it("keeps provider catalog config materialized while reporting source field presence", async () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            models: [model("vision-model"), model("text-only-model")],
+          },
+        },
+      },
+    };
+    const sourceConfigForSecrets = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            models: [
+              { id: "vision-model", name: "vision-model" },
+              { id: "text-only-model", name: "text-only-model", input: ["text"] },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const resolveImplicitProviders = vi.fn<ResolveImplicitProviders>(async () => ({}));
+
+    await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg,
+        sourceConfigForSecrets,
+        agentDir: "/tmp/openclaw-model-input-presence",
+        env: {},
+      },
+      { resolveImplicitProviders },
+    );
+
+    const params = resolveImplicitProviders.mock.calls[0]?.[0];
+    expect(params?.config.models?.providers?.["amazon-bedrock"]?.models[0]?.input).toEqual([
+      "text",
+    ]);
+    expect(params?.resolveModelInputConfigured?.("amazon-bedrock", "vision-model")).toBe(false);
+    expect(params?.resolveModelInputConfigured?.("amazon-bedrock", "text-only-model")).toBe(true);
+    expect(params?.resolveModelInputConfigured?.("amazon-bedrock", "custom-model")).toBeUndefined();
+  });
+
+  it.each([
+    {
+      name: "inherits discovered input when source input was omitted",
+      sourceModel: { id: "vision-model", name: "vision-model" },
+      expected: ["text", "image"],
+    },
+    {
+      name: "preserves text-only input when source input was explicit",
+      sourceModel: { id: "vision-model", name: "vision-model", input: ["text"] },
+      expected: ["text"],
+    },
+  ] as const)("$name in the final generated models.json", async ({ sourceModel, expected }) => {
+    const configuredProvider = {
+      baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      apiKey: "AWS_PROFILE",
+      models: [model("vision-model")],
+    };
+    const cfg: OpenClawConfig = {
+      models: { providers: { "amazon-bedrock": configuredProvider } },
+    };
+    const sourceConfigForSecrets = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: configuredProvider.baseUrl,
+            apiKey: configuredProvider.apiKey,
+            models: [sourceModel],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const resolveImplicitProviders = vi.fn<ResolveImplicitProviders>(async () => ({
+      "amazon-bedrock": {
+        ...configuredProvider,
+        models: [model("vision-model", ["text", "image"])],
+      },
+    }));
+
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg,
+        sourceConfigForSecrets,
+        agentDir: "/tmp/openclaw-model-input-presence",
+        env: { AWS_PROFILE: "default" },
+        existingRaw: "",
+        existingParsed: {},
+      },
+      { resolveImplicitProviders },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error(`expected write plan, got ${plan.action}`);
+    }
+    const generated = JSON.parse(plan.contents) as {
+      providers: Record<string, { models?: Array<{ input?: string[] }> }>;
+    };
+    expect(generated.providers["amazon-bedrock"]?.models?.[0]?.input).toEqual(expected);
+  });
+});

--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -1,14 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  planOpenClawModelsJsonWithDeps,
-  resolveProvidersForModelsJsonWithDeps,
-} from "./models-config.plan.test-support.js";
+import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.test-support.js";
 
 type ResolveImplicitProviders = NonNullable<
-  NonNullable<
-    Parameters<typeof resolveProvidersForModelsJsonWithDeps>[1]
-  >["resolveImplicitProviders"]
+  NonNullable<Parameters<typeof planOpenClawModelsJsonWithDeps>[1]>["resolveImplicitProviders"]
 >;
 
 function model(id: string, input: Array<"text" | "image"> = ["text"]) {
@@ -24,63 +19,23 @@ function model(id: string, input: Array<"text" | "image"> = ["text"]) {
 }
 
 describe("models config input presence", () => {
-  it("keeps provider catalog config materialized while reporting source field presence", async () => {
-    const cfg: OpenClawConfig = {
-      models: {
-        providers: {
-          "amazon-bedrock": {
-            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-            models: [model("vision-model"), model("text-only-model")],
-          },
-        },
-      },
-    };
-    const sourceConfigForSecrets = {
-      models: {
-        providers: {
-          "amazon-bedrock": {
-            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-            models: [
-              { id: "vision-model", name: "vision-model" },
-              { id: "text-only-model", name: "text-only-model", input: ["text"] },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
-    const resolveImplicitProviders = vi.fn<ResolveImplicitProviders>(async () => ({}));
-
-    await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg,
-        sourceConfigForSecrets,
-        agentDir: "/tmp/openclaw-model-input-presence",
-        env: {},
-      },
-      { resolveImplicitProviders },
-    );
-
-    const params = resolveImplicitProviders.mock.calls[0]?.[0];
-    expect(params?.config.models?.providers?.["amazon-bedrock"]?.models[0]?.input).toEqual([
-      "text",
-    ]);
-    expect(params?.resolveModelInputConfigured?.("amazon-bedrock", "vision-model")).toBe(false);
-    expect(params?.resolveModelInputConfigured?.("amazon-bedrock", "text-only-model")).toBe(true);
-    expect(params?.resolveModelInputConfigured?.("amazon-bedrock", "custom-model")).toBeUndefined();
-  });
-
   it.each([
     {
       name: "inherits discovered input when source input was omitted",
-      sourceModel: { id: "vision-model", name: "vision-model" },
+      sourceModels: [{ id: "vision-model", name: "vision-model" }],
       expected: ["text", "image"],
     },
     {
       name: "preserves text-only input when source input was explicit",
-      sourceModel: { id: "vision-model", name: "vision-model", input: ["text"] },
+      sourceModels: [{ id: "vision-model", name: "vision-model", input: ["text"] }],
       expected: ["text"],
     },
-  ] as const)("$name in the final generated models.json", async ({ sourceModel, expected }) => {
+    {
+      name: "keeps materialized input when the source row is missing",
+      sourceModels: [],
+      expected: ["text"],
+    },
+  ] as const)("$name in the final generated models.json", async ({ sourceModels, expected }) => {
     const configuredProvider = {
       baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
       apiKey: "AWS_PROFILE",
@@ -95,7 +50,7 @@ describe("models config input presence", () => {
           "amazon-bedrock": {
             baseUrl: configuredProvider.baseUrl,
             apiKey: configuredProvider.apiKey,
-            models: [sourceModel],
+            models: sourceModels,
           },
         },
       },

--- a/src/agents/models-config.plan.test-support.ts
+++ b/src/agents/models-config.plan.test-support.ts
@@ -1,7 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import "./models-config.plan.js";
-import type { ProviderCatalogModelInputPresenceResolver } from "./models-config.merge.js";
 import type { PreparedModelsConfigContext } from "./models-config.plan.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 
@@ -16,7 +15,7 @@ type ResolveImplicitProvidersForModelsJson = (params: {
   providerDiscoveryProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
-  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+  sourceModelInputOmissions?: ReadonlySet<string>;
 }) => Promise<Record<string, ProviderConfig>>;
 
 type PreparedPlanParams = Parameters<

--- a/src/agents/models-config.plan.test-support.ts
+++ b/src/agents/models-config.plan.test-support.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import "./models-config.plan.js";
+import type { ProviderCatalogModelInputPresenceResolver } from "./models-config.merge.js";
 import type { PreparedModelsConfigContext } from "./models-config.plan.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 
@@ -15,6 +16,7 @@ type ResolveImplicitProvidersForModelsJson = (params: {
   providerDiscoveryProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
+  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
 }) => Promise<Record<string, ProviderConfig>>;
 
 type PreparedPlanParams = Parameters<

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -3,19 +3,18 @@
  * this module to merge implicit provider discovery, explicit config, and
  * preserved secrets before touching models.json.
  */
-import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import { isRecord } from "../utils.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
+import { modelKey, normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
+  normalizeProviderMapKeys,
   type ExistingProviderConfig,
-  type ProviderCatalogModelInputPresenceResolver,
 } from "./models-config.merge.js";
 import {
   enforceSourceManagedProviderSecrets,
@@ -65,7 +64,7 @@ type ResolveImplicitProvidersForModelsJson = (params: {
   providerDiscoveryProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
-  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+  sourceModelInputOmissions?: ReadonlySet<string>;
 }) => Promise<Record<string, ProviderConfig>>;
 
 /**
@@ -122,29 +121,22 @@ function buildPluginCatalogWrites(
   );
 }
 
-function buildModelInputPresenceResolver(params: {
-  sourceProviders: Record<string, ProviderConfig> | undefined;
-  manifestPlugins: PluginMetadataSnapshot["manifestRegistry"]["plugins"] | undefined;
-}): ProviderCatalogModelInputPresenceResolver | undefined {
-  if (!params.sourceProviders) {
-    return undefined;
-  }
-  return (providerId, modelId) => {
-    const provider = findNormalizedProviderValue(params.sourceProviders, providerId);
-    if (!provider?.models) {
-      return undefined;
-    }
-    const normalizedModelId = normalizeConfiguredProviderCatalogModelId(providerId, modelId, {
-      manifestPlugins: params.manifestPlugins,
-    });
-    const sourceModel = provider.models.find(
-      (model) =>
-        normalizeConfiguredProviderCatalogModelId(providerId, model.id, {
-          manifestPlugins: params.manifestPlugins,
-        }) === normalizedModelId,
-    );
-    return sourceModel ? Object.hasOwn(sourceModel, "input") : undefined;
-  };
+function buildSourceModelInputOmissions(
+  sourceProviders: Record<string, ProviderConfig> | undefined,
+  manifestPlugins: PluginMetadataSnapshot["manifestRegistry"]["plugins"] | undefined,
+): ReadonlySet<string> {
+  return new Set(
+    Object.entries(normalizeProviderMapKeys(sourceProviders)).flatMap(([providerId, provider]) =>
+      (provider.models ?? [])
+        .filter((model) => !Object.hasOwn(model, "input"))
+        .map((model) =>
+          modelKey(
+            providerId,
+            normalizeConfiguredProviderCatalogModelId(providerId, model.id, { manifestPlugins }),
+          ),
+        ),
+    ),
+  );
 }
 
 /** Resolves providers for models.json with injectable implicit-provider discovery. */
@@ -163,6 +155,11 @@ async function resolveProvidersForModelsJsonWithDeps(
   const cfg = context.cfg.models?.providers
     ? { ...context.cfg, models: { ...context.cfg.models, providers: explicitProviders } }
     : context.cfg;
+  const manifestPlugins = context.pluginMetadataSnapshot?.manifestRegistry.plugins;
+  const sourceModelInputOmissions = buildSourceModelInputOmissions(
+    context.sourceConfigForSecrets.models?.providers,
+    manifestPlugins,
+  );
   // When models.mode is "replace" the user opts out of provider discovery, so
   // skip the (potentially slow) implicit-provider resolver entirely and return
   // only the explicit providers. See openclaw#66957.
@@ -170,10 +167,6 @@ async function resolveProvidersForModelsJsonWithDeps(
     return mergeProviders({ implicit: {}, explicit: explicitProviders });
   }
   const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
-  const resolveModelInputConfigured = buildModelInputPresenceResolver({
-    sourceProviders: context.sourceConfigForSecrets.models?.providers,
-    manifestPlugins: context.pluginMetadataSnapshot?.manifestRegistry.plugins,
-  });
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,
     ...(params.authStore ? { authStore: params.authStore } : {}),
@@ -182,7 +175,7 @@ async function resolveProvidersForModelsJsonWithDeps(
     env,
     ...(context.workspaceDir ? { workspaceDir: context.workspaceDir } : {}),
     explicitProviders,
-    ...(resolveModelInputConfigured ? { resolveModelInputConfigured } : {}),
+    sourceModelInputOmissions,
     ...(context.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: context.pluginMetadataSnapshot }
       : {}),
@@ -205,7 +198,8 @@ async function resolveProvidersForModelsJsonWithDeps(
   return mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,
-    resolveModelInputConfigured,
+    sourceModelInputOmissions,
+    manifestPlugins,
   });
 }
 

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -3,16 +3,19 @@
  * this module to merge implicit provider discovery, explicit config, and
  * preserved secrets before touching models.json.
  */
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import { isRecord } from "../utils.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
   type ExistingProviderConfig,
+  type ProviderCatalogModelInputPresenceResolver,
 } from "./models-config.merge.js";
 import {
   enforceSourceManagedProviderSecrets,
@@ -62,6 +65,7 @@ type ResolveImplicitProvidersForModelsJson = (params: {
   providerDiscoveryProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
+  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
 }) => Promise<Record<string, ProviderConfig>>;
 
 /**
@@ -118,6 +122,31 @@ function buildPluginCatalogWrites(
   );
 }
 
+function buildModelInputPresenceResolver(params: {
+  sourceProviders: Record<string, ProviderConfig> | undefined;
+  manifestPlugins: PluginMetadataSnapshot["manifestRegistry"]["plugins"] | undefined;
+}): ProviderCatalogModelInputPresenceResolver | undefined {
+  if (!params.sourceProviders) {
+    return undefined;
+  }
+  return (providerId, modelId) => {
+    const provider = findNormalizedProviderValue(params.sourceProviders, providerId);
+    if (!provider?.models) {
+      return undefined;
+    }
+    const normalizedModelId = normalizeConfiguredProviderCatalogModelId(providerId, modelId, {
+      manifestPlugins: params.manifestPlugins,
+    });
+    const sourceModel = provider.models.find(
+      (model) =>
+        normalizeConfiguredProviderCatalogModelId(providerId, model.id, {
+          manifestPlugins: params.manifestPlugins,
+        }) === normalizedModelId,
+    );
+    return sourceModel ? Object.hasOwn(sourceModel, "input") : undefined;
+  };
+}
+
 /** Resolves providers for models.json with injectable implicit-provider discovery. */
 async function resolveProvidersForModelsJsonWithDeps(
   params: {
@@ -141,6 +170,10 @@ async function resolveProvidersForModelsJsonWithDeps(
     return mergeProviders({ implicit: {}, explicit: explicitProviders });
   }
   const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
+  const resolveModelInputConfigured = buildModelInputPresenceResolver({
+    sourceProviders: context.sourceConfigForSecrets.models?.providers,
+    manifestPlugins: context.pluginMetadataSnapshot?.manifestRegistry.plugins,
+  });
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,
     ...(params.authStore ? { authStore: params.authStore } : {}),
@@ -149,6 +182,7 @@ async function resolveProvidersForModelsJsonWithDeps(
     env,
     ...(context.workspaceDir ? { workspaceDir: context.workspaceDir } : {}),
     explicitProviders,
+    ...(resolveModelInputConfigured ? { resolveModelInputConfigured } : {}),
     ...(context.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: context.pluginMetadataSnapshot }
       : {}),
@@ -171,6 +205,7 @@ async function resolveProvidersForModelsJsonWithDeps(
   return mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,
+    resolveModelInputConfigured,
   });
 }
 

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -694,6 +694,38 @@ describe("resolveImplicitProviders startup discovery scope", () => {
     expect(providers?.minimax?.models.map((model) => model.id)).toEqual(["MiniMax-M2.7"]);
   });
 
+  it("inherits discovered input for a configured model whose source row omitted it", async () => {
+    const explicitProvider = {
+      baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      apiKey: "AWS_PROFILE",
+      models: [createTextModel("vision-model", "Vision Model")],
+    };
+    mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+      createProvider("amazon-bedrock"),
+    ]);
+    mocks.runProviderCatalog.mockResolvedValue({
+      provider: {
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        models: [
+          { ...createTextModel("vision-model", "Vision Model"), input: ["text", "image"] },
+          createTextModel("discovered-only", "Discovered Only"),
+        ],
+      },
+    });
+
+    const providers = await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: { models: { providers: { "amazon-bedrock": explicitProvider } } },
+      env: { AWS_PROFILE: "default" } as NodeJS.ProcessEnv,
+      explicitProviders: { "amazon-bedrock": explicitProvider },
+      sourceModelInputOmissions: new Set(["amazon-bedrock/vision-model"]),
+    });
+
+    expect(providers?.["amazon-bedrock"]?.models).toMatchObject([
+      { id: "vision-model", input: ["text", "image"] },
+    ]);
+  });
+
   it("keeps explicit provider models manual without provider wildcard visibility", async () => {
     const explicitProvider = {
       baseUrl: "http://vllm.example/v1",

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -31,11 +31,7 @@ import {
   resolveNonEnvSecretRefApiKeyMarker,
 } from "./model-auth-markers.js";
 import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
-import {
-  inheritDiscoveredModelInput,
-  mergeProviderModels,
-  type ProviderCatalogModelInputPresenceResolver,
-} from "./models-config.merge.js";
+import { mergeProviderModels } from "./models-config.merge.js";
 import type {
   ProviderApiKeyResolver,
   ProviderAuthResolver,
@@ -75,7 +71,7 @@ type ImplicitProviderParams = {
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
   onProviderCatalogOutcome?: (outcome: ProviderCatalogOutcome) => void;
-  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+  sourceModelInputOmissions?: ReadonlySet<string>;
 };
 
 type ImplicitProviderContext = ImplicitProviderParams & {
@@ -269,7 +265,8 @@ function mergeImplicitProviderConfig(params: {
   existing: ProviderConfig | undefined;
   implicit: ProviderConfig;
   dynamicProviderModels?: boolean;
-  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
+  sourceModelInputOmissions?: ReadonlySet<string>;
+  manifestPlugins?: PluginMetadataSnapshot["manifestRegistry"]["plugins"];
 }): ProviderConfig {
   const { providerId, existing, implicit } = params;
   if (!existing) {
@@ -279,27 +276,12 @@ function mergeImplicitProviderConfig(params: {
   if (merge) {
     return merge({ existing, implicit });
   }
-  if (params.dynamicProviderModels) {
-    // Wildcard-visible providers preserve discovered catalog updates while
-    // keeping explicit user config authoritative for non-model fields.
-    return mergeProviderModels(implicit, existing, {
-      providerId,
-      resolveModelInputConfigured: params.resolveModelInputConfigured,
-    });
-  }
-  const merged = {
-    ...implicit,
-    ...existing,
-    models:
-      Array.isArray(existing.models) && existing.models.length > 0
-        ? existing.models
-        : implicit.models,
-  };
-  return inheritDiscoveredModelInput({
+  return mergeProviderModels(implicit, existing, {
     providerId,
-    implicit,
-    explicit: merged,
-    resolveModelInputConfigured: params.resolveModelInputConfigured,
+    sourceModelInputOmissions: params.sourceModelInputOmissions,
+    manifestPlugins: params.manifestPlugins,
+    preserveConfiguredModelMembership:
+      !params.dynamicProviderModels && Array.isArray(existing.models) && existing.models.length > 0,
   });
 }
 
@@ -498,7 +480,8 @@ async function resolvePluginImplicitProviders(
           config: ctx.config,
           providerId,
         }),
-        resolveModelInputConfigured: ctx.resolveModelInputConfigured,
+        sourceModelInputOmissions: ctx.sourceModelInputOmissions,
+        manifestPlugins: ctx.pluginMetadataSnapshot?.manifestRegistry.plugins,
       });
       discovered[providerId] = resolveImplicitProviderAuthMarker({
         ctx,

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -31,7 +31,11 @@ import {
   resolveNonEnvSecretRefApiKeyMarker,
 } from "./model-auth-markers.js";
 import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
-import { mergeProviderModels } from "./models-config.merge.js";
+import {
+  inheritDiscoveredModelInput,
+  mergeProviderModels,
+  type ProviderCatalogModelInputPresenceResolver,
+} from "./models-config.merge.js";
 import type {
   ProviderApiKeyResolver,
   ProviderAuthResolver,
@@ -71,6 +75,7 @@ type ImplicitProviderParams = {
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
   onProviderCatalogOutcome?: (outcome: ProviderCatalogOutcome) => void;
+  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
 };
 
 type ImplicitProviderContext = ImplicitProviderParams & {
@@ -264,6 +269,7 @@ function mergeImplicitProviderConfig(params: {
   existing: ProviderConfig | undefined;
   implicit: ProviderConfig;
   dynamicProviderModels?: boolean;
+  resolveModelInputConfigured?: ProviderCatalogModelInputPresenceResolver;
 }): ProviderConfig {
   const { providerId, existing, implicit } = params;
   if (!existing) {
@@ -276,9 +282,12 @@ function mergeImplicitProviderConfig(params: {
   if (params.dynamicProviderModels) {
     // Wildcard-visible providers preserve discovered catalog updates while
     // keeping explicit user config authoritative for non-model fields.
-    return mergeProviderModels(implicit, existing);
+    return mergeProviderModels(implicit, existing, {
+      providerId,
+      resolveModelInputConfigured: params.resolveModelInputConfigured,
+    });
   }
-  return {
+  const merged = {
     ...implicit,
     ...existing,
     models:
@@ -286,6 +295,12 @@ function mergeImplicitProviderConfig(params: {
         ? existing.models
         : implicit.models,
   };
+  return inheritDiscoveredModelInput({
+    providerId,
+    implicit,
+    explicit: merged,
+    resolveModelInputConfigured: params.resolveModelInputConfigured,
+  });
 }
 
 function resolveImplicitProviderAuthMarker(params: {
@@ -483,6 +498,7 @@ async function resolvePluginImplicitProviders(
           config: ctx.config,
           providerId,
         }),
+        resolveModelInputConfigured: ctx.resolveModelInputConfigured,
       });
       discovered[providerId] = resolveImplicitProviderAuthMarker({
         ctx,


### PR DESCRIPTION
Closes #71921

Replacement for #120919. Original contributor qingminlong remains credited as a
co-author.

## What Problem This Solves

Configured Bedrock, Bedrock Mantle, and Anthropic Vertex model rows are
materialized with `input: ["text"]` before discovery runs. When source config
omitted `input`, that default looked authored and overwrote discovered image
support.

## Why This Change Was Made

Core now records one normalized set of source model rows that omitted their own
`input` field. The three bundled plugin catalog runners return raw discovery,
and core applies the omission fact at both existing merge boundaries:

- explicit source `input`, including text-only, remains authoritative;
- omitted source `input` inherits only matching discovered capability metadata;
- configured model membership remains authoritative;
- unmatched rows and absent source-presence data retain existing behavior.

Provider fields, wildcard/replace semantics, persistence, config, protocol, and
the public plugin SDK are unchanged.

## User Impact

Configured image-capable Bedrock-family and Anthropic Vertex models keep image
support when operators omit `input`. Operators who explicitly configure
text-only input keep that choice.

## Evidence

Exact reviewed head: `dcbcc558457aba17c84fd862cded7eb83ba37f03`.

- Regression proof failed before the repair with final input `["text"]` instead
  of `["text", "image"]` at both the core merge and real host merge boundary.
- Focused exact-head Vitest: 6 files, 153 tests passed.
- Exact-head changed-file/type gates, docs checks, `git diff --check`, and fresh
  branch autoreview passed.
- Exact-head GitHub CI passed: 207 successful, 43 skipped, 0 failing or
  pending.
- `pnpm build` passed on the patch-identical repaired series before its
  conflict-free rebase onto current `main`.
- A full exact-head Testbox run exercised the repository suite. Its failures
  were unrelated infrastructure/systemic surfaces: the known Testbox umask
  mismatch, memory pressure, cross-suite registry contamination, one leaked
  gateway test state, and a late removal of the pinned Node toolchain path.
- Fresh isolated Testbox `tbx_01m13r4pp8f63a7ka9h06ns5xv` then passed every
  failed surface: commands 347 files / 4,793 tests; gateway 6 tests; runtime
  plugins 16 tests; Codex app-server 62 tests; Codex surface 35 files / 878
  tests. Actions run:
  https://github.com/openclaw/openclaw/actions/runs/33155941606.
- Production delta: +92/-37, net +55; the added state is the source-authorship
  fact crossing the two existing core merge boundaries.

The original live AWS proof used `ListFoundationModels` in `us-east-1` and
observed `anthropic.claude-opus-4-7` with `TEXT` and `IMAGE` modalities. It
confirmed omitted input generated `["text", "image"]` while explicit text-only
remained `["text"]`.

Exact-head Testbox proof was attempted twice. The corrected ESM harness reached
`discoverBedrockModels` but the isolated runner had no usable AWS control-plane
credentials, so discovery returned no models:
https://github.com/openclaw/openclaw/actions/runs/33072591582. This cannot prove
or disprove the product path. The landing evidence is therefore the original
real-AWS proof plus exact-head deterministic owner-boundary tests, full CI,
dependency inspection, and independent audit/review.
