### PR TITLE
feat(llama-cpp): support external llama-server

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1790,5 +1790,21 @@
   {
     "source": "llama-server (external llama.cpp)",
     "target": "llama-server（外部 llama.cpp）"
+  },
+  {
+    "source": "llama-server Provider",
+    "target": "llama-server 提供商"
+  },
+  {
+    "source": "llama.cpp plugin",
+    "target": "llama.cpp 插件"
+  },
+  {
+    "source": "Local model services",
+    "target": "本地模型服务"
+  },
+  {
+    "source": "LM Studio",
+    "target": "LM Studio"
   }
 ]

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1782,5 +1782,13 @@
   {
     "source": "CLI Automation",
     "target": "CLI 自动化"
+  },
+  {
+    "source": "llama-server",
+    "target": "llama-server"
+  },
+  {
+    "source": "llama-server (external llama.cpp)",
+    "target": "llama-server（外部 llama.cpp）"
   }
 ]

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -534,6 +534,22 @@ Plugin-owned capability split:
 - Image understanding is plugin-owned `MiniMax-VL-01` on both MiniMax auth paths
 - Web search stays on provider id `minimax`
 
+### llama.cpp
+
+The bundled `llama-cpp` plugin provides two local text providers:
+
+- `llama-cpp` installs and manages a verified llama-server and local GGUF files.
+- `llama-server` connects to a server that you already run and discovers its models.
+
+Install the plugin once for either path:
+
+```bash
+openclaw plugins install @openclaw/llama-cpp-provider
+```
+
+See [llama.cpp](/plugins/llama-cpp) for the managed path and
+[llama-server](/providers/llama-server) for the external path.
+
 ### LM Studio
 
 LM Studio ships as a bundled provider plugin which uses the native API:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1549,6 +1549,7 @@
                   "providers/inworld",
                   "providers/kilocode",
                   "providers/litellm",
+                  "providers/llama-server",
                   "providers/lmstudio",
                   "providers/longcat",
                   "providers/meta",

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -1,29 +1,41 @@
 ---
-summary: "Run local GGUF chat and memory embeddings with an OpenClaw-managed llama.cpp server"
+summary: "Run GGUF chat and memory embeddings with managed or external llama.cpp servers"
 read_when:
-  - You want local text inference without an API key or separately managed model server
+  - You want OpenClaw to install and manage a local llama.cpp server
+  - You want OpenClaw to connect to an existing llama-server
   - You want memory search embeddings from a local GGUF model
   - You are configuring memory.search.provider = "local"
-  - You need to inspect or repair OpenClaw's managed llama.cpp server
 title: "llama.cpp Provider"
 sidebarTitle: "llama.cpp Provider"
 ---
 
-The `llama-cpp` plugin manages a loopback-only `llama-server` for local GGUF
-chat and embeddings. OpenClaw installs a pinned, integrity-verified llama.cpp
-release, starts it only when a request needs it, reuses it across concurrent
-chat and embedding requests, and stops it after an idle period.
+The `llama-cpp` plugin supports two llama.cpp server ownership modes. The
+`llama-cpp` provider installs and manages a loopback-only `llama-server` for
+chat and embeddings. The `llama-server` provider connects to an existing server
+that you manage outside OpenClaw.
 
-Install the official plugin before using either local inference or local memory
-embeddings:
+Install the official plugin before using either mode or local memory embeddings:
 
 ```bash
 openclaw plugins install @openclaw/llama-cpp-provider
 ```
 
-## Guided setup
+## Choose a server
 
-Choose **llama.cpp** once during interactive onboarding or configuration.
+Interactive onboarding shows two choices in the **Local llama.cpp** group:
+
+| Choice                | Model reference        | Process owner |
+| --------------------- | ---------------------- | ------------- |
+| Managed local server  | `llama-cpp/<model>`    | OpenClaw      |
+| Existing llama-server | `llama-server/<model>` | User          |
+
+Both providers can be configured at the same time. The external provider
+supports passive model discovery, router status, chat-template capabilities,
+and optional authentication. See [llama-server](/providers/llama-server).
+
+## Managed server setup
+
+Choose **Managed local server** during interactive onboarding or configuration.
 OpenClaw then:
 
 1. Selects the verified llama-server build for the Gateway platform.

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -258,7 +258,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[line](/plugins/reference/line)** (`@openclaw/line`) - npm; ClawHub. OpenClaw LINE channel plugin for LINE Bot API chats.
 
-- **[llama-cpp](/plugins/reference/llama-cpp)** (`@openclaw/llama-cpp-provider`) - npm; ClawHub. Managed local llama.cpp server for GGUF chat and embeddings.
+- **[llama-cpp](/plugins/reference/llama-cpp)** (`@openclaw/llama-cpp-provider`) - npm; ClawHub. Managed and external llama.cpp servers for GGUF chat and embeddings.
 
 - **[lobster](/plugins/reference/lobster)** (`@openclaw/lobster`) - npm; ClawHub. Lobster workflow tool plugin for typed pipelines and resumable approvals.
 

--- a/docs/plugins/reference/llama-cpp.md
+++ b/docs/plugins/reference/llama-cpp.md
@@ -1,5 +1,5 @@
 ---
-summary: "Managed local llama.cpp server for GGUF chat and embeddings."
+summary: "Managed and external llama.cpp servers for GGUF chat and embeddings."
 read_when:
   - You are installing, configuring, or auditing the llama-cpp plugin
 title: "Llama Cpp plugin"
@@ -7,7 +7,7 @@ title: "Llama Cpp plugin"
 
 # Llama Cpp plugin
 
-Managed local llama.cpp server for GGUF chat and embeddings.
+Managed and external llama.cpp servers for GGUF chat and embeddings.
 
 ## Distribution
 
@@ -16,7 +16,7 @@ Managed local llama.cpp server for GGUF chat and embeddings.
 
 ## Surface
 
-providers: `llama-cpp`; contracts: `embeddingProviders`
+providers: `llama-cpp`, `llama-server`; contracts: `embeddingProviders`
 
 <!-- openclaw-plugin-reference:manual-start -->
 
@@ -36,4 +36,5 @@ choose a cloud provider.
 
 ## Related docs
 
+- [llama-server](/providers/llama-server)
 - [llama-cpp](/plugins/llama-cpp)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -53,6 +53,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [inferrs (local models)](/providers/inferrs)
 - [Kilocode](/providers/kilocode)
 - [LiteLLM (unified gateway)](/providers/litellm)
+- [llama-server (external llama.cpp)](/providers/llama-server)
 - [LM Studio (local models)](/providers/lmstudio)
 - [LongCat](/providers/longcat)
 - [MiniMax](/providers/minimax)

--- a/docs/providers/llama-server.md
+++ b/docs/providers/llama-server.md
@@ -75,10 +75,10 @@ Install the `llama-cpp` plugin once for either provider:
 openclaw plugins install @openclaw/llama-cpp-provider
 ```
 
-| Model reference          | Server owner | Setup behavior                    |
-| ------------------------ | ------------ | --------------------------------- |
-| `llama-cpp/<model>`      | OpenClaw     | Installs and manages the runtime  |
-| `llama-server/<model>`   | User         | Connects to an existing endpoint  |
+| Model reference        | Server owner | Setup behavior                   |
+| ---------------------- | ------------ | -------------------------------- |
+| `llama-cpp/<model>`    | OpenClaw     | Installs and manages the runtime |
+| `llama-server/<model>` | User         | Connects to an existing endpoint |
 
 Both providers can be configured at the same time. Use `llama-cpp` when you
 want OpenClaw to manage the process. Use `llama-server` when another terminal,

--- a/docs/providers/llama-server.md
+++ b/docs/providers/llama-server.md
@@ -16,8 +16,9 @@ chat requests through its OpenAI-compatible API.
 
 The same [`llama-cpp` plugin](/plugins/llama-cpp) also provides the managed
 `llama-cpp` provider. The managed provider installs and runs a verified server.
-The external provider described here never installs, starts, stops, downloads,
-or reconfigures anything.
+New external setups never install, start, stop, download, or reconfigure
+anything. Existing configurations with an explicit `localService` block retain
+their previous supervisor behavior for compatibility.
 
 | Property         | Value                             |
 | ---------------- | --------------------------------- |
@@ -150,8 +151,10 @@ openclaw onboard \
 ```
 
 Pass `--llama-server-api-key` or set `LLAMA_SERVER_API_KEY` for an authenticated
-endpoint. Non-interactive setup verifies the endpoint and selected model before
-it writes configuration.
+endpoint. When you replace an existing endpoint, pass `--llama-server-api-key`
+explicitly. OpenClaw does not reuse the previous endpoint's environment,
+profile, header, or configured credentials. Non-interactive setup verifies the
+endpoint and selected model before it writes configuration.
 
 ## Manual configuration
 

--- a/docs/providers/llama-server.md
+++ b/docs/providers/llama-server.md
@@ -1,0 +1,231 @@
+---
+summary: "Connect OpenClaw to an existing llama.cpp llama-server"
+read_when:
+  - You already run llama-server locally or on a private model host
+  - You want automatic model, context, and tool-capability discovery
+  - You use llama-server router mode
+  - You are choosing between managed and external llama.cpp setup
+sidebarTitle: "llama-server"
+title: "llama-server Provider"
+---
+
+`llama-server` is llama.cpp's standalone HTTP server. The `llama-server`
+provider connects OpenClaw to a process that you already run and manage.
+OpenClaw discovers the models and capabilities exposed by the server and sends
+chat requests through its OpenAI-compatible API.
+
+The same [`llama-cpp` plugin](/plugins/llama-cpp) also provides the managed
+`llama-cpp` provider. The managed provider installs and runs a verified server.
+The external provider described here never installs, starts, stops, downloads,
+or reconfigures anything.
+
+| Property         | Value                             |
+| ---------------- | --------------------------------- |
+| Provider ID      | `llama-server`                    |
+| API              | `openai-completions`              |
+| Default base URL | `http://127.0.0.1:8080/v1`        |
+| Authentication   | Optional `LLAMA_SERVER_API_KEY`   |
+| Model discovery  | Model-list and property endpoints |
+| Process owner    | User or external supervisor       |
+
+## Quick start
+
+<Steps>
+  <Step title="Start llama-server">
+    Start an official llama.cpp server with a stable model alias:
+
+    ```bash
+    llama-server \
+      --model /path/to/model.gguf \
+      --alias my-model \
+      --host 127.0.0.1 \
+      --port 8080
+    ```
+
+    Choose the context, GPU, slot, batching, and chat-template flags for your
+    deployment. OpenClaw does not change them.
+
+  </Step>
+  <Step title="Run OpenClaw setup">
+    ```bash
+    openclaw onboard
+    ```
+
+    In the **Local llama.cpp** group, choose **Existing llama-server**. Accept
+    the default URL or enter another local or private endpoint. Leave API-key
+    authentication disabled unless the server or its reverse proxy requires it.
+
+  </Step>
+  <Step title="Select the discovered model">
+    ```bash
+    openclaw models list --provider llama-server
+    openclaw models set llama-server/my-model
+    ```
+  </Step>
+</Steps>
+
+A stable `--alias` keeps the OpenClaw model reference independent of the GGUF
+file path.
+
+## Managed and external providers
+
+Install the `llama-cpp` plugin once for either provider:
+
+```bash
+openclaw plugins install @openclaw/llama-cpp-provider
+```
+
+| Model reference          | Server owner | Setup behavior                    |
+| ------------------------ | ------------ | --------------------------------- |
+| `llama-cpp/<model>`      | OpenClaw     | Installs and manages the runtime  |
+| `llama-server/<model>`   | User         | Connects to an existing endpoint  |
+
+Both providers can be configured at the same time. Use `llama-cpp` when you
+want OpenClaw to manage the process. Use `llama-server` when another terminal,
+container, host manager, or machine owns the process.
+
+`models.providers.llama-server.localService` is not supported. Configure the
+managed `llama-cpp` provider instead when OpenClaw must own the server process.
+
+## Discovery
+
+Discovery reads these endpoints:
+
+- `/health`
+- `/models`, with `/v1/models` as a compatibility fallback
+- `/props` for a single loaded model
+- `/props?model=<id>&autoload=false` in router mode
+
+Discovery does not load, wake, unload, download, or reload a model. Router
+property requests set `autoload=false`, and model-list requests do not set
+`reload=1`.
+
+For each model, OpenClaw uses server metadata for the active context, maximum
+output, input types, slot count, build information, status, and chat-template
+capabilities. It enables tools only when the server reports both
+`supports_tools` and `supports_tool_calls`.
+
+Explicit model entries in `openclaw.json` take priority over discovered rows
+with the same model ID.
+
+## Authentication
+
+Set `LLAMA_SERVER_API_KEY` when llama-server or its reverse proxy requires a
+bearer token:
+
+```bash
+export LLAMA_SERVER_API_KEY="your-key"
+openclaw onboard
+```
+
+Guided setup can save the key in an OpenClaw auth profile. Provider API keys,
+SecretRef values, and explicit authorization headers are also supported. An
+explicit authorization header takes priority over bearer-key resolution.
+
+Do not put credentials in the endpoint URL. OpenClaw rejects URLs that contain
+a username or password.
+
+## Non-interactive setup
+
+An unauthenticated local server needs its URL:
+
+```bash
+openclaw onboard \
+  --non-interactive \
+  --accept-risk \
+  --auth-choice llama-server \
+  --custom-base-url http://127.0.0.1:8080/v1
+```
+
+Select an advertised model explicitly when needed:
+
+```bash
+openclaw onboard \
+  --non-interactive \
+  --accept-risk \
+  --auth-choice llama-server \
+  --custom-base-url http://127.0.0.1:8080/v1 \
+  --custom-model-id my-model
+```
+
+Pass `--llama-server-api-key` or set `LLAMA_SERVER_API_KEY` for an authenticated
+endpoint. Non-interactive setup verifies the endpoint and selected model before
+it writes configuration.
+
+## Manual configuration
+
+Guided setup is recommended because it discovers and verifies model metadata.
+A minimal manual provider has this shape:
+
+```json5
+{
+  models: {
+    mode: "merge",
+    providers: {
+      "llama-server": {
+        baseUrl: "http://127.0.0.1:8080/v1",
+        api: "openai-completions",
+        request: { allowPrivateNetwork: true },
+        models: [],
+      },
+    },
+  },
+}
+```
+
+The private-network option is required for loopback and private endpoints.
+OpenClaw still pins requests to the configured origin and blocks cloud metadata
+and unsafe redirects.
+
+## Troubleshooting
+
+### Server is unavailable
+
+Check the public health and model endpoints:
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8080/models
+```
+
+HTTP 503 from `/health` means the model is still loading. Wait for the external
+process to become ready. OpenClaw does not restart it.
+
+### Tools are disabled
+
+Inspect the active model properties:
+
+```bash
+curl http://127.0.0.1:8080/props
+```
+
+Check `chat_template_caps.supports_tools` and
+`chat_template_caps.supports_tool_calls`. Start llama-server with Jinja enabled
+and a tool-capable template. OpenClaw does not guess tool support from the model
+name.
+
+### Router discovery loaded a model
+
+OpenClaw property requests include `autoload=false`, and model-list requests do
+not include `reload=1`. Check other clients and the server's
+`--models-autoload` setting if a model loads outside an inference request.
+
+### Authentication fails during inference
+
+Health and model-list endpoints can remain public while chat inference requires
+a key. Set `LLAMA_SERVER_API_KEY` to the value expected by llama-server or its
+reverse proxy, then rerun setup or restart the Gateway so it can read the new
+environment value.
+
+### Structured output fails
+
+Use a current official llama.cpp release. OpenClaw sends the standard OpenAI
+`json_schema` response format, which is supported by the managed b10357 server
+and newer releases.
+
+## Related
+
+- [llama.cpp plugin](/plugins/llama-cpp)
+- [Local model services](/gateway/local-model-services)
+- [Model providers](/concepts/model-providers)
+- [LM Studio](/providers/lmstudio)

--- a/docs/providers/llama-server.md
+++ b/docs/providers/llama-server.md
@@ -84,8 +84,9 @@ Both providers can be configured at the same time. Use `llama-cpp` when you
 want OpenClaw to manage the process. Use `llama-server` when another terminal,
 container, host manager, or machine owns the process.
 
-`models.providers.llama-server.localService` is not supported. Configure the
-managed `llama-cpp` provider instead when OpenClaw must own the server process.
+Existing manual `llama-server` configurations that use `localService` continue
+to work. New setups should use the managed `llama-cpp` provider when OpenClaw
+must own the server process.
 
 ## Discovery
 

--- a/docs/providers/llama-server.md
+++ b/docs/providers/llama-server.md
@@ -219,9 +219,9 @@ environment value.
 
 ### Structured output fails
 
-Use a current official llama.cpp release. OpenClaw sends the standard OpenAI
-`json_schema` response format, which is supported by the managed b10357 server
-and newer releases.
+Use a current official llama.cpp release. OpenClaw maps JSON Schema requests to
+llama-server's `json_object` schema shape so structured output also works with
+older external server builds.
 
 ## Related
 

--- a/extensions/llama-cpp/README.md
+++ b/extensions/llama-cpp/README.md
@@ -1,10 +1,12 @@
 # @openclaw/llama-cpp-provider
 
-Official managed llama.cpp provider for OpenClaw GGUF chat and embeddings.
+Official llama.cpp provider for managed and external OpenClaw model servers.
 
-The plugin installs a pinned, integrity-verified `llama-server` and configures
-OpenClaw's existing `localService` supervisor. Model traffic uses the normal
-OpenAI-compatible chat and embedding transports.
+The `llama-cpp` provider installs a pinned, integrity-verified `llama-server`
+and configures OpenClaw's existing `localService` supervisor. The
+`llama-server` provider connects to a server that you already run and discovers
+its models and capabilities. Both use OpenClaw's normal OpenAI-compatible chat
+transport; managed local embeddings stay on `llama-cpp`.
 
 ## Install
 
@@ -12,10 +14,11 @@ OpenAI-compatible chat and embedding transports.
 openclaw plugins install @openclaw/llama-cpp-provider
 ```
 
-Restart the Gateway after installing or updating the plugin, then choose
-**llama.cpp** once during interactive onboarding or configuration.
+Restart the Gateway after installing or updating the plugin. Interactive setup
+shows **Managed local server** and **Existing llama-server** under one
+**Local llama.cpp** group.
 
-## Configure text inference
+## Configure managed text inference
 
 After explicit consent, OpenClaw installs the matching server build and
 downloads Gemma 4 E4B IT Q4_K_M (approximately 5.0 GB) plus EmbeddingGemma
@@ -29,6 +32,15 @@ the managed router preset.
 See the [llama.cpp provider guide](https://docs.openclaw.ai/plugins/llama-cpp)
 for platform requirements, custom GGUF configuration, diagnostics, and repair.
 
+## Connect to an existing server
+
+Choose **Existing llama-server** during setup and enter the endpoint and
+optional API key. OpenClaw passively discovers single-model and router catalogs.
+It never installs, starts, stops, or reconfigures the external process.
+
+See the [llama-server provider guide](https://docs.openclaw.ai/providers/llama-server)
+for authentication, router behavior, manual configuration, and troubleshooting.
+
 ## Configure embeddings
 
 Set `memory.search.provider` to `local`. The plugin preserves the historical
@@ -38,5 +50,6 @@ the managed server's `/v1/embeddings` endpoint.
 ## Package
 
 - Plugin id: `llama-cpp`
+- Provider ids: `llama-cpp`, `llama-server`
 - Package: `@openclaw/llama-cpp-provider`
 - Minimum OpenClaw host: `2026.6.2`

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -80,7 +80,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function registerTextProvider(): ProviderPlugin {
+function registerTextProviders(): ProviderPlugin[] {
   const providers: ProviderPlugin[] = [];
   llamaCppPlugin.register(
     createTestPluginApi({
@@ -93,7 +93,14 @@ function registerTextProvider(): ProviderPlugin {
       registerProvider: (provider) => providers.push(provider),
     }),
   );
-  return expectDefined(providers[0], "llama.cpp provider");
+  return providers;
+}
+
+function registerTextProvider(): ProviderPlugin {
+  return expectDefined(
+    registerTextProviders().find((provider) => provider.id === LLAMA_CPP_PROVIDER_ID),
+    "llama.cpp provider",
+  );
 }
 
 function configuredOptions() {
@@ -132,6 +139,13 @@ function configuredOptions() {
 }
 
 describe("llama.cpp provider plugin", () => {
+  it("registers managed and external providers once", () => {
+    expect(registerTextProviders().map((provider) => provider.id)).toEqual([
+      "llama-cpp",
+      "llama-server",
+    ]);
+  });
+
   it("keeps pre-managed installed provider imports loadable without reviving the old runtime", async () => {
     await expect(createLocalEmbeddingProvider({}, {})).rejects.toThrow(
       "The legacy in-process llama.cpp embedding runtime is retired",

--- a/extensions/llama-cpp/index.ts
+++ b/extensions/llama-cpp/index.ts
@@ -1,88 +1,15 @@
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
-import {
-  LLAMA_CPP_PROVIDER_ID,
-  LLAMA_CPP_PROVIDER_LABEL,
-  buildLlamaCppProviderConfig,
-  resolveLlamaCppSyntheticApiKey,
-} from "./src/defaults.js";
 import { llamaCppEmbeddingProviderAdapter } from "./src/embedding-provider.js";
-import { ensureManagedLlamaServerForChat } from "./src/managed-server.js";
-import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./src/setup.js";
+import { registerExternalLlamaServerProvider } from "./src/external-server/register.js";
+import { registerManagedLlamaCppProvider } from "./src/managed-provider.js";
 
 export default definePluginEntry({
   id: "llama-cpp",
   name: "llama.cpp Provider",
-  description: "Managed local llama.cpp server for GGUF chat and embeddings",
+  description: "Managed and external llama.cpp servers for GGUF chat and embeddings",
   register(api: OpenClawPluginApi) {
     api.registerEmbeddingProvider(llamaCppEmbeddingProviderAdapter);
-    api.registerProvider({
-      id: LLAMA_CPP_PROVIDER_ID,
-      label: LLAMA_CPP_PROVIDER_LABEL,
-      docsPath: "/plugins/llama-cpp",
-      auth: [
-        {
-          id: "local",
-          label: LLAMA_CPP_PROVIDER_LABEL,
-          hint: "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
-          kind: "custom",
-          appGuidedSetup: {
-            detect: detectLlamaCppSetup,
-            prepare: prepareLlamaCppSetup,
-          },
-          run: runLlamaCppSetup,
-        },
-      ],
-      catalog: {
-        order: "late",
-        run: async (ctx) => ({
-          provider: buildLlamaCppProviderConfig(
-            ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID],
-          ),
-        }),
-      },
-      staticCatalog: {
-        order: "late",
-        run: async () => ({ provider: buildLlamaCppProviderConfig() }),
-      },
-      resolveSyntheticAuth: () => ({
-        apiKey: resolveLlamaCppSyntheticApiKey(),
-        source: "managed local llama.cpp server",
-        mode: "api-key" as const,
-      }),
-      wrapStreamFn: (ctx) => {
-        const inner = ctx.streamFn;
-        const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-        const selectedModel = ctx.model;
-        if (!inner || !providerConfig?.localService || !selectedModel) {
-          return undefined;
-        }
-        return async (model, context, options) => {
-          await ensureManagedLlamaServerForChat({
-            provider: providerConfig,
-            model: selectedModel,
-          });
-          return inner(model, context, options);
-        };
-      },
-      ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
-      wizard: {
-        setup: {
-          choiceId: LLAMA_CPP_PROVIDER_ID,
-          choiceLabel: LLAMA_CPP_PROVIDER_LABEL,
-          choiceHint:
-            "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
-          groupId: LLAMA_CPP_PROVIDER_ID,
-          groupLabel: "Local llama.cpp",
-          groupHint: "No API key required",
-          methodId: "local",
-        },
-        modelPicker: {
-          label: "llama.cpp",
-          hint: "Run a GGUF model with OpenClaw's managed local llama.cpp server",
-          methodId: "local",
-        },
-      },
-    });
+    registerManagedLlamaCppProvider(api);
+    registerExternalLlamaServerProvider(api);
   },
 });

--- a/extensions/llama-cpp/openclaw.plugin.json
+++ b/extensions/llama-cpp/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "llama-cpp",
   "name": "llama.cpp Provider",
-  "description": "Managed local llama.cpp server for GGUF chat and embeddings.",
+  "description": "Managed and external llama.cpp servers for GGUF chat and embeddings.",
   "doctorContract": {
     "configRepair": true
   },
@@ -9,11 +9,23 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["llama-cpp"],
+  "autoEnableWhenConfiguredProviders": ["llama-cpp", "llama-server"],
+  "providers": ["llama-cpp", "llama-server"],
+  "modelCatalog": {
+    "discovery": {
+      "llama-server": "refreshable"
+    }
+  },
   "providerRequest": {
     "providers": {
       "llama-cpp": {
         "family": "llama-cpp"
+      },
+      "llama-server": {
+        "family": "llama-server",
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
       }
     }
   },
@@ -21,11 +33,22 @@
     "providers": {
       "llama-cpp": {
         "external": false
+      },
+      "llama-server": {
+        "external": false
       }
     }
   },
-  "syntheticAuthRefs": ["llama-cpp"],
-  "nonSecretAuthMarkers": ["llama-cpp-local"],
+  "syntheticAuthRefs": ["llama-cpp", "llama-server"],
+  "nonSecretAuthMarkers": ["llama-cpp-local", "llama-server-local"],
+  "setup": {
+    "providers": [
+      {
+        "id": "llama-server",
+        "envVars": ["LLAMA_SERVER_API_KEY"]
+      }
+    ]
+  },
   "providerAuthChoices": [
     {
       "provider": "llama-cpp",
@@ -33,11 +56,27 @@
       "choiceId": "llama-cpp",
       "appGuidedDiscovery": true,
       "appGuidedActionLabel": "Set up model",
-      "choiceLabel": "llama.cpp",
+      "choiceLabel": "Managed local server",
       "choiceHint": "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
       "groupId": "llama-cpp",
       "groupLabel": "Local llama.cpp",
-      "groupHint": "No API key required"
+      "groupHint": "Managed or external llama.cpp server"
+    },
+    {
+      "provider": "llama-server",
+      "method": "custom",
+      "choiceId": "llama-server",
+      "appGuidedDiscovery": true,
+      "appGuidedSecret": true,
+      "choiceLabel": "Existing llama-server",
+      "choiceHint": "Connect to a llama.cpp server managed outside OpenClaw",
+      "groupId": "llama-cpp",
+      "groupLabel": "Local llama.cpp",
+      "groupHint": "Managed or external llama.cpp server",
+      "optionKey": "llamaServerApiKey",
+      "cliFlag": "--llama-server-api-key",
+      "cliOption": "--llama-server-api-key <key>",
+      "cliDescription": "llama-server API key"
     }
   ],
   "contracts": {

--- a/extensions/llama-cpp/package.json
+++ b/extensions/llama-cpp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/llama-cpp-provider",
   "version": "2026.8.1",
-  "description": "OpenClaw managed llama.cpp server provider plugin",
+  "description": "OpenClaw provider for managed and external llama.cpp servers",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/llama-cpp/src/external-server/auth.test.ts
+++ b/extensions/llama-cpp/src/external-server/auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLlamaServerAuthHeaders,
+  hasLlamaServerAuthorizationHeader,
+  resolveLlamaServerProviderHeaders,
+  shouldUseLlamaServerSyntheticAuth,
+} from "./auth.js";
+
+describe("llama-server auth", () => {
+  it("uses synthetic runtime auth for no-auth and header-only providers", () => {
+    expect(
+      shouldUseLlamaServerSyntheticAuth({ baseUrl: "http://localhost:8080/v1", models: [] }),
+    ).toBe(true);
+    expect(
+      shouldUseLlamaServerSyntheticAuth({
+        baseUrl: "http://localhost:8080/v1",
+        headers: { authorization: "Bearer proxy-token" },
+        models: [],
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseLlamaServerSyntheticAuth({
+        baseUrl: "http://localhost:8080/v1",
+        apiKey: "server-key",
+        models: [],
+      }),
+    ).toBe(false);
+    expect(hasLlamaServerAuthorizationHeader({ authorization: "Bearer proxy-token" })).toBe(true);
+  });
+
+  it("preserves configured headers unless a real API key replaces authorization", () => {
+    expect(
+      buildLlamaServerAuthHeaders(undefined, {
+        Authorization: "Bearer proxy-token",
+        "X-Tenant": "one",
+      }),
+    ).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer proxy-token",
+      "X-Tenant": "one",
+    });
+    expect(
+      buildLlamaServerAuthHeaders("server-key", {
+        authorization: "Bearer proxy-token",
+        "X-Tenant": "one",
+      }),
+    ).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer server-key",
+      "X-Tenant": "one",
+    });
+  });
+
+  it("resolves provider header templates for discovery", async () => {
+    const config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            headers: { "X-Proxy-Key": "${LLAMA_PROXY_TOKEN}" },
+            models: [],
+          },
+        },
+      },
+    };
+    await expect(
+      resolveLlamaServerProviderHeaders({
+        config,
+        env: { LLAMA_PROXY_TOKEN: "proxy-token" },
+        headers: config.models.providers["llama-server"].headers,
+      }),
+    ).resolves.toEqual({ "X-Proxy-Key": "proxy-token" });
+  });
+});

--- a/extensions/llama-cpp/src/external-server/auth.ts
+++ b/extensions/llama-cpp/src/external-server/auth.ts
@@ -1,0 +1,102 @@
+import {
+  CUSTOM_LOCAL_AUTH_MARKER,
+  hasConfiguredSecretInput,
+  isNonSecretApiKeyMarker,
+  normalizeOptionalSecretInput,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import { LLAMA_SERVER_LOCAL_AUTH_MARKER, LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+
+export function hasLlamaServerAuthorizationHeader(headers: unknown): boolean {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return false;
+  }
+  return Object.entries(headers).some(
+    ([name, value]) =>
+      name.trim().toLowerCase() === "authorization" && hasConfiguredSecretInput(value),
+  );
+}
+
+export function shouldUseLlamaServerSyntheticAuth(
+  providerConfig: ModelProviderConfig | undefined,
+): boolean {
+  const apiKey = normalizeOptionalSecretInput(providerConfig?.apiKey)?.trim();
+  const hasRealApiKey =
+    hasConfiguredSecretInput(providerConfig?.apiKey) &&
+    apiKey !== LLAMA_SERVER_LOCAL_AUTH_MARKER &&
+    apiKey !== CUSTOM_LOCAL_AUTH_MARKER;
+  return !hasRealApiKey;
+}
+
+export function buildLlamaServerAuthHeaders(
+  apiKey?: string,
+  configuredHeaders?: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...configuredHeaders,
+  };
+  const normalized = apiKey?.trim();
+  if (normalized && !isNonSecretApiKeyMarker(normalized)) {
+    for (const name of Object.keys(headers)) {
+      if (name.trim().toLowerCase() === "authorization") {
+        delete headers[name];
+      }
+    }
+    headers.Authorization = `Bearer ${normalized}`;
+  }
+  return headers;
+}
+
+export async function resolveLlamaServerProviderHeaders(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  headers?: unknown;
+}): Promise<Record<string, string> | undefined> {
+  if (!params.headers || typeof params.headers !== "object" || Array.isArray(params.headers)) {
+    return undefined;
+  }
+  const resolved: Record<string, string> = {};
+  for (const [name, value] of Object.entries(params.headers)) {
+    if (!params.config) {
+      if (typeof value === "string" && value.trim()) {
+        resolved[name] = value.trim();
+      }
+      continue;
+    }
+    const path = `models.providers.${LLAMA_SERVER_PROVIDER_ID}.headers.${name}`;
+    const header = await resolveConfiguredSecretInputString({
+      config: params.config,
+      env: params.env ?? process.env,
+      value,
+      path,
+      unresolvedReasonStyle: "detailed",
+    });
+    if (header.unresolvedRefReason) {
+      throw new Error(`${path}: ${header.unresolvedRefReason}`);
+    }
+    if (header.value) {
+      resolved[name] = header.value;
+    }
+  }
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
+export async function resolveLlamaServerRuntimeApiKey(params: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+  profileId?: string;
+}): Promise<string | undefined> {
+  const auth = await resolveApiKeyForProvider({
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    cfg: params.config,
+    agentDir: params.agentDir,
+    profileId: params.profileId,
+    lockedProfile: params.profileId !== undefined,
+  });
+  const apiKey = auth.apiKey?.trim();
+  return apiKey && !isNonSecretApiKeyMarker(apiKey) ? apiKey : undefined;
+}

--- a/extensions/llama-cpp/src/external-server/defaults.ts
+++ b/extensions/llama-cpp/src/external-server/defaults.ts
@@ -1,0 +1,8 @@
+export const LLAMA_SERVER_PROVIDER_ID = "llama-server";
+export const LLAMA_SERVER_PROVIDER_LABEL = "llama-server";
+export const LLAMA_SERVER_DEFAULT_ORIGIN = "http://127.0.0.1:8080";
+export const LLAMA_SERVER_DEFAULT_BASE_URL = `${LLAMA_SERVER_DEFAULT_ORIGIN}/v1`;
+export const LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR = "LLAMA_SERVER_API_KEY";
+export const LLAMA_SERVER_LOCAL_AUTH_MARKER = "llama-server-local";
+export const LLAMA_SERVER_DISCOVERY_TIMEOUT_MS = 5_000;
+export const LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS = 30_000;

--- a/extensions/llama-cpp/src/external-server/defaults.ts
+++ b/extensions/llama-cpp/src/external-server/defaults.ts
@@ -1,7 +1,6 @@
 export const LLAMA_SERVER_PROVIDER_ID = "llama-server";
 export const LLAMA_SERVER_PROVIDER_LABEL = "llama-server";
 export const LLAMA_SERVER_DEFAULT_ORIGIN = "http://127.0.0.1:8080";
-export const LLAMA_SERVER_DEFAULT_BASE_URL = `${LLAMA_SERVER_DEFAULT_ORIGIN}/v1`;
 export const LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR = "LLAMA_SERVER_API_KEY";
 export const LLAMA_SERVER_LOCAL_AUTH_MARKER = "llama-server-local";
 export const LLAMA_SERVER_DISCOVERY_TIMEOUT_MS = 5_000;

--- a/extensions/llama-cpp/src/external-server/discovery.test.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  clearLlamaServerDiscoveryCacheForTests,
-  discoverLlamaServer,
-  type LlamaServerFetchGuard,
-} from "./discovery.js";
+import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { discoverLlamaServer } from "./discovery.js";
+
+type LlamaServerFetchGuard = typeof fetchWithSsrFGuard;
+type DiscoveryParams = Parameters<typeof discoverLlamaServer>[0];
+
+async function discoverTest(params: DiscoveryParams) {
+  return await discoverLlamaServer({ cacheTtlMs: 0, ...params });
+}
 
 type RouteValue = Response | Error | (() => Response | Promise<Response>);
 
@@ -36,10 +40,6 @@ function json(value: unknown, status = 200): Response {
 }
 
 describe("llama-server discovery", () => {
-  beforeEach(() => {
-    clearLlamaServerDiscoveryCacheForTests();
-  });
-
   it("discovers a single model and reads runtime properties", async () => {
     const { guard, requests } = createFetchGuard({
       "http://localhost:8080/health": json({ status: "ok" }),
@@ -53,7 +53,7 @@ describe("llama-server discovery", () => {
       }),
     });
 
-    const result = await discoverLlamaServer({
+    const result = await discoverTest({
       baseUrl: "http://localhost:8080/v1",
       apiKey: "server-key",
       fetchGuard: guard,
@@ -110,7 +110,7 @@ describe("llama-server discovery", () => {
       }),
     });
 
-    const result = await discoverLlamaServer({
+    const result = await discoverTest({
       baseUrl: "http://localhost:8080",
       fetchGuard: guard,
       cacheTtlMs: 0,
@@ -157,7 +157,7 @@ describe("llama-server discovery", () => {
     }
     const { guard } = createFetchGuard(routes);
 
-    const result = await discoverLlamaServer({
+    const result = await discoverTest({
       baseUrl: "http://localhost:8080",
       fetchGuard: guard,
       cacheTtlMs: 0,
@@ -190,7 +190,7 @@ describe("llama-server discovery", () => {
     }
     const { guard, requests } = createFetchGuard(routes);
 
-    const result = await discoverLlamaServer({
+    const result = await discoverTest({
       baseUrl: "http://localhost:8080",
       fetchGuard: guard,
       cacheTtlMs: 0,
@@ -270,7 +270,7 @@ describe("llama-server discovery", () => {
     });
 
     for (let index = 0; index < 2; index += 1) {
-      await discoverLlamaServer({
+      await discoverTest({
         baseUrl: "http://localhost:8080",
         headers: { "X-Proxy-Key": "proxy-token" },
         fetchGuard: guard,
@@ -298,15 +298,17 @@ describe("llama-server discovery", () => {
       "http://localhost:8080/models": json({ data: [] }),
     });
 
-    await discoverLlamaServer({
+    await discoverTest({
       baseUrl: "http://localhost:8080",
       apiKey: "custom-local",
       fetchGuard: guard,
+      cacheTtlMs: 30_000,
     });
-    await discoverLlamaServer({
+    await discoverTest({
       baseUrl: "http://localhost:8080",
       apiKey: "custom-local",
       fetchGuard: guard,
+      cacheTtlMs: 30_000,
     });
     expect(guard).toHaveBeenCalledTimes(2);
   });
@@ -319,25 +321,28 @@ describe("llama-server discovery", () => {
     })) as unknown as LlamaServerFetchGuard;
 
     for (let index = 0; index <= 100; index += 1) {
-      await discoverLlamaServer({
+      await discoverTest({
         baseUrl: `http://localhost:${10_000 + index}`,
         apiKey: "custom-local",
         fetchGuard: guard,
+        cacheTtlMs: 30_000,
       });
     }
     expect(guard).toHaveBeenCalledTimes(202);
 
-    await discoverLlamaServer({
+    await discoverTest({
       baseUrl: "http://localhost:10100",
       apiKey: "custom-local",
       fetchGuard: guard,
+      cacheTtlMs: 30_000,
     });
     expect(guard).toHaveBeenCalledTimes(202);
 
-    await discoverLlamaServer({
+    await discoverTest({
       baseUrl: "http://localhost:10000",
       apiKey: "custom-local",
       fetchGuard: guard,
+      cacheTtlMs: 30_000,
     });
     expect(guard).toHaveBeenCalledTimes(204);
   });

--- a/extensions/llama-cpp/src/external-server/discovery.test.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLlamaServerDiscoveryCacheForTests,
+  discoverLlamaServer,
+  type LlamaServerFetchGuard,
+} from "./discovery.js";
+
+type RouteValue = Response | Error | (() => Response | Promise<Response>);
+
+function createFetchGuard(routes: Record<string, RouteValue>) {
+  const requests: string[] = [];
+  const guard = vi.fn(async (params: Parameters<LlamaServerFetchGuard>[0]) => {
+    requests.push(params.url);
+    const route = routes[params.url];
+    if (!route) {
+      throw new Error(`unexpected request: ${params.url}`);
+    }
+    if (route instanceof Error) {
+      throw route;
+    }
+    const response = typeof route === "function" ? await route() : route;
+    return {
+      response,
+      finalUrl: params.url,
+      release: async () => undefined,
+    };
+  }) as unknown as LlamaServerFetchGuard;
+  return { guard, requests };
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("llama-server discovery", () => {
+  beforeEach(() => {
+    clearLlamaServerDiscoveryCacheForTests();
+  });
+
+  it("discovers a single model and reads runtime properties", async () => {
+    const { guard, requests } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({
+        object: "list",
+        data: [{ id: "qwen/model:Q4_K_M", object: "model", owned_by: "llamacpp" }],
+      }),
+      "http://localhost:8080/props": json({
+        default_generation_settings: { n_ctx: 32768 },
+        chat_template_caps: { supports_tools: true, supports_tool_calls: true },
+      }),
+    });
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080/v1",
+      apiKey: "server-key",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+    });
+
+    expect(result).toMatchObject({
+      kind: "success",
+      health: "ready",
+      models: [
+        {
+          status: "unknown",
+          config: {
+            id: "qwen/model:Q4_K_M",
+            contextWindow: 32768,
+            compat: { supportsTools: true },
+          },
+        },
+      ],
+    });
+    expect(requests).toEqual([
+      "http://localhost:8080/health",
+      "http://localhost:8080/models",
+      "http://localhost:8080/props",
+    ]);
+    expect(guard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        init: {
+          headers: {
+            Accept: "application/json",
+            Authorization: "Bearer server-key",
+          },
+        },
+      }),
+    );
+  });
+
+  it("lists router models without loading an unloaded model", async () => {
+    const { guard, requests } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({
+        data: [
+          { id: "loaded/model", object: "model", status: { value: "loaded" } },
+          { id: "sleeping:model", object: "model", status: { value: "sleeping" } },
+          { id: "unloaded/model", object: "model", status: { value: "unloaded" } },
+        ],
+      }),
+      "http://localhost:8080/props?model=loaded%2Fmodel&autoload=false": json({
+        default_generation_settings: { n_ctx: 16384 },
+      }),
+      "http://localhost:8080/props?model=sleeping%3Amodel&autoload=false": json({
+        default_generation_settings: { n_ctx: 8192 },
+        is_sleeping: true,
+      }),
+    });
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+    });
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") {
+      throw new Error("expected successful discovery");
+    }
+    expect(result.models.map((model) => [model.config.id, model.status])).toEqual([
+      ["loaded/model", "loaded"],
+      ["sleeping:model", "sleeping"],
+      ["unloaded/model", "unloaded"],
+    ]);
+    expect(requests).not.toContain(
+      "http://localhost:8080/props?model=unloaded%2Fmodel&autoload=false",
+    );
+    expect(requests.every((url) => !url.includes("reload=1"))).toBe(true);
+  });
+
+  it("bounds concurrent router property probes", async () => {
+    const rows = Array.from({ length: 17 }, (_, index) => ({
+      id: `loaded/model-${index}`,
+      object: "model",
+      status: { value: "loaded" },
+    }));
+    let active = 0;
+    let maximumActive = 0;
+    const routes: Record<string, RouteValue> = {
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: rows }),
+    };
+    for (const row of rows) {
+      routes[`http://localhost:8080/props?model=${encodeURIComponent(row.id)}&autoload=false`] =
+        async () => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          await new Promise((resolve) => {
+            setTimeout(resolve, 5);
+          });
+          active -= 1;
+          return json({ default_generation_settings: { n_ctx: 8192 } });
+        };
+    }
+    const { guard } = createFetchGuard(routes);
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+    });
+
+    expect(result).toMatchObject({ kind: "success", models: expect.any(Array) });
+    expect(result.kind === "success" ? result.models : []).toHaveLength(17);
+    expect(maximumActive).toBeGreaterThan(1);
+    expect(maximumActive).toBeLessThanOrEqual(8);
+  });
+
+  it("stops scheduling router property probes after the total budget", async () => {
+    const rows = Array.from({ length: 17 }, (_, index) => ({
+      id: `loaded/model-${index}`,
+      object: "model",
+      status: { value: "loaded" },
+    }));
+    const routes: Record<string, RouteValue> = {
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: rows }),
+    };
+    for (const row of rows) {
+      routes[`http://localhost:8080/props?model=${encodeURIComponent(row.id)}&autoload=false`] =
+        async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+          });
+          return json({ default_generation_settings: { n_ctx: 8192 } });
+        };
+    }
+    const { guard, requests } = createFetchGuard(routes);
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+      timeoutMs: 10,
+    });
+
+    expect(result.kind === "success" ? result.models : []).toHaveLength(17);
+    expect(requests.filter((url) => url.includes("/props?"))).toHaveLength(8);
+  });
+
+  it("falls back to /v1/models for an older compatible server", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ error: "missing" }, 404),
+      "http://localhost:8080/v1/models": json({
+        data: [{ id: "model", object: "model" }],
+      }),
+      "http://localhost:8080/props": json({}),
+    });
+
+    await expect(
+      discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard, cacheTtlMs: 0 }),
+    ).resolves.toMatchObject({ kind: "success", models: [{ config: { id: "model" } }] });
+  });
+
+  it("keeps a loading health state while listing available models", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ error: "loading" }, 503),
+      "http://localhost:8080/models": json({ data: [] }),
+    });
+
+    await expect(
+      discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard, cacheTtlMs: 0 }),
+    ).resolves.toMatchObject({ kind: "success", health: "loading", models: [] });
+  });
+
+  it("separates transport, HTTP, and malformed-response failures", async () => {
+    const unreachable = createFetchGuard({
+      "http://localhost:8080/health": new Error("connection refused"),
+    });
+    await expect(
+      discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        fetchGuard: unreachable.guard,
+        cacheTtlMs: 0,
+      }),
+    ).resolves.toMatchObject({ kind: "unreachable" });
+
+    const unauthorized = createFetchGuard({
+      "http://localhost:8080/health": json({ error: "unauthorized" }, 401),
+    });
+    await expect(
+      discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        fetchGuard: unauthorized.guard,
+        cacheTtlMs: 0,
+      }),
+    ).resolves.toMatchObject({ kind: "http-error", status: 401, path: "/health" });
+
+    const malformed = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": new Response("{", { status: 200 }),
+    });
+    await expect(
+      discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        fetchGuard: malformed.guard,
+        cacheTtlMs: 0,
+      }),
+    ).resolves.toMatchObject({ kind: "invalid-response", path: "/models" });
+  });
+
+  it("forwards configured headers and bypasses the shared cache for credentialed discovery", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": () => json({ status: "ok" }),
+      "http://localhost:8080/models": () => json({ data: [] }),
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      await discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        headers: { "X-Proxy-Key": "proxy-token" },
+        fetchGuard: guard,
+      });
+    }
+
+    expect(guard).toHaveBeenCalledTimes(4);
+    for (const call of vi.mocked(guard).mock.calls) {
+      expect(call[0]).toEqual(
+        expect.objectContaining({
+          init: {
+            headers: {
+              Accept: "application/json",
+              "X-Proxy-Key": "proxy-token",
+            },
+          },
+        }),
+      );
+    }
+  });
+
+  it("reuses only successful cached discovery", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: [] }),
+    });
+
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds cached endpoint discovery", async () => {
+    const guard = vi.fn(async (params: Parameters<LlamaServerFetchGuard>[0]) => ({
+      response: params.url.endsWith("/health") ? json({ status: "ok" }) : json({ data: [] }),
+      finalUrl: params.url,
+      release: async () => undefined,
+    })) as unknown as LlamaServerFetchGuard;
+
+    for (let index = 0; index <= 100; index += 1) {
+      await discoverLlamaServer({
+        baseUrl: `http://localhost:${10_000 + index}`,
+        apiKey: "custom-local",
+        fetchGuard: guard,
+      });
+    }
+    expect(guard).toHaveBeenCalledTimes(202);
+
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:10100",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    expect(guard).toHaveBeenCalledTimes(202);
+
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:10000",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    expect(guard).toHaveBeenCalledTimes(204);
+  });
+});

--- a/extensions/llama-cpp/src/external-server/discovery.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.ts
@@ -1,0 +1,351 @@
+import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import { buildLlamaServerAuthHeaders } from "./auth.js";
+import {
+  LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS,
+  LLAMA_SERVER_DISCOVERY_TIMEOUT_MS,
+} from "./defaults.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+import {
+  mapLlamaServerModel,
+  type LlamaServerDiscoveredModel,
+  type LlamaServerModelWire,
+  type LlamaServerPropsWire,
+} from "./models.js";
+
+export type LlamaServerHealth = "ready" | "loading" | "unknown";
+
+export type LlamaServerDiscoveryResult =
+  | {
+      kind: "success";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      health: LlamaServerHealth;
+      models: LlamaServerDiscoveredModel[];
+      fetchedAt: number;
+    }
+  | {
+      kind: "unreachable";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      error: unknown;
+    }
+  | {
+      kind: "http-error";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      status: number;
+      path: string;
+    }
+  | {
+      kind: "invalid-response";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      path: string;
+      error: unknown;
+    };
+
+export type LlamaServerFetchGuard = typeof fetchWithSsrFGuard;
+
+type FetchJsonResult =
+  | { kind: "response"; status: number; ok: boolean; body?: unknown }
+  | { kind: "unreachable"; error: unknown }
+  | { kind: "invalid-response"; error: unknown };
+
+type CachedDiscovery = {
+  expiresAt: number;
+  result: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
+};
+
+const discoveryCache = new Map<string, CachedDiscovery>();
+const LLAMA_SERVER_DISCOVERY_CACHE_MAX_ENTRIES = 100;
+const LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS = 200;
+const LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY = 8;
+
+function cacheDiscovery(key: string, entry: CachedDiscovery, now: number): void {
+  for (const [cachedKey, cached] of discoveryCache) {
+    if (cached.expiresAt <= now) {
+      discoveryCache.delete(cachedKey);
+    }
+  }
+  discoveryCache.delete(key);
+  discoveryCache.set(key, entry);
+  while (discoveryCache.size > LLAMA_SERVER_DISCOVERY_CACHE_MAX_ENTRIES) {
+    const oldest = discoveryCache.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    discoveryCache.delete(oldest.value);
+  }
+}
+
+export function clearLlamaServerDiscoveryCacheForTests(): void {
+  discoveryCache.clear();
+}
+
+async function fetchJson(params: {
+  url: string;
+  origin: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  readBody: boolean;
+  fetchGuard: LlamaServerFetchGuard;
+}): Promise<FetchJsonResult> {
+  let guarded: Awaited<ReturnType<LlamaServerFetchGuard>>;
+  try {
+    guarded = await params.fetchGuard({
+      url: params.url,
+      init: { headers: buildLlamaServerAuthHeaders(params.apiKey, params.headers) },
+      timeoutMs: params.timeoutMs,
+      signal: params.signal,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(params.origin),
+      auditContext: "llama-server-discovery",
+    });
+  } catch (error) {
+    return { kind: "unreachable", error };
+  }
+
+  try {
+    if (!params.readBody || !guarded.response.ok) {
+      return {
+        kind: "response",
+        status: guarded.response.status,
+        ok: guarded.response.ok,
+      };
+    }
+    try {
+      return {
+        kind: "response",
+        status: guarded.response.status,
+        ok: true,
+        body: await readProviderJsonResponse(guarded.response, "llama-server discovery"),
+      };
+    } catch (error) {
+      return { kind: "invalid-response", error };
+    }
+  } finally {
+    if (!guarded.response.bodyUsed) {
+      await guarded.response.body?.cancel().catch(() => undefined);
+    }
+    await guarded.release();
+  }
+}
+
+function readModelRows(body: unknown): LlamaServerModelWire[] {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("llama-server model list must be an object");
+  }
+  const data = (body as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error("llama-server model list must contain data[]");
+  }
+  return data.filter(
+    (entry): entry is LlamaServerModelWire =>
+      Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+  );
+}
+
+function shouldReadProps(row: LlamaServerModelWire): boolean {
+  const status = row.status?.value;
+  return status === undefined || status === "loaded" || status === "sleeping";
+}
+
+async function readModelProps(params: {
+  row: LlamaServerModelWire;
+  routerMode: boolean;
+  origin: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  fetchGuard: LlamaServerFetchGuard;
+}): Promise<LlamaServerPropsWire | undefined> {
+  if (!shouldReadProps(params.row) || typeof params.row.id !== "string") {
+    return undefined;
+  }
+  const query = params.routerMode
+    ? `?model=${encodeURIComponent(params.row.id)}&autoload=false`
+    : "";
+  const result = await fetchJson({
+    url: `${params.origin}/props${query}`,
+    origin: params.origin,
+    apiKey: params.apiKey,
+    headers: params.headers,
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+    readBody: true,
+    fetchGuard: params.fetchGuard,
+  });
+  return result.kind === "response" && result.ok
+    ? (result.body as LlamaServerPropsWire)
+    : undefined;
+}
+
+/** Discovers llama-server models without loading, waking, or unloading them. */
+export async function discoverLlamaServer(params: {
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  cacheTtlMs?: number;
+  signal?: AbortSignal;
+  fetchGuard?: LlamaServerFetchGuard;
+}): Promise<LlamaServerDiscoveryResult> {
+  const endpoint = resolveLlamaServerEndpoint(params.baseUrl);
+  const normalizedApiKey = params.apiKey?.trim();
+  const hasCredentialScope =
+    Boolean(normalizedApiKey && !isNonSecretApiKeyMarker(normalizedApiKey)) ||
+    Boolean(params.headers && Object.keys(params.headers).length > 0);
+  const cacheTtlMs = hasCredentialScope
+    ? 0
+    : Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
+  const cached = discoveryCache.get(endpoint.origin);
+  if (cacheTtlMs > 0 && cached) {
+    if (cached.expiresAt > Date.now()) {
+      return cached.result;
+    }
+    discoveryCache.delete(endpoint.origin);
+  }
+
+  const timeoutMs = params.timeoutMs ?? LLAMA_SERVER_DISCOVERY_TIMEOUT_MS;
+  const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
+  const healthResult = await fetchJson({
+    url: `${endpoint.origin}/health`,
+    origin: endpoint.origin,
+    apiKey: params.apiKey,
+    headers: params.headers,
+    timeoutMs,
+    signal: params.signal,
+    readBody: false,
+    fetchGuard,
+  });
+  if (healthResult.kind === "unreachable") {
+    return { kind: "unreachable", endpoint, error: healthResult.error };
+  }
+  const health: LlamaServerHealth =
+    healthResult.kind === "response" && healthResult.status === 200
+      ? "ready"
+      : healthResult.kind === "response" && healthResult.status === 503
+        ? "loading"
+        : "unknown";
+  if (
+    healthResult.kind === "response" &&
+    healthResult.status !== 200 &&
+    healthResult.status !== 404 &&
+    healthResult.status !== 503
+  ) {
+    return {
+      kind: "http-error",
+      endpoint,
+      status: healthResult.status,
+      path: "/health",
+    };
+  }
+
+  let modelsPath = "/models";
+  let modelsResult = await fetchJson({
+    url: `${endpoint.origin}${modelsPath}`,
+    origin: endpoint.origin,
+    apiKey: params.apiKey,
+    headers: params.headers,
+    timeoutMs,
+    signal: params.signal,
+    readBody: true,
+    fetchGuard,
+  });
+  if (modelsResult.kind === "response" && modelsResult.status === 404) {
+    modelsPath = "/v1/models";
+    modelsResult = await fetchJson({
+      url: `${endpoint.origin}${modelsPath}`,
+      origin: endpoint.origin,
+      apiKey: params.apiKey,
+      headers: params.headers,
+      timeoutMs,
+      signal: params.signal,
+      readBody: true,
+      fetchGuard,
+    });
+  }
+  if (modelsResult.kind === "unreachable") {
+    return { kind: "unreachable", endpoint, error: modelsResult.error };
+  }
+  if (modelsResult.kind === "invalid-response") {
+    return {
+      kind: "invalid-response",
+      endpoint,
+      path: modelsPath,
+      error: modelsResult.error,
+    };
+  }
+  if (!modelsResult.ok) {
+    return {
+      kind: "http-error",
+      endpoint,
+      status: modelsResult.status,
+      path: modelsPath,
+    };
+  }
+
+  let rows: LlamaServerModelWire[];
+  try {
+    rows = readModelRows(modelsResult.body);
+  } catch (error) {
+    return { kind: "invalid-response", endpoint, path: modelsPath, error };
+  }
+  const routerMode = rows.some((row) => row.status !== undefined);
+  const propsByRowIndex = new Map<number, LlamaServerPropsWire>();
+  const propsDeadline = Date.now() + Math.max(0, timeoutMs);
+  const propsRowIndexes = rows
+    .map((row, index) => (shouldReadProps(row) ? index : -1))
+    .filter((index) => index >= 0)
+    .slice(0, LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS);
+  for (
+    let offset = 0;
+    offset < propsRowIndexes.length;
+    offset += LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY
+  ) {
+    const remainingMs = propsDeadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    const results = await Promise.all(
+      propsRowIndexes
+        .slice(offset, offset + LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY)
+        .map(async (index) => {
+          const row = rows[index];
+          if (!row) {
+            return undefined;
+          }
+          const props = await readModelProps({
+            row,
+            routerMode,
+            origin: endpoint.origin,
+            apiKey: params.apiKey,
+            headers: params.headers,
+            timeoutMs: Math.min(timeoutMs, remainingMs),
+            signal: params.signal,
+            fetchGuard,
+          });
+          return props ? ([index, props] as const) : undefined;
+        }),
+    );
+    for (const result of results) {
+      if (result) {
+        propsByRowIndex.set(...result);
+      }
+    }
+  }
+  const models = rows.flatMap((row, index) => {
+    const model = mapLlamaServerModel(row, propsByRowIndex.get(index));
+    return model ? [model] : [];
+  });
+
+  const fetchedAt = Date.now();
+  const result = { kind: "success", endpoint, health, models, fetchedAt } as const;
+  if (cacheTtlMs > 0) {
+    cacheDiscovery(endpoint.origin, { result, expiresAt: fetchedAt + cacheTtlMs }, fetchedAt);
+  }
+  return result;
+}

--- a/extensions/llama-cpp/src/external-server/discovery.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.ts
@@ -4,6 +4,7 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
 } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { buildLlamaServerAuthHeaders } from "./auth.js";
 import {
   LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS,
@@ -17,7 +18,7 @@ import {
   type LlamaServerPropsWire,
 } from "./models.js";
 
-export type LlamaServerHealth = "ready" | "loading" | "unknown";
+type LlamaServerHealth = "ready" | "loading" | "unknown";
 
 export type LlamaServerDiscoveryResult =
   | {
@@ -45,7 +46,7 @@ export type LlamaServerDiscoveryResult =
       error: unknown;
     };
 
-export type LlamaServerFetchGuard = typeof fetchWithSsrFGuard;
+type LlamaServerFetchGuard = typeof fetchWithSsrFGuard;
 
 type FetchJsonResult =
   | { kind: "response"; status: number; ok: boolean; body?: unknown }
@@ -77,10 +78,6 @@ function cacheDiscovery(key: string, entry: CachedDiscovery, now: number): void 
     }
     discoveryCache.delete(oldest.value);
   }
-}
-
-export function clearLlamaServerDiscoveryCacheForTests(): void {
-  discoveryCache.clear();
 }
 
 async function fetchJson(params: {
@@ -134,10 +131,10 @@ async function fetchJson(params: {
 }
 
 function readModelRows(body: unknown): LlamaServerModelWire[] {
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
+  if (!isRecord(body)) {
     throw new Error("llama-server model list must be an object");
   }
-  const data = (body as { data?: unknown }).data;
+  const data = body.data;
   if (!Array.isArray(data)) {
     throw new Error("llama-server model list must contain data[]");
   }
@@ -178,9 +175,7 @@ async function readModelProps(params: {
     readBody: true,
     fetchGuard: params.fetchGuard,
   });
-  return result.kind === "response" && result.ok
-    ? (result.body as LlamaServerPropsWire)
-    : undefined;
+  return result.kind === "response" && result.ok && isRecord(result.body) ? result.body : undefined;
 }
 
 /** Discovers llama-server models without loading, waking, or unloading them. */

--- a/extensions/llama-cpp/src/external-server/endpoint.test.ts
+++ b/extensions/llama-cpp/src/external-server/endpoint.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLlamaServerProviderConfig, resolveLlamaServerEndpoint } from "./endpoint.js";
+
+describe("llama-server endpoint", () => {
+  it.each([
+    ["http://127.0.0.1:8080", "http://127.0.0.1:8080", "http://127.0.0.1:8080/v1"],
+    ["http://127.0.0.1:8080/v1/", "http://127.0.0.1:8080", "http://127.0.0.1:8080/v1"],
+    ["localhost:8010/v1", "http://localhost:8010", "http://localhost:8010/v1"],
+    [
+      "https://models.example.com/llama/v1",
+      "https://models.example.com/llama",
+      "https://models.example.com/llama/v1",
+    ],
+  ])("normalizes %s", (input, origin, inferenceBaseUrl) => {
+    expect(resolveLlamaServerEndpoint(input)).toEqual({ origin, inferenceBaseUrl });
+  });
+
+  it("rejects embedded credentials", () => {
+    const endpoint = new URL("http://localhost:8080/v1");
+    endpoint.username = "user";
+    endpoint.password = "secret";
+    expect(() => resolveLlamaServerEndpoint(endpoint.toString())).toThrow(
+      "must not contain credentials",
+    );
+  });
+
+  it("rejects non-HTTP schemes", () => {
+    expect(() => resolveLlamaServerEndpoint("ftp://localhost:8080/v1")).toThrow(
+      "Unsupported llama-server protocol",
+    );
+  });
+
+  it("normalizes provider transport and private-network request policy", () => {
+    expect(
+      normalizeLlamaServerProviderConfig({
+        baseUrl: "http://localhost:8080/",
+        api: "openai-responses",
+        models: [],
+      }),
+    ).toEqual({
+      baseUrl: "http://localhost:8080/v1",
+      api: "openai-completions",
+      models: [],
+      request: { allowPrivateNetwork: true },
+    });
+  });
+
+  it("rejects local service ownership", () => {
+    expect(() =>
+      normalizeLlamaServerProviderConfig({
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+        models: [],
+        localService: {
+          command: "/usr/local/bin/llama-server",
+          healthUrl: "http://localhost:8080/health",
+        },
+      }),
+    ).toThrow("use the llama-cpp provider when OpenClaw should manage the server");
+  });
+});

--- a/extensions/llama-cpp/src/external-server/endpoint.test.ts
+++ b/extensions/llama-cpp/src/external-server/endpoint.test.ts
@@ -45,8 +45,8 @@ describe("llama-server endpoint", () => {
     });
   });
 
-  it("rejects local service ownership", () => {
-    expect(() =>
+  it("preserves explicitly configured local service compatibility", () => {
+    expect(
       normalizeLlamaServerProviderConfig({
         baseUrl: "http://localhost:8080/v1",
         api: "openai-completions",
@@ -56,6 +56,11 @@ describe("llama-server endpoint", () => {
           healthUrl: "http://localhost:8080/health",
         },
       }),
-    ).toThrow("use the llama-cpp provider when OpenClaw should manage the server");
+    ).toMatchObject({
+      localService: {
+        command: "/usr/local/bin/llama-server",
+        healthUrl: "http://localhost:8080/health",
+      },
+    });
   });
 });

--- a/extensions/llama-cpp/src/external-server/endpoint.ts
+++ b/extensions/llama-cpp/src/external-server/endpoint.ts
@@ -6,15 +6,6 @@ type LlamaServerEndpoint = {
   inferenceBaseUrl: string;
 };
 
-const LLAMA_SERVER_LOCAL_SERVICE_ERROR =
-  "models.providers.llama-server.localService is not supported; use the llama-cpp provider when OpenClaw should manage the server";
-
-export function assertExternalLlamaServerConfig(provider: ModelProviderConfig): void {
-  if (provider.localService) {
-    throw new Error(LLAMA_SERVER_LOCAL_SERVICE_ERROR);
-  }
-}
-
 function toFetchableBaseUrl(value: string): string {
   if (/^[a-z][a-z\d+.-]*:\/\//iu.test(value)) {
     return value;
@@ -48,7 +39,6 @@ export function resolveLlamaServerEndpoint(configuredBaseUrl?: string): LlamaSer
 export function normalizeLlamaServerProviderConfig(
   provider: ModelProviderConfig,
 ): ModelProviderConfig {
-  assertExternalLlamaServerConfig(provider);
   const endpoint = resolveLlamaServerEndpoint(provider.baseUrl);
   const request = provider.request ?? {};
   const normalizedRequest =

--- a/extensions/llama-cpp/src/external-server/endpoint.ts
+++ b/extensions/llama-cpp/src/external-server/endpoint.ts
@@ -1,12 +1,12 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { LLAMA_SERVER_DEFAULT_ORIGIN } from "./defaults.js";
 
-export type LlamaServerEndpoint = {
+type LlamaServerEndpoint = {
   origin: string;
   inferenceBaseUrl: string;
 };
 
-export const LLAMA_SERVER_LOCAL_SERVICE_ERROR =
+const LLAMA_SERVER_LOCAL_SERVICE_ERROR =
   "models.providers.llama-server.localService is not supported; use the llama-cpp provider when OpenClaw should manage the server";
 
 export function assertExternalLlamaServerConfig(provider: ModelProviderConfig): void {

--- a/extensions/llama-cpp/src/external-server/endpoint.ts
+++ b/extensions/llama-cpp/src/external-server/endpoint.ts
@@ -1,0 +1,64 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { LLAMA_SERVER_DEFAULT_ORIGIN } from "./defaults.js";
+
+export type LlamaServerEndpoint = {
+  origin: string;
+  inferenceBaseUrl: string;
+};
+
+export const LLAMA_SERVER_LOCAL_SERVICE_ERROR =
+  "models.providers.llama-server.localService is not supported; use the llama-cpp provider when OpenClaw should manage the server";
+
+export function assertExternalLlamaServerConfig(provider: ModelProviderConfig): void {
+  if (provider.localService) {
+    throw new Error(LLAMA_SERVER_LOCAL_SERVICE_ERROR);
+  }
+}
+
+function toFetchableBaseUrl(value: string): string {
+  if (/^[a-z][a-z\d+.-]*:\/\//iu.test(value)) {
+    return value;
+  }
+  return `http://${value}`;
+}
+
+/** Resolves the server origin and its OpenAI-compatible `/v1` inference base. */
+export function resolveLlamaServerEndpoint(configuredBaseUrl?: string): LlamaServerEndpoint {
+  const configured = configuredBaseUrl?.trim() || LLAMA_SERVER_DEFAULT_ORIGIN;
+  const parsed = new URL(toFetchableBaseUrl(configured));
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new TypeError(`Unsupported llama-server protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new TypeError("llama-server base URL must not contain credentials");
+  }
+
+  const pathname = parsed.pathname.replace(/\/+$/u, "").replace(/\/v1$/iu, "");
+  parsed.pathname = pathname || "/";
+  parsed.search = "";
+  parsed.hash = "";
+  const origin = parsed.toString().replace(/\/$/u, "");
+  return {
+    origin,
+    inferenceBaseUrl: `${origin}/v1`,
+  };
+}
+
+/** Canonicalizes persisted provider config for the shared OpenAI transport. */
+export function normalizeLlamaServerProviderConfig(
+  provider: ModelProviderConfig,
+): ModelProviderConfig {
+  assertExternalLlamaServerConfig(provider);
+  const endpoint = resolveLlamaServerEndpoint(provider.baseUrl);
+  const request = provider.request ?? {};
+  const normalizedRequest =
+    typeof request.allowPrivateNetwork === "boolean"
+      ? request
+      : { ...request, allowPrivateNetwork: true };
+  return {
+    ...provider,
+    baseUrl: endpoint.inferenceBaseUrl,
+    api: "openai-completions",
+    request: normalizedRequest,
+  };
+}

--- a/extensions/llama-cpp/src/external-server/llama-server.live.test.ts
+++ b/extensions/llama-cpp/src/external-server/llama-server.live.test.ts
@@ -1,0 +1,248 @@
+// Llama-server live tests exercise discovery and the shared OpenAI completions transport.
+import {
+  streamSimple,
+  type AssistantMessage,
+  type Context,
+  type Model,
+  type SimpleStreamOptions,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { discoverLlamaServer } from "./src/discovery.js";
+import { wrapLlamaServerStream } from "./src/stream.js";
+
+const LIVE_URL = process.env.LLAMA_SERVER_LIVE_URL?.trim() ?? "";
+const LIVE_KEY = process.env.LLAMA_SERVER_API_KEY?.trim() ?? "";
+const LIVE_MODEL_ID = process.env.LLAMA_SERVER_LIVE_MODEL_ID?.trim() ?? "";
+const LIVE = isLiveTestEnabled(["LLAMA_SERVER_LIVE_TEST"]) && LIVE_URL.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+const liveStream = wrapLlamaServerStream({
+  streamFn: streamSimple,
+} as unknown as ProviderWrapStreamFnContext);
+
+async function completeViaPlugin(
+  model: Model<"openai-completions">,
+  context: Context,
+  options: SimpleStreamOptions,
+): Promise<AssistantMessage> {
+  const stream = await liveStream(model, context, options);
+  return await stream.result();
+}
+
+async function resolveLiveModel(): Promise<{
+  model: Model<"openai-completions">;
+  supportsTools: boolean;
+}> {
+  const discovery = await discoverLlamaServer({
+    baseUrl: LIVE_URL,
+    apiKey: LIVE_KEY,
+    cacheTtlMs: 0,
+  });
+  if (discovery.kind !== "success") {
+    throw new Error(`llama-server discovery failed: ${discovery.kind}`);
+  }
+  const discovered = LIVE_MODEL_ID
+    ? discovery.models.find((entry) => entry.config.id === LIVE_MODEL_ID)
+    : (discovery.models.find((entry) => entry.status === "loaded") ?? discovery.models[0]);
+  if (!discovered) {
+    throw new Error("llama-server returned no models");
+  }
+  return {
+    model: {
+      ...discovered.config,
+      provider: "llama-server",
+      api: "openai-completions",
+      baseUrl: discovery.endpoint.inferenceBaseUrl,
+      input: discovered.config.input.filter(
+        (entry): entry is "text" | "image" => entry === "text" || entry === "image",
+      ),
+    } as Model<"openai-completions">,
+    supportsTools: discovered.config.compat?.supportsTools === true,
+  };
+}
+
+function disableThinking(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const record = payload as Record<string, unknown>;
+  const current =
+    record.chat_template_kwargs &&
+    typeof record.chat_template_kwargs === "object" &&
+    !Array.isArray(record.chat_template_kwargs)
+      ? (record.chat_template_kwargs as Record<string, unknown>)
+      : {};
+  return {
+    ...record,
+    chat_template_kwargs: { ...current, enable_thinking: false },
+  };
+}
+
+function echoTool(): Tool {
+  return {
+    name: "live_echo",
+    description: "Return the supplied value.",
+    parameters: Type.Object({ value: Type.String() }, { additionalProperties: false }),
+  };
+}
+
+function requireToolCall(message: AssistantMessage) {
+  const toolCall = message.content.find((block) => block.type === "toolCall");
+  if (toolCall?.type !== "toolCall") {
+    throw new Error(`llama-server model did not call a tool: ${message.stopReason}`);
+  }
+  return toolCall;
+}
+
+describeLive("llama-server live", () => {
+  it("discovers and completes through the OpenAI completions transport", async () => {
+    const { model } = await resolveLiveModel();
+    const responses = await Promise.all(
+      ["one", "two"].map((word) =>
+        completeViaPlugin(
+          model,
+          {
+            messages: [
+              {
+                role: "user",
+                content: `Reply with exactly: ${word}`,
+                timestamp: Date.now(),
+              },
+            ],
+          },
+          {
+            apiKey: LIVE_KEY || "llama-server-local",
+            maxTokens: 64,
+            onPayload: disableThinking,
+          },
+        ),
+      ),
+    );
+
+    for (const response of responses) {
+      if (response.stopReason === "error") {
+        throw new Error(response.errorMessage || "llama-server returned an error");
+      }
+      expect(extractNonEmptyAssistantText(response.content).length).toBeGreaterThan(0);
+    }
+  }, 120_000);
+
+  it("returns schema-constrained JSON", async () => {
+    const { model } = await resolveLiveModel();
+    expect(model).toMatchObject({ compat: { supportsJsonSchemaResponseFormat: true } });
+    const response = await completeViaPlugin(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Return a JSON object with ok set to true.",
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 64,
+        responseFormat: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+        onPayload: disableThinking,
+      },
+    );
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "llama-server JSON turn returned an error");
+    }
+    expect(JSON.parse(extractNonEmptyAssistantText(response.content))).toEqual({ ok: true });
+  }, 120_000);
+
+  it("cancels an in-flight generation", async () => {
+    const { model } = await resolveLiveModel();
+    const controller = new AbortController();
+    const pending = completeViaPlugin(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Write a detailed 2000-word history of computing.",
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 4096,
+        signal: controller.signal,
+        onPayload: disableThinking,
+      },
+    );
+    setTimeout(() => controller.abort(), 250);
+    const response = await pending;
+    expect(response.stopReason).toBe("aborted");
+  }, 120_000);
+
+  it("completes a tool-call round trip when the template advertises tools", async (ctx) => {
+    const { model, supportsTools } = await resolveLiveModel();
+    if (!supportsTools) {
+      ctx.skip();
+      return;
+    }
+    const tool = echoTool();
+    const user = {
+      role: "user" as const,
+      content: "Call live_echo with value llama-server. Do not answer directly.",
+      timestamp: Date.now() - 2,
+    };
+    const first = await completeViaPlugin(
+      model,
+      { messages: [user], tools: [tool] },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 256,
+        onPayload: disableThinking,
+      },
+    );
+    if (first.stopReason === "error") {
+      throw new Error(first.errorMessage || "llama-server tool turn returned an error");
+    }
+    const toolCall = requireToolCall(first);
+    expect(toolCall.name).toBe("live_echo");
+    expect(toolCall.arguments).toEqual({ value: "llama-server" });
+
+    const second = await completeViaPlugin(
+      model,
+      {
+        messages: [
+          user,
+          first,
+          {
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: Date.now() - 1,
+          },
+          { role: "user", content: "Reply with exactly: ok", timestamp: Date.now() },
+        ],
+        tools: [tool],
+      },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 128,
+        onPayload: disableThinking,
+      },
+    );
+    if (second.stopReason === "error") {
+      throw new Error(second.errorMessage || "llama-server result turn returned an error");
+    }
+    expect(extractNonEmptyAssistantText(second.content)).toMatch(/^ok[.!]?$/iu);
+  }, 120_000);
+});

--- a/extensions/llama-cpp/src/external-server/llama-server.live.test.ts
+++ b/extensions/llama-cpp/src/external-server/llama-server.live.test.ts
@@ -11,8 +11,8 @@ import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-ent
 import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { discoverLlamaServer } from "./src/discovery.js";
-import { wrapLlamaServerStream } from "./src/stream.js";
+import { discoverLlamaServer } from "./discovery.js";
+import { wrapLlamaServerStream } from "./stream.js";
 
 const LIVE_URL = process.env.LLAMA_SERVER_LIVE_URL?.trim() ?? "";
 const LIVE_KEY = process.env.LLAMA_SERVER_API_KEY?.trim() ?? "";
@@ -21,6 +21,7 @@ const LIVE = isLiveTestEnabled(["LLAMA_SERVER_LIVE_TEST"]) && LIVE_URL.length > 
 const describeLive = LIVE ? describe : describe.skip;
 const liveStream = wrapLlamaServerStream({
   streamFn: streamSimple,
+  thinkingLevel: "off",
 } as unknown as ProviderWrapStreamFnContext);
 
 async function completeViaPlugin(
@@ -64,23 +65,6 @@ async function resolveLiveModel(): Promise<{
   };
 }
 
-function disableThinking(payload: unknown): unknown {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    return payload;
-  }
-  const record = payload as Record<string, unknown>;
-  const current =
-    record.chat_template_kwargs &&
-    typeof record.chat_template_kwargs === "object" &&
-    !Array.isArray(record.chat_template_kwargs)
-      ? (record.chat_template_kwargs as Record<string, unknown>)
-      : {};
-  return {
-    ...record,
-    chat_template_kwargs: { ...current, enable_thinking: false },
-  };
-}
-
 function echoTool(): Tool {
   return {
     name: "live_echo",
@@ -116,7 +100,6 @@ describeLive("llama-server live", () => {
           {
             apiKey: LIVE_KEY || "llama-server-local",
             maxTokens: 64,
-            onPayload: disableThinking,
           },
         ),
       ),
@@ -153,7 +136,6 @@ describeLive("llama-server live", () => {
           required: ["ok"],
           additionalProperties: false,
         },
-        onPayload: disableThinking,
       },
     );
     if (response.stopReason === "error") {
@@ -180,7 +162,6 @@ describeLive("llama-server live", () => {
         apiKey: LIVE_KEY || "llama-server-local",
         maxTokens: 4096,
         signal: controller.signal,
-        onPayload: disableThinking,
       },
     );
     setTimeout(() => controller.abort(), 250);
@@ -206,7 +187,6 @@ describeLive("llama-server live", () => {
       {
         apiKey: LIVE_KEY || "llama-server-local",
         maxTokens: 256,
-        onPayload: disableThinking,
       },
     );
     if (first.stopReason === "error") {
@@ -237,7 +217,6 @@ describeLive("llama-server live", () => {
       {
         apiKey: LIVE_KEY || "llama-server-local",
         maxTokens: 128,
-        onPayload: disableThinking,
       },
     );
     if (second.stopReason === "error") {

--- a/extensions/llama-cpp/src/external-server/models.test.ts
+++ b/extensions/llama-cpp/src/external-server/models.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { buildLlamaServerProviderConfig, mapLlamaServerModel } from "./models.js";
+
+describe("llama-server model mapping", () => {
+  it("maps runtime context and chat-template capabilities", () => {
+    expect(
+      mapLlamaServerModel(
+        {
+          id: "ggml-org/model:Q4_K_M",
+          object: "model",
+          status: { value: "loaded" },
+        },
+        {
+          default_generation_settings: {
+            n_ctx: 65536,
+            params: { max_tokens: 4096 },
+          },
+          total_slots: 2,
+          build_info: "b10000-deadbeef",
+          chat_template_caps: {
+            supports_tools: true,
+            supports_tool_calls: true,
+            supports_typed_content: true,
+          },
+        },
+      ),
+    ).toMatchObject({
+      status: "loaded",
+      buildInfo: "b10000-deadbeef",
+      totalSlots: 2,
+      config: {
+        id: "ggml-org/model:Q4_K_M",
+        contextWindow: 65536,
+        contextTokens: 65536,
+        maxTokens: 4096,
+        compat: {
+          supportsTools: true,
+          supportsUsageInStreaming: true,
+          supportsJsonSchemaResponseFormat: true,
+          requiresStringContent: false,
+          maxTokensField: "max_tokens",
+        },
+      },
+    });
+  });
+
+  it("uses an older server's top-level runtime context limit", () => {
+    expect(
+      mapLlamaServerModel({ id: "model", object: "model" }, { n_ctx: 8192 })?.config,
+    ).toMatchObject({
+      contextWindow: 8192,
+      contextTokens: 8192,
+      maxTokens: 8192,
+    });
+  });
+
+  it("preserves image input advertised by router rows or runtime properties", () => {
+    expect(
+      mapLlamaServerModel({
+        id: "router-vision",
+        object: "model",
+        architecture: { input_modalities: ["text", "image"] },
+      })?.config.input,
+    ).toEqual(["text", "image"]);
+    expect(
+      mapLlamaServerModel(
+        { id: "server-vision", object: "model" },
+        { modalities: { vision: true } },
+      )?.config.input,
+    ).toEqual(["text", "image"]);
+  });
+
+  it("defaults unknown capabilities conservatively", () => {
+    expect(mapLlamaServerModel({ id: "model", object: "model" })?.config.compat).toMatchObject({
+      supportsTools: false,
+      requiresStringContent: true,
+    });
+  });
+
+  it("rejects malformed and non-model rows", () => {
+    expect(mapLlamaServerModel({ id: " " })).toBeNull();
+    expect(mapLlamaServerModel({ id: "model", object: "collection" })).toBeNull();
+  });
+
+  it("keeps explicit model rows ahead of discovered rows", () => {
+    const explicit = {
+      id: "model",
+      name: "Configured model",
+      reasoning: true,
+      input: ["text"] as Array<"text" | "image">,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 2048,
+    };
+    const discovered = mapLlamaServerModel({ id: "model", object: "model" });
+    const second = mapLlamaServerModel({ id: "other", object: "model" });
+    if (!discovered || !second) {
+      throw new Error("expected model fixtures to map");
+    }
+
+    const provider = buildLlamaServerProviderConfig({
+      configured: {
+        baseUrl: "http://localhost:8080/v1",
+        models: [explicit],
+      },
+      discoveredModels: [discovered, second],
+    });
+
+    expect(provider.models).toHaveLength(2);
+    expect(provider.models[0]).toBe(explicit);
+    expect(provider.models[1]?.id).toBe("other");
+  });
+});

--- a/extensions/llama-cpp/src/external-server/models.ts
+++ b/extensions/llama-cpp/src/external-server/models.ts
@@ -7,10 +7,10 @@ import {
   SELF_HOSTED_DEFAULT_COST,
   SELF_HOSTED_DEFAULT_MAX_TOKENS,
 } from "openclaw/plugin-sdk/provider-setup";
-import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { asBoolean, asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { assertExternalLlamaServerConfig, resolveLlamaServerEndpoint } from "./endpoint.js";
 
-export type LlamaServerModelStatus =
+type LlamaServerModelStatus =
   | "unloaded"
   | "loading"
   | "loaded"
@@ -61,14 +61,6 @@ export type LlamaServerDiscoveredModel = {
   totalSlots?: number;
 };
 
-function readBoolean(
-  record: Record<string, unknown> | undefined,
-  key: string,
-): boolean | undefined {
-  const value = record?.[key];
-  return typeof value === "boolean" ? value : undefined;
-}
-
 function normalizeStatus(value: unknown): LlamaServerModelStatus {
   switch (value) {
     case "unloaded":
@@ -113,9 +105,8 @@ function buildCompat(
 ): NonNullable<ModelDefinitionConfig["compat"]> {
   const caps = props?.chat_template_caps;
   const supportsTools =
-    readBoolean(caps, "supports_tools") === true &&
-    readBoolean(caps, "supports_tool_calls") === true;
-  const supportsTypedContent = readBoolean(caps, "supports_typed_content") === true;
+    asBoolean(caps?.supports_tools) === true && asBoolean(caps?.supports_tool_calls) === true;
+  const supportsTypedContent = asBoolean(caps?.supports_typed_content) === true;
   return {
     supportsStore: false,
     supportsDeveloperRole: false,
@@ -165,7 +156,7 @@ export function mapLlamaServerModel(
 }
 
 /** Keeps explicit rows first and appends models discovered from the server. */
-export function mergeLlamaServerModels(params: {
+function mergeLlamaServerModels(params: {
   explicitModels?: ModelDefinitionConfig[];
   discoveredModels: readonly LlamaServerDiscoveredModel[];
 }): ModelDefinitionConfig[] {

--- a/extensions/llama-cpp/src/external-server/models.ts
+++ b/extensions/llama-cpp/src/external-server/models.ts
@@ -8,7 +8,7 @@ import {
   SELF_HOSTED_DEFAULT_MAX_TOKENS,
 } from "openclaw/plugin-sdk/provider-setup";
 import { asBoolean, asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { assertExternalLlamaServerConfig, resolveLlamaServerEndpoint } from "./endpoint.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
 
 type LlamaServerModelStatus =
   | "unloaded"
@@ -177,9 +177,6 @@ export function buildLlamaServerProviderConfig(params: {
   configured?: ModelProviderConfig;
   discoveredModels: readonly LlamaServerDiscoveredModel[];
 }): ModelProviderConfig {
-  if (params.configured) {
-    assertExternalLlamaServerConfig(params.configured);
-  }
   const endpoint = resolveLlamaServerEndpoint(params.configured?.baseUrl);
   const request = params.configured?.request ?? {};
   return {

--- a/extensions/llama-cpp/src/external-server/models.ts
+++ b/extensions/llama-cpp/src/external-server/models.ts
@@ -1,0 +1,207 @@
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
+  SELF_HOSTED_DEFAULT_COST,
+  SELF_HOSTED_DEFAULT_MAX_TOKENS,
+} from "openclaw/plugin-sdk/provider-setup";
+import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { assertExternalLlamaServerConfig, resolveLlamaServerEndpoint } from "./endpoint.js";
+
+export type LlamaServerModelStatus =
+  | "unloaded"
+  | "loading"
+  | "loaded"
+  | "sleeping"
+  | "downloading"
+  | "unknown";
+
+export type LlamaServerModelWire = {
+  id?: unknown;
+  object?: unknown;
+  owned_by?: unknown;
+  status?: {
+    value?: unknown;
+    failed?: unknown;
+    exit_code?: unknown;
+  };
+  architecture?: {
+    input_modalities?: unknown;
+    output_modalities?: unknown;
+  };
+  meta?: {
+    n_ctx_train?: unknown;
+  } | null;
+};
+
+export type LlamaServerPropsWire = {
+  n_ctx?: unknown;
+  default_generation_settings?: {
+    n_ctx?: unknown;
+    params?: {
+      max_tokens?: unknown;
+      n_predict?: unknown;
+    };
+  };
+  total_slots?: unknown;
+  chat_template_caps?: Record<string, unknown>;
+  modalities?: Record<string, unknown>;
+  build_info?: unknown;
+  is_sleeping?: unknown;
+};
+
+export type LlamaServerDiscoveredModel = {
+  config: ModelDefinitionConfig;
+  status: LlamaServerModelStatus;
+  failed: boolean;
+  exitCode?: number;
+  buildInfo?: string;
+  totalSlots?: number;
+};
+
+function readBoolean(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeStatus(value: unknown): LlamaServerModelStatus {
+  switch (value) {
+    case "unloaded":
+    case "loading":
+    case "loaded":
+    case "sleeping":
+    case "downloading":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
+function resolveContextWindow(props: LlamaServerPropsWire | undefined): number {
+  return (
+    asPositiveSafeInteger(props?.default_generation_settings?.n_ctx) ??
+    asPositiveSafeInteger(props?.n_ctx) ??
+    SELF_HOSTED_DEFAULT_CONTEXT_WINDOW
+  );
+}
+
+function resolveMaxTokens(props: LlamaServerPropsWire | undefined, contextWindow: number): number {
+  const params = props?.default_generation_settings?.params;
+  const advertised =
+    asPositiveSafeInteger(params?.max_tokens) ?? asPositiveSafeInteger(params?.n_predict);
+  return Math.min(advertised ?? SELF_HOSTED_DEFAULT_MAX_TOKENS, contextWindow);
+}
+
+function resolveInput(
+  row: LlamaServerModelWire,
+  props: LlamaServerPropsWire | undefined,
+): Array<"text" | "image"> {
+  const advertised = row.architecture?.input_modalities;
+  const supportsImage =
+    (Array.isArray(advertised) && advertised.includes("image")) ||
+    props?.modalities?.vision === true;
+  return supportsImage ? ["text", "image"] : ["text"];
+}
+
+function buildCompat(
+  props: LlamaServerPropsWire | undefined,
+): NonNullable<ModelDefinitionConfig["compat"]> {
+  const caps = props?.chat_template_caps;
+  const supportsTools =
+    readBoolean(caps, "supports_tools") === true &&
+    readBoolean(caps, "supports_tool_calls") === true;
+  const supportsTypedContent = readBoolean(caps, "supports_typed_content") === true;
+  return {
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: false,
+    supportsTemperature: true,
+    supportsUsageInStreaming: true,
+    supportsTools,
+    supportsStrictMode: false,
+    supportsJsonSchemaResponseFormat: true,
+    requiresStringContent: !supportsTypedContent,
+    maxTokensField: "max_tokens",
+  };
+}
+
+/** Maps one llama-server model row plus optional runtime properties into OpenClaw config. */
+export function mapLlamaServerModel(
+  row: LlamaServerModelWire,
+  props?: LlamaServerPropsWire,
+): LlamaServerDiscoveredModel | null {
+  const id = typeof row.id === "string" ? row.id.trim() : "";
+  if (!id || (row.object !== undefined && row.object !== "model")) {
+    return null;
+  }
+  const contextWindow = resolveContextWindow(props);
+  const buildInfo = typeof props?.build_info === "string" ? props.build_info.trim() : "";
+  const exitCode = asPositiveSafeInteger(row.status?.exit_code);
+  return {
+    config: {
+      id,
+      name: id,
+      reasoning: false,
+      input: resolveInput(row, props),
+      cost: { ...SELF_HOSTED_DEFAULT_COST },
+      contextWindow,
+      contextTokens: contextWindow,
+      maxTokens: resolveMaxTokens(props, contextWindow),
+      compat: buildCompat(props),
+    },
+    status: normalizeStatus(row.status?.value),
+    failed: row.status?.failed === true,
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(buildInfo ? { buildInfo } : {}),
+    ...(asPositiveSafeInteger(props?.total_slots) !== undefined
+      ? { totalSlots: asPositiveSafeInteger(props?.total_slots) }
+      : {}),
+  };
+}
+
+/** Keeps explicit rows first and appends models discovered from the server. */
+export function mergeLlamaServerModels(params: {
+  explicitModels?: ModelDefinitionConfig[];
+  discoveredModels: readonly LlamaServerDiscoveredModel[];
+}): ModelDefinitionConfig[] {
+  const explicit = Array.isArray(params.explicitModels) ? params.explicitModels : [];
+  const merged = [...explicit];
+  const seen = new Set(explicit.map((model) => model.id));
+  for (const discovered of params.discoveredModels) {
+    if (seen.has(discovered.config.id)) {
+      continue;
+    }
+    seen.add(discovered.config.id);
+    merged.push(discovered.config);
+  }
+  return merged;
+}
+
+export function buildLlamaServerProviderConfig(params: {
+  configured?: ModelProviderConfig;
+  discoveredModels: readonly LlamaServerDiscoveredModel[];
+}): ModelProviderConfig {
+  if (params.configured) {
+    assertExternalLlamaServerConfig(params.configured);
+  }
+  const endpoint = resolveLlamaServerEndpoint(params.configured?.baseUrl);
+  const request = params.configured?.request ?? {};
+  return {
+    ...params.configured,
+    baseUrl: endpoint.inferenceBaseUrl,
+    api: "openai-completions",
+    request:
+      typeof request.allowPrivateNetwork === "boolean"
+        ? request
+        : { ...request, allowPrivateNetwork: true },
+    models: mergeLlamaServerModels({
+      explicitModels: params.configured?.models,
+      discoveredModels: params.discoveredModels,
+    }),
+  };
+}

--- a/extensions/llama-cpp/src/external-server/provider.test.ts
+++ b/extensions/llama-cpp/src/external-server/provider.test.ts
@@ -5,7 +5,6 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearLlamaServerDynamicModelsForTests,
   discoverLlamaServerProvider,
   listLlamaServerCatalog,
   prepareLlamaServerDynamicModels,
@@ -76,7 +75,6 @@ describe("llama-server provider catalog", () => {
     discoverMock.mockReset();
     runtimeApiKeyMock.mockReset();
     runtimeApiKeyMock.mockResolvedValue(undefined);
-    clearLlamaServerDynamicModelsForTests();
   });
 
   it("builds the legacy runtime provider from live discovery", async () => {

--- a/extensions/llama-cpp/src/external-server/provider.test.ts
+++ b/extensions/llama-cpp/src/external-server/provider.test.ts
@@ -1,0 +1,264 @@
+import type {
+  ProviderCatalogContext,
+  ProviderPrepareDynamicModelContext,
+  UnifiedModelCatalogProviderContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLlamaServerDynamicModelsForTests,
+  discoverLlamaServerProvider,
+  listLlamaServerCatalog,
+  prepareLlamaServerDynamicModels,
+  resolveLlamaServerDynamicModel,
+} from "./provider.js";
+
+const discoverMock = vi.hoisted(() => vi.fn());
+const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./discovery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./discovery.js")>()),
+  discoverLlamaServer: discoverMock,
+}));
+
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
+  resolveLlamaServerRuntimeApiKey: runtimeApiKeyMock,
+}));
+
+function model() {
+  return {
+    config: {
+      id: "org/model:Q4",
+      name: "org/model:Q4",
+      reasoning: false,
+      input: ["text" as const],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16384,
+      contextTokens: 16384,
+      maxTokens: 4096,
+      compat: { supportsTools: true },
+    },
+    status: "sleeping" as const,
+    failed: false,
+    buildInfo: "b10000-test",
+    totalSlots: 2,
+  };
+}
+
+function success() {
+  return {
+    kind: "success" as const,
+    endpoint: {
+      origin: "http://localhost:8080",
+      inferenceBaseUrl: "http://localhost:8080/v1",
+    },
+    health: "ready" as const,
+    models: [model()],
+    fetchedAt: 1000,
+  };
+}
+
+function catalogContext(): ProviderCatalogContext {
+  return {
+    config: {},
+    env: {},
+    resolveProviderApiKey: vi.fn(() => ({ apiKey: undefined })),
+    resolveProviderAuth: vi.fn(() => ({
+      apiKey: undefined,
+      mode: "none" as const,
+      source: "none" as const,
+    })),
+  };
+}
+
+describe("llama-server provider catalog", () => {
+  beforeEach(() => {
+    discoverMock.mockReset();
+    runtimeApiKeyMock.mockReset();
+    runtimeApiKeyMock.mockResolvedValue(undefined);
+    clearLlamaServerDynamicModelsForTests();
+  });
+
+  it("builds the legacy runtime provider from live discovery", async () => {
+    discoverMock.mockResolvedValue(success());
+
+    await expect(discoverLlamaServerProvider(catalogContext())).resolves.toMatchObject({
+      provider: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+        models: [expect.objectContaining({ id: "org/model:Q4" })],
+      },
+    });
+  });
+
+  it("prefers configured Authorization over ambient API-key discovery auth", async () => {
+    discoverMock.mockResolvedValue(success());
+    const ctx = catalogContext();
+    ctx.config.models = {
+      providers: {
+        "llama-server": {
+          baseUrl: "http://localhost:8080/v1",
+          headers: { Authorization: "Bearer proxy-key" },
+          models: [],
+        },
+      },
+    };
+    ctx.resolveProviderApiKey = vi.fn(() => ({
+      apiKey: "LLAMA_SERVER_API_KEY",
+      discoveryApiKey: "ambient-key",
+    }));
+
+    await discoverLlamaServerProvider(ctx);
+
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key" },
+      }),
+    );
+  });
+
+  it("preserves explicit models when the server is unavailable", async () => {
+    discoverMock.mockResolvedValue({
+      kind: "unreachable",
+      endpoint: { origin: "http://localhost:8080", inferenceBaseUrl: "http://localhost:8080/v1" },
+      error: new Error("offline"),
+    });
+    const ctx = catalogContext();
+    ctx.config.models = {
+      providers: {
+        "llama-server": {
+          baseUrl: "http://localhost:8080/v1",
+          models: [model().config],
+        },
+      },
+    };
+
+    await expect(discoverLlamaServerProvider(ctx)).resolves.toMatchObject({
+      provider: { models: [expect.objectContaining({ id: "org/model:Q4" })] },
+    });
+  });
+
+  it("projects router state into unified catalog warnings", async () => {
+    discoverMock.mockResolvedValue(success());
+    const ctx = {
+      ...catalogContext(),
+      includeLive: true,
+    } as UnifiedModelCatalogProviderContext;
+
+    await expect(listLlamaServerCatalog(ctx)).resolves.toEqual([
+      expect.objectContaining({
+        kind: "text",
+        provider: "llama-server",
+        model: "org/model:Q4",
+        source: "live",
+        warnings: ["llama-server model is sleeping"],
+        capabilities: expect.objectContaining({
+          contextWindow: 16384,
+          status: "sleeping",
+          buildInfo: "b10000-test",
+          totalSlots: 2,
+        }),
+      }),
+    ]);
+  });
+
+  it("scopes dynamic catalogs by agent runtime and auth profile", async () => {
+    const first = success();
+    const second = {
+      ...success(),
+      models: [
+        {
+          ...model(),
+          config: { ...model().config, name: "second scope" },
+        },
+      ],
+    };
+    discoverMock.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    const base = {
+      config: {},
+      provider: "llama-server",
+      modelId: "org/model:Q4",
+      modelRegistry: {},
+      providerConfig: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+      },
+    };
+    const firstCtx = {
+      ...base,
+      agentRuntimeId: "runtime-one",
+      authProfileId: "profile-one",
+    } as unknown as ProviderPrepareDynamicModelContext;
+    const secondCtx = {
+      ...base,
+      agentRuntimeId: "runtime-two",
+      authProfileId: "profile-two",
+    } as unknown as ProviderPrepareDynamicModelContext;
+
+    await prepareLlamaServerDynamicModels(firstCtx);
+    await prepareLlamaServerDynamicModels(secondCtx);
+
+    expect(runtimeApiKeyMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ profileId: "profile-one" }),
+    );
+    expect(runtimeApiKeyMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ profileId: "profile-two" }),
+    );
+    expect(resolveLlamaServerDynamicModel(firstCtx)?.name).toBe("org/model:Q4");
+    expect(resolveLlamaServerDynamicModel(secondCtx)?.name).toBe("second scope");
+  });
+
+  it("bounds dynamic model snapshots by scope", async () => {
+    discoverMock.mockResolvedValue(success());
+    const contexts = Array.from(
+      { length: 101 },
+      (_, index) =>
+        ({
+          config: {},
+          provider: "llama-server",
+          modelId: "org/model:Q4",
+          modelRegistry: {},
+          agentRuntimeId: `runtime-${index}`,
+          providerConfig: {
+            baseUrl: "http://localhost:8080/v1",
+            api: "openai-completions",
+          },
+        }) as unknown as ProviderPrepareDynamicModelContext,
+    );
+
+    for (const ctx of contexts) {
+      await prepareLlamaServerDynamicModels(ctx);
+    }
+
+    expect(resolveLlamaServerDynamicModel(contexts[0]!)).toBeUndefined();
+    expect(resolveLlamaServerDynamicModel(contexts.at(-1)!)).toMatchObject({
+      id: "org/model:Q4",
+    });
+  });
+
+  it("refreshes and resolves dynamic model ids containing slashes", async () => {
+    discoverMock.mockResolvedValue(success());
+    const ctx = {
+      config: {},
+      provider: "llama-server",
+      modelId: "org/model:Q4",
+      modelRegistry: {},
+      providerConfig: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+      },
+    } as unknown as ProviderPrepareDynamicModelContext;
+
+    await prepareLlamaServerDynamicModels(ctx);
+
+    expect(resolveLlamaServerDynamicModel(ctx)).toMatchObject({
+      provider: "llama-server",
+      id: "org/model:Q4",
+      baseUrl: "http://localhost:8080/v1",
+      api: "openai-completions",
+    });
+  });
+});

--- a/extensions/llama-cpp/src/external-server/provider.ts
+++ b/extensions/llama-cpp/src/external-server/provider.ts
@@ -1,0 +1,203 @@
+import type {
+  ProviderCatalogContext,
+  ProviderPrepareDynamicModelContext,
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+  UnifiedModelCatalogEntry,
+  UnifiedModelCatalogProviderContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  hasLlamaServerAuthorizationHeader,
+  resolveLlamaServerProviderHeaders,
+  resolveLlamaServerRuntimeApiKey,
+} from "./auth.js";
+import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+import { discoverLlamaServer, type LlamaServerDiscoveryResult } from "./discovery.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+import { buildLlamaServerProviderConfig, type LlamaServerDiscoveredModel } from "./models.js";
+
+const dynamicModels = new Map<string, ProviderRuntimeModel[]>();
+const LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES = 100;
+
+function cacheDynamicModels(key: string, models: ProviderRuntimeModel[]): void {
+  dynamicModels.delete(key);
+  dynamicModels.set(key, models);
+  while (dynamicModels.size > LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES) {
+    const oldest = dynamicModels.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    dynamicModels.delete(oldest.value);
+  }
+}
+
+function dynamicModelScopeKey(
+  ctx: Pick<
+    ProviderResolveDynamicModelContext,
+    "agentRuntimeId" | "agentDir" | "authProfileId" | "providerConfig"
+  >,
+): string {
+  return [
+    ctx.agentRuntimeId ?? ctx.agentDir ?? "",
+    ctx.authProfileId ?? "",
+    ctx.providerConfig?.baseUrl ?? "",
+  ].join("\u0000");
+}
+
+function toRuntimeModel(
+  model: LlamaServerDiscoveredModel,
+  providerConfig: {
+    baseUrl?: string;
+    api?: ProviderRuntimeModel["api"];
+  },
+): ProviderRuntimeModel {
+  return {
+    ...model.config,
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    api: providerConfig.api ?? "openai-completions",
+    baseUrl: resolveLlamaServerEndpoint(providerConfig.baseUrl).inferenceBaseUrl,
+    input: model.config.input.filter(
+      (entry): entry is "text" | "image" => entry === "text" || entry === "image",
+    ),
+  };
+}
+
+function statusWarning(model: LlamaServerDiscoveredModel): string | undefined {
+  if (model.failed) {
+    return model.exitCode
+      ? `llama-server model process failed with exit code ${model.exitCode}`
+      : "llama-server model process failed";
+  }
+  return model.status === "loaded" || model.status === "unknown"
+    ? undefined
+    : `llama-server model is ${model.status}`;
+}
+
+function toUnifiedCatalogEntry(
+  model: LlamaServerDiscoveredModel,
+  fetchedAt: number,
+): UnifiedModelCatalogEntry {
+  const warning = statusWarning(model);
+  return {
+    kind: "text",
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    model: model.config.id,
+    label: model.config.name,
+    source: "live",
+    fetchedAt,
+    capabilities: {
+      input: model.config.input,
+      reasoning: model.config.reasoning,
+      contextWindow: model.config.contextWindow,
+      contextTokens: model.config.contextTokens,
+      maxTokens: model.config.maxTokens,
+      status: model.status,
+      buildInfo: model.buildInfo,
+      totalSlots: model.totalSlots,
+    },
+    ...(warning ? { warnings: [warning] } : {}),
+  };
+}
+
+async function discoverFromCatalogContext(
+  ctx: ProviderCatalogContext | UnifiedModelCatalogProviderContext,
+): Promise<LlamaServerDiscoveryResult> {
+  const providerConfig = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const auth = ctx.resolveProviderApiKey(LLAMA_SERVER_PROVIDER_ID);
+  const headers = await resolveLlamaServerProviderHeaders({
+    config: ctx.config,
+    env: ctx.env,
+    headers: providerConfig?.headers,
+  });
+  return await discoverLlamaServer({
+    baseUrl: providerConfig?.baseUrl,
+    apiKey: hasLlamaServerAuthorizationHeader(headers)
+      ? undefined
+      : (auth.discoveryApiKey ?? auth.apiKey),
+    headers,
+    signal: "signal" in ctx ? ctx.signal : undefined,
+    timeoutMs: "timeoutMs" in ctx ? ctx.timeoutMs : undefined,
+  });
+}
+
+/** Legacy text runtime catalog until the unified loader owns model resolution. */
+export async function discoverLlamaServerProvider(
+  ctx: ProviderCatalogContext,
+): Promise<{ provider: ModelProviderConfig } | null> {
+  const configured = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const discovery = await discoverFromCatalogContext(ctx);
+  if (discovery.kind !== "success") {
+    return configured
+      ? {
+          provider: buildLlamaServerProviderConfig({
+            configured,
+            discoveredModels: [],
+          }),
+        }
+      : null;
+  }
+  return {
+    provider: buildLlamaServerProviderConfig({
+      configured: {
+        ...configured,
+        baseUrl: discovery.endpoint.inferenceBaseUrl,
+        models: configured?.models ?? [],
+      },
+      discoveredModels: discovery.models,
+    }),
+  };
+}
+
+/** Live rows for model pickers and other unified catalog consumers. */
+export async function listLlamaServerCatalog(
+  ctx: UnifiedModelCatalogProviderContext,
+): Promise<UnifiedModelCatalogEntry[]> {
+  if (ctx.includeLive === false) {
+    return [];
+  }
+  const discovery = await discoverFromCatalogContext(ctx);
+  return discovery.kind === "success"
+    ? discovery.models.map((model) => toUnifiedCatalogEntry(model, discovery.fetchedAt))
+    : [];
+}
+
+export async function prepareLlamaServerDynamicModels(
+  ctx: ProviderPrepareDynamicModelContext,
+): Promise<void> {
+  const apiKey = await resolveLlamaServerRuntimeApiKey({
+    config: ctx.config,
+    agentDir: ctx.agentDir,
+    profileId: ctx.authProfileId,
+  });
+  const headers = await resolveLlamaServerProviderHeaders({
+    config: ctx.config,
+    env: process.env,
+    headers: ctx.providerConfig?.headers,
+  });
+  const discovery = await discoverLlamaServer({
+    baseUrl: ctx.providerConfig?.baseUrl,
+    apiKey: hasLlamaServerAuthorizationHeader(headers) ? undefined : apiKey,
+    headers,
+    cacheTtlMs: 0,
+  });
+  const key = dynamicModelScopeKey(ctx);
+  cacheDynamicModels(
+    key,
+    discovery.kind === "success"
+      ? discovery.models.map((model) => toRuntimeModel(model, ctx.providerConfig ?? {}))
+      : [],
+  );
+}
+
+export function resolveLlamaServerDynamicModel(
+  params: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel | undefined {
+  return dynamicModels
+    .get(dynamicModelScopeKey(params))
+    ?.find((model) => model.id === params.modelId);
+}
+
+export function clearLlamaServerDynamicModelsForTests(): void {
+  dynamicModels.clear();
+}

--- a/extensions/llama-cpp/src/external-server/provider.ts
+++ b/extensions/llama-cpp/src/external-server/provider.ts
@@ -197,7 +197,3 @@ export function resolveLlamaServerDynamicModel(
     .get(dynamicModelScopeKey(params))
     ?.find((model) => model.id === params.modelId);
 }
-
-export function clearLlamaServerDynamicModelsForTests(): void {
-  dynamicModels.clear();
-}

--- a/extensions/llama-cpp/src/external-server/register.test.ts
+++ b/extensions/llama-cpp/src/external-server/register.test.ts
@@ -1,0 +1,137 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import { describe, expect, it } from "vitest";
+import { LLAMA_SERVER_LOCAL_AUTH_MARKER } from "./defaults.js";
+import { registerExternalLlamaServerProvider } from "./register.js";
+
+function captureProvider() {
+  type Provider = Parameters<OpenClawPluginApi["registerProvider"]>[0];
+  type CatalogProvider = Parameters<OpenClawPluginApi["registerModelCatalogProvider"]>[0];
+  const providers: Provider[] = [];
+  const modelCatalogProviders: CatalogProvider[] = [];
+  registerExternalLlamaServerProvider({
+    registerProvider: (provider) => providers.push(provider),
+    registerModelCatalogProvider: (provider) => modelCatalogProviders.push(provider),
+  } as unknown as OpenClawPluginApi);
+  const provider = providers[0];
+  if (!provider) {
+    throw new Error("expected llama-server provider registration");
+  }
+  return { captured: { modelCatalogProviders }, provider };
+}
+
+function configuredProvider() {
+  return {
+    baseUrl: "http://localhost:8080/v1",
+    api: "openai-completions" as const,
+    models: [
+      {
+        id: "model",
+        name: "model",
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    ],
+  };
+}
+
+describe("external llama-server registration", () => {
+  it("registers the provider and unified live catalog", () => {
+    const { captured, provider } = captureProvider();
+
+    expect(provider.id).toBe("llama-server");
+    expect(provider.catalog).toBeDefined();
+    expect(captured.modelCatalogProviders).toEqual([
+      expect.objectContaining({ provider: "llama-server", kinds: ["text"] }),
+    ]);
+  });
+
+  it("registers llama.cpp GBNF schema projection", () => {
+    const { provider } = captureProvider();
+    expect(provider).toMatchObject({
+      normalizeToolSchemas: expect.any(Function),
+      inspectToolSchemas: expect.any(Function),
+    });
+  });
+
+  it("normalizes config onto the OpenAI completions transport", () => {
+    const { provider } = captureProvider();
+    expect(
+      provider.normalizeConfig?.({
+        provider: "llama-server",
+        providerConfig: {
+          ...configuredProvider(),
+          baseUrl: "localhost:8080/",
+          api: "openai-responses",
+        },
+      }),
+    ).toMatchObject({
+      baseUrl: "http://localhost:8080/v1",
+      api: "openai-completions",
+      request: { allowPrivateNetwork: true },
+    });
+  });
+
+  it("uses synthetic auth unless a real API key is configured", () => {
+    const { provider } = captureProvider();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "llama-server",
+        config: {},
+        providerConfig: configuredProvider(),
+      }),
+    ).toEqual({
+      apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      source: "models.providers.llama-server (synthetic local key)",
+      mode: "api-key",
+    });
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "llama-server",
+        config: {},
+        providerConfig: { ...configuredProvider(), apiKey: "real-key" },
+      }),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "llama-server",
+        config: {},
+        providerConfig: {
+          ...configuredProvider(),
+          headers: { Authorization: "Bearer proxy-key" },
+        },
+      }),
+    ).toEqual({
+      apiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+      source: "models.providers.llama-server (synthetic local key)",
+      mode: "api-key",
+    });
+  });
+
+  it("defers both supported synthetic auth markers", () => {
+    const { provider } = captureProvider();
+    const context = {
+      provider: "llama-server",
+      config: {},
+      providerConfig: configuredProvider(),
+    };
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({
+        ...context,
+        resolvedApiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+      }),
+    ).toBe(true);
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({
+        ...context,
+        resolvedApiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      }),
+    ).toBe(true);
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({ ...context, resolvedApiKey: "real-key" }),
+    ).toBe(false);
+  });
+});

--- a/extensions/llama-cpp/src/external-server/register.test.ts
+++ b/extensions/llama-cpp/src/external-server/register.test.ts
@@ -10,8 +10,9 @@ function captureProvider() {
   const providers: Provider[] = [];
   const modelCatalogProviders: CatalogProvider[] = [];
   registerExternalLlamaServerProvider({
-    registerProvider: (provider) => providers.push(provider),
-    registerModelCatalogProvider: (provider) => modelCatalogProviders.push(provider),
+    registerProvider: (provider: Provider) => providers.push(provider),
+    registerModelCatalogProvider: (provider: CatalogProvider) =>
+      modelCatalogProviders.push(provider),
   } as unknown as OpenClawPluginApi);
   const provider = providers[0];
   if (!provider) {

--- a/extensions/llama-cpp/src/external-server/register.test.ts
+++ b/extensions/llama-cpp/src/external-server/register.test.ts
@@ -76,6 +76,46 @@ describe("external llama-server registration", () => {
     });
   });
 
+  it("preserves existing managed config when the provider takes ownership", () => {
+    const { provider } = captureProvider();
+    const config = {
+      agents: {
+        defaults: { model: { primary: "llama-server/model" } },
+      },
+      models: {
+        providers: {
+          "llama-server": {
+            ...configuredProvider(),
+            apiKey: "existing-key",
+            headers: { "X-Tenant": "one" },
+            localService: {
+              command: "/usr/local/bin/llama-server",
+              args: ["--model", "/models/model.gguf"],
+              healthUrl: "http://localhost:8080/health",
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      provider.normalizeConfig?.({
+        provider: "llama-server",
+        providerConfig: config.models.providers["llama-server"],
+      }),
+    ).toMatchObject({
+      baseUrl: "http://localhost:8080/v1",
+      apiKey: "existing-key",
+      headers: { "X-Tenant": "one" },
+      localService: {
+        command: "/usr/local/bin/llama-server",
+        args: ["--model", "/models/model.gguf"],
+        healthUrl: "http://localhost:8080/health",
+      },
+    });
+    expect(config.agents.defaults.model.primary).toBe("llama-server/model");
+  });
+
   it("uses synthetic auth unless a real API key is configured", () => {
     const { provider } = captureProvider();
     expect(

--- a/extensions/llama-cpp/src/external-server/register.ts
+++ b/extensions/llama-cpp/src/external-server/register.ts
@@ -1,0 +1,96 @@
+import {
+  type OpenClawPluginApi,
+  type ProviderAuthMethodNonInteractiveContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { hasLlamaServerAuthorizationHeader, shouldUseLlamaServerSyntheticAuth } from "./auth.js";
+import {
+  LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+  LLAMA_SERVER_LOCAL_AUTH_MARKER,
+  LLAMA_SERVER_PROVIDER_ID,
+  LLAMA_SERVER_PROVIDER_LABEL,
+} from "./defaults.js";
+import { normalizeLlamaServerProviderConfig } from "./endpoint.js";
+import {
+  discoverLlamaServerProvider,
+  listLlamaServerCatalog,
+  prepareLlamaServerDynamicModels,
+  resolveLlamaServerDynamicModel,
+} from "./provider.js";
+import {
+  configureLlamaServerNonInteractive,
+  detectLlamaServerSetup,
+  prepareLlamaServerSetup,
+  runLlamaServerSetup,
+  validateLlamaServerNonInteractive,
+} from "./setup.js";
+import { wrapLlamaServerStream } from "./stream.js";
+
+export function registerExternalLlamaServerProvider(api: OpenClawPluginApi): void {
+  api.registerModelCatalogProvider({
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    kinds: ["text"],
+    liveCatalog: listLlamaServerCatalog,
+  });
+  api.registerProvider({
+    id: LLAMA_SERVER_PROVIDER_ID,
+    label: LLAMA_SERVER_PROVIDER_LABEL,
+    docsPath: "/providers/llama-server",
+    envVars: [LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR],
+    auth: [
+      {
+        id: "custom",
+        label: LLAMA_SERVER_PROVIDER_LABEL,
+        hint: "Existing local or private llama.cpp server",
+        kind: "custom",
+        appGuidedSetup: {
+          detect: detectLlamaServerSetup,
+          prepare: prepareLlamaServerSetup,
+        },
+        run: runLlamaServerSetup,
+        validateNonInteractive: validateLlamaServerNonInteractive,
+        runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) =>
+          await configureLlamaServerNonInteractive(ctx),
+      },
+    ],
+    catalog: {
+      order: "late",
+      run: discoverLlamaServerProvider,
+    },
+    resolveSyntheticAuth: ({ providerConfig }) =>
+      shouldUseLlamaServerSyntheticAuth(providerConfig)
+        ? {
+            apiKey: hasLlamaServerAuthorizationHeader(providerConfig?.headers)
+              ? LLAMA_SERVER_LOCAL_AUTH_MARKER
+              : CUSTOM_LOCAL_AUTH_MARKER,
+            source: "models.providers.llama-server (synthetic local key)",
+            mode: "api-key" as const,
+          }
+        : undefined,
+    shouldDeferSyntheticProfileAuth: ({ resolvedApiKey }) =>
+      resolvedApiKey?.trim() === LLAMA_SERVER_LOCAL_AUTH_MARKER ||
+      resolvedApiKey?.trim() === CUSTOM_LOCAL_AUTH_MARKER,
+    normalizeConfig: ({ providerConfig }) => normalizeLlamaServerProviderConfig(providerConfig),
+    prepareDynamicModel: prepareLlamaServerDynamicModels,
+    resolveDynamicModel: resolveLlamaServerDynamicModel,
+    wrapStreamFn: wrapLlamaServerStream,
+    ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
+    wizard: {
+      setup: {
+        choiceId: LLAMA_SERVER_PROVIDER_ID,
+        choiceLabel: LLAMA_SERVER_PROVIDER_LABEL,
+        choiceHint: "Connect to an existing llama.cpp server",
+        groupId: "llama-cpp",
+        groupLabel: "Local llama.cpp",
+        groupHint: "Managed or external llama.cpp server",
+        methodId: "custom",
+      },
+      modelPicker: {
+        label: "llama-server (external)",
+        hint: "Discover models from an existing llama-server",
+        methodId: "custom",
+      },
+    },
+  });
+}

--- a/extensions/llama-cpp/src/external-server/register.ts
+++ b/extensions/llama-cpp/src/external-server/register.ts
@@ -79,7 +79,7 @@ export function registerExternalLlamaServerProvider(api: OpenClawPluginApi): voi
     wizard: {
       setup: {
         choiceId: LLAMA_SERVER_PROVIDER_ID,
-        choiceLabel: LLAMA_SERVER_PROVIDER_LABEL,
+        choiceLabel: "Existing llama-server",
         choiceHint: "Connect to an existing llama.cpp server",
         groupId: "llama-cpp",
         groupLabel: "Local llama.cpp",

--- a/extensions/llama-cpp/src/external-server/register.ts
+++ b/extensions/llama-cpp/src/external-server/register.ts
@@ -1,6 +1,6 @@
-import {
-  type OpenClawPluginApi,
-  type ProviderAuthMethodNonInteractiveContext,
+import type {
+  OpenClawPluginApi,
+  ProviderAuthMethodNonInteractiveContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";

--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -1,0 +1,453 @@
+import type {
+  ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+import {
+  configureLlamaServerNonInteractive,
+  detectLlamaServerSetup,
+  prepareLlamaServerSetup,
+  runLlamaServerSetup,
+  validateLlamaServerNonInteractive,
+} from "./setup.js";
+
+const discoverMock = vi.hoisted(() => vi.fn());
+const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
+const updateAuthProfileStoreMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
+  updateAuthProfileStoreWithLock: updateAuthProfileStoreMock,
+}));
+
+vi.mock("./discovery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./discovery.js")>()),
+  discoverLlamaServer: discoverMock,
+}));
+
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
+  resolveLlamaServerRuntimeApiKey: runtimeApiKeyMock,
+}));
+
+function successfulDiscovery() {
+  return {
+    kind: "success" as const,
+    endpoint: {
+      origin: "http://localhost:8080",
+      inferenceBaseUrl: "http://localhost:8080/v1",
+    },
+    health: "ready" as const,
+    fetchedAt: 123,
+    models: [
+      {
+        config: {
+          id: "qwen/model:Q4_K_M",
+          name: "qwen/model:Q4_K_M",
+          reasoning: false,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32768,
+          contextTokens: 32768,
+          maxTokens: 8192,
+        },
+        status: "loaded" as const,
+        failed: false,
+      },
+    ],
+  };
+}
+
+function runtime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn() as never,
+  };
+}
+
+function nonInteractiveContext(
+  opts: Record<string, unknown> = {},
+): ProviderAuthMethodNonInteractiveContext {
+  return {
+    authChoice: LLAMA_SERVER_PROVIDER_ID,
+    config: {},
+    baseConfig: {},
+    opts,
+    runtime: runtime(),
+    resolveApiKey: vi.fn(async () => null),
+    toApiKeyCredential: vi.fn(() => null),
+  };
+}
+
+describe("llama-server setup", () => {
+  beforeEach(() => {
+    discoverMock.mockReset();
+    runtimeApiKeyMock.mockReset();
+    runtimeApiKeyMock.mockResolvedValue(undefined);
+    updateAuthProfileStoreMock.mockReset();
+    updateAuthProfileStoreMock.mockResolvedValue({ version: 1, profiles: {} });
+  });
+
+  it("detects a running local server without writing config", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+
+    await expect(detectLlamaServerSetup({ config: {}, env: {} })).resolves.toEqual({
+      modelRef: "llama-server/qwen/model:Q4_K_M",
+      detail: "qwen/model:Q4_K_M at http://localhost:8080",
+    });
+  });
+
+  it("does not select a failed router model while a healthy model is available", async () => {
+    const discovery = successfulDiscovery();
+    discovery.models = [
+      {
+        ...discovery.models[0],
+        config: { ...discovery.models[0].config, id: "qwen-failed", name: "qwen-failed" },
+        status: "unloaded",
+        failed: true,
+      },
+      {
+        ...discovery.models[0],
+        config: { ...discovery.models[0].config, id: "healthy-model", name: "healthy-model" },
+        status: "unloaded",
+        failed: false,
+      },
+    ];
+    discoverMock.mockResolvedValue(discovery);
+
+    await expect(detectLlamaServerSetup({ config: {}, env: {} })).resolves.toMatchObject({
+      modelRef: "llama-server/healthy-model",
+    });
+  });
+
+  it("prefers configured Authorization over ambient auth during guided detection", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    runtimeApiKeyMock.mockResolvedValue("ambient-key");
+
+    await detectLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              headers: { Authorization: "Bearer proxy-key" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(runtimeApiKeyMock).not.toHaveBeenCalled();
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key" },
+      }),
+    );
+  });
+
+  it("skips guided detection when configured auth cannot be resolved", async () => {
+    runtimeApiKeyMock.mockRejectedValue(new Error("unresolved SecretRef"));
+
+    await expect(detectLlamaServerSetup({ config: {}, env: {} })).resolves.toBeNull();
+    expect(discoverMock).not.toHaveBeenCalled();
+  });
+
+  it("prepares only the exact discovered model", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+
+    await expect(
+      prepareLlamaServerSetup({
+        config: {},
+        env: {},
+        modelRef: "llama-server/qwen/model:Q4_K_M",
+      }),
+    ).resolves.toMatchObject({
+      profiles: [],
+      defaultModel: "llama-server/qwen/model:Q4_K_M",
+      configPatch: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              api: "openai-completions",
+            },
+          },
+        },
+      },
+    });
+    await expect(
+      prepareLlamaServerSetup({ config: {}, env: {}, modelRef: "llama-server/missing" }),
+    ).resolves.toBeNull();
+  });
+
+  it("configures an unauthenticated server without persisting a fake key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const prompter = {
+      text: vi.fn(async () => "http://localhost:8080"),
+      confirm: vi.fn(async () => false),
+    };
+    const result = await runLlamaServerSetup({
+      config: {
+        auth: {
+          profiles: {
+            "llama-server:default": { provider: "llama-server", mode: "api_key" },
+            "llama-server:custom": { provider: "llama-server", mode: "api_key" },
+          },
+          order: { "llama-server": ["llama-server:default", "llama-server:custom"] },
+        },
+      },
+      env: {},
+      prompter,
+      runtime: runtime(),
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(result.profiles).toEqual([]);
+    expect(
+      result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.apiKey,
+    ).toBeUndefined();
+    expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
+    expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
+      agentDir: undefined,
+      updater: expect.any(Function),
+    });
+    expect(result.configPatch?.auth).toEqual({
+      profiles: { "llama-server:default": undefined },
+      order: { "llama-server": ["llama-server:custom"] },
+    });
+  });
+
+  it("does not send stored credentials to a replacement endpoint", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    runtimeApiKeyMock.mockResolvedValue("stored-profile-key");
+    const prompter = {
+      text: vi.fn(async () => "http://replacement.example:8080"),
+      confirm: vi.fn(async () => false),
+    };
+    const result = await runLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              apiKey: "stored-provider-key",
+              headers: { Authorization: "Bearer stored-header-key", "X-Tenant": "one" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: { LLAMA_SERVER_API_KEY: "ambient-key" },
+      prompter,
+      runtime: runtime(),
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(runtimeApiKeyMock).not.toHaveBeenCalled();
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://replacement.example:8080/v1",
+        apiKey: undefined,
+        headers: undefined,
+      }),
+    );
+    const provider = result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toBeUndefined();
+  });
+
+  it("returns an API-key profile when the operator enables auth", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:8080")
+        .mockResolvedValueOnce("secret-key"),
+      confirm: vi.fn(async () => true),
+    };
+    const result = await runLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              auth: "api-key",
+              apiKey: "stale-inline-key",
+              headers: { authorization: "Bearer stale-key", "X-Tenant": "one" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      prompter,
+      runtime: runtime(),
+      secretInputMode: "plaintext",
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(result.profiles).toEqual([
+      {
+        profileId: "llama-server:default",
+        credential: {
+          type: "api_key",
+          provider: "llama-server",
+          key: "secret-key",
+        },
+      },
+    ]);
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "secret-key", cacheTtlMs: 0 }),
+    );
+    const provider = result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.auth).toBeUndefined();
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toEqual({ "X-Tenant": "one" });
+  });
+
+  it("validates and configures non-interactively without requiring an API key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ customBaseUrl: "http://localhost:8080/v1" });
+    ctx.config = {
+      auth: {
+        profiles: {
+          "llama-server:default": { provider: "llama-server", mode: "api_key" },
+        },
+        order: { "llama-server": ["llama-server:default"] },
+      },
+    };
+
+    await expect(validateLlamaServerNonInteractive(ctx)).resolves.toBe(true);
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(ctx.resolveApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ required: false, envVar: "LLAMA_SERVER_API_KEY" }),
+    );
+    expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]).toMatchObject({
+      baseUrl: "http://localhost:8080/v1",
+      models: [expect.objectContaining({ id: "qwen/model:Q4_K_M" })],
+    });
+    expect(configured?.agents?.defaults?.model).toEqual(
+      expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
+    );
+    expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
+      agentDir: undefined,
+      updater: expect.any(Function),
+    });
+    expect(configured?.auth).toEqual({ profiles: {}, order: undefined });
+  });
+
+  it("does not reuse ambient or configured credentials for a replacement endpoint non-interactively", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ customBaseUrl: "http://replacement.example:8080/v1" });
+    ctx.config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            apiKey: "stored-provider-key",
+            headers: { Authorization: "Bearer stored-header-key" },
+            models: [],
+          },
+        },
+      },
+    };
+    ctx.resolveApiKey = vi.fn(async () => ({ key: "ambient-key", source: "env" as const }));
+
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://replacement.example:8080/v1",
+        apiKey: undefined,
+        headers: undefined,
+      }),
+    );
+    const provider = configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toBeUndefined();
+  });
+
+  it("removes stale Authorization when non-interactive setup selects an API key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ llamaServerApiKey: "new-key" });
+    ctx.config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            auth: "api-key",
+            apiKey: "stale-inline-key",
+            headers: { Authorization: "Bearer stale-key", "X-Tenant": "one" },
+            models: [],
+          },
+        },
+      },
+    };
+    ctx.resolveApiKey = vi.fn(async () => ({ key: "new-key", source: "flag" as const }));
+    ctx.toApiKeyCredential = vi.fn(() => ({
+      type: "api_key" as const,
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      key: "new-key",
+    }));
+
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    const provider = configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.auth).toBeUndefined();
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toEqual({ "X-Tenant": "one" });
+  });
+
+  it("preserves Authorization when non-interactive auth came from the environment", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext();
+    ctx.config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            headers: { Authorization: "Bearer proxy-key" },
+            models: [],
+          },
+        },
+      },
+    };
+    ctx.resolveApiKey = vi.fn(async () => ({ key: "ambient-key", source: "env" as const }));
+
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key" },
+      }),
+    );
+    expect(ctx.toApiKeyCredential).not.toHaveBeenCalled();
+    expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
+      Authorization: "Bearer proxy-key",
+    });
+  });
+
+  it("rejects a requested model absent from discovery", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ customModelId: "missing" });
+
+    await expect(validateLlamaServerNonInteractive(ctx)).resolves.toBe(false);
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      "llama-server model missing was not found. Available models: qwen/model:Q4_K_M",
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -270,6 +270,63 @@ describe("llama-server setup", () => {
     expect(provider?.headers).toBeUndefined();
   });
 
+  it("prompts for a new API key when a replacement endpoint needs auth", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://replacement.example:8080")
+        .mockResolvedValueOnce("replacement-key"),
+      confirm: vi.fn(async () => true),
+    };
+
+    const result = await runLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              apiKey: "old-config-key",
+              headers: { Authorization: "Bearer old-header-key" },
+              models: [],
+            },
+          },
+        },
+        auth: {
+          profiles: {
+            "llama-server:default": { provider: "llama-server", mode: "api_key" },
+          },
+          order: { "llama-server": ["llama-server:default"] },
+        },
+      },
+      env: { LLAMA_SERVER_API_KEY: "old-endpoint-key" },
+      prompter,
+      runtime: runtime(),
+      secretInputMode: "plaintext",
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(prompter.text).toHaveBeenCalledTimes(2);
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://replacement.example:8080/v1",
+        apiKey: "replacement-key",
+      }),
+    );
+    expect(result.profiles).toEqual([
+      {
+        profileId: "llama-server:default",
+        credential: {
+          type: "api_key",
+          provider: "llama-server",
+          key: "replacement-key",
+        },
+      },
+    ]);
+  });
+
   it("returns an API-key profile when the operator enables auth", async () => {
     discoverMock.mockResolvedValue(successfulDiscovery());
     const prompter = {

--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+import type { LlamaServerDiscoveryResult } from "./discovery.js";
 import {
   configureLlamaServerNonInteractive,
   detectLlamaServerSetup,
@@ -31,7 +32,7 @@ vi.mock("./auth.js", async (importOriginal) => ({
   resolveLlamaServerRuntimeApiKey: runtimeApiKeyMock,
 }));
 
-function successfulDiscovery() {
+function successfulDiscovery(): Extract<LlamaServerDiscoveryResult, { kind: "success" }> {
   return {
     kind: "success" as const,
     endpoint: {
@@ -101,16 +102,20 @@ describe("llama-server setup", () => {
 
   it("does not select a failed router model while a healthy model is available", async () => {
     const discovery = successfulDiscovery();
+    const baseModel = discovery.models[0];
+    if (!baseModel) {
+      throw new Error("expected discovery fixture model");
+    }
     discovery.models = [
       {
-        ...discovery.models[0],
-        config: { ...discovery.models[0].config, id: "qwen-failed", name: "qwen-failed" },
+        ...baseModel,
+        config: { ...baseModel.config, id: "qwen-failed", name: "qwen-failed" },
         status: "unloaded",
         failed: true,
       },
       {
-        ...discovery.models[0],
-        config: { ...discovery.models[0].config, id: "healthy-model", name: "healthy-model" },
+        ...baseModel,
+        config: { ...baseModel.config, id: "healthy-model", name: "healthy-model" },
         status: "unloaded",
         failed: false,
       },

--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -270,6 +270,45 @@ describe("llama-server setup", () => {
     expect(provider?.headers).toBeUndefined();
   });
 
+  it("preserves explicit Authorization instead of selecting an ambient API key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const prompter = {
+      text: vi.fn(async () => "http://localhost:8080"),
+      confirm: vi.fn(async () => false),
+    };
+
+    const result = await runLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              headers: { Authorization: "Bearer proxy-key", "X-Tenant": "one" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: { LLAMA_SERVER_API_KEY: "ambient-key" },
+      prompter,
+      runtime: runtime(),
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(prompter.confirm).toHaveBeenCalledOnce();
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key", "X-Tenant": "one" },
+      }),
+    );
+    const provider = result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.headers).toEqual({ Authorization: "Bearer proxy-key", "X-Tenant": "one" });
+    expect(result.profiles).toEqual([]);
+  });
+
   it("prompts for a new API key when a replacement endpoint needs auth", async () => {
     discoverMock.mockResolvedValue(successfulDiscovery());
     const prompter = {

--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -198,12 +198,16 @@ describe("llama-server setup", () => {
     };
     const result = await runLlamaServerSetup({
       config: {
-        auth: {
-          profiles: {
-            "llama-server:default": { provider: "llama-server", mode: "api_key" },
-            "llama-server:custom": { provider: "llama-server", mode: "api_key" },
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              auth: "api-key",
+              apiKey: "old-inline-key",
+              headers: { "X-Tenant": "one" },
+              models: [],
+            },
           },
-          order: { "llama-server": ["llama-server:default", "llama-server:custom"] },
         },
       },
       env: {},
@@ -215,18 +219,16 @@ describe("llama-server setup", () => {
     } as unknown as ProviderAuthContext);
 
     expect(result.profiles).toEqual([]);
-    expect(
-      result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.apiKey,
-    ).toBeUndefined();
+    const provider = result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.auth).toBeUndefined();
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toEqual({ "X-Tenant": "one" });
     expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
     expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
       agentDir: undefined,
       updater: expect.any(Function),
     });
-    expect(result.configPatch?.auth).toEqual({
-      profiles: { "llama-server:default": undefined },
-      order: { "llama-server": ["llama-server:custom"] },
-    });
+    expect(result.configPatch?.auth).toBeUndefined();
   });
 
   it("does not send stored credentials to a replacement endpoint", async () => {

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -82,6 +82,18 @@ function stripCredentialOverrides(
   };
 }
 
+function stripApiKeyOverrides(
+  provider: ModelProviderConfig | undefined,
+): ModelProviderConfig | undefined {
+  return provider
+    ? {
+        ...provider,
+        auth: undefined,
+        apiKey: undefined,
+      }
+    : undefined;
+}
+
 function stripEndpointCredentials(
   provider: ModelProviderConfig | undefined,
 ): ModelProviderConfig | undefined {
@@ -182,6 +194,7 @@ function buildSetupResult(params: {
   modelId: string;
   credentialInput?: SecretInput;
   useApiKey?: boolean;
+  clearApiKeyOverrides?: boolean;
   clearStoredProfile?: boolean;
   clearEndpointCredentials?: boolean;
 }): ProviderAuthResult {
@@ -191,7 +204,9 @@ function buildSetupResult(params: {
     : configuredProvider;
   const existingProvider = params.useApiKey
     ? stripCredentialOverrides(endpointSafeProvider)
-    : endpointSafeProvider;
+    : params.clearApiKeyOverrides
+      ? stripApiKeyOverrides(endpointSafeProvider)
+      : endpointSafeProvider;
   return {
     profiles: params.credentialInput
       ? [
@@ -436,6 +451,7 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     modelId,
     credentialInput,
     useApiKey: Boolean(apiKey),
+    clearApiKeyOverrides: !usesApiKey,
     clearStoredProfile: !credentialInput,
     clearEndpointCredentials: endpointChanged,
   });

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -381,10 +381,13 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
   const endpoint = resolveLlamaServerEndpoint(baseUrl);
   const endpointChanged = hasEndpointChanged(existing, endpoint.inferenceBaseUrl);
 
+  const hasExplicitAuthorization =
+    !endpointChanged && hasLlamaServerAuthorizationHeader(existing?.headers);
   let credentialInput: SecretInput | undefined;
-  let apiKey = endpointChanged
-    ? undefined
-    : ctx.env?.[LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR]?.trim();
+  let apiKey =
+    endpointChanged || hasExplicitAuthorization
+      ? undefined
+      : ctx.env?.[LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR]?.trim();
   const usesApiKey =
     Boolean(apiKey) ||
     (await ctx.prompter.confirm({

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -1,0 +1,549 @@
+import type {
+  ProviderAppGuidedSetupContext,
+  ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
+  ProviderAuthResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+import {
+  applyAuthProfileConfig,
+  buildApiKeyCredential,
+  ensureApiKeyFromEnvOrPrompt,
+  normalizeOptionalSecretInput,
+  updateAuthProfileStoreWithLock,
+  upsertAuthProfileWithLock,
+  type OpenClawConfig,
+  type SecretInput,
+} from "openclaw/plugin-sdk/provider-auth";
+import {
+  type ModelProviderConfig,
+  selectPreferredLocalModelId,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { applyProviderDefaultModel } from "openclaw/plugin-sdk/provider-setup";
+import {
+  hasLlamaServerAuthorizationHeader,
+  resolveLlamaServerProviderHeaders,
+  resolveLlamaServerRuntimeApiKey,
+} from "./auth.js";
+import {
+  LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+  LLAMA_SERVER_DEFAULT_ORIGIN,
+  LLAMA_SERVER_PROVIDER_ID,
+  LLAMA_SERVER_PROVIDER_LABEL,
+} from "./defaults.js";
+import { discoverLlamaServer, type LlamaServerDiscoveryResult } from "./discovery.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+import { buildLlamaServerProviderConfig } from "./models.js";
+
+const PROFILE_ID = `${LLAMA_SERVER_PROVIDER_ID}:default`;
+
+function selectSetupModelId(discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>) {
+  const healthy = discovery.models.filter((model) => !model.failed);
+  const candidates = healthy.length > 0 ? healthy : discovery.models;
+  const ordered = candidates.toSorted((left, right) => {
+    const leftLoaded = left.status === "loaded" || left.status === "sleeping";
+    const rightLoaded = right.status === "loaded" || right.status === "sleeping";
+    return Number(rightLoaded) - Number(leftLoaded);
+  });
+  const ids = ordered.map((model) => model.config.id);
+  return selectPreferredLocalModelId(ids) ?? ids[0];
+}
+
+function describeDiscoveryFailure(
+  result: Exclude<LlamaServerDiscoveryResult, { kind: "success" }>,
+): string {
+  switch (result.kind) {
+    case "unreachable":
+      return `llama-server could not be reached at ${result.endpoint.origin}.`;
+    case "http-error":
+      return `llama-server returned HTTP ${result.status} for ${result.path} at ${result.endpoint.origin}.`;
+    case "invalid-response":
+      return `llama-server returned an invalid response from ${result.path} at ${result.endpoint.origin}.`;
+    default:
+      throw new Error("Unexpected llama-server discovery result");
+  }
+}
+
+function stripCredentialOverrides(
+  provider: ModelProviderConfig | undefined,
+): ModelProviderConfig | undefined {
+  if (!provider) {
+    return provider;
+  }
+  const headers = Object.fromEntries(
+    Object.entries(provider.headers ?? {}).filter(
+      ([name]) => name.toLowerCase() !== "authorization",
+    ),
+  );
+  return {
+    ...provider,
+    auth: undefined,
+    apiKey: undefined,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
+  };
+}
+
+function stripEndpointCredentials(
+  provider: ModelProviderConfig | undefined,
+): ModelProviderConfig | undefined {
+  return provider
+    ? {
+        ...provider,
+        apiKey: undefined,
+        headers: undefined,
+      }
+    : undefined;
+}
+
+function hasEndpointChanged(provider: ModelProviderConfig | undefined, baseUrl: string): boolean {
+  if (!provider) {
+    return false;
+  }
+  const configuredBaseUrl = provider.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN;
+  return (
+    resolveLlamaServerEndpoint(configuredBaseUrl).inferenceBaseUrl !==
+    resolveLlamaServerEndpoint(baseUrl).inferenceBaseUrl
+  );
+}
+
+function removeLlamaServerAuthProfileConfig(config: OpenClawConfig): OpenClawConfig {
+  const profiles = Object.fromEntries(
+    Object.entries(config.auth?.profiles ?? {}).filter(([id]) => id !== PROFILE_ID),
+  );
+  const order = Object.entries(config.auth?.order ?? {}).reduce<Record<string, string[]>>(
+    (nextOrder, [providerId, providerOrder]) => {
+      const next = providerOrder.filter((id) => id !== PROFILE_ID);
+      if (next.length > 0 || next.length === providerOrder.length) {
+        nextOrder[providerId] = next;
+      }
+      return nextOrder;
+    },
+    {},
+  );
+  return {
+    ...config,
+    auth: {
+      ...config.auth,
+      profiles,
+      order: Object.keys(order).length > 0 ? order : undefined,
+    },
+  };
+}
+
+function buildAuthProfileRemovalPatch(config: OpenClawConfig): Partial<OpenClawConfig> {
+  const profiles = config.auth?.profiles;
+  const order = config.auth?.order;
+  const profileExists = profiles ? Object.hasOwn(profiles, PROFILE_ID) : false;
+  const referencedOrders = Object.entries(order ?? {}).filter(([, ids]) =>
+    ids.includes(PROFILE_ID),
+  );
+  if (!profileExists && referencedOrders.length === 0) {
+    return {};
+  }
+  const profilePatch = profileExists ? { [PROFILE_ID]: undefined } : undefined;
+  const orderPatch = Object.fromEntries(
+    referencedOrders.map(([providerId, ids]) => {
+      const next = ids.filter((id) => id !== PROFILE_ID);
+      return [providerId, next.length > 0 ? next : undefined];
+    }),
+  );
+  return {
+    auth: {
+      ...(profilePatch ? { profiles: profilePatch } : {}),
+      ...(referencedOrders.length > 0 ? { order: orderPatch } : {}),
+    },
+  } as Partial<OpenClawConfig>;
+}
+
+function buildSetupResult(params: {
+  config: OpenClawConfig;
+  discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
+  modelId: string;
+  credentialInput?: SecretInput;
+  useApiKey?: boolean;
+  clearStoredProfile?: boolean;
+  clearEndpointCredentials?: boolean;
+}): ProviderAuthResult {
+  const configuredProvider = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const endpointSafeProvider = params.clearEndpointCredentials
+    ? stripEndpointCredentials(configuredProvider)
+    : configuredProvider;
+  const existingProvider = params.useApiKey
+    ? stripCredentialOverrides(endpointSafeProvider)
+    : endpointSafeProvider;
+  return {
+    profiles: params.credentialInput
+      ? [
+          {
+            profileId: PROFILE_ID,
+            credential: buildApiKeyCredential(
+              LLAMA_SERVER_PROVIDER_ID,
+              params.credentialInput,
+              undefined,
+              { config: params.config },
+            ),
+          },
+        ]
+      : [],
+    defaultModel: `${LLAMA_SERVER_PROVIDER_ID}/${params.modelId}`,
+    configPatch: {
+      ...(params.clearStoredProfile ? buildAuthProfileRemovalPatch(params.config) : {}),
+      models: {
+        mode: params.config.models?.mode ?? "merge",
+        providers: {
+          [LLAMA_SERVER_PROVIDER_ID]: buildLlamaServerProviderConfig({
+            configured: {
+              ...existingProvider,
+              baseUrl: params.discovery.endpoint.inferenceBaseUrl,
+              models: existingProvider?.models ?? [],
+            },
+            discoveredModels: params.discovery.models,
+          }),
+        },
+      },
+    },
+  };
+}
+
+async function removeDefaultAuthProfile(agentDir?: string): Promise<void> {
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    updater: (store) => {
+      let changed = false;
+      if (store.profiles[PROFILE_ID]) {
+        delete store.profiles[PROFILE_ID];
+        changed = true;
+      }
+      if (store.usageStats?.[PROFILE_ID]) {
+        delete store.usageStats[PROFILE_ID];
+        changed = true;
+      }
+      for (const [provider, order] of Object.entries(store.order ?? {})) {
+        const next = order.filter((profileId) => profileId !== PROFILE_ID);
+        if (next.length === order.length) {
+          continue;
+        }
+        changed = true;
+        if (next.length > 0) {
+          store.order![provider] = next;
+        } else {
+          delete store.order![provider];
+        }
+      }
+      for (const [provider, profileId] of Object.entries(store.lastGood ?? {})) {
+        if (profileId === PROFILE_ID) {
+          delete store.lastGood![provider];
+          changed = true;
+        }
+      }
+      if (store.order && Object.keys(store.order).length === 0) {
+        store.order = undefined;
+      }
+      if (store.lastGood && Object.keys(store.lastGood).length === 0) {
+        store.lastGood = undefined;
+      }
+      if (store.usageStats && Object.keys(store.usageStats).length === 0) {
+        store.usageStats = undefined;
+      }
+      return changed;
+    },
+  });
+  if (!updated) {
+    throw new Error(
+      "Failed to remove the previous llama-server auth profile; wait a moment and retry.",
+    );
+  }
+}
+
+async function discoverForSetup(params: {
+  config: OpenClawConfig;
+  baseUrl: string;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+  apiKey?: string;
+  signal?: AbortSignal;
+  reuseStoredAuth?: boolean;
+}): Promise<LlamaServerDiscoveryResult> {
+  const reuseStoredAuth = params.reuseStoredAuth !== false;
+  const providerConfig = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const headers = reuseStoredAuth
+    ? await resolveLlamaServerProviderHeaders({
+        config: params.config,
+        env: params.env,
+        headers: providerConfig?.headers,
+      })
+    : undefined;
+  const resolvedApiKey =
+    params.apiKey ??
+    (reuseStoredAuth && !hasLlamaServerAuthorizationHeader(headers)
+      ? await resolveLlamaServerRuntimeApiKey({
+          config: params.config,
+          agentDir: params.agentDir,
+        })
+      : undefined);
+  return await discoverLlamaServer({
+    baseUrl: params.baseUrl,
+    apiKey: resolvedApiKey,
+    headers,
+    signal: params.signal,
+    cacheTtlMs: 0,
+  });
+}
+
+/** Read-only discovery for the guided local-provider setup ladder. */
+export async function detectLlamaServerSetup(
+  ctx: ProviderAppGuidedSetupContext,
+): Promise<{ modelRef: string; detail?: string } | null> {
+  const provider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const baseUrl = provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN;
+  let discovery: LlamaServerDiscoveryResult;
+  try {
+    discovery = await discoverForSetup({
+      config: ctx.config,
+      baseUrl,
+      env: ctx.env,
+      signal: ctx.signal,
+    });
+  } catch {
+    return null;
+  }
+  if (discovery.kind !== "success") {
+    return null;
+  }
+  const modelId = selectSetupModelId(discovery);
+  if (!modelId) {
+    return null;
+  }
+  return {
+    modelRef: `${LLAMA_SERVER_PROVIDER_ID}/${modelId}`,
+    detail: `${modelId} at ${discovery.endpoint.origin}`,
+  };
+}
+
+/** Rechecks one guided candidate and returns the config needed for a live probe. */
+export async function prepareLlamaServerSetup(
+  ctx: ProviderAppGuidedSetupContext & { modelRef: string },
+): Promise<ProviderAuthResult | null> {
+  const provider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  let discovery: LlamaServerDiscoveryResult;
+  try {
+    discovery = await discoverForSetup({
+      config: ctx.config,
+      baseUrl: provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN,
+      env: ctx.env,
+      signal: ctx.signal,
+    });
+  } catch {
+    return null;
+  }
+  if (discovery.kind !== "success") {
+    return null;
+  }
+  const prefix = `${LLAMA_SERVER_PROVIDER_ID}/`;
+  const modelId = ctx.modelRef.startsWith(prefix) ? ctx.modelRef.slice(prefix.length) : "";
+  if (!modelId || !discovery.models.some((model) => model.config.id === modelId)) {
+    return null;
+  }
+  return buildSetupResult({ config: ctx.config, discovery, modelId });
+}
+
+/** Interactive setup for an existing llama-server endpoint. */
+export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
+  const existing = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const defaultOrigin = resolveLlamaServerEndpoint(existing?.baseUrl).origin;
+  const baseUrl = await ctx.prompter.text({
+    message: `${LLAMA_SERVER_PROVIDER_LABEL} URL`,
+    initialValue: defaultOrigin,
+    placeholder: LLAMA_SERVER_DEFAULT_ORIGIN,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const endpoint = resolveLlamaServerEndpoint(baseUrl);
+  const endpointChanged = hasEndpointChanged(existing, endpoint.inferenceBaseUrl);
+
+  let credentialInput: SecretInput | undefined;
+  let apiKey = endpointChanged
+    ? undefined
+    : ctx.env?.[LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR]?.trim();
+  const usesApiKey =
+    Boolean(apiKey) ||
+    (await ctx.prompter.confirm({
+      message: "Does this llama-server require an API key?",
+      initialValue: false,
+    }));
+  if (usesApiKey && !apiKey) {
+    apiKey = await ensureApiKeyFromEnvOrPrompt({
+      config: ctx.config,
+      env: ctx.env,
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      envLabel: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+      promptMessage: "Enter the llama-server API key",
+      normalize: (value) => value.trim(),
+      validate: (value) => (value.trim() ? undefined : "Required"),
+      prompter: ctx.prompter,
+      secretInputMode: ctx.secretInputMode,
+      setCredential: async (input) => {
+        credentialInput = input;
+      },
+    });
+  }
+
+  const discovery = await discoverForSetup({
+    config: ctx.config,
+    agentDir: ctx.agentDir,
+    baseUrl: endpoint.inferenceBaseUrl,
+    env: ctx.env,
+    apiKey,
+    signal: ctx.signal,
+    reuseStoredAuth: !endpointChanged,
+  });
+  if (discovery.kind !== "success") {
+    throw new Error(describeDiscoveryFailure(discovery));
+  }
+  const modelId = selectSetupModelId(discovery);
+  if (!modelId) {
+    throw new Error(`No llama-server text models were found at ${discovery.endpoint.origin}.`);
+  }
+  if (!credentialInput) {
+    await removeDefaultAuthProfile(ctx.agentDir);
+  }
+  return buildSetupResult({
+    config: ctx.config,
+    discovery,
+    modelId,
+    credentialInput,
+    useApiKey: Boolean(apiKey),
+    clearStoredProfile: !credentialInput,
+    clearEndpointCredentials: endpointChanged,
+  });
+}
+
+async function validateNonInteractiveDiscovery(
+  ctx: Omit<ProviderAuthMethodNonInteractiveContext, "toApiKeyCredential">,
+): Promise<{
+  discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
+  modelId: string;
+  resolvedApiKey: Awaited<ReturnType<typeof ctx.resolveApiKey>>;
+  endpointChanged: boolean;
+} | null> {
+  const configuredProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const baseUrl =
+    normalizeOptionalSecretInput(ctx.opts.customBaseUrl) ??
+    configuredProvider?.baseUrl ??
+    LLAMA_SERVER_DEFAULT_ORIGIN;
+  const endpointChanged = hasEndpointChanged(configuredProvider, baseUrl);
+  const providerApiKey = normalizeOptionalSecretInput(ctx.opts.llamaServerApiKey);
+  const customApiKey = normalizeOptionalSecretInput(ctx.opts.customApiKey);
+  const resolvedApiKey = await ctx.resolveApiKey({
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    flagValue: providerApiKey ?? customApiKey,
+    flagName: providerApiKey === undefined ? "--custom-api-key" : "--llama-server-api-key",
+    envVar: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+    envVarName: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+    required: false,
+  });
+  const headers = endpointChanged
+    ? undefined
+    : await resolveLlamaServerProviderHeaders({
+        config: ctx.config,
+        env: process.env,
+        headers: configuredProvider?.headers,
+      });
+  const selectedApiKey = endpointChanged
+    ? resolvedApiKey?.source === "flag"
+      ? resolvedApiKey
+      : null
+    : hasLlamaServerAuthorizationHeader(headers) && resolvedApiKey?.source !== "flag"
+      ? null
+      : resolvedApiKey;
+  const discovery = await discoverLlamaServer({
+    baseUrl,
+    apiKey: selectedApiKey?.key,
+    headers,
+    cacheTtlMs: 0,
+  });
+  if (discovery.kind !== "success") {
+    ctx.runtime.error(describeDiscoveryFailure(discovery));
+    ctx.runtime.exit(1);
+    return null;
+  }
+  const requestedModelId = normalizeOptionalSecretInput(ctx.opts.customModelId);
+  const modelId = requestedModelId ?? selectSetupModelId(discovery);
+  if (!modelId || !discovery.models.some((model) => model.config.id === modelId)) {
+    const available = discovery.models.map((model) => model.config.id).join(", ");
+    ctx.runtime.error(
+      requestedModelId
+        ? `llama-server model ${requestedModelId} was not found. Available models: ${available}`
+        : `No llama-server text models were found at ${discovery.endpoint.origin}.`,
+    );
+    ctx.runtime.exit(1);
+    return null;
+  }
+  return { discovery, modelId, resolvedApiKey: selectedApiKey, endpointChanged };
+}
+
+export async function validateLlamaServerNonInteractive(
+  ctx: Omit<ProviderAuthMethodNonInteractiveContext, "toApiKeyCredential">,
+): Promise<boolean> {
+  return Boolean(await validateNonInteractiveDiscovery(ctx));
+}
+
+/** Non-interactive setup with optional API-key persistence. */
+export async function configureLlamaServerNonInteractive(
+  ctx: ProviderAuthMethodNonInteractiveContext,
+): Promise<OpenClawConfig | null> {
+  const validated = await validateNonInteractiveDiscovery(ctx);
+  if (!validated) {
+    return null;
+  }
+  const configuredProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const endpointSafeProvider = validated.endpointChanged
+    ? stripEndpointCredentials(configuredProvider)
+    : configuredProvider;
+  const existingProvider = validated.resolvedApiKey
+    ? stripCredentialOverrides(endpointSafeProvider)
+    : endpointSafeProvider;
+  const providerConfig = buildLlamaServerProviderConfig({
+    configured: {
+      ...existingProvider,
+      baseUrl: validated.discovery.endpoint.inferenceBaseUrl,
+      models: existingProvider?.models ?? [],
+    },
+    discoveredModels: validated.discovery.models,
+  });
+  let config: OpenClawConfig = {
+    ...ctx.config,
+    models: {
+      ...ctx.config.models,
+      mode: ctx.config.models?.mode ?? "merge",
+      providers: {
+        ...ctx.config.models?.providers,
+        [LLAMA_SERVER_PROVIDER_ID]: providerConfig,
+      },
+    },
+  };
+
+  if (validated.resolvedApiKey) {
+    const credential = ctx.toApiKeyCredential({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      resolved: validated.resolvedApiKey,
+    });
+    if (!credential) {
+      return null;
+    }
+    await upsertAuthProfileWithLock({
+      profileId: PROFILE_ID,
+      credential,
+      agentDir: ctx.agentDir,
+    });
+    config = applyAuthProfileConfig(config, {
+      profileId: PROFILE_ID,
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      mode: "api_key",
+    });
+  } else {
+    await removeDefaultAuthProfile(ctx.agentDir);
+    config = removeLlamaServerAuthProfileConfig(config);
+  }
+
+  ctx.runtime.log(`Default ${LLAMA_SERVER_PROVIDER_LABEL} model: ${validated.modelId}`);
+  return applyProviderDefaultModel(config, `${LLAMA_SERVER_PROVIDER_ID}/${validated.modelId}`);
+}

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -129,6 +129,25 @@ function removeLlamaServerAuthProfileConfig(config: OpenClawConfig): OpenClawCon
   };
 }
 
+function stripLlamaServerEndpointAuth(config: OpenClawConfig): OpenClawConfig {
+  const withoutProfile = removeLlamaServerAuthProfileConfig(config);
+  const provider = withoutProfile.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const endpointSafeProvider = stripEndpointCredentials(provider);
+  if (!endpointSafeProvider) {
+    return withoutProfile;
+  }
+  return {
+    ...withoutProfile,
+    models: {
+      ...withoutProfile.models,
+      providers: {
+        ...withoutProfile.models?.providers,
+        [LLAMA_SERVER_PROVIDER_ID]: endpointSafeProvider,
+      },
+    },
+  };
+}
+
 function buildAuthProfileRemovalPatch(config: OpenClawConfig): Partial<OpenClawConfig> {
   const profiles = config.auth?.profiles;
   const order = config.auth?.order;
@@ -374,8 +393,8 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     }));
   if (usesApiKey && !apiKey) {
     apiKey = await ensureApiKeyFromEnvOrPrompt({
-      config: ctx.config,
-      env: ctx.env,
+      config: endpointChanged ? stripLlamaServerEndpointAuth(ctx.config) : ctx.config,
+      env: endpointChanged ? {} : ctx.env,
       provider: LLAMA_SERVER_PROVIDER_ID,
       envLabel: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
       promptMessage: "Enter the llama-server API key",

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -146,12 +146,15 @@ function buildAuthProfileRemovalPatch(config: OpenClawConfig): Partial<OpenClawC
       return [providerId, next.length > 0 ? next : undefined];
     }),
   );
-  return {
-    auth: {
-      ...(profilePatch ? { profiles: profilePatch } : {}),
-      ...(referencedOrders.length > 0 ? { order: orderPatch } : {}),
-    },
-  } as Partial<OpenClawConfig>;
+  const authPatch: NonNullable<OpenClawConfig["auth"]> = {};
+  // Config patches use undefined map values as deletion markers.
+  if (profilePatch) {
+    Reflect.set(authPatch, "profiles", profilePatch);
+  }
+  if (referencedOrders.length > 0) {
+    Reflect.set(authPatch, "order", orderPatch);
+  }
+  return { auth: authPatch };
 }
 
 function buildSetupResult(params: {

--- a/extensions/llama-cpp/src/external-server/stream.test.ts
+++ b/extensions/llama-cpp/src/external-server/stream.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLlamaServerThinking } from "./stream.js";
+
+describe("llama-server stream payload", () => {
+  it("maps thinking off to llama-server chat-template kwargs", () => {
+    expect(
+      normalizeLlamaServerThinking(
+        {
+          model: "model",
+          chat_template_kwargs: { preserve_thinking: true, enable_thinking: true },
+        },
+        "off",
+      ),
+    ).toEqual({
+      model: "model",
+      chat_template_kwargs: { preserve_thinking: true, enable_thinking: false },
+    });
+  });
+
+  it("does not force thinking on when OpenClaw selected another level", () => {
+    const payload = { model: "model" };
+    expect(normalizeLlamaServerThinking(payload, "high")).toBe(payload);
+  });
+});

--- a/extensions/llama-cpp/src/external-server/stream.test.ts
+++ b/extensions/llama-cpp/src/external-server/stream.test.ts
@@ -1,24 +1,47 @@
-import { describe, expect, it } from "vitest";
-import { normalizeLlamaServerThinking } from "./stream.js";
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import { wrapLlamaServerStream } from "./stream.js";
+
+function capturePayloadHook(thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"]) {
+  let payloadHook: ((payload: unknown, model: unknown) => unknown) | undefined;
+  const underlying = vi.fn((_model, _context, options) => {
+    payloadHook = options?.onPayload;
+    return {} as ReturnType<StreamFn>;
+  }) as StreamFn;
+  const wrapped = wrapLlamaServerStream({
+    streamFn: underlying,
+    thinkingLevel,
+  } as ProviderWrapStreamFnContext);
+  void wrapped({ provider: "llama-server" } as never, { messages: [] }, {});
+  if (!payloadHook) {
+    throw new Error("expected llama-server payload hook");
+  }
+  return payloadHook;
+}
 
 describe("llama-server stream payload", () => {
-  it("maps thinking off to llama-server chat-template kwargs", () => {
-    expect(
-      normalizeLlamaServerThinking(
+  it("maps thinking off to llama-server chat-template kwargs", async () => {
+    const payloadHook = capturePayloadHook("off");
+
+    await expect(
+      payloadHook(
         {
           model: "model",
           chat_template_kwargs: { preserve_thinking: true, enable_thinking: true },
         },
-        "off",
+        {},
       ),
-    ).toEqual({
+    ).resolves.toEqual({
       model: "model",
       chat_template_kwargs: { preserve_thinking: true, enable_thinking: false },
     });
   });
 
-  it("does not force thinking on when OpenClaw selected another level", () => {
+  it("does not force thinking on when OpenClaw selected another level", async () => {
+    const payloadHook = capturePayloadHook("high");
     const payload = { model: "model" };
-    expect(normalizeLlamaServerThinking(payload, "high")).toBe(payload);
+
+    await expect(payloadHook(payload, {})).resolves.toBe(payload);
   });
 });

--- a/extensions/llama-cpp/src/external-server/stream.test.ts
+++ b/extensions/llama-cpp/src/external-server/stream.test.ts
@@ -3,17 +3,20 @@ import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-ent
 import { describe, expect, it, vi } from "vitest";
 import { wrapLlamaServerStream } from "./stream.js";
 
-function capturePayloadHook(thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"]) {
+function capturePayloadHook(
+  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
+  options: Record<string, unknown> = {},
+) {
   let payloadHook: ((payload: unknown, model: unknown) => unknown) | undefined;
-  const underlying = vi.fn((_model, _context, options) => {
-    payloadHook = options?.onPayload;
+  const underlying = vi.fn((_model, _context, streamOptions) => {
+    payloadHook = streamOptions?.onPayload;
     return {} as ReturnType<StreamFn>;
   }) as StreamFn;
   const wrapped = wrapLlamaServerStream({
     streamFn: underlying,
     thinkingLevel,
   } as ProviderWrapStreamFnContext);
-  void wrapped({ provider: "llama-server" } as never, { messages: [] }, {});
+  void wrapped({ provider: "llama-server" } as never, { messages: [] }, options as never);
   if (!payloadHook) {
     throw new Error("expected llama-server payload hook");
   }
@@ -43,5 +46,42 @@ describe("llama-server stream payload", () => {
     const payload = { model: "model" };
 
     await expect(payloadHook(payload, {})).resolves.toBe(payload);
+  });
+
+  it("maps OpenAI nested JSON Schema to llama-server's direct schema field", async () => {
+    const payloadHook = capturePayloadHook("off");
+    const schema = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    };
+
+    await expect(
+      payloadHook(
+        {
+          model: "model",
+          response_format: {
+            type: "json_schema",
+            json_schema: { name: "openclaw_response", schema },
+          },
+        },
+        {},
+      ),
+    ).resolves.toMatchObject({
+      response_format: { type: "json_object", schema },
+    });
+  });
+
+  it("injects a direct schema when the shared transport omits it", async () => {
+    const schema = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    };
+    const payloadHook = capturePayloadHook("off", { responseFormat: schema });
+
+    await expect(payloadHook({ model: "model" }, {})).resolves.toMatchObject({
+      response_format: { type: "json_object", schema },
+    });
   });
 });

--- a/extensions/llama-cpp/src/external-server/stream.ts
+++ b/extensions/llama-cpp/src/external-server/stream.ts
@@ -1,14 +1,11 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
 /** Disables chat-template reasoning when OpenClaw selected thinking off. */
-export function normalizeLlamaServerThinking(
+function normalizeLlamaServerThinking(
   payload: unknown,
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): unknown {

--- a/extensions/llama-cpp/src/external-server/stream.ts
+++ b/extensions/llama-cpp/src/external-server/stream.ts
@@ -22,7 +22,41 @@ function normalizeLlamaServerThinking(
   };
 }
 
-/** Keeps the shared OpenAI transport and adjusts only llama-server template behavior. */
+/** Maps shared structured-output requests to the shape accepted by older llama-server builds. */
+function normalizeLlamaServerResponseFormat(
+  payload: unknown,
+  requestedResponseFormat?: Record<string, unknown>,
+): unknown {
+  if (!isRecord(payload)) {
+    return payload;
+  }
+  const responseFormat = isRecord(payload.response_format)
+    ? payload.response_format
+    : requestedResponseFormat;
+  if (!responseFormat || responseFormat.type === "text") {
+    return payload;
+  }
+  const schema =
+    responseFormat.type === "json_schema"
+      ? isRecord(responseFormat.json_schema)
+        ? responseFormat.json_schema.schema
+        : responseFormat.schema
+      : responseFormat.type === "json_object"
+        ? responseFormat.schema
+        : responseFormat;
+  if (!isRecord(schema)) {
+    return payload;
+  }
+  return {
+    ...payload,
+    response_format: {
+      type: "json_object",
+      schema,
+    },
+  };
+}
+
+/** Keeps the shared OpenAI transport and adjusts llama-server request compatibility. */
 export function wrapLlamaServerStream(ctx: ProviderWrapStreamFnContext): StreamFn {
   const underlying = ctx.streamFn ?? streamSimple;
   return (model, context, options) => {
@@ -34,7 +68,8 @@ export function wrapLlamaServerStream(ctx: ProviderWrapStreamFnContext): StreamF
       ...options,
       onPayload: async (payload, requestModel) => {
         const customized = (await onPayload?.(payload, requestModel)) ?? payload;
-        return normalizeLlamaServerThinking(customized, ctx.thinkingLevel);
+        const thinkingNormalized = normalizeLlamaServerThinking(customized, ctx.thinkingLevel);
+        return normalizeLlamaServerResponseFormat(thinkingNormalized, options?.responseFormat);
       },
     });
   };

--- a/extensions/llama-cpp/src/external-server/stream.ts
+++ b/extensions/llama-cpp/src/external-server/stream.ts
@@ -1,0 +1,44 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { streamSimple } from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Disables chat-template reasoning when OpenClaw selected thinking off. */
+export function normalizeLlamaServerThinking(
+  payload: unknown,
+  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
+): unknown {
+  if (!isRecord(payload) || thinkingLevel !== "off") {
+    return payload;
+  }
+  const existing = isRecord(payload.chat_template_kwargs) ? payload.chat_template_kwargs : {};
+  return {
+    ...payload,
+    chat_template_kwargs: {
+      ...existing,
+      enable_thinking: false,
+    },
+  };
+}
+
+/** Keeps the shared OpenAI transport and adjusts only llama-server template behavior. */
+export function wrapLlamaServerStream(ctx: ProviderWrapStreamFnContext): StreamFn {
+  const underlying = ctx.streamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.provider !== LLAMA_SERVER_PROVIDER_ID) {
+      return underlying(model, context, options);
+    }
+    const onPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: async (payload, requestModel) => {
+        const customized = (await onPayload?.(payload, requestModel)) ?? payload;
+        return normalizeLlamaServerThinking(customized, ctx.thinkingLevel);
+      },
+    });
+  };
+}

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -63,7 +63,7 @@ export function registerManagedLlamaCppProvider(api: OpenClawPluginApi): void {
     wizard: {
       setup: {
         choiceId: LLAMA_CPP_PROVIDER_ID,
-        choiceLabel: LLAMA_CPP_PROVIDER_LABEL,
+        choiceLabel: "Managed local server",
         choiceHint:
           "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
         groupId: LLAMA_CPP_PROVIDER_ID,

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -1,0 +1,81 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import {
+  LLAMA_CPP_PROVIDER_ID,
+  LLAMA_CPP_PROVIDER_LABEL,
+  buildLlamaCppProviderConfig,
+  resolveLlamaCppSyntheticApiKey,
+} from "./defaults.js";
+import { ensureManagedLlamaServerForChat } from "./managed-server.js";
+import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
+
+export function registerManagedLlamaCppProvider(api: OpenClawPluginApi): void {
+  api.registerProvider({
+    id: LLAMA_CPP_PROVIDER_ID,
+    label: LLAMA_CPP_PROVIDER_LABEL,
+    docsPath: "/plugins/llama-cpp",
+    auth: [
+      {
+        id: "local",
+        label: LLAMA_CPP_PROVIDER_LABEL,
+        hint: "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
+        kind: "custom",
+        appGuidedSetup: {
+          detect: detectLlamaCppSetup,
+          prepare: prepareLlamaCppSetup,
+        },
+        run: runLlamaCppSetup,
+      },
+    ],
+    catalog: {
+      order: "late",
+      run: async (ctx) => ({
+        provider: buildLlamaCppProviderConfig(
+          ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID],
+        ),
+      }),
+    },
+    staticCatalog: {
+      order: "late",
+      run: async () => ({ provider: buildLlamaCppProviderConfig() }),
+    },
+    resolveSyntheticAuth: () => ({
+      apiKey: resolveLlamaCppSyntheticApiKey(),
+      source: "managed local llama.cpp server",
+      mode: "api-key" as const,
+    }),
+    wrapStreamFn: (ctx) => {
+      const inner = ctx.streamFn;
+      const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+      const selectedModel = ctx.model;
+      if (!inner || !providerConfig?.localService || !selectedModel) {
+        return undefined;
+      }
+      return async (model, context, options) => {
+        await ensureManagedLlamaServerForChat({
+          provider: providerConfig,
+          model: selectedModel,
+        });
+        return inner(model, context, options);
+      };
+    },
+    ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
+    wizard: {
+      setup: {
+        choiceId: LLAMA_CPP_PROVIDER_ID,
+        choiceLabel: LLAMA_CPP_PROVIDER_LABEL,
+        choiceHint:
+          "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
+        groupId: LLAMA_CPP_PROVIDER_ID,
+        groupLabel: "Local llama.cpp",
+        groupHint: "Managed or external llama.cpp server",
+        methodId: "local",
+      },
+      modelPicker: {
+        label: "llama.cpp (managed)",
+        hint: "Run a GGUF model with OpenClaw's managed local llama.cpp server",
+        methodId: "local",
+      },
+    },
+  });
+}

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -315,6 +315,28 @@ describe("OpenAI-compatible completions params", () => {
     }
   });
 
+  it("keeps explicit authorization headers when API-key auth is also present", async () => {
+    mockOpenAIOptionsRef.options = [];
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+
+    const result = await streamOpenAICompletions(
+      {
+        ...model,
+        provider: "llama-server",
+        headers: { Authorization: "Bearer proxy-key" },
+      },
+      context,
+      { apiKey: "ambient-key" },
+    ).result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(mockOpenAIOptionsRef.options).toHaveLength(1);
+    expect(mockOpenAIOptionsRef.options[0]).toMatchObject({
+      apiKey: "ambient-key",
+      defaultHeaders: { Authorization: "Bearer proxy-key" },
+    });
+  });
+
   it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
     mockChunksRef.chunks = [makeRefusalChunk("I can't help with that.")];
 

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -140,6 +140,7 @@ describe("scripts/test-live-shard", () => {
       "extensions/openai/realtime-voice-provider.live.test.ts",
     ]);
     expect(selectLiveShardFiles("native-live-extensions-l-n", allFiles)).toEqual([
+      "extensions/llama-cpp/src/external-server/llama-server.live.test.ts",
       "extensions/memory-lancedb/memory-lancedb.live.test.ts",
       "extensions/meta/meta.live.test.ts",
       "extensions/microsoft/microsoft.live.test.ts",


### PR DESCRIPTION
Closes #116765

## What Problem This Solves

OpenClaw can manage its own llama.cpp server, but users who already run `llama-server` must configure it as a generic OpenAI-compatible endpoint and repeat model metadata by hand.
This change adds first-class external-server support to the existing `llama-cpp` plugin.
Users can keep the managed `llama-cpp/*` path, use the new `llama-server/*` path, or configure both at the same time.

## Why This Change Was Made

One plugin now owns both llama.cpp connection modes while keeping their provider identities and lifecycle rules separate.
The existing managed path is unchanged. New external setups never install, start, stop, download, or reconfigure a server. Existing explicit `localService` configurations retain their previous supervisor behavior for compatibility.

- Keeps plugin/package identity `llama-cpp` / `@openclaw/llama-cpp-provider`.
- Keeps `llama-cpp/*` for OpenClaw-managed chat and local embeddings.
- Adds `llama-server/*` for an existing user-managed HTTP server.
- Adds passive single-model and router discovery through `/health`, `/models`, and `/props?autoload=false`.
- Maps active context, slots, vision, tool support, build information, and router state from server metadata.
- Supports unauthenticated endpoints, API keys, SecretRefs, auth profiles, and explicit authorization headers.
- Scopes credentials and caches to the endpoint and auth profile. Replacement endpoints cannot inherit the prior endpoint's environment, config, header, or stored-profile credentials.
- Uses OpenClaw's guarded provider transport and llama.cpp tool-schema compatibility hooks.
- Maps structured-output requests to llama-server's direct `json_object` schema shape for older and current server builds.
- Adds guided and non-interactive setup under one **Local llama.cpp** group.
- Preserves existing explicit `llama-server.localService` configurations for upgrade compatibility; new managed setups use `llama-cpp`.

## User Impact

Users can select **Existing llama-server**, enter its URL and optional key, and choose a discovered model without writing model metadata manually.
The existing managed llama.cpp setup, downloads, chat model references, local embeddings, diagnostics, and cache identities remain available without configuration changes.

Model references clearly show process ownership:

- `llama-cpp/<model>`: OpenClaw-managed server
- `llama-server/<model>`: user-managed external server

## Evidence

The focused, contract, type, boundary, docs, build, and changed-file checks pass.
A live external-server suite also passes discovery, concurrent generation, cancellation, structured output, and a tool-call round trip.

Live target:

- Runtime: `ggml-org/llama.cpp` build `b9204-06c40534b`
- Model: `unsloth/Qwen3.6-35B-A3B-GGUF`
- Revision: `a483e9e6cbd595906af30beda3187c2663a1118c`
- File: `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`
- Alias: `qwen3.6-35b-a3b`
- Advertised context: 65,536 tokens
- Slots: 1

Validation:

```text
node scripts/run-vitest.mjs extensions/llama-cpp
13 files passed, 94 tests passed

node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.test.ts
1 file passed, 61 tests passed

LLAMA_SERVER_LIVE_TEST=1 \
LLAMA_SERVER_LIVE_URL=http://127.0.0.1:8080/v1 \
LLAMA_SERVER_LIVE_MODEL_ID=qwen3.6-35b-a3b \
pnpm test:live -- extensions/llama-cpp/src/external-server/llama-server.live.test.ts
1 file passed, 4 tests passed

pnpm test:contracts:plugins
42 files passed, 1036 tests passed

pnpm test:extensions:package-boundary
122 plugins and 1 canary passed

pnpm plugin-sdk:surface:check
passed

pnpm plugins:inventory:check
passed

pnpm check:docs
passed; 6,530 internal links checked, 0 broken

pnpm tsgo:test
passed

pnpm check:changed
passed

pnpm build
passed
```

The first live structured-output run exposed an older-server compatibility gap: nested OpenAI `json_schema` produced fenced JSON on b9204.
The final implementation maps that request to llama-server's direct schema shape, and the same live test then passed.

## Risks

The main risk is connecting to a user-supplied private endpoint with user-supplied credentials.
The implementation keeps inference on the shared guarded transport, pins discovery to the configured origin, bounds response bodies, deadlines, caches, and router concurrency, and prevents credentials from crossing endpoint changes.

Discovery is intentionally read-only. Router load, unload, wake, sleep, and download controls remain outside this provider. Existing explicit `localService` configurations keep their prior generic supervisor behavior, while new external setup never creates one.

