### PR TITLE
fix(ui): preserve automation mutation lifecycle

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4125,7 +4125,7 @@ ui/src/lib/chat/tool-display.ts	1
 ui/src/lib/config-form-utils.ts	7
 ui/src/lib/config/config-draft-model.ts	5
 ui/src/lib/config/config-gateway-operations.ts	1
-ui/src/lib/cron/index.ts	16
+ui/src/lib/cron/index.ts	14
 ui/src/lib/gateway-diagnostics.ts	3
 ui/src/lib/gateway-errors.ts	1
 ui/src/lib/keyboard-shortcuts.ts	1

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -19,6 +19,7 @@ const suite = createControlUiE2eSuite({
 function cronJob(id: string, name: string, schedule: Record<string, unknown>, state = {}) {
   return {
     id,
+    configRevision: `config-revision-${id}`,
     name,
     enabled: true,
     createdAtMs: Date.parse("2026-05-29T08:00:00.000Z"),
@@ -913,6 +914,7 @@ suite.define(() => {
         const updateRequest = await gateway.waitForRequest("cron.update");
         expect(requestParams(updateRequest)).toMatchObject({
           id: existingJob.id,
+          expectedConfigRevision: existingJob.configRevision,
           patch: {
             payload: {
               kind: "agentTurn",
@@ -971,6 +973,7 @@ suite.define(() => {
         const request = await gateway.waitForRequest("cron.update");
         const params = requestParams(request);
         expect(params.id).toBe(existingJob.id);
+        expect(params.expectedConfigRevision).toBe(existingJob.configRevision);
         expect(requireRecord(params.patch)).toMatchObject({
           deleteAfterRun: true,
           schedule: { kind: "at", at: expectedAt },

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -850,7 +850,7 @@ describe("cron controller", () => {
     expect(state.cronJobs).toEqual([updatedJob]);
   });
 
-  it("commits authoritative toggle state before a deferred jobs reconciliation", async () => {
+  it("commits authoritative toggle state and advances an open editor revision", async () => {
     const loadedJob = createCronJob({
       id: "job-authoritative-toggle",
       name: "Toggle job",
@@ -864,7 +864,7 @@ describe("cron controller", () => {
       configRevision: "revision-toggled",
     };
     const listResponse = createDeferred<CronJobsListResult>();
-    const request = vi.fn(async (method: string) => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.update") {
         return updatedJob;
       }
@@ -877,6 +877,8 @@ describe("cron controller", () => {
       return {};
     });
     const state = createStateWithRequest(request, { cronJobs: [loadedJob] });
+    startCronEdit(state, loadedJob);
+    state.cronForm.name = "Unsaved rename";
 
     const toggle = toggleCronJob(state, loadedJob, false);
     await vi.waitFor(() => expect(request).toHaveBeenCalledWith("cron.list", expect.anything()));
@@ -887,9 +889,20 @@ describe("cron controller", () => {
       patch: { enabled: false },
     });
     expect(state.cronJobs).toEqual([updatedJob]);
+    expect(state.cronEditingConfigRevision).toBe("revision-toggled");
+    expect(state.cronForm.name).toBe("Unsaved rename");
 
     listResponse.resolve(cronJobsListResponse([updatedJob]));
     await expect(toggle).resolves.toBe(true);
+
+    await addCronJob(state);
+    const updateCalls = request.mock.calls.filter(([method]) => method === "cron.update");
+    expect(updateCalls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        expectedConfigRevision: "revision-toggled",
+        patch: expect.objectContaining({ name: "Unsaved rename" }),
+      }),
+    );
   });
 
   it("removes confirmed jobs locally before a failed reconciliation", async () => {

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -21,6 +21,7 @@ import {
   loadCronScopeStats,
   loadMoreCronRuns,
   normalizeCronFormState,
+  removeCronJob,
   resolveConfiguredCronModelSuggestions,
   runCronJob,
   startCronEdit,
@@ -40,10 +41,14 @@ function createState(overrides: Partial<CronState> = {}): CronState {
 }
 
 function createCronRequest(jobId: string, options: { existing?: boolean } = {}) {
-  const jobs = options.existing ? [{ id: jobId }] : [];
+  const existingJob = createCronJob({ id: jobId, name: "Existing job" });
+  const jobs = options.existing ? [existingJob] : [];
   return vi.fn(async (method: string, _payload?: unknown) => {
-    if (method === "cron.add" || method === "cron.update") {
+    if (method === "cron.add") {
       return { id: jobId };
+    }
+    if (method === "cron.update") {
+      return existingJob;
     }
     if (method === "cron.list") {
       return cronJobsListResponse(jobs as CronJob[]);
@@ -64,6 +69,7 @@ function createCronJob(overrides: Partial<CronJob> & Pick<CronJob, "id" | "name"
     enabled: true,
     createdAtMs: 0,
     updatedAtMs: 0,
+    configRevision: "config-revision-1",
     schedule: { kind: "cron", expr: "0 * * * *" },
     sessionTarget: "isolated",
     wakeMode: "next-heartbeat",
@@ -109,10 +115,20 @@ function createCronSubmitHarness(
   const request = createCronRequest(jobId, {
     existing: options.listExisting ?? method === "cron.update",
   });
+  const loadedJobs = options.jobs?.map((job) =>
+    createCronJob({
+      ...job,
+      configRevision: job.configRevision ?? "config-revision-1",
+    }),
+  );
   const state = createStateWithRequest(request, {
     ...options.state,
-    ...(options.jobs ? { cronJobs: options.jobs } : {}),
+    ...(loadedJobs ? { cronJobs: loadedJobs } : {}),
+    ...(method === "cron.update" && !loadedJobs
+      ? { cronJobs: [createCronJob({ id: jobId, name: options.form?.name ?? "Existing job" })] }
+      : {}),
     cronEditingJobId: method === "cron.update" ? jobId : null,
+    cronEditingConfigRevision: method === "cron.update" ? "config-revision-1" : null,
     cronForm: createCronForm(options.form),
   });
   const submit = async () => {
@@ -636,6 +652,7 @@ describe("cron controller", () => {
 
     expectRecordFields(requestPayload(call), {
       id: "job-1",
+      expectedConfigRevision: "config-revision-1",
     });
     expectRecordFields(requestPatch(call), {
       name: "edited job",
@@ -647,6 +664,265 @@ describe("cron controller", () => {
     });
     expect(requestPatch(call)).not.toHaveProperty("deleteAfterRun");
     expect(state.cronEditingJobId).toBeNull();
+    expect(state.cronEditingConfigRevision).toBeNull();
+  });
+
+  it("requires a loaded config revision before form saves and toggles", async () => {
+    const job = createCronJob({
+      id: "job-missing-revision",
+      name: "Missing revision",
+      configRevision: undefined,
+    });
+    const request = vi.fn(async () => {
+      throw new Error("unguarded mutation should not be issued");
+    });
+    const saveState = createStateWithRequest(request, { cronJobs: [job] });
+    startCronEdit(saveState, job);
+    saveState.cronForm.name = "Unsafe edit";
+
+    await expect(addCronJob(saveState)).resolves.toEqual({ saved: false });
+    expect(saveState.cronEditingJobId).toBe(job.id);
+    expect(saveState.cronError).toContain("configuration revision");
+    expect(request).not.toHaveBeenCalled();
+
+    const toggleState = createStateWithRequest(request, { cronJobs: [job] });
+    await expect(toggleCronJob(toggleState, job, false)).resolves.toBe(false);
+    expect(toggleState.cronError).toContain("configuration revision");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("freezes the edit revision across list refreshes and reloads the exact job after conflict", async () => {
+    const staleJob = createCronJob({
+      id: "job-conflict",
+      name: "Loaded name",
+      description: "loaded description",
+      configRevision: "revision-stale",
+    });
+    const listedJob = {
+      ...staleJob,
+      name: "Listed name",
+      description: "newer listed definition",
+      updatedAtMs: 2,
+      configRevision: "revision-current",
+    };
+    const authoritativeJob = {
+      ...listedJob,
+      name: "Authoritative name",
+      description: "third writer definition",
+      updatedAtMs: 3,
+      configRevision: "revision-newest",
+    };
+    const conflict = Object.assign(new Error("cron job definition changed"), {
+      name: "GatewayRequestError",
+      details: {
+        code: "CRON_JOB_CHANGED",
+        expectedConfigRevision: "revision-stale",
+        actualConfigRevision: "revision-current",
+      },
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.update") {
+        throw conflict;
+      }
+      if (method === "cron.list") {
+        return cronJobsListResponse([listedJob]);
+      }
+      if (method === "cron.get") {
+        return authoritativeJob;
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1 };
+      }
+      return {};
+    });
+    const state = createStateWithRequest(request, { cronJobs: [staleJob] });
+    startCronEdit(state, staleJob);
+    state.cronForm.name = "My stale edit";
+    state.cronJobs = [listedJob];
+
+    await expect(addCronJob(state)).resolves.toEqual({ saved: false });
+
+    expect(request).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({
+        id: staleJob.id,
+        expectedConfigRevision: "revision-stale",
+      }),
+    );
+    expect(request).toHaveBeenCalledWith("cron.get", { id: staleJob.id });
+    expect(state.cronEditingJobId).toBe(staleJob.id);
+    expect(state.cronEditingConfigRevision).toBe("revision-newest");
+    expect(state.cronJobs).toEqual([authoritativeJob]);
+    expect(state.cronForm.name).toBe("Authoritative name");
+    expect(state.cronForm.description).toBe("third writer definition");
+    expect(state.cronError).toContain("latest definition is loaded");
+  });
+
+  it("keeps a stale form paired with its frozen revision when conflict refresh fails", async () => {
+    const staleJob = createCronJob({
+      id: "job-conflict-deferred",
+      name: "Loaded name",
+      configRevision: "revision-stale",
+    });
+    const listedJob = {
+      ...staleJob,
+      name: "Newer listed name",
+      configRevision: "revision-current",
+    };
+    const conflict = Object.assign(new Error("cron job definition changed"), {
+      details: { code: "CRON_JOB_CHANGED" },
+    });
+    const firstList = createDeferred<CronJobsListResult>();
+    const updateRevisions: unknown[] = [];
+    let listCalls = 0;
+    const request = vi.fn(async (method: string, payload?: unknown) => {
+      if (method === "cron.update") {
+        updateRevisions.push(requireRecord(payload, "cron.update payload").expectedConfigRevision);
+        throw conflict;
+      }
+      if (method === "cron.list") {
+        listCalls += 1;
+        return listCalls === 1 ? firstList.promise : cronJobsListResponse([listedJob]);
+      }
+      if (method === "cron.get") {
+        throw new Error("exact job refresh unavailable");
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1 };
+      }
+      return {};
+    });
+    const state = createStateWithRequest(request, { cronJobs: [staleJob] });
+    startCronEdit(state, staleJob);
+    state.cronForm.name = "My stale edit";
+
+    const inFlightList = loadCronJobsPage(state, { tableFilters: true });
+    await vi.waitFor(() => expect(listCalls).toBe(1));
+    await expect(addCronJob(state)).resolves.toEqual({ saved: false });
+
+    expect(state.cronForm.name).toBe("My stale edit");
+    expect(state.cronEditingConfigRevision).toBe("revision-stale");
+    expect(state.cronError).toContain("could not be loaded");
+
+    firstList.resolve(cronJobsListResponse([listedJob], { snapshotRevision: "newer-list" }));
+    await inFlightList;
+    expect(state.cronJobs).toEqual([listedJob]);
+    expect(state.cronForm.name).toBe("My stale edit");
+    expect(state.cronEditingConfigRevision).toBe("revision-stale");
+
+    await expect(addCronJob(state)).resolves.toEqual({ saved: false });
+    expect(updateRevisions).toEqual(["revision-stale", "revision-stale"]);
+  });
+
+  it("commits authoritative update state before a failed jobs reconciliation", async () => {
+    const loadedJob = createCronJob({
+      id: "job-authoritative-save",
+      name: "Loaded name",
+      configRevision: "revision-loaded",
+    });
+    const updatedJob = {
+      ...loadedJob,
+      name: "Saved name",
+      updatedAtMs: 2,
+      configRevision: "revision-saved",
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.update") {
+        return updatedJob;
+      }
+      if (method === "cron.list") {
+        throw new Error("reconciliation unavailable");
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1 };
+      }
+      return {};
+    });
+    const state = createStateWithRequest(request, { cronJobs: [loadedJob] });
+    startCronEdit(state, loadedJob);
+    state.cronForm.name = "Saved name";
+
+    await expect(addCronJob(state)).resolves.toEqual({
+      saved: true,
+      jobId: loadedJob.id,
+    });
+
+    expect(state.cronJobs).toEqual([updatedJob]);
+  });
+
+  it("commits authoritative toggle state before a deferred jobs reconciliation", async () => {
+    const loadedJob = createCronJob({
+      id: "job-authoritative-toggle",
+      name: "Toggle job",
+      enabled: true,
+      configRevision: "revision-loaded",
+    });
+    const updatedJob = {
+      ...loadedJob,
+      enabled: false,
+      updatedAtMs: 2,
+      configRevision: "revision-toggled",
+    };
+    const listResponse = createDeferred<CronJobsListResult>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.update") {
+        return updatedJob;
+      }
+      if (method === "cron.list") {
+        return listResponse.promise;
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1 };
+      }
+      return {};
+    });
+    const state = createStateWithRequest(request, { cronJobs: [loadedJob] });
+
+    const toggle = toggleCronJob(state, loadedJob, false);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("cron.list", expect.anything()));
+
+    expect(request).toHaveBeenCalledWith("cron.update", {
+      id: loadedJob.id,
+      expectedConfigRevision: "revision-loaded",
+      patch: { enabled: false },
+    });
+    expect(state.cronJobs).toEqual([updatedJob]);
+
+    listResponse.resolve(cronJobsListResponse([updatedJob]));
+    await expect(toggle).resolves.toBe(true);
+  });
+
+  it("removes confirmed jobs locally before a failed reconciliation", async () => {
+    const removedJob = createCronJob({ id: "job-remove-local", name: "Remove locally" });
+    const remainingJob = createCronJob({ id: "job-remaining", name: "Keep locally" });
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.remove") {
+        return { ok: true, removed: true };
+      }
+      if (method === "cron.list") {
+        throw new Error("reconciliation unavailable");
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1 };
+      }
+      return {};
+    });
+    const state = createStateWithRequest(request, {
+      cronJobs: [removedJob, remainingJob],
+      cronJobsTotal: 2,
+      cronEditingJobId: removedJob.id,
+      cronRunsJobId: removedJob.id,
+      cronRuns: [{ ts: 1, jobId: removedJob.id, action: "finished", status: "ok" }],
+      cronRunsTotal: 1,
+    });
+
+    await removeCronJob(state, removedJob);
+
+    expect(state.cronJobs).toEqual([remainingJob]);
+    expect(state.cronJobsTotal).toBe(1);
+    expect(state.cronEditingJobId).toBeNull();
+    expect(state.cronRunsJobId).toBeNull();
+    expect(state.cronRuns).toEqual([]);
   });
 
   it("sends null delivery.accountId in cron.update to clear persisted account routing", async () => {
@@ -724,6 +1000,7 @@ describe("cron controller", () => {
     startCronEdit(state, job);
 
     expect(state.cronEditingJobId).toBe("job-9");
+    expect(state.cronEditingConfigRevision).toBe("config-revision-1");
     expect(state.cronRunsJobId).toBe("job-9");
     expect(state.cronForm.name).toBe("Weekly report");
     expect(state.cronForm.sessionKey).toBe("agent:ops:main");
@@ -1390,6 +1667,7 @@ describe("cron controller", () => {
     cancelCronEdit(state, scenario.selectedAgentId);
 
     expect(state.cronEditingJobId).toBeNull();
+    expect(state.cronEditingConfigRevision).toBeNull();
     expect(state.cronForm).toEqual({
       ...DEFAULT_CRON_FORM,
       agentId: scenario.selectedAgentId,
@@ -1419,6 +1697,7 @@ describe("cron controller", () => {
     startCronClone(state, sourceJob);
 
     expect(state.cronEditingJobId).toBeNull();
+    expect(state.cronEditingConfigRevision).toBeNull();
     expect(state.cronRunsJobId).toBe("job-1");
     expect(state.cronForm.name).toBe("Daily ping copy");
     expect(state.cronForm.payloadText).toBe("ping");
@@ -2073,6 +2352,7 @@ describe("cron controller", () => {
 
     expect(request).toHaveBeenCalledWith("cron.run", { id: "job-due", mode: "due" });
     expect(request).toHaveBeenCalledWith("cron.runs", expect.any(Object));
+    expect(state.cronError).toBe("Run queued. Run ID: run-due");
   });
 
   it.each([
@@ -2221,6 +2501,39 @@ describe("cron every-interval lossless round-trip", () => {
   });
 });
 
+describe("cron one-shot schedule precision", () => {
+  it("omits an unchanged minute but sends a genuinely changed minute", async () => {
+    const originalAt = "2030-01-02T03:04:56.789Z";
+    const original = createCronJob({
+      id: "job-at-precision",
+      name: "Precise one-shot",
+      schedule: { kind: "at", at: originalAt },
+      deleteAfterRun: true,
+    });
+
+    const unchanged = createCronEditHarness(original);
+    unchanged.state.cronForm.description = "metadata only";
+    const unchangedPatch = requestPatch(await unchanged.submit());
+    expect(unchangedPatch).not.toHaveProperty("schedule");
+
+    const changed = createCronEditHarness(original);
+    const originalMinute = new Date(originalAt);
+    originalMinute.setMinutes(originalMinute.getMinutes() + 1);
+    originalMinute.setSeconds(0, 0);
+    const year = originalMinute.getFullYear();
+    const month = String(originalMinute.getMonth() + 1).padStart(2, "0");
+    const day = String(originalMinute.getDate()).padStart(2, "0");
+    const hour = String(originalMinute.getHours()).padStart(2, "0");
+    const minute = String(originalMinute.getMinutes()).padStart(2, "0");
+    changed.state.cronForm.scheduleAt = `${year}-${month}-${day}T${hour}:${minute}`;
+    const changedPatch = requestPatch(await changed.submit());
+    expect(changedPatch.schedule).toEqual({
+      kind: "at",
+      at: originalMinute.toISOString(),
+    });
+  });
+});
+
 describe("loadCronFailingCount", () => {
   it("queries the unfiltered enabled+error total and stores it", async () => {
     const request = vi.fn(async () => ({ jobs: [], total: 4, offset: 0, limit: 1 }));
@@ -2238,6 +2551,7 @@ describe("loadCronFailingCount", () => {
   });
 
   it("refreshes after job mutations such as pause/resume", async () => {
+    const job = createCronJob({ id: "job-1", name: "Pause me" });
     const request = vi.fn(async (method: string, payload?: unknown) => {
       if (
         method === "cron.list" &&
@@ -2251,10 +2565,13 @@ describe("loadCronFailingCount", () => {
       if (method === "cron.status") {
         return { enabled: true, jobs: 0 };
       }
+      if (method === "cron.update") {
+        return { ...job, enabled: false, configRevision: "config-revision-2" };
+      }
       return {};
     });
-    const state = createStateWithRequest(request);
-    await toggleCronJob(state, { id: "job-1" } as never, false);
+    const state = createStateWithRequest(request, { cronJobs: [job] });
+    await toggleCronJob(state, job, false);
 
     expect(state.cronFailingCount).toBe(1);
   });

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -2330,7 +2330,7 @@ describe("cron controller", () => {
     expect(state.cronError).toBe("cron.runs unavailable");
   });
 
-  it("runs cron job in due mode when requested", async () => {
+  it("preserves queued run feedback when due-mode history refresh fails", async () => {
     const request = vi.fn(async (method: string, payload?: unknown) => {
       if (method === "cron.run") {
         expectRecordFields(requireRecord(payload, "cron.run payload"), {
@@ -2340,7 +2340,7 @@ describe("cron controller", () => {
         return { ok: true, enqueued: true, runId: "run-due" };
       }
       if (method === "cron.runs") {
-        return { entries: [], total: 0, hasMore: false, nextOffset: null };
+        throw new Error("run history refresh unavailable");
       }
       return {};
     });

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -1299,6 +1299,9 @@ export async function toggleCronJob(
       patch: { enabled },
     });
     replaceLocalCronJob(state, updatedJob);
+    if (state.cronEditingJobId === updatedJob.id) {
+      state.cronEditingConfigRevision = requireCronConfigRevision(updatedJob.configRevision);
+    }
     updated = true;
     await reloadCronJobsSnapshot(state);
   });

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -219,6 +219,7 @@ export type CronState = {
   cronCreateOpen: boolean;
   cronFieldErrors: CronFieldErrors;
   cronEditingJobId: string | null;
+  cronEditingConfigRevision: string | null;
   cronRunsJobId: string | null;
   cronRunsLoadingMore: boolean;
   cronRuns: CronRunLogEntry[];
@@ -273,6 +274,7 @@ export function createInitialCronState(
     cronCreateOpen: false,
     cronFieldErrors: {},
     cronEditingJobId: null,
+    cronEditingConfigRevision: null,
     cronRunsJobId: null,
     cronRunsLoadingMore: false,
     cronRuns: [],
@@ -521,6 +523,22 @@ async function withCronBusy(
   }
 }
 
+function requireCronConfigRevision(revision: string | null | undefined): string {
+  if (revision) {
+    return revision;
+  }
+  throw new Error("This automation is missing its configuration revision. Refresh and try again.");
+}
+
+function replaceLocalCronJob(state: CronState, updatedJob: CronJob) {
+  state.cronJobs = state.cronJobs.map((job) => (job.id === updatedJob.id ? updatedJob : job));
+}
+
+function isCronJobChangedError(error: unknown): boolean {
+  const details = isRecord(error) && isRecord(error.details) ? error.details : null;
+  return details?.code === "CRON_JOB_CHANGED";
+}
+
 function normalizeCronRunsPageMeta(params: {
   totalRaw: unknown;
   offsetRaw: unknown;
@@ -764,6 +782,7 @@ function resolveCronJobScheduleKind(job: CronJob): string | null {
 
 function clearCronEditState(state: CronState) {
   state.cronEditingJobId = null;
+  state.cronEditingConfigRevision = null;
 }
 
 function clearCronRunsPage(state: CronState) {
@@ -1113,14 +1132,19 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
     const editingJob = state.cronEditingJobId
       ? state.cronJobs.find((job) => job.id === state.cronEditingJobId)
       : undefined;
+    const expectedConfigRevision = state.cronEditingJobId
+      ? requireCronConfigRevision(state.cronEditingConfigRevision)
+      : undefined;
     const editingPayload = editingJob ? getCronJobPayload(editingJob) : null;
     // Preserve a process-backed schedule while the form still points at it; if the
     // user selects an editable schedule kind, the update must apply it.
     const preserveSchedule = Boolean(
       state.cronEditingJobId &&
-      ((editingJob?.schedule as { kind?: string } | undefined)?.kind === "on-exit" ||
-        (editingJob?.schedule as { kind?: string } | undefined)?.kind === "stream") &&
-      form.scheduleKind === editingJob?.schedule.kind,
+      (((editingJob?.schedule.kind === "on-exit" || editingJob?.schedule.kind === "stream") &&
+        form.scheduleKind === editingJob.schedule.kind) ||
+        (editingJob?.schedule.kind === "at" &&
+          form.scheduleKind === "at" &&
+          form.scheduleAt === formatDateTimeLocal(editingJob.schedule.at))),
     );
     const schedule = preserveSchedule ? undefined : buildCronSchedule(form);
     const preserveLockedPayload = Boolean(
@@ -1216,10 +1240,30 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
     }
     if (state.cronEditingJobId) {
       const editedJobId = state.cronEditingJobId;
-      await client.request("cron.update", {
-        id: editedJobId,
-        patch: job,
-      });
+      try {
+        const updatedJob = await client.request<CronJob>("cron.update", {
+          id: editedJobId,
+          expectedConfigRevision,
+          patch: job,
+        });
+        replaceLocalCronJob(state, updatedJob);
+      } catch (error) {
+        if (!isCronJobChangedError(error)) {
+          throw error;
+        }
+        await reloadCronJobsSnapshot(state);
+        try {
+          const latestJob = await client.request<CronJob>("cron.get", { id: editedJobId });
+          replaceLocalCronJob(state, latestJob);
+          startCronEdit(state, latestJob);
+          state.cronError =
+            "This automation changed on the Gateway. The latest definition is loaded; review it before retrying.";
+        } catch {
+          state.cronError =
+            "This automation changed on the Gateway, but the latest definition could not be loaded. Refresh before retrying.";
+        }
+        return;
+      }
       clearCronEditState(state);
       result = { saved: true, jobId: editedJobId };
     } else {
@@ -1249,7 +1293,12 @@ export async function toggleCronJob(
   // can be queued or fail without invalidating the confirmed toggle.
   let updated = false;
   await withCronBusy(state, async (client) => {
-    await client.request("cron.update", { id: job.id, patch: { enabled } });
+    const updatedJob = await client.request<CronJob>("cron.update", {
+      id: job.id,
+      expectedConfigRevision: requireCronConfigRevision(job.configRevision),
+      patch: { enabled },
+    });
+    replaceLocalCronJob(state, updatedJob);
     updated = true;
     await reloadCronJobsSnapshot(state);
   });
@@ -1287,6 +1336,9 @@ export async function runCronJob(state: CronState, jobId: string, mode: "force" 
       }
       return;
     }
+    if ("enqueued" in result && result.enqueued) {
+      state.cronError = `Run queued. Run ID: ${result.runId}`;
+    }
     await loadCronRuns(state, state.cronRunsScope === "all" ? null : jobId);
   });
 }
@@ -1294,6 +1346,11 @@ export async function runCronJob(state: CronState, jobId: string, mode: "force" 
 export async function removeCronJob(state: CronState, job: CronJob) {
   await withCronBusy(state, async (client) => {
     await client.request("cron.remove", { id: job.id });
+    const previousLength = state.cronJobs.length;
+    state.cronJobs = state.cronJobs.filter((candidate) => candidate.id !== job.id);
+    if (state.cronJobs.length !== previousLength) {
+      state.cronJobsTotal = Math.max(0, state.cronJobsTotal - 1);
+    }
     if (state.cronEditingJobId === job.id) {
       clearCronEditState(state);
     }
@@ -1465,10 +1522,12 @@ export function updateCronRunsFilter(
 }
 
 export function startCronEdit(state: CronState, job: CronJob) {
+  const form = jobToForm(job, state.cronForm);
   state.cronEditingJobId = job.id;
+  state.cronEditingConfigRevision = job.configRevision ?? null;
   state.cronRunsJobId = job.id;
-  state.cronForm = jobToForm(job, state.cronForm);
-  state.cronFieldErrors = validateCronForm(state.cronForm);
+  state.cronForm = form;
+  state.cronFieldErrors = validateCronForm(form);
 }
 
 function buildCloneName(name: string, existingNames: Set<string>) {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -1336,10 +1336,10 @@ export async function runCronJob(state: CronState, jobId: string, mode: "force" 
       }
       return;
     }
+    await loadCronRuns(state, state.cronRunsScope === "all" ? null : jobId);
     if ("enqueued" in result && result.enqueued) {
       state.cronError = `Run queued. Run ID: ${result.runId}`;
     }
-    await loadCronRuns(state, state.cronRunsScope === "all" ? null : jobId);
   });
 }
 

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -135,7 +135,10 @@ function createPage(context: ApplicationContext, options: { render?: boolean } =
 
 function cronListResponse(jobs: CronJob[]): CronJobsListResult {
   return {
-    jobs,
+    jobs: jobs.map((job) => ({
+      configRevision: job.configRevision ?? `config-revision-${job.id}`,
+      ...job,
+    })),
     snapshotRevision: "cron-page-fixture",
     total: jobs.length,
     offset: 0,
@@ -348,6 +351,9 @@ describe("CronPage editor state sync", () => {
       if (method === "cron.runs") {
         return { entries: [], total: 0, offset: 0, hasMore: false };
       }
+      if (method === "cron.run") {
+        return { ok: true, enqueued: true, runId: "run-fresh" };
+      }
       if (method === "models.list") {
         return { models: [] };
       }
@@ -376,6 +382,9 @@ describe("CronPage editor state sync", () => {
     );
     expect(request).toHaveBeenCalledWith("cron.run", { id: "job-fresh", mode: "force" });
     await waitForCronPage(() => expect(page.cron.cronCreateOpen).toBe(false));
+    await waitForCronPage(() =>
+      expect(page.textContent).toContain("Run queued. Run ID: run-fresh"),
+    );
   });
 
   it("drills from the failing stat into run history filtered to errors", async () => {
@@ -422,7 +431,12 @@ describe("CronPage editor state sync", () => {
         if (typeof patch?.enabled === "boolean") {
           serverEnabled = patch.enabled;
         }
-        return {};
+        return {
+          ...job,
+          enabled: serverEnabled,
+          updatedAtMs: 1,
+          configRevision: "config-revision-job-1-updated",
+        };
       }
       if (method === "cron.remove") {
         removed = true;
@@ -457,6 +471,11 @@ describe("CronPage editor state sync", () => {
     enabledToggle.dispatchEvent(new Event("change", { bubbles: true }));
     await waitForCronPage(() => expect(page.cron.cronForm.enabled).toBe(false));
     expect(serverEnabled).toBe(false);
+    expect(request).toHaveBeenCalledWith("cron.update", {
+      id: job.id,
+      expectedConfigRevision: "config-revision-job-1",
+      patch: { enabled: false },
+    });
 
     const findRemoveButton = () =>
       Array.from(page.querySelectorAll<HTMLButtonElement>(".cron-job-menu__item")).find(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users managing Automations could receive no visible acknowledgement for queued **Run now** actions, overwrite a newer job definition from a stale editor, lose sub-minute precision from an unchanged one-shot schedule, or continue seeing stale rows after a confirmed update/removal when list reconciliation was delayed or unavailable.

## Why This Change Was Made

The Control UI cron controller now owns the mutation lifecycle coherently: editor sessions freeze the job definition revision they opened against, updates send that revision as the existing Gateway precondition, conflicts reload the exact latest job before allowing another save, and successful update/remove responses update local state before best-effort inventory reconciliation. Unchanged one-shot schedules remain omitted from update patches, and queued runs surface their exact run ID through the existing page feedback path. No protocol or schema changes are involved.

## User Impact

Operators now get an immediate queued-run acknowledgement, concurrent edits fail closed instead of silently overwriting newer definitions, metadata-only edits preserve exact one-shot timestamps, and confirmed job mutations remain reflected in the page even if the follow-up list request is slow or fails.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/cron/index.test.ts ui/src/pages/cron/cron-page.test.ts` — 130/130 passed
- `node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt ui/src/lib/cron/index.ts ui/src/lib/cron/index.test.ts ui/src/pages/cron/cron-page.test.ts` — passed, including typecheck, lint, Knip, i18n, and ratchets
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted ...` — clean, no accepted/actionable findings; overall 0.98
- Source-backed Playwright flow against `pnpm dev:ui:mock`: clicked **Run now**, asserted the visible acknowledgement exactly matched `Run queued. Run ID: mock-cron-manual-mock-cron-release-digest`, and inspected both captures

### Before

![Automation detail before Run now](https://github.com/user-attachments/assets/5be7dda5-f538-4d85-932e-e3faececeb80)

### After

![Queued Run now acknowledgement with run ID](https://github.com/user-attachments/assets/a1beea56-9ee5-44a8-a2d3-62406dbd178e)

AI-assisted implementation; the final diff, tests, browser evidence, and lifecycle invariants were independently reviewed.
