### PR TITLE
fix(skills): keep proposal list metadata-only

### DIFF
--- a/src/agents/tools/skill-workshop-tool.list.test.ts
+++ b/src/agents/tools/skill-workshop-tool.list.test.ts
@@ -116,4 +116,38 @@ describe("skill_workshop list", () => {
     });
     expect(commitLockState.calls).toBe(51);
   });
+
+  it("lists pending create metadata without reading its draft", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-list-");
+    const tool = createSkillWorkshopTool({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+      env: testState.env,
+    });
+    const created = await tool.execute("call-create", {
+      action: "create",
+      name: "Missing Draft",
+      description: "Proposal whose durable draft artifact is unavailable",
+      proposal_content: "# Missing Draft\n",
+    });
+    const proposalId = (created.details as { id: string }).id;
+
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+    await expect(
+      tool.execute("call-list-missing-workspace", { action: "list" }),
+    ).resolves.toMatchObject({
+      details: { proposals: [expect.objectContaining({ id: proposalId, status: "pending" })] },
+    });
+
+    await fs.rm(testState.statePath("skill-workshop", "proposals", proposalId, "PROPOSAL.md"));
+    await expect(
+      tool.execute("call-list-filtered", { action: "list", status: "applied" }),
+    ).resolves.toMatchObject({ details: { proposals: [] } });
+    await expect(
+      tool.execute("call-list-missing-draft", { action: "list" }),
+    ).resolves.toMatchObject({
+      details: { proposals: [expect.objectContaining({ id: proposalId, status: "pending" })] },
+    });
+  });
 });

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -19,7 +19,11 @@ import {
   readSkillProposalRollback,
 } from "./store.js";
 import { withSkillProposalCommitLock } from "./target-lock.js";
-import type { SkillProposalManifest, SkillProposalReadResult } from "./types.js";
+import type {
+  SkillProposalManifest,
+  SkillProposalReadResult,
+  SkillProposalRecord,
+} from "./types.js";
 
 type SkillProposalScopeOptions = {
   agentId?: string;
@@ -55,9 +59,9 @@ export async function listSkillProposals(
     if (proposal.kind !== "create" || proposal.status !== "pending") {
       continue;
     }
-    const read = await readSkillProposal(proposal.id, store, scope);
-    if (read) {
-      await reconcilePendingCreateProposal(read, options);
+    const record = await readSkillProposalRecord(proposal.id, store, scope);
+    if (record) {
+      await reconcilePendingCreateProposal(record, options);
     }
   }
   return await readSkillProposalManifest(store, scope);
@@ -185,13 +189,23 @@ export async function readRequiredProposal(
 async function reconcilePendingCreateProposal(
   read: SkillProposalReadResult,
   options: SkillProposalScopeOptions,
-): Promise<SkillProposalReadResult> {
+): Promise<SkillProposalReadResult>;
+async function reconcilePendingCreateProposal(
+  read: SkillProposalRecord,
+  options: SkillProposalScopeOptions,
+): Promise<SkillProposalRecord>;
+async function reconcilePendingCreateProposal(
+  value: SkillProposalReadResult | SkillProposalRecord,
+  options: SkillProposalScopeOptions,
+): Promise<SkillProposalReadResult | SkillProposalRecord> {
+  const recordOnly = "schema" in value;
+  const record = recordOnly ? value : value.record;
   const workspaceDir = options.workspaceDir;
-  if (!workspaceDir || read.record.kind !== "create" || read.record.status !== "pending") {
-    return read;
+  if (!workspaceDir || record.kind !== "create" || record.status !== "pending") {
+    return value;
   }
   const resolvedWorkspaceDir = path.resolve(workspaceDir);
-  const resolvedTarget = path.resolve(read.record.target.skillFile);
+  const resolvedTarget = path.resolve(record.target.skillFile);
   // Agent-scoped reads intentionally include proposals bound to earlier workspaces.
   // Only reconcile a target against the workspace that owns it.
   if (
@@ -199,28 +213,36 @@ async function reconcilePendingCreateProposal(
     resolvedTarget !== resolvedWorkspaceDir &&
     !isPathInside(resolvedWorkspaceDir, resolvedTarget)
   ) {
-    return read;
+    return value;
   }
   const store = storeOptions(options.env);
   const scope = proposalScope(options);
   const reconciled = await withSkillProposalCommitLock(
     workspaceDir,
-    read.record,
+    record,
     async () => {
-      const current = await readSkillProposal(read.record.id, store, scope, { reconcile: false });
-      if (!current || current.record.kind !== "create" || current.record.status !== "pending") {
-        return { read: current ?? read };
+      const current = recordOnly
+        ? await readSkillProposalRecord(record.id, store, scope, { reconcile: false })
+        : await readSkillProposal(record.id, store, scope, { reconcile: false });
+      const currentRecord = current ? ("schema" in current ? current : current.record) : null;
+      if (
+        !current ||
+        !currentRecord ||
+        currentRecord.kind !== "create" ||
+        currentRecord.status !== "pending"
+      ) {
+        return { value: current ?? value };
       }
-      assertInsideWorkspace(workspaceDir, current.record.target.skillFile, "skill file");
-      if (await readSkillProposalRollback(current.record.id, store)) {
-        return { read: current };
+      assertInsideWorkspace(workspaceDir, currentRecord.target.skillFile, "skill file");
+      if (await readSkillProposalRollback(currentRecord.id, store)) {
+        return { value: current };
       }
-      const targetContent = await readWorkspaceSkillFile(current.record.target.skillFile);
+      const targetContent = await readWorkspaceSkillFile(currentRecord.target.skillFile);
       if (targetContent === null) {
-        return { read: current };
+        return { value: current };
       }
       const transition = transitionPendingSkillProposalToStale({
-        record: current.record,
+        record: currentRecord,
         reason: "Target skill was created after proposal creation.",
         input: {
           workspaceDir,
@@ -230,11 +252,14 @@ async function reconcilePendingCreateProposal(
         },
       });
       return {
-        read: {
-          ...current,
-          record: transition.record,
-          revisionHash: hashSkillProposalRevision(transition.record),
-        },
+        value:
+          "schema" in current
+            ? transition.record
+            : {
+                ...current,
+                record: transition.record,
+                revisionHash: hashSkillProposalRevision(transition.record),
+              },
         transition,
       };
     },
@@ -248,7 +273,7 @@ async function reconcilePendingCreateProposal(
       ...(options.agentId ? { agentId: options.agentId } : {}),
     });
   }
-  return reconciled.read;
+  return reconciled.value;
 }
 
 async function hydrateProposalSupportFiles(

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1,6 +1,7 @@
 // Workshop service tests cover skill workshop generation, storage, and validation behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   closeOpenClawStateDatabaseByPath,
@@ -70,6 +71,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  __setFsSafeTestHooksForTest();
   resetSkillsRefreshStateForTest();
   await tempDirs.cleanup();
 });
@@ -606,6 +608,67 @@ describe("skill workshop proposals", () => {
     ).resolves.toBe(
       '---\nname: "draftable-skill"\ndescription: "Revised proposal"\n---\n\n# Draftable\n\nLater body.\n',
     );
+  });
+
+  it("keeps inspected content coherent with a concurrent create-proposal revision", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Concurrent Revision",
+      description: "Keep inspection on one proposal revision",
+      content: "# Concurrent Revision\n\nFirst body.\n",
+    });
+    let releaseLock: (() => void) | undefined;
+    let markAcquired: (() => void) | undefined;
+    const acquired = new Promise<void>((resolve) => {
+      markAcquired = resolve;
+    });
+    const heldLock = withSkillCollectionLock(workspaceDir, async () => {
+      markAcquired?.();
+      await new Promise<void>((resolve) => {
+        releaseLock = resolve;
+      });
+    });
+    await acquired;
+    const draftPath = await fs.realpath(
+      path.join(stateDir, "skill-workshop", "proposals", proposal.record.id, "PROPOSAL.md"),
+    );
+    let markDraftOpened: (() => void) | undefined;
+    const draftOpened = new Promise<void>((resolve) => {
+      markDraftOpened = resolve;
+    });
+    let sawDraftOpen = false;
+    __setFsSafeTestHooksForTest({
+      afterOpen: (filePath) => {
+        if (!sawDraftOpen && filePath === draftPath) {
+          sawDraftOpen = true;
+          markDraftOpened?.();
+        }
+      },
+    });
+    const inspection = inspectSkillProposal(proposal.record.id, { workspaceDir });
+
+    const revised = await (async () => {
+      try {
+        await draftOpened;
+        return await reviseSkillProposal({
+          workspaceDir,
+          proposalId: proposal.record.id,
+          expectedRevisionHash: proposal.revisionHash,
+          content: "# Concurrent Revision\n\nSecond body.\n",
+        });
+      } finally {
+        __setFsSafeTestHooksForTest();
+        releaseLock?.();
+        await heldLock;
+      }
+    })();
+
+    await expect(inspection).resolves.toMatchObject({
+      record: { proposedVersion: "v2" },
+      revisionHash: revised.revisionHash,
+      content: revised.content,
+    });
   });
 
   it("recovers run progress from canonical proposal records", async () => {

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -216,12 +216,15 @@ export async function readSkillProposalRecord(
   proposalId: string,
   options: SkillWorkshopStoreOptions = {},
   scope: SkillProposalLookupScope = {},
+  readOptions: { reconcile?: boolean } = {},
 ): Promise<SkillProposalRecord | null> {
   let stored = readStoredProposal(proposalId, options);
   if (!stored || !isStoredProposalVisible(stored.row, scope)) {
     return null;
   }
-  await reconcileInterruptedApply(proposalId, options);
+  if (readOptions.reconcile !== false) {
+    await reconcileInterruptedApply(proposalId, options);
+  }
   stored = readStoredProposal(proposalId, options);
   return stored && isStoredProposalVisible(stored.row, scope) ? stored.record : null;
 }


### PR DESCRIPTION
Related: #125653

## What Problem This Solves

Fixes an issue where listing Skill Workshop proposals could abort with `file not found` when a visible pending create proposal was missing its canonical durable `PROPOSAL.md`. Because reconciliation ran before tool-side filters, one affected proposal could poison every list request.

## Why This Change Was Made

- keep pending-create list reconciliation on SQLite proposal records
- avoid reading proposal draft content that list does not return
- preserve coherent full-proposal rereads for inspect and resolve
- add missing-draft and concurrent-revision regressions

`listSkillProposals` previously loaded every visible pending create proposal solely to reconcile targets created outside the workshop. That full read opened the canonical state-owned `PROPOSAL.md`; a valid SQLite `kind=create,status=pending` row whose draft artifact was missing therefore aborted the entire list before status or query filters ran.

A deterministic create/update × status matrix showed that deleting the original workspace or update target does not cause this failure. Only a pending create with a missing canonical draft reproduces it.

The list path now uses proposal records for reconciliation. Content-bearing inspection paths still reread complete proposals under the commit lock so record, revision hash, and content remain from one coherent revision.

## User Impact

Operators can list proposal metadata even when an aged pending-create record has lost its durable draft artifact. Inspect and resolve continue to require proposal content and retain their existing content-integrity behavior.

This fixes only the proposal-list correctness bug. It does not change where autonomous updates may be applied or resolve the separate policy question around ephemeral reviewer worktrees and durable agent workspaces. It does not merge the ownership-policy work from #125666 into this PR.

## Evidence

- Before the fix, the regression fails with `not-found: file not found`; it passes after the fix.
- A 20-case diagnostic state matrix covered create/update proposals across pending, applied, rejected, quarantined, and stale states.
- `pnpm test src/agents/tools/skill-workshop-tool.list.test.ts src/skills/workshop/service.test.ts src/skills/workshop/store.test.ts src/commands/doctor-skill-workshop-sqlite.test.ts src/gateway/server-methods/skills.proposals.test.ts` — 73 tests passed on the rebased head.
- `pnpm check:changed` — passed on the rebased head.
- `test/skills-proposal-manual-target.e2e.test.ts` — passed during validation.
- `pnpm build` — passed during validation; `git range-diff` confirms the current-main rebase preserved the patch exactly.
- Independent AI-assisted diff review found and corrected a concurrent inspect/revise snapshot hazard; final re-review found no actionable issues.

## AI Assistance

AI-assisted with OpenAI Codex for source tracing, deterministic fixture construction, implementation, tests, collision checking, review, and PR preparation. I reviewed the resulting code, evidence, and scope and understand what the change does.
