### PR TITLE
test(ui): make the correct e2e wait the easy one to write

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,3 +1,4 @@
 # Test Rules
 
 - Fake-timer tests in `unit-fast` belong in `vitest.unit-fast-fake-timers`: `unit-fast` is `isolate: false` and parallel, so fake timers share worker globals and can hang unrelated real-timer tests.
+- Async E2E waits synchronize on the state an action produces, never on the action returning: #125441 process readiness after `spawn()`, #125456 committed form state before Save, #125548 durable draft persistence before reload. Do not substitute longer timeouts, sleeps, retry-wrapped downstream assertions, or trimmed expectation fields.

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   waitForConfirmModal,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { waitForSettledFormControls } from "./settle.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI cloud workers settings mocked Gateway E2E",
@@ -77,8 +78,10 @@ suite.define(() => {
       await page.getByRole("button", { name: "Add profile" }).click();
       await page.getByLabel("Profile ID").fill("build-fleet");
       await page.getByLabel("Crabbox backend").fill("hetzner");
-      await expect.poll(() => page.getByLabel("Profile ID").inputValue()).toBe("build-fleet");
-      await expect.poll(() => page.getByLabel("Crabbox backend").inputValue()).toBe("hetzner");
+      await waitForSettledFormControls(page, [
+        { locator: page.getByLabel("Profile ID"), value: "build-fleet" },
+        { locator: page.getByLabel("Crabbox backend"), value: "hetzner" },
+      ]);
       await gateway.deferNext("config.patch");
       const addRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();
@@ -141,19 +144,16 @@ suite.define(() => {
         .locator("wa-switch")
         .click();
       await page.getByLabel("Crabbox binary").fill("/opt/bin/crabbox");
-      await expect
-        .poll(() => page.getByLabel("Machine class", { exact: true }).inputValue())
-        .toBe("custom");
-      await expect.poll(() => page.getByLabel("Custom machine class").inputValue()).toBe("ccx53");
-      await expect.poll(() => page.getByLabel("Max lifetime").inputValue()).toBe("12h");
-      await expect
-        .poll(() =>
-          page.getByRole("switch", { name: "Desktop", exact: true }).getAttribute("aria-checked"),
-        )
-        .toBe("true");
-      await expect
-        .poll(() => page.getByLabel("Crabbox binary").inputValue())
-        .toBe("/opt/bin/crabbox");
+      await waitForSettledFormControls(page, [
+        { locator: page.getByLabel("Machine class", { exact: true }), value: "custom" },
+        { locator: page.getByLabel("Custom machine class"), value: "ccx53" },
+        { locator: page.getByLabel("Max lifetime"), value: "12h" },
+        {
+          locator: page.getByRole("switch", { name: "Desktop", exact: true }),
+          checked: true,
+        },
+        { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox" },
+      ]);
       await gateway.deferNext("config.patch");
       const editRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();
@@ -210,8 +210,10 @@ suite.define(() => {
       await page.getByRole("button", { name: "Add profile" }).click();
       await page.getByLabel("Profile ID").fill("pending");
       await page.getByLabel("Crabbox backend").fill("aws");
-      await expect.poll(() => page.getByLabel("Profile ID").inputValue()).toBe("pending");
-      await expect.poll(() => page.getByLabel("Crabbox backend").inputValue()).toBe("aws");
+      await waitForSettledFormControls(page, [
+        { locator: page.getByLabel("Profile ID"), value: "pending" },
+        { locator: page.getByLabel("Crabbox backend"), value: "aws" },
+      ]);
       await gateway.deferNext("config.patch");
       const pendingRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -16,7 +16,7 @@ import {
   pastePng,
   pollLocatorText,
   reconnectProofArtifactDir,
-  waitForPersistedNewSessionDraft,
+  waitForCommittedNewSessionDraft,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -48,7 +48,7 @@ suite.define(() => {
       await firstPage.goto(`${suite.server.baseUrl}new`);
       const firstMessage = firstPage.locator(".new-session-page__message");
       await firstMessage.fill(text);
-      await waitForPersistedNewSessionDraft(firstPage, text, 0);
+      await waitForCommittedNewSessionDraft(firstPage, text, 0);
       await firstPage.reload();
       await expect.poll(() => firstMessage.inputValue()).toBe(text);
       await firstPage.close();
@@ -88,12 +88,12 @@ suite.define(() => {
       const incognito = firstPage.getByRole("switch", { name: "Incognito" });
       await incognito.click();
       await expect.poll(() => incognito.getAttribute("aria-checked")).toBe("true");
-      await waitForPersistedNewSessionDraft(firstPage, null, 0);
+      await waitForCommittedNewSessionDraft(firstPage, null, 0);
       await incognito.click();
       await expect.poll(() => incognito.getAttribute("aria-checked")).toBe("false");
       await firstMessage.fill("restore this prompt after restart and incognito");
       await expect.poll(() => firstPage.locator(".chat-attachment-thumb").count()).toBe(1);
-      await waitForPersistedNewSessionDraft(
+      await waitForCommittedNewSessionDraft(
         firstPage,
         "restore this prompt after restart and incognito",
         1,

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -12,6 +12,7 @@ import {
   waitForControlUiRoute,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { waitForCommittedState } from "./settle.test-support.ts";
 
 export { controlUiSessionPath, controlUiSessionUrl, waitForConfirmModal };
 
@@ -194,15 +195,20 @@ export async function pastePng(target: Locator, count = 1) {
   );
 }
 
-export async function waitForPersistedNewSessionDraft(
+export async function waitForCommittedNewSessionDraft(
   page: Page,
   expectedText: string | null,
   expectedAttachmentCount: number,
 ): Promise<void> {
   // Filling only proves DOM state. The durable read waits for the IndexedDB
   // transaction so reload or navigation cannot beat the snapshot write.
-  await page.waitForFunction(
-    async ({ text, attachmentCount }) => {
+  await waitForCommittedState(
+    page,
+    async (expected) => {
+      const { text, attachmentCount } = expected;
+      if ((typeof text !== "string" && text !== null) || typeof attachmentCount !== "number") {
+        return false;
+      }
       try {
         const app = document.querySelector("openclaw-app") as HTMLElement & {
           runtime?: {

--- a/ui/src/e2e/settle.test-support.ts
+++ b/ui/src/e2e/settle.test-support.ts
@@ -1,0 +1,51 @@
+import type { Locator, Page } from "playwright";
+import { expect } from "vitest";
+
+type SettledFormControl =
+  | { locator: Locator; value: string }
+  | { locator: Locator; checked: boolean };
+
+async function waitForBrowserRenderBoundary(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      }),
+  );
+}
+
+export async function waitForSettledFormControls(
+  page: Page,
+  controls: readonly SettledFormControl[],
+): Promise<void> {
+  const expected = controls.map((control) =>
+    "value" in control ? { value: control.value } : { checked: control.checked ? "true" : "false" },
+  );
+  const readControls = async () =>
+    Promise.all(
+      controls.map(async (control) =>
+        "value" in control
+          ? { value: await control.locator.inputValue() }
+          : { checked: await control.locator.getAttribute("aria-checked") },
+      ),
+    );
+  await expect.poll(readControls).toEqual(expected);
+  await waitForBrowserRenderBoundary(page);
+  await expect.poll(readControls).toEqual(expected);
+}
+
+type CommittedStateArgs = Record<string, boolean | null | number | string>;
+
+export async function waitForCommittedState(
+  page: Page,
+  probe: (arg: CommittedStateArgs) => boolean | Promise<boolean>,
+  arg: CommittedStateArgs,
+): Promise<void> {
+  const firstMatch = await page.waitForFunction(probe, arg);
+  await firstMatch.dispose();
+  // A matching store read may still have an older mutation queued behind it.
+  // Require the committed state to survive a browser render boundary before acting.
+  await waitForBrowserRenderBoundary(page);
+  const settledMatch = await page.waitForFunction(probe, arg);
+  await settledMatch.dispose();
+}


### PR DESCRIPTION
## What Problem This Solves

Four flaky tests were fixed in this repo over the last day, and three were the **same mistake**:
synchronizing on an action instead of on the state that action is supposed to produce.

- #125441 — a fixture wrote a descendant's pid immediately after `spawn()`, so waiting for that file proved
  a pid had been written, not that a process was running.
- #125456 — the cloud-workers settings test filled Web Awesome controls and clicked Save at once, so the
  config patch could be assembled from state the form had not committed.
- #125548 — the new-session test filled the composer and reloaded before the durable draft was persisted,
  destroying the draft it then asserted on.

Every fix was correct and every one was bespoke. Nothing made the right pattern obvious to the next author,
and the wrong version is always shorter to type — which is why the same bug shipped three times.

## Why This Change Was Made

Two helpers in a new `ui/src/e2e/settle.test-support.ts` cover the shapes that actually bit us:
`waitForSettledFormControls` (input values and accessible checked state) and `waitForCommittedState`
(committed state survives a render boundary before acting). Nine inline polls in the two affected specs
collapse into them, and `waitForPersistedNewSessionDraft` is generalized and renamed
`waitForCommittedNewSessionDraft` so there is one way to express this rather than two overlapping ones.

The rule is also written down in `test/AGENTS.md`, citing the three shipped instances as evidence and naming
the workarounds that are not acceptable — longer timeouts, sleeps, retry-wrapped downstream assertions, or
trimmed expectation fields. A convention with a citation is harder to argue with in review than a
convention with a rationale.

## User Impact

None. Test infrastructure only; zero production lines.

## Evidence

Both affected specs were already green before this PR, so this is a pure refactor and the assertions had to
survive untouched. They did: the nine deleted lines are exactly the inline polls, and every asserted value —
`build-fleet`, `hetzner`, `custom`, `ccx53`, `12h`, the Desktop switch's checked state, `/opt/bin/crabbox` —
is carried into the helper call. No `waitForTimeout`, sleep, or raised timeout appears anywhere in the diff.

```
bounded loop: 10/10 passes, 18 tests each
 Test Files  2 passed (2)      Tests  18 passed (18)
```

`pnpm check:changed` green; Codex autoreview clean.

**reviewMetrics — production vs test LOC**: production `0`, tests/support/guidance `+84 / −24`. The net
growth is the shared helper module; the two specs shrank.

No `CHANGELOG.md` edit — release-only per repo policy; test-infrastructure change.
