### PR TITLE
fix(ui): start cloud workers from registered projects

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -208,8 +208,16 @@ suite.define(() => {
         "Syncs target-repo to the cloud worker",
       );
       await page.keyboard.press("Escape");
+      await expect
+        .poll(() => detail.evaluate((element) => (element as HTMLElement & { open: boolean }).open))
+        .toBe(false);
 
       await projectTrigger.click();
+      await expect
+        .poll(() =>
+          project.evaluate((element) => (element as HTMLElement & { open: boolean }).open),
+        )
+        .toBe(true);
       await project.getByRole("button", { name: "OpenClaw", exact: true }).click();
       await expect.poll(() => projectTrigger.getAttribute("data-project-id")).toBe("openclaw");
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("aws");

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -44,6 +44,7 @@ suite.define(() => {
       featureMethods: [
         "chat.metadata",
         "chat.startup",
+        "projects.list",
         "sessions.create",
         "sessions.dispatch",
         "sessions.reclaim",
@@ -64,6 +65,16 @@ suite.define(() => {
           defaultId: "cloud",
           mainKey: "main",
           scope: "agent",
+        },
+        "projects.list": {
+          projects: [
+            {
+              id: "openclaw",
+              displayName: "OpenClaw",
+              repoRoot: TARGET_REPO,
+              source: "registered",
+            },
+          ],
         },
         "environments.list": {
           environments: [],
@@ -132,6 +143,7 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}new`);
+      await gateway.waitForRequest("projects.list");
       expect(
         await page.evaluate(() => ({
           hasSubtleCrypto: Boolean(globalThis.crypto.subtle),
@@ -182,8 +194,7 @@ suite.define(() => {
         .poll(() => effortSelect.evaluate((element) => element.closest("details")?.open ?? false))
         .toBe(false);
 
-      // Picking a Gateway repo keeps the cloud selection: that folder is what
-      // the managed worktree checks out and dispatch syncs to the worker.
+      // Both Gateway folders and registered projects remain eligible cloud sources.
       const projectTrigger = page.locator("#new-session-project-trigger");
       const project = page.locator("wa-popover.new-session-page__project-popover");
       await projectTrigger.click();
@@ -195,6 +206,17 @@ suite.define(() => {
       await detailTrigger.click();
       await pollLocatorText(detail.locator(".new-session-page__menu-note").last()).toContain(
         "Syncs target-repo to the cloud worker",
+      );
+      await page.keyboard.press("Escape");
+
+      await projectTrigger.click();
+      await project.getByRole("button", { name: "OpenClaw", exact: true }).click();
+      await expect.poll(() => projectTrigger.getAttribute("data-project-id")).toBe("openclaw");
+      await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("aws");
+      await expect.poll(() => detailTrigger.getAttribute("data-worktree")).toBe("true");
+      await detailTrigger.click();
+      await pollLocatorText(detail.locator(".new-session-page__menu-note").last()).toContain(
+        "Syncs OpenClaw to the cloud worker",
       );
       await captureUiProof(page, "01-cloud-worker-target.png");
       await page.keyboard.press("Escape");
@@ -231,12 +253,13 @@ suite.define(() => {
       expect(create.params).toMatchObject({
         agentId: "cloud",
         message: "",
+        projectId: "openclaw",
         worktree: true,
         worktreeBaseRef: "main",
-        cwd: TARGET_REPO,
         thinkingLevel: "high",
       });
       expect(create.params).not.toHaveProperty("attachments");
+      expect(create.params).not.toHaveProperty("cwd");
       await expect.poll(() => runtimeRequested).toBe(true);
       const startupStatus = await expectPendingCloudStartupBeforeRuntime(page, gateway, sessionKey);
       runtimeLoad.resolve();

--- a/ui/src/lib/sessions/cloud-recovery.ts
+++ b/ui/src/lib/sessions/cloud-recovery.ts
@@ -43,7 +43,7 @@ const CLOUD_CREATE_STRING_FIELDS = [
   "catalogId",
   "projectId",
 ] as const;
-const CLOUD_CREATE_FIELDS: readonly string[] = [
+const CLOUD_CREATE_FIELDS = new Set<string>([
   "key",
   "agentId",
   "message",
@@ -51,7 +51,7 @@ const CLOUD_CREATE_FIELDS: readonly string[] = [
   "incognito",
   "visibility",
   ...CLOUD_CREATE_STRING_FIELDS,
-];
+]);
 
 export function parseCloudSessionCreateParams(
   value: unknown,
@@ -63,7 +63,7 @@ export function parseCloudSessionCreateParams(
   }
   const record = value;
   if (
-    Object.keys(record).some((key) => !CLOUD_CREATE_FIELDS.includes(key)) ||
+    Object.keys(record).some((key) => !CLOUD_CREATE_FIELDS.has(key)) ||
     record.key !== sessionKey ||
     record.agentId !== agentId ||
     record.message !== "" ||

--- a/ui/src/lib/sessions/cloud-recovery.ts
+++ b/ui/src/lib/sessions/cloud-recovery.ts
@@ -43,7 +43,7 @@ const CLOUD_CREATE_STRING_FIELDS = [
   "catalogId",
   "projectId",
 ] as const;
-const CLOUD_CREATE_FIELDS = [
+const CLOUD_CREATE_FIELDS: readonly string[] = [
   "key",
   "agentId",
   "message",
@@ -51,7 +51,7 @@ const CLOUD_CREATE_FIELDS = [
   "incognito",
   "visibility",
   ...CLOUD_CREATE_STRING_FIELDS,
-] as const;
+];
 
 export function parseCloudSessionCreateParams(
   value: unknown,
@@ -63,7 +63,7 @@ export function parseCloudSessionCreateParams(
   }
   const record = value;
   if (
-    Object.keys(record).some((key) => !(CLOUD_CREATE_FIELDS as readonly string[]).includes(key)) ||
+    Object.keys(record).some((key) => !CLOUD_CREATE_FIELDS.includes(key)) ||
     record.key !== sessionKey ||
     record.agentId !== agentId ||
     record.message !== "" ||

--- a/ui/src/lib/sessions/cloud-recovery.ts
+++ b/ui/src/lib/sessions/cloud-recovery.ts
@@ -70,6 +70,8 @@ export function parseCloudSessionCreateParams(
     record.worktree !== true ||
     (record.incognito !== undefined && record.incognito !== true) ||
     (record.visibility !== undefined && record.visibility !== "draft") ||
+    (record.projectId !== undefined &&
+      (record.cwd !== undefined || record.execNode !== undefined)) ||
     CLOUD_CREATE_STRING_FIELDS.some(
       (key) => record[key] !== undefined && !isNonEmptyString(record[key]),
     )

--- a/ui/src/lib/sessions/cloud-recovery.ts
+++ b/ui/src/lib/sessions/cloud-recovery.ts
@@ -11,6 +11,8 @@ export type CloudSessionCreateParams = SessionCreateParams & {
   key?: string;
   agentId: string;
   message: "";
+  projectId?: string;
+  visibility?: "draft";
   worktree: true;
 };
 
@@ -39,6 +41,7 @@ const CLOUD_CREATE_STRING_FIELDS = [
   "cwd",
   "execNode",
   "catalogId",
+  "projectId",
 ] as const;
 
 export function parseCloudSessionCreateParams(
@@ -56,6 +59,7 @@ export function parseCloudSessionCreateParams(
     "message",
     "worktree",
     "incognito",
+    "visibility",
     ...CLOUD_CREATE_STRING_FIELDS,
   ]);
   if (
@@ -65,6 +69,7 @@ export function parseCloudSessionCreateParams(
     record.message !== "" ||
     record.worktree !== true ||
     (record.incognito !== undefined && record.incognito !== true) ||
+    (record.visibility !== undefined && record.visibility !== "draft") ||
     CLOUD_CREATE_STRING_FIELDS.some(
       (key) => record[key] !== undefined && !isNonEmptyString(record[key]),
     )

--- a/ui/src/lib/sessions/cloud-recovery.ts
+++ b/ui/src/lib/sessions/cloud-recovery.ts
@@ -43,6 +43,15 @@ const CLOUD_CREATE_STRING_FIELDS = [
   "catalogId",
   "projectId",
 ] as const;
+const CLOUD_CREATE_FIELDS = [
+  "key",
+  "agentId",
+  "message",
+  "worktree",
+  "incognito",
+  "visibility",
+  ...CLOUD_CREATE_STRING_FIELDS,
+] as const;
 
 export function parseCloudSessionCreateParams(
   value: unknown,
@@ -53,17 +62,8 @@ export function parseCloudSessionCreateParams(
     return null;
   }
   const record = value;
-  const allowed = new Set<string>([
-    "key",
-    "agentId",
-    "message",
-    "worktree",
-    "incognito",
-    "visibility",
-    ...CLOUD_CREATE_STRING_FIELDS,
-  ]);
   if (
-    Object.keys(record).some((key) => !allowed.has(key)) ||
+    Object.keys(record).some((key) => !(CLOUD_CREATE_FIELDS as readonly string[]).includes(key)) ||
     record.key !== sessionKey ||
     record.agentId !== agentId ||
     record.message !== "" ||

--- a/ui/src/pages/new-session/cloud-recovery.test.ts
+++ b/ui/src/pages/new-session/cloud-recovery.test.ts
@@ -8,6 +8,7 @@ import {
   clearCloudSessionRecovery,
   listCloudSessionRecoveries,
   migrateCloudSessionRecoveryScope,
+  parseCloudSessionCreateParams,
   readCloudSessionRecovery,
   writeCloudSessionRecovery,
   writeCloudSessionRecoveryIfAvailable,
@@ -394,7 +395,9 @@ describe("cloud session recovery", () => {
         agentId: "cloud",
         message: "" as const,
         category: "Client work",
+        projectId: "openclaw",
         thinkingLevel: "high",
+        visibility: "draft" as const,
         worktree: true as const,
       },
     };
@@ -409,6 +412,27 @@ describe("cloud session recovery", () => {
     );
     expect(
       readCloudSessionRecovery(recovery.gatewayUrl, recovery.recoveryScope, recovery.sessionKey),
+    ).toBeNull();
+  });
+
+  it.each([
+    { name: "an empty project id", value: { projectId: "" } },
+    { name: "a non-string project id", value: { projectId: 42 } },
+    { name: "an unsupported visibility", value: { visibility: "shared" } },
+    { name: "an unknown field", value: { unknown: true } },
+  ])("rejects $name in creating parameters", ({ value }) => {
+    expect(
+      parseCloudSessionCreateParams(
+        {
+          key: recovery.sessionKey,
+          agentId: "cloud",
+          message: "",
+          worktree: true,
+          ...value,
+        },
+        recovery.sessionKey,
+        "cloud",
+      ),
     ).toBeNull();
   });
 

--- a/ui/src/pages/new-session/cloud-recovery.test.ts
+++ b/ui/src/pages/new-session/cloud-recovery.test.ts
@@ -418,6 +418,11 @@ describe("cloud session recovery", () => {
   it.each([
     { name: "an empty project id", value: { projectId: "" } },
     { name: "a non-string project id", value: { projectId: 42 } },
+    { name: "a project id with a cwd", value: { projectId: "openclaw", cwd: "/tmp/repo" } },
+    {
+      name: "a project id with an exec node",
+      value: { projectId: "openclaw", execNode: "macbook" },
+    },
     { name: "an unsupported visibility", value: { visibility: "shared" } },
     { name: "an unknown field", value: { unknown: true } },
   ])("rejects $name in creating parameters", ({ value }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a cloud worker from a registered project in New Session would see `cloud recovery storage is unavailable` before the session could dispatch. The same recovery boundary also rejected otherwise valid sessions started with draft visibility.

## Why This Change Was Made

The New Session flow legitimately includes a registered `projectId` and optional `visibility: "draft"` in `sessions.create`, but the strict cloud-recovery parser did not recognize those fields. This change updates that recovery owner boundary to accept and validate the two current create parameters while preserving rejection of malformed values, unknown fields, and Gateway-invalid combinations of `projectId` with `cwd` or `execNode`.

The browser regression keeps the existing Gateway-folder path covered and adds the registered-project create → dispatch → first-send flow. Release-note context: registered projects can now start cloud workers without a misleading local storage failure.

AI-assisted: yes. The change was reviewed and validated by the author.

## User Impact

Users can select a registered project, start its managed worktree on a cloud worker, and send the first turn after dispatch. Draft visibility is also recoverable across the same startup boundary. Invalid, ambiguous, or unexpected recovery payloads still fail closed.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/new-session/cloud-recovery.test.ts` — 21 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts` — 1 passed
- `node scripts/check-changed.mjs -- ui/src/lib/sessions/cloud-recovery.ts ui/src/pages/new-session/cloud-recovery.test.ts ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- exact-file `oxlint` — passed
- `pnpm ui:build` after the required-gate rebase — passed; startup JS 342,514 bytes gzip against a 343,289-byte baseline
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` — clean on every edit cycle
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32118416555 — passed
- Source-blind behavior validation reran the registered-project browser E2E successfully before commit.

ClawSweeper moves: applied the `projectId` plus raw-placement rejection and focused parser cases. The branch was rebased again when moving-main drift caused material required-gate failures. A public live trace is skipped because the original evidence is from a private instance and separate disclosure approval was not granted; deterministic mocked-browser E2E is the redacted behavioral proof.

This changes behavior, not layout. No image or video is attached.
