### PR TITLE
fix: stop showing raw image markdown beside attachments

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1116,6 +1116,51 @@ describe("runCliAgent reliability", () => {
     expect(JSON.stringify(result)).not.toContain("/tmp/untrusted.png");
   });
 
+  it("deduplicates a CLI Markdown image selected from structured tool media", async () => {
+    const mediaUrl = "/root/.openclaw/media/tool-image-generation/our-agent-soviet-meme.png";
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<ReturnType<typeof getProcessSupervisor>["spawn"]>[0];
+      const captureHandle = markMcpLoopbackToolCallStarted({
+        captureKey: input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "",
+        toolName: "image_generate",
+        args: { prompt: "our agent" },
+      });
+      if (!captureHandle) {
+        throw new Error("Expected outbound media capture");
+      }
+      recordMcpLoopbackToolCallResult({
+        captureHandle,
+        toolName: "image_generate",
+        args: { prompt: "our agent" },
+        result: {
+          content: [{ type: "text", text: "Image generated" }],
+          details: { media: { mediaUrls: [mediaUrl], trustedLocalMedia: true } },
+        },
+        outcome: "completed",
+      });
+      markMcpLoopbackToolCallFinished(captureHandle);
+      return makeManagedRun({
+        stdout: `Our agent.\n\n![Our Agent meme](${mediaUrl})`,
+      });
+    });
+    const context = makeClaudePreparedContext({
+      sessionKey: "agent:main:markdown-tool-media",
+      runId: "run-markdown-tool-media",
+    });
+    context.mcpDeliveryCapture = true;
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.payloads).toEqual([
+      {
+        text: "Our agent.",
+        mediaUrls: [mediaUrl],
+        mediaUrl,
+        trustedLocalMedia: true,
+      },
+    ]);
+  });
+
   it("surfaces a CLI failure after a delivered progress reply", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
@@ -219,6 +219,48 @@ describe("mergeAttemptToolMediaPayloads", () => {
     });
   });
 
+  it("uses exact structured Markdown references to select tool media", () => {
+    const selected = "/root/.openclaw/media/tool-image-generation/our-agent-soviet-meme.png";
+    const unselected = "/root/.openclaw/media/tool-image-generation/alternate.png";
+    const visibleReply = setReplyPayloadMetadata(
+      { text: `Our agent.\n\n![Our Agent meme](${selected})` },
+      { assistantMessageIndex: 7 },
+    );
+
+    const [reply] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [visibleReply],
+        toolMediaUrls: [selected, unselected],
+        toolTrustedLocalMedia: true,
+      }) ?? [];
+
+    expect(reply).toEqual({
+      text: "Our agent.",
+      mediaUrls: [selected],
+      mediaUrl: selected,
+      audioAsVoice: undefined,
+      trustedLocalMedia: true,
+    });
+    expect(getReplyPayloadMetadata(reply ?? {})).toEqual({ assistantMessageIndex: 7 });
+  });
+
+  it("keeps unmatched local Markdown visible without selecting it", () => {
+    const input = "Caption\n\n![not tool media](/tmp/unrelated.png)";
+
+    expect(
+      mergeAttemptToolMediaPayloads({
+        payloads: [{ text: input }],
+        toolMediaUrls: ["/tmp/pending.png"],
+      }),
+    ).toEqual([
+      {
+        text: input,
+        mediaUrls: ["/tmp/pending.png"],
+        mediaUrl: "/tmp/pending.png",
+      },
+    ]);
+  });
+
   it("preserves trusted local media provenance when merging tool media", () => {
     expect(
       mergeAttemptToolMediaPayloads({

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -7,6 +7,7 @@ import {
   getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
 } from "../../../auto-reply/reply-payload.js";
+import { splitMediaFromOutput } from "../../../media/parse.js";
 import type { EmbeddedAgentRunResult } from "../types.js";
 
 /** Channel payload shape produced by embedded runs after auto-reply normalization. */
@@ -26,9 +27,31 @@ export function mergeAttemptToolMediaPayloads(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 }): EmbeddedRunPayload[] | undefined {
   // Trim and dedupe tool media before merging with assistant-owned payload media.
-  const mediaUrls = Array.from(
+  let mediaUrls = Array.from(
     new Set(params.toolMediaUrls?.map((url) => url.trim()).filter(Boolean) ?? []),
   );
+  const payloads = params.payloads?.length ? [...params.payloads] : [];
+  const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning);
+  const visiblePayload = payloads.at(payloadIndex);
+  const isSourceReplyTranscriptMirror =
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    visiblePayload &&
+    getReplyPayloadMetadata(visiblePayload)?.sourceReplyTranscriptMirror;
+  if (visiblePayload?.text && mediaUrls.length > 0 && !isSourceReplyTranscriptMirror) {
+    const selected = splitMediaFromOutput(visiblePayload.text, {
+      extractAudioDirectives: false,
+      extractMediaDirectives: false,
+      markdownImageAllowlist: mediaUrls,
+    });
+    if (selected.mediaUrls?.length) {
+      const selectedMediaUrls = new Set(selected.mediaUrls);
+      mediaUrls = mediaUrls.filter((url) => selectedMediaUrls.has(url));
+      payloads[payloadIndex] = copyReplyPayloadMetadata(visiblePayload, {
+        ...visiblePayload,
+        text: selected.text,
+      });
+    }
+  }
   const mediaUrlSet = new Set(mediaUrls);
   const hostOwnedMediaUrls = Array.from(
     new Set(
@@ -65,17 +88,12 @@ export function mergeAttemptToolMediaPayloads(params: {
     ];
   };
 
-  const payloads = params.payloads?.length ? [...params.payloads] : [];
-  const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning);
   if (payloadIndex >= 0) {
     const payload = payloads.at(payloadIndex);
     if (!payload) {
       return payloads;
     }
-    if (
-      params.sourceReplyDeliveryMode === "message_tool_only" &&
-      getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror
-    ) {
+    if (isSourceReplyTranscriptMirror) {
       // Message-tool-only source replies are transcript mirrors of a send that
       // already happened elsewhere; attaching generated media here would create
       // a duplicate channel delivery.

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -383,6 +383,17 @@ describe("splitMediaFromOutput", () => {
     );
   });
 
+  it("extracts only exact allowlisted Markdown image targets", () => {
+    expectParsedMediaOutputCase(
+      "Before ![selected](/tmp/selected.png) after ![remote](https://example.com/remote.png)",
+      {
+        text: "Before after ![remote](https://example.com/remote.png)",
+        mediaUrls: ["file:///tmp/selected.png"],
+      },
+      { markdownImageAllowlist: ["file:///tmp/selected.png"] },
+    );
+  });
+
   it("keeps inline caption text around markdown images when enabled", () => {
     expectParsedMediaOutputCase(
       "Look ![chart](https://example.com/chart.png) now",

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -33,6 +33,7 @@ type SplitMediaFromOutputOptions = {
   extractAudioDirectives?: boolean;
   extractMarkdownImages?: boolean;
   extractMediaDirectives?: boolean;
+  markdownImageAllowlist?: readonly string[];
 };
 
 const FILE_URL_PREFIX_RE = /^file:(?:\/\/)?/i;
@@ -243,6 +244,10 @@ function unwrapQuoted(value: string): string | undefined {
   return trimmed.slice(1, -1).trim();
 }
 
+function normalizeMarkdownImageDestination(destination: string): string {
+  return normalizeMediaSource(cleanCandidate(unwrapQuoted(destination) ?? destination));
+}
+
 function mayContainFenceMarkers(input: string): boolean {
   return input.includes("```") || input.includes("~~~");
 }
@@ -448,7 +453,11 @@ function findMarkdownImageMatches(line: string): MarkdownImageMatch[] {
   return matches;
 }
 
-function collectMarkdownImageSegments(params: { line: string; media: string[] }): {
+function collectMarkdownImageSegments(params: {
+  line: string;
+  media: string[];
+  allowlist?: ReadonlyMap<string, string>;
+}): {
   cleanedLine?: string;
   lineSegments: ParsedMediaOutputSegment[];
   foundMedia: boolean;
@@ -469,17 +478,17 @@ function collectMarkdownImageSegments(params: { line: string; media: string[] })
     segmentPieces.push(before);
     visiblePieces.push(before);
 
-    const target = normalizeMediaSource(
-      cleanCandidate(unwrapQuoted(match.destination) ?? match.destination),
-    );
-    if (isRemoteMarkdownImageMedia(target)) {
+    const target = normalizeMarkdownImageDestination(match.destination);
+    const selectedTarget = params.allowlist?.get(target);
+    if (selectedTarget || (!params.allowlist && isRemoteMarkdownImageMedia(target))) {
       const beforeText = cleanLineText(segmentPieces.join(""));
       if (beforeText) {
         lineSegments.push({ type: "text", text: beforeText });
       }
       segmentPieces.length = 0;
-      params.media.push(target);
-      lineSegments.push({ type: "media", url: target });
+      const mediaTarget = selectedTarget ?? target;
+      params.media.push(mediaTarget);
+      lineSegments.push({ type: "media", url: mediaTarget });
       foundMedia = true;
     } else {
       const original = params.line.slice(match.start, match.end);
@@ -522,7 +531,17 @@ export function splitMediaFromOutput(
   if (!trimmedRaw.trim()) {
     return { text: "" };
   }
-  const extractMarkdownImages = options.extractMarkdownImages === true;
+  const markdownImageAllowlist =
+    options.markdownImageAllowlist === undefined
+      ? undefined
+      : new Map(
+          options.markdownImageAllowlist.map((source) => [
+            normalizeMarkdownImageDestination(source),
+            source,
+          ]),
+        );
+  const extractMarkdownImages =
+    markdownImageAllowlist !== undefined || options.extractMarkdownImages === true;
   const extractMediaDirectives = options.extractMediaDirectives !== false;
   const mayContainMediaToken = extractMediaDirectives && /media:/i.test(trimmedRaw);
   const mayContainMarkdownImage = extractMarkdownImages && /!\[[^\]]*]\(/.test(trimmedRaw);
@@ -571,7 +590,7 @@ export function splitMediaFromOutput(
     const trimmedStart = line.trimStart();
     if (!extractMediaDirectives || !trimmedStart.toUpperCase().startsWith("MEDIA:")) {
       const markdownImageResult = extractMarkdownImages
-        ? collectMarkdownImageSegments({ line, media })
+        ? collectMarkdownImageSegments({ line, media, allowlist: markdownImageAllowlist })
         : { lineSegments: [], foundMedia: false };
       if (!markdownImageResult.foundMedia) {
         keptLines.push(line);


### PR DESCRIPTION
Closes #125655

AI-assisted: Yes. The implementation and evidence were reviewed and understood; no agent transcript or session log is included.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users receiving generated media in Discord or sibling text/media channels could see a raw local Markdown image path beside the same attachment after a CLI-backed structured-media handoff.

The regression became visible after #124910 (`b65879e4b648`) extended structured media capture to the CLI runtime. The shared payload owner then combined the assistant's Markdown representation with the same trusted structured tool media. Discord correctly rendered the full text as the caption and uploaded the attachment once.

## Why This Change Was Made

The shared tool-media payload owner now reconciles assistant presentation with already-trusted structured media. It uses an exact allowlist through the existing bounded Markdown image parser: only destinations that normalize to an already-owned tool media URL are consumed and selected, while surrounding text, metadata, provenance, ordering, and existing source-reply behavior are preserved.

This does not weaken local-path security, promote arbitrary Markdown paths, add channel-specific cleanup, or create a second parser. Discord remains a transport consumer rather than the policy owner.

## User Impact

Users receive one clean caption plus one attachment when assistant Markdown exactly references trusted structured tool media. Unmatched local Markdown remains plain visible text and is not promoted to an attachment; unrelated remote Markdown remains unchanged in exact-allowlist mode.

## Evidence

### Reproduction and observed payload

Before:

```json
{
  "text": "Our agent.\n\n![Our Agent meme](/root/.openclaw/media/tool-image-generation/generated.png)",
  "mediaUrl": "/root/.openclaw/media/tool-image-generation/generated.png"
}
```

After:

```json
{
  "text": "Our agent.",
  "mediaUrl": "/root/.openclaw/media/tool-image-generation/generated.png"
}
```

The actual Discord outbound adapter with a mock transport produced exactly one send after the fix: caption `Our agent.` and one media URL at the generated path. This is deterministic adapter proof, not a live external Discord send.

A source-blind behavior validation also varied an unmatched `/tmp/unrelated.png` Markdown target. The exact structured reference was stripped and delivered once; the unmatched local Markdown remained visible and was not promoted.

### Focused tests

```shell
node scripts/run-vitest.mjs src/media/parse.test.ts src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts src/agents/cli-runner.reliability.test.ts
```

Result after rebasing onto `origin/main`: 3 files, 214 tests passed (124 unit-fast + 90 agents-core) in 98.56s.

### Changed-file gate

```shell
node scripts/check-changed.mjs -- src/media/parse.ts src/media/parse.test.ts src/agents/embedded-agent-runner/run/tool-media-payloads.ts src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts src/agents/cli-runner.reliability.test.ts
```

Result: passed all selected core/core-test formatting, typecheck, lint, dead-export, import-cycle, max-lines/assertion ratchet, database/media, and runtime guard lanes.

```shell
git diff --check origin/main...HEAD
```

Result: clean.

### Review, size, and dependency contract

- Fresh branch-mode autoreview: TruffleHog clean; no accepted/actionable findings; patch judged correct for the scoped owner-boundary repair.
- Production LOC: +53/-16 (net +37). Tests: +98/-0. The production growth is the canonical exact-allowlist parser seam plus the shared tool-media owner repair; there is no channel guard or duplicate parser.
- Direct Codex source inspection at `86b1123ff6b5` confirmed generated image results persist `savedPath`, and the model-facing output explicitly says the image is already displayed and need not be repeated as Markdown. No upstream Codex change is needed.

### Live-proof limitation

No live external Discord send was performed because the only provided visual capture contains private workspace data, and the operator's live Gateway was not modified. The actual Discord adapter with mock transport plus source-blind behavior validation covered the changed path; neither is claimed as live-channel proof.
