### PR TITLE
fix(agents): finalize guided creation safely

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -41,9 +41,9 @@ Options: `--json`, `--bindings` (include full routing rules, not only per-agent 
 
 Options: `--workspace <dir>`, `--model <id>`, `--agent-dir <dir>`, `--bind <channel[:accountId]>` (repeatable), `--non-interactive`, `--json`.
 
-- Passing any explicit add flag switches the command into the non-interactive path.
-- Non-interactive mode requires both an agent name and `--workspace`.
-- `main` is reserved and cannot be used as the new agent id.
+- The automation flags `--workspace`, `--model`, `--agent-dir`, `--bind`, and `--non-interactive` select the non-interactive path. Non-interactive mode requires both an agent name and `--workspace`.
+- `--json` alone keeps the guided wizard interactive. Prompts and status are written to stderr, and stdout contains one JSON summary after setup completes.
+- `main` is an ordinary agent id. Recreating it after another agent owns the installation can require `openclaw doctor --fix` to repair legacy session or shared-auth ownership first.
 - Interactive mode seeds auth by copying only portable static credentials (`api_key` and static `token` profiles) unless a credential opts out with `copyToAgents: false`; OAuth refresh-token profiles are not copied unless a provider opts in with `copyToAgents: true`. Without a copy, OAuth stays available through the shared auth base. If the configured default agent has its own local OAuth profile, sign in separately for the new agent.
 
 ### `agents bindings`

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -206,30 +206,34 @@ export function resolveNoteOutputColumns(message: string, columns: number): numb
   return Math.max(columns, widestLine + 6);
 }
 
-function createNoteOutput(columns: number): NodeJS.WriteStream {
-  if (process.stdout.columns === columns) {
-    return process.stdout;
+function createNoteOutput(output: NodeJS.WriteStream, columns: number): NodeJS.WriteStream {
+  if (output.columns === columns) {
+    return output;
   }
-  const output = Object.create(process.stdout) as NodeJS.WriteStream;
-  Object.defineProperty(output, "columns", {
+  const adaptedOutput = Object.create(output) as NodeJS.WriteStream;
+  Object.defineProperty(adaptedOutput, "columns", {
     value: columns,
     configurable: true,
   });
-  output.write = process.stdout.write.bind(process.stdout);
-  return output;
+  adaptedOutput.write = output.write.bind(output);
+  return adaptedOutput;
 }
 
-export function note(message: unknown, title?: string) {
+export function note(
+  message: unknown,
+  title?: string,
+  output: NodeJS.WriteStream = process.stdout,
+) {
   if (
     suppressNotesStorage.getStore() === true ||
     isSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)
   ) {
     return;
   }
-  const columns = resolveNoteColumns(process.stdout.columns);
+  const columns = resolveNoteColumns(output.columns);
   const wrappedMessage = wrapNoteMessage(message, { columns });
   clackNote(wrappedMessage, stylePromptTitle(title), {
-    output: createNoteOutput(resolveNoteOutputColumns(wrappedMessage, columns)),
+    output: createNoteOutput(output, resolveNoteOutputColumns(wrappedMessage, columns)),
   });
 }
 

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -219,10 +219,10 @@ function createNoteOutput(output: NodeJS.WriteStream, columns: number): NodeJS.W
   return adaptedOutput;
 }
 
-export function note(
+export function noteToStream(
   message: unknown,
-  title?: string,
-  output: NodeJS.WriteStream = process.stdout,
+  title: string | undefined,
+  output: NodeJS.WriteStream,
 ) {
   if (
     suppressNotesStorage.getStore() === true ||
@@ -235,6 +235,10 @@ export function note(
   clackNote(wrappedMessage, stylePromptTitle(title), {
     output: createNoteOutput(output, resolveNoteOutputColumns(wrappedMessage, columns)),
   });
+}
+
+export function note(message: unknown, title?: string) {
+  noteToStream(message, title, process.stdout);
 }
 
 export function withSuppressedNotes<T>(callback: () => T): T {

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { note as clackNote } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi, visibleWidth } from "./ansi.js";
-import { note, resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
+import {
+  noteToStream,
+  resolveNoteColumns,
+  resolveNoteOutputColumns,
+  wrapNoteMessage,
+} from "./note.js";
 import { renderTable } from "./table.js";
 
 function mockProcessPlatform(platform: NodeJS.Platform): void {
@@ -821,7 +826,7 @@ describe("wrapNoteMessage", () => {
     } as unknown as NodeJS.WriteStream;
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
-    note("word ".repeat(18).trim(), "Wide note", output);
+    noteToStream("word ".repeat(18).trim(), "Wide note", output);
 
     const rendered = stripAnsi(writes.join(""));
     expect(rendered).toContain("word ".repeat(17).trim());

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -2,8 +2,8 @@
 import path from "node:path";
 import { note as clackNote } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { visibleWidth } from "./ansi.js";
-import { resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
+import { stripAnsi, visibleWidth } from "./ansi.js";
+import { note, resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
 import { renderTable } from "./table.js";
 
 function mockProcessPlatform(platform: NodeJS.Platform): void {
@@ -808,6 +808,24 @@ describe("wrapNoteMessage", () => {
     expect(rendered).toContain(
       "- ~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock",
     );
+  });
+
+  it("routes notes and wrapping through the selected output", () => {
+    const writes: string[] = [];
+    const output = {
+      columns: 120,
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    } as unknown as NodeJS.WriteStream;
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    note("word ".repeat(18).trim(), "Wide note", output);
+
+    const rendered = stripAnsi(writes.join(""));
+    expect(rendered).toContain("word ".repeat(17).trim());
+    expect(stdoutWrite).not.toHaveBeenCalled();
   });
 
   it("coerces nullish and non-string note messages before wrapping", () => {

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -89,7 +89,9 @@ const EXTENSION_TEST_COST_MULTIPLIERS: Record<string, number> = {
   // overstates its real wall-clock cost during CI shard planning.
   "test/vitest/vitest.extensions.config.ts": 1.1,
 };
-const CODEX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 40;
+// A 34-file changed shard starved real-time watches on 4-vCPU CI while the same
+// inventory completed normally when split or run without host contention (#125768).
+const CODEX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 20;
 const MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT = 1;
 const TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT = 10;

--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -319,11 +319,15 @@ describe("createAgent", () => {
     });
 
     expect(result).toMatchObject({ status: "created", agentId: "researcher" });
+    if (result.status === "error") {
+      throw new Error(result.message);
+    }
     expect(mocks.transformConfigFileWithRetry).toHaveBeenCalledOnce();
     expect(mocks.persisted).toMatchObject({
       agents: { entries: { main: expect.any(Object), researcher: expect.any(Object) } },
       channels: { telegram: { enabled: true } },
     });
+    expect(result.config).toEqual(mocks.persisted);
   });
 
   it("requires a config revision for guided staging", async () => {

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -36,34 +36,34 @@ import { DEFAULT_IDENTITY_FILENAME, ensureAgentWorkspace } from "./workspace.js"
 
 const BOOTSTRAP_AGENT_ID = "main";
 
-type CreateAgentResult =
-  | {
-      status: "created" | "existing";
-      agentId: string;
-      name: string;
-      workspace: string;
-      agentDir: string;
-      model?: string;
-      bootstrapPending: boolean;
-      configHash?: string;
-      bindingResult?: ReturnType<typeof applyAgentBindings>;
-    }
-  | {
-      status: "error";
-      reason:
-        | "invalid-name"
-        | "reserved-id"
-        | "already-exists"
-        | "deletion-pending"
-        | "invalid-bindings"
-        | "legacy-session-migration-required"
-        | "shared-auth-store-owned-by-main"
-        | "unsafe-identity-file";
-      agentId?: string;
-      message: string;
-    };
+type CreateAgentSuccess = {
+  status: "created" | "existing";
+  agentId: string;
+  name: string;
+  workspace: string;
+  agentDir: string;
+  model?: string;
+  bootstrapPending: boolean;
+  configHash?: string;
+  bindingResult?: ReturnType<typeof applyAgentBindings>;
+};
 
-type CreateError = Extract<CreateAgentResult, { status: "error" }>;
+type CreateError = {
+  status: "error";
+  reason:
+    | "invalid-name"
+    | "reserved-id"
+    | "already-exists"
+    | "deletion-pending"
+    | "invalid-bindings"
+    | "legacy-session-migration-required"
+    | "shared-auth-store-owned-by-main"
+    | "unsafe-identity-file";
+  agentId?: string;
+  message: string;
+};
+
+type CreateAgentResult = (CreateAgentSuccess & { config: OpenClawConfig }) | CreateError;
 type AgentEntryConfig = NonNullable<NonNullable<OpenClawConfig["agents"]>["entries"]>[string];
 type CreateAgentEntry = AgentEntryConfig & { id: string };
 
@@ -280,7 +280,7 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
         }
         tombstoneClaimed = true;
       }
-      const committed = await transformConfig<CreateAgentResult>({
+      const committed = await transformConfig<CreateAgentSuccess>({
         afterWrite: { mode: "auto" },
         maxAttempts: 1,
         ...(params.bootstrapFirstAgent
@@ -464,9 +464,13 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
       if (result.status === "created") {
         recordAgentProvenance(agentId, params.provenance ?? { createdVia: "operator" });
       }
-      return typeof committed.persistedHash === "string"
-        ? { ...result, configHash: committed.persistedHash }
-        : result;
+      return {
+        ...result,
+        config: committed.nextConfig,
+        ...(typeof committed.persistedHash === "string"
+          ? { configHash: committed.persistedHash }
+          : {}),
+      };
     });
   } catch (error) {
     if (error instanceof DuplicateAgentError) {

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -262,14 +262,14 @@ describe("agent command registration", () => {
     );
   });
 
-  it("runs agents add and computes hasFlags based on explicit options", async () => {
+  it("runs agents add and detects explicit automation options", async () => {
     await runCli(["agents", "add", "alpha"]);
     const [alphaOptions, alphaRuntime, alphaFlags] = commandCall(agentsAddCommandMock, 0);
     expect((alphaOptions as { name?: string }).name).toBe("alpha");
     expect((alphaOptions as { workspace?: string }).workspace).toBeUndefined();
     expect((alphaOptions as { bind?: string[] }).bind).toEqual([]);
     expect(alphaRuntime).toBe(runtime);
-    expect(alphaFlags).toEqual({ hasFlags: false, hasAutomationFlags: false });
+    expect(alphaFlags).toEqual({ hasAutomationFlags: false });
 
     await runCli([
       "agents",
@@ -291,10 +291,10 @@ describe("agent command registration", () => {
     expect((betaOptions as { nonInteractive?: boolean }).nonInteractive).toBe(true);
     expect((betaOptions as { json?: boolean }).json).toBe(true);
     expect(betaRuntime).toBe(runtime);
-    expect(betaFlags).toEqual({ hasFlags: true, hasAutomationFlags: true });
+    expect(betaFlags).toEqual({ hasAutomationFlags: true });
   });
 
-  it("keeps JSON-only agent creation non-interactive", async () => {
+  it("keeps JSON-only agent creation in wizard mode", async () => {
     await runCli(["agents", "add", "alpha", "--json"]);
 
     const [options, callRuntime, flags] = commandCall(agentsAddCommandMock);
@@ -302,7 +302,7 @@ describe("agent command registration", () => {
       expect.objectContaining({ name: "alpha", json: true, nonInteractive: false }),
     );
     expect(callRuntime).toBe(runtime);
-    expect(flags).toEqual({ hasFlags: true, hasAutomationFlags: false });
+    expect(flags).toEqual({ hasAutomationFlags: false });
   });
 
   it("runs agents list when root agents command is invoked", async () => {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -176,14 +176,6 @@ export function registerAgentsCommands(program: Command): void {
     .option("--json", "Output JSON summary", false)
     .action(async (name, opts, command): Promise<void> => {
       await runAgentsCommandAction(async (runtime) => {
-        const hasFlags = hasExplicitOptions(command, [
-          "workspace",
-          "model",
-          "agentDir",
-          "bind",
-          "nonInteractive",
-          "json",
-        ]);
         const hasAutomationFlags = hasExplicitOptions(command, [
           "workspace",
           "model",
@@ -203,7 +195,7 @@ export function registerAgentsCommands(program: Command): void {
             json: Boolean(opts.json),
           },
           runtime,
-          { hasFlags, hasAutomationFlags },
+          { hasAutomationFlags },
         );
       });
     });

--- a/src/cli/terminal-interactivity.test.ts
+++ b/src/cli/terminal-interactivity.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isTerminalInteractive } from "./terminal-interactivity.js";
+
+const stdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+
+afterEach(() => {
+  if (stdinIsTTYDescriptor) {
+    Object.defineProperty(process.stdin, "isTTY", stdinIsTTYDescriptor);
+  } else {
+    Reflect.deleteProperty(process.stdin, "isTTY");
+  }
+});
+
+describe("isTerminalInteractive", () => {
+  it("checks stdin with an explicitly selected output stream", () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    const stderrLikeOutput = { isTTY: true };
+
+    expect(isTerminalInteractive(stderrLikeOutput)).toBe(true);
+    expect(isTerminalInteractive({ isTTY: false })).toBe(false);
+  });
+});

--- a/src/cli/terminal-interactivity.ts
+++ b/src/cli/terminal-interactivity.ts
@@ -3,8 +3,8 @@ function isTtyStream(stream: { isTTY?: boolean }): boolean {
   return stream.isTTY === true;
 }
 
-export function isTerminalInteractive(): boolean {
-  return isTtyStream(process.stdin) && isTtyStream(process.stdout);
+export function isTerminalInteractive(output: { isTTY?: boolean } = process.stdout): boolean {
+  return isTtyStream(process.stdin) && isTtyStream(output);
 }
 
 export const NON_INTERACTIVE_GATEWAY_STOP_MESSAGE =

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -14,7 +14,12 @@ import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.j
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { createQueuedWizardPrompter } from "../test-utils/plugin-setup-wizard.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+
+type SetupChannels = typeof import("./onboard-channels.js").setupChannels;
+type EnsureWorkspaceAndSessions = typeof import("./onboard-helpers.js").ensureWorkspaceAndSessions;
+type ApplyAuthChoice = typeof import("./auth-choice.js").applyAuthChoice;
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -77,14 +82,16 @@ const terminalMocks = vi.hoisted(() => ({
   isTerminalInteractive: vi.fn(() => true),
 }));
 const authChoiceMocks = vi.hoisted(() => ({
-  applyAuthChoice: vi.fn(),
+  applyAuthChoice: vi.fn<ApplyAuthChoice>(),
   warnIfModelConfigLooksOff: vi.fn(async () => {}),
 }));
 const onboardChannelsMocks = vi.hoisted(() => ({
-  setupChannels: vi.fn(async (config: Record<string, unknown>) => config),
+  setupChannels: vi.fn<SetupChannels>(async (config) => config),
 }));
 const onboardHelpersMocks = vi.hoisted(() => ({
-  ensureWorkspaceAndSessions: vi.fn(async () => {}),
+  ensureWorkspaceAndSessions: vi.fn<EnsureWorkspaceAndSessions>(async () => ({
+    bootstrapPending: false,
+  })),
 }));
 
 vi.mock("../config/config.js", async () => ({
@@ -218,10 +225,56 @@ describe("agents add command", () => {
     await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => await run(root));
   }
 
+  async function seedAgentAuthStore(
+    root: string,
+    agentId: string,
+    store: AuthProfileStore,
+  ): Promise<string> {
+    const agentDir = path.join(root, "agents", agentId, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    saveAuthProfileStore(store, agentDir);
+    return agentDir;
+  }
+
+  function setConfigSnapshot(config: Record<string, unknown>): void {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config,
+      sourceConfig: config,
+    });
+  }
+
+  function useFreshAgentWizard(params: { workspaceDir: string; confirmValues?: boolean[] }) {
+    const wizard = createQueuedWizardPrompter({
+      textValues: ["work", params.workspaceDir],
+      confirmValues: params.confirmValues,
+    });
+    wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+    return wizard;
+  }
+
+  function useExistingAgentWizard(workspaceDir = "/tmp/workspace-work") {
+    const wizard = createQueuedWizardPrompter({
+      textValues: [workspaceDir],
+      confirmValues: [true, false],
+    });
+    wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+    return wizard;
+  }
+
+  function stageChannelPostWriteHook(run: () => Promise<void>): void {
+    onboardChannelsMocks.setupChannels.mockImplementationOnce(
+      async (config, _runtime, _prompter, options) => {
+        options?.onPostWriteHook?.({ channel: "matrix", accountId: "ops", run });
+        return config;
+      },
+    );
+  }
+
   it("requires --workspace when flags are present", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
 
-    await agentsAddCommand({ name: "Work" }, runtime, { hasFlags: true });
+    await agentsAddCommand({ name: "Work" }, runtime, { hasAutomationFlags: true });
 
     expect(runtime.error).toHaveBeenCalledOnce();
     expect(runtime.error).toHaveBeenCalledWith(
@@ -235,7 +288,7 @@ describe("agents add command", () => {
     readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
 
     await agentsAddCommand({ name: "Work", nonInteractive: true }, runtime, {
-      hasFlags: false,
+      hasAutomationFlags: false,
     });
 
     expect(runtime.error).toHaveBeenCalledOnce();
@@ -251,7 +304,9 @@ describe("agents add command", () => {
     async (name) => {
       readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
 
-      await agentsAddCommand({ name, workspace: "/tmp/reserved" }, runtime, { hasFlags: true });
+      await agentsAddCommand({ name, workspace: "/tmp/reserved" }, runtime, {
+        hasAutomationFlags: true,
+      });
 
       expect(runtime.error).toHaveBeenCalledWith(
         `"${name}" is reserved. Choose another name, or run ${formatCliCommand("openclaw agents list")} to inspect configured agents.`,
@@ -325,9 +380,12 @@ describe("agents add command", () => {
     expect(writeConfigFileMock).not.toHaveBeenCalled();
   });
 
-  it.each([{ json: false }, { json: true }])(
+  it.each([
+    { json: false, output: process.stdout },
+    { json: true, output: process.stderr },
+  ])(
     "refuses the interactive wizard without a usable terminal (json=$json)",
-    async ({ json }) => {
+    async ({ json, output }) => {
       readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
       terminalMocks.isTerminalInteractive.mockReturnValue(false);
       wizardMocks.createClackPrompter.mockReturnValue({
@@ -345,6 +403,7 @@ describe("agents add command", () => {
       );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(runtime.log).not.toHaveBeenCalled();
+      expect(terminalMocks.isTerminalInteractive).toHaveBeenCalledWith(output);
       expect(wizardMocks.createClackPrompter).not.toHaveBeenCalled();
       expect(createAgentMock).not.toHaveBeenCalled();
       expect(writeConfigFileMock).not.toHaveBeenCalled();
@@ -369,6 +428,8 @@ describe("agents add command", () => {
     await agentsAddCommand({}, runtime);
 
     expect(terminalMocks.isTerminalInteractive).toHaveBeenCalledOnce();
+    expect(terminalMocks.isTerminalInteractive).toHaveBeenCalledWith(process.stdout);
+    expect(wizardMocks.createClackPrompter).toHaveBeenCalledWith(process.stdout);
     expect(prompter.intro).toHaveBeenCalledWith("Add OpenClaw agent");
     expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledOnce();
     expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledWith(
@@ -387,6 +448,50 @@ describe("agents add command", () => {
         transformConfig: transformConfigWithPendingPluginInstallsMock,
       }),
     );
+  });
+
+  it("keeps guided JSON stdout isolated while wizard logs and UI use stderr", async () => {
+    const config = { agents: { entries: { work: { id: "work" } } } };
+    setConfigSnapshot(config);
+    const wizard = createQueuedWizardPrompter({
+      textValues: ["/tmp/workspace-work"],
+      confirmValues: [true, false],
+    });
+    wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+    onboardChannelsMocks.setupChannels.mockImplementationOnce(
+      async (nextConfig, wizardRuntime, _prompter, options) => {
+        wizardRuntime.log("channel log");
+        options?.onPostWriteHook?.({
+          channel: "matrix",
+          accountId: "ops",
+          run: async ({ runtime: hookRuntime }) => hookRuntime.log("hook log"),
+        });
+        return nextConfig;
+      },
+    );
+    onboardHelpersMocks.ensureWorkspaceAndSessions.mockImplementationOnce(
+      async (_workspace, workspaceRuntime) => {
+        workspaceRuntime.log("workspace log");
+        return { bootstrapPending: false };
+      },
+    );
+
+    await agentsAddCommand({ name: "work", json: true }, runtime);
+
+    expect(terminalMocks.isTerminalInteractive).toHaveBeenCalledWith(process.stderr);
+    expect(wizardMocks.createClackPrompter).toHaveBeenCalledWith(process.stderr);
+    expect(runtime.error.mock.calls.map(([message]) => message)).toEqual([
+      "channel log",
+      "workspace log",
+      "hook log",
+    ]);
+    expect(runtime.log).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+      agentId: "work",
+      name: "work",
+      workspace: "/tmp/workspace-work",
+      agentDir: expect.stringContaining("/agents/work/agent"),
+    });
   });
 
   it("surfaces the canonical main gate before guided auth or workspace side effects", async () => {
@@ -423,10 +528,8 @@ describe("agents add command", () => {
     "reports only auth profiles persisted to the new agent store with %s shared auth",
     async (location) => {
       await withAgentsAddStateRoot("openclaw-agents-add-auth-copy-", async (root) => {
-        const sourceAgentDir = path.join(root, "agents", "main", "agent");
         const destAgentDir = path.join(root, "agents", "work", "agent");
         const workspaceDir = path.join(root, "workspace-work");
-        await fs.mkdir(sourceAgentDir, { recursive: true });
         const sourceStore: AuthProfileStore = {
           version: AUTH_STORE_VERSION,
           profiles: {
@@ -449,28 +552,17 @@ describe("agents add command", () => {
           writeConfigMachineState("auth.sharedStore", { location: "state-db" });
           saveAuthProfileStore(sourceStore);
         } else {
-          saveAuthProfileStore(sourceStore, sourceAgentDir);
+          await seedAgentAuthStore(root, "main", sourceStore);
         }
-        readConfigFileSnapshotMock.mockResolvedValue({
-          ...baseConfigSnapshot,
-          config: { agents: { list: [{ id: "main", default: true }] } },
-          sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
-        });
-        const prompter = {
-          intro: vi.fn(),
-          text: vi.fn().mockResolvedValueOnce("work").mockResolvedValueOnce(workspaceDir),
-          confirm: vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
-          note: vi.fn(),
-          outro: vi.fn(),
-        };
-        wizardMocks.createClackPrompter.mockReturnValue(prompter);
+        setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+        const wizard = useFreshAgentWizard({ workspaceDir, confirmValues: [true, false] });
 
         await agentsAddCommand({}, runtime);
 
         expect(Object.keys(loadPersistedAuthProfileStore(destAgentDir)?.profiles ?? {})).toEqual([
           "openai:api-key",
         ]);
-        expect(prompter.note).toHaveBeenCalledWith(
+        expect(wizard.note).toHaveBeenCalledWith(
           'Copied 1 portable auth profile from "main". OAuth profiles stay shared from "main" unless this agent signs in separately.',
           "Auth profiles",
         );
@@ -511,6 +603,158 @@ describe("agents add command", () => {
     });
   });
 
+  it("does not copy accepted portable auth when the guided wizard is cancelled", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-cancel-", async (root) => {
+      const destAgentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      await seedAgentAuthStore(root, "main", {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:api-key": { type: "api_key", provider: "openai", key: "sk-test" },
+        },
+      });
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+      const wizard = useFreshAgentWizard({ workspaceDir });
+      wizard.confirm.mockResolvedValueOnce(true).mockRejectedValueOnce(new WizardCancelledError());
+
+      await agentsAddCommand({}, runtime);
+
+      await expect(fs.stat(destAgentDir)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(createAgentMock).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("keeps guided auth written after portable copy acceptance when finalizing the copy", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-guided-", async (root) => {
+      const destAgentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      await seedAgentAuthStore(root, "main", {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            key: "portable-conflict",
+          },
+          "openai:portable": {
+            type: "api_key",
+            provider: "openai",
+            key: "portable-retained",
+          },
+        },
+        order: { openai: ["openai:api-key", "openai:portable"] },
+      });
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+      const wizard = createQueuedWizardPrompter({
+        textValues: ["work", workspaceDir],
+        confirmValues: [true, true],
+        selectValues: ["openai", "openai-api-key"],
+      });
+      wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+      authChoiceMocks.applyAuthChoice.mockImplementationOnce(async ({ config, agentDir }) => {
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "openai:api-key": {
+                type: "api_key",
+                provider: "openai",
+                key: "guided-wins",
+              },
+              "openai:guided": {
+                type: "api_key",
+                provider: "openai",
+                key: "guided-retained",
+              },
+            },
+            order: { openai: ["openai:guided", "openai:api-key"] },
+          },
+          agentDir,
+        );
+        return { config, retrySelection: false };
+      });
+
+      await agentsAddCommand({}, runtime);
+
+      const persisted = loadPersistedAuthProfileStore(destAgentDir);
+      expect(persisted?.profiles).toMatchObject({
+        "openai:api-key": { key: "guided-wins" },
+        "openai:portable": { key: "portable-retained" },
+        "openai:guided": { key: "guided-retained" },
+      });
+      expect(persisted?.order?.openai).toEqual(["openai:guided", "openai:api-key"]);
+      expect(wizard.note).toHaveBeenCalledWith(
+        'Copied 2 portable auth profiles from "main".',
+        "Auth profiles",
+      );
+    });
+  });
+
+  it("runs channel post-write hooks only after fresh agent creation", async () => {
+    const hook = vi.fn(async () => {});
+    setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+    useFreshAgentWizard({ workspaceDir: "/tmp/workspace-work", confirmValues: [false] });
+    stageChannelPostWriteHook(hook);
+
+    await agentsAddCommand({}, runtime);
+
+    expect(hook).toHaveBeenCalledOnce();
+    expect(createAgentMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      hook.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("does not run channel post-write hooks when fresh agent creation fails", async () => {
+    const hook = vi.fn(async () => {});
+    setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+    useFreshAgentWizard({ workspaceDir: "/tmp/workspace-work", confirmValues: [false] });
+    stageChannelPostWriteHook(hook);
+    createAgentMock.mockResolvedValueOnce({
+      status: "error",
+      reason: "write-failed",
+      agentId: "work",
+      message: "controlled create failure",
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it("provisions an existing agent workspace before committing its update and running hooks", async () => {
+    const config = { agents: { entries: { work: { id: "work" } } } };
+    const hook = vi.fn(async () => {});
+    setConfigSnapshot(config);
+    useExistingAgentWizard();
+    stageChannelPostWriteHook(hook);
+
+    await agentsAddCommand({ name: "work" }, runtime);
+
+    expect(
+      onboardHelpersMocks.ensureWorkspaceAndSessions.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(commitConfigWithPendingPluginInstallsMock.mock.invocationCallOrder[0]!);
+    expect(commitConfigWithPendingPluginInstallsMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      hook.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("does not commit an existing-agent update when workspace provisioning fails", async () => {
+    const config = { agents: { entries: { work: { id: "work" } } } };
+    setConfigSnapshot(config);
+    useExistingAgentWizard();
+    onboardHelpersMocks.ensureWorkspaceAndSessions.mockRejectedValueOnce(
+      new Error("controlled mkdir failure"),
+    );
+
+    await expect(agentsAddCommand({ name: "work" }, runtime)).rejects.toThrow(
+      /workspace provisioning.*agent "work".*controlled mkdir failure/i,
+    );
+
+    expect(commitConfigWithPendingPluginInstallsMock).not.toHaveBeenCalled();
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
   describe("non-interactive config mutation", () => {
     it("creates with explicit non-interactive inputs without a usable terminal", async () => {
       readConfigFileSnapshotMock.mockResolvedValue({
@@ -523,7 +767,7 @@ describe("agents add command", () => {
       await agentsAddCommand(
         { name: "Work", workspace: "/tmp/work", nonInteractive: true },
         runtime,
-        { hasFlags: false },
+        { hasAutomationFlags: false },
       );
 
       expect(createAgentMock).toHaveBeenCalledWith({
@@ -534,6 +778,7 @@ describe("agents add command", () => {
       expect(transformConfigWithPendingPluginInstallsMock).not.toHaveBeenCalled();
       expect(runtime.exit).not.toHaveBeenCalled();
       expect(runtime.error).not.toHaveBeenCalled();
+      expect(terminalMocks.isTerminalInteractive).not.toHaveBeenCalled();
     });
 
     it("reports a duplicate rejected by the canonical service", async () => {
@@ -550,7 +795,7 @@ describe("agents add command", () => {
       });
 
       await agentsAddCommand({ name: "Work", workspace: "/tmp/work" }, runtime, {
-        hasFlags: true,
+        hasAutomationFlags: true,
       });
 
       expect(writeConfigFileMock).not.toHaveBeenCalled();
@@ -582,7 +827,7 @@ describe("agents add command", () => {
       await agentsAddCommand(
         { name: "Work", workspace: "/tmp/work", bind: ["telegram"], json: true },
         runtime,
-        { hasFlags: true },
+        { hasAutomationFlags: true },
       );
 
       const payload = JSON.parse(String(runtime.log.mock.calls.at(-1)?.[0])) as {

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -8,6 +8,7 @@ import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { ChannelOnboardingPostWriteHook } from "../channels/plugins/setup-wizard-types.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -172,6 +173,7 @@ describe("agents add command", () => {
         workspace?: string;
         entry?: { id: string; name?: string; workspace?: string; agentDir?: string };
         bindingSpecs?: string[];
+        stagedConfig?: Record<string, unknown>;
       }) => {
         const name = params.name ?? params.entry?.name ?? params.entry?.id ?? "";
         const agentId = (params.entry?.id ?? name).toLowerCase();
@@ -192,6 +194,7 @@ describe("agents add command", () => {
           workspace: params.workspace ?? params.entry?.workspace ?? `/tmp/workspace-${agentId}`,
           agentDir: params.entry?.agentDir ?? `/tmp/agent-${agentId}`,
           bootstrapPending: true,
+          config: params.stagedConfig ?? {},
           ...(binding
             ? {
                 bindingResult: {
@@ -262,7 +265,7 @@ describe("agents add command", () => {
     return wizard;
   }
 
-  function stageChannelPostWriteHook(run: () => Promise<void>): void {
+  function stageChannelPostWriteHook(run: ChannelOnboardingPostWriteHook["run"]): void {
     onboardChannelsMocks.setupChannels.mockImplementationOnce(
       async (config, _runtime, _prompter, options) => {
         options?.onPostWriteHook?.({ channel: "matrix", accountId: "ops", run });
@@ -703,6 +706,30 @@ describe("agents add command", () => {
     expect(createAgentMock.mock.invocationCallOrder[0]!).toBeLessThan(
       hook.mock.invocationCallOrder[0]!,
     );
+  });
+
+  it("passes canonical created config to fresh-agent post-write hooks", async () => {
+    const persistedConfig = {
+      agents: { entries: { work: { id: "work", workspace: "/tmp/canonical-workspace" } } },
+      plugins: { installs: {} },
+    };
+    const hook = vi.fn(async () => {});
+    setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+    useFreshAgentWizard({ workspaceDir: "/tmp/staged-workspace", confirmValues: [false] });
+    stageChannelPostWriteHook(hook);
+    createAgentMock.mockResolvedValueOnce({
+      status: "created",
+      agentId: "work",
+      name: "work",
+      workspace: "/tmp/canonical-workspace",
+      agentDir: "/tmp/agent-work",
+      bootstrapPending: true,
+      config: persistedConfig,
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({ cfg: persistedConfig }));
   });
 
   it("does not run channel post-write hooks when fresh agent creation fails", async () => {

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -21,7 +21,10 @@ import {
   type AuthProfileStore,
 } from "../agents/auth-profiles.js";
 import { AuthProfileStoreUnreadableError } from "../agents/auth-profiles/legacy-source-diagnostic.js";
-import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import {
+  loadPersistedAuthProfileStore,
+  mergeAuthProfileStores,
+} from "../agents/auth-profiles/persisted.js";
 import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
   inspectPersistedAuthProfileStoreRaw,
@@ -34,6 +37,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { logConfigUpdated } from "../config/logging.js";
+import { createChannelSetupTransaction } from "../flows/channel-setup.js";
 import {
   commitConfigWithPendingPluginInstalls,
   transformConfigWithPendingPluginInstalls,
@@ -97,12 +101,12 @@ function formatSkippedOAuthProfilesMessage(
 export async function agentsAddCommand(
   opts: AgentsAddOptions,
   runtime: RuntimeEnv = defaultRuntime,
-  params?: { hasFlags?: boolean; hasAutomationFlags?: boolean },
+  params?: { hasAutomationFlags?: boolean },
 ) {
-  const hasFlags = params?.hasFlags === true;
-  const hasAutomationFlags = params?.hasAutomationFlags ?? hasFlags;
-  const nonInteractive = opts.nonInteractive === true || hasFlags;
-  if (!opts.nonInteractive && !hasAutomationFlags && !isTerminalInteractive()) {
+  const hasAutomationFlags = params?.hasAutomationFlags === true;
+  const nonInteractive = opts.nonInteractive === true || hasAutomationFlags;
+  const wizardOutput = opts.json ? process.stderr : process.stdout;
+  if (!nonInteractive && !isTerminalInteractive(wizardOutput)) {
     runtime.error(
       `Agent creation needs an interactive TTY. Use \`${formatCliCommand("openclaw agents add <id> --non-interactive --workspace <dir>")}\` for automation.`,
     );
@@ -216,7 +220,10 @@ export async function agentsAddCommand(
     return;
   }
 
-  const prompter = createClackPrompter();
+  const prompter = createClackPrompter(wizardOutput);
+  const wizardRuntime: RuntimeEnv = opts.json
+    ? { ...runtime, log: (...args) => runtime.error(...args) }
+    : runtime;
   try {
     await prompter.intro("Add OpenClaw agent");
     const name =
@@ -289,6 +296,7 @@ export async function agentsAddCommand(
       workspace: workspaceDir,
       agentDir,
     });
+    let finalizePortableAuthCopy: (() => Promise<void>) | undefined;
 
     const defaultAgentId = resolveDefaultAgentId(cfg);
     if (defaultAgentId !== agentId) {
@@ -310,6 +318,10 @@ export async function agentsAddCommand(
         const portable = sourceStore
           ? buildPortableAuthProfileStoreForAgentCopy(sourceStore)
           : undefined;
+        const skippedOAuthProfiles =
+          sourceStore && portable
+            ? hasOAuthProfiles(sourceStore, portable.skippedProfileIds)
+            : false;
         if (
           sourceStore &&
           portable &&
@@ -321,40 +333,50 @@ export async function agentsAddCommand(
             initialValue: false,
           });
           if (shouldCopy) {
-            await fs.mkdir(agentDir, { recursive: true });
-            saveAuthProfileStore(portable.store, agentDir, {
-              filterExternalAuthProfiles: false,
-              syncExternalCli: false,
-            });
-            const persistedDestStore = loadPersistedAuthProfileStore(agentDir);
-            const copiedCount = portable.copiedProfileIds.filter(
-              (profileId) => persistedDestStore?.profiles[profileId] !== undefined,
-            ).length;
-            const skippedOAuthProfiles =
-              hasOAuthProfiles(sourceStore, portable.skippedProfileIds) ||
-              portable.copiedProfileIds.some(
-                (profileId) =>
-                  sourceStore.profiles[profileId]?.type === "oauth" &&
-                  persistedDestStore?.profiles[profileId] === undefined,
-              );
-            const copiedText =
-              copiedCount > 0
-                ? `Copied ${copiedCount} portable auth profile${copiedCount === 1 ? "" : "s"} from "${defaultAgentId}".`
+            const portableStore = portable.store;
+            const copiedProfileIds = portable.copiedProfileIds;
+            const copiedOAuthProfileIds = copiedProfileIds.filter(
+              (profileId) => sourceStore.profiles[profileId]?.type === "oauth",
+            );
+            const sourceAgentId = defaultAgentId;
+            const sourceInheritedMain = sourceIsInheritedMain;
+            const destinationAgentDir = agentDir;
+            finalizePortableAuthCopy = async () => {
+              await fs.mkdir(destinationAgentDir, { recursive: true });
+              const destinationStore = loadPersistedAuthProfileStore(destinationAgentDir);
+              const storeToPersist = destinationStore
+                ? mergeAuthProfileStores(portableStore, destinationStore)
+                : portableStore;
+              saveAuthProfileStore(storeToPersist, destinationAgentDir, {
+                filterExternalAuthProfiles: false,
+                syncExternalCli: false,
+              });
+              const persisted = loadPersistedAuthProfileStore(destinationAgentDir);
+              const persistedIds = new Set(Object.keys(persisted?.profiles ?? {}));
+              const copiedCount = copiedProfileIds.filter((profileId) =>
+                persistedIds.has(profileId),
+              ).length;
+              const skippedOAuth =
+                skippedOAuthProfiles ||
+                copiedOAuthProfileIds.some((profileId) => !persistedIds.has(profileId));
+              const copied = copiedCount
+                ? `Copied ${copiedCount} portable auth profile${copiedCount === 1 ? "" : "s"} from "${sourceAgentId}".`
                 : "";
-            const skippedText = skippedOAuthProfiles
-              ? ` ${formatSkippedOAuthProfilesMessage(defaultAgentId, sourceIsInheritedMain)}`
-              : "";
-            await prompter.note(`${copiedText}${skippedText}`.trim(), "Auth profiles");
+              const skipped = skippedOAuth
+                ? ` ${formatSkippedOAuthProfilesMessage(sourceAgentId, sourceInheritedMain)}`
+                : "";
+              await prompter.note(`${copied}${skipped}`.trim(), "Auth profiles");
+            };
           }
-        } else if (
-          sourceStore &&
-          portable &&
-          hasOAuthProfiles(sourceStore, portable.skippedProfileIds)
-        ) {
-          await prompter.note(
-            formatSkippedOAuthProfilesMessage(defaultAgentId, sourceIsInheritedMain),
-            "Auth profiles",
-          );
+        } else if (skippedOAuthProfiles) {
+          const sourceAgentId = defaultAgentId;
+          const sourceInheritedMain = sourceIsInheritedMain;
+          finalizePortableAuthCopy = async () => {
+            await prompter.note(
+              formatSkippedOAuthProfilesMessage(sourceAgentId, sourceInheritedMain),
+              "Auth profiles",
+            );
+          };
         }
       }
     }
@@ -379,7 +401,7 @@ export async function agentsAddCommand(
           authChoice,
           config: nextConfig,
           prompter,
-          runtime,
+          runtime: wizardRuntime,
           agentDir,
           setDefaultModel: false,
           agentId,
@@ -404,9 +426,10 @@ export async function agentsAddCommand(
       validateCatalog: false,
     });
 
+    const channelSetup = createChannelSetupTransaction({ runtime: wizardRuntime });
     let selection: ChannelChoice[] = [];
     const channelAccountIds: Partial<Record<ChannelChoice, string>> = {};
-    nextConfig = await setupChannels(nextConfig, runtime, prompter, {
+    nextConfig = await setupChannels(nextConfig, wizardRuntime, prompter, {
       allowIMessageInstall: true,
       allowSignalInstall: true,
       onSelection: (value) => {
@@ -416,6 +439,7 @@ export async function agentsAddCommand(
       onAccountId: (channel, accountId) => {
         channelAccountIds[channel] = accountId;
       },
+      onPostWriteHook: channelSetup.onPostWriteHook,
     });
 
     if (selection.length > 0) {
@@ -457,15 +481,17 @@ export async function agentsAddCommand(
 
     let payload: { agentId: string; name: string; workspace: string; agentDir: string };
     if (existingAgent) {
-      const committed = await commitConfigWithPendingPluginInstalls({
-        nextConfig,
-        ...(baseHash !== undefined ? { baseHash } : {}),
-      });
-      nextConfig = committed.config;
       const target = resolveOnboardingAgentTarget(nextConfig, agentId);
-      await ensureOnboardingAgentWorkspace(target, runtime, {
+      await ensureOnboardingAgentWorkspace(target, wizardRuntime, {
         skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
         skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
+      });
+      nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
+        const committed = await commitConfigWithPendingPluginInstalls({
+          nextConfig: configToCommit,
+          ...(baseHash !== undefined ? { baseHash } : {}),
+        });
+        return committed.config;
       });
       payload = {
         agentId: target.agentId,
@@ -496,8 +522,12 @@ export async function agentsAddCommand(
         workspace: created.workspace,
         agentDir: created.agentDir,
       };
+      await channelSetup.runPostWriteHooks(nextConfig);
     }
-    logConfigUpdated(runtime);
+    await finalizePortableAuthCopy?.();
+    if (!opts.json) {
+      logConfigUpdated(runtime);
+    }
     if (opts.json) {
       writeRuntimeJson(runtime, payload);
     }

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -516,6 +516,7 @@ export async function agentsAddCommand(
         await prompter.outro(created.message);
         return;
       }
+      nextConfig = created.config;
       payload = {
         agentId: created.agentId,
         name: created.name,

--- a/src/commands/configure.wizard.default-agent.test.ts
+++ b/src/commands/configure.wizard.default-agent.test.ts
@@ -4,12 +4,16 @@ import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 
+type SetupChannels = typeof import("./onboard-channels.js").setupChannels;
+
 const mocks = vi.hoisted(() => ({
   state: { snapshot: undefined as unknown },
   commitConfig: vi.fn(),
   ensureWorkspaceAndSessions: vi.fn(),
   setupPluginConfig: vi.fn(),
   setupSkills: vi.fn(),
+  setupChannels: vi.fn<SetupChannels>(async (config) => config),
+  select: vi.fn(),
   text: vi.fn(),
 }));
 
@@ -67,7 +71,7 @@ vi.mock("./configure.shared.js", () => ({
   confirm: vi.fn(),
   intro: vi.fn(),
   outro: vi.fn(),
-  select: vi.fn(),
+  select: mocks.select,
   text: mocks.text,
 }));
 
@@ -84,6 +88,8 @@ vi.mock("./onboard-helpers.js", () => ({
 }));
 
 vi.mock("./onboard-skills.js", () => ({ setupSkills: mocks.setupSkills }));
+
+vi.mock("./onboard-channels.js", () => ({ setupChannels: mocks.setupChannels }));
 
 import { runConfigureWizard } from "./configure.wizard.js";
 
@@ -117,6 +123,7 @@ describe("runConfigureWizard default-agent ownership", () => {
       issues: [],
     };
     mocks.text.mockResolvedValue("/tmp/new-ops-workspace");
+    mocks.select.mockResolvedValue("configure");
     mocks.setupPluginConfig.mockImplementation(
       async ({ config }: { config: OpenClawConfig }) => config,
     );
@@ -359,5 +366,24 @@ describe("runConfigureWizard default-agent ownership", () => {
     expect(mocks.setupPluginConfig).not.toHaveBeenCalled();
     expect(mocks.setupSkills).not.toHaveBeenCalled();
     expect(mocks.commitConfig).not.toHaveBeenCalled();
+  });
+
+  it("runs channel post-write hooks after the converged config write", async () => {
+    const hook = vi.fn(async () => {});
+    mocks.setupChannels.mockImplementationOnce(async (config, _runtime, _prompter, options) => {
+      options?.onPostWriteHook?.({
+        channel: "matrix",
+        accountId: "ops",
+        run: hook,
+      });
+      return config;
+    });
+
+    await runConfigureWizard({ command: "configure", sections: ["channels"] }, runtime);
+
+    expect(hook).toHaveBeenCalledOnce();
+    expect(mocks.commitConfig.mock.invocationCallOrder[0]!).toBeLessThan(
+      hook.mock.invocationCallOrder[0]!,
+    );
   });
 });

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -11,6 +11,7 @@ import { readConfigFileSnapshotForWrite, resolveGatewayPort } from "../config/co
 import { inheritLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { logConfigUpdated } from "../config/logging.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createChannelSetupTransaction } from "../flows/channel-setup.js";
 import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../gateway/probe-auth.js";
 import { formatWindowsGatewayFirewallGuidance } from "../infra/windows-gateway-firewall-diagnostics.js";
 import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
@@ -622,6 +623,7 @@ export async function runConfigureWizard(
     let didPersistConfig = false;
     let daemonSetupOutcome: DaemonSetupOutcome | undefined;
     let healthCheckOutcome: GatewayHealthCheckOutcome | undefined;
+    const channelSetup = createChannelSetupTransaction({ runtime });
 
     const persistPendingConfig = async () => {
       if (!hasPendingConfig) {
@@ -632,11 +634,14 @@ export async function runConfigureWizard(
         mode: metadataMode,
       });
 
-      nextConfig = await writeWizardConfigFile(nextConfig, {
-        mergeBase: mergeBaseConfig,
-        writeOptions: configWriteOwnership,
+      nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
+        const committedConfig = await writeWizardConfigFile(configToCommit, {
+          mergeBase: mergeBaseConfig,
+          writeOptions: configWriteOwnership,
+        });
+        mergeBaseConfig = structuredClone(committedConfig);
+        return committedConfig;
       });
-      mergeBaseConfig = structuredClone(nextConfig);
       hasPendingConfig = false;
       didPersistConfig = true;
       logConfigUpdated(runtime);
@@ -731,6 +736,7 @@ export async function runConfigureWizard(
           deferStatusUntilSelection: true,
           skipConfirm: true,
           skipStatusNote: true,
+          onPostWriteHook: channelSetup.onPostWriteHook,
         });
       } else {
         nextConfig = await removeChannelConfigWizard(nextConfig, runtime);

--- a/src/commands/onboard-agent-target.ts
+++ b/src/commands/onboard-agent-target.ts
@@ -12,9 +12,11 @@ import {
 } from "../config/model-input.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { applyPrimaryModel } from "../plugins/provider-model-primary.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { shortenHomePath } from "../utils.js";
 import { ensureWorkspaceAndSessions } from "./onboard-helpers.js";
 
 export type OnboardingAgentTarget = {
@@ -50,10 +52,17 @@ export async function ensureOnboardingAgentWorkspace(
     skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
   },
 ): Promise<{ bootstrapPending: boolean }> {
-  return ensureWorkspaceAndSessions(target.workspaceDir, runtime, {
-    ...options,
-    agentId: target.agentId,
-  });
+  try {
+    return await ensureWorkspaceAndSessions(target.workspaceDir, runtime, {
+      ...options,
+      agentId: target.agentId,
+    });
+  } catch (error) {
+    throw new Error(
+      `Workspace provisioning for agent "${target.agentId}" at ${shortenHomePath(target.workspaceDir)} failed: ${formatErrorMessage(error)}`,
+      { cause: error },
+    );
+  }
 }
 
 export function applyOnboardingPrimaryModel(

--- a/src/commands/systemd-linger.ts
+++ b/src/commands/systemd-linger.ts
@@ -42,7 +42,7 @@ export async function ensureSystemdUserLingerInteractive(params: {
     return;
   }
   const env = params.env ?? process.env;
-  const prompter = params.prompter ?? { note };
+  const prompter: LingerPrompter = params.prompter ?? { note };
   const title = params.title ?? "Systemd";
   if (!(await isSystemdUserServiceAvailable())) {
     await prompter.note("Systemd user services are unavailable. Skipping lingering checks.", title);

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -971,6 +971,50 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
   });
 
+  it("fails visibly when configured channel setup has no post-write hook sink", async () => {
+    const externalChatPlugin = makeSetupPlugin({
+      id: "external-chat",
+      label: "External Chat",
+      setupWizard: {
+        channel: "external-chat",
+        getStatus: vi.fn(async () => ({
+          channel: "external-chat",
+          configured: false,
+          statusLines: [],
+        })),
+        configure: vi.fn(),
+        configureInteractive: vi.fn(async ({ cfg }) => ({
+          cfg: {
+            ...cfg,
+            channels: { ...cfg.channels, "external-chat": { token: "configured" } },
+          },
+          accountId: "external-account",
+        })),
+        afterConfigWritten: vi.fn(async () => {}),
+      } as ChannelSetupPlugin["setupWizard"],
+    });
+    resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
+    listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
+
+    await expect(
+      setupChannels(
+        {} as OpenClawConfig,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note: vi.fn(async () => undefined),
+          select: vi.fn(async () => "__done__"),
+        } as never,
+        {
+          initialSelection: ["external-chat"],
+          finishAfterInitialSelection: true,
+          deferStatusUntilSelection: true,
+          skipDmPolicyPrompt: true,
+        },
+      ),
+    ).rejects.toThrow(/post-write hook.*transaction sink/i);
+  });
+
   it("keeps completed setup when the follow-up status refresh fails", async () => {
     const getStatus = vi
       .fn()

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -72,7 +72,7 @@ export function createChannelSetupTransaction(params: {
     hooks.clear();
   };
   return {
-    onPostWriteHook(hook: ChannelOnboardingPostWriteHook) {
+    onPostWriteHook: (hook: ChannelOnboardingPostWriteHook) => {
       hooks.set(`${hook.channel}:${hook.accountId}`, hook);
     },
     async commit(
@@ -471,7 +471,12 @@ export async function setupChannels(
         previousCfg,
       });
       if (postWriteHook) {
-        options?.onPostWriteHook?.(postWriteHook);
+        if (!options?.onPostWriteHook) {
+          throw new Error(
+            `Channel setup internal error: ${channel} produced a post-write hook without a transaction sink.`,
+          );
+        }
+        options.onPostWriteHook(postWriteHook);
       }
     }
     addSelection(channel);

--- a/src/system-agent/chat-turn-router.approval.test.ts
+++ b/src/system-agent/chat-turn-router.approval.test.ts
@@ -267,6 +267,7 @@ describe("SystemAgentChatEngine approval", () => {
         workspace: "/tmp/researcher",
         agentDir: "/tmp/agent-researcher",
         bootstrapPending: true,
+        config: {},
       }));
       const engine = new SystemAgentChatEngine({
         runAgentTurn: async () => null,

--- a/src/system-agent/rescue-message.test.ts
+++ b/src/system-agent/rescue-message.test.ts
@@ -668,6 +668,7 @@ describe("OpenClaw rescue message", () => {
           workspace: "/tmp/work",
           agentDir: "/tmp/agent-work",
           bootstrapPending: true,
+          config: cfg,
         })),
       };
 

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -88,7 +88,7 @@ vi.mock("../cli/progress.js", () => ({
 }));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
-  note: terminalNoteMocks.note,
+  noteToStream: terminalNoteMocks.note,
 }));
 
 vi.mock("./clack-navigation-prompts.js", () => ({

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -24,6 +24,10 @@ const cliProgressMocks = vi.hoisted(() => ({
   })),
 }));
 
+const terminalNoteMocks = vi.hoisted(() => ({
+  note: vi.fn(),
+}));
+
 const clackMocks = vi.hoisted(() => ({
   autocomplete: vi.fn(),
   autocompleteMultiselect: vi.fn(),
@@ -81,6 +85,10 @@ vi.mock("@clack/prompts", () => ({
 
 vi.mock("../cli/progress.js", () => ({
   createCliProgress: cliProgressMocks.createCliProgress,
+}));
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({
+  note: terminalNoteMocks.note,
 }));
 
 vi.mock("./clack-navigation-prompts.js", () => ({
@@ -241,6 +249,7 @@ describe("createClackPrompter", () => {
       frames: ["(\\/)", "(||)", "(--)", "(||)"],
       delay: 120,
       styleFrame: theme.accent,
+      output: process.stdout,
     });
   });
 
@@ -253,7 +262,40 @@ describe("createClackPrompter", () => {
 
     prompter.progress("Loading");
 
-    expect(clackMocks.spinner).toHaveBeenCalledWith();
+    expect(clackMocks.spinner).toHaveBeenCalledWith({ output: process.stdout });
+  });
+
+  it("routes Clack UI, prompts, notes, plain text, and progress to the selected output", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    clackMocks.confirm.mockResolvedValue(true);
+    const prompter = createClackPrompter(process.stderr);
+
+    await prompter.intro("Add agent");
+    await prompter.note("Details", "Agent");
+    await prompter.plain?.("plain");
+    await prompter.confirm({ message: "Continue?" });
+    await prompter.outro("Ready");
+    const progress = prompter.progress("Loading");
+    progress.update("Still loading");
+    progress.stop();
+
+    expect(clackMocks.intro).toHaveBeenCalledWith(expect.any(String), {
+      output: process.stderr,
+    });
+    expect(terminalNoteMocks.note).toHaveBeenCalledWith("Details", "Agent", process.stderr);
+    expect(stderrWrite).toHaveBeenCalledWith("plain\n");
+    expect(clackMocks.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ output: process.stderr }),
+    );
+    expect(clackMocks.outro).toHaveBeenCalledWith(expect.any(String), {
+      output: process.stderr,
+    });
+    expect(clackMocks.spinner).toHaveBeenCalledWith({ output: process.stderr });
+    expect(cliProgressMocks.createCliProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: process.stderr }),
+    );
+    expect(stdoutWrite).not.toHaveBeenCalled();
   });
 
   it("prints plain output without note framing", async () => {
@@ -508,7 +550,9 @@ describe("createClackPrompter", () => {
       WizardCancelledError,
     );
 
-    expect(clackMocks.cancel).toHaveBeenCalledOnce();
+    expect(clackMocks.cancel).toHaveBeenCalledWith(expect.any(String), {
+      output: process.stdout,
+    });
   });
 
   it("rejects navigation after Clack resolves an aborted prompt", async () => {

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -46,8 +46,8 @@ import { WizardCancelledError, WizardNavigationError } from "./prompts.js";
 const CLAW_SPINNER_FRAMES = ["(\\/)", "(||)", "(--)", "(||)"];
 const SPINNER_DECORATION_COLUMNS = 10;
 
-function readProgressColumns(): number | undefined {
-  const columns = process.stdout.columns;
+function readProgressColumns(output: NodeJS.WriteStream): number | undefined {
+  const columns = output.columns;
   if (typeof columns !== "number" || !Number.isFinite(columns) || columns <= 0) {
     return undefined;
   }
@@ -70,10 +70,10 @@ function clampProgressLabel(label: string, columns: number | undefined): string 
 
 // Clack-backed WizardPrompter implementation for interactive CLI setup. It
 // converts the generic wizard prompt contract into styled Clack prompts.
-function guardCancel<T>(value: T | symbol, signal?: AbortSignal): T {
+function guardCancel<T>(value: T | symbol, output: NodeJS.WriteStream, signal?: AbortSignal): T {
   if (isCancel(value)) {
     if (!signal?.aborted) {
-      cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+      cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.", { output });
     }
     throw new WizardCancelledError();
   }
@@ -129,6 +129,7 @@ async function withHorizontalCursorActionsDisabled<T>(
 async function runPromptWithNavigation<T>(
   navigation: WizardPromptNavigation | undefined,
   work: (signal: AbortSignal | undefined) => Promise<T | symbol>,
+  output: NodeJS.WriteStream,
   externalSignal?: AbortSignal,
 ): Promise<T> {
   const controller = new AbortController();
@@ -177,7 +178,7 @@ async function runPromptWithNavigation<T>(
     if (navigationDirection) {
       throw new WizardNavigationError(navigationDirection);
     }
-    return guardCancel(value, externalSignal);
+    return guardCancel(value, output, externalSignal);
   } finally {
     if (cancellationImmediate) {
       clearImmediate(cancellationImmediate);
@@ -213,19 +214,19 @@ export function tokenizedOptionFilter<T>(search: string, option: Option<T>): boo
 
 // Public factory used by setup/onboard commands. Keep side effects inside method
 // calls so tests can import the module without starting prompts.
-export function createClackPrompter(): WizardPrompter {
+export function createClackPrompter(output: NodeJS.WriteStream = process.stdout): WizardPrompter {
   return {
     intro: async (title) => {
-      intro(stylePromptTitle(title) ?? title);
+      intro(stylePromptTitle(title) ?? title, { output });
     },
     outro: async (message) => {
-      outro(stylePromptTitle(message) ?? message);
+      outro(stylePromptTitle(message) ?? message, { output });
     },
     note: async (message, title) => {
-      emitNote(message, title);
+      emitNote(message, title, output);
     },
     plain: async (message) => {
-      process.stdout.write(message.endsWith("\n") ? message : `${message}\n`);
+      output.write(message.endsWith("\n") ? message : `${message}\n`);
     },
     select: async (params) => {
       const { message, options: styledOptions } = styleSelectParams(params);
@@ -234,40 +235,48 @@ export function createClackPrompter(): WizardPrompter {
       return await withHorizontalCursorActionsDisabled(
         hasPromptNavigation(params.navigation),
         async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) => {
-            if (params.searchable) {
+          await runPromptWithNavigation(
+            params.navigation,
+            async (signal) => {
+              if (params.searchable) {
+                return params.navigation
+                  ? await autocompleteWithNavigationFooter({
+                      message,
+                      options,
+                      initialValue: params.initialValue,
+                      filter: tokenizedOptionFilter,
+                      signal,
+                      navigation: params.navigation,
+                      output,
+                    })
+                  : await autocomplete({
+                      message,
+                      options,
+                      initialValue: params.initialValue,
+                      filter: tokenizedOptionFilter,
+                      signal,
+                      output,
+                    });
+              }
               return params.navigation
-                ? await autocompleteWithNavigationFooter({
+                ? await selectWithNavigationFooter({
                     message,
                     options,
                     initialValue: params.initialValue,
-                    filter: tokenizedOptionFilter,
                     signal,
                     navigation: params.navigation,
+                    output,
                   })
-                : await autocomplete({
+                : await select({
                     message,
                     options,
                     initialValue: params.initialValue,
-                    filter: tokenizedOptionFilter,
                     signal,
+                    output,
                   });
-            }
-            return params.navigation
-              ? await selectWithNavigationFooter({
-                  message,
-                  options,
-                  initialValue: params.initialValue,
-                  signal,
-                  navigation: params.navigation,
-                })
-              : await select({
-                  message,
-                  options,
-                  initialValue: params.initialValue,
-                  signal,
-                });
-          }),
+            },
+            output,
+          ),
       );
     },
     multiselect: async (params) => {
@@ -277,40 +286,48 @@ export function createClackPrompter(): WizardPrompter {
       return await withHorizontalCursorActionsDisabled(
         hasPromptNavigation(params.navigation),
         async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) => {
-            if (params.searchable) {
+          await runPromptWithNavigation(
+            params.navigation,
+            async (signal) => {
+              if (params.searchable) {
+                return params.navigation
+                  ? await autocompleteMultiselectWithNavigationFooter({
+                      message,
+                      options,
+                      initialValues: params.initialValues,
+                      filter: tokenizedOptionFilter,
+                      signal,
+                      navigation: params.navigation,
+                      output,
+                    })
+                  : await autocompleteMultiselect({
+                      message,
+                      options,
+                      initialValues: params.initialValues,
+                      filter: tokenizedOptionFilter,
+                      signal,
+                      output,
+                    });
+              }
               return params.navigation
-                ? await autocompleteMultiselectWithNavigationFooter({
+                ? await multiselectWithNavigationFooter({
                     message,
                     options,
                     initialValues: params.initialValues,
-                    filter: tokenizedOptionFilter,
                     signal,
                     navigation: params.navigation,
+                    output,
                   })
-                : await autocompleteMultiselect({
+                : await multiselect({
                     message,
                     options,
                     initialValues: params.initialValues,
-                    filter: tokenizedOptionFilter,
                     signal,
+                    output,
                   });
-            }
-            return params.navigation
-              ? await multiselectWithNavigationFooter({
-                  message,
-                  options,
-                  initialValues: params.initialValues,
-                  signal,
-                  navigation: params.navigation,
-                })
-              : await multiselect({
-                  message,
-                  options,
-                  initialValues: params.initialValues,
-                  signal,
-                });
-          }),
+            },
+            output,
+          ),
       );
     },
     text: async (params) => {
@@ -332,8 +349,9 @@ export function createClackPrompter(): WizardPrompter {
                       validate: validateInput,
                       navigation: params.navigation,
                       signal,
+                      output,
                     })
-                  : await password({ message, validate: validateInput, signal });
+                  : await password({ message, validate: validateInput, signal, output });
               }
               return params.navigation
                 ? await textWithNavigationFooter({
@@ -343,6 +361,7 @@ export function createClackPrompter(): WizardPrompter {
                     validate: validateInput,
                     navigation: params.navigation,
                     signal,
+                    output,
                   })
                 : await text({
                     message,
@@ -350,8 +369,10 @@ export function createClackPrompter(): WizardPrompter {
                     placeholder: params.placeholder,
                     validate: validateInput,
                     signal,
+                    output,
                   });
             },
+            output,
             params.signal,
           ),
       );
@@ -360,40 +381,46 @@ export function createClackPrompter(): WizardPrompter {
       await withHorizontalCursorActionsDisabled(
         hasPromptNavigation(params.navigation),
         async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) => {
-            const message = stylePromptMessage(params.message);
-            if (params.navigation) {
-              return await confirmWithNavigationFooter({
+          await runPromptWithNavigation(
+            params.navigation,
+            async (signal) => {
+              const message = stylePromptMessage(params.message);
+              if (params.navigation) {
+                return await confirmWithNavigationFooter({
+                  message,
+                  initialValue: params.initialValue,
+                  vertical: params.layout === "vertical",
+                  navigation: params.navigation,
+                  signal,
+                  output,
+                });
+              }
+              return await confirm({
                 message,
                 initialValue: params.initialValue,
                 vertical: params.layout === "vertical",
-                navigation: params.navigation,
                 signal,
+                output,
               });
-            }
-            return await confirm({
-              message,
-              initialValue: params.initialValue,
-              vertical: params.layout === "vertical",
-              signal,
-            });
-          }),
+            },
+            output,
+          ),
       ),
     progress: (label: string): WizardProgress => {
-      const useClawSpinner =
-        process.stdout.isTTY && isRich() && !process.env.CI && !process.env.VITEST;
+      const useClawSpinner = output.isTTY && isRich() && !process.env.CI && !process.env.VITEST;
       const spin = useClawSpinner
         ? spinner({
             frames: CLAW_SPINNER_FRAMES,
             delay: 120,
             styleFrame: theme.accent,
+            output,
           })
-        : spinner();
+        : spinner({ output });
       let currentLabel = label;
-      let maxColumns = readProgressColumns();
+      let maxColumns = readProgressColumns(output);
       const renderLabel = () => theme.accent(clampProgressLabel(currentLabel, maxColumns));
       const handleResize = () => {
-        const columns = readProgressColumns();
+        const columns = readProgressColumns(output);
         if (maxColumns === undefined || columns === undefined || columns >= maxColumns) {
           return;
         }
@@ -403,7 +430,7 @@ export function createClackPrompter(): WizardPrompter {
         spin.message(renderLabel());
       };
       if (maxColumns !== undefined) {
-        process.stdout.on("resize", handleResize);
+        output.on("resize", handleResize);
       }
       // Clack erases using bare-message wrapping but writes the frame and dots too.
       // Keeping animated labels to one row prevents long scans from leaking a line each tick.
@@ -413,6 +440,7 @@ export function createClackPrompter(): WizardPrompter {
         indeterminate: true,
         enabled: true,
         fallback: "none",
+        stream: output,
       });
       // Drive both Clack spinner UI and OSC progress output for terminals that
       // display command progress outside the prompt line.
@@ -423,7 +451,7 @@ export function createClackPrompter(): WizardPrompter {
           osc.setLabel(message);
         },
         stop: (message) => {
-          process.stdout.off("resize", handleResize);
+          output.off("resize", handleResize);
           osc.done();
           if (message === undefined) {
             spin.clear();

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -21,7 +21,7 @@ import {
   truncateToVisibleWidth,
   visibleWidth,
 } from "../../packages/terminal-core/src/ansi.js";
-import { note as emitNote } from "../../packages/terminal-core/src/note.js";
+import { noteToStream as emitNote } from "../../packages/terminal-core/src/note.js";
 import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
   stylePromptMessage,

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -20,7 +20,7 @@ import { hasImportGraphImpactOnTargets } from "../../scripts/test-projects.test-
 import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
 
-const CODEX_TEST_PROCESS_FILE_LIMIT = 40;
+const CODEX_TEST_PROCESS_FILE_LIMIT = 20;
 
 function expectBoundedCodexFallback(
   shards: ReturnType<typeof createChangedExtensionFallbackShards>,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -39,7 +39,7 @@ import {
 } from "../vitest/vitest.contracts-shared.ts";
 
 const normalizeRepoPath = toRepoPath;
-const CODEX_TEST_PROCESS_FILE_LIMIT = 40;
+const CODEX_TEST_PROCESS_FILE_LIMIT = 20;
 const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_TEST_PROCESS_FILE_LIMIT = 1;
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw agents add` could publish an apparently configured channel while silently dropping its required post-write bootstrap, write portable auth state before canonical creation succeeded, and publish an existing agent's new workspace before that workspace could be provisioned. `--json` alone also incorrectly selected automation mode, making the guided JSON summary unreachable.

## Why This Change Was Made

Use the shared channel setup transaction at every missing caller and reject future hook drops. Successful agent creation now returns the mutation writer's committed config, so fresh-agent hooks receive canonical state rather than the earlier staged proposal. Defer portable copying until creation succeeds, then merge under current destination auth so later credentials win. Provision existing workspaces before commit. Separate guided JSON's terminal UI onto stderr while preserving the existing public note API, so stdout remains one document. The CLI reference now documents the guided JSON contract and the actual automation flags.

The post-write hook contract originated in `94693f7ff036`; `fc8ee406a240` / #124736 introduced the shared transaction that exposed the missing `agents add` and `configure` callers. SQLite portable-copy persistence is traced to `e16ac0433092` / #89102, while `e6eebc5ad8f9` / #123609 established the canonical create/update boundary. JSON joined the automation option set in `433bb3f954ed` / #116033; `907f5bacaa79` / #124940 added the correct JSON-excluding automation signal but retained the older path selector.

## User Impact

Channel setup from `agents add` (including Matrix bootstrap) now finishes after config is durable instead of silently stopping halfway. Cancelled or failed creation no longer leaves a portable-copy credential store for a nonexistent agent, and deferred copying cannot overwrite credentials entered later in the same wizard. Existing-agent updates do not publish unusable workspace paths. `agents add --json` can be used interactively with machine-readable stdout, while explicit non-interactive creation still works.

## Evidence

- Final head: `cc0b636696aa5608b74dc934c26394f131157af2`.
- Exact-head CI: [run 32154936795](https://github.com/openclaw/openclaw/actions/runs/32154936795) green.
- Focused proof: 364 tests across 12 changed/sibling files, routed through 8 Vitest shards; all passed.
- `node scripts/check-changed.mjs`: passed the selected core/coreTests typecheck, lint, formatting, dead-export, import-cycle, database-first, auth, and boundary gates.
- `pnpm build`: passed after disk cleanup; final run completed in 6m03s.
- Final branch P1 autoreview: clean, no accepted/actionable findings.
- Source-blind real CLI proof: isolated HOME/state and built launcher; guided `agents add exact-guided --json` ran in a PTY with stdout redirected, the entire stdout parsed as one JSON document, prompts/status remained on stderr, and the workspace/config entry existed. Explicit `agents add exact-batch --non-interactive --workspace ... --json` also produced parseable JSON and its workspace. `agents list --json` contained both agents.
- Current-main CI diagnosis: a 34-file non-isolated Codex changed-target process repeatedly took ~288s on 4-vCPU automatic CI, starving a 1s real-time watch and a materialization test, or stalled without output for 300s. The identical 34-file/two-worker envelope passed locally and under Node 24 in ~95–97s, and the hosted exact-head shard passed. The existing per-process planner cap is tightened from 40 to 20 files; both Codex partitions pass and planner coverage remains complete.
- Docs: `pnpm docs:list`, `pnpm docs:check-mdx`, focused formatting, and docs autoreview passed. The ClawSweeper JSON-only guided-mode finding is addressed.
- Production LOC: +270/-187 (net +83). Tooling: +3/-1 (net +2). Tests: +477/-40 (net +437). Docs: +3/-3. The production growth is the committed-config owner result, shared no-drop transaction invariant, output-stream capability, and contextual workspace/auth ownership; repeated test setup was consolidated.
- Live limitation: no credentialed Matrix account/bootstrap was exercised. Hook construction, committed-config delivery, post-write ordering, and failure behavior are covered at the command/owner boundaries; the real CLI, config, workspace, interactive JSON, and non-interactive JSON flows were exercised.
- AI-assisted.
