### PR TITLE
fix(ui): suppress tooltips that repeat visible labels

### DIFF
--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -7,7 +7,7 @@ import "../components/gateway-url-confirmation.ts";
 import "../components/github-link-hovercard-registration.ts";
 import "../components/login-gate.ts";
 import "../components/openclaw-mascot.ts";
-import "../components/tooltip.ts";
+import { installNativeTitleGuard } from "../components/tooltip.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
@@ -114,7 +114,8 @@ export class OpenClawApp extends OpenClawLightDomElement {
       .watch(
         () => (this.terminalOnly ? this.context?.agentSelection : undefined),
         (selection, notify) => selection.subscribe(notify),
-      );
+      )
+      .effect(() => this.ownerDocument, installNativeTitleGuard);
   }
 
   override connectedCallback() {

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -13,16 +13,11 @@ type TooltipProviderElement = HTMLElement & {
   skipDelay: number;
 };
 
-function defineVisibleText(element: HTMLElement, text: string) {
-  Object.defineProperty(element, "innerText", { value: text, configurable: true });
-}
-
 function createTooltip(content: string, triggerText = "trigger") {
   const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
   tooltip.content = content;
   const trigger = document.createElement("button");
   trigger.textContent = triggerText;
-  defineVisibleText(trigger, triggerText);
   tooltip.append(trigger);
   return { tooltip, trigger };
 }
@@ -31,7 +26,6 @@ function createRichTooltip(content: string, triggerText = "trigger") {
   const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
   const trigger = document.createElement("button");
   trigger.textContent = triggerText;
-  defineVisibleText(trigger, triggerText);
   const card = document.createElement("div");
   card.slot = "content";
   card.textContent = content;
@@ -243,7 +237,6 @@ describe("openclaw-tooltip", () => {
     const { tooltip, trigger } = createTooltip("Claude Opus 4.7", "");
     const label = document.createElement("span");
     label.textContent = "Claude Opus 4.7 Anthropic";
-    defineVisibleText(trigger, label.textContent);
     Object.defineProperty(label, "scrollWidth", { value: 160, configurable: true });
     Object.defineProperty(label, "clientWidth", { value: 80, configurable: true });
     trigger.append(label);
@@ -428,7 +421,6 @@ describe("native title guard", () => {
     const label = document.createElement("span");
     label.textContent = "GPT-5.6 Sol";
     trigger.append(label);
-    defineVisibleText(trigger, label.textContent);
     shadowRoot.append(trigger);
     document.body.append(host);
 
@@ -461,7 +453,6 @@ describe("native title guard", () => {
       text: "Open settings",
       prepare: (trigger: HTMLElement) => {
         trigger.firstElementChild?.setAttribute("hidden", "");
-        defineVisibleText(trigger, "");
       },
     },
   ])("keeps $name native titles", ({ title, text, prepare }) => {
@@ -470,7 +461,6 @@ describe("native title guard", () => {
     const label = document.createElement("span");
     label.textContent = text;
     trigger.append(label);
-    defineVisibleText(trigger, text);
     prepare(trigger);
     document.body.append(trigger);
 
@@ -483,7 +473,6 @@ describe("native title guard", () => {
     const removedTrigger = document.createElement("button");
     removedTrigger.title = "High";
     removedTrigger.textContent = "High";
-    defineVisibleText(removedTrigger, "High");
     document.body.append(removedTrigger);
     removedTrigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
     expect(removedTrigger.getAttribute("title")).toBe("");
@@ -491,7 +480,6 @@ describe("native title guard", () => {
 
     const nextTrigger = document.createElement("button");
     nextTrigger.title = "Open settings";
-    defineVisibleText(nextTrigger, "");
     document.body.append(nextTrigger);
     nextTrigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
 
@@ -507,7 +495,6 @@ describe("native title guard", () => {
     const trigger = document.createElement("button");
     trigger.title = "High";
     trigger.textContent = "High";
-    defineVisibleText(trigger, "High");
     document.body.append(trigger);
     trigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
     expect(trigger.getAttribute("title")).toBe("");

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import "./tooltip.ts";
+import { installNativeTitleGuard } from "./tooltip.ts";
 
 type TooltipElement = HTMLElement & {
   content: string;
@@ -13,11 +13,16 @@ type TooltipProviderElement = HTMLElement & {
   skipDelay: number;
 };
 
+function defineVisibleText(element: HTMLElement, text: string) {
+  Object.defineProperty(element, "innerText", { value: text, configurable: true });
+}
+
 function createTooltip(content: string, triggerText = "trigger") {
   const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
   tooltip.content = content;
   const trigger = document.createElement("button");
   trigger.textContent = triggerText;
+  defineVisibleText(trigger, triggerText);
   tooltip.append(trigger);
   return { tooltip, trigger };
 }
@@ -26,6 +31,7 @@ function createRichTooltip(content: string, triggerText = "trigger") {
   const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
   const trigger = document.createElement("button");
   trigger.textContent = triggerText;
+  defineVisibleText(trigger, triggerText);
   const card = document.createElement("div");
   card.slot = "content";
   card.textContent = content;
@@ -220,11 +226,24 @@ describe("openclaw-tooltip", () => {
     expectOpenCount(1);
   });
 
+  it("keeps a repeated-label tooltip with an explicit overflow marker", async () => {
+    const provider = createProvider();
+    const { tooltip, trigger } = createTooltip("Claude Opus 4.7", "Claude Opus 4.7 Anthropic");
+    trigger.setAttribute("data-tooltip-overflow", "");
+    provider.append(tooltip);
+    document.body.append(provider);
+    await tooltip.updateComplete;
+
+    focusTrigger(trigger);
+    expectOpenCount(1);
+  });
+
   it("keeps a repeated-label tooltip when a nested label clips", async () => {
     const provider = createProvider();
     const { tooltip, trigger } = createTooltip("Claude Opus 4.7", "");
     const label = document.createElement("span");
     label.textContent = "Claude Opus 4.7 Anthropic";
+    defineVisibleText(trigger, label.textContent);
     Object.defineProperty(label, "scrollWidth", { value: 160, configurable: true });
     Object.defineProperty(label, "clientWidth", { value: 80, configurable: true });
     trigger.append(label);
@@ -386,5 +405,116 @@ describe("openclaw-tooltip", () => {
     expectOpenCount(0);
     vi.advanceTimersByTime(1);
     expectOpenCount(1);
+  });
+});
+
+describe("native title guard", () => {
+  let stopGuard: (() => void) | undefined;
+
+  beforeEach(() => {
+    stopGuard = installNativeTitleGuard(document);
+  });
+
+  afterEach(() => {
+    stopGuard?.();
+    document.body.replaceChildren();
+  });
+
+  it("suppresses a redundant title through open shadow DOM until true pointer leave", () => {
+    const host = document.createElement("div");
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    const trigger = document.createElement("button");
+    trigger.title = "GPT-5.6 Sol";
+    const label = document.createElement("span");
+    label.textContent = "GPT-5.6 Sol";
+    trigger.append(label);
+    defineVisibleText(trigger, label.textContent);
+    shadowRoot.append(trigger);
+    document.body.append(host);
+
+    label.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+
+    expect(trigger.getAttribute("title")).toBe("");
+    label.dispatchEvent(new MouseEvent("pointerleave", { composed: true }));
+    expect(trigger.getAttribute("title")).toBe("");
+
+    trigger.dispatchEvent(new MouseEvent("pointerleave", { composed: true }));
+    expect(trigger.title).toBe("GPT-5.6 Sol");
+  });
+
+  it.each([
+    {
+      name: "contextual",
+      title: "GPT-5.6 Sol · Chat only",
+      text: "GPT-5.6 Sol",
+      prepare: (_trigger: HTMLElement) => undefined,
+    },
+    {
+      name: "icon-only",
+      title: "Open settings",
+      text: "",
+      prepare: (_trigger: HTMLElement) => undefined,
+    },
+    {
+      name: "hidden-only label",
+      title: "Open settings",
+      text: "Open settings",
+      prepare: (trigger: HTMLElement) => {
+        trigger.firstElementChild?.setAttribute("hidden", "");
+        defineVisibleText(trigger, "");
+      },
+    },
+  ])("keeps $name native titles", ({ title, text, prepare }) => {
+    const trigger = document.createElement("button");
+    trigger.title = title;
+    const label = document.createElement("span");
+    label.textContent = text;
+    trigger.append(label);
+    defineVisibleText(trigger, text);
+    prepare(trigger);
+    document.body.append(trigger);
+
+    label.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+
+    expect(trigger.title).toBe(title);
+  });
+
+  it("restores a removed suppressed trigger when hover moves elsewhere", () => {
+    const removedTrigger = document.createElement("button");
+    removedTrigger.title = "High";
+    removedTrigger.textContent = "High";
+    defineVisibleText(removedTrigger, "High");
+    document.body.append(removedTrigger);
+    removedTrigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+    expect(removedTrigger.getAttribute("title")).toBe("");
+    removedTrigger.remove();
+
+    const nextTrigger = document.createElement("button");
+    nextTrigger.title = "Open settings";
+    defineVisibleText(nextTrigger, "");
+    document.body.append(nextTrigger);
+    nextTrigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+
+    expect(removedTrigger.title).toBe("High");
+    document.body.append(removedTrigger);
+    removedTrigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+    expect(removedTrigger.getAttribute("title")).toBe("");
+    removedTrigger.dispatchEvent(new MouseEvent("pointerleave", { composed: true }));
+    expect(removedTrigger.title).toBe("High");
+  });
+
+  it("restores a suppressed title when the app-owned guard is disposed", () => {
+    const trigger = document.createElement("button");
+    trigger.title = "High";
+    trigger.textContent = "High";
+    defineVisibleText(trigger, "High");
+    document.body.append(trigger);
+    trigger.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+    expect(trigger.getAttribute("title")).toBe("");
+
+    stopGuard?.();
+    stopGuard = undefined;
+
+    expect(trigger.title).toBe("High");
   });
 });

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -24,8 +24,105 @@ function normalizeTooltipText(text: string) {
   return text.replace(/\s+/gu, " ").trim();
 }
 
-function isHtmlElement(element: Element): element is HTMLElement {
-  return element.namespaceURI === "http://www.w3.org/1999/xhtml";
+function isHtmlElement(element: unknown): element is HTMLElement {
+  return (
+    typeof element === "object" &&
+    element !== null &&
+    "namespaceURI" in element &&
+    element.namespaceURI === "http://www.w3.org/1999/xhtml"
+  );
+}
+
+function hasTooltipOverflow(element: HTMLElement) {
+  return (
+    element.matches("[data-tooltip-overflow]") ||
+    element.scrollWidth > element.clientWidth ||
+    element.scrollHeight > element.clientHeight
+  );
+}
+
+function isTooltipTextRedundant(content: string, trigger: HTMLElement) {
+  const tooltipText = normalizeTooltipText(content);
+  if (!tooltipText || !normalizeTooltipText(trigger.textContent ?? "").includes(tooltipText)) {
+    return false;
+  }
+  /* oxlint-disable unicorn/prefer-dom-node-text-content -- Hidden text must not make a tooltip redundant. */
+  const triggerText = normalizeTooltipText(trigger.innerText);
+  /* oxlint-enable unicorn/prefer-dom-node-text-content */
+  if (!triggerText.includes(tooltipText)) {
+    return false;
+  }
+  if (hasTooltipOverflow(trigger)) {
+    return false;
+  }
+  for (const element of trigger.querySelectorAll("*")) {
+    if (isHtmlElement(element) && hasTooltipOverflow(element)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function installNativeTitleGuard(ownerDocument: Document) {
+  const suppressed = new Map<HTMLElement, string>();
+  const restore = (trigger: HTMLElement) => {
+    const title = suppressed.get(trigger);
+    if (title === undefined) {
+      return;
+    }
+    suppressed.delete(trigger);
+    trigger.removeEventListener("pointerleave", handlePointerLeave);
+    if (trigger.getAttribute("title") === "") {
+      trigger.setAttribute("title", title);
+    }
+  };
+  const handlePointerLeave = (event: Event) => {
+    if (isHtmlElement(event.currentTarget)) {
+      restore(event.currentTarget);
+    }
+  };
+  const handlePointerOver = (event: PointerEvent) => {
+    if (event.pointerType === "touch") {
+      return;
+    }
+    const path = event.composedPath();
+    if (suppressed.size > 0) {
+      for (const trigger of suppressed.keys()) {
+        if (!path.includes(trigger)) {
+          restore(trigger);
+        }
+      }
+    }
+    for (const candidate of path) {
+      if (!isHtmlElement(candidate)) {
+        continue;
+      }
+      const title = candidate.getAttribute("title");
+      const previous = suppressed.get(candidate);
+      if (previous && title === "") {
+        continue;
+      }
+      if (previous !== undefined) {
+        candidate.removeEventListener("pointerleave", handlePointerLeave);
+        suppressed.delete(candidate);
+      }
+      if (title === null || !isTooltipTextRedundant(title, candidate)) {
+        continue;
+      }
+      suppressed.set(candidate, title);
+      // An empty title also blocks inherited native titles until the pointer
+      // truly leaves this trigger; removing the attribute would expose them.
+      candidate.setAttribute("title", "");
+      candidate.addEventListener("pointerleave", handlePointerLeave, { once: true });
+    }
+  };
+  ownerDocument.addEventListener("pointerover", handlePointerOver, true);
+  return () => {
+    ownerDocument.removeEventListener("pointerover", handlePointerOver, true);
+    for (const trigger of suppressed.keys()) {
+      restore(trigger);
+    }
+  };
 }
 
 class TooltipProvider extends OpenClawLitElement {
@@ -364,7 +461,7 @@ class Tooltip extends OpenClawLitElement {
   };
 
   private scheduleOpen() {
-    if (this.webAwesomeTooltip?.open || this.openTimer !== null || this.isRedundant()) {
+    if (this.webAwesomeTooltip?.open || this.openTimer !== null) {
       return;
     }
     const delay = this.provider?.shouldDelayOpen() === false ? 0 : this.hoverDelay;
@@ -411,15 +508,7 @@ class Tooltip extends OpenClawLitElement {
     if (!trigger) {
       return false;
     }
-    const content = normalizeTooltipText(this.content);
-    const triggerText = normalizeTooltipText(trigger.textContent ?? "");
-    const clipsContent =
-      trigger.matches("[data-tooltip-overflow]") ||
-      trigger.querySelector("[data-tooltip-overflow]") !== null ||
-      [trigger, ...trigger.querySelectorAll("*")].some(
-        (element) => isHtmlElement(element) && element.scrollWidth > element.clientWidth,
-      );
-    return Boolean(content && triggerText && triggerText.includes(content) && !clipsContent);
+    return isTooltipTextRedundant(this.content, trigger);
   }
 
   private syncDescription() {

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -33,6 +33,35 @@ function isHtmlElement(element: unknown): element is HTMLElement {
   );
 }
 
+function isElementNode(node: Node): node is Element {
+  return node.nodeType === Node.ELEMENT_NODE;
+}
+
+function collectVisibleText(element: Element): string {
+  const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+  if (
+    (isHtmlElement(element) && element.hidden) ||
+    style?.display === "none" ||
+    style?.contentVisibility === "hidden"
+  ) {
+    return "";
+  }
+  const rendersOwnText =
+    style?.visibility !== "hidden" &&
+    style?.visibility !== "collapse" &&
+    (style?.display === "contents" ||
+      typeof element.checkVisibility !== "function" ||
+      element.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true }));
+  return [...element.childNodes]
+    .map((node) => {
+      if (isElementNode(node)) {
+        return collectVisibleText(node);
+      }
+      return node.nodeType === Node.TEXT_NODE && rendersOwnText ? (node.textContent ?? "") : "";
+    })
+    .join(" ");
+}
+
 function hasTooltipOverflow(element: HTMLElement) {
   return (
     element.matches("[data-tooltip-overflow]") ||
@@ -46,9 +75,7 @@ function isTooltipTextRedundant(content: string, trigger: HTMLElement) {
   if (!tooltipText || !normalizeTooltipText(trigger.textContent ?? "").includes(tooltipText)) {
     return false;
   }
-  /* oxlint-disable unicorn/prefer-dom-node-text-content -- Hidden text must not make a tooltip redundant. */
-  const triggerText = normalizeTooltipText(trigger.innerText);
-  /* oxlint-enable unicorn/prefer-dom-node-text-content */
+  const triggerText = normalizeTooltipText(collectVisibleText(trigger));
   if (!triggerText.includes(tooltipText)) {
     return false;
   }

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -307,6 +307,14 @@ suite.define(() => {
           (await effort.locator(".chat-controls__inline-select-label").textContent())?.trim(),
         )
         .toBe("High");
+      for (const trigger of [model, effort]) {
+        const title = await trigger.getAttribute("title");
+        expect(title).toBeTruthy();
+        await trigger.hover();
+        expect(await trigger.getAttribute("title")).toBe("");
+        await page.mouse.move(0, 0);
+        await expect.poll(() => trigger.getAttribute("title")).toBe(title);
+      }
       await expect.poll(() => contextUsage.locator(".context-ring__detail").count()).toBe(0);
       await expect
         .poll(() => contextUsage.getAttribute("aria-label"))


### PR DESCRIPTION
Closes #125651

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users hovering fully visible Control UI labels would see browser tooltips that repeated the exact same text. The compact model and reasoning controls exposed the bug directly, and the same bypass was possible anywhere the web UI used a native `title` attribute instead of the shared tooltip component.

## Why This Change Was Made

The shared tooltip already suppresses content that is fully visible while preserving clipped labels and additional context. This change makes that invariant system-wide: the app installs one document-level native-title guard that reuses the same rendered-text and overflow decision, temporarily disarms only redundant titles during hover, and restores them on true pointer leave. Contextual, icon-only, hidden-label, clipped, and rich-content tooltips remain available.

The guard follows the existing app subscription lifecycle rather than adding a second cleanup path. Production LOC is +131/-14 (net +117); tests are +126/-1 (net +125). The production growth is the generic ownership seam covering the Control UI’s native-title surface rather than two call-site exceptions.

AI-assisted: yes. The final diff was independently reviewed and the behavior was validated source-blind against the running mocked UI.

## User Impact

Hovering a fully visible label no longer produces a duplicate tooltip that obscures nearby UI. Tooltips still reveal truncated text and still explain icon-only or context-bearing controls.

## Evidence

![Before and after redundant native tooltip suppression proof](https://github.com/user-attachments/assets/1fba2d7d-b427-4f41-ba70-48921fa37d28)

The visual proof shows the same real hovered model trigger before and after. Browser-native tooltip chrome is outside Playwright’s page capture, so the proof also records the live `title` state that controls whether the browser can open it: non-empty before, synchronously empty while hovered after, then restored on pointer leave.

- `node scripts/run-vitest.mjs ui/src/components/tooltip.test.ts` — 26/26 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 3/3 passed in Chromium.
- Source-blind browser validation — two deterministic runs passed: model and effort titles were empty while hovered, restored afterward, and contextual/icon-only/clipped probes retained their titles.
- `node scripts/check-changed.mjs -- ui/src/app/app-root.ts ui/src/components/tooltip.ts ui/src/components/tooltip.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts` — passed formatting, type checks, lint, i18n, guards, and dead-export scans.
- `git diff --check origin/main...HEAD` — passed.
- Fresh independent autoreview on the final uncommitted diff — clean, no accepted/actionable findings.
