### PR TITLE
fix(update): complete managed auto-updates after late gateway exits

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -192,7 +192,7 @@ async function runHelperWithExistingSentinel(params: {
   prepareStateDatabase?: (env: NodeJS.ProcessEnv) => Promise<void> | void;
   sentinel?: unknown;
   deepStatePath?: boolean;
-  parentExitTimeoutMs?: number;
+  commandDelayMs?: number;
   whileHelperRunning?: (env: NodeJS.ProcessEnv) => Promise<void> | void;
 }) {
   const { execFile } =
@@ -242,13 +242,16 @@ async function runHelperWithExistingSentinel(params: {
     writeRestartSentinelRow(env, params.sentinel);
   }
   const helperParamsPath = path.join(tmpDir, "helper-params.json");
+  const exitedParentPid = await spawnExitedPid();
+  const failureScript = `setTimeout(() => process.exit(1), ${params.commandDelayMs ?? 0})`;
   await fs.writeFile(
     helperParamsPath,
     `${JSON.stringify(
       {
         ...helperParams,
-        parentPid: process.pid,
-        parentExitTimeoutMs: params.parentExitTimeoutMs ?? 1,
+        parentPid: exitedParentPid,
+        parentExitTimeoutMs: 5_000,
+        commandArgv: [process.execPath, "-e", failureScript],
         logPath: path.join(tmpDir, "handoff.log"),
         sensitivePaths: [],
       },
@@ -317,6 +320,7 @@ async function runHelperWithCommand(params: {
 }): Promise<{
   ready: Promise<void>;
   completion: Promise<{ code: number }>;
+  logPath: string;
 }> {
   const { execFile } =
     await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -345,6 +349,7 @@ async function runHelperWithCommand(params: {
   >;
 
   const helperParamsPath = path.join(tmpDir, "helper-params.json");
+  const logPath = path.join(tmpDir, "handoff.log");
   await fs.writeFile(
     helperParamsPath,
     `${JSON.stringify(
@@ -355,7 +360,7 @@ async function runHelperWithCommand(params: {
           params.parentExitTimeoutMs === undefined ? 5000 : params.parentExitTimeoutMs,
         cwd: tmpDir,
         commandArgv: params.commandArgv,
-        logPath: path.join(tmpDir, "handoff.log"),
+        logPath,
         sensitivePaths: [],
         ...(params.serviceRecovery ? { serviceRecovery: params.serviceRecovery } : {}),
       },
@@ -382,7 +387,7 @@ async function runHelperWithCommand(params: {
       },
     );
   });
-  return { ready: waitForHandoffReady(child.stdout), completion };
+  return { ready: waitForHandoffReady(child.stdout), completion, logPath };
 }
 
 async function writeFakeSystemctl(): Promise<{ binDir: string; recordPath: string }> {
@@ -782,7 +787,7 @@ describe("managed service update handoff", () => {
         sessionKey: "agent:test:webchat:dm:user-123",
         stats: {
           handoffId: "handoff-123",
-          reason: "managed-service-handoff-parent-timeout",
+          reason: "managed-service-handoff-failed",
         },
       },
     });
@@ -839,7 +844,7 @@ describe("managed service update handoff", () => {
         status: "error",
         stats: {
           handoffId: "handoff-locked",
-          reason: "managed-service-handoff-parent-timeout",
+          reason: "managed-service-handoff-failed",
         },
       },
     });
@@ -859,7 +864,7 @@ describe("managed service update handoff", () => {
         kind: "update",
         status: "error",
         stats: {
-          reason: "managed-service-handoff-parent-timeout",
+          reason: "managed-service-handoff-failed",
         },
       },
     });
@@ -936,7 +941,7 @@ describe("managed service update handoff", () => {
       handoffId: "old-handoff",
       metaHandoffId: "old-handoff",
       sentinel: oldSentinel,
-      parentExitTimeoutMs: 200,
+      commandDelayMs: 200,
       whileHelperRunning: async (stateEnv) => {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, 50);
@@ -1002,17 +1007,19 @@ describe("managed service update handoff", () => {
     await expect(pathExists(unrelatedDir)).resolves.toBe(true);
   });
 
-  it("waits for the configured restart drain and shutdown reserve (#99666)", async () => {
+  it.each([
+    ["the configured restart drain and shutdown reserve (#99666)", 60_000, 2_000, 92_000],
+    ["indefinitely when restart draining has no deadline", undefined, 0, null],
+  ])("waits %s", async (_name, restartDrainTimeoutMs, restartDelayMs, expectedTimeoutMs) => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-timeout-test-"));
     tempDirs.add(tmpDir);
-
     const { startManagedServiceUpdateHandoff } =
       await import("./update-managed-service-handoff.js");
+
     await startManagedServiceUpdateHandoff({
       root: tmpDir,
-      timeoutMs: 1_800_000,
-      restartDrainTimeoutMs: 60_000,
-      restartDelayMs: 2_000,
+      restartDrainTimeoutMs,
+      restartDelayMs,
       parentPid: process.pid,
       execPath: "/usr/local/bin/node",
       argv1: "/opt/openclaw/openclaw.mjs",
@@ -1021,45 +1028,22 @@ describe("managed service update handoff", () => {
     });
 
     const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
-    const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as Record<
-      string,
-      unknown
-    >;
-
-    expect(helperParams.parentExitTimeoutMs).toBe(92_000);
+    const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as {
+      parentExitTimeoutMs?: unknown;
+    };
+    expect(helperParams.parentExitTimeoutMs).toBe(expectedTimeoutMs);
   });
 
-  it("waits indefinitely when restart draining has no deadline", async () => {
-    const tmpDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-handoff-default-timeout-test-"),
-    );
-    tempDirs.add(tmpDir);
-
-    const { startManagedServiceUpdateHandoff } =
-      await import("./update-managed-service-handoff.js");
-    await startManagedServiceUpdateHandoff({
-      root: tmpDir,
-      restartDrainTimeoutMs: undefined,
-      restartDelayMs: 0,
-      parentPid: process.pid,
-      execPath: "/usr/local/bin/node",
-      argv1: "/opt/openclaw/openclaw.mjs",
-      env: {},
-      meta: { sessionKey: "agent:test:webchat:dm:user-123" },
-    });
-
-    const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
-    const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as Record<
-      string,
-      unknown
-    >;
-
-    expect(helperParams.parentExitTimeoutMs).toBeNull();
-  });
-
-  it("runs the handoff after an indefinitely awaited parent exits", async () => {
+  it.each([
+    ["past the expected parent-exit deadline", 50, true],
+    ["through an indefinite parent wait", null, false],
+  ])("runs the update only after the parent exits %s", async (_name, timeoutMs, expectLateLog) => {
     const { spawn } =
       await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    const markerDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-marker-test-"));
+    tempDirs.add(markerDir);
+    const markerPath = path.join(markerDir, "update-ran");
+    const markerScript = `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "ran")`;
     const parent = spawn(process.execPath, ["-e", "process.stdin.resume()"], {
       stdio: ["pipe", "ignore", "ignore"],
     });
@@ -1067,18 +1051,30 @@ describe("managed service update handoff", () => {
 
     try {
       const helper = await runHelperWithCommand({
-        commandArgv: [process.execPath, "-e", ""],
+        commandArgv: [process.execPath, "-e", markerScript],
         parentPid: parent.pid,
-        parentExitTimeoutMs: null,
+        parentExitTimeoutMs: timeoutMs,
       });
       completion = helper.completion;
       await helper.ready;
+
+      if (expectLateLog) {
+        await vi.waitFor(
+          async () => {
+            const log = await fs.readFile(helper.logPath, "utf-8");
+            const expected = `gateway parent pid ${parent.pid} exceeded expected handoff timeout; continuing to wait`;
+            expect(log.split(expected)).toHaveLength(2);
+          },
+          { interval: 10, timeout: 2_000 },
+        );
+      }
       expect(parent.exitCode).toBeNull();
+      await expect(pathExists(markerPath)).resolves.toBe(false);
       parent.stdin.end();
       await expect(completion).resolves.toEqual({ code: 0 });
+      await expect(fs.readFile(markerPath, "utf-8")).resolves.toBe("ran");
     } finally {
       parent.stdin.end();
-      parent.kill();
       await completion?.catch(() => undefined);
     }
   });

--- a/src/infra/update-managed-service-handoff-ownership.test.ts
+++ b/src/infra/update-managed-service-handoff-ownership.test.ts
@@ -144,8 +144,9 @@ async function runOwnershipHelper(params: {
     `${JSON.stringify(
       {
         ...helperParams,
-        parentPid: process.pid,
-        parentExitTimeoutMs: 1,
+        parentPid: 0,
+        parentExitTimeoutMs: 5_000,
+        commandArgv: [process.execPath, "-e", "process.exit(7)"],
         logPath,
         sensitivePaths: [],
       },
@@ -204,7 +205,7 @@ describe("managed service update handoff external ownership", () => {
       },
     });
 
-    expect(result).toEqual({ code: 1, signal: null });
+    expect(result).toEqual({ code: 7, signal: null });
     const databasePath = resolveOpenClawStateSqlitePath(env);
     const stat = await fs.stat(databasePath);
     expect({
@@ -268,7 +269,7 @@ describe("managed service update handoff external ownership", () => {
           await vi.waitFor(
             async () => {
               await expect(fs.readFile(logPath, "utf8")).resolves.toContain(
-                "did not exit before handoff timeout",
+                "managed update command exited code=7",
               );
             },
             { interval: 5, timeout: 2_000 },
@@ -299,7 +300,7 @@ describe("managed service update handoff external ownership", () => {
     if (!helperResult) {
       throw new Error("expected the detached helper to return a result");
     }
-    expect(helperResult.result).toEqual({ code: 1, signal: null });
+    expect(helperResult.result).toEqual({ code: 7, signal: null });
     const databasePath = resolveOpenClawStateSqlitePath(helperResult.env);
     const sqlite = await import("node:sqlite");
     const verifyDb = new sqlite.DatabaseSync(databasePath, { readOnly: true });

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -26,7 +26,8 @@ import { MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX } from "./update-managed-ser
 import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payload.js";
 
 // The Gateway may spend its full restart-drain budget before entering the
-// bounded shutdown phase. Keep the helper alive through both phases. (#99666)
+// bounded shutdown phase. This estimate only controls the late-parent
+// diagnostic; exact parent exit is the update mutation boundary. (#99666)
 const PARENT_EXIT_SHUTDOWN_RESERVE_MS = 30_000;
 const HANDOFF_READY_TIMEOUT_MS = 30_000;
 const HANDOFF_READY_MARKER = "OPENCLAW_UPDATE_HANDOFF_READY\n";
@@ -950,18 +951,20 @@ function startGatewayServiceBestEffort() {
   fs.writeSync(1, ${JSON.stringify(HANDOFF_READY_MARKER)});
 
   try {
-    const deadline =
+    let deadline =
       typeof params.parentExitTimeoutMs === "number"
         ? Date.now() + params.parentExitTimeoutMs
         : null;
-    while (isPidAlive(params.parentPid) && (deadline === null || Date.now() < deadline)) {
+    while (isPidAlive(params.parentPid)) {
+      if (deadline !== null && Date.now() >= deadline) {
+        appendLog(
+          "gateway parent pid " +
+            params.parentPid +
+            " exceeded expected handoff timeout; continuing to wait",
+        );
+        deadline = null;
+      }
       await sleep(250);
-    }
-    if (deadline !== null && isPidAlive(params.parentPid)) {
-      appendLog("gateway parent pid " + params.parentPid + " did not exit before handoff timeout");
-      markUpdateSentinelFailureIfPending("managed-service-handoff-parent-timeout");
-      process.exitCode = 1;
-      return;
     }
 
     appendLog("starting managed update command: " + params.commandLabel);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where managed automatic updates could fail without applying when a busy Gateway exited slightly later than the handoff helper's estimated parent-exit deadline.

A live current-main observation reproduced this deterministically under permanent load: the helper started with `parentExitTimeoutMs=332000`, reported `managed-service-handoff-parent-timeout` after about 5m33s, and exited. The old Gateway completed its normal restart about 34 seconds later, but no helper remained to run the updater.

Related: #99666
Regression from the finite parent-exit failure policy landed in #99695.

## Why This Change Was Made

The handoff's duration estimate is now diagnostic rather than authoritative. The detached helper keeps its existing per-install SQLite lease, logs once when the expected parent-exit window is exceeded, and continues waiting for the exact parent process to exit before mutating the install.

This preserves the documented automatic-update contract: the 15-minute campaign deadline starts apply despite ongoing work, while the Gateway still uses its normal restart drain and session-recovery path. It does not add a larger guessed timeout, force active-run aborts, change supervisor behavior, or create a second updater path. Joiners continue to join the live lease owner.

## User Impact

Managed Gateways under sustained load can complete automatic updates even when restart scheduling, draining, shutdown, or supervisor timing carries the old process slightly beyond the estimated handoff window. The updater still never runs while the old Gateway process is alive, terminal behavior is unchanged, and interrupted sessions keep the normal restart-recovery path.

## Evidence

- Live pre-fix observation on current main: helper deadline at about 5m33s; old Gateway exit/restart at about 6m07s; updater command never ran.
- Pre-fix regression: the late-parent helper test failed with 1 failed / 78 skipped because the helper exited code 1 while the real parent remained alive and the updater marker was absent.
- Focused post-fix proof: `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/update-managed-service-handoff-ownership.test.ts src/infra/update-managed-service-handoff-cross-process.test.ts src/infra/update-managed-service-handoff-command.test.ts` — 30 passed, 2 platform-skipped.
- Full changed gate: `node scripts/check-changed.mjs -- src/infra/update-managed-service-handoff.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/update-managed-service-handoff-ownership.test.ts` — passed.
- `git diff --check` — passed.
- Fresh Codex-backed autoreview — clean, no accepted/actionable findings.
- Production LOC: +12/-9 (net +3). Tests: +53/-56 (net -3). Total patch: +65/-65 (net 0).
- Post-fix production deployment was intentionally not performed; the task explicitly prohibited touching the running production Gateway. The regression uses real child processes and the actual detached helper boundary.
- AI-assisted; maintainer reviewed the full lifecycle, history, diff, and proof.
