### PR TITLE
fix(worktrees): keep cleanup running with stale Git metadata

### DIFF
--- a/src/agents/worktrees/service.orphans.test.ts
+++ b/src/agents/worktrees/service.orphans.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { listGitWorktrees } from "./git.js";
-import { ManagedWorktreeService } from "./service.js";
+import { ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -119,16 +119,31 @@ describe("ManagedWorktreeService orphan reconciliation", () => {
     await expect(fs.stat(debris)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("defers cleanup when checkout metadata cannot be inspected", async () => {
-    const target = path.join(stateDir, "worktrees", "fingerprint", "broken-checkout");
+  it("preserves unreadable checkout metadata without blocking later cleanup", async () => {
+    let now = Date.now();
+    service = new ManagedWorktreeService({ env, now: () => now });
+    const expired = await service.create({ repoRoot: repo, name: "expired-snapshot" });
+    await service.remove({ id: expired.id, reason: "retention" });
+    now += SNAPSHOT_RETENTION_MS + 1;
+
+    const fingerprint = path.join(stateDir, "worktrees", "fingerprint");
+    const target = path.join(fingerprint, "a-broken-checkout");
+    const debris = path.join(fingerprint, "z-plain-debris");
     await fs.mkdir(path.join(target, "payload"), { recursive: true });
     await fs.writeFile(path.join(target, ".git"), "gitdir: /missing/openclaw-worktree-control\n");
     await fs.writeFile(path.join(target, "payload", "keep.txt"), "uncertain\n");
+    await fs.mkdir(debris, { recursive: true });
+    await fs.writeFile(path.join(debris, "remove.txt"), "debris\n");
 
-    await expect(service.gc()).rejects.toThrow("git worktree list");
+    const result = await service.gc();
+
+    expect(result.orphansDeleted).toBe(1);
+    expect(result.snapshotsPruned).toBe(1);
     await expect(fs.readFile(path.join(target, "payload", "keep.txt"), "utf8")).resolves.toBe(
       "uncertain\n",
     );
+    await expect(fs.stat(debris)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(service.listRegistryRecords().some((record) => record.id === expired.id)).toBe(false);
   });
 
   it.skipIf(process.platform === "win32")(

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -239,28 +239,9 @@ async function shouldPreserveOrphanCandidate(
   if (managedPaths.has(targetKey)) {
     return true;
   }
-  const hasOwnGitMarker = await worktreePathExists(path.join(target, ".git"));
-  if (!hasOwnGitMarker) {
-    return false;
-  }
-  // Query from the checkout itself so registered unborn worktrees do not pass
-  // through resolveRepository's intentional HEAD commit requirement.
-  const listed = await listGitWorktrees(target);
-  for (const entry of listed) {
-    let listedKey: string;
-    try {
-      listedKey = await canonicalPathKey(entry.path);
-    } catch (error) {
-      if (isMissingPathError(error)) {
-        continue;
-      }
-      throw error;
-    }
-    if (listedKey === targetKey) {
-      return true;
-    }
-  }
-  return false;
+  // Any top-level .git entry marks uncertain user work; broken indirection only
+  // strengthens preservation and must never abort global orphan cleanup.
+  return await worktreePathExists(path.join(target, ".git"));
 }
 
 async function cleanupFailedCreate(repoRoot: string, worktreePath: string, branch: string) {


### PR DESCRIPTION
Closes #125719

## What Problem This Solves

Fixes an issue where startup and hourly managed-worktree cleanup would stop entirely when one preserved checkout had a top-level `.git` file pointing to linked-worktree admin metadata that had already moved or disappeared. The uncertain checkout remained safe, but unrelated orphan deletion and snapshot-retention cleanup were starved on every pass.

## Why This Change Was Made

Orphan classification now treats any top-level `.git` entry as a conservative preservation signal without invoking Git from an unregistered candidate. This keeps the data-safety boundary local to that directory: unknown work is never deleted or repaired automatically, while marker-free debris and later retention work continue normally.

The registered-worktree removal flow, stale linked-admin run-admission failure, lossless snapshot construction, nested-repository detection, and gitlink rejection are unchanged. Automatically pruning or repairing the dangling metadata was rejected because OpenClaw cannot prove ownership or losslessness for an unregistered candidate.

Root cause: #119709 correctly hardened orphan cleanup against deleting direct-root and unborn worktrees, but its candidate-root `git worktree list` probe let one stale `.git` indirection reject the entire GC pass.

Production LOC: +3/-22 (net -19) | Tests: +19/-4 (net +15)

## User Impact

Operators can replace or relocate a canonical repository without one surviving stale worktree directory disabling all managed-worktree maintenance. OpenClaw preserves the uncertain directory, continues safe cleanup elsewhere, and retains the same warnings and fail-closed behavior for registered stale worktrees and unsnapshotable nested repositories.

Release note: managed-worktree cleanup now keeps progressing when a preserved checkout has stale linked-worktree metadata.

## Evidence

- Before: the updated real-Git regression failed with `git worktree list --porcelain -z failed` when the candidate `.git` file pointed to a missing admin directory.
- Local macOS: `node scripts/run-vitest.mjs src/agents/worktrees/service.orphans.test.ts src/agents/worktrees/service.test.ts src/agents/worktrees/run-lease.test.ts` — 3 files, 71 tests passed.
- Isolated AWS Linux: the same real-Git/SQLite suites passed, including stale linked-admin admission refusal and unchanged nested-repository snapshot protection. Run: https://crabbox.openclaw.ai/portal/runs/run_c0d5062774e7
- Changed gates: `core, coreTests` passed, including production/test typecheck, lint, architecture/import-cycle, database-first, and schema-version guards. The initial wrapper exceeded 10 minutes after dead-code scans had already passed; rerunning the remaining gates with that completed scan skipped finished successfully.
- Formatting: `oxfmt --check` and `git diff --check` passed.
- Fresh Codex autoreview (`--mode uncommitted`): no accepted/actionable findings.
- Rebased exact head: `b33dda71b41889ec8b7931a2f89f81724b99fd6c`. Required CI passed in run 32119008182: https://github.com/openclaw/openclaw/actions/runs/32119008182. One failed compact-shard job was rerun unchanged after its 8-vCPU runner reported only 2 CPUs; the retry passed.
- Pre-rebase exact-head run 32116103099 failed only in `build-artifacts` on inherited red-main Control UI startup gzip debt (342097 B versus the then-342050 B limit). Rebasing onto main after the existing UI budget repair removed that inherited failure; this PR does not change UI budget or baseline files.
- Read-only production evidence confirmed the stale admin directories moved with a preserved prior checkout while the replacement canonical repository remained healthy. No live worktree, Git metadata, registry row, service, or config was changed.

AI-assisted; the final diff, lifecycle boundary, upstream Git contract, tests, and live evidence were inspected by the maintainer.
