### PR TITLE
fix(models): surface ambient CLI logins in gateway model availability

### DIFF
--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -1,5 +1,6 @@
 import type { PreparedAgentCredentialModes } from "../../agents/agent-auth-credential-modes.js";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { resolveExternalCliAuthScopeFromConfig } from "../../agents/auth-profiles/external-cli-scope.js";
 import type { RuntimeAuthMaterialization } from "../../agents/auth-profiles/runtime-materializations.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import {
@@ -40,7 +41,7 @@ export function createModelsListAuthResolver(params: {
     preparedRuntimeAuthMaterializations: params.preparedRuntimeAuthMaterializations,
     skipSetupProviderFallback: true,
     syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(params.metadataSnapshot),
-    externalCliProviderIds: [],
+    externalCliProviderIds: resolveExternalCliAuthScopeFromConfig(params.cfg)?.providerIds ?? [],
     preparedRuntimeAuthStore: params.preparedAuthStore,
     routeResolverFactory: params.routeResolverFactory,
   });

--- a/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  listModels,
+  providerCatalogEntry,
+} from "./models-list-result.openai-routes.test-support.js";
+
+const mocks = vi.hoisted(() => ({
+  readClaudeCliCredentialsCached: vi.fn<() => unknown>(() => null),
+  readCodexCliCredentialsCached: vi.fn<() => unknown>(() => null),
+  readMiniMaxCliCredentialsCached: vi.fn<() => unknown>(() => null),
+}));
+
+vi.mock("../../agents/cli-credentials.js", () => mocks);
+
+const config = {
+  agents: {
+    defaults: { model: { primary: "anthropic/claude-opus-5" } },
+    list: [
+      {
+        id: "main",
+        default: true,
+        models: {
+          "anthropic/claude-opus-5": { agentRuntime: { id: "claude-cli" } },
+        },
+      },
+    ],
+  },
+} satisfies OpenClawConfig;
+
+async function listClaudeCliModel() {
+  return await listModels({
+    catalog: [],
+    staticEntries: [providerCatalogEntry("anthropic", "claude-opus-5")],
+    cfg: config,
+    view: "configured",
+  });
+}
+
+describe("models.list CLI runtime availability", () => {
+  beforeEach(() => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    mocks.readClaudeCliCredentialsCached.mockReset();
+    mocks.readClaudeCliCredentialsCached.mockReturnValue(null);
+    mocks.readCodexCliCredentialsCached.mockReset();
+    mocks.readCodexCliCredentialsCached.mockReturnValue(null);
+    mocks.readMiniMaxCliCredentialsCached.mockReset();
+    mocks.readMiniMaxCliCredentialsCached.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("marks a Claude CLI runtime model available with ambient CLI OAuth", async () => {
+    mocks.readClaudeCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: "test-access",
+      refresh: "test-refresh",
+      expires: Date.now() + 3_600_000,
+    });
+
+    await expect(listClaudeCliModel()).resolves.toEqual({
+      models: [expect.objectContaining({ id: "claude-opus-5", available: true })],
+    });
+  });
+
+  it("marks a Claude CLI runtime model unavailable without ambient CLI OAuth", async () => {
+    await expect(listClaudeCliModel()).resolves.toEqual({
+      models: [expect.objectContaining({ id: "claude-opus-5", available: false })],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The gateway `models.list` auth resolver hardcoded `externalCliProviderIds: []`, so a model pinned to a CLI runtime (`agentRuntime.id="claude-cli"`, gemini-cli, minimax) reported `available: false` whenever no persisted OpenClaw auth profile existed — the Control UI picker rendered "Sign-in needed" and disabled the row even though the operator's ambient CLI login (`~/.claude/.credentials.json`) was valid and the same gateway executed turns on that model fine via `--model`.

Execution already scopes the external-CLI credential overlay from config (`resolveExternalCliAuthScopeFromConfig`, used by `btw.ts`); availability now uses the identical scope, so the picker matches what the gateway will actually run. A configured CLI-runtime model is an operator declaration of that CLI's login, so this does not surface credentials nothing in config points at; with no CLI login present, the row still reads signed-out.

## Change
- `models-list-auth-resolver.ts`: derive `externalCliProviderIds` from `resolveExternalCliAuthScopeFromConfig(cfg)` instead of `[]` (+2/-1).
- New focused test: ambient Claude CLI OAuth present → `available: true`; absent → `available: false`. Signed-in case fails without the fix.

## Proof
```
pnpm vitest run src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts \
  src/gateway/server-methods/models-list-result.configured-static.test.ts \
  src/gateway/server-methods/models-list-result.openai-routes.test.ts \
  src/gateway/server-methods/models-list-result.plugin-runtime.test.ts \
  src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
Test Files  5 passed (5) / Tests  33 passed (33)
```
Field repro: live deployment with `anthropic/claude-fable-5` pinned to `agentRuntime.id="claude-cli"` — picker showed "Sign-in needed" while `openclaw agent --model anthropic/claude-fable-5` succeeded; after importing a profile the row went selectable, confirming the availability path was the only gap.

Local `tsgo -p test/tsconfig/tsconfig.core.test.gateway-other.json` fails on `packages/terminal-core/src/ansi.ts(194)` — file is byte-identical to base `36f838349788`; pre-existing, not from this diff.

Related but distinct: #125471 handles expired *cached* OAuth for an already-persisted CLI profile; this PR handles the profile never having been imported at all.
