### PR TITLE
fix: report unknown gateway service state when inspection fails

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -367,7 +367,7 @@ describe("runServiceRestart token drift", () => {
     );
   });
 
-  it("restarts an installed system-scope service when its loaded-state probe is unavailable", async () => {
+  it("fails restart when an installed service cannot be inspected", async () => {
     service.isLoaded.mockRejectedValue(
       new Error(
         "systemctl is-enabled unavailable: Command failed during launch or output capture (EACCES)",
@@ -383,14 +383,14 @@ describe("runServiceRestart token drift", () => {
         service: { ...service, hasInstalledDefinition } as GatewayService,
         postRestartCheck,
       }),
-    ).resolves.toBe(true);
+    ).rejects.toThrow("__exit__:1");
 
-    expect(hasInstalledDefinition).toHaveBeenCalledWith({ env: process.env });
-    expect(service.restart).toHaveBeenCalledTimes(1);
-    expect(postRestartCheck).toHaveBeenCalledTimes(1);
-    expect(readJsonLog<{ ok?: boolean; result?: string }>()).toMatchObject({
-      ok: true,
-      result: "restarted",
+    expect(hasInstalledDefinition).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(postRestartCheck).not.toHaveBeenCalled();
+    expect(readJsonLog<{ ok?: boolean; error?: string }>()).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("systemctl is-enabled unavailable"),
     });
   });
 

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -4,6 +4,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { GatewayServiceControlArgs } from "../../daemon/service-types.js";
 import type { GatewayService } from "../../daemon/service.js";
 import {
+  createGatewayServiceRunArgs as createServiceRunArgs,
+  createGatewayUninstallArgs,
   lifecycleTestRuntime,
   resetLifecycleRuntimeLogs,
   resetLifecycleServiceMocks,
@@ -71,21 +73,12 @@ vi.mock("./lifecycle-audit.js", () => ({
 let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;
 let runServiceStart: typeof import("./lifecycle-core.js").runServiceStart;
 let runServiceStop: typeof import("./lifecycle-core.js").runServiceStop;
+let runServiceUninstall: typeof import("./lifecycle-core.js").runServiceUninstall;
 
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test helper lets assertions ascribe logged JSON shape.
 function readJsonLog<T extends object>() {
   const jsonLine = lifecycleRuntimeLogs.find((line) => line.trim().startsWith("{"));
   return JSON.parse(jsonLine ?? "{}") as T;
-}
-
-function createServiceRunArgs(checkTokenDrift?: boolean) {
-  return {
-    serviceNoun: "Gateway",
-    service,
-    renderStartHints: () => [],
-    opts: { json: true as const },
-    ...(checkTokenDrift ? { checkTokenDrift } : {}),
-  };
 }
 
 function stubConfigSecretRefGatewayToken() {
@@ -140,7 +133,8 @@ function expectUnsupportedServiceCheckFailure() {
 
 describe("runServiceRestart token drift", () => {
   beforeAll(async () => {
-    ({ runServiceRestart, runServiceStart, runServiceStop } = await import("./lifecycle-core.js"));
+    ({ runServiceRestart, runServiceStart, runServiceStop, runServiceUninstall } =
+      await import("./lifecycle-core.js"));
   });
 
   beforeEach(() => {
@@ -232,6 +226,58 @@ describe("runServiceRestart token drift", () => {
     expect(onNotLoaded).not.toHaveBeenCalled();
     expect(postRestartCheck).not.toHaveBeenCalled();
     expectUnsupportedServiceCheckFailure();
+  });
+
+  it.each([
+    {
+      name: "initial uninstall inspection",
+      arrange: () => service.isLoaded.mockRejectedValue(new Error("initial inspection failed")),
+      run: () => runServiceUninstall(createGatewayUninstallArgs()),
+      action: "uninstall",
+      detail: "initial inspection failed",
+      stopCalls: 0,
+      uninstallCalls: 0,
+    },
+    {
+      name: "post-uninstall verification",
+      arrange: () =>
+        service.isLoaded
+          .mockResolvedValueOnce(false)
+          .mockRejectedValueOnce(new Error("uninstall verification failed")),
+      run: () => runServiceUninstall(createGatewayUninstallArgs()),
+      action: "uninstall",
+      detail: "uninstall verification failed",
+      stopCalls: 0,
+      uninstallCalls: 1,
+    },
+    {
+      name: "post-stop verification",
+      arrange: () =>
+        service.isLoaded
+          .mockResolvedValueOnce(true)
+          .mockRejectedValueOnce(new Error("stop verification failed")),
+      run: () => runServiceStop({ serviceNoun: "Gateway", service, opts: { json: true } }),
+      action: "stop",
+      detail: "stop verification failed",
+      stopCalls: 1,
+      uninstallCalls: 0,
+    },
+  ])("fails $name without reporting false absence", async (testCase) => {
+    testCase.arrange();
+
+    await expect(testCase.run()).rejects.toThrow("__exit__:1");
+
+    expect(
+      readJsonLog<{ action?: string; ok?: boolean; result?: string; error?: string }>(),
+    ).toEqual(
+      expect.objectContaining({
+        action: testCase.action,
+        ok: false,
+        error: expect.stringContaining(testCase.detail),
+      }),
+    );
+    expect(service.stop).toHaveBeenCalledTimes(testCase.stopCalls);
+    expect(service.uninstall).toHaveBeenCalledTimes(testCase.uninstallCalls);
   });
 
   it("fails restart with the container hint when no service is installed", async () => {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -124,9 +124,6 @@ async function resolveServiceLoadedOrFail(params: {
       : Boolean(await params.service.readCommand(process.env).catch(() => null));
   const loadState = await readGatewayServiceLoadState(params.service, { env: process.env });
   if (loadState.status === "unknown") {
-    if (params.acceptInstalledDefinition && (await hasInstalledDefinition())) {
-      return true;
-    }
     params.fail(
       `${params.inspectionFailureMessage ?? `${params.serviceNoun} service check failed`}: ${loadState.detail}`,
     );

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -334,10 +334,11 @@ export async function runServiceStart(params: {
       );
       return;
     }
+    const serviceLoaded = startResult.state.loadState.status === "loaded";
     emit({
       ok: true,
       result: "started",
-      service: buildDaemonServiceSnapshot(params.service, startResult.state.loaded),
+      service: buildDaemonServiceSnapshot(params.service, serviceLoaded),
       warnings: warnings.length ? warnings : undefined,
     });
   } catch (err) {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -12,6 +12,7 @@ import type {
 import {
   describeGatewayServiceRestart,
   inspectGatewayServiceStartRepair,
+  readGatewayServiceLoadState,
   startGatewayService,
 } from "../../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../../daemon/systemd-hints.js";
@@ -114,24 +115,27 @@ async function resolveServiceLoadedOrFail(params: {
   service: GatewayService;
   fail: ReturnType<typeof createDaemonActionContext>["fail"];
   acceptInstalledDefinition?: boolean;
+  inspectionFailureMessage?: string;
 }): Promise<boolean | null> {
   // Keep native scope discovery in the adapter and failure emission in the action context.
   const hasInstalledDefinition = async () =>
     params.service.hasInstalledDefinition
       ? await params.service.hasInstalledDefinition({ env: process.env }).catch(() => false)
       : Boolean(await params.service.readCommand(process.env).catch(() => null));
-  try {
-    const loaded = await params.service.isLoaded({ env: process.env });
-    return (
-      loaded || (Boolean(params.acceptInstalledDefinition) && (await hasInstalledDefinition()))
-    );
-  } catch (err) {
+  const loadState = await readGatewayServiceLoadState(params.service, { env: process.env });
+  if (loadState.status === "unknown") {
     if (params.acceptInstalledDefinition && (await hasInstalledDefinition())) {
       return true;
     }
-    params.fail(`${params.serviceNoun} service check failed: ${String(err)}`);
+    params.fail(
+      `${params.inspectionFailureMessage ?? `${params.serviceNoun} service check failed`}: ${loadState.detail}`,
+    );
     return null;
   }
+  return (
+    loadState.status === "loaded" ||
+    (Boolean(params.acceptInstalledDefinition) && (await hasInstalledDefinition()))
+  );
 }
 
 export async function runServiceUninstall(params: {
@@ -157,11 +161,14 @@ export async function runServiceUninstall(params: {
     }
   }
 
-  let loaded;
-  try {
-    loaded = await params.service.isLoaded({ env: process.env });
-  } catch {
-    loaded = false;
+  let loaded = await resolveServiceLoadedOrFail({
+    serviceNoun: params.serviceNoun,
+    service: params.service,
+    fail,
+    inspectionFailureMessage: `${params.serviceNoun} uninstall aborted because service status is unknown; resolve the inspection error before retrying`,
+  });
+  if (loaded === null) {
+    return;
   }
   if (loaded && params.stopBeforeUninstall) {
     try {
@@ -176,10 +183,14 @@ export async function runServiceUninstall(params: {
     fail(`${params.serviceNoun} uninstall failed: ${String(err)}`);
     return;
   }
-  try {
-    loaded = await params.service.isLoaded({ env: process.env });
-  } catch {
-    loaded = false;
+  loaded = await resolveServiceLoadedOrFail({
+    serviceNoun: params.serviceNoun,
+    service: params.service,
+    fail,
+    inspectionFailureMessage: `${params.serviceNoun} uninstall verification failed because service status is unknown`,
+  });
+  if (loaded === null) {
+    return;
   }
   if (loaded && params.assertNotLoadedAfterUninstall) {
     fail(`${params.serviceNoun} service still loaded after uninstall.`);
@@ -438,16 +449,19 @@ export async function runServiceStop(params: {
     return;
   }
 
-  let stopped;
-  try {
-    stopped = await params.service.isLoaded({ env: process.env });
-  } catch {
-    stopped = false;
+  const finalLoaded = await resolveServiceLoadedOrFail({
+    serviceNoun: params.serviceNoun,
+    service: params.service,
+    fail,
+    inspectionFailureMessage: `${params.serviceNoun} stop verification failed because service status is unknown`,
+  });
+  if (finalLoaded === null) {
+    return;
   }
   emit({
     ok: true,
     result: "stopped",
-    service: buildDaemonServiceSnapshot(params.service, stopped),
+    service: buildDaemonServiceSnapshot(params.service, finalLoaded),
   });
 }
 

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -23,6 +23,7 @@ function createDaemonStatus(rpc: NonNullable<DaemonStatus["rpc"]>): DaemonStatus
   return {
     service: {
       label: "test service",
+      loaded: true,
       loadState: { status: "loaded" },
       loadedText: "loaded",
       notLoadedText: "not loaded",

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -23,7 +23,7 @@ function createDaemonStatus(rpc: NonNullable<DaemonStatus["rpc"]>): DaemonStatus
   return {
     service: {
       label: "test service",
-      loaded: true,
+      loadState: { status: "loaded" },
       loadedText: "loaded",
       notLoadedText: "not loaded",
     },

--- a/src/cli/daemon-cli/start-repair.test.ts
+++ b/src/cli/daemon-cli/start-repair.test.ts
@@ -155,7 +155,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     };
     const state: GatewayServiceState = {
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: false,
       env: {},
       command: {
@@ -214,7 +214,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
       } as unknown as GatewayService;
       const state: GatewayServiceState = {
         installed: true,
-        loaded: true,
+        loadState: { status: "loaded" },
         running: false,
         env: {},
         command: {
@@ -282,7 +282,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     } as unknown as GatewayService;
     const state: GatewayServiceState = {
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: false,
       env: {},
       command: {
@@ -313,7 +313,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     } as unknown as GatewayService;
     const state: GatewayServiceState = {
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: false,
       env: {},
       command: {
@@ -348,7 +348,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     } as unknown as GatewayService;
     const state: GatewayServiceState = {
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: false,
       env: {},
       command: {

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -441,7 +441,7 @@ describe("gatherDaemonStatus", () => {
     const status = {
       service: {
         label: "Scheduled Task",
-        loaded: true,
+        loadState: { status: "loaded" as const },
         loadedText: "registered",
         notLoadedText: "not registered",
       },
@@ -760,7 +760,10 @@ describe("gatherDaemonStatus", () => {
 
     expect(serviceIsLoaded).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 100 }));
     expect(serviceReadRuntime).toHaveBeenCalledWith(expect.any(Object), { timeoutMs: 100 });
-    expect(status.service.loaded).toBe(false);
+    expect(status.service.loadState).toEqual({
+      status: "unknown",
+      detail: "Error: systemctl is-enabled timed out",
+    });
     expect(status.service.runtime).toEqual({
       status: "unknown",
       detail: "Error: systemctl show timed out",
@@ -776,7 +779,10 @@ describe("gatherDaemonStatus", () => {
       }
       expect(JSON.parse(serialized)).toMatchObject({
         service: {
-          loaded: false,
+          loadState: {
+            status: "unknown",
+            detail: "Error: systemctl is-enabled timed out",
+          },
           runtime: {
             status: "unknown",
             detail: "Error: systemctl show timed out",
@@ -792,6 +798,8 @@ describe("gatherDaemonStatus", () => {
     try {
       printDaemonStatus(status, { json: false, deep: true });
       const output = log.mock.calls.flat().join("\n");
+      expect(output).toContain("Service: LaunchAgent (unknown)");
+      expect(output).not.toContain("Service: LaunchAgent (not loaded)");
       expect(output).toContain("Runtime: unknown (Error: systemctl show timed out)");
     } finally {
       log.mockRestore();
@@ -810,7 +818,7 @@ describe("gatherDaemonStatus", () => {
     const status = await gatherStatus({ probe: false });
 
     expect(status.service.command).toBeNull();
-    expect(status.service.loaded).toBe(false);
+    expect(status.service.loadState).toEqual({ status: "not-loaded" });
     expect(status.service.runtime).toEqual({
       status: "unknown",
       detail: "Gateway service install not supported on aix",

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -441,6 +441,7 @@ describe("gatherDaemonStatus", () => {
     const status = {
       service: {
         label: "Scheduled Task",
+        loaded: true,
         loadState: { status: "loaded" as const },
         loadedText: "registered",
         notLoadedText: "not registered",
@@ -734,6 +735,7 @@ describe("gatherDaemonStatus", () => {
     expect(
       serviceReadRuntime.mock.calls.some(([env]) => env?.OPENCLAW_GATEWAY_PORT === "19001"),
     ).toBe(true);
+    expect(status.service.loaded).toBe(true);
     expect(status.service.runtime?.status).toBe("running");
     expect((status.service.runtime as { detail?: string }).detail).toBe("19001");
   });
@@ -764,6 +766,7 @@ describe("gatherDaemonStatus", () => {
       status: "unknown",
       detail: "Error: systemctl is-enabled timed out",
     });
+    expect(status.service.loaded).toBeNull();
     expect(status.service.runtime).toEqual({
       status: "unknown",
       detail: "Error: systemctl show timed out",
@@ -779,6 +782,7 @@ describe("gatherDaemonStatus", () => {
       }
       expect(JSON.parse(serialized)).toMatchObject({
         service: {
+          loaded: null,
           loadState: {
             status: "unknown",
             detail: "Error: systemctl is-enabled timed out",
@@ -818,6 +822,7 @@ describe("gatherDaemonStatus", () => {
     const status = await gatherStatus({ probe: false });
 
     expect(status.service.command).toBeNull();
+    expect(status.service.loaded).toBe(false);
     expect(status.service.loadState).toEqual({ status: "not-loaded" });
     expect(status.service.runtime).toEqual({
       status: "unknown",

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -293,6 +293,7 @@ export type DaemonStatus = {
   logFile?: string;
   service: {
     label: string;
+    loaded: boolean | null;
     loadState: GatewayServiceLoadState;
     loadedText: string;
     notLoadedText: string;
@@ -807,6 +808,7 @@ export async function gatherDaemonStatus(
     logFile: resolveConfiguredLogFilePath(cliCfg),
     service: {
       label: service.label,
+      loaded: loadState.status === "unknown" ? null : loaded,
       loadState,
       loadedText: service.loadedText,
       notLoadedText: service.notLoadedText,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -25,6 +25,7 @@ import type { ExtraGatewayService, FindExtraGatewayServicesOptions } from "../..
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
+import type { GatewayServiceLoadState } from "../../daemon/service-types.js";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { projectGatewayUrlForDiagnostics } from "../../gateway/connection-details.js";
 import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
@@ -292,7 +293,7 @@ export type DaemonStatus = {
   logFile?: string;
   service: {
     label: string;
-    loaded: boolean;
+    loadState: GatewayServiceLoadState;
     loadedText: string;
     notLoadedText: string;
     targetRole?: "target" | "diagnostic-only";
@@ -601,7 +602,8 @@ export async function gatherDaemonStatus(
     env: process.env,
     timeoutMs,
   });
-  const { command, env: serviceEnv, loaded, runtime } = serviceState;
+  const { command, env: serviceEnv, loadState, runtime } = serviceState;
+  const loaded = loadState.status === "loaded";
   // A non-default or externally supervised process does not own the host's
   // native service. Keep that service visible, but do not let it retarget probes.
   const useNativeServiceTargetContext =
@@ -805,7 +807,7 @@ export async function gatherDaemonStatus(
     logFile: resolveConfiguredLogFilePath(cliCfg),
     service: {
       label: service.label,
-      loaded,
+      loadState,
       loadedText: service.loadedText,
       notLoadedText: service.notLoadedText,
       targetRole: serviceTargetsProbe ? "target" : "diagnostic-only",

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -119,7 +119,7 @@ describe("printDaemonStatus", () => {
         {
           service: {
             label: "LaunchAgent",
-            loaded: true,
+            loadState: { status: "loaded" },
             loadedText: "loaded",
             notLoadedText: "not loaded",
             command: { programArguments: ["node"], environment: { OPENCLAW_STATE_DIR: "/tmp" } },
@@ -143,7 +143,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
         },
@@ -163,7 +163,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "systemd",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
         },
@@ -187,7 +187,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           gatewayHeap: {
@@ -225,7 +225,7 @@ describe("printDaemonStatus", () => {
             {
               service: {
                 label: "Scheduled Task",
-                loaded: true,
+                loadState: { status: "loaded" },
                 loadedText: "registered",
                 notLoadedText: "not registered",
               },
@@ -250,7 +250,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -292,7 +292,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -334,7 +334,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -373,7 +373,10 @@ describe("printDaemonStatus", () => {
         {
           service: {
             label: "systemd",
-            loaded: true,
+            loadState: {
+              status: "unknown",
+              detail: "System has not been booted with systemd as init system",
+            },
             loadedText: "loaded",
             notLoadedText: "not loaded",
             runtime: {
@@ -404,6 +407,8 @@ describe("printDaemonStatus", () => {
       kind: "generic_unavailable",
       container: false,
     });
+    expectMockLineContains(runtime.log, "Service: systemd (unknown)");
+    expect(runtime.log.mock.calls.flat().join("\n")).not.toContain("Service: systemd (not loaded)");
     expectMockLineContains(runtime.error, "wsl hint");
   });
 
@@ -412,7 +417,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -454,7 +459,7 @@ describe("printDaemonStatus", () => {
         {
           service: {
             label: "LaunchAgent",
-            loaded: true,
+            loadState: { status: "loaded" },
             loadedText: "loaded",
             notLoadedText: "not loaded",
             runtime: { status: "running", pid: 8000 },
@@ -501,7 +506,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "Scheduled Task",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "registered",
           notLoadedText: "not registered",
           runtime: { status: "running", pid: 8000 },
@@ -540,7 +545,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: false,
+          loadState: { status: "not-loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: {
@@ -565,7 +570,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -597,7 +602,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "systemd user",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "enabled",
           notLoadedText: "disabled",
           runtime: { status: "running", pid: 8000 },
@@ -645,7 +650,7 @@ describe("printDaemonStatus", () => {
         },
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -687,7 +692,7 @@ describe("printDaemonStatus", () => {
         },
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -721,7 +726,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "stopped" },
@@ -752,7 +757,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -804,7 +809,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
         },
@@ -848,7 +853,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -882,7 +887,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -931,7 +936,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -956,7 +961,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -987,7 +992,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -1018,7 +1023,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -1059,7 +1064,7 @@ describe("printDaemonStatus", () => {
         {
           service: {
             label: "systemd user",
-            loaded: false,
+            loadState: { status: "not-loaded" },
             loadedText: "not loaded",
             notLoadedText: "not loaded",
             runtime: { status: "unknown", detail: "systemd user services unavailable" },
@@ -1095,7 +1100,7 @@ describe("printDaemonStatus", () => {
         {
           service: {
             label: "systemd",
-            loaded: true,
+            loadState: { status: "loaded" },
             loadedText: "loaded",
             notLoadedText: "not loaded",
             runtime: {
@@ -1126,7 +1131,7 @@ describe("printDaemonStatus", () => {
         {
           service: {
             label: "systemd",
-            loaded: true,
+            loadState: { status: "loaded" },
             loadedText: "loaded",
             notLoadedText: "not loaded",
             runtime: {
@@ -1154,7 +1159,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -1194,7 +1199,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           targetRole: "diagnostic-only",
@@ -1237,7 +1242,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -1275,7 +1280,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },
@@ -1320,7 +1325,7 @@ describe("printDaemonStatus", () => {
       {
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
           runtime: { status: "running", pid: 8000 },

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -5,7 +5,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { withEnv } from "../../test-utils/env.js";
 import { formatCliCommand } from "../command-format.js";
-import { printDaemonStatus } from "./status.print.js";
+import type { DaemonStatus } from "./status.gather.js";
+import { printDaemonStatus as printDaemonStatusRuntime } from "./status.print.js";
+
+type TestDaemonStatus = Omit<DaemonStatus, "service"> & {
+  service: Omit<DaemonStatus["service"], "loaded"> & { loaded?: boolean | null };
+};
+
+function printDaemonStatus(
+  status: TestDaemonStatus,
+  options: Parameters<typeof printDaemonStatusRuntime>[1],
+) {
+  const loaded =
+    status.service.loaded !== undefined
+      ? status.service.loaded
+      : status.service.loadState.status === "unknown"
+        ? null
+        : status.service.loadState.status === "loaded";
+  printDaemonStatusRuntime(
+    {
+      ...status,
+      service: { ...status.service, loaded },
+    },
+    options,
+  );
+}
 
 const runtime = vi.hoisted(() => ({
   log: vi.fn<(line: string) => void>(),

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -104,9 +104,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
 
   const { service, rpc, extraServices } = status;
   const serviceTargetsProbe = service.targetRole !== "diagnostic-only";
-  const serviceStatus = service.loaded
+  const serviceLoaded = service.loadState.status === "loaded";
+  const serviceStatus = serviceLoaded
     ? okText(service.loadedText)
-    : warnText(service.notLoadedText);
+    : warnText(service.loadState.status === "not-loaded" ? service.notLoadedText : "unknown");
   defaultRuntime.log(`${label("Service:")} ${accent(service.label)} (${serviceStatus})`);
   if (status.logFile) {
     defaultRuntime.log(`${label("File logs:")} ${infoText(shortenHomePath(status.logFile))}`);
@@ -292,7 +293,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     rpc &&
     !rpc.ok &&
     serviceTargetsProbe &&
-    service.loaded &&
+    serviceLoaded &&
     service.runtime?.status === "running"
   ) {
     // The RPC probe failed while the service is loaded and running. Only the case where
@@ -386,17 +387,25 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     spacer();
   }
 
+  const serviceInspectionDetail =
+    service.loadState.status === "unknown" ? service.loadState.detail : undefined;
+  if (serviceInspectionDetail) {
+    defaultRuntime.error(errorText(`Service inspection failed: ${serviceInspectionDetail}`));
+    defaultRuntime.error(errorText(`Retry: ${formatCliCommand("openclaw gateway status --deep")}`));
+    spacer();
+  }
+  const systemdUnavailableDetail = serviceInspectionDetail ?? service.runtime?.detail;
   const systemdUnavailable =
     process.platform === "linux" &&
-    rpc?.ok !== true &&
-    isSystemdUnavailableDetail(service.runtime?.detail);
+    (serviceInspectionDetail !== undefined || rpc?.ok !== true) &&
+    isSystemdUnavailableDetail(systemdUnavailableDetail);
   if (systemdUnavailable) {
     const serviceEnv = service.command?.environment ?? process.env;
     const container = Boolean(resolveDaemonContainerContext(serviceEnv));
     defaultRuntime.error(errorText("systemd user services unavailable."));
     for (const hint of renderSystemdUnavailableHints({
       wsl: isWSLEnv(serviceEnv),
-      kind: classifySystemdUnavailableDetail(service.runtime?.detail),
+      kind: classifySystemdUnavailableDetail(systemdUnavailableDetail),
       container,
     })) {
       defaultRuntime.error(errorText(hint));
@@ -429,7 +438,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     )) {
       defaultRuntime.error(errorText(hint));
     }
-  } else if (service.loaded && service.runtime?.status === "stopped") {
+  } else if (serviceLoaded && service.runtime?.status === "stopped") {
     const startLimitHit = process.platform === "linux" && isSystemdStartLimitHit(service.runtime);
     defaultRuntime.error(
       errorText(
@@ -501,7 +510,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
 
   if (
     serviceTargetsProbe &&
-    service.loaded &&
+    serviceLoaded &&
     service.runtime?.status === "running" &&
     status.port &&
     status.port.status === "free"

--- a/src/cli/daemon-cli/status.test.ts
+++ b/src/cli/daemon-cli/status.test.ts
@@ -7,7 +7,7 @@ const gatherDaemonStatus = vi.fn(
   async (_opts?: unknown): Promise<DaemonStatus> => ({
     service: {
       label: "LaunchAgent",
-      loaded: true,
+      loadState: { status: "loaded" },
       loadedText: "loaded",
       notLoadedText: "not loaded",
     },
@@ -56,7 +56,7 @@ describe("runDaemonStatus", () => {
     gatherDaemonStatus.mockResolvedValueOnce({
       service: {
         label: "LaunchAgent",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "loaded",
         notLoadedText: "not loaded",
       },
@@ -91,7 +91,7 @@ describe("runDaemonStatus", () => {
       gatherDaemonStatus.mockResolvedValueOnce({
         service: {
           label: "LaunchAgent",
-          loaded: true,
+          loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
         },
@@ -207,7 +207,7 @@ describe("runDaemonStatus", () => {
     gatherDaemonStatus.mockResolvedValueOnce({
       service: {
         label: "LaunchAgent",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "loaded",
         notLoadedText: "not loaded",
       },

--- a/src/cli/daemon-cli/status.test.ts
+++ b/src/cli/daemon-cli/status.test.ts
@@ -7,6 +7,7 @@ const gatherDaemonStatus = vi.fn(
   async (_opts?: unknown): Promise<DaemonStatus> => ({
     service: {
       label: "LaunchAgent",
+      loaded: true,
       loadState: { status: "loaded" },
       loadedText: "loaded",
       notLoadedText: "not loaded",
@@ -56,6 +57,7 @@ describe("runDaemonStatus", () => {
     gatherDaemonStatus.mockResolvedValueOnce({
       service: {
         label: "LaunchAgent",
+        loaded: true,
         loadState: { status: "loaded" },
         loadedText: "loaded",
         notLoadedText: "not loaded",
@@ -91,6 +93,7 @@ describe("runDaemonStatus", () => {
       gatherDaemonStatus.mockResolvedValueOnce({
         service: {
           label: "LaunchAgent",
+          loaded: true,
           loadState: { status: "loaded" },
           loadedText: "loaded",
           notLoadedText: "not loaded",
@@ -207,6 +210,7 @@ describe("runDaemonStatus", () => {
     gatherDaemonStatus.mockResolvedValueOnce({
       service: {
         label: "LaunchAgent",
+        loaded: true,
         loadState: { status: "loaded" },
         loadedText: "loaded",
         notLoadedText: "not loaded",

--- a/src/cli/daemon-cli/test-helpers/lifecycle-core-harness.ts
+++ b/src/cli/daemon-cli/test-helpers/lifecycle-core-harness.ts
@@ -22,6 +22,26 @@ type LifecycleServiceHarness = GatewayService & {
 
 export const lifecycleTestRuntime: LifecycleRuntimeHarness = lifecycleRuntimeCapture.defaultRuntime;
 
+export function createGatewayUninstallArgs() {
+  return {
+    serviceNoun: "Gateway",
+    service,
+    opts: { json: true as const },
+    stopBeforeUninstall: true,
+    assertNotLoadedAfterUninstall: true,
+  };
+}
+
+export function createGatewayServiceRunArgs(checkTokenDrift?: boolean) {
+  return {
+    serviceNoun: "Gateway",
+    service,
+    renderStartHints: () => [],
+    opts: { json: true as const },
+    ...(checkTokenDrift ? { checkTokenDrift } : {}),
+  };
+}
+
 export const service: LifecycleServiceHarness = {
   label: "TestService",
   loadedText: "loaded",

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -369,13 +369,17 @@ vi.mock("../daemon/service.js", () => ({
         : undefined),
     };
     args?.validateEnvBeforeStatusRead?.(env);
-    const [loaded, runtime] = await Promise.all([
-      serviceLoaded({ env }).catch(() => false),
+    const [loadState, runtime] = await Promise.all([
+      serviceLoaded({ env })
+        .then((loaded: boolean) =>
+          loaded ? ({ status: "loaded" } as const) : ({ status: "not-loaded" } as const),
+        )
+        .catch((error: unknown) => ({ status: "unknown" as const, detail: String(error) })),
       serviceReadRuntime(env).catch(() => undefined),
     ]);
     return {
       installed: command !== null,
-      loaded,
+      loadState,
       running: runtime?.status === "running",
       env,
       command,
@@ -551,7 +555,7 @@ describe("update-cli", () => {
   };
 
   const createTrackedTempDir = async (prefix: string) => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
     tempDirsToCleanup.add(dir);
     return dir;
   };

--- a/src/cli/update-cli/update-command-launch-agent-recovery.ts
+++ b/src/cli/update-cli/update-command-launch-agent-recovery.ts
@@ -30,7 +30,7 @@ export async function recoverInstalledLaunchAgentAfterUpdate(params: {
   const readState = params.deps?.readState ?? readGatewayServiceState;
   const recover = params.deps?.recover ?? recoverInstalledLaunchAgent;
   const state = await readState(service, { env: params.env }).catch(() => null);
-  if (state?.loaded) {
+  if (!state || state.loadState.status !== "not-loaded") {
     return { attempted: false, recovered: false };
   }
   if (state && !state.installed && !state.runtime?.missingSupervision) {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -401,11 +401,12 @@ export async function finishUpdate(params: {
       const knownForeignService =
         params.preManagedServiceStop?.serviceMatchesMutationRoot === false &&
         serviceMatchesUpdateRoot !== true;
+      const serviceLoaded = serviceState.loadState.status === "loaded";
       skipLegacyServiceRestart =
         knownForeignService ||
         (resultWithPostUpdate.mode === "git" &&
           serviceState.installed &&
-          serviceState.loaded &&
+          serviceLoaded &&
           params.preManagedServiceStop?.stopped !== true &&
           serviceMatchesUpdateRoot === false);
       if (
@@ -413,7 +414,7 @@ export async function finishUpdate(params: {
         shouldPrepareUpdatedInstallRestart({
           updateMode: resultWithPostUpdate.mode,
           serviceInstalled: serviceState.installed,
-          serviceLoaded: serviceState.loaded,
+          serviceLoaded,
           serviceStoppedForUpdate: params.preManagedServiceStop?.stopped,
           serviceMatchesMutationRoot: serviceOwnershipConfirmed
             ? true

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -481,14 +481,15 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
 
   // A loaded LaunchAgent can be between KeepAlive respawns. Other supervisors
   // need the handoff marker to distinguish that transition from operator-stopped state.
+  const serviceLoaded = serviceState.loadState.status === "loaded";
   const launchAgentMayRespawn =
     process.platform === "darwin" &&
-    serviceState.loaded &&
+    serviceLoaded &&
     (await service.isEnabled?.({ env: serviceState.env })) === true;
   const handoffSupervisorMayRespawn =
     process.platform !== "darwin" && process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1";
   const supervisorMayRespawn =
-    serviceState.loaded && (launchAgentMayRespawn || handoffSupervisorMayRespawn);
+    serviceLoaded && (launchAgentMayRespawn || handoffSupervisorMayRespawn);
   if (!serviceState.running && !supervisorMayRespawn) {
     const windowsTaskAutoStartRecovery = await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
       updateInstallKind: params.updateInstallKind,

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -750,7 +750,7 @@ describe("recoverInstalledLaunchAgentAfterUpdate", () => {
     const recoveredEnv = { ...serviceEnv, OPENCLAW_PORT: "18790" } as NodeJS.ProcessEnv;
     const readState = vi.fn(async () => ({
       installed: true,
-      loaded: false,
+      loadState: { status: "not-loaded" },
       running: false,
       env: recoveredEnv,
       command: null,
@@ -804,7 +804,7 @@ describe("recoverInstalledLaunchAgentAfterUpdate", () => {
   it("does not recover a loaded LaunchAgent", async () => {
     const readState = vi.fn(async () => ({
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: true,
       env: { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv,
       command: null,
@@ -829,7 +829,7 @@ describe("recoverInstalledLaunchAgentAfterUpdate", () => {
   it("returns an explicit failed recovery state when bootstrap repair fails", async () => {
     const readState = vi.fn(async () => ({
       installed: true,
-      loaded: false,
+      loadState: { status: "not-loaded" },
       running: false,
       env: { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv,
       command: null,
@@ -857,7 +857,7 @@ describe("recoverInstalledLaunchAgentAfterUpdate", () => {
   it("preserves system LaunchDaemon recovery guidance", async () => {
     const readState = vi.fn(async () => ({
       installed: true,
-      loaded: false,
+      loadState: { status: "not-loaded" },
       running: false,
       env: { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv,
       command: null,

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -36,6 +36,7 @@ const findSystemGatewayServices = vi.hoisted(() =>
 );
 const buildGatewayRuntimeHints = vi.hoisted(() => vi.fn((): string[] => []));
 const formatGatewayRuntimeSummary = vi.hoisted(() => vi.fn((): string | null => null));
+const renderSystemdUnavailableHints = vi.hoisted(() => vi.fn((): string[] => []));
 const isDefaultInstallIdentity = vi.hoisted(() => vi.fn(() => true));
 const resolveGatewayBindHost = vi.hoisted(() => vi.fn(async () => "127.0.0.1"));
 
@@ -86,17 +87,8 @@ vi.mock("../daemon/service.js", async () => {
 });
 
 vi.mock("../daemon/systemd-hints.js", () => ({
-  renderSystemdUnavailableHints: vi.fn(() => []),
+  renderSystemdUnavailableHints,
 }));
-
-vi.mock("../daemon/systemd.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../daemon/systemd.js")>("../daemon/systemd.js");
-  return {
-    ...actual,
-    isSystemdUserServiceAvailable: vi.fn(async () => true),
-  };
-});
 
 vi.mock("../gateway/net.js", () => ({
   resolveGatewayBindHost,
@@ -203,6 +195,7 @@ describe("maybeRepairGatewayDaemon", () => {
     });
     buildGatewayRuntimeHints.mockReturnValue([]);
     formatGatewayRuntimeSummary.mockReturnValue(null);
+    renderSystemdUnavailableHints.mockReset().mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -419,6 +412,41 @@ describe("maybeRepairGatewayDaemon", () => {
     });
 
     expect(note).toHaveBeenCalledWith("Gateway service not installed.", "Gateway");
+  });
+
+  it("reports unknown service inspection without offering or executing repair", async () => {
+    setPlatform("linux");
+    service.isLoaded.mockRejectedValueOnce(
+      new Error("systemctl is-enabled unavailable: Failed to connect to bus: No medium found"),
+    );
+    renderSystemdUnavailableHints.mockReturnValueOnce(["restore the systemd user bus"]);
+    const prompter = createPrompter(() => true);
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter,
+      options: { deep: false },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+    });
+
+    expect(renderSystemdUnavailableHints).toHaveBeenCalledWith({
+      wsl: false,
+      kind: "user_bus_unavailable",
+    });
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service status could not be determined"),
+      "Gateway",
+    );
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("restore the systemd user bus"),
+      "Gateway",
+    );
+    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+    expect(service.install).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(findSystemGatewayServices).not.toHaveBeenCalled();
   });
 
   it("does not audit local services when skipped gateway health is remote", async () => {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -16,9 +16,14 @@ import {
   repairLaunchAgentBootstrap,
 } from "../daemon/launchd.js";
 import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
-import { describeGatewayServiceRestart, resolveGatewayService } from "../daemon/service.js";
+import type { GatewayServiceLoadState } from "../daemon/service-types.js";
+import {
+  describeGatewayServiceRestart,
+  readGatewayServiceState,
+  resolveGatewayService,
+} from "../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
-import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
+import { classifySystemdUnavailableDetail } from "../daemon/systemd-unavailable.js";
 import { resolveGatewayBindHost, resolveGatewayRequiredListenHosts } from "../gateway/net.js";
 import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import { formatPortDiagnostics, isExpectedGatewayListeners } from "../infra/ports-format.js";
@@ -185,6 +190,20 @@ async function maybeReportEstablishedGatewayClients(params: {
   }
 }
 
+async function noteGatewayServiceInspectionFailure(
+  loadState: Extract<GatewayServiceLoadState, { status: "unknown" }>,
+): Promise<void> {
+  const lines = [`Gateway service status could not be determined: ${loadState.detail}`];
+  if (process.platform === "linux") {
+    const kind = classifySystemdUnavailableDetail(loadState.detail);
+    if (kind) {
+      lines.push(...renderSystemdUnavailableHints({ wsl: await isWSL(), kind }));
+    }
+  }
+  lines.push(`Run ${formatCliCommand("openclaw gateway status --deep")} and retry doctor.`);
+  note(lines.join("\n"), "Gateway");
+}
+
 /**
  * Repairs or diagnoses the local gateway service after the health check fails.
  *
@@ -232,27 +251,14 @@ export async function maybeRepairGatewayDaemon(params: {
   };
   const isLocalDarwinGateway =
     process.platform === "darwin" && params.cfg.gateway?.mode !== "remote";
-  // systemd can throw in containers/WSL; treat as "not loaded" and fall back to hints.
-  let loaded;
-  try {
-    loaded = await service.isLoaded({ env: process.env });
-  } catch {
-    loaded = false;
+  const serviceState = await readGatewayServiceState(service, { env: process.env });
+  if (serviceState.loadState.status === "unknown") {
+    await noteGatewayServiceInspectionFailure(serviceState.loadState);
+    return;
   }
-  let serviceRuntime: Awaited<ReturnType<typeof service.readRuntime>> | undefined;
-  const command = params.options.deep
-    ? await Promise.resolve(service.readCommand(process.env)).catch(() => null)
-    : null;
-  const serviceEnv = command?.environment
-    ? ({
-        ...process.env,
-        ...command.environment,
-      } satisfies NodeJS.ProcessEnv)
-    : process.env;
-  const shouldReadRuntime = loaded || isLocalDarwinGateway;
-  if (shouldReadRuntime) {
-    serviceRuntime = await service.readRuntime(serviceEnv).catch(() => undefined);
-  }
+  let loaded = serviceState.loadState.status === "loaded";
+  let serviceRuntime = serviceState.runtime;
+  const serviceEnv = serviceState.env;
   if (params.options.deep) {
     const handoff = readGatewayRestartHandoffSync(serviceEnv);
     if (handoff) {
@@ -295,10 +301,13 @@ export async function maybeRepairGatewayDaemon(params: {
       };
     }
     if (gatewayRepair.status === "repaired") {
-      loaded = await service.isLoaded({ env: process.env });
-      if (loaded) {
-        serviceRuntime = await service.readRuntime(process.env).catch(() => undefined);
+      const repairedState = await readGatewayServiceState(service, { env: process.env });
+      if (repairedState.loadState.status === "unknown") {
+        await noteGatewayServiceInspectionFailure(repairedState.loadState);
+        return;
       }
+      loaded = repairedState.loadState.status === "loaded";
+      serviceRuntime = repairedState.runtime;
     }
   }
 
@@ -344,17 +353,6 @@ export async function maybeRepairGatewayDaemon(params: {
     ) {
       noteGatewayRuntime(serviceRuntime, process.env);
       return;
-    }
-    if (process.platform === "linux") {
-      const systemdAvailable = await isSystemdUserServiceAvailable().catch(() => false);
-      if (!systemdAvailable) {
-        const wsl = await isWSL();
-        note(
-          renderSystemdUnavailableHints({ wsl, kind: "generic_unavailable" }).join("\n"),
-          "Gateway",
-        );
-        return;
-      }
     }
     note("Gateway service not installed.", "Gateway");
     if (params.cfg.gateway?.mode !== "remote") {

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -86,6 +86,7 @@ beforeEach(async () => {
   });
   mocks.readGatewayServiceState.mockResolvedValue({
     installed: false,
+    loadState: { status: "not-loaded" },
     running: false,
     env: {},
   });
@@ -262,6 +263,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
     mocks.readGatewayServiceState.mockResolvedValue({
       installed: true,
+      loadState: { status: "loaded" },
       running: true,
       env: { OPENCLAW_PROFILE: "work" },
       command: {
@@ -300,6 +302,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     mocks.readGatewayServiceState
       .mockResolvedValueOnce({
         installed: true,
+        loadState: { status: "loaded" },
         running: true,
         env: { OPENCLAW_PROFILE: "work" },
         command: {
@@ -308,6 +311,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
       })
       .mockResolvedValueOnce({
         installed: true,
+        loadState: { status: "loaded" },
         running: false,
         env: { OPENCLAW_PROFILE: "work" },
         command: {
@@ -335,6 +339,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
     mocks.readGatewayServiceState.mockResolvedValue({
       installed: true,
+      loadState: { status: "loaded" },
       running: true,
       env: { OPENCLAW_PROFILE: "work" },
       command: {
@@ -371,6 +376,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
     mocks.readGatewayServiceState.mockResolvedValue({
       installed: true,
+      loadState: { status: "loaded" },
       running: true,
       env: { OPENCLAW_PROFILE: "work" },
       command: {
@@ -407,6 +413,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
     mocks.readGatewayServiceState.mockResolvedValue({
       installed: true,
+      loadState: { status: "loaded" },
       running: false,
       env: { OPENCLAW_PROFILE: "work" },
       command: {
@@ -428,6 +435,78 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     expect(mocks.restartGatewayService).not.toHaveBeenCalled();
   });
 
+  it("does not repair or activate when the initial service inspection is unknown", async () => {
+    mockGitCheckout();
+    mocks.runGatewayUpdate.mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      root: "/repo/link",
+    });
+    mocks.readGatewayServiceState.mockResolvedValue({
+      installed: true,
+      loadState: { status: "unknown", detail: "systemctl is-enabled failed" },
+      running: true,
+      env: { OPENCLAW_PROFILE: "work" },
+      command: {
+        programArguments: ["node", "/repo/link/dist/index.js", "gateway", "run"],
+      },
+    });
+
+    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
+      updated: true,
+      handled: true,
+    });
+
+    expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowGatewayServiceRepair: false,
+        allowGatewayActivation: false,
+      }),
+    );
+    expect(mocks.restartGatewayService).not.toHaveBeenCalled();
+  });
+
+  it("does not restart when the post-update service inspection is unknown", async () => {
+    mockGitCheckout();
+    mocks.runGatewayUpdate.mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      root: "/repo/link",
+    });
+    mocks.readGatewayServiceState
+      .mockResolvedValueOnce({
+        installed: true,
+        loadState: { status: "loaded" },
+        running: true,
+        env: { OPENCLAW_PROFILE: "work" },
+        command: {
+          programArguments: ["node", "/repo/link/dist/index.js", "gateway", "run"],
+        },
+      })
+      .mockResolvedValueOnce({
+        installed: true,
+        loadState: { status: "unknown", detail: "launchctl inspection failed" },
+        running: true,
+        env: { OPENCLAW_PROFILE: "work" },
+        command: {
+          programArguments: ["node", "/repo/link/dist/index.js", "gateway", "run"],
+        },
+      });
+
+    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
+      updated: true,
+      handled: true,
+    });
+
+    expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowGatewayServiceRepair: true,
+        allowGatewayActivation: true,
+      }),
+    );
+    expect(mocks.restartGatewayService).not.toHaveBeenCalled();
+  });
+
   it("leaves a running gateway alone when service repair is externally managed", async () => {
     mockGitCheckout();
     process.env.OPENCLAW_SERVICE_REPAIR_POLICY = "external";
@@ -438,6 +517,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
     mocks.readGatewayServiceState.mockResolvedValue({
       installed: true,
+      loadState: { status: "loaded" },
       running: true,
       env: { OPENCLAW_PROFILE: "work" },
     });
@@ -467,6 +547,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
     mocks.readGatewayServiceState.mockResolvedValue({
       installed: true,
+      loadState: { status: "loaded" },
       running: true,
       env: { OPENCLAW_PROFILE: "work" },
     });

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -68,7 +68,7 @@ async function inspectGatewayServiceForUpdate(
   try {
     const service = resolveGatewayService();
     const state = await readGatewayServiceState(service, { env: process.env });
-    if (!state.installed) {
+    if (state.loadState.status === "unknown" || !state.installed) {
       return NO_GATEWAY_SERVICE_UPDATE;
     }
     const layout = await summarizeGatewayServiceLayout(state.command);

--- a/src/commands/gateway-readiness.test.ts
+++ b/src/commands/gateway-readiness.test.ts
@@ -3,15 +3,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DaemonStatus } from "../cli/daemon-cli/status.gather.js";
 import { ensureGatewayReadyForOperation } from "./gateway-readiness.js";
 
-function createStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
+type StatusOverrides = Omit<Partial<DaemonStatus>, "service"> & {
+  service?: Omit<DaemonStatus["service"], "loaded">;
+};
+
+function createStatus(overrides: StatusOverrides = {}): DaemonStatus {
+  const { service, ...rest } = overrides;
+  const serviceStatus = service ?? {
+    label: "systemd user",
+    loadState: { status: "not-loaded" as const },
+    loadedText: "enabled",
+    notLoadedText: "disabled",
+    command: null,
+    runtime: { status: "stopped" },
+  };
   return {
     service: {
-      label: "systemd user",
-      loadState: { status: "not-loaded" },
-      loadedText: "enabled",
-      notLoadedText: "disabled",
-      command: null,
-      runtime: { status: "stopped" },
+      ...serviceStatus,
+      loaded:
+        serviceStatus.loadState.status === "unknown"
+          ? null
+          : serviceStatus.loadState.status === "loaded",
     },
     gateway: {
       bindMode: "loopback",
@@ -31,7 +43,7 @@ function createStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
       error: "connect ECONNREFUSED 127.0.0.1:18789",
     },
     extraServices: [],
-    ...overrides,
+    ...rest,
   };
 }
 

--- a/src/commands/gateway-readiness.test.ts
+++ b/src/commands/gateway-readiness.test.ts
@@ -7,7 +7,7 @@ function createStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
   return {
     service: {
       label: "systemd user",
-      loaded: false,
+      loadState: { status: "not-loaded" },
       loadedText: "enabled",
       notLoadedText: "disabled",
       command: null,
@@ -94,7 +94,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const running = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run"] },
@@ -123,7 +123,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const stopped = createStatus({
       service: {
         label: "systemd user",
-        loaded: false,
+        loadState: { status: "not-loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run"] },
@@ -133,7 +133,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const running = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run"] },
@@ -162,7 +162,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         targetRole: "diagnostic-only",
@@ -212,7 +212,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run"] },
@@ -241,7 +241,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run", "--port", "18789"] },
@@ -274,7 +274,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run", "--port", "18789"] },
@@ -306,7 +306,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run", "--port", "18789"] },
@@ -338,7 +338,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run", "--port", "18789"] },
@@ -369,7 +369,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run"] },
@@ -399,7 +399,7 @@ describe("ensureGatewayReadyForOperation", () => {
     const status = createStatus({
       service: {
         label: "systemd user",
-        loaded: true,
+        loadState: { status: "loaded" },
         loadedText: "enabled",
         notLoadedText: "disabled",
         command: { programArguments: ["openclaw", "gateway", "run"] },

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -124,7 +124,7 @@ function gatewayLooksStopped(status: DaemonStatus): boolean {
 }
 
 function gatewayServiceIsInstalled(status: DaemonStatus): boolean {
-  return Boolean(status.service.command || status.service.loaded);
+  return Boolean(status.service.command || status.service.loadState.status === "loaded");
 }
 
 function nativeServiceTargetsGateway(status: DaemonStatus): boolean {

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -5,16 +5,35 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
-import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { setTestEnvValue } from "../test-utils/env.js";
 import {
+  createOnboardGatewayTimeoutCapture,
+  createOnboardJsonCaptureRuntime,
+  createOnboardLocalDaemonOptions,
+  createOnboardStateDirHarness,
+  createOnboardTestConfigStore,
   createThrowingRuntime,
+  expectOnboardLocalJsonSetupFailure,
   mockOnboardingAgent,
+  prepareOnboardGatewayTestEnv,
+  readOnboardFirstMockCall,
+  runOnboardLocalDaemonSetup,
 } from "./onboard-non-interactive.test-helpers.js";
-import type { WaitForGatewayReachableMock } from "./onboard-non-interactive.test-helpers.js";
+import type {
+  OnboardEnsureWorkspaceOptions,
+  OnboardGatewayHealthCall,
+  OnboardHealthCommandCall,
+  WaitForGatewayReachableMock,
+} from "./onboard-non-interactive.test-helpers.js";
 import type { installGatewayDaemonNonInteractive } from "./onboard-non-interactive/local/daemon-install.js";
 
 const ensureWorkspaceAndSessionsMock = vi.fn(async (..._args: unknown[]) => {});
-const testConfigStore = new Map<string, OpenClawConfig>();
+const {
+  configStore: testConfigStore,
+  resolveConfigPath: resolveTestConfigPath,
+  readConfig: readTestConfig,
+  readSnapshot: readTestConfigSnapshot,
+} = createOnboardTestConfigStore();
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn<() => Promise<ConfigFileSnapshot>>());
 const pluginLifecycleLeaseState = vi.hoisted(() => ({ depth: 0 }));
 const configWritePluginLeaseDepths: number[] = [];
@@ -37,43 +56,6 @@ const readLastGatewayErrorLineMock = vi.hoisted(() =>
   vi.fn(async () => "Gateway failed to start: required secrets are unavailable."),
 );
 let waitForGatewayReachableMock: WaitForGatewayReachableMock;
-
-function resolveTestConfigPath() {
-  const override = process.env.OPENCLAW_CONFIG_PATH?.trim();
-  if (override) {
-    return override;
-  }
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
-  if (!stateDir) {
-    throw new Error("OPENCLAW_STATE_DIR must be set before config IO in this test");
-  }
-  return path.join(stateDir, "openclaw.json");
-}
-
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test helper lets assertions ascribe stored config shape.
-function readTestConfig<T = OpenClawConfig>(): T {
-  return (testConfigStore.get(resolveTestConfigPath()) ?? {}) as T;
-}
-
-function readTestConfigSnapshot(): ConfigFileSnapshot {
-  const config = testConfigStore.get(resolveTestConfigPath()) ?? {};
-  const exists = testConfigStore.has(resolveTestConfigPath());
-  return {
-    path: resolveTestConfigPath(),
-    exists,
-    raw: exists ? `${JSON.stringify(config, null, 2)}\n` : null,
-    parsed: config,
-    sourceConfig: config,
-    resolved: config,
-    valid: true,
-    runtimeConfig: config,
-    config,
-    ...(exists ? { hash: "test-config-hash" } : {}),
-    issues: [],
-    warnings: [],
-    legacyIssues: [],
-  };
-}
 
 readConfigFileSnapshotMock.mockImplementation(async () => readTestConfigSnapshot());
 
@@ -198,6 +180,20 @@ vi.mock("./health.js", () => ({
 }));
 
 vi.mock("../daemon/service.js", () => ({
+  readGatewayServiceState: async () => {
+    const [loaded, runtime] = await Promise.all([
+      gatewayServiceMock.isLoaded(),
+      gatewayServiceMock.readRuntime(),
+    ]);
+    return {
+      installed: true,
+      loadState: { status: loaded ? ("loaded" as const) : ("not-loaded" as const) },
+      running: runtime.status === "running",
+      env: {},
+      command: null,
+      runtime,
+    };
+  },
   resolveGatewayService: () => gatewayServiceMock,
 }));
 
@@ -219,173 +215,12 @@ const getPseudoPort = (base: number): number => base + (process.pid % 1000);
 
 const runtime = createThrowingRuntime();
 
-function createJsonCaptureRuntime() {
-  let capturedJson = "";
-  const runtimeWithCapture: RuntimeEnv = {
-    log: (...args: unknown[]) => {
-      const firstArg = args[0];
-      capturedJson =
-        typeof firstArg === "string"
-          ? firstArg
-          : firstArg instanceof Error
-            ? firstArg.message
-            : (JSON.stringify(firstArg) ?? "");
-    },
-    error: (...args: unknown[]) => {
-      const firstArg = args[0];
-      const capturedError =
-        typeof firstArg === "string"
-          ? firstArg
-          : firstArg instanceof Error
-            ? firstArg.message
-            : (JSON.stringify(firstArg) ?? "");
-      throw new Error(capturedError);
-    },
-    exit: (_code: number) => {
-      throw new Error("exit should not be reached after runtime.error");
-    },
-  };
-
-  return {
-    runtimeWithCapture,
-    readCapturedJson: () => capturedJson,
-  };
-}
-
-type MockWithCalls<TArgs extends unknown[]> = {
-  mock: {
-    calls: TArgs[];
-  };
-};
-
-function readFirstMockCall(mock: unknown, label: string): unknown[] {
-  const calls = (mock as MockWithCalls<unknown[]>).mock.calls;
-  const call = calls[0];
-  if (!call) {
-    throw new Error(`Expected ${label} to be called`);
-  }
-  return call;
-}
-
-type EnsureWorkspaceOptions = {
-  skipBootstrap?: boolean;
-};
-
-type GatewayHealthCall = {
-  password?: string;
-  token?: string;
-};
-
-type HealthCommandCall = GatewayHealthCall & {
-  config?: OpenClawConfig;
-};
-
-async function expectLocalJsonSetupFailure(stateDir: string, runtimeWithCapture: RuntimeEnv) {
-  await expect(
-    runNonInteractiveSetup(
-      {
-        nonInteractive: true,
-        mode: "local",
-        workspace: path.join(stateDir, "openclaw"),
-        authChoice: "skip",
-        skipSkills: true,
-        skipHealth: false,
-        installDaemon: true,
-        gatewayBind: "loopback",
-        json: true,
-      },
-      runtimeWithCapture,
-    ),
-  ).rejects.toThrow("exit should not be reached after runtime.error");
-}
-
-function createLocalDaemonSetupOptions(stateDir: string) {
-  return {
-    nonInteractive: true,
-    mode: "local" as const,
-    workspace: path.join(stateDir, "openclaw"),
-    authChoice: "skip" as const,
-    skipSkills: true,
-    skipHealth: false,
-    installDaemon: true,
-    gatewayBind: "loopback" as const,
-  };
-}
-
-async function runLocalDaemonSetup(stateDir: string, runtimeEnv: RuntimeEnv = runtime) {
-  await runNonInteractiveSetup(createLocalDaemonSetupOptions(stateDir), runtimeEnv);
-}
-
-function mockGatewayReachableWithCapturedTimeouts() {
-  let capturedDeadlineMs: number | undefined;
-  let capturedProbeTimeoutMs: number | undefined;
-  waitForGatewayReachableMock = vi.fn(
-    async (params: {
-      url: string;
-      token?: string;
-      password?: string;
-      deadlineMs?: number;
-      probeTimeoutMs?: number;
-    }) => {
-      capturedDeadlineMs = params.deadlineMs;
-      capturedProbeTimeoutMs = params.probeTimeoutMs;
-      return { ok: true };
-    },
-  );
-  return {
-    get deadlineMs() {
-      return capturedDeadlineMs;
-    },
-    get probeTimeoutMs() {
-      return capturedProbeTimeoutMs;
-    },
-  };
-}
-
 describe("onboard (non-interactive): gateway and remote auth", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
+  let envSnapshot: ReturnType<typeof prepareOnboardGatewayTestEnv>;
   let tempHome: string | undefined;
-
-  const initStateDir = async (prefix: string) => {
-    if (!tempHome) {
-      throw new Error("temp home not initialized");
-    }
-    const stateDir = await fs.realpath(await fs.mkdtemp(path.join(tempHome, prefix)));
-    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-    deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
-    return stateDir;
-  };
-  const withStateDir = async (
-    prefix: string,
-    run: (stateDir: string) => Promise<void>,
-  ): Promise<void> => {
-    const stateDir = await initStateDir(prefix);
-    try {
-      await run(stateDir);
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
-  };
+  const { withStateDir } = createOnboardStateDirHarness(() => tempHome);
   beforeAll(async () => {
-    envSnapshot = captureEnv([
-      "HOME",
-      "OPENCLAW_STATE_DIR",
-      "OPENCLAW_CONFIG_PATH",
-      "OPENCLAW_SKIP_CHANNELS",
-      "OPENCLAW_SKIP_GMAIL_WATCHER",
-      "OPENCLAW_SKIP_CRON",
-      "OPENCLAW_SKIP_CANVAS_HOST",
-      "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
-      "OPENCLAW_GATEWAY_TOKEN",
-      "OPENCLAW_GATEWAY_PASSWORD",
-    ]);
-    setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
-    setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
-    setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
-    setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
-    setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
-    deleteTestEnvValue("OPENCLAW_GATEWAY_TOKEN");
-    deleteTestEnvValue("OPENCLAW_GATEWAY_PASSWORD");
+    envSnapshot = prepareOnboardGatewayTestEnv();
 
     tempHome = await makeTempWorkspace("openclaw-onboard-");
     setTestEnvValue("HOME", tempHome);
@@ -691,10 +526,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(cfg.agents?.defaults?.workspace).toBe(workspace);
       expect(cfg.agents?.defaults?.skipBootstrap).toBe(true);
       expect(ensureWorkspaceAndSessionsMock).toHaveBeenCalledOnce();
-      const [workspaceArg, runtimeArg, optionsArg] = readFirstMockCall(
+      const [workspaceArg, runtimeArg, optionsArg] = readOnboardFirstMockCall(
         ensureWorkspaceAndSessionsMock,
         "ensureWorkspaceAndSessions",
-      ) as [string, RuntimeEnv, EnsureWorkspaceOptions];
+      ) as [string, RuntimeEnv, OnboardEnsureWorkspaceOptions];
       expect(workspaceArg).toBe(workspace);
       expect(runtimeArg).toBe(runtime);
       expect(optionsArg.skipBootstrap).toBe(true);
@@ -854,7 +689,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       const log = vi.fn();
 
       await runNonInteractiveSetup(
-        { ...createLocalDaemonSetupOptions(stateDir), installDaemon: false },
+        { ...createOnboardLocalDaemonOptions(stateDir), installDaemon: false },
         { ...runtime, log },
       );
 
@@ -873,7 +708,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
       await expect(
         runNonInteractiveSetup(
-          { ...createLocalDaemonSetupOptions(stateDir), installDaemon: undefined },
+          { ...createOnboardLocalDaemonOptions(stateDir), installDaemon: undefined },
           runtime,
         ),
       ).rejects.toThrow(
@@ -884,9 +719,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
   it("uses a longer health deadline when daemon install was requested", async () => {
     await withStateDir("state-local-daemon-health-", async (stateDir) => {
-      const captured = mockGatewayReachableWithCapturedTimeouts();
+      const captured = createOnboardGatewayTimeoutCapture();
+      waitForGatewayReachableMock = captured.mock;
 
-      await runLocalDaemonSetup(stateDir);
+      await runOnboardLocalDaemonSetup({ runSetup: runNonInteractiveSetup, stateDir, runtime });
 
       const cfg = readTestConfig<{
         gateway?: { mode?: string; bind?: string };
@@ -907,23 +743,23 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
       await runNonInteractiveSetup(
         {
-          ...createLocalDaemonSetupOptions(stateDir),
+          ...createOnboardLocalDaemonOptions(stateDir),
           gatewayAuth: "token",
           gatewayToken: token,
         },
         runtime,
       );
 
-      const [gatewayHealthCall] = readFirstMockCall(
+      const [gatewayHealthCall] = readOnboardFirstMockCall(
         waitForGatewayReachableMock,
         "waitForGatewayReachable",
-      ) as [GatewayHealthCall];
+      ) as [OnboardGatewayHealthCall];
       expect(gatewayHealthCall.token).toBe(token);
       expect(gatewayHealthCall.password).toBeUndefined();
-      const [healthCall, healthRuntime] = readFirstMockCall(healthCommandMock, "healthCommand") as [
-        HealthCommandCall,
-        RuntimeEnv,
-      ];
+      const [healthCall, healthRuntime] = readOnboardFirstMockCall(
+        healthCommandMock,
+        "healthCommand",
+      ) as [OnboardHealthCommandCall, RuntimeEnv];
       expect(healthCall.token).toBe(token);
       expect(healthCall.password).toBeUndefined();
       expect(healthCall.config?.gateway?.auth?.mode).toBe("token");
@@ -947,7 +783,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         skippedReason: "systemd-user-unavailable",
       });
 
-      const { runtimeWithCapture, readCapturedJson } = createJsonCaptureRuntime();
+      const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
 
       const originalPlatform = process.platform;
       Object.defineProperty(process, "platform", {
@@ -956,7 +792,11 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       });
 
       try {
-        await expectLocalJsonSetupFailure(stateDir, runtimeWithCapture);
+        await expectOnboardLocalJsonSetupFailure({
+          runSetup: runNonInteractiveSetup,
+          stateDir,
+          runtime: runtimeWithCapture,
+        });
       } finally {
         Object.defineProperty(process, "platform", {
           configurable: true,
@@ -994,8 +834,12 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         detail: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
       }));
 
-      const { runtimeWithCapture, readCapturedJson } = createJsonCaptureRuntime();
-      await expectLocalJsonSetupFailure(stateDir, runtimeWithCapture);
+      const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+      await expectOnboardLocalJsonSetupFailure({
+        runSetup: runNonInteractiveSetup,
+        stateDir,
+        runtime: runtimeWithCapture,
+      });
 
       const parsed = JSON.parse(readCapturedJson()) as {
         ok: boolean;
@@ -1007,7 +851,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         diagnostics?: {
           service?: {
             label?: string;
-            loaded?: boolean;
+            loadState?: { status?: string };
             runtimeStatus?: string;
             pid?: number;
           };
@@ -1021,7 +865,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(parsed.gateway?.wsUrl).toContain("ws://127.0.0.1:");
       expect(parsed.hints).toContain("Run `openclaw gateway status --deep` for more detail.");
       expect(parsed.diagnostics?.service?.label).toBe("LaunchAgent");
-      expect(parsed.diagnostics?.service?.loaded).toBe(true);
+      expect(parsed.diagnostics?.service?.loadState).toEqual({ status: "loaded" });
       expect(parsed.diagnostics?.service?.runtimeStatus).toBe("running");
       expect(parsed.diagnostics?.service?.pid).toBe(4242);
       expect(parsed.diagnostics?.lastGatewayError).toContain("required secrets are unavailable");
@@ -1041,8 +885,12 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       });
       readLastGatewayErrorLineMock.mockResolvedValueOnce("");
 
-      const { runtimeWithCapture, readCapturedJson } = createJsonCaptureRuntime();
-      await expectLocalJsonSetupFailure(stateDir, runtimeWithCapture);
+      const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+      await expectOnboardLocalJsonSetupFailure({
+        runSetup: runNonInteractiveSetup,
+        stateDir,
+        runtime: runtimeWithCapture,
+      });
 
       const parsed = JSON.parse(readCapturedJson()) as {
         ok: boolean;

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -181,13 +181,18 @@ vi.mock("./health.js", () => ({
 
 vi.mock("../daemon/service.js", () => ({
   readGatewayServiceState: async () => {
-    const [loaded, runtime] = await Promise.all([
-      gatewayServiceMock.isLoaded(),
+    const [loadState, runtime] = await Promise.all([
+      gatewayServiceMock
+        .isLoaded()
+        .then((loaded) =>
+          loaded ? ({ status: "loaded" } as const) : ({ status: "not-loaded" } as const),
+        )
+        .catch((error: unknown) => ({ status: "unknown" as const, detail: String(error) })),
       gatewayServiceMock.readRuntime(),
     ]);
     return {
       installed: true,
-      loadState: { status: loaded ? ("loaded" as const) : ("not-loaded" as const) },
+      loadState,
       running: runtime.status === "running",
       env: {},
       command: null,
@@ -452,7 +457,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         runtime,
       );
 
-      const cfg = readTestConfig<{
+      const cfg = readTestConfig() as {
         gateway?: {
           mode?: string;
           bind?: string;
@@ -462,7 +467,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         agents?: { defaults?: { workspace?: string } };
         tools?: { profile?: string };
         hooks?: { internal?: { entries?: Record<string, { enabled?: boolean }> } };
-      }>();
+      };
 
       expect(cfg?.agents?.defaults?.workspace).toBe(workspace);
       expect(cfg?.gateway?.mode).toBe("local");
@@ -724,9 +729,9 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
       await runOnboardLocalDaemonSetup({ runSetup: runNonInteractiveSetup, stateDir, runtime });
 
-      const cfg = readTestConfig<{
+      const cfg = readTestConfig() as {
         gateway?: { mode?: string; bind?: string };
-      }>();
+      };
 
       expect(cfg?.gateway?.mode).toBe("local");
       expect(cfg?.gateway?.bind).toBe("loopback");
@@ -851,6 +856,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         diagnostics?: {
           service?: {
             label?: string;
+            loaded?: boolean | null;
             loadState?: { status?: string };
             runtimeStatus?: string;
             pid?: number;
@@ -865,10 +871,39 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(parsed.gateway?.wsUrl).toContain("ws://127.0.0.1:");
       expect(parsed.hints).toContain("Run `openclaw gateway status --deep` for more detail.");
       expect(parsed.diagnostics?.service?.label).toBe("LaunchAgent");
+      expect(parsed.diagnostics?.service?.loaded).toBe(true);
       expect(parsed.diagnostics?.service?.loadState).toEqual({ status: "loaded" });
       expect(parsed.diagnostics?.service?.runtimeStatus).toBe("running");
       expect(parsed.diagnostics?.service?.pid).toBe(4242);
       expect(parsed.diagnostics?.lastGatewayError).toContain("required secrets are unavailable");
+    });
+  }, 60_000);
+
+  it("preserves unknown service inspection in JSON diagnostics", async () => {
+    await withStateDir("state-local-daemon-health-unknown-", async (stateDir) => {
+      waitForGatewayReachableMock = vi.fn(async () => ({
+        ok: false,
+        detail: "connect ECONNREFUSED 127.0.0.1:18789",
+      }));
+      gatewayServiceMock.isLoaded.mockRejectedValueOnce(new Error("systemctl timed out"));
+
+      const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+      await expectOnboardLocalJsonSetupFailure({
+        runSetup: runNonInteractiveSetup,
+        stateDir,
+        runtime: runtimeWithCapture,
+      });
+
+      const parsed = JSON.parse(readCapturedJson()) as {
+        diagnostics?: {
+          service?: { loaded?: boolean | null; loadState?: { status?: string; detail?: string } };
+        };
+      };
+      expect(parsed.diagnostics?.service?.loaded).toBeNull();
+      expect(parsed.diagnostics?.service?.loadState).toEqual({
+        status: "unknown",
+        detail: "Error: systemctl timed out",
+      });
     });
   }, 60_000);
 
@@ -932,13 +967,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         runtime,
       );
 
-      const cfg = readTestConfig<{
+      const cfg = readTestConfig() as {
         gateway?: {
           bind?: string;
           port?: number;
           auth?: { mode?: string; token?: string };
         };
-      }>();
+      };
 
       expect(cfg.gateway?.bind).toBe("lan");
       expect(cfg.gateway?.port).toBe(port);

--- a/src/commands/onboard-non-interactive.test-helpers.ts
+++ b/src/commands/onboard-non-interactive.test-helpers.ts
@@ -115,9 +115,8 @@ export function createOnboardTestConfigStore() {
     return path.join(stateDir, "openclaw.json");
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test helper lets assertions ascribe stored config shape.
-  function readConfig<T = OpenClawConfig>(): T {
-    return (configStore.get(resolveConfigPath()) ?? {}) as T;
+  function readConfig(): OpenClawConfig {
+    return configStore.get(resolveConfigPath()) ?? {};
   }
 
   function readSnapshot(): ConfigFileSnapshot {

--- a/src/commands/onboard-non-interactive.test-helpers.ts
+++ b/src/commands/onboard-non-interactive.test-helpers.ts
@@ -1,7 +1,11 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, vi } from "vitest";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 // Non-interactive onboarding test helpers build runtime stubs that throw instead of exiting.
 import type { RuntimeEnv } from "../runtime.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 
 type RuntimeLike = Pick<RuntimeEnv, "log" | "error" | "exit">;
 
@@ -21,6 +25,27 @@ export type WaitForGatewayReachableMock =
     }) => Promise<{ ok: boolean; detail?: string }>)
   | undefined;
 
+type RunNonInteractiveSetup = typeof import("./onboard-non-interactive.js").runNonInteractiveSetup;
+
+type MockWithCalls<TArgs extends unknown[]> = {
+  mock: {
+    calls: TArgs[];
+  };
+};
+
+export type OnboardEnsureWorkspaceOptions = {
+  skipBootstrap?: boolean;
+};
+
+export type OnboardGatewayHealthCall = {
+  password?: string;
+  token?: string;
+};
+
+export type OnboardHealthCommandCall = OnboardGatewayHealthCall & {
+  config?: OpenClawConfig;
+};
+
 export function createThrowingRuntime(): NonInteractiveRuntime {
   return {
     log: () => {},
@@ -29,6 +54,200 @@ export function createThrowingRuntime(): NonInteractiveRuntime {
     },
     exit: (code: number) => {
       throw new Error(`exit:${code}`);
+    },
+  };
+}
+
+export function createOnboardJsonCaptureRuntime() {
+  let capturedJson = "";
+  const runtimeWithCapture: RuntimeEnv = {
+    log: (...args: unknown[]) => {
+      const firstArg = args[0];
+      capturedJson =
+        typeof firstArg === "string"
+          ? firstArg
+          : firstArg instanceof Error
+            ? firstArg.message
+            : (JSON.stringify(firstArg) ?? "");
+    },
+    error: (...args: unknown[]) => {
+      const firstArg = args[0];
+      const capturedError =
+        typeof firstArg === "string"
+          ? firstArg
+          : firstArg instanceof Error
+            ? firstArg.message
+            : (JSON.stringify(firstArg) ?? "");
+      throw new Error(capturedError);
+    },
+    exit: (_code: number) => {
+      throw new Error("exit should not be reached after runtime.error");
+    },
+  };
+
+  return {
+    runtimeWithCapture,
+    readCapturedJson: () => capturedJson,
+  };
+}
+
+export function readOnboardFirstMockCall(mock: unknown, label: string): unknown[] {
+  const calls = (mock as MockWithCalls<unknown[]>).mock.calls;
+  const call = calls[0];
+  if (!call) {
+    throw new Error(`Expected ${label} to be called`);
+  }
+  return call;
+}
+
+export function createOnboardTestConfigStore() {
+  const configStore = new Map<string, OpenClawConfig>();
+
+  function resolveConfigPath() {
+    const override = process.env.OPENCLAW_CONFIG_PATH?.trim();
+    if (override) {
+      return override;
+    }
+    const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR must be set before config IO in this test");
+    }
+    return path.join(stateDir, "openclaw.json");
+  }
+
+  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test helper lets assertions ascribe stored config shape.
+  function readConfig<T = OpenClawConfig>(): T {
+    return (configStore.get(resolveConfigPath()) ?? {}) as T;
+  }
+
+  function readSnapshot(): ConfigFileSnapshot {
+    const config = configStore.get(resolveConfigPath()) ?? {};
+    const exists = configStore.has(resolveConfigPath());
+    return {
+      path: resolveConfigPath(),
+      exists,
+      raw: exists ? `${JSON.stringify(config, null, 2)}\n` : null,
+      parsed: config,
+      sourceConfig: config,
+      resolved: config,
+      valid: true,
+      runtimeConfig: config,
+      config,
+      ...(exists ? { hash: "test-config-hash" } : {}),
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    };
+  }
+
+  return { configStore, resolveConfigPath, readConfig, readSnapshot };
+}
+
+export function createOnboardStateDirHarness(getTempHome: () => string | undefined) {
+  async function withStateDir(
+    prefix: string,
+    run: (stateDir: string) => Promise<void>,
+  ): Promise<void> {
+    const tempHome = getTempHome();
+    if (!tempHome) {
+      throw new Error("temp home not initialized");
+    }
+    const stateDir = await fs.realpath(await fs.mkdtemp(path.join(tempHome, prefix)));
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
+    try {
+      await run(stateDir);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  }
+
+  return { withStateDir };
+}
+
+export function prepareOnboardGatewayTestEnv() {
+  const snapshot = captureEnv([
+    "HOME",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_SKIP_CHANNELS",
+    "OPENCLAW_SKIP_GMAIL_WATCHER",
+    "OPENCLAW_SKIP_CRON",
+    "OPENCLAW_SKIP_CANVAS_HOST",
+    "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+    "OPENCLAW_GATEWAY_TOKEN",
+    "OPENCLAW_GATEWAY_PASSWORD",
+  ]);
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  deleteTestEnvValue("OPENCLAW_GATEWAY_TOKEN");
+  deleteTestEnvValue("OPENCLAW_GATEWAY_PASSWORD");
+  return snapshot;
+}
+
+export function createOnboardLocalDaemonOptions(stateDir: string) {
+  return {
+    nonInteractive: true,
+    mode: "local" as const,
+    workspace: path.join(stateDir, "openclaw"),
+    authChoice: "skip" as const,
+    skipSkills: true,
+    skipHealth: false,
+    installDaemon: true,
+    gatewayBind: "loopback" as const,
+  };
+}
+
+export async function runOnboardLocalDaemonSetup(params: {
+  runSetup: RunNonInteractiveSetup;
+  stateDir: string;
+  runtime: RuntimeEnv;
+}) {
+  await params.runSetup(createOnboardLocalDaemonOptions(params.stateDir), params.runtime);
+}
+
+export async function expectOnboardLocalJsonSetupFailure(params: {
+  runSetup: RunNonInteractiveSetup;
+  stateDir: string;
+  runtime: RuntimeEnv;
+}) {
+  await expect(
+    params.runSetup(
+      {
+        ...createOnboardLocalDaemonOptions(params.stateDir),
+        json: true,
+      },
+      params.runtime,
+    ),
+  ).rejects.toThrow("exit should not be reached after runtime.error");
+}
+
+export function createOnboardGatewayTimeoutCapture() {
+  let capturedDeadlineMs: number | undefined;
+  let capturedProbeTimeoutMs: number | undefined;
+  const mock = vi.fn(
+    async (params: {
+      url: string;
+      token?: string;
+      password?: string;
+      deadlineMs?: number;
+      probeTimeoutMs?: number;
+    }) => {
+      capturedDeadlineMs = params.deadlineMs;
+      capturedProbeTimeoutMs = params.probeTimeoutMs;
+      return { ok: true };
+    },
+  );
+  return {
+    mock,
+    get deadlineMs() {
+      return capturedDeadlineMs;
+    },
+    get probeTimeoutMs() {
+      return capturedProbeTimeoutMs;
     },
   };
 }

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -82,8 +82,11 @@ async function collectGatewayHealthFailureDiagnostics(): Promise<
     const env = process.env as Record<string, string | undefined>;
     const state = await readGatewayServiceState(service, { env });
     const runtime = state.runtime;
+    const loaded =
+      state.loadState.status === "unknown" ? null : state.loadState.status === "loaded";
     diagnostics.service = {
       label: service.label,
+      loaded,
       loadState: state.loadState,
       loadedText: service.loadedText,
       runtimeStatus: runtime?.status,

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -76,16 +76,15 @@ async function collectGatewayHealthFailureDiagnostics(): Promise<
   try {
     // Load daemon diagnostics only on failure; successful setup should not pay
     // the service/log inspection cost or import daemon-specific modules.
-    const { resolveGatewayService } = await import("../../daemon/service.js");
+    const { readGatewayServiceState, resolveGatewayService } =
+      await import("../../daemon/service.js");
     const service = resolveGatewayService();
     const env = process.env as Record<string, string | undefined>;
-    const [loaded, runtime] = await Promise.all([
-      service.isLoaded({ env }).catch(() => false),
-      service.readRuntime(env).catch(() => undefined),
-    ]);
+    const state = await readGatewayServiceState(service, { env });
+    const runtime = state.runtime;
     diagnostics.service = {
       label: service.label,
-      loaded,
+      loadState: state.loadState,
       loadedText: service.loadedText,
       runtimeStatus: runtime?.status,
       state: runtime?.state,

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -4,6 +4,7 @@
  * JSON success/failure payloads and human-readable gateway health diagnostics
  * are kept here so local and remote setup report failures consistently.
  */
+import type { GatewayServiceLoadState } from "../../../daemon/service-types.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../../runtime.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 
@@ -11,7 +12,7 @@ import type { OnboardOptions } from "../../onboard-types.js";
 export type GatewayHealthFailureDiagnostics = {
   service?: {
     label: string;
-    loaded: boolean;
+    loadState: GatewayServiceLoadState;
     loadedText: string;
     runtimeStatus?: string;
     state?: string;
@@ -121,7 +122,10 @@ export function classifyGatewayHealthFailure(params: {
   ) {
     return "module-missing";
   }
-  if (params.diagnostics?.service?.loaded === false && hasConnectionRefusedDetail(detail)) {
+  if (
+    params.diagnostics?.service?.loadState.status === "not-loaded" &&
+    hasConnectionRefusedDetail(detail)
+  ) {
     return "service-missing";
   }
   const runtimeStatus = params.diagnostics?.service?.runtimeStatus;
@@ -193,6 +197,12 @@ export function logNonInteractiveOnboardingFailure(params: {
   const recoveryHint = recoveryHintForGatewayHealthFailure(classification);
   const hints = [...(recoveryHint ? [recoveryHint] : []), ...(params.hints?.filter(Boolean) ?? [])];
   const gatewayRuntime = formatGatewayRuntimeSummary(params.diagnostics);
+  const service = params.diagnostics?.service;
+  const serviceLoadText = service
+    ? service.loadState.status === "loaded"
+      ? service.loadedText
+      : service.loadState.status.replace("-", " ")
+    : undefined;
 
   if (params.opts.json) {
     writeRuntimeJson(params.runtime, {
@@ -216,9 +226,7 @@ export function logNonInteractiveOnboardingFailure(params: {
     params.message,
     classification ? `Classification: ${classification}` : undefined,
     params.detail ? `Last probe: ${params.detail}` : undefined,
-    params.diagnostics?.service
-      ? `Service: ${params.diagnostics.service.label} (${params.diagnostics.service.loaded ? params.diagnostics.service.loadedText : "not loaded"})`
-      : undefined,
+    service ? `Service: ${service.label} (${serviceLoadText})` : undefined,
     gatewayRuntime ? `Runtime: ${gatewayRuntime}` : undefined,
     params.diagnostics?.lastGatewayError
       ? `Last gateway error: ${params.diagnostics.lastGatewayError}`

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -12,6 +12,7 @@ import type { OnboardOptions } from "../../onboard-types.js";
 export type GatewayHealthFailureDiagnostics = {
   service?: {
     label: string;
+    loaded: boolean | null;
     loadState: GatewayServiceLoadState;
     loadedText: string;
     runtimeStatus?: string;

--- a/src/commands/status.daemon.test.ts
+++ b/src/commands/status.daemon.test.ts
@@ -25,7 +25,7 @@ describe("status daemon summary", () => {
     mocks.readServiceStatusSummary.mockResolvedValueOnce({
       label: "systemd",
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       managedByOpenClaw: true,
       externallyManaged: false,
       loadedText: "enabled",
@@ -48,7 +48,7 @@ describe("status daemon summary", () => {
     mocks.readServiceStatusSummary.mockResolvedValueOnce({
       label: "systemd user",
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       managedByOpenClaw: true,
       externallyManaged: false,
       loadedText: "enabled",
@@ -80,7 +80,7 @@ describe("status daemon summary", () => {
     mocks.readServiceStatusSummary.mockResolvedValueOnce({
       label: "systemd user",
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       managedByOpenClaw: true,
       externallyManaged: false,
       loadedText: "enabled",
@@ -104,7 +104,7 @@ describe("status daemon summary", () => {
     mocks.readServiceStatusSummary.mockResolvedValueOnce({
       label: "Gateway service",
       installed: false,
-      loaded: false,
+      loadState: { status: "unknown", detail: "Gateway service install not supported on aix" },
       managedByOpenClaw: false,
       externallyManaged: false,
       loadedText: "not installed",

--- a/src/commands/status.daemon.test.ts
+++ b/src/commands/status.daemon.test.ts
@@ -38,6 +38,7 @@ describe("status daemon summary", () => {
     });
 
     const summary = await getDaemonStatusSummary();
+    expect(summary.loaded).toBe(true);
     expect(summary.runtimeShort).toBe("running (pid 1234)");
     expect(summary.layout?.execStart).toBe("/usr/bin/node /opt/openclaw/dist/entry.js gateway");
     expect(summary.layout?.sourceScope).toBe("system");
@@ -116,6 +117,7 @@ describe("status daemon summary", () => {
     expect(mocks.resolveGatewayService).toHaveBeenCalled();
     expect(summary.label).toBe("Gateway service");
     expect(summary.installed).toBe(false);
+    expect(summary.loaded).toBeNull();
     expect(summary.runtimeShort).toBe("unknown (Gateway service install not supported on aix)");
   });
 });

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -9,6 +9,7 @@ import { readServiceStatusSummary } from "./status.service-summary.js";
 type DaemonStatusSummary = {
   label: string;
   installed: boolean | null;
+  loaded: boolean | null;
   loadState: Awaited<ReturnType<typeof readServiceStatusSummary>>["loadState"];
   managedByOpenClaw: boolean;
   externallyManaged: boolean;
@@ -26,9 +27,12 @@ async function buildDaemonStatusSummary(
   const service = serviceLabel === "gateway" ? resolveGatewayService() : resolveNodeService();
   const fallbackLabel = serviceLabel === "gateway" ? "Daemon" : "Node";
   const summary = await readServiceStatusSummary(service, fallbackLabel, timeoutMs);
+  const loaded =
+    summary.loadState.status === "unknown" ? null : summary.loadState.status === "loaded";
   return {
     label: summary.label,
     installed: summary.installed,
+    loaded,
     loadState: summary.loadState,
     managedByOpenClaw: summary.managedByOpenClaw,
     externallyManaged: summary.externallyManaged,

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -9,7 +9,7 @@ import { readServiceStatusSummary } from "./status.service-summary.js";
 type DaemonStatusSummary = {
   label: string;
   installed: boolean | null;
-  loaded: boolean;
+  loadState: Awaited<ReturnType<typeof readServiceStatusSummary>>["loadState"];
   managedByOpenClaw: boolean;
   externallyManaged: boolean;
   loadedText: string;
@@ -29,7 +29,7 @@ async function buildDaemonStatusSummary(
   return {
     label: summary.label,
     installed: summary.installed,
-    loaded: summary.loaded,
+    loadState: summary.loadState,
     managedByOpenClaw: summary.managedByOpenClaw,
     externallyManaged: summary.externallyManaged,
     loadedText: summary.loadedText,

--- a/src/commands/status.node-mode.test.ts
+++ b/src/commands/status.node-mode.test.ts
@@ -28,7 +28,7 @@ describe("resolveNodeOnlyGatewayInfo", () => {
         daemon: { installed: false },
         node: {
           installed: true,
-          loaded: true,
+          loadState: { status: "loaded" },
           externallyManaged: false,
           runtime: { status: "running", pid: 4321 },
         },
@@ -57,7 +57,7 @@ describe("resolveNodeOnlyGatewayInfo", () => {
         daemon: { installed: false },
         node: {
           installed: true,
-          loaded: false,
+          loadState: { status: "not-loaded" },
           externallyManaged: false,
           runtime: { status: "stopped" },
         },
@@ -73,7 +73,7 @@ describe("resolveNodeOnlyGatewayInfo", () => {
         daemon: { installed: false },
         node: {
           installed: true,
-          loaded: true,
+          loadState: { status: "loaded" },
           externallyManaged: false,
         },
       }),

--- a/src/commands/status.node-mode.ts
+++ b/src/commands/status.node-mode.ts
@@ -2,11 +2,12 @@
 // On these machines the local gateway daemon is absent by design, but the node service may point at a remote gateway.
 
 import { DEFAULT_GATEWAY_PORT } from "../config/paths.js";
+import type { GatewayServiceLoadState } from "../daemon/service-types.js";
 import { loadNodeHostConfigReadOnly } from "../node-host/config.js";
 
 type NodeOnlyServiceLike = {
   installed: boolean | null;
-  loaded?: boolean | null;
+  loadState?: GatewayServiceLoadState;
   externallyManaged?: boolean;
   runtime?:
     | {
@@ -47,7 +48,7 @@ function isNodeServiceActive(node: NodeOnlyServiceLike): boolean {
     // Externally managed node services can be healthy even without local launchd/systemd loaded state.
     return true;
   }
-  if (node.loaded === true) {
+  if (node.loadState?.status === "loaded") {
     return true;
   }
   return hasRunningRuntime(node.runtime);

--- a/src/commands/status.service-summary.test.ts
+++ b/src/commands/status.service-summary.test.ts
@@ -86,7 +86,7 @@ describe("readServiceStatusSummary", () => {
       expect(summary).toMatchObject({
         label: "systemd",
         installed: true,
-        loaded: true,
+        loadState: { status: "loaded" },
         managedByOpenClaw: true,
         externallyManaged: false,
         loadedText: "enabled",
@@ -104,10 +104,13 @@ describe("readServiceStatusSummary", () => {
 
       expect(summary.label).toBe("Gateway service");
       expect(summary.installed).toBe(false);
-      expect(summary.loaded).toBe(false);
+      expect(summary.loadState).toEqual({
+        status: "unknown",
+        detail: "Error: Gateway service install not supported on aix",
+      });
       expect(summary.managedByOpenClaw).toBe(false);
       expect(summary.externallyManaged).toBe(false);
-      expect(summary.loadedText).toBe("not installed");
+      expect(summary.loadedText).toBe("unknown");
       expect(summary.runtime).toEqual({
         status: "unknown",
         detail: "Gateway service install not supported on aix",
@@ -140,7 +143,7 @@ describe("readServiceStatusSummary", () => {
     const runtimeEnv = requireMockArg(readRuntime, "readRuntime") as NodeJS.ProcessEnv;
     expect(runtimeEnv?.OPENCLAW_GATEWAY_PORT).toBe("18789");
     expect(summary.installed).toBe(true);
-    expect(summary.loaded).toBe(true);
+    expect(summary.loadState).toEqual({ status: "loaded" });
     expect(summary.runtime?.status).toBe("running");
   });
 

--- a/src/commands/status.service-summary.ts
+++ b/src/commands/status.service-summary.ts
@@ -7,13 +7,16 @@ import {
   type GatewayServiceLayoutSummary,
 } from "../daemon/service-layout.js";
 import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
-import type { GatewayServiceCommandConfig } from "../daemon/service-types.js";
+import type {
+  GatewayServiceCommandConfig,
+  GatewayServiceLoadState,
+} from "../daemon/service-types.js";
 import { readGatewayServiceState, type GatewayService } from "../daemon/service.js";
 
 type ServiceStatusSummary = {
   label: string;
   installed: boolean | null;
-  loaded: boolean;
+  loadState: GatewayServiceLoadState;
   managedByOpenClaw: boolean;
   externallyManaged: boolean;
   loadedText: string;
@@ -47,13 +50,15 @@ export async function readServiceStatusSummary(
     const installed = managedByOpenClaw || externallyManaged;
     const loadedText = externallyManaged
       ? "running (externally managed)"
-      : state.loaded
+      : state.loadState.status === "loaded"
         ? service.loadedText
-        : service.notLoadedText;
+        : state.loadState.status === "not-loaded"
+          ? service.notLoadedText
+          : "unknown";
     return {
       label: service.label,
       installed,
-      loaded: state.loaded,
+      loadState: state.loadState,
       managedByOpenClaw,
       externallyManaged,
       loadedText,
@@ -61,12 +66,12 @@ export async function readServiceStatusSummary(
       ...(layout ? { layout } : {}),
       ...(wrapperPath ? { wrapperPath } : {}),
     };
-  } catch {
+  } catch (error) {
     // Status output should survive service-manager errors and show an unknown row.
     return {
       label: fallbackLabel,
       installed: null,
-      loaded: false,
+      loadState: { status: "unknown", detail: String(error) },
       managedByOpenClaw: false,
       externallyManaged: false,
       loadedText: "unknown",

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -86,6 +86,11 @@ export type GatewayServiceReadOptions = {
 
 export type GatewayServiceEnvironmentValueSource = "inline" | "file" | "inline-and-file";
 
+export type GatewayServiceLoadState =
+  | { status: "loaded" }
+  | { status: "not-loaded" }
+  | { status: "unknown"; detail: string };
+
 /** Parsed command and env metadata from an installed platform service. */
 export type GatewayServiceCommandConfig = {
   programArguments: string[];
@@ -97,7 +102,7 @@ export type GatewayServiceCommandConfig = {
 
 export type GatewayServiceState = {
   installed: boolean;
-  loaded: boolean;
+  loadState: GatewayServiceLoadState;
   running: boolean;
   env: GatewayServiceEnv;
   command: GatewayServiceCommandConfig | null;

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -288,6 +288,27 @@ describe("startGatewayService", () => {
     expect(result.state.running).toBe(true);
   });
 
+  it("rejects an unknown post-start service inspection", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+      })),
+      isLoaded: vi
+        .fn<GatewayService["isLoaded"]>()
+        .mockResolvedValueOnce(false)
+        .mockRejectedValueOnce(new Error("post-start inspection failed")),
+      readRuntime: vi
+        .fn<GatewayService["readRuntime"]>()
+        .mockResolvedValueOnce({ status: "stopped" })
+        .mockResolvedValueOnce({ status: "running" }),
+    });
+
+    await expect(startGatewayService(service, { env: {}, stdout: process.stdout })).rejects.toThrow(
+      "Service status inspection failed after start: Error: post-start inspection failed",
+    );
+    expect(service.start).toHaveBeenCalledTimes(1);
+  });
+
   it("reports an explicit post-start process failure instead of claiming success", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -153,7 +153,7 @@ describe("readGatewayServiceState", () => {
     });
 
     expect(state.installed).toBe(true);
-    expect(state.loaded).toBe(true);
+    expect(state.loadState).toEqual({ status: "loaded" });
     expect(state.running).toBe(true);
     expect(state.env.OPENCLAW_GATEWAY_PORT).toBe("18789");
   });
@@ -199,6 +199,21 @@ describe("readGatewayServiceState", () => {
     expect(state.runtime).toEqual({
       status: "unknown",
       detail: "Error: systemctl show timed out",
+    });
+  });
+
+  it("preserves loaded-state probe failures as an explicit unknown state", async () => {
+    const service = createService({
+      isLoaded: vi.fn(async () => {
+        throw new Error("systemctl is-enabled timed out");
+      }),
+    });
+
+    const state = await readGatewayServiceState(service, { timeoutMs: 100 });
+
+    expect(state.loadState).toEqual({
+      status: "unknown",
+      detail: "Error: systemctl is-enabled timed out",
     });
   });
 
@@ -269,7 +284,7 @@ describe("startGatewayService", () => {
     expect(service.start).toHaveBeenCalledTimes(1);
     expect(service.restart).not.toHaveBeenCalled();
     expect(result.state.installed).toBe(true);
-    expect(result.state.loaded).toBe(true);
+    expect(result.state.loadState).toEqual({ status: "loaded" });
     expect(result.state.running).toBe(true);
   });
 

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -272,6 +272,9 @@ export async function startGatewayService(
     throw err;
   }
 
+  if (nextState.loadState.status === "unknown") {
+    throw new Error(`Service status inspection failed after start: ${nextState.loadState.detail}`);
+  }
   const runtime = nextState.runtime;
   const failedState = normalizeLowercaseStringOrEmpty(runtime?.state) === "failed";
   const newFailedExit =

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -176,6 +176,18 @@ export function formatGatewayServiceStartRepairIssues(
   return issues.map((issue) => issue.message).join("; ");
 }
 
+export async function readGatewayServiceLoadState(
+  service: GatewayService,
+  args: GatewayServiceEnvArgs = {},
+): Promise<GatewayServiceLoadState> {
+  try {
+    const loaded = await service.isLoaded(args);
+    return { status: loaded ? "loaded" : "not-loaded" };
+  } catch (error) {
+    return { status: "unknown", detail: String(error) };
+  }
+}
+
 export async function readGatewayServiceState(
   service: GatewayService,
   args: ReadGatewayServiceStateArgs = {},
@@ -190,15 +202,7 @@ export async function readGatewayServiceState(
   // instead of hanging both probes. readCommand parses local files and needs no
   // bound; isLoaded/readRuntime can spawn service-manager subprocesses.
   const [loadState, runtime] = await Promise.all([
-    service
-      .isLoaded({ env, timeoutMs: args.timeoutMs })
-      .then((loaded): GatewayServiceLoadState => ({ status: loaded ? "loaded" : "not-loaded" }))
-      .catch(
-        (error: unknown): GatewayServiceLoadState => ({
-          status: "unknown",
-          detail: String(error),
-        }),
-      ),
+    readGatewayServiceLoadState(service, { env, timeoutMs: args.timeoutMs }),
     service.readRuntime(env, { timeoutMs: args.timeoutMs }).catch(
       (error: unknown) =>
         ({

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -37,6 +37,7 @@ import type {
   GatewayServiceEnv,
   GatewayServiceEnvArgs,
   GatewayServiceInstallArgs,
+  GatewayServiceLoadState,
   GatewayServiceManageArgs,
   GatewayServiceReadOptions,
   GatewayServiceRestartResult,
@@ -125,7 +126,7 @@ function collectGatewayServiceStartRepairIssues(
   expectedPort?: number,
 ): GatewayServiceStartRepairIssue[] {
   const command = state.command;
-  if (!state.loaded || !command) {
+  if (state.loadState.status !== "loaded" || !command) {
     return [];
   }
   const issues: GatewayServiceStartRepairIssue[] = [];
@@ -188,8 +189,16 @@ export async function readGatewayServiceState(
   // Propagate the status read deadline so a wedged service manager fails soft
   // instead of hanging both probes. readCommand parses local files and needs no
   // bound; isLoaded/readRuntime can spawn service-manager subprocesses.
-  const [loaded, runtime] = await Promise.all([
-    service.isLoaded({ env, timeoutMs: args.timeoutMs }).catch(() => false),
+  const [loadState, runtime] = await Promise.all([
+    service
+      .isLoaded({ env, timeoutMs: args.timeoutMs })
+      .then((loaded): GatewayServiceLoadState => ({ status: loaded ? "loaded" : "not-loaded" }))
+      .catch(
+        (error: unknown): GatewayServiceLoadState => ({
+          status: "unknown",
+          detail: String(error),
+        }),
+      ),
     service.readRuntime(env, { timeoutMs: args.timeoutMs }).catch(
       (error: unknown) =>
         ({
@@ -200,7 +209,7 @@ export async function readGatewayServiceState(
   ]);
   return {
     installed: command !== null,
-    loaded,
+    loadState,
     running: runtime?.status === "running",
     env,
     command,
@@ -218,14 +227,17 @@ export async function startGatewayService(
     { env: args.env },
     expectedPort,
   );
-  if (!state.loaded && !state.installed) {
+  if (state.loadState.status === "unknown") {
+    throw new Error(`Service status inspection failed: ${state.loadState.detail}`);
+  }
+  if (state.loadState.status === "not-loaded" && !state.installed) {
     return {
       outcome: "missing-install",
       state,
     };
   }
 
-  if (state.loaded && state.running) {
+  if (state.loadState.status === "loaded" && state.running) {
     return {
       outcome: "already-running",
       state,

--- a/src/daemon/systemd-runtime.ts
+++ b/src/daemon/systemd-runtime.ts
@@ -126,7 +126,7 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+  if (!isSystemctlMissing(detail) && isSystemdUnitNotEnabled(detail)) {
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -437,14 +437,15 @@ describe("isSystemdServiceEnabled", () => {
     execFileMock.mockReset();
   });
 
-  it("returns false when systemctl is not present", async () => {
+  it("throws when systemctl is not present", async () => {
     execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
       const err = new Error("spawn systemctl EACCES") as Error & { code?: string };
       err.code = "EACCES";
       cb(err, "", "");
     });
-    const result = await readManagedServiceEnabled();
-    expect(result).toBe(false);
+    await expect(readManagedServiceEnabled()).rejects.toThrow(
+      "systemctl is-enabled unavailable: spawn systemctl EACCES",
+    );
   });
 
   it("returns false without calling systemctl when the managed unit file is missing", async () => {

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -114,7 +114,7 @@ describe("doctor runtime tool schema checks", () => {
     });
     mocks.readGatewayServiceState.mockReset().mockResolvedValue({
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: true,
       env: {},
       command: { programArguments: ["openclaw", "gateway"], sourcePath: "/tmp/gateway.service" },
@@ -573,7 +573,7 @@ describe("doctor gateway runtime checks", () => {
     });
     mocks.readGatewayServiceState.mockReset().mockResolvedValue({
       installed: true,
-      loaded: true,
+      loadState: { status: "loaded" },
       running: true,
       env: {},
       command: { programArguments: ["openclaw", "gateway"], sourcePath: "/tmp/gateway.service" },
@@ -648,7 +648,7 @@ describe("doctor gateway runtime checks", () => {
   it("reports missing local gateway daemon service", async () => {
     mocks.readGatewayServiceState.mockResolvedValueOnce({
       installed: false,
-      loaded: false,
+      loadState: { status: "not-loaded" },
       running: false,
       env: {},
       command: null,

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -178,6 +178,17 @@ export async function collectGatewayDaemonFindings(
   const service = resolveGatewayService();
   const state = await readGatewayServiceState(service, { env: process.env });
   const findings: HealthFinding[] = [];
+  if (state.loadState.status === "unknown") {
+    findings.push({
+      checkId: "core/doctor/gateway-daemon",
+      severity: "warning",
+      message: `Gateway service status could not be determined: ${state.loadState.detail}`,
+      path: state.command?.sourcePath,
+      target: service.label,
+      fixHint: "Run `openclaw gateway status --deep`, restore service-manager access, and retry.",
+    });
+    return findings;
+  }
   if (!state.installed) {
     findings.push({
       checkId: "core/doctor/gateway-daemon",
@@ -189,7 +200,7 @@ export async function collectGatewayDaemonFindings(
     });
     return findings;
   }
-  if (!state.loaded) {
+  if (state.loadState.status === "not-loaded") {
     findings.push({
       checkId: "core/doctor/gateway-daemon",
       severity: "warning",
@@ -200,7 +211,7 @@ export async function collectGatewayDaemonFindings(
     });
   }
   const status = gatewayRuntimeStatus(state.runtime);
-  if (state.loaded && !state.running) {
+  if (state.loadState.status === "loaded" && !state.running) {
     findings.push({
       checkId: "core/doctor/gateway-daemon",
       severity: "warning",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -273,6 +273,16 @@ vi.mock("../daemon/service.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../daemon/service.js")>();
   return {
     ...actual,
+    readGatewayServiceState: async () => ({
+      installed: true,
+      loadState: {
+        status: (await mocks.gatewayServiceIsLoaded()) ? "loaded" : "not-loaded",
+      },
+      running: false,
+      env: {},
+      command: null,
+      runtime: { status: "stopped" },
+    }),
     resolveGatewayService: mocks.resolveGatewayService,
   };
 });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -282,17 +282,12 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
   ) {
     return;
   }
-  const { resolveGatewayService } = await import("../daemon/service.js");
+  const { readGatewayServiceState, resolveGatewayService } = await import("../daemon/service.js");
   const { ensureSystemdUserLingerInteractive } = await import("../commands/systemd-linger.js");
   const { note } = await loadNoteModule();
   const service = resolveGatewayService();
-  let loaded;
-  try {
-    loaded = await service.isLoaded({ env: process.env });
-  } catch {
-    loaded = false;
-  }
-  if (!loaded) {
+  const state = await readGatewayServiceState(service, { env: process.env });
+  if (state.loadState.status !== "loaded") {
     return;
   }
   await ensureSystemdUserLingerInteractive({
@@ -313,15 +308,10 @@ async function detectSystemdLingerFindings(
   if (process.platform !== "linux" || resolveDoctorMode(ctx.cfg) !== "local") {
     return [];
   }
-  const { resolveGatewayService } = await import("../daemon/service.js");
+  const { readGatewayServiceState, resolveGatewayService } = await import("../daemon/service.js");
   const service = resolveGatewayService();
-  let loaded;
-  try {
-    loaded = await service.isLoaded({ env: process.env });
-  } catch {
-    loaded = false;
-  }
-  if (!loaded) {
+  const state = await readGatewayServiceState(service, { env: process.env });
+  if (state.loadState.status !== "loaded") {
     return [];
   }
   const {


### PR DESCRIPTION
Related: #123961

## What Problem This Solves

Fixes an issue where operators running gateway status or doctor could be told that the managed service was not loaded or not installed when the service manager inspection itself had failed. Doctor could then offer install/start repair based on an unknown fact even while a gateway runtime might still be running.

## Why This Change Was Made

Gateway service inspection now owns one closed loaded/not-loaded/unknown result. Status, doctor, onboarding diagnostics, update/lifecycle consumers, and compact status projections carry that result instead of collapsing inspection failures to false. Linux keeps the existing classified systemd/WSL/user-bus guidance, while doctor and service start paths fail closed before install/start repair when inspection is unknown.

ClawSweeper's compatibility findings were accepted. Public onboarding diagnostics and both machine-readable status projections preserve their legacy `loaded` field alongside canonical `loadState`; the legacy field remains boolean for known loaded/not-loaded states and is `null` when inspection is unknown. This retains compatibility without presenting an unknown fact as false.

Both lifecycle P1 findings are resolved through canonical `readGatewayServiceLoadState`, with `readGatewayServiceState` reusing that mapping. Uninstall now fails before stop/uninstall mutation when initial inspection is unknown, and post-stop or post-uninstall verification treats unknown inspection as action failure instead of successful `loaded=false`.

The restart path is resolved at the same owner boundary: an unknown initial inspection now fails before installed-definition lookup, restart mutation, or post-restart verification. The existing known-not-loaded restart path remains unchanged.

The current-head ClawSweeper findings are also resolved at their owners. `startGatewayService` now rejects an unknown post-start inspection instead of returning `started`, and Doctor update returns its existing no-repair/no-activation policy when either the initial or post-update inspection is unknown.

The final branch rebases cleanly onto `68f808f2c4c`, inheriting #125800 at `f1453c7c778`. That canonical main fix owns the unrelated dialog-reopen and startup-baseline failures that prevented the prior exact-head CI run from becoming green.

AI-assisted implementation; the change and owner boundary were reviewed directly. Do not include agent transcripts.

## User Impact

Operators now see an explicit unknown service state, the inspection failure, and a command to retry deeper status. Doctor reports actionable service-manager guidance without claiming the service is absent or offering/executing install, start, or restart repair from an unknown inspection. Existing scripts consuming `loaded` from either status JSON surface continue to work, with `null` representing an inspection that could not establish the state.

## Evidence

- Pre-fix regressions failed for the intended behavior: producer state had no unknown variant; status collapsed the failure and rendered loaded/not-loaded instead of unknown; doctor continued into installation repair.
- Rebased focused service/lifecycle/status/doctor/onboarding proof: 845 tests passed, 1 skipped, split across the owning daemon, CLI, command, update, and doctor lanes.
- Current-head ClawSweeper acceptance suite: `node scripts/run-vitest.mjs src/daemon/service.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/commands/doctor-update.test.ts` — 78 passed across three shards. Regressions cover post-start inspection failure, initial Doctor-update unknown state, and post-update unknown state.
- Exact Codex CI include-plan reproduction: 34 files, 1,031 tests passed in 97s. The rebased `node scripts/run-vitest.mjs extensions/codex` fallback sweep also passed all five shards and reproduced the same 34-file/1,031-test subgroup in 85s.
- Final `node scripts/check-changed.mjs` — passed through the final pairing-account guard after both ClawSweeper fixes. The temp-directory migration report remained warning-only for two canonicalized `mkdtemp` sites.
- `git diff --check origin/main...HEAD` — passed.
- Final `pnpm build` — passed locally in 12m16s after the current-head fixes; the earlier clean Blacksmith Testbox build also passed at https://github.com/openclaw/openclaw/actions/runs/32148382993.
- Final branch-vs-main P1 autoreview — clean, no P0/P1 findings (0.90 confidence). The focused four-file pre-commit review was also clean (0.95 confidence).
- Direct Codex app-server lifecycle/protocol source inspection confirmed that the Codex plugin test surface is independent from OpenClaw's host service-manager load-state contract.
- No real gateway or host service manager was mutated. Deterministic producer/status/doctor/lifecycle boundaries are the behavioral proof; authenticated live host-service proof remains intentionally absent.
- Production LOC: +197/-126 (net +71) | Tests/support: +739/-348. The production growth replaces a lossy boolean across the service-state owner and consumers with an explicit closed result, removes duplicate doctor inspection catches, preserves actionable diagnostics, retains legacy JSON compatibility without misreporting unknown state, and makes lifecycle/update mutation and verification fail closed on unknown inspection.

Provenance: clearly introduced by #94149's status-timeout catch (code author @ZengWen-DT, merged by @vincentkoc on 2026-07-01), which converted `isLoaded()` inspection failure to `false` while runtime failure remained `unknown`.
