### PR TITLE
refactor(ui): heal chat-pane max-lines and markdown-tables mock isolation

### DIFF
--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -5,6 +5,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/app/app-host.server-prefs.test.ts",
   "ui/src/app/bootstrap.test.ts",
   "ui/src/app/router-outlet.test.ts",
+  "ui/src/components/markdown-tables.test.ts",
   "ui/src/components/resizable-divider.test.ts",
   "ui/src/components/sidebar-update-card.test.ts",
   "ui/src/components/viewer-facepile.test.ts",

--- a/ui/src/pages/chat/chat-pane-rails.ts
+++ b/ui/src/pages/chat/chat-pane-rails.ts
@@ -1,0 +1,80 @@
+import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
+import { openTaskDetailId } from "./components/chat-detail-slot.ts";
+import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
+import {
+  SIDEBAR_NARROW_BREAKPOINT_PX,
+  closeSlot,
+  isSidebarSlotVisible,
+  openSlot,
+  type SidebarSlotId,
+} from "./sidebar-layout.ts";
+
+type ChatPaneSidebarLayout = Parameters<typeof isSidebarSlotVisible>[0];
+type ChatPaneGatewaySnapshot = Parameters<typeof isDesktopPanelAvailable>[0];
+
+/** Builds the two rail models and their shared sidebar slot controls. */
+export function createChatPaneRails(params: {
+  state: ChatPageHost;
+  sidebarLayout: ChatPaneSidebarLayout;
+  paneWidth: number;
+  presentationId: string;
+  gatewaySnapshot: ChatPaneGatewaySnapshot;
+  setObserverVisibility: (visible: boolean) => void;
+}) {
+  const { state, sidebarLayout } = params;
+  const hasPanelSlot = (slot: SidebarSlotId) =>
+    sidebarLayout.columns[0]?.panels.some((panel) => panel.slot === slot) === true;
+  const openPanelSlot = (slot: SidebarSlotId) => {
+    state.updateSidebarLayout(openSlot(state.sidebarLayout, slot));
+    if (slot === "companion") {
+      params.setObserverVisibility(true);
+    }
+  };
+  const closePanelSlot = (slot: SidebarSlotId) => {
+    if (slot === "companion") {
+      params.setObserverVisibility(false);
+    }
+    state.updateSidebarLayout(closeSlot(state.sidebarLayout, slot));
+  };
+  const togglePanelSlot = (slot: SidebarSlotId) =>
+    hasPanelSlot(slot) ? closePanelSlot(slot) : openPanelSlot(slot);
+  const sessionWorkspaceBase = createSessionWorkspaceProps(state, {
+    draftScope: params.presentationId,
+    expanded: hasPanelSlot("workspace"),
+    narrowLayout: false,
+  });
+  const sessionWorkspace = {
+    ...sessionWorkspaceBase,
+    collapsed: !hasPanelSlot("workspace"),
+    narrowLayout: false,
+    onToggleCollapsed: () => togglePanelSlot("workspace"),
+    onToggleTerminal: state.terminalAvailable ? () => togglePanelSlot("terminal") : undefined,
+    onToggleBrowser: state.browserPanelAvailable ? () => togglePanelSlot("browser") : undefined,
+    onToggleDesktop: isDesktopPanelAvailable(params.gatewaySnapshot)
+      ? () => togglePanelSlot("desktop")
+      : undefined,
+  };
+  const backgroundTasksBase = createBackgroundTasksProps(state, {
+    narrowLayout: false,
+    openTaskId: openTaskDetailId(state.sidebarContent, sidebarLayout),
+    onOpenTaskDetail: (task) => state.handleOpenSidebar({ kind: "task", taskId: task.id }),
+  });
+  const backgroundTasks = {
+    ...backgroundTasksBase,
+    collapsed: !hasPanelSlot("tasks"),
+    narrowLayout: false,
+    onToggleCollapsed: () => togglePanelSlot("tasks"),
+  };
+  const progressCardInRail =
+    params.paneWidth >= SIDEBAR_NARROW_BREAKPOINT_PX &&
+    isSidebarSlotVisible(sidebarLayout, "companion");
+  return {
+    backgroundTasks,
+    closePanelSlot,
+    openPanelSlot,
+    progressCardInRail,
+    sessionWorkspace,
+  };
+}

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -1,5 +1,4 @@
 import { html, nothing } from "lit";
-import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
 import { findInlineApproval } from "../../app/approval-presentation.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-prompt.ts";
@@ -23,6 +22,7 @@ import { clearChatHistory } from "./chat-history.ts";
 import { resolveChatMessageAccess } from "./chat-message-access.ts";
 import { requiresChatModelSetup } from "./chat-model-setup.ts";
 import { ChatPaneLayoutRender } from "./chat-pane-layout-render.ts";
+import { createChatPaneRails } from "./chat-pane-rails.ts";
 import {
   createChatPaneSessionActionCallbacks,
   readChatPaneMutationAccess,
@@ -44,24 +44,14 @@ import {
   selectedChatSessionRow,
 } from "./chat-state-route.ts";
 import type { ChatProps } from "./chat-view.ts";
-import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
-import { openTaskDetailId } from "./components/chat-detail-slot.ts";
 import { chatPullRequestId, createPullRequestBranch } from "./components/chat-pull-requests.ts";
 import {
-  createSessionWorkspaceProps,
   openSessionWorkspaceFile,
   revealSessionWorkspaceFile,
 } from "./components/chat-session-workspace.ts";
 import { activeQueuedMessageEdit } from "./queued-message-edit.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
-import {
-  SIDEBAR_NARROW_BREAKPOINT_PX,
-  closeSlot,
-  isSidebarSlotVisible,
-  openSlot,
-  type SidebarSlotId,
-} from "./sidebar-layout.ts";
 import { resolveActiveRunOutputTokens, resolveChatProjectionRunId } from "./tool-stream.ts";
 import { configureToolTitleFetcher } from "./tool-titles.ts";
 import { workspaceResultConflictFromPlacement } from "./workspace-conflict.ts";
@@ -111,25 +101,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       layout: state.sidebarLayout,
       paneWidth: this.paneWidth,
     });
-    const hasPanelSlot = (slot: SidebarSlotId) =>
-      sidebarLayout.columns[0]?.panels.some((panel) => panel.slot === slot) === true;
-    const progressCardInRail =
-      this.paneWidth >= SIDEBAR_NARROW_BREAKPOINT_PX &&
-      isSidebarSlotVisible(sidebarLayout, "companion");
-    const openPanelSlot = (slot: SidebarSlotId) => {
-      state.updateSidebarLayout(openSlot(state.sidebarLayout, slot));
-      if (slot === "companion") {
-        this.setSessionObserverVisibility(true);
-      }
-    };
-    const closePanelSlot = (slot: SidebarSlotId) => {
-      if (slot === "companion") {
-        this.setSessionObserverVisibility(false);
-      }
-      state.updateSidebarLayout(closeSlot(state.sidebarLayout, slot));
-    };
-    const togglePanelSlot = (slot: SidebarSlotId) =>
-      hasPanelSlot(slot) ? closePanelSlot(slot) : openPanelSlot(slot);
     state.chatFollowUpMode = resolveControlUiFollowUpMode(
       state.settings.chatFollowUpMode,
       resolveControlUiServerQueueMode(
@@ -223,33 +194,15 @@ export class ChatPane extends ChatPaneLayoutRender {
           ? t("chat.catalog.remoteViewOnly")
           : t("chat.catalog.unsupportedViewOnly")
         : null;
-    const sessionWorkspaceBase = createSessionWorkspaceProps(state, {
-      draftScope: this.presentationId,
-      expanded: hasPanelSlot("workspace"),
-      narrowLayout: false,
-    });
-    const sessionWorkspace = {
-      ...sessionWorkspaceBase,
-      collapsed: !hasPanelSlot("workspace"),
-      narrowLayout: false,
-      onToggleCollapsed: () => togglePanelSlot("workspace"),
-      onToggleTerminal: state.terminalAvailable ? () => togglePanelSlot("terminal") : undefined,
-      onToggleBrowser: state.browserPanelAvailable ? () => togglePanelSlot("browser") : undefined,
-      onToggleDesktop: isDesktopPanelAvailable(gatewaySnapshot)
-        ? () => togglePanelSlot("desktop")
-        : undefined,
-    };
-    const backgroundTasksBase = createBackgroundTasksProps(state, {
-      narrowLayout: false,
-      openTaskId: openTaskDetailId(state.sidebarContent, sidebarLayout),
-      onOpenTaskDetail: (task) => state.handleOpenSidebar({ kind: "task", taskId: task.id }),
-    });
-    const backgroundTasks = {
-      ...backgroundTasksBase,
-      collapsed: !hasPanelSlot("tasks"),
-      narrowLayout: false,
-      onToggleCollapsed: () => togglePanelSlot("tasks"),
-    };
+    const { backgroundTasks, closePanelSlot, openPanelSlot, progressCardInRail, sessionWorkspace } =
+      createChatPaneRails({
+        state,
+        sidebarLayout,
+        paneWidth: this.paneWidth,
+        presentationId: this.presentationId,
+        gatewaySnapshot,
+        setObserverVisibility: this.setSessionObserverVisibility,
+      });
     const selfUser = resolveCurrentSelfUser({
       snapshotUser: gatewaySnapshot.selfUser,
       presenceEntries: readPresenceEntries(gatewaySnapshot.hello?.snapshot),


### PR DESCRIPTION
## What Problem This Solves

Two latent shared-infrastructure defects on `main` that surface on unrelated PRs:

1. `ui/src/pages/chat/chat-pane-render.ts` sits at 702/700 effective `max-lines`, so any change that pulls it into a lint lane fails on untouched code.
2. `ui/src/components/markdown-tables.test.ts` runs in the shared `isolate: false` UI lane while depending on a hoisted clipboard `vi.mock`; depending on worker file packing, the mock can bind a stale module-graph instance and the copy spy records zero calls (observed twice on PR #125668's `checks-ui`, e.g. run 32119287262; not reproducible on machines with different packing).

## Why This Change Was Made

- Behavior-neutral extraction of the rail/sidebar-slot model building into `chat-pane-rails.ts`, bringing the file well under the limit with no suppression and no baseline edit.
- `markdown-tables.test.ts` is added to the canonical singleton-sensitive list (`test/vitest/vitest.ui-isolated-paths.mjs`), the repo's designed placement for exactly this class — the test still runs in full, in the isolated lane.

## User Impact

None at runtime. CI reliability: unrelated PRs stop failing on these two latent issues.

## Evidence

- `node scripts/run-oxlint.mjs ui/src/pages/chat/chat-pane-render.ts` fails on current main (max-lines 702/700) and passes with the extraction.
- Isolated mock-registry lane green locally with the new entry (31 files, 528 tests).
- Chat-pane tests green post-extraction (`chat-pane-board`, `chat-view`); typecheck/lint lanes green via `check-changed`.
- Failure evidence for the leak: PR #125668 checks-ui failures at two different heads with `expected copyToClipboard to be called; Number of calls: 0`, while the full suite passes locally under `--maxWorkers 3` on different packing.
