### PR TITLE
fix(agents): keep completion workers on one generation

### DIFF
--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -107,6 +107,9 @@ vi.mock("../infra/tmp-openclaw-dir.js", () => ({
 
 import { runIsolatedCompletion } from "./isolated-completion.js";
 
+let preparedModelRuntime: object;
+let releaseRuntimeLease: ReturnType<typeof vi.fn>;
+
 function assistant(
   content: AssistantMessage["content"],
   stopReason: AssistantMessage["stopReason"] = "stop",
@@ -144,15 +147,17 @@ function request() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  preparedModelRuntime = {
+    config: {},
+    metadataSnapshot: createEmptyPluginMetadataSnapshot("/tmp/workspace"),
+    pluginRegistry: createEmptyPluginRegistry(),
+    workspaceDir: "/tmp/workspace",
+    createStores: () => ({ modelRegistry: {} }),
+  };
+  releaseRuntimeLease = vi.fn();
   mocks.acquireAgentRunPreparedModelRuntime.mockResolvedValue({
-    snapshot: {
-      config: {},
-      metadataSnapshot: createEmptyPluginMetadataSnapshot("/tmp/workspace"),
-      pluginRegistry: createEmptyPluginRegistry(),
-      workspaceDir: "/tmp/workspace",
-      createStores: () => ({ modelRegistry: {} }),
-    },
-    release: vi.fn(),
+    snapshot: preparedModelRuntime,
+    release: releaseRuntimeLease,
   });
   mocks.isCliRuntimeAliasForProvider.mockReturnValue(false);
   mocks.resolveCliRuntimeExecutionProvider.mockReturnValue(undefined);
@@ -523,6 +528,11 @@ describe("runIsolatedCompletion", () => {
     await runIsolatedCompletion(request());
 
     expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledOnce();
+    expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
+      expect.objectContaining({ preparedModelRuntime, workspaceDir: "/tmp/workspace" }),
+    );
+    expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledOnce();
+    expect(releaseRuntimeLease).toHaveBeenCalledOnce();
     expect(runIsolatedCompletionV2).toHaveBeenCalledWith(
       expect.objectContaining({ authorization: expect.objectContaining({ owner: "host" }) }),
     );
@@ -550,8 +560,15 @@ describe("runIsolatedCompletion", () => {
       usage: expect.objectContaining({ input: 1, output: 1, totalTokens: 2 }),
     });
     expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
-      expect.objectContaining({ profileId: undefined, bindAuthOwner: true }),
+      expect.objectContaining({
+        profileId: undefined,
+        bindAuthOwner: true,
+        preparedModelRuntime,
+        workspaceDir: "/tmp/workspace",
+      }),
     );
+    expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledOnce();
+    expect(releaseRuntimeLease).toHaveBeenCalledOnce();
     expect(runIsolatedCompletionHarness).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -33,7 +33,10 @@ import {
   isCliRuntimeAliasForProvider,
   resolveCliRuntimeExecutionProvider,
 } from "./model-runtime-aliases.js";
-import { acquireAgentRunPreparedModelRuntime } from "./prepared-model-runtime.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  type PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.js";
 import {
   unwrapModelHeaderSentinelsForProviderEgress,
   unwrapSecretSentinelsForProviderEgress,
@@ -396,6 +399,8 @@ async function prepareHostAuthorization(params: {
   provider: string;
   modelId: string;
   authProfileId?: string;
+  workspaceDir: string;
+  preparedModelRuntime: PreparedModelRuntimeSnapshot;
 }): Promise<Extract<AgentHarnessIsolatedCompletionAuthorization, { owner: "host" }>> {
   const prepared = await prepareSimpleCompletionModel({
     cfg: params.config,
@@ -408,6 +413,8 @@ async function prepareHostAuthorization(params: {
     allowBundledStaticCatalogFallback: true,
     skipAgentDiscovery: true,
     bindAuthOwner: true,
+    workspaceDir: params.workspaceDir,
+    preparedModelRuntime: params.preparedModelRuntime,
   });
   if ("error" in prepared) {
     throw new Error(`Isolated completion preparation failed: ${prepared.error}`);
@@ -609,6 +616,8 @@ export async function runIsolatedCompletion(
                 modelId: request.model,
                 authProfileId:
                   attempt?.kind === "profile" ? attempt.profileId : request.authProfileId,
+                workspaceDir,
+                preparedModelRuntime: lease.snapshot,
               });
               modelMaxTokens = authorization.model.maxTokens;
             }
@@ -654,6 +663,8 @@ export async function runIsolatedCompletion(
           provider,
           modelId: request.model,
           authProfileId: request.authProfileId,
+          workspaceDir,
+          preparedModelRuntime: lease.snapshot,
         });
         const harnessParams: AgentHarnessIsolatedCompletionParams = {
           ...commonParams,

--- a/src/agents/simple-completion-execution.test.ts
+++ b/src/agents/simple-completion-execution.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Model } from "../llm/types.js";
+
+const mocks = vi.hoisted(() => ({
+  complete: vi.fn(),
+  prepareModel: vi.fn((params: { model: unknown }) => params.model),
+}));
+
+vi.mock("../llm/stream.js", () => ({ completeSimple: mocks.complete }));
+vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@openclaw/ai/transports")>()),
+  prepareModelForSimpleCompletion: mocks.prepareModel,
+}));
+
+import { completeWithPreparedSimpleCompletionModel } from "./simple-completion-runtime.js";
+
+const context = { messages: [{ role: "user" as const, content: "pong", timestamp: 1 }] };
+
+beforeEach(() => {
+  mocks.complete.mockReset();
+  mocks.complete.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+  mocks.prepareModel.mockReset();
+  mocks.prepareModel.mockImplementation((params: { model: unknown }) => params.model);
+});
+
+describe("completeWithPreparedSimpleCompletionModel", () => {
+  it("prepares provider-owned stream APIs before running a completion", async () => {
+    const model = {
+      provider: "ollama",
+      id: "llama3.2:latest",
+      name: "llama3.2:latest",
+      api: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8192,
+      maxTokens: 1024,
+    } satisfies Model<"ollama">;
+    const preparedModel = { ...model, api: "openclaw-ollama-simple-test" };
+    const cfg = {
+      models: { providers: { ollama: { baseUrl: "http://remote-ollama:11434", models: [] } } },
+    };
+    mocks.prepareModel.mockReturnValueOnce(preparedModel);
+
+    await completeWithPreparedSimpleCompletionModel({
+      model,
+      auth: { apiKey: "ollama-local", source: "models.json (local marker)", mode: "api-key" },
+      cfg,
+      context,
+    });
+
+    expect(mocks.prepareModel).toHaveBeenCalledWith({
+      apiRegistry: expect.anything(),
+      model,
+      cfg,
+    });
+    expect(mocks.complete).toHaveBeenCalledWith(preparedModel, context, {
+      apiKey: "ollama-local",
+    });
+  });
+
+  it.each(["max", "ultra"] as const)(
+    "normalizes OpenClaw-only %s before using shared model runtime simple completion",
+    async (reasoning) => {
+      const model = {
+        provider: "openai",
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 4096,
+      } satisfies Model<"openai-responses">;
+
+      await completeWithPreparedSimpleCompletionModel({
+        model,
+        auth: { apiKey: "sk-test", source: "env:OPENAI_API_KEY", mode: "api-key" },
+        context,
+        options: { reasoning },
+      });
+
+      expect(mocks.complete).toHaveBeenCalledWith(model, context, {
+        reasoning: "xhigh",
+        apiKey: "sk-test",
+      });
+    },
+  );
+
+  it.each(["max", "ultra"] as const)(
+    "uses max for GPT-5.6 simple completions requested with %s",
+    async (reasoning) => {
+      const model = {
+        provider: "openai",
+        id: "gpt-5.6-terra",
+        name: "gpt-5.6-terra",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 372_000,
+        maxTokens: 128_000,
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      } satisfies Model<"openai-responses">;
+
+      await completeWithPreparedSimpleCompletionModel({
+        model,
+        auth: { apiKey: "sk-test", source: "env:OPENAI_API_KEY", mode: "api-key" },
+        context,
+        options: { reasoning },
+      });
+
+      expect(mocks.complete).toHaveBeenCalledWith(model, context, {
+        reasoning: "max",
+        apiKey: "sk-test",
+      });
+    },
+  );
+
+  it("omits reasoning for local simple completion when thinking is off", async () => {
+    const model = {
+      provider: "openai",
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-responses">;
+
+    await completeWithPreparedSimpleCompletionModel({
+      model,
+      auth: { apiKey: "sk-test", source: "env:OPENAI_API_KEY", mode: "api-key" },
+      context,
+      options: { reasoning: "off" },
+    });
+
+    expect(mocks.complete).toHaveBeenCalledWith(model, context, { apiKey: "sk-test" });
+  });
+
+  it("preserves explicit off for a prepared Claude Sonnet 5 alias", async () => {
+    const model = {
+      provider: "anthropic",
+      id: "production-sonnet",
+      name: "Production Sonnet",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+      params: { canonicalModelId: "claude-sonnet-5" },
+    } satisfies Model<"anthropic-messages">;
+    const preparedModel = {
+      ...model,
+      api: "openclaw-provider-simple:anthropic:production-sonnet",
+    } satisfies Model;
+    mocks.prepareModel.mockReturnValueOnce(preparedModel);
+
+    await completeWithPreparedSimpleCompletionModel({
+      model,
+      auth: { apiKey: "sk-test", source: "env:ANTHROPIC_API_KEY", mode: "api-key" },
+      context,
+      options: { reasoning: "off" },
+    });
+
+    expect(mocks.complete).toHaveBeenCalledWith(preparedModel, context, {
+      reasoning: "off",
+      apiKey: "sk-test",
+    });
+  });
+});

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import type { Model } from "../llm/types.js";
+import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import { AuthStorage, ModelRegistry } from "./sessions/index.js";
+
+const mocks = vi.hoisted(() => ({
+  acquireRuntimeLease: vi.fn(),
+  getApiKeyForModel: vi.fn(),
+  prepareProviderRuntimeAuth: vi.fn(),
+  publishedGeneration: "A",
+  readGeneration: (() => "unscoped") as () => string,
+}));
+
+vi.mock("./prepared-model-runtime.js", () => ({
+  acquireAgentRunPreparedModelRuntime: mocks.acquireRuntimeLease,
+}));
+
+vi.mock("../plugins/runtime/generation-scope.js", async () => {
+  const { AsyncLocalStorage } = await import("node:async_hooks");
+  const generation = new AsyncLocalStorage<string>();
+  mocks.readGeneration = () => generation.getStore() ?? mocks.publishedGeneration;
+  return {
+    withPluginRuntimeGenerationScope: (snapshot: { testGeneration?: string }, run: () => unknown) =>
+      generation.run(snapshot.testGeneration ?? "unknown", run),
+  };
+});
+
+vi.mock("./model-auth.js", () => ({
+  applySecretRefHeaderSentinels: (model: Model) => model,
+  applyLocalNoAuthHeaderOverride: (model: Model) => model,
+  formatMissingAuthError: vi.fn(),
+  getApiKeyForModelCore: mocks.getApiKeyForModel,
+  resolveApiKeyForProviderCore: mocks.getApiKeyForModel,
+}));
+
+vi.mock("../plugins/provider-runtime.runtime.js", () => ({
+  prepareProviderRuntimeAuth: mocks.prepareProviderRuntimeAuth,
+}));
+
+vi.mock("./sessions/model-registry-runtime.js", () => ({
+  initializeModelRegistryRuntime: vi.fn(),
+  getModelRegistryRuntime: () => ({ llmRuntime: { registry: {}, streamSimple: vi.fn() } }),
+}));
+
+import { prepareSimpleCompletionModel } from "./simple-completion-runtime.js";
+
+beforeEach(() => {
+  mocks.publishedGeneration = "A";
+  mocks.acquireRuntimeLease.mockReset();
+  mocks.getApiKeyForModel.mockReset();
+  mocks.prepareProviderRuntimeAuth.mockReset();
+  const authStorage = AuthStorage.inMemory({});
+  const modelRegistry = ModelRegistry.inMemory(authStorage);
+  mocks.acquireRuntimeLease.mockResolvedValue({
+    snapshot: {
+      testGeneration: "A",
+      agentDir: "/tmp/openclaw-agent",
+      workspaceDir: "/tmp/runtime-workspace",
+      config: {},
+      authModes: {},
+      metadataSnapshot: { plugins: [], index: { plugins: [] } },
+      allowGatewaySubagentBinding: false,
+      modelCatalog: { entries: [] },
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      activeProjectKeys: [],
+      createStores: () => ({ authStorage, modelRegistry }),
+    },
+    release: vi.fn(),
+  });
+});
+
+it("keeps route rematerialization and runtime auth on the acquired generation", async () => {
+  const observedModelGenerations: string[] = [];
+  const observedRuntimeAuthGenerations: string[] = [];
+  const modelResolver: typeof resolveModelAsync = vi.fn(
+    async (provider, modelId, _agentDir, cfg, options) => {
+      if (!options?.authStorage || !options.modelRegistry) {
+        throw new Error("prepared stores were not bound");
+      }
+      const generation = mocks.readGeneration();
+      observedModelGenerations.push(generation);
+      const configured = cfg?.models?.providers?.openai;
+      return {
+        model: {
+          provider,
+          id: modelId,
+          name: modelId,
+          api: configured?.api ?? "openai-chatgpt-responses",
+          baseUrl: configured?.baseUrl ?? "https://chatgpt.com/backend-api/codex",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 4096,
+          params: { generation },
+        } satisfies Model,
+        authStorage: options.authStorage,
+        modelRegistry: options.modelRegistry,
+      };
+    },
+  );
+  mocks.getApiKeyForModel.mockImplementation(async () => {
+    await Promise.resolve();
+    mocks.publishedGeneration = "B";
+    return {
+      apiKey: "sk-platform",
+      profileId: "openai:platform",
+      source: "profile:openai:platform",
+      mode: "api-key",
+    };
+  });
+  mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
+    observedRuntimeAuthGenerations.push(mocks.readGeneration());
+    return undefined;
+  });
+
+  const result = await prepareSimpleCompletionModel({
+    cfg: {},
+    agentId: "main",
+    provider: "openai",
+    modelId: "gpt-5.5",
+    agentDir: "/tmp/openclaw-agent",
+    modelResolver,
+  });
+
+  expect(result).not.toHaveProperty("error");
+  if ("error" in result) {
+    throw new Error(result.error);
+  }
+  expect(result.model.params).toMatchObject({ generation: "A" });
+  expect(observedModelGenerations).toEqual(["A", "A"]);
+  expect(observedRuntimeAuthGenerations).toEqual(["A"]);
+});

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -10,25 +10,27 @@ import {
 } from "../secrets/sentinel.js";
 import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { fingerprintResolvedProviderAuth } from "./execution-auth-binding.js";
-import { bindSimpleCompletionModelResolverWorkspace } from "./simple-completion-scope.js";
 
 // Hoisted mocks keep Vitest module replacement stable while the implementation
 // under test imports auth, model resolution, and transport helpers at module load.
 const hoisted = vi.hoisted(() => ({
+  acquireRuntimeLeaseMock: vi.fn(),
   resolveModelMock: vi.fn(),
   resolveModelAsyncMock: vi.fn(),
   getApiKeyForModelMock: vi.fn(),
   applyLocalNoAuthHeaderOverrideMock: vi.fn(),
   setRuntimeApiKeyMock: vi.fn(),
   prepareProviderRuntimeAuthMock: vi.fn(),
-  prepareModelForSimpleCompletionMock: vi.fn((params: { model: unknown }) => params.model),
-  completeMock: vi.fn(),
   ensureAuthProfileStoreMock: vi.fn(),
   getCurrentPluginMetadataSnapshotMock: vi.fn(),
 }));
 
-vi.mock("../llm/stream.js", () => ({
-  completeSimple: hoisted.completeMock,
+vi.mock("./prepared-model-runtime.js", () => ({
+  acquireAgentRunPreparedModelRuntime: hoisted.acquireRuntimeLeaseMock,
+}));
+
+vi.mock("../plugins/runtime/generation-scope.js", () => ({
+  withPluginRuntimeGenerationScope: (_snapshot: unknown, run: () => unknown) => run(),
 }));
 
 vi.mock("./sessions/model-registry-runtime.js", () => ({
@@ -38,7 +40,7 @@ vi.mock("./sessions/model-registry-runtime.js", () => ({
       apiRegistry,
       llmRuntime: {
         registry: apiRegistry,
-        completeSimple: (...args: unknown[]) => hoisted.completeMock(...args),
+        completeSimple: vi.fn(),
         streamSimple: vi.fn(),
       },
     };
@@ -59,11 +61,6 @@ vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal)
   getCurrentPluginMetadataSnapshot: hoisted.getCurrentPluginMetadataSnapshotMock,
 }));
 
-vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@openclaw/ai/transports")>()),
-  prepareModelForSimpleCompletion: hoisted.prepareModelForSimpleCompletionMock,
-}));
-
 vi.mock("./model-auth.js", () => ({
   applySecretRefHeaderSentinels: (model: unknown) => model,
   formatMissingAuthError: vi.fn(
@@ -80,28 +77,41 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
 }));
 
 import {
-  completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
 beforeEach(() => {
+  hoisted.acquireRuntimeLeaseMock.mockReset();
   hoisted.resolveModelMock.mockReset();
   hoisted.resolveModelAsyncMock.mockReset();
   hoisted.getApiKeyForModelMock.mockReset();
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockReset();
   hoisted.setRuntimeApiKeyMock.mockReset();
   hoisted.prepareProviderRuntimeAuthMock.mockReset();
-  hoisted.prepareModelForSimpleCompletionMock.mockReset();
-  hoisted.completeMock.mockReset();
   hoisted.ensureAuthProfileStoreMock.mockReset();
   hoisted.getCurrentPluginMetadataSnapshotMock.mockReset();
+  hoisted.acquireRuntimeLeaseMock.mockResolvedValue({
+    snapshot: {
+      agentDir: "/tmp/openclaw-agent",
+      workspaceDir: "/tmp/runtime-workspace",
+      config: {},
+      authModes: {},
+      metadataSnapshot: { plugins: [], index: { plugins: [] } },
+      allowGatewaySubagentBinding: false,
+      modelCatalog: { entries: [] },
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      activeProjectKeys: [],
+      createStores: () => ({
+        authStorage: { setRuntimeApiKey: hoisted.setRuntimeApiKeyMock },
+        modelRegistry: {},
+      }),
+    },
+    release: vi.fn(),
+  });
 
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockImplementation((model: unknown) => model);
-  hoisted.prepareModelForSimpleCompletionMock.mockImplementation(
-    (params: { model: unknown }) => params.model,
-  );
-  hoisted.completeMock.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
 
   hoisted.resolveModelMock.mockReturnValue({
     model: {
@@ -201,10 +211,8 @@ describe("prepareSimpleCompletionModel", () => {
       provider: "anthropic",
       modelId: "claude-opus-4-6",
       agentDir: "/tmp/openclaw-agent",
-      modelResolver: bindSimpleCompletionModelResolverWorkspace(
-        hoisted.resolveModelAsyncMock as typeof resolveModelAsync,
-        "/tmp/runtime-workspace",
-      ),
+      workspaceDir: "/tmp/runtime-workspace",
+      modelResolver: hoisted.resolveModelAsyncMock as typeof resolveModelAsync,
     });
 
     expectPreparedModelResult(result);
@@ -584,7 +592,7 @@ describe("prepareSimpleCompletionModel", () => {
       };
     };
     expect(runtimeAuthInput.provider).toBe("amazon-bedrock-mantle");
-    expect(runtimeAuthInput.workspaceDir).toBe("/tmp/openclaw-agent");
+    expect(runtimeAuthInput.workspaceDir).toBe("/tmp/runtime-workspace");
     expect(runtimeAuthInput.context?.apiKey).toBe("__amazon_bedrock_mantle_iam__");
     expect(runtimeAuthInput.context?.authMode).toBe("api-key");
     expect(runtimeAuthInput.context?.modelId).toBe("anthropic.claude-opus-4-7");
@@ -633,11 +641,13 @@ describe("prepareSimpleCompletionModel", () => {
     expect(hoisted.resolveModelAsyncMock).toHaveBeenCalledWith(
       "ollama",
       "llama3.2:latest",
+      "/tmp/openclaw-agent",
       undefined,
-      undefined,
-      {
+      expect.objectContaining({
         skipAgentDiscovery: true,
-      },
+        workspaceDir: "/tmp/runtime-workspace",
+        preparedModelRuntime: expect.anything(),
+      }),
     );
   });
 
@@ -671,9 +681,12 @@ describe("prepareSimpleCompletionModel", () => {
     expect(resolveModelAsync).toHaveBeenCalledWith(
       "anthropic",
       "claude-opus-4-6",
+      "/tmp/openclaw-agent",
       undefined,
-      undefined,
-      {},
+      expect.objectContaining({
+        workspaceDir: "/tmp/runtime-workspace",
+        preparedModelRuntime: expect.anything(),
+      }),
     );
   });
 
@@ -702,12 +715,14 @@ describe("prepareSimpleCompletionModel", () => {
     expect(hoisted.resolveModelAsyncMock).toHaveBeenCalledWith(
       "mistral",
       "mistral-medium-3-5",
+      "/tmp/openclaw-agent",
       undefined,
-      undefined,
-      {
+      expect.objectContaining({
         allowBundledStaticCatalogFallback: true,
         skipAgentDiscovery: true,
-      },
+        workspaceDir: "/tmp/runtime-workspace",
+        preparedModelRuntime: expect.anything(),
+      }),
     );
   });
 });
@@ -863,230 +878,5 @@ describe("prepareSimpleCompletionModelForAgent", () => {
     expectPreparedModelResult(result);
     expect(result.selection).toMatchObject({ provider: "openai", modelId: "gpt-5.5" });
     expect(result.model).toMatchObject({ id: "gpt-5.5", api: "openai-responses" });
-  });
-});
-
-describe("completeWithPreparedSimpleCompletionModel", () => {
-  it("prepares provider-owned stream APIs before running a completion", async () => {
-    const model = {
-      provider: "ollama",
-      id: "llama3.2:latest",
-      name: "llama3.2:latest",
-      api: "ollama",
-      baseUrl: "http://127.0.0.1:11434",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 8192,
-      maxTokens: 1024,
-    } satisfies Model<"ollama">;
-    const preparedModel = {
-      ...model,
-      api: "openclaw-ollama-simple-test",
-    };
-    const cfg = {
-      models: { providers: { ollama: { baseUrl: "http://remote-ollama:11434", models: [] } } },
-    };
-    hoisted.prepareModelForSimpleCompletionMock.mockReturnValueOnce(preparedModel);
-
-    await completeWithPreparedSimpleCompletionModel({
-      model,
-      auth: {
-        apiKey: "ollama-local",
-        source: "models.json (local marker)",
-        mode: "api-key",
-      },
-      cfg,
-      context: {
-        messages: [{ role: "user", content: "pong", timestamp: 1 }],
-      },
-    });
-
-    expect(hoisted.prepareModelForSimpleCompletionMock).toHaveBeenCalledWith({
-      apiRegistry: expect.anything(),
-      model,
-      cfg,
-    });
-    expect(hoisted.completeMock).toHaveBeenCalledWith(
-      preparedModel,
-      {
-        messages: [{ role: "user", content: "pong", timestamp: 1 }],
-      },
-      {
-        apiKey: "ollama-local",
-      },
-    );
-  });
-
-  it.each(["max", "ultra"] as const)(
-    "normalizes OpenClaw-only %s before using shared model runtime simple completion",
-    async (reasoning) => {
-      const model = {
-        provider: "openai",
-        id: "gpt-5.4",
-        name: "gpt-5.4",
-        api: "openai-responses",
-        baseUrl: "https://api.openai.com/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 128000,
-        maxTokens: 4096,
-      } satisfies Model<"openai-responses">;
-
-      await completeWithPreparedSimpleCompletionModel({
-        model,
-        auth: {
-          apiKey: "sk-test",
-          source: "env:OPENAI_API_KEY",
-          mode: "api-key",
-        },
-        context: {
-          messages: [{ role: "user", content: "pong", timestamp: 1 }],
-        },
-        options: { reasoning },
-      });
-
-      expect(hoisted.completeMock).toHaveBeenCalledWith(
-        model,
-        {
-          messages: [{ role: "user", content: "pong", timestamp: 1 }],
-        },
-        {
-          reasoning: "xhigh",
-          apiKey: "sk-test",
-        },
-      );
-    },
-  );
-
-  it.each(["max", "ultra"] as const)(
-    "uses max for GPT-5.6 simple completions requested with %s",
-    async (reasoning) => {
-      const model = {
-        provider: "openai",
-        id: "gpt-5.6-terra",
-        name: "gpt-5.6-terra",
-        api: "openai-responses",
-        baseUrl: "https://api.openai.com/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 372_000,
-        maxTokens: 128_000,
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-      } satisfies Model<"openai-responses">;
-
-      await completeWithPreparedSimpleCompletionModel({
-        model,
-        auth: {
-          apiKey: "sk-test",
-          source: "env:OPENAI_API_KEY",
-          mode: "api-key",
-        },
-        context: {
-          messages: [{ role: "user", content: "pong", timestamp: 1 }],
-        },
-        options: { reasoning },
-      });
-
-      expect(hoisted.completeMock).toHaveBeenCalledWith(
-        model,
-        {
-          messages: [{ role: "user", content: "pong", timestamp: 1 }],
-        },
-        {
-          reasoning: "max",
-          apiKey: "sk-test",
-        },
-      );
-    },
-  );
-
-  it("omits reasoning for local simple completion when thinking is off", async () => {
-    const model = {
-      provider: "openai",
-      id: "gpt-5.4",
-      name: "gpt-5.4",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128000,
-      maxTokens: 4096,
-    } satisfies Model<"openai-responses">;
-
-    await completeWithPreparedSimpleCompletionModel({
-      model,
-      auth: {
-        apiKey: "sk-test",
-        source: "env:OPENAI_API_KEY",
-        mode: "api-key",
-      },
-      context: {
-        messages: [{ role: "user", content: "pong", timestamp: 1 }],
-      },
-      options: {
-        reasoning: "off",
-      },
-    });
-
-    expect(hoisted.completeMock).toHaveBeenCalledWith(
-      model,
-      {
-        messages: [{ role: "user", content: "pong", timestamp: 1 }],
-      },
-      {
-        apiKey: "sk-test",
-      },
-    );
-  });
-
-  it("preserves explicit off for a prepared Claude Sonnet 5 alias", async () => {
-    const model = {
-      provider: "anthropic",
-      id: "production-sonnet",
-      name: "Production Sonnet",
-      api: "anthropic-messages",
-      baseUrl: "https://api.anthropic.com",
-      reasoning: true,
-      input: ["text", "image"],
-      cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
-      contextWindow: 1_000_000,
-      maxTokens: 128_000,
-      params: { canonicalModelId: "claude-sonnet-5" },
-    } satisfies Model<"anthropic-messages">;
-    const preparedModel = {
-      ...model,
-      api: "openclaw-provider-simple:anthropic:production-sonnet",
-    } satisfies Model;
-    hoisted.prepareModelForSimpleCompletionMock.mockReturnValueOnce(preparedModel);
-
-    await completeWithPreparedSimpleCompletionModel({
-      model,
-      auth: {
-        apiKey: "sk-test",
-        source: "env:ANTHROPIC_API_KEY",
-        mode: "api-key",
-      },
-      context: {
-        messages: [{ role: "user", content: "pong", timestamp: 1 }],
-      },
-      options: {
-        reasoning: "off",
-      },
-    });
-
-    expect(hoisted.completeMock).toHaveBeenCalledWith(
-      preparedModel,
-      {
-        messages: [{ role: "user", content: "pong", timestamp: 1 }],
-      },
-      {
-        reasoning: "off",
-        apiKey: "sk-test",
-      },
-    );
   });
 });

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -22,7 +22,13 @@ import type {
   ThinkingLevel as SimpleCompletionThinkingLevel,
 } from "../llm/types.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
-import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentEffectiveModelPrimary,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "./agent-scope.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
 import { resolveModelAsync } from "./embedded-agent-runner/model.js";
@@ -49,6 +55,10 @@ import {
 import { resolveOpenAIModelRoutes, selectOpenAIModelRouteAuth } from "./openai-model-routes.js";
 import { OPENAI_PROVIDER_ID, isOpenAIProvider } from "./openai-routing.js";
 import {
+  acquireAgentRunPreparedModelRuntime,
+  type PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.js";
+import {
   buildProviderModelAuthDirectSource,
   buildProviderModelAuthSourcePlan,
 } from "./provider-model-auth-source-plan.js";
@@ -57,17 +67,11 @@ import { protectPreparedProviderRuntimeAuth } from "./provider-secret-egress.js"
 import { buildAgentRuntimeAuthPlan } from "./runtime-plan/auth.js";
 import { materializePreparedRuntimeModel } from "./runtime-plan/materialize-model.js";
 import { getModelRegistryRuntime } from "./sessions/model-registry-runtime.js";
-import { resolveSimpleCompletionModelResolverWorkspace } from "./simple-completion-scope.js";
+import {
+  createPreparedSimpleCompletionResolverContext,
+  type PreparedSimpleCompletionResolverContext,
+} from "./simple-completion-scope.js";
 import { resolveUtilityModelRefForAgent } from "./utility-model.js";
-
-type SimpleCompletionAuthStorage = {
-  setRuntimeApiKey: (provider: string, apiKey: string) => void;
-};
-
-type CompletionRuntimeCredential = {
-  apiKey: string;
-  model: Model;
-};
 
 type AllowedMissingApiKeyMode = ResolvedProviderAuth["mode"];
 
@@ -100,17 +104,12 @@ type AgentSimpleCompletionSelection = {
 };
 
 type PreparedSimpleCompletionModelForAgent =
-  | {
+  | (Extract<PreparedSimpleCompletionModel, { model: Model }> & {
       selection: AgentSimpleCompletionSelection;
-      model: Model;
-      auth: ResolvedProviderAuth;
-      sourceAuthFingerprint?: string;
-    }
-  | {
-      error: string;
+    })
+  | (Extract<PreparedSimpleCompletionModel, { error: string }> & {
       selection?: AgentSimpleCompletionSelection;
-      auth?: ResolvedProviderAuth;
-    };
+    });
 
 export function resolveSimpleCompletionSelectionForAgent(params: {
   cfg: OpenClawConfig;
@@ -156,80 +155,19 @@ export function resolveSimpleCompletionSelectionForAgent(params: {
   if (!provider || !modelId) {
     return null;
   }
+  const runtimeProvider =
+    isOpenAIProvider(provider) &&
+    resolveAgentHarnessPolicy({ provider, modelId, config: params.cfg, agentId: params.agentId })
+      .runtime === "codex"
+      ? OPENAI_PROVIDER_ID
+      : undefined;
   return {
     provider,
     modelId,
-    ...resolveSimpleCompletionRuntimeProvider({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      provider,
-      modelId,
-    }),
+    ...(runtimeProvider ? { runtimeProvider } : {}),
     profileId: split?.profile || undefined,
     agentDir: params.agentDir?.trim() || resolveAgentDir(params.cfg, params.agentId),
   };
-}
-
-function resolveSimpleCompletionRuntimeProvider(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  provider: string;
-  modelId: string;
-}): Pick<AgentSimpleCompletionSelection, "runtimeProvider"> {
-  if (!isOpenAIProvider(params.provider)) {
-    return {};
-  }
-  const policy = resolveAgentHarnessPolicy({
-    provider: params.provider,
-    modelId: params.modelId,
-    config: params.cfg,
-    agentId: params.agentId,
-  });
-  return policy.runtime === "codex" ? { runtimeProvider: OPENAI_PROVIDER_ID } : {};
-}
-
-async function setRuntimeApiKeyForCompletion(params: {
-  authStorage: SimpleCompletionAuthStorage;
-  model: Model;
-  apiKey: string;
-  authMode: ResolvedProviderAuth["mode"];
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-  profileId?: string;
-}): Promise<CompletionRuntimeCredential> {
-  const preparedAuth = protectPreparedProviderRuntimeAuth({
-    provider: params.model.provider,
-    preparedAuth: await prepareProviderRuntimeAuth({
-      provider: params.model.provider,
-      config: params.cfg,
-      workspaceDir: params.workspaceDir,
-      env: process.env,
-      context: {
-        config: params.cfg,
-        workspaceDir: params.workspaceDir,
-        env: process.env,
-        provider: params.model.provider,
-        modelId: params.model.id,
-        model: params.model,
-        apiKey: params.apiKey,
-        authMode: params.authMode,
-        profileId: params.profileId,
-      },
-    }),
-  });
-  const runtimeApiKey = preparedAuth?.apiKey?.trim() || params.apiKey;
-  params.authStorage.setRuntimeApiKey(params.model.provider, runtimeApiKey);
-  return {
-    apiKey: runtimeApiKey,
-    model: applyPreparedRuntimeAuthToModel(params.model, preparedAuth),
-  };
-}
-
-function hasMissingApiKeyAllowance(params: {
-  mode: ResolvedProviderAuth["mode"];
-  allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
-}): boolean {
-  return Boolean(params.allowMissingApiKeyModes?.includes(params.mode));
 }
 
 export async function prepareSimpleCompletionModel(params: {
@@ -245,9 +183,27 @@ export async function prepareSimpleCompletionModel(params: {
   skipAgentDiscovery?: boolean;
   bindAuthOwner?: boolean;
   modelResolver?: typeof resolveModelAsync;
+  /** Internal caller-owned generation. Public plugin callers use the agent helper below. */
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
+  workspaceDir?: string;
+  agentRuntimeId?: string;
 }): Promise<PreparedSimpleCompletionModel> {
-  const workspaceDir = resolveSimpleCompletionModelResolverWorkspace(params.modelResolver);
-  const resolved = await (params.modelResolver ?? resolveModelAsync)(
+  return await withPreparedSimpleCompletionRuntime(
+    params,
+    async (context) =>
+      await prepareSimpleCompletionModelCore(
+        { ...params, agentDir: context.preparedModelRuntime.agentDir },
+        context,
+      ),
+  );
+}
+
+async function prepareSimpleCompletionModelCore(
+  params: Parameters<typeof prepareSimpleCompletionModel>[0],
+  context: PreparedSimpleCompletionResolverContext,
+): Promise<PreparedSimpleCompletionModel> {
+  const { modelResolver, workspaceDir } = context;
+  const resolved = await modelResolver(
     params.provider,
     params.modelId,
     params.agentDir,
@@ -258,7 +214,6 @@ export async function prepareSimpleCompletionModel(params: {
         ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
         : {}),
       ...(params.skipAgentDiscovery ? { skipAgentDiscovery: true } : {}),
-      workspaceDir,
       authProfileId: params.profileId,
       preferredProfile: params.preferredProfile,
     },
@@ -376,23 +331,14 @@ export async function prepareSimpleCompletionModel(params: {
           config: params.cfg,
           model: initialModel,
           resolveModel: ({ config, authProfileId, authProfileMode }) =>
-            (params.modelResolver ?? resolveModelAsync)(
-              initialModel.provider,
-              initialModel.id,
-              params.agentDir,
-              config,
-              {
-                ...(params.agentId ? { agentId: params.agentId } : {}),
-                authStorage: resolved.authStorage,
-                modelRegistry: resolved.modelRegistry,
-                skipAgentDiscovery: true,
-                allowBundledStaticCatalogFallback: true,
-                preferBundledStaticCatalogTransport: true,
-                workspaceDir,
-                authProfileId,
-                authProfileMode,
-              },
-            ),
+            modelResolver(initialModel.provider, initialModel.id, params.agentDir, config, {
+              ...(params.agentId ? { agentId: params.agentId } : {}),
+              skipAgentDiscovery: true,
+              allowBundledStaticCatalogFallback: true,
+              preferBundledStaticCatalogTransport: true,
+              authProfileId,
+              authProfileMode,
+            }),
         })) ?? initialModel;
       if (resolvesAuthBeforePhysicalRoute) {
         auth = await getApiKeyForModelCore({
@@ -414,13 +360,7 @@ export async function prepareSimpleCompletionModel(params: {
     };
   }
   const rawApiKey = auth.apiKey?.trim();
-  if (
-    !rawApiKey &&
-    !hasMissingApiKeyAllowance({
-      mode: auth.mode,
-      allowMissingApiKeyModes: params.allowMissingApiKeyModes,
-    })
-  ) {
+  if (!rawApiKey && !params.allowMissingApiKeyModes?.includes(auth.mode)) {
     return {
       error: formatMissingAuthError(auth, resolvedModel.provider),
       auth,
@@ -429,17 +369,29 @@ export async function prepareSimpleCompletionModel(params: {
 
   let authValue = rawApiKey;
   if (rawApiKey) {
-    const runtimeCredential = await setRuntimeApiKeyForCompletion({
-      authStorage: resolved.authStorage,
-      model: resolvedModel,
-      apiKey: rawApiKey,
-      authMode: auth.mode,
-      cfg: params.cfg,
-      workspaceDir: workspaceDir ?? params.agentDir,
-      profileId: auth.profileId,
+    const preparedAuth = protectPreparedProviderRuntimeAuth({
+      provider: resolvedModel.provider,
+      preparedAuth: await prepareProviderRuntimeAuth({
+        provider: resolvedModel.provider,
+        config: params.cfg,
+        workspaceDir,
+        env: process.env,
+        context: {
+          config: params.cfg,
+          workspaceDir,
+          env: process.env,
+          provider: resolvedModel.provider,
+          modelId: resolvedModel.id,
+          model: resolvedModel,
+          apiKey: rawApiKey,
+          authMode: auth.mode,
+          profileId: auth.profileId,
+        },
+      }),
     });
-    authValue = runtimeCredential.apiKey;
-    resolvedModel = runtimeCredential.model;
+    authValue = preparedAuth?.apiKey?.trim() || rawApiKey;
+    resolved.authStorage.setRuntimeApiKey(resolvedModel.provider, authValue);
+    resolvedModel = applyPreparedRuntimeAuthToModel(resolvedModel, preparedAuth);
   }
 
   const resolvedAuth: ResolvedProviderAuth = {
@@ -470,6 +422,49 @@ export async function prepareSimpleCompletionModel(params: {
   };
 }
 
+async function withPreparedSimpleCompletionRuntime<T>(
+  params: {
+    cfg: OpenClawConfig | undefined;
+    agentId?: string;
+    agentDir?: string;
+    modelResolver?: typeof resolveModelAsync;
+    preparedModelRuntime?: PreparedModelRuntimeSnapshot;
+    workspaceDir?: string;
+    agentRuntimeId?: string;
+  },
+  run: (context: PreparedSimpleCompletionResolverContext) => Promise<T>,
+): Promise<T> {
+  const config = params.cfg ?? {};
+  const agentId = params.agentId ?? resolveDefaultAgentId(config);
+  const agentDir = params.agentDir?.trim() || resolveAgentDir(config, agentId);
+  const requestedWorkspaceDir =
+    params.workspaceDir ??
+    params.preparedModelRuntime?.workspaceDir ??
+    resolveAgentWorkspaceDir(config, agentId);
+  const lease = params.preparedModelRuntime
+    ? undefined
+    : await acquireAgentRunPreparedModelRuntime({
+        config,
+        agentId,
+        agentDir,
+        workspaceDir: requestedWorkspaceDir,
+      });
+  const preparedModelRuntime = params.preparedModelRuntime ?? lease!.snapshot;
+  const workspaceDir =
+    params.workspaceDir ?? preparedModelRuntime.workspaceDir ?? requestedWorkspaceDir;
+  const context = createPreparedSimpleCompletionResolverContext({
+    preparedModelRuntime,
+    workspaceDir,
+    modelResolver: params.modelResolver,
+    agentRuntimeId: params.agentRuntimeId,
+  });
+  try {
+    return await withPluginRuntimeGenerationScope(preparedModelRuntime, () => run(context));
+  } finally {
+    lease?.release();
+  }
+}
+
 export async function prepareSimpleCompletionModelForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -485,48 +480,38 @@ export async function prepareSimpleCompletionModelForAgent(params: {
   bindAuthOwner?: boolean;
   modelResolver?: typeof resolveModelAsync;
 }): Promise<PreparedSimpleCompletionModelForAgent> {
-  const selection = resolveSimpleCompletionSelectionForAgent({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    agentDir: params.agentDir,
-    modelRef: params.modelRef,
-    useUtilityModel: params.useUtilityModel,
+  return await withPreparedSimpleCompletionRuntime(params, async (context) => {
+    const selection = resolveSimpleCompletionSelectionForAgent({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      agentDir: context.preparedModelRuntime.agentDir,
+      modelRef: params.modelRef,
+      useUtilityModel: params.useUtilityModel,
+      manifestPlugins: context.preparedModelRuntime.metadataSnapshot.plugins,
+    });
+    if (!selection) {
+      return { error: `No model configured for agent ${params.agentId}.` };
+    }
+    const prepared = await prepareSimpleCompletionModelCore(
+      {
+        cfg: params.cfg,
+        agentId: params.agentId,
+        provider: selection.runtimeProvider ?? selection.provider,
+        modelId: selection.modelId,
+        agentDir: selection.agentDir,
+        profileId: selection.profileId,
+        preferredProfile: params.preferredProfile,
+        allowMissingApiKeyModes: params.allowMissingApiKeyModes,
+        ...(params.allowBundledStaticCatalogFallback !== undefined
+          ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
+          : {}),
+        skipAgentDiscovery: params.skipAgentDiscovery,
+        bindAuthOwner: params.bindAuthOwner,
+      },
+      context,
+    );
+    return { ...prepared, selection };
   });
-  if (!selection) {
-    return {
-      error: `No model configured for agent ${params.agentId}.`,
-    };
-  }
-  const prepared = await prepareSimpleCompletionModel({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    provider: selection.runtimeProvider ?? selection.provider,
-    modelId: selection.modelId,
-    agentDir: selection.agentDir,
-    profileId: selection.profileId,
-    preferredProfile: params.preferredProfile,
-    allowMissingApiKeyModes: params.allowMissingApiKeyModes,
-    ...(params.allowBundledStaticCatalogFallback !== undefined
-      ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
-      : {}),
-    skipAgentDiscovery: params.skipAgentDiscovery,
-    bindAuthOwner: params.bindAuthOwner,
-    modelResolver: params.modelResolver,
-  });
-  if ("error" in prepared) {
-    return {
-      ...prepared,
-      selection,
-    };
-  }
-  return {
-    selection,
-    model: prepared.model,
-    auth: prepared.auth,
-    ...(prepared.sourceAuthFingerprint
-      ? { sourceAuthFingerprint: prepared.sourceAuthFingerprint }
-      : {}),
-  };
 }
 
 export async function completeWithPreparedSimpleCompletionModel(params: {

--- a/src/agents/simple-completion-scope.ts
+++ b/src/agents/simple-completion-scope.ts
@@ -1,27 +1,34 @@
-import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 
 type SimpleCompletionModelResolver = typeof resolveModelAsync;
 
-const workspaceByResolver = new WeakMap<SimpleCompletionModelResolver, string>();
+export type PreparedSimpleCompletionResolverContext = Readonly<{
+  modelResolver: SimpleCompletionModelResolver;
+  preparedModelRuntime: PreparedModelRuntimeSnapshot;
+  workspaceDir: string;
+}>;
 
-/** Keep request-local workspace scope without growing the public completion SDK signature. */
-export function bindSimpleCompletionModelResolverWorkspace(
-  resolver: SimpleCompletionModelResolver,
-  workspaceDir: string,
-): SimpleCompletionModelResolver {
-  const scopedResolver: SimpleCompletionModelResolver = (
-    provider,
-    modelId,
-    agentDir,
-    cfg,
-    options,
-  ) => resolver(provider, modelId, agentDir, cfg, options);
-  workspaceByResolver.set(scopedResolver, workspaceDir);
-  return scopedResolver;
-}
-
-export function resolveSimpleCompletionModelResolverWorkspace(
-  resolver: SimpleCompletionModelResolver | undefined,
-): string | undefined {
-  return resolver ? workspaceByResolver.get(resolver) : undefined;
+/** Bind every resolution in one completion to one prepared generation and store pair. */
+export function createPreparedSimpleCompletionResolverContext(params: {
+  preparedModelRuntime: PreparedModelRuntimeSnapshot;
+  workspaceDir: string;
+  modelResolver?: SimpleCompletionModelResolver;
+  agentRuntimeId?: string;
+}): PreparedSimpleCompletionResolverContext {
+  const stores = params.preparedModelRuntime.createStores();
+  const modelResolver = params.modelResolver ?? resolveModelAsync;
+  return {
+    preparedModelRuntime: params.preparedModelRuntime,
+    workspaceDir: params.workspaceDir,
+    modelResolver: (provider, modelId, agentDir, cfg, options) =>
+      modelResolver(provider, modelId, agentDir, cfg, {
+        ...options,
+        authStorage: stores.authStorage,
+        modelRegistry: stores.modelRegistry,
+        preparedModelRuntime: params.preparedModelRuntime,
+        workspaceDir: params.workspaceDir,
+        ...(params.agentRuntimeId ? { agentRuntimeId: params.agentRuntimeId } : {}),
+      }),
+  };
 }

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -13,13 +13,21 @@ import type {
 } from "../../agents/prepared-model-runtime.js";
 import type { registerProviderStreamForModel } from "../../agents/provider-stream.js";
 import type { prepareSimpleCompletionModel } from "../../agents/simple-completion-runtime.js";
-import { resolveSimpleCompletionModelResolverWorkspace } from "../../agents/simple-completion-scope.js";
+import { createEmptyPluginMetadataSnapshot } from "../../agents/test-helpers/embedded-agent-runner-e2e-mocks.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { onTrustedInternalDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import { bindModelLlmRuntime } from "../../llm/model-runtime-binding.js";
 import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm/types.js";
 import { createAssistantMessageEventStream } from "../../llm/utils/event-stream.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import {
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { getPluginRuntimeGenerationRegistry } from "../../plugins/runtime/generation-scope.js";
 import {
   isWorkerTranscriptMessageFrameSafe,
   WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE,
@@ -178,7 +186,17 @@ function providerStream(message = finalMessage(), options: { omitToolEnd?: boole
   return stream;
 }
 
-function setup(entry: SessionEntry = sessionEntry) {
+function setup(
+  entry: SessionEntry = sessionEntry,
+  options: {
+    pluginRegistry?: PluginRegistry;
+    afterModelPreparation?: () => void;
+    observeStage?: (
+      stage: "factory" | "policy" | "wrapper" | "execution",
+      registry: PluginRegistry | null | undefined,
+    ) => void;
+  } = {},
+) {
   const scope: {
     agentDir?: string;
     agentRuntime?: string;
@@ -194,7 +212,8 @@ function setup(entry: SessionEntry = sessionEntry) {
     workspaceDir: WORKSPACE,
     config,
     authModes: {},
-    metadataSnapshot: { plugins: [] } as never,
+    metadataSnapshot: createEmptyPluginMetadataSnapshot(WORKSPACE),
+    pluginRegistry: options.pluginRegistry ?? createEmptyPluginRegistry(),
     modelCatalog: {
       entries: [
         { provider: PROVIDER, id: MODEL, name: "Approved model" },
@@ -207,18 +226,14 @@ function setup(entry: SessionEntry = sessionEntry) {
     createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
   } satisfies PreparedModelRuntimeSnapshot;
   let leasedPreparedModelRuntime: PreparedModelRuntimeSnapshot | undefined;
-  const resolveModel = vi.fn<Deps["resolveModel"]>(
-    async (_provider, _model, _dir, _cfg, options) => {
-      scope.agentRuntime = options?.agentRuntimeId;
-      scope.preparedModelRuntime = options?.preparedModelRuntime === leasedPreparedModelRuntime;
-      return {} as Awaited<ReturnType<Deps["resolveModel"]>>;
-    },
-  );
+  const resolveModel = vi.fn<Deps["resolveModel"]>(async () => {
+    return {} as Awaited<ReturnType<Deps["resolveModel"]>>;
+  });
   const prepareModel = vi.fn<Deps["prepareModel"]>(async (modelParams) => {
-    scope.prepareWorkspace = resolveSimpleCompletionModelResolverWorkspace(
-      modelParams.modelResolver,
-    );
-    await modelParams.modelResolver?.(PROVIDER, MODEL, modelParams.agentDir, modelParams.cfg, {});
+    scope.agentRuntime = modelParams.agentRuntimeId;
+    scope.preparedModelRuntime = modelParams.preparedModelRuntime === leasedPreparedModelRuntime;
+    scope.prepareWorkspace = modelParams.workspaceDir;
+    options.afterModelPreparation?.();
     return {
       model: bindModelLlmRuntime(logicalModel, {
         registry: {},
@@ -233,16 +248,24 @@ function setup(entry: SessionEntry = sessionEntry) {
     };
   });
   const resolveAuthProfileMode = vi.fn<Deps["resolveAuthProfileMode"]>(() => undefined);
-  const stream = vi.fn<StreamFn>(() => providerStream());
+  const observedRegistry = () => getPluginRuntimeGenerationRegistry() ?? getActivePluginRegistry();
+  const stream = vi.fn<StreamFn>(() => {
+    options.observeStage?.("execution", observedRegistry());
+    return providerStream();
+  });
   const fallbackStream = vi.fn<StreamFn>(() => providerStream());
-  const resolveProviderStream = vi.fn<Deps["resolveProviderStream"]>(() => stream);
+  const resolveProviderStream = vi.fn<Deps["resolveProviderStream"]>(() => {
+    options.observeStage?.("factory", observedRegistry());
+    return stream;
+  });
   const resolveStream = vi.fn<Deps["resolveStream"]>((streamParams) => {
     scope.authProfile = streamParams.authProfileId;
     return streamParams.providerStreamFn ?? streamParams.currentStreamFn ?? fallbackStream;
   });
-  const applyStreamPolicy = vi.fn<Deps["applyStreamPolicy"]>(() => ({
-    effectiveExtraParams: {},
-  }));
+  const applyStreamPolicy = vi.fn<Deps["applyStreamPolicy"]>(() => {
+    options.observeStage?.("policy", observedRegistry());
+    return { effectiveExtraParams: {} };
+  });
   const releaseRuntime = vi.fn();
   const acquireRuntimeLease = vi.fn<Deps["acquireRuntimeLease"]>(async (runtimeParams) => {
     scope.agentDir = runtimeParams.agentDir;
@@ -272,7 +295,10 @@ function setup(entry: SessionEntry = sessionEntry) {
     resolveProviderStream,
     resolveStream,
     applyStreamPolicy,
-    wrapStream: vi.fn((streamFn: StreamFn) => streamFn),
+    wrapStream: vi.fn((streamFn: StreamFn) => {
+      options.observeStage?.("wrapper", observedRegistry());
+      return streamFn;
+    }),
     createTrace: vi.fn(() => ({ traceId: "1".repeat(32), spanId: "2".repeat(16) })),
   };
   return {
@@ -309,6 +335,32 @@ const MODEL_ERROR = {
 };
 
 describe("worker inference provider runtime", () => {
+  it("keeps provider construction and execution on the leased generation", async () => {
+    const generationA = createEmptyPluginRegistry();
+    const generationB = createEmptyPluginRegistry();
+    const observed: string[] = [];
+    const runtime = setup(sessionEntry, {
+      pluginRegistry: generationA,
+      afterModelPreparation: () =>
+        setActivePluginRegistry(generationB, "worker-generation-b", "default", WORKSPACE),
+      observeStage: (stage, registry) =>
+        observed.push(
+          `${stage}:${registry === generationA ? "A" : registry === generationB ? "B" : "none"}`,
+        ),
+    });
+
+    try {
+      await expect(runtime.executor(params(request(), vi.fn()))).resolves.toMatchObject({
+        type: "done",
+      });
+    } finally {
+      resetPluginRuntimeStateForTest();
+    }
+
+    expect(observed).toEqual(["factory:A", "policy:A", "wrapper:A", "execution:A"]);
+    expect(runtime.releaseRuntime).toHaveBeenCalledOnce();
+  });
+
   it("projects the gateway-owned auth profile onto the provider route", async () => {
     const oauthRuntime = setup();
     oauthRuntime.resolveAuthProfileMode.mockReturnValue("oauth");

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -36,7 +36,10 @@ import {
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
 } from "../../agents/model-visibility-policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
-import { acquireAgentRunPreparedModelRuntime } from "../../agents/prepared-model-runtime.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  type PreparedModelRuntimeSnapshot,
+} from "../../agents/prepared-model-runtime.js";
 import { resolveProviderModelRouteAuthRequirement } from "../../agents/provider-model-route-auth.js";
 import { projectProviderModelRouteConfig } from "../../agents/provider-model-route.js";
 import { registerProviderStreamForModel } from "../../agents/provider-stream.js";
@@ -44,7 +47,6 @@ import {
   prepareSimpleCompletionModel,
   type PreparedSimpleCompletionModel,
 } from "../../agents/simple-completion-runtime.js";
-import { bindSimpleCompletionModelResolverWorkspace } from "../../agents/simple-completion-scope.js";
 import { normalizeUsage, hasNonzeroUsage } from "../../agents/usage.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
@@ -67,6 +69,7 @@ import type {
   Usage,
 } from "../../llm/types.js";
 import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "../../worker/transcript-message.js";
 import {
@@ -383,6 +386,7 @@ async function resolveApprovedModel(params: {
       agentDir: string;
       workspaceDir: string;
       prepared: PreparedSimpleCompletionModel;
+      runtimeSnapshot: PreparedModelRuntimeSnapshot;
       release: () => void;
     }
   | undefined
@@ -399,185 +403,182 @@ async function resolveApprovedModel(params: {
   });
   const runtimeSnapshot = runtimeLease.snapshot;
   try {
-    const lifecycleConfig = runtimeSnapshot.config;
-    const agentDir = runtimeSnapshot.agentDir;
-    const workspaceDir =
-      runtimeSnapshot.workspaceDir ?? resolveAgentWorkspaceDir(lifecycleConfig, target.agentId);
-    const manifestSnapshot = runtimeSnapshot.metadataSnapshot;
-    const preparedStores = runtimeSnapshot.createStores();
-    const defaultModel = dependencies.resolveDefaultModel({
-      cfg: lifecycleConfig,
-      agentId: target.agentId,
-      manifestPlugins: manifestSnapshot.plugins,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    });
-    const agentModels = resolveAgentConfig(lifecycleConfig, target.agentId)?.models;
-    const aliasConfig = agentModels
-      ? {
-          ...lifecycleConfig,
-          agents: {
-            ...lifecycleConfig.agents,
-            defaults: {
-              ...lifecycleConfig.agents?.defaults,
-              models: { ...lifecycleConfig.agents?.defaults?.models, ...agentModels },
-            },
-          },
-        }
-      : lifecycleConfig;
-    const aliasIndex = buildModelAliasIndex({
-      cfg: aliasConfig,
-      defaultProvider: defaultModel.provider,
-      manifestPlugins: manifestSnapshot.plugins,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    });
-    const resolved = resolveModelRefFromString({
-      cfg: aliasConfig,
-      raw: rawRef,
-      defaultProvider: defaultModel.provider,
-      aliasIndex,
-      manifestPlugins: manifestSnapshot.plugins,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    });
-    if (
-      !resolved ||
-      normalizeProviderId(resolved.ref.provider) !== normalizeProviderId(request.modelRef.provider)
-    ) {
-      runtimeLease.release();
-      return undefined;
-    }
-    const catalog = runtimeSnapshot.modelCatalog.entries;
-    const policy = createModelVisibilityPolicy({
-      cfg: lifecycleConfig,
-      catalog,
-      defaultProvider: defaultModel.provider,
-      defaultModel: `${defaultModel.provider}/${defaultModel.model}`,
-      agentId: target.agentId,
-      manifestPlugins: manifestSnapshot.plugins,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    });
-    const resolvedKey = modelCatalogLogicalKey({
-      provider: resolved.ref.provider,
-      id: resolved.ref.model,
-    });
-    // Retained refs stay approved during cold discovery.
-    const known =
-      policy.allowedCatalog.some(
-        (entry: ModelCatalogEntry) => resolvedKey === modelCatalogLogicalKey(entry),
-      ) || policy.retainedKeys.has(resolvedKey);
-    if (!known || !policy.allows(resolved.ref)) {
-      runtimeLease.release();
-      return undefined;
-    }
-    const configuredDefaultProfile =
-      resolvedKey ===
-      modelCatalogLogicalKey({ provider: defaultModel.provider, id: defaultModel.model })
-        ? splitTrailingAuthProfile(
-            resolveAgentEffectiveModelPrimary(lifecycleConfig, target.agentId) ?? "",
-          ).profile
-        : undefined;
-    const harnessPolicy = resolveAgentHarnessPolicy({
-      provider: resolved.ref.provider,
-      modelId: resolved.ref.model,
-      config: lifecycleConfig,
-      agentId: target.agentId,
-      sessionKey: target.sessionKey,
-    });
-    const agentRuntimeId =
-      harnessPolicy.runtimeSource !== "implicit" ||
-      lifecycleConfig.plugins?.entries?.codex?.enabled === true
-        ? harnessPolicy.runtime
-        : undefined;
-    const sessionProfileId = await dependencies.resolveSessionAuthProfile({
-      cfg: lifecycleConfig,
-      provider: resolved.ref.provider,
-      acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-        provider: resolved.ref.provider,
-        harnessRuntime: harnessPolicy.runtime,
-        config: lifecycleConfig,
-      }),
-      agentDir,
-      sessionEntry: target.sessionEntry,
-      sessionStore: target.sessionStore,
-      sessionKey: target.sessionKey,
-      storePath: target.storePath,
-      isNewSession: false,
-    });
-    const sessionProfileSource = resolveReturnedProfileSource(
-      target.sessionEntry,
-      sessionProfileId,
-    );
-    const selectedProfile =
-      sessionProfileId && sessionProfileSource === "user"
-        ? { id: sessionProfileId, source: sessionProfileSource }
-        : configuredDefaultProfile
-          ? { id: configuredDefaultProfile, source: "user" as const }
-          : sessionProfileId
-            ? { id: sessionProfileId, source: sessionProfileSource }
-            : undefined;
-    let modelConfig = lifecycleConfig;
-    const authMode = selectedProfile
-      ? dependencies.resolveAuthProfileMode({
-          config: lifecycleConfig,
-          agentDir,
-          profileId: selectedProfile.id,
-        })
-      : undefined;
-    const authRequirement = resolveProviderModelRouteAuthRequirement(authMode);
-    const routeResolution = authRequirement
-      ? resolveProviderModelRoutes({
-          provider: resolved.ref.provider,
-          modelId: resolved.ref.model,
-          config: lifecycleConfig,
-        })
-      : undefined;
-    const route =
-      routeResolution?.kind === "routes"
-        ? routeResolution.routes.find((candidate) => candidate.authRequirement === authRequirement)
-        : undefined;
-    if (route) {
-      // Worker placement owns the agent harness, while the gateway-owned profile
-      // owns the provider route. Keep those decisions separate or OAuth can be
-      // materialized as a public API-key endpoint and fail before the first token.
-      modelConfig = projectProviderModelRouteConfig({
-        provider: resolved.ref.provider,
-        config: lifecycleConfig,
-        route,
+    return await withPluginRuntimeGenerationScope(runtimeSnapshot, async () => {
+      const lifecycleConfig = runtimeSnapshot.config;
+      const agentDir = runtimeSnapshot.agentDir;
+      const workspaceDir =
+        runtimeSnapshot.workspaceDir ?? resolveAgentWorkspaceDir(lifecycleConfig, target.agentId);
+      const manifestSnapshot = runtimeSnapshot.metadataSnapshot;
+      const defaultModel = dependencies.resolveDefaultModel({
+        cfg: lifecycleConfig,
+        agentId: target.agentId,
+        manifestPlugins: manifestSnapshot.plugins,
+        ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
       });
-    }
-    const modelResolver = bindSimpleCompletionModelResolverWorkspace(
-      (provider, modelId, resolvedAgentDir, cfg, options) =>
-        dependencies.resolveModel(provider, modelId, resolvedAgentDir, cfg, {
-          ...options,
-          authStorage: preparedStores.authStorage,
-          modelRegistry: preparedStores.modelRegistry,
-          preparedModelRuntime: runtimeSnapshot,
-          ...(agentRuntimeId ? { agentRuntimeId } : {}),
-          workspaceDir,
+      const agentModels = resolveAgentConfig(lifecycleConfig, target.agentId)?.models;
+      const aliasConfig = agentModels
+        ? {
+            ...lifecycleConfig,
+            agents: {
+              ...lifecycleConfig.agents,
+              defaults: {
+                ...lifecycleConfig.agents?.defaults,
+                models: { ...lifecycleConfig.agents?.defaults?.models, ...agentModels },
+              },
+            },
+          }
+        : lifecycleConfig;
+      const aliasIndex = buildModelAliasIndex({
+        cfg: aliasConfig,
+        defaultProvider: defaultModel.provider,
+        manifestPlugins: manifestSnapshot.plugins,
+        ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+      });
+      const resolved = resolveModelRefFromString({
+        cfg: aliasConfig,
+        raw: rawRef,
+        defaultProvider: defaultModel.provider,
+        aliasIndex,
+        manifestPlugins: manifestSnapshot.plugins,
+        ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+      });
+      if (
+        !resolved ||
+        normalizeProviderId(resolved.ref.provider) !==
+          normalizeProviderId(request.modelRef.provider)
+      ) {
+        runtimeLease.release();
+        return undefined;
+      }
+      const catalog = runtimeSnapshot.modelCatalog.entries;
+      const policy = createModelVisibilityPolicy({
+        cfg: lifecycleConfig,
+        catalog,
+        defaultProvider: defaultModel.provider,
+        defaultModel: `${defaultModel.provider}/${defaultModel.model}`,
+        agentId: target.agentId,
+        manifestPlugins: manifestSnapshot.plugins,
+        ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+      });
+      const resolvedKey = modelCatalogLogicalKey({
+        provider: resolved.ref.provider,
+        id: resolved.ref.model,
+      });
+      // Retained refs stay approved during cold discovery.
+      const known =
+        policy.allowedCatalog.some(
+          (entry: ModelCatalogEntry) => resolvedKey === modelCatalogLogicalKey(entry),
+        ) || policy.retainedKeys.has(resolvedKey);
+      if (!known || !policy.allows(resolved.ref)) {
+        runtimeLease.release();
+        return undefined;
+      }
+      const configuredDefaultProfile =
+        resolvedKey ===
+        modelCatalogLogicalKey({ provider: defaultModel.provider, id: defaultModel.model })
+          ? splitTrailingAuthProfile(
+              resolveAgentEffectiveModelPrimary(lifecycleConfig, target.agentId) ?? "",
+            ).profile
+          : undefined;
+      const harnessPolicy = resolveAgentHarnessPolicy({
+        provider: resolved.ref.provider,
+        modelId: resolved.ref.model,
+        config: lifecycleConfig,
+        agentId: target.agentId,
+        sessionKey: target.sessionKey,
+      });
+      const agentRuntimeId =
+        harnessPolicy.runtimeSource !== "implicit" ||
+        lifecycleConfig.plugins?.entries?.codex?.enabled === true
+          ? harnessPolicy.runtime
+          : undefined;
+      const sessionProfileId = await dependencies.resolveSessionAuthProfile({
+        cfg: lifecycleConfig,
+        provider: resolved.ref.provider,
+        acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+          provider: resolved.ref.provider,
+          harnessRuntime: harnessPolicy.runtime,
+          config: lifecycleConfig,
         }),
-      workspaceDir,
-    );
-    // Route projection and credential selection are one decision. Pin even an
-    // automatic profile so generic auth fallback cannot cross to another route.
-    const prepared = await dependencies.prepareModel({
-      cfg: modelConfig,
-      provider: resolved.ref.provider,
-      modelId: resolved.ref.model,
-      agentDir,
-      ...(selectedProfile ? { profileId: selectedProfile.id } : {}),
-      ...(selectedProfile ? { preferredProfile: selectedProfile.id } : {}),
-      ...(selectedProfile ? { bindAuthOwner: true } : {}),
-      allowMissingApiKeyModes: ["aws-sdk"],
-      modelResolver,
+        agentDir,
+        sessionEntry: target.sessionEntry,
+        sessionStore: target.sessionStore,
+        sessionKey: target.sessionKey,
+        storePath: target.storePath,
+        isNewSession: false,
+      });
+      const sessionProfileSource = resolveReturnedProfileSource(
+        target.sessionEntry,
+        sessionProfileId,
+      );
+      const selectedProfile =
+        sessionProfileId && sessionProfileSource === "user"
+          ? { id: sessionProfileId, source: sessionProfileSource }
+          : configuredDefaultProfile
+            ? { id: configuredDefaultProfile, source: "user" as const }
+            : sessionProfileId
+              ? { id: sessionProfileId, source: sessionProfileSource }
+              : undefined;
+      let modelConfig = lifecycleConfig;
+      const authMode = selectedProfile
+        ? dependencies.resolveAuthProfileMode({
+            config: lifecycleConfig,
+            agentDir,
+            profileId: selectedProfile.id,
+          })
+        : undefined;
+      const authRequirement = resolveProviderModelRouteAuthRequirement(authMode);
+      const routeResolution = authRequirement
+        ? resolveProviderModelRoutes({
+            provider: resolved.ref.provider,
+            modelId: resolved.ref.model,
+            config: lifecycleConfig,
+          })
+        : undefined;
+      const route =
+        routeResolution?.kind === "routes"
+          ? routeResolution.routes.find(
+              (candidate) => candidate.authRequirement === authRequirement,
+            )
+          : undefined;
+      if (route) {
+        // Worker placement owns the agent harness, while the gateway-owned profile
+        // owns the provider route. Keep those decisions separate or OAuth can be
+        // materialized as a public API-key endpoint and fail before the first token.
+        modelConfig = projectProviderModelRouteConfig({
+          provider: resolved.ref.provider,
+          config: lifecycleConfig,
+          route,
+        });
+      }
+      // Route projection and credential selection are one decision. Pin even an
+      // automatic profile so generic auth fallback cannot cross to another route.
+      const prepared = await dependencies.prepareModel({
+        cfg: modelConfig,
+        agentId: target.agentId,
+        provider: resolved.ref.provider,
+        modelId: resolved.ref.model,
+        agentDir,
+        ...(selectedProfile ? { profileId: selectedProfile.id } : {}),
+        ...(selectedProfile ? { preferredProfile: selectedProfile.id } : {}),
+        ...(selectedProfile ? { bindAuthOwner: true } : {}),
+        allowMissingApiKeyModes: ["aws-sdk"],
+        modelResolver: dependencies.resolveModel,
+        preparedModelRuntime: runtimeSnapshot,
+        workspaceDir,
+        ...(agentRuntimeId ? { agentRuntimeId } : {}),
+      });
+      return {
+        provider: resolved.ref.provider,
+        model: resolved.ref.model,
+        config: lifecycleConfig,
+        agentDir,
+        workspaceDir,
+        prepared,
+        runtimeSnapshot,
+        release: runtimeLease.release,
+      };
     });
-    return {
-      provider: resolved.ref.provider,
-      model: resolved.ref.model,
-      config: lifecycleConfig,
-      agentDir,
-      workspaceDir,
-      prepared,
-      release: runtimeLease.release,
-    };
   } catch (error) {
     runtimeLease.release();
     throw error;
@@ -621,227 +622,230 @@ export function createWorkerInferenceExecutor(
     if (!approved) {
       return inferenceError("model-not-approved");
     }
-    try {
-      if ("error" in approved.prepared) {
-        return inferenceError("provider-error");
-      }
-      // Keep logical identity separate from transport endpoint encoding.
-      const modelIdentity: WorkerInferenceModelIdentity = {
-        api: approved.prepared.model.api,
-        provider: approved.provider,
-        model: approved.model,
-      };
-      const logicalModel = approved.prepared.model;
-      const llmRuntime = getModelLlmRuntime(logicalModel);
-      if (!llmRuntime) {
-        throw new Error("Prepared worker model has no lifecycle runtime owner");
-      }
-      const providerModel =
-        logicalModel.provider === "openai" && logicalModel.api === "openai-chatgpt-responses"
-          ? {
-              ...logicalModel,
-              baseUrl: normalizeCodexResponsesBaseUrlForOpenAISdk(logicalModel.baseUrl),
-            }
-          : logicalModel;
-      const providerStream = dependencies.resolveProviderStream({
-        model: providerModel,
-        cfg: approved.config,
-        agentDir: approved.agentDir,
-        workspaceDir: approved.workspaceDir,
-      });
-      const authValue = approved.prepared.auth.apiKey;
-      const streamAgent = {
-        streamFn: dependencies.resolveStream({
-          llmRuntime,
-          currentStreamFn: llmRuntime.streamSimple,
-          ...(providerStream ? { providerStreamFn: providerStream } : {}),
-          sessionId: request.sessionId,
-          signal,
-          model: providerModel,
-          resolvedApiKey: authValue,
-          authProfileId: approved.prepared.auth.profileId,
-        }),
-      };
-      const streamPolicyOptions: WorkerInferenceStartParams["options"] = {
-        ...(request.options.temperature !== undefined
-          ? { temperature: request.options.temperature }
-          : {}),
-        ...(request.options.maxTokens !== undefined
-          ? { maxTokens: request.options.maxTokens }
-          : {}),
-        ...(request.options.reasoning !== undefined
-          ? { reasoning: request.options.reasoning }
-          : {}),
-        ...(request.options.thinkingBudgets
-          ? { thinkingBudgets: { ...request.options.thinkingBudgets } }
-          : {}),
-      };
-      dependencies.applyStreamPolicy(
-        streamAgent,
-        approved.config,
-        approved.provider,
-        approved.model,
-        streamPolicyOptions,
-        streamPolicyOptions.reasoning,
-        target.agentId,
-        approved.workspaceDir,
-        providerModel,
-        approved.agentDir,
-      );
-      const scopedStream = streamAgent.streamFn;
-      const model = providerModel;
-      if (!optionBudgetsFitModel(request.options, model)) {
-        return inferenceError("invalid-context");
-      }
-      if (signal.aborted || !params.isCurrent()) {
-        return inferenceError("cancelled");
-      }
-
-      const startedAt = dependencies.now();
-      const trace = dependencies.createTrace();
-      let modelCallSeq = 0;
-      const stream = dependencies.wrapStream(scopedStream, {
-        runId: request.runId,
-        sessionKey: target.sessionKey,
-        sessionId: request.sessionId,
-        provider: model.provider,
-        model: model.id,
-        api: model.api,
-        contextTokenBudget: model.contextTokens ?? model.contextWindow,
-        trace,
-        contentCapture: resolveDiagnosticModelContentCapturePolicy(approved.config),
-        nextCallId: () => `${request.runId}:${request.turnId}:worker-model:${(modelCallSeq += 1)}`,
-      });
-      let usageRecorded = false;
-      const recordUsage = (usage: Usage) => {
-        if (usageRecorded) {
-          return;
-        }
-        usageRecorded = true;
-        dependencies.recordUsage({
-          config: approved.config,
-          target,
-          request,
-          model,
-          usage,
-          durationMs: Math.max(0, dependencies.now() - startedAt),
-          trace,
-        });
-      };
-      const executionIsCurrent = () => !signal.aborted && params.isCurrent();
-      const toolCalls = createWorkerToolCallStream({
-        emit: params.emit,
-        isCurrent: executionIsCurrent,
-      });
-
-      const providerAbort = new AbortController();
-      const providerSignal = AbortSignal.any([signal, providerAbort.signal]);
+    return await withPluginRuntimeGenerationScope(approved.runtimeSnapshot, async () => {
       try {
-        const events = await stream(
-          model,
-          context,
-          buildStreamOptions({
-            request,
-            signal: providerSignal,
-            apiKey: authValue,
+        if ("error" in approved.prepared) {
+          return inferenceError("provider-error");
+        }
+        // Keep logical identity separate from transport endpoint encoding.
+        const modelIdentity: WorkerInferenceModelIdentity = {
+          api: approved.prepared.model.api,
+          provider: approved.provider,
+          model: approved.model,
+        };
+        const logicalModel = approved.prepared.model;
+        const llmRuntime = getModelLlmRuntime(logicalModel);
+        if (!llmRuntime) {
+          throw new Error("Prepared worker model has no lifecycle runtime owner");
+        }
+        const providerModel =
+          logicalModel.provider === "openai" && logicalModel.api === "openai-chatgpt-responses"
+            ? {
+                ...logicalModel,
+                baseUrl: normalizeCodexResponsesBaseUrlForOpenAISdk(logicalModel.baseUrl),
+              }
+            : logicalModel;
+        const providerStream = dependencies.resolveProviderStream({
+          model: providerModel,
+          cfg: approved.config,
+          agentDir: approved.agentDir,
+          workspaceDir: approved.workspaceDir,
+        });
+        const authValue = approved.prepared.auth.apiKey;
+        const streamAgent = {
+          streamFn: dependencies.resolveStream({
+            llmRuntime,
+            currentStreamFn: llmRuntime.streamSimple,
+            ...(providerStream ? { providerStreamFn: providerStream } : {}),
+            sessionId: request.sessionId,
+            signal,
+            model: providerModel,
+            resolvedApiKey: authValue,
+            authProfileId: approved.prepared.auth.profileId,
           }),
+        };
+        const streamPolicyOptions: WorkerInferenceStartParams["options"] = {
+          ...(request.options.temperature !== undefined
+            ? { temperature: request.options.temperature }
+            : {}),
+          ...(request.options.maxTokens !== undefined
+            ? { maxTokens: request.options.maxTokens }
+            : {}),
+          ...(request.options.reasoning !== undefined
+            ? { reasoning: request.options.reasoning }
+            : {}),
+          ...(request.options.thinkingBudgets
+            ? { thinkingBudgets: { ...request.options.thinkingBudgets } }
+            : {}),
+        };
+        dependencies.applyStreamPolicy(
+          streamAgent,
+          approved.config,
+          approved.provider,
+          approved.model,
+          streamPolicyOptions,
+          streamPolicyOptions.reasoning,
+          target.agentId,
+          approved.workspaceDir,
+          providerModel,
+          approved.agentDir,
         );
-        for await (const event of events) {
-          if (event.type === "done") {
-            recordUsage(event.message.usage);
-            if (signal.aborted || !params.isCurrent()) {
-              return inferenceError("cancelled", event.message.usage);
-            }
-            for (const [contentIndex, content] of event.message.content.entries()) {
-              if (content.type === "toolCall") {
-                const endResult = toolCalls.end(contentIndex, event.message, content);
-                if (endResult === "cancelled") {
-                  return inferenceError("cancelled", event.message.usage);
-                }
-                if (endResult === "invalid") {
-                  return inferenceError("provider-error");
+        const scopedStream = streamAgent.streamFn;
+        const model = providerModel;
+        if (!optionBudgetsFitModel(request.options, model)) {
+          return inferenceError("invalid-context");
+        }
+        if (signal.aborted || !params.isCurrent()) {
+          return inferenceError("cancelled");
+        }
+
+        const startedAt = dependencies.now();
+        const trace = dependencies.createTrace();
+        let modelCallSeq = 0;
+        const stream = dependencies.wrapStream(scopedStream, {
+          runId: request.runId,
+          sessionKey: target.sessionKey,
+          sessionId: request.sessionId,
+          provider: model.provider,
+          model: model.id,
+          api: model.api,
+          contextTokenBudget: model.contextTokens ?? model.contextWindow,
+          trace,
+          contentCapture: resolveDiagnosticModelContentCapturePolicy(approved.config),
+          nextCallId: () =>
+            `${request.runId}:${request.turnId}:worker-model:${(modelCallSeq += 1)}`,
+        });
+        let usageRecorded = false;
+        const recordUsage = (usage: Usage) => {
+          if (usageRecorded) {
+            return;
+          }
+          usageRecorded = true;
+          dependencies.recordUsage({
+            config: approved.config,
+            target,
+            request,
+            model,
+            usage,
+            durationMs: Math.max(0, dependencies.now() - startedAt),
+            trace,
+          });
+        };
+        const executionIsCurrent = () => !signal.aborted && params.isCurrent();
+        const toolCalls = createWorkerToolCallStream({
+          emit: params.emit,
+          isCurrent: executionIsCurrent,
+        });
+
+        const providerAbort = new AbortController();
+        const providerSignal = AbortSignal.any([signal, providerAbort.signal]);
+        try {
+          const events = await stream(
+            model,
+            context,
+            buildStreamOptions({
+              request,
+              signal: providerSignal,
+              apiKey: authValue,
+            }),
+          );
+          for await (const event of events) {
+            if (event.type === "done") {
+              recordUsage(event.message.usage);
+              if (signal.aborted || !params.isCurrent()) {
+                return inferenceError("cancelled", event.message.usage);
+              }
+              for (const [contentIndex, content] of event.message.content.entries()) {
+                if (content.type === "toolCall") {
+                  const endResult = toolCalls.end(contentIndex, event.message, content);
+                  if (endResult === "cancelled") {
+                    return inferenceError("cancelled", event.message.usage);
+                  }
+                  if (endResult === "invalid") {
+                    return inferenceError("provider-error");
+                  }
                 }
               }
-            }
-            if (!toolCalls.matchesTerminal(event.message)) {
-              return inferenceError("provider-error");
-            }
-            const terminal = projectWorkerInferenceTerminalMessage({
-              message: event.message,
-              modelIdentity,
-              stopReason: event.reason,
-            });
-            if (terminal.kind === "provider-replay-unavailable") {
-              if (isDiagnosticsEnabled(approved.config)) {
-                const { bytes, limitBytes, reason } = terminal.details;
-                emitTrustedDiagnosticEvent({
-                  type: "payload.large",
-                  surface: "worker.provider-replay",
-                  action: "rejected",
-                  bytes,
-                  limitBytes,
-                  reason,
-                  trace: freezeDiagnosticTraceContext(trace),
-                });
+              if (!toolCalls.matchesTerminal(event.message)) {
+                return inferenceError("provider-error");
               }
+              const terminal = projectWorkerInferenceTerminalMessage({
+                message: event.message,
+                modelIdentity,
+                stopReason: event.reason,
+              });
+              if (terminal.kind === "provider-replay-unavailable") {
+                if (isDiagnosticsEnabled(approved.config)) {
+                  const { bytes, limitBytes, reason } = terminal.details;
+                  emitTrustedDiagnosticEvent({
+                    type: "payload.large",
+                    surface: "worker.provider-replay",
+                    action: "rejected",
+                    bytes,
+                    limitBytes,
+                    reason,
+                    trace: freezeDiagnosticTraceContext(trace),
+                  });
+                }
+                return inferenceError(
+                  "provider-error",
+                  event.message.usage,
+                  WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE,
+                );
+              }
+              return { type: "done", message: terminal.message };
+            }
+            if (event.type === "error") {
+              recordUsage(event.error.usage);
               return inferenceError(
-                "provider-error",
-                event.message.usage,
-                WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE,
+                event.reason === "aborted" ? "cancelled" : "provider-error",
+                event.error.usage,
               );
             }
-            return { type: "done", message: terminal.message };
-          }
-          if (event.type === "error") {
-            recordUsage(event.error.usage);
-            return inferenceError(
-              event.reason === "aborted" ? "cancelled" : "provider-error",
-              event.error.usage,
-            );
-          }
-          if (signal.aborted || !params.isCurrent()) {
-            return inferenceError("cancelled");
-          }
-          if (event.type === "toolcall_start") {
-            if (toolCalls.start(event.contentIndex, event.partial) === "cancelled") {
+            if (signal.aborted || !params.isCurrent()) {
               return inferenceError("cancelled");
             }
-            continue;
-          }
-          if (event.type === "toolcall_delta") {
-            const deltaResult = toolCalls.delta(event.contentIndex, event.delta, event.partial);
-            if (deltaResult === "cancelled") {
-              return inferenceError("cancelled");
+            if (event.type === "toolcall_start") {
+              if (toolCalls.start(event.contentIndex, event.partial) === "cancelled") {
+                return inferenceError("cancelled");
+              }
+              continue;
             }
-            if (deltaResult === "invalid") {
-              return inferenceError("provider-error");
+            if (event.type === "toolcall_delta") {
+              const deltaResult = toolCalls.delta(event.contentIndex, event.delta, event.partial);
+              if (deltaResult === "cancelled") {
+                return inferenceError("cancelled");
+              }
+              if (deltaResult === "invalid") {
+                return inferenceError("provider-error");
+              }
+              continue;
             }
-            continue;
-          }
-          if (event.type === "toolcall_end") {
-            const endResult = toolCalls.end(event.contentIndex, event.partial, event.toolCall);
-            if (endResult === "cancelled") {
-              return inferenceError("cancelled");
+            if (event.type === "toolcall_end") {
+              const endResult = toolCalls.end(event.contentIndex, event.partial, event.toolCall);
+              if (endResult === "cancelled") {
+                return inferenceError("cancelled");
+              }
+              if (endResult === "invalid") {
+                return inferenceError("provider-error");
+              }
+              continue;
             }
-            if (endResult === "invalid") {
-              return inferenceError("provider-error");
+            const workerEvent = toWorkerStreamEvent(event, modelIdentity);
+            if (workerEvent) {
+              params.emit(workerEvent);
             }
-            continue;
           }
-          const workerEvent = toWorkerStreamEvent(event, modelIdentity);
-          if (workerEvent) {
-            params.emit(workerEvent);
-          }
+          return inferenceError(signal.aborted ? "cancelled" : "provider-error");
+        } catch {
+          return inferenceError(signal.aborted ? "cancelled" : "provider-error");
+        } finally {
+          providerAbort.abort();
         }
-        return inferenceError(signal.aborted ? "cancelled" : "provider-error");
-      } catch {
-        return inferenceError(signal.aborted ? "cancelled" : "provider-error");
       } finally {
-        providerAbort.abort();
+        approved.release();
       }
-    } finally {
-      approved.release();
-    }
+    });
   };
 }
 


### PR DESCRIPTION
Related: #125569, #125688

## What Problem This Solves

Fixes an issue where a lightweight completion or Gateway worker inference could start with prepared plugin generation A, then borrow model rematerialization, provider runtime-auth, stream factory, stream policy, or wrapper behavior from process-current generation B after a reload completed mid-operation.

## Why This Change Was Made

Simple completion now uses one typed prepared resolver context and one non-recursive owner body. Direct callers self-acquire a generation; agent model selection runs inside that owner; isolated completion reuses its existing lease; and Gateway worker approval plus the complete stream lifecycle run under the same snapshot. The hidden resolver-to-workspace `WeakMap` and duplicate worker resolver closure are removed.

This is AI-assisted work. The final diff was inspected directly, validated locally, and passed the repository autoreview gate.

## User Impact

In-flight direct completions and worker turns remain internally consistent across plugin reloads—from model selection and auth through stream execution and terminal projection. No public Plugin SDK signature, configuration, protocol, or persisted-state changes are required.

Production code changes are +7 net lines. Test coverage is +173 net lines.

## Evidence

- Simple completion pre-fix reproduction: initial model resolution used generation A; auth published B; route rematerialization returned generation B and its runtime-auth hook. The fixed path observes A for both resolutions and runtime auth.
- Worker pre-fix reproduction: removing only the executor generation scope caused the provider factory, policy hook, wrapper, and execution stages to observe B. The fixed path observes `factory:A`, `policy:A`, `wrapper:A`, and `execution:A`.
- Focused owner suites passed: 37 simple completion/selection/generation tests, 21 isolated completion tests, and 25 worker inference tests.
- Provider/model-hook siblings passed: 129 tests.
- Direct caller siblings passed: 49 tests across TTS, plugin runtime LLM, chat titles, and session observer.
- `pnpm build` passed on the current codebase.
- `pnpm check:changed` passed on the verified branch head.
- Fresh branch autoreview reported no accepted/actionable P0 findings.
- Live-proof gap: QA Lab currently has no scenario for Gateway worker inference or multi-stage simple-completion route rematerialization. These request-local generation races are covered by the failing/passing owner-boundary tests; a QA Lab run would not execute the changed worker path.
