### PR TITLE
fix(telegram): scope progress to the active plan step

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -350,6 +350,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `channels.telegram.streaming` is `off | partial | block | progress` (default: `progress`); set `mode: "partial"` to stream answer text into the preview instead of a status draft
     - short initial answer previews are debounced, then materialized after a bounded delay if the run is still active
     - `progress` keeps one editable status draft for tool progress, shows the stable status label when answer activity arrives before tool progress, clears it at completion, and sends the final answer as a normal message
+    - when a structured plan has no authored preamble or explanation, Telegram derives a live `⏳ current/total · step` headline; rolling tool rows stay beneath the active step and reset when that step changes
     - `streaming.preview.toolProgress` controls whether tool/progress updates reuse the same edited preview message (default: `true` when preview streaming is active)
     - `streaming.preview.commandText` controls command/exec detail inside those lines: `status` (default, tool label only) or `raw` (explicit command text)
     - `streaming.progress.commentary` (default: `false`) opts into assistant commentary/preamble text in the temporary progress draft

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -281,13 +281,15 @@ On Discord, when a utility model resolves for the agent — an explicit
 [`utilityModel`](/gateway/config-agents#agents-defaults-model), or the primary
 provider's declared small-model default (OpenAI → `gpt-5.6-luna`,
 Anthropic → `claude-haiku-4-5`) — it supplies a short plain-language filler
-when the model emits no preamble or has been quiet for about 20 seconds
-(Telegram's headline is preamble-only today):
+when the model emits no preamble or has been quiet for about 20 seconds:
 
 ```text
 Updating the default model in your config, then restarting the gateway to pick
 it up. One agent listing call failed and is being retried.
 ```
+
+Telegram does not use this utility narration. When authored status text is
+absent, it derives a headline from the active or next pending plan step.
 
 Utility narration is on by default (`streaming.progress.narration`, default
 `true`) and never falls back to the primary model: it runs only with an explicit

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -55,11 +55,11 @@ migration, see [Streaming and chunking](/concepts/streaming).
 
 ## What users see
 
-| Part            | Purpose                                                                           |
-| --------------- | --------------------------------------------------------------------------------- |
-| Status headline | On Discord and Telegram, the model preamble; Discord adds a utility filler.       |
-| Label           | Optional starter/status line such as `Working`.                                   |
-| Progress lines  | Compact run updates using the same tool icons and detail formatter as `/verbose`. |
+| Part            | Purpose                                                                                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Status headline | On Discord and Telegram, the model preamble; Telegram falls back to the active plan step when authored status is absent, while Discord adds a utility filler. |
+| Label           | Optional starter/status line such as `Working`.                                                                                                               |
+| Progress lines  | Compact run updates using the same tool icons and detail formatter as `/verbose`.                                                                             |
 
 The status headline sits above the rolling progress lines and both stay visible,
 so one message answers what the agent is doing and how far it has got.

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -82,8 +82,11 @@ export function createProgressState(
     // headline/checklist mode, so they must not also arrive inside the text.
     rendersRollingLinesNatively: true,
     update: async (streamText, options) => {
-      getTurn().draftEverRendered = true;
       await prepareAnswerLaneForToolProgress();
+      if (options?.isCurrentPlanGeneration?.() === false) {
+        return false;
+      }
+      getTurn().draftEverRendered = true;
       draftState.answerLane.lastPartialText = streamText;
       draftState.answerLane.hasStreamedMessage = true;
       draftState.answerLane.finalized = false;
@@ -93,11 +96,13 @@ export function createProgressState(
           options?.lines ?? [],
           config.telegramCfg.richMessages === true,
           progressCompositor.hasStatusHeadline || progressCompositor.hasPlanProgress,
+          options?.planLayout,
         ),
       );
       if (options?.flush) {
         await draftState.answerLane.stream?.flush();
       }
+      return true;
     },
   });
   return Object.assign(progressState, {

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -75,6 +75,8 @@ export function createProgressState(
     commentaryLinePrefix: "💬 ",
     commentaryItalics: false,
     updateOnLineChange: true,
+    resetRollingLinesOnPlanStepChange: true,
+    derivePlanStatusHeadline: true,
     shouldStartNow: (line) => typeof line !== "string" && line?.kind === "tool",
     // renderTelegramProgressDraftPreview draws the work lines from `lines` in
     // headline/checklist mode, so they must not also arrive inside the text.

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -129,6 +129,15 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
       });
       expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("Read");
 
+      await replyOptions?.onItemEvent?.({
+        toolCallId: "inspect-1",
+        kind: "tool",
+        name: "Read",
+        phase: "end",
+        status: "completed",
+      });
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("Read");
+
       await replyOptions?.onToolStart?.({
         name: "exec",
         phase: "start",
@@ -146,6 +155,47 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
       });
       expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("Exec");
       expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("↳");
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: false } } },
+    });
+  });
+
+  it("drops an in-flight tool render when the plan advances", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        steps: [
+          { step: "Inspect", status: "in_progress" },
+          { step: "Patch", status: "pending" },
+        ],
+      });
+      const callsBeforeRace = draftStream.updatePreview.mock.calls.length;
+      const staleToolRender = replyOptions?.onToolStart?.({
+        name: "Read",
+        phase: "start",
+        toolCallId: "inspect-race",
+      });
+      const nextPlanRender = replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        steps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+        ],
+      });
+      await Promise.all([staleToolRender, nextPlanRender]);
+
+      const racedPreviews = draftStream.updatePreview.mock.calls
+        .slice(callsBeforeRace)
+        .map((call) => call[0]?.text ?? "");
+      expect(racedPreviews.some((text) => text.includes("Read"))).toBe(false);
+      expect(racedPreviews.at(-1)).toContain("▸ Patch");
       return { queuedFinal: false };
     });
 

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -94,8 +94,66 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     });
 
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
-      telegramProgressPreview("▸ Patch\n▢ Test", "<b>▸ Patch</b><br>▢ Test"),
+      telegramProgressPreview(
+        "⏳ 1/2 · Patch\n▸ Patch\n▢ Test",
+        "<b>⏳ 1/2 · Patch</b><br>▸ Patch<br>▢ Test",
+      ),
     );
+  });
+
+  it("keeps only the current plan step's tool rows and clears them on completion", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        steps: [
+          { step: "Inspect", status: "in_progress" },
+          { step: "Patch", status: "pending" },
+        ],
+      });
+      await replyOptions?.onToolStart?.({
+        name: "Read",
+        phase: "start",
+        toolCallId: "inspect-1",
+      });
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).toContain("↳");
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).toContain("Read");
+
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        steps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+        ],
+      });
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("Read");
+
+      await replyOptions?.onToolStart?.({
+        name: "exec",
+        phase: "start",
+        toolCallId: "patch-1",
+      });
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).toContain("↳");
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).toContain("Exec");
+
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        steps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "completed" },
+        ],
+      });
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("Exec");
+      expect(draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).not.toContain("↳");
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: false } } },
+    });
   });
 
   it("renders the headline immediately when the preamble arrives after tool progress", async () => {

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -22,6 +22,49 @@ function renderToolLine(name: string) {
 }
 
 describe("renderTelegramProgressDraftPreview", () => {
+  it("nests workflow details beneath the active plan step in every preview format", () => {
+    const lines = ["exec", "Read"].map((name, index) => {
+      const line = buildChannelProgressDraftLine(
+        {
+          event: "tool",
+          toolCallId: `call-${index + 1}`,
+          name,
+          phase: "start",
+          args: name === "exec" ? { command: "echo alpha" } : { file_path: "/tmp/x.ts" },
+        },
+        { commandText: "raw" },
+      );
+      if (!line) {
+        throw new Error(`expected a progress line for ${name}`);
+      }
+      return line;
+    });
+    const status = "Implementing the change.\n\n✅ Inspect\n▸ Patch\n▢ Test";
+
+    const html = renderTelegramProgressDraftPreview(status, lines, false, true);
+    const rich = renderTelegramProgressDraftPreview(status, lines, true, true);
+
+    expect(html.text).toMatch(/▸ Patch<br>↳ .*Exec.*<br>↳ .*Read.*<br>▢ Test/u);
+    expect(rich.text).toMatch(/▸ Patch\n↳ 🛠️ .*\n↳ 📖 .*\n▢ Test/u);
+    expect(JSON.stringify(rich.richMessage)).toContain("↳ ");
+  });
+
+  it("keeps unplanned progress flat", () => {
+    const line = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "call-1",
+      name: "exec",
+      phase: "start",
+    });
+    if (!line) {
+      throw new Error("expected a progress line for exec");
+    }
+
+    expect(renderTelegramProgressDraftPreview("Working", [line], false, true).text).toBe(
+      "Working<br><b>🛠️ Exec</b>",
+    );
+  });
+
   it("prints one tool icon per line for every backend spelling", () => {
     for (const name of ["Bash", "bash", "exec"]) {
       const rendered = renderToolLine(name);

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -41,8 +41,9 @@ describe("renderTelegramProgressDraftPreview", () => {
     });
     const status = "Implementing the change.\n\n✅ Inspect\n▸ Patch\n▢ Test";
 
-    const html = renderTelegramProgressDraftPreview(status, lines, false, true);
-    const rich = renderTelegramProgressDraftPreview(status, lines, true, true);
+    const planLayout = { lineCount: 3, activeLineIndex: 1 };
+    const html = renderTelegramProgressDraftPreview(status, lines, false, true, planLayout);
+    const rich = renderTelegramProgressDraftPreview(status, lines, true, true, planLayout);
 
     expect(html.text).toMatch(/▸ Patch<br>↳ .*Exec.*<br>↳ .*Read.*<br>▢ Test/u);
     expect(rich.text).toMatch(/▸ Patch\n↳ 🛠️ .*\n↳ 📖 .*\n▢ Test/u);
@@ -63,6 +64,36 @@ describe("renderTelegramProgressDraftPreview", () => {
     expect(renderTelegramProgressDraftPreview("Working", [line], false, true).text).toBe(
       "Working<br><b>🛠️ Exec</b>",
     );
+  });
+
+  it("uses structured plan layout when authored text begins with the active marker", () => {
+    const line = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "call-1",
+      name: "Read",
+      phase: "start",
+    });
+    if (!line) {
+      throw new Error("expected a progress line for Read");
+    }
+
+    const active = renderTelegramProgressDraftPreview(
+      "▸ authored headline\n\n✅ Inspect\n▸ Patch\n▢ Test",
+      [line],
+      false,
+      true,
+      { lineCount: 3, activeLineIndex: 1 },
+    );
+    expect(active.text).toMatch(/✅ Inspect<br>▸ Patch<br>↳ .*Read.*<br>▢ Test/u);
+
+    const pendingOnly = renderTelegramProgressDraftPreview(
+      "▸ authored headline\n\n▢ Patch",
+      [line],
+      false,
+      true,
+      { lineCount: 1 },
+    );
+    expect(pendingOnly.text).toBe("<b>▸ authored headline</b><br>▢ Patch<br><b>📖 Read</b>");
   });
 
   it("prints one tool icon per line for every backend spelling", () => {

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -158,8 +158,11 @@ function insertWorkLinesAfterActivePlanStep<T>(
   statusLines: readonly string[],
   renderedStatusLines: readonly T[],
   renderedWorkLines: readonly T[],
+  planLayout?: Readonly<{ lineCount: number; activeLineIndex?: number }>,
 ): T[] {
-  const activePlanIndex = statusLines.findIndex((line) => /^▸(?:\s|$)/u.test(line));
+  const planStartIndex = Math.max(0, statusLines.length - (planLayout?.lineCount ?? 0));
+  const activePlanIndex =
+    planLayout?.activeLineIndex === undefined ? -1 : planStartIndex + planLayout.activeLineIndex;
   if (activePlanIndex < 0 || renderedWorkLines.length === 0) {
     return [...renderedStatusLines, ...renderedWorkLines];
   }
@@ -175,6 +178,7 @@ export function renderTelegramProgressDraftPreview(
   lines: readonly ChannelProgressDraftCompositorLine[],
   richMessages: boolean,
   statusHeadlineActive = false,
+  planLayout?: Readonly<{ lineCount: number; activeLineIndex?: number }>,
 ): TelegramDraftPreview {
   const trimmed = text.trimEnd();
   if (statusHeadlineActive) {
@@ -183,7 +187,7 @@ export function renderTelegramProgressDraftPreview(
       .map((line) => line.trim())
       .filter(Boolean);
     const workLines = lines.filter(isStatusHeadlineWorkLine);
-    const hasActivePlanStep = statusLines.some((line) => /^▸(?:\s|$)/u.test(line));
+    const hasActivePlanStep = planLayout?.activeLineIndex !== undefined;
     const renderedLines = workLines
       .map(renderTelegramProgressLine)
       .filter(Boolean)
@@ -201,6 +205,7 @@ export function renderTelegramProgressDraftPreview(
           statusLines,
           renderedStatusLines,
           renderedLines,
+          planLayout,
         ).join("<br>"),
         parseMode: "HTML",
       };
@@ -222,11 +227,13 @@ export function renderTelegramProgressDraftPreview(
       statusLines,
       richStatusParts,
       richLineParts,
+      planLayout,
     );
     const plainText = insertWorkLinesAfterActivePlanStep(
       statusLines,
       statusLines,
       plainLineTexts,
+      planLayout,
     ).join("\n");
     return {
       text: plainText,

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -154,6 +154,22 @@ function isStatusHeadlineWorkLine(
   return !line.id?.startsWith("reasoning:") && !line.id?.startsWith("commentary:");
 }
 
+function insertWorkLinesAfterActivePlanStep<T>(
+  statusLines: readonly string[],
+  renderedStatusLines: readonly T[],
+  renderedWorkLines: readonly T[],
+): T[] {
+  const activePlanIndex = statusLines.findIndex((line) => /^▸(?:\s|$)/u.test(line));
+  if (activePlanIndex < 0 || renderedWorkLines.length === 0) {
+    return [...renderedStatusLines, ...renderedWorkLines];
+  }
+  return [
+    ...renderedStatusLines.slice(0, activePlanIndex + 1),
+    ...renderedWorkLines,
+    ...renderedStatusLines.slice(activePlanIndex + 1),
+  ];
+}
+
 export function renderTelegramProgressDraftPreview(
   text: string,
   lines: readonly ChannelProgressDraftCompositorLine[],
@@ -167,7 +183,11 @@ export function renderTelegramProgressDraftPreview(
       .map((line) => line.trim())
       .filter(Boolean);
     const workLines = lines.filter(isStatusHeadlineWorkLine);
-    const renderedLines = workLines.map(renderTelegramProgressLine).filter(Boolean);
+    const hasActivePlanStep = statusLines.some((line) => /^▸(?:\s|$)/u.test(line));
+    const renderedLines = workLines
+      .map(renderTelegramProgressLine)
+      .filter(Boolean)
+      .map((line) => (hasActivePlanStep ? `↳ ${line}` : line));
     if (!richMessages) {
       const renderedStatusLines =
         statusLines.length > 1
@@ -176,7 +196,14 @@ export function renderTelegramProgressDraftPreview(
               ...statusLines.slice(1).map(renderTelegramProgressStringLine),
             ]
           : statusLines.map(renderTelegramProgressStringLine);
-      return { text: [...renderedStatusLines, ...renderedLines].join("<br>"), parseMode: "HTML" };
+      return {
+        text: insertWorkLinesAfterActivePlanStep(
+          statusLines,
+          renderedStatusLines,
+          renderedLines,
+        ).join("<br>"),
+        parseMode: "HTML",
+      };
     }
     const richStatusParts: RichText[] =
       statusLines.length > 1
@@ -184,21 +211,29 @@ export function renderTelegramProgressDraftPreview(
         : statusLines.map(markdownLineToRichText);
     const richLineParts = workLines
       .map(progressLineToRichText)
-      .filter((part): part is RichText => part !== undefined);
+      .filter((part): part is RichText => part !== undefined)
+      .map((part) => (hasActivePlanStep ? joinRichText(["↳ ", part], "") : part));
     const plainLineTexts = workLines
       .map((line) => line.text)
       .map((line) => line.trim())
-      .filter(Boolean);
-    const plainText = [...statusLines, ...plainLineTexts].join("\n");
+      .filter(Boolean)
+      .map((line) => (hasActivePlanStep ? `↳ ${line}` : line));
+    const richParts = insertWorkLinesAfterActivePlanStep(
+      statusLines,
+      richStatusParts,
+      richLineParts,
+    );
+    const plainText = insertWorkLinesAfterActivePlanStep(
+      statusLines,
+      statusLines,
+      plainLineTexts,
+    ).join("\n");
     return {
       text: plainText,
-      richMessage: buildTelegramRichBlocksPlan(
-        buildProgressRichBlocks([...richStatusParts, ...richLineParts]),
-        {
-          skipEntityDetection: true,
-          plainText,
-        },
-      ).richMessage,
+      richMessage: buildTelegramRichBlocksPlan(buildProgressRichBlocks(richParts), {
+        skipEntityDetection: true,
+        plainText,
+      }).richMessage,
     };
   }
   const renderedLines = lines.map(renderTelegramProgressLine).filter(Boolean);

--- a/src/channels/progress-draft-compositor.status.test.ts
+++ b/src/channels/progress-draft-compositor.status.test.ts
@@ -1,0 +1,389 @@
+// Status-headline tests are split from the core compositor suite to keep both files bounded.
+import { describe, expect, it, vi } from "vitest";
+import {
+  createChannelProgressDraftCompositor,
+  PROGRESS_STATUS_PREAMBLE_FRESH_MS,
+} from "./progress-draft-compositor.js";
+
+function createTestProgressDraftCompositor(
+  overrides: Omit<
+    Parameters<typeof createChannelProgressDraftCompositor>[0],
+    "mode" | "active" | "seed"
+  >,
+) {
+  return createChannelProgressDraftCompositor({
+    mode: "progress",
+    active: true,
+    seed: "test",
+    ...overrides,
+  });
+}
+
+const DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS = 1_500;
+
+describe("createChannelProgressDraftCompositor status headlines", () => {
+  it("hands preambles to the commentary lane when it is enabled", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: "Shelling", commentary: true } },
+      },
+      update,
+    });
+
+    // The opt-in 💬 lane renders every preamble as an interleaved line; the
+    // headline must decline so it cannot replace those documented lines.
+    expect(await progress.pushPreambleHeadline("Reading the workspace.")).toBe(false);
+    expect(progress.hasStatusHeadline).toBe(false);
+  });
+
+  it("derives a stable headline from plan state when authored status is absent", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: "Working", commentary: true } },
+      },
+      update,
+      derivePlanStatusHeadline: true,
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Read system time", status: "completed" },
+      { step: "Read   kernel version", status: "in_progress" },
+      { step: "Read disk usage", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().statusHeadline).toBe("⏳ 2/3 · Read kernel version");
+    expect(update).toHaveBeenLastCalledWith(
+      "Working\n\n⏳ 2/3 · Read kernel version\n\n✅ Read system time\n▸ Read kernel version\n▢ Read disk usage",
+      expect.objectContaining({ flush: true }),
+    );
+
+    await progress.pushPlanProgress([
+      { step: "Read system time", status: "completed" },
+      { step: "Read kernel version", status: "completed" },
+      { step: "Read disk usage", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().statusHeadline).toBe("⏳ 3/3 · Read disk usage");
+
+    await progress.pushPlanProgress([
+      { step: "Read system time", status: "completed" },
+      { step: "Read kernel version", status: "completed" },
+      { step: "Read disk usage", status: "completed" },
+    ]);
+    expect(progress.getSnapshot().statusHeadline).toBe("✅ 3/3");
+  });
+
+  it("does not derive a plan headline unless the channel opts in", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
+      update: vi.fn(),
+    });
+
+    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }]);
+
+    expect(progress.getSnapshot().statusHeadline).toBeUndefined();
+  });
+
+  it("keeps an authored plan explanation ahead of the derived plan headline", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
+      update: vi.fn(),
+      derivePlanStatusHeadline: true,
+    });
+
+    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }], {
+      explanation: "Applying the revised plan.",
+    });
+
+    expect(progress.getSnapshot().statusHeadline).toBe("Applying the revised plan.");
+  });
+
+  it("holds a preamble headline until the gate starts and hides the implicit label", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress" } },
+      update,
+    });
+
+    expect(await progress.pushPreambleHeadline("  Reading\n the workspace. ")).toBe(false);
+    expect(await progress.pushPreambleHeadline("   ")).toBe(false);
+    expect(progress.hasStarted).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+
+    await progress.start();
+
+    expect(update).toHaveBeenCalledWith("Reading the workspace.", { flush: true, lines: [] });
+  });
+
+  it("publishes rolling tool-line changes beneath a stable preamble headline", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { maxLines: 8 } } },
+      updateOnLineChange: true,
+      update,
+    });
+
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    await progress.pushToolProgress("🛠️ Exec one", { startImmediately: true });
+    await progress.pushToolProgress("🛠️ Exec two", { startImmediately: true });
+
+    expect(update).toHaveBeenLastCalledWith("Reading the workspace.\n\n🛠️ Exec one\n🛠️ Exec two", {
+      lines: ["🛠️ Exec one", "🛠️ Exec two"],
+    });
+  });
+
+  it("rejects control-only preambles without clobbering a valid headline", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress" } },
+      now: () => nowMs,
+      update,
+    });
+
+    expect(progress.hasStatusHeadline).toBe(false);
+    expect(await progress.pushPreambleHeadline("[[reply_to_current]]")).toBe(false);
+    expect(progress.hasStatusHeadline).toBe(false);
+    await progress.pushPreambleHeadline(
+      "[[reply_to_current]] Reading   the workspace. [[audio_as_voice]]",
+    );
+    expect(progress.hasStatusHeadline).toBe(true);
+    await progress.start();
+    expect(update).toHaveBeenLastCalledWith("Reading the workspace.", {
+      flush: true,
+      lines: [],
+    });
+
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    const calls = update.mock.calls.length;
+    expect(await progress.pushPreambleHeadline("[[reply_to_current]]")).toBe(false);
+    expect(
+      await progress.pushPreambleHeadline("[[reply_to_current]] ~~NO_REPLY~~ [[audio_as_voice]]"),
+    ).toBe(false);
+    expect(progress.hasStatusHeadline).toBe(true);
+    expect(update).toHaveBeenCalledTimes(calls);
+
+    await progress.pushNarrationProgress("Utility filler.");
+    expect(update).toHaveBeenLastCalledWith("Utility filler.", expect.anything());
+    await progress.pushNarrationProgress("");
+    expect(update).toHaveBeenLastCalledWith("Reading the workspace.", expect.anything());
+  });
+
+  it("retracts only the matching preamble headline", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.", { itemId: "preamble-1" });
+    await progress.pushPreambleHeadline("Checking the config.", { itemId: "preamble-2" });
+    const callsBeforeStaleRetraction = update.mock.calls.length;
+
+    expect(await progress.pushPreambleHeadline("", { itemId: "preamble-1" })).toBe(false);
+    expect(update).toHaveBeenCalledTimes(callsBeforeStaleRetraction);
+    expect(progress.hasStatusHeadline).toBe(true);
+
+    expect(await progress.pushPreambleHeadline("", { itemId: "preamble-2" })).toBe(true);
+    expect(progress.hasStatusHeadline).toBe(false);
+    expect(update).toHaveBeenLastCalledWith("Shelling", expect.anything());
+  });
+
+  it("keeps a fresh preamble ahead of later narration", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS - 1;
+    await progress.pushNarrationProgress("Utility narration should wait.");
+
+    expect(update).toHaveBeenLastCalledWith(
+      "Shelling\n\nReading the workspace.",
+      expect.anything(),
+    );
+  });
+
+  it("uses newer narration after the preamble becomes stale", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    await progress.pushNarrationProgress("Comparing the configuration now.");
+
+    expect(update).toHaveBeenLastCalledWith(
+      "Shelling\n\nComparing the configuration now.",
+      expect.anything(),
+    );
+  });
+
+  it("uses a plan explanation after the preamble becomes stale", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }], {
+      explanation: "Applying the revised plan.",
+    });
+
+    expect(update).toHaveBeenLastCalledWith(
+      "Shelling\n\nApplying the revised plan.\n\n▸ Patch",
+      expect.anything(),
+    );
+  });
+
+  it("refreshes a new preamble item when its text matches the stale item", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.", { itemId: "first" });
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    await progress.pushNarrationProgress("Comparing the configuration now.");
+    await progress.pushPreambleHeadline("Reading the workspace.", { itemId: "second" });
+
+    expect(update).toHaveBeenLastCalledWith(
+      "Shelling\n\nReading the workspace.",
+      expect.anything(),
+    );
+  });
+
+  it("refreshes to retained narration when a visible preamble expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const update = vi.fn();
+      const progress = createTestProgressDraftCompositor({
+        entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+        update,
+      });
+
+      await progress.start();
+      await progress.pushPreambleHeadline("Reading the workspace.");
+      await progress.pushNarrationProgress("Comparing the configuration now.");
+      expect(update).toHaveBeenLastCalledWith(
+        "Shelling\n\nReading the workspace.",
+        expect.anything(),
+      );
+
+      await vi.advanceTimersByTimeAsync(PROGRESS_STATUS_PREAMBLE_FRESH_MS);
+
+      expect(update).toHaveBeenLastCalledWith(
+        "Shelling\n\nComparing the configuration now.",
+        expect.anything(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a pending preamble-expiry refresh when the final starts", async () => {
+    vi.useFakeTimers();
+    try {
+      const progress = createTestProgressDraftCompositor({
+        entry: { streaming: { mode: "progress" } },
+        update: vi.fn(),
+      });
+
+      await progress.start();
+      await progress.pushPreambleHeadline("Reading the workspace.");
+      await progress.pushNarrationProgress("Comparing the configuration now.");
+      expect(vi.getTimerCount()).toBe(1);
+
+      progress.markFinalReplyStarted();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns to the retained preamble when narration clears", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    await progress.pushNarrationProgress("Comparing the configuration now.");
+    await progress.pushNarrationProgress("");
+
+    expect(update).toHaveBeenLastCalledWith(
+      "Shelling\n\nReading the workspace.",
+      expect.anything(),
+    );
+  });
+
+  it("clears both status sources on reset", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    await progress.pushNarrationProgress("Comparing the configuration now.");
+    progress.reset();
+    await progress.pushToolProgress("🛠️ Next", { startImmediately: true });
+
+    expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Next", expect.anything());
+  });
+
+  it("holds narration behind the initial progress delay", async () => {
+    vi.useFakeTimers();
+    try {
+      const update = vi.fn();
+      const progress = createTestProgressDraftCompositor({
+        entry: { streaming: { mode: "progress" } },
+        update,
+      });
+
+      await progress.pushToolProgress("🛠️ Exec");
+      await progress.pushNarrationProgress("Reading the gateway config.");
+
+      expect(update).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS - 1);
+      expect(update).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(update).toHaveBeenCalledWith("Reading the gateway config.\n\n🛠️ Exec", {
+        flush: true,
+        lines: ["🛠️ Exec"],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -134,6 +134,23 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(progress.getSnapshot().lines).toEqual(["🛠️ Patch command"]);
 
     await progress.pushPlanProgress([
+      { step: "Run tests", status: "in_progress" },
+      { step: "Run tests", status: "pending" },
+    ]);
+    await progress.pushToolProgress("🛠️ First test run", { startImmediately: true });
+    await progress.pushPlanProgress([
+      { step: "Run tests", status: "in_progress" },
+      { step: "Run tests", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ First test run"]);
+
+    await progress.pushPlanProgress([
+      { step: "Run tests", status: "completed" },
+      { step: "Run tests", status: "in_progress" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+
+    await progress.pushPlanProgress([
       { step: "Inspect", status: "completed" },
       { step: "Patch", status: "completed" },
     ]);

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createChannelProgressDraftCompositor,
   createChannelProgressWorkCounter,
-  PROGRESS_STATUS_PREAMBLE_FRESH_MS,
 } from "./progress-draft-compositor.js";
 
 function createTestProgressDraftCompositor(
@@ -90,6 +89,7 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update).toHaveBeenLastCalledWith("Applying the change.\n\n▸ Patch", {
       flush: true,
       lines: [],
+      planLayout: { activeLineIndex: 0, lineCount: 1 },
     });
   });
 
@@ -147,8 +147,16 @@ describe("createChannelProgressDraftCompositor", () => {
     await progress.pushPlanProgress([
       { step: "Run tests", status: "completed" },
       { step: "Run tests", status: "in_progress" },
+      { step: "Run tests", status: "pending" },
     ]);
     expect(progress.getSnapshot().lines).toEqual([]);
+
+    await progress.pushToolProgress("🛠️ Second test run", { startImmediately: true });
+    await progress.pushPlanProgress([
+      { step: "Run tests", status: "in_progress" },
+      { step: "Run tests", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Second test run"]);
 
     await progress.pushPlanProgress([
       { step: "Inspect", status: "completed" },
@@ -178,6 +186,151 @@ describe("createChannelProgressDraftCompositor", () => {
     ]);
 
     expect(progress.getSnapshot().lines).toEqual(["🛠️ Inspect command"]);
+  });
+
+  it("rejects correlated tool updates from a retired plan step", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      update: vi.fn(),
+      resetRollingLinesOnPlanStepChange: true,
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "in_progress" },
+      { step: "Patch", status: "pending" },
+    ]);
+    await progress.pushToolEvent({
+      toolCallId: "inspect-1",
+      name: "Read",
+      phase: "start",
+    });
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+
+    await progress.pushItemEvent({
+      toolCallId: "inspect-1",
+      kind: "tool",
+      name: "Read",
+      phase: "end",
+      status: "completed",
+    });
+    expect(progress.getSnapshot().lines).toEqual([]);
+  });
+
+  it("binds item-first tool updates to the admitting plan step", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      update: vi.fn(),
+      resetRollingLinesOnPlanStepChange: true,
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "in_progress" },
+      { step: "Patch", status: "pending" },
+    ]);
+    expect(
+      await progress.pushItemEvent({
+        toolCallId: "item-first-1",
+        kind: "tool",
+        name: "Read",
+        phase: "end",
+        status: "completed",
+        progressText: "first result",
+      }),
+    ).toBe(true);
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+    expect(
+      await progress.pushItemEvent({
+        toolCallId: "item-first-1",
+        kind: "tool",
+        name: "Read",
+        phase: "end",
+        status: "completed",
+        progressText: "late result",
+      }),
+    ).toBe(false);
+    expect(progress.getSnapshot().lines).toEqual([]);
+  });
+
+  it("clears ambiguous duplicate-labeled step transitions", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      update: vi.fn(),
+      resetRollingLinesOnPlanStepChange: true,
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Run tests", status: "in_progress" },
+      { step: "Run tests", status: "pending" },
+    ]);
+    await progress.pushToolProgress("🛠️ First run", { startImmediately: true });
+    await progress.pushPlanProgress([{ step: "Run tests", status: "in_progress" }]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+
+    await progress.pushToolProgress("🛠️ Current run", { startImmediately: true });
+    await progress.pushPlanProgress([
+      { step: "Run tests", status: "completed" },
+      { step: "Run tests", status: "in_progress" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+  });
+
+  it("lets plan-generation-aware renderers drop in-flight stale updates", async () => {
+    let releaseLateUpdate = () => {};
+    const lateUpdateReleased = new Promise<void>((resolve) => {
+      releaseLateUpdate = resolve;
+    });
+    let markLateUpdateStarted = () => {};
+    const lateUpdateStarted = new Promise<void>((resolve) => {
+      markLateUpdateStarted = resolve;
+    });
+    const visibleUpdates: string[] = [];
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      resetRollingLinesOnPlanStepChange: true,
+      update: async (text, options) => {
+        if (options?.lines?.length) {
+          markLateUpdateStarted();
+          await lateUpdateReleased;
+        }
+        const generationAwareOptions = options as typeof options & {
+          isCurrentPlanGeneration?: () => boolean;
+        };
+        if (generationAwareOptions?.isCurrentPlanGeneration?.() === false) {
+          return false;
+        }
+        visibleUpdates.push(`${text}\n${JSON.stringify(options?.lines ?? [])}`);
+        return true;
+      },
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "in_progress" },
+      { step: "Patch", status: "pending" },
+    ]);
+    const lateToolUpdate = progress.pushToolEvent({
+      toolCallId: "inspect-late",
+      name: "Read",
+      phase: "start",
+    });
+    await lateUpdateStarted;
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+    releaseLateUpdate();
+    await lateToolUpdate;
+
+    expect(visibleUpdates.at(-1)).toContain("▸ Patch");
+    expect(visibleUpdates.at(-1)).not.toContain("Read");
   });
 
   it("publishes partial-preview tool lines without enabling progress-only plans", async () => {
@@ -718,371 +871,6 @@ describe("createChannelProgressDraftCompositor", () => {
     // Narration stopping (empty update) leaves the raw tool lines.
     await progress.pushNarrationProgress("");
     expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n🛠️ Wc", expect.anything());
-  });
-
-  it("hands preambles to the commentary lane when it is enabled", async () => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: {
-        streaming: { mode: "progress", progress: { label: "Shelling", commentary: true } },
-      },
-      update,
-    });
-
-    // The opt-in 💬 lane renders every preamble as an interleaved line; the
-    // headline must decline so it cannot replace those documented lines.
-    expect(await progress.pushPreambleHeadline("Reading the workspace.")).toBe(false);
-    expect(progress.hasStatusHeadline).toBe(false);
-  });
-
-  it("derives a stable headline from plan state when authored status is absent", async () => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: {
-        streaming: { mode: "progress", progress: { label: "Working", commentary: true } },
-      },
-      update,
-      derivePlanStatusHeadline: true,
-    });
-
-    await progress.pushPlanProgress([
-      { step: "Read system time", status: "completed" },
-      { step: "Read   kernel version", status: "in_progress" },
-      { step: "Read disk usage", status: "pending" },
-    ]);
-    expect(progress.getSnapshot().statusHeadline).toBe("⏳ 2/3 · Read kernel version");
-    expect(update).toHaveBeenLastCalledWith(
-      "Working\n\n⏳ 2/3 · Read kernel version\n\n✅ Read system time\n▸ Read kernel version\n▢ Read disk usage",
-      expect.objectContaining({ flush: true }),
-    );
-
-    await progress.pushPlanProgress([
-      { step: "Read system time", status: "completed" },
-      { step: "Read kernel version", status: "completed" },
-      { step: "Read disk usage", status: "pending" },
-    ]);
-    expect(progress.getSnapshot().statusHeadline).toBe("⏳ 3/3 · Read disk usage");
-
-    await progress.pushPlanProgress([
-      { step: "Read system time", status: "completed" },
-      { step: "Read kernel version", status: "completed" },
-      { step: "Read disk usage", status: "completed" },
-    ]);
-    expect(progress.getSnapshot().statusHeadline).toBe("✅ 3/3");
-  });
-
-  it("does not derive a plan headline unless the channel opts in", async () => {
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
-      update: vi.fn(),
-    });
-
-    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }]);
-
-    expect(progress.getSnapshot().statusHeadline).toBeUndefined();
-  });
-
-  it("keeps an authored plan explanation ahead of the derived plan headline", async () => {
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
-      update: vi.fn(),
-      derivePlanStatusHeadline: true,
-    });
-
-    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }], {
-      explanation: "Applying the revised plan.",
-    });
-
-    expect(progress.getSnapshot().statusHeadline).toBe("Applying the revised plan.");
-  });
-
-  it("holds a preamble headline until the gate starts and hides the implicit label", async () => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress" } },
-      update,
-    });
-
-    expect(await progress.pushPreambleHeadline("  Reading\n the workspace. ")).toBe(false);
-    expect(await progress.pushPreambleHeadline("   ")).toBe(false);
-    expect(progress.hasStarted).toBe(false);
-    expect(update).not.toHaveBeenCalled();
-
-    await progress.start();
-
-    expect(update).toHaveBeenCalledWith("Reading the workspace.", { flush: true, lines: [] });
-  });
-
-  it("publishes rolling tool-line changes beneath a stable preamble headline", async () => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { maxLines: 8 } } },
-      updateOnLineChange: true,
-      update,
-    });
-
-    await progress.pushPreambleHeadline("Reading the workspace.");
-    await progress.pushToolProgress("🛠️ Exec one", { startImmediately: true });
-    await progress.pushToolProgress("🛠️ Exec two", { startImmediately: true });
-
-    expect(update).toHaveBeenLastCalledWith("Reading the workspace.\n\n🛠️ Exec one\n🛠️ Exec two", {
-      lines: ["🛠️ Exec one", "🛠️ Exec two"],
-    });
-  });
-
-  it("rejects control-only preambles without clobbering a valid headline", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress" } },
-      now: () => nowMs,
-      update,
-    });
-
-    expect(progress.hasStatusHeadline).toBe(false);
-    expect(await progress.pushPreambleHeadline("[[reply_to_current]]")).toBe(false);
-    expect(progress.hasStatusHeadline).toBe(false);
-    await progress.pushPreambleHeadline(
-      "[[reply_to_current]] Reading   the workspace. [[audio_as_voice]]",
-    );
-    expect(progress.hasStatusHeadline).toBe(true);
-    await progress.start();
-    expect(update).toHaveBeenLastCalledWith("Reading the workspace.", {
-      flush: true,
-      lines: [],
-    });
-
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    const calls = update.mock.calls.length;
-    expect(await progress.pushPreambleHeadline("[[reply_to_current]]")).toBe(false);
-    expect(
-      await progress.pushPreambleHeadline("[[reply_to_current]] ~~NO_REPLY~~ [[audio_as_voice]]"),
-    ).toBe(false);
-    expect(progress.hasStatusHeadline).toBe(true);
-    expect(update).toHaveBeenCalledTimes(calls);
-
-    await progress.pushNarrationProgress("Utility filler.");
-    expect(update).toHaveBeenLastCalledWith("Utility filler.", expect.anything());
-    await progress.pushNarrationProgress("");
-    expect(update).toHaveBeenLastCalledWith("Reading the workspace.", expect.anything());
-  });
-
-  it("retracts only the matching preamble headline", async () => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.", { itemId: "preamble-1" });
-    await progress.pushPreambleHeadline("Checking the config.", { itemId: "preamble-2" });
-    const callsBeforeStaleRetraction = update.mock.calls.length;
-
-    expect(await progress.pushPreambleHeadline("", { itemId: "preamble-1" })).toBe(false);
-    expect(update).toHaveBeenCalledTimes(callsBeforeStaleRetraction);
-    expect(progress.hasStatusHeadline).toBe(true);
-
-    expect(await progress.pushPreambleHeadline("", { itemId: "preamble-2" })).toBe(true);
-    expect(progress.hasStatusHeadline).toBe(false);
-    expect(update).toHaveBeenLastCalledWith("Shelling", expect.anything());
-  });
-
-  it("keeps a fresh preamble ahead of later narration", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      now: () => nowMs,
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.");
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS - 1;
-    await progress.pushNarrationProgress("Utility narration should wait.");
-
-    expect(update).toHaveBeenLastCalledWith(
-      "Shelling\n\nReading the workspace.",
-      expect.anything(),
-    );
-  });
-
-  it("uses newer narration after the preamble becomes stale", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      now: () => nowMs,
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.");
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    await progress.pushNarrationProgress("Comparing the configuration now.");
-
-    expect(update).toHaveBeenLastCalledWith(
-      "Shelling\n\nComparing the configuration now.",
-      expect.anything(),
-    );
-  });
-
-  it("uses a plan explanation after the preamble becomes stale", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      now: () => nowMs,
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.");
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }], {
-      explanation: "Applying the revised plan.",
-    });
-
-    expect(update).toHaveBeenLastCalledWith(
-      "Shelling\n\nApplying the revised plan.\n\n▸ Patch",
-      expect.anything(),
-    );
-  });
-
-  it("refreshes a new preamble item when its text matches the stale item", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      now: () => nowMs,
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.", { itemId: "first" });
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    await progress.pushNarrationProgress("Comparing the configuration now.");
-    await progress.pushPreambleHeadline("Reading the workspace.", { itemId: "second" });
-
-    expect(update).toHaveBeenLastCalledWith(
-      "Shelling\n\nReading the workspace.",
-      expect.anything(),
-    );
-  });
-
-  it("refreshes to retained narration when a visible preamble expires", async () => {
-    vi.useFakeTimers();
-    try {
-      const update = vi.fn();
-      const progress = createTestProgressDraftCompositor({
-        entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-        update,
-      });
-
-      await progress.start();
-      await progress.pushPreambleHeadline("Reading the workspace.");
-      await progress.pushNarrationProgress("Comparing the configuration now.");
-      expect(update).toHaveBeenLastCalledWith(
-        "Shelling\n\nReading the workspace.",
-        expect.anything(),
-      );
-
-      await vi.advanceTimersByTimeAsync(PROGRESS_STATUS_PREAMBLE_FRESH_MS);
-
-      expect(update).toHaveBeenLastCalledWith(
-        "Shelling\n\nComparing the configuration now.",
-        expect.anything(),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("cancels a pending preamble-expiry refresh when the final starts", async () => {
-    vi.useFakeTimers();
-    try {
-      const progress = createTestProgressDraftCompositor({
-        entry: { streaming: { mode: "progress" } },
-        update: vi.fn(),
-      });
-
-      await progress.start();
-      await progress.pushPreambleHeadline("Reading the workspace.");
-      await progress.pushNarrationProgress("Comparing the configuration now.");
-      expect(vi.getTimerCount()).toBe(1);
-
-      progress.markFinalReplyStarted();
-      expect(vi.getTimerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("returns to the retained preamble when narration clears", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      now: () => nowMs,
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.");
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    await progress.pushNarrationProgress("Comparing the configuration now.");
-    await progress.pushNarrationProgress("");
-
-    expect(update).toHaveBeenLastCalledWith(
-      "Shelling\n\nReading the workspace.",
-      expect.anything(),
-    );
-  });
-
-  it("clears both status sources on reset", async () => {
-    let nowMs = 0;
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      now: () => nowMs,
-      update,
-    });
-
-    await progress.start();
-    await progress.pushPreambleHeadline("Reading the workspace.");
-    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    await progress.pushNarrationProgress("Comparing the configuration now.");
-    progress.reset();
-    await progress.pushToolProgress("🛠️ Next", { startImmediately: true });
-
-    expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Next", expect.anything());
-  });
-
-  it("holds narration behind the initial progress delay", async () => {
-    vi.useFakeTimers();
-    try {
-      const update = vi.fn();
-      const progress = createTestProgressDraftCompositor({
-        entry: { streaming: { mode: "progress" } },
-        update,
-      });
-
-      await progress.pushToolProgress("🛠️ Exec");
-      await progress.pushNarrationProgress("Reading the gateway config.");
-
-      expect(update).not.toHaveBeenCalled();
-      await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS - 1);
-      expect(update).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(update).toHaveBeenCalledWith("Reading the gateway config.\n\n🛠️ Exec", {
-        flush: true,
-        lines: ["🛠️ Exec"],
-      });
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("normalizes transport-neutral agent events through the compositor", async () => {

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -93,6 +93,76 @@ describe("createChannelProgressDraftCompositor", () => {
     });
   });
 
+  it("optionally scopes rolling lines to the active plan step", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      update: vi.fn(),
+      resetRollingLinesOnPlanStepChange: true,
+    });
+
+    await progress.pushToolProgress("🛠️ Early command", { startImmediately: true });
+    await progress.pushPlanProgress([
+      { step: "Prepare", status: "completed" },
+      { step: "Inspect", status: "in_progress" },
+      { step: "Patch", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Early command"]);
+
+    await progress.pushPlanProgress(
+      [
+        { step: "Prepare", status: "completed" },
+        { step: "Inspect", status: "in_progress" },
+        { step: "Patch", status: "pending" },
+      ],
+      { explanation: "Still inspecting." },
+    );
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Early command"]);
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "in_progress" },
+      { step: "Patch", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Early command"]);
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+
+    await progress.pushToolProgress("🛠️ Patch command", { startImmediately: true });
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Patch command"]);
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "completed" },
+    ]);
+    expect(progress.getSnapshot().lines).toEqual([]);
+    expect(await progress.pushToolProgress("🛠️ Late command", { startImmediately: true })).toBe(
+      true,
+    );
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Late command"]);
+  });
+
+  it("keeps rolling lines across plan steps when scoping is not enabled", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      update: vi.fn(),
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "in_progress" },
+      { step: "Patch", status: "pending" },
+    ]);
+    await progress.pushToolProgress("🛠️ Inspect command", { startImmediately: true });
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+
+    expect(progress.getSnapshot().lines).toEqual(["🛠️ Inspect command"]);
+  });
+
   it("publishes partial-preview tool lines without enabling progress-only plans", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({
@@ -646,6 +716,67 @@ describe("createChannelProgressDraftCompositor", () => {
     // headline must decline so it cannot replace those documented lines.
     expect(await progress.pushPreambleHeadline("Reading the workspace.")).toBe(false);
     expect(progress.hasStatusHeadline).toBe(false);
+  });
+
+  it("derives a stable headline from plan state when authored status is absent", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: "Working", commentary: true } },
+      },
+      update,
+      derivePlanStatusHeadline: true,
+    });
+
+    await progress.pushPlanProgress([
+      { step: "Read system time", status: "completed" },
+      { step: "Read   kernel version", status: "in_progress" },
+      { step: "Read disk usage", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().statusHeadline).toBe("⏳ 2/3 · Read kernel version");
+    expect(update).toHaveBeenLastCalledWith(
+      "Working\n\n⏳ 2/3 · Read kernel version\n\n✅ Read system time\n▸ Read kernel version\n▢ Read disk usage",
+      expect.objectContaining({ flush: true }),
+    );
+
+    await progress.pushPlanProgress([
+      { step: "Read system time", status: "completed" },
+      { step: "Read kernel version", status: "completed" },
+      { step: "Read disk usage", status: "pending" },
+    ]);
+    expect(progress.getSnapshot().statusHeadline).toBe("⏳ 3/3 · Read disk usage");
+
+    await progress.pushPlanProgress([
+      { step: "Read system time", status: "completed" },
+      { step: "Read kernel version", status: "completed" },
+      { step: "Read disk usage", status: "completed" },
+    ]);
+    expect(progress.getSnapshot().statusHeadline).toBe("✅ 3/3");
+  });
+
+  it("does not derive a plan headline unless the channel opts in", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
+      update: vi.fn(),
+    });
+
+    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }]);
+
+    expect(progress.getSnapshot().statusHeadline).toBeUndefined();
+  });
+
+  it("keeps an authored plan explanation ahead of the derived plan headline", async () => {
+    const progress = createTestProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
+      update: vi.fn(),
+      derivePlanStatusHeadline: true,
+    });
+
+    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }], {
+      explanation: "Applying the revised plan.",
+    });
+
+    expect(progress.getSnapshot().statusHeadline).toBe("Applying the revised plan.");
   });
 
   it("holds a preamble headline until the gate starts and hides the implicit label", async () => {

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -10,6 +10,12 @@ import {
 // It merges status, tool, reasoning, and commentary updates until the final reply replaces them.
 import { removeChannelProgressDraftLine } from "./progress-draft-lines.js";
 import {
+  createProgressDraftPlanState,
+  type ChannelProgressDraftPlanLayout,
+  resolveProgressDraftPlanLayout,
+  resolveProgressDraftPlanStatusHeadline,
+} from "./progress-draft-plan-state.js";
+import {
   formatReasoningProgressDisplayLine,
   mergeReasoningProgressText,
   normalizeCommentaryProgressText,
@@ -56,43 +62,9 @@ export type ChannelProgressDraftCompositorSnapshot = Readonly<{
 type ChannelProgressDraftUpdateOptions = {
   flush?: boolean;
   lines?: readonly ChannelProgressDraftCompositorLine[];
+  planLayout?: ChannelProgressDraftPlanLayout;
+  isCurrentPlanGeneration?: () => boolean;
 };
-
-function normalizePlanStepText(step: string | undefined): string {
-  return step?.replace(/\s+/g, " ").trim() ?? "";
-}
-
-function resolveActivePlanStepKey(steps: readonly AgentPlanStep[] | undefined): string | undefined {
-  if (!steps?.length) {
-    return undefined;
-  }
-  const activeIndex = steps.findIndex((entry) => entry.status === "in_progress");
-  if (activeIndex >= 0) {
-    const activeStep = normalizePlanStepText(steps[activeIndex]?.step);
-    const occurrence = steps
-      .slice(0, activeIndex + 1)
-      .filter((entry) => normalizePlanStepText(entry.step) === activeStep).length;
-    return `active:${activeStep}:${occurrence}`;
-  }
-  return steps.every((entry) => entry.status === "completed") ? "completed" : undefined;
-}
-
-function resolvePlanStatusHeadline(steps: readonly AgentPlanStep[] | undefined): string {
-  if (!steps?.length) {
-    return "";
-  }
-  const currentIndex = steps.findIndex((entry) => entry.status === "in_progress");
-  const fallbackIndex = steps.findIndex((entry) => entry.status === "pending");
-  const stepIndex = currentIndex >= 0 ? currentIndex : fallbackIndex;
-  if (stepIndex >= 0) {
-    const step = normalizePlanStepText(steps[stepIndex]?.step);
-    const counter = `${stepIndex + 1}/${steps.length}`;
-    return step ? `⏳ ${counter} · ${step}` : `⏳ ${counter}`;
-  }
-  return steps.every((entry) => entry.status === "completed")
-    ? `✅ ${steps.length}/${steps.length}`
-    : "";
-}
 
 /** Creates a stateful compositor for one streaming channel reply. */
 export function createChannelProgressDraftCompositor(params: {
@@ -174,7 +146,7 @@ export function createChannelProgressDraftCompositor(params: {
   let narrationText = "";
   let planSteps: AgentPlanStep[] | undefined;
   let planExplanation = "";
-  let activePlanStepKey: string | undefined;
+  const planState = createProgressDraftPlanState();
   let finalReplyStarted = false;
   let finalReplyDelivered = false;
   const diffStatTracker = createProgressDraftDiffStatTracker({
@@ -213,7 +185,9 @@ export function createChannelProgressDraftCompositor(params: {
       preambleText && (preambleIsFresh || !effectiveNarration) ? preambleText : effectiveNarration;
     return (
       authoredStatus ||
-      (params.derivePlanStatusHeadline === true ? resolvePlanStatusHeadline(planSteps) : "")
+      (params.derivePlanStatusHeadline === true
+        ? resolveProgressDraftPlanStatusHeadline(planSteps)
+        : "")
     );
   };
 
@@ -268,7 +242,7 @@ export function createChannelProgressDraftCompositor(params: {
     narrationText = "";
     planSteps = undefined;
     planExplanation = "";
-    activePlanStepKey = undefined;
+    planState.reset();
     diffStatTracker.reset();
     lastStartRendered = false;
   };
@@ -282,8 +256,18 @@ export function createChannelProgressDraftCompositor(params: {
     if (!text || (text === lastRenderedText && !structuredStateChanged)) {
       return false;
     }
+    const planLayout = resolveProgressDraftPlanLayout(planSteps, params.entry);
+    const isCurrentPlanGeneration =
+      params.resetRollingLinesOnPlanStepChange === true
+        ? planState.createGenerationGuard()
+        : undefined;
     const observed = await settleProgressVisibilityCallbackResult(
-      params.update(text, { ...options, lines: [...lines] }),
+      params.update(text, {
+        ...options,
+        lines: [...lines],
+        ...(planLayout ? { planLayout } : {}),
+        ...(isCurrentPlanGeneration ? { isCurrentPlanGeneration } : {}),
+      }),
     );
     if (!observed.visible) {
       return false;
@@ -463,6 +447,8 @@ export function createChannelProgressDraftCompositor(params: {
     pushLine: noteProgress,
     onTool: diffStatTracker.stageToolEvent,
     onItem: diffStatTracker.commitItemEvent,
+    shouldAcceptEvent: (input) =>
+      params.resetRollingLinesOnPlanStepChange !== true || planState.acceptEvent(input),
     ...(params.buildProgressEventLine ? { buildLine: params.buildProgressEventLine } : {}),
   });
 
@@ -574,15 +560,9 @@ export function createChannelProgressDraftCompositor(params: {
       }
       const nextPlanSteps =
         steps && steps.length > 0 ? steps.map((entry) => ({ ...entry })) : undefined;
-      const nextActivePlanStepKey = resolveActivePlanStepKey(nextPlanSteps);
-      if (
-        params.resetRollingLinesOnPlanStepChange === true &&
-        activePlanStepKey !== undefined &&
-        nextActivePlanStepKey !== activePlanStepKey
-      ) {
+      if (params.resetRollingLinesOnPlanStepChange === true && planState.update(nextPlanSteps)) {
         clearRollingProgressLines();
       }
-      activePlanStepKey = nextActivePlanStepKey;
       planSteps = nextPlanSteps;
       planExplanation = options?.explanation?.replace(/\s+/g, " ").trim() ?? "";
       if (!planSteps && !planExplanation) {

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -68,7 +68,11 @@ function resolveActivePlanStepKey(steps: readonly AgentPlanStep[] | undefined): 
   }
   const activeIndex = steps.findIndex((entry) => entry.status === "in_progress");
   if (activeIndex >= 0) {
-    return `active:${normalizePlanStepText(steps[activeIndex]?.step)}`;
+    const activeStep = normalizePlanStepText(steps[activeIndex]?.step);
+    const occurrence = steps
+      .slice(0, activeIndex + 1)
+      .filter((entry) => normalizePlanStepText(entry.step) === activeStep).length;
+    return `active:${activeStep}:${occurrence}`;
   }
   return steps.every((entry) => entry.status === "completed") ? "completed" : undefined;
 }

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -58,6 +58,38 @@ type ChannelProgressDraftUpdateOptions = {
   lines?: readonly ChannelProgressDraftCompositorLine[];
 };
 
+function normalizePlanStepText(step: string | undefined): string {
+  return step?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function resolveActivePlanStepKey(steps: readonly AgentPlanStep[] | undefined): string | undefined {
+  if (!steps?.length) {
+    return undefined;
+  }
+  const activeIndex = steps.findIndex((entry) => entry.status === "in_progress");
+  if (activeIndex >= 0) {
+    return `active:${normalizePlanStepText(steps[activeIndex]?.step)}`;
+  }
+  return steps.every((entry) => entry.status === "completed") ? "completed" : undefined;
+}
+
+function resolvePlanStatusHeadline(steps: readonly AgentPlanStep[] | undefined): string {
+  if (!steps?.length) {
+    return "";
+  }
+  const currentIndex = steps.findIndex((entry) => entry.status === "in_progress");
+  const fallbackIndex = steps.findIndex((entry) => entry.status === "pending");
+  const stepIndex = currentIndex >= 0 ? currentIndex : fallbackIndex;
+  if (stepIndex >= 0) {
+    const step = normalizePlanStepText(steps[stepIndex]?.step);
+    const counter = `${stepIndex + 1}/${steps.length}`;
+    return step ? `⏳ ${counter} · ${step}` : `⏳ ${counter}`;
+  }
+  return steps.every((entry) => entry.status === "completed")
+    ? `✅ ${steps.length}/${steps.length}`
+    : "";
+}
+
 /** Creates a stateful compositor for one streaming channel reply. */
 export function createChannelProgressDraftCompositor(params: {
   entry: StreamingCompatEntry | null | undefined;
@@ -72,6 +104,10 @@ export function createChannelProgressDraftCompositor(params: {
   tryNativeUpdate?: (text: string) => Promise<boolean> | boolean;
   /** Publish when structured lines change even if the rendered text does not. */
   updateOnLineChange?: boolean;
+  /** Drop the previous plan step's rolling rows when the active step changes. */
+  resetRollingLinesOnPlanStepChange?: boolean;
+  /** Derive a status headline from plan state when the channel has no authored status text. */
+  derivePlanStatusHeadline?: boolean;
   /**
    * Set when the channel renders `update`'s structured `lines` itself, so the
    * composed text carries only the status block (label, headline, checklist).
@@ -134,6 +170,7 @@ export function createChannelProgressDraftCompositor(params: {
   let narrationText = "";
   let planSteps: AgentPlanStep[] | undefined;
   let planExplanation = "";
+  let activePlanStepKey: string | undefined;
   let finalReplyStarted = false;
   let finalReplyDelivered = false;
   const diffStatTracker = createProgressDraftDiffStatTracker({
@@ -168,9 +205,12 @@ export function createChannelProgressDraftCompositor(params: {
     const preambleIsFresh =
       preambleAt !== undefined && now() - preambleAt < PROGRESS_STATUS_PREAMBLE_FRESH_MS;
     const effectiveNarration = narrationText || planExplanation;
-    return preambleText && (preambleIsFresh || !effectiveNarration)
-      ? preambleText
-      : effectiveNarration;
+    const authoredStatus =
+      preambleText && (preambleIsFresh || !effectiveNarration) ? preambleText : effectiveNarration;
+    return (
+      authoredStatus ||
+      (params.derivePlanStatusHeadline === true ? resolvePlanStatusHeadline(planSteps) : "")
+    );
   };
 
   const formatDraftText = (draftLines = lines, options?: { formatted?: boolean }) => {
@@ -203,23 +243,28 @@ export function createChannelProgressDraftCompositor(params: {
     };
   };
 
-  const clearProgressState = (suppressed: boolean) => {
-    clearPreambleExpiryTimer();
-    progressSuppressed = suppressed;
+  const clearRollingProgressLines = () => {
     lines = [];
-    lastRenderedText = "";
-    lastRenderedLines = lines;
-    lastRenderedDiffStatKey = "";
     reasoningRawText = "";
     lastReasoningLine = undefined;
     lastIdLessCommentaryId = undefined;
     lastIdLessCommentaryBare = "";
+  };
+
+  const clearProgressState = (suppressed: boolean) => {
+    clearPreambleExpiryTimer();
+    progressSuppressed = suppressed;
+    clearRollingProgressLines();
+    lastRenderedText = "";
+    lastRenderedLines = lines;
+    lastRenderedDiffStatKey = "";
     preambleText = "";
     preambleItemId = undefined;
     preambleAt = undefined;
     narrationText = "";
     planSteps = undefined;
     planExplanation = "";
+    activePlanStepKey = undefined;
     diffStatTracker.reset();
     lastStartRendered = false;
   };
@@ -523,7 +568,18 @@ export function createChannelProgressDraftCompositor(params: {
       ) {
         return false;
       }
-      planSteps = steps && steps.length > 0 ? steps.map((entry) => ({ ...entry })) : undefined;
+      const nextPlanSteps =
+        steps && steps.length > 0 ? steps.map((entry) => ({ ...entry })) : undefined;
+      const nextActivePlanStepKey = resolveActivePlanStepKey(nextPlanSteps);
+      if (
+        params.resetRollingLinesOnPlanStepChange === true &&
+        activePlanStepKey !== undefined &&
+        nextActivePlanStepKey !== activePlanStepKey
+      ) {
+        clearRollingProgressLines();
+      }
+      activePlanStepKey = nextActivePlanStepKey;
+      planSteps = nextPlanSteps;
       planExplanation = options?.explanation?.replace(/\s+/g, " ").trim() ?? "";
       if (!planSteps && !planExplanation) {
         if (!gate.hasStarted) {

--- a/src/channels/progress-draft-events.ts
+++ b/src/channels/progress-draft-events.ts
@@ -14,6 +14,7 @@ type ProgressPayload<TEvent extends ChannelProgressDraftLineInput["event"]> = Om
 type ToolProgressPayload = ProgressPayload<"tool"> & { detailMode?: "explain" | "raw" };
 type ItemProgressPayload = Omit<ProgressPayload<"item">, "itemKind"> & { kind?: string };
 type ChannelProgressDraftEventLine = string | ChannelProgressDraftLine;
+type ChannelProgressDraftEventInput = Exclude<ChannelProgressDraftLineInput, { event: "plan" }>;
 export type ChannelProgressDraftEventLineBuilder = (
   input: ChannelProgressDraftLineInput,
   options?: ChannelProgressLineOptions,
@@ -24,15 +25,21 @@ export function createChannelProgressDraftEventHandlers(params: {
   buildLine?: ChannelProgressDraftEventLineBuilder;
   onTool?: (payload: ToolProgressPayload) => void;
   onItem?: (payload: ItemProgressPayload) => void;
+  shouldAcceptEvent?: (input: ChannelProgressDraftEventInput) => boolean;
   pushLine: (
     line: ChannelProgressDraftEventLine | undefined,
     options?: { toolName?: string; startImmediately?: boolean },
   ) => Promise<boolean>;
 }) {
   const pushEvent = (
-    input: Exclude<ChannelProgressDraftLineInput, { event: "plan" }>,
+    input: ChannelProgressDraftEventInput,
     detailMode?: "explain" | "raw",
+    onAccepted?: () => void,
   ) => {
+    if (params.shouldAcceptEvent?.(input) === false) {
+      return Promise.resolve(false);
+    }
+    onAccepted?.();
     const lineOptions = detailMode ? { detailMode } : undefined;
     const line = params.buildLine
       ? params.buildLine(input, lineOptions)
@@ -43,13 +50,13 @@ export function createChannelProgressDraftEventHandlers(params: {
   return {
     pushToolEvent: (payload: ToolProgressPayload) => {
       const { detailMode, ...input } = payload;
-      params.onTool?.(payload);
-      return pushEvent({ event: "tool", ...input }, detailMode);
+      return pushEvent({ event: "tool", ...input }, detailMode, () => params.onTool?.(payload));
     },
     pushItemEvent: (payload: ItemProgressPayload) => {
       const { kind: itemKind, ...input } = payload;
-      params.onItem?.(payload);
-      return pushEvent({ event: "item", ...input, itemKind });
+      return pushEvent({ event: "item", ...input, itemKind }, undefined, () =>
+        params.onItem?.(payload),
+      );
     },
     pushApprovalEvent: (payload: ProgressPayload<"approval">) => {
       return payload.phase === "requested"

--- a/src/channels/progress-draft-plan-state.ts
+++ b/src/channels/progress-draft-plan-state.ts
@@ -1,0 +1,165 @@
+import {
+  type AgentPlanStep,
+  formatPlanChecklistLines,
+  resolveChannelProgressDraftMaxLineChars,
+  resolveChannelProgressDraftMaxLines,
+  type StreamingCompatEntry,
+} from "./streaming.js";
+
+export type ChannelProgressDraftPlanLayout = Readonly<{
+  lineCount: number;
+  activeLineIndex?: number;
+}>;
+
+type ActivePlanStepIdentity =
+  | Readonly<{
+      kind: "active";
+      text: string;
+      occurrenceFromStart: number;
+      occurrenceFromEnd: number;
+    }>
+  | Readonly<{ kind: "completed" }>;
+
+type ProgressDraftPlanEvent = {
+  event: string;
+  itemId?: string;
+  toolCallId?: string;
+};
+
+function normalizePlanStepText(step: string | undefined): string {
+  return step?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function resolveActivePlanStepIdentity(
+  steps: readonly AgentPlanStep[] | undefined,
+): ActivePlanStepIdentity | undefined {
+  if (!steps?.length) {
+    return undefined;
+  }
+  const activeIndex = steps.findIndex((entry) => entry.status === "in_progress");
+  if (activeIndex >= 0) {
+    const activeStep = normalizePlanStepText(steps[activeIndex]?.step);
+    const occurrenceFromStart = steps
+      .slice(0, activeIndex + 1)
+      .filter((entry) => normalizePlanStepText(entry.step) === activeStep).length;
+    const occurrenceFromEnd = steps
+      .slice(activeIndex)
+      .filter((entry) => normalizePlanStepText(entry.step) === activeStep).length;
+    return {
+      kind: "active",
+      text: activeStep,
+      occurrenceFromStart,
+      occurrenceFromEnd,
+    };
+  }
+  return steps.every((entry) => entry.status === "completed") ? { kind: "completed" } : undefined;
+}
+
+function isSameActivePlanStep(
+  previous: ActivePlanStepIdentity | undefined,
+  next: ActivePlanStepIdentity | undefined,
+): boolean {
+  if (previous === undefined || next === undefined) {
+    return previous === next;
+  }
+  if (previous.kind !== "active" || next.kind !== "active") {
+    return previous.kind === next.kind;
+  }
+  if (previous.text !== next.text) {
+    return false;
+  }
+  if (
+    previous.occurrenceFromStart === next.occurrenceFromStart &&
+    previous.occurrenceFromEnd === next.occurrenceFromEnd
+  ) {
+    return true;
+  }
+  // The only safe one-sided renumbering is pruning completed same-label
+  // predecessors without changing the active step's position from the end.
+  // Other duplicate edits are ambiguous, so clear their rows conservatively.
+  return (
+    previous.occurrenceFromEnd === next.occurrenceFromEnd &&
+    next.occurrenceFromStart < previous.occurrenceFromStart
+  );
+}
+
+function resolveEventId(event: ProgressDraftPlanEvent): string | undefined {
+  return event.toolCallId?.trim() || event.itemId?.trim() || undefined;
+}
+
+export function resolveProgressDraftPlanStatusHeadline(
+  steps: readonly AgentPlanStep[] | undefined,
+): string {
+  if (!steps?.length) {
+    return "";
+  }
+  const currentIndex = steps.findIndex((entry) => entry.status === "in_progress");
+  const fallbackIndex = steps.findIndex((entry) => entry.status === "pending");
+  const stepIndex = currentIndex >= 0 ? currentIndex : fallbackIndex;
+  if (stepIndex >= 0) {
+    const step = normalizePlanStepText(steps[stepIndex]?.step);
+    const counter = `${stepIndex + 1}/${steps.length}`;
+    return step ? `⏳ ${counter} · ${step}` : `⏳ ${counter}`;
+  }
+  return steps.every((entry) => entry.status === "completed")
+    ? `✅ ${steps.length}/${steps.length}`
+    : "";
+}
+
+export function resolveProgressDraftPlanLayout(
+  steps: readonly AgentPlanStep[] | undefined,
+  entry: StreamingCompatEntry | null | undefined,
+): ChannelProgressDraftPlanLayout | undefined {
+  if (!steps?.length) {
+    return undefined;
+  }
+  const planLines = formatPlanChecklistLines(steps, {
+    maxLines: resolveChannelProgressDraftMaxLines(entry),
+    maxLineChars: resolveChannelProgressDraftMaxLineChars(entry),
+  });
+  const activeLineIndex = planLines.findIndex((line) => /^▸(?:\s|$)/u.test(line));
+  return {
+    lineCount: planLines.length,
+    ...(activeLineIndex >= 0 ? { activeLineIndex } : {}),
+  };
+}
+
+export function createProgressDraftPlanState() {
+  let activeStepIdentity: ActivePlanStepIdentity | undefined;
+  let generation = 0;
+  const toolGenerations = new Map<string, number>();
+
+  const acceptToolCallId = (toolCallId: string, remember: boolean): boolean => {
+    const admittedGeneration = toolGenerations.get(toolCallId);
+    if (admittedGeneration === undefined && remember) {
+      toolGenerations.set(toolCallId, generation);
+    }
+    return admittedGeneration === undefined || admittedGeneration === generation;
+  };
+
+  return {
+    reset() {
+      activeStepIdentity = undefined;
+      generation = 0;
+      toolGenerations.clear();
+    },
+    update(steps: readonly AgentPlanStep[] | undefined): boolean {
+      const nextIdentity = resolveActivePlanStepIdentity(steps);
+      const activeStepChanged =
+        activeStepIdentity !== undefined && !isSameActivePlanStep(activeStepIdentity, nextIdentity);
+      activeStepIdentity = nextIdentity;
+      if (activeStepChanged) {
+        generation += 1;
+      }
+      return activeStepChanged;
+    },
+    createGenerationGuard(): () => boolean {
+      const admittedGeneration = generation;
+      return () => admittedGeneration === generation;
+    },
+    acceptEvent(event: ProgressDraftPlanEvent): boolean {
+      const eventId = resolveEventId(event);
+      return eventId ? acceptToolCallId(eventId, true) : true;
+    },
+  };
+}


### PR DESCRIPTION
Closes #125775

## What Problem This Solves

Telegram's structured progress draft could retain rolling tool rows across plan-step transitions, render those rows outside the active checklist item, and omit the top status headline when `update_plan.explanation` was absent.

## Implementation

- Keeps rolling rows scoped to the active plan step without changing the one-message draft lifecycle.
- Uses normalized step text plus its same-label occurrence as a collision-aware identity. Unrelated plan pruning/reordering preserves rows, while advancing between repeated labels clears the prior step's rows.
- Makes plan-derived status headlines an explicit Telegram opt-in; other shared-compositor consumers retain their previous behavior.
- Nests current work rows beneath the active checklist item in HTML, rich, and plain previews.
- Documents the Telegram fallback headline and active-step row behavior.

The patch does not infer tool ownership from tool text and does not change tool execution. Plan entries do not expose stable IDs, so structurally ambiguous repeated-label reshaping conservatively resets rolling rows rather than risking stale rows under a new step.

## Verification

- Focused Telegram tests: 57 passed.
- Focused shared-compositor tests: 48 passed.
- Total focused tests: 105 passed.
- The repeated-label regression failed on the prior implementation and passed after the fix.
- `pnpm plugin-sdk:surface:check`: PASS on the preceding public-surface revision; this follow-up does not change the exported type surface.
- `git diff --check`: PASS.
- Independent final source review: PASS, no P0/P1/P2.

Covered boundaries include Telegram-only headline opt-in, authored-headline precedence, unrelated plan pruning/reordering, repeated-label handoff, true step transitions, HTML/rich/plain nesting, non-plan flat layout, and the one-message draft lifecycle.

The scoped changed-file check passed 15 repository gates; its dead-export launcher alone was blocked before analysis by the Windows sandbox denying `realpath C:\Users\sunny`.

## Visible Proof

The deterministic renderer and dispatch coverage is green on the final tree. A maintainer-triggered Telegram Desktop/Mantis proof is still requested for the external Bot API/client rendering boundary; this PR does not claim that live proof has already run.