### PR TITLE
fix(codex): coalesce dynamic tool progress by callId

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -334,6 +334,7 @@ export class CodexToolProgressProjection {
     this.emitToolResultMessage({
       itemId: item.id,
       text: formatToolSummary(toolName, meta),
+      progressItemId: item.type === "dynamicToolCall" ? `tool:${item.id}` : undefined,
     });
   }
 
@@ -354,6 +355,7 @@ export class CodexToolProgressProjection {
       text: formatToolOutput(toolName, itemMeta(item, this.toolProgressDetailMode()), output),
       finalOutput: true,
       isError: isNonSuccessItemStatus(itemStatus(item)),
+      progressItemId: item.type === "dynamicToolCall" ? `tool:${item.id}` : undefined,
     });
   }
 
@@ -389,18 +391,24 @@ export class CodexToolProgressProjection {
     });
   }
 
-  recordTranscriptCall(params: ToolTranscriptCallInput): void {
+  recordTranscriptCall(
+    params: ToolTranscriptCallInput,
+    options?: { progressItemId?: string },
+  ): void {
     this.transcriptArgumentsById.set(params.id, params.arguments);
     if (!shouldEmitTranscriptToolProgress(params.name, params.arguments)) {
       this.transcriptProgressSuppressedIds.add(params.id);
     } else {
       this.transcriptProgressSuppressedIds.delete(params.id);
     }
-    this.emitTranscriptToolCallProgress(params);
+    this.emitTranscriptToolCallProgress(params, options);
   }
 
-  recordTranscriptResult(params: ToolTranscriptResultInput): void {
-    this.emitTranscriptToolResultProgress(params);
+  recordTranscriptResult(
+    params: ToolTranscriptResultInput,
+    options?: { progressItemId?: string },
+  ): void {
+    this.emitTranscriptToolResultProgress(params, options);
   }
 
   matchesEcho(text: string): boolean {
@@ -443,6 +451,7 @@ export class CodexToolProgressProjection {
     text: string;
     finalOutput?: boolean;
     isError?: boolean;
+    progressItemId?: string;
   }): void {
     const rawText = params.text.trim();
     const text = truncateToolTranscriptText(rawText);
@@ -458,6 +467,9 @@ export class CodexToolProgressProjection {
         this.params.onToolResult?.({
           text,
           ...(params.isError === true ? { isError: true } : {}),
+          ...(params.progressItemId
+            ? { channelData: { openclawProgressItemId: params.progressItemId } }
+            : {}),
         }),
       ).catch(() => {});
     } catch {
@@ -477,7 +489,10 @@ export class CodexToolProgressProjection {
       : this.params.verboseLevel === "full";
   }
 
-  private emitTranscriptToolCallProgress(params: ToolTranscriptCallInput): void {
+  private emitTranscriptToolCallProgress(
+    params: ToolTranscriptCallInput,
+    options?: { progressItemId?: string },
+  ): void {
     if (!shouldEmitTranscriptToolProgress(params.name, params.arguments)) {
       return;
     }
@@ -501,10 +516,14 @@ export class CodexToolProgressProjection {
     this.emitToolResultMessage({
       itemId: params.id,
       text: formatToolSummary(params.name, meta),
+      progressItemId: options?.progressItemId,
     });
   }
 
-  private emitTranscriptToolResultProgress(params: ToolTranscriptResultInput): void {
+  private emitTranscriptToolResultProgress(
+    params: ToolTranscriptResultInput,
+    options?: { progressItemId?: string },
+  ): void {
     if (
       this.transcriptProgressSuppressedIds.has(params.id) ||
       !shouldEmitTranscriptToolProgress(params.name, this.transcriptArgumentsById.get(params.id))
@@ -512,7 +531,10 @@ export class CodexToolProgressProjection {
       return;
     }
     if (!this.transcriptProgressCallIds.has(params.id)) {
-      this.emitTranscriptToolCallProgress({ id: params.id, name: params.name, arguments: {} });
+      this.emitTranscriptToolCallProgress(
+        { id: params.id, name: params.name, arguments: {} },
+        options,
+      );
     }
     if (
       !this.params.onToolResult ||
@@ -529,6 +551,7 @@ export class CodexToolProgressProjection {
         text: formatToolOutput(params.name, undefined, text),
         finalOutput: true,
         isError: params.isError,
+        progressItemId: options?.progressItemId,
       });
     }
   }

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -207,11 +207,14 @@ export class CodexToolTranscriptProjection {
   }
 
   recordDynamicToolCall(params: { callId: string; tool: string; arguments?: JsonValue }): void {
-    this.recordToolCall({
-      id: params.callId,
-      name: params.tool,
-      arguments: sanitizeCodexToolArguments(params.arguments),
-    });
+    this.recordToolCall(
+      {
+        id: params.callId,
+        name: params.tool,
+        arguments: sanitizeCodexToolArguments(params.arguments),
+      },
+      { progressItemId: `tool:${params.callId}` },
+    );
   }
 
   recordDynamicToolResult(
@@ -224,14 +227,17 @@ export class CodexToolTranscriptProjection {
     },
     resultContentSource?: "network",
   ): void {
-    this.recordToolResult({
-      id: params.callId,
-      name: params.tool,
-      text: collectDynamicToolContentText(params.contentItems),
-      isError: !params.success,
-      details: params.details,
-      ...(resultContentSource ? { resultContentSource } : {}),
-    });
+    this.recordToolResult(
+      {
+        id: params.callId,
+        name: params.tool,
+        text: collectDynamicToolContentText(params.contentItems),
+        isError: !params.success,
+        details: params.details,
+        ...(resultContentSource ? { resultContentSource } : {}),
+      },
+      { progressItemId: `tool:${params.callId}` },
+    );
   }
 
   recordNativeToolCall(item: CodexThreadItem | undefined): void {
@@ -594,13 +600,16 @@ export class CodexToolTranscriptProjection {
     );
   }
 
-  private recordToolCall(params: ToolTranscriptCallInput): void {
+  private recordToolCall(
+    params: ToolTranscriptCallInput,
+    options?: { progressItemId?: string },
+  ): void {
     if (!params.id || !params.name || this.callIds.has(params.id)) {
       return;
     }
     this.callIds.add(params.id);
     this.namesById.set(params.id, params.name);
-    this.progress.recordTranscriptCall(params);
+    this.progress.recordTranscriptCall(params, options);
     this.messages.push(
       attachCodexMirrorIdentity(
         this.createToolCallMessage(params),
@@ -609,12 +618,15 @@ export class CodexToolTranscriptProjection {
     );
   }
 
-  private recordToolResult(params: ToolTranscriptResultInput): void {
+  private recordToolResult(
+    params: ToolTranscriptResultInput,
+    options?: { progressItemId?: string },
+  ): void {
     if (!params.id || !params.name || this.resultIds.has(params.id)) {
       return;
     }
     this.resultIds.add(params.id);
-    this.progress.recordTranscriptResult(params);
+    this.progress.recordTranscriptResult(params, options);
     this.messages.push(
       attachCodexMirrorIdentity(
         this.createToolResultMessage(params),

--- a/extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts
+++ b/extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts
@@ -145,7 +145,64 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
     expect(onToolResult).toHaveBeenCalledTimes(1);
     expect(onToolResult).toHaveBeenCalledWith({
       text: "🧩 Lcm Grep: `inProgress text`",
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
+  });
+
+  it("tags dynamic tool summaries with their structured progress identity", async () => {
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "on",
+      onToolResult,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "dynamicToolCall",
+          id: "dynamic-call-1",
+          namespace: null,
+          tool: "memory_search",
+          arguments: { query: "retention policy" },
+          status: "inProgress",
+          contentItems: null,
+          success: null,
+          durationMs: null,
+        },
+      }),
+    );
+
+    expect(onToolResult).toHaveBeenCalledWith({
+      text: expect.stringContaining("Memory Search"),
+      channelData: { openclawProgressItemId: "tool:dynamic-call-1" },
+    });
+  });
+
+  it("tags a result-first dynamic tool summary and full output with the same identity", async () => {
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "full",
+      onToolResult,
+    });
+
+    projector.recordDynamicToolResult({
+      callId: "dynamic-call-1",
+      tool: "memory_search",
+      success: true,
+      contentItems: [{ type: "inputText", text: "retained policy details" }],
+    });
+
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    for (const [payload] of onToolResult.mock.calls) {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          channelData: { openclawProgressItemId: "tool:dynamic-call-1" },
+        }),
+      );
+    }
+    expect(onToolResult.mock.calls[1]?.[0]?.text).toContain("retained policy details");
   });
 
   it("hides command arguments from dynamic tool summaries unless verbose is full", async () => {
@@ -172,7 +229,10 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
       }),
     );
 
-    expect(onToolResult).toHaveBeenCalledWith({ text: "🧩 Server.exec" });
+    expect(onToolResult).toHaveBeenCalledWith({
+      text: "🧩 Server.exec",
+      channelData: { openclawProgressItemId: "tool:tool-command-1" },
+    });
     expect(JSON.stringify(onToolResult.mock.calls)).not.toContain("private/operator-file");
   });
 
@@ -203,9 +263,11 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
     expect(onToolResult).toHaveBeenCalledTimes(2);
     expect(onToolResult).toHaveBeenNthCalledWith(1, {
       text: "📖 Read: `from README.md`",
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
     expect(onToolResult).toHaveBeenNthCalledWith(2, {
       text: "📖 Read: `from README.md`\n```txt\nfile contents\n```",
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
   });
 
@@ -236,6 +298,7 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
     expect(onToolResult).toHaveBeenNthCalledWith(2, {
       text: "🛠️ `list files in /tmp/missing`\n```txt\nNo such file or directory\n```",
       isError: true,
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
   });
 
@@ -265,6 +328,7 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
 
     expect(onToolResult).toHaveBeenNthCalledWith(2, {
       text: "📖 Read: `from README.md`\n````txt\nline\n```\nMEDIA:/tmp/secret.png\n````",
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
   });
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1760,8 +1760,11 @@ describe("runCodexAppServerAttempt", () => {
     const harness = createStartedThreadHarness();
     const params = createParams(sessionFile, workspaceDir);
     const onRunAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
     params.timeoutMs = 60_000;
     params.onAgentEvent = onRunAgentEvent;
+    params.verboseLevel = "full";
+    params.onToolResult = onToolResult;
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
     const request = {
@@ -1828,6 +1831,15 @@ describe("runCodexAppServerAttempt", () => {
       .filter((event) => event.stream === "tool")
       .map((event) => event.data?.phase);
     expect(toolPhases).toEqual(["start", "result"]);
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    for (const [payload] of onToolResult.mock.calls) {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          channelData: { openclawProgressItemId: "tool:call-1" },
+        }),
+      );
+    }
+    expect(onToolResult.mock.calls[1]?.[0]?.text).toContain("Unknown OpenClaw tool: python");
   });
   it("keeps leading delivery hints out of the Codex current user request", async () => {
     for (const [index, deliveryHint] of MESSAGE_TOOL_DELIVERY_HINTS.entries()) {
@@ -4493,9 +4505,11 @@ describe("runCodexAppServerAttempt", () => {
     expect(onToolResult).toHaveBeenCalledTimes(2);
     expect(onToolResult).toHaveBeenNthCalledWith(1, {
       text: "📖 Read: `from README.md`",
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
     expect(onToolResult).toHaveBeenNthCalledWith(2, {
       text: "📖 Read: `from README.md`\n```txt\nfile contents\n```",
+      channelData: { openclawProgressItemId: "tool:tool-1" },
     });
   });
 

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -34,8 +34,9 @@ function buildTelegramThinkingProgressLine(progressTokens: number): ChannelProgr
   };
 }
 
-function buildTelegramTextToolProgressLine(text: string): ChannelProgressDraftLine {
+function buildTelegramTextToolProgressLine(text: string, id?: string): ChannelProgressDraftLine {
   return {
+    ...(id ? { id } : {}),
     kind: "item",
     label: "",
     text,
@@ -123,13 +124,13 @@ async function pushProgressEvent(turn: Turn, event: () => Promise<boolean>): Pro
 export async function pushToolProgress(
   turn: Turn,
   line?: string | ChannelProgressDraftLine,
-  options?: { toolName?: string; startImmediately?: boolean },
+  options?: { toolName?: string; startImmediately?: boolean; id?: string },
 ): Promise<boolean> {
   if (!canPushToolProgress(turn)) {
     return false;
   }
   return await turn.progressCompositor.pushToolProgress(
-    typeof line === "string" ? buildTelegramTextToolProgressLine(line) : line,
+    typeof line === "string" ? buildTelegramTextToolProgressLine(line, options?.id) : line,
     options,
   );
 }

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -275,8 +275,13 @@ export async function runTelegramDispatchTurn(turn: Turn) {
               if (!text) {
                 return false;
               }
+              const progressItemId =
+                typeof payload.channelData?.openclawProgressItemId === "string"
+                  ? payload.channelData.openclawProgressItemId.trim()
+                  : "";
               const updatedDraft = await pushToolProgress(turn, text, {
                 startImmediately: true,
+                ...(progressItemId ? { id: progressItemId } : {}),
               });
               if (updatedDraft) {
                 return true;

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -370,6 +370,151 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
+  it("merges dynamic tool summary and full output into its structured progress row", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({
+        name: "memory_search",
+        phase: "start",
+        toolCallId: "dynamic-call-1",
+        args: { query: "retention policy" },
+      });
+      await replyOptions?.onToolResult?.({
+        text: "🧠 Memory Search: retained policy details",
+        channelData: { openclawProgressItemId: "tool:dynamic-call-1" },
+      });
+      await replyOptions?.onToolResult?.({
+        text: "🧠 Memory Search: retained policy details\n```txt\nfull result\n```",
+        channelData: { openclawProgressItemId: "tool:dynamic-call-1" },
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text ?? "";
+    expect(lastPreview.match(/Memory Search/gu)).toHaveLength(1);
+    expect(lastPreview).toContain("full result");
+  });
+
+  it("merges a structured dynamic tool row into an earlier tagged summary", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolResult?.({
+        text: "🧠 Memory Search: retained policy details",
+        channelData: { openclawProgressItemId: "tool:dynamic-call-1" },
+      });
+      await replyOptions?.onToolStart?.({
+        name: "memory_search",
+        phase: "start",
+        toolCallId: "dynamic-call-1",
+        args: { query: "retention policy" },
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text ?? "";
+    expect(lastPreview.split("<br>")).toHaveLength(2);
+    expect(lastPreview).not.toContain("retained policy details");
+  });
+
+  it("keeps identical dynamic tool summaries distinct when call ids differ", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      for (const toolCallId of ["dynamic-call-1", "dynamic-call-2"]) {
+        await replyOptions?.onToolStart?.({
+          name: "memory_search",
+          phase: "start",
+          toolCallId,
+          args: { query: "retention policy" },
+        });
+        await replyOptions?.onToolResult?.({
+          text: "🧠 Memory Search: retained policy details",
+          channelData: { openclawProgressItemId: `tool:${toolCallId}` },
+        });
+      }
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text ?? "";
+    expect(lastPreview.split("<br>")).toHaveLength(3);
+    expect(lastPreview.match(/retained policy details/gu)).toHaveLength(2);
+  });
+
+  it("keeps replayed tagged summaries for one dynamic call idempotent", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({
+        name: "memory_search",
+        phase: "start",
+        toolCallId: "dynamic-call-1",
+        args: { query: "retention policy" },
+      });
+      const summary = {
+        text: "🧠 Memory Search: retained policy details",
+        channelData: { openclawProgressItemId: "tool:dynamic-call-1" },
+      };
+      await replyOptions?.onToolResult?.(summary);
+      await replyOptions?.onToolResult?.(summary);
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text ?? "";
+    expect(lastPreview.split("<br>")).toHaveLength(2);
+    expect(lastPreview.match(/retained policy details/gu)).toHaveLength(1);
+  });
+
+  it("preserves legacy untagged tool results as separate progress rows", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({
+        name: "memory_search",
+        phase: "start",
+        toolCallId: "dynamic-call-1",
+        args: { query: "retention policy" },
+      });
+      await replyOptions?.onToolResult?.({ text: "legacy result without an identity" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text ?? "";
+    expect(lastPreview.split("<br>")).toHaveLength(3);
+    expect(lastPreview).toContain("legacy result without an identity");
+  });
+
   it("reopens progress drafts for queued followups after the source dispatch settles", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);


### PR DESCRIPTION
Closes #125776

## What Problem This Solves

One Codex dynamic tool invocation could produce two Telegram progress rows: a structured row keyed by `tool:<callId>` and an id-less textual summary or full-output row.

## Implementation

Codex already preserves a canonical `callId` through the dynamic-tool request, started item, and completed item. This patch carries `tool:<callId>` through:

- item-notification-first summaries and full output;
- server-request/transcript-first summaries and full output;
- result-first fallback synthesis.

Telegram therefore updates one keyed row from start to summary to full output. It does not deduplicate by tool name or arguments: distinct call IDs remain separate, and legacy summaries without a usable ID retain their prior behavior.

## Verification

- Event-projector focused cases: 4 passed (11 unrelated cases skipped by the filter).
- Telegram progress focused cases: 3 passed (29 unrelated cases skipped by the filter).
- `git diff --check`: PASS.
- Independent final source review: PASS, no P0/P1.

The focused coverage includes item-first, server-request-first, result-first fallback, same-ID replay, summary-to-full-output replacement, different IDs remaining separate, and untagged legacy behavior.

The large `run-attempt.test.ts` case was updated for the server-request path, but its exact local Windows run was blocked after three bounded attempts by the test harness failing to open its SQLite state database before the assertion. It is intentionally left to CI rather than masking or repeatedly retrying that infrastructure failure.

## Visible Proof

A maintainer-triggered Telegram Desktop/Mantis proof is still requested for the external client boundary. This PR does not claim that live proof has already run.