### PR TITLE
fix(agents): report offline Trash failures in JSON

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2661,7 +2661,7 @@ src/commands/models/list.status-command.ts	1
 src/commands/models/shared.ts	3
 src/commands/onboard-agent.ts	1
 src/commands/onboard-config.ts	3
-src/commands/onboard-helpers.ts	3
+src/commands/onboard-helpers.ts	2
 src/commands/onboard-non-interactive/local.ts	3
 src/commands/onboard-non-interactive/local/auth-choice-inference.ts	2
 src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts	1

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -68,7 +68,7 @@ Options: `--force`, `--json`.
 
 - The only configured agent cannot be deleted.
 - Without `--force`, interactive confirmation is required (fails in a non-TTY session; re-run with `--force`).
-- Workspace, agent state, and session transcript directories move to Trash, not hard-deleted. If Trash is unavailable, agent config deletion still succeeds and reports paths requiring manual cleanup.
+- Workspace, agent state, and session transcript directories move to Trash, not hard-deleted. If Trash is unavailable, agent config deletion still succeeds and reports paths requiring manual cleanup; `--json` exposes path outcomes in `removed` and `failed` arrays.
 - On installations that have not migrated shared auth yet, the legacy owner cannot be deleted. Run `openclaw doctor --fix`; after relocation into shared state SQLite, `main` follows the same deletion rules as any other agent.
 - When the Gateway is reachable, deletion routes through the Gateway so config and session-store cleanup share the same writer as runtime traffic. If the Gateway is unreachable, the CLI falls back to the offline local path.
 - If another agent's workspace is the same path, inside this workspace, or contains this workspace, the workspace is retained, and `--json` reports `workspaceRetained`, `workspaceRetainedReason`, and `workspaceSharedWith`.

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -20,7 +20,7 @@ import {
   resolveWorkspaceBootstrapStatus,
 } from "../agents/workspace.js";
 import { pruneAgentConfig } from "../commands/agents.config.js";
-import { moveToTrash } from "../commands/onboard-helpers.js";
+import { moveToTrash } from "../commands/cleanup-utils.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,4 +1,5 @@
 // Implements agent deletion with gateway delegation and local cleanup fallback.
+import type { AgentsDeleteResult } from "../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import {
   findOverlappingWorkspaceAgentIds,
   formatSharedAuthStoreOwnerDeleteError,
@@ -49,8 +50,8 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-cha
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { createQuietRuntime } from "./agents.command-shared.js";
 import { findAgentEntryIndex, listAgentEntries, pruneAgentConfig } from "./agents.config.js";
+import { moveToTrashResult } from "./cleanup-utils.js";
 import { requireValidConfigFileSnapshot } from "./config-validation.js";
-import { moveToTrash } from "./onboard-helpers.js";
 
 type AgentsDeleteOptions = {
   id: string;
@@ -58,14 +59,8 @@ type AgentsDeleteOptions = {
   json?: boolean;
 };
 
-type AgentsDeleteGatewayResult = {
-  ok: true;
-  agentId: string;
-  removedBindings: number;
-  removed?: Array<{ path: string; method: "trash" | "missing" }>;
-  failed?: Array<{ path: string; reason: string }>;
-  purgeFailed?: true;
-};
+type AgentDeleteRemovedPath = NonNullable<AgentsDeleteResult["removed"]>[number];
+type AgentDeleteFailedPath = NonNullable<AgentsDeleteResult["failed"]>[number];
 
 function failAgentsDelete(opts: AgentsDeleteOptions, runtime: RuntimeEnv, message: string): void {
   if (opts.json) {
@@ -94,9 +89,9 @@ function logSessionPurgeWarning(runtime: RuntimeEnv, agentId: string, purgeFaile
 async function maybeDeleteAgentThroughGateway(params: {
   agentId: string;
   deleteFiles: boolean;
-}): Promise<AgentsDeleteGatewayResult | null> {
+}): Promise<AgentsDeleteResult | null> {
   try {
-    return await callGateway<AgentsDeleteGatewayResult>({
+    return await callGateway<AgentsDeleteResult>({
       method: "agents.delete",
       params: {
         agentId: params.agentId,
@@ -238,9 +233,9 @@ export async function agentsDeleteCommand(
     deleteFiles: true,
   });
   if (gatewayResult) {
-    const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
-    const workspaceRetained = workspaceSharedWith.length > 0;
     if (opts.json) {
+      const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
+      const workspaceRetained = workspaceSharedWith.length > 0;
       writeRuntimeJson(runtime, {
         agentId,
         workspace: workspaceDir,
@@ -269,6 +264,9 @@ export async function agentsDeleteCommand(
     }
     return;
   }
+
+  const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
+  const workspaceRetained = workspaceSharedWith.length > 0;
 
   const deleteFiles = existingJournal?.deleteFiles ?? true;
   const deletion = beginAgentDeletion(
@@ -301,10 +299,18 @@ export async function agentsDeleteCommand(
 
   const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
   // Only trash the workspace if no other agent can depend on that path (#70890).
-  const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
-  const workspaceRetained = workspaceSharedWith.length > 0;
   let workspaceCleanupError: Error | undefined;
-  let workspaceRemoved = workspaceRetained || !deleteFiles;
+  const removed: AgentDeleteRemovedPath[] = [];
+  const failed: AgentDeleteFailedPath[] = [];
+  const removePath = async (pathname: string) => {
+    const outcome = await moveToTrashResult(pathname, quietRuntime);
+    if ("removed" in outcome) {
+      removed.push(outcome.removed);
+    } else {
+      failed.push(outcome.failed);
+    }
+    return outcome;
+  };
   if (deleteFiles && workspaceRetained) {
     quietRuntime.log(
       `Skipped workspace removal (shared with other agents: ${workspaceSharedWith.join(", ")}): ${workspaceDir}`,
@@ -312,8 +318,8 @@ export async function agentsDeleteCommand(
   } else if (deleteFiles) {
     const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
     const statePlan = prepareWorkspaceStateDeletion(workspaceDir);
-    workspaceRemoved = await moveToTrash(workspaceDir, quietRuntime);
-    if (workspaceRemoved) {
+    const workspaceResult = await removePath(workspaceDir);
+    if ("removed" in workspaceResult) {
       try {
         const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
         for (const warning of legacyCleanup.warnings) {
@@ -325,12 +331,14 @@ export async function agentsDeleteCommand(
       }
     }
   }
-  const agentDirRemoved = !deleteFiles || (await moveToTrash(agentDir, quietRuntime));
-  const sessionsDirRemoved = !deleteFiles || (await moveToTrash(sessionsDir, quietRuntime));
+  if (deleteFiles) {
+    await removePath(agentDir);
+    await removePath(sessionsDir);
+  }
   if (workspaceCleanupError) {
     throw workspaceCleanupError;
   }
-  if (workspaceRemoved && agentDirRemoved && sessionsDirRemoved) {
+  if (failed.length === 0) {
     if (deleteFiles) {
       // Keep registry ownership until every cleanup target is terminal. A crash before journal
       // completion leaves this idempotent deregistration reachable on the next delete attempt.
@@ -351,6 +359,8 @@ export async function agentsDeleteCommand(
       removedBindings: result.removedBindings,
       removedAllow: result.removedAllow,
       clearedOwnerRefs: result.clearedOwnerRefs.length > 0 ? result.clearedOwnerRefs : undefined,
+      removed,
+      failed,
       ...(purgeFailed ? { purgeFailed: true } : {}),
     });
   } else {

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -984,6 +984,8 @@ describe("agents delete command", () => {
   it("retains workspace state when workspace trash fails", async () => {
     await withStateDirEnv("openclaw-agents-delete-trash-failure-", async ({ stateDir }) => {
       const opsWorkspace = path.join(stateDir, "workspace-ops");
+      const opsAgentDir = path.join(stateDir, "agents", "ops", "agent");
+      const opsSessionsDir = path.join(stateDir, "agents", "ops", "sessions");
       const cfg: OpenClawConfig = {
         agents: {
           list: [
@@ -998,6 +1000,14 @@ describe("agents delete command", () => {
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
       expect(workspaceStateMocks.deleteWorkspaceState).not.toHaveBeenCalled();
+      expect(readJsonLogs()[0]).toMatchObject({
+        removed: [
+          { path: opsAgentDir, method: "trash" },
+          { path: opsSessionsDir, method: "missing" },
+        ],
+        failed: [{ path: opsWorkspace, reason: "trash unavailable" }],
+      });
+      expect(readAgentDeletionJournal("ops")?.cleanupCompleted).toBe(false);
     });
   });
 });

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -1,6 +1,7 @@
 // Cleanup utility tests cover filesystem cleanup helpers, temp paths, and command runtime behavior.
 import { spawn } from "node:child_process";
 import { once } from "node:events";
+import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -65,6 +66,23 @@ const workspaceStateMocks = vi.hoisted(() => ({
   prepareWorkspaceStateDeletion: vi.fn((workspaceDir: string) => ({ workspaceDir })),
 }));
 
+const fsSafeMocks = vi.hoisted(() => ({
+  movePathToTrash: vi.fn(async (targetPath: string) => `${targetPath}.trashed`),
+}));
+
+const processMocks = vi.hoisted(() => ({
+  runCommandWithTimeout: vi.fn(),
+}));
+
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
+  movePathToTrash: fsSafeMocks.movePathToTrash,
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: processMocks.runCommandWithTimeout,
+}));
+
 vi.mock("../agents/workspace-state-store.js", async () => ({
   ...(await vi.importActual<typeof import("../agents/workspace-state-store.js")>(
     "../agents/workspace-state-store.js",
@@ -76,10 +94,114 @@ vi.mock("../agents/workspace-state-store.js", async () => ({
 import {
   buildCleanupPlan,
   listAgentSessionDirs,
+  moveToTrash,
   removePath,
   removeStateAndLinkedPaths,
   removeWorkspaceDirs,
 } from "./cleanup-utils.js";
+
+afterEach(() => {
+  fsSafeMocks.movePathToTrash.mockReset();
+  fsSafeMocks.movePathToTrash.mockImplementation(
+    async (targetPath: string) => `${targetPath}.trashed`,
+  );
+  vi.restoreAllMocks();
+});
+
+function expectedTrashSourcePath(targetPath: string): string {
+  return path.join(fsSync.realpathSync(path.dirname(targetPath)), path.basename(targetPath));
+}
+
+describe("moveToTrash", () => {
+  it("uses fs-safe trash instead of resolving a PATH trash command", async () => {
+    const testRoot = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-helper-"));
+    const targetPath = path.join(testRoot, "target");
+    fsSync.mkdirSync(targetPath, { recursive: true });
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+    const sourcePath = expectedTrashSourcePath(targetPath);
+
+    try {
+      await moveToTrash(targetPath, runtime);
+    } finally {
+      fsSync.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
+      allowedRoots: [path.dirname(sourcePath)],
+    });
+    expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(`Moved to Trash: ${targetPath}`);
+  });
+
+  it("allows fs-safe trash to move a symlink whose target resolves outside the parent", async () => {
+    const testRoot = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-symlink-"));
+    const targetPath = path.join(testRoot, "target-link");
+    const outsideTarget = path.join(os.tmpdir(), "openclaw-trash-symlink-target");
+    fsSync.writeFileSync(targetPath, "link placeholder");
+    vi.spyOn(fs, "lstat").mockResolvedValue({
+      isSymbolicLink: () => true,
+    } as fsSync.Stats);
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) =>
+      String(candidate) === path.dirname(targetPath) ? path.dirname(targetPath) : outsideTarget,
+    );
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    try {
+      await moveToTrash(targetPath, runtime);
+    } finally {
+      fsSync.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(targetPath, {
+      allowedRoots: [path.dirname(targetPath), path.dirname(outsideTarget)],
+    });
+  });
+
+  it("moves a dangling symlink instead of treating it as already removed", async () => {
+    const testRoot = tempDirs.make("openclaw-trash-dangling-link-");
+    const targetPath = path.join(testRoot, "workspace-link");
+    fsSync.symlinkSync(path.join(testRoot, "missing-target"), targetPath, "dir");
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+    const sourcePath = expectedTrashSourcePath(targetPath);
+
+    try {
+      await expect(moveToTrash(targetPath, runtime)).resolves.toBe(true);
+    } finally {
+      fsSync.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
+      allowedRoots: [path.dirname(sourcePath)],
+    });
+  });
+
+  it("canonicalizes a symlinked parent before calling fs-safe trash", async () => {
+    const testRoot = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-parent-link-"));
+    const lexicalParent = path.join(testRoot, "state-link");
+    const realParent = path.join(testRoot, "state-real");
+    const targetPath = path.join(lexicalParent, "openclaw.json");
+    const sourcePath = path.join(realParent, "openclaw.json");
+    fsSync.mkdirSync(lexicalParent, { recursive: true });
+    fsSync.writeFileSync(targetPath, "{}\n");
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) =>
+      String(candidate) === lexicalParent ? realParent : String(candidate),
+    );
+    vi.spyOn(fs, "lstat").mockResolvedValue({
+      isSymbolicLink: () => false,
+    } as fsSync.Stats);
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    try {
+      await moveToTrash(targetPath, runtime);
+    } finally {
+      fsSync.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
+      allowedRoots: [realParent],
+    });
+  });
+});
 
 describe("buildCleanupPlan", () => {
   test("resolves inside-state flags and workspace dirs", () => {

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -2,6 +2,8 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { AgentsDeleteResult } from "../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
 import {
@@ -13,17 +15,23 @@ import {
   prepareWorkspaceStateDeletion,
 } from "../agents/workspace-state-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage, isMissingPathError } from "../infra/errors.js";
+import { movePathToTrash } from "../infra/fs-safe.js";
 import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
 import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { resolveHomeDir, shortenHomeInString } from "../utils.js";
+import { resolveHomeDir, shortenHomeInString, shortenHomePath } from "../utils.js";
 
 type RemovalResult = {
   ok: boolean;
   skipped?: boolean;
 };
+
+type AgentDeleteRemovedPath = NonNullable<AgentsDeleteResult["removed"]>[number];
+type AgentDeleteFailedPath = NonNullable<AgentsDeleteResult["failed"]>[number];
+type MoveToTrashResult = { removed: AgentDeleteRemovedPath } | { failed: AgentDeleteFailedPath };
 
 type CleanupResolvedPaths = {
   stateDir: string;
@@ -45,6 +53,62 @@ type StateRemovalOptions = {
 
 const STATE_CLEANUP_LOCK_TIMEOUT_MS = 250;
 const STATE_CLEANUP_LOCK_POLL_INTERVAL_MS = 25;
+
+function trashFailure(pathname: string, error: unknown, runtime: RuntimeEnv): MoveToTrashResult {
+  runtime.log(`Failed to move to Trash (manual delete): ${shortenHomePath(pathname)}`);
+  return { failed: { path: pathname, reason: formatErrorMessage(error) } };
+}
+
+export async function moveToTrashResult(
+  pathname: string,
+  runtime: RuntimeEnv,
+): Promise<MoveToTrashResult> {
+  if (!pathname) {
+    return { failed: { path: pathname, reason: "path is empty" } };
+  }
+  try {
+    await fs.lstat(pathname);
+  } catch (error) {
+    return isMissingPathError(error)
+      ? { removed: { path: pathname, method: "missing" } }
+      : trashFailure(pathname, error, runtime);
+  }
+  try {
+    const targetPath = path.resolve(pathname);
+    const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
+    await movePathToTrash(sourcePath, {
+      allowedRoots: await resolveMoveToTrashAllowedRoots(sourcePath),
+    });
+    runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
+    return { removed: { path: pathname, method: "trash" } };
+  } catch (error) {
+    return trashFailure(pathname, error, runtime);
+  }
+}
+
+/** Moves a path to Trash when it exists, logging a manual-delete fallback on failure. */
+export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promise<boolean> {
+  return "removed" in (await moveToTrashResult(pathname, runtime));
+}
+
+async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string> {
+  return path.join(await fs.realpath(path.dirname(targetPath)), path.basename(targetPath));
+}
+
+async function resolveMoveToTrashAllowedRoots(targetPath: string): Promise<string[]> {
+  const allowedRoots = [path.dirname(targetPath)];
+  const stat = await fs.lstat(targetPath);
+  if (stat.isSymbolicLink()) {
+    try {
+      // fs-safe resolves valid symlinks before allow-root checks; include the
+      // resolved parent so deleting a configured symlink moves the link itself.
+      allowedRoots.push(path.dirname(await fs.realpath(targetPath)));
+    } catch {
+      // Broken symlinks are handled lexically by fs-safe.
+    }
+  }
+  return uniqueStrings(allowedRoots);
+}
 
 function collectWorkspaceDirs(cfg: OpenClawConfig | undefined): string[] {
   const dirs = new Set<string>();

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -14,7 +14,6 @@ import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import {
   formatControlUiSshHint,
   handleReset,
-  moveToTrash,
   normalizeGatewayTokenInput,
   openUrl,
   printWizardHeader,
@@ -484,97 +483,6 @@ describe("handleReset", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       expect.stringMatching(/Failed to move to Trash \(manual delete\): .*workspace$/),
     );
-  });
-});
-
-describe("moveToTrash", () => {
-  it("uses fs-safe trash instead of resolving a PATH trash command", async () => {
-    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-helper-"));
-    const targetPath = path.join(testRoot, "target");
-    fs.mkdirSync(targetPath, { recursive: true });
-    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
-    const sourcePath = expectedTrashSourcePath(targetPath);
-
-    try {
-      await moveToTrash(targetPath, runtime);
-    } finally {
-      fs.rmSync(testRoot, { recursive: true, force: true });
-    }
-
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
-      allowedRoots: [path.dirname(sourcePath)],
-    });
-    expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith(`Moved to Trash: ${targetPath}`);
-  });
-
-  it("allows fs-safe trash to move a symlink whose target resolves outside the parent", async () => {
-    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-symlink-"));
-    const targetPath = path.join(testRoot, "target-link");
-    const outsideTarget = path.join(os.tmpdir(), "openclaw-trash-symlink-target");
-    fs.writeFileSync(targetPath, "link placeholder");
-    vi.spyOn(fsPromises, "lstat").mockResolvedValue({
-      isSymbolicLink: () => true,
-    } as fs.Stats);
-    vi.spyOn(fsPromises, "realpath").mockImplementation(async (candidate) =>
-      String(candidate) === path.dirname(targetPath) ? path.dirname(targetPath) : outsideTarget,
-    );
-    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
-
-    try {
-      await moveToTrash(targetPath, runtime);
-    } finally {
-      fs.rmSync(testRoot, { recursive: true, force: true });
-    }
-
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(targetPath, {
-      allowedRoots: [path.dirname(targetPath), path.dirname(outsideTarget)],
-    });
-  });
-
-  it("moves a dangling symlink instead of treating it as already removed", async () => {
-    const testRoot = tempDirs.make("openclaw-trash-dangling-link-");
-    const targetPath = path.join(testRoot, "workspace-link");
-    fs.symlinkSync(path.join(testRoot, "missing-target"), targetPath, "dir");
-    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
-    const sourcePath = expectedTrashSourcePath(targetPath);
-
-    try {
-      await expect(moveToTrash(targetPath, runtime)).resolves.toBe(true);
-    } finally {
-      fs.rmSync(testRoot, { recursive: true, force: true });
-    }
-
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
-      allowedRoots: [path.dirname(sourcePath)],
-    });
-  });
-
-  it("canonicalizes a symlinked parent before calling fs-safe trash", async () => {
-    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-parent-link-"));
-    const lexicalParent = path.join(testRoot, "state-link");
-    const realParent = path.join(testRoot, "state-real");
-    const targetPath = path.join(lexicalParent, "openclaw.json");
-    const sourcePath = path.join(realParent, "openclaw.json");
-    fs.mkdirSync(lexicalParent, { recursive: true });
-    fs.writeFileSync(targetPath, "{}\n");
-    vi.spyOn(fsPromises, "realpath").mockImplementation(async (candidate) =>
-      String(candidate) === lexicalParent ? realParent : String(candidate),
-    );
-    vi.spyOn(fsPromises, "lstat").mockResolvedValue({
-      isSymbolicLink: () => false,
-    } as fs.Stats);
-    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
-
-    try {
-      await moveToTrash(targetPath, runtime);
-    } finally {
-      fs.rmSync(testRoot, { recursive: true, force: true });
-    }
-
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
-      allowedRoots: [realParent],
-    });
   });
 });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -5,7 +5,6 @@ import { inspect } from "node:util";
 import { cancel, isCancel } from "@clack/prompts";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   ConnectErrorDetailCodes,
@@ -34,15 +33,11 @@ import {
   resolveBrowserOpenCommand,
 } from "../infra/browser-open.js";
 import { detectBinary } from "../infra/detect-binary.js";
-import {
-  canonicalPathFromExistingAncestor,
-  isPathInside,
-  movePathToTrash,
-} from "../infra/fs-safe.js";
+import { canonicalPathFromExistingAncestor, isPathInside } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveConfigDir, shortenHomeInString, shortenHomePath, sleep } from "../utils.js";
 import { VERSION } from "../version.js";
-import { listAgentSessionDirs, removeWorkspaceDirs } from "./cleanup-utils.js";
+import { listAgentSessionDirs, moveToTrash, removeWorkspaceDirs } from "./cleanup-utils.js";
 import type { OnboardMode, ResetScope } from "./onboard-types.js";
 export { randomToken } from "./random-token.js";
 
@@ -239,49 +234,6 @@ export async function ensureWorkspaceAndSessions(
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
   return { bootstrapPending: ws.bootstrapPending === true };
-}
-
-/** Moves a path to Trash when it exists, logging a manual-delete fallback on failure. */
-export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promise<boolean> {
-  if (!pathname) {
-    return false;
-  }
-  try {
-    await fs.lstat(pathname);
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT";
-  }
-  try {
-    const targetPath = path.resolve(pathname);
-    const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
-    await movePathToTrash(sourcePath, {
-      allowedRoots: await resolveMoveToTrashAllowedRoots(sourcePath),
-    });
-    runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
-    return true;
-  } catch {
-    runtime.log(`Failed to move to Trash (manual delete): ${shortenHomePath(pathname)}`);
-    return false;
-  }
-}
-
-async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string> {
-  return path.join(await fs.realpath(path.dirname(targetPath)), path.basename(targetPath));
-}
-
-async function resolveMoveToTrashAllowedRoots(targetPath: string): Promise<string[]> {
-  const allowedRoots = [path.dirname(targetPath)];
-  const stat = await fs.lstat(targetPath);
-  if (stat.isSymbolicLink()) {
-    try {
-      // fs-safe resolves valid symlinks before allow-root checks; include the
-      // resolved parent so deleting a configured symlink moves the link itself.
-      allowedRoots.push(path.dirname(await fs.realpath(targetPath)));
-    } catch {
-      // Broken symlinks are handled lexically by fs-safe.
-    }
-  }
-  return uniqueStrings(allowedRoots);
 }
 
 async function assertFullResetPreservesOnboardingLock(workspaceDir: string): Promise<void> {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -19,6 +19,7 @@ import {
   validateAgentsListParams,
   validateAgentsUpdateParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import type { AgentsDeleteResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { createAgent } from "../../agents/agent-create.js";
 import {
   findOverlappingWorkspaceAgentIds,
@@ -330,15 +331,8 @@ function respondAgentNotFound(respond: RespondFn, agentId: string): void {
   respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, `agent "${agentId}" not found`));
 }
 
-type AgentDeleteRemovedPath = {
-  path: string;
-  method: "trash" | "missing";
-};
-
-type AgentDeleteFailedPath = {
-  path: string;
-  reason: string;
-};
+type AgentDeleteRemovedPath = NonNullable<AgentsDeleteResult["removed"]>[number];
+type AgentDeleteFailedPath = NonNullable<AgentsDeleteResult["failed"]>[number];
 
 type AgentDeletePathOutcome =
   | { removed: AgentDeleteRemovedPath }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw agents delete <id> --force --json` without a reachable Gateway received success-shaped JSON when Trash cleanup failed. The agent was removed from config, but failed paths stayed on disk and the deletion journal remained unfinished without any machine-readable indication that manual cleanup or a retry was required.

## Why This Change Was Made

The offline deletion path now emits the same per-path `removed` and `failed` outcome shapes as Gateway deletion. The generic Trash helper returns structured outcomes from the shared cleanup owner, while the deletion journal remains incomplete until every required path reaches a terminal state so a later delete retries safely. The Gateway protocol and session-store purge contract are unchanged.

## User Impact

Scripts can now detect exactly which workspace, agent-state, or session paths failed to move to Trash and can retry deletion after fixing the host Trash condition. Human-readable deletion output remains unchanged.

Release note: Offline `agents delete --json` now reports per-path Trash failures instead of silently returning an incomplete cleanup result.

## Evidence

- Regression first failed on the pre-fix code because local JSON omitted `removed` and `failed`; the extended command-boundary test now verifies the failed workspace path and unfinished retry journal.
- Focused Vitest:
  - `src/commands/agents.delete.test.ts`: 22 passed
  - `src/commands/cleanup-utils.test.ts`: 25 passed
  - `src/commands/onboard-helpers.test.ts`: 51 passed
  - `src/claws/lifecycle-state.test.ts`: 29 passed
- `node scripts/check-changed.mjs -- <changed files>`: passed (`core`, `coreTests`, `docs`, `tooling`).
- `pnpm build`: passed locally after clearing exhausted build caches.
- Real local CLI proof with an isolated HOME/state and `.Trash` replaced by a regular file:
  - first delete exited 0 with `removed: []` and all three required paths in `failed`
  - failed paths remained on disk, config entry was removed, and journal `cleanup_completed` stayed `0`
  - after restoring Trash, the same command removed all three paths with `failed: []` and completed the journal
- The same clean-machine command passed on Blacksmith Testbox `tbx_01m09knqn2ckmqfp00bfb3s2wr`; the hosting workflow was canceled when the completed lease was stopped: https://github.com/openclaw/openclaw/actions/runs/32101010684
- Fresh branch autoreview: no accepted/actionable P0 or P1 findings.
- Production LOC: +102/-82 (net +20); tests: +132/-92 (net +40); docs and shrink-only tooling baseline are net neutral.

AI-assisted: yes. The implementation, tests, and live behavior were inspected and verified by the maintainer agent.
