### PR TITLE
fix(agents): recurse into the sendResult envelope key when probing delivery

### DIFF
--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -14,7 +14,17 @@ type EmbeddedMessageDeliveryFact = {
 
 const NON_DELIVERY_IDS = new Set(["skipped", "suppressed"]);
 const STATUSES = new Set(["settled", "suppressed", "dryRun", "failed"]);
-const PLUGIN_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
+// "sendResult" is the canonical nesting key of MessageActionResult
+// ({ kind: "send", sendResult?: MessageSendResult }); without it, delivery
+// evidence embedded in action results is invisible to envelope probing.
+const PLUGIN_ENVELOPE_KEYS = [
+  "details",
+  "payload",
+  "result",
+  "results",
+  "sendResult",
+  "toolResult",
+];
 
 const EMPTY_DELIVERY_FACT: Pick<
   EmbeddedMessageDeliveryFact,

--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -288,6 +288,21 @@ describe("isDeliveredMessagingToolResult", () => {
     ).toBe(true);
   });
 
+  it("detects delivery evidence nested under the sendResult envelope key", () => {
+    // MessageActionResult nests the send result under sendResult; probing
+    // must recurse into it or real deliveries are missed (duplicate sends).
+    expect(
+      isDeliveredMessagingToolResult({
+        toolName: "message",
+        args: { action: "send", to: "chat-1" },
+        result: {
+          kind: "send",
+          sendResult: { messageId: "m-proof-1", deliveryStatus: "sent" },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects successful plugin broadcast wrappers around suppressed sends", () => {
     expect(
       isDeliveredMessagingToolResult({


### PR DESCRIPTION
## Summary

fix(agents): recurse into the `sendResult` envelope key when probing plugin delivery evidence, so real deliveries nested in `MessageActionResult` are detected instead of sent twice

## What Problem This Solves

The canonical action-result contract nests send results under `sendResult` (`src/infra/outbound/message-action-contracts.ts:130`: `{ kind: "send", sendResult?: MessageSendResult }`). The envelope-probing rewrite in `7e7b860bca5` (#125497) recurses only through these keys:

```ts
const PLUGIN_ENVELOPE_KEYS = ["details", "payload", "result", "results", "toolResult"];
```

`sendResult` is missing. The pre-rewrite implementation recursed through exactly the same list **plus** `sendResult` (and `error`/`cause` for partial detection).

So when a plugin messaging tool returns a result shaped like `{ kind: "send", sendResult: { messageId: "m1", deliveryStatus: "sent" } }`, the delivery evidence is invisible to the prober: `pluginEnvelopeHas(value, "delivery")` returns false, `isDeliveredMessagingToolResult` judges the send as not delivered, and the final visible reply is **not** suppressed — the same content goes out twice (once via the tool, once via the final reply).

**代码证据**: `src/agents/embedded-agent-message-delivery.ts:17` (key list without `sendResult`); pre-rewrite `RESULT_ENVELOPE_KEYS` in `embedded-agent-message-tool-source-reply.ts` (included it); the contract at `message-action-contracts.ts:130`.

Trigger condition: any plugin tool result that nests its send outcome under `sendResult` — the documented shape of `MessageActionResult`.

## Root Cause

- Regression introduced by commit `7e7b860bca5` (2026-08-17).
- Violated invariant: envelope probing must recurse through every key under which the platform nests tool results. Dropping `sendResult` makes the documented `MessageActionResult` shape opaque to delivery detection.

## Why This Fix

- Option A (chosen): restore `sendResult` to `PLUGIN_ENVELOPE_KEYS`. One line, exactly the pre-rewrite behavior.
- Option B: handle `sendResult` per consumer. Duplicates nesting knowledge at every call site and keeps the shared prober incomplete.

## User Impact

- Affected scenarios: agent turns where a plugin messaging tool returns `MessageActionResult`-shaped results.
- Before: the message is delivered by the tool and then delivered again as the final reply — duplicate messages.
- After: the nested delivery evidence is found and the final reply is correctly suppressed.
- Behavior change: restores pre-rewrite detection semantics.

## Evidence

Runs the real `isDeliveredMessagingToolResult` with a `MessageActionResult`-shaped envelope (Node v24, tsx) — no mocks.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-sendresult-envelope-key.mjs
[proof] envelope: {"kind":"send","sendResult":{"messageId":"m-proof-1","deliveryStatus":"sent"}}
[proof] isDeliveredMessagingToolResult -> false
[proof] RESULT: FAIL - nested sendResult evidence missed; the final reply would be sent a second time (duplicate message)
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-sendresult-envelope-key.mjs
[proof] envelope: {"kind":"send","sendResult":{"messageId":"m-proof-1","deliveryStatus":"sent"}}
[proof] isDeliveredMessagingToolResult -> true
[proof] RESULT: PASS - nested sendResult evidence detected; reply suppressed (no duplicate)
```

## Tests and Validation

- `npx vitest run src/agents/embedded-agent-message-tool-source-reply.test.ts` — 94/94 passed, including the new regression test `detects delivery evidence nested under the sendResult envelope key` (fails on main: nested evidence missed).
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
