### PR TITLE
fix(talk): transcribe the speaker on browser-owned realtime calls

### DIFF
--- a/ui/src/pages/chat/realtime-talk-webrtc-control.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-control.test.ts
@@ -149,6 +149,32 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     vi.unstubAllGlobals();
   });
 
+  it("asks a session created without transcription to transcribe the speaker", async () => {
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      { provider: "openai", transport: "webrtc", clientSecret: "client-secret-123" },
+      { client: {} as never, sessionKey: "main", callbacks: {} },
+    );
+
+    await transport.start();
+    const peer = FakePeerConnection.instances[0];
+    peer?.channel.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "session.created", session: { audio: { input: {} } } }),
+      }),
+    );
+
+    expect(peer?.channel.send.mock.calls.map(([payload]) => JSON.parse(String(payload)))).toEqual([
+      {
+        type: "session.update",
+        session: {
+          type: "realtime",
+          audio: { input: { transcription: { model: "gpt-4o-mini-transcribe" } } },
+        },
+      },
+    ]);
+    transport.stop();
+  });
+
   it("submits semantic realtime control tool results through the OpenAI data channel", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "talk.client.steer") {

--- a/ui/src/pages/chat/realtime-talk-webrtc-support.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-support.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { RealtimeTalkWebRtcOfferExchange } from "./realtime-talk-webrtc-support.ts";
+import {
+  RealtimeTalkWebRtcOfferExchange,
+  realtimeTalkInputTranscriptionUpdate,
+} from "./realtime-talk-webrtc-support.ts";
 
 describe("RealtimeTalkWebRtcOfferExchange", () => {
   afterEach(() => {
@@ -33,5 +36,31 @@ describe("RealtimeTalkWebRtcOfferExchange", () => {
         }),
       }),
     );
+  });
+});
+
+describe("realtimeTalkInputTranscriptionUpdate", () => {
+  it("requests transcription for a session created without it", () => {
+    expect(
+      realtimeTalkInputTranscriptionUpdate({
+        type: "session.created",
+        session: { audio: { input: { turn_detection: { type: "server_vad" } } } },
+      }),
+    ).toEqual({
+      type: "session.update",
+      session: {
+        type: "realtime",
+        audio: { input: { transcription: { model: "gpt-4o-mini-transcribe" } } },
+      },
+    });
+  });
+
+  it("leaves a session that already transcribes input alone", () => {
+    expect(
+      realtimeTalkInputTranscriptionUpdate({
+        type: "session.created",
+        session: { audio: { input: { transcription: { model: "whisper-1" } } } },
+      }),
+    ).toBeNull();
   });
 });

--- a/ui/src/pages/chat/realtime-talk-webrtc-support.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-support.ts
@@ -33,7 +33,36 @@ export type RealtimeServerEvent = {
     role?: string;
     transcript?: string;
   };
+  session?: {
+    audio?: { input?: Record<string, unknown> };
+  };
 };
+
+// The model OpenAI realtime sessions use to transcribe captured speech. Kept in
+// step with the provider-side session policy default; a session that omits
+// transcription emits no user utterances at all.
+const REALTIME_INPUT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe";
+
+/**
+ * A browser-owned GA realtime call can start without any session policy, because
+ * ChatGPT subscription auth cannot mint the client secret that normally carries
+ * one. Such a session never transcribes the speaker, so ask for it once the
+ * server reports the session it actually created.
+ */
+export function realtimeTalkInputTranscriptionUpdate(
+  event: RealtimeServerEvent,
+): { type: "session.update"; session: unknown } | null {
+  if (event.session?.audio?.input?.transcription) {
+    return null;
+  }
+  return {
+    type: "session.update",
+    session: {
+      type: "realtime",
+      audio: { input: { transcription: { model: REALTIME_INPUT_TRANSCRIPTION_MODEL } } },
+    },
+  };
+}
 
 export class RealtimeTalkResponseOutcomeOwner {
   private activeResponseId: string | undefined;

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -24,6 +24,7 @@ import {
   RealtimeTalkResponseOutcomeOwner,
   realtimeTalkDataChannelMaxMessageSize,
   realtimeTalkImageEvent,
+  realtimeTalkInputTranscriptionUpdate,
   type RealtimeServerEvent,
 } from "./realtime-talk-webrtc-support.ts";
 
@@ -320,6 +321,13 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       return;
     }
     switch (event.type) {
+      case "session.created": {
+        const update = realtimeTalkInputTranscriptionUpdate(event);
+        if (update) {
+          this.send(update);
+        }
+        return;
+      }
       case "input_transcript.added":
         this.emitFramelessTranscript("user", event.item?.text, false, event.item?.id);
         return;


### PR DESCRIPTION
### Summary

- **Problem**: Browser Talk over client-owned WebRTC persists the assistant's realtime replies to the agent session but never the user's own utterances, so half of every spoken conversation is lost. The session record shows why the loss is silent rather than reported: the closed voice session carries `transcriptCapable: true` with an empty `transcriptFailureKeys` and no `hasUserTranscript`, meaning no finalized user transcript ever reached the append path in the first place. Later written or spoken turns cannot refer back to anything the user said, and transcript exports keep only one side of the conversation.
- **Root Cause**: A browser-owned realtime call is created by POSTing the raw SDP offer to the GA calls endpoint in `extensions/openai/realtime-quicksilver-wire.ts`. That request carries a session payload only for GPT-Live models or the Gateway-controlled sideband; for every other model the body is the bare offer and the `Content-Type` is `application/sdp`, so the session object the Gateway builds for it is computed and then dropped. On the Platform API path this costs nothing, because the session policy — including `audio.input.transcription` — is registered through the client secret instead. ChatGPT subscription auth cannot mint a client secret, so that route has no remaining channel for session configuration and the call runs on server defaults, which do not transcribe input audio. The browser then opens the `oai-events` data channel and sends no session configuration either, so nothing ever asks OpenAI to transcribe the speaker. Both halves of the receive path are already complete and role-agnostic — `ui/src/pages/chat/realtime-talk-webrtc.ts` maps user transcript events to `talk.client.transcript`, and the Gateway appends whatever role it is given — which is why only the request is missing and why the assistant side works.
- **Fix**: React to the session OpenAI reports it actually created. On `session.created`, if the reported session has no `audio.input.transcription`, the transport sends one `session.update` asking for it; if the session already transcribes input, nothing is sent. Reading the server's own report rather than inferring from local configuration keeps the change inert on every path that is already correct: a Platform API session arrives with transcription configured and is left untouched, and the frameless GPT-Live protocol reports `session.started` instead of `session.created`, so it is never affected. `session.update` merges the fields it carries, so the request cannot disturb the voice, instructions, tools, or turn detection the call was created with — the same partial-update shape this repository already relies on when it toggles auto-response through `audio.input.turn_detection`.
- **What changed**:
  - `ui/src/pages/chat/realtime-talk-webrtc-support.ts` — adds `realtimeTalkInputTranscriptionUpdate`, which returns the session update for a session that does not transcribe input and `null` for one that does, and widens the server-event type with the reported `session.audio.input.transcription`.
  - `ui/src/pages/chat/realtime-talk-webrtc.ts` — handles `session.created` by sending that update when one is needed.
  - `ui/src/pages/chat/realtime-talk-webrtc-support.test.ts` — covers both helper branches.
  - `ui/src/pages/chat/realtime-talk-webrtc-control.test.ts` — covers the transport wiring end to end over the data channel.
- **What did NOT change (scope boundary)**:
  - Call creation: the SDP exchange, endpoint selection, multipart handling, and authentication headers are untouched, so no currently working call can fail to connect.
  - The Platform API path, which already registers input transcription through its client secret and is left alone by the guard.
  - The frameless GPT-Live protocol and its `session.started` handshake, sideband, and delegation flow.
  - Assistant transcript handling, audio playback, turn detection, voice, instructions, and tool calling.
  - The Gateway transcript append path, voice-session records, and `talk.client.transcript`.
  - Config surface unchanged. Plugin surface unchanged. No dependency changes.

### Reproduction

1. Configure browser Talk with a GA realtime model over WebRTC, authenticated with a ChatGPT subscription rather than a Platform API key.
2. Open a Talk session bound to an existing agent session and say a distinctive sentence.
3. Let the model answer, close the session, then read the agent session history and the durable voice-session record.
4. **Before this PR**: the realtime model hears and answers, the assistant reply is appended, and the user's utterance is absent — with `transcriptCapable: true`, no `hasUserTranscript`, and no recorded transcript failure, because the session was never asked to transcribe input.
5. **After this PR**: the transport asks the created session to transcribe input, the finalized user utterance travels the existing transcript path, and both roles appear in the session history.

### Real behavior proof

**Behavior addressed (#125601)**: silent loss of the user's side of realtime voice conversations on browser-owned calls that carry no session policy. The report attributed the gap to the subscription session builder omitting input-transcription configuration; source shows the omission is real but not reachable that way, because the call this path creates never transmits that session at all — a fix there would not change the request OpenAI receives. What is claimed here is the mechanism reproduced against current `main` with production code: the call sends only the SDP offer, the created session therefore has no input transcription, and no user transcript is ever produced.

**Real environment tested (Linux x64, Node 22.22.3 — Vitest against the production transport over a driven data channel, plus a tsx harness invoking the production call builder and session-update helper with the network stubbed at `fetch`)**: the transport tests dispatch real `session.created` messages through the transport's data-channel listener and assert what it sends back; the harness calls `createOpenAIQuicksilverCall` with a subscription auth object and captures the exact request that would go to OpenAI.

**Exact steps or command run after this patch**: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-webrtc-control.test.ts ui/src/pages/chat/realtime-talk-webrtc-support.test.ts`; then the full realtime Talk suite with `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-*.test.ts`; then `node --import tsx /tmp/qmd125601/repro.mts`; then `./node_modules/.bin/oxlint --tsconfig tsconfig.ui.json` over the changed files.

**Evidence after fix (verbatim suite output and harness run)**:

```text
 Test Files  17 passed (17)
      Tests  252 passed (252)

=== what the subscription call actually sends ===
url:          https://api.openai.com/v1/realtime/calls?model=gpt-realtime-2.1
content-type: application/sdp
body carries a session payload: false
body is the raw SDP offer:      true

=== session the builder produced but the call discarded ===
{"output":{"voice":"marin"}}

=== BEFORE: server-reported session for that call ===
{"audio":{"input":{"turn_detection":{"type":"server_vad"}}}}
transcribes the speaker: false

=== AFTER: update the transport now sends on session.created ===
{"type":"session.update","session":{"type":"realtime","audio":{"input":{"transcription":{"model":"gpt-4o-mini-transcribe"}}}}}
already-configured session is left alone: true

=== protocol witness (sibling OpenAI Codex checkout) ===
protocol.rs:93: pub(super) transcription: Option<SessionInputAudioTranscription>,
protocol.rs:99: pub(super) struct SessionInputAudioTranscription {
methods_v2.rs:37: const REALTIME_V2_INPUT_TRANSCRIPTION_MODEL: &str = "gpt-4o-mini-transcribe";
```

**Observed result after fix**: the harness shows the subscription call transmitting only the SDP offer, with the session the Gateway built for it — carrying output voice and nothing for input — never reaching the request, which is why the created session does not transcribe. It then shows the transport producing exactly one transcription request for such a session and producing nothing for a session that already transcribes. The realtime Talk suite passes in full, so assistant transcripts, tool calls, control events, video frames, and lifecycle behavior are unchanged. The sibling OpenAI Codex checkout was inspected directly for the protocol contract: its realtime session struct declares input transcription at the same position and its realtime v2 path selects the same `gpt-4o-mini-transcribe` model that this repository's provider-side session policy already uses.

**What was not tested**: no live ChatGPT subscription WebRTC call was placed, because that route needs subscription OAuth credentials this environment does not have; the request shape is proven against production code with the network stubbed, and the payload contract against the provider-side session policy and the Codex protocol source. Repository-wide typecheck was not completed here — the toolchain is terminated by the kernel out-of-memory killer on this 8 GB host — so it is left to CI; lint and formatting were run locally on every changed file.

**Repro confirmation**: with only the test files applied and the production change reverted, all three new tests fail on current `main` — the transport sends nothing for a session created without transcription, and the helper does not exist — and all three pass with the production change applied.

### Risk / Mitigation

- **Risk**: a sparse `session.update` could reset session fields it does not mention, disturbing voice, instructions, or turn detection. **Mitigation**: `session.update` merges by field, and this repository already ships a sparser update of the same `audio.input` object to toggle auto-response mid-conversation; the payload adds one sibling key under that same object.
- **Risk**: the update could reach a protocol that does not accept it. **Mitigation**: it is sent only in response to `session.created`, which is the GA realtime handshake; the frameless GPT-Live protocol announces `session.started` and therefore never triggers it.
- **Risk**: a session that is already transcribing could be reconfigured needlessly. **Mitigation**: the guard reads the server-reported session and returns nothing when input transcription is present, which is the Platform API case; a dedicated test pins it.
- **Risk**: an update sent before the channel is ready would be dropped. **Mitigation**: it is sent while handling a message that arrived on that channel, and the send helper still checks the channel is open.
- **Risk**: configuring after the session starts is later than configuring at call creation, so speech in the moment between the two would not be transcribed. **Mitigation**: `session.created` is the first server event on the connection and is handled synchronously, so the gap closes before a speaker can reach the microphone; delivering the policy at creation instead would require changing how a subscription-authenticated call is posted, which cannot be verified without a live subscription and would fail the connection outright if that shape were rejected.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] UI / DX
- [x] Sessions / storage
- [x] Integrations

### Linked Issue/PR

Fixes #125601
