### PR TITLE
fix(skills): preserve routing descriptions on workshop updates

### DIFF
--- a/packages/gateway-protocol/src/schema/agents-models-skills-routing-description.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills-routing-description.test.ts
@@ -1,0 +1,57 @@
+import { Value } from "typebox/value";
+import { describe, expect, it } from "vitest";
+import { SkillsProposalInspectResultSchema } from "./agents-models-skills.js";
+
+function proposalRecord() {
+  return {
+    schema: "openclaw.skill-workshop.proposal.v1",
+    id: "proposal-routing-1",
+    kind: "update",
+    status: "pending",
+    title: "Update cron guard",
+    description: "Correct dead-man secret storage path",
+    createdAt: "2026-08-18T00:00:00.000Z",
+    updatedAt: "2026-08-18T00:00:00.000Z",
+    createdBy: "gateway",
+    proposedVersion: "v1",
+    draftFile: "PROPOSAL.md",
+    draftHash: "a".repeat(64),
+    target: {
+      skillName: "cron-guard",
+      skillKey: "cron-guard",
+      skillDir: "/tmp/workspace/skills/cron-guard",
+      skillFile: "/tmp/workspace/skills/cron-guard/SKILL.md",
+    },
+    scan: {
+      state: "clean",
+      scannedAt: "2026-08-18T00:00:00.000Z",
+      critical: 0,
+      warn: 0,
+      info: 0,
+      findings: [],
+    },
+  };
+}
+
+// Public Gateway proposal records intentionally exclude internal routing provenance.
+describe("Skill Workshop routing description protocol", () => {
+  it("keeps internal routingDescription out of public proposal records", () => {
+    const baseResult = {
+      record: proposalRecord(),
+      revisionHash: "b".repeat(64),
+      content: "# Cron Guard\n",
+    };
+
+    expect(Value.Check(SkillsProposalInspectResultSchema, baseResult)).toBe(true);
+    expect(
+      Value.Check(SkillsProposalInspectResultSchema, {
+        ...baseResult,
+        record: {
+          ...baseResult.record,
+          routingDescription:
+            "Route cron-guard for cron safety, dry-run planning, alerts, digest review, rollback, and recovery workflows.",
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/commands/doctor-skill-workshop-routing-provenance.test.ts
+++ b/src/commands/doctor-skill-workshop-routing-provenance.test.ts
@@ -1,0 +1,418 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderProposalMarkdown } from "../skills/workshop/frontmatter.js";
+import {
+  applySkillProposal,
+  inspectSkillProposal,
+  listSkillProposals,
+  reviseSkillProposal,
+} from "../skills/workshop/service.js";
+import { writeSkillProposalRollback } from "../skills/workshop/store-sqlite-rollback.js";
+import {
+  hashSkillProposalContent,
+  readSkillProposalRecord,
+  readSkillProposalRollback,
+  writeSkillProposal,
+} from "../skills/workshop/store.js";
+import {
+  SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+  SKILL_WORKSHOP_SCHEMA,
+  type SkillProposalRecord,
+  type SkillProposalRollback,
+} from "../skills/workshop/types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { migrateLegacySkillWorkshopProposals } from "./doctor-skill-workshop-sqlite.js";
+
+const LEGACY_UPDATE_REDRAFT_REASON =
+  "This pending skill update predates routing-description provenance. Redraft the update before revising or applying it.";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-doctor-workshop-routing-provenance-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+function legacyPendingUpdate(params: {
+  proposalId: string;
+  targetDir: string;
+  content: string;
+  description: string;
+  now: string;
+  currentContentHash?: string;
+}): SkillProposalRecord {
+  return {
+    schema: SKILL_WORKSHOP_SCHEMA,
+    id: params.proposalId,
+    kind: "update",
+    status: "pending",
+    title: `Update ${path.basename(params.targetDir)}`,
+    description: params.description,
+    createdAt: params.now,
+    updatedAt: params.now,
+    createdBy: "skill-workshop",
+    origin: {
+      agentId: "main",
+      sessionKey: `agent:main:${path.basename(params.targetDir)}`,
+      runId: `${path.basename(params.targetDir)}-run`,
+    },
+    originRunIds: [`${path.basename(params.targetDir)}-run`],
+    originRunMutationCounts: { [`${path.basename(params.targetDir)}-run`]: 1 },
+    proposedVersion: "v1",
+    draftFile: "PROPOSAL.md",
+    draftHash: hashSkillProposalContent(params.content),
+    target: {
+      skillName: path.basename(params.targetDir),
+      skillKey: path.basename(params.targetDir),
+      skillDir: params.targetDir,
+      skillFile: path.join(params.targetDir, "SKILL.md"),
+      source: "openclaw-workspace",
+      ...(params.currentContentHash ? { currentContentHash: params.currentContentHash } : {}),
+    },
+    scan: {
+      state: "clean",
+      scannedAt: params.now,
+      critical: 0,
+      warn: 0,
+      info: 0,
+      findings: [],
+    },
+  };
+}
+
+function doctorConfig(workspaceDir: string) {
+  return {
+    agents: {
+      entries: {
+        main: { default: true, workspace: workspaceDir },
+      },
+    },
+  };
+}
+
+describe("doctor Skill Workshop routing provenance migration", () => {
+  it("marks legacy pending update proposals stale and requires a redraft", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-legacy-routing-");
+    const proposalId = "legacy-routing-update-20260818-1234567890";
+    const proposalDir = path.join(testState.stateDir, "skill-workshop", "proposals", proposalId);
+    const targetDir = path.join(workspaceDir, "skills", "legacy-routing-update");
+    const now = "2026-08-18T00:00:00.000Z";
+    const content = renderProposalMarkdown({
+      name: "legacy-routing-update",
+      description: "Adjust legacy update behavior",
+      content: "# Legacy Routing Update\n\nPending update body.\n",
+      date: now,
+    });
+    const record = legacyPendingUpdate({
+      proposalId,
+      targetDir,
+      content,
+      description: "Adjust legacy update behavior",
+      now,
+    });
+
+    await fs.mkdir(proposalDir, { recursive: true });
+    await fs.writeFile(path.join(proposalDir, "proposal.json"), JSON.stringify(record), "utf8");
+    await fs.writeFile(path.join(proposalDir, "PROPOSAL.md"), content, "utf8");
+
+    await expect(
+      migrateLegacySkillWorkshopProposals({ config: doctorConfig(workspaceDir) }),
+    ).resolves.toMatchObject({ detected: 1, migrated: 1, warnings: [] });
+
+    const inspected = await inspectSkillProposal(proposalId, {
+      agentId: "main",
+      workspaceDir,
+    });
+    if (!inspected) {
+      throw new Error(`Expected migrated proposal: ${proposalId}`);
+    }
+    expect(inspected.record).toMatchObject({
+      id: proposalId,
+      kind: "update",
+      status: "stale",
+      statusReason: LEGACY_UPDATE_REDRAFT_REASON,
+      staleAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+    expect(inspected.record.updatedAt).toBe(inspected.record.staleAt);
+
+    await expect(listSkillProposals({ agentId: "main", workspaceDir })).resolves.toMatchObject({
+      proposals: [expect.objectContaining({ id: proposalId, status: "stale" })],
+    });
+
+    await expect(
+      reviseSkillProposal({
+        workspaceDir,
+        agentId: "main",
+        proposalId,
+        content: "# Legacy Routing Update\n\nAttempted revision.\n",
+      }),
+    ).rejects.toThrow("Current status: stale");
+    await expect(applySkillProposal({ workspaceDir, agentId: "main", proposalId })).rejects.toThrow(
+      "Current status: stale",
+    );
+  });
+
+  it("reconciles an interrupted legacy update before marking it stale", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-legacy-routing-recovery-");
+    const proposalId = "legacy-routing-recovery-20260818-1234567890";
+    const proposalDir = path.join(testState.stateDir, "skill-workshop", "proposals", proposalId);
+    const targetDir = path.join(workspaceDir, "skills", "legacy-routing-recovery");
+    const targetSkillFile = path.join(targetDir, "SKILL.md");
+    const now = "2026-08-18T00:00:00.000Z";
+    const previousContent =
+      "---\nname: legacy-routing-recovery\ndescription: Preserve this live routing description\n---\n\n# Legacy Routing Recovery\n\nOriginal live body.\n";
+    const content = renderProposalMarkdown({
+      name: "legacy-routing-recovery",
+      description: "Adjust recovery behavior",
+      content: "# Legacy Routing Recovery\n\nProposed update body.\n",
+      date: now,
+    });
+    const record = legacyPendingUpdate({
+      proposalId,
+      targetDir,
+      content,
+      description: "Adjust recovery behavior",
+      now,
+      currentContentHash: hashSkillProposalContent(previousContent),
+    });
+    const rollback: SkillProposalRollback = {
+      schema: SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+      proposalId,
+      writtenAt: now,
+      targetSkillFile,
+      action: "update",
+      previousContentHash: hashSkillProposalContent(previousContent),
+      previousContent,
+    };
+
+    await fs.mkdir(proposalDir, { recursive: true });
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(targetSkillFile, previousContent, "utf8");
+    await fs.writeFile(path.join(proposalDir, "proposal.json"), JSON.stringify(record), "utf8");
+    await fs.writeFile(path.join(proposalDir, "PROPOSAL.md"), content, "utf8");
+    await fs.writeFile(path.join(proposalDir, "rollback.json"), JSON.stringify(rollback), "utf8");
+
+    await expect(
+      migrateLegacySkillWorkshopProposals({ config: doctorConfig(workspaceDir) }),
+    ).resolves.toMatchObject({ detected: 1, migrated: 1, warnings: [] });
+
+    await expect(readSkillProposalRollback(proposalId)).resolves.toBeNull();
+    await expect(fs.readFile(targetSkillFile, "utf8")).resolves.toBe(previousContent);
+
+    const inspected = await inspectSkillProposal(proposalId, {
+      agentId: "main",
+      workspaceDir,
+    });
+    if (!inspected) {
+      throw new Error(`Expected migrated proposal: ${proposalId}`);
+    }
+    expect(inspected.record).toMatchObject({
+      id: proposalId,
+      status: "stale",
+      statusReason: LEGACY_UPDATE_REDRAFT_REASON,
+      staleAt: expect.any(String),
+    });
+  });
+
+  it("normalizes pending legacy updates already stored in SQLite", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-sqlite-routing-");
+    const proposalId = "sqlite-routing-update-20260818-1234567890";
+    const targetDir = path.join(workspaceDir, "skills", "sqlite-routing-update");
+    const targetSkillFile = path.join(targetDir, "SKILL.md");
+    const now = "2026-08-18T00:00:00.000Z";
+    const liveContent =
+      "---\nname: sqlite-routing-update\ndescription: Preserve this live routing description\n---\n\n# SQLite Routing Update\n\nOriginal live body.\n";
+    const content = renderProposalMarkdown({
+      name: "sqlite-routing-update",
+      description: "Adjust persisted SQLite update behavior",
+      content: "# SQLite Routing Update\n\nProposed update body.\n",
+      date: now,
+    });
+    const record = legacyPendingUpdate({
+      proposalId,
+      targetDir,
+      content,
+      description: "Adjust persisted SQLite update behavior",
+      now,
+      currentContentHash: hashSkillProposalContent(liveContent),
+    });
+
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(targetSkillFile, liveContent, "utf8");
+    await writeSkillProposal({
+      record,
+      content,
+      workspaceDir,
+      ownerAgentId: "main",
+      maxPending: 10,
+      store: { env: testState.env },
+    });
+
+    await expect(
+      inspectSkillProposal(proposalId, {
+        agentId: "main",
+        workspaceDir,
+        env: testState.env,
+      }),
+    ).resolves.toMatchObject({ record: { id: proposalId, status: "pending" } });
+
+    await expect(
+      migrateLegacySkillWorkshopProposals({
+        config: doctorConfig(workspaceDir),
+        env: testState.env,
+      }),
+    ).resolves.toMatchObject({ warnings: [] });
+
+    const inspected = await inspectSkillProposal(proposalId, {
+      agentId: "main",
+      workspaceDir,
+      env: testState.env,
+    });
+    if (!inspected) {
+      throw new Error(`Expected stored proposal: ${proposalId}`);
+    }
+    expect(inspected.record).toMatchObject({
+      id: proposalId,
+      kind: "update",
+      status: "stale",
+      statusReason: LEGACY_UPDATE_REDRAFT_REASON,
+      staleAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+    expect(inspected.record.updatedAt).toBe(inspected.record.staleAt);
+    await expect(fs.readFile(targetSkillFile, "utf8")).resolves.toBe(liveContent);
+  });
+
+  it("reconciles rollback facts for pending legacy updates already stored in SQLite", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-sqlite-routing-recovery-");
+    const proposalId = "sqlite-routing-recovery-20260818-1234567890";
+    const targetDir = path.join(workspaceDir, "skills", "sqlite-routing-recovery");
+    const targetSkillFile = path.join(targetDir, "SKILL.md");
+    const now = "2026-08-18T00:00:00.000Z";
+    const liveContent =
+      "---\nname: sqlite-routing-recovery\ndescription: Preserve stored SQLite routing\n---\n\n# SQLite Routing Recovery\n\nOriginal live body.\n";
+    const content = renderProposalMarkdown({
+      name: "sqlite-routing-recovery",
+      description: "Recover persisted SQLite update",
+      content: "# SQLite Routing Recovery\n\nProposed update body.\n",
+      date: now,
+    });
+    const record = legacyPendingUpdate({
+      proposalId,
+      targetDir,
+      content,
+      description: "Recover persisted SQLite update",
+      now,
+      currentContentHash: hashSkillProposalContent(liveContent),
+    });
+    const rollback: SkillProposalRollback = {
+      schema: SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+      proposalId,
+      writtenAt: now,
+      targetSkillFile,
+      action: "update",
+      previousContentHash: hashSkillProposalContent(liveContent),
+      previousContent: liveContent,
+    };
+
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(targetSkillFile, liveContent, "utf8");
+    await writeSkillProposal({
+      record,
+      content,
+      workspaceDir,
+      ownerAgentId: "main",
+      maxPending: 10,
+      store: { env: testState.env },
+    });
+    await writeSkillProposalRollback({
+      proposalId,
+      rollback,
+      store: { env: testState.env },
+    });
+
+    await expect(
+      readSkillProposalRollback(proposalId, { env: testState.env }),
+    ).resolves.toMatchObject(rollback);
+
+    await expect(
+      migrateLegacySkillWorkshopProposals({
+        config: doctorConfig(workspaceDir),
+        env: testState.env,
+      }),
+    ).resolves.toMatchObject({ warnings: [] });
+
+    await expect(readSkillProposalRollback(proposalId, { env: testState.env })).resolves.toBeNull();
+    await expect(fs.readFile(targetSkillFile, "utf8")).resolves.toBe(liveContent);
+    await expect(
+      readSkillProposalRecord(proposalId, { env: testState.env }, {}, { reconcile: false }),
+    ).resolves.toMatchObject({
+      id: proposalId,
+      status: "stale",
+      statusReason: LEGACY_UPDATE_REDRAFT_REASON,
+    });
+  });
+
+  it("warns and preserves a stored legacy update when its draft is missing", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-sqlite-routing-missing-draft-");
+    const proposalId = "sqlite-routing-missing-draft-20260818-1234567890";
+    const targetDir = path.join(workspaceDir, "skills", "sqlite-routing-missing-draft");
+    const now = "2026-08-18T00:00:00.000Z";
+    const content = renderProposalMarkdown({
+      name: "sqlite-routing-missing-draft",
+      description: "Preserve degraded persisted state",
+      content: "# SQLite Routing Missing Draft\n\nProposed update body.\n",
+      date: now,
+    });
+    const record = legacyPendingUpdate({
+      proposalId,
+      targetDir,
+      content,
+      description: "Preserve degraded persisted state",
+      now,
+    });
+
+    await writeSkillProposal({
+      record,
+      content,
+      workspaceDir,
+      ownerAgentId: "main",
+      maxPending: 10,
+      store: { env: testState.env },
+    });
+    await fs.rm(path.join(testState.stateDir, "skill-workshop", "proposals"), {
+      recursive: true,
+      force: true,
+    });
+
+    const result = await migrateLegacySkillWorkshopProposals({
+      config: doctorConfig(workspaceDir),
+      env: testState.env,
+    });
+    expect(result.warnings).toEqual([
+      expect.stringContaining(`Failed to normalize stored Skill Workshop proposal ${proposalId}`),
+    ]);
+
+    await expect(
+      readSkillProposalRecord(proposalId, { env: testState.env }, {}, { reconcile: false }),
+    ).resolves.toMatchObject({
+      id: proposalId,
+      kind: "update",
+      status: "pending",
+    });
+  });
+});

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -7,11 +7,15 @@ import { isMissingPathError } from "../infra/errors.js";
 import { removePathWithinRoot } from "../infra/fs-safe-remove.js";
 import { pathExists, root, type Root } from "../infra/fs-safe.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { LEGACY_UPDATE_REDRAFT_MESSAGE } from "../skills/workshop/routing-description-provenance.js";
+import { listStoredProposalRecords } from "../skills/workshop/store-sqlite-record.js";
 import {
   hashSkillProposalContent,
   importLegacySkillProposal,
   readSkillProposal,
+  readSkillProposalRecord,
   readSkillProposalRollback,
+  updateSkillProposalRecord,
   validateSkillProposalRecord,
   validateSkillProposalRollback,
 } from "../skills/workshop/store.js";
@@ -123,6 +127,111 @@ async function verifyImportedProposal(params: {
   }
 }
 
+function requiresLegacyUpdateRedraft(record: SkillProposalRecord): boolean {
+  return (
+    record.kind === "update" &&
+    record.status === "pending" &&
+    record.routingDescription === undefined
+  );
+}
+
+async function normalizeLegacyUpdateProvenance(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  proposalId: string;
+}): Promise<boolean> {
+  // Inspect only persisted metadata first. Doctor can therefore identify the
+  // compatibility case even when a draft is degraded or missing, without
+  // reconciling unrelated records as a side effect of enumeration.
+  const initial = await readSkillProposalRecord(
+    params.proposalId,
+    { env: params.env },
+    {},
+    { reconcile: false },
+  );
+  if (!initial) {
+    throw new Error("SQLite verification failed before legacy update normalization");
+  }
+  if (!requiresLegacyUpdateRedraft(initial)) {
+    return false;
+  }
+
+  // A targeted legacy update may have a rollback journal proving that its
+  // target is still previous, fully proposed, or partially written. Reconcile
+  // that interrupted apply before terminalizing it so recovery facts are not
+  // stranded and a partially mutated live skill is never left behind.
+  const recovered = await readSkillProposal(
+    params.proposalId,
+    { env: params.env },
+    {},
+    { config: params.config },
+  );
+  if (!recovered) {
+    throw new Error("SQLite verification failed after legacy update recovery");
+  }
+  if (!requiresLegacyUpdateRedraft(recovered.record)) {
+    return false;
+  }
+  if (await readSkillProposalRollback(params.proposalId, { env: params.env })) {
+    throw new Error(
+      "legacy update rollback could not be reconciled; persisted recovery evidence was retained for manual recovery",
+    );
+  }
+
+  const now = new Date().toISOString();
+  const stale: SkillProposalRecord = {
+    ...recovered.record,
+    status: "stale",
+    updatedAt: now,
+    staleAt: now,
+    statusReason: LEGACY_UPDATE_REDRAFT_MESSAGE,
+  };
+  await updateSkillProposalRecord({
+    record: stale,
+    store: { env: params.env },
+  });
+  return true;
+}
+
+async function normalizeStoredLegacyUpdates(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<{ normalized: number; warnings: string[] }> {
+  let records: SkillProposalRecord[];
+  try {
+    records = listStoredProposalRecords({ env: params.env });
+  } catch (error) {
+    return {
+      normalized: 0,
+      warnings: [`Failed to inspect stored Skill Workshop proposals: ${String(error)}`],
+    };
+  }
+
+  let normalized = 0;
+  const warnings: string[] = [];
+  for (const record of records) {
+    if (!requiresLegacyUpdateRedraft(record)) {
+      continue;
+    }
+    try {
+      if (
+        await normalizeLegacyUpdateProvenance({
+          config: params.config,
+          env: params.env,
+          proposalId: record.id,
+        })
+      ) {
+        normalized += 1;
+      }
+    } catch (error) {
+      warnings.push(
+        `Failed to normalize stored Skill Workshop proposal ${record.id}: ${String(error)}`,
+      );
+    }
+  }
+  return { normalized, warnings };
+}
+
 async function migrateProposal(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -175,79 +284,92 @@ async function migrateProposal(params: {
   return result;
 }
 
-/** Import verified legacy proposal sidecars, then remove only the imported JSON metadata. */
+/** Import legacy sidecars, then normalize every persisted update lacking provenance. */
 export async function migrateLegacySkillWorkshopProposals(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): Promise<MigrationResult> {
   const env = params.env ?? process.env;
   const stateDir = resolveStateDir(env);
-  if (!(await pathExists(path.join(stateDir, PROPOSALS_DIR)))) {
-    if (!(await pathExists(path.join(stateDir, MANIFEST_PATH)))) {
-      return { changes: [], warnings: [], detected: 0, migrated: 0 };
+  const warnings: string[] = [];
+  const changes: string[] = [];
+  let proposalIds: string[] = [];
+  let migrated = 0;
+
+  const hadProposalDir = await pathExists(path.join(stateDir, PROPOSALS_DIR));
+  if (hadProposalDir) {
+    const stateRoot = await root(stateDir);
+    try {
+      const entries = await stateRoot.list(PROPOSALS_DIR, { withFileTypes: true });
+      proposalIds = entries
+        .filter((entry) => entry.isDirectory && PROPOSAL_ID_PATTERN.test(entry.name))
+        .map((entry) => entry.name)
+        .toSorted((left, right) => left.localeCompare(right));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "not-found") {
+        warnings.push(`Failed to inspect legacy Skill Workshop proposals: ${String(error)}`);
+      }
     }
-    await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH });
-    return {
-      changes: ["Removed the empty legacy Skill Workshop proposal index."],
-      warnings: [],
-      detected: 0,
-      migrated: 0,
-    };
-  }
-  const stateRoot = await root(stateDir);
-  let entries;
-  try {
-    entries = await stateRoot.list(PROPOSALS_DIR, { withFileTypes: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "not-found") {
-      return { changes: [], warnings: [], detected: 0, migrated: 0 };
+
+    for (const proposalId of proposalIds) {
+      try {
+        await migrateProposal({
+          config: params.config,
+          env,
+          proposalId,
+          stateRoot,
+        });
+        migrated += 1;
+      } catch (error) {
+        if (isMissingPathError(error)) {
+          const stored = await readSkillProposalRecord(
+            proposalId,
+            { env },
+            {},
+            { reconcile: false },
+          );
+          if (stored) {
+            // Healthy SQLite-backed proposals intentionally have no legacy
+            // proposal.json. The SQLite-wide normalization pass below owns any
+            // routing-provenance upgrade that record still needs.
+            continue;
+          }
+        }
+        warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
+      }
     }
-    return {
-      changes: [],
-      warnings: [`Failed to inspect legacy Skill Workshop proposals: ${String(error)}`],
-      detected: 0,
-      migrated: 0,
-    };
   }
 
-  const proposalIds = entries
-    .filter((entry) => entry.isDirectory && PROPOSAL_ID_PATTERN.test(entry.name))
-    .map((entry) => entry.name)
-    .toSorted((left, right) => left.localeCompare(right));
-  const warnings: string[] = [];
-  let migrated = 0;
-  for (const proposalId of proposalIds) {
-    try {
-      await migrateProposal({
-        config: params.config,
-        env,
-        proposalId,
-        stateRoot,
-      });
-      migrated += 1;
-    } catch (error) {
-      if (isMissingPathError(error)) {
-        if (await readSkillProposal(proposalId, { env }, {}, { reconcile: false })) {
-          continue;
+  const hadLegacyManifest = await pathExists(path.join(stateDir, MANIFEST_PATH));
+  if (hadLegacyManifest) {
+    await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH }).catch(
+      (error: unknown) => {
+        if (!isMissingPathError(error)) {
+          warnings.push(`Failed to remove legacy Skill Workshop proposal index: ${String(error)}`);
         }
-      }
-      warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
+      },
+    );
+    if (!hadProposalDir) {
+      changes.push("Removed the empty legacy Skill Workshop proposal index.");
     }
   }
-  await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH }).catch(
-    (error: unknown) => {
-      if (!isMissingPathError(error)) {
-        warnings.push(`Failed to remove legacy Skill Workshop proposal index: ${String(error)}`);
-      }
-    },
-  );
+
+  const normalized = await normalizeStoredLegacyUpdates({ config: params.config, env });
+  warnings.push(...normalized.warnings);
+
+  if (migrated > 0) {
+    changes.push(
+      `Migrated ${migrated} Skill Workshop proposal${migrated === 1 ? "" : "s"} into shared SQLite.`,
+    );
+  }
+  if (normalized.normalized > 0) {
+    changes.push(
+      `Marked ${normalized.normalized} stored legacy Skill Workshop update proposal${normalized.normalized === 1 ? "" : "s"} stale for redraft.`,
+    );
+  }
+
   return {
-    changes:
-      migrated > 0
-        ? [
-            `Migrated ${migrated} Skill Workshop proposal${migrated === 1 ? "" : "s"} into shared SQLite.`,
-          ]
-        : [],
+    changes,
     warnings,
     detected: proposalIds.length,
     migrated,

--- a/src/gateway/server-methods/skills-workspace-handler.test.ts
+++ b/src/gateway/server-methods/skills-workspace-handler.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveSkillsAgentWorkspace } from "./skills-workspace-handler.js";
+import {
+  resolveSkillsAgentWorkspace,
+  runSkillsProposalWorkspaceHandler,
+} from "./skills-workspace-handler.js";
 import type { GatewayRequestContext } from "./types.js";
 
 function context(config: OpenClawConfig): GatewayRequestContext {
@@ -28,5 +31,71 @@ describe("resolveSkillsAgentWorkspace", () => {
     const result = resolveSkillsAgentWorkspace({ agentId: "research" }, context(config));
 
     expect(result).toMatchObject({ ok: true, agentId: "research" });
+  });
+});
+
+describe("Skill Workshop Gateway response projection", () => {
+  it("removes routing provenance from proposal responses without mutating input", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        list: [{ id: "ops" }],
+      },
+    };
+    const input = {
+      record: {
+        schema: "openclaw.skill-workshop.proposal.v1",
+        id: "proposal-routing-1",
+        description: "Correct dead-man secret storage path",
+        routingDescription: "Route cron-guard for scheduling and recovery workflows.",
+      },
+      nested: [
+        {
+          schema: "openclaw.skill-workshop.proposal.v1",
+          id: "proposal-routing-2",
+          routingDescription: "Route another skill for durable recovery workflows.",
+        },
+      ],
+      unrelated: {
+        schema: "other.v1",
+        routingDescription: "This unrelated field is not proposal provenance.",
+      },
+    };
+    let projected: unknown;
+
+    await runSkillsProposalWorkspaceHandler({
+      method: "skills.proposals.inspect",
+      rawParams: { agentId: "ops" },
+      respond: (ok, result, error) => {
+        expect(ok).toBe(true);
+        expect(error).toBeUndefined();
+        projected = result;
+      },
+      context: context(config),
+      validate: (params: unknown): params is { agentId: string } =>
+        Boolean(params && typeof params === "object" && "agentId" in params),
+      run: async () => input,
+    });
+
+    expect(projected).toEqual({
+      record: {
+        schema: "openclaw.skill-workshop.proposal.v1",
+        id: "proposal-routing-1",
+        description: "Correct dead-man secret storage path",
+      },
+      nested: [
+        {
+          schema: "openclaw.skill-workshop.proposal.v1",
+          id: "proposal-routing-2",
+        },
+      ],
+      unrelated: {
+        schema: "other.v1",
+        routingDescription: "This unrelated field is not proposal provenance.",
+      },
+    });
+    expect(input.record.routingDescription).toBe(
+      "Route cron-guard for scheduling and recovery workflows.",
+    );
   });
 });

--- a/src/gateway/server-methods/skills-workspace-handler.ts
+++ b/src/gateway/server-methods/skills-workspace-handler.ts
@@ -60,6 +60,25 @@ export type ResolvedSkillsWorkspace = Extract<
 
 export const SKILL_PROPOSAL_RESPONSE_HANDLED = Symbol("skill proposal response handled");
 
+function projectSkillProposalGatewayResult(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(projectSkillProposalGatewayResult);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  // SAFETY: the guards above establish that value is a non-null object before record access.
+  const record = value as Record<string, unknown>;
+  const projected = Object.fromEntries(
+    Object.entries(record).map(([key, entry]) => [key, projectSkillProposalGatewayResult(entry)]),
+  );
+  if (record.schema === "openclaw.skill-workshop.proposal.v1") {
+    delete projected.routingDescription;
+  }
+  return projected;
+}
+
 export async function runSkillsProposalWorkspaceHandler<TParams, TResult>(params: {
   method: string;
   rawParams: unknown;
@@ -82,7 +101,7 @@ export async function runSkillsProposalWorkspaceHandler<TParams, TResult>(params
   try {
     const result = await params.run(params.rawParams, resolved);
     if (result !== SKILL_PROPOSAL_RESPONSE_HANDLED) {
-      params.respond(true, result, undefined);
+      params.respond(true, projectSkillProposalGatewayResult(result), undefined);
     }
   } catch (error) {
     const details =

--- a/src/skills/workshop/apply-transition.ts
+++ b/src/skills/workshop/apply-transition.ts
@@ -25,6 +25,7 @@ import { readSkillProposalTargetTreeSha256 } from "./proposal-bundle.js";
 import { hashSkillProposalContent } from "./proposal-hash.js";
 import { scanProposalBundle } from "./proposal-scan.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
+import { requireUpdateRoutingDescription } from "./routing-description-provenance.js";
 import type { NewSkillProposalEvent } from "./store-sqlite-event.js";
 import { readStoredProposal } from "./store-sqlite-record.js";
 import { clearSkillProposalRollback, writeSkillProposalRollback } from "./store-sqlite-rollback.js";
@@ -137,6 +138,7 @@ export async function applySkillProposalTransition(
       `Only pending proposals can be applied. Current status: ${initial.record.status}.`,
     );
   }
+  requireUpdateRoutingDescription(initial.record);
   dependencies.assertExpectedRevisionHash(initial.revisionHash, input.expectedRevisionHash);
 
   let evaluated: SkillProposalEvaluateResult;
@@ -209,6 +211,7 @@ export async function applySkillProposalTransition(
       if (record.status !== "pending") {
         throw new Error(`Only pending proposals can be applied. Current status: ${record.status}.`);
       }
+      requireUpdateRoutingDescription(record);
       dependencies.assertExpectedRevisionHash(read.revisionHash, evaluated.evaluation.revisionHash);
       if (hashSkillProposalContent(content) !== record.draftHash) {
         throw new Error("Proposal draft changed without updating proposal metadata.");

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -85,6 +85,20 @@ export function stripProposalFrontmatterForSkill(content: string): string {
   return result.endsWith("\n") ? result : `${result}\n`;
 }
 
+/** Removes internal routing provenance from proposal content returned by inspection. */
+export function stripProposalDescriptionForInspection(content: string): string {
+  const normalized = normalizeNewlines(content);
+  const extracted = extractFrontmatterBlock(normalized);
+  if (!extracted) {
+    return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
+  }
+
+  const body = extracted.body.replace(/^\n+/, "");
+  const keptFrontmatter = filterFrontmatterBlock(extracted.block, ["description"]);
+  const result = keptFrontmatter ? `---\n${keptFrontmatter}\n---\n\n${body}` : body;
+  return result.endsWith("\n") ? result : `${result}\n`;
+}
+
 function filterFrontmatterBlock(block: string, keysToDrop: readonly string[]): string {
   const drop = new Set(keysToDrop.map((key) => key.toLowerCase()));
   const lines = block.split("\n");

--- a/src/skills/workshop/proposal-draft.ts
+++ b/src/skills/workshop/proposal-draft.ts
@@ -39,6 +39,7 @@ type PreparedSkillProposalDraft = {
 export function prepareSkillProposalDraft(input: {
   name: string;
   description: string;
+  skillDescription?: string;
   content: string;
   fallbackFrontmatterContent?: string;
   version?: string;
@@ -55,7 +56,7 @@ export function prepareSkillProposalDraft(input: {
     const supportFiles = prepareSkillProposalSupportFiles(input.supportFiles);
     const content = renderProposalMarkdown({
       name: input.name,
-      description: input.description,
+      description: input.skillDescription ?? input.description,
       content: input.content,
       fallbackFrontmatterContent: input.fallbackFrontmatterContent,
       version: input.version,

--- a/src/skills/workshop/routing-description-provenance.ts
+++ b/src/skills/workshop/routing-description-provenance.ts
@@ -1,0 +1,63 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { parseSkillFrontmatter } from "../loading/frontmatter.js";
+import { resolveUpdateProposalDescription } from "./proposal-draft.js";
+import type { SkillProposalRecord } from "./types.js";
+
+export const LEGACY_UPDATE_REDRAFT_MESSAGE =
+  "This pending skill update predates routing-description provenance. Redraft the update before revising or applying it.";
+
+type DescriptionFields = {
+  draft: { description: string; skillDescription?: string };
+  record: { description: string; routingDescription?: string };
+};
+
+export function requireUpdateRoutingDescription(
+  record: Pick<SkillProposalRecord, "kind" | "routingDescription">,
+): string | undefined {
+  if (record.kind !== "update") {
+    return undefined;
+  }
+  if (record.routingDescription === undefined) {
+    throw new Error(LEGACY_UPDATE_REDRAFT_MESSAGE);
+  }
+  return record.routingDescription;
+}
+
+export function resolveForUpdate(
+  requestedDescription: string | undefined,
+  content: string,
+  fallbackRoutingDescription: string,
+): DescriptionFields {
+  const description = resolveUpdateProposalDescription(
+    requestedDescription,
+    fallbackRoutingDescription,
+  );
+  const routingDescription =
+    normalizeOptionalString(parseSkillFrontmatter(content).description) ??
+    fallbackRoutingDescription;
+  return {
+    draft: { description, skillDescription: routingDescription },
+    record: { description, routingDescription },
+  };
+}
+
+export function resolveForRevision(
+  record: Pick<SkillProposalRecord, "kind" | "description" | "routingDescription">,
+  requestedDescription: string | undefined,
+  content: string | undefined,
+): DescriptionFields {
+  const description = normalizeOptionalString(requestedDescription) ?? record.description;
+  if (record.kind !== "update") {
+    return { draft: { description }, record: { description } };
+  }
+  const existingRoutingDescription = requireUpdateRoutingDescription(record);
+  const routingDescription =
+    content === undefined
+      ? existingRoutingDescription
+      : (normalizeOptionalString(parseSkillFrontmatter(content).description) ??
+        existingRoutingDescription);
+  return {
+    draft: { description, skillDescription: routingDescription },
+    record: { description, routingDescription },
+  };
+}

--- a/src/skills/workshop/service-description-boundary.test.ts
+++ b/src/skills/workshop/service-description-boundary.test.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { parseSkillFrontmatter } from "../loading/frontmatter.js";
+import { writeSkill } from "../test-support/e2e-test-helpers.js";
+import {
+  applySkillProposal,
+  inspectSkillProposal,
+  proposeCreateSkill,
+  proposeUpdateSkill,
+  reviseSkillProposal,
+} from "./service.js";
+import { hashSkillProposalContent, replaceSkillProposalDraft } from "./store.js";
+import type { SkillProposalReadResult, SkillProposalRecord } from "./types.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-description-boundary-state-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+async function rewriteAsLegacyPendingUpdate(params: {
+  proposal: SkillProposalReadResult;
+  liveDescription: string;
+  proposalSummary: string;
+}): Promise<void> {
+  const legacyContent = params.proposal.content.replace(
+    `description: ${JSON.stringify(params.liveDescription)}`,
+    `description: ${JSON.stringify(params.proposalSummary)}`,
+  );
+  expect(legacyContent).not.toBe(params.proposal.content);
+  const legacyRecord = {
+    ...params.proposal.record,
+    draftHash: hashSkillProposalContent(legacyContent),
+  } as SkillProposalRecord & { routingDescription?: string };
+  delete legacyRecord.routingDescription;
+  await replaceSkillProposalDraft({
+    record: legacyRecord,
+    content: legacyContent,
+    store: { env: testState.env },
+  });
+}
+
+async function createOwnedSkill(params: {
+  workspaceDir: string;
+  name: string;
+  description: string;
+  body: string;
+}): Promise<string> {
+  const proposal = await proposeCreateSkill({
+    workspaceDir: params.workspaceDir,
+    env: testState.env,
+    name: params.name,
+    description: params.description,
+    content: params.body,
+  });
+  const applied = await applySkillProposal({
+    workspaceDir: params.workspaceDir,
+    env: testState.env,
+    proposalId: proposal.record.id,
+    expectedRevisionHash: proposal.revisionHash,
+  });
+  return applied.targetSkillFile;
+}
+
+describe("Skill Workshop update description boundary", () => {
+  it("keeps proposal summaries separate from applied skill routing descriptions", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-description-boundary-");
+    const activeSkillFile = await createOwnedSkill({
+      workspaceDir,
+      name: "cron-guard",
+      description: "Initial workshop-owned cron routing description.",
+      body: "# Cron Guard\n\nExisting behavior.\n",
+    });
+    const skillDir = path.dirname(activeSkillFile);
+    const liveDescription =
+      "Route this skill for cron safety, dry-run planning, alerts, digest review, rollback, and recovery " +
+      "when operators need a durable workflow without changing the capability routing contract.";
+    const proposalSummary = "Correct dead-man secret storage path.";
+
+    expect(Buffer.byteLength(liveDescription, "utf8")).toBeGreaterThan(160);
+    await writeSkill({
+      dir: skillDir,
+      name: "cron-guard",
+      description: liveDescription,
+      body: "# Cron Guard\n\nExisting behavior.\n",
+    });
+
+    const proposal = await proposeUpdateSkill({
+      workspaceDir,
+      env: testState.env,
+      skillName: "cron-guard",
+      description: proposalSummary,
+      content: "# Cron Guard\n\nUpdated behavior.\n",
+    });
+
+    expect(proposal.record.description).toBe(proposalSummary);
+    expect(proposal.record.routingDescription).toBe(liveDescription);
+    expect(proposal.content).toContain(`description: ${JSON.stringify(liveDescription)}`);
+    expect(proposal.content).not.toContain(`description: ${JSON.stringify(proposalSummary)}`);
+
+    const inspected = await inspectSkillProposal(proposal.record.id, {
+      workspaceDir,
+      env: testState.env,
+    });
+    if (!inspected) {
+      throw new Error(`Expected proposal inspection: ${proposal.record.id}`);
+    }
+    expect(inspected.revisionHash).toBe(proposal.revisionHash);
+    expect(inspected.record).not.toHaveProperty("routingDescription");
+    expect(inspected.content).not.toContain(liveDescription);
+    expect(parseSkillFrontmatter(inspected.content).description).toBeUndefined();
+
+    const revisedSummary = "Document the dead-man storage correction.";
+    const revised = await reviseSkillProposal({
+      workspaceDir,
+      env: testState.env,
+      proposalId: proposal.record.id,
+      expectedRevisionHash: inspected.revisionHash,
+      description: revisedSummary,
+      content: inspected.content,
+    });
+
+    expect(revised.record.description).toBe(revisedSummary);
+    expect(revised.record.routingDescription).toBe(liveDescription);
+    expect(revised.content).toContain(`description: ${JSON.stringify(liveDescription)}`);
+    expect(revised.content).not.toContain(`description: ${JSON.stringify(revisedSummary)}`);
+
+    await applySkillProposal({
+      workspaceDir,
+      env: testState.env,
+      proposalId: revised.record.id,
+      expectedRevisionHash: revised.revisionHash,
+    });
+
+    await expect(fs.readFile(activeSkillFile, "utf8")).resolves.toContain(
+      `description: ${JSON.stringify(liveDescription)}`,
+    );
+
+    const replacementDescription =
+      "Route this skill when operators ask to inspect, repair, or verify cron safety workflows.";
+    const replacementSummary = "Clarify cron routing triggers.";
+    const replacement = await proposeUpdateSkill({
+      workspaceDir,
+      env: testState.env,
+      skillName: "cron-guard",
+      description: replacementSummary,
+      content: `---
+name: cron-guard
+description: ${JSON.stringify(replacementDescription)}
+---
+
+# Cron Guard
+
+Final behavior.
+`,
+    });
+
+    expect(replacement.record.description).toBe(replacementSummary);
+    expect(replacement.record.routingDescription).toBe(replacementDescription);
+    expect(replacement.content).toContain(`description: ${JSON.stringify(replacementDescription)}`);
+    expect(replacement.content).not.toContain(`description: ${JSON.stringify(replacementSummary)}`);
+
+    await applySkillProposal({
+      workspaceDir,
+      env: testState.env,
+      proposalId: replacement.record.id,
+      expectedRevisionHash: replacement.revisionHash,
+    });
+    await expect(fs.readFile(activeSkillFile, "utf8")).resolves.toContain(
+      `description: ${JSON.stringify(replacementDescription)}`,
+    );
+  });
+
+  it("requires a legacy pending update to be redrafted before revision", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-description-legacy-revise-");
+    const liveDescription = "Route legacy-revise for durable scheduling and recovery workflows.";
+    const proposalSummary = "Adjust one legacy behavior.";
+    await createOwnedSkill({
+      workspaceDir,
+      name: "legacy-revise",
+      description: liveDescription,
+      body: "# Legacy Revise\n\nExisting behavior.\n",
+    });
+    const proposal = await proposeUpdateSkill({
+      workspaceDir,
+      env: testState.env,
+      skillName: "legacy-revise",
+      description: proposalSummary,
+      content: "# Legacy Revise\n\nUpdated behavior.\n",
+    });
+    await rewriteAsLegacyPendingUpdate({ proposal, liveDescription, proposalSummary });
+
+    await expect(
+      reviseSkillProposal({
+        workspaceDir,
+        env: testState.env,
+        proposalId: proposal.record.id,
+        description: "Revise the legacy proposal summary.",
+      }),
+    ).rejects.toThrow(/redraft/i);
+  });
+
+  it("requires a legacy pending update to be redrafted before apply", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-description-legacy-apply-");
+    const liveDescription = "Route legacy-apply for durable scheduling and recovery workflows.";
+    const proposalSummary = "Adjust one legacy behavior.";
+    const activeSkillFile = await createOwnedSkill({
+      workspaceDir,
+      name: "legacy-apply",
+      description: liveDescription,
+      body: "# Legacy Apply\n\nExisting behavior.\n",
+    });
+    const proposal = await proposeUpdateSkill({
+      workspaceDir,
+      env: testState.env,
+      skillName: "legacy-apply",
+      description: proposalSummary,
+      content: "# Legacy Apply\n\nUpdated behavior.\n",
+    });
+    await rewriteAsLegacyPendingUpdate({ proposal, liveDescription, proposalSummary });
+
+    await expect(
+      applySkillProposal({
+        workspaceDir,
+        env: testState.env,
+        proposalId: proposal.record.id,
+      }),
+    ).rejects.toThrow(/redraft/i);
+    const unchangedSkill = await fs.readFile(activeSkillFile, "utf8");
+    expect(parseSkillFrontmatter(unchangedSkill).description).toBe(liveDescription);
+  });
+});

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -10,8 +10,9 @@ import { resolveSkillWorkshopConfig } from "./config.js";
 import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import { isWorkshopOwnedSkillDir } from "./ownership.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
-import { prepareSkillProposalDraft, resolveUpdateProposalDescription } from "./proposal-draft.js";
+import { prepareSkillProposalDraft } from "./proposal-draft.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
+import { resolveForUpdate } from "./routing-description-provenance.js";
 import {
   createSkillProposalId,
   hashSkillProposalContent,
@@ -251,12 +252,12 @@ export async function proposeUpdateSkill(
   if (draftContent === undefined) {
     throw new Error("Update proposal requires content or composePatch.");
   }
-  const description = resolveUpdateProposalDescription(input.description, targetSkill.description);
+  const descriptions = resolveForUpdate(input.description, draftContent, targetSkill.description);
 
   const now = new Date().toISOString();
   const prepared = prepareSkillProposalDraft({
     name: targetSkill.skillKey,
-    description,
+    ...descriptions.draft,
     content: draftContent,
     fallbackFrontmatterContent: currentContent,
     date: now,
@@ -288,7 +289,7 @@ export async function proposeUpdateSkill(
     kind: "update",
     status: "pending",
     title: `Update ${targetSkill.name}`,
-    description,
+    ...descriptions.record,
     createdAt: now,
     updatedAt: now,
     createdBy: input.createdBy ?? "skill-workshop",

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -9,6 +9,7 @@ import {
   readWorkspaceSkillFile,
 } from "../lifecycle/workspace-skill-write.js";
 import { transitionPendingSkillProposalToStale } from "./apply-transition.js";
+import { stripProposalDescriptionForInspection } from "./frontmatter.js";
 import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
@@ -41,6 +42,18 @@ function proposalScope(options: SkillProposalScopeOptions) {
   return {
     ...(options.agentId ? { agentId: options.agentId } : {}),
     ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+  };
+}
+
+function projectProposalForInspection(read: SkillProposalReadResult): SkillProposalReadResult {
+  if (read.record.kind !== "update" || read.record.routingDescription === undefined) {
+    return read;
+  }
+  const { routingDescription: _routingDescription, ...record } = read.record;
+  return {
+    ...read,
+    record,
+    content: stripProposalDescriptionForInspection(read.content),
   };
 }
 
@@ -113,9 +126,11 @@ export async function inspectSkillProposal(
   if (!read) {
     return null;
   }
-  return await hydrateProposalSupportFiles(
-    await reconcilePendingCreateProposal(read, options),
-    options.env,
+  return projectProposalForInspection(
+    await hydrateProposalSupportFiles(
+      await reconcilePendingCreateProposal(read, options),
+      options.env,
+    ),
   );
 }
 

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -16,6 +16,7 @@ import { resolveSkillWorkshopConfig } from "./config.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { nextProposalVersion, prepareSkillProposalDraft } from "./proposal-draft.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
+import { resolveForRevision } from "./routing-description-provenance.js";
 import {
   assertExpectedRevisionHash,
   evaluateSkillProposal,
@@ -123,11 +124,11 @@ export async function reviseSkillProposal(
         : input.supportFiles;
     const requestedContent = input.content ?? read.content;
     const nextVersion = nextProposalVersion(record.proposedVersion);
-    const description = normalizeOptionalString(input.description) ?? record.description;
+    const descriptions = resolveForRevision(record, input.description, input.content);
     const now = new Date().toISOString();
     const prepared = prepareSkillProposalDraft({
       name: record.target.skillKey,
-      description,
+      ...descriptions.draft,
       content: requestedContent,
       fallbackFrontmatterContent: read.content,
       version: nextVersion,
@@ -160,7 +161,7 @@ export async function reviseSkillProposal(
     const previousSupportFiles = record.supportFiles;
     const revised: SkillProposalRecord = {
       ...record,
-      description,
+      ...descriptions.record,
       updatedAt: now,
       proposedVersion: nextVersion,
       draftHash,

--- a/src/skills/workshop/store-record.ts
+++ b/src/skills/workshop/store-record.ts
@@ -133,6 +133,7 @@ const skillProposalRecordSchema = z
     status: z.enum(["pending", "applied", "rejected", "quarantined", "stale"]),
     title: z.string(),
     description: z.string(),
+    routingDescription: z.string().optional(),
     createdAt: z.string(),
     updatedAt: z.string(),
     autonomousCapture: z.literal(true).optional(),

--- a/src/skills/workshop/store-sqlite-record.ts
+++ b/src/skills/workshop/store-sqlite-record.ts
@@ -56,6 +56,20 @@ export function readStoredProposal(
   return record ? { record, row } : null;
 }
 
+/** Return all valid persisted proposal records without reconciling or reading draft files. */
+export function listStoredProposalRecords(
+  options: SkillWorkshopStoreOptions = {},
+): SkillProposalRecord[] {
+  const { database, kysely } = openSkillWorkshopStore(options);
+  return executeSqliteQuerySync(
+    database.db,
+    kysely.selectFrom("skill_workshop_proposals").selectAll().orderBy("proposal_id", "asc"),
+  ).rows.flatMap((row) => {
+    const record = parseSkillProposalRow(row);
+    return record ? [record] : [];
+  });
+}
+
 function proposalRowValues(params: {
   record: SkillProposalRecord;
   ownerAgentId: string | null;

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -146,6 +146,8 @@ export type SkillProposalRecord = {
   status: SkillProposalStatus;
   title: string;
   description: string;
+  /** Canonical routing description intended for the live skill after an update. */
+  routingDescription?: string;
   createdAt: string;
   updatedAt: string;
   createdBy: SkillProposalSource;


### PR DESCRIPTION
Closes #125570

## What Problem This Solves

Skill Workshop update proposals historically used one `description` value for two different responsibilities:

- the concise proposal/listing summary describing what changed; and
- the live skill `SKILL.md` description used for capability discovery and routing.

Applying an update could therefore silently replace a skill's routing description with change-summary text while leaving the skill installed and apparently healthy.

## Core Repair

This PR makes that ownership boundary explicit across persistence, revise/apply behavior, legacy migration, and output projection:

- `record.description` remains the concise proposal/listing summary, retaining the existing 160-byte validation and metadata scanning behavior.
- Update proposals persist full canonical `record.routingDescription` internally for safe revise/apply behavior.
- Candidate `SKILL.md` frontmatter can intentionally replace that routing description; body-only updates preserve the current routing description.
- Summary-only revisions preserve persisted routing provenance instead of re-inferring it from proposal content.
- Apply checks routing-description provenance before evaluation and again after the locked re-read.
- Create-proposal semantics are unchanged.

This does not attempt to reconstruct routing text that had already been overwritten before this fix; there is no authoritative historical value from which to do that safely.

## P1 Follow-up: Bound Model/Public Output

ClawSweeper correctly identified that the persisted routing description can be legitimately large and therefore should not be copied unbounded into model inspection output or the public Gateway proposal record.

The corrective pass keeps the full canonical value internally while projecting it out at both output boundaries:

1. `inspectSkillProposal()` preserves the canonical `revisionHash`, omits `record.routingDescription`, and removes proposal-frontmatter `description` from inspected update content.
2. Feeding that projected inspected content back through `reviseSkillProposal()` preserves the full canonical routing description because absence of a candidate frontmatter description means “preserve existing routing provenance,” rather than replacing it with a truncated preview.
3. Gateway proposal responses recursively project internal proposal records and omit `routingDescription` only when `schema === "openclaw.skill-workshop.proposal.v1"`; unrelated objects with a same-named field are preserved and inputs are not mutated.
4. The closed public `SkillProposalRecordSchema` no longer includes `routingDescription`, removing the generated Swift/Kotlin protocol drift introduced by exposing the internal field.

This is a bounded inspection projection rather than truncation, so the authoritative value needed for safe apply is retained without creating a preview-to-revise data-loss path.

## Legacy Upgrade / Doctor Policy

Pending updates created by the old single-description format have no trustworthy routing-description provenance. Doctor owns that upgrade boundary for both forms of persisted legacy state:

1. legacy `proposal.json` sidecars being imported into shared SQLite; and
2. pending update rows already present in shared SQLite whose proposal directory no longer contains `proposal.json`.

For either form, only `kind: update`, `status: pending` records without routing provenance enter the compatibility path. Doctor inspects persisted metadata without reconciliation, reconciles interrupted-apply rollback facts under the real config, and then marks still-ambiguous rollback-clean records `stale` with an explicit redraft reason. Unsafe recovery cases warn and leave persisted state untouched rather than guessing or discarding evidence.

The steady-state revise/apply guard remains in place as defense in depth.

## Regression Coverage

The P1 corrective coverage verifies:

- long canonical routing text is preserved internally and through apply;
- inspection omits internal routing provenance while retaining the canonical revision hash;
- inspect → revise round trips preserve the full canonical routing description;
- public Gateway proposal responses omit the internal field;
- unrelated `routingDescription` fields are not stripped;
- Gateway projection does not mutate the source value;
- the closed public protocol schema rejects `routingDescription` on proposal records;
- legacy pending updates remain fail-closed and require redraft.

## Validation Evidence

The isolated formatter-backed verifier ran against the exact semantic tree later promoted to the contribution branch. Before its final bookkeeping/push step it completed successfully:

```text
Focused routing provenance tests
  service-description-boundary.test.ts                  3 passed
  skills-workspace-handler.test.ts                      3 passed
  agents-models-skills-routing-description.test.ts      1 passed
  doctor-skill-workshop-routing-provenance.test.ts      5 passed

Changed-file static checks                              PASS
Core + core-test typechecks                             PASS
Dead-export / dependency / boundary guards              PASS
Runtime import cycle check                              PASS
pnpm protocol:check                                     PASS
oxfmt --check on the targeted files                     PASS
git diff --check                                        PASS
```

The verifier's final step created a mechanical formatting commit touching only:

- `src/commands/doctor-skill-workshop-routing-provenance.test.ts`
- `src/commands/doctor-skill-workshop-sqlite.ts`

One concurrent verifier attempt then reported a non-fast-forward push rejection because another attempt had already pushed that same two-file formatter result. This was a branch-update race, not a test, static-analysis, protocol, or formatting failure.

The promoted corrective tree was audited against the prior PR head and changes exactly nine files: seven P1 semantic/regression files plus those two mechanical formatting files. No temporary validation workflow files are included.

Current corrective commit: `618c8a5a25ee7409b93f23171ed7dcbb90ab13cf`

## After-Fix Workspace Behavior Proof

A repository-native run exercised the production Skill Workshop service against real temporary workspace files:

```text
PROPOSAL_SUMMARY=Correct dead-man secret storage path.
PROPOSAL_ROUTING=Route cron-guard for cron safety, dry-run planning, alerts, digest review, rollback, and recovery workflows.
APPLIED_ROUTING=Route cron-guard for cron safety, dry-run planning, alerts, digest review, rollback, and recovery workflows.
LEGACY_APPLY=BLOCKED_REDRAFT:This pending skill update predates routing-description provenance. Redraft the update before revising or applying it.
PROOF_PASS=summary-separated-routing-preserved-legacy-fails-closed
```

This demonstrates the original invariant end-to-end: proposal summary and routing metadata remain separate through apply, while ambiguous legacy state cannot silently mutate the live skill.

AI assistance was used for investigation, implementation, testing, and review-response work. The contribution remains scoped to the source-level invariant, persisted-state compatibility policy, bounded output contract, and executable regression evidence described above.