### PR TITLE
refactor(ui): make task detail a detail-slot document

### DIFF
--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -45,7 +45,7 @@ import {
 } from "./chat-state-route.ts";
 import type { ChatProps } from "./chat-view.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
-import { detailSlotOpen } from "./components/chat-detail-slot.ts";
+import { openTaskDetailId } from "./components/chat-detail-slot.ts";
 import { chatPullRequestId, createPullRequestBranch } from "./components/chat-pull-requests.ts";
 import {
   createSessionWorkspaceProps,
@@ -241,10 +241,7 @@ export class ChatPane extends ChatPaneLayoutRender {
     };
     const backgroundTasksBase = createBackgroundTasksProps(state, {
       narrowLayout: false,
-      openTaskId:
-        state.sidebarContent?.kind === "task" && detailSlotOpen(sidebarLayout)
-          ? state.sidebarContent.taskId
-          : undefined,
+      openTaskId: openTaskDetailId(state.sidebarContent, sidebarLayout),
       onOpenTaskDetail: (task) => state.handleOpenSidebar({ kind: "task", taskId: task.id }),
     });
     const backgroundTasks = {

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -6,7 +6,7 @@ import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import "./chat-sidebar.ts";
 import { openSessionWorkspaceFile, revealSessionWorkspaceFile } from "./chat-session-workspace.ts";
 import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar.ts";
-import { resetTaskDetail } from "./chat-task-detail-state.ts";
+import { resetTaskDetail, type TaskDetailHost } from "./chat-task-detail-state.ts";
 import { renderTaskDetailPanel } from "./chat-task-detail.ts";
 import type { ChatTranscriptController } from "./chat-transcript-controller.ts";
 
@@ -34,9 +34,10 @@ export function renderChatDetailSlot(params: {
   transcript: ChatTranscriptController;
 }): TemplateResult {
   const { content, host } = params;
+  const taskDetailHost: TaskDetailHost = host;
   const taskId = openTaskDetailId(content, params.layout);
-  if (taskId === undefined) {
-    resetTaskDetail(host);
+  if (taskId === undefined && taskDetailHost.taskDetailState !== undefined) {
+    resetTaskDetail(taskDetailHost);
   }
   const documents: Partial<Record<SidebarContent["kind"], TemplateResult>> = {
     task:

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -17,6 +17,13 @@ export function detailSlotOpen(layout: SidebarLayout): boolean {
   return layout.columns.some((column) => column.panels.some((panel) => panel.slot === "detail"));
 }
 
+export function openTaskDetailId(
+  content: SidebarContent | null | undefined,
+  layout: SidebarLayout,
+): string | undefined {
+  return content?.kind === "task" && detailSlotOpen(layout) ? content.taskId : undefined;
+}
+
 export function renderChatDetailSlot(params: {
   backgroundTasks: BackgroundTasksProps;
   chat: ChatProps;
@@ -27,38 +34,43 @@ export function renderChatDetailSlot(params: {
   transcript: ChatTranscriptController;
 }): TemplateResult {
   const { content, host } = params;
-  if (content.kind === "task") {
-    if (!detailSlotOpen(params.layout)) {
-      resetTaskDetail(host);
-      return html``;
-    }
-    return renderTaskDetailPanel({
-      backgroundTasks: params.backgroundTasks,
-      chat: params.chat,
-      host,
-      task: params.backgroundTasks.tasks?.find((task) => task.id === content.taskId) ?? undefined,
-      transcript: params.transcript,
-    });
+  const taskId = openTaskDetailId(content, params.layout);
+  if (taskId === undefined) {
+    resetTaskDetail(host);
   }
-  resetTaskDetail(host);
-  return html`<openclaw-chat-detail-panel
-    class="chat-sidebar"
-    .content=${content}
-    .basePath=${params.chat.basePath ?? ""}
-    .loadFullMessage=${params.fullMessageLoader}
-    .canvasPluginSurfaceUrl=${host.canvasPluginSurfaceUrl}
-    .embedSandboxMode=${host.embedSandboxMode}
-    .allowExternalEmbedUrls=${host.allowExternalEmbedUrls}
-    .onOpenWorkspaceFile=${(target: { path: string; line?: number | null }) =>
-      openSessionWorkspaceFile(host, target)}
-    .onOpenSessionLink=${params.chat.onOpenSessionLink}
-    .onRevealInWorkspace=${(path: string) => {
-      revealSessionWorkspaceFile(host, path);
-      host.updateSidebarLayout(openSlot(host.sidebarLayout, "workspace"));
-    }}
-    .onOpenImage=${(item: Parameters<typeof host.handleOpenImage>[0]) =>
-      host.handleOpenImage(item, host.beginImageOpen())}
-    .embedded=${true}
-    @chat-detail-panel-close=${() => host.handleCloseSidebar()}
-  ></openclaw-chat-detail-panel>`;
+  const documents: Partial<Record<SidebarContent["kind"], TemplateResult>> = {
+    task:
+      taskId === undefined
+        ? html``
+        : renderTaskDetailPanel({
+            backgroundTasks: params.backgroundTasks,
+            chat: params.chat,
+            host,
+            task: params.backgroundTasks.tasks?.find((task) => task.id === taskId) ?? undefined,
+            transcript: params.transcript,
+          }),
+  };
+  return (
+    documents[content.kind] ??
+    html`<openclaw-chat-detail-panel
+      class="chat-sidebar"
+      .content=${content}
+      .basePath=${params.chat.basePath ?? ""}
+      .loadFullMessage=${params.fullMessageLoader}
+      .canvasPluginSurfaceUrl=${host.canvasPluginSurfaceUrl}
+      .embedSandboxMode=${host.embedSandboxMode}
+      .allowExternalEmbedUrls=${host.allowExternalEmbedUrls}
+      .onOpenWorkspaceFile=${(target: { path: string; line?: number | null }) =>
+        openSessionWorkspaceFile(host, target)}
+      .onOpenSessionLink=${params.chat.onOpenSessionLink}
+      .onRevealInWorkspace=${(path: string) => {
+        revealSessionWorkspaceFile(host, path);
+        host.updateSidebarLayout(openSlot(host.sidebarLayout, "workspace"));
+      }}
+      .onOpenImage=${(item: Parameters<typeof host.handleOpenImage>[0]) =>
+        host.handleOpenImage(item, host.beginImageOpen())}
+      .embedded=${true}
+      @chat-detail-panel-close=${() => host.handleCloseSidebar()}
+    ></openclaw-chat-detail-panel>`
+  );
 }

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -147,16 +147,19 @@ function setRetainedFileDraft(content: FileSidebarContent, draft: RetainedFileDr
   retainedFileDrafts.set(key, draft);
 }
 
-type ChatDetailContent =
+export type SidebarContent =
   | MarkdownSidebarContent
   | CanvasSidebarContent
   | ImageSidebarContent
   | FileSidebarContent
-  | SessionDiffSidebarContent;
+  | SessionDiffSidebarContent
+  | { kind: "task"; taskId: string };
 
-export type SidebarContent = ChatDetailContent | { kind: "task"; taskId: string };
+type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
 
-function hasFullMessageRequest(content: ChatDetailContent): content is ChatDetailContent & {
+function hasFullMessageRequest(
+  content: ChatDetailPanelContent,
+): content is ChatDetailPanelContent & {
   fullMessageRequest: SidebarFullMessageRequest;
 } {
   return Boolean(
@@ -192,8 +195,8 @@ function toPlainTextCodeFence(value: string, language = ""): string {
 }
 
 function buildRawSidebarContent(
-  content: ChatDetailContent | null | undefined,
-): ChatDetailContent | null {
+  content: ChatDetailPanelContent | null | undefined,
+): ChatDetailPanelContent | null {
   if (!content) {
     return null;
   }
@@ -501,7 +504,7 @@ function renderFileSidebarContent(
 }
 
 function resolveSidebarCanvasSandbox(
-  content: ChatDetailContent,
+  content: ChatDetailPanelContent,
   embedSandboxMode: EmbedSandboxMode,
 ): string {
   return content.kind === "canvas"
@@ -510,7 +513,7 @@ function resolveSidebarCanvasSandbox(
 }
 
 type MarkdownSidebarProps = {
-  content: ChatDetailContent | null;
+  content: ChatDetailPanelContent | null;
   error: string | null;
   fileView?: FileViewControls;
   onClose: () => void;
@@ -699,7 +702,7 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
 }
 
 class ChatDetailPanel extends OpenClawLightDomElement {
-  @property({ attribute: false }) content: ChatDetailContent | null = null;
+  @property({ attribute: false }) content: ChatDetailPanelContent | null = null;
   @property({ attribute: false }) loadFullMessage?: SidebarFullMessageLoader | null = null;
   @property() basePath = "";
   @property() canvasPluginSurfaceUrl: string | null = null;
@@ -714,7 +717,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   @property({ attribute: false }) onRevealInWorkspace?: ((path: string) => void) | null = null;
   @property({ attribute: false }) onOpenImage?: ((item: ImageLightboxItem) => void) | null = null;
 
-  @state() private visibleContent: ChatDetailContent | null = null;
+  @state() private visibleContent: ChatDetailPanelContent | null = null;
   @state() private error: string | null = null;
   @state() private fileSearchOpen = false;
   @state() private fileSearchQuery = "";
@@ -1244,7 +1247,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       });
   };
 
-  private async upgradeToFullMessage(content: ChatDetailContent, version: number) {
+  private async upgradeToFullMessage(content: ChatDetailPanelContent, version: number) {
     if (!hasFullMessageRequest(content) || !this.loadFullMessage) {
       return;
     }

--- a/ui/src/pages/chat/components/chat-task-detail-state.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
+import type { ChatPageHost } from "../chat-state-host.ts";
+import type { ChatProps } from "../chat-view.ts";
+import { closeSlot, openSlot, type SidebarLayout } from "../sidebar-layout.ts";
+import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
+import { renderChatDetailSlot } from "./chat-detail-slot.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
+import * as taskDetailState from "./chat-task-detail-state.ts";
 import {
   observeTaskDetailEvent,
   readTaskTranscript,
   type TaskDetailHost,
 } from "./chat-task-detail-state.ts";
+import type { ChatTranscriptController } from "./chat-transcript-controller.ts";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -49,6 +57,55 @@ function task(status: TaskSummary["status"]): TaskSummary {
   };
 }
 
+function backgroundTasks(selectedTask: TaskSummary): BackgroundTasksProps {
+  return {
+    sessionKey: "agent:main:main",
+    statusRowId: "chat-tasks-status-test",
+    collapsed: false,
+    narrowLayout: false,
+    connected: true,
+    canCancel: false,
+    loading: false,
+    error: null,
+    tasks: [selectedTask],
+    subagentActivity: {
+      rows: [],
+      overflowWorking: 0,
+      taskIds: new Set(),
+      nextExpiryAt: null,
+    },
+    taskDetails: new Map(),
+    taskDetailErrors: new Map(),
+    taskDetailLoadingIds: new Set(),
+    cancellingTaskIds: new Set(),
+    finishedCollapsed: false,
+    onToggleCollapsed: () => undefined,
+    onToggleFinished: () => undefined,
+    onRefresh: () => undefined,
+    onCancel: () => undefined,
+  };
+}
+
+const taskContent = { kind: "task", taskId: "task-1" } satisfies SidebarContent;
+const fileContent = {
+  kind: "file",
+  path: "notes.txt",
+  name: "notes.txt",
+  content: "Non-task detail",
+} satisfies SidebarContent;
+
+function renderDetail(host: TaskDetailHost, content: SidebarContent, layout: SidebarLayout) {
+  renderChatDetailSlot({
+    backgroundTasks: backgroundTasks(task("running")),
+    chat: { paneId: "pane-1" } as ChatProps,
+    content,
+    fullMessageLoader: null,
+    host: host as ChatPageHost,
+    layout,
+    transcript: {} as ChatTranscriptController,
+  });
+}
+
 async function flushAsync() {
   await Promise.resolve();
   await Promise.resolve();
@@ -60,6 +117,52 @@ afterEach(() => {
 });
 
 describe("task detail transcript state", () => {
+  it.each([
+    {
+      label: "the detail slot closes",
+      nextContent: taskContent,
+      nextLayout: closeSlot(openSlot({ columns: [] }, "detail"), "detail"),
+    },
+    {
+      label: "the detail slot switches to a file",
+      nextContent: fileContent,
+      nextLayout: openSlot({ columns: [] }, "detail"),
+    },
+  ])("clears transcript state when $label", ({ nextContent, nextLayout }) => {
+    const pending = deferred<never>();
+    const host = hostWith(vi.fn().mockReturnValue(pending.promise));
+    const openDetailLayout = openSlot({ columns: [] }, "detail");
+
+    renderDetail(host, taskContent, openDetailLayout);
+    expect(host.taskDetailState).toBeDefined();
+
+    renderDetail(host, nextContent, nextLayout);
+    expect(host.taskDetailState).toBeUndefined();
+  });
+
+  it("does not reset transcript state during stable task or non-task renders", () => {
+    const pending = deferred<never>();
+    const request = vi.fn().mockReturnValue(pending.promise);
+    const host = hostWith(request);
+    const openDetailLayout = openSlot({ columns: [] }, "detail");
+    const reset = vi.spyOn(taskDetailState, "resetTaskDetail");
+
+    renderDetail(host, taskContent, openDetailLayout);
+    const openTaskState = host.taskDetailState;
+    renderDetail(host, taskContent, openDetailLayout);
+
+    expect(host.taskDetailState).toBe(openTaskState);
+    expect(request).toHaveBeenCalledOnce();
+    expect(reset).not.toHaveBeenCalled();
+
+    renderDetail(host, fileContent, openDetailLayout);
+    expect(host.taskDetailState).toBeUndefined();
+    expect(reset).toHaveBeenCalledOnce();
+
+    renderDetail(host, fileContent, openDetailLayout);
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
   it("loads the selected child transcript", async () => {
     const pending = deferred<ReturnType<typeof history>>();
     const request = vi.fn().mockReturnValue(pending.promise);


### PR DESCRIPTION
## What Problem This Solves

The five-PR sidebar contract series (#124950, #125019, #125105, #125138, #125174) gave every chat side-panel
slot one declaration carrying availability, content, empty state, and header action. One corner stayed
outside it.

`SidebarContent` was `ChatDetailContent | { kind: "task"; taskId: string }`, so the detail slot was
*sometimes a document and sometimes a special mode*. `renderChatDetailSlot` branched on
`content.kind === "task"`, `resetTaskDetail(host)` was called down **both** arms of that conditional, and
`chat-pane-render.ts` independently re-derived the same condition
(`state.sidebarContent?.kind === "task" && detailSlotOpen(...)`) for rail highlighting. One fact, asserted in
three places — the exact scattering the series existed to remove, and the same shape that produced the
original Review bug in #124824.

## Why This Change Was Made

`SidebarContent` is now a single document union dispatched through a typed content-to-template table, and
`openTaskDetailId` is the one source deriving task visibility for both rendering and rail highlighting. The
outer union special case, the task branch, the duplicated per-branch resets, and the duplicate condition in
`chat-pane-render.ts` are all deleted. Slot-level `resetTaskDetail` runs once before dispatch; the separate
state-machine and pane-retirement resets are untouched.

## User Impact

None. The task detail panel renders exactly as before, with the same teardown semantics.

## Evidence

The refactor restructured a lifecycle that had **no test**: nothing asserted transcript-state teardown on
slot close or on switching away from a task. Since a leaked transcript controller fails silently, that gap
was closed before landing rather than after.

New coverage in `ui/src/pages/chat/components/chat-task-detail-state.test.ts` asserts the contract by
observable state, not just call counts:

- teardown on slot close while showing a task;
- teardown when switching task → file document;
- **no** spurious reset — stable state identity across re-renders keeping the same task open, and a tight
  spy across repeated non-task renders.

The honest control: the pre-refactor arrangement could not serve as a failing baseline, because it reset in
both branches too. Suppressing the reset instead made all three lifecycle cases fail with leaked state,
which demonstrates the test actually bites.

```
focused unit: 21/21 passed
both E2E suites: 3/3 passed
```

`background-tasks.e2e` passed on one retry after an unrelated fixture timeout. `pnpm check:changed` green;
Codex autoreview clean. No existing test was edited.

**reviewMetrics — production vs test LOC**: production `+63 / −50` (net **+13**), tests `+103`. The growth is
the centralized selector, the typed dispatch table, and an explicit classic-panel subset — bought against
three scattered assertions of one fact, plus a lifecycle that is now guarded instead of assumed.

No `CHANGELOG.md` edit — release-only per repo policy; behavior-neutral.
