### PR TITLE
fix: prevent session continuation conflicts during concurrent updates

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -800,7 +800,7 @@ describe("SQLite lifecycle cleanup races", () => {
     let materializations = 0;
     archiveMaterializationHook.afterMaterialize = () => {
       materializations += 1;
-      if (materializations !== 2) {
+      if (materializations !== 1) {
         return;
       }
       const changedEntry = { ...entry, label: "changed", updatedAt: 2 };
@@ -823,7 +823,7 @@ describe("SQLite lifecycle cleanup races", () => {
       pruned: 0,
       capped: 0,
     });
-    expect(materializations).toBe(2);
+    expect(materializations).toBe(1);
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ label: "changed" });
   });
 

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -254,24 +254,40 @@ export async function applySessionEntryLifecycleMutation(params: {
     }
     throw error;
   };
-  const projected = await runExclusiveSqliteSessionWrite(resolved, async () => {
+  let projected!: ProjectedLifecycleMutation;
+  let committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    return await projectSessionEntryLifecycleMutation(database, {
+    projected = await projectSessionEntryLifecycleMutation(database, {
       ...(params.allowCanonicalRepair ? { allowCanonicalRepair: true } : {}),
       archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
       removals,
       upserts,
     });
+    return projected.deletePlans.length === 0
+      ? commitProjectedLifecycleMutation([], false)
+      : undefined;
   });
-  let materializedRemovalPlans: MaterializedSessionStateDeletePlan[] = [];
-  let removalArchiveMaterializationFailed = false;
-  try {
-    materializedRemovalPlans = await materializeSessionStateDeletePlans(projected.deletePlans);
-  } catch (error) {
-    removalArchiveMaterializationFailed = true;
-    captureArtifactCleanupError(error);
+  if (!committed) {
+    let materializedRemovalPlans: MaterializedSessionStateDeletePlan[] = [];
+    let removalArchiveMaterializationFailed = false;
+    try {
+      materializedRemovalPlans = await materializeSessionStateDeletePlans(projected.deletePlans);
+    } catch (error) {
+      removalArchiveMaterializationFailed = true;
+      captureArtifactCleanupError(error);
+    }
+    committed = await runExclusiveSqliteSessionWrite(resolved, async () =>
+      commitProjectedLifecycleMutation(
+        materializedRemovalPlans,
+        removalArchiveMaterializationFailed,
+      ),
+    );
   }
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+
+  function commitProjectedLifecycleMutation(
+    removalPlans: MaterializedSessionStateDeletePlan[],
+    materializationFailed: boolean,
+  ) {
     let beforeCount = 0;
     const removedSessionKeys: string[] = [];
     let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
@@ -280,10 +296,7 @@ export async function applySessionEntryLifecycleMutation(params: {
       params.beforeCommitInTransaction?.();
       beforeCount = readSessionEntryCount(transactionDb);
       const validatedRemovals = projected.removals.filter((removal) => {
-        if (
-          removalArchiveMaterializationFailed &&
-          removal.removal.archiveRemovedTranscript === true
-        ) {
+        if (materializationFailed && removal.removal.archiveRemovedTranscript === true) {
           return false;
         }
         const entry = readProjectedRemovalEntry(
@@ -314,7 +327,7 @@ export async function applySessionEntryLifecycleMutation(params: {
       });
       archivedTranscripts = deleteMaterializedSessionStatePlans(
         transactionDb,
-        materializedRemovalPlans,
+        removalPlans,
         undefined,
         new Set(validatedRemovals.map((removal) => removal.sessionKey)),
       );
@@ -433,7 +446,8 @@ export async function applySessionEntryLifecycleMutation(params: {
     }, toDatabaseOptions(resolved));
     emitCommittedLifecycleIdentityMutations({ projected, removedSessionKeys });
     return { archivedTranscripts, beforeCount, maintenancePlans, removedSessionKeys };
-  });
+  }
+
   const { archivedTranscripts: maintenanceArchivedTranscripts, ...maintenance } =
     await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
       resolved,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
@@ -2457,20 +2457,14 @@ describe("session accessor seam", () => {
       sessionId: "replacement-prepare",
       updatedAt: 10,
     });
-    let releasePlanner!: () => void;
-    let markPlannerStarted!: () => void;
-    const plannerStarted = new Promise<void>((resolve) => {
-      markPlannerStarted = resolve;
-    });
-    const plannerGate = new Promise<void>((resolve) => {
-      releasePlanner = resolve;
-    });
+    const plannerStarted = createDeferred();
+    const plannerGate = createDeferred();
     const pendingReplacement = applySessionEntryReplacements({
       sessionKeys: [scope.sessionKey],
       storePath,
       update: async (entries) => {
-        markPlannerStarted();
-        await plannerGate;
+        plannerStarted.resolve();
+        await plannerGate.promise;
         return {
           replacements: entries.map(({ entry, sessionKey }) => ({
             entry: { ...entry, model: "planned" },
@@ -2481,7 +2475,7 @@ describe("session accessor seam", () => {
       },
     });
 
-    await plannerStarted;
+    await plannerStarted.promise;
     let replacementError: unknown;
     try {
       replaceSessionEntrySync(scope, {
@@ -2492,7 +2486,7 @@ describe("session accessor seam", () => {
     } catch (error) {
       replacementError = error;
     } finally {
-      releasePlanner();
+      plannerGate.resolve();
     }
     const planningError = await pendingReplacement.then(
       () => undefined,
@@ -2506,36 +2500,31 @@ describe("session accessor seam", () => {
     expect(loadSessionEntry(scope)).toMatchObject({ model: "newer", updatedAt: 20 });
   });
 
-  it("does not hold a write transaction while awaiting a lifecycle entry builder", async () => {
-    const sessionKey = "agent:main:lifecycle-prepare";
-    await upsertSessionEntryCore(
-      { sessionKey, storePath },
-      { model: "base", sessionId: "lifecycle-prepare", updatedAt: 10 },
-    );
-    let releaseBuilder!: () => void;
-    let markBuilderStarted!: () => void;
-    const builderStarted = new Promise<void>((resolve) => {
-      markBuilderStarted = resolve;
+  it("awaits lifecycle builders outside transactions while keeping their commit indivisible", async () => {
+    const scope = { sessionKey: "agent:main:lifecycle-prepare", storePath };
+    await upsertSessionEntryCore(scope, {
+      model: "base",
+      sessionId: "lifecycle-prepare",
+      updatedAt: 10,
     });
-    const builderGate = new Promise<void>((resolve) => {
-      releaseBuilder = resolve;
-    });
+    const builderStarted = createDeferred();
+    const builderGate = createDeferred();
     const pendingMutation = applySessionEntryLifecycleMutation({
       storePath,
       upserts: [
         {
-          sessionKey,
+          sessionKey: scope.sessionKey,
           buildEntry: async ({ currentEntry }) => {
-            markBuilderStarted();
-            await builderGate;
-            return { ...currentEntry, model: "projected" } as SessionEntry;
+            builderStarted.resolve();
+            await builderGate.promise;
+            return { ...currentEntry, model: "projected", updatedAt: 20 } as SessionEntry;
           },
         },
       ],
       skipMaintenance: true,
     });
 
-    await builderStarted;
+    await builderStarted.promise;
     let unrelatedWriteError: unknown;
     try {
       appendSqliteTrajectoryRuntimeEvents({ sessionId: "lifecycle-prepare", storePath }, [
@@ -2543,13 +2532,19 @@ describe("session accessor seam", () => {
       ]);
     } catch (error) {
       unrelatedWriteError = error;
-    } finally {
-      releaseBuilder();
     }
+    const replacement = {
+      model: "replacement",
+      sessionId: "lifecycle-prepare",
+      updatedAt: 30,
+    };
+    const queuedReplacement = replaceSessionEntry(scope, replacement);
+    builderGate.resolve();
 
     await expect(pendingMutation).resolves.toMatchObject({ afterCount: 1 });
     expect(unrelatedWriteError).toBeUndefined();
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ model: "projected" });
+    await expect(queuedReplacement).resolves.toMatchObject(replacement);
+    expect(loadSessionEntry(scope)).toMatchObject(replacement);
   });
 
   it("rejects a lifecycle projection when its source row changes", async () => {
@@ -2559,22 +2554,16 @@ describe("session accessor seam", () => {
       sessionId: "lifecycle-stale",
       updatedAt: 10,
     });
-    let releaseBuilder!: () => void;
-    let markBuilderStarted!: () => void;
-    const builderStarted = new Promise<void>((resolve) => {
-      markBuilderStarted = resolve;
-    });
-    const builderGate = new Promise<void>((resolve) => {
-      releaseBuilder = resolve;
-    });
+    const builderStarted = createDeferred();
+    const builderGate = createDeferred();
     const pendingMutation = applySessionEntryLifecycleMutation({
       storePath,
       upserts: [
         {
           sessionKey: scope.sessionKey,
           buildEntry: async ({ currentEntry }) => {
-            markBuilderStarted();
-            await builderGate;
+            builderStarted.resolve();
+            await builderGate.promise;
             return { ...currentEntry, model: "stale-projection" } as SessionEntry;
           },
         },
@@ -2582,7 +2571,7 @@ describe("session accessor seam", () => {
       skipMaintenance: true,
     });
 
-    await builderStarted;
+    await builderStarted.promise;
     let replacementError: unknown;
     try {
       replaceSessionEntrySync(scope, {
@@ -2593,7 +2582,7 @@ describe("session accessor seam", () => {
     } catch (error) {
       replacementError = error;
     } finally {
-      releaseBuilder();
+      builderGate.resolve();
     }
     const mutationError = await pendingMutation.then(
       () => undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting or continuing an untitled dashboard session could see a raw `SQLite session entry changed before lifecycle upsert` error when concurrent session metadata—especially dashboard title generation—landed during reply initialization.

## Why This Change Was Made

Pure lifecycle upserts now project and commit in one SQLite writer slot. Mutations with any delete or archive plan retain the existing two-phase project → writer release → materialize → reacquire → authoritative revalidation flow, and all strict compare fences remain intact.

Regression provenance: https://github.com/openclaw/openclaw/pull/119460 split lifecycle projection, archive materialization, and commit unconditionally to keep archive work outside the writer slot; the no-delete path did not need that gap.

## User Impact

The dashboard turn continues instead of forcing users to fork or retry after concurrent metadata updates. Title generation remains concurrent and durable.

## Evidence

- Red before the fix: `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts -t "keeps no-delete lifecycle upserts indivisible from queued same-store writes"` failed with `SQLite session entry changed before lifecycle upsert for agent:main:lifecycle-queued-writer`.
- Green after the fix: the consolidated regression `awaits lifecycle builders outside transactions while keeping their commit indivisible` preserves both contracts: async builders run outside SQLite transactions, while a no-delete projection and commit remain indivisible from queued same-store writers.
- Post-rebase local proof on exact head `a463fa11bddce18ae53a674bd0114e8b036e5bb3`:
  - `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts` — 107/107 passed.
  - `node scripts/run-vitest.mjs src/config/sessions/session-accessor.reply-init-concurrency.test.ts` — 6/6 passed.
  - `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts` — 18/18 passed.
  - `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts -t 'chat.send persists a dashboard title while the first turn is still running'` — 1 passed.
  - `node scripts/check-changed.mjs -- src/config/sessions/session-accessor.sqlite-projection.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts` — core/coreTests checks passed, including typecheck, lint, dead-export, import-cycle, database-first, schema-version, and ratchet gates.
  - `git diff --check origin/main...HEAD` — passed.
  - `pnpm build` — passed on the final patch before rebase; the rebase retained the identical stable patch ID.
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1` — clean, no accepted/actionable findings; overall correctness 0.93.
- LOC: production +30/-16 (net +14); tests +37/-48 (net -11); total +67/-64 (net +3). The production growth is one shared commit continuation that keeps projection and transaction commit under the same writer slot without duplicating the transaction body.
- Source-blind live validation used a final built Gateway, the real Gateway-served Control UI, deterministic mock OpenAI transport, and isolated state/port. A fresh first turn completed durably with title `OPENCLAW_E2E_OK`, status `done`, `abortedLastRun=false`, exactly one user and one assistant message, HTTP 200 provider responses, and no lifecycle-upsert conflict in exact-session logs. All four behavior-contract clauses passed with a fresh nonce session.

Before send — the first-turn prompt in the real new-session UI:

![Before send: first-turn prompt in the real Control UI](https://github.com/user-attachments/assets/05c18040-b209-4bc1-8978-f820ae6fe984)

After completion — the generated title persisted in the sidebar after the durable run completed:

![After completion: generated title persisted in the Control UI sidebar](https://github.com/user-attachments/assets/8b1068a6-2083-4966-aa92-8c81011a74e3)

Known proof gap: current `main`'s lazy `openclaw-chat-pane` remained blank/unrendered in Chromium even though the runtime held both messages. That is separate from this storage repair; this PR does not claim to fix it. Sidebar/session creation, generated title, durable completion, CLI metadata/history, provider responses, and exact-session logs were verified.

AI-assisted: yes.
