### PR TITLE
fix(codex): keep approval timeouts from killing runs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1936,7 +1936,7 @@ src/agents/harness/context-engine-lifecycle.ts	3
 src/agents/harness/context-engine-turn-outbox.ts	3
 src/agents/harness/gateway-question.ts	6
 src/agents/harness/hook-helpers.ts	1
-src/agents/harness/host-capability.ts	4
+src/agents/harness/host-capability.ts	3
 src/agents/harness/lifecycle-hook-helpers.ts	1
 src/agents/harness/native-hook-relay-client.ts	2
 src/agents/harness/native-hook-relay-codec.ts	2

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { codexTestTurnIds } from "./codex-app-server.test-fixtures.js";
 import {
+  codexApprovalTimeoutText,
   requestPluginApproval,
   waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
@@ -172,8 +173,12 @@ function createParams(): EmbeddedRunAttemptParams {
         "plugin.approval.waitDecision",
         { timeoutMs: request.timeoutMs },
         { id: request.approvalId },
-      )) as { id?: string; decision?: "allow-once" | "allow-always" | "deny" | null };
-      return result?.id === request.approvalId ? result.decision : undefined;
+      )) as { id?: string } & Partial<
+        NonNullable<Awaited<ReturnType<AgentHarnessHostCapabilities["waitForApproval"]>>>
+      >;
+      return result?.id === request.approvalId
+        ? { decision: result.decision, terminalReason: result.terminalReason }
+        : undefined;
     },
   };
   return Object.assign(params, { hostCapabilities });
@@ -198,6 +203,15 @@ describe("Codex app-server approval bridge", () => {
       blocked: false,
       params,
     }));
+  });
+
+  it.each([
+    ["command", "Command approval timed out before an operator responded."],
+    ["file-change", "File change approval timed out before an operator responded."],
+    ["permissions", "Permission approval timed out before an operator responded."],
+    ["other", "Approval timed out before an operator responded."],
+  ] as const)("formats %s approval timeout evidence", (kind, expected) => {
+    expect(codexApprovalTimeoutText(kind)).toBe(expected);
   });
 
   it("keeps unrelated command approval policy unchanged for scheduled app authority", async () => {
@@ -1232,6 +1246,32 @@ describe("Codex app-server approval bridge", () => {
     ]);
   });
 
+  it("declines a denied execve approval instead of cancelling the turn", async () => {
+    const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-execve-denied", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-execve-denied", decision: "deny" });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        ...codexTestTurnIds(),
+        itemId: "cmd-execve-denied",
+        approvalId: "execve-approval-1",
+        command: "git status",
+        availableDecisions: ["accept", "cancel"],
+      },
+      paramsForRun: params,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ decision: "decline" });
+  });
+
   it("does not invoke the exec auto-review model before plugin approval", async () => {
     const params = createParams();
     params.config = {
@@ -2127,7 +2167,7 @@ describe("Codex app-server approval bridge", () => {
         reason: "Approval cancelled because the run stopped",
       });
 
-      await handleCodexAppServerApprovalRequest({
+      const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
           ...codexTestTurnIds(),
@@ -2140,6 +2180,7 @@ describe("Codex app-server approval bridge", () => {
         onNativeToolFailureDisposition,
       });
 
+      expect(result).toEqual({ decision: "cancel" });
       expect(onNativeToolFailureDisposition).toHaveBeenCalledWith(
         "cmd-aborted-policy",
         disposition,
@@ -2594,12 +2635,16 @@ describe("Codex app-server approval bridge", () => {
     await expect(pending).rejects.toThrow("approval expired or not found");
   });
 
-  it("preserves an accepted approval expiry as timed out", async () => {
+  it("uses the gateway terminal reason as the authoritative approval timeout", async () => {
     const params = createParams();
     const onNativeToolFailureDisposition = vi.fn();
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-expired", status: "accepted" })
-      .mockResolvedValueOnce({ id: "plugin:approval-expired", decision: null });
+      .mockResolvedValueOnce({
+        id: "plugin:approval-expired",
+        decision: "deny",
+        terminalReason: "timeout",
+      });
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -2607,6 +2652,7 @@ describe("Codex app-server approval bridge", () => {
         ...codexTestTurnIds(),
         itemId: "cmd-expired",
         command: "pnpm test",
+        availableDecisions: ["accept", "cancel"],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2614,10 +2660,15 @@ describe("Codex app-server approval bridge", () => {
     });
 
     expect(result).toEqual({ decision: "decline" });
-    expect(onNativeToolFailureDisposition).toHaveBeenCalledWith("cmd-expired", "timed_out");
+    expect(onNativeToolFailureDisposition).toHaveBeenCalledWith(
+      "cmd-expired",
+      "timed_out",
+      "command",
+    );
     findApprovalEvent(params, {
-      status: "unavailable",
+      status: "denied",
       approvalId: "plugin:approval-expired",
+      message: codexApprovalTimeoutText("command"),
     });
   });
 

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -23,12 +23,14 @@ import { formatCodexDisplayText } from "../command-formatters.js";
 import { resolveCodexToolAbortTerminalReason } from "./dynamic-tool-execution.js";
 import {
   approvalRequestExplicitlyUnavailable,
+  codexApprovalTimeoutText,
   mapExecDecisionToOutcome,
   requestPluginApproval,
   sanitizeCodexApprovalVisibleText,
   stripDanglingCodexApprovalTerminalSequence,
   truncateCodexApprovalDisplayText as truncate,
   type AppServerApprovalOutcome,
+  type CodexApprovalKind,
   waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
@@ -75,6 +77,7 @@ export async function handleCodexAppServerApprovalRequest(params: {
   onNativeToolFailureDisposition?: (
     itemId: string,
     disposition: Exclude<BeforeToolCallFailureDisposition, "blocked">,
+    approvalKind?: CodexApprovalKind,
   ) => void;
 }): Promise<JsonValue | undefined> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
@@ -86,6 +89,10 @@ export async function handleCodexAppServerApprovalRequest(params: {
     requestParams,
     paramsForRun: params.paramsForRun,
   });
+  if (params.signal?.aborted) {
+    recordNativeToolFailureDisposition(params, context, "cancelled");
+    return buildApprovalResponse(params.method, context.requestParams, "cancelled");
+  }
   let revalidateMutableFileApproval:
     | (() => Promise<{ ok: true } | { ok: false; message: string }>)
     | undefined;
@@ -210,23 +217,28 @@ export async function handleCodexAppServerApprovalRequest(params: {
     });
 
     const requestUnavailable = approvalRequestExplicitlyUnavailable(requestResult);
-    const decision = requestUnavailable
-      ? null
+    const approvalResult = requestUnavailable
+      ? undefined
       : await waitForPluginApprovalDecision({
           approvalId,
           signal: params.signal,
           hostCapabilities: params.paramsForRun.hostCapabilities,
         });
-    const approvalExpired = !requestUnavailable && decision === null;
-    const outcome = params.signal?.aborted ? "cancelled" : mapExecDecisionToOutcome(decision);
-    if (outcome === "cancelled") {
+    const approvalTimedOut =
+      !params.signal?.aborted && approvalResult?.terminalReason === "timeout";
+    const outcome = params.signal?.aborted
+      ? "cancelled"
+      : mapExecDecisionToOutcome(approvalResult?.decision);
+    if (approvalTimedOut) {
+      recordNativeToolFailureDisposition(params, context, "timed_out", context.approvalKind);
+    } else if (outcome === "cancelled") {
       recordNativeToolFailureDisposition(
         params,
         context,
         params.signal?.aborted ? resolveCodexToolAbortTerminalReason(params.signal) : "cancelled",
       );
     } else if (outcome === "unavailable") {
-      recordNativeToolFailureDisposition(params, context, approvalExpired ? "timed_out" : "failed");
+      recordNativeToolFailureDisposition(params, context, "failed");
     }
 
     if (outcome === "approved-once" || outcome === "approved-session") {
@@ -249,7 +261,9 @@ export async function handleCodexAppServerApprovalRequest(params: {
       approvalSlug: approvalId,
       ...context.eventDetails,
       ...approvalEventScope(params.method, outcome),
-      message: approvalResolutionMessage(outcome),
+      message: approvalTimedOut
+        ? codexApprovalTimeoutText(context.approvalKind)
+        : approvalResolutionMessage(outcome),
     });
     return buildApprovalResponse(params.method, context.requestParams, outcome);
   } catch (error) {
@@ -287,14 +301,19 @@ function recordNativeToolFailureDisposition(
   >,
   context: Pick<ApprovalContext, "itemId">,
   disposition: Exclude<BeforeToolCallFailureDisposition, "blocked"> | undefined,
+  approvalKind?: CodexApprovalKind,
 ): void {
   if (!context.itemId || !disposition) {
     return;
   }
   try {
+    const resolvedDisposition = params.signal?.aborted
+      ? resolveCodexToolAbortTerminalReason(params.signal)
+      : disposition;
     params.onNativeToolFailureDisposition?.(
       context.itemId,
-      params.signal?.aborted ? resolveCodexToolAbortTerminalReason(params.signal) : disposition,
+      resolvedDisposition,
+      ...(resolvedDisposition === "timed_out" && approvalKind ? [approvalKind] : []),
     );
   } catch {
     // Audit projection must not alter the approval decision sent to Codex.
@@ -322,7 +341,10 @@ function buildApprovalResponse(
     }
     return { permissions: {}, scope: "turn" };
   }
-  return unsupportedApprovalResponse();
+  return {
+    decision: "decline",
+    reason: "OpenClaw codex app-server bridge does not grant native approvals yet.",
+  };
 }
 
 function matchesCurrentTurn(
@@ -364,7 +386,15 @@ function buildApprovalContext(params: {
   );
   const command = commandPreview.text;
   const reason = reasonPreview.text;
-  const kind = approvalKindForMethod(params.method);
+  const approvalKind: CodexApprovalKind = params.method.includes("commandExecution")
+    ? "command"
+    : params.method.includes("fileChange")
+      ? "file-change"
+      : params.method.includes("permissions")
+        ? "permissions"
+        : "other";
+  const kind: AgentApprovalEventData["kind"] =
+    approvalKind === "command" ? "exec" : approvalKind === "other" ? "unknown" : "plugin";
   const permissionLines =
     params.method === "item/permissions/requestApproval"
       ? describeRequestedPermissions(params.requestParams)
@@ -393,6 +423,7 @@ function buildApprovalContext(params: {
       ? joinDescriptionLinesWithinLimit(permissionLines, PERMISSION_DESCRIPTION_MAX_LENGTH)
       : [subject, ...commandDetailLines].join("\n");
   return {
+    approvalKind,
     kind,
     title,
     description,
@@ -773,10 +804,10 @@ function commandApprovalDecision(
   outcome: AppServerApprovalOutcome,
 ): JsonValue {
   if (outcome === "cancelled") {
-    return commandRejectionDecision(requestParams, "cancel");
+    return "cancel";
   }
   if (outcome === "denied" || outcome === "unavailable") {
-    return commandRejectionDecision(requestParams, "decline");
+    return "decline";
   }
   if (outcome === "approved-session") {
     if (hasAvailableDecision(requestParams, "acceptForSession")) {
@@ -787,9 +818,7 @@ function commandApprovalDecision(
       return amendmentDecision;
     }
   }
-  return hasAvailableDecision(requestParams, "accept")
-    ? "accept"
-    : commandRejectionDecision(requestParams, "decline");
+  return hasAvailableDecision(requestParams, "accept") ? "accept" : "decline";
 }
 
 function fileChangeApprovalDecision(outcome: AppServerApprovalOutcome): JsonValue {
@@ -812,13 +841,6 @@ function requestedPermissions(requestParams: JsonObject | undefined): JsonObject
     granted.fileSystem = permissions.fileSystem;
   }
   return granted;
-}
-
-function unsupportedApprovalResponse(): JsonValue {
-  return {
-    decision: "decline",
-    reason: "OpenClaw codex app-server bridge does not grant native approvals yet.",
-  };
 }
 
 function describeRequestedPermissions(requestParams: JsonObject | undefined): string[] {
@@ -1147,10 +1169,7 @@ function isPrivateNetworkHostPattern(value: string): boolean {
 
 function hasAvailableDecision(requestParams: JsonObject | undefined, decision: string): boolean {
   const available = requestParams?.availableDecisions;
-  if (!Array.isArray(available)) {
-    return true;
-  }
-  return available.includes(decision);
+  return !Array.isArray(available) || available.includes(decision);
 }
 
 function findAvailableCommandAmendmentDecision(
@@ -1168,38 +1187,14 @@ function findAvailableCommandAmendmentDecision(
   );
 }
 
-function commandRejectionDecision(
-  requestParams: JsonObject | undefined,
-  preferred: "decline" | "cancel",
-): JsonValue {
-  const available = requestParams?.availableDecisions;
-  if (!Array.isArray(available)) {
-    return preferred;
-  }
-  if (available.includes(preferred)) {
-    return preferred;
-  }
-  const alternate = preferred === "decline" ? "cancel" : "decline";
-  if (available.includes(alternate)) {
-    return alternate;
-  }
-  return preferred;
-}
-
 function approvalResolutionMessage(outcome: AppServerApprovalOutcome): string {
-  if (outcome === "approved-session") {
-    return "Codex app-server approval granted for the session.";
-  }
-  if (outcome === "approved-once") {
-    return "Codex app-server approval granted for this turn.";
-  }
-  if (outcome === "cancelled") {
-    return "Codex app-server approval cancelled.";
-  }
-  if (outcome === "unavailable") {
-    return "Codex app-server approval unavailable.";
-  }
-  return "Codex app-server approval denied.";
+  return {
+    "approved-session": "Codex app-server approval granted for the session.",
+    "approved-once": "Codex app-server approval granted for this turn.",
+    cancelled: "Codex app-server approval cancelled.",
+    unavailable: "Codex app-server approval unavailable.",
+    denied: "Codex app-server approval denied.",
+  }[outcome];
 }
 
 function approvalEventScope(
@@ -1209,16 +1204,6 @@ function approvalEventScope(
   return method === "item/permissions/requestApproval"
     ? { scope: outcome === "approved-session" ? "session" : "turn" }
     : {};
-}
-
-function approvalKindForMethod(method: string): AgentApprovalEventData["kind"] {
-  if (method.includes("commandExecution") || method.includes("execCommand")) {
-    return "exec";
-  }
-  if (method.includes("fileChange") || method.includes("Patch") || method.includes("permissions")) {
-    return "plugin";
-  }
-  return "unknown";
 }
 
 function emitApprovalEvent(params: EmbeddedRunAttemptParams, data: AgentApprovalEventData): void {

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -56,8 +56,12 @@ function createParams(): EmbeddedRunAttemptParams {
         "plugin.approval.waitDecision",
         { timeoutMs: request.transportTimeoutMs ?? request.timeoutMs },
         { id: request.approvalId },
-      )) as { id?: string; decision?: "allow-once" | "allow-always" | "deny" | null };
-      return result?.id === request.approvalId ? result.decision : undefined;
+      )) as { id?: string } & Partial<
+        NonNullable<Awaited<ReturnType<AgentHarnessHostCapabilities["waitForApproval"]>>>
+      >;
+      return result?.id === request.approvalId
+        ? { decision: result.decision, terminalReason: result.terminalReason }
+        : undefined;
     },
   };
   return {

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -671,14 +671,14 @@ async function requestPluginApprovalOutcome(params: {
       return "unavailable";
     }
 
-    const decision = approvalRequestExplicitlyUnavailable(requestResult)
-      ? null
+    const approvalResult = approvalRequestExplicitlyUnavailable(requestResult)
+      ? undefined
       : await waitForPluginApprovalDecision({
           hostCapabilities: params.paramsForRun.hostCapabilities,
           approvalId,
           signal: params.signal,
         });
-    return mapExecDecisionToOutcome(decision);
+    return mapExecDecisionToOutcome(approvalResult?.decision);
   } catch {
     return params.signal?.aborted ? "cancelled" : "denied";
   }

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -36,6 +36,7 @@ import {
   toolOutputRawEchoSignature,
   truncateToolTranscriptText,
 } from "./event-projector-tool-output.js";
+import { codexApprovalTimeoutText, type CodexApprovalKind } from "./plugin-approval-roundtrip.js";
 import type {
   CodexDynamicToolCallOutputContentItem,
   CodexThreadItem,
@@ -77,6 +78,7 @@ export type ToolTranscriptResultInput = {
 };
 
 type ToolProgressRawSignature = { length: number; prefix: string };
+type NativeToolStatus = ReturnType<typeof itemStatus>;
 type ToolProgressEchoState = {
   displayTexts: string[];
   streamedDisplayText?: string;
@@ -100,6 +102,7 @@ export class CodexToolProgressProjection {
   private readonly sideEffectingNativeIds = new Set<string>();
   private readonly sideEffectingDynamicIds = new Set<string>();
   private readonly transcriptProgressCallIds = new Set<string>();
+  readonly approvalTimeoutKinds = new Map<string, CodexApprovalKind>();
   private lastNativeToolError: EmbeddedRunAttemptResult["lastToolError"];
 
   constructor(private readonly params: EmbeddedRunAttemptParams) {}
@@ -122,6 +125,11 @@ export class CodexToolProgressProjection {
 
   get hasPotentialSideEffects(): boolean {
     return this.sideEffectingNativeIds.size > 0 || this.sideEffectingDynamicIds.size > 0;
+  }
+
+  approvalTimeoutExplanation(itemId: string, status: NativeToolStatus): string | undefined {
+    const kind = isNonSuccessItemStatus(status) && this.approvalTimeoutKinds.get(itemId);
+    return kind ? codexApprovalTimeoutText(kind) : undefined;
   }
 
   setLastToolError(error: EmbeddedRunAttemptResult["lastToolError"]): void {
@@ -260,15 +268,27 @@ export class CodexToolProgressProjection {
     item: CodexThreadItem;
     name: string;
     meta?: string;
-    status: ReturnType<typeof itemStatus>;
+    status: NativeToolStatus;
   }): void {
     const executionStarted = params.status !== "blocked";
     const mutatingAction = executionStarted && isMutatingNativeToolItem(params.item);
     const actionFingerprint = mutatingAction ? nativeToolActionFingerprint(params.item) : undefined;
     const isFailure = isNonSuccessItemStatus(params.status);
+    const approvalTimeoutExplanation = this.approvalTimeoutExplanation(
+      params.item.id,
+      params.status,
+    );
     const error = isFailure
-      ? itemToolError(params.item, params.status, this.output.textByItem)
+      ? (approvalTimeoutExplanation ??
+        itemToolError(params.item, params.status, this.output.textByItem))
       : undefined;
+    const failure = error
+      ? {
+          ...(approvalTimeoutExplanation ? { errorCode: "approval_timeout" as const } : {}),
+          error,
+          ...(approvalTimeoutExplanation ? { timedOut: true } : {}),
+        }
+      : {};
     const terminalResolution = this.params.observeToolTerminal?.({
       toolCallId: params.item.id,
       toolName: params.name,
@@ -276,7 +296,7 @@ export class CodexToolProgressProjection {
       ...(params.meta ? { meta: params.meta } : {}),
       executionStarted,
       outcome: isFailure ? "failure" : "success",
-      ...(isFailure ? { failure: error ? { error } : {} } : {}),
+      ...(isFailure ? { failure } : {}),
       nativeMutation: {
         mutatingAction,
         replaySafe: !mutatingAction,
@@ -291,7 +311,7 @@ export class CodexToolProgressProjection {
       this.lastNativeToolError = {
         toolName: params.name,
         ...(params.meta ? { meta: params.meta } : {}),
-        ...(error ? { error } : {}),
+        ...failure,
         ...(mutatingAction ? { mutatingAction: true } : {}),
         ...(actionFingerprint ? { actionFingerprint } : {}),
       };

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -188,21 +188,25 @@ export class CodexToolTranscriptProjection {
   }
 
   recordNativeToolResult(item: CodexThreadItem | undefined, details?: unknown): void {
-    if (!item || !shouldRecordNativeToolTranscript(item)) {
+    if (!item || !shouldRecordNativeToolTranscript(item) || this.resultIds.has(item.id)) {
       return;
     }
     const name = itemName(item);
     if (name) {
+      const status = itemStatus(item);
+      const approvalTimeoutExplanation = this.progress.approvalTimeoutExplanation(item.id, status);
       this.recordToolResult({
         id: item.id,
         name,
         text:
+          approvalTimeoutExplanation ??
           this.rawNativeToolOutputByCallId.get(item.id) ??
           itemTranscriptResultText(item, this.progress.outputTextByItem),
-        isError: isNonSuccessItemStatus(itemStatus(item)),
+        isError: isNonSuccessItemStatus(status),
         details,
         ...(item.type === "webSearch" ? { resultContentSource: "network" } : {}),
       });
+      this.progress.approvalTimeoutKinds.delete(item.id);
     }
   }
 
@@ -398,7 +402,9 @@ export class CodexToolTranscriptProjection {
     }
     this.trajectoryResultIds.add(params.item.id);
     const toolResult = itemToolResult(params.item).result;
-    const output = itemOutputText(params.item, this.progress.outputTextByItem);
+    const output =
+      this.progress.approvalTimeoutExplanation(params.item.id, params.status) ??
+      itemOutputText(params.item, this.progress.outputTextByItem);
     this.options.trajectoryRecorder?.recordEvent("tool.result", {
       threadId: this.threadId,
       turnId: this.turnId,
@@ -423,7 +429,9 @@ export class CodexToolTranscriptProjection {
     }
     this.afterToolCallObservedItemIds.add(item.id);
     const result = itemToolResult(item).result;
-    const error = itemToolError(item, status, this.progress.outputTextByItem);
+    const error =
+      this.progress.approvalTimeoutExplanation(item.id, status) ??
+      itemToolError(item, status, this.progress.outputTextByItem);
     const startedAt = resolveStartedAtFromDurationMs(item.durationMs);
     const hookParams = {
       toolName: name,

--- a/extensions/codex/src/app-server/event-projector.native-failures.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-failures.test.ts
@@ -6,13 +6,17 @@ import {
   it,
   vi,
   createCodexTestToolTerminalObserver,
+  createMockPluginRegistry,
   flushDiagnosticEvents,
+  initializeGlobalHookRunner,
   createParams,
   createProjector,
   buildEmptyToolTelemetry,
   forCurrentTurn,
+  readAttemptTerminal,
   type DiagnosticEventPayload,
 } from "./event-projector.test-harness.js";
+import { codexApprovalTimeoutText } from "./plugin-approval-roundtrip.js";
 
 registerCodexEventProjectorTestLifecycle();
 
@@ -175,6 +179,69 @@ describe("CodexAppServerEventProjector native tool failure recovery", () => {
       ]);
     },
   );
+
+  it("persists an approval timeout as failed tool evidence without aborting the turn", async () => {
+    const afterToolCall = vi.fn();
+    const recordTrajectoryEvent = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const projector = await createProjector(undefined, {
+      trajectoryRecorder: { recordEvent: recordTrajectoryEvent, flush: vi.fn() },
+    });
+    const item = {
+      type: "commandExecution" as const,
+      id: "cmd-approval-timeout",
+      command: "pnpm test extensions/codex",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent" as const,
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+    };
+    const timeoutExplanation = codexApprovalTimeoutText("command");
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { ...item, status: "inProgress", durationMs: null },
+      }),
+    );
+    projector.recordNativeToolApprovalFailure(item.id, "timed_out", "command");
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: { ...item, status: "declined", durationMs: 1 },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResult = result.messagesSnapshot.find(
+      (message) => message.role === "toolResult" && message.toolCallId === item.id,
+    );
+    expect(toolResult).toMatchObject({
+      role: "toolResult",
+      toolCallId: item.id,
+      isError: true,
+      content: [expect.objectContaining({ content: timeoutExplanation, text: timeoutExplanation })],
+    });
+    expect(result.lastToolError).toMatchObject({
+      toolName: "bash",
+      error: timeoutExplanation,
+      errorCode: "approval_timeout",
+      timedOut: true,
+    });
+    expect(recordTrajectoryEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({ output: timeoutExplanation, isError: true }),
+    );
+    await vi.waitFor(() =>
+      expect(afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ error: timeoutExplanation }),
+        expect.anything(),
+      ),
+    );
+    expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, timedOut: false });
+  });
 
   it("coalesces a native pre-tool failure with the matching item terminal", async () => {
     const projector = await createProjector();

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -43,6 +43,7 @@ import {
   isCodexNotificationForTurn,
   readCodexNotificationThreadId,
 } from "./notification-correlation.js";
+import type { CodexApprovalKind } from "./plugin-approval-roundtrip.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
@@ -200,8 +201,15 @@ export class CodexAppServerEventProjector {
     }
   }
 
-  recordNativeToolApprovalFailure(toolCallId: string, disposition: ApprovalFailure): void {
+  recordNativeToolApprovalFailure(
+    toolCallId: string,
+    disposition: ApprovalFailure,
+    approvalKind?: CodexApprovalKind,
+  ): void {
     this.nativeToolLifecycleProjector.recordApprovalFailureDisposition(toolCallId, disposition);
+    if (disposition === "timed_out" && approvalKind) {
+      this.toolProgressProjection.approvalTimeoutKinds.set(toolCallId, approvalKind);
+    }
   }
 
   recordNativeToolPreToolUseFailure(failure: CodexNativePreToolUseFailure): void {
@@ -548,6 +556,7 @@ export class CodexAppServerEventProjector {
       this.toolProgressProjection.emitToolResultSummary(item);
       this.toolProgressProjection.emitToolResultOutput(item);
     }
+    this.toolProgressProjection.approvalTimeoutKinds.clear();
     this.assistantProjection.finalizeAnswerCandidate(turn);
     this.activeCompactionItemIds.clear();
     await this.reasoningProjection.maybeEndReasoning();

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -31,6 +31,18 @@ const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
 
 export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
 
+export type CodexApprovalKind = "command" | "file-change" | "permissions" | "other";
+const CODEX_APPROVAL_TIMEOUT_SUBJECTS: Record<CodexApprovalKind, string> = {
+  command: "Command approval",
+  "file-change": "File change approval",
+  permissions: "Permission approval",
+  other: "Approval",
+};
+
+export function codexApprovalTimeoutText(kind: CodexApprovalKind): string {
+  return `${CODEX_APPROVAL_TIMEOUT_SUBJECTS[kind]} timed out before an operator responded.`;
+}
+
 /** Normalized Codex app-server approval outcome after a gateway decision. */
 export type AppServerApprovalOutcome =
   | "approved-once"
@@ -89,7 +101,7 @@ export async function waitForPluginApprovalDecision(params: {
   hostCapabilities: AgentHarnessHostCapabilities;
   approvalId: string;
   signal?: AbortSignal;
-}): Promise<ExecApprovalDecision | null | undefined> {
+}): ReturnType<AgentHarnessHostCapabilities["waitForApproval"]> {
   const timeoutMs = DEFAULT_CODEX_APPROVAL_TIMEOUT_MS;
   const waitPromise = params.hostCapabilities
     .waitForApproval({
@@ -100,15 +112,12 @@ export async function waitForPluginApprovalDecision(params: {
     })
     .catch((error: unknown) => {
       if (isApprovalNotFoundError(error)) {
-        return null;
+        return undefined;
       }
       throw error;
     });
-  // Bind the verdict to the approval that parked this prompt. A stale or
-  // misrouted reply maps to "unavailable" instead of releasing another gate.
-  const bindDecision = (result: ExecApprovalDecision | null | undefined) => result;
   if (!params.signal) {
-    return bindDecision(await waitPromise);
+    return await waitPromise;
   }
   let onAbort: (() => void) | undefined;
   const abortPromise = new Promise<never>((_, reject) => {
@@ -120,7 +129,7 @@ export async function waitForPluginApprovalDecision(params: {
     params.signal!.addEventListener("abort", onAbort, { once: true });
   });
   try {
-    return bindDecision(await Promise.race([waitPromise, abortPromise]));
+    return await Promise.race([waitPromise, abortPromise]);
   } finally {
     if (onAbort) {
       params.signal.removeEventListener("abort", onAbort);
@@ -132,16 +141,16 @@ export async function waitForPluginApprovalDecision(params: {
 export function mapExecDecisionToOutcome(
   decision: ExecApprovalDecision | null | undefined,
 ): AppServerApprovalOutcome {
-  if (decision === "allow-once") {
-    return "approved-once";
+  switch (decision) {
+    case "allow-once":
+      return "approved-once";
+    case "allow-always":
+      return "approved-session";
+    case "deny":
+      return "denied";
+    default:
+      return "unavailable";
   }
-  if (decision === "allow-always") {
-    return "approved-session";
-  }
-  if (decision === null || decision === undefined) {
-    return "unavailable";
-  }
-  return "denied";
 }
 
 export function truncateCodexApprovalDisplayText(value: string, maxLength: number): string {

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -134,8 +134,8 @@ export function createCodexAttemptServerRequestController(
             nativeHookRelay: resourceState.nativeHookRelay,
             autoApprove: shouldAutoApproveCodexAppServerApprovals(appServer),
             signal,
-            onNativeToolFailureDisposition: (itemId, disposition) =>
-              projector?.recordNativeToolApprovalFailure(itemId, disposition),
+            onNativeToolFailureDisposition: (itemId, disposition, approvalKind) =>
+              projector?.recordNativeToolApprovalFailure(itemId, disposition, approvalKind),
           });
         }
         return undefined;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -62,6 +62,7 @@ import {
   buildCodexAppServerConnectionFingerprint,
   buildCodexPluginAppCacheKey,
 } from "./plugin-app-cache-key.js";
+import { codexApprovalTimeoutText } from "./plugin-approval-roundtrip.js";
 import { buildCodexPluginThreadConfig } from "./plugin-thread-config.js";
 import {
   flattenCodexDynamicToolFunctions,
@@ -2022,6 +2023,72 @@ describe("runCodexAppServerAttempt", () => {
     expect(snapshotJson).toContain('"isError":true');
     expect(snapshotJson).toContain("without a matching tool.result");
   });
+
+  it("wires approval timeouts into native tool evidence without aborting the turn", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session-approval-timeout.jsonl"),
+      path.join(tempDir, "workspace-approval-timeout"),
+    );
+    params.hostCapabilities = Object.freeze({
+      ...params.hostCapabilities,
+      requestApproval: async () => ({ id: "plugin:approval-timeout" }),
+      waitForApproval: async () => ({
+        decision: "deny" as const,
+        terminalReason: "timeout" as const,
+      }),
+    });
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "guardian" } },
+    });
+    await harness.waitForMethod("turn/start");
+    const item = {
+      type: "fileChange" as const,
+      id: "patch-approval-timeout",
+      changes: [{ path: "src/example.ts", kind: { type: "add" as const } }],
+    };
+    await harness.notify(
+      itemNotification("item/started", {
+        ...item,
+        status: "inProgress",
+        durationMs: null,
+      }),
+    );
+
+    await expect(
+      harness.handleServerRequest({
+        id: "request-approval-timeout",
+        method: "item/fileChange/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: item.id,
+          reason: "write src/example.ts",
+        },
+      }),
+    ).resolves.toEqual({ decision: "decline" });
+    await harness.notify(
+      itemNotification("item/completed", { ...item, status: "declined", durationMs: 1 }),
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    const result = await run;
+    expect(result.lastToolError).toMatchObject({
+      toolName: "apply_patch",
+      error: codexApprovalTimeoutText("file-change"),
+      errorCode: "approval_timeout",
+      timedOut: true,
+    });
+    const toolResult = result.messagesSnapshot.find(
+      (message) => message.role === "toolResult" && message.toolCallId === item.id,
+    );
+    expect(toolResult).toMatchObject({
+      role: "toolResult",
+      content: [expect.objectContaining({ text: result.lastToolError?.error })],
+    });
+    expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, timedOut: false });
+  });
+
   it("keeps OpenClaw control-path tools direct when code-mode-only is enabled", () => {
     const tools = [
       createRuntimeDynamicTool("message"),

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.test.ts
@@ -333,6 +333,24 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
     });
   });
 
+  it.each(["bash", "write"])(
+    "includes a semantic %s timeout explanation at normal verbosity",
+    (toolName) => {
+      const timeoutExplanation = "approval wait expired";
+      const payloads = buildPayloads({
+        lastToolError: {
+          toolName,
+          error: timeoutExplanation,
+          errorCode: "approval_timeout",
+          timedOut: true,
+        },
+        verboseLevel: "on",
+      });
+
+      expect(payloads[0]?.text).toContain(timeoutExplanation);
+    },
+  );
+
   it("keeps exec-like tool error warnings for recoverable-looking errors when there is no reply", () => {
     const payloads = buildPayloads({
       lastToolError: {

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.ts
@@ -61,6 +61,8 @@ function formatToolErrorWarningText(params: {
     return `⚠️ ${toolLabel} failed (${reason})${errorSuffix}${recoveryHint}.`;
   }
 
+  const includeError =
+    params.includeDetails || params.lastToolError.errorCode === "approval_timeout";
   if (isExecLikeToolName(params.lastToolError.toolName)) {
     const toolLabel = formatToolAggregate(params.lastToolError.toolName, undefined, {
       markdown: params.useMarkdown,
@@ -72,7 +74,7 @@ function formatToolErrorWarningText(params: {
       ? ""
       : formatConciseExecExitSuffix(params.lastToolError.error);
     const errorSuffix =
-      params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+      includeError && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
     return subject
       ? `⚠️ ${toolLabel} failed: ${subject}${conciseExitSuffix}${errorSuffix}`
       : `⚠️ ${toolLabel} failed${conciseExitSuffix}${errorSuffix}`;
@@ -84,7 +86,7 @@ function formatToolErrorWarningText(params: {
     { markdown: params.useMarkdown },
   );
   const errorSuffix =
-    params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+    includeError && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
   return `⚠️ ${toolSummary} failed${errorSuffix}`;
 }
 

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -2,6 +2,20 @@ import type { AnyAgentTool } from "../tools/common.js";
 
 type AgentHarnessHostApprovalDecision = "allow-once" | "allow-always" | "deny";
 
+type AgentHarnessHostApprovalTerminalReason =
+  | "user"
+  | "timeout"
+  | "malformed-verdict"
+  | "no-route"
+  | "run-aborted"
+  | "gateway-restart"
+  | "storage-corrupt";
+
+type AgentHarnessHostApprovalResult = Readonly<{
+  decision: AgentHarnessHostApprovalDecision | null | undefined;
+  terminalReason: AgentHarnessHostApprovalTerminalReason | null | undefined;
+}>;
+
 type AgentHarnessPreparedEnvironment = Readonly<{
   credentialScrubEnv: Readonly<Record<string, string>>;
   localIdentityEnv: Readonly<Record<string, string>>;
@@ -54,5 +68,5 @@ export type AgentHarnessHostCapabilities = Readonly<{
     timeoutMs: number;
     transportTimeoutMs?: number;
     signal?: AbortSignal;
-  }) => Promise<AgentHarnessHostApprovalDecision | null | undefined>;
+  }) => Promise<AgentHarnessHostApprovalResult | undefined>;
 }>;

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -503,6 +503,20 @@ describe("agent harness host capability", () => {
     }
   });
 
+  it("preserves the gateway decision and terminal reason at the host boundary", async () => {
+    const { attempt } = await admittedAttempt("run-approval-timeout-result");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "approval-1",
+      decision: "deny",
+      terminalReason: "timeout",
+    });
+
+    await expect(
+      host.capabilities.waitForApproval({ approvalId: "approval-1", timeoutMs: 1_000 }),
+    ).resolves.toEqual({ decision: "deny", terminalReason: "timeout" });
+  });
+
   it("revokes a retained bound tool when the same run id gets a replacement owner", async () => {
     const first = await admittedAttempt("run-replaced");
     const { tool, execute } = testTool();

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -33,6 +33,9 @@ import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
 
 type AgentHarnessHostAttempt = Partial<EmbeddedRunAttemptParams> &
   Pick<EmbeddedRunAttemptParams, "admittedRunContext" | "runId">;
+type AgentHarnessHostApprovalResult = NonNullable<
+  Awaited<ReturnType<AgentHarnessHostCapabilities["waitForApproval"]>>
+>;
 
 const MAX_NATIVE_OPERATION_CWD_BYTES = 4096;
 
@@ -378,7 +381,7 @@ export function createAgentHarnessHostCapabilities(params: {
       assertActive();
       const result = await withCaller(
         async () =>
-          await callGatewayTool<{ id?: string; decision?: string | null }>(
+          await callGatewayTool<{ id?: string } & Partial<AgentHarnessHostApprovalResult>>(
             "plugin.approval.waitDecision",
             { timeoutMs: request.transportTimeoutMs ?? request.timeoutMs },
             { id: request.approvalId },
@@ -388,9 +391,13 @@ export function createAgentHarnessHostCapabilities(params: {
       // An allowed decision is useful only while this exact admitted owner is
       // still live; fail closed if closure raced the awaited Gateway result.
       assertActive();
-      return result?.id === request.approvalId
-        ? (result.decision as "allow-once" | "allow-always" | "deny" | null | undefined)
-        : undefined;
+      if (result?.id !== request.approvalId) {
+        return undefined;
+      }
+      return {
+        decision: result.decision,
+        terminalReason: result.terminalReason,
+      };
     },
   });
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a command approval that expired could terminate the entire Codex turn instead of rejecting only the command. The durable approval record retained `decision=deny` and `terminalReason=timeout`, but the runtime discarded that distinction, projected the result as Codex `cancel`, and could leave chat without a final assistant response.

## Why This Change Was Made

The host capability now preserves the structured approval decision and terminal reason. The Codex bridge maps operator denial, timeout, and unavailable approval routes to `decline`, reserving `cancel` for an actually aborted run, matching Codex's upstream contract that Decline continues the turn while Cancel aborts it.

Timeouts also retain a bounded, static explanation through lifecycle diagnostics, trajectory, post-tool hooks, the durable native tool result, settled-turn finalization, and the existing visible failure fallback. The old decline-to-cancel fallback and null-decision timeout inference were removed.

AI-assisted; the complete diff was independently reviewed with the repository autoreview workflow.

Provenance: the decision fallback was added in #71338 by @Lucenx9 and merged by @steipete on 2026-04-25. The later harness capability introduced in #120534 by @joshavant carried only the decision and dropped the Gateway-owned terminal reason. The combined behavior made approval expiry abort the turn.

Production LOC: +158/-104 (net +54) | Tests: +230/-9 | Tooling baseline: +1/-1

The positive production delta is the closed beta host result contract plus one item-scoped timeout fact reused by native progress, transcript, trajectory, and post-tool projection. The bridge itself is net-negative and the obsolete fallback path is deleted.

## User Impact

When an operator does not answer a command approval before its deadline, the requested command is declined and the agent can explain the timeout or continue the turn. The session is no longer killed solely because the approval expired, and chat retains an explicit failure outcome instead of a hidden generic declined result.

## Evidence

- Regression uses realistic Codex `availableDecisions: ["accept", "cancel"]` and verifies timeout returns `decline`, not `cancel`.
- Harness regression verifies `{ decision: "deny", terminalReason: "timeout" }` survives the host boundary.
- Projector coverage verifies the exact timeout explanation reaches the durable tool result, trajectory, post-tool hook, and `lastToolError` without marking the turn aborted.
- Run-level mocked app-server proof verifies an approval timeout returns `decline`, records exact failed tool evidence, and leaves the turn non-aborted.
- Visible fallback coverage verifies `approval_timeout` evidence remains obvious at normal verbosity without exposing arbitrary timeout error details.
- `node scripts/run-vitest.mjs src/agents/harness/host-capability.test.ts extensions/codex/src/app-server/approval-bridge.test.ts extensions/codex/src/app-server/elicitation-bridge.test.ts extensions/codex/src/app-server/event-projector.native-failures.test.ts src/agents/embedded-agent-runner/run/tool-error-warning.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- -t 'wires approval timeouts'`
- `node scripts/check-changed.mjs`
- `pnpm plugin-sdk:surface:check`
- `pnpm build`
- Direct sibling Codex source inspection confirms `Decline` rejects the command and continues the turn, while `Cancel` maps to abort/`TurnAborted`; the real exec approval list can omit `decline` while retaining `cancel`.
- Release-boundary check: the V2 host capability first appears only in `v2026.8.1-beta.2`; no stable release contains it. Per the beta-only SDK policy, this fixes the internal V2 shape directly without a compatibility alias.
- Authenticated isolated live proof used a real OpenAI API key and real Codex app-server in a temporary `CODEX_HOME`, workspace, and `OPENCLAW_STATE_DIR`. A deliberately outside-workspace command produced an approval list containing `accept` and `cancel` but no `decline`; the proof waited the real 120-second approval deadline, returned deny/timeout, verified the command did not execute, retained exact `approval_timeout` tool evidence, kept the turn non-aborted, and received a non-empty final assistant response. The live test passed in 145.94 seconds.
- Final Codex autoreview: clean, no accepted/actionable findings.

A broad `pnpm test:changed` run also surfaced independent failures in `src/claws/project.test.ts` and `src/worker/worker.runtime.test.ts`; both reproduce standalone and do not import this repair. They are tracked separately rather than mixed into this fix.
