### PR TITLE
fix(cli): mark in-flight agent runs unsuccessful

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -2136,18 +2136,23 @@ describe("agentCliCommand", () => {
 
   it("surfaces duplicate in-flight gateway runs without pretending a reply arrived", async () => {
     await withTempStore(async () => {
+      const signals = createSignalProcess();
       callGateway.mockResolvedValue({
         runId: "idem-1",
         status: "in_flight",
         sessionKey: "agent:main:main",
       });
 
-      await agentCliCommand({ message: "hi", to: "+1555", runId: "idem-1" }, runtime);
+      await agentCliCommand({ message: "hi", to: "+1555", runId: "idem-1" }, runtime, {
+        process: signals.processLike,
+      });
 
       expect(runtime.error).toHaveBeenCalledWith(
         "Agent run idem-1 is already in flight; not starting a duplicate run.",
       );
       expect(runtime.log).not.toHaveBeenCalledWith("No reply from agent.");
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(signals.processLike.exitCode).toBe(1);
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1170,10 +1170,10 @@ async function agentViaGatewayCommand(
   if (!response) {
     throw new Error("gateway agent call did not return a response");
   }
+  markAgentRunExitCode(response.status, signalBridge);
 
   if (opts.json) {
     writeRuntimeJson(runtime, buildGatewayJsonResponse(response));
-    markAgentRunExitCode(response.status, signalBridge);
     return response;
   }
 
@@ -1189,7 +1189,6 @@ async function agentViaGatewayCommand(
     if (response?.status !== "ok") {
       runtime.log(response?.summary ? response.summary : "No reply from agent.");
     }
-    markAgentRunExitCode(response.status, signalBridge);
     return response;
   }
 
@@ -1199,8 +1198,6 @@ async function agentViaGatewayCommand(
       runtime.log(out);
     }
   }
-
-  markAgentRunExitCode(response.status, signalBridge);
 
   return response;
 }


### PR DESCRIPTION
## What Problem This Solves
Text-mode `openclaw agent` handled a duplicate `in_flight` Gateway result by printing an error and returning before the shared exit-status marker ran. It therefore exited successfully despite explicitly saying the run was not started. JSON mode and other non-success outcomes already exited nonzero.

## Why This Change Was Made
Move the existing status-to-exit-code projection immediately after receiving any non-null Gateway response, before output-mode and streaming branches. This creates one canonical outcome point and deletes the three duplicated late calls; no new status policy is introduced.

## User Impact
Scripts invoking text-mode `openclaw agent` now receive exit code 1 for duplicate in-flight runs, matching the visible error and JSON mode.

## Evidence
- Pre-fix regression: exitCode was undefined, expected 1.
- Post-fix full agent-via-gateway test file: 103 passed, 1 skipped.
- Core tsgo, oxfmt, oxlint, full changed gate and diff check pass.
- Production LOC +1/-4; tests +6/-1.
- Final Codex autoreview clean 0.99.
