### PR TITLE
feat: nudge progress cards only when visible

### DIFF
--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -11,6 +11,16 @@ read_when:
 
 The card is durable session state. A reconnect or page reload reads the latest card from the Gateway instead of reconstructing it from tool events or transcript history. The transcript keeps only a short update receipt, not another full copy of the card.
 
+## Adoption
+
+OpenClaw adds a short progress-card reminder only for non-main sessions when a web, iOS, Android, or macOS card renderer is paired with the Gateway and the run is not using the agent's utility model. Channel-only deployments such as a WhatsApp-only Gateway do not receive the reminder.
+
+The reminder says:
+
+> During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.
+
+The reminder does not override tool policy. `tools.updatePlan: false` or a matching `tools.deny` entry still removes `progress_card` from the run entirely.
+
 ## Update a card
 
 Both input fields are optional:

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -46,6 +46,9 @@ type CodexThreadLifecycleTimingLogger = NonNullable<
   NonNullable<Parameters<typeof startOrResumeThreadImpl>[0]["timing"]>["log"]
 >;
 
+const PROGRESS_CARD_SYSTEM_PROMPT =
+  "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
+
 describe("Codex incognito thread persistence", () => {
   it("marks only incognito-shaped harness sessions ephemeral", () => {
     const appServer = createAppServerOptions() as never;
@@ -1396,13 +1399,21 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).not.toContain("<available_skills>");
   });
 
-  it("carries the progress-card nudge into thread developer instructions", () => {
-    const params = createAttemptParams({ provider: "openai" });
-    params.extraSystemPrompt =
-      "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
+  it.each([
+    { name: "available", extraSystemPrompt: PROGRESS_CARD_SYSTEM_PROMPT, expected: true },
+    { name: "denied", extraSystemPrompt: undefined, expected: false },
+  ])(
+    "$name progress-card nudge propagation into thread developer instructions",
+    ({ extraSystemPrompt, expected }) => {
+      const params = createAttemptParams({ provider: "openai" });
+      params.toolsAllow = expected ? ["progress_card"] : ["read"];
+      params.extraSystemPrompt = extraSystemPrompt;
 
-    expect(buildDeveloperInstructions(params)).toContain(params.extraSystemPrompt);
-  });
+      expect(buildDeveloperInstructions(params).includes(PROGRESS_CARD_SYSTEM_PROMPT)).toBe(
+        expected,
+      );
+    },
+  );
 
   it("enables Codex code mode on thread/start without clobbering other config", () => {
     const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1396,6 +1396,14 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).not.toContain("<available_skills>");
   });
 
+  it("carries the progress-card nudge into thread developer instructions", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.extraSystemPrompt =
+      "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
+
+    expect(buildDeveloperInstructions(params)).toContain(params.extraSystemPrompt);
+  });
+
   it("enables Codex code mode on thread/start without clobbering other config", () => {
     const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
       cwd: "/repo",

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -806,6 +806,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             toolBindings: options?.toolBindings,
             pluginToolAllowlist,
             pluginToolDenylist,
+            runtimeToolAllowlist: options?.runtimeToolAllowlist,
             cronCreatorToolAllowlist,
             cronCreatorToolAllowlistCaptureRef,
             resolveCronCreatorToolAuthority: cronCreatorAuthorityResolver,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -5,6 +5,7 @@ import { resolveDelegationCapability } from "../../delegation-capability.js";
 import type { AgentHarnessRuntimeArtifactBinding } from "../../harness/runtime-artifact.types.js";
 import { appendIncognitoSystemPrompt } from "../../incognito-system-prompt.js";
 import { applyAuthHeaderOverride, applyLocalNoAuthHeaderOverride } from "../../model-auth.js";
+import { appendProgressCardSystemPrompt } from "../../progress-card-system-prompt.js";
 import type { AgentRunSessionTarget } from "../../run-session-target.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { resolveSandboxContext } from "../../sandbox/context.js";
@@ -250,6 +251,21 @@ export async function dispatchEmbeddedRunAttempt(input: {
         mode: resolveSessionPermissionExecMode({ mode: params.permissionMode }),
       }
     : params.execOverrides;
+  const incognitoSystemPrompt = appendIncognitoSystemPrompt({
+    agentId: runtime.agentId,
+    extraSystemPrompt: params.extraSystemPrompt,
+    sessionKey: params.sessionKey,
+    storePath: params.sessionTarget?.storePath,
+  });
+  const extraSystemPrompt = await appendProgressCardSystemPrompt({
+    agentId: runtime.agentId,
+    authProfileId: runtime.authProfileId,
+    config: params.config,
+    extraSystemPrompt: incognitoSystemPrompt,
+    modelId: runtime.modelId,
+    provider: runtime.provider,
+    sessionKey: params.sessionKey,
+  });
   const attemptParams: EmbeddedRunAttemptParams = {
     admittedRunContext: params.admittedRunContext,
     contextEngineAgentId: runtime.contextEngineAgentId,
@@ -441,12 +457,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     // Normalize the shipped harness alias once; attempt internals consume only the canonical flag.
     deferTerminalLifecycle: params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
     onExecutionPhase: params.onExecutionPhase,
-    extraSystemPrompt: appendIncognitoSystemPrompt({
-      agentId: runtime.agentId,
-      extraSystemPrompt: params.extraSystemPrompt,
-      sessionKey: params.sessionKey,
-      storePath: params.sessionTarget?.storePath,
-    }),
+    extraSystemPrompt,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     taskSuggestionDeliveryMode: params.taskSuggestionDeliveryMode,
     inputProvenance: params.inputProvenance,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -265,6 +265,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     modelId: runtime.modelId,
     provider: runtime.provider,
     sessionKey: params.sessionKey,
+    toolsAllow: params.toolsAllow,
   });
   const attemptParams: EmbeddedRunAttemptParams = {
     admittedRunContext: params.admittedRunContext,

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -360,6 +360,25 @@ describe("openclaw-tools progress_card gating", () => {
     expect(includeProgressCard).toBe(true);
   });
 
+  it.each([
+    {
+      name: "a configured profile",
+      options: { config: { tools: { profile: "messaging" as const } } },
+    },
+    {
+      name: "the runtime allowlist",
+      options: { runtimeToolAllowlist: ["read"] },
+    },
+  ])("omits progress_card when $name excludes it", ({ options }) => {
+    expect(
+      createFastToolNames({
+        ...options,
+        modelProvider: "openai",
+        modelId: "gpt-5.6-sol",
+      }),
+    ).not.toContain("progress_card");
+  });
+
   it("leaves normal deny policy enforcement to the assembled tool set", () => {
     const tools = createFastToolNames({
       config: {} as OpenClawConfig,

--- a/src/agents/openclaw-tools.registration.ts
+++ b/src/agents/openclaw-tools.registration.ts
@@ -5,10 +5,31 @@
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
 import { isPrimaryBootstrapRun } from "./bootstrap-routing.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
-import { expandShippedCoreToolPolicyNames } from "./tool-policy.js";
+import {
+  isRuntimeToolAllowed,
+  isToolAllowedByPolicies,
+  isToolAllowedByPolicyName,
+} from "./tool-policy-match.js";
+import {
+  expandShippedCoreToolPolicyNames,
+  mergeAlsoAllowPolicy,
+  resolveToolProfilePolicy,
+  type ToolPolicyLike,
+} from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+function expandProgressCardPolicyNames(
+  policy: ToolPolicyLike | undefined,
+): ToolPolicyLike | undefined {
+  return policy
+    ? {
+        allow: expandShippedCoreToolPolicyNames(policy.allow),
+        deny: expandShippedCoreToolPolicyNames(policy.deny),
+      }
+    : undefined;
+}
 
 /**
  * Registration helpers for optional OpenClaw-owned tools.
@@ -25,8 +46,13 @@ export function collectPresentOpenClawTools(
 
 /** Decides whether progress_card should be included in the assembled OpenClaw tool set. */
 export function shouldIncludeProgressCardToolForOpenClawTools(params: {
+  agentId?: string;
+  agentSessionKey?: string;
   config?: OpenClawConfig;
+  modelId?: string;
+  modelProvider?: string;
   pluginToolDenylist?: string[];
+  runtimeToolAllowlist?: string[];
 }): boolean {
   // `tools.updatePlan` is the shipped kill switch for the replacement progress_card tool.
   if (params.config?.tools?.updatePlan === false) {
@@ -36,9 +62,40 @@ export function shouldIncludeProgressCardToolForOpenClawTools(params: {
     ...(params.config?.tools?.deny ?? []),
     ...(params.pluginToolDenylist ?? []),
   ]);
-  return isToolAllowedByPolicyName("progress_card", {
-    deny: expandShippedCoreToolPolicyNames(deny),
+  if (
+    !isToolAllowedByPolicyName("progress_card", {
+      deny: expandShippedCoreToolPolicyNames(deny),
+    }) ||
+    !isRuntimeToolAllowed("progress_card", params.runtimeToolAllowlist)
+  ) {
+    return false;
+  }
+  const effective = resolveEffectiveToolPolicy({
+    config: params.config,
+    sessionKey: params.agentSessionKey,
+    agentId: params.agentId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
   });
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(effective.profile),
+    effective.profileAlsoAllow,
+  );
+  const providerProfilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(effective.providerProfile),
+    effective.providerProfileAlsoAllow,
+  );
+  return isToolAllowedByPolicies(
+    "progress_card",
+    [
+      profilePolicy,
+      providerProfilePolicy,
+      effective.globalPolicy,
+      effective.globalProviderPolicy,
+      effective.agentPolicy,
+      effective.agentProviderPolicy,
+    ].map(expandProgressCardPolicyNames),
+  );
 }
 
 /** Includes ask_user only on a primary session and when normal deny policy permits it. */

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -457,7 +457,6 @@ export function createOpenClawTools(
   const progressCardTool = shouldIncludeProgressCardToolForOpenClawTools({
     ...options,
     agentId: sessionAgentId,
-    config: resolvedConfig,
   })
     ? createProgressCardTool({
         agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -104,10 +104,7 @@ export function createOpenClawTools(
     allowHostBrowserControl?: boolean;
     agentSessionKey?: string;
     toolBindings?: Readonly<Record<string, unknown>>;
-    /**
-     * The durable store session key for the live run when it differs from the
-     * sandbox/policy session key used to construct the tool set.
-     */
+    /** Durable store key when it differs from the sandbox/policy session key. */
     runSessionKey?: string;
     agentChannel?: string;
     runId?: string;
@@ -139,6 +136,7 @@ export function createOpenClawTools(
     clientCaps?: string[];
     pluginToolAllowlist?: string[];
     pluginToolDenylist?: string[];
+    runtimeToolAllowlist?: string[];
     /** Effective caller tool surface to persist on isolated cron agentTurn jobs. */
     cronCreatorToolAllowlist?: CronToolOptions["creatorToolAllowlist"];
     cronCreatorToolAllowlistCaptureRef?: CronToolOptions["creatorToolAllowlistCaptureRef"];
@@ -211,10 +209,7 @@ export function createOpenClawTools(
     sessionId?: string;
     /** Trusted runtime-only authorization for one bounded cross-conversation recall pass. */
     conversationRecall?: ConversationRecallContext;
-    /**
-     * Explicit one-shot local CLI runs should not keep plugin-owned process
-     * resources alive after emitting their result.
-     */
+    /** One-shot local CLI runs release plugin-owned resources after their result. */
     oneShotCliRun?: boolean;
     /**
      * Workspace directory to pass to spawned subagents for inheritance.
@@ -460,8 +455,9 @@ export function createOpenClawTools(
     sessionLinkBase,
   };
   const progressCardTool = shouldIncludeProgressCardToolForOpenClawTools({
+    ...options,
+    agentId: sessionAgentId,
     config: resolvedConfig,
-    pluginToolDenylist: options?.pluginToolDenylist,
   })
     ? createProgressCardTool({
         agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,

--- a/src/agents/progress-card-system-prompt.test.ts
+++ b/src/agents/progress-card-system-prompt.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
+import { appendIncognitoSystemPrompt } from "./incognito-system-prompt.js";
+import { appendProgressCardSystemPrompt } from "./progress-card-system-prompt.js";
+
+const { hasPairedCardRenderer } = vi.hoisted(() => ({
+  hasPairedCardRenderer: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock("../infra/device-pairing.js", () => ({ hasPairedCardRenderer }));
+
+const SENTENCE =
+  "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
+
+function append(params: {
+  config?: Parameters<typeof appendProgressCardSystemPrompt>[0]["config"];
+  extraSystemPrompt?: string;
+  sessionKey?: string;
+}) {
+  return appendProgressCardSystemPrompt({
+    agentId: "main",
+    config: params.config,
+    extraSystemPrompt: params.extraSystemPrompt,
+    modelId: "gpt-5.6-sol",
+    provider: "openai",
+    sessionKey: params.sessionKey ?? "agent:main:work",
+  });
+}
+
+describe("progress card system prompt", () => {
+  beforeEach(() => {
+    hasPairedCardRenderer.mockReset().mockResolvedValue(true);
+  });
+
+  it("injects the exact instruction when every adoption gate passes", async () => {
+    await expect(append({})).resolves.toBe(SENTENCE);
+  });
+
+  it.each([
+    { config: undefined, sessionKey: "main" },
+    { config: { session: { scope: "global" as const } }, sessionKey: "global" },
+  ])("suppresses the instruction for the agent main session $sessionKey", async (params) => {
+    await expect(append(params)).resolves.toBeUndefined();
+    expect(hasPairedCardRenderer).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the instruction when no paired client can render the card", async () => {
+    hasPairedCardRenderer.mockResolvedValue(false);
+
+    await expect(append({})).resolves.toBeUndefined();
+  });
+
+  it("suppresses the instruction when the attempt uses the resolved utility model", async () => {
+    await expect(
+      append({
+        config: { agents: { defaults: { utilityModel: "openai/gpt-5.6-sol" } } },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("preserves incognito-first composition order", async () => {
+    const incognitoPrompt = appendIncognitoSystemPrompt({
+      agentId: "main",
+      extraSystemPrompt: "Existing context.",
+      storePath: resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main" }),
+    });
+
+    await expect(append({ extraSystemPrompt: incognitoPrompt })).resolves.toBe(
+      "Existing context.\n\nThis chat is incognito; do not store its conversation content in memory files or long-term notes.\n\n" +
+        SENTENCE,
+    );
+  });
+});

--- a/src/agents/progress-card-system-prompt.test.ts
+++ b/src/agents/progress-card-system-prompt.test.ts
@@ -16,6 +16,7 @@ function append(params: {
   config?: Parameters<typeof appendProgressCardSystemPrompt>[0]["config"];
   extraSystemPrompt?: string;
   sessionKey?: string;
+  toolsAllow?: string[];
 }) {
   return appendProgressCardSystemPrompt({
     agentId: "main",
@@ -24,6 +25,7 @@ function append(params: {
     modelId: "gpt-5.6-sol",
     provider: "openai",
     sessionKey: params.sessionKey ?? "agent:main:work",
+    toolsAllow: params.toolsAllow,
   });
 }
 
@@ -34,6 +36,27 @@ describe("progress card system prompt", () => {
 
   it("injects the exact instruction when every adoption gate passes", async () => {
     await expect(append({})).resolves.toBe(SENTENCE);
+  });
+
+  it.each([
+    {
+      name: "the progress-card kill switch is disabled",
+      params: { config: { tools: { updatePlan: false } } },
+    },
+    {
+      name: "progress_card is denied",
+      params: { config: { tools: { deny: ["progress_card"] } } },
+    },
+    {
+      name: "the configured profile excludes progress_card",
+      params: { config: { tools: { profile: "messaging" as const } } },
+    },
+    {
+      name: "the runtime allowlist excludes progress_card",
+      params: { toolsAllow: ["read"] },
+    },
+  ])("suppresses the instruction when $name", async ({ params }) => {
+    await expect(append(params)).resolves.toBeUndefined();
   });
 
   it.each([

--- a/src/agents/progress-card-system-prompt.ts
+++ b/src/agents/progress-card-system-prompt.ts
@@ -4,6 +4,7 @@ import {
 } from "../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasPairedCardRenderer } from "../infra/device-pairing.js";
+import { shouldIncludeProgressCardToolForOpenClawTools } from "./openclaw-tools.registration.js";
 import { resolveUtilityModelRefForAgent } from "./utility-model.js";
 
 const PROGRESS_CARD_SYSTEM_PROMPT =
@@ -43,8 +44,23 @@ export async function appendProgressCardSystemPrompt(params: {
   modelId: string;
   provider: string;
   sessionKey?: string;
+  toolsAllow?: string[];
 }): Promise<string | undefined> {
-  if (isAgentMainSession(params) || !(await hasPairedCardRenderer())) {
+  // This boundary covers kill-switch, global/provider/agent/profile policy, and runtime allow.
+  // Group, sender, sandbox, subagent, inherited, and plugin deny layers resolve during assembly.
+  const progressCardToolAvailable = shouldIncludeProgressCardToolForOpenClawTools({
+    agentId: params.agentId,
+    agentSessionKey: params.sessionKey,
+    config: params.config,
+    modelId: params.modelId,
+    modelProvider: params.provider,
+    runtimeToolAllowlist: params.toolsAllow,
+  });
+  if (
+    !progressCardToolAvailable ||
+    isAgentMainSession(params) ||
+    !(await hasPairedCardRenderer())
+  ) {
     return params.extraSystemPrompt;
   }
   const provider = params.provider.trim().toLowerCase();

--- a/src/agents/progress-card-system-prompt.ts
+++ b/src/agents/progress-card-system-prompt.ts
@@ -1,0 +1,65 @@
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentMainSessionKey,
+} from "../config/sessions/main-session.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasPairedCardRenderer } from "../infra/device-pairing.js";
+import { resolveUtilityModelRefForAgent } from "./utility-model.js";
+
+const PROGRESS_CARD_SYSTEM_PROMPT =
+  "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
+
+function isAgentMainSession(params: {
+  agentId: string;
+  config?: OpenClawConfig;
+  sessionKey?: string;
+}): boolean {
+  if (!params.sessionKey) {
+    return true;
+  }
+  const canonicalSessionKey = canonicalizeMainSessionAlias({
+    cfg: params.config,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  const canonicalMainSessionKey = canonicalizeMainSessionAlias({
+    cfg: params.config,
+    agentId: params.agentId,
+    sessionKey: resolveAgentMainSessionKey({ cfg: params.config, agentId: params.agentId }),
+  });
+  return canonicalSessionKey === canonicalMainSessionKey;
+}
+
+/**
+ * Pairing may change between sessions and embedded attempts because this fragment
+ * sits below the prompt-cache boundary. Codex pins developer instructions at
+ * thread creation, so a mid-session pairing change reaches its next thread.
+ */
+export async function appendProgressCardSystemPrompt(params: {
+  agentId: string;
+  authProfileId?: string;
+  config?: OpenClawConfig;
+  extraSystemPrompt?: string;
+  modelId: string;
+  provider: string;
+  sessionKey?: string;
+}): Promise<string | undefined> {
+  if (isAgentMainSession(params) || !(await hasPairedCardRenderer())) {
+    return params.extraSystemPrompt;
+  }
+  const provider = params.provider.trim().toLowerCase();
+  const modelId = params.modelId.trim();
+  const authProfileId = params.authProfileId?.trim();
+  const modelRef = `${provider}/${modelId}${authProfileId ? `@${authProfileId}` : ""}`;
+  const utilityModelRef = resolveUtilityModelRefForAgent({
+    cfg: params.config ?? {},
+    agentId: params.agentId,
+    primaryProvider: provider,
+    primaryModelRef: modelRef,
+  });
+  if (utilityModelRef === modelRef) {
+    return params.extraSystemPrompt;
+  }
+  const existing = params.extraSystemPrompt?.trim();
+  return existing ? `${existing}\n\n${PROGRESS_CARD_SYSTEM_PROMPT}` : PROGRESS_CARD_SYSTEM_PROMPT;
+}

--- a/src/infra/device-pairing-approval.ts
+++ b/src/infra/device-pairing-approval.ts
@@ -20,7 +20,11 @@ import {
 } from "./device-pairing-state.js";
 import { persistDevicePairingStoreState as persistState } from "./device-pairing-store.js";
 import { createDeviceAuthToken, resolveRoleTokenScopes } from "./device-pairing-tokens.js";
-import { clearNodePairingGenerationBins, resolveNodePairingGeneration } from "./device-pairing.js";
+import {
+  clearNodePairingGenerationBins,
+  invalidatePairedCardRendererCache,
+  resolveNodePairingGeneration,
+} from "./device-pairing.js";
 import type {
   DeviceAuthToken,
   DevicePairingPendingRequest,
@@ -370,6 +374,7 @@ async function approveDevicePairingWithOptions(
       "both",
       installationIdentityChanged ? { clearApnsNodeIds: [device.deviceId] } : undefined,
     );
+    invalidatePairedCardRendererCache();
     return {
       status: "approved",
       requestId,
@@ -493,6 +498,7 @@ export async function approveBootstrapDevicePairing(
       "both",
       installationIdentityChanged ? { clearApnsNodeIds: [device.deviceId] } : undefined,
     );
+    invalidatePairedCardRendererCache();
     return {
       status: "approved",
       requestId,

--- a/src/infra/device-pairing-prune.test.ts
+++ b/src/infra/device-pairing-prune.test.ts
@@ -5,6 +5,7 @@ import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { approveBootstrapDevicePairing, approveDevicePairing } from "./device-pairing-approval.js";
 import {
   getPairedDevice,
+  hasPairedCardRenderer,
   listDevicePairing,
   pruneSupersededSilentPairedDevices,
   requestDevicePairing,
@@ -45,6 +46,7 @@ async function pairDevice(params: {
   clientId?: string;
   clientMode?: string;
   displayName?: string;
+  platform?: string;
   roles?: string[];
 }) {
   const request = await requestDevicePairing(
@@ -54,6 +56,7 @@ async function pairDevice(params: {
       clientId: params.clientId ?? "cli",
       clientMode: params.clientMode ?? "cli",
       displayName: params.displayName,
+      platform: params.platform,
       role: params.roles?.[0] ?? "operator",
       roles: params.roles ?? ["operator"],
       scopes: [],
@@ -277,5 +280,30 @@ describe("pruneSupersededSilentPairedDevices", () => {
 
     expect(removed).toEqual([]);
     expect(await getPairedDevice("legacy", baseDir)).not.toBeNull();
+  });
+
+  test("invalidates the card renderer cache after pruning the last renderer", async () => {
+    const baseDir = await makeBaseDir();
+    await pairDevice({
+      baseDir,
+      deviceId: "stale-renderer",
+      approvedVia: "silent",
+      platform: "ios",
+    });
+    const anchor = await pairDevice({
+      baseDir,
+      deviceId: "anchor",
+      approvedVia: "silent",
+      platform: "linux",
+    });
+    await expect(hasPairedCardRenderer(baseDir)).resolves.toBe(true);
+
+    await pruneSupersededSilentPairedDevices({
+      deviceId: anchor.deviceId,
+      baseDir,
+      nowMs: agedNowMs(),
+    });
+
+    await expect(hasPairedCardRenderer(baseDir)).resolves.toBe(false);
   });
 });

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -27,6 +27,7 @@ import {
 } from "./device-pairing-tokens.js";
 import {
   getPairedDevice,
+  hasPairedCardRenderer,
   hasEffectivePairedDeviceRole,
   listEffectivePairedDeviceRoles,
   listDevicePairing,
@@ -2209,6 +2210,50 @@ describe("device pairing tokens", () => {
     await expect(loadApnsRegistration("device-1", baseDir)).resolves.toBeNull();
 
     await expect(removePairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
+  test.each([
+    { clientId: "openclaw-control-ui", platform: undefined, expected: true },
+    { clientId: "webchat-ui", platform: undefined, expected: true },
+    { clientId: "openclaw-ios", platform: undefined, expected: true },
+    { clientId: "openclaw-android", platform: undefined, expected: true },
+    { clientId: "openclaw-macos", platform: undefined, expected: true },
+    { clientId: "cli", platform: "web", expected: true },
+    { clientId: "cli", platform: "ios", expected: true },
+    { clientId: "cli", platform: "android", expected: true },
+    { clientId: "cli", platform: "macos", expected: true },
+    { clientId: "cli", platform: "darwin", expected: true },
+    { clientId: "cli", platform: "linux", expected: false },
+  ])(
+    "detects paired card renderer client=$clientId platform=$platform",
+    async ({ clientId, platform, expected }) => {
+      const baseDir = await suiteRootTracker.make("renderer-case");
+      await expect(hasPairedCardRenderer(baseDir)).resolves.toBe(false);
+      const request = await requestDevicePairing(
+        {
+          deviceId: "renderer-device",
+          publicKey: "renderer-public-key",
+          clientId,
+          platform,
+          role: "operator",
+          scopes: [],
+        },
+        baseDir,
+      );
+      await approveDevicePairing(request.request.requestId, { callerScopes: [] }, baseDir);
+
+      await expect(hasPairedCardRenderer(baseDir)).resolves.toBe(expected);
+    },
+  );
+
+  test("invalidates the card renderer cache when removing a paired device", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedBrowserOperatorDevice(baseDir);
+    await expect(hasPairedCardRenderer(baseDir)).resolves.toBe(true);
+
+    await removePairedDevice("browser-device-1", baseDir);
+
+    await expect(hasPairedCardRenderer(baseDir)).resolves.toBe(false);
   });
 
   test("clears APNs only when a node reapproval changes installation identity", async () => {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -1,7 +1,9 @@
 // Manages device pairing requests, records, metadata, and node pairing state.
 import { createHash, randomUUID } from "node:crypto";
+import { resolveStateDir } from "../config/paths.js";
 import { normalizeDeviceAuthScopes } from "../shared/device-auth.js";
 import { roleScopesAllow } from "../shared/operator-scope-compat.js";
+import { isProgressCardRendererClient } from "../utils/message-channel.js";
 import { revokeDeviceBootstrapTokensForDevice } from "./device-bootstrap.js";
 import {
   cloneDevicePairingTokens,
@@ -21,7 +23,7 @@ import {
 } from "./device-pairing-state.js";
 import {
   loadPairedDevicePairingStoreRecord,
-  persistDevicePairingStoreState as persistState,
+  persistDevicePairingStoreState,
   updatePairedDevicePresenceInTransaction,
 } from "./device-pairing-store.js";
 import type {
@@ -83,6 +85,31 @@ type DevicePairingList = {
   pending: DevicePairingPendingRequest[];
   paired: PairedDevice[];
 };
+
+// Pairing mutations own invalidation, so this single-slot cache keeps SQLite out
+// of attempt hot paths without serving a removed or newly approved renderer.
+let pairedCardRendererCache: { stateDir: string; value: Promise<boolean> } | undefined;
+
+export function invalidatePairedCardRendererCache(): void {
+  pairedCardRendererCache = undefined;
+}
+
+/** Return whether this Gateway has a paired client that can render progress cards. */
+export function hasPairedCardRenderer(baseDir?: string): Promise<boolean> {
+  const stateDir = baseDir ?? resolveStateDir();
+  if (pairedCardRendererCache?.stateDir !== stateDir) {
+    const value = listDevicePairingReadOnly(stateDir)
+      .then(({ paired }) => paired.some(isProgressCardRendererClient))
+      .catch(() => false);
+    pairedCardRendererCache = { stateDir, value };
+  }
+  return pairedCardRendererCache.value;
+}
+
+function persistState(...args: Parameters<typeof persistDevicePairingStoreState>): void {
+  persistDevicePairingStoreState(...args);
+  invalidatePairedCardRendererCache();
+}
 
 /**
  * Internal seam for the paired-device node-surface module: run one

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -111,6 +111,28 @@ export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean 
   return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.WEBCHAT_UI;
 }
 
+const PROGRESS_CARD_RENDERER_PLATFORMS = new Set(["web", "ios", "android", "macos", "darwin"]);
+
+/** Return whether a paired Gateway client can render progress cards. */
+export function isProgressCardRendererClient(
+  paired?: {
+    clientId?: string | null;
+    clientMode?: string | null;
+    platform?: string | null;
+  } | null,
+): boolean {
+  const client = { id: paired?.clientId, mode: paired?.clientMode };
+  const clientId = normalizeGatewayClientName(client?.id);
+  const rendererClient =
+    (clientId === GATEWAY_CLIENT_NAMES.CONTROL_UI && isBrowserOperatorUiClient(client)) ||
+    (clientId === GATEWAY_CLIENT_NAMES.WEBCHAT_UI && isWebchatClient(client)) ||
+    clientId === GATEWAY_CLIENT_NAMES.IOS_APP ||
+    clientId === GATEWAY_CLIENT_NAMES.ANDROID_APP ||
+    clientId === GATEWAY_CLIENT_NAMES.MACOS_APP;
+  const platform = paired?.platform?.trim().toLowerCase();
+  return rendererClient || (platform ? PROGRESS_CARD_RENDERER_PLATFORMS.has(platform) : false);
+}
+
 /** Resolve whether a channel can receive markdown without plain-text downgrade. */
 export function isMarkdownCapableMessageChannel(raw?: string | null): boolean {
   const channel = normalizeMessageChannel(raw);


### PR DESCRIPTION
Related: #125613

## What Problem This Solves

The A/B in #125613 showed zero unprompted `progress_card` adoption from the tool description alone. A global ambient reminder would waste context on main sessions, utility-model work, and channel-only deployments where nobody can render the card.

## Why This Change Was Made

This adds the maintainer-agreed ambient reminder at the shared attempt prompt boundary, after incognito context, so embedded and Codex runtimes receive one canonical fragment. The roughly 25-token nudge appears only when three facts agree: the session is not the agent's canonical main session, the Gateway has a paired card-rendering web/iOS/Android/macOS client, and the attempt is not using the agent's resolved utility model.

The audience fact is read from the existing paired-device owner and kept in a lifecycle-invalidated single-slot process cache, so attempts do not poll SQLite. No storage, schema, protocol, or Codex-specific injection was added.

## User Impact

Full-size models can now maintain progress cards spontaneously during work sessions when someone has a paired client that can see them. Channel-only deployments such as WhatsApp-only Gateways pay no prompt cost, main sessions remain unchanged, and utility-model work remains compact. Existing `tools.updatePlan: false` and `tools.deny` policies still remove the tool entirely.

## Evidence

- Fragment coverage: exact sentence, canonical/global main suppression, no-renderer suppression, utility-model suppression, and incognito-first ordering.
- Pairing coverage: all supported client IDs and platform fallbacks, non-renderer false case, approval/remove invalidation, and prune invalidation without restart.
- Codex coverage: the existing `extraSystemPrompt` path places the sentence in thread developer instructions; upstream Codex thread creation/session configuration behavior was inspected directly.
- `node scripts/run-vitest.mjs src/agents/progress-card-system-prompt.test.ts src/infra/device-pairing.test.ts src/infra/device-pairing-prune.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts src/agents/system-prompt-stability.test.ts`
- `pnpm tsgo:core`
- `pnpm check:assertion-safety`
- Production/full-tree/script dead-code and unused-export scans: zero task findings. The initial repository-wide file scan saw one unrelated pre-existing local-only script; the same scans passed with only that local file excluded.
- `pnpm prompt:snapshots:check` (7 snapshot files current; no main-session fixture drift)
- `pnpm format` on all touched files
- `node scripts/check-changed.mjs -- <touched files>`
- `pnpm check:docs` (0 lint issues, 0 broken links)
- Autoreview clean in both local and branch modes.
- Exact-head CI: [run 32112952807](https://github.com/openclaw/openclaw/actions/runs/32112952807) passed for `537627832ac172a2d0c415e4294c95acdd44cecc`.
