### PR TITLE
refactor(realtime): deduplicate voice audio handling

### DIFF
--- a/extensions/discord/src/voice/realtime-playback.ts
+++ b/extensions/discord/src/voice/realtime-playback.ts
@@ -1,6 +1,8 @@
 import { PassThrough, pipeline } from "node:stream";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
+  REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+  realtimeVoiceAudioDurationMs,
   resolveRealtimeVoiceBargeIn,
   type RealtimeVoiceActivationNameTranscriptResult,
   type RealtimeVoiceBridgeEvent,
@@ -24,7 +26,6 @@ const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_MESSAGES = 32;
 const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_BYTES = 32 * 1024;
 const DISCORD_REALTIME_CANCELLATION_RACE_DETAIL = "Cancellation failed: no active response found";
 const DISCORD_REALTIME_WAKE_ACKS = ["Yeah.", "Mm-hmm.", "Got it.", "One sec."];
-const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
 const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
 const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
 
@@ -50,14 +51,6 @@ function isRealtimeResponseCancellationRace(event: RealtimeVoiceBridgeEvent): bo
 
 function normalizeControlSpeechText(text: string): string {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
-}
-
-function pcm16MonoDurationMs(audio: Buffer, sampleRate: number): number {
-  if (audio.length === 0 || sampleRate <= 0) {
-    return 0;
-  }
-  const samples = audio.length / REALTIME_PCM16_BYTES_PER_SAMPLE;
-  return (samples * 1000) / sampleRate;
 }
 
 export type DiscordRealtimePlaybackPort = Pick<
@@ -187,7 +180,10 @@ export class DiscordRealtimePlayback<TState> {
       this.exactSpeechState = { ...this.exactSpeechState, audioStarted: true };
     }
     this.params.harness.recordOutputAudio(realtimePcm24kMono, {
-      audioMs: pcm16MonoDurationMs(realtimePcm24kMono, 24_000),
+      audioMs: realtimeVoiceAudioDurationMs(
+        REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+        realtimePcm24kMono.byteLength,
+      ),
       sourceAudioBytes: realtimePcm24kMono.length,
       sinkAudioBytes: discordPcm.length,
     });

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -82,12 +82,11 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         if (event.item_id && event.item_id !== this.assistantAudioItem?.itemId) {
           this.assistantAudioItem = {
             itemId: event.item_id,
-            bytes: 0,
+            bytes: audio.byteLength,
             startTimestamp: this.latestMediaTimestamp,
           };
-        }
-        // Playback clocks can lead provider output, but truncate cannot exceed item audio.
-        if (this.assistantAudioItem) {
+        } else if (this.assistantAudioItem) {
+          // Playback clocks can lead provider output, but truncate cannot exceed item audio.
           this.assistantAudioItem.bytes += audio.byteLength;
         }
         this.responseActive = true;

--- a/extensions/openai/realtime-voice-session-policy.ts
+++ b/extensions/openai/realtime-voice-session-policy.ts
@@ -5,6 +5,7 @@ import {
   resolveProviderAuthProfileApiKey,
 } from "openclaw/plugin-sdk/provider-auth";
 import type {
+  OpenAICompatibleRealtimeAudioFormat,
   RealtimeVoiceAudioFormat,
   RealtimeVoiceBrowserSessionCreateRequest,
   RealtimeVoiceBridgeCreateRequest,
@@ -15,6 +16,7 @@ import type {
 import {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+  toOpenAICompatibleRealtimeAudioFormat,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { warn } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -191,13 +193,13 @@ type RealtimeGaSessionPolicy = {
   output_modalities: string[];
   audio: {
     input: {
-      format: OpenAIRealtimeAudioFormatConfig;
+      format: OpenAICompatibleRealtimeAudioFormat;
       turn_detection: RealtimeTurnDetectionConfig;
       noise_reduction: { type: "near_field" } | null;
       transcription: { model: string; language?: string };
     };
     output: {
-      format: OpenAIRealtimeAudioFormatConfig;
+      format: OpenAICompatibleRealtimeAudioFormat;
       voice: OpenAIRealtimeVoice;
     };
   };
@@ -226,15 +228,6 @@ export type RealtimeAzureDeploymentSessionUpdate = {
     tool_choice?: string;
   };
 };
-
-type OpenAIRealtimeAudioFormatConfig =
-  | {
-      type: "audio/pcm";
-      rate: 24000;
-    }
-  | {
-      type: "audio/pcmu";
-    };
 
 export function normalizeProviderConfig(
   config: RealtimeVoiceProviderConfig,
@@ -438,14 +431,6 @@ export function normalizeOpenAIRealtimeTools(
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function resolveOpenAIRealtimeAudioFormat(
-  audioFormat: RealtimeVoiceAudioFormat = REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
-): OpenAIRealtimeAudioFormatConfig {
-  return audioFormat.encoding === "pcm16"
-    ? { type: "audio/pcm", rate: 24000 }
-    : { type: "audio/pcmu" };
-}
-
 export function buildOpenAIRealtimeTurnDetectionConfig(params: {
   autoRespondToAudio?: boolean;
   createResponse?: boolean;
@@ -485,7 +470,9 @@ export function buildOpenAIRealtimeGaSessionPolicy(params: {
   vadThreshold?: number;
   voice: OpenAIRealtimeVoice;
 }): RealtimeGaSessionPolicy {
-  const format = resolveOpenAIRealtimeAudioFormat(params.audioFormat);
+  const format = toOpenAICompatibleRealtimeAudioFormat(
+    params.audioFormat ?? REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+  );
   return {
     type: "realtime",
     model: params.model,

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -4,6 +4,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-auth";
 import type {
+  OpenAICompatibleRealtimeAudioFormat,
   RealtimeVoiceBridgeCreateRequest,
   RealtimeVoiceProviderConfig,
 } from "openclaw/plugin-sdk/realtime-voice";
@@ -79,10 +80,6 @@ export type XaiRealtimeEvent = {
   error?: unknown;
 };
 
-export type XaiRealtimeAudioFormatConfig =
-  | { type: "audio/pcm"; rate: 24000 }
-  | { type: "audio/pcmu" };
-
 export type XaiRealtimeSessionUpdate = {
   type: "session.update";
   session: {
@@ -97,10 +94,10 @@ export type XaiRealtimeSessionUpdate = {
     };
     audio: {
       input: {
-        format: XaiRealtimeAudioFormatConfig;
+        format: OpenAICompatibleRealtimeAudioFormat;
         transcription: { model: string };
       };
-      output: { format: XaiRealtimeAudioFormatConfig };
+      output: { format: OpenAICompatibleRealtimeAudioFormat };
     };
     reasoning?: { effort: XaiRealtimeReasoningEffort };
     resumption?: { enabled: boolean };

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -91,11 +91,10 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         if (event.item_id && event.item_id !== this.assistantAudioItem?.itemId) {
           this.assistantAudioItem = {
             itemId: event.item_id,
-            bytes: 0,
+            bytes: audio.byteLength,
             startTimestamp: this.latestMediaTimestamp,
           };
-        }
-        if (this.assistantAudioItem) {
+        } else if (this.assistantAudioItem) {
           this.assistantAudioItem.bytes += audio.byteLength;
         }
         this.responseActive = true;

--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -8,6 +8,7 @@ import type {
 import {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   realtimeVoiceAudioDurationMs,
+  toOpenAICompatibleRealtimeAudioFormat,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -17,7 +18,6 @@ import {
   XAI_REALTIME_INPUT_TRANSCRIPTION_MODEL,
   XAI_REALTIME_MAX_PENDING_PLAYBACK_MARKS,
   serializeXaiRealtimeToolResult,
-  type XaiRealtimeAudioFormatConfig,
   type XaiRealtimeEvent,
   type XaiRealtimeSessionUpdate,
   type XaiRealtimeVoiceBridgeConfig,
@@ -118,16 +118,8 @@ export abstract class XaiRealtimeVoiceProtocol {
       this.sendEvent({ type: "response.cancel" }, "reason=barge-in");
       this.responseCancelInFlight = true;
     }
-    if (shouldInterruptProvider) {
-      this.sendEvent(
-        {
-          type: "conversation.item.truncate",
-          item_id: assistantAudioItem.itemId,
-          content_index: 0,
-          audio_end_ms: audioEndMs,
-        },
-        `reason=barge-in audioEndMs=${audioEndMs}`,
-      );
+    if (shouldInterruptProvider && audioEndMs !== null) {
+      this.truncateAssistantAudio(assistantAudioItem, "barge-in", audioEndMs);
       this.config.onClearAudio("barge-in");
       this.markQueue = [];
       this.assistantAudioItem = null;
@@ -142,16 +134,7 @@ export abstract class XaiRealtimeVoiceProtocol {
     // queued audio actually played. Trim provider history to that boundary.
     const assistantAudioItem = this.assistantAudioItem;
     if (assistantAudioItem !== null && this.markQueue.length > 0) {
-      const audioEndMs = this.audioEndMs(assistantAudioItem);
-      this.sendEvent(
-        {
-          type: "conversation.item.truncate",
-          item_id: assistantAudioItem.itemId,
-          content_index: 0,
-          audio_end_ms: audioEndMs,
-        },
-        `reason=server-vad-barge-in audioEndMs=${audioEndMs}`,
-      );
+      this.truncateAssistantAudio(assistantAudioItem, "server-vad-barge-in");
     }
     this.config.onClearAudio("barge-in");
     this.markQueue = [];
@@ -164,8 +147,25 @@ export abstract class XaiRealtimeVoiceProtocol {
     return Math.min(producedAudioMs, playbackAudioMs);
   }
 
+  private truncateAssistantAudio(
+    item: XaiAssistantAudioItem,
+    reason: "barge-in" | "server-vad-barge-in",
+    audioEndMs = this.audioEndMs(item),
+  ): void {
+    this.sendEvent(
+      {
+        type: "conversation.item.truncate",
+        item_id: item.itemId,
+        content_index: 0,
+        audio_end_ms: audioEndMs,
+      },
+      `reason=${reason} audioEndMs=${audioEndMs}`,
+    );
+  }
+
   protected buildSessionUpdate(): XaiRealtimeSessionUpdate {
     const cfg = this.config;
+    const format = toOpenAICompatibleRealtimeAudioFormat(this.audioFormat);
     return {
       type: "session.update",
       session: {
@@ -180,10 +180,10 @@ export abstract class XaiRealtimeVoiceProtocol {
         },
         audio: {
           input: {
-            format: this.resolveRealtimeAudioFormat(),
+            format,
             transcription: { model: XAI_REALTIME_INPUT_TRANSCRIPTION_MODEL },
           },
-          output: { format: this.resolveRealtimeAudioFormat() },
+          output: { format },
         },
         ...(cfg.sessionResumption === true ? { resumption: { enabled: true } } : {}),
         ...(cfg.reasoningEffort ? { reasoning: { effort: cfg.reasoningEffort } } : {}),
@@ -195,12 +195,6 @@ export abstract class XaiRealtimeVoiceProtocol {
           : {}),
       },
     };
-  }
-
-  private resolveRealtimeAudioFormat(): XaiRealtimeAudioFormatConfig {
-    return this.audioFormat.encoding === "pcm16"
-      ? { type: "audio/pcm", rate: 24000 }
-      : { type: "audio/pcmu" };
   }
 
   protected emitToolCallOnce(fields: {

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1,8 +1,5 @@
 // Xai tests cover realtime voice provider plugin behavior.
-import {
-  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
-  REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-} from "openclaw/plugin-sdk/realtime-voice";
+import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { XAI_REALTIME_MAX_PENDING_PLAYBACK_MARKS } from "./realtime-voice-config.js";
 import { buildXaiRealtimeVoiceProvider } from "./realtime-voice-provider.js";
@@ -890,16 +887,13 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it.each([
     {
       name: "lets server VAD own interruption before an audio item exists",
-      hasAudio: false,
       timestamp: 1000,
       expectedActions: [],
     },
     {
       name: "clamps manual barge-in to produced G.711 audio",
-      hasAudio: true,
       manual: true,
       audioBytes: 3_700 * 8,
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
       timestamp: 4760,
       expectedActions: [
         { type: "response.cancel" },
@@ -913,7 +907,6 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
     {
       name: "clamps server-VAD barge-in to produced PCM16 audio without cancelling xAI",
-      hasAudio: true,
       audioBytes: 3_700 * 48,
       audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
       timestamp: 4760,
@@ -928,14 +921,14 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
     {
       name: "clears relay playback on server-VAD barge-in after marks are acknowledged",
-      hasAudio: true,
+      audioBytes: 16,
       acknowledged: true,
       timestamp: 1250,
       expectedActions: [],
     },
     {
       name: "does not truncate completed assistant audio on a later user turn",
-      hasAudio: true,
+      audioBytes: 16,
       acknowledged: true,
       completed: true,
       timestamp: 2000,
@@ -943,7 +936,6 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
     {
       name: "keeps completed assistant item state so relay playback cancel can truncate it",
-      hasAudio: true,
       acknowledged: true,
       completed: true,
       manual: true,
@@ -960,7 +952,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
     {
       name: "lets server VAD interrupt a new response before it produces audio",
-      hasAudio: true,
+      audioBytes: 16,
       acknowledged: true,
       completed: true,
       startNewResponse: true,
@@ -970,7 +962,6 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   ])(
     "$name",
     async ({
-      hasAudio,
       acknowledged,
       completed,
       startNewResponse,
@@ -991,12 +982,12 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       const { socket } = await startRealtimeBridge(bridge);
 
       socket.emitServer({ type: "response.created", response: { id: "resp_1" } });
-      if (hasAudio) {
+      if (audioBytes !== undefined) {
         bridge.setMediaTimestamp(1000);
         socket.emitServer({
           type: "response.output_audio.delta",
           item_id: "item_1",
-          delta: Buffer.alloc(audioBytes ?? 16).toString("base64"),
+          delta: Buffer.alloc(audioBytes).toString("base64"),
         });
       }
       if (acknowledged) {
@@ -1016,7 +1007,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       }
       bridge.close();
 
-      expect(onAudio).toHaveBeenCalledTimes(hasAudio ? 1 : 0);
+      expect(onAudio).toHaveBeenCalledTimes(audioBytes === undefined ? 0 : 1);
       expect(onClearAudio).toHaveBeenCalledTimes(1);
       if (!manual) {
         expect(onClearAudio).toHaveBeenCalledWith("barge-in");

--- a/src/plugin-sdk/realtime-voice.test.ts
+++ b/src/plugin-sdk/realtime-voice.test.ts
@@ -6,31 +6,31 @@ import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   realtimeVoiceAudioDurationMs,
   RealtimeVoiceSessionLifecycle,
+  toOpenAICompatibleRealtimeAudioFormat,
   type RealtimeVoiceSessionConnection,
 } from "./realtime-voice.js";
 
 describe("realtimeVoiceAudioDurationMs", () => {
   it.each([
-    {
-      name: "G.711 μ-law 8 kHz mono",
-      format: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
-      byteLength: 8_000,
-      durationMs: 1_000,
-    },
-    {
-      name: "PCM16 24 kHz mono",
-      format: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      byteLength: 48_000,
-      durationMs: 1_000,
-    },
-    {
-      name: "one G.711 μ-law sample without rounding",
-      format: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
-      byteLength: 1,
-      durationMs: 0.125,
-    },
-  ])("calculates $name", ({ format, byteLength, durationMs }) => {
+    ["G.711 μ-law 8 kHz mono", REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ, 8_000, 1_000],
+    ["PCM16 24 kHz mono", REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ, 48_000, 1_000],
+    [
+      "one G.711 μ-law sample without rounding",
+      REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+      1,
+      0.125,
+    ],
+  ] as const)("calculates %s", (_name, format, byteLength, durationMs) => {
     expect(realtimeVoiceAudioDurationMs(format, byteLength)).toBe(durationMs);
+  });
+});
+
+describe("toOpenAICompatibleRealtimeAudioFormat", () => {
+  it.each([
+    ["G.711 μ-law", REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ, { type: "audio/pcmu" }],
+    ["PCM16", REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ, { type: "audio/pcm", rate: 24000 }],
+  ] as const)("maps %s", (_name, format, expected) => {
+    expect(toOpenAICompatibleRealtimeAudioFormat(format)).toEqual(expected);
   });
 });
 

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -1,6 +1,7 @@
 /** Production-private runtime seam for bundled and separately published official plugins. */
 export type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 export type {
+  OpenAICompatibleRealtimeAudioFormat,
   RealtimeVoiceAudioFormat,
   RealtimeVoiceAgentConsultRunner,
   RealtimeVoiceBargeInOptions,
@@ -29,6 +30,7 @@ export {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   realtimeVoiceAudioDurationMs,
+  toOpenAICompatibleRealtimeAudioFormat,
 } from "../talk/provider-types.js";
 export {
   createTalkEventSequencer,

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -30,6 +30,16 @@ export function realtimeVoiceAudioDurationMs(
   return (byteLength * 1000) / (format.sampleRateHz * format.channels * bytesPerSample);
 }
 
+export type OpenAICompatibleRealtimeAudioFormat =
+  | { type: "audio/pcm"; rate: 24000 }
+  | { type: "audio/pcmu" };
+
+export function toOpenAICompatibleRealtimeAudioFormat(
+  format: RealtimeVoiceAudioFormat,
+): OpenAICompatibleRealtimeAudioFormat {
+  return format.encoding === "pcm16" ? { type: "audio/pcm", rate: 24000 } : { type: "audio/pcmu" };
+}
+
 export const REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ: RealtimeVoiceAudioFormat = {
   encoding: "g711_ulaw",
   sampleRateHz: 8000,


### PR DESCRIPTION
Context: #125502 and #125612

## What Problem This Solves

#125612 centralized realtime audio duration calculation, but the realtime voice stack still retained duplicate ownership around Discord PCM duration, OpenAI-compatible audio wire-format mapping, provider output-byte initialization, and xAI truncate payload construction. That duplication made equivalent OpenAI/xAI/Discord paths easier to drift even though their observable behavior was intended to stay aligned.

## Why This Change Was Made

This finishes the bounded cleanup by reusing the existing production-private realtime voice SDK seam for the canonical 24 kHz PCM16 duration and the OpenAI-compatible PCM24k/PCMU wire-format mapping. It also removes transient zero-byte assistant state and deduplicates xAI truncate construction while preserving manual-versus-server-VAD predicates, response cancellation ordering, callback ordering, playback marks, and assistant-item retention.

Provider interruption policy and lifecycle ownership remain local to each provider. The change intentionally does not introduce shared mutable assistant trackers, generic clamp helpers, shared provider interruption state, broad event DTOs, voice-call disconnect-grace changes, or a Google mapping that does not share this wire contract.

Production LOC: +56/-72 (net -16). Tests: +26/-35 (net -9). Total: net -25.

## User Impact

No user-visible behavior changes. This is a maintainer-requested, behavior-neutral cleanup that leaves provider and Discord voice behavior unchanged while reducing duplicate implementation paths.

## Evidence

- Rebased conflict-free onto `origin/main`; the stable patch ID remained identical before and after rebase.
- Focused post-rebase proof: 261 tests passed — Plugin SDK 22, Discord 88, OpenAI 48, and xAI/lazy 103. The prior 260-test result became 261 because current `origin/main` added one unrelated Plugin SDK test; the cleanup patch itself is unchanged.
- `pnpm plugin-sdk:surface:check` passed.
- `pnpm build` passed before publication with no ineffective dynamic-import diagnostics.
- Full `node scripts/check-changed.mjs` passed before publication; its dry run selected the relevant core, core-test, plugin, and plugin-test lanes.
- Formatting and `git diff --check origin/main...HEAD` passed.
- Duplicate search leaves one canonical realtime duration implementation and one canonical OpenAI-compatible wire-format mapping. Discord's generic PCM-seconds utility and realtime-turn silence-byte construction remain separate contracts.
- Fresh Codex-backed autoreview of the complete reviewed diff reported no accepted/actionable findings.
- Provider live tests were not repeated because this patch is behavior-neutral; the affected behavior was live-proven in #125502 and #125612, and the exact wire/session payload regressions remain covered.

AI-assisted: yes. The implementation and proof were reviewed by the maintainer.
