### PR TITLE
fix(codex): file approval hooks miss changed-file details

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -320,6 +320,8 @@ describe("Codex app-server approval bridge", () => {
     "maps file operator decision %s to native %s",
     async (gatewayDecision, nativeDecision) => {
       const params = createParams();
+      const changes = [{ path: "memory/2026-07-29.md", kind: { type: "add" } }];
+
       mockCallGatewayTool
         .mockResolvedValueOnce({ id: `plugin:file-${gatewayDecision}`, status: "accepted" })
         .mockResolvedValueOnce({
@@ -334,6 +336,7 @@ describe("Codex app-server approval bridge", () => {
           itemId: `file-${gatewayDecision}`,
           reason: "update generated output",
         },
+        fileChangeToolParams: { changes },
         paramsForRun: params,
         ...codexTestTurnIds(),
       });
@@ -382,6 +385,10 @@ describe("Codex app-server approval bridge", () => {
 
   it("auto-accepts app-server command approvals in yolo mode without opening plugin approvals", async () => {
     const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -411,6 +418,7 @@ describe("Codex app-server approval bridge", () => {
 
   it("auto-accepts app-server file approvals in yolo mode without opening plugin approvals", async () => {
     const params = createParams();
+    const changes = [{ path: "memory/2026-07-29.md", kind: { type: "add" } }];
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
@@ -418,7 +426,10 @@ describe("Codex app-server approval bridge", () => {
         ...codexTestTurnIds(),
         itemId: "patch-yolo",
         reason: "needs write access",
+        grantRoot: "/workspace/generated",
+        futureApprovalField: "preserved",
       },
+      fileChangeToolParams: { changes },
       paramsForRun: params,
       ...codexTestTurnIds(),
       autoApprove: true,
@@ -426,10 +437,54 @@ describe("Codex app-server approval bridge", () => {
 
     expect(result).toEqual({ decision: "acceptForSession" });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(mockRunBeforeToolCallHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "apply_patch",
+        params: {
+          ...codexTestTurnIds(),
+          itemId: "patch-yolo",
+          reason: "needs write access",
+          grantRoot: "/workspace/generated",
+          futureApprovalField: "preserved",
+          changes,
+        },
+      }),
+    );
     findApprovalEvent(params, {
       status: "approved",
       reason: "needs write access",
       message: "Codex app-server approval auto-approved by runtime policy.",
+    });
+  });
+
+  it("fails closed when a file approval has no correlated changes", async () => {
+    const params = createParams();
+    const onNativeToolFailureDisposition = vi.fn();
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/fileChange/requestApproval",
+      requestParams: {
+        ...codexTestTurnIds(),
+        itemId: "patch-missing-correlation",
+        reason: "needs write access",
+      },
+      paramsForRun: params,
+      ...codexTestTurnIds(),
+      autoApprove: true,
+      onNativeToolFailureDisposition,
+    });
+
+    expect(result).toEqual({ decision: "decline" });
+    expect(mockRunBeforeToolCallHook).not.toHaveBeenCalled();
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(onNativeToolFailureDisposition).toHaveBeenCalledWith(
+      "patch-missing-correlation",
+      "failed",
+    );
+    findApprovalEvent(params, {
+      status: "denied",
+      message:
+        "OpenClaw could not correlate the Codex file-change approval with its proposed changes.",
     });
   });
 
@@ -2077,6 +2132,10 @@ describe("Codex app-server approval bridge", () => {
 
   it("auto-approves when the expected native hook relay is unavailable in full-auto", async () => {
     const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
     mockInvokeNativeHookRelay.mockRejectedValueOnce(new Error("native hook relay not found"));
 
     const result = await handleCodexAppServerApprovalRequest({
@@ -2157,6 +2216,9 @@ describe("Codex app-server approval bridge", () => {
         ...codexTestTurnIds(),
         itemId: "patch-native-relay-registered",
         reason: "needs write access",
+      },
+      fileChangeToolParams: {
+        changes: [{ path: "src/native-relay.ts", kind: { type: "update" } }],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2749,6 +2811,9 @@ describe("Codex app-server approval bridge", () => {
         itemId: "patch-1",
         reason: "needs write access",
       },
+      fileChangeToolParams: {
+        changes: [{ path: "src/unavailable.ts", kind: { type: "update" } }],
+      },
       paramsForRun: params,
       ...codexTestTurnIds(),
       onNativeToolFailureDisposition,
@@ -2772,6 +2837,9 @@ describe("Codex app-server approval bridge", () => {
         ...codexTestTurnIds(),
         itemId: "patch-stale",
         reason: "needs write access",
+      },
+      fileChangeToolParams: {
+        changes: [{ path: "src/stale.ts", kind: { type: "update" } }],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
@@ -2883,6 +2951,9 @@ describe("Codex app-server approval bridge", () => {
         ...codexTestTurnIds(),
         itemId: "patch-sanitized",
         reason: "needs write access\nfor \u001b[31m/tmp\u001b[0m\tplease",
+      },
+      fileChangeToolParams: {
+        changes: [{ path: "/tmp/sanitized", kind: { type: "update" } }],
       },
       paramsForRun: params,
       ...codexTestTurnIds(),

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -66,6 +66,7 @@ type SanitizedApprovalPreview = {
 export async function handleCodexAppServerApprovalRequest(params: {
   method: string;
   requestParams: JsonValue | undefined;
+  fileChangeToolParams?: JsonObject;
   paramsForRun: EmbeddedRunAttemptParams;
   threadId: string;
   turnId: string;
@@ -160,6 +161,7 @@ export async function handleCodexAppServerApprovalRequest(params: {
     const policyOutcome = await runOpenClawToolPolicyForApprovalRequest({
       method: params.method,
       requestParams,
+      fileChangeToolParams: params.fileChangeToolParams,
       paramsForRun: params.paramsForRun,
       context,
       nativeHookRelay: params.nativeHookRelay,
@@ -480,6 +482,7 @@ type ApprovalPolicyOutcome =
 async function runOpenClawToolPolicyForApprovalRequest(params: {
   method: string;
   requestParams: JsonObject | undefined;
+  fileChangeToolParams?: JsonObject;
   paramsForRun: EmbeddedRunAttemptParams;
   context: ApprovalContext;
   nativeHookRelay?: Pick<
@@ -489,7 +492,19 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
   autoApprove?: boolean;
   signal?: AbortSignal;
 }): Promise<ApprovalPolicyOutcome | undefined> {
-  const policyRequest = buildOpenClawToolPolicyRequest(params.method, params.requestParams);
+  if (params.method === "item/fileChange/requestApproval" && !params.fileChangeToolParams) {
+    return {
+      outcome: "denied",
+      reason:
+        "OpenClaw could not correlate the Codex file-change approval with its proposed changes.",
+      failureDisposition: "failed",
+    };
+  }
+  const policyRequest = buildOpenClawToolPolicyRequest(
+    params.method,
+    params.requestParams,
+    params.fileChangeToolParams,
+  );
   if (!policyRequest) {
     return undefined;
   }
@@ -760,6 +775,7 @@ function sanitizeRelayDecisionReason(value: string | undefined): string | undefi
 function buildOpenClawToolPolicyRequest(
   method: string,
   requestParams: JsonObject | undefined,
+  fileChangeToolParams?: JsonObject,
 ): { toolName: string; params: JsonObject } | undefined {
   if (method === "item/commandExecution/requestApproval") {
     if (readNetworkApprovalContext(requestParams)) {
@@ -779,7 +795,15 @@ function buildOpenClawToolPolicyRequest(
     };
   }
   if (method === "item/fileChange/requestApproval") {
-    return { toolName: "apply_patch", params: requestParams ?? {} };
+    return fileChangeToolParams
+      ? {
+          toolName: "apply_patch",
+          params: {
+            ...requestParams,
+            ...fileChangeToolParams,
+          },
+        }
+      : undefined;
   }
   if (method === "item/permissions/requestApproval") {
     return { toolName: "codex_permission_approval", params: requestParams ?? {} };

--- a/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
+++ b/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
@@ -14,6 +14,7 @@ import {
   type CodexNativeToolAuditStatus,
   type CodexNativeToolUnfinishedStatus,
 } from "./event-projector-items.js";
+import { fileChangeToolArgs } from "./event-projector-tool-items.js";
 import { readItem } from "./event-projector-values.js";
 import {
   emitCodexNativePreToolUseFailureDiagnostic,
@@ -26,6 +27,7 @@ import {
   type CodexServerNotification,
   type CodexThreadItem,
   type JsonObject,
+  type JsonValue,
 } from "./protocol.js";
 
 type CodexNativeToolLifecycleContext = Pick<
@@ -45,6 +47,7 @@ type CodexNativePreToolUseFailureRecord = {
 /** Projects metadata-only lifecycle diagnostics for native tool items. */
 export class CodexNativeToolLifecycleProjector {
   private readonly startedAtByItem = new Map<string, number>();
+  private readonly pendingFileChangeApprovalToolParamsByItem = new Map<string, JsonObject>();
   private readonly activeItems = new Map<
     string,
     { toolName: string; unfinishedStatus: CodexNativeToolUnfinishedStatus }
@@ -81,6 +84,7 @@ export class CodexNativeToolLifecycleProjector {
       for (const item of turn.items ?? []) {
         this.recordSnapshotItem(item);
       }
+      this.pendingFileChangeApprovalToolParamsByItem.clear();
       return;
     }
     if (notification.method === "rawResponseItem/completed") {
@@ -111,11 +115,22 @@ export class CodexNativeToolLifecycleProjector {
     item: CodexThreadItem;
     sourceTimestampMs?: number;
   }): void {
+    if (params.phase === "result") {
+      this.pendingFileChangeApprovalToolParamsByItem.delete(params.item.id);
+    }
     const toolName = auditNativeToolName(params.item);
     if (!toolName || this.completedItemIds.has(params.item.id)) {
       return;
     }
     if (params.phase === "start") {
+      if (params.item.type === "fileChange") {
+        // Codex blocks after item/started and before writing. Retain these
+        // turn-owned args only until the matching approval consumes them.
+        this.pendingFileChangeApprovalToolParamsByItem.set(
+          params.item.id,
+          fileChangeToolArgs(params.item),
+        );
+      }
       this.recordStarted(
         params.item.id,
         toolName,
@@ -149,6 +164,23 @@ export class CodexNativeToolLifecycleProjector {
     if (!this.completedItemIds.has(toolCallId)) {
       this.approvalFailureDispositionByItem.set(toolCallId, disposition);
     }
+  }
+
+  takeFileChangeApprovalToolParams(requestParams: JsonValue | undefined): JsonObject | undefined {
+    const request = isJsonObject(requestParams) ? requestParams : undefined;
+    const itemId = readString(request, "itemId");
+    if (
+      !itemId ||
+      readString(request, "threadId") !== this.threadId ||
+      readString(request, "turnId") !== this.turnId
+    ) {
+      return undefined;
+    }
+    const toolParams = this.pendingFileChangeApprovalToolParamsByItem.get(itemId);
+    if (toolParams) {
+      this.pendingFileChangeApprovalToolParamsByItem.delete(itemId);
+    }
+    return toolParams;
   }
 
   recordPreToolUseFailure(
@@ -284,6 +316,7 @@ export class CodexNativeToolLifecycleProjector {
 
   finalizeActive(runWasAborted = this.options.runAbortSignal?.aborted === true): void {
     this.finalized = true;
+    this.pendingFileChangeApprovalToolParamsByItem.clear();
     for (const [toolCallId, { toolName, unfinishedStatus }] of this.activeItems) {
       const webSearchCompletion = this.webSearchCompletionByItem.get(toolCallId);
       const itemRunWasAborted = webSearchCompletion

--- a/extensions/codex/src/app-server/event-projector-tool-items.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-items.ts
@@ -16,7 +16,7 @@ import {
   readNonEmptyString,
   readNonEmptyStringArray,
 } from "./event-projector-values.js";
-import { isJsonObject, type CodexThreadItem, type JsonObject } from "./protocol.js";
+import { isJsonObject, type CodexThreadItem, type JsonObject, type JsonValue } from "./protocol.js";
 import {
   sanitizeCodexAgentEventRecord,
   sanitizeCodexToolArguments,
@@ -61,6 +61,10 @@ export function itemToolArgs(item: CodexThreadItem): Record<string, unknown> | u
     return sanitizeCodexToolArguments(item.arguments);
   }
   return undefined;
+}
+
+export function fileChangeToolArgs(item: CodexThreadItem): JsonObject {
+  return { changes: itemFileChanges(item) };
 }
 
 export function isCommandBearingToolItem(
@@ -150,7 +154,7 @@ function webSearchToolResult(item: CodexThreadItem): Record<string, unknown> {
 
 type CodexFileChangeSummary = {
   path: string;
-  kind: unknown;
+  kind: JsonValue;
 };
 
 type CodexTranscriptFileChange = CodexFileChangeSummary & {

--- a/extensions/codex/src/app-server/event-projector.file-change-approval.test.ts
+++ b/extensions/codex/src/app-server/event-projector.file-change-approval.test.ts
@@ -1,0 +1,94 @@
+import {
+  describe,
+  registerCodexEventProjectorTestLifecycle,
+  expect,
+  it,
+  THREAD_ID,
+  TURN_ID,
+  createParams,
+  createProjector,
+  forCurrentTurn,
+} from "./event-projector.test-harness.js";
+
+registerCodexEventProjectorTestLifecycle();
+
+describe("CodexAppServerEventProjector file-change approval correlation", () => {
+  it("isolates and consumes correlated file-change approval params", async () => {
+    const projector = await createProjector(await createParams());
+    const changes = [{ path: "src/correlated.ts", kind: { type: "update" } }];
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "fileChange",
+          id: "patch-correlated",
+          changes,
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(
+      projector.takeFileChangeApprovalToolParams({
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        itemId: "patch-other",
+      }),
+    ).toBeUndefined();
+
+    expect(
+      projector.takeFileChangeApprovalToolParams({
+        threadId: THREAD_ID,
+        turnId: "turn-other",
+        itemId: "patch-correlated",
+      }),
+    ).toBeUndefined();
+
+    expect(
+      projector.takeFileChangeApprovalToolParams({
+        threadId: "thread-other",
+        turnId: TURN_ID,
+        itemId: "patch-correlated",
+      }),
+    ).toBeUndefined();
+
+    const requestParams = {
+      threadId: THREAD_ID,
+      turnId: TURN_ID,
+      itemId: "patch-correlated",
+    };
+
+    expect(projector.takeFileChangeApprovalToolParams(requestParams)).toEqual({ changes });
+    expect(projector.takeFileChangeApprovalToolParams(requestParams)).toBeUndefined();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "fileChange",
+          id: "patch-completed",
+          changes,
+          status: "inProgress",
+        },
+      }),
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "fileChange",
+          id: "patch-completed",
+          changes,
+          status: "completed",
+        },
+      }),
+    );
+
+    expect(
+      projector.takeFileChangeApprovalToolParams({
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        itemId: "patch-completed",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -633,7 +633,7 @@ export class CodexAppServerEventProjector {
     // Only its last relevant tool may change the terminal presentation.
     for (let index = turnItems.length - 1; index >= 0; index -= 1) {
       const item = turnItems[index];
-      if (!item || !this.isCurrentTurnSnapshotItem(item)) {
+      if (!item || (readItemString(item, "turnId") ?? this.turnId) !== this.turnId) {
         continue;
       }
       if (item?.type === "dynamicToolCall") {
@@ -676,7 +676,7 @@ export class CodexAppServerEventProjector {
   private async emitSnapshotOnlyNativeToolProgress(item: CodexThreadItem): Promise<void> {
     if (
       !shouldSynthesizeToolProgressForItem(item) ||
-      !this.isCurrentTurnSnapshotItem(item) ||
+      (readItemString(item, "turnId") ?? this.turnId) !== this.turnId ||
       this.completedItemIds.has(item.id) ||
       itemStatus(item) === "running"
     ) {
@@ -691,10 +691,6 @@ export class CodexAppServerEventProjector {
     this.eventProjection.emitStandardItemEvent({ phase: "end", item });
     await this.eventProjection.emitNormalizedToolItemEvent({ phase: "result", item });
     this.completedItemIds.add(item.id);
-  }
-
-  private isCurrentTurnSnapshotItem(item: CodexThreadItem): boolean {
-    return (readItemString(item, "turnId") ?? this.turnId) === this.turnId;
   }
 
   private async handleRawResponseItemCompleted(params: JsonObject): Promise<void> {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -245,6 +245,10 @@ export class CodexAppServerEventProjector {
     }
   }
 
+  takeFileChangeApprovalToolParams(requestParams: JsonValue | undefined): JsonObject | undefined {
+    return this.nativeToolLifecycleProjector.takeFileChangeApprovalToolParams(requestParams);
+  }
+
   recordNativeToolPreToolUseFailure(failure: CodexNativePreToolUseFailure): void {
     this.nativeToolLifecycleProjector.recordPreToolUseFailure(failure);
   }
@@ -690,8 +694,7 @@ export class CodexAppServerEventProjector {
   }
 
   private isCurrentTurnSnapshotItem(item: CodexThreadItem): boolean {
-    const itemTurnId = readItemString(item, "turnId");
-    return itemTurnId === undefined || itemTurnId === this.turnId;
+    return (readItemString(item, "turnId") ?? this.turnId) === this.turnId;
   }
 
   private async handleRawResponseItemCompleted(params: JsonObject): Promise<void> {

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -141,6 +141,10 @@ export function createCodexAttemptServerRequestController(
           return await handleCodexAppServerApprovalRequest({
             method: request.method,
             requestParams: request.params,
+            fileChangeToolParams:
+              request.method === "item/fileChange/requestApproval"
+                ? projector?.takeFileChangeApprovalToolParams(request.params)
+                : undefined,
             paramsForRun: params,
             threadId: resourceState.thread.threadId,
             turnId,

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay-approvals.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay-approvals.test.ts
@@ -1,0 +1,134 @@
+// Codex tests cover run attempt.native hook relay approval behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { nativeHookRelayTesting } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import {
+  createEmptyPluginRegistry,
+  createMockPluginRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as approvalBridge from "./approval-bridge.js";
+import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
+import {
+  bindProductionHarnessHostCapabilitiesForTest,
+  createParams,
+  createStartedThreadHarness,
+  extractRelayIdFromThreadRequest,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+} from "./run-attempt-test-harness.js";
+
+setupRunAttemptTestHooks();
+
+afterEach(() => {
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
+
+const testing = {
+  flushPendingCodexNativeHookRelayUnregistersForTests(): void {
+    nativeHookRelayUnregisterQueue.flush();
+  },
+};
+
+describe("run attempt native hook relay approvals", () => {
+  it("auto-answers defensive yolo command and correlated workspace file approvals", async () => {
+    const approvalSpy = vi.spyOn(approvalBridge, "handleCodexAppServerApprovalRequest");
+    const beforeToolCall = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const sessionFile = path.join(tempDir, "policy-allow.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-policy-allow");
+    const commandFile = path.join(workspaceDir, "byte-bound-command.mjs");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(commandFile, "process.stdout.write('ok\\n');\n");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.trigger = "user";
+    params.approvalReviewerDeviceId = "device-tui-reviewer";
+    const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
+
+    const run = runCodexAppServerAttempt(params, {
+      nativeHookRelay: { enabled: true, events: ["pre_tool_use"] },
+    });
+    await harness.waitForMethod("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    expect((startRequest?.params as { approvalPolicy?: string })?.approvalPolicy).toBe("never");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toMatchObject({
+      approvalContext: {
+        trigger: "user",
+        approvalReviewerDeviceId: "device-tui-reviewer",
+      },
+    });
+
+    const commandResponse = await harness.handleServerRequest({
+      id: "request-command-policy-allow",
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-policy-allow",
+        command: `node ${commandFile}`,
+        cwd: workspaceDir,
+      },
+    });
+    expect(approvalSpy).toHaveBeenCalledWith(expect.objectContaining({ autoApprove: true }));
+    // Commands backed by mutable file bytes cannot receive reusable approval.
+    expect(commandResponse).toEqual({ decision: "accept" });
+    const changes = [
+      {
+        path: "memory/2026-07-29.md",
+        kind: { type: "add" },
+      },
+    ];
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "patch-policy-allow",
+          type: "fileChange",
+          changes,
+          status: "inProgress",
+        },
+      },
+    });
+    await expect(
+      harness.handleServerRequest({
+        id: "request-file-policy-allow",
+        method: "item/fileChange/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "patch-policy-allow",
+          reason: "write memory/2026-07-29.md",
+          grantRoot: workspaceDir,
+        },
+      }),
+    ).resolves.toEqual({ decision: "acceptForSession" });
+
+    expect(beforeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "apply_patch",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "patch-policy-allow",
+          reason: "write memory/2026-07-29.md",
+          grantRoot: workspaceDir,
+          changes,
+        },
+      }),
+      expect.any(Object),
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    closeHostCapabilities();
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -1,5 +1,4 @@
 // Codex tests cover run attempt.native hook relay plugin behavior.
-import fs from "node:fs/promises";
 import path from "node:path";
 import {
   abortAgentHarnessRun,
@@ -331,75 +330,6 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     await run;
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
-  });
-
-  it("auto-answers defensive yolo command and workspace file approvals at their safe scopes", async () => {
-    const approvalSpy = vi.spyOn(approvalBridge, "handleCodexAppServerApprovalRequest");
-    const beforeToolCall = vi.fn(() => undefined);
-    initializeGlobalHookRunner(
-      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
-    );
-    const sessionFile = path.join(tempDir, "policy-allow.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace-policy-allow");
-    const commandFile = path.join(workspaceDir, "byte-bound-command.mjs");
-    await fs.mkdir(workspaceDir, { recursive: true });
-    await fs.writeFile(commandFile, "process.stdout.write('ok\\n');\n");
-    const harness = createStartedThreadHarness();
-    const params = createParams(sessionFile, workspaceDir);
-    params.trigger = "user";
-    params.approvalReviewerDeviceId = "device-tui-reviewer";
-    const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
-
-    const run = runCodexAppServerAttempt(params, {
-      nativeHookRelay: { enabled: true, events: ["pre_tool_use"] },
-    });
-    await harness.waitForMethod("turn/start");
-    const startRequest = harness.requests.find((request) => request.method === "thread/start");
-    expect((startRequest?.params as { approvalPolicy?: string })?.approvalPolicy).toBe("never");
-    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
-    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toMatchObject({
-      approvalContext: {
-        trigger: "user",
-        approvalReviewerDeviceId: "device-tui-reviewer",
-      },
-    });
-
-    const commandResponse = await harness.handleServerRequest({
-      id: "request-command-policy-allow",
-      method: "item/commandExecution/requestApproval",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "cmd-policy-allow",
-        command: `node ${commandFile}`,
-        cwd: workspaceDir,
-      },
-    });
-    expect(approvalSpy).toHaveBeenCalledWith(expect.objectContaining({ autoApprove: true }));
-    // Commands backed by mutable file bytes cannot receive reusable approval.
-    expect(commandResponse).toEqual({ decision: "accept" });
-    await expect(
-      harness.handleServerRequest({
-        id: "request-file-policy-allow",
-        method: "item/fileChange/requestApproval",
-        params: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          itemId: "patch-policy-allow",
-          reason: "write memory/2026-07-29.md",
-          grantRoot: workspaceDir,
-        },
-      }),
-    ).resolves.toEqual({ decision: "acceptForSession" });
-
-    expect(beforeToolCall).toHaveBeenCalledWith(
-      expect.objectContaining({ toolName: "apply_patch" }),
-      expect.any(Object),
-    );
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
-    closeHostCapabilities();
-    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
   it("fails a defensive unattended yolo approval immediately when the hook requires review", async () => {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1781,10 +1781,10 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(codexHookStateForEvent(hookState, "pre_tool_use")).toEqual({ enabled: false });
   });
 
-  it("forwards side-thread command approvals through the active native hook relay", async () => {
+  it("forwards side-thread command and correlated file approvals through the native relay", async () => {
     const client = createFakeClient();
     let relayIdDuringFork: string | undefined;
-    handleCodexAppServerApprovalRequestMock.mockResolvedValueOnce({ decision: "decline" });
+    handleCodexAppServerApprovalRequestMock.mockResolvedValue({ decision: "decline" });
     client.request.mockImplementation(async (method: string, requestParams: unknown) => {
       if (method === "thread/fork") {
         const config = (requestParams as { config?: Record<string, unknown> }).config;
@@ -1829,15 +1829,39 @@ describe("runCodexAppServerSideQuestion", () => {
         cwd: "/tmp/workspace",
       },
     });
+    const changes = [{ path: "memory/side.md", kind: { type: "add" } }];
+    client.emit({
+      method: "item/started",
+      params: {
+        ...codexTestTurnIds("side-thread"),
+        item: {
+          id: "patch-side",
+          type: "fileChange",
+          changes,
+          status: "inProgress",
+        },
+      },
+    });
+    const fileApprovalResponse = await handleClientRequestWhenReady(client, {
+      id: 43,
+      method: "item/fileChange/requestApproval",
+      params: {
+        ...codexTestTurnIds("side-thread"),
+        itemId: "patch-side",
+        reason: "write memory/side.md",
+      },
+    });
     client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
     await expect(run).resolves.toEqual({ text: "Side answer." });
 
     expect(approvalResponse).toEqual({ decision: "decline" });
-    expect(handleCodexAppServerApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(fileApprovalResponse).toEqual({ decision: "decline" });
+    expect(handleCodexAppServerApprovalRequestMock).toHaveBeenCalledTimes(2);
     const approvalArgs = handleCodexAppServerApprovalRequestMock.mock.calls[0]?.[0] as
       | {
           method?: string;
           requestParams?: Record<string, unknown>;
+          fileChangeToolParams?: Record<string, unknown>;
           threadId?: string;
           turnId?: string;
           paramsForRun?: { messageChannel?: string; messageProvider?: string };
@@ -1862,6 +1886,16 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(approvalArgs?.nativeHookRelay).toMatchObject({
       relayId: relayIdDuringFork,
       allowedEvents: expect.arrayContaining(["pre_tool_use"]),
+    });
+    expect(handleCodexAppServerApprovalRequestMock.mock.calls[1]?.[0]).toMatchObject({
+      method: "item/fileChange/requestApproval",
+      requestParams: {
+        ...codexTestTurnIds("side-thread"),
+        itemId: "patch-side",
+        reason: "write memory/side.md",
+      },
+      fileChangeToolParams: { changes },
+      ...codexTestTurnIds("side-thread"),
     });
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayIdDuringFork!),

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -578,6 +578,10 @@ export async function runCodexAppServerSideQuestion(
           return handleCodexAppServerApprovalRequest({
             method: request.method,
             requestParams: request.params,
+            fileChangeToolParams:
+              request.method === "item/fileChange/requestApproval"
+                ? nativeToolLifecycleProjector?.takeFileChangeApprovalToolParams(request.params)
+                : undefined,
             paramsForRun: sideRunParams,
             threadId: childThreadId,
             turnId,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment if a related issue exists.
-->

> AI-assisted: implementation and review used AI coding assistance; the contributor reviewed the change and validated the behavior against Codex 0.150.1.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where OpenClaw integrations receiving an `apply_patch` approval could not see the actual files being changed. The approval hook received approval metadata but not the correlated file-change data, preventing integrations such as Memory Capture from identifying the affected files.

## Why This Change Was Made

Codex provides the actual changed-file data in the earlier `item/started` lifecycle event, while the later `item/fileChange/requestApproval` request contains the correlation IDs and approval metadata but not the changes payload. This change caches the earlier file-change data, matches it to the approval request by thread, turn, and item ID, and enriches the existing OpenClaw `before_tool_call` approval parameters with the matching normalized structured `changes`, preserving the original approval metadata (`threadId`, `turnId`, `itemId`, `reason`, `grantRoot`, and future fields).

The cache is scoped to one lifecycle projector, consumed once, and cleaned up on item completion, turn completion, and finalization. The same correlation owner is used by normal runs and side-question runs.

## Pinned Codex Contract

The current PR head `b3d5a676da85dab59bb23969641b1cc1ad640363` pins `@openai/codex` **0.150.1** in `extensions/codex/package.json`.

The exact release tag `rust-v0.150.1` resolves to Codex commit `90854393966b21e9ebfd21b122334eb09a20c93d`.

The tagged 0.150.1 source preserves the correlation contract used by this PR:

1. `item/started` emits a `fileChange` item with `changes` and `status: "inProgress"`.
2. `item/fileChange/requestApproval` follows with the same `itemId`, `threadId`, and `turnId`, but no `changes` payload.
3. The client returns the approval decision.
4. `serverRequest/resolved` follows.
5. `item/completed` returns the same file-change item with terminal status.

Exact tagged implementation:
- `codex-rs/app-server-protocol/src/protocol/item_builders.rs` lines 70–77 creates the FileChange item with `id: payload.call_id.clone()` and converted `payload.changes`.
- `codex-rs/app-server/src/bespoke_event_handling.rs` lines 576–589 handles `ApplyPatchApprovalRequest` by cloning the same `event.call_id` into `item_id`, then builds `FileChangeRequestApprovalParams` with thread/turn/item identity and no `changes` field.
- `codex-rs/app-server/README.md` lines 1753–1757 documents the same start → approval → decision → resolved → completed order.

Pinned sources:
https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/app-server-protocol/src/protocol/item_builders.rs#L70-L93
https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/app-server/src/bespoke_event_handling.rs#L576-L603
https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/app-server/README.md#file-change-approvals

## Real Behavior Evidence — Codex 0.150.1, Approval-Implementation Head

A disposable Linux Docker run exercised approval-implementation head:

`bf9d0633bdedcf873c1c4e954fc5ee78be2a52a3`

Current head `b3d5a676da85dab59bb23969641b1cc1ad640363` adds only a line-count-preserving refactor in `event-projector.ts` after current `main` independently reached the same 700-effective-line lint ceiling. The approval/correlation implementation and its dedicated tests are otherwise unchanged.

The run installed and executed the real bundled binary:

```text
Real Codex version: codex-cli 0.150.1
```

Runtime policy was deliberately approval-gated:

```text
approvalPolicy: on-request
sandbox: read-only
approvalsReviewer: user
model: gpt-5.6-sol
```

Temporary Codex auth was provided only to initialize the real client, then removed before the model-directed turn.

The exact runtime trace showed:

```text
seq 4   item/started
        type: fileChange
        itemId: <file-change-id>
        threadId: <thread-id>
        turnId: <turn-id>
        status: inProgress
        changes:
          - path: <workspace>/memory/pr125725-current-head.txt
            kind: { type: add }

seq 5   item/fileChange/requestApproval
        itemId: <same-file-change-id>
        threadId: <same-thread-id>
        turnId: <same-turn-id>
        containsChanges: false

seq 6   OpenClaw before_tool_call
        toolName: apply_patch
        toolCallId: <same-file-change-id>
        params:
          threadId: <same-thread-id>
          turnId: <same-turn-id>
          itemId: <same-file-change-id>
          changes:
            - path: <workspace>/memory/pr125725-current-head.txt
              kind: { type: add }

seq 7   codex_file_approval requested
        allowedDecisions: [allow-once, allow-always, deny]

seq 9   operator decision: allow-once
seq 10  approval resolved: approved
seq 11  serverRequest/resolved

seq 12  item/completed
        itemId: <same-file-change-id>
        threadId: <same-thread-id>
        turnId: <same-turn-id>
        status: completed

seq 13  turn/completed
```

The resulting file was verified with exact contents:

```text
PR125725_CURRENT_HEAD_OK
```

The proof assertions all passed:
- the runtime-proof checkout exactly matched `bf9d0633bdedcf873c1c4e954fc5ee78be2a52a3`;
- bundled Codex and real server version were both `0.150.1`;
- file-change start and approval request used matching thread, turn, and item IDs;
- the approval request itself contained no `changes`;
- OpenClaw `before_tool_call` preserved the approval metadata present on the real request and added the correlated normalized `changes`;
- exactly one operator approval was requested;
- the operator decision was `allow-once`;
- the file-change completed successfully;
- the turn completed successfully;
- temporary auth had been removed before the model turn;
- the PR checkout remained unchanged;
- nothing was pushed by the proof run.

Regression coverage additionally verifies preservation of `reason`, `grantRoot`, and an unknown future approval field alongside `threadId`, `turnId`, `itemId`, and normalized `changes`.

## Fresh Current-Main Integration Validation — Current Head

Current head `b3d5a676da85dab59bb23969641b1cc1ad640363` was merged without conflict into fresh OpenClaw main `f265c0dfb16301ddc6d0390b376be9fde197197d` in a disposable Docker checkout.

This validation was added because current main and the PR independently sat at the 700-effective-line limit for `event-projector.ts`; their clean merge initially reached 702 lines. The current head removes an avoidable private helper and inlines its unchanged turn-ID predicate at the two existing call sites.

Validation on the fresh merge:

- `git diff --check`: pass;
- formatting check for `event-projector.ts`: pass;
- `event-projector.replay-safety.test.ts` plus `event-projector.file-change-approval.test.ts`: **18/18 passed**;
- full extension lint: **0 warnings, 0 errors**;
- the preceding identical focused-suite comparison found **0 additional failures introduced by the PR** relative to the locked current-main baseline;
- the two approval-bridge failures present on current main were removed by the PR merge, while the remaining native-relay assertion failure was identical to current main;
- host checkout remained unchanged during disposable validation.

## User Impact

OpenClaw integrations using `before_tool_call` can receive the actual files associated with an `apply_patch` approval.

This allows approval hooks and integrations such as Memory Capture to identify the files involved in the requested change. Command approvals, permission approvals, plugin approval UX, and unrelated tool behavior remain on their existing paths.

## Evidence

- Current PR head: `b3d5a676da85dab59bb23969641b1cc1ad640363`.
- Exact tested base at rebase time: OpenClaw main `6c10672d95072cc1a4b645c519a4513621cd940a`.
- Current OpenClaw main still declares `@openai/codex` 0.150.1.
- Exact Codex tag `rust-v0.150.1` resolves to `90854393966b21e9ebfd21b122334eb09a20c93d`.
- Tagged 0.150.1 source confirms identical FileChange/approval call-ID correlation and approval payload shape.
- Real Codex 0.150.1 app-server file edit passed on approval-implementation head `bf9d0633bdedcf873c1c4e954fc5ee78be2a52a3`; current head `b3d5a676da85dab59bb23969641b1cc1ad640363` changes only the snapshot-turn helper shape needed to keep the fresh merge within the lint limit.
- Exact runtime trace on `bf9d0633bdedcf873c1c4e954fc5ee78be2a52a3` verified `item/started` → matching `item/fileChange/requestApproval` → metadata-preserving correlated `before_tool_call` → operator `allow-once` → `serverRequest/resolved` → matching `item/completed` → turn completion.
- Approval request verified to omit `changes`; on runtime-proof head `bf9d0633bdedcf873c1c4e954fc5ee78be2a52a3` the hook preserved the real request metadata (`threadId`, `turnId`, `itemId`) and added correlated normalized `changes`. Regression coverage also preserves `reason`, `grantRoot`, and unknown future fields.
- Real current-head file edit completed and exact resulting contents `PR125725_CURRENT_HEAD_OK\n` were verified.
- Current compatibility regression verifies `threadId`, `turnId`, `itemId`, `reason`, `grantRoot`, an unknown future approval field, and normalized `changes` are all preserved together.
- Fresh Docker full extension lint passed with 0 warnings and 0 errors after the production compatibility repair.
- Full approval-bridge suite passed 104/104 after the compatibility repair.
- Approval-bridge file decision regression passed.
- File-change correlation regression passed.
- Dedicated native approval relay regression passed.
- Native relay file passed 22/22 with the Windows `gh` executable-resolution preflight satisfied.
- Side-question file-change correlation regression passed.
- Exact thread, turn, and item correlation tested.
- Isolation between separate approval requests tested.
- Cleanup after consumption, item completion, turn completion, and finalization tested.
- `git diff --check` passed.
- Official OpenClaw `autoreview` passed on exact current head in one bounded P0 Codex pass (`gpt-5.6-sol`, high reasoning): `autoreview clean: no accepted/actionable findings reported`; overall assessment `patch is correct (0.97)`. The disposable review used current upstream main `8e4eb78fa20b12a700cb60507fd15442b4c1c018` as its review base, and the host checkout remained unchanged.
- The PR remains exactly 11 changed files.

## Scope

The implementation is contained within the Codex app-server approval and lifecycle paths. It does not change OpenClaw's installation model, providers/models, unrelated plugins, or other runtime subsystems.