### PR TITLE
fix(tui): local /auth exits 1 with no diagnostics when the session provider is CLI-backed

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   resolveAgentDir: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentWorkspaceDir: vi.fn(),
+  isCliProvider: vi.fn(),
   upsertAuthProfile: vi.fn(),
   upsertAuthProfileAfterLoginWithLock: vi.fn(),
   upsertAuthProfileWithLock: vi.fn(),
@@ -124,6 +125,10 @@ vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
 
 vi.mock("../../agents/workspace.js", () => ({
   resolveDefaultAgentWorkspaceDir: mocks.resolveDefaultAgentWorkspaceDir,
+}));
+
+vi.mock("../../agents/model-selection-cli.js", () => ({
+  isCliProvider: mocks.isCliProvider,
 }));
 
 vi.mock("../../plugins/providers.runtime.js", () => ({
@@ -372,6 +377,7 @@ describe("modelsAuthLoginCommand", () => {
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.resolveDefaultAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.isRemoteEnvironment.mockReturnValue(false);
+    mocks.isCliProvider.mockReturnValue(false);
     mocks.resolvePluginSetupProviderCore.mockReturnValue(undefined);
     mocks.resolvePluginSetupRegistry.mockReturnValue({
       providers: [],
@@ -1239,6 +1245,44 @@ describe("modelsAuthLoginCommand", () => {
 
     await expect(modelsAuthLoginCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
       'Unknown provider "anthropic". Loaded providers: openai. Verify plugins via `openclaw plugins list --json`.',
+    );
+  });
+
+  it("opens the provider picker when a CLI backend has no provider auth method", async () => {
+    const runtime = createRuntime();
+    const prompter = {
+      note: vi.fn(async () => {}),
+      select: vi.fn(async () => "openai"),
+    };
+    mocks.createClackPrompter.mockReturnValue(prompter);
+    mocks.isCliProvider.mockImplementation((provider: string) => provider === "claude-cli");
+    const openaiProvider = createProvider({
+      id: "openai",
+      label: "OpenAI Codex",
+      run: runProviderAuth as ProviderPlugin["auth"][number]["run"],
+    });
+    mocks.resolvePluginProvidersCore.mockImplementation(
+      (params: ResolvePluginProvidersCall | undefined) =>
+        params?.providerRefs?.includes("claude-cli") ? [] : [openaiProvider],
+    );
+
+    await modelsAuthLoginCommand({ provider: "claude-cli" }, runtime);
+
+    expect(prompter.note).toHaveBeenCalledWith(
+      'Provider "claude-cli" uses its own CLI login. Select a provider with an OpenClaw auth flow.',
+      "Provider auth",
+    );
+    expect(prompter.select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select a provider" }),
+    );
+    expect(runProviderAuth).toHaveBeenCalledOnce();
+    expect(mocks.resolvePluginProvidersCore).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ providerRefs: ["claude-cli"], activate: true }),
+    );
+    expect(mocks.resolvePluginProvidersCore).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({ providerRefs: expect.anything() }),
     );
   });
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -25,6 +25,7 @@ import {
 } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { normalizeProviderId } from "../../agents/model-ref-shared.js";
+import { isCliProvider } from "../../agents/model-selection-cli.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -950,23 +951,43 @@ function maybeLogOpenAICodexNativeSearchTip(runtime: RuntimeEnv, providerId: str
 export async function runModelsAuthLoginFlowCore(
   opts: ModelsAuthLoginFlowOptions,
 ): Promise<ModelsAuthLoginFlowResult> {
-  const { config, agentId, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
-    requestedProvider: opts.provider,
+  const requestedProviderId = opts.provider
+    ? normalizeManualAuthProvider(opts.provider)
+    : undefined;
+  let context = await resolveModelsAuthContext({
+    requestedProvider: requestedProviderId,
     rawAgentId: opts.agent,
     config: opts.config,
   });
   const prompter = opts.prompter;
-  const authProviders = listProvidersWithAuthMethods(providers);
+  let authProviders = listProvidersWithAuthMethods(context.providers);
+  let requestedProvider = requestedProviderId
+    ? resolveProviderMatch(authProviders, requestedProviderId)
+    : null;
+  const useProviderPicker =
+    requestedProviderId !== undefined &&
+    requestedProvider === null &&
+    isCliProvider(requestedProviderId, context.config);
+  if (useProviderPicker) {
+    context = await resolveModelsAuthContext({
+      rawAgentId: opts.agent,
+      config: context.config,
+    });
+    authProviders = listProvidersWithAuthMethods(context.providers);
+  }
   if (authProviders.length === 0) {
     throw new Error(
       `No provider plugins found. Install one via \`${formatCliCommand("openclaw plugins install")}\`.`,
     );
   }
-
-  const requestedProvider = resolveRequestedLoginProviderOrThrow(
-    authProviders,
-    opts.provider ? normalizeManualAuthProvider(opts.provider) : undefined,
-  );
+  if (useProviderPicker) {
+    await prompter.note(
+      `Provider "${requestedProviderId}" uses its own CLI login. Select a provider with an OpenClaw auth flow.`,
+      "Provider auth",
+    );
+  } else if (requestedProviderId && !requestedProvider) {
+    requestedProvider = resolveRequestedLoginProviderOrThrow(authProviders, requestedProviderId);
+  }
   const selectedProvider =
     requestedProvider ??
     (await prompter
@@ -1010,7 +1031,7 @@ export async function runModelsAuthLoginFlowCore(
     try {
       const clearedStore = await removeProviderAuthProfilesWithLock({
         provider: selectedProvider.id,
-        agentDir,
+        agentDir: context.agentDir,
       });
       if (!clearedStore) {
         throw new Error("profile store update failed");
@@ -1028,10 +1049,10 @@ export async function runModelsAuthLoginFlowCore(
   }
 
   const { result, profiles } = await runProviderAuthMethod({
-    config,
-    agentId,
-    agentDir,
-    workspaceDir,
+    config: context.config,
+    agentId: context.agentId,
+    agentDir: context.agentDir,
+    workspaceDir: context.workspaceDir,
     provider: selectedProvider,
     method: chosenMethod,
     runtime: opts.runtime,

--- a/src/tui/tui-auth-child-pty.e2e.test.ts
+++ b/src/tui/tui-auth-child-pty.e2e.test.ts
@@ -12,7 +12,7 @@ const STARTUP_TIMEOUT_MS = 60_000;
 const EXIT_TIMEOUT_MS = 4_000;
 const tempDirs: string[] = [];
 
-async function createCodexFixture(exitMs?: number) {
+async function createCodexFixture(exitMs?: number, exitCode = 0) {
   const dir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-auth-"));
   tempDirs.push(dir);
   const scriptPath = path.join(dir, "codex-fixture.cjs");
@@ -22,7 +22,7 @@ async function createCodexFixture(exitMs?: number) {
       'console.log("AUTH_CHILD_STARTED:" + process.pid);',
       exitMs === undefined
         ? "setInterval(() => {}, 1000);"
-        : `setTimeout(() => process.exit(0), ${String(exitMs)});`,
+        : `setTimeout(() => process.exit(${String(exitCode)}), ${String(exitMs)});`,
     ].join("\n"),
     "utf8",
   );
@@ -101,6 +101,26 @@ describe.sequential("TUI auth child lifecycle", () => {
       await fixture.run.waitForOutput("auth flow finished for openai", STARTUP_TIMEOUT_MS);
       await fixture.run.write("/gateway-status\r", { delay: false });
       await fixture.run.waitForOutput("fixture gateway ok", STARTUP_TIMEOUT_MS);
+    },
+    STARTUP_TIMEOUT_MS * 2,
+  );
+
+  it(
+    "keeps a failed auth command visible after the TUI resumes",
+    async () => {
+      const auth = await createCodexFixture(50, 1);
+      const fixture = await startTuiFixture({
+        env: {
+          PATH: auth.pathEnv,
+        },
+      });
+      await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+      await fixture.run.write("/auth openai\r", { delay: false });
+      await fixture.run.waitForOutput("auth flow failed (exit 1)", STARTUP_TIMEOUT_MS);
+      await fixture.run.waitForOutput(
+        "in a regular terminal to see its output",
+        STARTUP_TIMEOUT_MS,
+      );
     },
     STARTUP_TIMEOUT_MS * 2,
   );

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -191,7 +191,11 @@ function createHarness(params?: {
   const runAuthFlow: RunAuthFlow | undefined =
     params?.runAuthFlow ??
     (params?.opts?.local
-      ? (vi.fn().mockResolvedValue({ exitCode: 0, signal: null }) as unknown as RunAuthFlow)
+      ? (vi.fn().mockResolvedValue({
+          exitCode: 0,
+          signal: null,
+          commandArgv: '["codex","login"]',
+        }) as unknown as RunAuthFlow)
       : undefined);
   const state = {
     agentDefaultId: params?.agentDefaultId ?? "main",
@@ -3130,7 +3134,11 @@ describe("tui command handlers", () => {
 
   it("runs /auth through the local auth flow and refreshes session info", async () => {
     const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
-    const runAuthFlow = vi.fn().mockResolvedValue({ exitCode: 0, signal: null });
+    const runAuthFlow = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      commandArgv: '["codex","login"]',
+    });
     const { handleCommand, addSystem, setActivityStatus } = createHarness({
       opts: { local: true },
       refreshSessionInfo,
@@ -3148,6 +3156,25 @@ describe("tui command handlers", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
   });
 
+  it("shows the failed auth command and a safe terminal retry", async () => {
+    const runAuthFlow = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      signal: null,
+      commandArgv: '["codex","login"]',
+    });
+    const { handleCommand, addSystem, setActivityStatus } = createHarness({
+      opts: { local: true },
+      runAuthFlow,
+    });
+
+    await handleCommand("/auth openai");
+
+    expect(addSystem).toHaveBeenCalledWith(
+      'auth flow failed (exit 1) — command argv: ["codex","login"]; retry provider login in a regular terminal to see its output',
+    );
+    expect(setActivityStatus).toHaveBeenLastCalledWith("error");
+  });
+
   it("rejects /auth in non-local mode", async () => {
     const { handleCommand, addSystem } = createHarness();
 
@@ -3157,7 +3184,11 @@ describe("tui command handlers", () => {
   });
 
   it("blocks /auth while an optimistic run is still pending", async () => {
-    const runAuthFlow = vi.fn().mockResolvedValue({ exitCode: 0, signal: null });
+    const runAuthFlow = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      commandArgv: '["codex","login"]',
+    });
     const { handleCommand, addSystem } = createHarness({
       opts: { local: true },
       pendingSubmit: {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -93,9 +93,11 @@ type CommandHandlerContext = {
   consumeCompletedRunForPendingSend?: (runId: string) => boolean;
   isRunObserved?: (runId: string) => boolean;
   flushPendingHistoryRefreshIfIdle?: () => void;
-  runAuthFlow?: (params: {
-    provider?: string;
-  }) => Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>;
+  runAuthFlow?: (params: { provider?: string }) => Promise<{
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+    commandArgv: string;
+  }>;
   requestExit: (result?: Partial<TuiResult>) => void;
 };
 
@@ -500,7 +502,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             : typeof result.exitCode === "number"
               ? ` (exit ${String(result.exitCode)})`
               : "";
-          chatLog.addSystem(`auth flow failed${failureSuffix}`);
+          chatLog.addSystem(
+            `auth flow failed${failureSuffix} — command argv: ${result.commandArgv}; retry provider login in a regular terminal to see its output`,
+          );
           setActivityStatus("error");
         }
       } catch (err) {

--- a/src/tui/tui.local-auth.test.ts
+++ b/src/tui/tui.local-auth.test.ts
@@ -1,4 +1,8 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withEnv } from "../test-utils/env.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   formatTuiAuthCommandArgv,
   resolveCodexCliBin,
@@ -17,6 +21,25 @@ describe("formatTuiAuthCommandArgv", () => {
     expect(
       formatTuiAuthCommandArgv("/tmp/" + "x".repeat(400), ["login"]).length,
     ).toBeLessThanOrEqual(320);
+  });
+
+  it("keeps built-in masking when custom log patterns are configured", async () => {
+    await withTempDir("openclaw-tui-auth-redaction-", async (dir) => {
+      const configPath = path.join(dir, "openclaw.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ logging: { redactPatterns: ["project-secret-\\d+"] } }),
+      );
+      const token = "sk-proof-only-1234567890";
+      const customSecret = "project-secret-12345";
+
+      const rendered = withEnv({ OPENCLAW_CONFIG_PATH: configPath }, () =>
+        formatTuiAuthCommandArgv("codex", ["login", token, customSecret]),
+      );
+
+      expect(rendered).not.toContain(token);
+      expect(rendered).not.toContain(customSecret);
+    });
   });
 });
 

--- a/src/tui/tui.local-auth.test.ts
+++ b/src/tui/tui.local-auth.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { resolveCodexCliBin, resolveLocalAuthSpawnInvocation } from "./tui.js";
+import {
+  formatTuiAuthCommandArgv,
+  resolveCodexCliBin,
+  resolveLocalAuthSpawnInvocation,
+} from "./tui.js";
+
+describe("formatTuiAuthCommandArgv", () => {
+  it("renders bounded redacted argv without shell semantics", () => {
+    const rendered = formatTuiAuthCommandArgv("C:\\Users\\%USERNAME%\\codex.exe\n", ["login"]);
+    expect(rendered).toContain("%USERNAME%");
+    expect(rendered).toContain("\\n");
+    expect(rendered).not.toContain("\n");
+
+    const secret = "sk-proof-only-1234567890";
+    expect(formatTuiAuthCommandArgv("codex", ["login", secret])).not.toContain(secret);
+    expect(
+      formatTuiAuthCommandArgv("/tmp/" + "x".repeat(400), ["login"]).length,
+    ).toBeLessThanOrEqual(320);
+  });
+});
 
 describe("resolveCodexCliBin", () => {
   it("returns null or a valid Codex executable path", async () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -9,6 +9,7 @@ import {
   Text,
   TuiMainScreen,
 } from "@earendil-works/pi-tui";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { classifyGatewayConnectFailure } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js";
 import {
@@ -30,7 +31,9 @@ import { resolveCurrentOpenClawCliInvocation } from "../infra/openclaw-cli-invoc
 import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { setConsoleSubsystemFilter } from "../logging/console.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import { loggingState } from "../logging/state.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
   buildWindowsCmdExeCommandLine,
@@ -98,8 +101,10 @@ export {
 
 const OPENAI_CODEX_PROVIDER = "openai";
 const CODEX_CLI_LOOKUP_TIMEOUT_MS = 5_000;
+const TUI_AUTH_COMMAND_MAX_CHARS = 320;
 const SESSION_SUBSCRIPTION_MAX_ATTEMPTS = 5;
 const SESSION_SUBSCRIPTION_RETRY_DELAY_MS = 25;
+const tuiAuthLog = createSubsystemLogger("tui/auth");
 
 type RunTuiOptions = TuiOptions & {
   /** Explicit owner for a global session key, which cannot carry an agent prefix itself. */
@@ -181,6 +186,13 @@ export function resolveTuiLocalAuthCliInvocation(params: {
       execArgv: params.execArgv ?? process.execArgv,
     },
   );
+}
+
+export function formatTuiAuthCommandArgv(command: string, args: readonly string[]): string {
+  const value = sanitizeRenderableLine(redactSensitiveText(JSON.stringify([command, ...args])));
+  return value.length > TUI_AUTH_COMMAND_MAX_CHARS
+    ? `${truncateUtf16Safe(value, TUI_AUTH_COMMAND_MAX_CHARS - 1)}…`
+    : value;
 }
 
 export function resolveTuiSessionKey(params: {
@@ -1362,12 +1374,8 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
         await withTuiSuspended(async () => {
           const provider = params.provider?.trim() || undefined;
 
-          // Codex owns its auth store; delegate when the CLI is available.
-          const codexBin =
-            provider === OPENAI_CODEX_PROVIDER ||
-            (!provider && state.sessionInfo.modelProvider === OPENAI_CODEX_PROVIDER)
-              ? await resolveCodexCliBin()
-              : null;
+          // Codex owns its auth store; the command handler already resolves the session provider.
+          const codexBin = provider === OPENAI_CODEX_PROVIDER ? await resolveCodexCliBin() : null;
 
           let command: string;
           let args: string[];
@@ -1382,14 +1390,30 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
           }
 
           const invocation = resolveLocalAuthSpawnInvocation({ command, args });
-          return await authChild.spawnAndWait(() =>
-            spawn(invocation.command, invocation.args, {
-              cwd,
-              env: process.env,
-              stdio: "inherit",
-              ...invocation.options,
-            }),
-          );
+          const commandArgv = formatTuiAuthCommandArgv(command, args);
+          tuiAuthLog.info(`auth child spawn: argv=${commandArgv}`);
+          try {
+            const result = await authChild.spawnAndWait(() =>
+              spawn(invocation.command, invocation.args, {
+                cwd,
+                env: process.env,
+                stdio: "inherit",
+                ...invocation.options,
+              }),
+            );
+            const outcome = `argv=${commandArgv} exitCode=${String(result.exitCode)} signal=${String(result.signal)}`;
+            if (result.exitCode === 0 && !result.signal) {
+              tuiAuthLog.info(`auth child finished: ${outcome}`);
+            } else {
+              tuiAuthLog.error(`auth child failed: ${outcome}`);
+            }
+            return { ...result, commandArgv };
+          } catch (error) {
+            tuiAuthLog.error(
+              `auth child failed to start: argv=${commandArgv} error=${formatTuiErrorMessage(error)}`,
+            );
+            throw error;
+          }
         })
     : undefined;
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -31,7 +31,7 @@ import { resolveCurrentOpenClawCliInvocation } from "../infra/openclaw-cli-invoc
 import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { setConsoleSubsystemFilter } from "../logging/console.js";
-import { redactSensitiveText } from "../logging/redact.js";
+import { redactToolPayloadText } from "../logging/redact.js";
 import { loggingState } from "../logging/state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -189,7 +189,7 @@ export function resolveTuiLocalAuthCliInvocation(params: {
 }
 
 export function formatTuiAuthCommandArgv(command: string, args: readonly string[]): string {
-  const value = sanitizeRenderableLine(redactSensitiveText(JSON.stringify([command, ...args])));
+  const value = sanitizeRenderableLine(redactToolPayloadText(JSON.stringify([command, ...args])));
   return value.length > TUI_AUTH_COMMAND_MAX_CHARS
     ? `${truncateUtf16Safe(value, TUI_AUTH_COMMAND_MAX_CHARS - 1)}…`
     : value;


### PR DESCRIPTION
Closes #125635

## What Problem This Solves

Fixes an issue where local TUI users could run `/auth`, get only `auth flow failed (exit 1)`, and find no useful `tui/auth` record.

It also fixes a dead end where a session that uses a CLI-only provider could send that provider to an OpenClaw auth wizard that cannot authenticate it.

## Why This Change Was Made

The foreground auth-child owner now records one bounded, redacted JSON argument list and the child result. The TUI uses that same result for the visible failure message. This preserves the existing child shutdown owner from #126476.

The provider-auth command now detects a requested CLI-only provider through the existing provider registry. It explains the mismatch and opens the supported provider picker. It does not hardcode a provider.

Explicit OpenAI auth still delegates to `codex login`. Session-derived CLI providers no longer enter the Codex path by accident.

## User Impact

- A failed local `/auth` action ends with an actionable bounded result.
- The file log records redacted `tui/auth` spawn and result events.
- A CLI-only session provider opens the provider picker instead of a dead-end wizard.
- Interactive terminal behavior, successful provider auth, and Codex delegation stay unchanged.

## Evidence

Live red and green used the real local TUI in a PTY. Each run used disposable `HOME`, OpenClaw state, config, XDG, workspace, binary, and temp directories. A deterministic child failed or succeeded at the real process boundary.

| Scenario | Dispatch main `640d73e` | Live-proven repair `cb1aaf0` |
| --- | --- | --- |
| Failed `/auth openai` | Final frame: `auth flow failed (exit 1)`; 0 `tui/auth` records | Final frame includes bounded redacted JSON arguments and retry guidance; 2 `tui/auth` records |
| Session provider is CLI-only | Provider command rejects the provider; final result stays generic | Provider picker opens; captured child arguments are `["models","auth","login","--provider","claude-cli"]` |
| Explicit `/auth openai` | Delegates to Codex | Still delegates to Codex; captured Codex arguments are `["login"]`; TUI reports success |

The failure child wrote a fake secret-like diagnostic. It did not appear in the repaired visible result or either repaired `tui/auth` record.

The security follow-up at `cbdcb64` changes only the auth argument redactor and its regression test. Auth arguments now use the existing merged UI-payload policy, so custom `logging.redactPatterns` add to built-in token masking instead of replacing it. The new formatter-boundary test failed on `cb1aaf0` because a token-shaped argument remained visible, then passed on `cbdcb64`; the operator's custom pattern remained active in the same result.

Current `main` was also checked at `5b07247`. The affected auth and redaction owner files have no overlapping repair that supersedes this PR.

### Required Codex Source Check

The reviewer personally inspected the sibling Codex source at commit `a73bf25d17805` and mapped it to the retained PTY result:

- `codex-rs/cli/src/main.rs:1515-1555` routes a bare `login` argument to `run_login_with_chatgpt`.
- `codex-rs/cli/src/login.rs:116-119` writes browser-login guidance to stderr.
- `codex-rs/cli/src/login.rs:170-200` exits with status 0 on success or status 1 with an stderr error on failure.
- The repaired PTY capture records the explicit OpenAI child arguments as exactly `["login"]`.
- The OpenClaw child keeps inherited interactive standard input and output, so the Codex interaction contract is unchanged.

Validation on the exact repaired head:

- One full build passed. Its build and runtime stamps name `cb1aaf06f30e631f496f37333caa264b3d3a55ed`.
- 230 focused TUI tests passed on the live-proven repair.
- 45 provider-auth tests passed on the live-proven repair.
- 3 real-PTY auth-child tests passed on the live-proven repair.
- The security follow-up passed 179 redaction tests and 6 TUI auth tests.
- The security regression failed before the redactor cutover and passed after it.
- Focused formatting and lint passed on the security follow-up.
- Exact-head hosted CI passed on `cbdcb64ceda68daa6dc9c7b1d4e7613f1ec58573`.
- Exact-head local ClawSweeper passed with no findings, security concerns, maintainer decisions, or rank-up moves.
- The changed-scope gate passed formatting, type checks, lint, dead-code scans, dependency guards, and repository guards.
- `git diff --check` passed.

## Change Size

- Production: `+80/-31` lines, net `+49`.
- Tests: `+143/-6` lines, net `+137`.

The production growth adds one bounded diagnostic result at the existing foreground-child owner and one registry-driven picker route. The security follow-up is net-neutral production and reuses the existing merged UI redactor. The repair replaces the contributor branch's parallel lifecycle path and reduces its earlier net production growth by 96 lines. No new config, schema, protocol, fallback stack, or provider-specific policy was added.
