### PR TITLE
fix(system-agent): reject a second staged proposal instead of overwriting the first

### DIFF
--- a/src/agents/tools/system-agent-tool.test.ts
+++ b/src/agents/tools/system-agent-tool.test.ts
@@ -6,6 +6,7 @@ import {
   resolveSystemAgentDirectiveTransition,
   resolveSystemAgentProposalTransition,
   type SystemAgentToolDirective,
+  type SystemAgentToolOptions,
 } from "./system-agent-tool.js";
 
 const mocks = vi.hoisted(() => ({
@@ -159,7 +160,7 @@ describe("openclaw tool", () => {
   });
 
   it("keeps the first staged config_set proposal instead of overwriting it with a second", async () => {
-    const proposalRef: { current?: string } = {};
+    const proposalRef: NonNullable<SystemAgentToolOptions["proposalRef"]> = {};
     const tool = createSystemAgentTool({ surface: "gateway", proposalRef });
 
     const first = await tool.execute("multi-a", {
@@ -181,6 +182,11 @@ describe("openclaw tool", () => {
     // operation: only one operation can ever be approved and applied.
     expect(toolText(second)).toContain("proposal-conflict");
     expect(proposalRef.current).toBe(firstHash);
+    expect(proposalRef.operation).toEqual({
+      kind: "config-set",
+      path: "tts.providers.fish-audio.model",
+      value: "s2.1-pro",
+    });
     expect(mocks.executeSystemAgentOperation).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/system-agent-tool.test.ts
+++ b/src/agents/tools/system-agent-tool.test.ts
@@ -158,6 +158,32 @@ describe("openclaw tool", () => {
     expect(proposalRef.current).toBeUndefined();
   });
 
+  it("keeps the first staged config_set proposal instead of overwriting it with a second", async () => {
+    const proposalRef: { current?: string } = {};
+    const tool = createSystemAgentTool({ surface: "gateway", proposalRef });
+
+    const first = await tool.execute("multi-a", {
+      action: "config_set",
+      path: "tts.providers.fish-audio.model",
+      value: "s2.1-pro",
+    });
+    expect(toolText(first)).toContain("needs-approval");
+    const firstHash = proposalRef.current;
+    expect(firstHash).toBeDefined();
+
+    const second = await tool.execute("multi-b", {
+      action: "config_set",
+      path: "talk.providers.fish-audio.model",
+      value: "s2.1-pro",
+    });
+
+    // The second, different path must not silently replace the first staged
+    // operation: only one operation can ever be approved and applied.
+    expect(toolText(second)).toContain("proposal-conflict");
+    expect(proposalRef.current).toBe(firstHash);
+    expect(mocks.executeSystemAgentOperation).not.toHaveBeenCalled();
+  });
+
   it("binds setup approval to the exact verified model and workspace", async () => {
     const proposalRef: { current?: string } = {};
     const args = {

--- a/src/agents/tools/system-agent-tool.test.ts
+++ b/src/agents/tools/system-agent-tool.test.ts
@@ -531,6 +531,14 @@ describe("openclaw tool", () => {
     expect(
       resolveSystemAgentProposalTransition({ args, resultText: "Default model updated." }),
     ).toEqual({ proposal: undefined });
+    // A rejected second proposal must not overwrite the mirrored first
+    // operation: the host keeps proposalRef untouched on a null transition.
+    expect(
+      resolveSystemAgentProposalTransition({
+        args: { action: "config_set", path: "talk.providers.fish-audio.model", value: "s2.1-pro" },
+        resultText: `proposal-conflict:${hash}\nA different operation is already staged and awaiting the user's approval.`,
+      }),
+    ).toBeNull();
     // Read actions and unparsable calls never touch the proposal.
     expect(
       resolveSystemAgentProposalTransition({ args: { action: "status" }, resultText: "ok" }),

--- a/src/agents/tools/system-agent-tool.ts
+++ b/src/agents/tools/system-agent-tool.ts
@@ -67,6 +67,7 @@ export function hashSystemAgentOperation(operation: SystemAgentOperation): strin
 /** Result markers shared with out-of-process hosts (CLI MCP runs). */
 const SYSTEM_AGENT_NEEDS_APPROVAL_PREFIX = "needs-approval:";
 const SYSTEM_AGENT_APPROVAL_MISMATCH_PREFIX = "approval-mismatch:";
+const SYSTEM_AGENT_PROPOSAL_CONFLICT_PREFIX = "proposal-conflict:";
 const SYSTEM_AGENT_DIRECTIVE_PREFIX = "directive:";
 const SYSTEM_AGENT_APPROVED_OPERATION_PREFIX = `${SYSTEM_AGENT_DIRECTIVE_PREFIX}approved-operation:`;
 
@@ -150,6 +151,11 @@ export function resolveSystemAgentProposalTransition(params: {
   }
   if (params.resultText.startsWith(SYSTEM_AGENT_APPROVAL_MISMATCH_PREFIX)) {
     return { proposal: undefined };
+  }
+  if (params.resultText.startsWith(SYSTEM_AGENT_PROPOSAL_CONFLICT_PREFIX)) {
+    // The already-staged proposal was kept as-is; this rejected call must not
+    // overwrite the mirrored operation with the one that was just refused.
+    return null;
   }
   if (params.resultText.startsWith(SYSTEM_AGENT_NEEDS_APPROVAL_PREFIX)) {
     const markerLine = params.resultText.split("\n", 1)[0] ?? "";
@@ -464,6 +470,16 @@ export function createSystemAgentTool(options: SystemAgentToolOptions): AnyAgent
             }
             return textResult(
               `${SYSTEM_AGENT_APPROVAL_MISMATCH_PREFIX} this call is not the operation the user approved. The approval is void; describe the new change and get a fresh yes before retrying.`,
+              { needsApproval: true },
+            );
+          }
+          const stagedProposal = options.proposalRef?.current;
+          if (stagedProposal !== undefined && stagedProposal !== operationHash) {
+            // A second unarmed persistent call must never silently replace the
+            // first: the model's response would then report both changes as
+            // staged while only the last-written one is ever applied.
+            return textResult(
+              `${SYSTEM_AGENT_PROPOSAL_CONFLICT_PREFIX}${stagedProposal}\nA different operation is already staged and awaiting the user's approval. It was NOT replaced. Tell the user only the first change is pending; get it approved (or explicitly declined) before proposing this one.`,
               { needsApproval: true },
             );
           }


### PR DESCRIPTION
## What Problem This Solves

A delegated Ask OpenClaw turn can issue two distinct persistent operations before the operator approves either one. The second operation replaced the first pending proposal. The reply could then imply both changes were staged, while approval applied only the second change.

This silently dropped the first requested config change.

## Why This Change Was Made

The proposal owner stores one exact operation for one operator approval. Each unapproved persistent tool call previously replaced that single slot.

This repair keeps that one-operation contract. A different later proposal now returns a visible conflict and leaves the first proposal unchanged. It does not add grouped or transactional proposals.

The command-line-interface harness mirrors tool results from another process. Its transition parser now treats the conflict result as no state change, so the host cannot clear or replace the first proposal.

Fixes #125609.

## User Impact

Before: a request for two config changes could report both as staged, then apply only the second after approval.

After: the second change is visibly rejected. The first change remains pending. Approving it applies only that first exact operation.

Identical retries of the first operation still refer to the same proposal. Armed mismatches still void approval. Declines and completed approvals still clear the pending proposal.

## Evidence

Live production-flow proof used the Ask OpenClaw agent loop, two model-issued `config_set` calls in one turn, the real typed `yes` approval path, disposable config, and a controlled OpenAI-compatible provider.

- Current `main` at `a4ef5726cc650af78b86d8504c9f659162e19907`: the second path became authoritative. Approval changed `gateway.bind` to `lan`; `gateway.port` stayed `19001`.
- Final head at `9c4f1d30096eb76b821e7be58bfb16432e136eab`: the reply said the second change was rejected and only the first remained pending. Approval changed `gateway.port` to `19002`; `gateway.bind` stayed `loopback`.
- Anti-cheat check: the saved config was read after approval. On the final head, only the first path changed.

Focused regression and sibling checks:

```text
node scripts/run-vitest.mjs src/agents/tools/system-agent-tool.test.ts
Test Files  1 passed (1)
Tests  16 passed (16)

node scripts/run-vitest.mjs src/system-agent/chat-turn-router.approval.test.ts
Test Files  1 passed (1)
Tests  110 passed (110)

node scripts/run-vitest.mjs src/system-agent/agent-turn.test.ts
Test Files  1 passed (1)
Tests  15 passed (15)

node_modules/.bin/oxfmt --check src/agents/tools/system-agent-tool.ts src/agents/tools/system-agent-tool.test.ts
All matched files use the correct format.

node scripts/run-oxlint.mjs src/agents/tools/system-agent-tool.ts src/agents/tools/system-agent-tool.test.ts
Exit 0
```

Hosted continuous integration owns type checking and the full build.

## Scope

- `src/agents/tools/system-agent-tool.ts`: reject a different second persistent proposal and preserve the first.
- `src/agents/tools/system-agent-tool.ts`: preserve command-line-interface mirrored state for that conflict result.
- `src/agents/tools/system-agent-tool.test.ts`: prove the first hash and stored operation both remain authoritative.

Production delta is +16 lines. The new lines define one visible conflict outcome at the proposal owner and its required no-change mapping at the process boundary. Reusing the mismatch outcome would incorrectly clear approval state.

No config schema, protocol, persistence schema, or default changed.

## AI Assistance

The contributor repair was implemented with Claude assistance. Maintainer review added the stored-operation assertion and live red/green production-flow proof.
