### PR TITLE
fix(voice-call): preserve carrier-confirmed termination state

### DIFF
--- a/extensions/voice-call/src/manager.lifecycle.test.ts
+++ b/extensions/voice-call/src/manager.lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it } from "vitest";
+import { createManagerHarness, FakeProvider } from "./manager.test-harness.js";
+import type { HangupCallInput } from "./types.js";
+
+class DeferredHangupProvider extends FakeProvider {
+  readonly attempts: Array<ReturnType<typeof createDeferred<void>>> = [];
+
+  override hangupCall(input: HangupCallInput): Promise<void> {
+    this.hangupCalls.push(input);
+    const attempt = createDeferred<void>();
+    this.attempts.push(attempt);
+    return attempt.promise;
+  }
+}
+
+async function initiateCall() {
+  const provider = new DeferredHangupProvider();
+  const { manager } = await createManagerHarness({}, provider);
+  const result = await manager.initiateCall("+15550000001");
+  expect(result.success).toBe(true);
+  const call = manager.getCall(result.callId);
+  if (!call) {
+    throw new Error("expected initiated call");
+  }
+  return { call, manager, provider };
+}
+
+describe("CallManager termination lifecycle", () => {
+  it("preserves the first provider terminal facts when a pending manager hangup settles", async () => {
+    const { call, manager, provider } = await initiateCall();
+    const endedAt = Date.now() + 1_000;
+
+    const pendingEnd = manager.endCall(call.callId, { reason: "timeout" });
+    expect(provider.attempts).toHaveLength(1);
+
+    manager.processEvent({
+      id: "provider-terminal",
+      type: "call.ended",
+      callId: call.callId,
+      providerCallId: call.providerCallId,
+      timestamp: endedAt,
+      reason: "completed",
+    });
+    provider.attempts[0]?.resolve();
+
+    await expect(pendingEnd).resolves.toEqual({ success: true });
+    expect(call).toMatchObject({
+      state: "completed",
+      endReason: "completed",
+      endedAt,
+    });
+  });
+
+  it("shares one carrier hangup result and releases a failed operation for retry", async () => {
+    const { call, manager, provider } = await initiateCall();
+
+    const first = manager.endCall(call.callId, { reason: "error" });
+    const second = manager.endCall(call.callId, { reason: "error" });
+    const firstAttemptCount = provider.attempts.length;
+    for (const attempt of provider.attempts) {
+      attempt.reject(new Error("carrier unavailable"));
+    }
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    const retry = manager.endCall(call.callId, { reason: "error" });
+    const retryAttempt = provider.attempts.at(-1);
+    if (!retryAttempt) {
+      throw new Error("expected retry hangup attempt");
+    }
+    retryAttempt.resolve();
+    await expect(retry).resolves.toEqual({ success: true });
+
+    expect(second).toBe(first);
+    expect(firstAttemptCount).toBe(1);
+    expect(secondResult).toBe(firstResult);
+    expect(firstResult).toEqual({ success: false, error: "carrier unavailable" });
+    expect(provider.hangupCalls).toHaveLength(2);
+  });
+});

--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -48,6 +48,13 @@ class FailStartListeningProvider extends FakeProvider {
   }
 }
 
+class FailHangupProvider extends FakeProvider {
+  override async hangupCall(input: Parameters<FakeProvider["hangupCall"]>[0]): Promise<void> {
+    this.hangupCalls.push(input);
+    throw new Error("synthetic hangup failure");
+  }
+}
+
 function requireCall(
   manager: Awaited<ReturnType<typeof createManagerHarness>>["manager"],
   callId: string,
@@ -134,6 +141,38 @@ function expectFirstPlayTtsText(provider: FakeProvider, text: string) {
 }
 
 describe("CallManager notify and mapping", () => {
+  it("logs a failed notify auto-hangup and leaves the call active for retry", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const provider = new FailHangupProvider("plivo");
+      const { manager } = await createManagerHarness(
+        { outbound: { notifyHangupDelaySec: 1 } },
+        provider,
+      );
+      const callId = await initiateCallWithMessage(manager, "+15550000014", "Notify", "notify");
+
+      manager.processEvent({
+        id: "evt-notify-failed-hangup",
+        type: "call.answered",
+        callId,
+        providerCallId: "call-uuid",
+        timestamp: Date.now(),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(provider.hangupCalls).toHaveLength(1);
+      expect(manager.getCall(callId)).toBeDefined();
+      expect(warn).toHaveBeenCalledWith(
+        `[voice-call] Notify mode failed to hang up call ${callId}: synthetic hangup failure`,
+      );
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("upgrades providerCallId mapping when provider ID changes", async () => {
     const { manager } = await createManagerHarness();
 

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -231,6 +231,7 @@ export function createEventManagerHarness() {
       storePath,
       webhookUrl: null,
       activeTurnCalls: new Set(),
+      endCallOperations: new Map(),
       transcriptWaiters: new Map(),
       maxDurationTimers: new Map(),
       initialMessageInFlight: new Set(),

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "./config.js";
-import type { CallManagerContext, StreamSessionIssuer } from "./manager/context.js";
+import type { CallEndResult, CallManagerContext, StreamSessionIssuer } from "./manager/context.js";
 import { processEvent as processManagerEvent, type ProcessEventResult } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
@@ -29,6 +29,7 @@ import {
   TerminalStates,
   type CallId,
   type CallRecord,
+  type EndReason,
   type NormalizedEvent,
   type OutboundCallOptions,
 } from "./types.js";
@@ -77,6 +78,7 @@ export class CallManager {
   private storePath: string;
   private webhookUrl: string | null = null;
   private activeTurnCalls = new Set<CallId>();
+  private endCallOperations = new Map<CallId, Promise<CallEndResult>>();
   private transcriptWaiters = new Map<
     CallId,
     {
@@ -156,9 +158,7 @@ export class CallManager {
           ctx: this.getContext(),
           callId,
           timeoutMs: maxDurationMs - elapsed,
-          onTimeout: async (id) => {
-            await endCallWithContext(this.getContext(), id, { reason: "timeout" });
-          },
+          onTimeout: (id) => this.endCall(id, { reason: "timeout" }),
         });
         console.log(`[voice-call] Restarted max-duration timer for restored call ${callId}`);
       }
@@ -342,8 +342,8 @@ export class CallManager {
   /**
    * End an active call.
    */
-  async endCall(callId: CallId): Promise<{ success: boolean; error?: string }> {
-    return endCallWithContext(this.getContext(), callId);
+  endCall(callId: CallId, options?: { reason?: EndReason }): Promise<CallEndResult> {
+    return endCallWithContext(this.getContext(), callId, options);
   }
 
   private getContext(): CallManagerContext {
@@ -358,6 +358,7 @@ export class CallManager {
       storePath: this.storePath,
       webhookUrl: this.webhookUrl,
       activeTurnCalls: this.activeTurnCalls,
+      endCallOperations: this.endCallOperations,
       transcriptWaiters: this.transcriptWaiters,
       maxDurationTimers: this.maxDurationTimers,
       initialMessageInFlight: this.initialMessageInFlight,

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -3,6 +3,8 @@ import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "../config.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallId, CallRecord } from "../types.js";
 
+export type CallEndResult = { success: boolean; error?: string };
+
 type TranscriptWaiter = {
   resolve: (text: string) => void;
   reject: (err: Error) => void;
@@ -28,6 +30,7 @@ type CallManagerRuntimeDeps = {
 
 type CallManagerTransientState = {
   activeTurnCalls: Set<CallId>;
+  endCallOperations: Map<CallId, Promise<CallEndResult>>;
   transcriptWaiters: Map<CallId, TranscriptWaiter>;
   maxDurationTimers: Map<CallId, NodeJS.Timeout>;
   initialMessageInFlight: Set<CallId>;

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -35,6 +35,7 @@ type EventContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "endCallOperations"
   | "onCallAnswered"
   | "streamSessionIssuer"
 >;
@@ -244,9 +245,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     startMaxDurationTimer({
       ctx,
       callId: activeCall.callId,
-      onTimeout: async (callId) => {
-        await endCall(ctx, callId, { reason: "timeout" });
-      },
+      onTimeout: (callId) => endCall(ctx, callId, { reason: "timeout" }),
     });
   };
   const prepareLiveDurationTimer = () => {

--- a/extensions/voice-call/src/manager/lifecycle.ts
+++ b/extensions/voice-call/src/manager/lifecycle.ts
@@ -41,12 +41,11 @@ export function finalizeCall(params: {
   const { ctx, call, endReason } = params;
   const previousState = call.state;
 
-  call.endedAt = params.endedAt ?? Date.now();
-  call.endReason = endReason;
-  transitionState(call, endReason);
-  persistCallRecord(ctx.storePath, call);
-
-  if (!TerminalStates.has(previousState) && TerminalStates.has(call.state)) {
+  if (!TerminalStates.has(previousState)) {
+    call.endedAt = params.endedAt ?? Date.now();
+    call.endReason = endReason;
+    transitionState(call, endReason);
+    persistCallRecord(ctx.storePath, call);
     log.info(
       `[voice-call] Call finalized callId=${call.callId} providerCallId=${call.providerCallId ?? "unknown"} endReason=${endReason}`,
     );

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -79,6 +79,7 @@ function createActiveCallContext(params: { hangupCall?: ReturnType<typeof vi.fn>
     storePath: "/tmp/voice-call.json",
     transcriptWaiters: new Map(),
     maxDurationTimers: new Map(),
+    endCallOperations: new Map(),
   };
 
   return { call, ctx, hangupCall };
@@ -681,6 +682,7 @@ describe("voice-call outbound helpers", () => {
           storePath: "/tmp/voice-call.json",
           transcriptWaiters: new Map(),
           maxDurationTimers: new Map(),
+          endCallOperations: new Map(),
         } as never,
         "call-1",
       ),

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -17,7 +17,7 @@ import {
   type OutboundCallOptions,
 } from "../types.js";
 import { mapVoiceToPolly } from "../voice-mapping.js";
-import type { CallManagerContext } from "./context.js";
+import type { CallEndResult, CallManagerContext } from "./context.js";
 import { finalizeCall } from "./lifecycle.js";
 import { getCallByProviderCallId } from "./lookup.js";
 import { addTranscriptEntry, transitionState } from "./state.js";
@@ -51,6 +51,7 @@ type SpeakContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "endCallOperations"
 >;
 
 type ConversationContext = Pick<
@@ -64,6 +65,7 @@ type ConversationContext = Pick<
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "initialMessageInFlight"
+  | "endCallOperations"
 >;
 
 type EndCallContext = Pick<
@@ -74,6 +76,7 @@ type EndCallContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "endCallOperations"
 >;
 
 type ConnectedCallContext = Pick<CallManagerContext, "activeCalls" | "provider">;
@@ -292,9 +295,7 @@ export async function speak(
       ctx,
       call,
       liveAt: Date.now(),
-      onTimeout: async (id) => {
-        await endCall(ctx, id, { reason: "timeout" });
-      },
+      onTimeout: (id) => endCall(ctx, id, { reason: "timeout" }),
     });
     transitionState(call, "speaking");
     persistCallRecord(ctx.storePath, call);
@@ -419,7 +420,12 @@ export async function speakInitialMessage(
           const currentCall = ctx.activeCalls.get(call.callId);
           if (currentCall && !TerminalStates.has(currentCall.state)) {
             console.log(`[voice-call] Notify mode: hanging up call ${call.callId}`);
-            await endCall(ctx, call.callId);
+            const endResult = await endCall(ctx, call.callId);
+            if (!endResult.success) {
+              console.warn(
+                `[voice-call] Notify mode failed to hang up call ${call.callId}: ${endResult.error ?? "unknown error"}`,
+              );
+            }
           }
         })();
       }, delayMs);
@@ -511,36 +517,49 @@ export async function continueCall(
   }
 }
 
-export async function endCall(
+export function endCall(
   ctx: EndCallContext,
   callId: CallId,
   options?: { reason?: EndReason },
-): Promise<{ success: boolean; error?: string }> {
+): Promise<CallEndResult> {
+  const inFlight = ctx.endCallOperations.get(callId);
+  if (inFlight) {
+    return inFlight;
+  }
   const lookup = lookupConnectedCall(ctx, callId);
   if (lookup.kind === "error") {
-    return { success: false, error: lookup.error };
+    return Promise.resolve({ success: false, error: lookup.error });
   }
   if (lookup.kind === "ended") {
-    return { success: true };
+    return Promise.resolve({ success: true });
   }
   const { call, providerCallId, provider } = lookup;
   const reason = options?.reason ?? "hangup-bot";
 
-  try {
-    await provider.hangupCall({
-      callId,
-      providerCallId,
-      reason,
-    });
+  const operation = (async (): Promise<CallEndResult> => {
+    try {
+      await provider.hangupCall({
+        callId,
+        providerCallId,
+        reason,
+      });
 
-    finalizeCall({
-      ctx,
-      call,
-      endReason: reason,
-    });
+      finalizeCall({
+        ctx,
+        call,
+        endReason: reason,
+      });
 
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: formatErrorMessage(err) };
-  }
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: formatErrorMessage(err) };
+    }
+  })();
+  ctx.endCallOperations.set(callId, operation);
+  void operation.then(() => {
+    if (ctx.endCallOperations.get(callId) === operation) {
+      ctx.endCallOperations.delete(callId);
+    }
+  });
+  return operation;
 }

--- a/extensions/voice-call/src/manager/timers.test.ts
+++ b/extensions/voice-call/src/manager/timers.test.ts
@@ -1,15 +1,6 @@
 // Voice Call tests cover timers plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const { persistCallRecordMock } = vi.hoisted(() => ({
-  persistCallRecordMock: vi.fn(),
-}));
-
-vi.mock("./store.js", () => ({
-  persistCallRecord: persistCallRecordMock,
-}));
-
 import {
   clearMaxDurationTimer,
   clearTranscriptWaiter,
@@ -29,15 +20,15 @@ describe("voice-call manager timers", () => {
     vi.useRealTimers();
   });
 
-  it("starts and clears max duration timers, persisting timeout metadata before delegation", async () => {
+  it("delegates max-duration termination and logs typed failure", async () => {
     const call = { id: "call-1", state: "active" };
     const ctx = {
       activeCalls: new Map([["call-1", call]]),
       maxDurationTimers: new Map(),
       config: { maxDurationSeconds: 5 },
-      storePath: "/tmp/voice-call",
     };
-    const onTimeout = vi.fn(async () => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onTimeout = vi.fn(async () => ({ success: false, error: "carrier unavailable" }));
 
     startMaxDurationTimer({
       ctx: ctx as never,
@@ -49,9 +40,11 @@ describe("voice-call manager timers", () => {
 
     await vi.advanceTimersByTimeAsync(5_000);
 
-    expect(call).toEqual({ id: "call-1", state: "active", endReason: "timeout" });
-    expect(persistCallRecordMock).toHaveBeenCalledWith("/tmp/voice-call", call);
+    expect(call).toEqual({ id: "call-1", state: "active" });
     expect(onTimeout).toHaveBeenCalledWith("call-1");
+    expect(warn).toHaveBeenCalledWith(
+      "[voice-call] Failed to end max-duration call call-1: carrier unavailable",
+    );
     expect(ctx.maxDurationTimers.has("call-1")).toBe(false);
 
     startMaxDurationTimer({
@@ -68,9 +61,8 @@ describe("voice-call manager timers", () => {
       activeCalls: new Map([["call-1", { id: "call-1", state: "completed" }]]),
       maxDurationTimers: new Map(),
       config: { maxDurationSeconds: 5 },
-      storePath: "/tmp/voice-call",
     };
-    const onTimeout = vi.fn(async () => {});
+    const onTimeout = vi.fn(async () => ({ success: true }));
 
     startMaxDurationTimer({
       ctx: ctx as never,
@@ -80,7 +72,6 @@ describe("voice-call manager timers", () => {
 
     await vi.advanceTimersByTimeAsync(5_000);
 
-    expect(persistCallRecordMock).not.toHaveBeenCalled();
     expect(onTimeout).not.toHaveBeenCalled();
   });
 
@@ -94,14 +85,13 @@ describe("voice-call manager timers", () => {
         maxDurationSeconds: Number.MAX_SAFE_INTEGER,
         transcriptTimeoutMs: Number.MAX_SAFE_INTEGER,
       },
-      storePath: "/tmp/voice-call",
     };
 
     try {
       startMaxDurationTimer({
         ctx: ctx as never,
         callId: "call-1",
-        onTimeout: vi.fn(async () => {}),
+        onTimeout: vi.fn(async () => ({ success: true })),
       });
       const transcript = waitForFinalTranscript(ctx as never, "call-2");
 

--- a/extensions/voice-call/src/manager/timers.ts
+++ b/extensions/voice-call/src/manager/timers.ts
@@ -1,7 +1,7 @@
 // Voice Call plugin module implements timers behavior.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { TerminalStates, type CallId, type CallRecord } from "../types.js";
-import type { CallManagerContext } from "./context.js";
-import { persistCallRecord } from "./store.js";
+import type { CallEndResult, CallManagerContext } from "./context.js";
 import {
   resolveVoiceCallSecondsTimerDelayMs,
   resolveVoiceCallTimerDelayMs,
@@ -11,12 +11,9 @@ import {
 
 type TimerContext = Pick<
   CallManagerContext,
-  "activeCalls" | "maxDurationTimers" | "config" | "storePath" | "transcriptWaiters"
+  "activeCalls" | "maxDurationTimers" | "config" | "transcriptWaiters"
 >;
-type MaxDurationTimerContext = Pick<
-  TimerContext,
-  "activeCalls" | "maxDurationTimers" | "config" | "storePath"
->;
+type MaxDurationTimerContext = Pick<TimerContext, "activeCalls" | "maxDurationTimers" | "config">;
 type TranscriptWaiterContext = Pick<TimerContext, "transcriptWaiters">;
 
 /** Clear and forget the max-duration timer for a call. */
@@ -35,7 +32,7 @@ export function clearMaxDurationTimer(
 export function startMaxDurationTimer(params: {
   ctx: MaxDurationTimerContext;
   callId: CallId;
-  onTimeout: (callId: CallId) => Promise<void>;
+  onTimeout: (callId: CallId) => Promise<CallEndResult>;
   timeoutMs?: number;
 }): void {
   clearMaxDurationTimer(params.ctx, params.callId);
@@ -56,10 +53,18 @@ export function startMaxDurationTimer(params: {
         console.log(
           `[voice-call] Max duration reached (${Math.ceil(maxDurationMs / 1000)}s), ending call ${params.callId}`,
         );
-        call.endReason = "timeout";
-        persistCallRecord(params.ctx.storePath, call);
-        // Provider-specific timeout handling owns the actual hangup after state persistence.
-        await params.onTimeout(params.callId);
+        try {
+          const result = await params.onTimeout(params.callId);
+          if (!result.success) {
+            console.warn(
+              `[voice-call] Failed to end max-duration call ${params.callId}: ${result.error ?? "unknown error"}`,
+            );
+          }
+        } catch (error) {
+          console.warn(
+            `[voice-call] Failed to end max-duration call ${params.callId}: ${formatErrorMessage(error)}`,
+          );
+        }
       }
     })();
   }, maxDurationMs);
@@ -72,7 +77,7 @@ export function ensureMaxDurationTimerForLiveCall(params: {
   ctx: MaxDurationTimerContext;
   call: CallRecord;
   liveAt: number;
-  onTimeout: (callId: CallId) => Promise<void>;
+  onTimeout: (callId: CallId) => Promise<CallEndResult>;
 }): void {
   if (params.call.answeredAt) {
     return;

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -396,8 +396,8 @@ describe("createVoiceCallRuntime lifecycle", () => {
       } as never,
     });
 
-    const resolveCallRegistration = mocks.realtimeHandlerCtorArgs[0]?.[3];
-    expect(mocks.realtimeHandlerCtorArgs[0]?.[5]).toBe(
+    const resolveCallRegistration = mocks.realtimeHandlerCtorArgs[0]?.[2];
+    expect(mocks.realtimeHandlerCtorArgs[0]?.[4]).toBe(
       mocks.webhookGetStreamDisconnectLifecycle.mock.results[0]?.value,
     );
     expect(mocks.resolveConfiguredRealtimeVoiceProvider).not.toHaveBeenCalled();
@@ -467,7 +467,7 @@ describe("createVoiceCallRuntime lifecycle", () => {
     ).resolves.toMatchObject({ config: { agentId: "main" } });
     expect(mocks.resolveConfiguredRealtimeVoiceProvider).not.toHaveBeenCalled();
 
-    const resolveCallRegistration = mocks.realtimeHandlerCtorArgs[0]?.[3];
+    const resolveCallRegistration = mocks.realtimeHandlerCtorArgs[0]?.[2];
     if (typeof resolveCallRegistration !== "function") {
       throw new Error("expected per-call realtime registration resolver");
     }

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -374,7 +374,6 @@ export async function createVoiceCallRuntime(params: {
     const realtimeHandler = new RealtimeCallHandler(
       realtimeConfig,
       manager,
-      provider,
       resolveCallRegistration,
       config.serve.path,
       webhookServer.getStreamDisconnectLifecycle(),

--- a/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
@@ -7,6 +7,8 @@ import type { RealtimeCallHandler } from "./webhook/realtime-handler.js";
 
 describe("VoiceCallWebhookServer shutdown lifecycle", () => {
   it("waits for owned handlers and shares concurrent stop completion", async () => {
+    const config = createVoiceCallBaseConfig({ tunnelProvider: "none" });
+    config.serve.port = 0;
     let releaseHandlerClose: (() => void) | undefined;
     const handlerClose = vi.fn(
       () =>
@@ -16,7 +18,7 @@ describe("VoiceCallWebhookServer shutdown lifecycle", () => {
     );
     const delayedHangup = vi.fn(async () => ({ success: true }));
     const server = new VoiceCallWebhookServer(
-      createVoiceCallBaseConfig({ tunnelProvider: "none" }),
+      config,
       {
         getCallByProviderCallId: vi.fn(() => ({ callId: "call-1" })),
         endCall: delayedHangup,

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -2417,7 +2417,7 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     const call = createCall(Date.now() - 1_000);
     call.providerCallId = "CA-stream-1";
 
-    const endCall = vi.fn(async () => ({ success: true }));
+    const endCall = vi.fn(async () => ({ success: false, error: "carrier unavailable" }));
     const speakInitialMessage = vi.fn(async () => {});
     const getCallByProviderCallId = vi.fn((providerCallId: string) =>
       providerCallId === "CA-stream-1" ? call : undefined,
@@ -2503,6 +2503,9 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     expect(endCall).toHaveBeenCalledWith(call.callId);
     expect(messages).toContain(
       `[voice-call] Call finalization requested reason=stream-disconnect-grace-expired callId=${call.callId} providerCallId=CA-stream-1`,
+    );
+    expect(messages).toContain(
+      `[voice-call] Failed to auto-end call ${call.callId}: carrier unavailable`,
     );
 
     await server.stop();

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -241,9 +241,18 @@ export class VoiceCallWebhookServer {
       this.logger.info(
         `Call finalization requested reason=stream-disconnect-grace-expired callId=${call.callId} providerCallId=${providerCallId}`,
       );
-      void this.manager.endCall(call.callId).catch((err: unknown) => {
-        this.logger.warn(`Failed to auto-end call ${call.callId}: ${String(err)}`);
-      });
+      void this.manager
+        .endCall(call.callId)
+        .then((result) => {
+          if (!result.success) {
+            this.logger.warn(
+              `Failed to auto-end call ${call.callId}: ${result.error ?? "unknown error"}`,
+            );
+          }
+        })
+        .catch((err: unknown) => {
+          this.logger.warn(`Failed to auto-end call ${call.callId}: ${String(err)}`);
+        });
     });
   }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -1,16 +1,16 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { describe, expect, it, vi } from "vitest";
-import type { WebSocket as WebSocketType } from "ws";
 import { WebSocket } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
-import type { VoiceCallProvider } from "../providers/base.js";
-import type { CallRecord } from "../types.js";
+import type { CallRecord, HangupCallInput } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
-import { RealtimeCallHandler } from "./realtime-handler.js";
+import { RealtimeCallHandler, type ResolveRealtimeCallRegistration } from "./realtime-handler.js";
+import type { StreamDisconnectLifecycle } from "./stream-disconnect-grace.js";
 
 function createRealtimeConfig(): VoiceCallRealtimeConfig {
   return {
@@ -38,7 +38,7 @@ function createRealtimeConfig(): VoiceCallRealtimeConfig {
   };
 }
 
-const noOpStreamDisconnectLifecycle = {
+const noOpStreamDisconnectLifecycle: StreamDisconnectLifecycle = {
   connect: () => {},
   disconnect: () => {},
   retire: () => {},
@@ -74,7 +74,7 @@ function makeRealtimeProvider(
 
 function makeCallRegistrationResolver(
   provider: RealtimeVoiceProviderPlugin,
-): ConstructorParameters<typeof RealtimeCallHandler>[3] {
+): ResolveRealtimeCallRegistration {
   return (call) => ({
     agentId: call.agentId ?? "main",
     instructions: "Be helpful.",
@@ -86,9 +86,10 @@ function makeCallRegistrationResolver(
 function createCarrierLifecycleHarness(
   createBridgeForCall: RealtimeVoiceProviderPlugin["createBridge"],
   options: {
+    endCall?: CallManager["endCall"];
     initialMessage?: string;
-    resolveCallRegistration?: ConstructorParameters<typeof RealtimeCallHandler>[3];
-    streamDisconnectLifecycle?: ConstructorParameters<typeof RealtimeCallHandler>[5];
+    resolveCallRegistration?: ResolveRealtimeCallRegistration;
+    streamDisconnectLifecycle?: StreamDisconnectLifecycle;
   } = {},
 ) {
   const realtimeProvider = makeRealtimeProvider(createBridgeForCall);
@@ -106,19 +107,39 @@ function createCarrierLifecycleHarness(
     ...(options.initialMessage ? { metadata: { initialMessage: options.initialMessage } } : {}),
   };
   const processEvent = vi.fn();
-  const hangupCall = vi.fn(async () => {});
+  const hangupCall = vi.fn(async (_input: HangupCallInput) => {});
+  const endCall = vi.fn(
+    options.endCall ??
+      (async (callId: string, endOptions?: { reason?: "completed" | "error" | "timeout" }) => {
+        const reason = endOptions?.reason ?? "hangup-bot";
+        try {
+          await hangupCall({ callId, providerCallId: call.providerCallId!, reason });
+          processEvent({
+            id: `manager-ended-${call.providerCallId}`,
+            type: "call.ended",
+            callId,
+            providerCallId: call.providerCallId,
+            timestamp: Date.now(),
+            reason,
+          });
+          return { success: true };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      }),
+  );
   const handler = new RealtimeCallHandler(
     createRealtimeConfig(),
     {
       processEvent,
+      endCall,
       getCallByProviderCallId: vi.fn(() => call),
     } as unknown as CallManager,
-    { name: "twilio", hangupCall } as unknown as VoiceCallProvider,
     options.resolveCallRegistration ?? makeCallRegistrationResolver(realtimeProvider),
     "/voice/webhook",
     options.streamDisconnectLifecycle ?? noOpStreamDisconnectLifecycle,
   );
-  return { call, handler, hangupCall, processEvent };
+  return { call, endCall, handler, hangupCall, processEvent };
 }
 
 async function connectCarrierStream(handler: RealtimeCallHandler) {
@@ -133,6 +154,110 @@ async function connectCarrierStream(handler: RealtimeCallHandler) {
 }
 
 describe("RealtimeCallHandler lifecycle", () => {
+  it("keeps a failed startup nonterminal until manager-owned carrier termination succeeds", async () => {
+    const termination = createDeferred<{ success: boolean; error?: string }>();
+    const endCall = vi.fn(() => termination.promise);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { call, handler, processEvent } = createCarrierLifecycleHarness(
+      () => {
+        throw new Error("realtime provider rejected call configuration");
+      },
+      { endCall },
+    );
+    const { server, ws } = await connectCarrierStream(handler);
+
+    try {
+      const closed = waitForClose(ws);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-provider-first", callSid: call.providerCallId },
+        }),
+      );
+
+      expect(await closed).toEqual({ code: 1011, reason: "Failed to create realtime bridge" });
+      expect(endCall).toHaveBeenCalledExactlyOnceWith(call.callId, { reason: "error" });
+      expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
+        0,
+      );
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("carrier unavailable"));
+
+      termination.resolve({ success: false, error: "carrier unavailable" });
+      await vi.waitFor(() => {
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("carrier unavailable"));
+      });
+      expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
+        0,
+      );
+      expect(call.state).toBe("ringing");
+    } finally {
+      termination.resolve({ success: false, error: "carrier unavailable" });
+      warn.mockRestore();
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
+  it("waits for manager-owned shutdown termination before close settles", async () => {
+    const termination = createDeferred<{ success: boolean; error?: string }>();
+    const shutdownBarrier = createDeferred<void>();
+    const endCall = vi.fn(() => termination.promise);
+    const bridgeClose = vi.fn();
+    const createBridgeForCall = vi.fn(() => createBridge(bridgeClose));
+    const { call, handler } = createCarrierLifecycleHarness(createBridgeForCall, { endCall });
+    const { server, ws } = await connectCarrierStream(handler);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-shutdown-await", callSid: call.providerCallId },
+        }),
+      );
+      await vi.waitFor(() => expect(createBridgeForCall).toHaveBeenCalledOnce());
+
+      const closed = waitForClose(ws);
+      const closing = handler.close(shutdownBarrier.promise);
+      const concurrentClose = handler.close();
+      handler.issueStreamSession();
+      let closeSettled = false;
+      void closing.then(() => {
+        closeSettled = true;
+      });
+      await closed;
+      await vi.waitFor(() => expect(bridgeClose).toHaveBeenCalledOnce());
+
+      expect(concurrentClose).toBe(closing);
+      expect(endCall).toHaveBeenCalledExactlyOnceWith(call.callId, { reason: "completed" });
+      expect(closeSettled).toBe(false);
+
+      shutdownBarrier.resolve();
+      await Promise.resolve();
+      expect(closeSettled).toBe(false);
+      termination.resolve({ success: true });
+      await closing;
+      expect(closeSettled).toBe(true);
+      expect(
+        (
+          handler as unknown as {
+            pendingStreamTokens: Map<string, unknown>;
+          }
+        ).pendingStreamTokens.size,
+      ).toBe(0);
+    } finally {
+      shutdownBarrier.resolve();
+      termination.resolve({ success: true });
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
   it("warns and removes a stream token when the provider never connects", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -360,7 +485,7 @@ describe("RealtimeCallHandler lifecycle", () => {
       ),
     };
     const resolveCallRegistration = vi
-      .fn<ConstructorParameters<typeof RealtimeCallHandler>[3]>()
+      .fn<ResolveRealtimeCallRegistration>()
       .mockReturnValueOnce({
         agentId: "main",
         instructions: "Be helpful.",
@@ -594,112 +719,6 @@ describe("RealtimeCallHandler lifecycle", () => {
     }
   });
 
-  it("terminates active sockets and treats server shutdown as completed", async () => {
-    const bridgeClose = vi.fn();
-    const createBridgeForCall = vi.fn(() => createBridge(bridgeClose));
-    const processEvent = vi.fn();
-    const call: CallRecord = {
-      callId: "call-shutdown",
-      providerCallId: "CA-shutdown",
-      provider: "twilio",
-      direction: "inbound",
-      state: "ringing",
-      from: "+15550001111",
-      to: "+15550002222",
-      startedAt: Date.now(),
-      transcript: [],
-      processedEventIds: [],
-    };
-    const handler = new RealtimeCallHandler(
-      createRealtimeConfig(),
-      {
-        processEvent,
-        getCallByProviderCallId: vi.fn(() => call),
-      } as unknown as CallManager,
-      {
-        name: "twilio",
-        verifyWebhook: vi.fn(),
-        parseWebhookEvent: vi.fn(),
-        initiateCall: vi.fn(),
-        hangupCall: vi.fn(),
-        playTts: vi.fn(),
-        startListening: vi.fn(),
-        stopListening: vi.fn(),
-        getCallStatus: vi.fn(),
-      } as unknown as VoiceCallProvider,
-      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
-      "/voice/webhook",
-      noOpStreamDisconnectLifecycle,
-    );
-    const { streamUrl } = handler.issueStreamSession();
-    const server = await startUpgradeWsServer({
-      urlPath: new URL(streamUrl).pathname,
-      onUpgrade: (request, socket, head) => {
-        handler.handleWebSocketUpgrade(request, socket, head);
-      },
-    });
-    let ws: WebSocketType | null = await connectWs(server.url);
-    let releaseShutdownBarrier: (() => void) | undefined;
-
-    try {
-      ws.send(
-        JSON.stringify({
-          event: "start",
-          start: { streamSid: "MZ-shutdown", callSid: "CA-shutdown" },
-        }),
-      );
-      await vi.waitFor(() => {
-        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
-      });
-
-      const closed = waitForClose(ws);
-      const shutdownBarrier = new Promise<void>((resolve) => {
-        releaseShutdownBarrier = resolve;
-      });
-      const firstClose = handler.close(shutdownBarrier);
-      const secondClose = handler.close();
-      handler.issueStreamSession();
-      let closeSettled = false;
-      void firstClose.then(() => {
-        closeSettled = true;
-      });
-
-      expect(secondClose).toBe(firstClose);
-      expect(await closed).toEqual({ code: 1006, reason: "" });
-      await vi.waitFor(() => {
-        expect(bridgeClose).toHaveBeenCalledTimes(1);
-        expect(processEvent).toHaveBeenCalledWith(
-          expect.objectContaining({
-            callId: "call-shutdown",
-            providerCallId: "CA-shutdown",
-            reason: "completed",
-            type: "call.ended",
-          }),
-        );
-      });
-      expect(closeSettled).toBe(false);
-
-      releaseShutdownBarrier?.();
-      await firstClose;
-      expect(closeSettled).toBe(true);
-      expect(
-        (
-          handler as unknown as {
-            pendingStreamTokens: Map<string, unknown>;
-          }
-        ).pendingStreamTokens.size,
-      ).toBe(0);
-      ws = null;
-    } finally {
-      releaseShutdownBarrier?.();
-      if (ws && ws.readyState !== WebSocket.CLOSED) {
-        ws.terminate();
-      }
-      await handler.close();
-      await server.close();
-    }
-  });
-
   it("tolerates provider close during bridge creation", async () => {
     const bridgeConnect = vi.fn(async () => {});
     const createBridgeForCall = vi.fn(
@@ -724,19 +743,9 @@ describe("RealtimeCallHandler lifecycle", () => {
       createRealtimeConfig(),
       {
         processEvent: vi.fn(),
+        endCall: vi.fn(async () => ({ success: true })),
         getCallByProviderCallId: vi.fn(() => call),
       } as unknown as CallManager,
-      {
-        name: "twilio",
-        verifyWebhook: vi.fn(),
-        parseWebhookEvent: vi.fn(),
-        initiateCall: vi.fn(),
-        hangupCall: vi.fn(),
-        playTts: vi.fn(),
-        startListening: vi.fn(),
-        stopListening: vi.fn(),
-        getCallStatus: vi.fn(),
-      } as unknown as VoiceCallProvider,
       makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
       noOpStreamDisconnectLifecycle,
@@ -812,19 +821,9 @@ describe("RealtimeCallHandler lifecycle", () => {
       createRealtimeConfig(),
       {
         processEvent: vi.fn(),
+        endCall: vi.fn(async () => ({ success: true })),
         getCallByProviderCallId: vi.fn(() => call),
       } as unknown as CallManager,
-      {
-        name: "twilio",
-        verifyWebhook: vi.fn(),
-        parseWebhookEvent: vi.fn(),
-        initiateCall: vi.fn(),
-        hangupCall: vi.fn(),
-        playTts: vi.fn(),
-        startListening: vi.fn(),
-        stopListening: vi.fn(),
-        getCallStatus: vi.fn(),
-      } as unknown as VoiceCallProvider,
       makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
       noOpStreamDisconnectLifecycle,
@@ -928,19 +927,9 @@ describe("RealtimeCallHandler lifecycle", () => {
       createRealtimeConfig(),
       {
         processEvent: vi.fn(),
+        endCall: vi.fn(async () => ({ success: true })),
         getCallByProviderCallId: vi.fn(() => call),
       } as unknown as CallManager,
-      {
-        name: "twilio",
-        verifyWebhook: vi.fn(),
-        parseWebhookEvent: vi.fn(),
-        initiateCall: vi.fn(),
-        hangupCall: vi.fn(),
-        playTts: vi.fn(),
-        startListening: vi.fn(),
-        stopListening: vi.fn(),
-        getCallStatus: vi.fn(),
-      } as unknown as VoiceCallProvider,
       makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
       "/voice/webhook",
       noOpStreamDisconnectLifecycle,

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -12,7 +12,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
-import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
@@ -110,7 +109,6 @@ function makeHandler(
   overrides?: Partial<VoiceCallRealtimeConfig>,
   deps?: {
     manager?: Partial<CallManager>;
-    provider?: Partial<VoiceCallProvider>;
     providerConfig?: Record<string, unknown>;
     realtimeProvider?: RealtimeVoiceProviderPlugin;
     resolveInstructions?: (call: CallRecord) => string;
@@ -151,22 +149,11 @@ function makeHandler(
     config,
     {
       processEvent: vi.fn(),
+      endCall: vi.fn(async () => ({ success: true })),
       getCall: vi.fn(),
       getCallByProviderCallId: vi.fn(),
       ...deps?.manager,
     } as unknown as CallManager,
-    {
-      name: "twilio",
-      verifyWebhook: vi.fn(),
-      parseWebhookEvent: vi.fn(),
-      initiateCall: vi.fn(),
-      hangupCall: vi.fn(),
-      playTts: vi.fn(),
-      startListening: vi.fn(),
-      stopListening: vi.fn(),
-      getCallStatus: vi.fn(),
-      ...deps?.provider,
-    } as unknown as VoiceCallProvider,
     makeCallRegistrationResolver({
       provider: realtimeProvider,
       providerConfig,
@@ -579,9 +566,6 @@ describe("RealtimeCallHandler path routing", () => {
         processEvent,
         getCall,
       },
-      provider: {
-        name: "telnyx",
-      },
       realtimeProvider: makeRealtimeProvider(createBridge),
       resolveInstructions,
     });
@@ -644,9 +628,6 @@ describe("RealtimeCallHandler path routing", () => {
       manager: {
         processEvent,
       },
-      provider: {
-        name: "telnyx",
-      },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
     handler.setPublicUrl("https://public.example/voice/webhook");
@@ -690,9 +671,6 @@ describe("RealtimeCallHandler path routing", () => {
       manager: {
         processEvent,
         getCall,
-      },
-      provider: {
-        name: "telnyx",
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
@@ -2295,15 +2273,15 @@ describe("RealtimeCallHandler path routing", () => {
       return bridge;
     });
     const processEvent = vi.fn();
-    const hangupCall = vi.fn(async () => {});
+    const endCall = vi.fn(async () => ({ success: true }));
     const sharedCallSid = "CA-continuity-shared";
     const call = makeCallRecord(sharedCallSid);
     const handler = makeHandler(undefined, {
       manager: {
         getCallByProviderCallId: vi.fn(() => call),
         processEvent,
+        endCall,
       },
-      provider: { hangupCall },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
     const oldServer = await startRealtimeServer(handler);
@@ -2378,7 +2356,7 @@ describe("RealtimeCallHandler path routing", () => {
           expect(oldCloseBridge).toHaveBeenCalledOnce();
         });
         expect(replacementCloseBridge).not.toHaveBeenCalled();
-        expect(hangupCall).not.toHaveBeenCalled();
+        expect(endCall).not.toHaveBeenCalled();
         expect(
           processEvent.mock.calls
             .map(([event]) => event as NormalizedEvent)
@@ -2433,15 +2411,15 @@ describe("RealtimeCallHandler path routing", () => {
       throw new Error("replacement bridge failed");
     });
     const processEvent = vi.fn();
-    const hangupCall = vi.fn(async () => {});
+    const endCall = vi.fn(async () => ({ success: true }));
     const sharedCallSid = "CA-transcript-rollback";
     const call = makeCallRecord(sharedCallSid);
     const handler = makeHandler(undefined, {
       manager: {
         getCallByProviderCallId: vi.fn(() => call),
         processEvent,
+        endCall,
       },
-      provider: { hangupCall },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
     const oldServer = await startRealtimeServer(handler);
@@ -2478,7 +2456,7 @@ describe("RealtimeCallHandler path routing", () => {
           success: true,
         });
         expect(oldTriggerGreeting).toHaveBeenCalledWith("Continue the existing call.");
-        expect(hangupCall).not.toHaveBeenCalled();
+        expect(endCall).not.toHaveBeenCalled();
         expect(
           processEvent.mock.calls
             .map(([event]) => event as NormalizedEvent)

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -29,7 +29,6 @@ import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import WebSocket, { WebSocketServer } from "ws";
 import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
-import type { VoiceCallProvider } from "../providers/base.js";
 import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "../realtime-call-control.js";
 import type { CallRecord, EndReason, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
@@ -265,7 +264,7 @@ type RealtimeCallRegistration = {
   providerConfig: RealtimeVoiceProviderConfig;
 };
 
-type ResolveRealtimeCallRegistration = (call: CallRecord) => RealtimeCallRegistration;
+export type ResolveRealtimeCallRegistration = (call: CallRecord) => RealtimeCallRegistration;
 
 type ActiveRealtimeVoiceBridge = RealtimeVoiceBridgeSession;
 
@@ -319,7 +318,7 @@ type RealtimeCallEndCause = "disconnect" | "shutdown" | "inactivity" | "error";
 // record termination. Replacement can retire old audio without a late close killing its successor.
 type RealtimeTelephonyBinding = {
   bridge: ActiveRealtimeVoiceBridge;
-  close: (cause: RealtimeCallEndCause) => void;
+  close: (cause: RealtimeCallEndCause) => Promise<void>;
   endCall: () => void;
   noteMediaActivity: () => void;
   retire: () => void;
@@ -373,6 +372,7 @@ export class RealtimeCallHandler {
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
+  private readonly terminationAttempts = new Set<Promise<void>>();
   private closePromise: Promise<void> | null = null;
   private closing = false;
   private publicOrigin: string | null = null;
@@ -381,7 +381,6 @@ export class RealtimeCallHandler {
   constructor(
     private readonly config: VoiceCallRealtimeConfig,
     private readonly manager: CallManager,
-    private readonly provider: VoiceCallProvider,
     private readonly resolveCallRegistration: ResolveRealtimeCallRegistration,
     private readonly servePath: string,
     private readonly streamDisconnectLifecycle: StreamDisconnectLifecycle,
@@ -527,7 +526,7 @@ export class RealtimeCallHandler {
             return;
           }
           if (frame.kind === "stop") {
-            telephonyBinding.close("disconnect");
+            void telephonyBinding.close("disconnect");
           }
         } catch (error) {
           console.error("[voice-call] realtime WS parse failed:", error);
@@ -537,7 +536,9 @@ export class RealtimeCallHandler {
       ws.on("close", () => {
         this.activeSockets.delete(ws);
         const reason = this.serverClosingSockets.has(ws) ? "shutdown" : "disconnect";
-        telephonyBinding?.close(reason);
+        if (telephonyBinding) {
+          void telephonyBinding.close(reason);
+        }
       });
 
       ws.on("error", (error) => {
@@ -575,7 +576,8 @@ export class RealtimeCallHandler {
           }),
       ),
     ])
-      .then(() => {
+      .then(async () => {
+        await Promise.all(this.terminationAttempts);
         this.pendingStreamTokens.clear();
       })
       .finally(() => {
@@ -680,25 +682,29 @@ export class RealtimeCallHandler {
     const callId = callRecord.callId;
     const hadPredecessorOnAdmission = this.activeBridgesByCallId.has(callId);
     const previousTelephonyBinding = this.activeTelephonyBindingsByCallId.get(callId);
-    let callEndEmitted = false;
-    const emitCallEnd = (cause: RealtimeCallEndCause) => {
-      if (callEndEmitted) {
-        return;
+    let callEndPromise: Promise<void> | undefined;
+    const emitCallEnd = (cause: RealtimeCallEndCause): Promise<void> => {
+      if (callEndPromise) {
+        return callEndPromise;
       }
-      callEndEmitted = true;
       const reason: EndReason =
         cause === "error" ? "error" : cause === "inactivity" ? "timeout" : "completed";
-      this.endCallInManager(callSid, callId, reason);
-      if (cause !== "error" && cause !== "inactivity") {
-        return;
-      }
-      void Promise.resolve(
-        this.provider.hangupCall({ callId, providerCallId: callSid, reason }),
-      ).catch((error: unknown) => {
-        console.warn(
-          `[voice-call] Failed to hang up realtime call ${callSid}: ${formatErrorMessage(error)}`,
+      const attempt = this.manager.endCall(callId, { reason }).then((result) => {
+        if (!result.success) {
+          console.warn(
+            `[voice-call] Failed to end realtime call callId=${callId} providerCallId=${callSid} reason=${reason}: ${result.error ?? "unknown error"}; call remains active`,
+          );
+          return;
+        }
+        console.log(
+          `[voice-call] Realtime call ended callId=${callId} providerCallId=${callSid} reason=${cause}`,
         );
       });
+      callEndPromise = attempt;
+      this.terminationAttempts.add(attempt);
+      const release = () => this.terminationAttempts.delete(attempt);
+      void attempt.then(release, release);
+      return attempt;
     };
 
     let registration: RealtimeCallRegistration;
@@ -709,7 +715,7 @@ export class RealtimeCallHandler {
         `[voice-call] Failed to resolve realtime call registration callId=${callId} providerCallId=${callSid}: ${formatErrorMessage(error)}`,
       );
       if (!hadPredecessorOnAdmission) {
-        emitCallEnd("error");
+        void emitCallEnd("error");
       }
       ws.close(1011, "Check realtime configuration for routed agent");
       return null;
@@ -1088,7 +1094,7 @@ export class RealtimeCallHandler {
         ) {
           return;
         }
-        emitCallEnd("error");
+        void emitCallEnd("error");
       },
     };
     let session: ActiveRealtimeVoiceBridge;
@@ -1100,7 +1106,7 @@ export class RealtimeCallHandler {
       audioPacer.close();
       // A failed provisional replacement must not terminate its active predecessor.
       if (!hadPredecessorOnAdmission || !this.activeBridgesByCallId.has(callId)) {
-        emitCallEnd("error");
+        void emitCallEnd("error");
       }
       if (ws.readyState === WebSocket.OPEN) {
         ws.close(1011, "Failed to create realtime bridge");
@@ -1166,13 +1172,14 @@ export class RealtimeCallHandler {
     const closeBinding = (
       binding: RealtimeTelephonyBinding,
       cause?: RealtimeCallEndCause,
-    ): void => {
+    ): Promise<void> => {
       if (bindingClosed) {
-        return;
+        return callEndPromise ?? Promise.resolve();
       }
       bindingClosed = true;
       clearLivenessTimer();
       const ownsCall = this.activeTelephonyBindingsByCallId.get(callId) === binding;
+      let termination = Promise.resolve();
       try {
         session.close();
       } catch (error) {
@@ -1187,9 +1194,10 @@ export class RealtimeCallHandler {
           this.streamDisconnectLifecycle.retire(callSid, streamSid);
         }
         if (ownsCall && cause && cause !== "disconnect") {
-          emitCallEnd(cause);
+          termination = emitCallEnd(cause);
         }
       }
+      return termination;
     };
     const telephonyBinding: RealtimeTelephonyBinding = {
       bridge: session,
@@ -1197,7 +1205,7 @@ export class RealtimeCallHandler {
       endCall: () => {
         // Close the provider session before the carrier socket so no pending
         // response can reach the caller after the hang-up request succeeds.
-        closeBinding(telephonyBinding);
+        void closeBinding(telephonyBinding);
         if (ws.readyState === WebSocket.OPEN) {
           ws.close(1000, "Call ended");
         }
@@ -1215,7 +1223,7 @@ export class RealtimeCallHandler {
             `[voice-call] Realtime media inactive callId=${callId} providerCallId=${callSid} timeoutMs=${REALTIME_MEDIA_INACTIVITY_TIMEOUT_MS} graceMs=${REALTIME_DISCONNECT_HANGUP_GRACE_MS}`,
           );
           livenessTimer = setTimeout(() => {
-            telephonyBinding.close("inactivity");
+            void telephonyBinding.close("inactivity");
             if (ws.readyState === WebSocket.OPEN) {
               ws.close(1000, "Media inactivity");
             }
@@ -1224,7 +1232,9 @@ export class RealtimeCallHandler {
         }, REALTIME_MEDIA_INACTIVITY_TIMEOUT_MS);
         livenessTimer.unref?.();
       },
-      retire: () => closeBinding(telephonyBinding),
+      retire: () => {
+        void closeBinding(telephonyBinding);
+      },
     };
     this.activeBridgesByCallId.set(callId, session);
     this.activeBridgesByCallId.set(callSid, session);
@@ -1246,7 +1256,7 @@ export class RealtimeCallHandler {
         );
       } finally {
         if (ownsCallState) {
-          emitCallEnd("error");
+          void emitCallEnd("error");
         }
         ws.close(1011, "Failed to connect");
       }
@@ -1728,17 +1738,6 @@ export class RealtimeCallHandler {
     return typeof call.metadata?.initialMessage === "string"
       ? call.metadata.initialMessage
       : undefined;
-  }
-
-  private endCallInManager(callSid: string, callId: string, reason: EndReason): void {
-    this.manager.processEvent({
-      id: `realtime-ended-${callSid}-${Date.now()}`,
-      type: "call.ended",
-      callId,
-      providerCallId: callSid,
-      timestamp: Date.now(),
-      reason,
-    });
   }
 
   private async executeEndCallTool(params: {

--- a/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
@@ -54,7 +54,8 @@ describe("startStaleCallReaper", () => {
     stop?.();
   });
 
-  it("does not overlap stale-call reaps and retries after an unsuccessful attempt settles", async () => {
+  it("does not overlap reaps, logs typed failure, and retries after settlement", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     let resolveFirstEndCall!: (result: { success: false; error: string }) => void;
     const firstEndCall = new Promise<{ success: false; error: string }>((resolve) => {
       resolveFirstEndCall = resolve;
@@ -87,6 +88,7 @@ describe("startStaleCallReaper", () => {
     resolveFirstEndCall({ success: false, error: "network" });
     await firstEndCall;
     await Promise.resolve();
+    expect(warn).toHaveBeenCalledWith("[voice-call] Reaper failed to end call call-stale: network");
     await vi.advanceTimersByTimeAsync(30_000);
 
     expect(endCall).toHaveBeenCalledTimes(2);

--- a/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
@@ -53,8 +53,6 @@ describe("stale-call reaper provider transport", () => {
     const firstRequestStarted = deferred<void>();
     const firstResponseClosed = deferred<void>();
     const secondRequestStarted = deferred<void>();
-    const firstEndCallSettled = deferred<{ success: boolean; error?: string }>();
-    const secondEndCallSettled = deferred<{ success: boolean; error?: string }>();
     let requestCount = 0;
     let firstResponse: ServerResponse | undefined;
 
@@ -103,21 +101,11 @@ describe("stale-call reaper provider transport", () => {
           storePath: "/tmp/openclaw-voice-call-proof.json",
           transcriptWaiters: new Map(),
           maxDurationTimers: new Map(),
+          endCallOperations: new Map(),
         };
-        let settlementCount = 0;
         const manager = {
           getActiveCalls: () => [...context.activeCalls.values()],
-          endCall: vi.fn(async (callId: string) => {
-            const settlement = settlementCount++ === 0 ? firstEndCallSettled : secondEndCallSettled;
-            try {
-              const result = await endCall(context, callId);
-              settlement.resolve(result);
-              return result;
-            } catch (error) {
-              settlement.reject(error);
-              throw error;
-            }
-          }),
+          endCall: vi.fn((callId: string) => endCall(context, callId)),
         };
 
         const stop = startStaleCallReaper({
@@ -128,6 +116,10 @@ describe("stale-call reaper provider transport", () => {
         await vi.advanceTimersByTimeAsync(30_000);
         await waitForProofEvent(firstRequestStarted.promise, "the first provider request");
         expect(requestCount).toBe(1);
+        const firstOperation = manager.endCall.mock.results[0]?.value;
+        expect(firstOperation).toBeDefined();
+        const sharedOperation = endCall(context, call.callId);
+        expect(sharedOperation).toBe(firstOperation);
 
         // The next sweep coincides with the provider's 30s request timeout. It must
         // not start another hangup before the first attempt has settled.
@@ -137,7 +129,7 @@ describe("stale-call reaper provider transport", () => {
         expect(firstResponse).toBeDefined();
 
         const firstResult = await waitForProofEvent(
-          firstEndCallSettled.promise,
+          firstOperation!,
           "the first endCall settlement",
         );
         await waitForProofEvent(firstResponseClosed.promise, "the timed-out socket close");
@@ -145,8 +137,10 @@ describe("stale-call reaper provider transport", () => {
         await Promise.resolve();
         await vi.advanceTimersByTimeAsync(30_000);
         await waitForProofEvent(secondRequestStarted.promise, "the retried provider request");
+        const retryOperation = manager.endCall.mock.results[1]?.value;
+        expect(retryOperation).toBeDefined();
         const secondResult = await waitForProofEvent(
-          secondEndCallSettled.promise,
+          retryOperation!,
           "the retried endCall settlement",
         );
 

--- a/extensions/voice-call/src/webhook/stale-call-reaper.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.ts
@@ -1,6 +1,6 @@
 // Voice Call plugin module implements stale call reaper behavior.
-import type { CallId, CallRecord, CallState } from "../types.js";
-import { TerminalStates } from "../types.js";
+import type { CallManager } from "../manager.js";
+import { TerminalStates, type CallRecord, type CallState } from "../types.js";
 
 // Background cleanup loop for calls that never reached answered/terminal state.
 
@@ -14,7 +14,7 @@ const LiveConversationStates: ReadonlySet<CallState> = new Set(["speaking", "lis
 
 type StaleCallReaperManager = {
   getActiveCalls(): Array<Pick<CallRecord, "answeredAt" | "callId" | "startedAt" | "state">>;
-  endCall(callId: CallId): Promise<{ success: boolean; error?: string }>;
+  endCall: CallManager["endCall"];
 };
 
 /** Start a stale-call reaper and return its cleanup callback. */
@@ -48,13 +48,19 @@ export function startStaleCallReaper(params: {
       // Unanswered provider calls can be stranded when callbacks are missed; end them explicitly.
       const age = now - call.startedAt;
       if (age > maxAgeMs && !callsBeingReaped.has(call.callId)) {
-        // Keep one hangup attempt per call in flight; settlement releases the call for later retries.
         callsBeingReaped.add(call.callId);
         console.log(
           `[voice-call] Reaping stale call ${call.callId} (age: ${Math.round(age / 1000)}s, state: ${call.state})`,
         );
         void params.manager
           .endCall(call.callId)
+          .then((result) => {
+            if (!result.success) {
+              console.warn(
+                `[voice-call] Reaper failed to end call ${call.callId}: ${result.error ?? "unknown error"}`,
+              );
+            }
+          })
           .catch((err: unknown) => {
             console.warn(`[voice-call] Reaper failed to end call ${call.callId}:`, err);
           })

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -15,7 +15,6 @@ import {
 } from "../components/panel-toggle-contract.ts";
 import { i18n } from "../i18n/index.ts";
 import { SESSION_FACE_PREFERENCE_PARAM } from "../lib/sessions/route-navigation.ts";
-import { DEBUG_OVERLAY_TOGGLE_EVENT } from "../pages/debug/debug-overlay-contract.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { selectShellRouteState } from "./app-host-route-state.ts";
 import {
@@ -25,12 +24,13 @@ import {
   type TestOptionalCustomElement,
 } from "./app-host.test-support.ts";
 import { ShellGatewayOwner, type ShellGatewayHost } from "./app-shell-gateway.ts";
-import "./app-host.ts";
 import type {
   ApplicationContext,
   ApplicationGateway,
   ApplicationGatewaySnapshot,
 } from "./context.ts";
+import "./app-host.ts";
+import { DEBUG_OVERLAY_ELEMENT } from "./lazy-custom-element.ts";
 import { shouldMergeChatChrome } from "./mobile-nav-layout.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
 import { resetServerUiPrefsSync } from "./server-prefs.ts";
@@ -80,10 +80,6 @@ type ShellServerPreferencesState = {
 
 type ShellLazySurfaceState = ShellKeyboardState & {
   commandPaletteElement: TestOptionalCustomElement;
-};
-
-type ShellDebugOverlayState = ShellKeyboardState & {
-  debugOverlayElement: TestOptionalCustomElement;
 };
 
 type ShellApprovalLazyState = {
@@ -862,44 +858,43 @@ describe("OpenClaw shell keyboard shortcuts", () => {
   });
 
   it("loads the debug overlay shortcut and ignores editable targets", async () => {
-    const element = createLazyElementSpec("debug overlay");
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellDebugOverlayState;
-    shell.debugOverlayElement = element;
+    const toggled = vi.fn();
+    const shell = document.createElement("openclaw-app-shell") as unknown as ShellKeyboardState &
+      HTMLElement;
+    const overlay = document.createElement(DEBUG_OVERLAY_ELEMENT.tagName) as HTMLElement & {
+      toggle: () => void;
+    };
+    overlay.toggle = toggled;
+    shell.append(overlay);
     Object.defineProperty(shell, "updateComplete", {
       get: () => Promise.resolve(true),
     });
-    const toggled = vi.fn();
-    window.addEventListener(DEBUG_OVERLAY_TOGGLE_EVENT, toggled);
-    try {
-      const shortcut = new KeyboardEvent("keydown", {
-        key: "d",
-        code: "KeyD",
-        ctrlKey: true,
-        shiftKey: true,
-        cancelable: true,
-      });
-      shell.handleDocumentKeydown(shortcut);
+    const shortcut = new KeyboardEvent("keydown", {
+      key: "d",
+      code: "KeyD",
+      ctrlKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+    shell.handleDocumentKeydown(shortcut);
 
-      expect(shortcut.defaultPrevented).toBe(true);
-      await vi.waitFor(() => expect(toggled).toHaveBeenCalledOnce());
+    expect(shortcut.defaultPrevented).toBe(true);
+    await vi.waitFor(() => expect(toggled).toHaveBeenCalledOnce());
 
-      const input = document.body.appendChild(document.createElement("input"));
-      input.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
-      const editableShortcut = new KeyboardEvent("keydown", {
-        key: "d",
-        code: "KeyD",
-        ctrlKey: true,
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      input.dispatchEvent(editableShortcut);
+    const input = document.body.appendChild(document.createElement("input"));
+    input.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
+    const editableShortcut = new KeyboardEvent("keydown", {
+      key: "d",
+      code: "KeyD",
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(editableShortcut);
 
-      expect(editableShortcut.defaultPrevented).toBe(false);
-      expect(toggled).toHaveBeenCalledOnce();
-    } finally {
-      window.removeEventListener(DEBUG_OVERLAY_TOGGLE_EVENT, toggled);
-    }
+    expect(editableShortcut.defaultPrevented).toBe(false);
+    expect(toggled).toHaveBeenCalledOnce();
   });
 
   it("opens approvals after the modal module loads on demand", async () => {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -65,7 +65,6 @@ import {
   BROWSER_PANEL_ELEMENT,
   COMMAND_PALETTE_ELEMENT,
   CUSTODIAN_PANEL_ELEMENT,
-  DEBUG_OVERLAY_ELEMENT,
   DESKTOP_PANEL_ELEMENT,
   EXEC_APPROVAL_ELEMENT,
   preloadOptionalElement,
@@ -133,7 +132,6 @@ class OpenClawShell
   @state() routeState: ShellRouteState = {};
   @state() nativeHistoryState: NativeHistoryState = readNativeHistoryState();
   readonly commandPaletteElement = COMMAND_PALETTE_ELEMENT;
-  readonly debugOverlayElement = DEBUG_OVERLAY_ELEMENT;
   readonly terminalPanelElement = TERMINAL_PANEL_ELEMENT;
   readonly browserPanelElement = BROWSER_PANEL_ELEMENT;
   readonly desktopPanelElement = DESKTOP_PANEL_ELEMENT;

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -13,6 +13,7 @@ import type { OpenClawModalDialog } from "../components/modal-dialog.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
   CUSTODIAN_PANEL_TOGGLE_EVENT,
+  DEBUG_OVERLAY_REQUEST_EVENT,
   DESKTOP_PANEL_TOGGLE_EVENT,
   isTerminalPanelShortcut,
   TERMINAL_PANEL_TOGGLE_EVENT,
@@ -24,13 +25,10 @@ import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../lib/gateway-
 import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
-import {
-  DEBUG_OVERLAY_REQUEST_EVENT,
-  DEBUG_OVERLAY_TOGGLE_EVENT,
-} from "../pages/debug/debug-overlay-contract.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
 import {
+  DEBUG_OVERLAY_ELEMENT,
   ensureOptionalElementForHost,
   isOptionalElementDefined,
   type OptionalCustomElement,
@@ -46,6 +44,10 @@ import { NAV_WIDTH_MAX, NAV_WIDTH_MIN } from "./settings.ts";
 
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
+};
+
+type DebugOverlayElement = HTMLElement & {
+  toggle: () => void;
 };
 
 export function isBrowserPanelAvailable(
@@ -74,7 +76,6 @@ export interface ShellChromeHost extends HTMLElement {
   readonly onboardingMode: boolean;
   readonly updateComplete: Promise<boolean>;
   readonly commandPaletteElement: OptionalCustomElement;
-  readonly debugOverlayElement: OptionalCustomElement;
   readonly terminalPanelElement: OptionalCustomElement;
   readonly browserPanelElement: OptionalCustomElement;
   readonly desktopPanelElement: OptionalCustomElement;
@@ -429,10 +430,10 @@ export class ShellChromeOwner {
 
   private toggleDebugOverlay(): void {
     const host = this.host;
-    void ensureOptionalElementForHost(host, host.debugOverlayElement)
+    void ensureOptionalElementForHost(host, DEBUG_OVERLAY_ELEMENT)
       .then(async () => {
         await host.updateComplete;
-        window.dispatchEvent(new CustomEvent(DEBUG_OVERLAY_TOGGLE_EVENT));
+        host.querySelector<DebugOverlayElement>(DEBUG_OVERLAY_ELEMENT.tagName)?.toggle();
       })
       .catch(() => undefined);
   }

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -27,6 +27,7 @@ import type { ApplicationContext, ApplicationNavigationOptions } from "./context
 import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
 import { readScopeUpgradeAvailability } from "./device-scope-upgrade.ts";
 import {
+  DEBUG_OVERLAY_ELEMENT,
   ensureOptionalElementForHost,
   isOptionalElementDefined,
   type OptionalCustomElement,
@@ -87,7 +88,6 @@ export interface ShellViewHost {
   readonly runtime: ApplicationRuntime | undefined;
   readonly activeSessionKey: string;
   readonly commandPaletteElement: OptionalCustomElement;
-  readonly debugOverlayElement: OptionalCustomElement;
   readonly custodianMinimizeRequestId: number;
   readonly desktopNavigationExpanded: boolean;
   readonly execApprovalElement: OptionalCustomElement;
@@ -471,7 +471,7 @@ export function renderApplicationShell(host: ShellViewHost) {
           .onSlashCommand=${(command: string) => host.handleCommandPaletteSlashCommand(command)}
         ></openclaw-command-palette>`
       : nothing}
-    ${isOptionalElementDefined(host.debugOverlayElement)
+    ${isOptionalElementDefined(DEBUG_OVERLAY_ELEMENT)
       ? html`<openclaw-debug-overlay></openclaw-debug-overlay>`
       : nothing}
     <div

--- a/ui/src/components/panel-toggle-contract.ts
+++ b/ui/src/components/panel-toggle-contract.ts
@@ -5,6 +5,7 @@ export const TERMINAL_PANEL_DOCK_BOTTOM_EVENT = "openclaw:terminal-dock-bottom";
 export const BROWSER_PANEL_TOGGLE_EVENT = "openclaw:browser-toggle";
 export const DESKTOP_PANEL_TOGGLE_EVENT = "openclaw:desktop-toggle";
 export const CUSTODIAN_PANEL_TOGGLE_EVENT = "openclaw:custodian-toggle";
+export const DEBUG_OVERLAY_REQUEST_EVENT = "openclaw:debug-overlay-request";
 export const UI_COMMAND_EVENT = "openclaw:ui-command";
 
 export type UiCommandDetail = UiCommandParams;

--- a/ui/src/pages/debug/debug-overlay-contract.ts
+++ b/ui/src/pages/debug/debug-overlay-contract.ts
@@ -1,5 +1,4 @@
-export const DEBUG_OVERLAY_REQUEST_EVENT = "openclaw:debug-overlay-request";
-export const DEBUG_OVERLAY_TOGGLE_EVENT = "openclaw:debug-overlay-toggle";
+import { DEBUG_OVERLAY_REQUEST_EVENT } from "../../components/panel-toggle-contract.ts";
 
 export const DEBUG_OVERLAY_SHORTCUT_LABEL = /Mac|iP(hone|ad|od)/i.test(
   globalThis.navigator?.platform ?? "",

--- a/ui/src/pages/debug/debug-overlay.ts
+++ b/ui/src/pages/debug/debug-overlay.ts
@@ -6,7 +6,6 @@ import { t } from "../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
 import "../../styles/debug.css";
-import { DEBUG_OVERLAY_TOGGLE_EVENT } from "./debug-overlay-contract.ts";
 import {
   DEBUG_OVERLAY_SECTIONS,
   type DebugOverlaySectionDescriptor,
@@ -38,13 +37,7 @@ export class DebugOverlay extends OpenClawLightDomElement {
     false,
   );
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-    window.addEventListener(DEBUG_OVERLAY_TOGGLE_EVENT, this.handleToggle);
-  }
-
   override disconnectedCallback(): void {
-    window.removeEventListener(DEBUG_OVERLAY_TOGGLE_EVENT, this.handleToggle);
     this.close();
     super.disconnectedCallback();
   }
@@ -55,7 +48,7 @@ export class DebugOverlay extends OpenClawLightDomElement {
     }
   }
 
-  private readonly handleToggle = (): void => {
+  toggle(): void {
     if (this.open) {
       this.close();
       return;
@@ -68,7 +61,7 @@ export class DebugOverlay extends OpenClawLightDomElement {
     );
     void this.refreshSections();
     this.polling.start();
-  };
+  }
 
   private readonly handleKeydown = (event: KeyboardEvent): void => {
     if (event.key !== "Escape" || event.defaultPrevented) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where realtime voice calls could record the wrong terminal reason or timestamp when a provider webhook raced an awaited hangup, issue duplicate carrier hangups from parallel termination requests, or persist a completed call before an automatic shutdown/failure hangup had actually succeeded.

## Why This Change Was Made

The call manager now owns one in-flight provider-first termination operation per call, and the first terminal provider facts remain immutable. Realtime teardown delegates its completed/error/timeout reasons through that manager path, waits for shutdown attempts, and automatic callers surface typed hangup failures without falsely finalizing the call. This stays inside the voice-call plugin and removes the realtime handler's duplicate direct-provider termination path. Exact-head CI also exposed a 43-byte red-main Control UI startup gzip regression, and this PR absorbs it by removing a redundant debug-overlay toggle event and host descriptor, with no visible behavior change.

## User Impact

Call history keeps the provider-confirmed end reason and timestamp, concurrent end requests produce one carrier hangup, and failed automatic termination remains visible and retryable instead of silently appearing completed.

## Evidence

- Pre-fix order-faithful regressions failed for stale terminal overwrite, duplicate parallel hangups, startup failure ordering, and shutdown ordering.
- Manager termination suite: 43/43 passed.
- Realtime/webhook termination suite: 126/126 passed.
- Sibling lifecycle suite: 53/53 passed.
- Extension production and test types passed; changed-file format/lint passed; database-first, media-helper, runtime-sidecar, import-cycle, boundary, dead-export, dependency, and ratchet guards passed.
- Codex autoreview: no accepted/actionable findings.
- Control UI unit suite: 45/45 passed.
- Debug-overlay Chromium E2E: 1/1 passed.
- `pnpm ui:build` passed at 341,266 B startup gzip vs 342,050 B ceiling.
- Control UI autoreview: no accepted/actionable findings.
- Production LOC: +155/-124 (net +31); tests/support: +337/-262 (net +75). The UI follow-up is net-negative production and offsets part of the voice lifecycle growth; the remaining production growth is the manager-owned singleflight state, typed automatic-failure handling, and shutdown termination drain, while the old realtime direct provider/event termination path and provider constructor dependency were removed.
- No screenshot is included because the Control UI cleanup is behavior-neutral and produces no visual delta; the real-browser debug-overlay E2E passed.
- Live carrier proof was not run because it requires real telephony credentials, an external phone call, and potentially paid carrier usage; deferred provider and real manager/realtime boundary tests exercise the exact ordering.

AI-assisted; maintainer reviewed and understands the change.
