### PR TITLE
fix(tts): normalize streamed speech and report fallbacks

### DIFF
--- a/extensions/discord/src/voice/segment.ts
+++ b/extensions/discord/src/voice/segment.ts
@@ -169,6 +169,13 @@ export async function processDiscordVoiceSegment(params: {
     logger.warn(`discord voice: TTS failed: ${voiceReplyAudio.error ?? "unknown error"}`);
     return;
   }
+  const streamFailure = voiceReplyAudio.mode === "file" ? voiceReplyAudio.streamFailure : undefined;
+  if (streamFailure && !entry.ttsStreamFallbackWarned) {
+    entry.ttsStreamFallbackWarned = true;
+    logger.warn(
+      `discord voice: streaming TTS failed provider=${streamFailure.provider} reasonCode=${streamFailure.reasonCode}; using file fallback`,
+    );
+  }
   logVoiceVerbose(
     `tts ok (${voiceReplyAudio.speakText.length} chars): guild ${entry.guildId} channel ${entry.channelId}`,
   );

--- a/extensions/discord/src/voice/session.ts
+++ b/extensions/discord/src/voice/session.ts
@@ -103,6 +103,7 @@ export type VoiceSessionEntry = {
   player: import("@discordjs/voice").AudioPlayer;
   playbackQueue: Promise<void>;
   processingQueue: Promise<void>;
+  ttsStreamFallbackWarned: boolean;
   capture: VoiceCaptureState;
   realtimeLifecycle: VoiceRealtimeLifecycle;
   transcripts?: {

--- a/extensions/discord/src/voice/tts.ts
+++ b/extensions/discord/src/voice/tts.ts
@@ -83,7 +83,9 @@ export async function synthesizeVoiceReplyAudio(params: {
     };
   }
   const streamFailure =
-    streamResult && !streamResult.success ? streamResult.attempts?.at(-1) : undefined;
+    streamResult && !streamResult.success
+      ? streamResult.attempts?.findLast((attempt) => attempt.outcome === "failed")
+      : undefined;
 
   const result = await runtime.tts.textToSpeech({
     text: speakText,

--- a/extensions/discord/src/voice/tts.ts
+++ b/extensions/discord/src/voice/tts.ts
@@ -2,8 +2,14 @@
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig, TtsConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { TtsStreamResult } from "openclaw/plugin-sdk/tts-runtime";
 import { getDiscordRuntime } from "../runtime.js";
 import { sanitizeVoiceReplyTextForSpeech } from "./sanitize.js";
+
+type VoiceStreamFailure = Pick<
+  NonNullable<TtsStreamResult["attempts"]>[number],
+  "provider" | "reasonCode"
+>;
 
 type VoiceReplyAudioResult =
   | {
@@ -11,6 +17,7 @@ type VoiceReplyAudioResult =
       mode: "file";
       audioPath: string;
       speakText: string;
+      streamFailure?: VoiceStreamFailure;
     }
   | {
       status: "ok";
@@ -75,6 +82,8 @@ export async function synthesizeVoiceReplyAudio(params: {
       speakText,
     };
   }
+  const streamFailure =
+    streamResult && !streamResult.success ? streamResult.attempts?.at(-1) : undefined;
 
   const result = await runtime.tts.textToSpeech({
     text: speakText,
@@ -85,5 +94,15 @@ export async function synthesizeVoiceReplyAudio(params: {
   if (!result.success || !result.audioPath) {
     return { status: "failed", error: result.error ?? "unknown error" };
   }
-  return { status: "ok", mode: "file", audioPath: result.audioPath, speakText };
+  return {
+    status: "ok",
+    mode: "file",
+    audioPath: result.audioPath,
+    speakText,
+    ...(streamFailure
+      ? {
+          streamFailure: { provider: streamFailure.provider, reasonCode: streamFailure.reasonCode },
+        }
+      : {}),
+  };
 }

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -422,6 +422,48 @@ defineDiscordVoiceTests(
       expect(fallbackWarnings[0]).not.toContain(replyText);
     });
 
+    it("does not warn when an unsupported streaming provider uses file fallback", async () => {
+      textToSpeechStreamMock.mockResolvedValueOnce({
+        success: false,
+        error: "TTS conversion failed: buffered does not support streaming TTS",
+        attemptedProviders: ["buffered"],
+        attempts: [
+          {
+            provider: "buffered",
+            outcome: "skipped",
+            reasonCode: "unsupported_for_streaming",
+            error: "buffered does not support streaming TTS",
+          },
+        ],
+      });
+      agentCommandMock.mockResolvedValueOnce({
+        payloads: [{ text: "buffered provider reply" }],
+      } as never);
+      const client = createClientWithMember("u-guest", "Guest", "4321");
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
+        client,
+      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+
+      await getVoiceReceive(manager).processSegment({
+        entry,
+        wavPath: "/tmp/test.wav",
+        userId: "u-guest",
+        durationSeconds: 1.2,
+      });
+      await entry.playbackQueue;
+
+      expect(textToSpeechMock).toHaveBeenCalledOnce();
+      expect(entry.player.play).toHaveBeenCalledOnce();
+      expect(
+        loggerWarnMock.mock.calls
+          .map(([message]) => String(message))
+          .filter((message) => message.includes("streaming TTS failed")),
+      ).toEqual([]);
+    });
+
     it("releases late TTS without playback after the voice session leaves", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -25,6 +25,7 @@ defineDiscordVoiceTests(
     textToSpeechStreamMock,
     textToSpeechMock,
     logVerboseMock,
+    loggerWarnMock,
     controlRealtimeVoiceAgentRunMock,
     realtimeSessionMock,
     decodeOpusStreamMock,
@@ -39,6 +40,7 @@ defineDiscordVoiceTests(
     makeVoiceConfig,
     createFollowManager,
     getSessionEntry,
+    getVoiceReceive,
     beginSpeakerTurn,
     lastAgentCommandArgs,
     lastAgentCommandToolNames,
@@ -227,6 +229,7 @@ defineDiscordVoiceTests(
           sessionLifecycle: { status: "active" },
           playbackQueue: Promise.resolve(),
           processingQueue: Promise.resolve(),
+          ttsStreamFallbackWarned: false,
           capture: createVoiceCaptureState(),
           receiveRecovery: createVoiceReceiveRecoveryState(),
           isStopped: () => false,
@@ -386,6 +389,37 @@ defineDiscordVoiceTests(
         throw new Error("expected Discord audio resource input");
       }
       await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+    });
+
+    it("logs a failed streaming provider once per session when using file fallback", async () => {
+      const replyText = "file fallback reply";
+      agentCommandMock.mockResolvedValue({ payloads: [{ text: replyText }] } as never);
+      const client = createClientWithMember("u-guest", "Guest", "4321");
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
+        client,
+      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+      const receive = getVoiceReceive(manager);
+
+      for (let index = 0; index < 2; index += 1) {
+        await receive.processSegment({
+          entry,
+          wavPath: "/tmp/test.wav",
+          userId: "u-guest",
+          durationSeconds: 1.2,
+        });
+      }
+      await entry.playbackQueue;
+
+      const fallbackWarnings = loggerWarnMock.mock.calls
+        .map(([message]) => String(message))
+        .filter((message) => message.includes("using file fallback"));
+      expect(fallbackWarnings).toEqual([
+        "discord voice: streaming TTS failed provider=elevenlabs reasonCode=provider_error; using file fallback",
+      ]);
+      expect(fallbackWarnings[0]).not.toContain(replyText);
     });
 
     it("releases late TTS without playback after the voice session leaves", async () => {

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -451,6 +451,7 @@ export class DiscordVoiceSessions {
       player,
       playbackQueue: Promise.resolve(),
       processingQueue: Promise.resolve(),
+      ttsStreamFallbackWarned: false,
       capture: createVoiceCaptureState(),
       transcripts: options?.transcripts,
       receiveRecovery: createVoiceReceiveRecoveryState(),

--- a/extensions/discord/src/voice/voice-test-harness.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-harness.test-support.ts
@@ -36,6 +36,7 @@ const {
   textToSpeechStreamMock,
   textToSpeechMock,
   logVerboseMock,
+  loggerWarnMock,
   resolveConfiguredRealtimeVoiceProviderMock,
   createRealtimeVoiceBridgeSessionMock,
   controlRealtimeVoiceAgentRunMock,
@@ -86,10 +87,24 @@ function buildVoiceTestHarness() {
       }),
     );
     textToSpeechStreamMock.mockReset();
-    textToSpeechStreamMock.mockResolvedValue({ success: false, error: "stream unavailable" });
+    textToSpeechStreamMock.mockResolvedValue({
+      success: false,
+      error: "TTS conversion failed: elevenlabs: upstream unavailable",
+      attemptedProviders: ["elevenlabs"],
+      attempts: [
+        {
+          provider: "elevenlabs",
+          outcome: "failed",
+          reasonCode: "provider_error",
+          latencyMs: 12,
+          error: "elevenlabs: upstream unavailable",
+        },
+      ],
+    });
     textToSpeechMock.mockReset();
     textToSpeechMock.mockResolvedValue({ success: true, audioPath: "/tmp/voice.mp3" });
     logVerboseMock.mockClear();
+    loggerWarnMock.mockClear();
     updateVoiceStateMock.mockClear();
     enqueueSystemEventMock.mockClear();
     enqueueSystemEventMock.mockReturnValue(true);
@@ -553,6 +568,7 @@ function buildVoiceTestHarness() {
         sessionLifecycle: { status: "active" },
         playbackQueue: Promise.resolve(),
         processingQueue: Promise.resolve(),
+        ttsStreamFallbackWarned: false,
         capture: createVoiceCaptureState(),
         receiveRecovery: createVoiceReceiveRecoveryState(),
       },
@@ -613,6 +629,7 @@ function buildVoiceTestHarness() {
     textToSpeechStreamMock,
     textToSpeechMock,
     logVerboseMock,
+    loggerWarnMock,
     resolveConfiguredRealtimeVoiceProviderMock,
     createRealtimeVoiceBridgeSessionMock,
     controlRealtimeVoiceAgentRunMock,

--- a/extensions/discord/src/voice/voice-test-mocks.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-mocks.test-support.ts
@@ -16,6 +16,7 @@ const {
   textToSpeechStreamMock,
   textToSpeechMock,
   logVerboseMock,
+  loggerWarnMock,
   resolveConfiguredRealtimeVoiceProviderMock,
   createRealtimeVoiceBridgeSessionMock,
   controlRealtimeVoiceAgentRunMock,
@@ -158,6 +159,7 @@ const {
     ),
     textToSpeechMock: vi.fn(async () => ({ success: true, audioPath: "/tmp/voice.mp3" })),
     logVerboseMock: vi.fn(),
+    loggerWarnMock: vi.fn(),
     resolveConfiguredRealtimeVoiceProviderMock: vi.fn<
       () => {
         provider: {
@@ -209,6 +211,7 @@ export const voiceTestMocks = {
   textToSpeechStreamMock,
   textToSpeechMock,
   logVerboseMock,
+  loggerWarnMock,
   resolveConfiguredRealtimeVoiceProviderMock,
   createRealtimeVoiceBridgeSessionMock,
   controlRealtimeVoiceAgentRunMock,
@@ -277,6 +280,10 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   );
   return {
     ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      warn: loggerWarnMock,
+    }),
     logVerbose: logVerboseMock,
   };
 });

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -29,7 +29,6 @@ vi.mock("node:child_process", async (importOriginal) => {
   };
 });
 
-import { isQaPosixProcessGroupAlive } from "./posix-process-group.js";
 import {
   resetQaScenarioCommandCleanupTimings,
   runQaScenarioCommandLifecycle,
@@ -135,10 +134,6 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
         timeoutMs: 5_000,
       });
       descendantPid = await waitForPidFile(descendantPidPath);
-      const processGroupId = (spawnMock.mock.results[0]?.value as ChildProcess | undefined)?.pid;
-      if (!processGroupId) {
-        throw new Error("scenario command did not expose its process group id");
-      }
       const startedAt = Date.now();
       const deadline = new AbortController();
       const result = await Promise.race([
@@ -155,7 +150,10 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
         stdout: "Docker scheduling finished\ndelayed descendant output\n",
         stderr: "",
       });
-      expect(isQaPosixProcessGroupAlive(processGroupId)).toBe(false);
+      if (descendantPid === undefined) {
+        throw new Error("scenario command descendant did not expose its pid");
+      }
+      expect(isProcessRunning(descendantPid)).toBe(false);
     } finally {
       if (descendantPid && isProcessRunning(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");

--- a/src/tts/tts-runtime-models.test.ts
+++ b/src/tts/tts-runtime-models.test.ts
@@ -283,7 +283,7 @@ describe("TTS runtime voice model and streaming behavior", () => {
     expect(streamSynthesize).toHaveBeenCalledOnce();
   });
 
-  it("classifies streaming timeouts before falling back with raw text", async () => {
+  it("classifies streaming timeouts before falling back with normalized speech text", async () => {
     // Real transport timeouts arrive as "TimeoutError" (fetch-timeout.ts), not
     // AbortError; the classifier must catch the shape providers actually throw.
     const timeoutStreamSynthesize = vi.fn(async () => {
@@ -338,6 +338,8 @@ describe("TTS runtime voice model and streaming behavior", () => {
       outcome: "success",
       reasonCode: "success",
     });
-    expect(fallbackStreamSynthesize).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(fallbackStreamSynthesize).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Keep streaming Markdown raw!" }),
+    );
   });
 });

--- a/src/tts/tts-streaming.ts
+++ b/src/tts/tts-streaming.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { TtsDirectiveOverrides } from "./provider-types.js";
 import { assertSpeechRuntimeAvailable } from "./runtime-availability.js";
+import { normalizeSpeechText } from "./speech-text.js";
 import type { TtsStreamResult, TtsSynthesisStreamResult } from "./tts-runtime-types.js";
 import { executeTtsProviderAttempts, resolveTtsRequestSetup } from "./tts-synthesis-support.js";
 import { resolveTtsSynthesisTarget } from "./tts-synthesis.js";
@@ -38,7 +39,7 @@ export async function streamSpeech(params: {
     config,
     persona,
     providers,
-    synthesisText: params.text,
+    synthesisText: normalizeSpeechText(params.text),
     providerOverrides: params.overrides?.providerOverrides,
     timeoutMs: params.timeoutMs,
     target,

--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -60,9 +60,14 @@ function interactiveOwner(): {
     scrollLeft: { configurable: true, value: 0, writable: true },
     scrollWidth: { configurable: true, value: 300 },
   });
-  owner.addEventListener("click", handleMarkdownTableInteraction);
   enhanceMarkdownTables(owner);
   return { owner, shell, viewport };
+}
+
+function markdownTableInteractionEvent(target: Element): Event {
+  const event = new MouseEvent("click", { bubbles: true });
+  Object.defineProperty(event, "target", { value: target });
+  return event;
 }
 
 describe("Markdown table interactions", () => {
@@ -140,14 +145,14 @@ describe("Markdown table interactions", () => {
     vi.useFakeTimers();
     const { owner } = interactiveOwner();
     const copy = owner.querySelector<HTMLButtonElement>(".markdown-table__copy")!;
-    copy.click();
+    handleMarkdownTableInteraction(markdownTableInteractionEvent(copy));
     expect(writeText).toHaveBeenCalledWith("Name\tValue\nAlpha\tOne");
     await vi.advanceTimersByTimeAsync(0);
     expect(copy.getAttribute("aria-label")).toBe("Copied!");
 
     const expand = owner.querySelector<HTMLButtonElement>(".markdown-table__expand")!;
     expand.focus();
-    expand.click();
+    handleMarkdownTableInteraction(markdownTableInteractionEvent(expand));
     const dialog = document.querySelector<HTMLDialogElement>(".markdown-table-dialog")!;
     expect(dialog.hasAttribute("open")).toBe(true);
     expect(dialog.querySelector("table")?.textContent).toContain("Alpha");

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -3,11 +3,17 @@ import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import {
+  resolveStoredChatOutboxScope,
+  storedChatOutboxScopeKey,
+  storageTargetForGateway,
+} from "../lib/chat/outbox-store.ts";
+import {
   controlUiSessionUrl,
   installMockGateway,
   navigateToControlUiSession,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { waitForCommittedState } from "./settle.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI chat attachment read lifecycle",
@@ -55,48 +61,67 @@ async function pastePng(composer: Locator): Promise<void> {
   }, ONE_PIXEL_PNG_B64);
 }
 
-async function waitForDurableDraft(
+async function waitForCommittedAttachmentDraft(
   page: Page,
   sessionKey: string,
-  expected: { text: string; attachments: number },
-) {
-  await expect
-    .poll(() =>
-      page.evaluate(async (targetKey) => {
-        const requestResult = <T>(request: IDBRequest<T>) =>
-          new Promise<T>((resolve, reject) => {
-            request.addEventListener("success", () => resolve(request.result), { once: true });
-            request.addEventListener(
-              "error",
-              () => reject(request.error ?? new Error("IndexedDB request failed")),
-              { once: true },
-            );
-          });
-        try {
-          const database = await requestResult(indexedDB.open("openclaw-control-ui", 1));
-          if (!database.objectStoreNames.contains("composerDrafts")) {
-            database.close();
-            return null;
-          }
-          const records = (await requestResult(
-            database
-              .transaction("composerDrafts", "readonly")
-              .objectStore("composerDrafts")
-              .getAll(),
-          )) as Array<{ attachments?: unknown[]; scopeKey?: string; text?: string }>;
-          database.close();
-          const record = records.find(
-            (candidate) => candidate.scopeKey === `${targetKey}\u0000agent:main`,
-          );
-          return record
-            ? { text: record.text, attachments: record.attachments?.length ?? 0 }
-            : null;
-        } catch {
-          return null;
+  text: string,
+): Promise<void> {
+  const gatewayUrl = await page.evaluate(() => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: { context: { gateway: { connection: { gatewayUrl: string } } } };
+    };
+    return app.runtime?.context.gateway.connection.gatewayUrl ?? null;
+  });
+  if (!gatewayUrl) {
+    throw new Error("OpenClaw application Gateway URL is unavailable");
+  }
+  const storedScope = resolveStoredChatOutboxScope({ settings: { gatewayUrl } }, sessionKey);
+  await waitForCommittedState(
+    page,
+    async (expected) => {
+      const { gatewayOwner, recoveryScope, scopeKey, draftText, attachmentCount } = expected;
+      if (
+        typeof gatewayOwner !== "string" ||
+        typeof recoveryScope !== "string" ||
+        typeof scopeKey !== "string" ||
+        typeof draftText !== "string" ||
+        typeof attachmentCount !== "number"
+      ) {
+        return false;
+      }
+      try {
+        const storeUrl = performance
+          .getEntriesByType("resource")
+          .map((entry) => entry.name)
+          .find((name) => /\/composer-draft-store\.runtime-[^/]+\.js$/u.test(name));
+        if (!storeUrl) {
+          return false;
         }
-      }, sessionKey),
-    )
-    .toEqual(expected);
+        const draftStore = (await import(
+          /* @vite-ignore */ storeUrl
+        )) as typeof import("../lib/chat/composer-draft-store.runtime.ts");
+        const result = await draftStore.readDurableComposerDraft({
+          gatewayOwner,
+          recoveryScope,
+          scopeKey,
+        });
+        return (
+          result.status === "found" &&
+          result.draft.text === draftText &&
+          result.draft.attachments.length === attachmentCount
+        );
+      } catch {
+        return false;
+      }
+    },
+    {
+      gatewayOwner: storageTargetForGateway(gatewayUrl).gatewayOwner,
+      recoveryScope: "e2e-recovery-scope",
+      scopeKey: storedChatOutboxScopeKey(storedScope),
+      draftText: text,
+      attachmentCount: 1,
+    },
+  );
 }
 
 suite.define(() => {
@@ -141,6 +166,7 @@ suite.define(() => {
       await activeComposer(firstPage).fill("restart draft A with image");
       await pastePng(activeComposer(firstPage));
       await expect.poll(() => activeAttachments(firstPage).count()).toBe(1);
+      await waitForCommittedAttachmentDraft(firstPage, firstSession, "restart draft A with image");
 
       await navigateToControlUiSession(firstPage, secondSession);
       await activeComposer(firstPage).fill("restart draft B with removable file");
@@ -152,14 +178,11 @@ suite.define(() => {
           buffer: Buffer.from("remove this attachment"),
         });
       await expect.poll(() => activeAttachments(firstPage).count()).toBe(1);
-      await waitForDurableDraft(firstPage, firstSession, {
-        text: "restart draft A with image",
-        attachments: 1,
-      });
-      await waitForDurableDraft(firstPage, secondSession, {
-        text: "restart draft B with removable file",
-        attachments: 1,
-      });
+      await waitForCommittedAttachmentDraft(
+        firstPage,
+        secondSession,
+        "restart draft B with removable file",
+      );
       await firstPage.close();
 
       const restoredPage = await context.newPage();

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -213,7 +213,8 @@ suite.define(() => {
       await completedChild.hover();
       await expect.poll(() => actionOpacity(childMenuButton)).toBe("1");
       await expect.poll(() => actionPointerEvents(childMenuButton)).toBe("auto");
-      await childMenuButton.click();
+      await childMenuButton.focus();
+      await page.keyboard.press("Enter");
       const childMenu = page.getByRole("menu", { name: "Actions for Verify tests" });
       await childMenu.waitFor({ state: "visible" });
       await page.getByRole("menuitem", { name: "Mark as unread" }).waitFor();

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6708,13 +6708,19 @@ describe("handleSendChat", () => {
     host.client = clientWithRequest(request);
     host.connected = true;
 
-    await retryReconnectableQueuedChatSends(host);
+    vi.useFakeTimers();
+    try {
+      await retryReconnectableQueuedChatSends(host);
 
-    expect(historyAttempts).toBe(1);
-    expect(sendAttempts).toBe(0);
-    await waitForFast(() => expect(sendAttempts).toBe(1));
-    expect(historyAttempts).toBeGreaterThanOrEqual(2);
-    await waitForFast(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]));
+      expect(historyAttempts).toBe(1);
+      expect(sendAttempts).toBe(0);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sendAttempts).toBe(1);
+      expect(historyAttempts).toBeGreaterThanOrEqual(2);
+      expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("persists queueable local commands entered while disconnected", async () => {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6665,13 +6665,23 @@ describe("handleSendChat", () => {
       chatMessage: "retry without disconnecting",
     });
 
-    await handleSendChat(host);
+    vi.useFakeTimers();
+    try {
+      await handleSendChat(host);
 
-    expect(host.connected).toBe(true);
-    expect(host.chatQueue[0]).toMatchObject({ sendAttempts: 0, sendState: "waiting-reconnect" });
-    await waitForFast(() => expect(sendAttempts).toBe(2));
-    expect(sendRunIds[1]).toBe(sendRunIds[0]);
-    await waitForFast(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]));
+      expect(host.connected).toBe(true);
+      expect(host.chatQueue[0]).toMatchObject({
+        sendAttempts: 0,
+        sendState: "waiting-reconnect",
+      });
+      expect(sendAttempts).toBe(1);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sendAttempts).toBe(2);
+      expect(sendRunIds[1]).toBe(sendRunIds[0]);
+      expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retries reconnect history after a retryable response without a socket close", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where streamed Discord voice replies could speak Markdown syntax and raw link destinations that buffered synthesis strips before speech. It also resolves a silent failure mode where a streaming provider error was hidden when file synthesis succeeded as a fallback.

## Why This Change Was Made

The core streaming TTS path passed raw input directly into provider attempts instead of applying the canonical speech-text normalization already used by buffered synthesis. The core TTS owner now normalizes streaming text at that boundary.

Discord voice also discarded the failed streaming attempt metadata before successful file fallback, leaving the session with no recordable explanation. The Discord voice owner now carries the failed provider and closed reason code across the fallback and records the first such fallback once per voice session. This preserves successful playback without repeated warnings.

ClawSweeper identified that expected `unsupported_for_streaming` skips were still flowing into the warning path. That finding is addressed by selecting only the last attempt whose outcome is `failed`: expected capability skips remain silent during successful buffered fallback, while actual failed attempts still preserve their warning metadata.

AI-assisted maintainer repair; the implementation and focused evidence were reviewed before publication.

## User Impact

Streamed Discord voice now reads cleaned speech instead of vocalizing Markdown markers or raw link destinations. When an actual streaming attempt fails but file synthesis succeeds, operators receive one useful warning per voice session naming the failed provider and reason code while playback continues normally. Buffered-only providers can use their expected file fallback without a misleading streaming-failure warning.

## Evidence

- Core regression: before the fix, the fallback stream received raw `## Keep [streaming Markdown](https://example.com) raw!!!!!`; after the fix, it receives `Keep streaming Markdown raw!`. The focused regression passes, and `src/tts/tts-runtime-models.test.ts` passes 7/7.
- Discord regression: before the fix, a streaming provider failure followed by successful file fallback emitted no warning. The focused voice runtime test now passes and records exactly one warning per session with `provider=elevenlabs` and `reasonCode=provider_error` while file fallback succeeds.
- ClawSweeper finding regression: before the follow-up fix, a fresh voice session using a buffered-only provider played the successful file fallback but emitted a misleading streaming-failure warning. The regression now proves the file fallback plays and emits no such warning.
- The targeted expected-skip and actual-failure tests passed, and the full Discord voice-runtime file passed 31/31. `oxfmt` and `git diff --check` are clean, and fresh Codex autoreview completed with no accepted or actionable findings.
- Live provider proof: ElevenLabs streaming synthesis produced `mp3_44100_128` audio (42,258 bytes), and ElevenLabs STT transcribed it as `Status done. Read the release notes`. The transcript contained no hash/hashtag/asterisk/URL/raw-URL speech.
- Absorbed CI repair: exact-head run [32110130614](https://github.com/openclaw/openclaw/actions/runs/32110130614), job [95627654678](https://github.com/openclaw/openclaw/actions/runs/32110130614/job/95627654678), exposed an unrelated Control UI reconnect-history retry test whose real 100 ms timer lost to `waitForFast`'s wall-clock timeout on the saturated `compact-large` shard.
- The test-only deterministic repair (+12/-6; production LOC 0) uses fake timers, advances the exact 100 ms retry delay, preserves the history/send ordering and outbox assertions, and restores real timers in `finally`. The focused test passed locally, a bounded worker loop passed 10/10, and fresh autoreview completed cleanly.
- Absorbed CI repair: exact-head run [32117859632](https://github.com/openclaw/openclaw/actions/runs/32117859632), job [95651522546](https://github.com/openclaw/openclaw/actions/runs/32117859632/job/95651522546), exposed the Markdown table test's delegated click delivery racing the assertions. The test now invokes the delegated handler directly with a targeted event while preserving exact TSV, copied-label timer, dialog-open, table-content, and focus-restoration assertions.
- Absorbed CI repair: the same run's [checks-ui-e2e failure](https://github.com/openclaw/openclaw/actions/runs/32117859632/job/95651523549) exposed navigation and page close racing the durable composer write. The shipped-bundle E2E now waits through `waitForCommittedState` until the real IndexedDB composer store contains the expected text and exactly one attachment for each session, while preserving all restoration, removal, and send assertions.
- Both focused UI files pass. Bounded repeats passed 5/5 for the Markdown test and 5/5 for the attachment E2E; the `coreTests` changed gate passed; formatting, diff checks, and fresh autoreview are clean. These synchronization repairs are production +0/-0 and tests +83/-3.
- Absorbed CI repair: exact-head run [32120793258](https://github.com/openclaw/openclaw/actions/runs/32120793258) exposed two unrelated identity assumptions: a delayed interactive hovercard could intercept the child-session menu pointer click, and the QA cleanup test checked a globally reusable process-group identity instead of its owned descendant process.
- The sidebar repair preserves the hover opacity and pointer-event assertions, then focuses and activates the child-session menu with Enter. Bounded focused repeats passed 5/5 and the full UI E2E lane passed 11/11.
- The QA repair asserts that the exact captured descendant PID is dead when cleanup completes. Bounded focused repeats passed 20/20 and the full QA lifecycle file passed 8/8.
- These owner-specific repairs are production +0/-0 and tests +6/-7. The changed gate, formatting, and diff checks pass, and fresh Codex autoreview completed with no accepted or actionable findings.
- Absorbed CI repair: exact-head run [32125741781](https://github.com/openclaw/openclaw/actions/runs/32125741781) exposed `retries an explicitly retryable send rejection while still connected` observing one send attempt instead of two because its 100 ms retry lost to wall-clock polling under CI load.
- The deterministic test-only repair uses fake timers, asserts the initial send occurred once, advances the exact 100 ms `retryAfter`, then verifies the second attempt reused the same idempotency key and emptied the outbox; real timers are restored in `finally`. The focused test passed, a bounded loop passed 10/10, and formatting, diff checks, and fresh Codex autoreview are clean. This repair is production +0/-0 and tests +16/-6.
- Production LOC: +33/-2 (net +31). Tests and test support: +217/-72 (net +145). The production growth is the Discord session-owned once-only diagnostic state and the provider/reason-code metadata carried across successful file fallback.
- Known local proof gap: the changed-gate wrapper ran for 55 minutes on a saturated host and passed guards, formatting, doctor contract tests, deprecated API checks, plugin boundaries, patch guard, dead-export scans, and reached core/core-test/extension/extension-test typechecks plus lint invocation with no printed failures, but it did not terminate and was stopped. This is not claimed as a completed local changed gate; exact-head pull-request CI is required.

### Rebase evidence

The earlier attachment-lifecycle CI failure from run 32116923052 was already fixed on main by 6b72d65ffe4f. After rebasing that fix, run 32117859632 exposed a distinct remaining durability race in the shipped-bundle lifecycle test; the new committed-state barrier covers that race without duplicating production code.

Main later advanced through #125665 with an independent raw IndexedDB draft poll in the same lifecycle test. The clean rebase retained this PR's canonical `waitForCommittedState` barrier and exact write-boundary calls, removed only the redundant helper overlap, and the rebased attachment lifecycle E2E passed 4/4.

Main then advanced through #125645 with a real `navigator.clipboard.writeText` test boundary in the Markdown table test. The clean rebase combined that boundary with this PR's direct handler invocation, preserving both fixes; the focused Markdown file passed 4/4 and the attachment lifecycle E2E passed 4/4. Fresh branch autoreview completed with no accepted or actionable findings.
