### PR TITLE
fix(browser): surface initial navigation failures

### DIFF
--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -449,7 +449,6 @@ export async function createPageViaPlaywright(
   const createdTargetId = (await pageTargetInfo(page).catch(() => null))?.targetId ?? null;
   clearBlockedTarget(opts.cdpUrl, createdTargetId ?? undefined);
 
-  // Navigate to the URL
   const targetUrl = opts.url.trim() || "about:blank";
   if (targetUrl !== "about:blank") {
     const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy, {
@@ -459,7 +458,7 @@ export async function createPageViaPlaywright(
       url: targetUrl,
       ...navigationPolicy,
     });
-    let response: Response | null = null;
+    let response: Response | null;
     try {
       response = await gotoPageWithNavigationGuard({
         cdpUrl: opts.cdpUrl,
@@ -471,9 +470,11 @@ export async function createPageViaPlaywright(
         targetId: createdTargetId ?? undefined,
       });
     } catch (err) {
-      if (isPolicyDenyNavigationError(err) || err instanceof BlockedBrowserTargetError) {
-        throw err;
+      if (!isPolicyDenyNavigationError(err) && !(err instanceof BlockedBrowserTargetError)) {
+        // This call owns the new page; best-effort cleanup must not replace its navigation error.
+        await page.close().catch(() => {});
       }
+      throw err;
     }
     // OpenClaw owns this newly-created tab: if the post-navigation safety
     // check trips, close the tab we just spawned.
@@ -498,7 +499,6 @@ export async function createPageViaPlaywright(
     }
   }
 
-  // Get the targetId for this page
   const tid = createdTargetId ?? (await pageTargetInfo(page).catch(() => null))?.targetId ?? null;
   if (!tid) {
     throw new Error("Failed to get targetId for new page");

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -354,23 +354,25 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(pageClose).not.toHaveBeenCalled();
   });
 
-  it("preserves the created tab on ordinary navigation failure", async () => {
+  it("closes the created tab and propagates ordinary navigation failure", async () => {
     const { pageGoto, pageClose } = installBrowserMocks();
-    pageGoto.mockRejectedValueOnce(new Error("page.goto: net::ERR_NAME_NOT_RESOLVED"));
+    const navigationError = new Error("page.goto: net::ERR_NAME_NOT_RESOLVED");
+    pageGoto.mockRejectedValueOnce(navigationError);
 
-    const created = await createPageViaPlaywright({
-      cdpUrl: "http://127.0.0.1:18792",
-      url: "https://93.184.216.34/start",
-    });
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBe(navigationError);
 
-    expect(created.targetId).toBe("TARGET_1");
-    expect(created.url).toBe("about:blank");
     expect(pageGoto).toHaveBeenCalledTimes(1);
-    expect(pageClose).not.toHaveBeenCalled();
+    expect(pageClose).toHaveBeenCalledTimes(1);
   });
 
-  it("does not quarantine a tab when route.continue fails", async () => {
+  it("closes the created tab when guarded route continuation fails", async () => {
     const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    const navigationError = new Error("page.goto: Frame has been detached");
     pageGoto.mockImplementationOnce(async () => {
       await dispatchMockNavigation({
         getRouteHandler,
@@ -378,21 +380,22 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         url: "https://example.com",
         route: {
           continue: vi.fn(async () => {
-            throw new Error("page.goto: Frame has been detached");
+            throw navigationError;
           }),
         },
       });
-      throw new Error("page.goto: Frame has been detached");
+      throw navigationError;
     });
 
-    const created = await createPageViaPlaywright({
-      cdpUrl: "http://127.0.0.1:18792",
-      url: "https://example.com",
-    });
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://example.com",
+      }),
+    ).rejects.toBe(navigationError);
 
-    expect(created.targetId).toBe("TARGET_1");
     expect(pageGoto).toHaveBeenCalledTimes(1);
-    expect(pageClose).not.toHaveBeenCalled();
+    expect(pageClose).toHaveBeenCalledTimes(1);
   });
 
   it("ignores already-handled route races during guarded navigation", async () => {
@@ -443,7 +446,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(pageClose).toHaveBeenCalledTimes(1);
   });
 
-  it("does not quarantine a tab on transient redirect lookup errors", async () => {
+  it("closes the created tab on transient redirect lookup errors", async () => {
     const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
     const assertNavigationAllowedSpy = vi.spyOn(
       navigationGuardModule,
@@ -457,18 +460,35 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     mockBlockedRedirectNavigation({ pageGoto, getRouteHandler, mainFrame });
 
     try {
-      const created = await createPageViaPlaywright({
-        cdpUrl: "http://127.0.0.1:18792",
-        url: "https://93.184.216.34/start",
-      });
+      await expect(
+        createPageViaPlaywright({
+          cdpUrl: "http://127.0.0.1:18792",
+          url: "https://93.184.216.34/start",
+        }),
+      ).rejects.toThrow(/getaddrinfo EAI_AGAIN internal-hop/);
       const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
 
-      expect(created.targetId).toBe("TARGET_1");
-      expect(pages).toHaveLength(1);
-      expect(pageClose).not.toHaveBeenCalled();
+      expect(pages).toHaveLength(0);
+      expect(pageClose).toHaveBeenCalledTimes(1);
     } finally {
       assertNavigationAllowedSpy.mockRestore();
     }
+  });
+
+  it("preserves the navigation error when closing the created tab fails", async () => {
+    const { pageGoto, pageClose } = installBrowserMocks();
+    const navigationError = new Error("page.goto: net::ERR_CONNECTION_REFUSED");
+    pageGoto.mockRejectedValueOnce(navigationError);
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBe(navigationError);
+
+    expect(pageClose).toHaveBeenCalledTimes(1);
   });
 
   it("does not quarantine a tab on transient post-navigation check errors", async () => {

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -302,6 +302,25 @@ describe("browser tab routes", () => {
     expect(forProfile).not.toHaveBeenCalled();
   });
 
+  it("returns tab-open navigation failures instead of a success payload", async () => {
+    const navigationError = new Error("page.goto: net::ERR_NAME_NOT_RESOLVED");
+    const profileCtx = createProfileContext({
+      openTab: vi.fn(async () => {
+        throw navigationError;
+      }),
+    });
+
+    const response = await callTabsRoute({
+      method: "post",
+      path: "/tabs/open",
+      body: { url: "https://unresolved.example" },
+      profileCtx,
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toEqual({ error: String(navigationError) });
+  });
+
   it("returns browser-not-running for close when the browser is not reachable", async () => {
     await expectBrowserNotRunningAction("close");
   });


### PR DESCRIPTION
## What Problem This Solves
The Playwright browser-session open path swallowed ordinary initial `page.goto()` failures and returned the newly created page as normal success—often an `about:blank` tab. DNS failures, refused connections, and guarded-route continuation errors could therefore produce a successful Browser `open` response even though the requested URL never committed.

## Why This Change Was Made
The page-creation owner now closes only its newly owned page on ordinary initial navigation failure and rethrows the original error. Cleanup is best-effort and cannot mask the navigation error. Existing SSRF/policy-deny handling, explicit direct-CDP unadopted-target behavior, Chrome MCP cleanup, and existing-page navigation remain unchanged.

## User Impact
Browser `open` now reports the real navigation failure instead of returning a valid-looking blank tab. Failed opens also do not leak the tab created for the attempt.

## Evidence
- Pre-fix regression demonstrated false success after `ERR_NAME_NOT_RESOLVED`.
- Post-fix 68 focused navigation-guard and tab-route tests pass.
- Extension production/test tsgo, oxfmt, oxlint, architecture checks and build pass.
- Production LOC +5/-5; tests +65/-26.
- Final Codex autoreview clean 0.98, no actionable findings.
