### PR TITLE
fix(agents): restore deliveryStatus checks in plugin envelope signals

### DIFF
--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -72,10 +72,13 @@ function visitPluginEnvelope(
 
 const PLUGIN_SIGNALS = {
   dryRun: (record: Record<string, unknown>) =>
-    record.dryRun === true || normalizeStatus(record.status) === "dry_run",
+    record.dryRun === true ||
+    normalizeStatus(record.deliveryStatus) === "dry_run" ||
+    normalizeStatus(record.status) === "dry_run",
   partial: (record: Record<string, unknown>) =>
     record.sentBeforeError === true ||
     record.visibleReplySent === true ||
+    normalizeStatus(record.deliveryStatus) === "partial_failed" ||
     normalizeStatus(record.status) === "partial_failed",
   conversation: (record: Record<string, unknown>) =>
     [
@@ -88,6 +91,7 @@ const PLUGIN_SIGNALS = {
     const id = normalizeStatus(record.messageId);
     return (
       (id !== undefined && NON_DELIVERY_IDS.has(id)) ||
+      normalizeStatus(record.deliveryStatus) === "suppressed" ||
       normalizeStatus(record.status) === "suppressed"
     );
   },
@@ -117,6 +121,7 @@ const PLUGIN_SIGNALS = {
       .filter((id): id is string => Boolean(id));
     return (
       ids.some((id) => !NON_DELIVERY_IDS.has(id)) ||
+      normalizeStatus(record.deliveryStatus) === "sent" ||
       normalizeStatus(record.status) === "sent" ||
       normalizeStatus(record.text) === "sent"
     );

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -13,6 +13,7 @@ type EmbeddedMessageDeliveryFact = {
 };
 
 const NON_DELIVERY_IDS = new Set(["skipped", "suppressed"]);
+const NON_DELIVERY_STATUSES = new Set(["failed", ...NON_DELIVERY_IDS]);
 const STATUSES = new Set(["settled", "suppressed", "dryRun", "failed"]);
 const PLUGIN_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
 
@@ -37,9 +38,14 @@ function normalizeStatus(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim().toLowerCase() : undefined;
 }
 
+type PluginEnvelopePredicate = (
+  record: Record<string, unknown>,
+  status: string | undefined,
+) => boolean;
+
 function visitPluginEnvelope(
   value: unknown,
-  predicate: (record: Record<string, unknown>) => boolean,
+  predicate: PluginEnvelopePredicate,
   depth = 0,
 ): boolean {
   if (!value || typeof value !== "object" || depth > 4) {
@@ -52,7 +58,8 @@ function visitPluginEnvelope(
   if (!record) {
     return false;
   }
-  if (predicate(record)) {
+  const status = normalizeStatus(record.deliveryStatus) ?? normalizeStatus(record.status);
+  if (predicate(record, status)) {
     return true;
   }
   if (typeof record.text === "string") {
@@ -71,15 +78,12 @@ function visitPluginEnvelope(
 }
 
 const PLUGIN_SIGNALS = {
-  dryRun: (record: Record<string, unknown>) =>
-    record.dryRun === true ||
-    normalizeStatus(record.deliveryStatus) === "dry_run" ||
-    normalizeStatus(record.status) === "dry_run",
-  partial: (record: Record<string, unknown>) =>
+  dryRun: (record: Record<string, unknown>, status: string | undefined) =>
+    record.dryRun === true || status === "dry_run",
+  partial: (record: Record<string, unknown>, status: string | undefined) =>
     record.sentBeforeError === true ||
     record.visibleReplySent === true ||
-    normalizeStatus(record.deliveryStatus) === "partial_failed" ||
-    normalizeStatus(record.status) === "partial_failed",
+    status === "partial_failed",
   conversation: (record: Record<string, unknown>) =>
     [
       record.topicId,
@@ -87,17 +91,15 @@ const PLUGIN_SIGNALS = {
       record.messageThreadId,
       asOptionalRecord(record.thread)?.id,
     ].some((id) => hasNonEmptyString(id) || (typeof id === "number" && Number.isFinite(id))),
-  nonDelivery: (record: Record<string, unknown>) => {
+  nonDelivery: (record: Record<string, unknown>, status: string | undefined) => {
     const id = normalizeStatus(record.messageId);
     return (
       (id !== undefined && NON_DELIVERY_IDS.has(id)) ||
-      normalizeStatus(record.deliveryStatus) === "suppressed" ||
-      normalizeStatus(record.status) === "suppressed"
+      (status !== undefined && NON_DELIVERY_STATUSES.has(status))
     );
   },
-  noOp: (record: Record<string, unknown>) => {
+  noOp: (record: Record<string, unknown>, status: string | undefined) => {
     const removed = record.removed;
-    const status = normalizeStatus(record.status);
     return (
       removed === null ||
       removed === false ||
@@ -114,15 +116,14 @@ const PLUGIN_SIGNALS = {
       status === "not_found"
     );
   },
-  delivery: (record: Record<string, unknown>) => {
+  delivery: (record: Record<string, unknown>, status: string | undefined) => {
     const message = asOptionalRecord(record.message);
     const ids = [record.messageId, record.pollId, message?.id]
       .map(normalizeStatus)
       .filter((id): id is string => Boolean(id));
     return (
       ids.some((id) => !NON_DELIVERY_IDS.has(id)) ||
-      normalizeStatus(record.deliveryStatus) === "sent" ||
-      normalizeStatus(record.status) === "sent" ||
+      status === "sent" ||
       normalizeStatus(record.text) === "sent"
     );
   },
@@ -132,7 +133,7 @@ const PLUGIN_SIGNALS = {
       .some((id) => Boolean(id && !NON_DELIVERY_IDS.has(id))),
   ok: (record: Record<string, unknown>) =>
     record.ok === true || normalizeStatus(record.text) === "ok",
-} satisfies Record<string, (record: Record<string, unknown>) => boolean>;
+} satisfies Record<string, PluginEnvelopePredicate>;
 
 export function pluginEnvelopeHas(value: unknown, signal: keyof typeof PLUGIN_SIGNALS): boolean {
   return visitPluginEnvelope(value, PLUGIN_SIGNALS[signal]);

--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -288,6 +288,32 @@ describe("isDeliveredMessagingToolResult", () => {
     ).toBe(true);
   });
 
+  it("rejects suppressed and dry-run deliveryStatus in plugin send envelopes", () => {
+    // deliveryStatus is the canonical marker emitted by core send results; a
+    // plugin-native tool echoing it must not be treated as delivered.
+    expect(
+      isDeliveredMessagingToolResult({
+        toolName: "message",
+        args: { action: "send", to: "channel-1" },
+        result: { ok: true, deliveryStatus: "suppressed" },
+      }),
+    ).toBe(false);
+    expect(
+      isDeliveredMessagingToolResult({
+        toolName: "message",
+        args: { action: "send", to: "channel-1" },
+        result: { ok: true, deliveryStatus: "dry_run" },
+      }),
+    ).toBe(false);
+    expect(
+      isDeliveredMessagingToolResult({
+        toolName: "message",
+        args: { action: "send", to: "channel-1" },
+        result: { ok: true, deliveryStatus: "sent" },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects successful plugin broadcast wrappers around suppressed sends", () => {
     expect(
       isDeliveredMessagingToolResult({

--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -288,30 +288,20 @@ describe("isDeliveredMessagingToolResult", () => {
     ).toBe(true);
   });
 
-  it("rejects suppressed and dry-run deliveryStatus in plugin send envelopes", () => {
-    // deliveryStatus is the canonical marker emitted by core send results; a
-    // plugin-native tool echoing it must not be treated as delivered.
+  it.each([
+    ["suppressed", false],
+    ["dry_run", false],
+    ["failed", false],
+    ["sent", true],
+    ["partial_failed", true],
+  ] as const)("maps plugin deliveryStatus %s to delivered=%s", (deliveryStatus, delivered) => {
     expect(
       isDeliveredMessagingToolResult({
         toolName: "message",
         args: { action: "send", to: "channel-1" },
-        result: { ok: true, deliveryStatus: "suppressed" },
+        result: { ok: true, deliveryStatus },
       }),
-    ).toBe(false);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "message",
-        args: { action: "send", to: "channel-1" },
-        result: { ok: true, deliveryStatus: "dry_run" },
-      }),
-    ).toBe(false);
-    expect(
-      isDeliveredMessagingToolResult({
-        toolName: "message",
-        args: { action: "send", to: "channel-1" },
-        result: { ok: true, deliveryStatus: "sent" },
-      }),
-    ).toBe(true);
+    ).toBe(delivered);
   });
 
   it("rejects successful plugin broadcast wrappers around suppressed sends", () => {


### PR DESCRIPTION
## Summary

Restore plugin-envelope delivery status handling so non-delivery results do not hide the assistant's final reply.

## What Problem This Solves

A plugin-native messaging tool can return a successful wrapper such as `{ ok: true, deliveryStatus: "suppressed" }` or `{ ok: true, deliveryStatus: "dry_run" }` without sending a message. The shared classifier ignored `deliveryStatus`, accepted the outer `ok`, and recorded the result as delivered. Route-aware reply deduplication then removed the assistant's real final reply, so the user saw nothing.

## Root Cause

The delivery-envelope rewrite in #125497 moved plugin result classification into `src/agents/embedded-agent-message-delivery.ts`. The new signal predicates checked `status` and message identifiers but dropped the canonical `deliveryStatus` field. The same gap also allowed `{ ok: true, deliveryStatus: "failed" }` to count as delivery.

## Why This Change Was Made

The recursive envelope visitor now resolves `deliveryStatus` before the generic `status` field once per record. All shared signals consume that normalized value:

- `dry_run` is not delivery.
- `suppressed`, `failed`, and `skipped` are not delivery.
- `partial_failed` preserves partial visible delivery.
- `sent` preserves confirmed delivery.

This keeps one owner for embedded completion, command-line runtime tracking, middleware, and plugin broadcast projection. The table-driven regression test covers the complete delivery-status contract.

## User Impact

- Suppressed, dry-run, and failed plugin sends no longer swallow the assistant's final reply.
- Partial sends remain delivered because some content reached the user.
- Sent results still suppress duplicate final text.

## Evidence

### Live Telegram Test Server red/green

The same three direct-message turns ran through a real Telegram Test Server user and bot, an isolated Gateway, a controlled Responses provider, and a plugin-native Telegram messaging tool. Each turn used a unique marker carried through the provider request and tool result.

| Plugin result | Exact main `c07b753819ebb140db95fdb090bec99b3fb5cc43` | Head `faec999b456570fb95a90f3a1294a8ec393f88fa` |
| --- | --- | --- |
| `deliveryStatus: "suppressed"` | Final marker absent | Final marker visible once |
| `deliveryStatus: "dry_run"` | Final marker absent | Final marker visible once |
| `deliveryStatus: "sent"` | Real tool send visible once | Real tool send visible once |

Every turn made two provider requests. The non-delivery controls returned no platform send. The sent control performed one real Telegram send, and the provider's matching final text did not create a duplicate.

### Regression and gates

- Pre-fix regression: 1 failed, 50 passed. Only `deliveryStatus: "failed"` was still misclassified on the contributor head.
- Post-fix regression: 51 passed in `src/agents/embedded-agent-message-tool-source-reply.test.ts`.
- Changed-scope gate passed, including core production and test type checks, lint, format, import cycles, and repository ratchets.
- Exact-head build passed.
- `git diff --check` passed.

Production is +19/-13 (net +6) and tests are +16/-0 against the contributor parent. The production growth defines the shared status input and the missing explicit failure set; the rewrite adds only one net production line over the contributor patch while removing ten test lines.
