### PR TITLE
fix(agents): prevent dead-end terminal and exec tool results

### DIFF
--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -49,6 +49,11 @@ function requireExecTool(tools: ReturnType<typeof createOpenClawCodingTools>) {
   return execTool;
 }
 
+function schemaPropertyNames(tool: ReturnType<typeof requireExecTool>): string[] {
+  const schema = tool.parameters as { properties?: Record<string, unknown> };
+  return Object.keys(schema.properties ?? {});
+}
+
 const tempDirs = createTempDirTracker();
 
 function createTempAgentDirs(prefix: string) {
@@ -138,6 +143,41 @@ describe("Agent-specific exec tool defaults", () => {
 
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("completed");
+  });
+
+  it("makes exec completion-only when the final runtime allowlist removes process", async () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        tools: {
+          exec: {
+            host: "gateway",
+            mode: "full",
+          },
+        },
+      },
+      runtimeToolAllowlist: ["exec"],
+      inheritRuntimeToolAllowlist: true,
+      sessionKey: "agent:main:main",
+      ...createTempAgentDirs("test-main-runtime-exec-only"),
+    });
+    const execTool = requireExecTool(tools);
+
+    expect.soft(tools.map((tool) => tool.name)).not.toContain("process");
+    expect.soft(execTool.description).not.toMatch(/background|yieldMs|process/);
+    expect.soft(schemaPropertyNames(execTool)).not.toContain("background");
+    expect.soft(schemaPropertyNames(execTool)).not.toContain("yieldMs");
+
+    const result = await execTool.execute("call-runtime-exec-only", {
+      command: `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 250)"`,
+      background: true,
+      yieldMs: 10,
+      timeoutSeconds: 0.05,
+    });
+
+    expect.soft(result.details).toMatchObject({ status: "failed", timedOut: true });
+    const text = (result.content[0] as { text?: string } | undefined)?.text ?? "";
+    expect.soft(text).toContain("Verify the resulting state before retrying");
+    expect.soft(text).not.toMatch(/process|background|yieldMs|poll|trailing &/i);
   });
 
   it("routes implicit auto exec to gateway without a sandbox runtime", async () => {

--- a/src/agents/agent-tools.deferred-followup.ts
+++ b/src/agents/agent-tools.deferred-followup.ts
@@ -16,10 +16,14 @@ export function applyToolAvailabilityDescriptions(
   params?: { agentId?: string },
 ): AnyAgentTool[] {
   const hasCronTool = tools.some((tool) => isAutomationsToolName(tool.name));
+  const hasProcessTool = tools.some((tool) => tool.name === "process");
   const hasSessionsSpawnTool = tools.some((tool) => tool.name === "sessions_spawn");
   return tools.map((tool) => {
     if (tool.name === "exec") {
-      return replaceDescription(tool, describeExecTool({ agentId: params?.agentId, hasCronTool }));
+      return replaceDescription(
+        tool,
+        describeExecTool({ agentId: params?.agentId, hasCronTool, hasProcessTool }),
+      );
     }
     if (tool.name === "process") {
       return replaceDescription(tool, describeProcessTool({ hasCronTool }));

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -91,7 +91,6 @@ import { resolveToolFsConfig } from "./tool-fs-policy.js";
 import type { PreparedSessionPermissionPolicy } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 import { buildDeclaredToolAllowlistContext } from "./tool-policy-declared-context.js";
-import { isToolAllowedByPolicies } from "./tool-policy-match.js";
 import { applyToolPolicyPipeline } from "./tool-policy-pipeline.js";
 import {
   expandToolGroups,
@@ -490,19 +489,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     sessionId: options?.sessionId,
     agentId,
   });
-  const allowBackground = isToolAllowedByPolicies("process", [
-    conversationToolPolicies.profilePolicy,
-    conversationToolPolicies.providerProfilePolicy,
-    conversationToolPolicies.globalPolicy,
-    conversationToolPolicies.globalProviderPolicy,
-    conversationToolPolicies.agentPolicy,
-    conversationToolPolicies.agentProviderPolicy,
-    conversationToolPolicies.groupPolicy,
-    conversationToolPolicies.senderPolicy,
-    conversationToolPolicies.sandboxPolicy,
-    conversationToolPolicies.subagentPolicy,
-    conversationToolPolicies.inheritedToolPolicy,
-  ]);
   options?.recordToolPrepStage?.("tool-policy");
   const execConfig = resolveExecToolConfig({ cfg: options?.config, agentId });
   const execRuntimeConfig = options?.exec?.config ?? options?.config;
@@ -578,6 +564,8 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   options?.recordToolPrepStage?.("workspace-policy");
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
+  const processToolAvailabilityRef: NonNullable<ExecToolDefaults["processToolAvailabilityRef"]> =
+    {};
   const coreTools = createCoreCodingTools({
     codingRoot,
     containmentRoot,
@@ -618,7 +606,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
       safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
       agentId,
-      allowBackground,
+      processToolAvailabilityRef,
       scopeKey,
       sessionKey: options?.sessionKey,
       runId: options?.runId,
@@ -960,6 +948,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     // Collector output is a run contract, not an operator-configurable capability.
     authorizedTools.push(swarmStructuredOutputTool);
   }
+  processToolAvailabilityRef.value = authorizedTools.some((tool) => tool.name === "process");
   if (shouldInheritEffectiveToolAllowlist) {
     // Snapshot exporter only: this copies authorizedTools for descendants and
     // never filters the mandatory structured_output tool from this turn.

--- a/src/agents/bash-tools.descriptions.ts
+++ b/src/agents/bash-tools.descriptions.ts
@@ -19,11 +19,21 @@ function deriveExecShortName(fullPath: string): string {
 }
 
 /** Builds the model-facing exec tool description for the current platform/config. */
-export function describeExecTool(params?: { agentId?: string; hasCronTool?: boolean }): string {
+export function describeExecTool(params?: {
+  agentId?: string;
+  hasCronTool?: boolean;
+  hasProcessTool?: boolean;
+}): string {
+  const continuation =
+    params?.hasProcessTool === false
+      ? ["Run shell and wait for completion."]
+      : [
+          "Run shell now; background continuation supported.",
+          "Use yieldMs/background, then process for logs/status/input/intervention.",
+          "Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion.",
+        ];
   const base = [
-    "Run shell now; background continuation supported.",
-    "Use yieldMs/background, then process for logs/status/input/intervention.",
-    "Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion.",
+    ...continuation,
     params?.hasCronTool ? "No sleep/delay loops for reminders/follow-ups; use cron." : undefined,
     "TTY CLI/UI/coding agent: pty=true.",
   ]

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -187,7 +187,7 @@ describe("exec foreground failures", () => {
 
     expect(result.details.status).toBe("completed");
     expect(requireTextContent(result)).toContain(
-      "Warning: background execution is disabled; running synchronously.",
+      "Warning: continuation options are unavailable; running synchronously.",
     );
   });
 
@@ -220,6 +220,7 @@ describe("exec foreground failures", () => {
     expect(text).toContain("Verify the resulting state before retrying");
     expect(text).toContain("Do not automatically rerun non-idempotent commands");
     expect(text).toContain("known to be safe to retry");
+    expect(text).not.toMatch(/process|background|yieldMs|poll|trailing &/i);
     expect(text).not.toContain("OOM-score wrapper");
     expect(text).not.toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ");
     const details = requireFailedDetails(result.details);

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -127,6 +127,7 @@ type ProcessGatewayAllowlistParams = {
   approvalRunningNoticeMs: number;
   maxOutput: number;
   pendingMaxOutput: number;
+  processContinuationAvailable?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;
 };
 
@@ -1488,6 +1489,7 @@ export async function processGatewayAllowlist(
         sentApproverDms,
         unavailableReason,
         allowedDecisions: approvalAllowedDecisions,
+        processContinuationAvailable: params.processContinuationAvailable,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -623,6 +623,7 @@ export async function executeNodeHostCommand(
           unavailableReason,
           allowedDecisions,
           nodeId: target.nodeId,
+          processContinuationAvailable: params.processContinuationAvailable,
         });
       }
     }

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -43,6 +43,7 @@ export type ExecuteNodeHostCommandParams = {
   warnings: string[];
   /** Warnings that apply only when the command runs inline, never while approval is pending. */
   foregroundWarnings?: string[];
+  processContinuationAvailable?: boolean;
   notifySessionKey?: string;
   notifyOnExit?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -582,6 +582,7 @@ export function buildExecApprovalPendingToolResult(params: {
   unavailableReason: ExecApprovalUnavailableReason | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
   nodeId?: string;
+  processContinuationAvailable?: boolean;
 }): AgentToolResult<ExecToolDetails> {
   const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
   return {
@@ -609,6 +610,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 cwd: params.cwd,
                 host: params.host,
                 nodeId: params.nodeId,
+                processContinuationAvailable: params.processContinuationAvailable,
               }),
       },
     ],

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -96,7 +96,8 @@ export function createExecTool(
     10,
     120_000,
   );
-  const allowBackground = defaults?.allowBackground ?? true;
+  const allowBackground =
+    defaults?.processToolAvailabilityRef?.value ?? defaults?.allowBackground ?? true;
   const defaultTimeoutSec =
     defaults?.timeoutSec && defaults.timeoutSec > 0 ? defaults.timeoutSec : 1800;
   const defaultPathPrepend = normalizePathPrepend(defaults?.pathPrepend);
@@ -206,14 +207,12 @@ export function createExecTool(
       const startedAt = Date.now();
       let execCommandOverride: string | undefined;
       let revalidateGatewayApproval: GatewayApprovalRevalidator | undefined;
-      const backgroundRequested = params.background === true;
-      const yieldRequested = typeof params.yieldMs === "number";
       const foregroundFallbackWarning =
-        !allowBackground && (backgroundRequested || yieldRequested)
-          ? "Warning: background execution is disabled; running synchronously."
+        !allowBackground && (params.background === true || typeof params.yieldMs === "number")
+          ? "Warning: continuation options are unavailable; running synchronously."
           : undefined;
       const yieldWindow = allowBackground
-        ? backgroundRequested
+        ? params.background === true
           ? 0
           : clampWithDefault(
               params.yieldMs ?? defaultBackgroundMs,
@@ -476,6 +475,7 @@ export function createExecTool(
             approvalRunningNoticeMs,
             warnings,
             foregroundWarnings: foregroundFallbackWarning ? [foregroundFallbackWarning] : [],
+            processContinuationAvailable: allowBackground,
             notifySessionKey,
             notifyOnExit,
             trustedSafeBinDirs,
@@ -528,6 +528,7 @@ export function createExecTool(
             approvalRunningNoticeMs,
             maxOutput,
             pendingMaxOutput,
+            processContinuationAvailable: allowBackground,
             trustedSafeBinDirs,
           });
           if (gatewayResult.pendingResult) {
@@ -549,8 +550,7 @@ export function createExecTool(
           warnings.push(foregroundFallbackWarning);
         }
 
-        const explicitTimeoutSec = params.timeoutSeconds ?? null;
-        effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
+        effectiveTimeout = params.timeoutSeconds ?? defaultTimeoutSec;
         const usePty = params.pty === true && !sandbox;
 
         // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
@@ -589,6 +589,7 @@ export function createExecTool(
           eventRouting: defaults?.eventRouting,
           notifyDeliveryContext,
           timeoutSec: effectiveTimeout,
+          processContinuationAvailable: allowBackground,
           onUpdate,
           onSettledBeforeNotify: (outcome) => {
             settledOutcome = outcome;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -408,6 +408,7 @@ export function buildApprovalPendingMessage(params: {
   cwd: string | undefined;
   host: "gateway" | "node";
   nodeId?: string;
+  processContinuationAvailable?: boolean;
 }) {
   const commandBlock = formatFencedCodeBlock(params.command, "sh");
   const lines: string[] = [];
@@ -426,11 +427,13 @@ export function buildApprovalPendingMessage(params: {
   lines.push("Command:");
   lines.push(commandBlock);
   lines.push("Mode: foreground (interactive approvals available).");
-  lines.push(
-    allowedDecisions.includes("allow-always")
-      ? "Background mode requires pre-approved policy (allow-always or ask=off)."
-      : "Background mode requires an effective policy that allows pre-approval (for example ask=off).",
-  );
+  if (params.processContinuationAvailable !== false) {
+    lines.push(
+      allowedDecisions.includes("allow-always")
+        ? "Background mode requires pre-approved policy (allow-always or ask=off)."
+        : "Background mode requires an effective policy that allows pre-approval (for example ask=off).",
+    );
+  }
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push("Allow Always is unavailable for this command.");
@@ -480,6 +483,7 @@ function formatExecFailureReason(params: {
   failureKind: ExecExitFailureKind;
   exitSignal: NodeJS.Signals | number | null;
   timeoutSec: number | null | undefined;
+  processContinuationAvailable: boolean;
 }): string {
   switch (params.failureKind) {
     case "shell-command-not-found":
@@ -491,7 +495,10 @@ function formatExecFailureReason(params: {
         typeof params.timeoutSec === "number" && params.timeoutSec > 0
           ? `Command timed out after ${params.timeoutSec} seconds.`
           : "Command timed out.";
-      return `${appendExecTimeoutRetryGuidance(timeoutText, params.failureKind)}\n\nIf it should keep running, start it with exec background=true or yieldMs so OpenClaw can register a pollable process session. Do not rely on shell backgrounding with a trailing &.`;
+      const retryGuidance = appendExecTimeoutRetryGuidance(timeoutText, params.failureKind);
+      return params.processContinuationAvailable
+        ? `${retryGuidance}\n\nIf it should keep running, start it with exec background=true or yieldMs so OpenClaw can register a pollable process session. Do not rely on shell backgrounding with a trailing &.`
+        : retryGuidance;
     }
     case "no-output-timeout":
       return appendExecTimeoutRetryGuidance(
@@ -512,6 +519,7 @@ function buildExecExitOutcome(params: {
   aggregated: string;
   durationMs: number;
   timeoutSec: number | null | undefined;
+  processContinuationAvailable: boolean;
 }): ExecProcessOutcome {
   const exitCode = params.exit.exitCode ?? 0;
   const isNormalExit = params.exit.reason === "exit";
@@ -541,6 +549,7 @@ function buildExecExitOutcome(params: {
     failureKind,
     exitSignal: params.exit.exitSignal,
     timeoutSec: params.timeoutSec,
+    processContinuationAvailable: params.processContinuationAvailable,
   });
   return {
     status: "failed",
@@ -643,6 +652,8 @@ export async function runExecProcess(opts: {
   eventRouting?: EventSessionRoutingPolicy;
   notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
+  /** Whether exec may return a supervised session for later continuation. */
+  processContinuationAvailable?: boolean;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
   /** Runs after process finalization and before the exit wake is queued. */
   onSettledBeforeNotify?: (outcome: ExecProcessOutcome) => void;
@@ -984,6 +995,7 @@ export async function runExecProcess(opts: {
         aggregated: session.aggregated.trim(),
         durationMs,
         timeoutSec: opts.timeoutSec,
+        processContinuationAvailable: opts.processContinuationAvailable !== false,
       });
 
       const finalOutcome = await finalizeAndSettleSession(outcome);

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -56,6 +56,8 @@ export type ExecToolDefaults = {
   sandbox?: BashSandboxConfig;
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;
+  /** Final run-local availability of the process continuation tool. */
+  processToolAvailabilityRef?: { value?: boolean };
   scopeKey?: string;
   sessionKey?: string;
   /** Stable agent run that owns any approval created by this tool. */

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -726,7 +726,7 @@ describe("exec approvals", () => {
 
     expect(result.details.status).toBe("completed");
     expect(getResultText(result)).toContain(
-      "Warning: background execution is disabled; running synchronously.",
+      "Warning: continuation options are unavailable; running synchronously.",
     );
     expect(getResultText(result)).toContain("node-ok");
   });
@@ -1005,7 +1005,7 @@ describe("exec approvals", () => {
   });
 
   it.each(["gateway", "node"] as const)(
-    "keeps background fallback warnings out of pending %s approvals",
+    "keeps unavailable continuation guidance out of pending %s approvals",
     async (host) => {
       let approvalRequest: Record<string, unknown> | undefined;
       vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
@@ -1042,7 +1042,7 @@ describe("exec approvals", () => {
       });
 
       expect(result.details.status).toBe("approval-pending");
-      expect(getResultText(result)).not.toContain("background execution is disabled");
+      expect(getResultText(result)).not.toMatch(/process|background|yieldMs|poll/i);
       expect(approvalRequest?.warningText).toBeUndefined();
     },
   );

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -72,6 +72,9 @@ export const execSchema = Type.Object({
   ),
 });
 
+/** Exec parameters when no process-control continuation is authorized. */
+export const execCompletionSchema = Type.Omit(execSchema, ["yieldMs", "background"]);
+
 /** Parameters exposed by node-only exec surfaces. */
 export const nodeExecSchema = Type.Object({
   command: execSchema.properties.command,

--- a/src/agents/lazy-exec-tool.ts
+++ b/src/agents/lazy-exec-tool.ts
@@ -7,7 +7,7 @@ import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
-import { execSchema } from "./bash-tools.schemas.js";
+import { execCompletionSchema, execSchema } from "./bash-tools.schemas.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -50,10 +50,16 @@ export function createLazyExecTool(
         describeExecTool({
           agentId: defaults?.agentId,
           hasCronTool: defaults?.hasCronTool === true,
+          hasProcessTool: defaults?.processToolAvailabilityRef?.value,
         })
       );
     },
-    parameters: presentation?.parameters ?? execSchema,
+    get parameters() {
+      return (
+        presentation?.parameters ??
+        (defaults?.processToolAvailabilityRef?.value === false ? execCompletionSchema : execSchema)
+      );
+    },
     prepareBeforeToolCallParams: async (...args) =>
       (await loadTool()).prepareBeforeToolCallParams?.(...args) ?? args[0],
     finalizeBeforeToolCallParams: (params, preparedParams) =>

--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -112,7 +112,7 @@ describe("terminal tool", () => {
     });
     expect(tool.outputSchema).toBeDefined();
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      "{ sessions: Array<{ agentId: string; attached: boolean; createdAtMs: number; cwd: string; owner: string; sessionId: string; shell: string }> } | { agentId: string; cwd: string; ok: true; sessionId: string; shell: string } | { sessionId: string; text: string } | { ok: boolean }",
+      "{ sessions: Array<{ agentId: string; attached: boolean; createdAtMs: number; cwd: string; owner: string; sessionId: string; shell: string }> } | { agentId: string; cwd: string; ok: true; sessionId: string; shell: string } | { sessionId: string; text: string } | { ok: true }",
     );
 
     const opened = await tool.execute("open", { action: "open", command: "echo ready" });
@@ -442,17 +442,21 @@ describe("terminal tool", () => {
 
     for (const sessionId of [conn.sessionId, other.sessionId]) {
       await expect(tool.execute("read", { action: "read", sessionId })).rejects.toThrow(
-        "terminal not owned by this agent session",
+        "Terminal session unavailable. Use action=list to find an owned terminal or action=open to acquire one.",
       );
       await expect(
         tool.execute("input", { action: "input", sessionId, data: "blocked" }),
-      ).resolves.toMatchObject({ details: { ok: false } });
+      ).rejects.toThrow(
+        "Terminal session unavailable. Use action=list to find an owned terminal or action=open to acquire one.",
+      );
       await expect(
         tool.execute("resize", { action: "resize", sessionId, cols: 120, rows: 40 }),
-      ).resolves.toMatchObject({ details: { ok: false } });
-      await expect(tool.execute("close", { action: "close", sessionId })).resolves.toMatchObject({
-        details: { ok: false },
-      });
+      ).rejects.toThrow(
+        "Terminal session unavailable. Use action=list to find an owned terminal or action=open to acquire one.",
+      );
+      await expect(tool.execute("close", { action: "close", sessionId })).rejects.toThrow(
+        "Terminal session unavailable. Use action=list to find an owned terminal or action=open to acquire one.",
+      );
     }
     await expect(tool.execute("list", { action: "list" })).resolves.toMatchObject({
       details: { sessions: [] },
@@ -462,4 +466,60 @@ describe("terminal tool", () => {
     expect(connBackend.killed).toBe(false);
     expect(otherBackend.killed).toBe(false);
   });
+
+  it.each([
+    {
+      name: "initial command",
+      configure: (backend: ReturnType<typeof makeBackend>) => {
+        backend.write = () => {
+          throw new Error("write failed");
+        };
+      },
+      execute: (tool: ReturnType<typeof createTerminalTool>) =>
+        tool.execute("open", { action: "open", command: "echo ready" }),
+    },
+    {
+      name: "input",
+      configure: (backend: ReturnType<typeof makeBackend>) => {
+        backend.write = () => {
+          throw new Error("write failed");
+        };
+      },
+      execute: async (tool: ReturnType<typeof createTerminalTool>) => {
+        const opened = await tool.execute("open", { action: "open" });
+        const sessionId = (opened.details as { sessionId: string }).sessionId;
+        return tool.execute("input", { action: "input", sessionId, data: "yes\r" });
+      },
+    },
+    {
+      name: "resize",
+      configure: (backend: ReturnType<typeof makeBackend>) => {
+        backend.resize = () => {
+          throw new Error("resize failed");
+        };
+      },
+      execute: async (tool: ReturnType<typeof createTerminalTool>) => {
+        const opened = await tool.execute("open", { action: "open" });
+        const sessionId = (opened.details as { sessionId: string }).sessionId;
+        return tool.execute("resize", { action: "resize", sessionId, cols: 120, rows: 40 });
+      },
+    },
+  ])(
+    "throws actionable recovery when backend $name fails",
+    async ({ name, configure, execute }) => {
+      const backend = makeBackend();
+      configure(backend);
+      const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+      const tool = createTerminalTool({
+        agentId: "main",
+        agentSessionKey: "agent:main:main",
+        getGatewayContext: () => makeContext(manager),
+      });
+
+      await expect(execute(tool)).rejects.toThrow(
+        `Terminal ${name} failed. Use action=list to find an owned terminal or action=open to acquire one.`,
+      );
+      expect(manager.size).toBe(0);
+    },
+  );
 });

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -7,6 +7,7 @@ import {
   TerminalOpenDeadlineError,
   waitForTerminalOpenDeadline,
 } from "../../gateway/terminal/open-deadline.js";
+import type { TerminalAgentActionOutcome } from "../../gateway/terminal/session-manager.types.js";
 import { getAgentRunTaskRunId } from "../../infra/agent-run-registry.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { isTerminalTaskStatus } from "../../tasks/task-executor-policy.js";
@@ -64,8 +65,26 @@ const TerminalToolOutputSchema = Type.Union([
     { additionalProperties: false },
   ),
   Type.Object({ sessionId: Type.String(), text: Type.String() }, { additionalProperties: false }),
-  Type.Object({ ok: Type.Boolean() }, { additionalProperties: false }),
+  Type.Object({ ok: Type.Literal(true) }, { additionalProperties: false }),
 ]);
+
+const TERMINAL_RECOVERY_GUIDANCE =
+  "Use action=list to find an owned terminal or action=open to acquire one.";
+const TERMINAL_UNAVAILABLE_MESSAGE = `Terminal session unavailable. ${TERMINAL_RECOVERY_GUIDANCE}`;
+
+function terminalActionResult(
+  action: "initial command" | "input" | "resize" | "close",
+  outcome: TerminalAgentActionOutcome,
+): ReturnType<typeof jsonResult> {
+  if (!outcome.ok) {
+    throw new ToolInputError(
+      outcome.code === "session_unavailable"
+        ? TERMINAL_UNAVAILABLE_MESSAGE
+        : `Terminal ${action} failed. ${TERMINAL_RECOVERY_GUIDANCE}`,
+    );
+  }
+  return jsonResult({ ok: true });
+}
 
 type TerminalToolGatewayContext = Pick<
   GatewayRequestContext,
@@ -252,12 +271,17 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
         if (!outcome.ok) {
           throw new ToolInputError(outcome.message);
         }
-        if (
-          command !== undefined &&
-          !manager.writeAgent(agentSessionKey, outcome.sessionId, `${command}\r`, agentId)
-        ) {
-          manager.closeAgent(agentSessionKey, outcome.sessionId, agentId);
-          throw new ToolInputError("terminal command failed");
+        if (command !== undefined) {
+          const commandOutcome = manager.writeAgent(
+            agentSessionKey,
+            outcome.sessionId,
+            `${command}\r`,
+            agentId,
+          );
+          if (!commandOutcome.ok) {
+            manager.closeAgent(agentSessionKey, outcome.sessionId, agentId);
+            terminalActionResult("initial command", commandOutcome);
+          }
         }
         return jsonResult(outcome);
       }
@@ -266,7 +290,7 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
       if (action === "read") {
         const raw = manager.snapshotAgent(agentSessionKey, sessionId, agentId);
         if (raw === undefined) {
-          throw new ToolInputError("terminal not owned by this agent session");
+          throw new ToolInputError(TERMINAL_UNAVAILABLE_MESSAGE);
         }
         return jsonResult({ sessionId, text: renderTerminalBufferText(raw) });
       }
@@ -276,23 +300,28 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
           trim: false,
           allowEmpty: true,
         });
-        return jsonResult({
-          ok: manager.writeAgent(agentSessionKey, sessionId, data, agentId),
-        });
+        return terminalActionResult(
+          "input",
+          manager.writeAgent(agentSessionKey, sessionId, data, agentId),
+        );
       }
       if (action === "resize") {
-        return jsonResult({
-          ok: manager.resizeAgent(
+        return terminalActionResult(
+          "resize",
+          manager.resizeAgent(
             agentSessionKey,
             sessionId,
             readDimension(params, "cols"),
             readDimension(params, "rows"),
             agentId,
           ),
-        });
+        );
       }
       if (action === "close") {
-        return jsonResult({ ok: manager.closeAgent(agentSessionKey, sessionId, agentId) });
+        return terminalActionResult(
+          "close",
+          manager.closeAgent(agentSessionKey, sessionId, agentId),
+        );
       }
       throw new ToolInputError(`Unknown action: ${action}`);
     },

--- a/src/gateway/terminal/session-manager.eviction.test.ts
+++ b/src/gateway/terminal/session-manager.eviction.test.ts
@@ -38,7 +38,9 @@ describe("TerminalSessionManager idle eviction", () => {
       }
       // Freshen the second session so the first is the idle-eviction candidate.
       await vi.advanceTimersByTimeAsync(5_000);
-      expect(manager.writeAgent("agent:main:main", second.sessionId, "keepalive\r")).toBe(true);
+      expect(manager.writeAgent("agent:main:main", second.sessionId, "keepalive\r")).toEqual({
+        ok: true,
+      });
 
       const third = await manager.open(baseOpenRequest({ owner: agentOwner }));
       expect(third.ok).toBe(true);
@@ -108,7 +110,9 @@ describe("TerminalSessionManager idle eviction", () => {
     expect(victimPty.killed).toBe(false);
     expect(replacementPty.killed).toBe(true);
     expect(manager.size).toBe(1);
-    expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toBe(true);
+    expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toEqual({
+      ok: true,
+    });
   });
 
   it("evicts the freshly idlest session when the claimed victim becomes active mid-spawn", async () => {
@@ -144,7 +148,9 @@ describe("TerminalSessionManager idle eviction", () => {
       // The claimed (oldest) session becomes active during the spawn, making
       // the newer session the genuinely idlest candidate.
       await vi.advanceTimersByTimeAsync(5_000);
-      expect(manager.writeAgent("agent:main:main", oldest.sessionId, "busy\r")).toBe(true);
+      expect(manager.writeAgent("agent:main:main", oldest.sessionId, "busy\r")).toEqual({
+        ok: true,
+      });
       releaseSpawn?.();
 
       const outcome = await opening;
@@ -253,7 +259,9 @@ describe("TerminalSessionManager idle eviction", () => {
     // The victim survives a failed replacement and stays claimable later.
     expect(manager.size).toBe(1);
     expect(pty.killed).toBe(false);
-    expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toBe(true);
+    expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toEqual({
+      ok: true,
+    });
 
     failNextSpawn = false;
     const replacement = await manager.open(baseOpenRequest({ owner: agentOwner }));

--- a/src/gateway/terminal/session-manager.task-lifecycle.test.ts
+++ b/src/gateway/terminal/session-manager.task-lifecycle.test.ts
@@ -45,16 +45,19 @@ describe("TerminalSessionManager task lifecycle", () => {
       throw new Error("expected terminal session");
     }
 
-    expect(manager.writeAgent("agent:research:main", opened.sessionId, "nope", "research")).toBe(
-      false,
+    expect(manager.writeAgent("agent:research:main", opened.sessionId, "nope", "research")).toEqual(
+      { ok: false, code: "session_unavailable" },
     );
-    expect(manager.resizeAgent("agent:research:main", opened.sessionId, 90, 30, "research")).toBe(
-      false,
-    );
+    expect(
+      manager.resizeAgent("agent:research:main", opened.sessionId, 90, 30, "research"),
+    ).toEqual({ ok: false, code: "session_unavailable" });
     expect(
       manager.snapshotAgent("agent:research:main", opened.sessionId, "research"),
     ).toBeUndefined();
-    expect(manager.closeAgent("agent:research:main", opened.sessionId, "research")).toBe(false);
+    expect(manager.closeAgent("agent:research:main", opened.sessionId, "research")).toEqual({
+      ok: false,
+      code: "session_unavailable",
+    });
     expect(fake.killed).toBe(false);
   });
 

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -633,7 +633,7 @@ describe("TerminalSessionManager agent ownership", () => {
       expect(emit).not.toHaveBeenCalled();
       expect(manager.snapshotAgent("agent:main:main", outcome.sessionId)).toBe("visiblebuffered");
 
-      expect(manager.closeAgent("agent:main:main", outcome.sessionId)).toBe(true);
+      expect(manager.closeAgent("agent:main:main", outcome.sessionId)).toEqual({ ok: true });
       expect(fake.killed).toBe(true);
       expect(manager.size).toBe(0);
     } finally {

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_SCROLLBACK_CHARS,
 } from "./session-limits.js";
 import type {
+  TerminalAgentActionOutcome,
   TerminalEventSink,
   TerminalExitReason,
   TerminalOpenOutcome,
@@ -317,9 +318,17 @@ export class TerminalSessionManager {
   }
 
   /** Writes agent input after proving session-key ownership. */
-  writeAgent(agentSessionKey: string, sessionId: string, data: string, agentId?: string): boolean {
+  writeAgent(
+    agentSessionKey: string,
+    sessionId: string,
+    data: string,
+    agentId?: string,
+  ): TerminalAgentActionOutcome {
     const session = this.agentOwnedSession(agentSessionKey, sessionId, agentId);
-    return session ? this.writeSession(session, data) : false;
+    if (!session) {
+      return { ok: false, code: "session_unavailable" };
+    }
+    return this.writeSession(session, data) ? { ok: true } : { ok: false, code: "backend_failed" };
   }
 
   private writeSession(session: TerminalSession, data: string): boolean {
@@ -350,9 +359,14 @@ export class TerminalSessionManager {
     cols: number,
     rows: number,
     agentId?: string,
-  ): boolean {
+  ): TerminalAgentActionOutcome {
     const session = this.agentOwnedSession(agentSessionKey, sessionId, agentId);
-    return session ? this.resizeSession(session, cols, rows) : false;
+    if (!session) {
+      return { ok: false, code: "session_unavailable" };
+    }
+    return this.resizeSession(session, cols, rows)
+      ? { ok: true }
+      : { ok: false, code: "backend_failed" };
   }
 
   private resizeSession(session: TerminalSession, cols: number, rows: number): boolean {
@@ -402,13 +416,17 @@ export class TerminalSessionManager {
   }
 
   /** Closes an agent-owned PTY after proving session-key ownership. */
-  closeAgent(agentSessionKey: string, sessionId: string, agentId?: string): boolean {
+  closeAgent(
+    agentSessionKey: string,
+    sessionId: string,
+    agentId?: string,
+  ): TerminalAgentActionOutcome {
     const session = this.agentOwnedSession(agentSessionKey, sessionId, agentId);
     if (!session) {
-      return false;
+      return { ok: false, code: "session_unavailable" };
     }
     this.finalize(session, "closed", {});
-    return true;
+    return { ok: true };
   }
 
   /** Closes every live or spawning PTY owned by one exact agent session or task. */

--- a/src/gateway/terminal/session-manager.types.ts
+++ b/src/gateway/terminal/session-manager.types.ts
@@ -66,6 +66,10 @@ export type TerminalOpenOutcome =
   | { ok: true; sessionId: string; agentId: string; cwd: string; shell: string }
   | { ok: false; code: "limit" | "spawn_failed" | "closed"; message: string };
 
+export type TerminalAgentActionOutcome =
+  | { ok: true }
+  | { ok: false; code: "session_unavailable" | "backend_failed" };
+
 /** Abort state shared between a pending open and lifecycle/policy teardown. */
 export type TerminalPendingOpen = {
   agentId: string;


### PR DESCRIPTION
Closes #125730

## What Problem This Solves

Fixes an issue where agents using expired or non-owned gateway terminals could receive an ordinary successful tool result containing only `{ok:false}`, with no actionable recovery path. It also fixes restricted agent tool surfaces where `exec` could advertise and create background work after effective policy removed the `process` tool needed to control that work.

## Why This Change Was Made

Terminal agent mutations now use a narrow discriminated manager outcome that distinguishes an unavailable session from a backend action failure without leaking ownership details. The terminal tool converts those failures into bounded guidance to list an owned terminal or open a new one.

Exec now consumes the final authorized availability of process control. When `process` is absent, exec exposes a completion-only description and schema, runs stale background/yield requests synchronously, and removes unavailable continuation guidance from approval and timeout results. The existing supervised background path is unchanged when process control remains available.

This is AI-assisted. I reviewed the complete change, its owner boundaries, and the focused proof.

## User Impact

Agents now receive a concrete next step when a terminal session is unavailable or a terminal backend action fails. Policy-restricted agents no longer start background commands they cannot inspect, interact with, or stop, and their tool schemas/results no longer advertise missing process-control capabilities.

Production LOC: +142/-58 (net +84) | Tests: +134/-22. The production growth establishes the discriminated terminal action contract and carries one final process-capability fact through exec descriptions, schemas, approvals, execution, and timeout results; it does not add a parallel execution path.

## Evidence

Pre-fix regression proof:

- Terminal contract test: 5 intended failures, showing `{ok:boolean}`, the old non-actionable ownership error, and backend failures resolving as `{ok:false}`.
- Final-policy exec test: 1 intended failure, showing the description/schema advertised continuation and `background:true` returned `status:"running"` without `process` available.
- Completion-only timeout test: 1 intended failure, showing timeout output still recommended the unavailable background/yield path.

Post-fix local proof:

- `node scripts/run-vitest.mjs src/agents/tools/terminal-tool.test.ts` — 15 passed.
- `node scripts/run-vitest.mjs src/gateway/terminal/session-manager.test.ts src/gateway/terminal/session-manager.task-lifecycle.test.ts src/gateway/terminal/session-manager.eviction.test.ts` — 48 passed.
- `node scripts/run-vitest.mjs src/agents/agent-tools-agent-config.exec.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec.approval-id.test.ts` — 81 passed.
- `node scripts/check-changed.mjs` — passed (`core`, `coreTests`), including formatting, core and test typechecks, changed-file lint, dead-export scan, import-cycle checks, and repository guards.
- `git diff --check` — passed.
- Fresh structured autoreview — clean; no accepted/actionable findings.

No live provider or channel run was needed: this is a deterministic tool result, schema, and effective-policy contract covered at the terminal manager/tool and assembled agent-tool boundaries.