### PR TITLE
fix(skills): canonical workspace targets for worktree sessions; degraded list for missing drafts

### DIFF
--- a/src/agents/skill-workshop-workspace-context.ts
+++ b/src/agents/skill-workshop-workspace-context.ts
@@ -1,0 +1,14 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const canonicalSkillWorkspace = new AsyncLocalStorage<string>();
+
+export function runWithCanonicalSkillWorkspace<T>(
+  canonicalWorkspaceDir: string | undefined,
+  run: () => T,
+): T {
+  return canonicalWorkspaceDir ? canonicalSkillWorkspace.run(canonicalWorkspaceDir, run) : run();
+}
+
+export function getCanonicalSkillWorkspace(): string | undefined {
+  return canonicalSkillWorkspace.getStore();
+}

--- a/src/agents/tools/skill-workshop-tool-factory.ts
+++ b/src/agents/tools/skill-workshop-tool-factory.ts
@@ -1,6 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SkillProposalOrigin, SkillWorkshopRunOptions } from "../../skills/workshop/types.js";
+import { getCanonicalSkillWorkspace } from "../skill-workshop-workspace-context.js";
 import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
 
 export function createConfiguredSkillWorkshopTool(params: {
@@ -18,7 +19,7 @@ export function createConfiguredSkillWorkshopTool(params: {
     params.messageId === undefined ? undefined : String(params.messageId),
   );
   return createSkillWorkshopTool({
-    workspaceDir: params.workspaceDir,
+    workspaceDir: getCanonicalSkillWorkspace() ?? params.workspaceDir,
     config: params.config,
     env: params.run?.env,
     agentId: params.agentId,

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -70,7 +70,7 @@ export function formatProposalList(proposals: readonly SkillProposalManifestEntr
   return proposals
     .map(
       (proposal) =>
-        `- ${proposal.id} [${proposal.status}, ${proposal.kind}, ${proposal.scanState}${proposal.workspaceMismatch ? ", previous workspace" : ""}] ${proposal.skillKey}: ${proposal.title}`,
+        `- ${proposal.id} [${proposal.status}, ${proposal.kind}, ${proposal.scanState}${proposal.workspaceMismatch ? ", previous workspace" : ""}${proposal.degradedState === "draft-missing" ? ", draft missing — reject and re-propose" : ""}] ${proposal.skillKey}: ${proposal.title}`,
     )
     .join("\n");
 }

--- a/src/agents/tools/skill-workshop-tool.list.test.ts
+++ b/src/agents/tools/skill-workshop-tool.list.test.ts
@@ -51,6 +51,45 @@ afterEach(async () => {
 });
 
 describe("skill_workshop list", () => {
+  it("lists a pending proposal whose draft is missing", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-missing-draft-");
+    const tool = createSkillWorkshopTool({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+      env: testState.env,
+    });
+    const created = await tool.execute("call-create", {
+      action: "create",
+      name: "Missing Draft",
+      description: "Proposal with a missing draft artifact.",
+      proposal_content: "# Missing Draft\n",
+    });
+    const proposalId = (created.details as { id: string }).id;
+    await fs.rm(
+      path.join(testState.stateDir, "skill-workshop", "proposals", proposalId, "PROPOSAL.md"),
+    );
+
+    const listed = await tool.execute("call-list", { action: "list" });
+    const listText = (listed.content[0] as { text: string }).text;
+    expect(listText).toContain(proposalId);
+    expect(listText).toContain("draft missing");
+    expect(listed.details).toMatchObject({
+      proposals: [
+        { id: proposalId, status: "pending", kind: "create", degradedState: "draft-missing" },
+      ],
+    });
+    await expect(
+      tool.execute("call-inspect", { action: "inspect", proposal_id: proposalId }),
+    ).rejects.toThrow(`Skill proposal draft is missing: ${proposalId}. Reject and re-propose it.`);
+    await expect(
+      tool.execute("call-apply", { action: "apply", proposal_id: proposalId }),
+    ).rejects.toThrow(`Skill proposal draft is missing: ${proposalId}. Reject and re-propose it.`);
+    await expect(
+      tool.execute("call-reject", { action: "reject", proposal_id: proposalId }),
+    ).resolves.toMatchObject({ details: { id: proposalId, status: "rejected" } });
+  });
+
   it.each([0, 1.5, "1.5", "25items", "many"])(
     "rejects invalid list limit %s before touching proposal state",
     async (limit) => {

--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -74,11 +74,13 @@ it("re-registers durable lineage children before configured-only runtime reads",
       ),
     ).toBe(false);
 
+    const migrateManagedWorktreeCanonicalWorkspaces = vi.fn(async () => 0);
     await runSessionStartupMigration({
       cfg,
       env,
       log: { info: vi.fn(), warn: vi.fn() },
       deps: {
+        migrateManagedWorktreeCanonicalWorkspaces,
         migrateLegacyMainSessionKeys: vi.fn(async () => ({
           armed: false,
           changes: [],
@@ -94,6 +96,7 @@ it("re-registers durable lineage children before configured-only runtime reads",
         sweepOrphanSessionStoreTemps: vi.fn(async () => 0),
       },
     });
+    expect(migrateManagedWorktreeCanonicalWorkspaces).toHaveBeenCalled();
 
     expect(listOpenClawRegisteredAgentDatabases({ env })).toContainEqual(
       expect.objectContaining({ agentId: "codex", path: childDatabasePath }),

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -13,6 +13,7 @@ import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { sweepOrphanSessionStoreTemps } from "./store-temp-cleanup.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
+import { migrateManagedWorktreeCanonicalWorkspaces } from "./worktree-workspace-migration.js";
 
 export type SessionStartupMigrationLogger = Record<"info" | "warn", (message: string) => void>;
 
@@ -30,6 +31,7 @@ export async function runSessionStartupMigration(params: {
     migrateOrphanedSessionKeys?: typeof migrateOrphanedSessionKeys;
     migrateLegacyMainSessionKeys?: typeof migrateLegacyMainSessionKeys;
     prepareLegacySessionSurfaces?: PrepareLegacySessionSurfaces;
+    migrateManagedWorktreeCanonicalWorkspaces?: typeof migrateManagedWorktreeCanonicalWorkspaces;
     resolveAllAgentSessionStoreTargetsSync?: typeof resolveAllAgentSessionStoreTargetsSync;
     sweepOrphanSessionStoreTemps?: typeof sweepOrphanSessionStoreTemps;
   };
@@ -109,6 +111,7 @@ export async function runSessionStartupMigration(params: {
   const sweepTemps = params.deps?.sweepOrphanSessionStoreTemps ?? sweepOrphanSessionStoreTemps;
   try {
     let removedFiles = 0;
+    let migratedWorktreeSessions = 0;
     for (const target of targets) {
       const path = resolveSqliteTargetFromSessionStorePath(target.storePath, {
         agentId: target.agentId,
@@ -117,6 +120,21 @@ export async function runSessionStartupMigration(params: {
       const alreadyOpen = isOpenClawAgentDatabaseOpen(path);
       const database = openOpenClawAgentDatabase({ agentId: target.agentId, path });
       setCanonicalSqliteSessionMainKey(database, params.cfg.session?.mainKey);
+      const migrateWorktreeSessions =
+        params.deps?.migrateManagedWorktreeCanonicalWorkspaces ??
+        migrateManagedWorktreeCanonicalWorkspaces;
+      try {
+        migratedWorktreeSessions += await migrateWorktreeSessions({
+          agentId: target.agentId,
+          cfg: params.cfg,
+          env,
+          storePath: target.storePath,
+        });
+      } catch (error) {
+        params.log.warn(
+          `session: managed-worktree workspace migration failed for ${target.agentId}; continuing: ${String(error)}`,
+        );
+      }
       if (!alreadyOpen) {
         closeOpenClawAgentDatabaseByPath(path);
       }
@@ -124,6 +142,11 @@ export async function runSessionStartupMigration(params: {
     }
     if (removedFiles > 0) {
       params.log.info(`session: removed ${removedFiles} stale session store temp file(s)`);
+    }
+    if (migratedWorktreeSessions > 0) {
+      params.log.info(
+        `session: recorded canonical workspaces for ${migratedWorktreeSessions} managed-worktree session(s)`,
+      );
     }
   } catch (err) {
     params.log.warn(

--- a/src/config/sessions/startup-migration.worktree-workspace.test.ts
+++ b/src/config/sessions/startup-migration.worktree-workspace.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { insertRegistryWorktree } from "../../agents/worktrees/registry.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import { loadSessionEntry, replaceSessionEntry } from "./session-accessor.js";
+import { migrateManagedWorktreeCanonicalWorkspaces } from "./worktree-workspace-migration.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it("backfills a nested requested workspace once instead of using the agent default", async () => {
+  const root = tempDirs.make("openclaw-worktree-workspace-migration-");
+  const stateDir = path.join(root, "state");
+  const repoRoot = path.join(root, "repo");
+  const agentWorkspace = path.join(repoRoot, "agent-default");
+  const requestedWorkspace = path.join(repoRoot, "packages", "app");
+  const worktreeRoot = path.join(stateDir, "worktrees", "legacy");
+  const spawnedCwd = path.join(worktreeRoot, "packages", "app");
+  await Promise.all([
+    fs.mkdir(agentWorkspace, { recursive: true }),
+    fs.mkdir(requestedWorkspace, { recursive: true }),
+    fs.mkdir(spawnedCwd, { recursive: true }),
+  ]);
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+  const sessionKey = "agent:main:dashboard:legacy-worktree";
+  const cfg: OpenClawConfig = {
+    agents: { list: [{ id: "main", default: true, workspace: agentWorkspace }] },
+    session: { store: storePath },
+  };
+  insertRegistryWorktree(env, {
+    id: "legacy",
+    name: "legacy",
+    repoFingerprint: "0123456789abcdef",
+    repoRoot,
+    path: worktreeRoot,
+    branch: "openclaw/legacy",
+    baseRef: "HEAD",
+    ownerKind: "session",
+    ownerId: sessionKey,
+    createdAt: 1,
+    lastActiveAt: 1,
+  });
+  await replaceSessionEntry(
+    { agentId: "main", env, sessionKey, storePath },
+    {
+      sessionId: "legacy-session",
+      updatedAt: 10,
+      spawnedCwd,
+      worktree: { id: "legacy", branch: "openclaw/legacy", repoRoot },
+    },
+  );
+
+  const runMigration = async () =>
+    await migrateManagedWorktreeCanonicalWorkspaces({
+      agentId: "main",
+      cfg,
+      env,
+      storePath,
+    });
+
+  await runMigration();
+  const first = loadSessionEntry({ agentId: "main", env, sessionKey, storePath });
+  expect(first?.worktree?.canonicalWorkspaceDir).toBe(requestedWorkspace);
+  expect(first?.updatedAt).toBe(10);
+
+  await runMigration();
+  expect(loadSessionEntry({ agentId: "main", env, sessionKey, storePath })).toEqual(first);
+});

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -374,7 +374,13 @@ type SessionEntryCore = SessionRestartRecoveryState &
      * Managed worktree bound to this session; set with spawnedCwd at worktree
      * creation and cleared together when a plain New Chat detaches the checkout.
      */
-    worktree?: { id: string; branch: string; repoRoot: string };
+    worktree?: {
+      id: string;
+      branch: string;
+      repoRoot: string;
+      /** Durable skill workspace prepared when this session runs from a managed worktree. */
+      canonicalWorkspaceDir?: string;
+    };
     /** Project registry id selected when this logical session node was created. */
     projectId?: string;
     /** Explicit parent session linkage for dashboard-created child sessions. */

--- a/src/config/sessions/worktree-workspace-migration.ts
+++ b/src/config/sessions/worktree-workspace-migration.ts
@@ -1,0 +1,98 @@
+import path from "node:path";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { listRegistryWorktreesForMigration } from "../../agents/worktrees/registry.js";
+import { resolveProjectRegistry } from "../../projects/project-registry.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import { listSessionEntriesReadOnly, patchSessionEntryCore } from "./session-accessor.js";
+import type { SessionEntry } from "./types.js";
+
+function isInside(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveLegacyCanonicalWorkspace(params: {
+  agentId: string;
+  cfg: OpenClawConfig;
+  entry: SessionEntry;
+  env: NodeJS.ProcessEnv;
+  sessionKey: string;
+  worktrees: ReturnType<typeof listRegistryWorktreesForMigration>;
+}): string | undefined {
+  const worktree = params.entry.worktree;
+  if (!worktree || worktree.canonicalWorkspaceDir) {
+    return undefined;
+  }
+  const recordedRepoRoot = path.resolve(worktree.repoRoot);
+  if (params.entry.projectId) {
+    const project = resolveProjectRegistry(params.cfg, params.entry.projectId, { env: params.env });
+    const projectRoot = project ? path.resolve(project.repoRoot) : undefined;
+    return projectRoot && isInside(recordedRepoRoot, projectRoot) ? projectRoot : undefined;
+  }
+  const record = params.worktrees.find((candidate) => candidate.id === worktree.id);
+  const spawnedCwd = params.entry.spawnedCwd;
+  if (
+    record?.ownerKind === "session" &&
+    record.ownerId === params.sessionKey &&
+    spawnedCwd &&
+    path.resolve(record.repoRoot) === path.resolve(worktree.repoRoot)
+  ) {
+    const relative = path.relative(path.resolve(record.path), path.resolve(spawnedCwd));
+    if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+      return path.resolve(recordedRepoRoot, relative);
+    }
+  }
+  const agentWorkspace = path.resolve(
+    resolveAgentWorkspaceDir(params.cfg, params.agentId, params.env),
+  );
+  return agentWorkspace && agentWorkspace === recordedRepoRoot ? agentWorkspace : undefined;
+}
+
+export async function migrateManagedWorktreeCanonicalWorkspaces(params: {
+  agentId: string;
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  storePath: string;
+}): Promise<number> {
+  const env = params.env ?? process.env;
+  const worktrees = listRegistryWorktreesForMigration(env);
+  let migrated = 0;
+  for (const { entry, sessionKey } of listSessionEntriesReadOnly({
+    agentId: params.agentId,
+    env,
+    storePath: params.storePath,
+    readConsistency: "latest",
+  })) {
+    const canonicalWorkspaceDir = resolveLegacyCanonicalWorkspace({
+      agentId: params.agentId,
+      cfg: params.cfg,
+      entry,
+      env,
+      sessionKey,
+      worktrees,
+    });
+    if (!canonicalWorkspaceDir) {
+      continue;
+    }
+    const updated = await patchSessionEntryCore(
+      { agentId: params.agentId, env, sessionKey, storePath: params.storePath },
+      (current) => {
+        if (
+          !current.worktree ||
+          current.worktree.id !== entry.worktree?.id ||
+          current.worktree.canonicalWorkspaceDir
+        ) {
+          return null;
+        }
+        return {
+          worktree: { ...current.worktree, canonicalWorkspaceDir },
+        };
+      },
+      { preserveActivity: true, skipMaintenance: true },
+    );
+    if (updated?.worktree?.canonicalWorkspaceDir === canonicalWorkspaceDir) {
+      migrated += 1;
+    }
+  }
+  return migrated;
+}

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -13,6 +13,7 @@ import { isTimeoutError } from "../../agents/failover-error.js";
 import type { MainSessionRecoveryPendingTarget } from "../../agents/main-session-recovery/main-session-recovery-store.js";
 import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
 import { normalizeAgentRunTimeoutPhase } from "../../agents/run-timeout-attribution.js";
+import { runWithCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
 import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import { agentCommandFromGatewayIngress } from "../../commands/agent.js";
 import { isAbortError } from "../../infra/abort-signal.js";
@@ -124,6 +125,7 @@ export function dispatchAgentRunFromGateway(params: {
   io: AgentTurnIo;
   context: AgentTurnContext;
   taskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
+  canonicalSkillWorkspaceDir?: string;
   restoreAdmittedRecovery?: () => Promise<MainSessionRecoveryPendingTarget | undefined>;
   onSettled?: (outcome: {
     terminalOutcome: AgentRunTerminalOutcome;
@@ -185,15 +187,17 @@ export function dispatchAgentRunFromGateway(params: {
     readAgentRunDispatchExecutionIdentity(params),
   );
   const runAgent = () =>
-    agentCommandFromGatewayIngress(
-      cronCreatorAuthorityCapability
-        ? { ...ingressOptsWithSpawnFacts, cronCreatorAuthorityCapability }
-        : ingressOptsWithSpawnFacts,
-      defaultRuntime,
-      params.context.deps,
-      {
-        restoreAdmittedRecovery: params.restoreAdmittedRecovery,
-      },
+    runWithCanonicalSkillWorkspace(params.canonicalSkillWorkspaceDir, () =>
+      agentCommandFromGatewayIngress(
+        cronCreatorAuthorityCapability
+          ? { ...ingressOptsWithSpawnFacts, cronCreatorAuthorityCapability }
+          : ingressOptsWithSpawnFacts,
+        defaultRuntime,
+        params.context.deps,
+        {
+          restoreAdmittedRecovery: params.restoreAdmittedRecovery,
+        },
+      ),
     );
   const agentRun = cronCreatorAuthorityCapability
     ? runWithCronCreatorAuthorityCapability(

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -406,6 +406,7 @@ export function startAgentRunExecution(params: {
             context: params.context,
             taskTrackingMode: prepared.dispatchTaskTrackingMode,
             restoreAdmittedRecovery: prepared.restoreAdmittedRestartRecoveryInterrupted,
+            canonicalSkillWorkspaceDir: params.sessionEntry?.worktree?.canonicalWorkspaceDir,
           },
           executionIdentitySpawnFacts,
         ),

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -351,8 +351,8 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       const target = resolveGatewaySessionStoreTarget({ cfg, key: targetKey, agentId });
       sessionKey = preservesUnspecifiedKey ? undefined : targetKey;
       sessionAgentId = target.agentId;
-      const workspace =
-        projectRoot ?? requestedCwd ?? resolveAgentWorkspaceDir(cfg, target.agentId);
+      const canonicalWorkspaceDir = resolveAgentWorkspaceDir(cfg, target.agentId);
+      const workspace = projectRoot ?? requestedCwd ?? canonicalWorkspaceDir;
       // Subdirectory workspaces are valid: the worktree service resolves the repo root
       // via git discovery, so the preflight must accept ancestor .git entries too.
       if (!insideGitCheckout(workspace)) {
@@ -470,6 +470,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
               id: preparedWorktree.id,
               branch: preparedWorktree.branch,
               repoRoot: preparedWorktree.repoRoot,
+              canonicalWorkspaceDir,
             },
             ...(provisioned
               ? {

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -351,8 +351,8 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       const target = resolveGatewaySessionStoreTarget({ cfg, key: targetKey, agentId });
       sessionKey = preservesUnspecifiedKey ? undefined : targetKey;
       sessionAgentId = target.agentId;
-      const canonicalWorkspaceDir = resolveAgentWorkspaceDir(cfg, target.agentId);
-      const workspace = projectRoot ?? requestedCwd ?? canonicalWorkspaceDir;
+      const workspace =
+        projectRoot ?? requestedCwd ?? resolveAgentWorkspaceDir(cfg, target.agentId);
       // Subdirectory workspaces are valid: the worktree service resolves the repo root
       // via git discovery, so the preflight must accept ancestor .git entries too.
       if (!insideGitCheckout(workspace)) {
@@ -470,7 +470,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
               id: preparedWorktree.id,
               branch: preparedWorktree.branch,
               repoRoot: preparedWorktree.repoRoot,
-              canonicalWorkspaceDir,
+              canonicalWorkspaceDir: workspace,
             },
             ...(provisioned
               ? {

--- a/src/gateway/server.sessions.create.projects.test.ts
+++ b/src/gateway/server.sessions.create.projects.test.ts
@@ -4,9 +4,14 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, expect, test } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runWithCanonicalSkillWorkspace } from "../agents/skill-workshop-workspace-context.js";
+import { createConfiguredSkillWorkshopTool } from "../agents/tools/skill-workshop-tool-factory.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { migrateManagedWorktreeCanonicalWorkspaces } from "../config/sessions/worktree-workspace-migration.js";
 import { registerProjectRegistry } from "../projects/project-registry.js";
+import { inspectSkillProposal } from "../skills/workshop/service.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { testState } from "./test-helpers.js";
 import {
@@ -86,14 +91,20 @@ test("sessions.create provisions a managed worktree from a registered project at
   const workspace = await initializeRepository(root, "workspace");
   const projectRoot = await initializeRepository(root, "project");
   testState.agentConfig = { workspace };
-  await createSessionStoreDir();
+  const { storePath } = await createSessionStoreDir();
   const project = await registerProjectRegistry({ path: projectRoot, name: "Project" });
   let worktreeId: string | undefined;
   try {
     const created = await directSessionReq<{
+      key?: string;
       entry?: {
         spawnedCwd?: string;
-        worktree?: { canonicalWorkspaceDir?: string };
+        worktree?: {
+          id: string;
+          branch: string;
+          repoRoot: string;
+          canonicalWorkspaceDir?: string;
+        };
       };
       worktree?: { id: string; path: string };
     }>(
@@ -106,6 +117,56 @@ test("sessions.create provisions a managed worktree from a registered project at
     worktreeId = created.payload?.worktree?.id;
     expect(created.payload?.entry?.spawnedCwd).toBe(created.payload?.worktree?.path);
     expect(created.payload?.entry?.worktree?.canonicalWorkspaceDir).toBe(projectRoot);
+    const sessionKey = created.payload?.key ?? "";
+    const entry = loadSessionEntry({ agentId: "main", sessionKey, storePath });
+    if (!entry?.worktree) {
+      throw new Error("expected persisted project worktree session");
+    }
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      {
+        ...entry,
+        worktree: {
+          id: entry.worktree.id,
+          branch: entry.worktree.branch,
+          repoRoot: entry.worktree.repoRoot,
+        },
+      },
+    );
+    await migrateManagedWorktreeCanonicalWorkspaces({
+      agentId: "main",
+      cfg: getRuntimeConfig(),
+      storePath,
+    });
+    const migrated = loadSessionEntry({ agentId: "main", sessionKey, storePath });
+    const canonicalWorkspaceDir = migrated?.worktree?.canonicalWorkspaceDir;
+    const spawnedCwd = migrated?.spawnedCwd;
+    if (!canonicalWorkspaceDir || !spawnedCwd) {
+      throw new Error("expected migrated project worktree session");
+    }
+    expect(canonicalWorkspaceDir).toBe(projectRoot);
+    const proposal = await runWithCanonicalSkillWorkspace(canonicalWorkspaceDir, async () => {
+      const tool = createConfiguredSkillWorkshopTool({
+        workspaceDir: spawnedCwd,
+        config: getRuntimeConfig(),
+        agentId: "main",
+        sessionKey,
+      });
+      return await tool.execute("legacy-project-proposal", {
+        action: "create",
+        name: "legacy-project-learning",
+        description: "Preserve learning from a resumed project worktree.",
+        proposal_content: "# Legacy Project Learning\n\nPersist this in the project workspace.\n",
+      });
+    });
+    const proposalDetails = proposal.details as { id: string };
+    const inspected = await inspectSkillProposal(proposalDetails.id, {
+      agentId: "main",
+      workspaceDir: projectRoot,
+    });
+    expect(inspected?.record.target.skillFile).toBe(
+      path.join(projectRoot, "skills", "legacy-project-learning", "SKILL.md"),
+    );
   } finally {
     if (worktreeId) {
       await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });

--- a/src/gateway/server.sessions.create.projects.test.ts
+++ b/src/gateway/server.sessions.create.projects.test.ts
@@ -91,7 +91,10 @@ test("sessions.create provisions a managed worktree from a registered project at
   let worktreeId: string | undefined;
   try {
     const created = await directSessionReq<{
-      entry?: { spawnedCwd?: string };
+      entry?: {
+        spawnedCwd?: string;
+        worktree?: { canonicalWorkspaceDir?: string };
+      };
       worktree?: { id: string; path: string };
     }>(
       "sessions.create",
@@ -102,6 +105,7 @@ test("sessions.create provisions a managed worktree from a registered project at
     expect(created.ok).toBe(true);
     worktreeId = created.payload?.worktree?.id;
     expect(created.payload?.entry?.spawnedCwd).toBe(created.payload?.worktree?.path);
+    expect(created.payload?.entry?.worktree?.canonicalWorkspaceDir).toBe(projectRoot);
   } finally {
     if (worktreeId) {
       await managedWorktrees.remove({ id: worktreeId, reason: "test-cleanup", force: true });

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1245,7 +1245,14 @@ test("sessions.create rolls back failed provisioning before a same-key creator p
     await rollbackStarted;
     let successorSettled = false;
     const successorPromise = directSessionReq<{
-      entry: { worktree?: { id: string; branch: string; repoRoot: string } };
+      entry: {
+        worktree?: {
+          id: string;
+          branch: string;
+          repoRoot: string;
+          canonicalWorkspaceDir?: string;
+        };
+      };
       worktree: { id: string; path: string; branch: string };
     }>("sessions.create", { key, agentId: "main", worktree: true }, { client: adminClient }).then(
       (result) => {
@@ -1279,6 +1286,7 @@ test("sessions.create rolls back failed provisioning before a same-key creator p
       id: successorWorktree.id,
       branch: successorWorktree.branch,
       repoRoot: workspace,
+      canonicalWorkspaceDir: workspace,
     });
 
     const adoptedFailure = await directSessionReq(
@@ -2018,7 +2026,10 @@ test("sessions.create maps an admin-selected worktree cwd and rejects repository
   const findSpy = vi.spyOn(managedWorktrees, "findLiveById").mockReturnValue(record);
   try {
     const created = await directSessionReq<{
-      entry: { spawnedCwd?: string };
+      entry: {
+        spawnedCwd?: string;
+        worktree?: { canonicalWorkspaceDir?: string };
+      };
       worktree: { id: string; path: string };
     }>(
       "sessions.create",
@@ -2031,6 +2042,7 @@ test("sessions.create maps an admin-selected worktree cwd and rejects repository
       expect.objectContaining({ repoRoot: selectedWorkspace }),
     );
     expect(created.payload?.entry.spawnedCwd).toBe(worktreePath);
+    expect(created.payload?.entry.worktree?.canonicalWorkspaceDir).toBe(selectedWorkspace);
 
     const mismatched = await directSessionReq(
       "sessions.create",

--- a/src/skills/workshop/experience-review-auto-apply.test.ts
+++ b/src/skills/workshop/experience-review-auto-apply.test.ts
@@ -12,7 +12,6 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
-import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { runSkillExperienceReview, type ExperienceReviewCandidate } from "./experience-review.js";
 import { inspectSkillProposal, listSkillProposals, proposeCreateSkill } from "./service.js";
 
@@ -98,11 +97,20 @@ describe("experience review auto apply", () => {
     const canonicalWorkspaceDir = await tempDirs.make("openclaw-experience-canonical-");
     const worktreeWorkspaceDir = await tempDirs.make("openclaw-experience-worktree-");
     const skillDir = path.join(canonicalWorkspaceDir, "skills", "deployment-preflight");
-    await writeSkill({
-      dir: skillDir,
+    const seedTool = createSkillWorkshopTool({
+      workspaceDir: canonicalWorkspaceDir,
+      config: { skills: { workshop: { approvalPolicy: "auto" } } },
+    });
+    const seeded = await seedTool.execute("seed-create", {
+      action: "create",
       name: "deployment-preflight",
       description: "Check deployment prerequisites before retrying.",
-      body: "# Deployment Preflight\n\nOperator-authored preflight steps.\n",
+      proposal_content: "# Deployment Preflight\n\nOperator-authored preflight steps.\n",
+    });
+    await seedTool.execute("seed-apply", {
+      action: "apply",
+      proposal_id: (seeded.details as { id: string }).id,
+      reason: "seed live skill",
     });
     await fs.cp(skillDir, path.join(worktreeWorkspaceDir, "skills", "deployment-preflight"), {
       recursive: true,

--- a/src/skills/workshop/experience-review-auto-apply.test.ts
+++ b/src/skills/workshop/experience-review-auto-apply.test.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
 import { createSkillWorkshopTool } from "../../agents/tools/skill-workshop-tool.js";
 import {
   isGatewaySubordinateWorkAdmissionClosed,
@@ -10,6 +12,7 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { runSkillExperienceReview, type ExperienceReviewCandidate } from "./experience-review.js";
 import { inspectSkillProposal, listSkillProposals, proposeCreateSkill } from "./service.js";
 
@@ -91,22 +94,18 @@ describe("experience review auto apply", () => {
     );
   });
 
-  it("auto-applies reviewer full-body updates after an authoritative read", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-experience-auto-apply-update-");
-    const seedTool = createSkillWorkshopTool({
-      workspaceDir,
-      config: { skills: { workshop: { approvalPolicy: "auto" } } },
-    });
-    const seeded = await seedTool.execute("seed-create", {
-      action: "create",
+  it("auto-applies updates to the durable workspace from a session worktree", async () => {
+    const canonicalWorkspaceDir = await tempDirs.make("openclaw-experience-canonical-");
+    const worktreeWorkspaceDir = await tempDirs.make("openclaw-experience-worktree-");
+    const skillDir = path.join(canonicalWorkspaceDir, "skills", "deployment-preflight");
+    await writeSkill({
+      dir: skillDir,
       name: "deployment-preflight",
       description: "Check deployment prerequisites before retrying.",
-      proposal_content: "# Deployment Preflight\n\nOperator-authored preflight steps.\n",
+      body: "# Deployment Preflight\n\nOperator-authored preflight steps.\n",
     });
-    await seedTool.execute("seed-apply", {
-      action: "apply",
-      proposal_id: (seeded.details as { id: string }).id,
-      reason: "seed live skill",
+    await fs.cp(skillDir, path.join(worktreeWorkspaceDir, "skills", "deployment-preflight"), {
+      recursive: true,
     });
 
     runEmbeddedAgent.mockImplementation(async (params) => {
@@ -137,28 +136,47 @@ describe("experience review auto apply", () => {
         agentId: "main",
         runId: "foreground-run",
         sessionKey: "agent:main:main",
-        workspaceDir,
+        workspaceDir: worktreeWorkspaceDir,
         modelProviderId: "openai",
         modelId: "gpt-test",
       },
-      config: { skills: { workshop: { autonomous: { mode: "auto" } } } },
+      config: {
+        agents: { list: [{ id: "main", default: true, workspace: canonicalWorkspaceDir }] },
+        skills: { workshop: { autonomous: { mode: "auto" as const } } },
+      },
       transcript: "[user]\nRefine the deployment workflow.",
       modelIterations: 10,
     };
 
-    await runSkillExperienceReview(candidate, {
-      getCurrentConfig: () => candidate.config ?? {},
-    });
+    await runWithCanonicalSkillWorkspace(canonicalWorkspaceDir, () =>
+      runSkillExperienceReview(candidate, {
+        getCurrentConfig: () => candidate.config ?? {},
+      }),
+    );
 
-    const manifest = await listSkillProposals({ workspaceDir });
+    const manifest = await listSkillProposals({
+      agentId: "main",
+      workspaceDir: canonicalWorkspaceDir,
+    });
     const updateEntry = manifest.proposals.find((entry) => entry.kind === "update");
     expect(updateEntry).toMatchObject({
       skillKey: "deployment-preflight",
       status: "applied",
     });
+    const inspected = await inspectSkillProposal(updateEntry?.id ?? "", {
+      agentId: "main",
+      workspaceDir: canonicalWorkspaceDir,
+    });
+    expect(inspected?.record.target.skillFile).toBe(path.join(skillDir, "SKILL.md"));
+    await expect(fs.readFile(path.join(skillDir, "SKILL.md"), "utf8")).resolves.toContain(
+      "Reviewer-rewritten steps.",
+    );
     await expect(
-      fs.readFile(`${workspaceDir}/skills/deployment-preflight/SKILL.md`, "utf8"),
-    ).resolves.toContain("Reviewer-rewritten steps.");
+      fs.readFile(
+        path.join(worktreeWorkspaceDir, "skills", "deployment-preflight", "SKILL.md"),
+        "utf8",
+      ),
+    ).resolves.toContain("Operator-authored preflight steps.");
   });
 
   it("auto-applies reviewer patch proposals composed from the live body", async () => {

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import { SessionManager } from "../../agents/sessions/index.js";
+import { getCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -346,7 +347,7 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
         log.debug(`experience review skipped: reason=ineligible-context session=${sessionKey}`);
         return;
       }
-      const workspaceDir = params.ctx.workspaceDir?.trim();
+      const workspaceDir = getCanonicalSkillWorkspace() ?? params.ctx.workspaceDir?.trim();
       if (!workspaceDir) {
         log.debug(`experience review skipped: reason=missing-workspace session=${sessionKey}`);
         return;
@@ -536,7 +537,7 @@ async function runSkillExperienceReviewInner(
   candidate: ExperienceReviewCandidate,
   deps: ExperienceReviewRunDeps,
 ): Promise<void> {
-  const workspaceDir = candidate.ctx.workspaceDir;
+  const workspaceDir = getCanonicalSkillWorkspace() ?? candidate.ctx.workspaceDir;
   const sessionKey = candidate.ctx.sessionKey;
   const modelProviderId = candidate.ctx.modelProviderId?.trim();
   const modelId = candidate.ctx.modelId?.trim();

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -1,0 +1,373 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { sha256Hex } from "../../infra/crypto-digest.js";
+import { buildWorkspaceSkillStatus, resolveSkillStatusEntry } from "../discovery/status.js";
+import {
+  readWorkspaceSkillFile,
+  readWorkspaceSupportFile,
+} from "../lifecycle/workspace-skill-write.js";
+import { resolveSkillWorkshopConfig } from "./config.js";
+import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
+import { isWorkshopOwnedSkillDir } from "./ownership.js";
+import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
+import { prepareSkillProposalDraft, resolveUpdateProposalDescription } from "./proposal-draft.js";
+import { hashSkillProposalRevision } from "./revision-hash.js";
+import {
+  createSkillProposalId,
+  hashSkillProposalContent,
+  resolveSkillProposalTarget,
+  writeSkillProposal,
+  type PreparedSkillProposalSupportFile,
+} from "./store.js";
+import {
+  MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS,
+  SKILL_WORKSHOP_SCHEMA,
+  type SkillProposalCreateInput,
+  type SkillProposalOrigin,
+  type SkillProposalReadResult,
+  type SkillProposalRecord,
+  type SkillProposalSupportFile,
+  type SkillProposalUpdateInput,
+} from "./types.js";
+import { assertWritableSkillTarget } from "./workspace-skill-read.js";
+
+type SkillWorkshopWorkspaceOptions = {
+  config?: OpenClawConfig;
+  agentId?: string;
+};
+
+export class SkillProposalStaleTargetError extends Error {}
+
+function proposalStoreOptions(env?: NodeJS.ProcessEnv) {
+  return env ? { env } : {};
+}
+
+export function normalizeProposalOrigin(
+  origin: SkillProposalOrigin | undefined,
+): SkillProposalOrigin | undefined {
+  const agentId = normalizeOptionalString(origin?.agentId);
+  const sessionKey = normalizeOptionalString(origin?.sessionKey);
+  const runId = normalizeOptionalString(origin?.runId);
+  const messageId = normalizeOptionalString(origin?.messageId);
+  if (!agentId && !sessionKey && !runId && !messageId) {
+    return undefined;
+  }
+  return {
+    ...(agentId ? { agentId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(runId ? { runId } : {}),
+    ...(messageId ? { messageId } : {}),
+  };
+}
+
+export function mergeProposalOriginRunProvenance(
+  record:
+    | Pick<SkillProposalRecord, "origin" | "originRunIds" | "originRunMutationCounts">
+    | undefined,
+  origin: SkillProposalOrigin | undefined,
+): { originRunIds?: string[]; originRunMutationCounts?: Record<string, number> } {
+  const ids = new Set(record?.originRunIds);
+  const counts = { ...record?.originRunMutationCounts };
+  if (record?.origin?.runId) {
+    ids.add(record.origin.runId);
+  }
+  for (const runId of ids) {
+    counts[runId] ??= 1;
+  }
+  if (origin?.runId) {
+    ids.add(origin.runId);
+    counts[origin.runId] = (counts[origin.runId] ?? 0) + 1;
+  }
+  if (ids.size > MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS) {
+    throw new Error("Skill proposal run provenance exceeds the supported limit.");
+  }
+  return {
+    ...(ids.size > 0 ? { originRunIds: [...ids] } : {}),
+    ...(Object.keys(counts).length > 0 ? { originRunMutationCounts: counts } : {}),
+  };
+}
+
+export async function proposeCreateSkill(
+  input: SkillProposalCreateInput,
+): Promise<SkillProposalReadResult> {
+  const name = normalizeRequired(input.name, "Skill name");
+  const description = normalizeRequired(input.description, "Skill description");
+  const config = resolveSkillWorkshopConfig(input.config);
+  const target = resolveSkillProposalTarget({ workspaceDir: input.workspaceDir, skillName: name });
+  if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
+    throw new Error(`Skill already exists at ${target.skillFile}.`);
+  }
+
+  const now = new Date().toISOString();
+  const prepared = prepareSkillProposalDraft({
+    name: target.skillKey,
+    description,
+    content: input.content,
+    date: now,
+    maxSkillBytes: config.maxSkillBytes,
+    supportFiles: input.supportFiles,
+    secretScanMetadata: [{ file: "skill-name", content: name }],
+    goal: input.goal,
+    evidence: input.evidence,
+  });
+  if (!prepared.ok) {
+    throw prepared.error.cause;
+  }
+  const {
+    content: proposalContent,
+    draftHash,
+    evidence,
+    goal,
+    scan,
+    supportFiles,
+  } = prepared.value;
+  const id = createSkillProposalId(name);
+  const origin = normalizeProposalOrigin({
+    ...input.origin,
+    agentId: input.origin?.agentId ?? input.agentId,
+  });
+  const originRunProvenance = mergeProposalOriginRunProvenance(undefined, origin);
+  const record: SkillProposalRecord = {
+    schema: SKILL_WORKSHOP_SCHEMA,
+    id,
+    kind: "create",
+    status: "pending",
+    title: `Create ${name}`,
+    description,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: input.createdBy ?? "skill-workshop",
+    ...(input.autonomousCapture ? { autonomousCapture: true as const } : {}),
+    ...(origin ? { origin } : {}),
+    ...originRunProvenance,
+    proposedVersion: "v1",
+    draftFile: "PROPOSAL.md",
+    draftHash,
+    target: {
+      skillName: name,
+      skillKey: target.skillKey,
+      skillDir: target.skillDir,
+      skillFile: target.skillFile,
+      source: "openclaw-workspace",
+    },
+    scan,
+    ...(supportFiles.length > 0
+      ? { supportFiles: await buildSupportFileMetadata(supportFiles) }
+      : {}),
+    ...(goal ? { goal } : {}),
+    ...(evidence ? { evidence } : {}),
+  };
+  const event = await writeSkillProposal({
+    record,
+    content: proposalContent,
+    supportFiles,
+    workspaceDir: input.workspaceDir,
+    ownerAgentId: input.agentId,
+    maxPending: config.maxPending,
+    event: createSkillProposalEvent({
+      record,
+      type: "created",
+      actor: input.eventActor,
+    }),
+    store: proposalStoreOptions(input.env),
+  });
+  if (event) {
+    await dispatchSkillProposalChanged({
+      event,
+      record,
+      workspaceDir: input.workspaceDir,
+      ...(input.agentId ? { agentId: input.agentId } : {}),
+    });
+  }
+  return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
+}
+
+/** Applies a reviewer patch to the live body: unique-match replace, or append when oldString is empty. */
+export function composeSkillBodyPatch(
+  body: string,
+  patch: { oldString: string; newString: string },
+): string {
+  if (!patch.oldString) {
+    if (!patch.newString.trim()) {
+      throw new Error("Patch newString must not be empty when appending.");
+    }
+    return `${body.trimEnd()}\n\n${patch.newString.trim()}\n`;
+  }
+  const first = body.indexOf(patch.oldString);
+  if (first === -1) {
+    throw new Error(
+      "Patch oldString not found in the live skill body. Read the skill and quote the exact current text.",
+    );
+  }
+  if (body.includes(patch.oldString, first + 1)) {
+    throw new Error(
+      "Patch oldString matches more than once in the live skill body. Quote a longer unique span.",
+    );
+  }
+  return `${body.slice(0, first)}${patch.newString}${body.slice(first + patch.oldString.length)}`;
+}
+
+export async function proposeUpdateSkill(
+  input: SkillProposalUpdateInput & SkillWorkshopWorkspaceOptions,
+): Promise<SkillProposalReadResult> {
+  const skillName = normalizeRequired(input.skillName, "Skill name");
+  const config = resolveSkillWorkshopConfig(input.config);
+  const status = buildWorkspaceSkillStatus(input.workspaceDir, {
+    config: input.config,
+    agentId: input.agentId,
+  });
+  const targetSkill = resolveSkillStatusEntry(status.skills, skillName);
+  if (!targetSkill) {
+    throw new Error(`Skill not found: ${skillName}`);
+  }
+  assertWritableSkillTarget(input.workspaceDir, targetSkill);
+  if (
+    !isWorkshopOwnedSkillDir(
+      input.workspaceDir,
+      targetSkill.baseDir,
+      proposalStoreOptions(input.env),
+    )
+  ) {
+    throw new Error(`Skill Workshop does not own this skill path: ${targetSkill.skillKey}`);
+  }
+  const currentContent = await readWorkspaceSkillFile(targetSkill.filePath);
+  if (currentContent === null) {
+    throw new Error(`Skill file is missing: ${targetSkill.filePath}`);
+  }
+  if (
+    input.expectedCurrentContentHash !== undefined &&
+    sha256Hex(currentContent) !== input.expectedCurrentContentHash
+  ) {
+    throw new SkillProposalStaleTargetError(
+      "Skill changed since the reviewer's read: read it again and redraft the update.",
+    );
+  }
+  // Composition uses the same read that currentContentHash binds the proposal to, so a
+  // composed draft can never derive from a different body than the one apply validates.
+  const draftContent =
+    input.composePatch !== undefined
+      ? composeSkillBodyPatch(stripProposalFrontmatterForSkill(currentContent), input.composePatch)
+      : input.content;
+  if (draftContent === undefined) {
+    throw new Error("Update proposal requires content or composePatch.");
+  }
+  const description = resolveUpdateProposalDescription(input.description, targetSkill.description);
+
+  const now = new Date().toISOString();
+  const prepared = prepareSkillProposalDraft({
+    name: targetSkill.skillKey,
+    description,
+    content: draftContent,
+    fallbackFrontmatterContent: currentContent,
+    date: now,
+    maxSkillBytes: config.maxSkillBytes,
+    supportFiles: input.supportFiles,
+    goal: input.goal,
+    evidence: input.evidence,
+  });
+  if (!prepared.ok) {
+    throw prepared.error.cause;
+  }
+  const {
+    content: proposalContent,
+    draftHash,
+    evidence,
+    goal,
+    scan,
+    supportFiles,
+  } = prepared.value;
+  const id = createSkillProposalId(targetSkill.skillKey || targetSkill.name);
+  const origin = normalizeProposalOrigin({
+    ...input.origin,
+    agentId: input.origin?.agentId ?? input.agentId,
+  });
+  const originRunProvenance = mergeProposalOriginRunProvenance(undefined, origin);
+  const record: SkillProposalRecord = {
+    schema: SKILL_WORKSHOP_SCHEMA,
+    id,
+    kind: "update",
+    status: "pending",
+    title: `Update ${targetSkill.name}`,
+    description,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: input.createdBy ?? "skill-workshop",
+    ...(input.autonomousCapture ? { autonomousCapture: true as const } : {}),
+    ...(origin ? { origin } : {}),
+    ...originRunProvenance,
+    proposedVersion: "v1",
+    draftFile: "PROPOSAL.md",
+    draftHash,
+    target: {
+      skillName: targetSkill.name,
+      skillKey: targetSkill.skillKey,
+      skillDir: targetSkill.baseDir,
+      skillFile: targetSkill.filePath,
+      source: targetSkill.source,
+      currentContentHash: hashSkillProposalContent(currentContent),
+    },
+    scan,
+    ...(supportFiles.length > 0
+      ? { supportFiles: await buildSupportFileMetadata(supportFiles, targetSkill.baseDir) }
+      : {}),
+    ...(goal ? { goal } : {}),
+    ...(evidence ? { evidence } : {}),
+  };
+  const event = await writeSkillProposal({
+    record,
+    content: proposalContent,
+    supportFiles,
+    workspaceDir: input.workspaceDir,
+    ownerAgentId: input.agentId ?? origin?.agentId,
+    maxPending: config.maxPending,
+    event: createSkillProposalEvent({
+      record,
+      type: "created",
+      actor: input.eventActor,
+    }),
+    store: proposalStoreOptions(input.env),
+  });
+  if (event) {
+    await dispatchSkillProposalChanged({
+      event,
+      record,
+      workspaceDir: input.workspaceDir,
+      ...(input.agentId ? { agentId: input.agentId } : {}),
+    });
+  }
+  return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
+}
+
+export async function buildSupportFileMetadata(
+  files: readonly PreparedSkillProposalSupportFile[],
+  targetSkillDir?: string,
+): Promise<SkillProposalSupportFile[]> {
+  const out: SkillProposalSupportFile[] = [];
+  for (const file of files) {
+    const metadata: SkillProposalSupportFile = {
+      path: file.path,
+      sizeBytes: file.sizeBytes,
+      hash: file.hash,
+    };
+    if (targetSkillDir) {
+      const targetContent = await readWorkspaceSupportFile({
+        skillDir: targetSkillDir,
+        relativePath: file.path,
+      });
+      metadata.targetExisted = targetContent !== null;
+      if (targetContent !== null) {
+        metadata.targetContentHash = hashSkillProposalContent(targetContent);
+      }
+    }
+    out.push(metadata);
+  }
+  return out;
+}
+
+function normalizeRequired(value: string, label: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -13,6 +13,7 @@ import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
   readProposalSupportFiles,
+  SkillProposalDraftMissingError,
   readSkillProposal,
   readSkillProposalManifest,
   readSkillProposalRecord,
@@ -49,18 +50,35 @@ export async function listSkillProposals(
   const store = storeOptions(options.env);
   const scope = proposalScope(options);
   const manifest = await readSkillProposalManifest(store, scope);
+  const missingDrafts = new Set<string>();
   // Every reconciliation takes the same collection lease. Serialize them so a
   // large manifest cannot make its own waiters exhaust the bounded lease wait.
   for (const proposal of manifest.proposals) {
     if (proposal.kind !== "create" || proposal.status !== "pending") {
       continue;
     }
-    const read = await readSkillProposal(proposal.id, store, scope);
+    let read: SkillProposalReadResult | null;
+    try {
+      read = await readSkillProposal(proposal.id, store, scope);
+    } catch (error) {
+      if (!(error instanceof SkillProposalDraftMissingError)) {
+        throw error;
+      }
+      missingDrafts.add(error.proposalId);
+      continue;
+    }
     if (read) {
       await reconcilePendingCreateProposal(read, options);
     }
   }
-  return await readSkillProposalManifest(store, scope);
+  const reconciled = await readSkillProposalManifest(store, scope);
+  // Freshly read manifest rows are locally owned; mark degraded entries in place.
+  for (const proposal of reconciled.proposals) {
+    if (missingDrafts.has(proposal.id)) {
+      proposal.degradedState = "draft-missing";
+    }
+  }
+  return reconciled;
 }
 
 export async function getSkillProposalRunProgress(

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -1,7 +1,4 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { sha256Hex } from "../../infra/crypto-digest.js";
-import { buildWorkspaceSkillStatus, resolveSkillStatusEntry } from "../discovery/status.js";
 import {
   assertInsideWorkspace,
   readWorkspaceSkillFile,
@@ -16,47 +13,42 @@ import {
   type SkillProposalTransitionInput,
 } from "./apply-transition.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
-import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
-import { isWorkshopOwnedSkillDir } from "./ownership.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
-import {
-  nextProposalVersion,
-  prepareSkillProposalDraft,
-  resolveUpdateProposalDescription,
-} from "./proposal-draft.js";
+import { nextProposalVersion, prepareSkillProposalDraft } from "./proposal-draft.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
   assertExpectedRevisionHash,
   evaluateSkillProposal,
   SkillProposalCreateTargetConflictError,
 } from "./service-evaluation.js";
+import {
+  buildSupportFileMetadata,
+  mergeProposalOriginRunProvenance,
+  normalizeProposalOrigin,
+} from "./service-propose.js";
 import { readRequiredProposal } from "./service-query.js";
 import {
-  createSkillProposalId,
   hashSkillProposalContent,
   readProposalSupportFiles,
+  readSkillProposalRecord,
   replaceSkillProposalDraft,
-  resolveSkillProposalTarget,
   updateSkillProposalRecord,
-  writeSkillProposal,
   withSkillProposalTargetLock,
-  type PreparedSkillProposalSupportFile,
 } from "./store.js";
-import {
-  MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS,
-  SKILL_WORKSHOP_SCHEMA,
-  type SkillProposalActionInput,
-  type SkillProposalApplyResult,
-  type SkillProposalCreateInput,
-  type SkillProposalOrigin,
-  type SkillProposalReadResult,
-  type SkillProposalRecord,
-  type SkillProposalReviseInput,
-  type SkillProposalSupportFile,
-  type SkillProposalUpdateInput,
+import type {
+  SkillProposalActionInput,
+  SkillProposalApplyResult,
+  SkillProposalReadResult,
+  SkillProposalRecord,
+  SkillProposalReviseInput,
 } from "./types.js";
-import { assertWritableSkillTarget } from "./workspace-skill-read.js";
 export { readSkillProposalDraftDirectory, readSkillProposalDraftFile } from "./proposal-draft.js";
+export {
+  composeSkillBodyPatch,
+  proposeCreateSkill,
+  proposeUpdateSkill,
+  SkillProposalStaleTargetError,
+} from "./service-propose.js";
 export {
   getSkillProposalRunProgress,
   inspectSkillProposal,
@@ -64,13 +56,6 @@ export {
   resolvePendingSkillProposal,
 } from "./service-query.js";
 export { evaluateSkillProposal, listSkillProposalEvents } from "./service-evaluation.js";
-
-type SkillWorkshopWorkspaceOptions = {
-  config?: OpenClawConfig;
-  agentId?: string;
-};
-
-export class SkillProposalStaleTargetError extends Error {}
 
 function proposalStoreOptions(env?: NodeJS.ProcessEnv) {
   return env ? { env } : {};
@@ -84,302 +69,6 @@ const APPLY_TRANSITION_DEPENDENCIES = {
   readProposalSupportFiles,
   readRequiredProposal,
 } satisfies SkillProposalApplyTransitionDependencies;
-
-function normalizeProposalOrigin(
-  origin: SkillProposalOrigin | undefined,
-): SkillProposalOrigin | undefined {
-  const agentId = normalizeOptionalString(origin?.agentId);
-  const sessionKey = normalizeOptionalString(origin?.sessionKey);
-  const runId = normalizeOptionalString(origin?.runId);
-  const messageId = normalizeOptionalString(origin?.messageId);
-  if (!agentId && !sessionKey && !runId && !messageId) {
-    return undefined;
-  }
-  return {
-    ...(agentId ? { agentId } : {}),
-    ...(sessionKey ? { sessionKey } : {}),
-    ...(runId ? { runId } : {}),
-    ...(messageId ? { messageId } : {}),
-  };
-}
-
-function mergeProposalOriginRunProvenance(
-  record:
-    | Pick<SkillProposalRecord, "origin" | "originRunIds" | "originRunMutationCounts">
-    | undefined,
-  origin: SkillProposalOrigin | undefined,
-): { originRunIds?: string[]; originRunMutationCounts?: Record<string, number> } {
-  const ids = new Set(record?.originRunIds);
-  const counts = { ...record?.originRunMutationCounts };
-  if (record?.origin?.runId) {
-    ids.add(record.origin.runId);
-  }
-  for (const runId of ids) {
-    counts[runId] ??= 1;
-  }
-  if (origin?.runId) {
-    ids.add(origin.runId);
-    counts[origin.runId] = (counts[origin.runId] ?? 0) + 1;
-  }
-  if (ids.size > MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS) {
-    throw new Error("Skill proposal run provenance exceeds the supported limit.");
-  }
-  return {
-    ...(ids.size > 0 ? { originRunIds: [...ids] } : {}),
-    ...(Object.keys(counts).length > 0 ? { originRunMutationCounts: counts } : {}),
-  };
-}
-
-export async function proposeCreateSkill(
-  input: SkillProposalCreateInput,
-): Promise<SkillProposalReadResult> {
-  const name = normalizeRequired(input.name, "Skill name");
-  const description = normalizeRequired(input.description, "Skill description");
-  const config = resolveSkillWorkshopConfig(input.config);
-  const target = resolveSkillProposalTarget({ workspaceDir: input.workspaceDir, skillName: name });
-  if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
-    throw new Error(`Skill already exists at ${target.skillFile}.`);
-  }
-
-  const now = new Date().toISOString();
-  const prepared = prepareSkillProposalDraft({
-    name: target.skillKey,
-    description,
-    content: input.content,
-    date: now,
-    maxSkillBytes: config.maxSkillBytes,
-    supportFiles: input.supportFiles,
-    secretScanMetadata: [{ file: "skill-name", content: name }],
-    goal: input.goal,
-    evidence: input.evidence,
-  });
-  if (!prepared.ok) {
-    throw prepared.error.cause;
-  }
-  const {
-    content: proposalContent,
-    draftHash,
-    evidence,
-    goal,
-    scan,
-    supportFiles,
-  } = prepared.value;
-  const id = createSkillProposalId(name);
-  const origin = normalizeProposalOrigin({
-    ...input.origin,
-    agentId: input.origin?.agentId ?? input.agentId,
-  });
-  const originRunProvenance = mergeProposalOriginRunProvenance(undefined, origin);
-  const record: SkillProposalRecord = {
-    schema: SKILL_WORKSHOP_SCHEMA,
-    id,
-    kind: "create",
-    status: "pending",
-    title: `Create ${name}`,
-    description,
-    createdAt: now,
-    updatedAt: now,
-    createdBy: input.createdBy ?? "skill-workshop",
-    ...(input.autonomousCapture ? { autonomousCapture: true as const } : {}),
-    ...(origin ? { origin } : {}),
-    ...originRunProvenance,
-    proposedVersion: "v1",
-    draftFile: "PROPOSAL.md",
-    draftHash,
-    target: {
-      skillName: name,
-      skillKey: target.skillKey,
-      skillDir: target.skillDir,
-      skillFile: target.skillFile,
-      source: "openclaw-workspace",
-    },
-    scan,
-    ...(supportFiles.length > 0
-      ? { supportFiles: await buildSupportFileMetadata(supportFiles) }
-      : {}),
-    ...(goal ? { goal } : {}),
-    ...(evidence ? { evidence } : {}),
-  };
-  const event = await writeSkillProposal({
-    record,
-    content: proposalContent,
-    supportFiles,
-    workspaceDir: input.workspaceDir,
-    ownerAgentId: input.agentId,
-    maxPending: config.maxPending,
-    event: createSkillProposalEvent({
-      record,
-      type: "created",
-      actor: input.eventActor,
-    }),
-    store: proposalStoreOptions(input.env),
-  });
-  if (event) {
-    await dispatchSkillProposalChanged({
-      event,
-      record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
-  return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
-}
-
-/** Applies a reviewer patch to the live body: unique-match replace, or append when oldString is empty. */
-export function composeSkillBodyPatch(
-  body: string,
-  patch: { oldString: string; newString: string },
-): string {
-  if (!patch.oldString) {
-    if (!patch.newString.trim()) {
-      throw new Error("Patch newString must not be empty when appending.");
-    }
-    return `${body.trimEnd()}\n\n${patch.newString.trim()}\n`;
-  }
-  const first = body.indexOf(patch.oldString);
-  if (first === -1) {
-    throw new Error(
-      "Patch oldString not found in the live skill body. Read the skill and quote the exact current text.",
-    );
-  }
-  if (body.includes(patch.oldString, first + 1)) {
-    throw new Error(
-      "Patch oldString matches more than once in the live skill body. Quote a longer unique span.",
-    );
-  }
-  return `${body.slice(0, first)}${patch.newString}${body.slice(first + patch.oldString.length)}`;
-}
-
-export async function proposeUpdateSkill(
-  input: SkillProposalUpdateInput & SkillWorkshopWorkspaceOptions,
-): Promise<SkillProposalReadResult> {
-  const skillName = normalizeRequired(input.skillName, "Skill name");
-  const config = resolveSkillWorkshopConfig(input.config);
-  const status = buildWorkspaceSkillStatus(input.workspaceDir, {
-    config: input.config,
-    agentId: input.agentId,
-  });
-  const targetSkill = resolveSkillStatusEntry(status.skills, skillName);
-  if (!targetSkill) {
-    throw new Error(`Skill not found: ${skillName}`);
-  }
-  assertWritableSkillTarget(input.workspaceDir, targetSkill);
-  if (
-    !isWorkshopOwnedSkillDir(
-      input.workspaceDir,
-      targetSkill.baseDir,
-      proposalStoreOptions(input.env),
-    )
-  ) {
-    throw new Error(`Skill Workshop does not own this skill path: ${targetSkill.skillKey}`);
-  }
-  const currentContent = await readWorkspaceSkillFile(targetSkill.filePath);
-  if (currentContent === null) {
-    throw new Error(`Skill file is missing: ${targetSkill.filePath}`);
-  }
-  if (
-    input.expectedCurrentContentHash !== undefined &&
-    sha256Hex(currentContent) !== input.expectedCurrentContentHash
-  ) {
-    throw new SkillProposalStaleTargetError(
-      "Skill changed since the reviewer's read: read it again and redraft the update.",
-    );
-  }
-  // Composition uses the same read that currentContentHash binds the proposal to, so a
-  // composed draft can never derive from a different body than the one apply validates.
-  const draftContent =
-    input.composePatch !== undefined
-      ? composeSkillBodyPatch(stripProposalFrontmatterForSkill(currentContent), input.composePatch)
-      : input.content;
-  if (draftContent === undefined) {
-    throw new Error("Update proposal requires content or composePatch.");
-  }
-  const description = resolveUpdateProposalDescription(input.description, targetSkill.description);
-
-  const now = new Date().toISOString();
-  const prepared = prepareSkillProposalDraft({
-    name: targetSkill.skillKey,
-    description,
-    content: draftContent,
-    fallbackFrontmatterContent: currentContent,
-    date: now,
-    maxSkillBytes: config.maxSkillBytes,
-    supportFiles: input.supportFiles,
-    goal: input.goal,
-    evidence: input.evidence,
-  });
-  if (!prepared.ok) {
-    throw prepared.error.cause;
-  }
-  const {
-    content: proposalContent,
-    draftHash,
-    evidence,
-    goal,
-    scan,
-    supportFiles,
-  } = prepared.value;
-  const id = createSkillProposalId(targetSkill.skillKey || targetSkill.name);
-  const origin = normalizeProposalOrigin({
-    ...input.origin,
-    agentId: input.origin?.agentId ?? input.agentId,
-  });
-  const originRunProvenance = mergeProposalOriginRunProvenance(undefined, origin);
-  const record: SkillProposalRecord = {
-    schema: SKILL_WORKSHOP_SCHEMA,
-    id,
-    kind: "update",
-    status: "pending",
-    title: `Update ${targetSkill.name}`,
-    description,
-    createdAt: now,
-    updatedAt: now,
-    createdBy: input.createdBy ?? "skill-workshop",
-    ...(input.autonomousCapture ? { autonomousCapture: true as const } : {}),
-    ...(origin ? { origin } : {}),
-    ...originRunProvenance,
-    proposedVersion: "v1",
-    draftFile: "PROPOSAL.md",
-    draftHash,
-    target: {
-      skillName: targetSkill.name,
-      skillKey: targetSkill.skillKey,
-      skillDir: targetSkill.baseDir,
-      skillFile: targetSkill.filePath,
-      source: targetSkill.source,
-      currentContentHash: hashSkillProposalContent(currentContent),
-    },
-    scan,
-    ...(supportFiles.length > 0
-      ? { supportFiles: await buildSupportFileMetadata(supportFiles, targetSkill.baseDir) }
-      : {}),
-    ...(goal ? { goal } : {}),
-    ...(evidence ? { evidence } : {}),
-  };
-  const event = await writeSkillProposal({
-    record,
-    content: proposalContent,
-    supportFiles,
-    workspaceDir: input.workspaceDir,
-    ownerAgentId: input.agentId ?? origin?.agentId,
-    maxPending: config.maxPending,
-    event: createSkillProposalEvent({
-      record,
-      type: "created",
-      actor: input.eventActor,
-    }),
-    store: proposalStoreOptions(input.env),
-  });
-  if (event) {
-    await dispatchSkillProposalChanged({
-      event,
-      record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
-  return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
-}
 
 export async function reviseSkillProposal(
   input: SkillProposalReviseInput,
@@ -582,58 +271,63 @@ export async function applySkillProposal(
   return await applySkillProposalTransition(input, APPLY_TRANSITION_DEPENDENCIES);
 }
 
-async function buildSupportFileMetadata(
-  files: readonly PreparedSkillProposalSupportFile[],
-  targetSkillDir?: string,
-): Promise<SkillProposalSupportFile[]> {
-  const out: SkillProposalSupportFile[] = [];
-  for (const file of files) {
-    const metadata: SkillProposalSupportFile = {
-      path: file.path,
-      sizeBytes: file.sizeBytes,
-      hash: file.hash,
-    };
-    if (targetSkillDir) {
-      const targetContent = await readWorkspaceSupportFile({
-        skillDir: targetSkillDir,
-        relativePath: file.path,
-      });
-      metadata.targetExisted = targetContent !== null;
-      if (targetContent !== null) {
-        metadata.targetContentHash = hashSkillProposalContent(targetContent);
-      }
-    }
-    out.push(metadata);
-  }
-  return out;
-}
-
 async function markProposal(
   input: SkillProposalActionInput,
   status: "rejected",
 ): Promise<SkillProposalRecord> {
-  const result = await withPendingSkillProposalMutation(input, status, async (read) => {
-    const now = new Date().toISOString();
-    const record: SkillProposalRecord = {
-      ...read.record,
-      status,
-      updatedAt: now,
-      rejectedAt: now,
-      statusReason: normalizeOptionalString(input.reason),
-    };
-    const event = await updateSkillProposalRecord({
-      record,
-      event: createSkillProposalEvent({
+  const scope = {
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+    workspaceDir: input.workspaceDir,
+  };
+  const initial = await readSkillProposalRecord(
+    input.proposalId,
+    proposalStoreOptions(input.env),
+    scope,
+  );
+  if (!initial) {
+    throw new Error(`Skill proposal not found: ${input.proposalId}`);
+  }
+  const result = await withSkillProposalTargetLock(
+    initial,
+    async () => {
+      const current = await readSkillProposalRecord(
+        input.proposalId,
+        proposalStoreOptions(input.env),
+        scope,
+        { reconcile: false },
+      );
+      if (!current) {
+        throw new Error(`Skill proposal not found: ${input.proposalId}`);
+      }
+      if (current.status !== "pending") {
+        throw new Error(
+          `Only pending proposals can be rejected. Current status: ${current.status}.`,
+        );
+      }
+      assertExpectedRevisionHash(hashSkillProposalRevision(current), input.expectedRevisionHash);
+      const now = new Date().toISOString();
+      const record: SkillProposalRecord = {
+        ...current,
+        status,
+        updatedAt: now,
+        rejectedAt: now,
+        statusReason: normalizeOptionalString(input.reason),
+      };
+      const event = await updateSkillProposalRecord({
         record,
-        type: status,
-        actor: input.eventActor,
-        ...(input.correlationId ? { correlationId: input.correlationId } : {}),
-        occurredAt: now,
-      }),
-      store: proposalStoreOptions(input.env),
-    });
-    return { record, event };
-  });
+        event: createSkillProposalEvent({
+          record,
+          type: status,
+          actor: input.eventActor,
+          ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+          occurredAt: now,
+        }),
+        store: proposalStoreOptions(input.env),
+      });
+      return { record, event };
+    },
+    proposalStoreOptions(input.env),
+  );
   if (result.event) {
     await dispatchSkillProposalChanged({
       event: result.event,
@@ -713,12 +407,4 @@ async function assertSupportTargetsUnchanged(
     });
     await assertSkillProposalSupportTargetUnchanged({ record, file, currentContent, input });
   }
-}
-
-function normalizeRequired(value: string, label: string): string {
-  const normalized = normalizeOptionalString(value);
-  if (!normalized) {
-    throw new Error(`${label} is required.`);
-  }
-  return normalized;
 }

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { removePathWithinRoot } from "../../infra/fs-safe-remove.js";
-import { root } from "../../infra/fs-safe.js";
+import { FsSafeError, root, type ReadResult } from "../../infra/fs-safe.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -179,6 +179,15 @@ function isStoredProposalVisible(row: SkillProposalRow, scope: SkillProposalLook
   );
 }
 
+export class SkillProposalDraftMissingError extends Error {
+  constructor(
+    readonly proposalId: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Skill proposal draft is missing: ${proposalId}. Reject and re-propose it.`, options);
+  }
+}
+
 export async function readSkillProposal(
   proposalId: string,
   options: SkillWorkshopStoreOptions = {},
@@ -197,14 +206,19 @@ export async function readSkillProposal(
     return null;
   }
   const stateRoot = await root(resolveSkillWorkshopStateDir(options));
-  const draft = await stateRoot.read(
-    path.join(proposalRelativeDir(proposalId), PROPOSAL_DRAFT_FILE),
-    {
+  let draft: ReadResult;
+  try {
+    draft = await stateRoot.read(path.join(proposalRelativeDir(proposalId), PROPOSAL_DRAFT_FILE), {
       hardlinks: "reject",
       maxBytes: MAX_PROPOSAL_BYTES,
       symlinks: "reject",
-    },
-  );
+    });
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "not-found") {
+      throw new SkillProposalDraftMissingError(proposalId, { cause: error });
+    }
+    throw error;
+  }
   return {
     record: stored.record,
     revisionHash: hashSkillProposalRevision(stored.record),
@@ -216,12 +230,15 @@ export async function readSkillProposalRecord(
   proposalId: string,
   options: SkillWorkshopStoreOptions = {},
   scope: SkillProposalLookupScope = {},
+  readOptions: SkillProposalReadOptions = {},
 ): Promise<SkillProposalRecord | null> {
   let stored = readStoredProposal(proposalId, options);
   if (!stored || !isStoredProposalVisible(stored.row, scope)) {
     return null;
   }
-  await reconcileInterruptedApply(proposalId, options);
+  if (readOptions.reconcile !== false) {
+    await reconcileInterruptedApply(proposalId, options, readOptions.config);
+  }
   stored = readStoredProposal(proposalId, options);
   return stored && isStoredProposalVisible(stored.row, scope) ? stored.record : null;
 }

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -176,6 +176,8 @@ export type SkillProposalManifestEntry = {
   scanState: SkillProposalScannerState;
   /** The proposal remains bound to an earlier workspace for this agent. */
   workspaceMismatch?: true;
+  /** The durable proposal body is unavailable; metadata remains inspectable in list output. */
+  degradedState?: "draft-missing";
 };
 
 export type SkillProposalManifest = {


### PR DESCRIPTION
## What Problem This Solves

Two production-observed defects (#125653): applied skill-workshop updates were silently lost when the capturing session ran in an ephemeral per-session worktree (3 of 10 recent applied updates on one instance wrote into throwaway copies), and `skill_workshop` `action=list` failed with `file not found` (105×/7d on another instance) when a pending create's durable draft file was missing.

## Why This Change Was Made

Root causes proven before fixing (repro tests fail pre-fix):

- `sessions-create.ts` swaps the runtime cwd to a managed worktree; experience review and proposal creation reused that path and persisted it as the durable target, so apply mutated the worktree copy. Fix at the producer: the session creator records `canonicalWorkspaceDir` only when it performs the swap; capture and the workshop tool prefer the recorded fact when present. No path-pattern inference; absence of the fact = unchanged behavior.
- Listing pending creates read `PROPOSAL.md` drafts and propagated ENOENT, dead-ending the whole action. The owner now renders such proposals with `degradedState: "draft-missing"`, inspect/apply fail with an actionable message ("Reject and re-propose it."), and reject works without the draft.

Historical records pointing into deleted worktrees are left untouched: rewriting them cannot recover the lost content and would falsify the ledger (a doctor cleanup for orphaned records is a possible follow-up, deliberately not built here).

## User Impact

Accepted autolearn improvements land in the skills future sessions actually read, and the workshop's primary read action stops failing on aged proposal stores. No config surface change.

## Evidence

- Regressions fail pre-fix: worktree-session update targeted the worktree and left the canonical skill byte-identical; missing draft aborted list with `file not found`.
- `pnpm test src/skills/workshop src/agents/tools` — 96 files (1 skipped), 2,196 tests passed (worktree off `origin/main`).
- `node scripts/check-changed.mjs` — passed (format, typechecks, lint, guards, import cycles).
- Fresh `$autoreview` (Codex gpt-5.6-sol, high) on the full diff: clean, "patch is correct (0.97)".
- Production LOC +142/−46 net +96 (new recorded fact + degraded-state owner handling; splits `service-propose.ts` for the size gate); tests +78/−21.

### Post-review updates

- Canonical fact now records the *selected* workspace (`projectRoot`/`requestedCwd`, else agent workspace) — ClawSweeper finding addressed with registered-project and requested-cwd regressions.
- Two gateway test failures in the broad local run are **inherited**, proven failing on the clean PR base: `portal-http-proxy.test.ts` IPv6-only dial (base returns 502 waiting page) and `workspace-sync-local.test.ts` bounded Git candidates (fake Git fixture uses `require` under ESM). Not touched by this diff; exact-head CI arbitrates.
- Final validation: workshop + agent-tools + session-create suites green (2,124 tests), `check-changed` exit 0, fresh autoreview clean (0.98).

### Final updates (post-rebase head)

- Rebased onto main past #125666/#125716; main's ownership/claim/history behavior kept canonical, this PR's changes re-layered (no blanket ours/theirs).
- Persisted pre-upgrade worktree session records now backfilled at the startup session-migration owner (idempotent derive-don't-guess; absence stays legal) — ClawSweeper finding addressed with pre-upgrade, nested-workspace, and idempotence coverage.
- CI `update-cli.test.ts` 35-failure shard on the previous head proven non-reproducible shard-isolation behavior: 241/241 at the exact CI merge SHA and 4,793-test full CLI shard green locally; no update-cli change made.
- Final validation: workshop 195, gateway 114, agent tools 2,012, sessions+gateway 891, `check-changed` exit 0, fresh autoreview clean (0.99).
