### PR TITLE
fix(update): schedule dev updates after slow Git fetches

### DIFF
--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -1,6 +1,6 @@
 import { runCommandBuffered, runCommandWithTimeout } from "../process/exec.js";
 
-const GIT_TIMEOUT_MS = 120_000;
+export const GIT_TIMEOUT_MS = 120_000;
 
 type GitCommandResult = {
   stdout: string;

--- a/src/infra/update-check-status.test.ts
+++ b/src/infra/update-check-status.test.ts
@@ -3,13 +3,18 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runCommandWithTimeout } from "../process/exec.js";
+import * as processExec from "../process/exec.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { checkUpdateStatus } from "./update-check.js";
 
+const runCommandWithTimeout = processExec.runCommandWithTimeout;
+
 async function runGit(cwd: string, ...args: string[]): Promise<string> {
-  const result = await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 5000 });
+  const result = await runCommandWithTimeout(["git", ...args], {
+    cwd,
+    timeoutMs: 5000,
+  });
   if (result.code !== 0) {
     throw new Error(result.stderr || `git ${args.join(" ")} failed`);
   }
@@ -32,6 +37,32 @@ afterEach(() => {
 });
 
 describe("checkUpdateStatus", () => {
+  it.each([
+    { name: "shared default", timeoutMs: undefined, expectedTimeoutMs: 120_000 },
+    { name: "explicit override", timeoutMs: 4321, expectedTimeoutMs: 4321 },
+  ])("uses the $name for Git fetches", async ({ timeoutMs, expectedTimeoutMs }) => {
+    await withTestDir({ prefix: "openclaw-update-check-fetch-timeout-" }, async (base) => {
+      const remoteRoot = path.join(base, "remote");
+      const localRoot = path.join(base, "local");
+      await initGitRepo(remoteRoot);
+      await commitGit(remoteRoot, "initial");
+      await runGit(base, "clone", "--quiet", remoteRoot, localRoot);
+      const runCommandSpy = vi.spyOn(processExec, "runCommandWithTimeout");
+
+      await checkUpdateStatus({
+        root: localRoot,
+        includeRegistry: false,
+        fetchGit: true,
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      });
+
+      const fetchCall = runCommandSpy.mock.calls.find(
+        ([argv]) => argv[0] === "git" && argv.includes("fetch"),
+      );
+      expect(fetchCall?.[1]).toMatchObject({ timeoutMs: expectedTimeoutMs });
+    });
+  });
+
   it("fetches a retained main upstream whose remote nickname contains a slash", async () => {
     await withTestDir({ prefix: "openclaw-update-check-slash-remote-" }, async (base) => {
       const sourceRoot = path.join(base, "source");
@@ -552,7 +583,10 @@ describe("checkUpdateStatus", () => {
         JSON.stringify({ name: "openclaw", packageManager: "pnpm@10.0.0" }),
         "utf8",
       );
-      await runCommandWithTimeout(["git", "init"], { cwd: repoRoot, timeoutMs: 1000 });
+      await runCommandWithTimeout(["git", "init"], {
+        cwd: repoRoot,
+        timeoutMs: 1000,
+      });
       await fs.symlink(repoRoot, linkedRoot);
 
       const status = await checkUpdateStatus({

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -8,6 +8,7 @@ import {
   isPnpmOwnedPackageRoot,
   resolvePnpmNodeModulesRoot,
 } from "./detect-package-manager.js";
+import { GIT_TIMEOUT_MS } from "./git-exec.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareValidSemver, normalizeLegacyDotBetaVersion } from "./semver.js";
 import {
@@ -238,12 +239,12 @@ async function detectGitRoot(root: string): Promise<string | null> {
 
 async function checkGitUpdateStatus(params: {
   root: string;
-  timeoutMs?: number;
+  timeoutMs: number | undefined;
   fetch?: boolean;
   useDetachedDevUpstream?: boolean;
   upstreamFallback?: { currentSha: string; upstreamRef: string };
 }): Promise<GitUpdateStatus> {
-  const timeoutMs = params.timeoutMs ?? 6000;
+  const timeoutMs = params.timeoutMs ?? (params.fetch ? GIT_TIMEOUT_MS : 6000);
   const root = path.resolve(params.root);
   const runGit = (...args: string[]) =>
     runCommandWithTimeout(["git", "-C", root, ...args], { timeoutMs }).catch(() => null);
@@ -633,7 +634,7 @@ export async function checkUpdateStatus(params: {
     isGit
       ? checkGitUpdateStatus({
           root,
-          timeoutMs,
+          timeoutMs: params.timeoutMs,
           fetch: Boolean(params.fetchGit),
           useDetachedDevUpstream: params.useDetachedDevUpstream,
           upstreamFallback: params.gitUpstreamFallback,

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1158,7 +1158,6 @@ describe("update-startup", () => {
 
     expect(checkUpdateStatus).toHaveBeenCalledWith({
       root: "/opt/openclaw",
-      timeoutMs: 2500,
       fetchGit: true,
       includeRegistry: false,
       useDetachedDevUpstream: true,
@@ -1344,7 +1343,6 @@ describe("update-startup", () => {
 
     expect(checkUpdateStatus).toHaveBeenCalledWith({
       root: "/opt/openclaw",
-      timeoutMs: 2500,
       fetchGit: true,
       includeRegistry: false,
       useDetachedDevUpstream: true,
@@ -1682,6 +1680,80 @@ describe("update-startup", () => {
     expect(checkUpdateStatus).toHaveBeenCalledTimes(3);
     stop();
     process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it("returns cleanup before slow dev git discovery schedules a campaign", async () => {
+    const remoteFetchDelayMs = 65_653;
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(checkUpdateStatus).mockImplementation(({ fetchGit, timeoutMs }) => {
+      const isRemoteFetch = fetchGit === true;
+      const effectiveTimeoutMs = timeoutMs ?? (isRemoteFetch ? 120_000 : 6000);
+      const remoteFetchFinished = isRemoteFetch && effectiveTimeoutMs >= remoteFetchDelayMs;
+      const status = {
+        root: "/opt/openclaw",
+        installKind: "git" as const,
+        packageManager: "pnpm" as const,
+        git: {
+          root: "/opt/openclaw",
+          sha: "current-sha",
+          tag: null,
+          branch: "main",
+          upstream: "origin/main",
+          upstreamSource: "tracking" as const,
+          upstreamSha: remoteFetchFinished ? "upstream-sha" : null,
+          commitAtMs: null,
+          dirty: false,
+          ahead: remoteFetchFinished ? 0 : null,
+          behind: remoteFetchFinished ? 2 : null,
+          fetchOk: isRemoteFetch ? remoteFetchFinished : null,
+        },
+      } satisfies UpdateCheckResult;
+      if (!isRemoteFetch) {
+        return Promise.resolve(status);
+      }
+      return new Promise<UpdateCheckResult>((resolve) => {
+        setTimeout(() => resolve(status), Math.min(effectiveTimeoutMs, remoteFetchDelayMs));
+      });
+    });
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    let stop: (() => void) | undefined;
+
+    try {
+      stop = scheduleGatewayUpdateCheck({
+        cfg: { update: { channel: "dev", auto: { enabled: true } } },
+        log: { info: vi.fn() },
+        isNixMode: false,
+        activeWorkInspectors: idleActiveWorkInspectors(),
+      });
+
+      expect(stop).toEqual(expect.any(Function));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(checkUpdateStatus).toHaveBeenCalledTimes(2);
+      expect(checkUpdateStatus).toHaveBeenNthCalledWith(1, {
+        root: "/opt/openclaw",
+        timeoutMs: 2500,
+        fetchGit: false,
+        includeRegistry: false,
+      });
+      expect(checkUpdateStatus).toHaveBeenNthCalledWith(2, {
+        root: "/opt/openclaw",
+        fetchGit: true,
+        includeRegistry: false,
+        useDetachedDevUpstream: true,
+      });
+      expect(getUpdateSchedule()?.campaign).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(remoteFetchDelayMs);
+      expect(getUpdateSchedule()?.campaign?.state).toBe("countdown");
+      expect(getUpdateSchedule()?.install?.git).toMatchObject({
+        status: "behind",
+        commitsBehind: 2,
+      });
+    } finally {
+      stop?.();
+      process.env.NODE_ENV = previousNodeEnv;
+    }
   });
 
   it("defers stable auto-update until rollout window is due", async () => {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -578,7 +578,7 @@ function clearAutoState(nextState: UpdateCheckState): void {
   delete nextState.autoFirstSeenAt;
 }
 
-async function resolveStartupInstallStatus(checkDevGit: boolean) {
+async function resolveStartupInstallStatus(fetchRemoteGit: boolean) {
   const [root, installReceipt] = await Promise.all([
     resolveOpenClawPackageRoot({
       moduleUrl: import.meta.url,
@@ -593,16 +593,16 @@ async function resolveStartupInstallStatus(checkDevGit: boolean) {
       : undefined;
   const status = await checkUpdateStatus({
     root,
-    timeoutMs: 2500,
-    fetchGit: checkDevGit,
+    ...(fetchRemoteGit ? {} : { timeoutMs: 2500 }),
+    fetchGit: fetchRemoteGit,
     includeRegistry: false,
-    ...(checkDevGit ? { useDetachedDevUpstream: true } : {}),
+    ...(fetchRemoteGit ? { useDetachedDevUpstream: true } : {}),
     ...(gitUpstreamFallback ? { gitUpstreamFallback } : {}),
   });
   return { root, status, installReceipt };
 }
 
-/** Starts the process-stable local install inspection owned by the update lifecycle. */
+/** Caches only the fast local install probe; remote Git refresh remains post-ready. */
 export function initializeGatewayUpdateStatus(): ReturnType<typeof resolveStartupInstallStatus> {
   if (installStatusInitialization) {
     return installStatusInitialization;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where automatic dev-channel update checks could report `fetch-failed` and never schedule an update campaign when an ordinary remote Git fetch took longer than 2.5 seconds. A production observation showed the same checkout updating successfully after a 65,653 ms fetch through `update.run` while every automatic status check failed before campaign creation.

## Why This Change Was Made

The 2.5-second budget belongs only to the process-stable local install identity probe. Remote Git discovery now inherits OpenClaw's existing 120-second Git-operation default from the Git fact owner, while explicit CLI/RPC timeout overrides remain authoritative. The Gateway lifecycle is unchanged: install identity stays fast and remote discovery remains post-ready, so network latency does not delay Gateway startup.

## User Impact

Managed dev-channel Gateways can discover ordinary-latency upstream changes and enter the existing idle/countdown automatic update campaign instead of remaining permanently unavailable. This adds no configuration, retry path, protocol change, or fallback behavior.

## Evidence

- Pre-fix regression: `src/infra/update-startup.test.ts` failed with 1 failed / 77 passed because the expected `countdown` campaign was absent after the 2.5-second timeout won.
- Focused post-fix proof: `node scripts/run-vitest.mjs src/infra/update-check-status.test.ts src/infra/update-startup.test.ts` — 96 passed.
- Startup lifecycle proof: `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts -t "starts the gateway update check after post-attach returns"` — 1 passed, 75 skipped.
- Changed gate: `node scripts/check-changed.mjs -- src/infra/git-exec.ts src/infra/update-check.ts src/infra/update-startup.ts src/infra/update-check-status.test.ts src/infra/update-startup.test.ts` — passed after the isolated worktree dependency install. Blacksmith Testbox was unavailable before allocation because the host lacked the `blacksmith` executable; repository policy therefore used the trusted local fallback.
- Formatting and diff checks passed.
- Fresh Codex-backed autoreview: clean, no accepted/actionable findings.
- Production LOC: +10/-9 (net +1), the single added line imports the existing shared Git timeout policy into the Git status owner. Tests: +111/-5 (net +106).
- AI-assisted; maintainer reviewed the complete source, history, diff, and proof.
