### PR TITLE
fix: keep provider usage bound to the refreshed account

### DIFF
--- a/src/gateway/server-methods/models-auth-status-usage-cache.ts
+++ b/src/gateway/server-methods/models-auth-status-usage-cache.ts
@@ -108,8 +108,12 @@ function retainLastGoodOnTimeout(
       .filter((provider) => provider.error === undefined)
       .map((provider) => [provider.provider, provider]),
   );
+  const retainedLastGood = summary.providers.some(
+    (provider) => provider.error === "Timeout" && lastGoodByProvider.has(provider.provider),
+  );
   return {
     ...summary,
+    updatedAt: retainedLastGood ? lastGood.updatedAt : summary.updatedAt,
     providers: summary.providers.map((provider) =>
       provider.error === "Timeout"
         ? (lastGoodByProvider.get(provider.provider) ?? provider)

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -1286,7 +1286,7 @@ describe("models.authStatus", () => {
       expect(warmed.providers[0]?.usage?.windows[0]?.usedPercent).toBe(10);
     });
 
-    setPreparedAuthStore({
+    const rotatedStore: AuthProfileStore = {
       version: 1,
       profiles: {
         "openai:default": {
@@ -1297,10 +1297,16 @@ describe("models.authStatus", () => {
           expires: 1_000_000,
         },
       },
-    });
+    };
+    // Prepared catalog refresh can replace its owner before the ambient snapshot revision advances.
+    preparedAuthStore = rotatedStore;
     const rotated = await readAuthStatus();
+    expect(mocks.buildAuthHealthSummary.mock.calls.at(-1)?.[0].store).toBe(rotatedStore);
     expect(rotated.providers[0]?.usage).toBeUndefined();
     expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(2);
+    expect(mocks.loadProviderUsageSummary).toHaveBeenLastCalledWith(
+      expect.objectContaining({ authStore: rotatedStore }),
+    );
   });
 
   it("does not reuse usage after a direct provider key rotates", async () => {

--- a/src/gateway/server-methods/provider-usage-runtime.ts
+++ b/src/gateway/server-methods/provider-usage-runtime.ts
@@ -115,6 +115,8 @@ export function getProviderUsageRuntimeSnapshot(params: {
   const authStoreGeneration = getRuntimeAuthProfileStoreSnapshotRevision(agentDir);
   if (
     current?.configRef === configRef &&
+    // Prepared owners can advance before the ambient snapshot; their exact store fences reuse.
+    (params.store === undefined || current.store === params.store) &&
     current.agentDir === agentDir &&
     current.agentId === agentId &&
     current.pluginRegistryGeneration === pluginRegistryGeneration &&

--- a/src/gateway/server-methods/usage.status-cache.test.ts
+++ b/src/gateway/server-methods/usage.status-cache.test.ts
@@ -226,10 +226,11 @@ describe("usage.status provider usage cache", () => {
     const stale = await runUsageStatus();
     expect(JSON.stringify(stale)).toBe(JSON.stringify(first));
     await mocks.loadProviderUsageSummary.mock.results[1]?.value;
+    now = 62_000;
     await vi.waitFor(async () => {
       const retained = (await runUsageStatus()) as UsageSummary;
       expect(retained.providers).toEqual(first.providers);
-      expect(retained.updatedAt).toBe(61_000);
+      expect(retained.updatedAt).toBe(first.updatedAt);
       expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(2);
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a refreshed provider account could show its new auth health alongside usage data fetched with the previously active account. Also fixes timeout fallback reporting a new update time while retaining older last-good usage.

## Why This Change Was Made

Prepared provider-usage snapshot reuse is now fenced on the exact explicit auth-store owner, and the last-good user-visible timestamp remains separate from internal refresh freshness and backoff. Auth policy and public configuration are unchanged.

## User Impact

Account switches no longer pair account B health with account A quota or usage, and retained timeout data accurately reports when it was last successfully updated.

## Evidence

Pre-fix regression proof with the production patch reversed and the regression assertions retained:

- `usage.status-cache` failed with `updatedAt` 61000 instead of the expected last-good 1000.
- `models-auth-status` kept account-A usage visible after the account-B prepared store replaced it.

Fixed focused and neighboring suites:

- `pnpm test src/gateway/server-methods/usage.status-cache.test.ts` — 6/6 passed.
- `pnpm test src/gateway/server-methods/models-auth-status.test.ts` — 85/85 passed.
- Provider usage load tests — 9/9 passed.
- Usage Gateway tests — 43/43 passed.

Static and repository gates passed: `pnpm tsgo:core`, `pnpm tsgo:core:test`, targeted oxlint and formatting, conflict markers, max-lines, assertion safety, deprecated API, plugin boundary, wrapper, patch, dead-code, temp-dir, native-schema, database-first, media, sidecar, import-cycle, webhook, and auth-pairing guards. `git diff --check` passed. Fresh automated autoreview was clean with no accepted or actionable findings.

Production delta: +6/-0. Test delta: +10/-3.

No live multi-account provider probe was run because reproducing it requires deliberately rotating persisted operator account state. The exact account-A-then-account-B owner-boundary regression test exercises the defect without touching live credentials. External provider protocol behavior is unchanged.

AI-assisted: Yes. No agent transcript is included.
