### PR TITLE
fix(ui): disable review-only approval actions

### DIFF
--- a/test/non-isolated-runner.resolve-mocks.test.ts
+++ b/test/non-isolated-runner.resolve-mocks.test.ts
@@ -3,17 +3,28 @@
 // invalidated) twice, while every caller's pass starts at or after its call so
 // previously queued ids are registered before the caller's fetch proceeds.
 import { describe, expect, it } from "vitest";
-import { serializeMockerResolveMocks } from "./non-isolated-runner.js";
+import { drainMockerResolveMocks, serializeMockerResolveMocks } from "./non-isolated-runner.js";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
 
 // Mirrors BareModuleMocker.resolveMocks: snapshots the static queue's contents
 // at pass start, awaits its RPCs, then reassigns the static to [] so ids
 // pushed during the await land in the abandoned array.
 class FakeMocker {
   static pendingIds: unknown[] = [];
+  beforeFirstPass?: () => Promise<void>;
+  nextPassError?: Error;
   passes = 0;
   active = 0;
   maxConcurrentPasses = 0;
   processed: unknown[] = [];
+  resetObservations: Array<{ active: number; pendingIds: unknown[]; processed: unknown[] }> = [];
 
   async resolveMocks(): Promise<void> {
     if (FakeMocker.pendingIds.length === 0) {
@@ -23,13 +34,32 @@ class FakeMocker {
     this.maxConcurrentPasses = Math.max(this.maxConcurrentPasses, this.active);
     this.passes += 1;
     const snapshot = [...FakeMocker.pendingIds];
-    // Simulate the parallel resolveId RPC round-trips inside one pass.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1);
-    });
+    if (this.passes === 1 && this.beforeFirstPass) {
+      await this.beforeFirstPass();
+    } else {
+      // Simulate the parallel resolveId RPC round-trips inside one pass.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+    const passError = this.nextPassError;
+    this.nextPassError = undefined;
+    if (passError) {
+      FakeMocker.pendingIds = [];
+      this.active -= 1;
+      throw passError;
+    }
     this.processed.push(...snapshot);
     FakeMocker.pendingIds = [];
     this.active -= 1;
+  }
+
+  reset(): void {
+    this.resetObservations.push({
+      active: this.active,
+      pendingIds: [...FakeMocker.pendingIds],
+      processed: [...this.processed],
+    });
   }
 }
 
@@ -93,5 +123,49 @@ describe("serializeMockerResolveMocks", () => {
     expect(mocker.passes).toBe(2);
     expect(mocker.processed).toEqual(["mock-a", "mock-b"]);
     expect(FakeMocker.pendingIds).toEqual([]);
+  });
+
+  it("drains every queued pass before cleanup resets the mocker", async () => {
+    FakeMocker.pendingIds = ["mock-a"];
+    const firstPassStarted = deferred();
+    const releaseFirstPass = deferred();
+    const mocker = new FakeMocker();
+    mocker.beforeFirstPass = async () => {
+      firstPassStarted.resolve();
+      await releaseFirstPass.promise;
+    };
+    serializeMockerResolveMocks(mocker);
+
+    const first = mocker.resolveMocks();
+    await firstPassStarted.promise;
+    const drain = drainMockerResolveMocks(mocker);
+    const drainState = Promise.race([drain.then(() => "settled"), Promise.resolve("pending")]);
+
+    expect(await drainState).toBe("pending");
+    FakeMocker.pendingIds.push("mock-late");
+    const second = mocker.resolveMocks();
+    releaseFirstPass.resolve();
+    await drain;
+    mocker.reset();
+
+    expect(mocker.resetObservations).toEqual([
+      { active: 0, pendingIds: [], processed: ["mock-a", "mock-late"] },
+    ]);
+    await Promise.all([first, second]);
+  });
+
+  it("keeps the internal drain usable after a caller-visible rejection", async () => {
+    FakeMocker.pendingIds = ["mock-a"];
+    const mocker = new FakeMocker();
+    mocker.nextPassError = new Error("synthetic resolution failure");
+    serializeMockerResolveMocks(mocker);
+
+    await expect(mocker.resolveMocks()).rejects.toThrow("synthetic resolution failure");
+    FakeMocker.pendingIds = ["mock-b"];
+    const recovered = mocker.resolveMocks();
+
+    await expect(drainMockerResolveMocks(mocker)).resolves.toBeUndefined();
+    await expect(recovered).resolves.toBeUndefined();
+    expect(mocker.passes).toBe(2);
   });
 });

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -309,6 +309,14 @@ function resetOpenClawSessionSuspensionState(): void {
 
 const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");
 
+type SerializedResolveMocksState = {
+  tail: Promise<void>;
+};
+
+type SerializedMocker = SerializableMocker & {
+  [SERIALIZED_RESOLVE_MOCKS]?: SerializedResolveMocksState;
+};
+
 // Vitest's BareModuleMocker.resolveMocks has no in-flight guard: pendingIds is
 // cleared only after all parallel resolveId RPCs settle, and every registration
 // re-invalidates the mock module node. In a shared isolate:false worker, stray
@@ -331,13 +339,13 @@ const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");
 //   then import with mock state unresolved (observed: auth-provenance's
 //   doUnmock + Promise.all imports loading the real provider-auth warm worker
 //   and a 120s oauth refresh instead of the mocked provider hook).
-export function serializeMockerResolveMocks(
-  mocker: SerializableMocker & { [SERIALIZED_RESOLVE_MOCKS]?: boolean },
-): void {
-  if (!mocker.resolveMocks || mocker[SERIALIZED_RESOLVE_MOCKS]) {
+export function serializeMockerResolveMocks(mocker: SerializableMocker): void {
+  const serializedMocker = mocker as SerializedMocker;
+  if (!mocker.resolveMocks || serializedMocker[SERIALIZED_RESOLVE_MOCKS]) {
     return;
   }
-  mocker[SERIALIZED_RESOLVE_MOCKS] = true;
+  const state: SerializedResolveMocksState = { tail: Promise.resolve() };
+  serializedMocker[SERIALIZED_RESOLVE_MOCKS] = state;
   const original = mocker.resolveMocks.bind(mocker);
   const statics = mocker.constructor as { pendingIds?: unknown[] };
   const runPass = async (): Promise<void> => {
@@ -352,17 +360,32 @@ export function serializeMockerResolveMocks(
       statics.pendingIds?.push(...queue.slice(processedCount));
     }
   };
-  let tail: Promise<void> = Promise.resolve();
   mocker.resolveMocks = () => {
-    const pass = tail.then(runPass);
+    const pass = state.tail.then(runPass);
     // Keep the chain alive after a rejected pass; the rejection still reaches
     // the caller that owns that pass, matching upstream behavior.
-    tail = pass.then(
+    state.tail = pass.then(
       () => undefined,
       () => undefined,
     );
     return pass;
   };
+}
+
+export async function drainMockerResolveMocks(
+  mocker: SerializableMocker | undefined,
+): Promise<void> {
+  const state = (mocker as SerializedMocker | undefined)?.[SERIALIZED_RESOLVE_MOCKS];
+  if (!state) {
+    return;
+  }
+  while (true) {
+    const tail = state.tail;
+    await tail;
+    if (state.tail === tail) {
+      return;
+    }
+  }
 }
 
 export default class OpenClawNonIsolatedRunner extends TestRunner {
@@ -399,11 +422,14 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
   // the next file's vi.mock factories silently never applied. The worker loop
   // calls startTests per file, so this hook runs after every file regardless
   // of its collect/run outcome.
-  override onAfterRunFiles() {
-    super.onAfterRunFiles();
+  override async onAfterRunFiles() {
+    await super.onAfterRunFiles();
     if (this.config.isolate) {
       return;
     }
+
+    const internals = this as unknown as TestRunnerInternals;
+    await drainMockerResolveMocks(internals.moduleRunner?.mocker);
 
     // Mirror the missing cleanup from Vitest isolate mode so shared workers do
     // not carry file-scoped timers, stubs, spies, or stale module state
@@ -424,7 +450,6 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     dropTrackedRepoOwnedCustomElements();
     resetSharedDocumentBody();
     vi.resetModules();
-    const internals = this as unknown as TestRunnerInternals;
     internals.moduleRunner?.mocker?.reset?.();
     resetEvaluatedModules(internals.workerState.evaluatedModules as EvaluatedModules, true);
   }

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -680,6 +680,7 @@ export function renderApplicationShell(host: ShellViewHost) {
             .props=${{
               queue: overlaySnapshot.approvalQueue,
               busy: overlaySnapshot.approvalBusy,
+              canGrant: overlaySnapshot.approvalCanGrant,
               errors: overlaySnapshot.approvalErrors,
               nowMs: overlaySnapshot.approvalNowMs,
               onDecision: (

--- a/ui/src/app/overlays-types.ts
+++ b/ui/src/app/overlays-types.ts
@@ -15,6 +15,7 @@ export type ApplicationOverlaySnapshot = {
   controlUiRefreshRequired: boolean;
   approvalQueue: readonly ExecApprovalRequest[];
   approvalBusy: boolean;
+  approvalCanGrant: boolean;
   approvalErrors: ReadonlyMap<string, string>;
   approvalNowMs: number;
   devicePairSetupOpen: boolean;

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -168,12 +168,42 @@ describe("application approval overlays", () => {
     expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual([
       "approval-review-only",
     ]);
+    expect(overlays.snapshot.approvalCanGrant).toBe(false);
     expect(overlays.snapshot.approvalBusy).toBe(false);
+    expect(overlays.snapshot.approvalErrors.get("approval-review-only")).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
     expect(
       request.mock.calls.some(
         ([method]) => method === "exec.approval.resolve" || method === "approval.resolve",
       ),
     ).toBe(false);
+    overlays.dispose();
+  });
+
+  it("surfaces a stale decision dispatched after grant revocation", async () => {
+    const request = vi.fn<RequestFn>((method) =>
+      Promise.resolve(method.endsWith(".list") ? [] : { ok: true }),
+    );
+    const harness = createGatewayHarness(client(request));
+    harness.update({
+      hello: {
+        auth: { role: "operator", scopes: ["operator.approvals"] },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    const overlays = createApplicationOverlays(harness.gateway);
+    await flushMicrotasks();
+    harness.emitApproval("approval-stale-action", 1_000);
+
+    // A rendered action can dispatch before the overlay subscriber consumes
+    // the snapshot that revokes its grant.
+    harness.replaceSnapshotWithoutPublishing({ hello: null });
+    await overlays.decideApproval("allow-once", "approval-stale-action");
+
+    expect(overlays.snapshot.approvalErrors.get("approval-stale-action")).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
+    expect(request.mock.calls.some(([method]) => method === "exec.approval.resolve")).toBe(false);
     overlays.dispose();
   });
 
@@ -407,9 +437,13 @@ describe("application approval overlays", () => {
 
     harness.update({ hello: null });
     expect(overlays.snapshot.approvalBusy).toBe(false);
+    expect(overlays.snapshot.approvalCanGrant).toBe(false);
     expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual([
       "approval-stale-grant",
     ]);
+    expect(overlays.snapshot.approvalErrors.get("approval-stale-grant")).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
     harness.update({
       hello: {
         auth: { role: "operator", scopes: ["operator.approvals"] },
@@ -417,6 +451,7 @@ describe("application approval overlays", () => {
     });
     harness.emitApproval("approval-current-grant", 2_000);
     const currentDecision = overlays.decideApproval("deny", "approval-current-grant");
+    expect(overlays.snapshot.approvalCanGrant).toBe(true);
 
     staleResolution.resolve({ ok: true });
     await staleDecision;
@@ -432,6 +467,9 @@ describe("application approval overlays", () => {
     expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual([
       "approval-stale-grant",
     ]);
+    expect(overlays.snapshot.approvalErrors.get("approval-stale-grant")).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
     overlays.dispose();
   });
 

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -88,6 +88,7 @@ export function createApplicationOverlays(
     controlUiRefreshRequired: false,
     approvalQueue: [],
     approvalBusy: false,
+    approvalCanGrant: false,
     approvalErrors: new Map(),
     approvalNowMs: Date.now(),
     devicePairSetupOpen: false,
@@ -135,6 +136,7 @@ export function createApplicationOverlays(
       updateReconciliationPending: pendingUpdate !== null,
       approvalQueue: promptState.execApprovalQueue,
       approvalBusy: promptState.execApprovalBusy,
+      approvalCanGrant: readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals,
       approvalErrors: new Map(promptState.execApprovalErrors),
       approvalNowMs: promptState.execApprovalNowMs ?? Date.now(),
       ...readDevicePairSetupSnapshot(devicePairSetupState),
@@ -261,6 +263,13 @@ export function createApplicationOverlays(
     if (accessTransition.grantRevoked) {
       // Review can remain available without a decision grant. Retire the
       // in-flight owner without discarding the still-readable approval queue.
+      const revokedDecision = approvalDecision;
+      if (
+        revokedDecision &&
+        promptState.execApprovalQueue.some((entry) => entry.id === revokedDecision.id)
+      ) {
+        promptState.execApprovalErrors.set(revokedDecision.id, t("execApproval.reviewOnly"));
+      }
       approvalDecision = null;
       promptState.execApprovalBusy = false;
     }
@@ -609,6 +618,8 @@ export function createApplicationOverlays(
         return;
       }
       if (!readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals) {
+        promptState.execApprovalErrors.set(active.id, t("execApproval.reviewOnly"));
+        publish();
         return;
       }
       promptState.execApprovalBusy = true;

--- a/ui/src/components/exec-approval-card.test.ts
+++ b/ui/src/components/exec-approval-card.test.ts
@@ -31,6 +31,7 @@ function renderCard(request: ExecApprovalRequest, variant: "inline" | "modal" = 
     renderExecApprovalCard({
       approval: request,
       busy: false,
+      canGrant: true,
       error: null,
       nowMs: 1_000,
       variant,

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -17,6 +17,7 @@ const DEFAULT_EXEC_APPROVAL_DECISIONS = [
 type ExecApprovalCardProps = {
   approval: ExecApprovalRequest;
   busy: boolean;
+  canGrant: boolean;
   error: string | null;
   nowMs: number;
   variant: "inline" | "modal";
@@ -165,6 +166,8 @@ export function approvalTitle(active: ExecApprovalRequest): string {
 export function renderExecApprovalCard(props: ExecApprovalCardProps) {
   const active = props.approval;
   const decisions = resolveApprovalDecisions(active);
+  const reviewOnlyMessage = t("execApproval.reviewOnly");
+  const grantError = !props.canGrant && props.error === reviewOnlyMessage;
   const rawSeverity = active.pluginSeverity?.trim().toLowerCase();
   const severity =
     active.kind === "exec" || rawSeverity === "warning" || rawSeverity === "warn"
@@ -202,7 +205,17 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
     ${active.kind === "exec" && !decisions.includes("allow-always")
       ? html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`
       : nothing}
-    ${props.error ? html`<div class="exec-approval-error">${props.error}</div>` : nothing}
+    ${!props.canGrant
+      ? html`<div
+          class=${grantError ? "exec-approval-error" : "exec-approval-warning"}
+          role=${grantError ? "alert" : "note"}
+        >
+          ${reviewOnlyMessage}
+        </div>`
+      : nothing}
+    ${props.error && !grantError
+      ? html`<div class="exec-approval-error" role="alert">${props.error}</div>`
+      : nothing}
     <div class="exec-approval-actions">
       ${decisions.map((decision) => {
         const label = decisionLabel(decision);
@@ -210,8 +223,10 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
           class=${decisionClass(decision)}
           type="button"
           aria-label=${label}
-          ?disabled=${props.busy}
-          title=${props.variant === "modal" ? `${label} (${decisionShortcut(decision)})` : label}
+          ?disabled=${props.busy || !props.canGrant}
+          title=${props.variant === "modal" && props.canGrant
+            ? `${label} (${decisionShortcut(decision)})`
+            : label}
           @click=${() => props.onDecision(active.id, decision)}
         >
           <span>${label}</span>

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -28,6 +28,7 @@ async function renderApproval(
   requestOrQueue: ExecApprovalRequest | ExecApprovalRequest[],
   overrides: Partial<{
     busy: boolean;
+    canGrant: boolean;
     errors: ReadonlyMap<string, string>;
     nowMs: number;
     onDecision: ReturnType<typeof vi.fn>;
@@ -40,6 +41,7 @@ async function renderApproval(
       .props=${{
         queue,
         busy: overrides.busy ?? false,
+        canGrant: overrides.canGrant ?? true,
         errors: overrides.errors ?? new Map(),
         nowMs: overrides.nowMs ?? Date.now(),
         onDecision,
@@ -217,6 +219,25 @@ describe("openclaw-exec-approval", () => {
       ["approval-1", "allow-always"],
       ["approval-1", "deny"],
     ]);
+  });
+
+  it("keeps review-only decisions disabled and ignores their shortcuts", async () => {
+    const { onDecision } = await renderOpenedApproval(createExecRequest(), { canGrant: false });
+    const { modal } = await getRenderedModalDialog(container);
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(".exec-approval-actions button"),
+    );
+
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+
+    buttons[0]?.click();
+    modal.dispatchEvent(chord("Enter"));
+    modal.dispatchEvent(chord("d"));
+
+    expect(onDecision).not.toHaveBeenCalled();
   });
 
   it("ignores bare keys so stray typing cannot authorize a command", async () => {

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -19,6 +19,7 @@ import "./modal-dialog.ts";
 type ExecApprovalProps = {
   queue: readonly ExecApprovalRequest[];
   busy: boolean;
+  canGrant: boolean;
   errors: ReadonlyMap<string, string>;
   nowMs: number;
   onDecision: (approvalId: string, decision: ExecApprovalDecision) => void | Promise<void>;
@@ -112,7 +113,7 @@ class ExecApproval extends OpenClawLightDomContentsElement {
   private handleKeydown(event: KeyboardEvent, active: ExecApprovalRequest): void {
     // A held chord auto-repeats: once a decision settles and the queue
     // advances, the repeat would apply the same decision to the next request.
-    if (event.defaultPrevented || event.repeat || this.props?.busy) {
+    if (event.defaultPrevented || event.repeat || this.props?.busy || !this.props?.canGrant) {
       return;
     }
     const decision = shortcutDecision(event);
@@ -168,6 +169,7 @@ class ExecApproval extends OpenClawLightDomContentsElement {
           ${renderExecApprovalCard({
             approval: active,
             busy: props.busy,
+            canGrant: props.canGrant,
             error: props.errors.get(active.id) ?? null,
             nowMs: props.nowMs,
             variant: "modal",

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -149,6 +149,75 @@ suite.define(() => {
     }
   });
 
+  it("keeps no-auth inline and modal approvals readable while blocking decisions and shortcuts", async () => {
+    if (captureUiProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage, {
+      omitConnectHelloAuth: true,
+      sessionKey: activeSessionKey,
+    });
+
+    await currentPage.goto(controlUiSessionUrl(suite.server?.baseUrl ?? "", activeSessionKey));
+    await gateway.waitForRequest("sessions.list");
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-review-only", "echo review only", 1_000),
+    );
+
+    const inlineCard = currentPage.locator(
+      '.chat-inline-approval [data-approval-id="approval-review-only"]',
+    );
+    await inlineCard.waitFor();
+    await inlineCard.getByText("echo review only", { exact: true }).waitFor();
+    await inlineCard
+      .getByText("Review only. Sign in with approval access to record a decision.", {
+        exact: true,
+      })
+      .waitFor();
+    const inlineDecisionButtons = inlineCard.locator(".exec-approval-actions button");
+    expect(await inlineDecisionButtons.count()).toBe(3);
+    expect(
+      await inlineDecisionButtons.evaluateAll((buttons) =>
+        buttons.every((button) => (button as HTMLButtonElement).disabled),
+      ),
+    ).toBe(true);
+    if (captureUiProof) {
+      await currentPage.screenshot({ path: path.join(proofDir, "review-only-inline.png") });
+    }
+
+    await approvalAttentionChip(currentPage).click();
+    const approvalModal = await waitForConfirmModal(currentPage);
+    const modalCard = approvalModal.locator('[data-approval-id="approval-review-only"]');
+    await modalCard.getByText("echo review only", { exact: true }).waitFor();
+    await modalCard
+      .getByText("Review only. Sign in with approval access to record a decision.", {
+        exact: true,
+      })
+      .waitFor();
+    const modalDecisionButtons = modalCard.locator(".exec-approval-actions button");
+    expect(await modalDecisionButtons.count()).toBe(3);
+    expect(
+      await modalDecisionButtons.evaluateAll((buttons) =>
+        buttons.every((button) => (button as HTMLButtonElement).disabled),
+      ),
+    ).toBe(true);
+
+    await approvalModal.dispatchEvent("keydown", {
+      bubbles: true,
+      ctrlKey: true,
+      key: "Enter",
+    });
+    expect(await gateway.getRequests("exec.approval.resolve")).toHaveLength(0);
+
+    if (captureUiProof) {
+      await currentPage.screenshot({ path: path.join(proofDir, "review-only-modal.png") });
+    }
+  });
+
   it("sends a typed approval command immediately while the active run waits", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -154,11 +154,29 @@ suite.define(() => {
         },
         { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox" },
       ]);
+      const saveButton = page.getByRole("button", { name: "Save" });
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      await gateway.deferNext("config.get");
+      await gateway.emitGatewayEvent("config.changed", {
+        path: "/tmp/openclaw.json",
+        hash: "cloud-workers-2",
+        ts: Date.now(),
+      });
+      await gateway.waitForRequest("config.get", { after: configGetCount });
+      await expect.poll(() => saveButton.isDisabled()).toBe(true);
+      await gateway.resolveDeferred(
+        "config.get",
+        configResponse(
+          { cloudWorkers: { profiles: { "build-fleet": buildFleet } } },
+          "cloud-workers-2",
+        ),
+      );
+      await expect.poll(() => saveButton.isEnabled()).toBe(true);
       await gateway.deferNext("config.patch");
       const editRequestCount = (await gateway.getRequests("config.patch")).length;
-      await page.getByRole("button", { name: "Save" }).click();
+      await saveButton.click();
       const editPatch = await waitForConfigPatch(gateway, editRequestCount);
-      expect(editPatch).toMatchObject({
+      expect(editPatch).toEqual({
         cloudWorkers: {
           profiles: {
             "build-fleet": {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1862,6 +1862,7 @@ export const en: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Allow Always is unavailable for this command.",
+    reviewOnly: "Review only. Sign in with approval access to record a decision.",
     deny: "Deny",
     details: "Details",
     labels: {

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -192,6 +192,9 @@ describe("ApprovalPage", () => {
     expect(request).toHaveBeenCalledWith("approval.get", { id: "exec:approval-1" });
     expect(page.querySelector(".approval-page__preview")?.textContent).toBe("printf safe");
     expect(decision.disabled).toBe(true);
+    expect(page.querySelector(".approval-page__heading p")?.textContent?.trim()).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
     decision.click();
     await settle(page);
 
@@ -292,6 +295,9 @@ describe("ApprovalPage", () => {
     expect(page.querySelector(".approval-page__preview")?.textContent).toBe("printf safe");
     expect((page.querySelector('[data-decision="allow-once"]') as HTMLButtonElement).disabled).toBe(
       true,
+    );
+    expect(page.querySelector(".approval-page__heading p")?.textContent?.trim()).toBe(
+      "Review only. Sign in with approval access to record a decision.",
     );
 
     resolveDecision({ applied: true, approval: allowedApproval() });

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -602,13 +602,14 @@ export class ApprovalPage extends OpenClawLightDomElement {
   private renderApproval(approval: ApprovalSnapshot) {
     const pending = approval.status === "pending";
     const presentation = approval.presentation;
+    const canGrant = this.hasApprovalGrantAccess;
     const title = pending
       ? presentation.kind === "plugin"
         ? presentation.title
         : t("approvalPage.execTitle")
       : terminalTitle(approval, this.resolutionOrigin);
     const statusDescription = pending
-      ? t("approvalPage.pendingDescription")
+      ? t(canGrant ? "approvalPage.pendingDescription" : "execApproval.reviewOnly")
       : terminalDescription(approval, this.resolutionOrigin);
     return html`
       <div class="approval-page__status" aria-live="polite" aria-atomic="true">
@@ -654,7 +655,7 @@ export class ApprovalPage extends OpenClawLightDomElement {
                     data-decision=${decision}
                     ?disabled=${this.resolving ||
                     !this.hasGatewayConnection ||
-                    !this.hasApprovalGrantAccess ||
+                    !canGrant ||
                     this.requestError !== null}
                     @click=${() => void this.resolveApproval(decision)}
                   >

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -399,6 +399,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       runError: catalogKey ? null : (state.chatRunError ?? placementRunError),
       inlineApproval: sessionParticipationBlocked ? null : inlineApproval,
       approvalBusy: overlays?.snapshot?.approvalBusy,
+      approvalCanGrant: overlays?.snapshot?.approvalCanGrant ?? false,
       approvalErrors: overlays?.snapshot?.approvalErrors,
       approvalNowMs: overlays?.snapshot?.approvalNowMs,
       onApprovalDecision:

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -682,6 +682,7 @@ function createChatProps(overrides: Partial<ChatProps> = {}): ChatProps {
     disabledReason: null,
     error: null,
     runError: null,
+    approvalCanGrant: false,
     sessions: null,
     canvasPluginSurfaceUrl: null,
     embedSandboxMode: "scripts",
@@ -892,7 +893,7 @@ describe("chat Swarm progress", () => {
 });
 
 describe("inline approval card", () => {
-  it("renders between the transcript and composer and forwards its decision id", () => {
+  it("renders between the transcript and composer and enforces its grant projection", () => {
     const onApprovalDecision = vi.fn();
     const inlineApproval = {
       id: "approval-inline",
@@ -910,6 +911,7 @@ describe("inline approval card", () => {
     const container = renderChatView({
       inlineApproval,
       approvalNowMs: 1_000,
+      approvalCanGrant: false,
       approvalErrors: new Map([["approval-inline", "Approval failed: gateway unavailable"]]),
       onApprovalDecision,
     });
@@ -928,7 +930,23 @@ describe("inline approval card", () => {
     expect(container.querySelector(".exec-approval-error")?.textContent).toBe(
       "Approval failed: gateway unavailable",
     );
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "Review only. Sign in with approval access to record a decision.",
+    );
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLButtonElement>(".exec-approval-actions button"),
+      ).every((button) => button.disabled),
+    ).toBe(true);
     container.querySelector<HTMLButtonElement>(".exec-approval-actions button")?.click();
+    expect(onApprovalDecision).not.toHaveBeenCalled();
+
+    const authorizedContainer = renderChatView({
+      inlineApproval,
+      approvalCanGrant: true,
+      onApprovalDecision,
+    });
+    authorizedContainer.querySelector<HTMLButtonElement>(".exec-approval-actions button")?.click();
     expect(onApprovalDecision).toHaveBeenCalledWith("approval-inline", "allow-once");
   });
 });

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -149,6 +149,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     runError?: { summary: string } | null;
     inlineApproval?: ExecApprovalRequest | null;
     approvalBusy?: boolean;
+    approvalCanGrant: boolean;
     approvalErrors?: ReadonlyMap<string, string>;
     approvalNowMs?: number;
     onApprovalDecision?: (
@@ -544,6 +545,7 @@ export function renderChat(props: ChatProps) {
                         ${renderExecApprovalCard({
                           approval: props.inlineApproval,
                           busy: props.approvalBusy === true,
+                          canGrant: props.approvalCanGrant,
                           error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
                           nowMs: props.approvalNowMs ?? Date.now(),
                           variant: "inline",

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -355,6 +355,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
       return nothing;
     }
     const busy = this.busyProfileId !== null;
+    const canSave = this.canManage();
     const editing = this.editor.kind === "edit";
     const classMode = this.draft.customClass ? "custom" : this.draft.machineClass;
     return renderSettingsSection(
@@ -510,7 +511,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
             <button
               class="btn primary"
               type="button"
-              ?disabled=${busy}
+              ?disabled=${!canSave}
               @click=${() => void this.saveProfile(this.draft)}
             >
               ${busy ? t("common.saving") : t("common.save")}

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -318,6 +318,8 @@ export type ControlUiMockGatewayScenario = {
   /** Partition sessions.list fixtures by archived state after applying patches. */
   sessionArchiveFiltering?: boolean;
   models?: ModelCatalogEntry[];
+  /** Simulate a legacy Gateway whose connect hello predates the auth projection. */
+  omitConnectHelloAuth?: boolean;
   /** Operator scopes returned by the mocked connect handshake. */
   operatorScopes?: string[];
   sessionKey?: string;
@@ -879,6 +881,7 @@ function normalizeScenario(
     inFlightRun: scenario.inFlightRun ?? null,
     presenceUsers: scenario.presenceUsers ?? [],
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+    omitConnectHelloAuth: scenario.omitConnectHelloAuth ?? false,
     operatorScopes: scenario.operatorScopes ?? [
       "operator.admin",
       "operator.read",
@@ -1653,13 +1656,17 @@ function installControlUiMockGateway(
         const connectedDeviceToken =
           auth && typeof auth.deviceToken === "string" ? auth.deviceToken : scenario.deviceToken;
         return {
-          auth: {
-            deviceToken: connectedDeviceToken,
-            recoveryMigrationAllowed: true as const,
-            recoveryScope: "e2e-recovery-scope",
-            role: "operator",
-            scopes: scenario.operatorScopes,
-          },
+          ...(scenario.omitConnectHelloAuth
+            ? {}
+            : {
+                auth: {
+                  deviceToken: connectedDeviceToken,
+                  recoveryMigrationAllowed: true as const,
+                  recoveryScope: "e2e-recovery-scope",
+                  role: "operator",
+                  scopes: scenario.operatorScopes,
+                },
+              }),
           features: {
             capabilities: scenario.featureCapabilities,
             events: [],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reviewing a pending exec approval without grant authority saw enabled decision buttons and keyboard shortcuts, but the owner silently ignored the attempted decision. The approval stayed pending with no visible outcome, leaving the waiting agent blocked.

## Why This Change Was Made

The Control UI now carries the Gateway's existing approval-grant capability through the overlay snapshot into inline, modal, and shellless approval surfaces. Review-only operators can still inspect the request, but decision controls and shortcuts are disabled with explicit sign-in guidance. The owner-side authorization guard remains authoritative and now attaches a visible error to the exact approval when a stale action or in-flight decision races grant revocation.

No approval access is widened; the Gateway continues to enforce `operator.approvals` independently.

## User Impact

Operators without approval grant authority now get a clear review-only state instead of apparently actionable controls that do nothing. If authority is revoked after the approval renders, the affected approval reports the authorization loss rather than silently remaining blocked.

Release note: Control UI approval prompts now disable decisions and explain required access for review-only operators, including grant-revocation races.

## Evidence

- Pre-fix real-browser capture: approval buttons appeared enabled under a no-auth/review-only Gateway hello.

![Before: review-only approval rendered enabled actions](https://github.com/user-attachments/assets/9d4369e5-0410-45e6-b994-9351cd3d57d4)
- Post-fix inline capture: the request remains readable with disabled controls and explicit review-only guidance.

![After: inline review-only approval with disabled actions and guidance](https://github.com/user-attachments/assets/ca6092da-3e4c-423e-b12f-4dcb20f8aca7)
- Post-fix modal capture: the full queue preserves the same disabled controls and guidance.

![After: modal review-only approval with disabled actions and guidance](https://github.com/user-attachments/assets/c66bff6a-1461-43a5-a02b-97e87ee76f4b)
- Focused Control UI regressions after rebase: 6 unit files, 369 tests passed.
- Mocked-Gateway browser E2E: 4/4 passed, including `keeps no-auth inline and modal approvals readable while blocking decisions and shortcuts`.
- Changed-scope Vitest after rebase: 654 UI files + 19 isolated UI files + approval E2E passed (9,618 tests passed, 50 skipped).
- Exact-head CI runs 32117256728 and 32121799174 exposed the same non-isolated Vitest mock-identity split across Markdown and update-CLI tests. The disproven timing-only change was removed; the shared runner now drains serialized mock resolution to a stable tail before resetting mock/module state.
- Exact-head CI run 32118649094 exposed an enabled-but-silent cloud-worker Save race during background config refresh. Save now follows the existing `canManage()` owner state; the forced-refresh E2E passes, including 10/10 serial stress runs.
- Blacksmith Testbox `tbx_01m0a5gwm3na7r39ca6pkm2h9y` passed the full CLI suite (4,830 tests) and full Control UI suite (9,367 tests): https://github.com/openclaw/openclaw/actions/runs/32125298771.
- `pnpm ui:build` passed.
- UI typecheck, oxlint, stylelint, Control UI i18n verification, formatting, and `git diff --check` passed.
- Security review: no qualifying high- or medium-severity findings.
- Source-blind behavior validation: 5/5 contract clauses passed with no findings or blockers.
- Codex autoreview: clean, no accepted/actionable findings.

Production LOC: +43/-7 (net +36), covering the explicit approval grant projection/revocation boundary plus the cloud-worker Save availability repair. Tests/test support and runner tooling: +303/-26, including deterministic approval, config-refresh, and mock-cleanup regressions.

AI-assisted; implementation and proof reviewed against the authorization owner boundary.
