### PR TITLE
fix(ui): restore mock chat startup

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1619,6 +1619,7 @@ async function createChatPickerScenario(
     assistantAgentId: "main",
     assistantName: "Molty",
     defaultAgentId: "main",
+    serverBuildId: "mock",
     // Advertised Gateway methods gate session actions (see
     // ui/src/lib/session-method-access.ts). Omitting the mutation methods left
     // every session context-menu row disabled, so the harness could not show
@@ -2860,7 +2861,7 @@ const server = await createServer({
       branch: null,
       dirty: null,
       release: false,
-      buildId: "mock",
+      buildId: scenario.serverBuildId,
     }),
   },
   logLevel: "error",

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -261,13 +261,36 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     }
   });
 
-  it("opens an idle generic session for ordinary sends", async () => {
+  it("starts with aligned build identity and an upgraded chat pane", async () => {
     const page = await browser.newPage();
     try {
       await page.goto(new URL("/chat", fixtureServer.url).toString(), { waitUntil: "networkidle" });
       await page.getByText("OpenClaw work checkout", { exact: true }).click();
 
       await page.getByRole("button", { name: "Write a message to send." }).waitFor();
+      expect(await page.getByText("Server updated", { exact: true }).count()).toBe(0);
+      const paneState = await page
+        .locator("openclaw-chat-pane.chat-pane-cache__pane--active")
+        .evaluate(async (pane) => {
+          const chatPane = pane as HTMLElement & {
+            hasUpdated?: boolean;
+            updateComplete?: Promise<boolean>;
+          };
+          await chatPane.updateComplete;
+          const constructor = customElements.get("openclaw-chat-pane");
+          return {
+            connected: chatPane.isConnected,
+            hasUpdated: chatPane.hasUpdated,
+            registered: constructor !== undefined,
+            upgraded: constructor !== undefined && chatPane instanceof constructor,
+          };
+        });
+      expect(paneState).toEqual({
+        connected: true,
+        hasUpdated: true,
+        registered: true,
+        upgraded: true,
+      });
       expect(await page.getByRole("button", { name: "Stop" }).count()).toBe(0);
     } finally {
       await page.close();

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -65,7 +65,7 @@ import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import { closeSlot, isSidebarSlotVisible, openSlot, setSidebarOpen } from "./sidebar-layout.ts";
 
 export abstract class ChatPaneBase extends OpenClawLightDomElement {
-  // Transfer a queued stream frame to Lit before parking; visibility resumes it.
+  // The first Lit update must render even while hidden; later hidden work parks.
   // Disconnect releases the waiter so reconnect can schedule in its new lifecycle.
   private hiddenUpdateResume: (() => void) | undefined;
   private readonly handleVisibilityChange = () =>
@@ -77,7 +77,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     super.connectedCallback();
   }
   protected override async scheduleUpdate() {
-    while (this.isConnected && document.visibilityState === "hidden") {
+    while (this.hasUpdated && this.isConnected && document.visibilityState === "hidden") {
       await new Promise<void>((resolve) => {
         this.hiddenUpdateResume = resolve;
       });

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -772,8 +772,8 @@ describe("chat pane presentation teardown", () => {
 });
 
 describe("chat pane connection lifecycle", () => {
-  it("reconciles hidden invalidations as one visible Lit update", async () => {
-    let visibilityState: DocumentVisibilityState = "visible";
+  it("renders once while initially hidden, then reconciles hidden invalidations", async () => {
+    let visibilityState: DocumentVisibilityState = "hidden";
     vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
     const { pane, requestUpdate, state } = createTestChatPane({
       client: { request: vi.fn() } as unknown as GatewayBrowserClient,
@@ -781,16 +781,17 @@ describe("chat pane connection lifecycle", () => {
     });
     const lifecycle = pane as TestChatPane & {
       performUpdate: () => void;
+      hasUpdated: boolean;
       render: () => unknown;
       requestUpdate: () => void;
     };
     lifecycle.render = () => null;
     ChatPaneBase.prototype.connectedCallback.call(lifecycle);
+    await vi.waitFor(() => expect(lifecycle.hasUpdated).toBe(true), { interval: 1, timeout: 50 });
     await lifecycle.updateComplete;
     const performUpdate = vi.spyOn(lifecycle, "performUpdate");
     const cancelAnimationFrame = vi.spyOn(globalThis, "cancelAnimationFrame");
 
-    visibilityState = "hidden";
     state.chatStreamRenderFrame = 7;
     document.dispatchEvent(new Event("visibilitychange"));
     expect(cancelAnimationFrame).toHaveBeenCalledWith(7);


### PR DESCRIPTION
Related: #125088

## What Problem This Solves

Fixes an issue where developers running `pnpm dev:ui:mock` could see a permanent false “Server updated / Refresh for full capabilities” card and an empty chat pane when a browser-preview host initially loaded the route with `document.visibilityState === "hidden"`.

## Why This Change Was Made

The standalone mock scenario now owns one `serverBuildId` (`mock`) that drives both the mock Gateway handshake and the UI build define. The chat pane's Lit scheduler also always permits the mandatory first render, then retains the existing coalescing behavior for later invalidations while the document is hidden.

This repair is intentionally separate from composer spacing and does not include any spacing changes.

Build-identity provenance: #103595 established the UI build identity, and #123660 made exact same-origin build-skew fencing visible. The hidden-first-render regression was introduced in #125088 (code/PR author @Alix-007, merged by @vyctorbrzezowski on 2026-08-17).

Production/tooling LOC: +4/-3 (net +1). Tests: +28/-4 (net +24).

## User Impact

Developers and reviewers can use the real mock Control UI in Claude Browser and Playwright previews without refreshing the page or manually patching the scenario. A route first opened while hidden now renders its chat pane and composer normally, without a false server-update warning.

## Evidence

Before: hidden startup showed an empty content area and a false server-update card.

![Before: hidden mock startup with empty chat and false server-update card](https://github.com/user-attachments/assets/7cf1b03f-0a9f-40ce-9b02-3826ab5af9b0)

After: the same mock route renders the upgraded chat pane and composer with no server-update card.

![After: hidden mock startup with rendered chat pane and composer](https://github.com/user-attachments/assets/0fd170a9-b2fa-4371-84cb-3eb793d4e757)

After video:

https://github.com/user-attachments/assets/b371da09-0945-4849-b4d6-cf69a53a6a58

- Real `pnpm dev:ui:mock -- --host 127.0.0.1 --port 5197` browser-preview proof with `document.visibilityState === "hidden"`: UI build ID `mock`; `openclaw-chat-page` and `openclaw-chat-pane` registered; pane connected and upgraded; `hasUpdated: true`; composer present; zero `Server updated` cards. The full 500-entry network capture contained only HTTP 200 responses, including the lazy chat route/pane chain.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-lifecycle.test.ts` — 28/28 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-fixture.e2e.test.ts` — 6/6 passed.
- `node scripts/check-changed.mjs -- scripts/control-ui-mock-dev.ts ui/src/e2e/board-fixture.e2e.test.ts ui/src/pages/chat/chat-pane-base.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts` — all selected lanes passed.
- `pnpm build` — passed with no ineffective dynamic-import warning.
- Final `oxfmt --check` and `git diff --check` passed.
- Codex autoreview was clean with no accepted or actionable findings.

## ClawSweeper Rank-up Resolution

- **Production/tooling net +1 accepted:** the one added scenario field is the canonical owner fact that replaces two divergent build identities. Keeping only a Vite-side literal would leave the Gateway identity implicit in the generic E2E default and preserve the bug class.
- **Upstream Lit contract verified:** the installed published dependency is `@lit/reactive-element` 2.1.2. Its published source shows that `__enqueueUpdate()` awaits `scheduleUpdate()`, `scheduleUpdate()` calls `performUpdate()`, and `hasUpdated` becomes true only in `_$didUpdate()` after the first completed update: https://unpkg.com/@lit/reactive-element@2.1.2/development/reactive-element.js. Parking `scheduleUpdate()` while `hasUpdated` is false therefore prevents the first update from ever completing.
- **Maintainer review complete:** the full entry point, scenario normalization/hello response, build-skew caller/callee, lazy route registration chain, chat-pane scheduler, focused tests, installed Lit source, browser proof, and exact-head CI were reviewed. ClawSweeper's partial live step searched for `Write a message to send.` as visible text, but that string is the composer's accessible button name; the repository E2E role query passes, and the independent hidden-preview probe directly confirmed the composer exists.

AI-assisted: yes.
