### PR TITLE
test(e2e): repair release validation harness drift

### DIFF
--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -1,7 +1,12 @@
 /** Reusable group-intro prompt assertions shared by auto-reply trigger tests. */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { makeCfg } from "../../test/helpers/auto-reply/trigger-handling-test-harness.js";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  resetPluginRuntimeStateForTest,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { buildGroupChatContext, buildGroupIntro } from "./reply/groups.js";
 
@@ -10,7 +15,10 @@ type InboundMessage = Parameters<GetReplyFromConfig>[0];
 
 export function registerGroupIntroPromptCases(): void {
   describe("group intro prompts", () => {
+    let previousPluginRegistry: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+
     beforeEach(() => {
+      previousPluginRegistry = captureActivePluginRegistrySnapshot();
       resetPluginRuntimeStateForTest();
       setActivePluginRegistry(
         createTestRegistry([
@@ -27,6 +35,7 @@ export function registerGroupIntroPromptCases(): void {
     });
     afterEach(() => {
       resetPluginRuntimeStateForTest();
+      restoreActivePluginRegistrySnapshot(previousPluginRegistry);
     });
 
     type GroupIntroCase = {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -5068,7 +5068,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
-  it("does not persist cumulative CLI usage as a fresh context snapshot", async () => {
+  it("marks prior context usage stale when CLI usage is only cumulative", async () => {
     const sessionEntry = makeSessionEntry({
       totalTokens: 42_000,
       totalTokensFresh: true,
@@ -5113,7 +5113,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(stored.fallbackNotice).toBeUndefined();
     expect(stored.modelProvider).toBe("claude-cli");
     expect(stored.model).toBe("claude-opus-4-7");
-    expect(stored.totalTokens).toBeUndefined();
+    expect(stored.totalTokens).toBe(42_000);
     expect(stored.totalTokensFresh).toBe(false);
   });
 

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
-function runSourceCli(tempHome: string, args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+function runBuiltCli(tempHome: string, args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: tempHome,
@@ -18,8 +18,8 @@ function runSourceCli(tempHome: string, args: string[], envOverrides: NodeJS.Pro
   delete env.VITEST;
   Object.assign(env, envOverrides);
 
-  const entry = path.resolve(process.cwd(), "src/entry.ts");
-  return spawnSync(process.execPath, ["--import", "tsx", entry, ...args], {
+  const entry = path.resolve(process.cwd(), "openclaw.mjs");
+  return spawnSync(process.execPath, [entry, ...args], {
     cwd: process.cwd(),
     env,
     encoding: "utf8",
@@ -68,7 +68,7 @@ describe("cli json stdout contract", () => {
           "utf8",
         );
 
-        const result = runSourceCli(tempHome, testCase.args, {
+        const result = runBuiltCli(tempHome, testCase.args, {
           OPENCLAW_CONFIG_PATH: configPath,
           OPENCLAW_STATE_DIR: stateDir,
           ...testCase.overrides,
@@ -99,7 +99,7 @@ describe("cli json stdout contract", () => {
         const configPath = path.join(tempHome, "read-only-openclaw.json");
         await fs.writeFile(configPath, "{}\n", "utf8");
 
-        const result = runSourceCli(
+        const result = runBuiltCli(
           tempHome,
           ["config", "get", "gateway.__proto__.token", "--json"],
           {
@@ -145,7 +145,7 @@ describe("cli json stdout contract", () => {
           "utf8",
         );
 
-        const result = runSourceCli(tempHome, ["config", "get", "gateway.port", "--json"], {
+        const result = runBuiltCli(tempHome, ["config", "get", "gateway.port", "--json"], {
           OPENCLAW_CONFIG_PATH: configPath,
           OPENCLAW_STATE_DIR: stateDir,
           ...testCase.overrides,
@@ -180,7 +180,7 @@ describe("cli json stdout contract", () => {
     await withTempHome(
       async (tempHome) => {
         const inheritedStateDir = path.join(tempHome, inherited.inheritedStateName);
-        const result = runSourceCli(tempHome, ["--profile", "work", "config", "file"], {
+        const result = runBuiltCli(tempHome, ["--profile", "work", "config", "file"], {
           OPENCLAW_PROFILE: inherited.inheritedProfile,
           OPENCLAW_STATE_DIR: inheritedStateDir,
           OPENCLAW_CONFIG_PATH: path.join(inheritedStateDir, "openclaw.json"),
@@ -207,7 +207,7 @@ describe("cli json stdout contract", () => {
         await fs.mkdir(scratchStateDir, { recursive: true });
         await fs.writeFile(approvalsPath, approvals, "utf8");
 
-        const result = runSourceCli(tempHome, ["config", "file"], {
+        const result = runBuiltCli(tempHome, ["config", "file"], {
           OPENCLAW_STATE_DIR: scratchStateDir,
         });
 
@@ -235,7 +235,7 @@ describe("cli json stdout contract", () => {
         await fs.mkdir(legacyDir, { recursive: true });
         await fs.writeFile(path.join(legacyDir, "clawdbot.json"), "{}", "utf8");
 
-        const result = runSourceCli(tempHome, ["update", "status", "--json", "--timeout", "1"]);
+        const result = runBuiltCli(tempHome, ["update", "status", "--json", "--timeout", "1"]);
 
         expect(result.status).toBe(0);
         const stdout = result.stdout.trim();
@@ -260,7 +260,7 @@ describe("cli json stdout contract", () => {
   it("rejects an explicitly empty update status timeout before emitting JSON", async () => {
     await withTempHome(
       async (tempHome) => {
-        const result = runSourceCli(tempHome, ["update", "status", "--json", "--timeout", ""]);
+        const result = runBuiltCli(tempHome, ["update", "status", "--json", "--timeout", ""]);
 
         expect(result.status, result.stderr).toBe(1);
         expect(JSON.parse(result.stdout)).toEqual({
@@ -280,7 +280,7 @@ describe("cli json stdout contract", () => {
     await withTempHome(
       async (tempHome) => {
         const missingArchive = path.join(tempHome, "missing-backup.tar.gz");
-        const result = runSourceCli(tempHome, ["backup", "verify", missingArchive, "--json"]);
+        const result = runBuiltCli(tempHome, ["backup", "verify", missingArchive, "--json"]);
 
         expect(result.status).toBe(1);
         expect(JSON.parse(result.stdout)).toEqual({
@@ -298,7 +298,7 @@ describe("cli json stdout contract", () => {
   it("keeps Commander parse failures machine-readable in JSON mode", async () => {
     await withTempHome(
       async (tempHome) => {
-        const result = runSourceCli(tempHome, [
+        const result = runBuiltCli(tempHome, [
           "config",
           "get",
           "gateway.port",
@@ -353,7 +353,7 @@ describe("cli json stdout contract", () => {
   ])("renders $name as actionable guidance", async (testCase) => {
     await withTempHome(
       async (tempHome) => {
-        const result = runSourceCli(tempHome, testCase.args);
+        const result = runBuiltCli(tempHome, testCase.args);
 
         expect(result.status).toBe(1);
         expect(result.stdout).toBe("");
@@ -389,7 +389,7 @@ describe("cli json stdout contract", () => {
   ])("reports $name once with structured JSON guidance", async (testCase) => {
     await withTempHome(
       async (tempHome) => {
-        const result = runSourceCli(tempHome, testCase.args);
+        const result = runBuiltCli(tempHome, testCase.args);
 
         expect(result.status).toBe(1);
         const payload = JSON.parse(result.stdout) as {
@@ -419,7 +419,7 @@ describe("cli json stdout contract", () => {
   it("keeps parse-error JSON free of terminal controls when color is forced", async () => {
     await withTempHome(
       async (tempHome) => {
-        const result = runSourceCli(tempHome, ["sessions", "lst", "--json"], {
+        const result = runBuiltCli(tempHome, ["sessions", "lst", "--json"], {
           FORCE_COLOR: "1",
         });
 
@@ -445,8 +445,8 @@ describe("cli json stdout contract", () => {
         await fs.writeFile(configPath, '{"gateway":{"port":28789}}\n', "utf8");
         const env = { OPENCLAW_CONFIG_PATH: configPath };
 
-        const getResult = runSourceCli(tempHome, ["config", "get", "gateway.port", "--json"], env);
-        const validateResult = runSourceCli(tempHome, ["config", "validate", "--json"], env);
+        const getResult = runBuiltCli(tempHome, ["config", "get", "gateway.port", "--json"], env);
+        const validateResult = runBuiltCli(tempHome, ["config", "validate", "--json"], env);
 
         expect(getResult.status, getResult.stderr).toBe(0);
         expect(getResult.stdout).toBe("28789\n");
@@ -462,7 +462,7 @@ describe("cli json stdout contract", () => {
   it("keeps `config schema` stdout parseable at debug log level", async () => {
     await withTempHome(
       async (tempHome) => {
-        const result = runSourceCli(tempHome, ["config", "schema"], {
+        const result = runBuiltCli(tempHome, ["config", "schema"], {
           OPENCLAW_LOG_LEVEL: "debug",
         });
 
@@ -483,7 +483,7 @@ describe("cli json stdout contract", () => {
       async (tempHome) => {
         const configPath = path.join(tempHome, "openclaw.json");
         await fs.writeFile(configPath, "{}", "utf8");
-        const result = runSourceCli(tempHome, ["config", "validate", "--json"], {
+        const result = runBuiltCli(tempHome, ["config", "validate", "--json"], {
           OPENCLAW_CONFIG_PATH: configPath,
           OPENCLAW_LOG_LEVEL: "debug",
         });
@@ -522,7 +522,7 @@ describe("cli json stdout contract", () => {
           "utf8",
         );
 
-        const result = runSourceCli(
+        const result = runBuiltCli(
           tempHome,
           [
             "doctor",

--- a/test/e2e/qa-lab/plugins/canvas-agent-node.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/canvas-agent-node.e2e.test.ts
@@ -305,7 +305,11 @@ describe("Canvas agent tool over a paired Linux node", () => {
             );
           }
           if (action.command === "canvas.eval") {
-            expect(result.details).toEqual({ result: "canvas-eval-result" });
+            expect(result.details).toEqual({
+              ok: true,
+              node: nodeId,
+              result: "canvas-eval-result",
+            });
           }
           if (action.command === "canvas.snapshot") {
             expect(result.details).toMatchObject({


### PR DESCRIPTION
## What Problem This Solves

Repairs deterministic drift and lifecycle leakage in the full-release repo E2E lane:

- cumulative CLI usage preserves the prior context token count but marks it stale
- Canvas eval results use the standard `{ ok, node, result }` envelope
- group-intro cases restore the plugin registry they temporarily replace, so later command cases do not bind to a retired generation
- CLI process tests use the already-built public launcher instead of compiling the source entry for every invocation

## Why This Change Was Made

The usage and Canvas expectations were stale against intentional owner contracts from #124969 and #125126. Exact-head GitHub proof confirmed both corrected assertions pass.

That same proof exposed nine later trigger cases failing after the nested group-intro suite retired the shared registry without restoring it. The harness now snapshots and restores that owner state around the nested cases.

The CLI harness launched `node --import tsx src/entry.ts`, including three unknown-root cases that took 55.6s, 34.2s, and 34.9s in exact-head CI. Repo E2E already builds the distribution before this suite, so the tests now exercise `openclaw.mjs`, the public dist-backed launcher.

No production code changes are included. The unrelated OTel timeout and hosted-web 404 remain unchanged because this run did not prove stale assertions there.

## User Impact

No user-visible runtime change. Full-release repo E2E validates the current contracts without leaking plugin registry state or paying source-compilation cost per CLI process.

## Evidence

- Baseline failure: [Full Release Validation job 95611743833](https://github.com/openclaw/openclaw/actions/runs/32099770866/job/95611743833)
- First exact-head proof: [run 32109951340](https://github.com/openclaw/openclaw/actions/runs/32109951340)
  - corrected usage and Canvas cases passed
  - nine trigger cases failed with `Plugin command runtime is bound to a retired registry generation`
  - unknown-root CLI cases passed but took 55.6s, 34.2s, and 34.9s through the source entry
- Final rebased exact-head proof: [run 32113064535](https://github.com/openclaw/openclaw/actions/runs/32113064535)
  - corrected usage and Canvas cases passed
  - all nine formerly retired-registry trigger cases passed
  - unknown-root CLI cases passed in 3.6s, 2.7s, and 3.1s through the built launcher
  - the job remained red only for the unchanged OTel timeout, hosted-web 404-vs-401 assertion, and anonymous 300-second no-output stall
- Source/history proof:
  - #124969 preserves the previous total while setting `totalTokensFresh: false`
  - #125126 standardized Canvas eval details as `{ ok: true, node, result }`
  - group-intro hooks reset the active registry after their final case without restoring the enclosing suite snapshot
- Local tests were not run, per release-validation policy. The final GitHub proof selected exact head `577616ea1930986bc7074960e093e3231e7f0a0d`.

Test-only delta: +37/-24. Production delta: +0/-0.
