### PR TITLE
fix(ui): match fullscreen table presentation

### DIFF
--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -144,6 +144,10 @@ describe("Markdown table interactions", () => {
     expect(writeText).toHaveBeenCalledWith("Name\tValue\nAlpha\tOne");
     await vi.advanceTimersByTimeAsync(0);
     expect(copy.getAttribute("aria-label")).toBe("Copied!");
+    expect(copy.querySelector("svg path")?.getAttribute("d")).toBe("M20 6 9 17l-5-5");
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(copy.getAttribute("aria-label")).toBe("Copy table");
+    expect(copy.querySelector("svg rect")).not.toBeNull();
 
     const expand = owner.querySelector<HTMLButtonElement>(".markdown-table__expand")!;
     expand.focus();

--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -152,7 +152,25 @@ describe("Markdown table interactions", () => {
     expect(dialog.hasAttribute("open")).toBe(true);
     expect(dialog.querySelector("table")?.textContent).toContain("Alpha");
 
-    dialog.querySelector<HTMLButtonElement>(".markdown-table-dialog__close")!.click();
+    vi.spyOn(dialog, "getBoundingClientRect").mockReturnValue({
+      bottom: 500,
+      height: 400,
+      left: 100,
+      right: 500,
+      top: 100,
+      width: 400,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    dialog.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 50, clientY: 50 }));
+    expect(document.querySelector(".markdown-table-dialog")).toBeNull();
+    expect(document.activeElement).toBe(expand);
+
+    expand.click();
+    const reopenedDialog = document.querySelector<HTMLDialogElement>(".markdown-table-dialog")!;
+
+    reopenedDialog.querySelector<HTMLButtonElement>(".markdown-table-dialog__close")!.click();
     expect(document.querySelector(".markdown-table-dialog")).toBeNull();
     expect(document.activeElement).toBe(expand);
   });

--- a/ui/src/components/markdown-tables.ts
+++ b/ui/src/components/markdown-tables.ts
@@ -151,6 +151,20 @@ function showTableDialog(table: HTMLTableElement, trigger: HTMLElement): void {
   const expandedTable = table.cloneNode(true);
   dialog.append(close, expandedTable);
   close.addEventListener("click", () => dialog.close());
+  dialog.addEventListener("click", (event) => {
+    if (event.target !== dialog) {
+      return;
+    }
+    const bounds = dialog.getBoundingClientRect();
+    const outside =
+      event.clientX < bounds.left ||
+      event.clientX > bounds.right ||
+      event.clientY < bounds.top ||
+      event.clientY > bounds.bottom;
+    if (outside) {
+      dialog.close();
+    }
+  });
   dialog.addEventListener("close", () => {
     dialog.remove();
     if (trigger.isConnected) {

--- a/ui/src/components/markdown-tables.ts
+++ b/ui/src/components/markdown-tables.ts
@@ -199,9 +199,13 @@ export function handleMarkdownTableInteraction(event: Event): void {
   if (copy) {
     void copyToClipboard(tableText(table)).then((copied) => {
       copy.setAttribute("aria-label", t(copied ? "common.copied" : "common.copyFailed"));
+      if (copied) {
+        render(icons.check, copy);
+      }
       clearTimeout(tableCopyResetTimers.get(copy));
       const resetTimer = setTimeout(
         () => {
+          render(icons.copy, copy);
           copy.setAttribute("aria-label", t("common.copyTable"));
           tableCopyResetTimers.delete(copy);
         },

--- a/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
@@ -121,7 +121,9 @@ describeControlUiE2e("Control UI Markdown table interactions", () => {
       const readStyles = async (locator: typeof inlineTable, properties: readonly string[]) =>
         locator.evaluate((element, propertyNames) => {
           const styles = getComputedStyle(element);
-          return Object.fromEntries(propertyNames.map((property) => [property, styles[property]]));
+          return Object.fromEntries(
+            propertyNames.map((property) => [property, styles.getPropertyValue(property)]),
+          );
         }, properties);
       expect(await readStyles(fullscreenTable, tableProperties)).toEqual(
         await readStyles(inlineTable, tableProperties),

--- a/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
@@ -105,24 +105,30 @@ describeControlUiE2e("Control UI Markdown table interactions", () => {
       const fullscreenCell = fullscreenTable.locator("td").first();
       expect(await fullscreenTable.textContent()).toContain("Gateway");
       const tableProperties = [
-        "backgroundColor",
-        "borderCollapse",
-        "borderTopWidth",
-        "boxShadow",
+        "background-color",
+        "border-collapse",
+        "border-top-width",
+        "box-shadow",
       ] as const;
       const cellProperties = [
-        "backgroundColor",
-        "borderRightWidth",
-        "borderBottomColor",
-        "overflowWrap",
-        "whiteSpace",
-        "wordBreak",
+        "background-color",
+        "border-right-width",
+        "border-bottom-color",
+        "overflow-wrap",
+        "white-space",
+        "word-break",
       ] as const;
       const readStyles = async (locator: typeof inlineTable, properties: readonly string[]) =>
         locator.evaluate((element, propertyNames) => {
           const styles = getComputedStyle(element);
           return Object.fromEntries(
-            propertyNames.map((property) => [property, styles.getPropertyValue(property)]),
+            propertyNames.map((property) => {
+              const value = styles.getPropertyValue(property);
+              if (!value) {
+                throw new Error(`Missing computed value for ${property}`);
+              }
+              return [property, value];
+            }),
           );
         }, properties);
       expect(await readStyles(fullscreenTable, tableProperties)).toEqual(
@@ -141,6 +147,21 @@ describeControlUiE2e("Control UI Markdown table interactions", () => {
         });
       }
 
+      const dialogBounds = await dialog.boundingBox();
+      if (!dialogBounds) {
+        throw new Error("Expanded table dialog has no layout bounds");
+      }
+      await page.mouse.click(
+        Math.max(1, dialogBounds.x - 8),
+        dialogBounds.y + Math.min(8, dialogBounds.height / 2),
+      );
+      await expect.poll(() => dialog.count()).toBe(0);
+      await expect
+        .poll(() => expand.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+
+      await expand.click();
+      await expect.poll(() => dialog.getAttribute("open")).toBe("");
       await page.keyboard.press("Escape");
       await expect.poll(() => dialog.count()).toBe(0);
       await expect

--- a/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
@@ -94,10 +94,44 @@ describeControlUiE2e("Control UI Markdown table interactions", () => {
         .toContain("Service\tOwner\tRegion\tStatus\tVersion\tDeploy\tIncidents\tNotes");
 
       await expand.focus();
+      const inlineTable = shell.locator("table");
+      const inlineHeader = inlineTable.locator("th").first();
+      const inlineCell = inlineTable.locator("td").first();
       await expand.click();
       const dialog = page.locator("dialog.markdown-table-dialog");
       await expect.poll(() => dialog.getAttribute("open")).toBe("");
-      expect(await dialog.locator("table").textContent()).toContain("Gateway");
+      const fullscreenTable = dialog.locator("table");
+      const fullscreenHeader = fullscreenTable.locator("th").first();
+      const fullscreenCell = fullscreenTable.locator("td").first();
+      expect(await fullscreenTable.textContent()).toContain("Gateway");
+      const tableProperties = [
+        "backgroundColor",
+        "borderCollapse",
+        "borderTopWidth",
+        "boxShadow",
+      ] as const;
+      const cellProperties = [
+        "backgroundColor",
+        "borderRightWidth",
+        "borderBottomColor",
+        "overflowWrap",
+        "whiteSpace",
+        "wordBreak",
+      ] as const;
+      const readStyles = async (locator: typeof inlineTable, properties: readonly string[]) =>
+        locator.evaluate((element, propertyNames) => {
+          const styles = getComputedStyle(element);
+          return Object.fromEntries(propertyNames.map((property) => [property, styles[property]]));
+        }, properties);
+      expect(await readStyles(fullscreenTable, tableProperties)).toEqual(
+        await readStyles(inlineTable, tableProperties),
+      );
+      expect(await readStyles(fullscreenHeader, cellProperties)).toEqual(
+        await readStyles(inlineHeader, cellProperties),
+      );
+      expect(await readStyles(fullscreenCell, cellProperties)).toEqual(
+        await readStyles(inlineCell, cellProperties),
+      );
       if (captureProof) {
         await page.screenshot({
           animations: "disabled",

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -147,10 +147,9 @@
 
 .markdown-table {
   position: relative;
-  width: fit-content;
+  width: 100%;
   max-width: 100%;
   margin-top: 0.75em;
-  padding-top: 40px;
 }
 
 .markdown-table :where(table) {
@@ -198,11 +197,10 @@
 }
 
 .markdown-table__actions {
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  right: 0;
   display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-block: 4px 8px;
 }
 
 .markdown-table__actions button,
@@ -213,14 +211,14 @@
   padding: 10px;
   border: 0;
   background: transparent;
-  color: var(--muted);
+  color: var(--text);
   cursor: var(--cursor-action);
   place-items: center;
 }
 
 .markdown-table__actions button:hover,
 .markdown-table-dialog__close:hover {
-  color: var(--text);
+  color: var(--text-strong);
 }
 
 .markdown-table__actions button:focus-visible,
@@ -232,31 +230,38 @@
 
 .markdown-table__actions svg,
 .markdown-table-dialog__close svg {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  min-width: 16px;
+  max-width: 16px;
+  height: 16px;
+  min-height: 16px;
+  max-height: 16px;
 }
 
 .markdown-table-dialog {
-  width: max-content;
-  max-width: calc(100vw - 32px);
-  max-height: calc(100dvh - 32px);
-  padding: 48px 28px 28px;
+  width: calc(100vw - 64px);
+  max-width: 1200px;
+  max-height: calc(100dvh - 64px);
+  padding: 20px 28px;
   border: 0;
-  background: transparent;
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--bg) 96%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text) 8%, transparent);
   color: var(--text);
   overflow: auto;
 }
 
 .markdown-table-dialog::backdrop {
-  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  backdrop-filter: blur(3px);
 }
 
-.markdown-table-dialog > table {
-  width: max-content;
-  min-width: max-content;
+.markdown-table-dialog.chat-text > table {
+  width: 100%;
+  min-width: 0;
   margin: 0;
   max-width: none;
-  overflow: visible;
+  table-layout: auto;
 }
 
 .markdown-table-dialog__close {
@@ -316,10 +321,8 @@
   font-weight: 500;
 }
 
-.chat-thread .chat-bubble .chat-text :where(table) {
+:is(.markdown-table, .markdown-table-dialog.chat-text) :where(table) {
   display: table;
-  width: max-content;
-  min-width: 100%;
   margin: 0;
   border: 0;
   border-collapse: collapse;
@@ -328,11 +331,16 @@
   overflow: visible;
 }
 
-.chat-thread .chat-bubble .chat-text :where(table, thead, tbody, tr, th, td) {
+.chat-thread .chat-bubble .chat-text :where(table) {
+  width: max-content;
+  min-width: 100%;
+}
+
+:is(.markdown-table, .markdown-table-dialog.chat-text) :where(table, thead, tbody, tr, th, td) {
   background: transparent;
 }
 
-.chat-thread .chat-bubble .chat-text :where(th, td) {
+:is(.markdown-table, .markdown-table-dialog.chat-text) :where(th, td) {
   padding-block: 12px;
   border-right: 0;
   border-bottom-color: color-mix(in srgb, var(--border) 42%, transparent);
@@ -341,20 +349,22 @@
   word-break: normal;
 }
 
-.chat-thread .chat-bubble .chat-text :where(th:first-child, td:first-child) {
+:is(.markdown-table, .markdown-table-dialog.chat-text) :where(th:first-child, td:first-child) {
   padding-inline-start: 0;
 }
 
-.chat-thread .chat-bubble .chat-text :where(th) {
+:is(.markdown-table, .markdown-table-dialog.chat-text) :where(th) {
   border-bottom-color: var(--border-strong);
   background: transparent;
+  white-space: nowrap;
 }
 
-.chat-thread .chat-bubble .chat-text :where(tbody tr) {
+:is(.markdown-table, .markdown-table-dialog.chat-text) :where(tbody tr) {
   transition: none;
 }
 
-.chat-thread .chat-bubble .chat-text :where(tbody tr:nth-child(even), tbody tr:hover) {
+:is(.markdown-table, .markdown-table-dialog.chat-text)
+  :where(tbody tr:nth-child(even), tbody tr:hover) {
   background: transparent;
 }
 


### PR DESCRIPTION
Related: #125245
Related: #125219

## What Problem This Solves

Fixes an issue where expanding a transcript Markdown table rendered the fullscreen clone with the legacy table card styling because the native dialog is attached to `document.body`, outside the transcript selector scope introduced by #125219.

## Why This Change Was Made

The transcript and fullscreen dialog now share one table presentation selector, so background, borders, row separators, wrapping, and header treatment stay identical without duplicating a second style block. The dialog also uses a bounded rounded surface, supports light-dismiss outside its bounds, preserves X and Escape dismissal, and restores focus to the expand action.

## User Impact

Expanded Markdown tables now look and wrap like their inline transcript source instead of reverting to the previous bordered card design. Operators can also dismiss the fullscreen view by clicking outside it.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/markdown-tables.test.ts ui/src/components/markdown.test.ts` — 101 tests passed on the rebased exact head (AWS Crabbox `run_5b4d1d3d9b81`).
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts` — 1 Chromium E2E passed on the rebased exact head, covering nonempty computed-style parity, copy feedback, backdrop/Escape dismissal, and focus restoration (AWS Crabbox `run_bbf3ab156329`).
- The Chromium run captured a dark-theme fullscreen screenshot; visual inspection confirmed the detached dialog matches the inline table presentation.
- `pnpm check:changed` — passed the full changed type/lint/guard plan on the rebased exact tree (AWS Crabbox `run_77291132fcd2`).
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.
- `git diff --check` passed.

## Review Resolution

Resolved the latest ClawSweeper finding by replacing camelCase `getPropertyValue()` inputs with valid CSS declaration names and failing fast on empty computed values. The requested refreshed Chromium proof and stale-base refresh are complete; no re-review was requested because the post-review changes only addressed that finding and mechanically rebased the branch.
