### PR TITLE
fix(agents): preserve context history after assembly failure

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -9,7 +9,6 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { openFileBackedSessionManagerForTest } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-delivery-hints";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -1181,20 +1180,13 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
         },
       } as EmbeddedRunAttemptParams["config"];
 
-      let runError: unknown;
-      const run = runCodexAppServerAttempt(params).catch((error: unknown) => {
-        runError = error;
-        throw error;
-      });
-      await vi.waitFor(
-        () => {
-          if (runError) {
-            throw toLintErrorObject(runError, "Non-Error thrown");
-          }
-          expect(harness.requests.map((request) => request.method)).toContain("turn/start");
-        },
-        { interval: 1 },
-      );
+      const run = runCodexAppServerAttempt(params);
+      await Promise.race([
+        harness.waitForMethod("turn/start"),
+        run.then(() => {
+          throw new Error("Codex attempt completed before turn/start");
+        }),
+      ]);
 
       expect(harness.requests.map((request) => request.method)).toEqual([
         "thread/start",
@@ -1912,9 +1904,31 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
   it("logs assemble failures as a formatted message instead of the raw error object", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
+    openFileBackedSessionManagerForTest(sessionFile, { sessionId: "session-1" }).appendMessage(
+      assistantMessage("first baseline message", 1) as never,
+    );
+    openFileBackedSessionManagerForTest(sessionFile, { sessionId: "session-1" }).appendMessage(
+      userMessage("second baseline message", 2) as never,
+    );
+    let preassemblyMessages: AgentMessage[] = [];
+    let promptHookMessages: AgentMessage[] = [];
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: async (event) => {
+            promptHookMessages = (event as { messages: AgentMessage[] }).messages;
+            return {};
+          },
+        },
+      ]),
+    );
     const rawError = new Error("Authorization: Bearer sk-abcdefghijklmnopqrstuv");
     const contextEngine = createContextEngine({
-      assemble: vi.fn(async () => {
+      assemble: vi.fn(async ({ messages }) => {
+        preassemblyMessages = messages.slice();
+        messages.reverse();
+        messages.pop();
         throw rawError;
       }),
       bootstrap: undefined,
@@ -1936,6 +1950,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(typeof details.error).toBe("string");
     expect(warning?.[1]).not.toEqual({ error: rawError });
     expect(String(details.error)).not.toContain("sk-abcdefghijklmnopqrstuv");
+    expect(promptHookMessages).toEqual(preassemblyMessages);
+    expect(promptHookMessages.map((message) => message.role)).toEqual(["assistant", "user"]);
+    expectRequestInputTextContains(harness, params.prompt);
   });
 
   it("does not advance context-engine state on prompt failure", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2260,8 +2260,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(hoisted.preemptiveCompactionCalls).toHaveLength(0);
   });
 
-  it("submits once to the provider when owning context engine assembly fails", async () => {
+  it("preserves pipeline history when owning context engine assembly mutates then fails", async () => {
     let sawPrompt = false;
+    let preassemblyMessages: AgentMessage[] = [];
+    let providerMessages: AgentMessage[] = [];
     const hugeHistory = "large raw history ".repeat(2_000);
 
     const result = await createContextEngineAttemptRunner({
@@ -2272,7 +2274,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
           version: "0.0.1",
           ownsCompaction: true,
         },
-        assemble: async () => {
+        assemble: async ({ messages }) => {
+          preassemblyMessages = messages.slice();
+          messages.reverse();
+          messages.pop();
           throw new Error("assembly failed");
         },
       }),
@@ -2284,6 +2289,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
       sessionPrompt: async (session) => {
         sawPrompt = true;
+        providerMessages = session.messages.slice() as AgentMessage[];
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -2292,6 +2298,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     });
 
     expect(sawPrompt).toBe(true);
+    expect(providerMessages).toEqual(preassemblyMessages);
+    for (const [index, message] of providerMessages.entries()) {
+      expect(message).toBe(preassemblyMessages[index]);
+    }
     expect(projectAgentRunAttemptTerminal(result.terminal).promptError).toBeNull();
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBeNull();
     expect(result.preflightRecovery).toBeUndefined();

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -972,7 +972,7 @@ describe("installContextEngineLoopHook", () => {
     );
   });
 
-  it("repairs same-reference ownsCompaction assembled loop views", async () => {
+  it("repairs successful in-place ownsCompaction assembled loop views", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();
     installContextEngineLoopHook({
@@ -991,7 +991,10 @@ describe("installContextEngineLoopHook", () => {
       firstResultText: "r",
     });
 
-    expect(recordMockArg(engine.assemble).messages).toBe(withNew);
+    const assembledInput = recordMockArg(engine.assemble).messages as AgentMessage[];
+    expect(assembledInput).not.toBe(withNew);
+    expect(assembledInput).toEqual(withNew);
+    expect(assembledInput[0]).toBe(withNew[0]);
     expect(transformed).not.toBe(withNew);
     expect(transformed).toEqual([expect.objectContaining({ role: "user", content: "first" })]);
     expect((transformed as AgentMessage[]).some((message) => message.role === "toolResult")).toBe(
@@ -1021,7 +1024,9 @@ describe("installContextEngineLoopHook", () => {
     expect(await callTransform(agent, secondSource)).toBe(secondSource);
 
     const retry = await callTransform(agent, secondSource);
-    expect(retry).toBe(secondSource);
+    expect(retry).not.toBe(secondSource);
+    expect(retry).toEqual(secondSource);
+    expect((retry as AgentMessage[])[0]).toBe(secondSource[0]);
     expect(retry).not.toBe(compactedView);
     expect(engine.assemble).toHaveBeenCalledTimes(3);
   });
@@ -1075,7 +1080,10 @@ describe("installContextEngineLoopHook", () => {
     expect(await callTransform(agent, source)).toBe(compactedView);
 
     const resetSource = [makeUser("reset"), makeToolResult("call_3", "r3"), makeUser("fresh")];
-    expect(await callTransform(agent, resetSource)).toBe(resetSource);
+    const transformed = await callTransform(agent, resetSource);
+    expect(transformed).not.toBe(resetSource);
+    expect(transformed).toEqual(resetSource);
+    expect((transformed as AgentMessage[])[0]).toBe(resetSource[0]);
   });
 
   it("returns the assembled view when the engine rewrites content without changing count", async () => {
@@ -1095,14 +1103,16 @@ describe("installContextEngineLoopHook", () => {
     expect(transformed).toBe(rewrittenView);
   });
 
-  it("returns the source when the engine returns the same array reference", async () => {
+  it("adopts the working array when the engine returns it in place", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();
     installHook(agent, engine);
 
     const { transformed, withNew } = await callAfterInitialToolResult(agent);
 
-    expect(transformed).toBe(withNew);
+    expect(transformed).not.toBe(withNew);
+    expect(transformed).toEqual(withNew);
+    expect((transformed as AgentMessage[])[0]).toBe(withNew[0]);
   });
 
   it("does not mutate the source messages array", async () => {
@@ -1194,10 +1204,14 @@ describe("installContextEngineLoopHook", () => {
     expect(transformed).toBe(withNew);
   });
 
-  it("falls through to source messages when engine.assemble throws", async () => {
+  it("preserves source messages when engine.assemble mutates then throws", async () => {
     const agent = makeGuardableAgent();
+    let preassemblyMessages: AgentMessage[] = [];
     const engine = makeMockEngine({
-      assemble: async () => {
+      assemble: async ({ messages }) => {
+        preassemblyMessages = messages.slice();
+        messages.reverse();
+        messages.pop();
         throw new Error("engine assemble boom");
       },
     });
@@ -1206,6 +1220,10 @@ describe("installContextEngineLoopHook", () => {
     const { transformed, withNew } = await callAfterInitialToolResult(agent);
 
     expect(transformed).toBe(withNew);
+    expect(withNew).toEqual(preassemblyMessages);
+    for (const [index, message] of withNew.entries()) {
+      expect(message).toBe(preassemblyMessages[index]);
+    }
   });
 
   it("invokes any pre-existing transformContext before the engine sees messages", async () => {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -423,7 +423,7 @@ export function installContextEngineLoopHook(params: {
       const assembled = await contextEngine.assemble({
         sessionId,
         sessionKey,
-        messages: providerMessages,
+        messages: providerMessages.slice(),
         tokenBudget,
         model: modelId,
         runtimeSettings: params.runtimeSettings,

--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -200,6 +200,60 @@ describe("harness context engine lifecycle", () => {
     expect(assembleParams?.messages).toEqual([visibleUser, visibleAssistant]);
   });
 
+  it("isolates the authoritative history array while preserving in-place assembly", async () => {
+    const first = textMessage("user", "first", 1);
+    const second = textMessage("assistant", "second", 2);
+    const messages = [first, second];
+    const assemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => {
+      expect(params.messages).not.toBe(messages);
+      expect(params.messages).toEqual(messages);
+      expect(params.messages[0]).toBe(first);
+      expect(params.messages[1]).toBe(second);
+      params.messages.reverse();
+      return { messages: params.messages, estimatedTokens: 0 };
+    });
+
+    const assembled = await assembleHarnessContextEngine({
+      contextEngine: createContextEngine({ assemble }),
+      sessionId: sessionParams.sessionId,
+      sessionKey: sessionParams.sessionKey,
+      messages,
+      modelId: "gpt-test",
+    });
+
+    expect(messages).toEqual([first, second]);
+    expect(assembled?.messages).toEqual([second, first]);
+    expect(assembled?.messages[0]).toBe(second);
+    expect(assembled?.messages[1]).toBe(first);
+  });
+
+  it("preserves the authoritative history when assembly mutates then throws", async () => {
+    const first = textMessage("user", "first", 1);
+    const second = textMessage("assistant", "second", 2);
+    const messages = [first, second];
+    const contextEngine = createContextEngine({
+      assemble: vi.fn(async ({ messages: workingMessages }) => {
+        workingMessages.reverse();
+        workingMessages.pop();
+        throw new Error("assembly failed after windowing");
+      }),
+    });
+
+    await expect(
+      assembleHarnessContextEngine({
+        contextEngine,
+        sessionId: sessionParams.sessionId,
+        sessionKey: sessionParams.sessionKey,
+        messages,
+        modelId: "gpt-test",
+      }),
+    ).rejects.toThrow("assembly failed after windowing");
+
+    expect(messages).toEqual([first, second]);
+    expect(messages[0]).toBe(first);
+    expect(messages[1]).toBe(second);
+  });
+
   it("passes declared runtime settings into assemble hooks", async () => {
     const visibleUser = textMessage("user", "visible ask", 1);
     const assemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => ({

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -189,7 +189,7 @@ export async function assembleHarnessContextEngine(params: {
     return undefined;
   }
   const contextEngine = params.contextEngine;
-  const messages = stripRuntimeContextCustomMessages(params.messages);
+  const messages = stripRuntimeContextCustomMessages(params.messages).slice();
   const runtimeSettings = buildHarnessContextEngineRuntimeSettings(params);
   const runtimeContext = preparePreTurnRuntimeContext(params.runtimeContext);
   const assemble = () =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a plugin-owned context engine could lose or reorder fallback conversation history when the engine mutated its input array in place and then failed. The same aliasing affected initial provider submission, mid-tool-loop reassembly, and the Codex app-server prompt path.

## Why This Change Was Made

Context assembly now receives a shallow working-array copy at both canonical assembly owners: the shared harness boundary used by initial/Codex assembly and the embedded mid-tool-loop boundary. Message objects remain shared and successful in-place windowing remains supported, but a mutate-then-throw engine can no longer corrupt the caller-owned history that fallback paths reuse.

The Codex regression fixture also replaces a default-timeout `vi.waitFor` startup probe with the harness's existing `turn/start` waiter raced against attempt completion. The previous one-second default could time out on a cold or saturated run, let `finally` unregister the sandbox backend, and then fail the still-running attempt for an unrelated lifecycle reason. This is a test-lifecycle repair only: no timeout increase, retry, environment override, mock bypass, or production seam.

## User Impact

When context-engine assembly fails after attempting in-place windowing, OpenClaw now submits the original ordered conversation history instead of a reversed, truncated, or empty fallback. This covers the initial embedded provider path, later tool-loop turns, and Codex app-server prompt hooks.

Release-note context: context-engine failures no longer corrupt fallback conversation history across embedded and Codex runtimes.

## Evidence

- Pre-fix owner regressions failed for the intended reason: shared lifecycle input was mutated, mid-tool fallback adopted reversed/truncated history, the embedded provider received an empty history, and the Codex prompt hook received only the mutated tail.
- Post-fix context suites: 128/128 passed.
- Post-fix Codex context-engine suite: 31/31 passed after exact cold reproduction.
- Full changed gate passed, including types, lint, formatting, architecture, storage, auth, and assertion checks.
- Final structured Codex autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Production LOC: +2/-2 (net 0). Tests: +125/-26.
- Direct Codex source inspection at `92cbfb4d2431bdc53dc03507aea2dc5b8e932e40`: [`TurnStartParams.input`](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L71-L75), [`turn/start` input mapping and submission](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/app-server/src/request_processors/turn_processor.rs#L512-L570), and [core turn admission/spawn](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/core/src/session/handlers.rs#L225-L268). These confirm Codex consumes the ordered `turn/start` input as the admitted turn; OpenClaw must preserve its fallback history before that boundary.
- No live Gateway/provider run was used for this deterministic array-ownership defect; the authentic owner-boundary regressions exercise the real initial, mid-tool, and Codex prompt compositions.

AI-assisted.
