### PR TITLE
fix(matrix): bound poll relation pagination

### DIFF
--- a/extensions/matrix/src/matrix/poll-summary.test.ts
+++ b/extensions/matrix/src/matrix/poll-summary.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { fetchMatrixPollSnapshot } from "./poll-summary.js";
+import type { MatrixRawEvent } from "./sdk.js";
+
+const POLL_START_EVENT: MatrixRawEvent = {
+  event_id: "$poll1",
+  type: "m.poll.start",
+  sender: "@alice:example.org",
+  content: {
+    "m.poll.start": {
+      question: { "m.text": "Lunch?" },
+      answers: [
+        { id: "yes", "m.text": "Yes" },
+        { id: "no", "m.text": "No" },
+      ],
+    },
+  },
+} as unknown as MatrixRawEvent;
+
+function createFakeClient(pages: Array<{ events: unknown[]; nextBatch?: string }>) {
+  const calls: Array<{ from?: string; limit?: number }> = [];
+  return {
+    calls,
+    client: {
+      getEvent: async () => POLL_START_EVENT,
+      getRelations: async (
+        _roomId: string,
+        _eventId: string,
+        _rel: string,
+        _type: undefined,
+        opts: { from?: string; limit?: number },
+      ) => {
+        calls.push(opts);
+        const page = pages[Math.min(calls.length - 1, pages.length - 1)];
+        return { events: page.events, nextBatch: page.nextBatch ?? null };
+      },
+    } as never,
+  };
+}
+
+describe("fetchMatrixPollSnapshot relation pagination", () => {
+  it("stops when the server keeps returning the same nextBatch (no infinite loop)", async () => {
+    const { calls, client } = createFakeClient([
+      { events: [{ type: "m.poll.response" }], nextBatch: "tok-loop" },
+    ]);
+
+    const snapshot = await fetchMatrixPollSnapshot(client, "room-1", POLL_START_EVENT);
+
+    expect(snapshot).not.toBeNull();
+    // 1 initial page + at most one repeated batch before the cursor check stops it.
+    expect(calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it("caps pagination when the server always advances the batch", async () => {
+    const { calls, client } = createFakeClient(
+      Array.from({ length: 50 }, (_, index) => ({
+        events: [{ type: "m.poll.response" }],
+        nextBatch: `tok-${index}`,
+      })),
+    );
+
+    const snapshot = await fetchMatrixPollSnapshot(client, "room-1", POLL_START_EVENT);
+
+    expect(snapshot).not.toBeNull();
+    expect(calls).toHaveLength(10);
+    expect(calls.every((call) => call.limit === 100)).toBe(true);
+  });
+});

--- a/extensions/matrix/src/matrix/poll-summary.test.ts
+++ b/extensions/matrix/src/matrix/poll-summary.test.ts
@@ -65,4 +65,26 @@ describe("fetchMatrixPollSnapshot relation pagination", () => {
     expect(calls).toHaveLength(10);
     expect(calls.every((call) => call.limit === 100)).toBe(true);
   });
+
+  it("hard-bounds collected events when a page exceeds the requested limit", async () => {
+    const oversizedPage = Array.from({ length: 5000 }, (_, index) => ({
+      event_id: `$vote${index}`,
+      type: "m.poll.response",
+      sender: `@user${index}:example.org`,
+      origin_server_ts: index,
+      content: {
+        "m.poll.response": { answers: ["yes"] },
+        "m.relates_to": { rel_type: "m.reference", event_id: "$poll1" },
+      },
+    }));
+    const { calls, client } = createFakeClient([{ events: oversizedPage, nextBatch: "tok-more" }]);
+
+    const snapshot = await fetchMatrixPollSnapshot(client, "room-1", POLL_START_EVENT);
+
+    expect(snapshot).not.toBeNull();
+    // The cap is already full after the first oversized page — no further requests.
+    expect(calls).toHaveLength(1);
+    // Only 1000 of the 5000 returned events are retained and counted.
+    expect(snapshot?.text).toContain("Total voters: 1000");
+  });
 });

--- a/extensions/matrix/src/matrix/poll-summary.ts
+++ b/extensions/matrix/src/matrix/poll-summary.ts
@@ -29,20 +29,33 @@ export function resolveMatrixPollRootEventId(
   return resolvePollReferenceEventId(event.content);
 }
 
+// Bound relation pagination: a malicious or faulty homeserver can keep
+// returning nextBatch forever, and every poll vote otherwise triggers an
+// unbounded O(votes) re-fetch inside the room's serial ingress queue.
+const POLL_RELATIONS_PAGE_LIMIT = 100;
+const POLL_RELATIONS_MAX_PAGES = 10;
+
 async function readAllPollRelations(
   client: MatrixClient,
   roomId: string,
   pollEventId: string,
 ): Promise<MatrixRawEvent[]> {
   const relationEvents: MatrixRawEvent[] = [];
+  const seenBatches = new Set<string>();
   let nextBatch: string | undefined;
-  do {
-    const page = await client.getRelations(roomId, pollEventId, "m.reference", undefined, {
+  for (let page = 0; page < POLL_RELATIONS_MAX_PAGES; page += 1) {
+    const pageResult = await client.getRelations(roomId, pollEventId, "m.reference", undefined, {
       from: nextBatch,
+      limit: POLL_RELATIONS_PAGE_LIMIT,
     });
-    relationEvents.push(...page.events);
-    nextBatch = page.nextBatch ?? undefined;
-  } while (nextBatch);
+    relationEvents.push(...pageResult.events);
+    const batch = pageResult.nextBatch ?? undefined;
+    if (!batch || seenBatches.has(batch)) {
+      break;
+    }
+    seenBatches.add(batch);
+    nextBatch = batch;
+  }
   return relationEvents;
 }
 

--- a/extensions/matrix/src/matrix/poll-summary.ts
+++ b/extensions/matrix/src/matrix/poll-summary.ts
@@ -34,6 +34,7 @@ export function resolveMatrixPollRootEventId(
 // unbounded O(votes) re-fetch inside the room's serial ingress queue.
 const POLL_RELATIONS_PAGE_LIMIT = 100;
 const POLL_RELATIONS_MAX_PAGES = 10;
+const POLL_RELATIONS_MAX_EVENTS = POLL_RELATIONS_PAGE_LIMIT * POLL_RELATIONS_MAX_PAGES;
 
 async function readAllPollRelations(
   client: MatrixClient,
@@ -48,7 +49,13 @@ async function readAllPollRelations(
       from: nextBatch,
       limit: POLL_RELATIONS_PAGE_LIMIT,
     });
-    relationEvents.push(...pageResult.events);
+    // `limit` is only a request hint — a faulty or malicious homeserver may
+    // return oversized pages, so enforce the hard event bound locally.
+    const remaining = POLL_RELATIONS_MAX_EVENTS - relationEvents.length;
+    relationEvents.push(...pageResult.events.slice(0, remaining));
+    if (relationEvents.length >= POLL_RELATIONS_MAX_EVENTS) {
+      break;
+    }
     const batch = pageResult.nextBatch ?? undefined;
     if (!batch || seenBatches.has(batch)) {
       break;


### PR DESCRIPTION
## Summary

fix(matrix): bound poll relation pagination in `fetchMatrixPollSnapshot` — page count, cursor progress, and a hard 1,000-event retained bound — so a poll's relation fetch can't spin forever or exhaust memory on a faulty/malicious homeserver

## What Problem This Solves

Every `m.poll.response` / `m.poll.end` event in a monitored room triggers `fetchMatrixPollSnapshot`, which re-fetches the poll's **entire** relation set — inside the room's serial ingress queue:

```ts
// extensions/matrix/src/matrix/poll-summary.ts
do {
  const page = await client.getRelations(roomId, pollEventId, "m.reference", undefined, {
    from: nextBatch,
  });
  relationEvents.push(...page.events);
  nextBatch = page.nextBatch ?? undefined;
} while (nextBatch);
```

No page-size limit (the wrapper supports `limit`, the caller passes none), no page-count cap, no event-count cap, and no cursor-progress check. Independent failure modes:

1. **Quadratic stall**: the K-th vote on an active poll costs O(K) paginated requests, so K votes cost O(K²) events — and every other message in the room queues behind each of those fetches.
2. **Non-terminating loop + memory blowout**: a homeserver that keeps returning a `nextBatch` (buggy federation peer, or a malicious one — room content is not fully trusted) makes the loop never exit while `relationEvents` grows without bound. Reproduced over real HTTP below: on main the fetch is still paginating after 15 s with thousands of requests issued and hundreds of thousands of events pulled.
3. **`limit` is only a request hint**: the Matrix wrapper (`sdk/client-core.ts:464`) forwards `limit` to the SDK and maps the **complete** returned `events` array, so a homeserver that ignores the requested page size can push arbitrarily large pages. The retained list must therefore be bounded locally, not just by request parameters.

**代码证据**: `extensions/matrix/src/matrix/poll-summary.ts:38-45` (on main) — the `do...while` has no exit condition other than an absent `nextBatch`, and appends every returned event.

Trigger condition: any poll in a monitored room (always-on amplification), or a homeserver returning a stuck/repeating cursor or oversized pages (fatal).

## Root Cause

- The relation fetch has existed unbounded since poll support landed (`bca2501c7f7`, 2026-05-27).
- Violated invariant: any network pagination loop must have an iteration bound, a progress check, and a local bound on retained data. This one had none of the three, on a hot path that runs inside a serial per-room queue.

## Why This Fix

- Option A (chosen): cap at 10 pages × 100 requested events, stop when the cursor stops advancing (`seenBatches`), and enforce a hard local bound of 1,000 retained events (`slice` to remaining capacity before appending, stop paginating once full). A poll with >1,000 recorded votes keeps a valid (if slightly stale-tail) summary; correctness for every realistic poll is unchanged, and all pathological cases become bounded — including servers that ignore `limit`.
- Option B: fetch only the latest N relations (reverse direction). Better long-term, but changes which votes are summarized — a behavior change beyond this fix's scope.
- Not chosen: rely on the `limit` request parameter alone — the server is not obligated to honor it, so it cannot be the memory bound (finding from review).
- Not chosen: dedupe after full fetch — does nothing for the unbounded loop itself.

## User Impact

- Affected scenarios: Matrix rooms with active polls; any room whose homeserver misbehaves on `/relations` pagination.
- Before: room message processing stalls behind O(K²) relation fetches; a repeating cursor paginates forever and grows memory until the process dies; an oversized page is retained in full.
- After: relation fetch is bounded (≤ 10 requests, ≤ 1,000 retained events, enforced locally); summaries are produced for all realistic polls and pathological servers can't stall or OOM the client.
- Behavior change: polls with more than 1,000 relation events are summarized from the first 1,000 (previously unbounded). All smaller polls are unaffected. This truncation is acceptable because poll summaries are a display aid: the first 1,000 votes still produce a correct, representative result, and the alternative is an unbounded stall/OOM that kills the whole room pipeline.

## Evidence

Real-transport proof (`proof-matrix-poll-pagination-http.mjs`, Node v24, tsx): runs the **real** `fetchMatrixPollSnapshot` through the **real** matrix-js-sdk client (`createClient().relations()` / `fetchRoomEvent()`, v41.9.0) over **real HTTP** against a local homeserver endpoint that misbehaves on purpose. The event mapping uses the production `matrixEventToRaw` helper; the adapter mirrors `MatrixClientCore.getRelations` exactly. Only the homeserver itself is substituted (local HTTP server) — no client, transport, mapping, or pagination code is faked. The `Before` run executes the same script against current `main` (`PROOF_TARGET_TREE`).

### Before (on main)

```bash
$ PROOF_TARGET_TREE=../openclaw node node_modules/tsx/dist/cli.mjs proof-matrix-poll-pagination-http.mjs
scenario: server repeats the same next_batch forever
  [http] GET /_matrix/client/v1/rooms/!proof-room%3Alocal/relations/%24poll1/m.reference -> 1 events, next_batch=e1-loop
  [http] GET /_matrix/client/v1/rooms/!proof-room%3Alocal/relations/%24poll1/m.reference?from=e1-loop -> 1 events, next_batch=e1-loop
  [http] GET /_matrix/client/v1/rooms/!proof-room%3Alocal/relations/%24poll1/m.reference?from=e1-loop -> 1 events, next_batch=e1-loop
FAIL server repeats the same next_batch forever: still paginating after 15s over real HTTP (3467 relation requests, 3467 events pulled) — unbounded loop
scenario: server advances next_batch forever
  [http] GET .../m.reference -> 100 events, next_batch=e2-tok-1
  [http] GET .../m.reference?from=e2-tok-1 -> 100 events, next_batch=e2-tok-2
FAIL server advances next_batch forever: still paginating after 15s over real HTTP (1775 relation requests, 177500 events pulled) — unbounded loop
scenario: server ignores limit and returns a 5000-event page
  [http] GET .../m.reference -> 5000 events, next_batch=e3-tok-1
  [http] GET .../m.reference?from=e3-tok-1 -> 100 events, next_batch=e3-tok-2
FAIL server ignores limit and returns a 5000-event page: still paginating after 15s over real HTTP (1708 relation requests, 175700 events pulled) — unbounded loop
RESULT: 3 FAILURES (unbounded pagination over real HTTP transport)
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-matrix-poll-pagination-http.mjs
scenario: server repeats the same next_batch forever
  [http] GET .../m.reference?limit=100 -> 1 events, next_batch=e1-loop
  [http] GET .../m.reference?from=e1-loop&limit=100 -> 1 events, next_batch=e1-loop
PASS server repeats the same next_batch forever: completed with 2 relation requests
scenario: server advances next_batch forever
  [http] GET .../m.reference?limit=100 -> 100 events, next_batch=e2-tok-1
  [http] GET .../m.reference?from=e2-tok-1&limit=100 -> 100 events, next_batch=e2-tok-2
PASS server advances next_batch forever: completed with 10 relation requests, summary bounded at 1000 voters
scenario: server ignores limit and returns a 5000-event page
  [http] GET .../m.reference?limit=100 -> 5000 events, next_batch=e3-tok-1
PASS server ignores limit and returns a 5000-event page: completed with 1 relation requests, summary bounded at 1000 voters
RESULT: ALL PASS (real matrix-js-sdk transport over real HTTP)
```

The third scenario is the review finding made concrete: the server ignores `limit=100` and returns 5,000 events in a single page; the fixed code retains exactly 1,000 and stops after one request.

## Tests and Validation

- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/poll-summary.test.ts` — 3/3 passed: repeating cursor terminates after at most one repeated batch; ever-advancing cursor stops at the 10-page cap; an oversized 5,000-event page is truncated to the 1,000-event bound after a single request (regression coverage for the review finding).
- `node scripts/check-changed.mjs -- extensions/matrix/src/matrix/poll-summary.ts extensions/matrix/src/matrix/poll-summary.test.ts` — all lanes pass, including the dead-export production scan (0 entries); the full-tree dead-export scan flags 3 pre-existing unused exports in untouched `scripts/crabbox-wrapper-providers.mts` / `scripts/testbox-lease-freshness.mts`, which are present identically on current `origin/main`.
- `npx oxlint --deny=warn` on both files — 0 warnings, 0 errors.
- Before/after real-transport proof logs are embedded above (real matrix-js-sdk client over real HTTP to a local misbehaving homeserver endpoint).
