### PR TITLE
fix(slack): require message timestamps for delivery success

### DIFF
--- a/extensions/slack/src/client-delivery.ts
+++ b/extensions/slack/src/client-delivery.ts
@@ -1,6 +1,6 @@
 // Slack plugin module owns WebClient-scoped message and file delivery primitives.
 import type { MessageMetadata } from "@slack/types";
-import type { Block, KnownBlock, WebClient } from "@slack/web-api";
+import type { Block, ChatPostMessageResponse, KnownBlock, WebClient } from "@slack/web-api";
 import {
   extractErrorCode,
   PlatformMessageNotDispatchedError,
@@ -11,6 +11,7 @@ import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-r
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { formatSlackError } from "./errors.js";
 import {
   postSlackMessageWithIdentityFallback,
   type SlackPostMessageIdentity,
@@ -212,6 +213,21 @@ export async function withSlackDnsRequestRetry<T>(
   throw new Error("unreachable Slack DNS retry loop exit");
 }
 
+export function requireSlackPostMessageTimestamp(
+  response: Partial<Pick<ChatPostMessageResponse, "error" | "ok" | "ts">>,
+): string {
+  if (response.ok === false) {
+    throw new Error(
+      `Slack chat.postMessage failed: ${formatSlackError(response.error, "unknown error")}`,
+    );
+  }
+  const timestamp = response.ts?.trim();
+  if (!timestamp) {
+    throw new Error("Slack chat.postMessage returned no message timestamp");
+  }
+  return timestamp;
+}
+
 export async function postSlackMessageBestEffort(params: {
   client: WebClient;
   channelId: string;
@@ -230,11 +246,16 @@ export async function postSlackMessageBestEffort(params: {
     response: await withSlackDnsRequestRetry("chat.postMessage", () => postChatMessage(payload)),
     identity,
   });
-  return await postSlackMessageWithIdentityFallback({
+  const posted = await postSlackMessageWithIdentityFallback({
     basePayload,
     identity: params.identity,
     post,
   });
+  const timestamp = requireSlackPostMessageTimestamp(posted.response);
+  return {
+    ...posted,
+    response: { ...posted.response, ts: timestamp },
+  };
 }
 
 export async function uploadSlackFile(params: {

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1501,8 +1501,10 @@ function createPolicyHarness(overrides?: {
   resolveChannelName?: () => Promise<{ name?: string; type?: string }>;
 }) {
   const commands = new Map<unknown, (args: unknown) => Promise<void>>();
+  const postMessage = vi.fn().mockResolvedValue({ ok: true, ts: "123.456" });
   const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
-  const listenerClient = { chat: { postEphemeral } };
+  const listenerClient = { chat: { postMessage, postEphemeral } };
+  const runtimeError = vi.fn();
   const installationIdentity = overrides?.installationIdentity ?? {
     kind: "workspace" as const,
     teamId: overrides?.teamId ?? "T1",
@@ -1534,7 +1536,7 @@ function createPolicyHarness(overrides?: {
 
   const ctx = {
     cfg: { commands: { native: false } },
-    runtime: {},
+    runtime: { error: runtimeError },
     botToken: "bot-token",
     botUserId: "bot",
     teamId: installationIdentity.kind === "enterprise" ? "" : installationIdentity.teamId,
@@ -1566,12 +1568,22 @@ function createPolicyHarness(overrides?: {
 
   const account = { accountId: "acct", config: { commands: { native: false } } } as unknown;
 
-  return { commands, ctx, account, postEphemeral, channelId, channelName };
+  return {
+    commands,
+    ctx,
+    account,
+    postMessage,
+    postEphemeral,
+    runtimeError,
+    channelId,
+    channelName,
+  };
 }
 
 async function runSlashHandler(params: {
   commands: Map<unknown, (args: unknown) => Promise<void>>;
   body?: unknown;
+  respond?: ReturnType<typeof vi.fn>;
   command: Partial<{
     user_id: string;
     user_name: string;
@@ -1587,7 +1599,7 @@ async function runSlashHandler(params: {
     throw new Error("Missing slash handler");
   }
 
-  const respond = vi.fn().mockResolvedValue(undefined);
+  const respond = params.respond ?? vi.fn().mockResolvedValue(undefined);
   const ack = vi.fn().mockResolvedValue(undefined);
 
   await handler({
@@ -2035,6 +2047,56 @@ describe("slack slash command session metadata", () => {
         isGroup: true,
         groupId: harness.channelId,
       }),
+    );
+  });
+
+  it("fails a public Web API fallback that returns no message timestamp", async () => {
+    deliverSlackSlashRepliesMock.mockImplementation(async (params: unknown) => {
+      const responseBudget = (
+        params as {
+          responseBudget: {
+            respond: (payload: { text: string; response_type: "in_channel" }) => Promise<unknown>;
+          };
+        }
+      ).responseBudget;
+      await responseBudget.respond({ text: "public answer", response_type: "in_channel" });
+    });
+    const asyncDispatchMock = dispatchMock as unknown as {
+      mockImplementation: (
+        implementation: (params: unknown) => Promise<unknown>,
+      ) => typeof dispatchMock;
+    };
+    asyncDispatchMock.mockImplementation(async (params: unknown) => {
+      const deliver = (
+        params as {
+          dispatcherOptions: {
+            deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+          };
+        }
+      ).dispatcherOptions.deliver;
+      await deliver({ text: "public answer" }, { kind: "final" });
+      return { counts: { final: 1, tool: 0, block: 0 } };
+    });
+    const harness = createPolicyHarness({ groupPolicy: "open", slashEphemeral: false });
+    harness.postMessage.mockResolvedValueOnce({ ok: true, channel: harness.channelId });
+    const respondError = Object.assign(new Error("response URL expired"), {
+      code: "slack_bolt_respond_error",
+    });
+    const respond = vi.fn().mockRejectedValue(respondError);
+    await registerCommands(harness.ctx, harness.account);
+
+    await runSlashHandler({
+      commands: harness.commands,
+      command: {
+        channel_id: harness.channelId,
+        channel_name: harness.channelName,
+      },
+      respond,
+    });
+
+    expect(harness.postMessage).toHaveBeenCalledOnce();
+    expect(harness.runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("Slack chat.postMessage returned no message timestamp"),
     );
   });
 

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -46,6 +46,7 @@ import {
 import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
+import { requireSlackPostMessageTimestamp } from "../client-delivery.js";
 import { formatSlackError } from "../errors.js";
 import { truncateSlackText } from "../truncate.js";
 import { resolveSlackCommandIngress, resolveSlackEffectiveAllowFrom } from "./auth.js";
@@ -1289,12 +1290,13 @@ async function deliverSlackSlashResponseWithWebApi(params: {
 
   if (payload.response_type === "in_channel") {
     const postSlackMessage = params.client.chat.postMessage;
-    await postSlackMessage({
+    const response = await postSlackMessage({
       channel: params.command.channel_id,
       text,
       ...(blocks ? { blocks } : {}),
       ...(mrkdwn !== undefined ? { mrkdwn } : {}),
     });
+    requireSlackPostMessageTimestamp(response);
   } else {
     await params.client.chat.postEphemeral({
       channel: params.command.channel_id,

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -275,6 +275,19 @@ describe("sendMessageSlack chunking", () => {
     expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["m1"]);
   });
 
+  it("rejects a successful Slack post that returns no message timestamp", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({ ok: true, channel: "C123" });
+
+    await expect(
+      sendMessageSlack("channel:C123", "hello", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+      }),
+    ).rejects.toThrow("Slack chat.postMessage returned no message timestamp");
+  });
+
   it("preserves the first canonical response thread across chunked sends", async () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -40,7 +40,6 @@ import {
 } from "./client-delivery.js";
 import { createSlackReadClient, createSlackTokenCacheKey, getSlackWriteClient } from "./client.js";
 import { assertSlackDetachedTargetAllowed } from "./detached-target-admission.js";
-import { formatSlackError } from "./errors.js";
 import { chunkSlackMrkdwnText, markdownToSlackMrkdwnChunks } from "./format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES, SLACK_TEXT_LIMIT } from "./limits.js";
 import type { SlackEventScope } from "./monitor/event-scope.js";
@@ -96,7 +95,6 @@ type SlackResolvedDelivery = Readonly<{
   credential: string;
   identity?: SlackSendIdentity;
   recipient: SlackRecipient;
-  requireMessageTimestamp: boolean;
   teamId?: string;
   unfurl: SlackUnfurlOptions;
   upload?: Readonly<{
@@ -409,7 +407,6 @@ function resolveSlackDelivery(params: {
       credential: SLACK_ENTERPRISE_LISTENER_QUEUE_CREDENTIAL,
       identity: normalizeSlackSendIdentity(params.opts.identity),
       recipient: params.recipient,
-      requireMessageTimestamp: true,
       teamId: params.eventScope.teamId,
       unfurl: { unfurlMedia: params.account.config.unfurlMedia },
       ...(params.eventScope.uploadCompletionClient
@@ -442,7 +439,6 @@ function resolveSlackDelivery(params: {
       explicit: params.opts.identity,
     }),
     recipient: params.recipient,
-    requireMessageTimestamp: false,
     teamId: params.recipient.teamId,
     unfurl: params.recipient.teamId
       ? { unfurlMedia: params.account.config.unfurlMedia }
@@ -451,20 +447,6 @@ function resolveSlackDelivery(params: {
           unfurlMedia: params.account.config.unfurlMedia,
         },
   });
-}
-
-function assertSlackPostMessageResponse(
-  response: { ok?: boolean; ts?: string; error?: unknown },
-  required: boolean,
-): void {
-  if (!required || (response.ok && response.ts)) {
-    return;
-  }
-  throw new Error(
-    response.ok
-      ? "Slack chat.postMessage returned no message timestamp"
-      : `Slack chat.postMessage failed: ${formatSlackError(response.error, "unknown error")}`,
-  );
 }
 
 function resolveSlackTextChunkLimit(params: {
@@ -1271,8 +1253,7 @@ async function sendMessageSlackQueuedInner(params: {
           ...(usesOrderedBlockAccessibility ? { mrkdwn: false } : {}),
           unfurl,
         });
-        assertSlackPostMessageResponse(response, delivery.requireMessageTimestamp);
-        const messageId = response.ts ?? "unknown";
+        const messageId = response.ts;
         deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
@@ -1325,14 +1306,10 @@ async function sendMessageSlackQueuedInner(params: {
           unfurl,
         });
         const response = posted.response;
-        assertSlackPostMessageResponse(response, delivery.requireMessageTimestamp);
         sendIdentity = posted.identity;
-        lastMessageId = response.ts ?? lastMessageId;
+        lastMessageId = response.ts;
         deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
         canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
-        if (!response.ts) {
-          continue;
-        }
         sentMessageIds.push(response.ts);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
@@ -1354,7 +1331,7 @@ async function sendMessageSlackQueuedInner(params: {
           questionDelivery = fallbackDelivery;
         }
       }
-      const messageId = lastMessageId || "unknown";
+      const messageId = lastMessageId;
       const deliveredThreadTs =
         canonicalDeliveredThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
       return {
@@ -1372,7 +1349,7 @@ async function sendMessageSlackQueuedInner(params: {
             }
           : {}),
         receipt: createSlackSendReceipt({
-          platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
+          platformMessageIds: sentMessageIds,
           channelId: deliveredChannelId,
           kind: fallbackMessages.some((message) => message.blocks) ? "card" : "text",
           threadTs: deliveredThreadTs,
@@ -1461,31 +1438,27 @@ async function sendMessageSlackQueuedInner(params: {
       unfurl,
     });
     const response = posted.response;
-    assertSlackPostMessageResponse(response, delivery.requireMessageTimestamp);
     sendIdentity = posted.identity;
-    lastMessageId = response.ts ?? lastMessageId;
+    lastMessageId = response.ts;
     deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
     canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
-    if (response.ts) {
-      sentMessageIds.push(response.ts);
-      await reportDelivery({
-        messageId: response.ts,
+    sentMessageIds.push(response.ts);
+    await reportDelivery({
+      messageId: response.ts,
+      channelId: deliveredChannelId,
+      threadTs:
+        resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs),
+      receipt: createSlackSendReceipt({
+        platformMessageIds: [response.ts],
         channelId: deliveredChannelId,
+        kind: "text",
         threadTs:
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs),
-        receipt: createSlackSendReceipt({
-          platformMessageIds: [response.ts],
-          channelId: deliveredChannelId,
-          kind: "text",
-          threadTs:
-            resolvePostedMessageThreadTs(response) ??
-            normalizeSlackThreadTsCandidate(opts.threadTs),
-        }),
-      });
-    }
+      }),
+    });
   }
 
-  const messageId = lastMessageId || "unknown";
+  const messageId = lastMessageId;
   const deliveredThreadTs =
     canonicalDeliveredThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
   return {
@@ -1493,7 +1466,7 @@ async function sendMessageSlackQueuedInner(params: {
     channelId: deliveredChannelId,
     threadTs: deliveredThreadTs,
     receipt: createSlackSendReceipt({
-      platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
+      platformMessageIds: sentMessageIds,
       channelId: deliveredChannelId,
       kind: opts.mediaUrl ? "media" : "text",
       threadTs: deliveredThreadTs,

--- a/src/channels/message/outbound-bridge.test.ts
+++ b/src/channels/message/outbound-bridge.test.ts
@@ -115,6 +115,23 @@ describe("createChannelMessageAdapterFromOutbound", () => {
     });
   });
 
+  it("preserves target-only routing metadata without fabricating delivery identity", async () => {
+    const target = { kind: "channel" as const, id: "route-only" };
+    const adapter = createChannelMessageAdapterFromOutbound({
+      outbound: {
+        sendText: vi.fn(async () => ({ target })),
+      },
+    });
+
+    const result = await adapter.send?.text?.({ cfg, to: "room-1", text: "hello" });
+
+    expect(result?.target).toEqual(target);
+    expect(result).not.toHaveProperty("messageId");
+    expect(result?.receipt.primaryPlatformMessageId).toBeUndefined();
+    expect(result?.receipt.platformMessageIds).toEqual([]);
+    expect(result?.receipt.parts).toEqual([]);
+  });
+
   it("preserves contracted delivery facts without exposing private provider fields", async () => {
     const sourceResult = (messageId: string) => ({
       channel: "forged-channel",

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -67,7 +67,6 @@ function resolveResultMessageId(result: ChannelMessageOutboundBridgeResult): str
     result.messageId ??
     result.receipt?.primaryPlatformMessageId ??
     result.receipt?.platformMessageIds[0] ??
-    result.target?.id ??
     result.chatId ??
     result.channelId ??
     result.roomId ??

--- a/src/channels/message/receipt.test.ts
+++ b/src/channels/message/receipt.test.ts
@@ -46,6 +46,19 @@ describe("createMessageReceiptFromOutboundResults", () => {
     expect(receipt.platformMessageIds).toEqual(["jid-1"]);
   });
 
+  it("does not use target routing metadata as platform message identity", () => {
+    const target = { kind: "channel" as const, id: "route-only" };
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "demo", messageId: "", target }],
+      sentAt: 123,
+    });
+
+    expect(receipt.primaryPlatformMessageId).toBeUndefined();
+    expect(receipt.platformMessageIds).toEqual([]);
+    expect(receipt.parts).toEqual([]);
+    expect(receipt.raw).toEqual([{ channel: "demo", messageId: "", target }]);
+  });
+
   it.each([
     {
       label: "Synology Chat destination IDs",

--- a/src/channels/message/receipt.ts
+++ b/src/channels/message/receipt.ts
@@ -17,7 +17,6 @@ type MessageReceiptInputResult = MessageReceiptSourceResult & {
 function resolveReceiptMessageId(result: MessageReceiptInputResult): string | undefined {
   return (
     result.messageId ||
-    result.target?.id ||
     result.chatId ||
     result.channelId ||
     result.roomId ||

--- a/src/infra/outbound/deliver-payload.ts
+++ b/src/infra/outbound/deliver-payload.ts
@@ -175,7 +175,7 @@ export function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPa
 }
 
 export function hasDeliveryResultIdentity(result: OutboundDeliveryResult): boolean {
-  return Boolean(result.messageId || result.target?.id || result.toJid || result.pollId);
+  return Boolean(result.messageId || result.toJid || result.pollId);
 }
 
 function normalizeDeliveryPin(payload: ReplyPayload): ReplyPayloadDeliveryPin | undefined {

--- a/src/infra/outbound/deliver.queue-integration.test.ts
+++ b/src/infra/outbound/deliver.queue-integration.test.ts
@@ -622,9 +622,11 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
     expect(sendMatrix).toHaveBeenCalledTimes(2);
   });
 
-  it("never acknowledges a platform send that returns no message identity", async () => {
+  it("never acknowledges target-only routing metadata as a platform message identity", async () => {
     process.env.OPENCLAW_STATE_DIR = tmpDir;
-    const sendMatrix = vi.fn().mockResolvedValue({});
+    const sendMatrix = vi.fn().mockResolvedValue({
+      target: { kind: "room", id: "!route-only:example" },
+    });
     const deliveryIntentId = "cron-direct-delivery:v1:no-platform-identity";
     const params = {
       cfg: {} as OpenClawConfig,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack sends could be reported as successful without a real Slack message timestamp, and where shared delivery code could mistake a routing target ID for a delivered platform message ID. Those false identities could make an unconfirmed or identityless send look complete.

## Why This Change Was Made

Slack now validates every successful `chat.postMessage` response through one plugin-owned timestamp validator, including ordinary sends and the slash-response Web API fallback. Shared delivery normalization also treats `target` only as routing metadata: receipts, bridge results, and queue admission use explicit delivery identities instead of synthesizing them from `target.id`.

This keeps provider-specific response validation at the Slack producer boundary and keeps generic delivery identity rules provider-neutral. No compatibility alias or `messageId: "unknown"` fallback remains.

## User Impact

Slack operators will now see a delivery failure when Slack does not return a usable message timestamp instead of receiving a false success. Queue recovery also retains custody of target-only sends rather than acknowledging them as delivered.

Release note: Slack delivery success now requires Slack's canonical message timestamp, and routing destination IDs no longer masquerade as delivery receipts.

## Evidence

- Focused routed Vitest proof: 6 shards, 9 files, 320 tests passed. Coverage includes ordinary Slack sends, enterprise and identity fallback paths, slash-response fallback, shared receipts and outbound bridge normalization, queue custody, plus Synology Chat and Discord sibling adapters.
- `pnpm check:changed` passed with exit 0 after the rebased worktree dependency tree was reconciled.
- `git diff --check origin/main...HEAD` passed.
- Fresh branch autoreview passed with no accepted/actionable findings.
- Production LOC: +45/-51 (net -6). Tests: +113/-6.
- Regression coverage proves missing Slack timestamps throw, target-only routing metadata creates no platform identity, and queue delivery remains unacknowledged without an explicit provider identity.
- AI-assisted change; the complete patch and behavior were reviewed before publication.

Known proof gap: no live authenticated Slack send was performed. The deterministic Slack API boundary regressions and exact-head CI cover the changed contract without claiming live-provider proof.
