### PR TITLE
perf(agents): avoid duplicate restart recovery scans

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -219,6 +219,7 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
   stateDir?: string;
   activeSessionIds?: Iterable<string>;
   activeSessionKeys?: Iterable<string>;
+  startupCheckedStorePaths?: Set<string>;
   updatedBeforeMs?: number;
 }): Promise<{ marked: number; skipped: number }> {
   const result = { marked: 0, skipped: 0 };
@@ -237,7 +238,12 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
   const resolveActiveSessionKeys = () =>
     providedActiveSessionKeys ?? normalizeStringSet(listActiveEmbeddedRunSessionKeys());
 
-  for (const storePath of await resolveRestartRecoveryStorePaths(params)) {
+  // Check each store path once at startup so rows added later in that same path remain current.
+  // Add paths only after every marking write succeeds so a failed scan retries safely.
+  const storePaths = (await resolveRestartRecoveryStorePaths(params)).filter(
+    (storePath) => !params.startupCheckedStorePaths?.has(storePath),
+  );
+  for (const storePath of storePaths) {
     const storeResult = await markRecoveryStore({
       storePath,
       statuses: ["running"],
@@ -269,6 +275,7 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
     result.marked += storeResult.marked;
     result.skipped += storeResult.skipped;
   }
+  storePaths.forEach((storePath) => params.startupCheckedStorePaths?.add(storePath));
 
   if (result.marked > 0) {
     mainSessionRecoveryLog.warn(

--- a/src/agents/main-session-recovery/main-session-restart-recovery-runtime.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-runtime.ts
@@ -282,26 +282,18 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
     params.shouldContinue?.() !== false &&
     isAgentEventLifecycleGenerationCurrent(lifecycleGeneration);
   const startupRecoveryCutoffMs = Date.now();
-  const markedStorePaths = new Set<string>();
+  const startupCheckedStorePaths = new Set<string>();
   const runRecoveryAttempt = async (
     exhaustedTargets: Map<string, ExhaustedRestartRecoveryTarget>,
   ): Promise<RecoveryCounts> => {
     return await runWithGatewayIndependentRootWorkAdmission(async () => {
       const cfg = params.getConfig();
-      const currentStorePaths = await resolveRestartRecoveryStorePaths({
+      await markStartupOrphanedMainSessionsForRecovery({
         cfg,
         stateDir: params.stateDir,
+        startupCheckedStorePaths,
+        updatedBeforeMs: startupRecoveryCutoffMs,
       });
-      if (currentStorePaths.some((storePath) => !markedStorePaths.has(storePath))) {
-        await markStartupOrphanedMainSessionsForRecovery({
-          cfg,
-          stateDir: params.stateDir,
-          updatedBeforeMs: startupRecoveryCutoffMs,
-        });
-        for (const storePath of currentStorePaths) {
-          markedStorePaths.add(storePath);
-        }
-      }
       return await recoverRestartAbortedMainSessions({
         cfg,
         onExhaustedTarget: (target) => {

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -10,6 +10,7 @@ import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as configSessions from "../../config/sessions.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import {
@@ -2896,6 +2897,70 @@ describe("main-session-restart-recovery", () => {
     expect(customStore["agent:main:main"]?.abortedLastRun).toBe(false);
   });
 
+  it("rediscovers a restored configured store between startup marking and recovery", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await writeMainSession({ sessionsDir, abortedLastRun: undefined });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "resume the interrupted main session" },
+      { role: "toolResult", content: "main result" },
+    ]);
+
+    const lateSessionsDir = path.join(tmpDir, "agents", "late", "sessions");
+    const lateStorePath = path.join(lateSessionsDir, "sessions.json");
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }, { id: "late" }] },
+    } as OpenClawConfig;
+    const discoverySpy = vi.spyOn(configSessions, "resolveAllAgentSessionStoreTargetsSync");
+    const originalApply = sessionAccessor.applySessionEntryReplacements;
+    let restoredLateStore = false;
+    const replacementSpy = vi
+      .spyOn(sessionAccessor, "applySessionEntryReplacements")
+      .mockImplementation(async (params) => {
+        const result = await originalApply(params);
+        if (params.requireWriteSuccess === true && !restoredLateStore) {
+          restoredLateStore = true;
+          await writeStorePath(lateStorePath, {
+            "agent:late:main": {
+              sessionId: "late-session",
+              updatedAt: 1,
+              status: "running",
+              abortedLastRun: true,
+            },
+          });
+          await writeTranscript(lateSessionsDir, "late-session", [
+            { role: "user", content: "resume the restored session" },
+            { role: "toolResult", content: "late result" },
+          ]);
+        }
+        return result;
+      });
+
+    const recovery = scheduleRestartAbortedMainSessionRecovery({
+      getConfig: () => cfg,
+      delayMs: 0,
+      stateDir: tmpDir,
+    });
+    try {
+      await waitForFast(() => expect(callGateway).toHaveBeenCalledTimes(2));
+      await recovery.stop();
+
+      expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
+        abortedLastRun: false,
+      });
+      expect(
+        loadSessionEntry({ sessionKey: "agent:late:main", storePath: lateStorePath }),
+      ).toMatchObject({ abortedLastRun: false });
+      expect(discoverySpy.mock.calls.filter(([observedCfg]) => observedCfg === cfg)).toHaveLength(
+        2,
+      );
+    } finally {
+      await recovery.stop();
+      replacementSpy.mockRestore();
+      discoverySpy.mockRestore();
+    }
+  });
+
   it("cancels startup recovery when its gateway lifecycle stops", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeMainSession({
@@ -3223,6 +3288,8 @@ describe("main-session-restart-recovery", () => {
       sessionsDir,
       pendingFinalDelivery: makePendingFinalDelivery(),
     });
+    const cfg = {} as OpenClawConfig;
+    const discoverySpy = vi.spyOn(configSessions, "resolveAllAgentSessionStoreTargetsSync");
     const firstDispatch = createDeferred();
     const secondDispatch = createDeferred();
     let firstAgentDispatch = true;
@@ -3255,7 +3322,7 @@ describe("main-session-restart-recovery", () => {
     let recovery: ReturnType<typeof scheduleRestartAbortedMainSessionRecovery> | undefined;
     try {
       recovery = scheduleRestartAbortedMainSessionRecovery({
-        getConfig: () => ({}),
+        getConfig: () => cfg,
         delayMs: 0,
         maxRetries: 2,
         stateDir: tmpDir,
@@ -3290,9 +3357,13 @@ describe("main-session-restart-recovery", () => {
       });
       expect(lateEntry).toMatchObject({ status: "running" });
       expect(lateEntry?.abortedLastRun).toBeUndefined();
+      expect(discoverySpy.mock.calls.filter(([observedCfg]) => observedCfg === cfg)).toHaveLength(
+        4,
+      );
     } finally {
       await recovery?.stop();
       setTimeoutSpy.mockRestore();
+      discoverySpy.mockRestore();
       vi.useRealTimers();
     }
   });


### PR DESCRIPTION
Related: #123439
Follow-up to #124516

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes repeated session-store topology discovery during scheduled Gateway restart recovery. A first or newly discovered-store attempt scanned topology once to decide whether startup marking should run, immediately scanned it again inside the marker, and scanned a third time before recovery. The obvious shared snapshot is unsafe because stores can be deleted or restored between marking and recovery.

## Why This Change Was Made

Move the first discovery and once-per-startup path tracking into the startup marker, which is the owner of cutoff and active-run write policy. Store paths are recorded only after the complete marking pass succeeds. Recovery retains its own independent fresh discovery, preserving deleted/restored-store visibility and ensuring late rows in an already-checked path are not reclassified as startup orphans. No process-global cache, polling, schema, config, protocol, or migration change.

## User Impact

Gateway restart recovery performs two topology scans per attempt instead of three on the first/new-path attempt, reducing synchronous startup work on multi-agent installations without weakening session recovery or store deletion fencing.

## Evidence

- Pre-fix: restored-store test observed 3 discoveries instead of 2; two-attempt retry observed 5 instead of 4.
- `node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts` — 159 passed.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts` — 76 passed.
- `node scripts/check-changed.mjs` and `git diff --check` — passed.
- Fresh structured P1 autoreview — clean.
- Live Blacksmith Testbox `tbx_01m09s1spedp8exs8v0yzces3t`: https://github.com/openclaw/openclaw/actions/runs/32107251548. Real built isolated Gateway marked and recovered 2/2 SQLite sessions, 2/2 provider responses succeeded, `/readyz` true, and 54 overlapping health probes had 0 failures/timeouts (p95 168.02ms under 250ms). Recovery logs reported `recovered=2 failed=0 skipped=0`.
- Production LOC +12/-13 (net -1); tests +72/-1.
- Live limitation: channels were disabled and the provider was a local mock; built Gateway HTTP, startup lifecycle, SQLite, recovery scheduler, provider transport, and health/readiness were real.

AI-assisted.
