### PR TITLE
fix: stabilize thinking gate rollback test under load

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -647,10 +647,23 @@ private actor AsyncStringRecorder {
 
 private actor SessionSubscribeGate {
     private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var blockedObservers: [CheckedContinuation<Void, Never>] = []
 
     func wait() async {
         await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
+            let observers = self.blockedObservers
+            self.blockedObservers = []
+            for observer in observers {
+                observer.resume()
+            }
+        }
+    }
+
+    func waitUntilBlocked() async {
+        guard self.waiters.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            self.blockedObservers.append(continuation)
         }
     }
 
@@ -8653,9 +8666,8 @@ struct ChatViewModelTests {
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
 
         vm.selectModel("openai/gpt-5.4")
-        try await waitUntil("model patch is in flight") {
-            await transport.patchedModels() == ["openai/gpt-5.4"]
-        }
+        await modelPatchGate.waitUntilBlocked()
+        #expect(await transport.patchedModels() == ["openai/gpt-5.4"])
 
         vm.input = "hello before switch"
         vm.send()
@@ -9778,12 +9790,15 @@ struct ChatViewModelTests {
             initialThinkingLevel: "medium")
 
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
-        await MainActor.run { vm.selectModel("openai/reasoning-model") }
-        try await waitUntil("reasoning model patch started") {
-            let pickerShown = await MainActor.run { vm.showsThinkingPicker }
-            let patchedModels = await transport.patchedModels()
-            return pickerShown && patchedModels == ["openai/reasoning-model"]
+        try await waitUntil("model picker bootstrap completed") {
+            await MainActor.run { !vm.isLoading }
         }
+        #expect(await MainActor.run { vm.modelSelectionID == "openai/plain-model" })
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+        await MainActor.run { vm.selectModel("openai/reasoning-model") }
+        await modelPatchGate.waitUntilBlocked()
+        #expect(await MainActor.run { vm.showsThinkingPicker })
+        #expect(await transport.patchedModels() == ["openai/reasoning-model"])
 
         await sendUserMessage(vm, text: "send after rollback")
         try await waitUntil("send waits for model patch") {
@@ -9843,13 +9858,12 @@ struct ChatViewModelTests {
         }
 
         await MainActor.run { vm.selectModel("openai/plain-model") }
-        try await waitUntil("local non-reasoning selection gated") {
-            await MainActor.run {
-                vm.modelSelectionID == "openai/plain-model" &&
-                    !vm.showsThinkingPicker &&
-                    vm.sessions.first?.model == "reasoning-model"
-            }
-        }
+        await modelPatchGate.waitUntilBlocked()
+        #expect(await MainActor.run {
+            vm.modelSelectionID == "openai/plain-model" &&
+                !vm.showsThinkingPicker &&
+                vm.sessions.first?.model == "reasoning-model"
+        })
         await modelPatchGate.release()
     }
 
@@ -9883,11 +9897,9 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { !vm.showsThinkingPicker })
 
         await MainActor.run { vm.selectModel("openai/model-y") }
-        try await waitUntil("model Y patch started") {
-            await transport.patchedModels() == ["openai/model-y"]
-        }
+        await modelPatchGate.waitUntilBlocked()
+        #expect(await transport.patchedModels() == ["openai/model-y"])
         await MainActor.run { vm.selectModel("openai/model-x") }
-        try await Task.sleep(for: .milliseconds(50))
         #expect(await transport.patchedModels() == ["openai/model-y"])
         await modelPatchGate.release()
         try await waitUntil("model X re-selection patched") {


### PR DESCRIPTION
## What Problem This Solves

Fixes a load-sensitive Swift test flake where `send reapplies thinking gate after model patch rollback` could time out while waiting for the reasoning-model patch to start during a full parallel OpenClawKit run.

The test treated health/session readiness as complete bootstrap readiness, so a late model-catalog refresh could overwrite the optimistic reasoning selection. It also observed the transport record before the blocking hook had registered its continuation, leaving a release-before-wait race.

## Why This Change Was Made

The test now waits for model-picker bootstrap completion, then synchronizes on a gate-owned fact recorded only after the patch hook is actually blocked. The same handshake replaces polling or sleeps in three nearby model-patch tests with the same lost-release shape. Production behavior is unchanged.

AI-assisted: yes. The change and its concurrency reasoning were independently reviewed before publication.

## User Impact

No product behavior changes. Apple CI and local full-suite validation no longer depend on a 15-second polling window or scheduler timing for these model-patch tests.

## Evidence

- Original observation: the target test timed out after 15.038 seconds during a heavily loaded full parallel suite, while isolated runs passed 6/6 in 0.07–0.27 seconds.
- Pre-fix bounded reproduction hit the ordering failure on run 4.
- `swift test --package-path apps/shared/OpenClawKit --parallel`: 1,376 tests in 106 suites passed in 25.924 seconds.
- Concurrent bounded loop: the filtered rollback test passed 40/40 while the full parallel suite ran.
- Four affected focused tests passed individually.
- `swiftformat --lint apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift --config config/swiftformat`: clean.
- `git diff --check`: clean.
- Fresh Codex autoreview: no accepted/actionable findings.
- `node scripts/check-changed.mjs -- apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift`: repository guards and Swift lint passed; the unrelated Node `vitest.tooling` shard produced no output for 15 minutes twice and was terminated by its existing watchdog. Exact-head PR CI remains the authoritative broad gate.
