### PR TITLE
test: pin model-selection path behavior incl. divergences

### DIFF
--- a/src/agents/command/model-selection.turn-model-differential.test.ts
+++ b/src/agents/command/model-selection.turn-model-differential.test.ts
@@ -1,0 +1,217 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  TURN_MODEL_DEFAULT_REF,
+  TURN_MODEL_DIFFERENTIAL_FIXTURES,
+  TURN_MODEL_OVERRIDE_REF,
+  turnModelRefLabel,
+  turnModelVerdict,
+  type TurnModelDifferentialFixture,
+} from "../../test-utils/turn-model-selection-differential.js";
+import type { AgentCommandOpts, AgentRunContext } from "./types.js";
+
+vi.mock("../agent-scope.js", () => ({
+  clearAutoFallbackPrimaryProbeSelection: vi.fn(),
+  hasLegacyAutoFallbackWithoutOrigin: () => false,
+  hasSessionAutoModelFallbackProvenance: () => false,
+  resolveAutoFallbackPrimaryProbe: () => undefined,
+  resolveAgentConfig: () => undefined,
+  resolveAgentEffectiveModelPrimary: () => undefined,
+}));
+vi.mock("../../channels/model-overrides.js", () => ({
+  resolveChannelModelOverride: (params: {
+    cfg: OpenClawConfig;
+    channel?: string | null;
+    groupId?: string | null;
+    groupChatType?: string | null;
+    groupChannel?: string | null;
+    groupSubject?: string | null;
+    directUserIds?: (string | null | undefined)[];
+  }) => {
+    const channel = params.channel?.trim().toLowerCase();
+    const entries = channel ? params.cfg.channels?.modelByChannel?.[channel] : undefined;
+    if (!channel || !entries) {
+      return null;
+    }
+    const candidates =
+      params.groupChatType === "direct"
+        ? [params.groupId, ...(params.directUserIds ?? [])]
+        : [params.groupId, params.groupChannel, params.groupSubject];
+    const matchKey = candidates.find((candidate) => candidate && entries[candidate] !== undefined);
+    const wildcard = entries["*"];
+    const model = matchKey ? entries[matchKey] : wildcard;
+    return model
+      ? { channel, model, matchKey: matchKey ?? "*", matchSource: matchKey ? "exact" : "wildcard" }
+      : null;
+  },
+}));
+
+vi.mock("../auth-profiles/order.js", () => ({
+  isStoredCredentialCompatibleWithAuthProvider: () => true,
+}));
+vi.mock("../auth-profiles/session-override.js", () => ({
+  clearSessionAuthProfileOverride: vi.fn(async () => undefined),
+}));
+vi.mock("../auth-profiles/store.js", () => ({
+  ensureAuthProfileStore: () => ({ profiles: {} }),
+}));
+vi.mock("../harness/runtime-plugin.js", () => ({
+  ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+}));
+vi.mock("../harness/selection.js", () => ({
+  resolveAvailableAgentHarnessPolicy: () => ({ runtime: "openclaw" }),
+}));
+vi.mock("../model-catalog.js", () => ({ loadManifestModelCatalog: () => [] }));
+vi.mock("../model-selection.js", () => ({
+  modelKey: (provider: string, model: string) => `${provider}/${model}`,
+  resolveDefaultModelForAgent: ({ cfg }: { cfg: OpenClawConfig }) => {
+    const configured = cfg.agents?.defaults?.model;
+    const raw =
+      typeof configured === "string"
+        ? configured
+        : (configured?.primary ?? turnModelRefLabel(TURN_MODEL_DEFAULT_REF));
+    const slash = raw.indexOf("/");
+    return slash > 0
+      ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
+      : { provider: TURN_MODEL_DEFAULT_REF.provider, model: raw };
+  },
+  resolveModelAliasFromPair: () => null,
+  resolveThinkingDefault: () => "off",
+}));
+vi.mock("../model-thinking-default.js", () => ({
+  resolveConfiguredThinkingDefault: () => undefined,
+}));
+vi.mock("../model-visibility-policy.js", () => ({
+  createModelVisibilityPolicy: () => ({
+    allowAny: true,
+    allowedCatalog: [],
+    selectionAliasIndex: { byAlias: new Map(), byKey: new Map() },
+    allowsKey: () => true,
+    resolveSelection: (ref: { provider: string; model: string }) => ref,
+  }),
+}));
+vi.mock("../openai-routing.js", () => ({
+  listOpenAIAuthProfileProvidersForAgentRuntime: ({ provider }: { provider: string }) => [provider],
+}));
+vi.mock("../provider-auth-aliases.js", () => ({
+  resolveProviderIdForAuth: (provider: string) => provider,
+}));
+vi.mock("../session-runtime-compat.js", () => ({
+  resolveSessionRuntimeOverrideForProvider: () => undefined,
+}));
+vi.mock("../thinking-runtime.js", () => ({
+  hasResolvedThinkingCatalogEntry: () => false,
+  normalizeThinkingCatalogProviders: (catalog: unknown) => catalog,
+  resolveEffectiveAgentRuntime: () => undefined,
+}));
+vi.mock("../../plugins/runtime.js", () => ({ requireActivePluginRegistry: () => ({}) }));
+vi.mock("../../sessions/agent-harness-session-key.js", () => ({
+  isValidAgentHarnessSessionStoreEntry: () => false,
+}));
+vi.mock("../../sessions/model-overrides.js", () => ({
+  applyModelOverrideToSessionEntry: () => ({ updated: false }),
+  isModelSelectionLocked: (entry?: SessionEntry) => entry?.modelSelectionLocked === true,
+  ModelSelectionLockedError: class ModelSelectionLockedError extends Error {},
+  repairProviderWrappedModelOverride: () => ({ updated: false }),
+}));
+vi.mock("./attempt-execution.shared.js", () => ({
+  persistAgentSession: async ({ entry }: { entry?: SessionEntry }) => entry,
+}));
+vi.mock("./model-ref.js", () => ({
+  normalizeAgentCommandDefaultModelRef: (
+    _cfg: OpenClawConfig,
+    provider: string,
+    model: string,
+  ) => ({ provider, model }),
+  normalizeAgentCommandModelRef: (_cfg: OpenClawConfig, provider: string, model: string) => ({
+    provider,
+    model,
+  }),
+  parseAgentCommandModelRef: (_cfg: OpenClawConfig, raw: string, defaultProvider: string) => {
+    const slash = raw.indexOf("/");
+    return slash > 0
+      ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
+      : { provider: defaultProvider, model: raw };
+  },
+}));
+vi.mock("./prepare.js", () => ({
+  normalizeExplicitOverrideInput: (value: string) => value.trim() || undefined,
+}));
+vi.mock("./runtime-loaders.js", () => ({
+  loadTranscriptResolveRuntime: async () => ({
+    resolveSessionTranscriptFile: async (params: { sessionEntry?: SessionEntry }) => ({
+      sessionEntry: params.sessionEntry,
+      sessionFile: "/tmp/turn-model-session.jsonl",
+    }),
+  }),
+}));
+
+const { resolveEmbeddedModelSelection } = await import("./model-selection.js");
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createConfig(fixture: TurnModelDifferentialFixture): OpenClawConfig {
+  return {
+    agents: { defaults: { model: { primary: turnModelRefLabel(TURN_MODEL_DEFAULT_REF) } } },
+    channels: fixture.modelByChannel ? { modelByChannel: fixture.modelByChannel } : undefined,
+  } as OpenClawConfig;
+}
+
+async function observeCommandSelection(fixture: TurnModelDifferentialFixture) {
+  const sessionKey = "agent:main:telegram:group:selection";
+  const sessionStore: Record<string, SessionEntry> = { [sessionKey]: fixture.child };
+  if (fixture.parent) {
+    sessionStore[fixture.parent.key] = fixture.parent.entry;
+  }
+  const opts: AgentCommandOpts = {
+    message: "hello",
+    to: "target",
+    channel: fixture.ctx.Provider,
+    messageChannel: fixture.ctx.Provider,
+    groupId: fixture.child.groupId,
+    groupChannel: fixture.child.groupChannel,
+    ...(fixture.heartbeat
+      ? {
+          provider: TURN_MODEL_OVERRIDE_REF.provider,
+          model: TURN_MODEL_OVERRIDE_REF.model,
+          allowModelOverride: true,
+        }
+      : {}),
+  };
+  const runContext: AgentRunContext = {
+    messageChannel: fixture.ctx.Provider,
+    groupId: fixture.child.groupId,
+    groupChannel: fixture.child.groupChannel,
+    currentChannelId: "target",
+  };
+  const selection = await resolveEmbeddedModelSelection({
+    cfg: createConfig(fixture),
+    opts,
+    sessionEntry: fixture.child,
+    sessionStore,
+    sessionKey,
+    sessionId: fixture.child.sessionId,
+    storePath: path.join(tempDirs.make("turn-model-command-"), "sessions.json"),
+    sessionAgentId: "main",
+    workspaceDir: tempDirs.make("turn-model-command-workspace-"),
+    pluginsEnabled: false,
+    modelManifestContext: {},
+    configuredThinkingCatalog: [],
+    isSubagentLane: false,
+    suppressVisibleSessionEffects: true,
+    runContext,
+  });
+  return turnModelVerdict(
+    { provider: selection.provider, model: selection.model },
+    fixture.locked ? "locked" : fixture.heartbeat ? "explicit" : undefined,
+  );
+}
+
+describe("turn model selection command-path differential", () => {
+  it.each(TURN_MODEL_DIFFERENTIAL_FIXTURES)("pins observed $name behavior", async (fixture) => {
+    await expect(observeCommandSelection(fixture)).resolves.toEqual(fixture.expected.command);
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { AgentHarness } from "../../agents/harness/types.js";
 import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
@@ -54,7 +55,7 @@ function observeHarnessSelection(fixture: TurnModelDifferentialFixture): TurnMod
   const storePath = path.join(tempDirs.make("turn-model-harness-"), "sessions.json");
   const sessionKey = "agent:main:telegram:group:selection";
   replaceSessionEntrySync({ agentId: "main", storePath, sessionKey }, fixture.child);
-  const sessionStore = { [sessionKey]: fixture.child };
+  const sessionStore: Record<string, SessionEntry> = { [sessionKey]: fixture.child };
   if (fixture.parent) {
     replaceSessionEntrySync(
       { agentId: "main", storePath, sessionKey: fixture.parent.key },

--- a/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { AgentHarness } from "../../agents/harness/types.js";
+import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import {
+  TURN_MODEL_DEFAULT_REF,
+  TURN_MODEL_DIFFERENTIAL_FIXTURES,
+  TURN_MODEL_OVERRIDE_REF,
+  turnModelRefLabel,
+  turnModelVerdict,
+  type TurnModelDifferentialFixture,
+  type TurnModelSelectionVerdict,
+} from "../../test-utils/turn-model-selection-differential.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+const selectAgentHarnessMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/harness/selection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/harness/selection.js")>();
+  return {
+    ...actual,
+    selectAgentHarness: (...args: unknown[]) => selectAgentHarnessMock(...args),
+  };
+});
+
+const { resolveVisibleRepliesPolicy } = await import("./dispatch-from-config.harness-defaults.js");
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const recorderHarness = {
+  id: "turn-model-recorder",
+  label: "Turn model recorder",
+  deliveryDefaults: { visibleReplies: "automatic" },
+  supports: () => ({ supported: true as const, priority: 1 }),
+  runAttempt: vi.fn(async () => ({}) as never),
+} satisfies AgentHarness;
+
+function createConfig(
+  storePath: string,
+  modelByChannel: TurnModelDifferentialFixture["modelByChannel"],
+): OpenClawConfig {
+  return {
+    session: { store: storePath },
+    agents: { defaults: { model: { primary: turnModelRefLabel(TURN_MODEL_DEFAULT_REF) } } },
+    channels: modelByChannel ? { modelByChannel } : undefined,
+  } as OpenClawConfig;
+}
+
+function observeHarnessSelection(fixture: TurnModelDifferentialFixture): TurnModelSelectionVerdict {
+  const storePath = path.join(tempDirs.make("turn-model-harness-"), "sessions.json");
+  const sessionKey = "agent:main:telegram:group:selection";
+  replaceSessionEntrySync({ agentId: "main", storePath, sessionKey }, fixture.child);
+  const sessionStore = { [sessionKey]: fixture.child };
+  if (fixture.parent) {
+    replaceSessionEntrySync(
+      { agentId: "main", storePath, sessionKey: fixture.parent.key },
+      fixture.parent.entry,
+    );
+    sessionStore[fixture.parent.key] = fixture.parent.entry;
+  }
+
+  selectAgentHarnessMock.mockClear();
+  resolveVisibleRepliesPolicy({
+    cfg: createConfig(storePath, fixture.modelByChannel),
+    // Visible-reply defaults are queried only for direct delivery. The stored
+    // chat type still drives the real channel matcher for group fixtures.
+    chatType: "direct",
+    ctx: buildTestCtx({ SessionKey: sessionKey, ...fixture.ctx }),
+    entry: fixture.child,
+    sessionAgentId: "main",
+    sessionKey,
+    sessionStore,
+    turnModelOverride: fixture.heartbeat ? turnModelRefLabel(TURN_MODEL_OVERRIDE_REF) : undefined,
+  });
+  const call = selectAgentHarnessMock.mock.calls.at(-1)?.[0] as
+    | { provider: string; modelId?: string }
+    | undefined;
+  if (!call?.modelId) {
+    throw new Error(`harness path did not select a model for ${fixture.name}`);
+  }
+  return turnModelVerdict(
+    { provider: call.provider, model: call.modelId },
+    fixture.locked ? "locked" : undefined,
+  );
+}
+
+describe("turn model selection harness-path differential", () => {
+  beforeEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createSessionConversationTestRegistry());
+    selectAgentHarnessMock.mockImplementation(() => recorderHarness);
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it.each(TURN_MODEL_DIFFERENTIAL_FIXTURES)("pins observed $name behavior", (fixture) => {
+    expect(observeHarnessSelection(fixture)).toEqual(fixture.expected.harness);
+  });
+});

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.turn-model-differential.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.turn-model-differential.test.ts
@@ -1,0 +1,157 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as preparedModelCatalog from "../../agents/prepared-model-catalog.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import {
+  TURN_MODEL_DEFAULT_REF,
+  TURN_MODEL_DIFFERENTIAL_FIXTURES,
+  TURN_MODEL_OVERRIDE_REF,
+  turnModelRefLabel,
+  turnModelVerdict,
+  type TurnModelDifferentialFixture,
+  type TurnModelSelectionVerdict,
+} from "../../test-utils/turn-model-selection-differential.js";
+import { markCompleteReplyConfig } from "./get-reply-fast-path.test-support.js";
+import { buildTestCtx } from "./test-ctx.js";
+import type { TypingController } from "./typing.js";
+
+const buildStatusReplyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./commands-status.js", () => ({
+  buildStatusReply: (...args: unknown[]) => buildStatusReplyMock(...args),
+}));
+
+const { maybeResolveNativeSlashCommandFastReply } =
+  await import("./get-reply-native-slash-fast-path.js");
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createTypingController(): TypingController {
+  return {
+    onReplyStart: async () => {},
+    startTypingLoop: async () => {},
+    startTypingOnText: async () => {},
+    refreshTypingTtl: () => {},
+    isActive: () => false,
+    markRunComplete: () => {},
+    markDispatchIdle: () => {},
+    cleanup: vi.fn(),
+  };
+}
+
+async function seedFixture(
+  storePath: string,
+  sessionKey: string,
+  fixture: TurnModelDifferentialFixture,
+): Promise<void> {
+  await replaceSessionEntry({ agentId: "main", storePath, sessionKey }, fixture.child);
+  if (fixture.parent) {
+    await replaceSessionEntry(
+      { agentId: "main", storePath, sessionKey: fixture.parent.key },
+      fixture.parent.entry,
+    );
+  }
+}
+
+function createConfig(
+  storePath: string,
+  modelByChannel: TurnModelDifferentialFixture["modelByChannel"],
+): OpenClawConfig {
+  return markCompleteReplyConfig({
+    session: { store: storePath },
+    agents: {
+      defaults: {
+        model: { primary: turnModelRefLabel(TURN_MODEL_DEFAULT_REF) },
+        modelPolicy: { allow: ["*/*"] },
+      },
+    },
+    channels: modelByChannel ? { modelByChannel } : undefined,
+  } as OpenClawConfig);
+}
+
+async function observeStatusSelection(
+  fixture: TurnModelDifferentialFixture,
+): Promise<TurnModelSelectionVerdict> {
+  const storePath = path.join(tempDirs.make("turn-model-status-"), "sessions.json");
+  const sessionKey = "agent:main:telegram:group:selection";
+  await seedFixture(storePath, sessionKey, fixture);
+  const cfg = createConfig(storePath, fixture.modelByChannel);
+
+  buildStatusReplyMock.mockClear();
+  buildStatusReplyMock.mockResolvedValue({ text: "status" });
+  await maybeResolveNativeSlashCommandFastReply({
+    ctx: buildTestCtx({
+      Body: "/status",
+      BodyForAgent: "/status",
+      RawBody: "/status",
+      CommandBody: "/status",
+      CommandSource: "native",
+      CommandAuthorized: true,
+      SessionKey: "telegram:slash:selection",
+      CommandTargetSessionKey: sessionKey,
+      CommandTurn: {
+        kind: "native",
+        source: "native",
+        authorized: true,
+        commandName: "status",
+        body: "/status",
+      },
+      ...fixture.ctx,
+    }),
+    cfg,
+    agentId: "main",
+    agentDir: "/tmp/agent",
+    agentCfg: undefined,
+    commandAuthorized: true,
+    defaultProvider: TURN_MODEL_DEFAULT_REF.provider,
+    defaultModel: TURN_MODEL_DEFAULT_REF.model,
+    aliasIndex: { byAlias: new Map(), byKey: new Map() },
+    provider: fixture.heartbeat
+      ? TURN_MODEL_OVERRIDE_REF.provider
+      : TURN_MODEL_DEFAULT_REF.provider,
+    model: fixture.heartbeat ? TURN_MODEL_OVERRIDE_REF.model : TURN_MODEL_DEFAULT_REF.model,
+    workspaceDir: "/tmp/workspace",
+    typing: createTypingController(),
+  });
+
+  const call = buildStatusReplyMock.mock.calls[0]?.[0] as
+    | { provider: string; model: string; sessionEntry?: SessionEntry }
+    | undefined;
+  if (!call) {
+    throw new Error(`status path did not build a reply for ${fixture.name}`);
+  }
+  const ref = call.sessionEntry?.modelOverride
+    ? {
+        provider: call.sessionEntry.providerOverride ?? call.provider,
+        model: call.sessionEntry.modelOverride,
+      }
+    : { provider: call.provider, model: call.model };
+  return turnModelVerdict(
+    ref,
+    fixture.locked ? "locked" : fixture.heartbeat ? "heartbeat" : undefined,
+  );
+}
+
+describe("turn model selection status-path differential", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createSessionConversationTestRegistry());
+    vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalog").mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.each(TURN_MODEL_DIFFERENTIAL_FIXTURES)("pins observed $name behavior", async (fixture) => {
+    await expect(observeStatusSelection(fixture)).resolves.toEqual(fixture.expected.status);
+  });
+});

--- a/src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts
@@ -1,0 +1,291 @@
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  TURN_MODEL_CHANNEL_REF,
+  TURN_MODEL_DEFAULT_REF,
+  TURN_MODEL_DIFFERENTIAL_FIXTURES,
+  TURN_MODEL_LIVE_CHANNEL_REF,
+  TURN_MODEL_OVERRIDE_REF,
+  TURN_MODEL_PERSISTED_CHANNEL_REF,
+  TURN_MODEL_PERSISTED_PEER_REF,
+  TURN_MODEL_SESSION_REF,
+  createTurnModelEntry,
+  turnModelRefLabel,
+  turnModelVerdict,
+  type TurnModelDifferentialFixture,
+  type TurnModelSelectionPath,
+  type TurnModelSelectionVerdict,
+} from "../../test-utils/turn-model-selection-differential.js";
+import { markCompleteReplyConfig } from "./get-reply-fast-path.test-support.js";
+import {
+  buildGetReplyCtx,
+  createGetReplyContinueDirectivesResult,
+  createGetReplySessionState,
+  registerGetReplyBaselineBypass,
+  registerGetReplyRuntimeOverrides,
+} from "./get-reply.test-fixtures.js";
+import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
+import "./get-reply.test-runtime-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  handleInlineActions: vi.fn(),
+  initSessionState: vi.fn(),
+  resolveReplyDirectives: vi.fn(),
+}));
+
+registerGetReplyBaselineBypass();
+registerGetReplyRuntimeOverrides(mocks);
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
+let resolveChannelModelOverrideMock: typeof import("../../channels/model-overrides.js").resolveChannelModelOverride;
+let resolveModelRefFromStringMock: typeof import("../../agents/model-selection.js").resolveModelRefFromString;
+let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
+
+function createConfig(params: {
+  storePath: string;
+  modelByChannel?: Record<string, Record<string, string>>;
+}): OpenClawConfig {
+  return markCompleteReplyConfig({
+    session: { store: params.storePath },
+    agents: {
+      defaults: {
+        model: { primary: turnModelRefLabel(TURN_MODEL_DEFAULT_REF) },
+        modelPolicy: { allow: ["*/*"] },
+      },
+    },
+    channels: params.modelByChannel ? { modelByChannel: params.modelByChannel } : undefined,
+  } as OpenClawConfig);
+}
+
+async function seedFixtureStore(
+  storePath: string,
+  sessionKey: string,
+  fixture: Pick<TurnModelDifferentialFixture, "child" | "parent">,
+): Promise<Record<string, SessionEntry>> {
+  const store: Record<string, SessionEntry> = { [sessionKey]: fixture.child };
+  replaceSessionEntrySync({ storePath, sessionKey }, fixture.child);
+  if (fixture.parent) {
+    store[fixture.parent.key] = fixture.parent.entry;
+    replaceSessionEntrySync({ storePath, sessionKey: fixture.parent.key }, fixture.parent.entry);
+  }
+  return store;
+}
+
+async function observeReplySelection(params: {
+  fixture: TurnModelDifferentialFixture;
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  sessionStore: Record<string, SessionEntry>;
+}): Promise<TurnModelSelectionVerdict> {
+  const { fixture, cfg, sessionKey, sessionStore } = params;
+  mocks.initSessionState.mockResolvedValue(
+    createGetReplySessionState({
+      sessionCtx: fixture.ctx,
+      sessionEntry: fixture.child,
+      sessionStore,
+      sessionKey,
+      sessionId: fixture.child.sessionId,
+      storePath: cfg.session?.store,
+      groupResolution:
+        fixture.child.chatType === "group"
+          ? { channel: undefined, id: fixture.child.groupId, type: "group" }
+          : undefined,
+      isGroup: fixture.child.chatType === "group",
+      triggerBodyNormalized: "hello",
+      bodyStripped: "hello",
+    }),
+  );
+  vi.mocked(runPreparedReplyMock).mockClear();
+  await getReplyFromConfig(
+    buildGetReplyCtx({ SessionKey: sessionKey, ...fixture.ctx }),
+    fixture.heartbeat
+      ? {
+          isHeartbeat: true,
+          heartbeatModelOverride: turnModelRefLabel(TURN_MODEL_OVERRIDE_REF),
+        }
+      : undefined,
+    cfg,
+  );
+  const selected = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
+  if (!selected) {
+    throw new Error(`reply path did not prepare a run for ${fixture.name}`);
+  }
+  return turnModelVerdict(
+    { provider: selected.provider, model: selected.model },
+    fixture.locked ? "locked" : undefined,
+  );
+}
+
+beforeAll(async () => {
+  ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ resolveDefaultModel: resolveDefaultModelMock } =
+    await import("./directive-handling.defaults.js"));
+  ({ resolveChannelModelOverride: resolveChannelModelOverrideMock } =
+    await import("../../channels/model-overrides.js"));
+  ({ resolveModelRefFromString: resolveModelRefFromStringMock } =
+    await import("../../agents/model-selection.js"));
+  ({ runPreparedReply: runPreparedReplyMock } = await import("./get-reply-run.js"));
+});
+
+beforeEach(async () => {
+  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+  const actualChannelModel = await vi.importActual<
+    typeof import("../../channels/model-overrides.js")
+  >("../../channels/model-overrides.js");
+  const actualModelSelection = await vi.importActual<
+    typeof import("../../agents/model-selection.js")
+  >("../../agents/model-selection.js");
+  vi.mocked(resolveChannelModelOverrideMock).mockImplementation(
+    actualChannelModel.resolveChannelModelOverride,
+  );
+  vi.mocked(resolveModelRefFromStringMock).mockImplementation(
+    actualModelSelection.resolveModelRefFromString,
+  );
+  vi.mocked(resolveDefaultModelMock).mockReturnValue({
+    defaultProvider: TURN_MODEL_DEFAULT_REF.provider,
+    defaultModel: TURN_MODEL_DEFAULT_REF.model,
+    aliasIndex: actualModelSelection.buildModelAliasIndex({
+      cfg: {},
+      defaultProvider: TURN_MODEL_DEFAULT_REF.provider,
+    }),
+  });
+  mocks.resolveReplyDirectives.mockImplementation(async (input: unknown) => {
+    const params = input as {
+      provider: string;
+      model: string;
+      sessionKey: string;
+      triggerBodyNormalized: string;
+    };
+    return createGetReplyContinueDirectivesResult({
+      body: params.triggerBodyNormalized,
+      abortKey: params.sessionKey,
+      from: "sender",
+      to: "target",
+      senderId: "sender",
+      commandSource: "text",
+      senderIsOwner: true,
+      resetHookTriggered: false,
+      provider: params.provider,
+      model: params.model,
+    });
+  });
+  mocks.handleInlineActions.mockImplementation(async (input: unknown) => {
+    const params = input as { directives?: unknown; cleanedBody?: string };
+    return {
+      kind: "continue",
+      directives: params.directives ?? {},
+      cleanedBody: params.cleanedBody ?? "hello",
+      abortedLastRun: false,
+    };
+  });
+  vi.mocked(runPreparedReplyMock).mockResolvedValue({ text: "ok" });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getReplyFromConfig channel model input boundary", () => {
+  const matrix = [
+    {
+      name: "child stored override",
+      childOverride: TURN_MODEL_SESSION_REF,
+      expected: TURN_MODEL_SESSION_REF,
+    },
+    {
+      name: "persisted direct peer",
+      directUserId: "persisted-peer",
+      expected: TURN_MODEL_PERSISTED_PEER_REF,
+    },
+    {
+      name: "persisted delivery channel exact conversation",
+      expected: TURN_MODEL_PERSISTED_CHANNEL_REF,
+    },
+    {
+      name: "live channel exact conversation",
+      omitPersistedChannel: true,
+      expected: TURN_MODEL_LIVE_CHANNEL_REF,
+    },
+    {
+      name: "parent conversation key",
+      groupId: "unmatched",
+      groupChannel: "parent-room",
+      expected: TURN_MODEL_CHANNEL_REF,
+    },
+    {
+      name: "wildcard",
+      groupId: "unmatched",
+      expected: TURN_MODEL_CHANNEL_REF,
+    },
+    {
+      name: "default",
+      groupId: "unmatched",
+      omitChannelConfig: true,
+      expected: TURN_MODEL_DEFAULT_REF,
+    },
+  ] as const;
+
+  it.each(matrix)("selects $name", async (testCase) => {
+    const storePath = path.join(tempDirs.make("turn-model-reply-matrix-"), "sessions.json");
+    const sessionKey = "agent:main:telegram:group:room";
+    const child = createTurnModelEntry({
+      channel: testCase.omitPersistedChannel ? undefined : "discord",
+      chatType: testCase.directUserId ? "direct" : "group",
+      groupId: testCase.directUserId ? undefined : (testCase.groupId ?? "room"),
+      groupChannel: testCase.groupChannel,
+      directUserId: testCase.directUserId,
+      override: testCase.childOverride,
+    });
+    const fixture: TurnModelDifferentialFixture = {
+      name: testCase.name,
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        OriginatingChannel: "telegram",
+        ChatType: testCase.directUserId ? "direct" : "group",
+        SenderId: "live-peer",
+      },
+      child,
+      modelByChannel: testCase.omitChannelConfig
+        ? undefined
+        : {
+            discord: {
+              room: turnModelRefLabel(TURN_MODEL_PERSISTED_CHANNEL_REF),
+              "persisted-peer": turnModelRefLabel(TURN_MODEL_PERSISTED_PEER_REF),
+              "parent-room": turnModelRefLabel(TURN_MODEL_CHANNEL_REF),
+              "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF),
+            },
+            telegram: {
+              room: turnModelRefLabel(TURN_MODEL_LIVE_CHANNEL_REF),
+              "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF),
+            },
+          },
+      expected: {} as Record<TurnModelSelectionPath, TurnModelSelectionVerdict>,
+    };
+    const sessionStore = await seedFixtureStore(storePath, sessionKey, fixture);
+    const cfg = createConfig({ storePath, modelByChannel: fixture.modelByChannel });
+    await expect(
+      observeReplySelection({ fixture, cfg, sessionKey, sessionStore }),
+    ).resolves.toEqual(turnModelVerdict(testCase.expected));
+  });
+});
+
+describe("turn model selection reply-path differential", () => {
+  it.each(TURN_MODEL_DIFFERENTIAL_FIXTURES)("pins observed $name behavior", async (fixture) => {
+    const storePath = path.join(tempDirs.make("turn-model-differential-"), "sessions.json");
+    const sessionKey = "agent:main:telegram:group:selection";
+    const sessionStore = await seedFixtureStore(storePath, sessionKey, fixture);
+    const cfg = createConfig({ storePath, modelByChannel: fixture.modelByChannel });
+
+    await expect(
+      observeReplySelection({ fixture, cfg, sessionKey, sessionStore }),
+    ).resolves.toEqual(fixture.expected.reply);
+  });
+});

--- a/src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { ModelRef } from "../../agents/model-ref-shared.js";
 import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -193,7 +194,16 @@ afterEach(() => {
 });
 
 describe("getReplyFromConfig channel model input boundary", () => {
-  const matrix = [
+  const matrix: Array<{
+    name: string;
+    childOverride?: ModelRef;
+    directUserId?: string;
+    groupId?: string;
+    groupChannel?: string;
+    omitPersistedChannel?: boolean;
+    omitChannelConfig?: boolean;
+    expected: ModelRef;
+  }> = [
     {
       name: "child stored override",
       childOverride: TURN_MODEL_SESSION_REF,
@@ -230,7 +240,7 @@ describe("getReplyFromConfig channel model input boundary", () => {
       omitChannelConfig: true,
       expected: TURN_MODEL_DEFAULT_REF,
     },
-  ] as const;
+  ];
 
   it.each(matrix)("selects $name", async (testCase) => {
     const storePath = path.join(tempDirs.make("turn-model-reply-matrix-"), "sessions.json");

--- a/src/test-utils/turn-model-selection-differential.ts
+++ b/src/test-utils/turn-model-selection-differential.ts
@@ -3,7 +3,7 @@ import type { FinalizedMsgContext } from "../auto-reply/templating.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 
-export type TurnModelSelectionSource =
+type TurnModelSelectionSource =
   | "locked"
   | "explicit"
   | "heartbeat"
@@ -21,9 +21,9 @@ export const TURN_MODEL_CHANNEL_REF = {
   model: "channel-model",
 } as const;
 export const TURN_MODEL_SESSION_REF = { provider: "google", model: "session-model" } as const;
-export const TURN_MODEL_PARENT_REF = { provider: "xai", model: "parent-model" } as const;
+const TURN_MODEL_PARENT_REF = { provider: "xai", model: "parent-model" } as const;
 export const TURN_MODEL_OVERRIDE_REF = { provider: "mistral", model: "turn-model" } as const;
-export const TURN_MODEL_LOCKED_REF = { provider: "cohere", model: "locked-model" } as const;
+const TURN_MODEL_LOCKED_REF = { provider: "cohere", model: "locked-model" } as const;
 export const TURN_MODEL_PERSISTED_CHANNEL_REF = {
   provider: "anthropic",
   model: "persisted-channel-model",
@@ -36,11 +36,11 @@ export const TURN_MODEL_PERSISTED_PEER_REF = {
   provider: "xai",
   model: "persisted-peer-model",
 } as const;
-export const TURN_MODEL_LIVE_PEER_REF = {
+const TURN_MODEL_LIVE_PEER_REF = {
   provider: "mistral",
   model: "live-peer-model",
 } as const;
-export const TURN_MODEL_COMMAND_STALE_PEER_REF = {
+const TURN_MODEL_COMMAND_STALE_PEER_REF = {
   provider: "cohere",
   model: "command-stale-peer-model",
 } as const;

--- a/src/test-utils/turn-model-selection-differential.ts
+++ b/src/test-utils/turn-model-selection-differential.ts
@@ -1,0 +1,272 @@
+import type { ModelRef } from "../agents/model-ref-shared.js";
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
+
+export type TurnModelSelectionSource =
+  | "locked"
+  | "explicit"
+  | "heartbeat"
+  | "session"
+  | "parent"
+  | "channel"
+  | "default";
+
+export type TurnModelSelectionVerdict = ModelRef & { source: TurnModelSelectionSource };
+export type TurnModelSelectionPath = "reply" | "status" | "harness" | "command";
+
+export const TURN_MODEL_DEFAULT_REF = { provider: "openai", model: "default-model" } as const;
+export const TURN_MODEL_CHANNEL_REF = {
+  provider: "anthropic",
+  model: "channel-model",
+} as const;
+export const TURN_MODEL_SESSION_REF = { provider: "google", model: "session-model" } as const;
+export const TURN_MODEL_PARENT_REF = { provider: "xai", model: "parent-model" } as const;
+export const TURN_MODEL_OVERRIDE_REF = { provider: "mistral", model: "turn-model" } as const;
+export const TURN_MODEL_LOCKED_REF = { provider: "cohere", model: "locked-model" } as const;
+export const TURN_MODEL_PERSISTED_CHANNEL_REF = {
+  provider: "anthropic",
+  model: "persisted-channel-model",
+} as const;
+export const TURN_MODEL_LIVE_CHANNEL_REF = {
+  provider: "google",
+  model: "live-channel-model",
+} as const;
+export const TURN_MODEL_PERSISTED_PEER_REF = {
+  provider: "xai",
+  model: "persisted-peer-model",
+} as const;
+export const TURN_MODEL_LIVE_PEER_REF = {
+  provider: "mistral",
+  model: "live-peer-model",
+} as const;
+export const TURN_MODEL_COMMAND_STALE_PEER_REF = {
+  provider: "cohere",
+  model: "command-stale-peer-model",
+} as const;
+
+export function turnModelRefLabel(ref: ModelRef): string {
+  return `${ref.provider}/${ref.model}`;
+}
+
+const SOURCE_BY_REF = new Map<string, TurnModelSelectionSource>([
+  [turnModelRefLabel(TURN_MODEL_DEFAULT_REF), "default"],
+  [turnModelRefLabel(TURN_MODEL_CHANNEL_REF), "channel"],
+  [turnModelRefLabel(TURN_MODEL_SESSION_REF), "session"],
+  [turnModelRefLabel(TURN_MODEL_PARENT_REF), "parent"],
+  [turnModelRefLabel(TURN_MODEL_OVERRIDE_REF), "heartbeat"],
+  [turnModelRefLabel(TURN_MODEL_LOCKED_REF), "locked"],
+  [turnModelRefLabel(TURN_MODEL_PERSISTED_CHANNEL_REF), "channel"],
+  [turnModelRefLabel(TURN_MODEL_LIVE_CHANNEL_REF), "channel"],
+  [turnModelRefLabel(TURN_MODEL_PERSISTED_PEER_REF), "channel"],
+  [turnModelRefLabel(TURN_MODEL_LIVE_PEER_REF), "channel"],
+  [turnModelRefLabel(TURN_MODEL_COMMAND_STALE_PEER_REF), "channel"],
+]);
+
+export function turnModelVerdict(
+  ref: ModelRef,
+  override?: TurnModelSelectionSource,
+): TurnModelSelectionVerdict {
+  const source = override ?? SOURCE_BY_REF.get(turnModelRefLabel(ref));
+  if (!source) {
+    throw new Error(`unknown selection source for ${turnModelRefLabel(ref)}`);
+  }
+  return { ...ref, source };
+}
+
+export function createTurnModelEntry(params: {
+  sessionId?: string;
+  channel?: string;
+  chatType?: "direct" | "group";
+  groupId?: string;
+  groupChannel?: string;
+  parentSessionKey?: string;
+  directUserId?: string;
+  override?: ModelRef;
+  locked?: boolean;
+}): SessionEntry {
+  return {
+    sessionId: params.sessionId ?? "child-session",
+    updatedAt: 1,
+    ...(params.channel
+      ? {
+          delivery: normalizeSessionDeliveryState({
+            context: { channel: params.channel },
+            origin: {
+              provider: params.channel,
+              ...(params.chatType ? { chatType: params.chatType } : {}),
+              ...(params.directUserId ? { nativeDirectUserId: params.directUserId } : {}),
+            },
+          }),
+        }
+      : {}),
+    ...(params.chatType ? { chatType: params.chatType } : {}),
+    ...(params.groupId ? { groupId: params.groupId } : {}),
+    ...(params.groupChannel ? { groupChannel: params.groupChannel } : {}),
+    ...(params.parentSessionKey ? { parentSessionKey: params.parentSessionKey } : {}),
+    ...(params.override
+      ? {
+          providerOverride: params.override.provider,
+          modelOverride: params.override.model,
+          modelOverrideSource: "user" as const,
+        }
+      : {}),
+    ...(params.locked ? { modelSelectionLocked: true, agentHarnessId: "turn-model-recorder" } : {}),
+  };
+}
+
+export type TurnModelDifferentialFixture = {
+  name: string;
+  ctx: Partial<FinalizedMsgContext>;
+  child: SessionEntry;
+  parent?: { key: string; entry: SessionEntry };
+  modelByChannel?: Record<string, Record<string, string>>;
+  heartbeat?: boolean;
+  locked?: boolean;
+  expected: Record<TurnModelSelectionPath, TurnModelSelectionVerdict>;
+};
+
+export const TURN_MODEL_DIFFERENTIAL_FIXTURES: TurnModelDifferentialFixture[] = [
+  {
+    name: "default only",
+    ctx: { Provider: undefined, Surface: undefined, ChatType: "group" },
+    child: createTurnModelEntry({ chatType: "group", groupId: "room" }),
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_DEFAULT_REF),
+      status: turnModelVerdict(TURN_MODEL_DEFAULT_REF),
+      harness: turnModelVerdict(TURN_MODEL_DEFAULT_REF),
+      command: turnModelVerdict(TURN_MODEL_DEFAULT_REF),
+    },
+  },
+  {
+    name: "channel wildcard",
+    ctx: { Provider: "telegram", Surface: "telegram", ChatType: "group" },
+    child: createTurnModelEntry({ channel: "telegram", chatType: "group", groupId: "room" }),
+    modelByChannel: { telegram: { "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF) } },
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+      status: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+      harness: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+      command: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+    },
+  },
+  {
+    name: "current session override before channel",
+    ctx: { Provider: "telegram", Surface: "telegram", ChatType: "group" },
+    child: createTurnModelEntry({
+      channel: "telegram",
+      chatType: "group",
+      groupId: "room",
+      override: TURN_MODEL_SESSION_REF,
+    }),
+    modelByChannel: { telegram: { "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF) } },
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_SESSION_REF),
+      status: turnModelVerdict(TURN_MODEL_SESSION_REF),
+      harness: turnModelVerdict(TURN_MODEL_SESSION_REF),
+      command: turnModelVerdict(TURN_MODEL_SESSION_REF),
+    },
+  },
+  {
+    name: "heartbeat or explicit turn override",
+    ctx: { Provider: "telegram", Surface: "telegram", ChatType: "group" },
+    child: createTurnModelEntry({ channel: "telegram", chatType: "group", groupId: "room" }),
+    modelByChannel: { telegram: { "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF) } },
+    heartbeat: true,
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_OVERRIDE_REF),
+      status: turnModelVerdict(TURN_MODEL_OVERRIDE_REF),
+      harness: turnModelVerdict(TURN_MODEL_OVERRIDE_REF),
+      command: turnModelVerdict(TURN_MODEL_OVERRIDE_REF, "explicit"),
+    },
+  },
+  {
+    name: "locked stored selection",
+    ctx: { Provider: "telegram", Surface: "telegram", ChatType: "group" },
+    child: createTurnModelEntry({
+      channel: "telegram",
+      chatType: "group",
+      groupId: "room",
+      override: TURN_MODEL_LOCKED_REF,
+      locked: true,
+    }),
+    locked: true,
+    modelByChannel: { telegram: { "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF) } },
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_LOCKED_REF),
+      status: turnModelVerdict(TURN_MODEL_LOCKED_REF),
+      harness: turnModelVerdict(TURN_MODEL_LOCKED_REF),
+      command: turnModelVerdict(TURN_MODEL_LOCKED_REF),
+    },
+  },
+  {
+    name: "persisted delivery channel versus current authorized channel",
+    ctx: { Provider: "telegram", Surface: "telegram", ChatType: "group" },
+    child: createTurnModelEntry({ channel: "discord", chatType: "group", groupId: "room" }),
+    modelByChannel: {
+      discord: { room: turnModelRefLabel(TURN_MODEL_PERSISTED_CHANNEL_REF) },
+      telegram: { room: turnModelRefLabel(TURN_MODEL_LIVE_CHANNEL_REF) },
+    },
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_PERSISTED_CHANNEL_REF),
+      status: turnModelVerdict(TURN_MODEL_LIVE_CHANNEL_REF),
+      harness: turnModelVerdict(TURN_MODEL_PERSISTED_CHANNEL_REF),
+      command: turnModelVerdict(TURN_MODEL_LIVE_CHANNEL_REF),
+    },
+  },
+  {
+    name: "persisted peer versus live sender",
+    ctx: {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      From: "telegram:live-peer",
+      SenderId: "live-peer",
+    },
+    child: createTurnModelEntry({
+      channel: "discord",
+      chatType: "direct",
+      directUserId: "stale-peer",
+    }),
+    modelByChannel: {
+      discord: {
+        "stale-peer": turnModelRefLabel(TURN_MODEL_PERSISTED_PEER_REF),
+        "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF),
+      },
+      telegram: {
+        "live-peer": turnModelRefLabel(TURN_MODEL_LIVE_PEER_REF),
+        "stale-peer": turnModelRefLabel(TURN_MODEL_COMMAND_STALE_PEER_REF),
+        "*": turnModelRefLabel(TURN_MODEL_LIVE_CHANNEL_REF),
+      },
+    },
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_PERSISTED_PEER_REF),
+      status: turnModelVerdict(TURN_MODEL_LIVE_PEER_REF),
+      harness: turnModelVerdict(TURN_MODEL_PERSISTED_PEER_REF),
+      command: turnModelVerdict(TURN_MODEL_COMMAND_STALE_PEER_REF),
+    },
+  },
+  {
+    name: "parent persisted override versus channel",
+    ctx: { Provider: "telegram", Surface: "telegram", ChatType: "group" },
+    child: createTurnModelEntry({
+      channel: "telegram",
+      chatType: "group",
+      groupId: "thread",
+      parentSessionKey: "agent:main:telegram:group:parent",
+    }),
+    parent: {
+      key: "agent:main:telegram:group:parent",
+      entry: createTurnModelEntry({ sessionId: "parent-session", override: TURN_MODEL_PARENT_REF }),
+    },
+    modelByChannel: { telegram: { "*": turnModelRefLabel(TURN_MODEL_CHANNEL_REF) } },
+    // OBSERVED, not endorsed: reply's child-only stored gate lets channel replace the
+    // resolved parent. Harness keeps parent; command does not inherit it. Product decision is separate.
+    expected: {
+      reply: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+      status: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+      harness: turnModelVerdict(TURN_MODEL_PARENT_REF),
+      command: turnModelVerdict(TURN_MODEL_CHANNEL_REF),
+    },
+  },
+];


### PR DESCRIPTION
## What Problem This Solves

The deferred prepared-fact model-selection refactor needs a protective baseline for the behavior that exists today across the main reply, status, harness, and command selection paths. Without one shared differential matrix, an ownership refactor could silently change precedence while the product decisions are still pending.

## Why This Change Was Made

This adds a shared eight-fixture matrix and exercises it through all four real entry paths, plus seven focused reply input-boundary cases. The tests pin current behavior without endorsing or changing it, including three documented divergences:

- Command parent-inheritance gap: the command path does not inherit the parent session's stored model override.
- Command live-peer absence: the command path does not use the live sender peer when resolving the channel model override.
- Reply channel-over-parent versus harness parent-over-channel: the reply path's effective-session gate lets the channel selection replace a resolved parent override at `src/auto-reply/reply/get-reply.ts:843`, while the harness path retains the parent override.

The pending owner decisions are which path owns the canonical prepared model fact, whether live or persisted channel/peer facts are authoritative for the turn, and whether parent or channel selection wins. The prepared-fact refactor remains deferred until those decisions land; this PR is its protective baseline.

## User Impact

No user-visible behavior changes. This is tests and test support only; it makes today's selection behavior and disagreements explicit before the later refactor.

## Evidence

- Four-path differential harness: 4 files, 39 assertions passed across 2 routed Vitest shards.
- Existing touched owner suites: 6 files, 154 tests passed across 2 routed Vitest shards.
- `node scripts/check-changed.mjs`: passed for `core, coreTests`.
- Autoreview: clean, no accepted/actionable findings.
