### PR TITLE
fix: show effective exec approval policy in Devices

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -17893,17 +17893,20 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
     public let exists: Bool
     public let hash: String
     public let file: [String: AnyCodable]
+    public let resolveddefaults: [String: AnyCodable]?
 
     public init(
         path: String,
         exists: Bool,
         hash: String,
-        file: [String: AnyCodable])
+        file: [String: AnyCodable],
+        resolveddefaults: [String: AnyCodable]? = nil)
     {
         self.path = path
         self.exists = exists
         self.hash = hash
         self.file = file
+        self.resolveddefaults = resolveddefaults
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -17911,6 +17914,7 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
         case exists
         case hash
         case file
+        case resolveddefaults = "resolvedDefaults"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -77,6 +77,7 @@ export const ExecApprovalsSnapshotSchema = closedObject({
   exists: Type.Boolean(),
   hash: NonEmptyString,
   file: ExecApprovalsFileSchema,
+  resolvedDefaults: Type.Optional(ExecApprovalsResolvedDefaultsSchema),
 });
 
 const NativeExecApprovalActionSchema = Type.Union([

--- a/src/gateway/server-methods/exec-approvals.test.ts
+++ b/src/gateway/server-methods/exec-approvals.test.ts
@@ -29,6 +29,37 @@ function makeSnapshot(file: ExecApprovalsFile = { version: 1, agents: {} }) {
 }
 
 describe("exec approvals gateway methods", () => {
+  it("reports runtime defaults for fresh local approval state", async () => {
+    ensureExecApprovalsSnapshotMock.mockResolvedValueOnce(makeSnapshot({ version: 1, agents: {} }));
+    const respond = vi.fn();
+
+    await expectDefined(
+      execApprovalsHandlers["exec.approvals.get"],
+      'execApprovalsHandlers["exec.approvals.get"] test invariant',
+    )({
+      req: { type: "req", id: "req-fresh", method: "exec.approvals.get", params: {} },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: { version: 1, agents: {} },
+        resolvedDefaults: {
+          security: "full",
+          ask: "off",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      }),
+      undefined,
+    );
+  });
+
   it("returns a structured unavailable error when local approvals get cannot read state", async () => {
     ensureExecApprovalsSnapshotMock.mockRejectedValueOnce(
       new Error("permission denied while ensuring approvals"),

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -18,6 +18,7 @@ import {
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  resolveExecApprovalsFromFile,
   updateExecApprovals,
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
@@ -104,6 +105,7 @@ function toExecApprovalsPayload(snapshot: ExecApprovalsSnapshot) {
     exists: snapshot.exists,
     hash: snapshot.hash,
     file: redactExecApprovals(snapshot.file),
+    resolvedDefaults: resolveExecApprovalsFromFile({ file: snapshot.file }).defaults,
   };
 }
 

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -344,10 +344,27 @@ describe("node host invoke", () => {
     fs.rmSync(path.dirname(payload.path), { recursive: true, force: true });
   });
 
-  it("returns a redacted exec approvals snapshot", async () => {
+  it.each([
+    { label: "when params are omitted", params: undefined, resolvedDefaults: undefined },
+    {
+      label: "when resolved defaults are not requested",
+      params: { includeResolvedDefaults: false },
+      resolvedDefaults: undefined,
+    },
+    {
+      label: "with resolved defaults when requested",
+      params: { includeResolvedDefaults: true },
+      resolvedDefaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+    },
+  ])("returns a redacted exec approvals snapshot $label", async ({ params, resolvedDefaults }) => {
     execApprovalsStoreMock.hasEnsureResult = true;
     execApprovalsStoreMock.ensureResult = createExecApprovalsSnapshot();
-    const result = await invokeExecApprovals("system.execApprovals.get");
+    const result = await invokeExecApprovals("system.execApprovals.get", params);
     const payload = JSON.parse(result.payloadJSON ?? "{}") as ExecApprovalsSnapshot;
     expect(payload).toEqual({
       path: "/tmp/exec-approvals.json",
@@ -357,6 +374,7 @@ describe("node host invoke", () => {
         version: 1,
         socket: { path: "/tmp/exec-approvals.sock" },
       },
+      ...(resolvedDefaults ? { resolvedDefaults } : {}),
     });
   });
 

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -13,6 +13,7 @@ import {
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
   resolveAllowAlwaysPatternCoverage,
+  resolveExecApprovalsFromFile,
   updateExecApprovals,
   type ExecAsk,
   type ExecApprovalsFile,
@@ -674,13 +675,33 @@ async function dispatchInvoke(
     return;
   }
   if (command === "system.execApprovals.get") {
+    let includeResolvedDefaults = false;
+    try {
+      if (frame.paramsJSON != null) {
+        const params = decodeParams<unknown>(frame.paramsJSON);
+        if (
+          !isRecord(params) ||
+          (params.includeResolvedDefaults !== undefined &&
+            typeof params.includeResolvedDefaults !== "boolean")
+        ) {
+          throw new Error("INVALID_REQUEST: includeResolvedDefaults must be boolean");
+        }
+        includeResolvedDefaults = params.includeResolvedDefaults === true;
+      }
+    } catch (err) {
+      await sendInvalidRequestResult(client, frame, err);
+      return;
+    }
     try {
       const snapshot = await ensureExecApprovalsSnapshot();
-      const payload: ExecApprovalsSnapshot = {
+      const payload = {
         path: snapshot.path,
         exists: snapshot.exists,
         hash: snapshot.hash,
         file: redactExecApprovals(snapshot.file),
+        ...(includeResolvedDefaults
+          ? { resolvedDefaults: resolveExecApprovalsFromFile({ file: snapshot.file }).defaults }
+          : {}),
       };
       await sendJsonPayloadResult(client, frame, payload);
     } catch (err) {

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -86,12 +86,16 @@ export type DevicePairingList = {
   paired: PairedDevice[];
 };
 
+export type ExecSecurity = "deny" | "allowlist" | "full";
+export type ExecAsk = "off" | "on-miss" | "always";
 type ExecApprovalsDefaults = {
-  security?: string;
-  ask?: string;
-  askFallback?: string;
+  security?: ExecSecurity;
+  ask?: ExecAsk;
+  askFallback?: ExecSecurity;
   autoAllowSkills?: boolean;
 };
+
+export type ExecApprovalsResolvedDefaults = Required<ExecApprovalsDefaults>;
 
 export type ExecApprovalsAllowlistEntry = {
   id?: string;
@@ -120,6 +124,7 @@ type FileExecApprovalsSnapshot = {
   exists: boolean;
   hash: string;
   file: ExecApprovalsFile;
+  resolvedDefaults?: ExecApprovalsResolvedDefaults;
 };
 
 type NativeExecApprovalRule = {

--- a/ui/src/pages/devices/view-exec-approvals.ts
+++ b/ui/src/pages/devices/view-exec-approvals.ts
@@ -15,6 +15,9 @@ import {
   isNativeExecApprovalsSnapshot,
   type ExecApprovalsAllowlistEntry,
   type ExecApprovalsFile,
+  type ExecApprovalsResolvedDefaults,
+  type ExecAsk,
+  type ExecSecurity,
   type NativeExecApprovalsSnapshot,
 } from "../../lib/nodes/index.ts";
 import {
@@ -23,16 +26,6 @@ import {
   type NodeTargetOption,
 } from "./view-shared.ts";
 import type { DevicesProps } from "./view.types.ts";
-
-type ExecSecurity = "deny" | "allowlist" | "full";
-type ExecAsk = "off" | "on-miss" | "always";
-
-type ExecApprovalsResolvedDefaults = {
-  security: ExecSecurity;
-  ask: ExecAsk;
-  askFallback: ExecSecurity;
-  autoAllowSkills: boolean;
-};
 
 type ExecApprovalsAgentOption = {
   id: string;
@@ -96,13 +89,19 @@ function normalizeAsk(value?: string): ExecAsk {
 
 function resolveExecApprovalsDefaults(
   form: ExecApprovalsFile | null,
+  reported: ExecApprovalsResolvedDefaults | undefined,
+  includeWildcard: boolean,
 ): ExecApprovalsResolvedDefaults {
   const defaults = form?.defaults ?? {};
+  const wildcard = includeWildcard ? (form?.agents?.["*"] ?? {}) : {};
   return {
-    security: normalizeSecurity(defaults.security),
-    ask: normalizeAsk(defaults.ask),
-    askFallback: normalizeSecurity(defaults.askFallback ?? "deny"),
-    autoAllowSkills: defaults.autoAllowSkills ?? false,
+    security: normalizeSecurity(wildcard.security ?? defaults.security ?? reported?.security),
+    ask: normalizeAsk(wildcard.ask ?? defaults.ask ?? reported?.ask),
+    askFallback: normalizeSecurity(
+      wildcard.askFallback ?? defaults.askFallback ?? reported?.askFallback ?? "deny",
+    ),
+    autoAllowSkills:
+      wildcard.autoAllowSkills ?? defaults.autoAllowSkills ?? reported?.autoAllowSkills ?? false,
   };
 }
 
@@ -165,7 +164,6 @@ export function resolveExecApprovalsState(props: DevicesProps): ExecApprovalsSta
   const fileSnapshot = snapshot && !isNativeExecApprovalsSnapshot(snapshot) ? snapshot : null;
   const form = nativePolicy ? null : (props.execApprovalsForm ?? fileSnapshot?.file ?? null);
   const ready = Boolean(form || nativePolicy);
-  const defaults = resolveExecApprovalsDefaults(form);
   const agents = resolveExecApprovalsAgents(props.configForm, form);
   const targetNodes = resolveExecApprovalsNodes(props.nodes);
   const target = props.execApprovalsTarget;
@@ -175,6 +173,11 @@ export function resolveExecApprovalsState(props: DevicesProps): ExecApprovalsSta
     targetNodeId = null;
   }
   const selectedScope = resolveExecApprovalsScope(props.execApprovalsSelectedAgent, agents);
+  const defaults = resolveExecApprovalsDefaults(
+    form,
+    fileSnapshot?.resolvedDefaults,
+    selectedScope !== EXEC_APPROVALS_DEFAULT_SCOPE,
+  );
   const selectedAgent =
     selectedScope !== EXEC_APPROVALS_DEFAULT_SCOPE
       ? (((form?.agents ?? {})[selectedScope] as Record<string, unknown> | undefined) ?? null)

--- a/ui/src/pages/devices/view-shared.ts
+++ b/ui/src/pages/devices/view-shared.ts
@@ -41,12 +41,12 @@ export function resolveNodeTargets(
   nodes: Array<Record<string, unknown>>,
   requiredCommands: string[],
 ): NodeTargetOption[] {
-  const required = new Set(requiredCommands);
   const list: NodeTargetOption[] = [];
 
   for (const node of nodes) {
     const commands = Array.isArray(node.commands) ? node.commands : [];
-    const supports = commands.some((cmd) => required.has(String(cmd)));
+    const advertised = new Set(commands.map(String));
+    const supports = requiredCommands.every((command) => advertised.has(command));
     if (!supports) {
       continue;
     }

--- a/ui/src/pages/devices/view.devices.test.ts
+++ b/ui/src/pages/devices/view.devices.test.ts
@@ -74,6 +74,17 @@ function getSection(container: Element, heading: string): Element {
   return section;
 }
 
+function getSettingsRow(container: Element, title: string): Element {
+  const row = Array.from(container.querySelectorAll(".settings-row")).find(
+    (candidate) => candidate.querySelector(".settings-row__title")?.textContent?.trim() === title,
+  );
+  expect(row).toBeInstanceOf(Element);
+  if (!(row instanceof Element)) {
+    throw new Error(`Expected ${title} row`);
+  }
+  return row;
+}
+
 function getInventorySection(container: Element): Element {
   return getSection(container, "Paired devices");
 }
@@ -626,6 +637,95 @@ describe("devices inventory rendering", () => {
 });
 
 describe("devices exec approvals rendering", () => {
+  it("renders owner-reported defaults for fresh approval state", () => {
+    const container = renderDevicesContainer({
+      execApprovalsSnapshot: {
+        path: "/tmp/exec-approvals.json",
+        exists: false,
+        hash: "missing:empty",
+        file: { version: 1, agents: {} },
+        resolvedDefaults: {
+          security: "full",
+          ask: "off",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      },
+    });
+    const section = getSection(container, "Exec approvals");
+
+    expect(
+      getSettingsRow(section, "Security").querySelector<HTMLSelectElement>("select")?.value,
+    ).toBe("full");
+    expect(getSettingsRow(section, "Ask").querySelector<HTMLSelectElement>("select")?.value).toBe(
+      "off",
+    );
+  });
+
+  it("preserves authored wildcard and agent overrides above owner defaults", () => {
+    const container = renderDevicesContainer({
+      execApprovalsSnapshot: {
+        path: "/tmp/exec-approvals.json",
+        exists: false,
+        hash: "missing:empty",
+        file: {
+          version: 1,
+          agents: {
+            "*": { security: "allowlist", ask: "always" },
+            main: { ask: "on-miss" },
+          },
+        },
+        resolvedDefaults: {
+          security: "full",
+          ask: "off",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      },
+      execApprovalsSelectedAgent: "main",
+    });
+    const section = getSection(container, "Exec approvals");
+    const security = getSettingsRow(section, "Security").querySelector<HTMLSelectElement>("select");
+    const ask = getSettingsRow(section, "Ask").querySelector<HTMLSelectElement>("select");
+    const fallback = getSettingsRow(section, "Ask fallback").querySelector<HTMLSelectElement>(
+      "select",
+    );
+
+    expect(security?.selectedOptions[0]?.textContent?.trim()).toBe("Use default (allowlist)");
+    expect(ask?.value).toBe("on-miss");
+    expect(fallback?.selectedOptions[0]?.textContent?.trim()).toBe("Use default (deny)");
+  });
+
+  it("offers only nodes that support both reading and writing approval policy", () => {
+    const container = renderDevicesContainer({
+      nodes: [
+        {
+          nodeId: "get-only",
+          displayName: "Get only",
+          commands: ["system.execApprovals.get"],
+        },
+        {
+          nodeId: "set-only",
+          displayName: "Set only",
+          commands: ["system.execApprovals.set"],
+        },
+        {
+          nodeId: "editable",
+          displayName: "Editable",
+          commands: ["system.execApprovals.get", "system.execApprovals.set"],
+        },
+      ],
+      execApprovalsTarget: "node",
+    });
+    const section = getSection(container, "Exec approvals");
+    const nodeSelect = section.querySelector<HTMLSelectElement>('select[aria-label="Node"]');
+
+    expect(Array.from(nodeSelect?.options ?? [], (option) => option.value)).toEqual([
+      "",
+      "editable",
+    ]);
+  });
+
   it("renders defaults, configured agents, and approval-only agents in the avatar picker", async () => {
     const onExecApprovalsSelectAgent = vi.fn();
     const container = renderDevicesContainer({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Devices → Exec approvals** could see UI fallback values instead of the effective policy reported by the local Gateway, especially for a fresh approvals file. The page could show `Deny` / `On miss` while the owner-resolved defaults were `Full` / `Off`. It also offered node targets as editable when they advertised only the read or only the write command.

## Why This Change Was Made

The approval-state owner now includes canonical `resolvedDefaults` in local Gateway snapshots, and the Control UI combines those reported defaults with authored defaults, wildcard overrides, and exact-agent overrides in the correct precedence. The shared node-host restores its opt-in `includeResolvedDefaults` response behavior for Mac node snapshots, while editable node targets now require both `system.execApprovals.get` and `system.execApprovals.set`.

This changes reporting and presentation only. Approval authorization, enforcement, and persisted policy semantics are unchanged.

Production LOC: +58/-22 (net +36), including +5/-1 generated Swift protocol projection. Tests: +151/-2 (net +149). The production growth is the new owner-reporting contract, restored node-host protocol behavior, stricter capability gate, and generated cross-language projection.

## User Impact

Devices now displays the policy that will actually apply, while preserving authored defaults and wildcard/agent overrides. Operators can select only nodes that support both reading and saving approval policy.

Release-note context: Devices now shows effective exec-approval defaults and limits editable node targets to nodes that support both policy reads and writes.

## Evidence

### Fresh approval defaults

Before, fresh state rendered UI fallbacks (`Deny` / `On miss`). After, it renders the owner-reported effective defaults (`Full` / `Off`).

| Before | After |
| --- | --- |
| ![Before: fresh approvals show Deny and On miss](https://github.com/user-attachments/assets/9e790c08-65da-4f96-b46c-4ba601fbeca2) | ![After: fresh approvals show Full and Off](https://github.com/user-attachments/assets/29cf0c6f-8460-4bc4-8416-97ac5cc38150) |

### Editable node targets

Before, a read-only node could be selected for editing. After, only the node advertising both read and write commands is offered.

| Before | After |
| --- | --- |
| ![Before: get-only node is selectable](https://github.com/user-attachments/assets/1e1124b1-c243-4769-80ee-5eb85a2b4b02) | ![After: only the editable node is selectable](https://github.com/user-attachments/assets/257ada95-a012-4397-ab09-faff61979e27) |

Source-blind browser evidence recorded the failing-before values and node list, then the passing-after values and capability-filtered list. All four captures were visually inspected and sanitized before upload.

Focused proof:

- `node scripts/run-vitest.mjs src/gateway/server-methods/exec-approvals.test.ts` — 17/17 passed
- `node scripts/run-vitest.mjs src/node-host/invoke.test.ts` — 27/27 passed
- `node scripts/run-vitest.mjs ui/src/pages/devices/view.devices.test.ts` — 22/22 passed
- Scoped `node scripts/check-changed.mjs -- <core and UI changed files>` — exit 0
- Protocol generation/checks — clean
- Fresh uncommitted autoreview — no accepted or actionable findings

Known proof gap: an unrelated broader local macOS packaging shard timed out and is not claimed as passing. Exact-head CI and the repository Testbox prepare gate remain required before landing.

AI-assisted; the maintainer inspected the implementation, proof, and final diff.
