### PR TITLE
fix: preserve plugin update recovery after commit

### DIFF
--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -895,6 +895,7 @@ describe("plugins cli update", () => {
     expect(notifyGatewayPluginMetadataChangedMock).not.toHaveBeenCalled();
     expect(rollback).toHaveBeenCalledTimes(1);
     expect(commit).not.toHaveBeenCalled();
+    expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("Updated");
   });
 
   it("rolls back persisted install records when included config changes during a records-only update", async () => {
@@ -1595,24 +1596,23 @@ describe("plugins cli update", () => {
   it("keeps durable state when transaction cleanup fails after the write", async () => {
     const cfg = {
       plugins: {
-        installs: {
-          alpha: {
-            source: "npm",
-            spec: "@openclaw/alpha@1.0.0",
-          },
+        entries: {
+          alpha: { enabled: true },
         },
       },
     } as OpenClawConfig;
-    const nextConfig = {
-      plugins: {
-        installs: {
-          alpha: {
-            source: "npm",
-            spec: "@openclaw/alpha@1.1.0",
-          },
-        },
+    const previousRecords = {
+      alpha: {
+        source: "npm" as const,
+        spec: "@openclaw/alpha@1.0.0",
       },
-    } as OpenClawConfig;
+    };
+    const nextRecords = {
+      alpha: {
+        source: "npm" as const,
+        spec: "@openclaw/alpha@1.1.0",
+      },
+    };
     const runtimeConfig = {
       ...cfg,
       messages: {
@@ -1620,7 +1620,11 @@ describe("plugins cli update", () => {
       },
     } as OpenClawConfig;
     const nextRuntimeConfig = {
-      ...nextConfig,
+      ...runtimeConfig,
+      plugins: {
+        ...runtimeConfig.plugins,
+        installs: nextRecords,
+      },
       messages: runtimeConfig.messages,
     } as OpenClawConfig;
     primeUpdateConfigSnapshot({
@@ -1630,7 +1634,7 @@ describe("plugins cli update", () => {
         "/tmp/plugins.json5": "plugins-start-hash",
       },
     });
-    setInstalledPluginIndexInstallRecords(cfg.plugins?.installs ?? {});
+    setInstalledPluginIndexInstallRecords(previousRecords);
     const rollback = vi.fn(async () => undefined);
     const failedCommit = vi.fn(async () => {
       throw new Error("cleanup failed");
@@ -1651,30 +1655,35 @@ describe("plugins cli update", () => {
       config: nextRuntimeConfig,
     });
 
-    await expect(runPluginsCommand(["plugins", "update", "alpha"])).rejects.toThrow(
-      "Plugin install transaction commit failed",
-    );
+    await runPluginsCommand(["plugins", "update", "alpha"]);
 
     const updateParams = expectSingleCallParams(updateNpmInstalledPluginsMock);
-    expect(updateParams.config).toEqual(runtimeConfig);
+    expect(updateParams.config).toEqual({
+      ...runtimeConfig,
+      plugins: {
+        ...runtimeConfig.plugins,
+        installs: previousRecords,
+      },
+    });
     expect(updateParams.pluginIds).toEqual(["alpha"]);
     expect(updateParams.dryRun).toBe(false);
-    expectInstallRecordsWrittenWithLease(nextConfig.plugins?.installs, {});
+    expectInstallRecordsWrittenWithLease(nextRecords, cfg);
     expect(updateNpmInstalledHookPacksMock).not.toHaveBeenCalled();
-    expect(configWriteMock).toHaveBeenCalledWith({});
-    expect(replaceConfigFileMock).toHaveBeenCalledWith({
-      nextConfig: {},
-      baseHash: "update-config",
-      writeOptions: expect.objectContaining({
-        includeFileHashesForWrite: {
-          "/tmp/plugins.json5": "plugins-start-hash",
-        },
-      }),
-    });
+    expect(configWriteMock).not.toHaveBeenCalled();
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
     expect(failedCommit).toHaveBeenCalledOnce();
     expect(remainingCommit).toHaveBeenCalledOnce();
     expect(rollback).not.toHaveBeenCalled();
-    expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
+    expect(refreshPluginRegistryMock).toHaveBeenCalledWith({
+      config: cfg,
+      installRecords: nextRecords,
+      reason: "source-changed",
+    });
+    expect(notifyGatewayPluginMetadataChangedMock).toHaveBeenCalledWith(runtimeConfig);
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Plugin update committed");
+    expect(pluginsCliRuntimeLogs).toContain("Updated alpha -> 1.1.0");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Restart is required");
+    expectRestartNoticeLogged();
   });
 
   it("exits non-zero when a plugin update reports an error after persisting successes", async () => {

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -445,10 +445,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
     await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
     throw error;
   }
-  const settlePluginTransactions = async (action: "commit" | "rollback") => {
-    await settlePluginInstallTransactions(deferredPluginTransactions, action);
-  };
-  let packageCommitFinalized = false;
+  let packageUpdatePersisted = false;
   try {
     if (pluginSelection.pluginIds.length > 0 && pluginResult.changed && !params.opts.dryRun) {
       const nextInstallRecords = pluginResult.config.plugins?.installs ?? {};
@@ -464,7 +461,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
         installOwnerMigrations: resolvePluginInstallOwnerMigrations(pluginResult),
       });
       if (!reconciled.ok) {
-        await settlePluginTransactions("rollback");
+        await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
         defaultRuntime.error(reconciled.error);
         return defaultRuntime.exit(1);
       }
@@ -498,11 +495,6 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           })
         : { config: pluginResult.config, changed: false, outcomes: [] };
 
-    const outcomeSummary = logPluginUpdateOutcomes({
-      outcomes: [...pluginResult.outcomes, ...hookResult.outcomes],
-      log: (message) => defaultRuntime.log(message),
-    });
-
     if (!params.opts.dryRun && (pluginResult.changed || hookResult.changed)) {
       const sourceSnapshot = mutationSnapshot ?? (await sourceSnapshotPromise);
       if (pluginResult.changed) {
@@ -516,7 +508,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           !currentSnapshot.ok ||
           !isDeepStrictEqual([...currentSnapshot.value], [...packageUpdateSnapshot])
         ) {
-          await settlePluginTransactions("rollback");
+          await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
           defaultRuntime.error(
             currentSnapshot.ok
               ? "Plugin package ownership changed during update; no config or index changes were committed. Refresh the plugin registry and retry."
@@ -575,8 +567,10 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           writeOptions: sourceSnapshot?.writeOptions,
         });
       }
-      packageCommitFinalized = true;
-      await settlePluginTransactions("commit");
+      packageUpdatePersisted = true;
+      await settlePluginInstallTransactions(deferredPluginTransactions, "commit").catch(() =>
+        logger.warn("Plugin update committed, but cleanup failed. Restart is required."),
+      );
       if (pluginResult.changed) {
         await refreshPluginRegistryAfterConfigMutation({
           config: nextConfig,
@@ -592,12 +586,16 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
       defaultRuntime.log("Restart the gateway to load plugins and hooks.");
     }
 
+    const outcomeSummary = logPluginUpdateOutcomes({
+      outcomes: [...pluginResult.outcomes, ...hookResult.outcomes],
+      log: (message) => defaultRuntime.log(message),
+    });
     if (outcomeSummary.hasErrors) {
       defaultRuntime.exit(1);
     }
   } catch (error) {
-    if (!packageCommitFinalized) {
-      await settlePluginTransactions("rollback");
+    if (!packageUpdatePersisted) {
+      await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
     }
     throw error;
   }


### PR DESCRIPTION
Related: #121174

## What Problem This Solves

Fixes an issue where `openclaw plugins update` could print a successful `Updated` outcome before config/index freshness and persistence completed, then roll the change back after a concurrent config conflict. A deferred package-transaction cleanup failure after persistence could also stop plugin registry recovery and restart guidance even though the update was already durably committed.

## Why This Change Was Made

Config/index persistence is now the canonical durable commit boundary. Success outcomes are deferred until that boundary completes, while deferred package cleanup is treated as best-effort post-commit work: a failure emits an explicit warning and recovery continues through registry refresh, gateway metadata notification, and restart guidance.

## User Impact

Rolled-back plugin updates no longer print a false `Updated` message. When package cleanup fails after a committed update, operators are clearly told that the update committed and a restart is required, and OpenClaw still refreshes runtime metadata and provides the normal restart guidance.

## Evidence

- `node scripts/run-vitest.mjs src/cli/plugins-cli.update.test.ts` — 51 passed.
- `node scripts/check-changed.mjs -- src/cli/plugins-update-command.ts src/cli/plugins-cli.update.test.ts` — passed.
- `git diff --check` — passed.
- Regression assertions failed on pre-fix code for premature `Updated` output and escaped post-persistence cleanup failure, then passed with this repair.
- Production LOC: +13/-15 (net -2). Tests: +41/-32 (net +9).
- Fresh `autoreview` completed cleanly with no accepted or actionable findings.

AI-assisted. I reviewed and understand the implementation and its persistence, cleanup, and recovery boundaries.
