### PR TITLE
fix(memory): recover indexing from explicit embedding item limits

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -50,7 +50,7 @@ import {
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
-  isSplittableMemoryEmbeddingTransportError,
+  isSplittableMemoryEmbeddingBatchError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -675,7 +675,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
               return result;
             },
             isRetryable: isRetryableMemoryEmbeddingError,
-            isSplittable: isSplittableMemoryEmbeddingTransportError,
+            isSplittable: isSplittableMemoryEmbeddingBatchError,
             waitForRetry: async (delayMs) => {
               await this.waitForEmbeddingRetry(
                 delayMs,
@@ -686,7 +686,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
             onSplit: ({ itemCount, splitAt }) => {
               log.warn(
-                `memory embeddings transport failed after retries; splitting ${label} of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+                `memory embeddings ${label} failed; splitting ${itemCount} inputs into ${splitAt} + ${itemCount - splitAt}`,
               );
             },
           }),

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -5,7 +5,7 @@ import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
-  isSplittableMemoryEmbeddingTransportError,
+  isSplittableMemoryEmbeddingBatchError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -168,16 +168,14 @@ describe("memory embedding policy", () => {
 
     for (const message of splittableMessages) {
       expect(isRetryableMemoryEmbeddingError(message)).toBe(true);
-      expect(isSplittableMemoryEmbeddingTransportError(message)).toBe(true);
+      expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
     }
     expect(isRetryableMemoryEmbeddingError("ECONNREFUSED")).toBe(true);
-    expect(isSplittableMemoryEmbeddingTransportError("ECONNREFUSED")).toBe(false);
+    expect(isSplittableMemoryEmbeddingBatchError("ECONNREFUSED")).toBe(false);
     expect(isRetryableMemoryEmbeddingError("EHOSTUNREACH")).toBe(true);
-    expect(isSplittableMemoryEmbeddingTransportError("EHOSTUNREACH")).toBe(false);
+    expect(isSplittableMemoryEmbeddingBatchError("EHOSTUNREACH")).toBe(false);
     expect(isRetryableMemoryEmbeddingError("memory embeddings batch timed out")).toBe(true);
-    expect(isSplittableMemoryEmbeddingTransportError("memory embeddings batch timed out")).toBe(
-      false,
-    );
+    expect(isSplittableMemoryEmbeddingBatchError("memory embeddings batch timed out")).toBe(false);
     expect(isRetryableMemoryEmbeddingError("worker terminated by user")).toBe(false);
     expect(isRetryableMemoryEmbeddingError("embedding validation failed")).toBe(false);
   });
@@ -196,7 +194,7 @@ describe("memory embedding policy", () => {
       items: ["a", "b", "c", "d"],
       run,
       isRetryable: isRetryableMemoryEmbeddingError,
-      isSplittable: isSplittableMemoryEmbeddingTransportError,
+      isSplittable: isSplittableMemoryEmbeddingBatchError,
       waitForRetry: async () => {},
       maxAttempts: 3,
       baseDelayMs: 500,
@@ -205,10 +203,79 @@ describe("memory embedding policy", () => {
     expect(result).toEqual([[97], [98], [99], [100]]);
     expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 2, 1, 1, 2, 1, 1]);
     expect(isRetryableMemoryEmbeddingError("431 request_headers_too_large")).toBe(false);
-    expect(isSplittableMemoryEmbeddingTransportError("431 request_headers_too_large")).toBe(true);
-    expect(
-      isSplittableMemoryEmbeddingTransportError("embedding validation failed at item 4312"),
-    ).toBe(false);
+    expect(isSplittableMemoryEmbeddingBatchError("431 request_headers_too_large")).toBe(true);
+    expect(isSplittableMemoryEmbeddingBatchError("embedding validation failed at item 4312")).toBe(
+      false,
+    );
+  });
+
+  it("splits explicit embedding item-count limits without replaying oversized requests", async () => {
+    const items = Array.from({ length: 33 }, (_, index) => `item-${index}`);
+    const waits: number[] = [];
+    const splits: string[] = [];
+    const itemLimitError = (itemCount: number) =>
+      `openai-compatible embeddings failed: HTTP 400: {"error":{"code":"InvalidParameter","message":"Embeddings API input limit exceeded: max 10, got ${itemCount}. Request id: fixture-000597000","param":"input","type":"BadRequest"}}`;
+    const run = vi.fn(async (batch: string[]) => {
+      if (batch.length > 10) {
+        throw new Error(itemLimitError(batch.length));
+      }
+      return batch.map((item) => [Number.parseInt(item.slice("item-".length), 10)]);
+    });
+
+    const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      items,
+      run,
+      isRetryable: isRetryableMemoryEmbeddingError,
+      isSplittable: isSplittableMemoryEmbeddingBatchError,
+      waitForRetry: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      maxAttempts: 3,
+      baseDelayMs: 500,
+      onSplit: ({ itemCount, splitAt }) => {
+        splits.push(`${itemCount}:${splitAt}`);
+      },
+    });
+
+    expect(run.mock.calls.map(([batch]) => batch.length)).toEqual([33, 17, 9, 8, 16, 8, 8]);
+    expect(waits).toEqual([]);
+    expect(splits).toEqual(["33:17", "17:9", "16:8"]);
+    expect(result).toEqual(items.map((_, index) => [index]));
+    expect(isRetryableMemoryEmbeddingError(itemLimitError(33))).toBe(false);
+    expect(isSplittableMemoryEmbeddingBatchError(itemLimitError(33))).toBe(true);
+  });
+
+  it("does not split unrelated generic HTTP 400 embedding errors", async () => {
+    const genericError = new Error(
+      'openai-compatible embeddings failed: HTTP 400: {"error":{"code":"InvalidParameter","message":"The parameter input specified in the request is not valid. Request id: fixture-000597000","param":"input","type":"BadRequest"}}',
+    );
+    const run = vi.fn(async () => {
+      throw genericError;
+    });
+    const waits: number[] = [];
+    const splits: string[] = [];
+
+    await expect(
+      runMemoryEmbeddingBatchRetryWithSplit({
+        items: ["a", "b"],
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isSplittableMemoryEmbeddingBatchError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        onSplit: ({ itemCount, splitAt }) => {
+          splits.push(`${itemCount}:${splitAt}`);
+        },
+      }),
+    ).rejects.toBe(genericError);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(waits).toEqual([]);
+    expect(splits).toEqual([]);
+    expect(isSplittableMemoryEmbeddingBatchError(genericError.message)).toBe(false);
   });
 
   it("retries too-many-tokens-per-day errors", async () => {
@@ -272,7 +339,7 @@ describe("memory embedding policy", () => {
       items: ["a", "b", "c", "d"],
       run,
       isRetryable: isRetryableMemoryEmbeddingError,
-      isSplittable: isSplittableMemoryEmbeddingTransportError,
+      isSplittable: isSplittableMemoryEmbeddingBatchError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
@@ -299,7 +366,7 @@ describe("memory embedding policy", () => {
         items: ["a", "b"],
         run,
         isRetryable: isRetryableMemoryEmbeddingError,
-        isSplittable: isSplittableMemoryEmbeddingTransportError,
+        isSplittable: isSplittableMemoryEmbeddingBatchError,
         waitForRetry: async () => {},
         maxAttempts: 1,
         baseDelayMs: 500,
@@ -318,7 +385,7 @@ describe("memory embedding policy", () => {
         items: ["a", "b"],
         run,
         isRetryable: isRetryableMemoryEmbeddingError,
-        isSplittable: isSplittableMemoryEmbeddingTransportError,
+        isSplittable: isSplittableMemoryEmbeddingBatchError,
         waitForRetry: async () => {},
         maxAttempts: 2,
         baseDelayMs: 500,

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -83,7 +83,7 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
 }
 
 const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
-  /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i;
+  /(rate[_ ]limit|too many requests|\b(?:429|5\d\d)\b|resource has been exhausted|cloudflare|tokens per day)/i;
 
 const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
@@ -91,18 +91,26 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
 const SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted))/i;
 
+const SPLITTABLE_MEMORY_EMBEDDING_ITEM_LIMIT_ERROR_RE =
+  /\bembeddings api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+\b/i;
+
 function isRetryableMemoryEmbeddingTransportError(message: string): boolean {
   return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
 }
 
-export function isSplittableMemoryEmbeddingTransportError(message: string): boolean {
-  return SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
+export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
+  return (
+    SPLITTABLE_MEMORY_EMBEDDING_ITEM_LIMIT_ERROR_RE.test(message) ||
+    SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message)
+  );
 }
 
 export function isRetryableMemoryEmbeddingError(message: string): boolean {
+  // Count-limit failures can only improve after splitting; replaying the same batch cannot succeed.
   return (
-    RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ||
-    isRetryableMemoryEmbeddingTransportError(message)
+    !SPLITTABLE_MEMORY_EMBEDDING_ITEM_LIMIT_ERROR_RE.test(message) &&
+    (RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ||
+      isRetryableMemoryEmbeddingTransportError(message))
   );
 }
 


### PR DESCRIPTION
Closes #125640

## What Problem This Solves

Fixes an issue where memory indexing would abort when an OpenAI-compatible embedding endpoint explicitly rejected a request for exceeding its input item count. The count-bearing HTTP 400 was not considered splittable, so the existing recursive batch recovery path never reduced the request.

The observed error also contained `597` inside a request ID. The prior unbounded `5\d\d` retry pattern treated those digits as a 5xx status and replayed the same 33-item request three times before failing.

## Why This Change Was Made

Memory Core now recognizes only the self-describing `Embeddings API input limit exceeded: max N, got M` shape as a splittable batch error and routes it through the existing recursive splitter. Count-limit errors bypass retries because replaying an unchanged oversized batch cannot succeed. Numeric HTTP status matching now excludes digits embedded in longer identifiers.

This does not classify arbitrary HTTP 400 responses, `InvalidParameter`, `BadRequest`, or `param=input` as splittable. It does not add a universal item cap or claim support for Qianfan's ambiguous generic response.

## User Impact

Memory indexing can complete against endpoints that return the explicit count-bearing item-limit error. Input order is preserved, and unrelated malformed requests still fail without recursive fanout.

## Evidence

- Baseline: `ebe9d38a5f9233ae62699ae582f548ac7a73bcd0`; rebased and rechecked on `ad475ce33ada88b2d35e8526acaece7c526bb72b`.
- Pre-fix regression: the explicit item-limit case called the provider with `[33, 33, 33]` and failed; the generic 400 fixture was also called three times because its synthetic request ID contained `597`.
- `pnpm test extensions/memory-core/src/memory/manager-embedding-policy.test.ts extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts` — 19 tests passed after the fix and again after rebase.
- `pnpm test:extension memory-core` — 87 files passed, 1 platform file skipped; 1,120 tests passed, 3 skipped.
- `pnpm check:changed -- extensions/memory-core/src/memory/manager-embedding-policy.ts extensions/memory-core/src/memory/manager-embedding-ops.ts extensions/memory-core/src/memory/manager-embedding-policy.test.ts` — passed, including extension production/test typechecks, type-aware lint, dead-export scans, formatting, import cycles, and boundary guards.
- TruffleHog preflight: clean. The structured external-model autoreview phase was unavailable because the local host policy denied uploading the private workspace diff; an independent read-only review found no actionable P0/P1/P2 findings.
- Production delta: +8 net lines. Tests: +67 net lines.

No live provider credentials were used. The claim is limited to the self-describing error shape exercised by the deterministic regression, not provider-wide vendor support.

## AI Assistance

AI-assisted investigation, implementation, tests, and review. I reviewed the memory batch policy, recursive split owner, OpenAI-compatible bridge, retry behavior, and regression coverage and understand the change.
