### PR TITLE
test(matrix): expose raw command mention safety

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.test.ts
@@ -617,7 +617,7 @@ describe("matrix qa config", () => {
     expect(config.messages?.groupChat?.mentionPatterns).toEqual(["\\S"]);
   });
 
-  it("resets preview overrides when a scalar streaming override follows an object", () => {
+  it("resets progress and preview overrides when a scalar follows an object", () => {
     const optedOut = buildMatrixQaConfig({} as OpenClawConfig, {
       driverUserId: "@driver:matrix-qa.test",
       homeserver: "http://127.0.0.1:28008/",
@@ -625,7 +625,8 @@ describe("matrix qa config", () => {
       overrides: {
         streaming: {
           mode: "quiet",
-          preview: { commandText: "raw", toolProgress: false },
+          progress: { commandText: "raw" },
+          preview: { toolProgress: false },
         },
       },
       sutAccessToken: "sut-token",
@@ -649,7 +650,8 @@ describe("matrix qa config", () => {
       block: { enabled: false },
       chunkMode: "length",
       mode: "quiet",
-      preview: { commandText: "raw", toolProgress: false },
+      progress: { commandText: "raw" },
+      preview: { toolProgress: false },
     });
     expect(reset.channels?.matrix?.accounts?.sut?.streaming).toEqual({
       block: { enabled: false },

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.test.ts
@@ -617,7 +617,7 @@ describe("matrix qa config", () => {
     expect(config.messages?.groupChat?.mentionPatterns).toEqual(["\\S"]);
   });
 
-  it("resets tool progress when a scalar streaming override follows an opt-out", () => {
+  it("resets preview overrides when a scalar streaming override follows an object", () => {
     const optedOut = buildMatrixQaConfig({} as OpenClawConfig, {
       driverUserId: "@driver:matrix-qa.test",
       homeserver: "http://127.0.0.1:28008/",
@@ -625,7 +625,7 @@ describe("matrix qa config", () => {
       overrides: {
         streaming: {
           mode: "quiet",
-          preview: { toolProgress: false },
+          preview: { commandText: "raw", toolProgress: false },
         },
       },
       sutAccessToken: "sut-token",
@@ -649,7 +649,7 @@ describe("matrix qa config", () => {
       block: { enabled: false },
       chunkMode: "length",
       mode: "quiet",
-      preview: { toolProgress: false },
+      preview: { commandText: "raw", toolProgress: false },
     });
     expect(reset.channels?.matrix?.accounts?.sut?.streaming).toEqual({
       block: { enabled: false },

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
@@ -442,11 +442,9 @@ function buildMatrixQaChannelAccountConfig(params: {
   const block = restoreOwnedFields(current?.streaming?.block, baseline?.streaming?.block, [
     "enabled",
   ]);
-  const progress = restoreOwnedFields(
-    current?.streaming?.progress,
-    baseline?.streaming?.progress,
-    ["commandText"],
-  );
+  const progress = restoreOwnedFields(current?.streaming?.progress, baseline?.streaming?.progress, [
+    "commandText",
+  ]);
   const preview = restoreOwnedFields(current?.streaming?.preview, baseline?.streaming?.preview, [
     "toolProgress",
   ]);

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
@@ -15,14 +15,13 @@ type MatrixQaAutoJoinMode = "allowlist" | "always" | "off";
 type MatrixQaStreamingMode = "off" | "partial" | "quiet";
 type MatrixQaActorRole = "driver" | "observer" | "sut";
 type MatrixQaChunkMode = "length" | "newline";
-type MatrixQaCommandTextMode = "raw" | "status";
 type MatrixQaExecApprovalTarget = "both" | "channel" | "dm";
 type MatrixQaExecApprovalsEnabled = boolean | "auto";
 type MatrixQaAllowBotsMode = boolean | "mentions";
 type MatrixQaStreamingConfig = {
   mode?: MatrixQaStreamingMode;
   progress?: {
-    commandText?: MatrixQaCommandTextMode;
+    commandText?: "raw" | "status";
   };
   preview?: {
     toolProgress?: boolean;
@@ -135,7 +134,7 @@ type MatrixQaConfigSnapshot = {
   replyToMode: MatrixQaReplyToMode;
   startupVerification?: "if-unverified" | "off";
   streaming: MatrixQaStreamingMode;
-  streamingProgressCommandText?: MatrixQaCommandTextMode;
+  streamingProgressCommandText?: "raw" | "status";
   streamingPreviewToolProgress: boolean;
   textChunkLimit?: number;
   threadBindings: MatrixQaThreadBindingsConfigOverrides;
@@ -293,18 +292,6 @@ function isMatrixQaStreamingConfig(
   value: MatrixQaConfigOverrides["streaming"],
 ): value is MatrixQaStreamingConfig {
   return isRecord(value);
-}
-
-function resolveMatrixQaStreamingProgressCommandText(
-  value: MatrixQaConfigOverrides["streaming"],
-): MatrixQaCommandTextMode | undefined {
-  return isMatrixQaStreamingConfig(value) ? value.progress?.commandText : undefined;
-}
-
-function resolveMatrixQaStreamingPreviewToolProgress(
-  value: MatrixQaConfigOverrides["streaming"],
-): boolean {
-  return isMatrixQaStreamingConfig(value) ? (value.preview?.toolProgress ?? true) : true;
 }
 
 function resolveMatrixQaAutoJoinAllowlist(params: { overrides?: MatrixQaConfigOverrides }) {
@@ -466,17 +453,16 @@ function buildMatrixQaChannelAccountConfig(params: {
   if (params.snapshot.streamingProgressCommandText) {
     progress.commandText = params.snapshot.streamingProgressCommandText;
   }
+  Object.assign(streaming, { progress });
+  if (Object.keys(progress).length === 0) {
+    delete streaming.progress;
+  }
   Object.assign(streaming, {
     block: { ...block, enabled: params.snapshot.blockStreaming },
     chunkMode: params.snapshot.chunkMode ?? "length",
     mode: params.snapshot.streaming,
     preview: { ...preview, toolProgress: params.snapshot.streamingPreviewToolProgress },
   });
-  if (Object.keys(progress).length > 0) {
-    streaming.progress = progress;
-  } else {
-    delete streaming.progress;
-  }
   const threadBindings = restoreOwnedFields(
     current?.threadBindings,
     baseline?.threadBindings,
@@ -534,6 +520,9 @@ function buildMatrixQaConfigSnapshot(params: {
   sutUserId: string;
   topology: MatrixQaProvisionedTopology;
 }): MatrixQaConfigSnapshot {
+  const streaming = isMatrixQaStreamingConfig(params.overrides?.streaming)
+    ? params.overrides.streaming
+    : undefined;
   return {
     allowBots: params.overrides?.allowBots,
     autoJoin: params.overrides?.autoJoin ?? "off",
@@ -554,12 +543,8 @@ function buildMatrixQaConfigSnapshot(params: {
     replyToMode: params.overrides?.replyToMode ?? "off",
     startupVerification: params.overrides?.startupVerification,
     streaming: resolveMatrixQaStreamingMode(params.overrides?.streaming),
-    streamingProgressCommandText: resolveMatrixQaStreamingProgressCommandText(
-      params.overrides?.streaming,
-    ),
-    streamingPreviewToolProgress: resolveMatrixQaStreamingPreviewToolProgress(
-      params.overrides?.streaming,
-    ),
+    streamingProgressCommandText: streaming?.progress?.commandText,
+    streamingPreviewToolProgress: streaming?.preview?.toolProgress ?? true,
     threadBindings: { ...params.overrides?.threadBindings },
     textChunkLimit: params.overrides?.textChunkLimit,
     threadReplies: params.overrides?.threadReplies ?? "inbound",

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
@@ -15,12 +15,14 @@ type MatrixQaAutoJoinMode = "allowlist" | "always" | "off";
 type MatrixQaStreamingMode = "off" | "partial" | "quiet";
 type MatrixQaActorRole = "driver" | "observer" | "sut";
 type MatrixQaChunkMode = "length" | "newline";
+type MatrixQaCommandTextMode = "raw" | "status";
 type MatrixQaExecApprovalTarget = "both" | "channel" | "dm";
 type MatrixQaExecApprovalsEnabled = boolean | "auto";
 type MatrixQaAllowBotsMode = boolean | "mentions";
 type MatrixQaStreamingConfig = {
   mode?: MatrixQaStreamingMode;
   preview?: {
+    commandText?: MatrixQaCommandTextMode;
     toolProgress?: boolean;
   };
 };
@@ -131,6 +133,7 @@ type MatrixQaConfigSnapshot = {
   replyToMode: MatrixQaReplyToMode;
   startupVerification?: "if-unverified" | "off";
   streaming: MatrixQaStreamingMode;
+  streamingPreviewCommandText?: MatrixQaCommandTextMode;
   streamingPreviewToolProgress: boolean;
   textChunkLimit?: number;
   threadBindings: MatrixQaThreadBindingsConfigOverrides;
@@ -299,6 +302,15 @@ function resolveMatrixQaStreamingPreviewToolProgress(
   return value.preview?.toolProgress ?? true;
 }
 
+function resolveMatrixQaStreamingPreviewCommandText(
+  value: MatrixQaConfigOverrides["streaming"],
+): MatrixQaCommandTextMode | undefined {
+  if (!isMatrixQaStreamingConfig(value)) {
+    return undefined;
+  }
+  return value.preview?.commandText;
+}
+
 function resolveMatrixQaAutoJoinAllowlist(params: { overrides?: MatrixQaConfigOverrides }) {
   if (params.overrides?.autoJoin !== "allowlist") {
     return [];
@@ -448,13 +460,20 @@ function buildMatrixQaChannelAccountConfig(params: {
     "enabled",
   ]);
   const preview = restoreOwnedFields(current?.streaming?.preview, baseline?.streaming?.preview, [
+    "commandText",
     "toolProgress",
   ]);
   Object.assign(streaming, {
     block: { ...block, enabled: params.snapshot.blockStreaming },
     chunkMode: params.snapshot.chunkMode ?? "length",
     mode: params.snapshot.streaming,
-    preview: { ...preview, toolProgress: params.snapshot.streamingPreviewToolProgress },
+    preview: {
+      ...preview,
+      ...(params.snapshot.streamingPreviewCommandText
+        ? { commandText: params.snapshot.streamingPreviewCommandText }
+        : {}),
+      toolProgress: params.snapshot.streamingPreviewToolProgress,
+    },
   });
   const threadBindings = restoreOwnedFields(
     current?.threadBindings,
@@ -533,6 +552,9 @@ function buildMatrixQaConfigSnapshot(params: {
     replyToMode: params.overrides?.replyToMode ?? "off",
     startupVerification: params.overrides?.startupVerification,
     streaming: resolveMatrixQaStreamingMode(params.overrides?.streaming),
+    streamingPreviewCommandText: resolveMatrixQaStreamingPreviewCommandText(
+      params.overrides?.streaming,
+    ),
     streamingPreviewToolProgress: resolveMatrixQaStreamingPreviewToolProgress(
       params.overrides?.streaming,
     ),

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
@@ -21,14 +21,12 @@ type MatrixQaExecApprovalsEnabled = boolean | "auto";
 type MatrixQaAllowBotsMode = boolean | "mentions";
 type MatrixQaStreamingConfig = {
   mode?: MatrixQaStreamingMode;
-  preview?: {
+  progress?: {
     commandText?: MatrixQaCommandTextMode;
+  };
+  preview?: {
     toolProgress?: boolean;
   };
-};
-type MatrixQaStreamingPreviewSnapshot = {
-  commandText?: MatrixQaCommandTextMode;
-  toolProgress: boolean;
 };
 type MatrixQaAgentDefaultsOverrides = {
   blockStreamingChunk?: {
@@ -137,7 +135,8 @@ type MatrixQaConfigSnapshot = {
   replyToMode: MatrixQaReplyToMode;
   startupVerification?: "if-unverified" | "off";
   streaming: MatrixQaStreamingMode;
-  streamingPreview: MatrixQaStreamingPreviewSnapshot;
+  streamingProgressCommandText?: MatrixQaCommandTextMode;
+  streamingPreviewToolProgress: boolean;
   textChunkLimit?: number;
   threadBindings: MatrixQaThreadBindingsConfigOverrides;
   threadReplies: MatrixQaThreadRepliesMode;
@@ -296,16 +295,16 @@ function isMatrixQaStreamingConfig(
   return isRecord(value);
 }
 
-function resolveMatrixQaStreamingPreview(
+function resolveMatrixQaStreamingProgressCommandText(
   value: MatrixQaConfigOverrides["streaming"],
-): MatrixQaStreamingPreviewSnapshot {
-  if (!isMatrixQaStreamingConfig(value)) {
-    return { toolProgress: true };
-  }
-  return {
-    ...(value.preview?.commandText ? { commandText: value.preview.commandText } : {}),
-    toolProgress: value.preview?.toolProgress ?? true,
-  };
+): MatrixQaCommandTextMode | undefined {
+  return isMatrixQaStreamingConfig(value) ? value.progress?.commandText : undefined;
+}
+
+function resolveMatrixQaStreamingPreviewToolProgress(
+  value: MatrixQaConfigOverrides["streaming"],
+): boolean {
+  return isMatrixQaStreamingConfig(value) ? (value.preview?.toolProgress ?? true) : true;
 }
 
 function resolveMatrixQaAutoJoinAllowlist(params: { overrides?: MatrixQaConfigOverrides }) {
@@ -456,19 +455,28 @@ function buildMatrixQaChannelAccountConfig(params: {
   const block = restoreOwnedFields(current?.streaming?.block, baseline?.streaming?.block, [
     "enabled",
   ]);
+  const progress = restoreOwnedFields(
+    current?.streaming?.progress,
+    baseline?.streaming?.progress,
+    ["commandText"],
+  );
   const preview = restoreOwnedFields(current?.streaming?.preview, baseline?.streaming?.preview, [
-    "commandText",
     "toolProgress",
   ]);
+  if (params.snapshot.streamingProgressCommandText) {
+    progress.commandText = params.snapshot.streamingProgressCommandText;
+  }
   Object.assign(streaming, {
     block: { ...block, enabled: params.snapshot.blockStreaming },
     chunkMode: params.snapshot.chunkMode ?? "length",
     mode: params.snapshot.streaming,
-    preview: {
-      ...preview,
-      ...params.snapshot.streamingPreview,
-    },
+    preview: { ...preview, toolProgress: params.snapshot.streamingPreviewToolProgress },
   });
+  if (Object.keys(progress).length > 0) {
+    streaming.progress = progress;
+  } else {
+    delete streaming.progress;
+  }
   const threadBindings = restoreOwnedFields(
     current?.threadBindings,
     baseline?.threadBindings,
@@ -546,7 +554,12 @@ function buildMatrixQaConfigSnapshot(params: {
     replyToMode: params.overrides?.replyToMode ?? "off",
     startupVerification: params.overrides?.startupVerification,
     streaming: resolveMatrixQaStreamingMode(params.overrides?.streaming),
-    streamingPreview: resolveMatrixQaStreamingPreview(params.overrides?.streaming),
+    streamingProgressCommandText: resolveMatrixQaStreamingProgressCommandText(
+      params.overrides?.streaming,
+    ),
+    streamingPreviewToolProgress: resolveMatrixQaStreamingPreviewToolProgress(
+      params.overrides?.streaming,
+    ),
     threadBindings: { ...params.overrides?.threadBindings },
     textChunkLimit: params.overrides?.textChunkLimit,
     threadReplies: params.overrides?.threadReplies ?? "inbound",

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
@@ -26,6 +26,10 @@ type MatrixQaStreamingConfig = {
     toolProgress?: boolean;
   };
 };
+type MatrixQaStreamingPreviewSnapshot = {
+  commandText?: MatrixQaCommandTextMode;
+  toolProgress: boolean;
+};
 type MatrixQaAgentDefaultsOverrides = {
   blockStreamingChunk?: {
     breakPreference?: "newline" | "paragraph" | "sentence";
@@ -133,8 +137,7 @@ type MatrixQaConfigSnapshot = {
   replyToMode: MatrixQaReplyToMode;
   startupVerification?: "if-unverified" | "off";
   streaming: MatrixQaStreamingMode;
-  streamingPreviewCommandText?: MatrixQaCommandTextMode;
-  streamingPreviewToolProgress: boolean;
+  streamingPreview: MatrixQaStreamingPreviewSnapshot;
   textChunkLimit?: number;
   threadBindings: MatrixQaThreadBindingsConfigOverrides;
   threadReplies: MatrixQaThreadRepliesMode;
@@ -293,22 +296,16 @@ function isMatrixQaStreamingConfig(
   return isRecord(value);
 }
 
-function resolveMatrixQaStreamingPreviewToolProgress(
+function resolveMatrixQaStreamingPreview(
   value: MatrixQaConfigOverrides["streaming"],
-): boolean {
+): MatrixQaStreamingPreviewSnapshot {
   if (!isMatrixQaStreamingConfig(value)) {
-    return true;
+    return { toolProgress: true };
   }
-  return value.preview?.toolProgress ?? true;
-}
-
-function resolveMatrixQaStreamingPreviewCommandText(
-  value: MatrixQaConfigOverrides["streaming"],
-): MatrixQaCommandTextMode | undefined {
-  if (!isMatrixQaStreamingConfig(value)) {
-    return undefined;
-  }
-  return value.preview?.commandText;
+  return {
+    ...(value.preview?.commandText ? { commandText: value.preview.commandText } : {}),
+    toolProgress: value.preview?.toolProgress ?? true,
+  };
 }
 
 function resolveMatrixQaAutoJoinAllowlist(params: { overrides?: MatrixQaConfigOverrides }) {
@@ -469,10 +466,7 @@ function buildMatrixQaChannelAccountConfig(params: {
     mode: params.snapshot.streaming,
     preview: {
       ...preview,
-      ...(params.snapshot.streamingPreviewCommandText
-        ? { commandText: params.snapshot.streamingPreviewCommandText }
-        : {}),
-      toolProgress: params.snapshot.streamingPreviewToolProgress,
+      ...params.snapshot.streamingPreview,
     },
   });
   const threadBindings = restoreOwnedFields(
@@ -552,12 +546,7 @@ function buildMatrixQaConfigSnapshot(params: {
     replyToMode: params.overrides?.replyToMode ?? "off",
     startupVerification: params.overrides?.startupVerification,
     streaming: resolveMatrixQaStreamingMode(params.overrides?.streaming),
-    streamingPreviewCommandText: resolveMatrixQaStreamingPreviewCommandText(
-      params.overrides?.streaming,
-    ),
-    streamingPreviewToolProgress: resolveMatrixQaStreamingPreviewToolProgress(
-      params.overrides?.streaming,
-    ),
+    streamingPreview: resolveMatrixQaStreamingPreview(params.overrides?.streaming),
     threadBindings: { ...params.overrides?.threadBindings },
     textChunkLimit: params.overrides?.textChunkLimit,
     threadReplies: params.overrides?.threadReplies ?? "inbound",

--- a/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
@@ -12,7 +12,10 @@ scenario:
     retryCount: 0
     config:
       matrixConfigOverrides:
-        streaming: partial
+        streaming:
+          mode: partial
+          preview:
+            commandText: raw
         toolProfile: coding
 
 flow:

--- a/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
@@ -14,7 +14,7 @@ scenario:
       matrixConfigOverrides:
         streaming:
           mode: partial
-          preview:
+          progress:
             commandText: raw
         toolProfile: coding
 


### PR DESCRIPTION
## Summary

- teach the Matrix QA config owner to project the existing `streaming.preview.commandText` setting
- opt the raw-command mention-safety scenario into `commandText: raw`
- keep ordinary/default Matrix progress status-only

## Root cause

Release validation at `c75d4dc9114272dbf7e8bea890d58c0e50dcbc69` timed out waiting for `@room`/user/room-id text in the Matrix progress draft. The product intentionally changed default command progress to status-only in `4c951398ef4` (#121600), while this QA scenario still expected raw exec text without enabling the documented `commandText: raw` path. The final replacement was delivered, so the scenario waited another 60 seconds for text the selected config suppresses by contract.

The owning fix is in the QA configuration projection: this scenario now explicitly selects the raw diagnostic surface whose mention formatting it is meant to validate. The default product path remains status-only.

## Validation

- failing reproduction: full release validation job https://github.com/openclaw/openclaw/actions/runs/32099770866/job/95611750107
- GitHub-only exact-head Matrix validation passed: https://github.com/openclaw/openclaw/actions/runs/32114475505
- `git diff --check` passed
- no local tests or validation were run, per release-validation instruction

## Test audit

This remains behavior-level live evidence: it requires a real Matrix replacement draft, asserts mention-looking raw command text is code-formatted, and rejects active `m.mentions`/`matrix.to` links. The config unit case also proves the scenario override is removed when the next scenario returns to scalar/default streaming config.

## Scope

QA/test-support only: +30/-5. No production runtime or public config surface changes.

<!-- agent transcript omitted: no user preference was provided -->