### PR TITLE
fix(config): redact plugin secrets and preserve safe mutations

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -461,13 +461,13 @@ After every successful `config set` / `config patch` / `config unset`, the CLI p
 | `Change will apply without restarting the gateway.` | Hot reload picks it up automatically.  |
 | `No gateway restart needed.`                        | Nothing runtime-relevant changed.      |
 
-Effective changes to `plugins.entries` (or any subpath) require a restart, since the CLI cannot prove every plugin's reload metadata is loaded. Idempotent writes with no effective diff report `No gateway restart needed.`
+Effective changes to `plugins.entries` (or any subpath) require a restart, since the CLI cannot prove every plugin's reload metadata is loaded. An authored `config set` or `config unset` no-op prints `No change` and leaves the JSON5 file byte-for-byte untouched. Setting an absent key to a value equal to its runtime default is still an authored change and persists the explicit value.
 
 ## Write safety
 
 `openclaw config set` and other OpenClaw-owned config writers validate the full post-change config before committing it to disk. If the new payload fails schema validation or looks like a destructive clobber, the active config is left alone and the rejected payload is saved beside it as `openclaw.json.rejected.*`.
 
-OpenClaw-owned writes reserialize JSON5 as standard JSON. When the source contains comments, the writer warns immediately before removing them; use a direct editor when preserving comments matters.
+OpenClaw-owned writes that change config reserialize JSON5 as standard JSON. When the source contains comments, the writer warns immediately before removing them; use a direct editor when preserving comments matters.
 
 <Warning>
 The active config path must be a regular file. Symlinked `openclaw.json` layouts are unsupported for writes; use `OPENCLAW_CONFIG_PATH` to point directly at the real file instead.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -103,7 +103,7 @@ machine-output spelling and keeps stdout reserved for the schema document.
 
 ### `config validate`
 
-Validates the current config against the active schema without starting the gateway.
+Validates the current config against the active schema without starting the gateway. It also checks provider/source compatibility for every registry-declared SecretRef, including disabled plugin or channel configuration. This strict command can report an inactive mismatch that does not block normal Gateway startup, where SecretRef resolution remains limited to effectively active surfaces.
 
 ```bash
 openclaw config validate

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { replaceConfigFile } from "../config/config.js";
 import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
@@ -42,7 +43,7 @@ import {
   collectPluginIntegrationProviderErrors,
   dedupeDryRunErrors,
   formatDryRunFailureMessage,
-  loadValidConfig,
+  loadValidConfigForWrite,
   selectDryRunRefsForResolution,
 } from "./config-cli-validation.js";
 import { checkTouchedTextModelRefs } from "./config-model-validation.js";
@@ -291,7 +292,8 @@ export async function runConfigOperations(params: {
   if (autoManagedTargets.length > 0) {
     throw new Error(formatAutoManagedMetaError(autoManagedTargets));
   }
-  const snapshot = await loadValidConfig(runtime);
+  const mutationStart = await loadValidConfigForWrite(runtime);
+  const { snapshot } = mutationStart;
   // Mutate resolved config so runtime defaults never leak into the authored file.
   const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
   const currentConfig = normalizeConfigMutationModelRefs(
@@ -339,7 +341,6 @@ export async function runConfigOperations(params: {
     config: nextConfig,
     operations,
   });
-
   if (options.dryRun) {
     const hasJsonMode = operations.some(({ inputMode }) => inputMode === "json");
     const hasBuilderMode = operations.some(({ inputMode }) => inputMode === "builder");
@@ -451,6 +452,10 @@ export async function runConfigOperations(params: {
       ].join("\n"),
     );
   }
+  if (params.successMode === "set" && isDeepStrictEqual(currentConfig, nextConfig)) {
+    runtime.log(info("No change"));
+    return;
+  }
   const modelRefCheck = await checkTouchedTextModelRefs({
     config: nextConfig,
     previousConfig: currentConfig,
@@ -463,8 +468,10 @@ export async function runConfigOperations(params: {
 
   await replaceConfigFile({
     nextConfig,
+    snapshot,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
     writeOptions: {
+      ...mutationStart.writeOptions,
       auditOrigin: "cli",
       ...(unsetPaths.length > 0 ? { unsetPaths } : {}),
       ...(normalizedExplicitSetPaths.length > 0

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -36,6 +36,7 @@ import {
   unsetAtPath,
 } from "./config-cli-path.js";
 import {
+  assertStrictConfigForMutation,
   collectDryRunRefs,
   collectDryRunResolvabilityErrors,
   collectDryRunSchemaErrors,
@@ -369,7 +370,12 @@ export async function runConfigOperations(params: {
     }
     errors.push(...pluginIntegrationErrors);
     if (requiresFullSchemaValidation) {
-      errors.push(...collectDryRunSchemaErrors(nextConfig));
+      errors.push(
+        ...collectDryRunSchemaErrors(
+          nextConfig,
+          mutationStart.writeOptions.basePluginMetadataSnapshot,
+        ),
+      );
     }
     if (checksRefs) {
       errors.push(
@@ -453,6 +459,10 @@ export async function runConfigOperations(params: {
     );
   }
   if (params.successMode === "set" && isDeepStrictEqual(currentConfig, nextConfig)) {
+    assertStrictConfigForMutation(
+      nextConfig,
+      mutationStart.writeOptions.basePluginMetadataSnapshot,
+    );
     runtime.log(info("No change"));
     return;
   }

--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -14,6 +14,7 @@ import {
 import { validateConfigObjectRawWithPlugins } from "../config/validation.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { type RuntimeEnv, defaultRuntime, writeRuntimeJson } from "../runtime.js";
 import {
   isPluginIntegrationSecretProviderConfig,
@@ -86,6 +87,20 @@ export async function loadValidConfigForWrite(runtime: RuntimeEnv = defaultRunti
 }
 
 export { formatInvalidConfigRepairHint };
+
+export function strictlyValidateConfigSnapshotForCli(
+  snapshot: ConfigFileSnapshot,
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">,
+): ConfigFileSnapshot {
+  if (!snapshot.valid) {
+    return snapshot;
+  }
+  const validated = validateConfigObjectRawWithPlugins(snapshot.sourceConfig, {
+    semanticValidation: "strict",
+    pluginMetadataSnapshot,
+  });
+  return validated.ok ? snapshot : { ...snapshot, valid: false, issues: validated.issues };
+}
 
 function collectSecretRefsFromUnknown(value: unknown): SecretRef[] {
   const refs: SecretRef[] = [];
@@ -230,8 +245,14 @@ export function selectDryRunRefsForResolution(params: {
   return { refsToResolve, skippedExecRefs };
 }
 
-export function collectDryRunSchemaErrors(config: OpenClawConfig): ConfigSetDryRunError[] {
-  const validated = validateConfigObjectRawWithPlugins(config);
+function collectStrictConfigErrors(
+  config: OpenClawConfig,
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">,
+): ConfigSetDryRunError[] {
+  const validated = validateConfigObjectRawWithPlugins(config, {
+    semanticValidation: "strict",
+    pluginMetadataSnapshot,
+  });
   if (validated.ok) {
     return [];
   }
@@ -239,6 +260,26 @@ export function collectDryRunSchemaErrors(config: OpenClawConfig): ConfigSetDryR
     kind: "schema",
     message,
   }));
+}
+
+export function assertStrictConfigForMutation(
+  config: OpenClawConfig,
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">,
+): void {
+  const errors = collectStrictConfigErrors(config, pluginMetadataSnapshot);
+  if (errors.length === 0) {
+    return;
+  }
+  throw new Error(
+    ["Config validation failed.", ...errors.map((error) => `- ${error.message}`)].join("\n"),
+  );
+}
+
+export function collectDryRunSchemaErrors(
+  config: OpenClawConfig,
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">,
+): ConfigSetDryRunError[] {
+  return collectStrictConfigErrors(config, pluginMetadataSnapshot);
 }
 
 function touchesSecretProviderCollection(path: readonly string[]): boolean {

--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -1,6 +1,6 @@
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ConfigFileSnapshot } from "../config/config.js";
-import { readConfigFileSnapshot } from "../config/config.js";
+import { readConfigFileSnapshot, readConfigFileSnapshotForWrite } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
@@ -42,6 +42,31 @@ function formatInvalidConfigRepairHint(
     : `Run \`${formatCliCommand("openclaw doctor --fix")}\` ${doctorMessage}`;
 }
 
+export function ensureValidConfigSnapshotForCli(
+  snapshot: ConfigFileSnapshot,
+  runtime: RuntimeEnv,
+  options: { json?: boolean } = {},
+): boolean {
+  if (snapshot.valid) {
+    return true;
+  }
+  if (options.json) {
+    writeRuntimeJson(runtime, {
+      ...formatCliJsonFailure(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`),
+      issues: normalizeConfigIssues(snapshot.issues),
+    });
+    runtime.exit(1);
+    return false;
+  }
+  runtime.error(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`);
+  for (const line of renderConfigValidationIssueLines(snapshot)) {
+    runtime.error(line);
+  }
+  runtime.error(formatInvalidConfigRepairHint(snapshot, "to repair, then retry."));
+  runtime.exit(1);
+  return false;
+}
+
 export async function loadValidConfig(
   runtime: RuntimeEnv = defaultRuntime,
   options: { observe?: boolean; json?: boolean } = {},
@@ -50,24 +75,14 @@ export async function loadValidConfig(
     options.observe === false
       ? await readConfigFileSnapshot({ observe: false })
       : await readConfigFileSnapshot();
-  if (snapshot.valid) {
-    return snapshot;
-  }
-  if (options.json) {
-    writeRuntimeJson(runtime, {
-      ...formatCliJsonFailure(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`),
-      issues: normalizeConfigIssues(snapshot.issues),
-    });
-    runtime.exit(1);
-    return snapshot;
-  }
-  runtime.error(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`);
-  for (const line of renderConfigValidationIssueLines(snapshot)) {
-    runtime.error(line);
-  }
-  runtime.error(formatInvalidConfigRepairHint(snapshot, "to repair, then retry."));
-  runtime.exit(1);
+  ensureValidConfigSnapshotForCli(snapshot, runtime, options);
   return snapshot;
+}
+
+export async function loadValidConfigForWrite(runtime: RuntimeEnv = defaultRuntime) {
+  const prepared = await readConfigFileSnapshotForWrite();
+  ensureValidConfigSnapshotForCli(prepared.snapshot, runtime);
+  return prepared;
 }
 
 export { formatInvalidConfigRepairHint };

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -5,14 +5,22 @@ import path from "node:path";
 import { Command } from "commander";
 import JSON5 from "json5";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as configRuntime from "../config/config.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { REDACTED_SENTINEL } from "../config/redact-snapshot.js";
 import * as runtimeSchema from "../config/runtime-schema.js";
 import { defaultRuntime } from "../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { registerConfigCli, runConfigGet, runConfigSet, runConfigUnset } from "./config-cli.js";
+import {
+  registerConfigCli,
+  runConfigGet,
+  runConfigPatch,
+  runConfigSet,
+  runConfigUnset,
+} from "./config-cli.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const registeredRuntimeLogs: string[] = [];
 const registeredRuntimeErrors: string[] = [];
 
@@ -82,7 +90,7 @@ async function withConfigFileHarness(
   raw: string,
   run: (params: { configPath: string; tempDir: string }) => Promise<void>,
 ): Promise<void> {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const tempDir = tempDirs.make(prefix);
   const configPath = path.join(tempDir, "openclaw.json");
   const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
   try {
@@ -96,7 +104,6 @@ async function withConfigFileHarness(
     envSnapshot.restore();
     clearConfigCache();
     clearRuntimeConfigSnapshot();
-    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -146,7 +153,7 @@ async function withExecDryRunConfigHarness(
     runtime: ReturnType<typeof createTestRuntime>;
   }) => Promise<void>,
 ) {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const tempDir = tempDirs.make(prefix);
   const configPath = path.join(tempDir, "openclaw.json");
   const batchPath = path.join(tempDir, "batch.json");
   const markerPath = path.join(tempDir, "marker.txt");
@@ -184,7 +191,6 @@ async function withExecDryRunConfigHarness(
     envSnapshot.restore();
     clearConfigCache();
     clearRuntimeConfigSnapshot();
-    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -348,6 +354,45 @@ describe("config cli integration", () => {
     );
   });
 
+  it("rejects impossible provider/source refs during real config patch", async () => {
+    const raw = `${JSON.stringify(
+      {
+        channels: {
+          discord: {
+            enabled: false,
+            token: { source: "env", provider: "shared", id: "DISCORD_TEST_TOKEN" },
+          },
+        },
+        secrets: {
+          defaults: { env: "shared" },
+          providers: {
+            shared: { source: "file", path: "/tmp/openclaw-unused-secrets.json", mode: "json" },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-patch-source-mismatch-",
+      raw,
+      async ({ configPath, tempDir }) => {
+        const patchPath = path.join(tempDir, "patch.json5");
+        fs.writeFileSync(patchPath, "{ secrets: { defaults: { env: null } } }\n", "utf8");
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigPatch({ cliOptions: { file: patchPath }, runtime: output.runtime }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        expect(output.errors.join("\n")).toContain(
+          'provider "shared" has source "file" but ref requests "env"',
+        );
+      },
+    );
+  });
+
   it("rejects impossible provider/source refs during real config validate", async () => {
     const refId = "DISCORD_TEST_TOKEN";
     await withConfigFileHarness(
@@ -375,8 +420,8 @@ describe("config cli integration", () => {
       )}\n`,
       async () => {
         const snapshot = await configRuntime.readConfigFileSnapshot({ observe: false });
-        expect(snapshot.valid).toBe(false);
-        expect(JSON.stringify(snapshot.issues)).not.toContain(refId);
+        expect(snapshot.valid).toBe(true);
+        expect(snapshot.issues).toStrictEqual([]);
 
         await expect(runRegisteredConfigCommand(["config", "validate"])).rejects.toThrow(
           "__exit__:1",
@@ -386,6 +431,101 @@ describe("config cli integration", () => {
           'Secret provider "shared" has source "file" but ref requests "exec"',
         );
         expect(registeredRuntimeErrors.join("\n")).not.toContain(refId);
+      },
+    );
+  });
+
+  it("allows a config set that repairs an inactive provider/source mismatch", async () => {
+    const raw = `${JSON.stringify(
+      {
+        channels: {
+          discord: {
+            enabled: false,
+            token: { source: "exec", provider: "shared", id: "discord/token" },
+          },
+        },
+        secrets: {
+          providers: {
+            shared: { source: "file", path: "/tmp/openclaw-unused-secrets.json", mode: "json" },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-repair-source-mismatch-",
+      raw,
+      async ({ configPath }) => {
+        const output = createTestRuntime();
+
+        await runConfigSet({
+          path: "channels.discord.token",
+          value: '{"source":"file","provider":"shared","id":"/discord/token"}',
+          cliOptions: { strictJson: true },
+          runtime: output.runtime,
+        });
+
+        expect(output.errors).toStrictEqual([]);
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({
+          channels: {
+            discord: {
+              token: { source: "file", provider: "shared", id: "/discord/token" },
+            },
+          },
+        });
+      },
+    );
+  });
+
+  it.each([
+    {
+      name: "setting an authored value to itself",
+      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
+        runConfigSet({
+          path: "gateway.port",
+          value: "18789",
+          cliOptions: { strictJson: true },
+          runtime,
+        }),
+    },
+    {
+      name: "unsetting an absent authored value",
+      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
+        runConfigUnset({ path: "gateway.bind", runtime }),
+    },
+  ])("strictly validates an existing mismatch when $name is a no-op", async (testCase) => {
+    const raw = `${JSON.stringify(
+      {
+        gateway: { port: 18789 },
+        channels: {
+          discord: {
+            enabled: false,
+            token: { source: "exec", provider: "shared", id: "discord/token" },
+          },
+        },
+        secrets: {
+          providers: {
+            shared: { source: "file", path: "/tmp/openclaw-unused-secrets.json", mode: "json" },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-noop-source-mismatch-",
+      raw,
+      async ({ configPath }) => {
+        const output = createTestRuntime();
+
+        await expect(testCase.run(output.runtime)).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        expect(output.logs).not.toContain("No change");
+        expect(output.errors.join("\n")).toContain(
+          'provider "shared" has source "file" but ref requests "exec"',
+        );
       },
     );
   });

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -2,14 +2,22 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Command } from "commander";
 import JSON5 from "json5";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as configRuntime from "../config/config.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { REDACTED_SENTINEL } from "../config/redact-snapshot.js";
+import * as runtimeSchema from "../config/runtime-schema.js";
+import { defaultRuntime } from "../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { runConfigSet } from "./config-cli.js";
+import { registerConfigCli, runConfigGet, runConfigSet, runConfigUnset } from "./config-cli.js";
+
+const registeredRuntimeLogs: string[] = [];
+const registeredRuntimeErrors: string[] = [];
 
 // Config mutation owns these assertions; plugin discovery suites own registry breadth.
-// Keep the two real schemas this suite exercises, but build their metadata only once.
+// Keep the real schemas this suite exercises, but build their metadata only once.
 vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
   let snapshot: ReturnType<typeof actual.loadPluginMetadataSnapshot> | undefined;
@@ -20,7 +28,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
     ) => {
       snapshot ??= actual.loadPluginMetadataSnapshot({
         ...params,
-        pluginIds: ["discord", "openclaw-mem0"],
+        pluginIds: ["codex", "discord", "openclaw-mem0"],
         pluginIdScope: undefined,
       });
       return snapshot;
@@ -42,6 +50,54 @@ function createTestRuntime() {
       },
     },
   };
+}
+
+async function runRegisteredConfigCommand(args: string[]): Promise<void> {
+  vi.spyOn(defaultRuntime, "log").mockImplementation((...values: unknown[]) => {
+    registeredRuntimeLogs.push(values.map(String).join(" "));
+  });
+  vi.spyOn(defaultRuntime, "error").mockImplementation((...values: unknown[]) => {
+    registeredRuntimeErrors.push(values.map(String).join(" "));
+  });
+  vi.spyOn(defaultRuntime, "exit").mockImplementation((code: number) => {
+    throw new Error(`__exit__:${code}`);
+  });
+  const program = new Command();
+  program.exitOverride();
+  registerConfigCli(program);
+  await program.parseAsync(args, { from: "user" });
+}
+
+function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
+  const readSchema = runtimeSchema.readBestEffortRuntimeConfigSchema;
+  vi.spyOn(runtimeSchema, "readBestEffortRuntimeConfigSchema").mockImplementation(async () => {
+    const result = await readSchema();
+    await hook();
+    return result;
+  });
+}
+
+async function withConfigFileHarness(
+  prefix: string,
+  raw: string,
+  run: (params: { configPath: string; tempDir: string }) => Promise<void>,
+): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const configPath = path.join(tempDir, "openclaw.json");
+  const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
+  try {
+    fs.writeFileSync(configPath, raw, "utf8");
+    setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    await run({ configPath, tempDir });
+  } finally {
+    envSnapshot.restore();
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 }
 
 function createExecDryRunBatch(params: { markerPath: string }) {
@@ -133,6 +189,292 @@ async function withExecDryRunConfigHarness(
 }
 
 describe("config cli integration", () => {
+  afterEach(() => {
+    registeredRuntimeLogs.length = 0;
+    registeredRuntimeErrors.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("redacts SecretRef ids and plugin-only sensitive fields in JSON/text order", async () => {
+    const secretRefId = "CONFIG_GET_TEST_TOKEN";
+    const schemaOnlySecrets = ["first-private-route", "second-private-route"];
+    await withConfigFileHarness(
+      "openclaw-config-cli-get-redaction-",
+      `${JSON.stringify(
+        {
+          channels: {
+            discord: {
+              enabled: false,
+              token: { source: "env", provider: "default", id: secretRefId },
+            },
+          },
+          plugins: {
+            entries: {
+              codex: {
+                enabled: true,
+                config: {
+                  appServer: {
+                    headers: {
+                      "X-First": schemaOnlySecrets[0],
+                      "X-Second": schemaOnlySecrets[1],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      async () => {
+        const output = createTestRuntime();
+        await runConfigGet({ path: "channels.discord.token", json: true, runtime: output.runtime });
+        await runConfigGet({ path: "channels.discord.token.id", runtime: output.runtime });
+        await runConfigGet({
+          path: "plugins.entries.codex.config.appServer.headers",
+          json: true,
+          runtime: output.runtime,
+        });
+        await runConfigGet({
+          path: "plugins.entries.codex.config.appServer.headers",
+          runtime: output.runtime,
+        });
+
+        expect(output.errors).toStrictEqual([]);
+        expect(output.logs).toStrictEqual([
+          JSON.stringify({ source: "env", provider: "default", id: REDACTED_SENTINEL }, null, 2),
+          `${REDACTED_SENTINEL}\n`,
+          JSON.stringify(REDACTED_SENTINEL),
+          `${REDACTED_SENTINEL}\n`,
+        ]);
+        expect(output.logs.join("\n")).not.toContain(secretRefId);
+        for (const secret of schemaOnlySecrets) {
+          expect(output.logs.join("\n")).not.toContain(secret);
+        }
+      },
+    );
+  });
+
+  it.each([
+    {
+      name: "plugin metadata is absent",
+      installFailure: async () => {
+        const snapshot = await configRuntime.readConfigFileSnapshot({ observe: false });
+        vi.spyOn(configRuntime, "readConfigFileSnapshotWithPluginMetadata").mockResolvedValue({
+          snapshot,
+        });
+      },
+      expectedError: "plugin metadata unavailable",
+    },
+    {
+      name: "schema construction fails",
+      installFailure: async () => {
+        vi.spyOn(runtimeSchema, "buildRuntimeConfigSchemaFromRegistry").mockImplementation(() => {
+          throw new Error("schema construction unavailable");
+        });
+      },
+      expectedError: "schema construction unavailable",
+    },
+  ])("fails closed before config get emits values when $name", async (testCase) => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-get-fail-closed-",
+      "{ gateway: { port: 19001 } }\n",
+      async () => {
+        await testCase.installFailure();
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigGet({ path: "gateway.port", runtime: output.runtime }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(output.logs).toStrictEqual([]);
+        expect(output.errors.join("\n")).toContain(testCase.expectedError);
+        expect(output.errors.join("\n")).not.toContain("19001");
+      },
+    );
+  });
+
+  it.each([
+    {
+      name: "set",
+      expectedSource: "exec",
+      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
+        runConfigSet({
+          path: "channels.discord.token",
+          value: '{"source":"exec","provider":"shared","id":"discord/token"}',
+          cliOptions: { strictJson: true },
+          runtime,
+        }),
+    },
+    {
+      name: "unset",
+      expectedSource: "env",
+      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
+        runConfigUnset({ path: "secrets.defaults.env", runtime }),
+    },
+  ])("rejects impossible provider/source refs during real config $name", async (testCase) => {
+    const raw = `${JSON.stringify(
+      {
+        channels: {
+          discord: {
+            enabled: false,
+            token: { source: "env", provider: "shared", id: "DISCORD_TEST_TOKEN" },
+          },
+        },
+        secrets: {
+          defaults: { env: "shared" },
+          providers: {
+            shared: { source: "file", path: "/tmp/openclaw-unused-secrets.json", mode: "json" },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-source-mismatch-",
+      raw,
+      async ({ configPath }) => {
+        const output = createTestRuntime();
+
+        await expect(testCase.run(output.runtime)).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        expect(output.errors.join("\n")).toContain(
+          `provider "shared" has source "file" but ref requests "${testCase.expectedSource}"`,
+        );
+      },
+    );
+  });
+
+  it("rejects impossible provider/source refs during real config validate", async () => {
+    const refId = "DISCORD_TEST_TOKEN";
+    await withConfigFileHarness(
+      "openclaw-config-cli-validate-source-mismatch-",
+      `${JSON.stringify(
+        {
+          channels: {
+            discord: {
+              enabled: false,
+              token: { source: "exec", provider: "shared", id: refId },
+            },
+          },
+          secrets: {
+            providers: {
+              shared: {
+                source: "file",
+                path: "/tmp/openclaw-unused-secrets.json",
+                mode: "json",
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      async () => {
+        const snapshot = await configRuntime.readConfigFileSnapshot({ observe: false });
+        expect(snapshot.valid).toBe(false);
+        expect(JSON.stringify(snapshot.issues)).not.toContain(refId);
+
+        await expect(runRegisteredConfigCommand(["config", "validate"])).rejects.toThrow(
+          "__exit__:1",
+        );
+
+        expect(registeredRuntimeErrors.join("\n")).toContain(
+          'Secret provider "shared" has source "file" but ref requests "exec"',
+        );
+        expect(registeredRuntimeErrors.join("\n")).not.toContain(refId);
+      },
+    );
+  });
+
+  it("conflicts when a top-level include changes after config set starts", async () => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-include-conflict-",
+      '{ gateway: { $include: "./gateway.json5" } }\n',
+      async ({ configPath, tempDir }) => {
+        const includePath = path.join(tempDir, "gateway.json5");
+        const concurrentRaw = '{ port: 19002, bind: "loopback" }\n';
+        fs.writeFileSync(includePath, "{ port: 18789 }\n", "utf8");
+        clearConfigCache();
+        installRuntimeSchemaReadHook(() => {
+          fs.writeFileSync(includePath, concurrentRaw, "utf8");
+        });
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigSet({
+            path: "gateway.port",
+            value: "19001",
+            cliOptions: { strictJson: true },
+            runtime: output.runtime,
+          }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(
+          '{ gateway: { $include: "./gateway.json5" } }\n',
+        );
+        expect(fs.readFileSync(includePath, "utf8")).toBe(concurrentRaw);
+        expect(output.errors.join("\n")).toContain("included config changed since last load");
+      },
+    );
+  });
+
+  it.each([
+    {
+      name: "setting an authored value to itself",
+      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
+        runConfigSet({
+          path: "gateway.port",
+          value: "18789",
+          cliOptions: { strictJson: true },
+          runtime,
+        }),
+    },
+    {
+      name: "unsetting an absent authored value",
+      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
+        runConfigUnset({ path: "gateway.bind", runtime }),
+    },
+  ])("preserves exact JSON5 bytes when $name is a no-op", async (testCase) => {
+    const raw =
+      '{\n  // preserve this comment and order\n  gateway: { port: 18789 },\n  logging: { level: "info" },\n}\n';
+    await withConfigFileHarness("openclaw-config-cli-noop-", raw, async ({ configPath }) => {
+      const output = createTestRuntime();
+
+      await testCase.run(output.runtime);
+
+      expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+      expect(output.errors).toStrictEqual([]);
+      expect(output.logs).toStrictEqual(["No change"]);
+    });
+  });
+
+  it("writes an absent key even when its value equals the resolved default", async () => {
+    const raw = "{\n  // the default is not authored yet\n  gateway: {},\n}\n";
+    await withConfigFileHarness(
+      "openclaw-config-cli-default-equal-write-",
+      raw,
+      async ({ configPath }) => {
+        const output = createTestRuntime();
+
+        await runConfigSet({
+          path: "gateway.port",
+          value: "18789",
+          cliOptions: { strictJson: true },
+          runtime: output.runtime,
+        });
+
+        const after = fs.readFileSync(configPath, "utf8");
+        expect(after).not.toBe(raw);
+        expect(JSON5.parse(after)).toMatchObject({ gateway: { port: 18789 } });
+        expect(output.logs.join("\n")).not.toContain("No change");
+      },
+    );
+  });
+
   it("accepts plugin hook conversation-access policy via config set", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-cli-plugin-hooks-"));
     const configPath = path.join(tempDir, "openclaw.json");

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -65,6 +65,16 @@ const mockLoadChannelSecretContractApi = vi.hoisted(() =>
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: (...args: Parameters<typeof mockReadConfigFileSnapshot>) =>
     mockReadConfigFileSnapshot(...args),
+  readConfigFileSnapshotWithPluginMetadata: async (
+    ...args: Parameters<typeof mockReadConfigFileSnapshot>
+  ) => ({
+    snapshot: await mockReadConfigFileSnapshot(...args),
+    pluginMetadataSnapshot: createPluginMetadataSnapshot(),
+  }),
+  readConfigFileSnapshotForWrite: async () => ({
+    snapshot: await mockReadConfigFileSnapshot(),
+    writeOptions: {},
+  }),
   writeConfigFile: (
     cfg: OpenClawConfig,
     options?: {
@@ -88,6 +98,7 @@ vi.mock("../secrets/resolve.js", () => ({
 }));
 
 vi.mock("../config/runtime-schema.js", () => ({
+  buildRuntimeConfigSchemaFromRegistry: () => ({ uiHints: {} }),
   readBestEffortRuntimeConfigSchema: () => mockReadBestEffortRuntimeConfigSchema(),
 }));
 
@@ -4140,7 +4151,7 @@ describe("config cli", () => {
       ]);
     });
 
-    it("explains when unset targets a runtime-only default shown by config get", async () => {
+    it("treats unsetting a runtime-only default shown by config get as an authored no-op", async () => {
       const resolved = {
         agents: {
           defaults: {
@@ -4168,14 +4179,11 @@ describe("config cli", () => {
       mockLog.mockClear();
       setSnapshot(resolved, runtimeMerged);
 
-      await expect(runConfigCommand(["config", "unset", aliasPath])).rejects.toThrow(ExitError);
+      await runConfigCommand(["config", "unset", aliasPath]);
 
-      expectErrorIncludes(`Config path not found in authored config: ${aliasPath}.`);
-      expectErrorIncludes("It only exists after runtime defaults are applied");
-      expectErrorIncludes("openclaw config set <path> <value>");
-      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
-        "Run openclaw config get <path>",
-      );
+      expectLogIncludes("No change");
+      expect(mockError).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
 
       setSnapshot(resolved, runtimeMerged);
       await expect(
@@ -4284,13 +4292,13 @@ describe("config cli", () => {
   });
 
   describe("config apply hints - issue #80722", () => {
-    it("prints a no-restart hint for a same-value config set", async () => {
+    it("prints No change without writing for a same-value config set", async () => {
       setGatewaySnapshot();
 
       await runConfigSet("gateway.port", "18789", "--strict-json");
 
-      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
-      expectLogIncludes("Updated gateway.port. No gateway restart needed.");
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectLogIncludes("No change");
       expectLogExcludes("Restart the gateway to apply.");
       expectLogExcludes("Change will apply without restarting the gateway.");
     });

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -3,11 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import {
-  readConfigFileSnapshot,
-  readConfigFileSnapshotWithPluginMetadata,
-  replaceConfigFile,
-} from "../config/config.js";
+import { readConfigFileSnapshotWithPluginMetadata, replaceConfigFile } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { CONFIG_PATH, resolveConfigPath } from "../config/paths.js";
@@ -52,10 +48,12 @@ import {
   runConfigOperations,
 } from "./config-cli-runner.js";
 import {
+  assertStrictConfigForMutation,
   ensureValidConfigSnapshotForCli,
   formatInvalidConfigRepairHint,
   loadValidConfig,
   loadValidConfigForWrite,
+  strictlyValidateConfigSnapshotForCli,
 } from "./config-cli-validation.js";
 import { checkTouchedTextModelRefs } from "./config-model-validation.js";
 import { isConfigMachineOutput, isConfigSetJsonParseOnly } from "./config-output-mode.js";
@@ -272,6 +270,10 @@ export async function runConfigUnset(opts: {
         runtime.exit(1);
         return;
       }
+      assertStrictConfigForMutation(
+        currentConfig,
+        mutationStart.writeOptions.basePluginMetadataSnapshot,
+      );
       runtime.log(info("No change"));
       return;
     }
@@ -287,6 +289,10 @@ export async function runConfigUnset(opts: {
     }
     const nextConfig = normalizeConfigMutationModelRefs(structuredClone(next) as OpenClawConfig);
     if (isDeepStrictEqual(currentConfig, nextConfig)) {
+      assertStrictConfigForMutation(
+        nextConfig,
+        mutationStart.writeOptions.basePluginMetadataSnapshot,
+      );
       runtime.log(info("No change"));
       return;
     }
@@ -348,7 +354,11 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
   const runtime = opts.runtime ?? defaultRuntime;
   let outputPath = CONFIG_PATH ?? "openclaw.json";
   try {
-    const snapshot = await readConfigFileSnapshot({ observe: false });
+    const read = await readConfigFileSnapshotWithPluginMetadata({ observe: false });
+    const snapshot = strictlyValidateConfigSnapshotForCli(
+      read.snapshot,
+      read.pluginMetadataSnapshot,
+    );
     outputPath = snapshot.path;
     const shortPath = shortenHomePath(outputPath);
     if (!snapshot.exists) {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,13 +1,21 @@
 // Config CLI command implementation for get/set/unset/patch/validate and secret refs.
+import { isDeepStrictEqual } from "node:util";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
+import {
+  readConfigFileSnapshot,
+  readConfigFileSnapshotWithPluginMetadata,
+  replaceConfigFile,
+} from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { CONFIG_PATH, resolveConfigPath } from "../config/paths.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
-import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
+import {
+  buildRuntimeConfigSchemaFromRegistry,
+  readBestEffortRuntimeConfigSchema,
+} from "../config/runtime-schema.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { danger, info, success, warn } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -43,7 +51,12 @@ import {
   handleConfigMutationError,
   runConfigOperations,
 } from "./config-cli-runner.js";
-import { formatInvalidConfigRepairHint, loadValidConfig } from "./config-cli-validation.js";
+import {
+  ensureValidConfigSnapshotForCli,
+  formatInvalidConfigRepairHint,
+  loadValidConfig,
+  loadValidConfigForWrite,
+} from "./config-cli-validation.js";
 import { checkTouchedTextModelRefs } from "./config-model-validation.js";
 import { isConfigMachineOutput, isConfigSetJsonParseOnly } from "./config-output-mode.js";
 import {
@@ -152,8 +165,18 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseConfigSetPath(opts.path);
-    const snapshot = await loadValidConfig(runtime, { observe: false, json: opts.json });
-    const res = getAtPath(redactConfigObject(snapshot.config), parsedPath);
+    const read = await readConfigFileSnapshotWithPluginMetadata({ observe: false });
+    const { snapshot, pluginMetadataSnapshot } = read;
+    if (!ensureValidConfigSnapshotForCli(snapshot, runtime, { json: opts.json })) {
+      return;
+    }
+    if (!pluginMetadataSnapshot) {
+      throw new Error("Config plugin metadata unavailable; refusing to display config values.");
+    }
+    const { uiHints } = buildRuntimeConfigSchemaFromRegistry(
+      pluginMetadataSnapshot.manifestRegistry,
+    );
+    const res = getAtPath(redactConfigObject(snapshot.config, uiHints), parsedPath);
     if (!res.found) {
       if (opts.json) {
         writeRuntimeJson(runtime, formatCliJsonFailure(`Config path not found: ${opts.path}`));
@@ -209,7 +232,10 @@ export async function runConfigUnset(opts: {
     }
     const parsedPath = parseConfigSetPath(opts.path);
     assertConfigPathIsNotAutoManaged(parsedPath);
-    const snapshot = await loadValidConfig(runtime);
+    const mutationStart = cliOptions.dryRun
+      ? { snapshot: await loadValidConfig(runtime), writeOptions: {} }
+      : await loadValidConfigForWrite(runtime);
+    const { snapshot } = mutationStart;
     // Mutate resolved config so runtime defaults never leak into the authored file.
     const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
     const currentConfig = normalizeConfigMutationModelRefs(
@@ -222,7 +248,7 @@ export async function runConfigUnset(opts: {
         path: opts.path,
         runtimeOnly,
       });
-      if (cliOptions.dryRun && cliOptions.json) {
+      if (cliOptions.json) {
         throw new ConfigSetDryRunValidationError({
           ok: false,
           operations: 1,
@@ -241,8 +267,12 @@ export async function runConfigUnset(opts: {
           ],
         });
       }
-      runtime.error(danger(missingPathMessage));
-      runtime.exit(1);
+      if (cliOptions.dryRun) {
+        runtime.error(danger(missingPathMessage));
+        runtime.exit(1);
+        return;
+      }
+      runtime.log(info("No change"));
       return;
     }
     const operation = buildUnsetOperation(parsedPath);
@@ -256,6 +286,10 @@ export async function runConfigUnset(opts: {
       return;
     }
     const nextConfig = normalizeConfigMutationModelRefs(structuredClone(next) as OpenClawConfig);
+    if (isDeepStrictEqual(currentConfig, nextConfig)) {
+      runtime.log(info("No change"));
+      return;
+    }
     const modelRefCheck = await checkTouchedTextModelRefs({
       config: nextConfig,
       previousConfig: currentConfig,
@@ -267,11 +301,12 @@ export async function runConfigUnset(opts: {
     }
     await replaceConfigFile({
       nextConfig,
+      snapshot,
       ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
       writeOptions:
         unsetResult.leafContainer === "array"
-          ? { auditOrigin: "cli" }
-          : { auditOrigin: "cli", unsetPaths: [parsedPath] },
+          ? { ...mutationStart.writeOptions, auditOrigin: "cli" }
+          : { ...mutationStart.writeOptions, auditOrigin: "cli", unsetPaths: [parsedPath] },
     });
     const hint = configApplyHintForOperations([operation], currentConfig, nextConfig);
     runtime.log(info(`Removed ${opts.path}. ${hint}`));

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -362,6 +362,8 @@ export async function writeConfigFileFromContext(
   const validated = validateConfigObjectRawWithPlugins(validationCandidate, {
     env: deps.env,
     pluginValidation: options.skipPluginValidation ? "skip" : "full",
+    semanticValidation: "strict",
+    pluginMetadataSnapshot: snapshotRead.pluginMetadataSnapshot,
     preservedLegacyRootKeys: options.preservedLegacyRootKeys,
   });
   if (!validated.ok) {

--- a/src/config/runtime-schema.ts
+++ b/src/config/runtime-schema.ts
@@ -1,4 +1,5 @@
 // Builds runtime config schema defaults from agent and workspace state.
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
   collectChannelSchemaMetadataCore,
   collectPluginSchemaMetadataCore,
@@ -16,14 +17,21 @@ function loadManifestRegistry(config: OpenClawConfig, env?: NodeJS.ProcessEnv) {
   });
 }
 
-/** Builds the config schema from the active runtime config and plugin metadata. */
-export function loadGatewayRuntimeConfigSchema(): ConfigSchemaResponse {
-  const config = getRuntimeConfig();
-  const registry = loadManifestRegistry(config);
+/** Builds one config schema from an exact manifest registry. */
+export function buildRuntimeConfigSchemaFromRegistry(
+  registry: PluginManifestRegistry,
+): ConfigSchemaResponse {
   return buildConfigSchemaCore({
     plugins: collectPluginSchemaMetadataCore(registry),
     channels: collectChannelSchemaMetadataCore(registry),
   });
+}
+
+/** Builds the config schema from the active runtime config and plugin metadata. */
+export function loadGatewayRuntimeConfigSchema(): ConfigSchemaResponse {
+  const config = getRuntimeConfig();
+  const registry = loadManifestRegistry(config);
+  return buildRuntimeConfigSchemaFromRegistry(registry);
 }
 
 export async function readBestEffortRuntimeConfigSchema(): Promise<ConfigSchemaResponse> {

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -266,6 +266,7 @@ vi.mock("../plugins/doctor-contract-registry.js", () => ({
 }));
 
 vi.mock("../secrets/target-registry-data.js", () => ({
+  buildSecretTargetRegistryFromPlugins: () => [],
   getCoreSecretTargetRegistry: () => [],
   getSecretTargetRegistry: () => [],
 }));

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -1,6 +1,7 @@
 // Covers config validation policy decisions and warning behavior.
 import { describe, expect, it, vi } from "vitest";
-import { validateConfigObjectRaw } from "./validation.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { validateConfigObjectRaw, validateConfigObjectRawWithPlugins } from "./validation.js";
 
 vi.mock("../channels/plugins/legacy-config.js", () => ({
   collectChannelLegacyConfigRules: () => [],
@@ -52,7 +53,93 @@ function requireIssue<T extends { path: string }>(issues: T[], path: string): T 
   return issue;
 }
 
+function createSecretFixturePlugin(): PluginManifestRecord {
+  return {
+    id: "secret-fixture",
+    channels: [],
+    cliBackends: [],
+    configContracts: {
+      secretInputs: { paths: [{ path: "credential", expected: "string" }] },
+    },
+    configSchema: { type: "object", additionalProperties: true },
+    hooks: [],
+    manifestPath: "/tmp/secret-fixture/openclaw.plugin.json",
+    origin: "bundled",
+    providers: [],
+    rootDir: "/tmp/secret-fixture",
+    skills: [],
+    source: "/tmp/secret-fixture/index.js",
+  };
+}
+
 describe("config validation SecretRef policy guards", () => {
+  it("rejects an impossible SecretRef on a disabled registry-declared plugin target", () => {
+    const refId = "PLUGIN_PRIVATE_CREDENTIAL";
+    const plugin = createSecretFixturePlugin();
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        plugins: {
+          entries: {
+            "secret-fixture": {
+              enabled: false,
+              config: {
+                credential: { source: "exec", provider: "shared", id: refId },
+              },
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            shared: { source: "file", path: "/tmp/unused-secrets.json", mode: "json" },
+          },
+        },
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: { diagnostics: [], plugins: [plugin] } } },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = requireIssue(result.issues, "plugins.entries.secret-fixture.config.credential");
+      expect(issue.message).toContain(
+        'Secret provider "shared" has source "file" but ref requests "exec"',
+      );
+      expect(JSON.stringify(result.issues)).not.toContain(refId);
+    }
+  });
+
+  it.each(["env", "store"] as const)(
+    "allows the %s default alias to shadow another-source provider entry",
+    (source) => {
+      const result = validateConfigObjectRawWithPlugins(
+        {
+          plugins: {
+            entries: {
+              "secret-fixture": {
+                enabled: false,
+                config: {
+                  credential: { source, provider: "shared", id: "PLUGIN_PRIVATE_CREDENTIAL" },
+                },
+              },
+            },
+          },
+          secrets: {
+            defaults: { [source]: "shared" },
+            providers: {
+              shared: { source: "file", path: "/tmp/unused-secrets.json", mode: "json" },
+            },
+          },
+        },
+        {
+          pluginMetadataSnapshot: {
+            manifestRegistry: { diagnostics: [], plugins: [createSecretFixturePlugin()] },
+          },
+        },
+      );
+
+      expect(result.ok).toBe(true);
+    },
+  );
+
   it("surfaces a policy error for hooks.token SecretRef objects", () => {
     const result = validateConfigObjectRaw({
       hooks: {

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -73,7 +73,37 @@ function createSecretFixturePlugin(): PluginManifestRecord {
 }
 
 describe("config validation SecretRef policy guards", () => {
-  it("rejects an impossible SecretRef on a disabled registry-declared plugin target", () => {
+  it("allows an impossible SecretRef on a disabled registry-declared plugin target", () => {
+    const plugin = createSecretFixturePlugin();
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        plugins: {
+          entries: {
+            "secret-fixture": {
+              enabled: false,
+              config: {
+                credential: {
+                  source: "exec",
+                  provider: "shared",
+                  id: "PLUGIN_PRIVATE_CREDENTIAL",
+                },
+              },
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            shared: { source: "file", path: "/tmp/unused-secrets.json", mode: "json" },
+          },
+        },
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: { diagnostics: [], plugins: [plugin] } } },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("strictly rejects an impossible SecretRef on a disabled registry-declared plugin target", () => {
     const refId = "PLUGIN_PRIVATE_CREDENTIAL";
     const plugin = createSecretFixturePlugin();
     const result = validateConfigObjectRawWithPlugins(
@@ -94,7 +124,10 @@ describe("config validation SecretRef policy guards", () => {
           },
         },
       },
-      { pluginMetadataSnapshot: { manifestRegistry: { diagnostics: [], plugins: [plugin] } } },
+      {
+        semanticValidation: "strict",
+        pluginMetadataSnapshot: { manifestRegistry: { diagnostics: [], plugins: [plugin] } },
+      },
     );
 
     expect(result.ok).toBe(false);
@@ -130,6 +163,7 @@ describe("config validation SecretRef policy guards", () => {
           },
         },
         {
+          semanticValidation: "strict",
           pluginMetadataSnapshot: {
             manifestRegistry: { diagnostics: [], plugins: [createSecretFixturePlugin()] },
           },

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -12,6 +12,8 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { resolveWebSearchInstallCatalogEntries } from "../plugins/web-search-install-catalog.js";
+import { resolveSecretRefProviderSourceMismatch } from "../secrets/ref-contract.js";
+import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
 import { isRecord } from "../utils.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import {
@@ -28,6 +30,7 @@ import { materializeLegacyDefaultAgentRoles } from "./legacy.default-agent-roles
 import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+import { resolveSecretInputRef } from "./types.secrets.js";
 import {
   bundledChannelIds,
   collectChannelDmPolicyDependencyWarnings,
@@ -36,6 +39,7 @@ import {
   normalizeBundledChannelId,
 } from "./validation-channel-rules.js";
 import { validateConfigObjectRaw } from "./validation-core.js";
+import { withConfigIssuePath } from "./validation-issues.js";
 import {
   collectExplicitPluginReferences,
   resolveExplicitPluginReferencePath,
@@ -68,6 +72,43 @@ type RegistryInfo = {
   channelDmAllowFromModes?: Map<string, ChannelDmAllowFromMode>;
   channelSchemas?: Map<string, { schema?: Record<string, unknown>; pluginId?: string }>;
 };
+
+function collectSecretRefProviderSourceIssues(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  manifestRegistry: PluginManifestRegistry;
+}): ConfigValidationIssue[] {
+  const issues: ConfigValidationIssue[] = [];
+  for (const target of discoverConfigSecretTargets(params.config, {
+    env: params.env,
+    manifestRegistry: params.manifestRegistry,
+  })) {
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults: params.config.secrets?.defaults,
+    });
+    if (!ref) {
+      continue;
+    }
+    const configuredSource = resolveSecretRefProviderSourceMismatch(params.config, ref);
+    if (!configuredSource) {
+      continue;
+    }
+    const path = target.refPath ?? target.path;
+    const pathSegments = target.refPathSegments ?? target.pathSegments;
+    issues.push(
+      withConfigIssuePath(
+        {
+          path,
+          message: `Secret provider "${ref.provider}" has source "${configuredSource}" but ref requests "${ref.source}".`,
+        },
+        pathSegments,
+      ),
+    );
+  }
+  return issues;
+}
 
 export function validateConfigObjectWithPlugins(
   raw: unknown,
@@ -666,28 +707,33 @@ function validateConfigObjectWithPluginsBase(
   validateWebSearchProvider();
   validateConfiguredModelRefs();
 
-  if (!hasExplicitPluginsConfig) {
-    return issues.length > 0
-      ? { ok: false, issues, warnings }
-      : { ok: true, config: mutatedConfig, warnings };
+  if (hasExplicitPluginsConfig) {
+    const { registry } = ensureRegistry();
+    validateExplicitPluginConfig({
+      raw,
+      config,
+      effectiveConfig: ensureCompatConfig(),
+      env: opts.env,
+      applyDefaults: opts.applyDefaults,
+      registry,
+      knownIds: ensureKnownIds(),
+      normalizedPlugins: ensureNormalizedPlugins(),
+      ensureCompatPluginIds,
+      ensureOverriddenPluginIds,
+      replacePluginEntryConfig,
+      issues,
+      warnings,
+    });
   }
-
-  const { registry } = ensureRegistry();
-  validateExplicitPluginConfig({
-    raw,
-    config,
-    effectiveConfig: ensureCompatConfig(),
-    env: opts.env,
-    applyDefaults: opts.applyDefaults,
-    registry,
-    knownIds: ensureKnownIds(),
-    normalizedPlugins: ensureNormalizedPlugins(),
-    ensureCompatPluginIds,
-    ensureOverriddenPluginIds,
-    replacePluginEntryConfig,
-    issues,
-    warnings,
-  });
+  if (Object.keys(mutatedConfig.secrets?.providers ?? {}).length > 0) {
+    issues.push(
+      ...collectSecretRefProviderSourceIssues({
+        config: mutatedConfig,
+        env: opts.env,
+        manifestRegistry: ensureLoadedRegistryInfo().registry,
+      }),
+    );
+  }
 
   return issues.length > 0
     ? { ok: false, issues, warnings }

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -56,6 +56,8 @@ type ValidateConfigWithPluginsResult =
 type ValidateConfigWithPluginsParams = {
   env?: NodeJS.ProcessEnv;
   pluginValidation?: "full" | "skip" | "core-only";
+  /** Runtime preserves inactive-owner startup; strict mode checks all declared targets for explicit validation and writes. */
+  semanticValidation?: "runtime" | "strict";
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "manifestRegistry">;
   loadPluginMetadataSnapshot?: (
     config: OpenClawConfig,
@@ -136,6 +138,7 @@ function validateConfigObjectWithPluginMode(
     applyDefaults,
     env: params?.env,
     pluginValidation: params?.pluginValidation ?? "full",
+    semanticValidation: params?.semanticValidation ?? "runtime",
     pluginMetadataSnapshot: params?.pluginMetadataSnapshot,
     loadPluginMetadataSnapshot: params?.loadPluginMetadataSnapshot,
     sourceRaw: params?.sourceRaw,
@@ -725,7 +728,10 @@ function validateConfigObjectWithPluginsBase(
       warnings,
     });
   }
-  if (Object.keys(mutatedConfig.secrets?.providers ?? {}).length > 0) {
+  if (
+    opts.semanticValidation === "strict" &&
+    Object.keys(mutatedConfig.secrets?.providers ?? {}).length > 0
+  ) {
     issues.push(
       ...collectSecretRefProviderSourceIssues({
         config: mutatedConfig,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -594,9 +594,7 @@ function validateSubmittedConfigOrRespond(params: {
       }),
     );
   };
-  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate, {
-    semanticValidation: "strict",
-  });
+  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
   if (!sourceValidated.ok) {
     respondInvalid(sourceValidated.issues);
     return null;
@@ -1083,6 +1081,17 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const actor = resolveControlPlaneActor(client);
+    if (restoredChangedPaths.length === 0) {
+      respondConfigPatchNoop({
+        snapshot,
+        config: snapshot.config,
+        uiHints: schemaPatch.uiHints,
+        actor,
+        context,
+        respond,
+      });
+      return;
+    }
     const validatedSubmission = validateSubmittedConfigOrRespond({
       candidate: restoredMerge.result,
       sourceConfig: snapshot.sourceConfig,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -594,7 +594,9 @@ function validateSubmittedConfigOrRespond(params: {
       }),
     );
   };
-  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate, {
+    semanticValidation: "strict",
+  });
   if (!sourceValidated.ok) {
     respondInvalid(sourceValidated.issues);
     return null;
@@ -1081,17 +1083,6 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const actor = resolveControlPlaneActor(client);
-    if (restoredChangedPaths.length === 0) {
-      respondConfigPatchNoop({
-        snapshot,
-        config: snapshot.config,
-        uiHints: schemaPatch.uiHints,
-        actor,
-        context,
-        respond,
-      });
-      return;
-    }
     const validatedSubmission = validateSubmittedConfigOrRespond({
       candidate: restoredMerge.result,
       sourceConfig: snapshot.sourceConfig,

--- a/src/secrets/ref-contract.ts
+++ b/src/secrets/ref-contract.ts
@@ -83,6 +83,35 @@ export function resolveDefaultSecretProviderAlias(
   return DEFAULT_SECRET_PROVIDER_ALIAS;
 }
 
+/** Whether a source-specific built-in provider owns this selected default alias. */
+export function isBuiltInDefaultSecretProviderRef(
+  config: SecretRefDefaultsCarrier,
+  ref: SecretRef,
+): boolean {
+  const configuredSource = config.secrets?.providers?.[ref.provider]?.source;
+  return (
+    configuredSource !== ref.source &&
+    (ref.source === "env" || ref.source === "store") &&
+    ref.provider === resolveDefaultSecretProviderAlias(config, ref.source)
+  );
+}
+
+/** Returns the configured provider source when a SecretRef selects an impossible pairing. */
+export function resolveSecretRefProviderSourceMismatch(
+  config: SecretRefDefaultsCarrier,
+  ref: SecretRef,
+): string | null {
+  const configuredSource = config.secrets?.providers?.[ref.provider]?.source;
+  if (
+    !configuredSource ||
+    configuredSource === ref.source ||
+    isBuiltInDefaultSecretProviderRef(config, ref)
+  ) {
+    return null;
+  }
+  return configuredSource;
+}
+
 /** Validates file secret ref ids against the shared JSON-pointer-style contract. */
 export function isValidFileSecretRefId(value: string): boolean {
   if (value === SINGLE_VALUE_FILE_REF_ID) {

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -32,12 +32,13 @@ import {
 } from "./provider-integrations.js";
 import {
   formatExecSecretRefIdValidationMessage,
+  isBuiltInDefaultSecretProviderRef,
   isValidExecSecretRefId,
   isValidFileSecretRefId,
   isValidSecretProviderAlias,
-  SINGLE_VALUE_FILE_REF_ID,
-  resolveDefaultSecretProviderAlias,
+  resolveSecretRefProviderSourceMismatch,
   secretRefKey,
+  SINGLE_VALUE_FILE_REF_ID,
 } from "./ref-contract.js";
 import {
   isMissingSecretRefResolutionError,
@@ -157,12 +158,13 @@ function resolveConfiguredProvider(params: {
 }): SecretProviderConfig {
   const { ref, config } = params;
   const providerConfig = config.secrets?.providers?.[ref.provider];
-  if (
-    providerConfig?.source !== ref.source &&
-    (ref.source === "env" || ref.source === "store") &&
-    ref.provider === resolveDefaultSecretProviderAlias(config, ref.source)
-  ) {
-    return { source: ref.source };
+  if (isBuiltInDefaultSecretProviderRef(config, ref)) {
+    if (ref.source === "env") {
+      return { source: "env" };
+    }
+    if (ref.source === "store") {
+      return { source: "store" };
+    }
   }
   if (!providerConfig) {
     throw providerResolutionError({
@@ -172,12 +174,13 @@ function resolveConfiguredProvider(params: {
       message: `Secret provider "${ref.provider}" is not configured (ref: ${ref.source}:${ref.provider}:${ref.id}).`,
     });
   }
-  if (providerConfig.source !== ref.source) {
+  const configuredSource = resolveSecretRefProviderSourceMismatch(config, ref);
+  if (configuredSource) {
     throw providerResolutionError({
       code: "SECRET_PROVIDER_INVALID",
       source: ref.source,
       provider: ref.provider,
-      message: `Secret provider "${ref.provider}" has source "${providerConfig.source}" but ref requests "${ref.source}".`,
+      message: `Secret provider "${ref.provider}" has source "${configuredSource}" but ref requests "${ref.source}".`,
     });
   }
   if (isPluginIntegrationSecretProviderConfig(providerConfig)) {

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -452,6 +452,13 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
     allowWorkspaceScopedCurrent: true,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
+  return buildSecretTargetRegistryFromPlugins(plugins);
+}
+
+/** Builds secret targets from one exact manifest-registry plugin set. */
+export function buildSecretTargetRegistryFromPlugins(
+  plugins: readonly PluginManifestRecord[],
+): SecretTargetRegistryEntry[] {
   const channelPlugins = plugins.filter(
     (record) =>
       record.channels.length > 0 ||

--- a/src/secrets/target-registry-query.ts
+++ b/src/secrets/target-registry-query.ts
@@ -1,8 +1,13 @@
 /** Query helpers for discovering secret target registry entries. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { loadChannelSecretContractApi } from "./channel-contract-api.js";
 import { getPath } from "./path-utils.js";
-import { getCoreSecretTargetRegistry, getSecretTargetRegistry } from "./target-registry-data.js";
+import {
+  buildSecretTargetRegistryFromPlugins,
+  getCoreSecretTargetRegistry,
+  getSecretTargetRegistry,
+} from "./target-registry-data.js";
 import {
   compileTargetRegistryEntry,
   expandPathTokens,
@@ -105,8 +110,16 @@ function getCompiledSecretTargetRegistryState() {
   return compiledSecretTargetRegistryState;
 }
 
-function getConfiguredSecretTargetRegistryState(config: OpenClawConfig, env: NodeJS.ProcessEnv) {
-  return compileSecretTargetRegistryState(getSecretTargetRegistry({ config, env }));
+function getConfiguredSecretTargetRegistryState(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">,
+) {
+  return compileSecretTargetRegistryState(
+    manifestRegistry
+      ? buildSecretTargetRegistryFromPlugins(manifestRegistry.plugins)
+      : getSecretTargetRegistry({ config, env }),
+  );
 }
 
 function getCompiledCoreOpenClawTargetState() {
@@ -495,7 +508,10 @@ export function resolveConfigSecretTargetByPath(pathSegments: string[]): Resolve
 /** Discovers configured secret-bearing values in openclaw.json. */
 export function discoverConfigSecretTargets(
   config: OpenClawConfig,
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+  } = {},
 ): DiscoveredConfigSecretTarget[] {
   return discoverConfigSecretTargetsByIds(config, undefined, options);
 }
@@ -506,7 +522,10 @@ export function discoverConfigSecretTargets(
 export function discoverConfigSecretTargetsByIds(
   config: OpenClawConfig,
   targetIds?: Iterable<string>,
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+  } = {},
 ): DiscoveredConfigSecretTarget[] {
   const env = options.env ?? process.env;
   const allowedTargetIds = normalizeAllowedTargetIds(targetIds);
@@ -515,7 +534,7 @@ export function discoverConfigSecretTargetsByIds(
     allowedTargetIds !== null &&
     Array.from(allowedTargetIds).every((targetId) => coreState.knownTargetIds.has(targetId));
   const configuredChannelEntries =
-    !hasOnlyCoreTargetIds && !configHasPluginEntries(config)
+    !options.manifestRegistry && !hasOnlyCoreTargetIds && !configHasPluginEntries(config)
       ? getConfiguredChannelOpenClawTargets(config, env)
       : null;
   const configuredEntries = hasOnlyCoreTargetIds
@@ -532,7 +551,7 @@ export function discoverConfigSecretTargetsByIds(
       Array.from(allowedTargetIds).every((targetId) => configuredEntriesById?.has(targetId)));
   const registryState = canUseConfiguredEntries
     ? null
-    : getConfiguredSecretTargetRegistryState(config, env);
+    : getConfiguredSecretTargetRegistryState(config, env, options.manifestRegistry);
   const discoveryEntries = resolveDiscoveryEntries({
     allowedTargetIds,
     defaultEntries: configuredEntries ?? registryState?.openClawCompiledSecretTargets ?? [],


### PR DESCRIPTION
## What Problem This Solves

Fixes a config CLI safety cluster where operators could expose structured SecretRef identifiers or plugin-schema-only sensitive values through `config get`, create impossible provider/source bindings through real config mutations, lose concurrent edits made in top-level `$include` files, and have authored no-op set/unset commands destructively reserialize JSON5.

## Why This Change Was Made

`config get` now redacts from one exact config snapshot plus its plugin metadata and fails closed when that metadata cannot produce UI hints. SecretRef provider/source compatibility is enforced by an explicit strict semantic-validation mode used by config validation and write paths; ordinary Gateway startup retains the shipped active-surface contract, so inactive owners remain non-blocking. CLI mutations carry their mutation-start include provenance into the compare-and-swap write boundary and skip authored no-op writes only after strict post-operation validation.

The production growth establishes missing security and ownership boundaries: exact plugin metadata pairing, one shared provider-binding classifier, registry-aware strict validation, and mutation-start include CAS propagation. This is AI-assisted; the final diff was independently reviewed and behavior-validated.

## User Impact

- `openclaw config get` no longer prints SecretRef IDs or fields marked sensitive only by active plugin metadata.
- Invalid SecretRef provider/source combinations are rejected by explicit `config validate` and config write/mutation paths, including authored no-ops.
- Disabled plugin/channel mismatches remain non-blocking during normal Gateway startup and can be repaired through a mutation.
- Concurrent edits in top-level included config files conflict instead of being overwritten.
- Authored no-op set/unset commands print `No change` and preserve JSON5 bytes, comments, and ordering.
- Setting an absent key to its runtime-default value still persists the explicit value.

## Evidence

Focused regression proof:

- Final focused runtime/config/CLI/Gateway regressions: 348 tests passed.
- Full Linux CLI group on Blacksmith Testbox `tbx_01m0a7abs4x6twcaq4d7a4xn94`: 4,844 passed, 42 skipped ([run](https://github.com/openclaw/openclaw/actions/runs/32127902353)).
- `node scripts/check-changed.mjs`: passed required formatting, typecheck, lint, boundary, dead-export, schema, and import-cycle gates.
- `pnpm build`, `pnpm docs:list`, and `git diff --check`: passed.

Source-blind isolated behavior:

- Structured SecretRef JSON/text and Codex plugin-only sensitive headers returned only `__OPENCLAW_REDACTED__`.
- Real set, unset, patch, and validate rejected provider/source mismatches without printing synthetic ref IDs.
- Same-authored-value set and absent-authored-value unset printed exactly `No change`; file hashes stayed identical.
- Setting absent `gateway.port` to its materialized default changed the file and persisted `18789`.
- Gateway started and reached `ready` with a disabled Discord mismatch, logging `SECRETS_REF_IGNORED_INACTIVE_SURFACE`; strict `config validate` rejected the same file.

Concurrency and metadata-construction fault injection require boundary hooks and are covered by exact integration regressions; they are not claimed as black-box CLI observations.

Review:

- ClawSweeper P1 accepted and repaired: startup uses runtime semantics; explicit validation/writes use strict semantics.
- Fresh Codex autoreview through P1 after the repair: clean, no accepted/actionable findings.
- Focused security audit: no concrete high- or medium-severity findings.

Production LOC: +309/-71 (net +238) | Tests: +630/-18 | Docs: +3/-3
