### PR TITLE
fix(ui): refresh chat checkout side panels

### DIFF
--- a/src/gateway/control-ui-session-prs-local-git.ts
+++ b/src/gateway/control-ui-session-prs-local-git.ts
@@ -36,9 +36,9 @@ type LocalGitCacheEntry<T> = { expiresAt: number; promise: Promise<T> };
 
 function createLocalGitCache<T>() {
   const entries = new Map<string, LocalGitCacheEntry<T>>();
-  return (key: string, load: () => Promise<T>): Promise<T> => {
+  return (key: string, refresh: boolean, load: () => Promise<T>): Promise<T> => {
     const cached = entries.get(key);
-    if (cached && cached.expiresAt > Date.now()) {
+    if (!refresh && cached && cached.expiresAt > Date.now()) {
       entries.delete(key);
       entries.set(key, cached);
       return cached.promise;
@@ -59,8 +59,9 @@ const cachedBranchFacts = createLocalGitCache<SessionPullRequestBranchFacts | un
 export function resolveCachedGitContext(
   root: string,
   deps: SessionPullRequestLocalGitDeps,
+  refresh = false,
 ): Promise<SessionPullRequestGitContext | null> {
-  return cachedGitContext(root, async () => {
+  return cachedGitContext(root, refresh, async () => {
     const output = deps.gitOutput ?? gitOutput;
     const branch = await output(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
     if (!branch || branch === "HEAD") {
@@ -84,7 +85,8 @@ export function resolveCachedSessionBranchFacts(
   context: SessionPullRequestGitContext & { root: string },
   mergedHeads: readonly MergedPullHead[],
   load: () => Promise<SessionPullRequestBranchFacts | undefined>,
+  refresh = false,
 ): Promise<SessionPullRequestBranchFacts | undefined> {
   const landingKey = JSON.stringify([context.defaultBranch ?? null, mergedHeads]);
-  return cachedBranchFacts(`${context.root}\0${context.branch}\0${landingKey}`, load);
+  return cachedBranchFacts(`${context.root}\0${context.branch}\0${landingKey}`, refresh, load);
 }

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -396,7 +396,7 @@ describe("loadControlUiSessionPullRequests", () => {
     expect(fetchImpl.mock.calls).toHaveLength(1);
   });
 
-  it("caches branch facts by root while refresh only bypasses the GitHub cache", async () => {
+  it("keeps normal local facts cached while forced refresh bypasses them", async () => {
     let pulls: Record<string, unknown>[] = [];
     const fetchImpl = routedFetch([
       { match: "/pulls?head=", response: () => githubJson(pulls) },
@@ -411,9 +411,9 @@ describe("loadControlUiSessionPullRequests", () => {
     const gitOutputImpl = vi.fn(async (_root: string, args: string[]) =>
       args[0] === "rev-list" ? "1" : null,
     );
+    let additions = 1;
     const runGitImpl = vi.fn(async (root: string) => ({
-      stdout:
-        root === "/repo/b" ? " 1 file changed, 2 insertions(+)" : " 1 file changed, 1 insertion(+)",
+      stdout: ` 1 file changed, ${root === "/repo/b" ? 3 : additions} insertions(+)`,
       stderr: "",
       code: 0,
     }));
@@ -435,10 +435,15 @@ describe("loadControlUiSessionPullRequests", () => {
       );
 
     expect((await load("agent:main:a")).branch?.additions).toBe(1);
-    expect((await load("agent:main:a", true)).branch?.additions).toBe(1);
+    additions = 2;
+    expect((await load("agent:main:a")).branch?.additions).toBe(1);
     expect(resolveBranchLanding).toHaveBeenCalledTimes(1);
     expect(runGitImpl).toHaveBeenCalledTimes(1);
     expect(gitOutputImpl).toHaveBeenCalledTimes(2);
+    expect((await load("agent:main:a", true)).branch?.additions).toBe(2);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(2);
+    expect(runGitImpl).toHaveBeenCalledTimes(2);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(4);
     expect(
       fetchImpl.mock.calls.filter((call) =>
         requestUrl(call[0] as RequestInfo | URL).includes("/pulls?head="),
@@ -446,21 +451,67 @@ describe("loadControlUiSessionPullRequests", () => {
     ).toHaveLength(2);
 
     pulls = [pullListItem({ merged_at: "2026-07-09T10:00:00Z" })];
-    expect((await load("agent:main:a", true)).branch?.additions).toBe(1);
-    expect(resolveBranchLanding).toHaveBeenCalledTimes(2);
-    expect(runGitImpl).toHaveBeenCalledTimes(2);
-    expect(gitOutputImpl).toHaveBeenCalledTimes(4);
-
-    vi.advanceTimersByTime(10_001);
-    expect((await load("agent:main:a")).branch?.additions).toBe(1);
+    additions = 4;
+    expect((await load("agent:main:a", true)).branch?.additions).toBe(4);
     expect(resolveBranchLanding).toHaveBeenCalledTimes(3);
     expect(runGitImpl).toHaveBeenCalledTimes(3);
     expect(gitOutputImpl).toHaveBeenCalledTimes(6);
 
-    expect((await load("agent:main:b")).branch?.additions).toBe(2);
+    vi.advanceTimersByTime(10_001);
+    additions = 5;
+    expect((await load("agent:main:a")).branch?.additions).toBe(5);
     expect(resolveBranchLanding).toHaveBeenCalledTimes(4);
     expect(runGitImpl).toHaveBeenCalledTimes(4);
     expect(gitOutputImpl).toHaveBeenCalledTimes(8);
+
+    expect((await load("agent:main:b")).branch?.additions).toBe(3);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(5);
+    expect(runGitImpl).toHaveBeenCalledTimes(5);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(10);
+  });
+
+  it("forced refresh bypasses cached checkout branch context", async () => {
+    let branch = "feature-a";
+    const fetchImpl = routedFetch([
+      { match: "/pulls?head=", response: () => githubJson([]) },
+      { match: "/repos/openclaw/openclaw", response: () => githubJson({ fork: false }) },
+    ]);
+    const gitOutputImpl = vi.fn(async (_root: string, args: string[]) => {
+      if (args[0] === "rev-parse") {
+        return branch;
+      }
+      if (args[0] === "remote") {
+        return "git@github.com:openclaw/openclaw.git";
+      }
+      if (args[0] === "symbolic-ref") {
+        return "origin/main";
+      }
+      if (args[0] === "rev-list") {
+        return "1";
+      }
+      return null;
+    });
+    const resolveBranchLanding = vi.fn(async () => ({
+      pushedSha: "a".repeat(40),
+      statsBase: null,
+      hasLandedPullRequest: false,
+      provenNewPushedWork: false,
+    }));
+    const load = (refresh = false) =>
+      loadControlUiSessionPullRequests(
+        { sessionKey: "agent:main:context-refresh", ...(refresh ? { refresh: true } : {}) },
+        {
+          fetchImpl,
+          resolveGitRoot: async () => "/repo/forced-context",
+          gitOutput: gitOutputImpl,
+          resolveBranchLanding,
+        },
+      );
+
+    expect((await load()).branch?.branch).toBe("feature-a");
+    branch = "feature-b";
+    expect((await load()).branch?.branch).toBe("feature-a");
+    expect((await load(true)).branch?.branch).toBe("feature-b");
   });
 
   it("refreshes a cached empty result after the assistant creates a PR", async () => {

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -136,7 +136,7 @@ async function resolveSessionPullRequestGitContext(
   if (!root) {
     return null;
   }
-  return resolveCachedGitContext(root, deps);
+  return resolveCachedGitContext(root, deps, params.refresh === true);
 }
 
 // git push's own "create a pull request" hint URL; GitHub resolves the base
@@ -269,6 +269,7 @@ async function resolveSessionBranch(
   context: SessionPullRequestGitContext,
   mergedHeads: readonly MergedPullHead[],
   deps: LoadSessionPullRequestDeps,
+  refresh: boolean,
 ): Promise<ControlUiSessionBranch | undefined> {
   const root = context.root;
   if (!root) {
@@ -303,6 +304,7 @@ async function resolveSessionBranch(
       // No createUrl until GitHub can compare, but local changes still get a row.
       return !creatable && !(stats && stats.changedFiles > 0) ? undefined : { creatable, stats };
     },
+    refresh,
   );
   if (!facts) {
     return undefined;
@@ -612,14 +614,14 @@ export async function loadControlUiSessionPullRequests(
   if (!context) {
     return { pullRequests: [], rateLimited: false };
   }
-  // Local Git uses a separate short TTL; refresh only forces the GitHub layer.
-  // Branch resolution follows the snapshot because merged head SHAs affect it.
+  // Normal polling keeps the short local-Git TTL; forced structural refreshes
+  // must observe the replacement checkout before publishing its branch facts.
   const { mergedHeads, ...snapshot } = await cachedBranchPullRequests(
     context,
     deps,
     params.refresh === true,
   );
-  const branch = await resolveSessionBranch(context, mergedHeads, deps);
+  const branch = await resolveSessionBranch(context, mergedHeads, deps, params.refresh === true);
   return branch ? { ...snapshot, branch } : snapshot;
 }
 

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -87,6 +87,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       }),
     getSelectedAgentId: () => this.selectedAgentIdForSessions(),
     getGateway: () => this.context?.gateway,
+    getSessions: () => this.context?.sessions,
   });
 
   protected readonly compareSidebarSessionRows = (

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -53,11 +53,11 @@ function createGatewayHarness() {
   return {
     gateway,
     request,
-    emit(payload: unknown) {
+    emit(payload: unknown, event = CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT) {
       for (const listener of eventListeners) {
         listener({
           type: "event",
-          event: CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT,
+          event,
           payload,
           seq: 1,
         });
@@ -185,6 +185,40 @@ describe("SessionPullRequestIndicatorsController", () => {
     selectedAgentId = "work";
     controller.hostUpdated();
     await vi.advanceTimersByTimeAsync(0);
+
+    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("none");
+  });
+
+  it("clears a structural session's indicator while replacement data is pending", async () => {
+    vi.useFakeTimers();
+    const host = new TestHost();
+    const harness = createGatewayHarness();
+    const row = {
+      key: "agent:main:demo",
+      isChild: false,
+      worktreeId: "wt-demo",
+    } as SidebarRecentSession;
+    const controller = new SessionPullRequestIndicatorsController(host, {
+      getConnected: () => true,
+      getRows: () => [row],
+      getSelectedAgentId: () => "main",
+      getGateway: () => harness.gateway,
+    });
+    controller.hostConnected();
+    controller.hostUpdated();
+    await vi.advanceTimersByTimeAsync(0);
+    harness.emit({
+      sessions: {
+        [row.key]: {
+          pullRequests: [{ number: 1, state: "open" }],
+          rateLimited: false,
+          status: "ready",
+        },
+      },
+    });
+    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("open");
+
+    harness.emit({ sessionKey: row.key, agentId: "main", reason: "rewind" }, "sessions.changed");
 
     expect(controller.state(row.key, row.worktreeId ?? "")).toBe("none");
   });

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -4,6 +4,7 @@ import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gat
 import type { GatewayBrowserClient, GatewayEventListener } from "../api/gateway.ts";
 import type { ApplicationGateway } from "../app/gateway.ts";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import type { SessionCapability } from "../lib/sessions/index.ts";
 import { SessionPullRequestIndicatorsController } from "./app-sidebar-session-pr-indicators.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 
@@ -80,6 +81,7 @@ describe("SessionPullRequestIndicatorsController", () => {
       getRows: () => [],
       getSelectedAgentId: () => "main",
       getGateway: () => harness.gateway,
+      getSessions: () => undefined,
     });
 
     controller.hostConnected();
@@ -103,6 +105,7 @@ describe("SessionPullRequestIndicatorsController", () => {
       getRows: () => [row],
       getSelectedAgentId: () => "main",
       getGateway: () => harness.gateway,
+      getSessions: () => undefined,
     });
 
     controller.hostConnected();
@@ -157,6 +160,7 @@ describe("SessionPullRequestIndicatorsController", () => {
       getRows: () => [row],
       getSelectedAgentId: () => selectedAgentId,
       getGateway: () => harness.gateway,
+      getSessions: () => undefined,
     });
     controller.hostConnected();
     controller.hostUpdated();
@@ -198,11 +202,18 @@ describe("SessionPullRequestIndicatorsController", () => {
       isChild: false,
       worktreeId: "wt-demo",
     } as SidebarRecentSession;
+    const epoch = {};
+    const setPullRequestSummary = vi.fn();
     const controller = new SessionPullRequestIndicatorsController(host, {
       getConnected: () => true,
       getRows: () => [row],
       getSelectedAgentId: () => "main",
       getGateway: () => harness.gateway,
+      getSessions: () =>
+        ({
+          capturePullRequestEpoch: vi.fn(() => epoch),
+          setPullRequestSummary,
+        }) as unknown as SessionCapability,
     });
     controller.hostConnected();
     controller.hostUpdated();
@@ -221,5 +232,6 @@ describe("SessionPullRequestIndicatorsController", () => {
     harness.emit({ sessionKey: row.key, agentId: "main", reason: "rewind" }, "sessions.changed");
 
     expect(controller.state(row.key, row.worktreeId ?? "")).toBe("none");
+    expect(setPullRequestSummary).toHaveBeenCalledExactlyOnceWith(row.key, undefined, epoch);
   });
 });

--- a/ui/src/components/app-sidebar-session-pr-indicators.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.ts
@@ -121,7 +121,11 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
       const snapshot = store.get(this.scopedKey(session.key));
       // Empty failure snapshots retain the rendered chip; snapshots carrying
       // last-known PRs can also hydrate a newly mounted row.
-      if (!snapshot || (snapshot.status !== "ready" && snapshot.pullRequests.length === 0)) {
+      if (!snapshot) {
+        changed = this.states.delete(session.key) || changed;
+        continue;
+      }
+      if (snapshot.status !== "ready" && snapshot.pullRequests.length === 0) {
         continue;
       }
       const entry = {

--- a/ui/src/components/app-sidebar-session-pr-indicators.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.ts
@@ -8,6 +8,7 @@ import {
   sessionPullRequestsForGateway,
   type SessionPullRequestSnapshotStore,
 } from "../lib/session-pull-requests.ts";
+import type { SessionCapability } from "../lib/sessions/index.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import {
@@ -25,6 +26,7 @@ type SessionPullRequestIndicatorsOptions = {
   getRows: () => readonly SidebarRecentSession[];
   getSelectedAgentId: () => string;
   getGateway: () => ApplicationGateway | undefined;
+  getSessions: () => SessionCapability | undefined;
 };
 
 /** Projects pushed PR snapshots for the currently visible worktree rows. */
@@ -122,7 +124,18 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
       // Empty failure snapshots retain the rendered chip; snapshots carrying
       // last-known PRs can also hydrate a newly mounted row.
       if (!snapshot) {
-        changed = this.states.delete(session.key) || changed;
+        const removed = this.states.delete(session.key);
+        if (removed) {
+          const sessions = this.options.getSessions();
+          if (sessions) {
+            sessions.setPullRequestSummary(
+              session.key,
+              undefined,
+              sessions.capturePullRequestEpoch(session.key),
+            );
+          }
+        }
+        changed = removed || changed;
         continue;
       }
       if (snapshot.status !== "ready" && snapshot.pullRequests.length === 0) {

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -402,6 +402,9 @@ describe("Control UI service-worker production update E2E", () => {
       await rename(outDir, previousOutDir);
       await rename(nextOutDir, outDir);
       await rm(previousOutDir, { force: true, recursive: true });
+      // Assets and Gateway identity advance together in a deployment. Publish
+      // build B before a stale lazy chunk can reload and reconnect the document.
+      await gateway.setServerBuildId(buildB);
       // The production preview serves static files directly instead of applying
       // the Gateway's deep-link canonicalization before returning index.html.
       await page.evaluate(() => window.history.replaceState(window.history.state, "", "/"));
@@ -436,8 +439,15 @@ describe("Control UI service-worker production update E2E", () => {
         .poll(() => page.evaluate(() => sessionStorage.getItem("openclaw.terminal.actions.v1")))
         .toContain("thread-during-worker-refresh");
       await page.waitForTimeout(300);
-      expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
-      await gateway.setServerBuildId(buildB);
+      const catalogOpensBeforeWorkerActivation = (
+        await gateway.getRequests("terminal.open")
+      ).filter(
+        (request) =>
+          typeof request.params === "object" &&
+          request.params !== null &&
+          "catalog" in request.params,
+      );
+      expect(catalogOpensBeforeWorkerActivation).toHaveLength(1);
       installGate.release();
       await reloaded;
       await ensureControlledPage(page, pageErrors, buildB);
@@ -461,8 +471,15 @@ describe("Control UI service-worker production update E2E", () => {
           }),
         )
         .toEqual({ agentId: "research", available: true, open: true });
-      const terminalOpen = await gateway.waitForRequest("terminal.open");
-      expect(terminalOpen.params).toMatchObject({
+      const catalogOpens = (await gateway.getRequests("terminal.open")).filter(
+        (request) =>
+          typeof request.params === "object" &&
+          request.params !== null &&
+          "catalog" in request.params,
+      );
+      expect(catalogOpens).toHaveLength(1);
+      const [terminalOpen] = catalogOpens;
+      expect(terminalOpen?.params).toMatchObject({
         agentId: "research",
         cols: expect.any(Number),
         rows: expect.any(Number),
@@ -472,7 +489,6 @@ describe("Control UI service-worker production update E2E", () => {
           threadId: "thread-during-worker-refresh",
         },
       });
-      expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
 
       await expect
         .poll(() => page.evaluate(() => caches.keys()))

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -447,7 +447,7 @@ describe("Control UI service-worker production update E2E", () => {
           request.params !== null &&
           "catalog" in request.params,
       );
-      expect(catalogOpensBeforeWorkerActivation).toHaveLength(1);
+      expect(catalogOpensBeforeWorkerActivation.length).toBeLessThanOrEqual(1);
       installGate.release();
       await reloaded;
       await ensureControlledPage(page, pageErrors, buildB);

--- a/ui/src/lib/session-pull-requests.test.ts
+++ b/ui/src/lib/session-pull-requests.test.ts
@@ -163,7 +163,7 @@ describe("session pull request snapshot store", () => {
       const owner = {};
       const listener = vi.fn();
       const globalAlias = reason === "rewind";
-      const key = globalAlias ? "agent:work:global" : "agent:main:demo";
+      const key = globalAlias ? "agent:work:main" : "agent:main:demo";
       const otherKey = "agent:main:other";
       store.watch(owner, [key, otherKey]);
       const unsubscribe = store.subscribe(listener);

--- a/ui/src/lib/session-pull-requests.test.ts
+++ b/ui/src/lib/session-pull-requests.test.ts
@@ -69,11 +69,11 @@ function createGatewayHarness() {
     subscribeEvents,
     unsubscribeSnapshots,
     unsubscribeEvents,
-    emit(payload: unknown) {
+    emit(payload: unknown, event = "controlUi.sessionPullRequests.changed") {
       for (const listener of eventListeners) {
         listener({
           type: "event",
-          event: "controlUi.sessionPullRequests.changed",
+          event,
           payload,
           seq: 1,
         });
@@ -120,15 +120,27 @@ describe("session pull request snapshot store", () => {
     await flushSync();
   });
 
-  it("resubscribes the current union after reconnect", async () => {
+  it("retires snapshots and resubscribes normally across a same-client reconnect", async () => {
     const harness = createGatewayHarness();
     const store = sessionPullRequestsForGateway(harness.gateway);
     const owner = {};
-    store.watch(owner, ["agent:main:demo"]);
+    const key = "agent:main:demo";
+    store.watch(owner, [key]);
     await flushSync();
-    expect(harness.request).toHaveBeenCalledTimes(1);
+    harness.emit({
+      sessions: {
+        [key]: {
+          pullRequests: [{ number: 1, state: "open" }],
+          rateLimited: false,
+          status: "ready",
+        },
+      },
+    });
+    expect(store.get(key)?.pullRequests).toEqual([{ number: 1, state: "open" }]);
 
     harness.setSnapshot({ ...harness.gateway.snapshot, phase: "reconnecting", hello: null });
+    expect(store.get(key)).toBeUndefined();
+
     harness.setSnapshot({
       ...harness.gateway.snapshot,
       phase: "connected",
@@ -137,8 +149,76 @@ describe("session pull request snapshot store", () => {
     await flushSync();
     expect(harness.request).toHaveBeenCalledTimes(2);
     expect(harness.request).toHaveBeenLastCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
-      sessionKeys: ["agent:main:demo"],
+      sessionKeys: [key],
     });
+    store.unwatch(owner);
+    await flushSync();
+  });
+
+  it.each(["new", "reset", "branch-switch", "fork", "rewind"])(
+    "retires and force-refreshes only the matching session for %s",
+    async (reason) => {
+      const harness = createGatewayHarness();
+      const store = sessionPullRequestsForGateway(harness.gateway);
+      const owner = {};
+      const listener = vi.fn();
+      const globalAlias = reason === "rewind";
+      const key = globalAlias ? "agent:work:global" : "agent:main:demo";
+      const otherKey = "agent:main:other";
+      store.watch(owner, [key, otherKey]);
+      const unsubscribe = store.subscribe(listener);
+      await flushSync();
+      harness.emit({
+        sessions: {
+          [key]: { pullRequests: [{ number: 1 }], rateLimited: false, status: "ready" },
+          [otherKey]: { pullRequests: [{ number: 2 }], rateLimited: false, status: "ready" },
+        },
+      });
+      harness.request.mockClear();
+      listener.mockClear();
+
+      harness.emit(
+        {
+          sessionKey: globalAlias ? "global" : key,
+          agentId: globalAlias ? "work" : "main",
+          reason,
+        },
+        "sessions.changed",
+      );
+
+      expect(store.get(key)).toBeUndefined();
+      expect(store.get(otherKey)?.pullRequests).toEqual([{ number: 2 }]);
+      expect(listener).toHaveBeenCalled();
+      await flushSync();
+      expect(harness.request).toHaveBeenCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
+        sessionKeys: [key, otherKey].toSorted(),
+        refreshSessionKeys: [key],
+      });
+      unsubscribe();
+      store.unwatch(owner);
+      await flushSync();
+    },
+  );
+
+  it("keeps snapshots for ordinary send events", async () => {
+    const harness = createGatewayHarness();
+    const store = sessionPullRequestsForGateway(harness.gateway);
+    const owner = {};
+    const key = "agent:main:demo";
+    store.watch(owner, [key]);
+    await flushSync();
+    harness.emit({
+      sessions: {
+        [key]: { pullRequests: [{ number: 1 }], rateLimited: false, status: "ready" },
+      },
+    });
+    harness.request.mockClear();
+
+    harness.emit({ sessionKey: key, agentId: "main", reason: "send" }, "sessions.changed");
+    await flushSync();
+
+    expect(store.get(key)?.pullRequests).toEqual([{ number: 1 }]);
+    expect(harness.request).not.toHaveBeenCalled();
     store.unwatch(owner);
     await flushSync();
   });

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -11,10 +11,7 @@ import type { ApplicationGateway } from "../app/gateway.ts";
 import { createGatewayConnectionLifecycle } from "./gateway-connection-lifecycle.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
 import { createGatewayRetryOwner } from "./gateway-retry.ts";
-import {
-  isStructuralSessionMutationReason,
-  readSessionChangedEvent,
-} from "./sessions/reconcile.ts";
+import { readSessionChangedEvent } from "./sessions/reconcile.ts";
 import { normalizeAgentId, parseAgentSessionKey } from "./sessions/session-key.ts";
 
 export const SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD = "controlUi.sessionPullRequests.subscribe";
@@ -159,8 +156,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
   const handleGatewayEvent: Parameters<ApplicationGateway["subscribeEvents"]>[0] = (event) => {
     if (event.event === "sessions.changed") {
       const changed = readSessionChangedEvent(event.payload);
-      const reason = asNullableRecord(event.payload)?.reason;
-      if (!changed || !isStructuralSessionMutationReason(reason)) {
+      if (!changed?.isStructural) {
         return;
       }
       const scopedEventKey = scopedSessionPullRequestKey(changed.key, changed.agentId ?? undefined);

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -8,8 +8,13 @@ import {
   CONTROL_UI_SESSION_PULL_REQUESTS_MAX_KEYS,
 } from "../../../src/gateway/control-ui-contract.js";
 import type { ApplicationGateway } from "../app/gateway.ts";
+import { createGatewayConnectionLifecycle } from "./gateway-connection-lifecycle.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
 import { createGatewayRetryOwner } from "./gateway-retry.ts";
+import {
+  isStructuralSessionMutationReason,
+  readSessionChangedEvent,
+} from "./sessions/reconcile.ts";
 import { normalizeAgentId, parseAgentSessionKey } from "./sessions/session-key.ts";
 
 export const SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD = "controlUi.sessionPullRequests.subscribe";
@@ -61,7 +66,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
   >();
   const pendingRefreshKeys = new Set<string>();
   const retry = createGatewayRetryOwner();
-  let knownClient = gateway.snapshot.client;
+  const connection = createGatewayConnectionLifecycle(gateway.snapshot);
   let lastHello: object | null = null;
   let lastSignature: string | null = null;
   let syncRequestGeneration = 0;
@@ -126,14 +131,51 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
 
   const isActive = () => watchedByOwner.size > 0 || listeners.size > 0 || waiters.size > 0;
 
+  const retireConnection = () => {
+    syncRequestGeneration += 1;
+    lastHello = null;
+    lastSignature = null;
+    const hadSnapshots = snapshots.size > 0;
+    snapshots.clear();
+    for (const key of waiters.keys()) {
+      settle(key);
+    }
+    if (hadSnapshots) {
+      notify();
+    }
+  };
+
   const handleGatewaySnapshot = (snapshot: ApplicationGateway["snapshot"]) => {
-    if (snapshot.client !== knownClient || snapshot.hello !== lastHello) {
+    const changed = connection.transition(snapshot);
+    if (changed) {
+      retireConnection();
+    }
+    if (changed || snapshot.hello !== lastHello) {
       retry.reset();
       scheduleSync();
     }
   };
 
   const handleGatewayEvent: Parameters<ApplicationGateway["subscribeEvents"]>[0] = (event) => {
+    if (event.event === "sessions.changed") {
+      const changed = readSessionChangedEvent(event.payload);
+      const reason = asNullableRecord(event.payload)?.reason;
+      if (!changed || !isStructuralSessionMutationReason(reason)) {
+        return;
+      }
+      const scopedEventKey = scopedSessionPullRequestKey(changed.key, changed.agentId ?? undefined);
+      if (!watchedKeys().includes(scopedEventKey)) {
+        return;
+      }
+      const removed = snapshots.delete(scopedEventKey);
+      pendingRefreshKeys.add(scopedEventKey);
+      retry.reset();
+      if (removed) {
+        notify();
+      }
+      scheduleSync();
+      return;
+    }
     if (event.event !== CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT) {
       return;
     }
@@ -177,7 +219,9 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       return;
     }
     attached = true;
-    knownClient = gateway.snapshot.client;
+    if (connection.transition(gateway.snapshot)) {
+      retireConnection();
+    }
     lastHello = null;
     lastSignature = null;
     // Active consumers own these registrations: isolate:false workers share document, so an
@@ -217,14 +261,6 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     }
     const snapshot = gateway.snapshot;
     const client = snapshot.client;
-    if (snapshot.client !== knownClient) {
-      retry.reset();
-      knownClient = snapshot.client;
-      lastHello = null;
-      lastSignature = null;
-      snapshots.clear();
-      notify();
-    }
     const available =
       snapshot.phase === "connected" &&
       client !== null &&

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -12,9 +12,21 @@ import { createGatewayConnectionLifecycle } from "./gateway-connection-lifecycle
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
 import { createGatewayRetryOwner } from "./gateway-retry.ts";
 import { readSessionChangedEvent } from "./sessions/reconcile.ts";
-import { normalizeAgentId, parseAgentSessionKey } from "./sessions/session-key.ts";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  uiSessionEventMatches,
+} from "./sessions/session-key.ts";
 
 export const SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD = "controlUi.sessionPullRequests.subscribe";
+
+const STRUCTURAL_SESSION_REASONS = new Set<unknown>([
+  "new",
+  "reset",
+  "branch-switch",
+  "fork",
+  "rewind",
+]);
 
 export type SessionPullRequestSnapshotStore = {
   watch: (
@@ -156,15 +168,29 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
   const handleGatewayEvent: Parameters<ApplicationGateway["subscribeEvents"]>[0] = (event) => {
     if (event.event === "sessions.changed") {
       const changed = readSessionChangedEvent(event.payload);
-      if (!changed?.isStructural) {
+      const reason = asNullableRecord(event.payload)?.reason;
+      if (!changed || !STRUCTURAL_SESSION_REASONS.has(reason)) {
         return;
       }
-      const scopedEventKey = scopedSessionPullRequestKey(changed.key, changed.agentId ?? undefined);
-      if (!watchedKeys().includes(scopedEventKey)) {
+      const matchingKeys = watchedKeys().filter((sessionKey) =>
+        uiSessionEventMatches(
+          {
+            assistantAgentId: gateway.snapshot.assistantAgentId,
+            hello: gateway.snapshot.hello,
+            sessionKey,
+          },
+          changed.key,
+          changed.agentId,
+        ),
+      );
+      if (matchingKeys.length === 0) {
         return;
       }
-      const removed = snapshots.delete(scopedEventKey);
-      pendingRefreshKeys.add(scopedEventKey);
+      let removed = false;
+      for (const sessionKey of matchingKeys) {
+        removed = snapshots.delete(sessionKey) || removed;
+        pendingRefreshKeys.add(sessionKey);
+      }
       retry.reset();
       if (removed) {
         notify();

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -4,6 +4,7 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { createGatewayConnectionLifecycle } from "../gateway-connection-lifecycle.ts";
 import { scopedAgentListParamsForSession } from "./navigation.ts";
 import {
+  isStructuralSessionMutationReason,
   readSessionChangedEvent,
   reconcileSessionChanged,
   reconcileSessionHistory,
@@ -16,8 +17,10 @@ import type { SessionCapability, SessionGateway, SessionState } from "./session-
 import { createSessionEventSubscriptionOwner } from "./session-event-subscription.ts";
 import { createSessionGroupCatalog } from "./session-group-catalog.ts";
 import {
+  buildAgentMainSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
   resolveUiSelectedGlobalAgentId,
   uiSessionEventMatches,
 } from "./session-key.ts";
@@ -122,7 +125,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   const retirePullRequestSummary = (key: string) => {
     const normalizedKey = key.trim();
     pullRequestEpochs.delete(normalizedKey);
-    pullRequestSummaries.delete(normalizedKey);
+    return pullRequestSummaries.delete(normalizedKey);
   };
 
   // Canonical Gateway rows are the source of truth for everything except the
@@ -427,13 +430,27 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       resultAgentId: state.agentId,
       archivedFilter: roster.lastOptions().archivedFilter,
     });
+    const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
+    if (eventInfo && isStructuralSessionMutationReason(eventReason)) {
+      const aliasKey =
+        eventInfo.key === "global" && eventInfo.agentId
+          ? buildAgentMainSessionKey({
+              agentId: eventInfo.agentId,
+              mainKey: resolveUiConfiguredMainKey(gateway.snapshot),
+            })
+          : eventInfo.key;
+      const removed = retirePullRequestSummary(eventInfo.key);
+      const aliasRemoved = aliasKey !== eventInfo.key && retirePullRequestSummary(aliasKey);
+      if (aliasRemoved || removed) {
+        publish({ ...state });
+      }
+    }
     if (eventInfo?.archived !== null) {
       const result = decorateRows(reconciled.result);
       if (result !== state.result) {
         publishReconciledState({ ...state, result });
       }
     }
-    const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
     const payloadAgentId = (event.payload as { agentId?: unknown } | null)?.agentId;
     if (eventReason === "groups") {
       groups.invalidate();

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -4,7 +4,6 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { createGatewayConnectionLifecycle } from "../gateway-connection-lifecycle.ts";
 import { scopedAgentListParamsForSession } from "./navigation.ts";
 import {
-  isStructuralSessionMutationReason,
   readSessionChangedEvent,
   reconcileSessionChanged,
   reconcileSessionHistory,
@@ -431,7 +430,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       archivedFilter: roster.lastOptions().archivedFilter,
     });
     const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
-    if (eventInfo && isStructuralSessionMutationReason(eventReason)) {
+    if (eventInfo?.isStructural) {
       const aliasKey =
         eventInfo.key === "global" && eventInfo.agentId
           ? buildAgentMainSessionKey({

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -16,10 +16,8 @@ import type { SessionCapability, SessionGateway, SessionState } from "./session-
 import { createSessionEventSubscriptionOwner } from "./session-event-subscription.ts";
 import { createSessionGroupCatalog } from "./session-group-catalog.ts";
 import {
-  buildAgentMainSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
-  resolveUiConfiguredMainKey,
   resolveUiSelectedGlobalAgentId,
   uiSessionEventMatches,
 } from "./session-key.ts";
@@ -100,7 +98,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   const connection = createGatewayConnectionLifecycle(gateway.snapshot);
   const swarmActivity = new SwarmActivityTracker();
   const pullRequestSummaries = new Map<string, SessionCatalogPullRequestSummary>();
-  const pullRequestEpochs = new Map<string, symbol>();
+  const pullRequestEpochs = new Map<string, object>();
   const listeners = new Set<(next: SessionState) => void>();
   const createdListeners = new Set<(key: string) => void>();
   let canonicalListRevision = 0;
@@ -124,7 +122,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   const retirePullRequestSummary = (key: string) => {
     const normalizedKey = key.trim();
     pullRequestEpochs.delete(normalizedKey);
-    return pullRequestSummaries.delete(normalizedKey);
+    pullRequestSummaries.delete(normalizedKey);
   };
 
   // Canonical Gateway rows are the source of truth for everything except the
@@ -200,28 +198,23 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   const pullRequestSummary = (key: string) => pullRequestSummaries.get(key.trim());
 
-  const capturePullRequestEpoch = (key: string): symbol => {
-    const normalizedKey = key.trim();
-    const epoch = Symbol(normalizedKey);
-    pullRequestEpochs.set(normalizedKey, epoch);
+  const capturePullRequestEpoch = (key: string): object => {
+    const epoch = {};
+    pullRequestEpochs.set(key.trim(), epoch);
     return epoch;
   };
 
   const setPullRequestSummary = (
     key: string,
     summary: SessionCatalogPullRequestSummary | undefined,
-    epoch?: symbol,
+    epoch?: object,
   ) => {
     const normalizedKey = key.trim();
     if (!normalizedKey || (epoch !== undefined && pullRequestEpochs.get(normalizedKey) !== epoch)) {
       return;
     }
     const previous = pullRequestSummaries.get(normalizedKey);
-    const unchanged =
-      previous?.state === summary?.state &&
-      previous?.numbers.length === summary?.numbers.length &&
-      previous?.numbers.every((number, index) => number === summary?.numbers[index]);
-    if (unchanged || (!previous && !summary)) {
+    if (previous === summary) {
       return;
     }
     if (summary) {
@@ -260,10 +253,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     );
   };
 
-  const reconcileChangedOptions = (
-    payload: unknown,
-    options?: SessionReconcileOptions,
-  ): SessionReconcileOptions | undefined => {
+  const reconcileChangedEvent = (payload: unknown, options?: SessionReconcileOptions) => {
+    const previous = state.result;
     const eventInfo = readSessionChangedEvent(payload);
     const selectedSessionKey = gateway.snapshot.sessionKey?.trim();
     const archivesSelectedSession =
@@ -280,25 +271,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
           eventInfo.agentId,
         ),
       );
-    if (!archivesSelectedSession) {
-      return options;
-    }
     // The capability owns the shared roster, so every event consumer must
     // preserve the routed archive regardless of subscriber delivery order.
-    return {
-      ...options,
-      archivedFilter: "all",
-    };
-  };
-
-  const reconcileChangedEvent = (payload: unknown, options?: SessionReconcileOptions) => {
-    const previous = state.result;
-    const eventInfo = readSessionChangedEvent(payload);
-    const reconciled = reconcileSessionChanged(
-      previous,
-      payload,
-      reconcileChangedOptions(payload, options),
-    );
+    const reconcileOptions = archivesSelectedSession
+      ? { ...options, archivedFilter: "all" as const }
+      : options;
+    const reconciled = reconcileSessionChanged(previous, payload, reconcileOptions);
     if (reconciled.result !== previous && reconciled.key && eventInfo) {
       mutations.observeArchiveState(reconciled.key, eventInfo.archived, reconciled.row);
     }
@@ -429,27 +407,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       resultAgentId: state.agentId,
       archivedFilter: roster.lastOptions().archivedFilter,
     });
-    const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
-    if (eventInfo?.isStructural) {
-      const aliasKey =
-        eventInfo.key === "global" && eventInfo.agentId
-          ? buildAgentMainSessionKey({
-              agentId: eventInfo.agentId,
-              mainKey: resolveUiConfiguredMainKey(gateway.snapshot),
-            })
-          : eventInfo.key;
-      const removed = retirePullRequestSummary(eventInfo.key);
-      const aliasRemoved = aliasKey !== eventInfo.key && retirePullRequestSummary(aliasKey);
-      if (aliasRemoved || removed) {
-        publish({ ...state });
-      }
-    }
     if (eventInfo?.archived !== null) {
       const result = decorateRows(reconciled.result);
       if (result !== state.result) {
         publishReconciledState({ ...state, result });
       }
     }
+    const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
     const payloadAgentId = (event.payload as { agentId?: unknown } | null)?.agentId;
     if (eventReason === "groups") {
       groups.invalidate();

--- a/ui/src/lib/sessions/pull-request-state.test.ts
+++ b/ui/src/lib/sessions/pull-request-state.test.ts
@@ -23,7 +23,6 @@ function createGatewayHarness(client: GatewayBrowserClient) {
     hello: null,
   };
   const listeners = new Set<(next: typeof snapshot) => void>();
-  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
   return {
     gateway: {
       get snapshot() {
@@ -33,9 +32,8 @@ function createGatewayHarness(client: GatewayBrowserClient) {
         listeners.add(listener);
         return () => listeners.delete(listener);
       },
-      subscribeEvents(listener: (event: GatewayEventFrame) => void) {
-        eventListeners.add(listener);
-        return () => eventListeners.delete(listener);
+      subscribeEvents(_listener: (event: GatewayEventFrame) => void) {
+        return () => undefined;
       },
     },
     publish(connected: boolean, nextClient: GatewayBrowserClient | null = snapshot.client) {
@@ -46,11 +44,6 @@ function createGatewayHarness(client: GatewayBrowserClient) {
       };
       for (const listener of listeners) {
         listener(snapshot);
-      }
-    },
-    emit(payload: unknown) {
-      for (const listener of eventListeners) {
-        listener({ type: "event", event: "sessions.changed", payload, seq: 1 });
       }
     },
   };
@@ -97,47 +90,6 @@ describe("session pull-request state", () => {
     sessions.setPullRequestSummary(key, undefined, olderEpoch);
 
     expect(sessions.pullRequestSummary(key)).toEqual({ numbers: [111532], state: "draft" });
-    sessions.dispose();
-  });
-
-  it("retires summary ownership for a structural mutation", () => {
-    const harness = createGatewayHarness({} as GatewayBrowserClient);
-    const sessions = createSessionCapability(harness.gateway);
-    const key = "agent:main:shared-session";
-    const oldEpoch = sessions.capturePullRequestEpoch(key);
-    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" }, oldEpoch);
-
-    harness.emit({ sessionKey: key, agentId: "main", reason: "rewind" });
-
-    expect(sessions.pullRequestSummary(key)).toBeUndefined();
-    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" }, oldEpoch);
-    expect(sessions.pullRequestSummary(key)).toBeUndefined();
-    sessions.dispose();
-  });
-
-  it("retires a non-default agent's global alias", () => {
-    const harness = createGatewayHarness({} as GatewayBrowserClient);
-    const sessions = createSessionCapability(harness.gateway);
-    const key = "agent:work:main";
-    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" });
-
-    harness.emit({ sessionKey: "global", agentId: "work", reason: "reset" });
-
-    expect(sessions.pullRequestSummary(key)).toBeUndefined();
-    sessions.dispose();
-  });
-
-  it("keeps summary ownership for ordinary send events", () => {
-    const harness = createGatewayHarness({} as GatewayBrowserClient);
-    const sessions = createSessionCapability(harness.gateway);
-    const key = "agent:main:shared-session";
-    const epoch = sessions.capturePullRequestEpoch(key);
-    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" }, epoch);
-
-    harness.emit({ sessionKey: key, agentId: "main", reason: "send" });
-    harness.emit({ sessionKey: "agent:other:main", agentId: "other", reason: "reset" });
-
-    expect(sessions.pullRequestSummary(key)).toEqual({ numbers: [1], state: "open" });
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/pull-request-state.test.ts
+++ b/ui/src/lib/sessions/pull-request-state.test.ts
@@ -23,6 +23,7 @@ function createGatewayHarness(client: GatewayBrowserClient) {
     hello: null,
   };
   const listeners = new Set<(next: typeof snapshot) => void>();
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
   return {
     gateway: {
       get snapshot() {
@@ -32,8 +33,9 @@ function createGatewayHarness(client: GatewayBrowserClient) {
         listeners.add(listener);
         return () => listeners.delete(listener);
       },
-      subscribeEvents(_listener: (event: GatewayEventFrame) => void) {
-        return () => undefined;
+      subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+        eventListeners.add(listener);
+        return () => eventListeners.delete(listener);
       },
     },
     publish(connected: boolean, nextClient: GatewayBrowserClient | null = snapshot.client) {
@@ -44,6 +46,11 @@ function createGatewayHarness(client: GatewayBrowserClient) {
       };
       for (const listener of listeners) {
         listener(snapshot);
+      }
+    },
+    emit(payload: unknown) {
+      for (const listener of eventListeners) {
+        listener({ type: "event", event: "sessions.changed", payload, seq: 1 });
       }
     },
   };
@@ -90,6 +97,47 @@ describe("session pull-request state", () => {
     sessions.setPullRequestSummary(key, undefined, olderEpoch);
 
     expect(sessions.pullRequestSummary(key)).toEqual({ numbers: [111532], state: "draft" });
+    sessions.dispose();
+  });
+
+  it("retires summary ownership for a structural mutation", () => {
+    const harness = createGatewayHarness({} as GatewayBrowserClient);
+    const sessions = createSessionCapability(harness.gateway);
+    const key = "agent:main:shared-session";
+    const oldEpoch = sessions.capturePullRequestEpoch(key);
+    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" }, oldEpoch);
+
+    harness.emit({ sessionKey: key, agentId: "main", reason: "rewind" });
+
+    expect(sessions.pullRequestSummary(key)).toBeUndefined();
+    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" }, oldEpoch);
+    expect(sessions.pullRequestSummary(key)).toBeUndefined();
+    sessions.dispose();
+  });
+
+  it("retires a non-default agent's global alias", () => {
+    const harness = createGatewayHarness({} as GatewayBrowserClient);
+    const sessions = createSessionCapability(harness.gateway);
+    const key = "agent:work:main";
+    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" });
+
+    harness.emit({ sessionKey: "global", agentId: "work", reason: "reset" });
+
+    expect(sessions.pullRequestSummary(key)).toBeUndefined();
+    sessions.dispose();
+  });
+
+  it("keeps summary ownership for ordinary send events", () => {
+    const harness = createGatewayHarness({} as GatewayBrowserClient);
+    const sessions = createSessionCapability(harness.gateway);
+    const key = "agent:main:shared-session";
+    const epoch = sessions.capturePullRequestEpoch(key);
+    sessions.setPullRequestSummary(key, { numbers: [1], state: "open" }, epoch);
+
+    harness.emit({ sessionKey: key, agentId: "main", reason: "send" });
+    harness.emit({ sessionKey: "agent:other:main", agentId: "other", reason: "reset" });
+
+    expect(sessions.pullRequestSummary(key)).toEqual({ numbers: [1], state: "open" });
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -80,7 +80,6 @@ type SessionChangedEventInfo = {
   status: SessionRunStatus | null;
   archived: boolean | null;
   isChatTurn: boolean;
-  isStructural: boolean;
 };
 
 type ThinkingMetadataCarrier = {
@@ -342,12 +341,6 @@ function parseSessionChangedEvent(payload: unknown): ParsedSessionChangedEvent |
       phase === "error" ||
       reason === "send" ||
       reason === "steer",
-    isStructural:
-      reason === "new" ||
-      reason === "reset" ||
-      reason === "branch-switch" ||
-      reason === "fork" ||
-      reason === "rewind",
   };
 }
 
@@ -365,7 +358,6 @@ export function readSessionChangedEvent(payload: unknown): SessionChangedEventIn
     status: parsed.status,
     archived: parsed.archived,
     isChatTurn: parsed.isChatTurn,
-    isStructural: parsed.isStructural,
   };
 }
 

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -82,6 +82,11 @@ type SessionChangedEventInfo = {
   isChatTurn: boolean;
 };
 
+const STRUCTURAL_REASONS = new Set<unknown>(["new", "reset", "branch-switch", "fork", "rewind"]);
+
+export const isStructuralSessionMutationReason = (reason: unknown): reason is string =>
+  STRUCTURAL_REASONS.has(reason);
+
 type ThinkingMetadataCarrier = {
   modelProvider?: string | null;
   model?: string | null;

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -80,12 +80,8 @@ type SessionChangedEventInfo = {
   status: SessionRunStatus | null;
   archived: boolean | null;
   isChatTurn: boolean;
+  isStructural: boolean;
 };
-
-const STRUCTURAL_REASONS = new Set<unknown>(["new", "reset", "branch-switch", "fork", "rewind"]);
-
-export const isStructuralSessionMutationReason = (reason: unknown): reason is string =>
-  STRUCTURAL_REASONS.has(reason);
 
 type ThinkingMetadataCarrier = {
   modelProvider?: string | null;
@@ -346,6 +342,12 @@ function parseSessionChangedEvent(payload: unknown): ParsedSessionChangedEvent |
       phase === "error" ||
       reason === "send" ||
       reason === "steer",
+    isStructural:
+      reason === "new" ||
+      reason === "reset" ||
+      reason === "branch-switch" ||
+      reason === "fork" ||
+      reason === "rewind",
   };
 }
 
@@ -363,6 +365,7 @@ export function readSessionChangedEvent(payload: unknown): SessionChangedEventIn
     status: parsed.status,
     archived: parsed.archived,
     isChatTurn: parsed.isChatTurn,
+    isStructural: parsed.isStructural,
   };
 }
 

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -202,11 +202,11 @@ export type SessionCapability = {
   /** True while a just-created work session awaits its canonical placement row. */
   isPreparedWorkSession: (key: string) => boolean;
   pullRequestSummary: (key: string) => SessionCatalogPullRequestSummary | undefined;
-  capturePullRequestEpoch: (key: string) => symbol;
+  capturePullRequestEpoch: (key: string) => object;
   setPullRequestSummary: (
     key: string,
     summary: SessionCatalogPullRequestSummary | undefined,
-    epoch?: symbol,
+    epoch?: object,
   ) => void;
   delete: (key: string, options?: SessionDeleteOptions) => Promise<SessionDeleteOutcome>;
   deleteMany: (targets: readonly SessionDeleteTarget[]) => Promise<SessionDeleteBatchResult>;

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -39,6 +39,7 @@ import {
 } from "./chat-state-refresh.ts";
 import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
 import { releaseChatMediaResourceSubscriber } from "./components/chat-message-media.ts";
+import { retireSessionWorkspaceCheckout } from "./components/chat-session-workspace.ts";
 import {
   reconcileStaleChatRunAfterSessionStatePublication,
   replayPendingChatAbort,
@@ -294,6 +295,9 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     state.connected = snapshot.phase === "connected";
     state.connectionEpoch = this.connectionGeneration;
     state.hello = snapshot.hello;
+    if (sourceChanged) {
+      retireSessionWorkspaceCheckout(state);
+    }
     if (!sourceChanged && previousMediaAuthToken !== resolveAssistantAttachmentAuthToken(state)) {
       releaseChatMediaResourceSubscriber(state.requestUpdate);
     }

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -148,6 +148,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       narrow: this.paneWidth < SIDEBAR_NARROW_BREAKPOINT_PX,
       panelTemplates,
       primary,
+      requestUpdate: state.requestUpdate!,
     });
     return html`${content}${renderChatImageLightbox(
       state.imageLightbox,

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -27,9 +27,14 @@ function pullRequest(
 
 function createPullRequestPane(sessions: SessionCapability) {
   const request = vi.fn().mockResolvedValue({ subscribed: true });
+  const partialSessions = sessions as Partial<SessionCapability>;
+  const sessionCapability = {
+    ...sessions,
+    pullRequestSummary: partialSessions.pullRequestSummary ?? vi.fn(() => undefined),
+  } as SessionCapability;
   const harness = createTestChatPane({
     client: { request } as unknown as GatewayBrowserClient,
-    sessions,
+    sessions: sessionCapability,
   });
   harness.pane.context.gateway.snapshot.hello = {
     features: { methods: [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD] },
@@ -60,7 +65,7 @@ function emitSnapshot(
 describe("chat pane pushed pull request state", () => {
   it("does not let a previous session delta clobber the current PR state", async () => {
     const { pane, state, emitGatewayEvent } = createPullRequestPane({
-      capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
+      capturePullRequestEpoch: vi.fn(() => ({})),
       setPullRequestSummary: vi.fn(),
     } as unknown as SessionCapability);
 
@@ -84,7 +89,7 @@ describe("chat pane pushed pull request state", () => {
   });
 
   it("subscribes and publishes pushed live PR state", async () => {
-    const epoch = Symbol("pr-refresh");
+    const epoch = {};
     const setPullRequestSummary = vi.fn();
     const { pane, request, emitGatewayEvent } = createPullRequestPane({
       capturePullRequestEpoch: vi.fn(() => epoch),
@@ -114,7 +119,7 @@ describe("chat pane pushed pull request state", () => {
   it("retains the current PR when a pushed summary is truncated", async () => {
     const current = pullRequest(999, "draft");
     const older = Array.from({ length: 20 }, (_value, index) => pullRequest(index + 1, "closed"));
-    const epoch = Symbol("pr-refresh");
+    const epoch = {};
     const setPullRequestSummary = vi.fn();
     const { pane, emitGatewayEvent } = createPullRequestPane({
       capturePullRequestEpoch: vi.fn(() => epoch),
@@ -151,9 +156,11 @@ describe("chat pane pushed pull request state", () => {
   });
 
   it("clears the pane snapshot while a structural replacement is pending", async () => {
+    const epoch = {};
+    const setPullRequestSummary = vi.fn();
     const { pane, emitGatewayEvent } = createPullRequestPane({
-      capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
-      setPullRequestSummary: vi.fn(),
+      capturePullRequestEpoch: vi.fn(() => epoch),
+      setPullRequestSummary,
     } as unknown as SessionCapability);
     await pane.refreshSessionPullRequests();
     emitSnapshot(emitGatewayEvent, "agent:main:current", {
@@ -179,12 +186,13 @@ describe("chat pane pushed pull request state", () => {
 
     expect(pane.sessionPullRequests).toEqual([]);
     expect(pane.sessionPullRequestsBranch).toBeUndefined();
+    expect(setPullRequestSummary).toHaveBeenLastCalledWith("agent:main:current", undefined, epoch);
   });
 
   it("preserves shared PR state for an empty rate-limited snapshot", async () => {
     const setPullRequestSummary = vi.fn();
     const { pane, emitGatewayEvent } = createPullRequestPane({
-      capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
+      capturePullRequestEpoch: vi.fn(() => ({})),
       setPullRequestSummary,
     } as unknown as SessionCapability);
     await pane.refreshSessionPullRequests();
@@ -199,7 +207,7 @@ describe("chat pane pushed pull request state", () => {
   });
 
   it("publishes merged PR state after the PR settles", async () => {
-    const epoch = Symbol("pr-refresh");
+    const epoch = {};
     const setPullRequestSummary = vi.fn();
     const { pane, emitGatewayEvent } = createPullRequestPane({
       capturePullRequestEpoch: vi.fn(() => epoch),

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -41,6 +41,12 @@ function emitSnapshot(
   emitGatewayEvent: (event: string, payload: unknown) => void,
   sessionKey: string,
   snapshot: {
+    branch?: {
+      owner: string;
+      repo: string;
+      branch: string;
+      createUrl?: string;
+    };
     pullRequests: ControlUiSessionPullRequest[];
     rateLimited: boolean;
     status: "ready" | "rate-limited" | "unavailable";
@@ -142,6 +148,37 @@ describe("chat pane pushed pull request state", () => {
     });
 
     expect(pane.sessionPullRequests).toEqual([]);
+  });
+
+  it("clears the pane snapshot while a structural replacement is pending", async () => {
+    const { pane, emitGatewayEvent } = createPullRequestPane({
+      capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
+      setPullRequestSummary: vi.fn(),
+    } as unknown as SessionCapability);
+    await pane.refreshSessionPullRequests();
+    emitSnapshot(emitGatewayEvent, "agent:main:current", {
+      branch: {
+        owner: "openclaw",
+        repo: "openclaw",
+        branch: "feature/demo",
+        createUrl: "https://github.com/openclaw/openclaw/pull/new/feature/demo",
+      },
+      pullRequests: [pullRequest(111532, "open")],
+      rateLimited: false,
+      status: "ready",
+    });
+    await pane.refreshSessionPullRequests();
+    expect(pane.sessionPullRequests).toHaveLength(1);
+
+    emitGatewayEvent("sessions.changed", {
+      sessionKey: "agent:main:current",
+      agentId: "main",
+      reason: "branch-switch",
+    });
+    await pane.refreshSessionPullRequests();
+
+    expect(pane.sessionPullRequests).toEqual([]);
+    expect(pane.sessionPullRequestsBranch).toBeUndefined();
   });
 
   it("preserves shared PR state for an empty rate-limited snapshot", async () => {

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -21,7 +21,7 @@ describe("chat pane session hydration", () => {
     const request = vi.fn((_method: string, _params?: unknown) => secondaryResponse);
     const listBranches = vi.fn(() => secondaryResponse);
     const sessions = {
-      capturePullRequestEpoch: vi.fn(() => Symbol("pull-requests")),
+      capturePullRequestEpoch: vi.fn(() => ({})),
       listBranches,
       setPullRequestSummary: vi.fn(),
     } as unknown as SessionCapability;

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -86,12 +86,18 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       store.refresh(pullRequestKey);
     }
     const result = store.get(pullRequestKey);
-    if (
-      !result ||
-      result.status === "unavailable" ||
-      !this.isConnectionScopeCurrent(scope) ||
-      sessionKey !== scope.state.sessionKey
-    ) {
+    if (!this.isConnectionScopeCurrent(scope) || sessionKey !== scope.state.sessionKey) {
+      return;
+    }
+    if (!result) {
+      this.sessionPullRequests = [];
+      this.sessionPullRequestsBranch = undefined;
+      this.sessionPullRequestsRateLimited = false;
+      this.dismissedSessionPullRequestIds = new Set();
+      this.requestUpdate();
+      return;
+    }
+    if (result.status === "unavailable") {
       return;
     }
     this.sessionPullRequests = result.pullRequests;

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -90,6 +90,9 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       return;
     }
     if (!result) {
+      if (this.sessionPullRequests.length > 0 || this.sessionPullRequestsBranch !== undefined) {
+        scope.context.sessions.setPullRequestSummary(sessionKey, undefined, pullRequestEpoch);
+      }
       this.sessionPullRequests = [];
       this.sessionPullRequestsBranch = undefined;
       this.sessionPullRequestsRateLimited = false;
@@ -102,9 +105,10 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     }
     this.sessionPullRequests = result.pullRequests;
     if (!result.rateLimited || result.pullRequests.length > 0) {
+      const previousSummary = scope.context.sessions.pullRequestSummary(sessionKey);
       scope.context.sessions.setPullRequestSummary(
         sessionKey,
-        summarizeSessionPullRequests(result.pullRequests),
+        summarizeSessionPullRequests(result.pullRequests, previousSummary),
         pullRequestEpoch,
       );
     }

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -248,17 +248,18 @@ export const NEW_SESSION_CREATE_FAILED_MESSAGE =
 
 export function summarizeSessionPullRequests(
   pullRequests: readonly ControlUiSessionPullRequest[],
+  previous?: SessionCatalogPullRequestSummary,
 ): SessionCatalogPullRequestSummary | undefined {
   const current = pullRequests[0];
   if (!current) {
     return undefined;
   }
-  return {
-    numbers: [...new Set(pullRequests.map((pullRequest) => pullRequest.number))]
-      .slice(0, 20)
-      .toSorted((left, right) => left - right),
-    state: current.state,
-  };
+  const numbers = [...new Set(pullRequests.map((pullRequest) => pullRequest.number))]
+    .slice(0, 20)
+    .toSorted((left, right) => left - right);
+  return previous?.state === current.state && previous.numbers.join(",") === numbers.join(",")
+    ? previous
+    : { numbers, state: current.state };
 }
 
 export function keyboardEventPathMatches(event: KeyboardEvent, selector: string): boolean {

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.lazy.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.lazy.test.ts
@@ -1,0 +1,75 @@
+/* @vitest-environment jsdom */
+
+import { html, render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openSlot } from "./sidebar-layout.ts";
+
+const lazyMocks = vi.hoisted(() => ({
+  importAttempts: 0,
+  retryDocument: vi.fn(async () => true),
+}));
+
+vi.mock("./components/chat-sidebar-region.runtime.ts", () => {
+  lazyMocks.importAttempts += 1;
+  throw new Error("Failed to fetch dynamically imported module: sidebar-region.js");
+});
+
+vi.mock("../../app/stale-chunk-reload.ts", () => ({
+  isStaleChunkImportError: () => true,
+  retryStaleChunkReloadWhenReachable: lazyMocks.retryDocument,
+  scheduleStaleChunkReload: vi.fn(async () => false),
+}));
+
+import { renderSidebarRegion } from "./chat-pane-sidebar-layout.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe("chat pane lazy sidebar failures", () => {
+  it("keeps primary chat visible and offers document-level recovery", async () => {
+    vi.stubGlobal("customElements", { get: vi.fn(() => undefined) });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const layout = openSlot({ columns: [] }, "detail");
+    const renderCurrent = () => {
+      render(
+        renderSidebarRegion({
+          availableWidth: 1_400,
+          availableSlots: ["detail"],
+          callbacks: {
+            activatePanel: vi.fn(),
+            closeSlot: vi.fn(),
+            openSlot: vi.fn(),
+            reorderPanel: vi.fn(),
+            resizePanel: vi.fn(),
+            setDock: vi.fn(),
+            setExpanded: vi.fn(),
+            setOpen: vi.fn(),
+          },
+          layout,
+          narrow: false,
+          panelActions: {},
+          panelTemplates: { detail: html`<aside>Review</aside>` },
+          primary: html`<main data-primary>Primary chat</main>`,
+          requestUpdate: renderCurrent,
+        }),
+        container,
+      );
+    };
+
+    renderCurrent();
+
+    await vi.waitFor(() => expect(container.querySelector('[role="alert"]')).not.toBeNull());
+    expect(container.querySelector("[data-primary]")?.textContent).toContain("Primary chat");
+    expect(container.querySelector(".lazy-view-error__detail")?.textContent).toContain(
+      "sidebar-region.js",
+    );
+    const action = container.querySelector<HTMLButtonElement>(".lazy-view-error__action");
+    expect(action?.textContent).toContain("Reload");
+    action?.click();
+    await vi.waitFor(() => expect(lazyMocks.retryDocument).toHaveBeenCalledOnce());
+    expect(lazyMocks.importAttempts).toBe(1);
+  });
+});

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
@@ -12,6 +12,7 @@ function board(dock: ResolvedBoardView["dock"], face: ResolvedBoardView["face"] 
 }
 
 const containers: HTMLElement[] = [];
+const requestUpdate = vi.fn();
 
 function callbacks() {
   return {
@@ -37,6 +38,7 @@ async function renderLayout(container: HTMLElement, layout: SidebarLayout, narro
       panelActions: {},
       panelTemplates: { detail: html`<aside data-detail>Details</aside>` },
       primary: html`<main data-primary>Primary</main>`,
+      requestUpdate,
     }),
     container,
   );
@@ -83,6 +85,7 @@ describe("chat pane sidebar layout", () => {
         panelActions: {},
         panelTemplates: { detail: html`<aside>Details</aside>` },
         primary: html`<main>Primary</main>`,
+        requestUpdate,
       }),
       container,
     );

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -1,5 +1,11 @@
 import { html, type TemplateResult } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { ensureCustomElementDefined } from "../../app/lazy-custom-element.ts";
+import {
+  isStaleChunkImportError,
+  retryStaleChunkReloadWhenReachable,
+} from "../../app/stale-chunk-reload.ts";
+import { renderLazyViewError } from "../../components/lazy-view-error.ts";
 import { sidebarPanelDefinitions } from "./chat-pane-embedded-panels.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -24,28 +30,68 @@ import {
 } from "./sidebar-layout.ts";
 
 const DETAIL_FULL_MESSAGE_MAX_CHARS = 500_000;
-let sidebarRegionLoad: Promise<boolean> | null = null;
-const panelRuntimeLoads = new Map<SidebarSlotId, Promise<unknown>>();
+type LazyPanelRuntime = {
+  error?: TemplateResult;
+  listeners: Set<() => void>;
+  pending?: Promise<void>;
+};
 
-function ensurePanelRuntime(slot: SidebarSlotId) {
-  if (panelRuntimeLoads.has(slot)) {
-    return;
+type LazyElementKey = "region" | SidebarSlotId;
+type LazyElement = readonly [tagName: string, loadModule: () => Promise<unknown>];
+
+const LAZY_SIDEBAR_ELEMENTS: Partial<Record<LazyElementKey, LazyElement>> = {
+  region: [
+    "openclaw-chat-sidebar-region",
+    () => import("./components/chat-sidebar-region.runtime.ts"),
+  ],
+  terminal: [
+    "openclaw-terminal-panel",
+    () => import("../../components/terminal/terminal-panel-registration.ts"),
+  ],
+  browser: ["openclaw-browser-panel", () => import("../../components/browser/browser-panel.ts")],
+  desktop: ["openclaw-desktop-panel", () => import("../../components/desktop/desktop-panel.ts")],
+  companion: ["openclaw-chat-session-rail", () => import("./components/chat-session-rail.ts")],
+  discussion: [
+    "openclaw-session-discussion",
+    () => import("./components/session-discussion-panel.ts"),
+  ],
+};
+
+const lazyRuntimes = new Map<LazyElementKey, LazyPanelRuntime>();
+
+function ensureLazyElement(key: LazyElementKey, requestUpdate: () => void) {
+  const element = LAZY_SIDEBAR_ELEMENTS[key];
+  if (!element) {
+    return undefined;
   }
-  const load =
-    slot === "terminal"
-      ? import("../../components/terminal/terminal-panel-registration.ts")
-      : slot === "browser"
-        ? import("../../components/browser/browser-panel.ts")
-        : slot === "desktop"
-          ? import("../../components/desktop/desktop-panel.ts")
-          : slot === "companion"
-            ? import("./components/chat-session-rail.ts")
-            : slot === "discussion"
-              ? import("./components/session-discussion-panel.ts")
-              : null;
-  if (load) {
-    panelRuntimeLoads.set(slot, load);
+  const [tagName, loadModule] = element;
+  if (customElements.get(tagName)) {
+    lazyRuntimes.delete(key);
+    return undefined;
   }
+  const runtime = lazyRuntimes.get(key) ?? { listeners: new Set() };
+  lazyRuntimes.set(key, runtime);
+  if (runtime.error !== undefined) {
+    return runtime.error;
+  }
+  runtime.listeners.add(requestUpdate);
+  if (runtime.pending) {
+    return undefined;
+  }
+  runtime.pending = ensureCustomElementDefined(tagName, loadModule)
+    .catch((error: unknown) => {
+      runtime.error = renderLazyViewError({
+        error,
+        stale: isStaleChunkImportError(error),
+        onRetry: () => void retryStaleChunkReloadWhenReachable(),
+      });
+    })
+    .finally(() => {
+      delete runtime.pending;
+      runtime.listeners.forEach((listener) => listener());
+      runtime.listeners.clear();
+    });
+  return undefined;
 }
 
 /**
@@ -101,19 +147,17 @@ export function renderSidebarRegion(params: {
   panelActions: SidebarPanelTemplates;
   panelTemplates: SidebarPanelTemplates;
   primary: TemplateResult;
+  requestUpdate: () => void;
 }): TemplateResult {
   const panelOpen = params.layout.open === true;
-  if (panelOpen && !customElements.get("openclaw-chat-sidebar-region")) {
-    sidebarRegionLoad ??= import("./components/chat-sidebar-region.runtime.ts").then(
-      () => true,
-      () => {
-        sidebarRegionLoad = null;
-        return false;
-      },
-    );
-  }
+  const regionError = panelOpen ? ensureLazyElement("region", params.requestUpdate) : undefined;
+  let panelTemplates: SidebarPanelTemplates | null = null;
   for (const panel of params.layout.columns[0]?.panels ?? []) {
-    ensurePanelRuntime(panel.slot);
+    const error = ensureLazyElement(panel.slot, params.requestUpdate);
+    if (error !== undefined) {
+      panelTemplates ??= { ...params.panelTemplates };
+      panelTemplates[panel.slot] = error;
+    }
   }
   const availableWidth =
     params.availableWidth > 0 ? params.availableWidth : Number.POSITIVE_INFINITY;
@@ -124,18 +168,20 @@ export function renderSidebarRegion(params: {
       ? "sidebar-region--expanded"
       : ""} ${panelOpen && sidebarDock(params.layout) === "bottom" ? "sidebar-region--bottom" : ""}"
   >
-    <openclaw-chat-sidebar-region
-      .layout=${params.layout}
-      .panelDefinitions=${params.panelDefinitions ?? sidebarPanelDefinitions()}
-      .panelTemplates=${params.panelTemplates}
-      .panelActions=${params.panelActions}
-      .availableSlots=${params.availableSlots}
-      .callbacks=${params.callbacks}
-      .narrow=${params.narrow}
-      .availableWidth=${params.availableWidth}
-    ></openclaw-chat-sidebar-region>
+    ${regionError !== undefined
+      ? null
+      : html`<openclaw-chat-sidebar-region
+          .layout=${params.layout}
+          .panelDefinitions=${params.panelDefinitions ?? sidebarPanelDefinitions()}
+          .panelTemplates=${panelTemplates ?? params.panelTemplates}
+          .panelActions=${params.panelActions}
+          .availableSlots=${params.availableSlots}
+          .callbacks=${params.callbacks}
+          .narrow=${params.narrow}
+          .availableWidth=${params.availableWidth}
+        ></openclaw-chat-sidebar-region>`}
     <div class="sidebar-region__primary">${params.primary}</div>
-    <div class="sidebar-region__right-runtime"></div>
+    <div class="sidebar-region__right-runtime">${regionError ?? null}</div>
   </div>`;
 }
 

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -9,7 +9,10 @@ import type {
   TaskSuggestion,
   TaskSuggestionEvent,
 } from "../../../../packages/gateway-protocol/src/index.js";
-import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
+import type {
+  ControlUiSessionBranch,
+  ControlUiSessionPullRequest,
+} from "../../../../src/gateway/control-ui-contract.js";
 import type {
   GatewayBrowserClient,
   GatewayEventFrame,
@@ -80,6 +83,7 @@ export type TestChatPane = HTMLElement & {
   refreshTaskSuggestions: () => Promise<void>;
   refreshSessionPullRequests: (options?: { refresh?: boolean }) => Promise<void>;
   sessionPullRequests: ControlUiSessionPullRequest[];
+  sessionPullRequestsBranch: ControlUiSessionBranch | undefined;
   taskSuggestions: TaskSuggestion[];
   presencePayload?: { presence: unknown[] };
   sessionSuggestionAddOperation: symbol | undefined;

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -7,6 +7,7 @@ import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { pickFreshestObserverDigest } from "../../lib/observer-digest.ts";
 import {
+  isStructuralSessionMutationReason,
   readSessionChangedEvent,
   type SessionChangedResult,
 } from "../../lib/sessions/reconcile.ts";
@@ -37,7 +38,10 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { requestChatPageUpdate } from "./chat-state-render.ts";
 import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
 import { handleBackgroundTasksEvent } from "./components/chat-background-tasks.ts";
-import { refreshSessionWorkspace } from "./components/chat-session-workspace.ts";
+import {
+  refreshSessionWorkspace,
+  retireSessionWorkspaceCheckout,
+} from "./components/chat-session-workspace.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
@@ -195,11 +199,6 @@ function replayPendingSessionMessageReload(
   void loadChatHistory(state).finally(() => state.requestUpdate?.());
 }
 
-// Branch topology only changes on structural mutations; the producer records
-// the reason, so reload branches only for those instead of on every
-// sessions.changed (each cache miss rescans the full transcript on the gateway).
-const BRANCH_TOPOLOGY_REASONS = new Set(["rewind", "branch-switch", "fork", "reset", "new"]);
-
 function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
   const runIdBeforeApply = state.chatRunId;
   const event = readSessionChangedEvent(payload);
@@ -218,11 +217,11 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
     // only proof that its old live and pending transcript no longer exists.
     reduceChatSessionProjection(state, { type: "sessionReset" }, { scope });
   }
-  if (
-    matchesChat &&
-    typeof source?.reason === "string" &&
-    BRANCH_TOPOLOGY_REASONS.has(source.reason)
-  ) {
+  if (matchesChat && isStructuralSessionMutationReason(source?.reason)) {
+    state.chatBranches = [];
+    state.chatBranchesSessionKey = null;
+    state.chatBranchesConnectionEpoch = null;
+    retireSessionWorkspaceCheckout(state);
     void loadChatBranches(state);
   }
   if (event && matchesChat && event.archived !== null) {

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -57,6 +57,8 @@ import { isAckedSteeredChip } from "./steered-chip.ts";
 import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
 
+const BRANCH_TOPOLOGY_REASONS = new Set(["rewind", "branch-switch", "fork", "reset", "new"]);
+
 function sessionMessageMatchesChat(
   state: ChatPageHost,
   event: NonNullable<ReturnType<typeof readSessionChangedEvent>>,
@@ -216,7 +218,11 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
     // only proof that its old live and pending transcript no longer exists.
     reduceChatSessionProjection(state, { type: "sessionReset" }, { scope });
   }
-  if (matchesChat && event?.isStructural) {
+  if (
+    matchesChat &&
+    typeof source?.reason === "string" &&
+    BRANCH_TOPOLOGY_REASONS.has(source.reason)
+  ) {
     state.chatBranches = [];
     state.chatBranchesSessionKey = null;
     state.chatBranchesConnectionEpoch = null;

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -7,7 +7,6 @@ import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { pickFreshestObserverDigest } from "../../lib/observer-digest.ts";
 import {
-  isStructuralSessionMutationReason,
   readSessionChangedEvent,
   type SessionChangedResult,
 } from "../../lib/sessions/reconcile.ts";
@@ -217,7 +216,7 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
     // only proof that its old live and pending transcript no longer exists.
     reduceChatSessionProjection(state, { type: "sessionReset" }, { scope });
   }
-  if (matchesChat && isStructuralSessionMutationReason(source?.reason)) {
+  if (matchesChat && event?.isStructural) {
     state.chatBranches = [];
     state.chatBranchesSessionKey = null;
     state.chatBranchesConnectionEpoch = null;

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -265,7 +265,6 @@ export function createPageState(
     renderLifecycle,
     requestUpdate: () => renderLifecycle.invalidate(),
     sessionWorkspaceState: undefined,
-    sessionWorkspaceOpenRequest: undefined,
     backgroundTasksState: undefined,
     querySelector: page.querySelector.bind(page),
   } as unknown as ChatPageHost;

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -733,6 +733,60 @@ describe("canonical session message recovery", () => {
     expect(retireSessionCompanion).toHaveBeenCalledExactlyOnceWith("agent:other:main", "other");
   });
 
+  it("retires current checkout presentation for a structural event", () => {
+    const listBranches = vi.fn(() => new Promise<never>(() => {}));
+    const { state } = createSessionEventState({
+      chatBranches: [
+        {
+          leafEntryId: "old-leaf",
+          headline: "Old checkout",
+          messageCount: 1,
+          active: true,
+        },
+      ],
+      chatBranchesConnectionEpoch: 1,
+      chatBranchesSessionKey: "agent:main:main",
+      sessions: {
+        listBranches,
+        reconcileChanged: vi.fn().mockReturnValue({ applied: false }),
+        refresh: vi.fn().mockResolvedValue(undefined),
+      } as never,
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "sessions.changed",
+      payload: { sessionKey: state.sessionKey, agentId: "main", reason: "branch-switch" },
+    });
+
+    expect(state.chatBranches).toEqual([]);
+    expect(state.chatBranchesSessionKey).toBeNull();
+    expect(listBranches).toHaveBeenCalled();
+  });
+
+  it.each([
+    { sessionKey: "agent:main:main", agentId: "main", reason: "send" },
+    { sessionKey: "agent:other:main", agentId: "other", reason: "rewind" },
+  ])("preserves checkout presentation for non-matching event $reason/$sessionKey", (payload) => {
+    const oldBranches = [
+      { leafEntryId: "old-leaf", headline: "Old checkout", messageCount: 1, active: true },
+    ];
+    const { state } = createSessionEventState({
+      chatBranches: oldBranches,
+      chatBranchesConnectionEpoch: 1,
+      chatBranchesSessionKey: "agent:main:main",
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "sessions.changed",
+      payload,
+    });
+
+    expect(state.chatBranches).toBe(oldBranches);
+    expect(state.chatBranchesSessionKey).toBe("agent:main:main");
+  });
+
   it("keeps the routed row when a hidden pane observes its archive first", () => {
     const archivedKey = "agent:main:dashboard:archived";
     const sharedHost = makeChatHost({

--- a/ui/src/pages/chat/components/chat-session-workspace-state.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-state.ts
@@ -16,7 +16,7 @@ import type {
 } from "./chat-session-workspace-types.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 
-export function resolvePaneAgent(state: SessionScopeHostWithKey): string {
+function resolvePaneAgent(state: SessionScopeHostWithKey): string {
   const normalizedKey = normalizeOptionalString(state.sessionKey)?.toLowerCase();
   const activeAgentId =
     normalizedKey === "global" ? null : resolveAgentIdFromSessionKey(state.sessionKey);

--- a/ui/src/pages/chat/components/chat-session-workspace-state.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-state.ts
@@ -14,6 +14,7 @@ import type {
   SessionWorkspaceHost,
   SessionWorkspaceState,
 } from "./chat-session-workspace-types.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
 
 export function resolvePaneAgent(state: SessionScopeHostWithKey): string {
   const normalizedKey = normalizeOptionalString(state.sessionKey)?.toLowerCase();
@@ -42,37 +43,68 @@ export function clearSessionWorkspaceTimers(state: SessionWorkspaceHost) {
   clearWorkspaceTimer(state.sessionWorkspaceState);
 }
 
-export function getSessionWorkspace(state: SessionWorkspaceHost): SessionWorkspaceState {
-  const sessionKey = state.sessionKey;
-  const agentId = resolvePaneAgent(state);
-  const current = state.sessionWorkspaceState;
-  if (current?.sessionKey === sessionKey && current.agentId === agentId) {
-    return current;
+const checkoutSidebarContents = new WeakSet<object>();
+
+export function trackSessionCheckoutSidebar(content: SidebarContent) {
+  checkoutSidebarContents.add(content);
+}
+
+export function openSessionCheckoutSidebar(state: SessionWorkspaceHost, content: SidebarContent) {
+  trackSessionCheckoutSidebar(content);
+  state.handleOpenSidebar(content);
+}
+
+function clearSessionCheckoutSidebar(state: SessionWorkspaceHost) {
+  if (state.sidebarContent && checkoutSidebarContents.has(state.sidebarContent)) {
+    state.handleOpenSidebar(null);
   }
-  clearWorkspaceTimer(current);
-  const next: SessionWorkspaceState = {
+}
+
+function createSessionWorkspaceState(
+  state: SessionWorkspaceHost,
+  previous?: SessionWorkspaceState,
+): SessionWorkspaceState {
+  return {
     activeId: null,
-    agentId,
+    agentId: resolvePaneAgent(state),
     browserPath: "",
     browserSearch: "",
     browserSearchTimer: null,
-    collapsed: true,
+    collapsed: previous?.collapsed ?? true,
+    connectionEpoch: state.connectionEpoch,
     // Dock preference is app-wide, seeded from the host's loaded settings;
     // per-session state just carries it forward.
-    dock: current?.dock ?? normalizeChatWorkspaceDock(state.settings?.chatWorkspaceDock),
+    dock: previous?.dock ?? normalizeChatWorkspaceDock(state.settings?.chatWorkspaceDock),
     error: null,
     list: null,
     loading: false,
     pendingReload: false,
-    requestId: 0,
-    sessionKey,
+    sessionKey: state.sessionKey,
   };
-  state.sessionWorkspaceState = next;
-  return next;
 }
 
-export function currentSessionWorkspace(state: SessionWorkspaceHost): SessionWorkspaceState {
-  return getSessionWorkspace(state);
+export function isCurrentSessionWorkspace(
+  state: SessionWorkspaceHost,
+  workspace: SessionWorkspaceState,
+) {
+  return (
+    state.sessionWorkspaceState === workspace &&
+    workspace.sessionKey === state.sessionKey &&
+    workspace.agentId === resolvePaneAgent(state) &&
+    workspace.connectionEpoch === state.connectionEpoch
+  );
+}
+
+export function getSessionWorkspace(state: SessionWorkspaceHost): SessionWorkspaceState {
+  const current = state.sessionWorkspaceState;
+  if (current && isCurrentSessionWorkspace(state, current)) {
+    return current;
+  }
+  clearSessionCheckoutSidebar(state);
+  clearWorkspaceTimer(current);
+  const next = createSessionWorkspaceState(state, current);
+  state.sessionWorkspaceState = next;
+  return next;
 }
 
 export function requestWorkspaceUpdate(state: SessionWorkspaceHost) {
@@ -93,8 +125,6 @@ export function loadSessionWorkspace(
     }
     return;
   }
-  const requestId = workspace.requestId + 1;
-  workspace.requestId = requestId;
   workspace.loading = true;
   workspace.error = null;
   if (force) {
@@ -103,6 +133,7 @@ export function loadSessionWorkspace(
   workspace.pendingReload = false;
   const sessionKey = state.sessionKey;
   const agentId = workspace.agentId;
+  const client = state.client;
   void (async () => {
     try {
       const files = await state.sessions.listFiles(sessionKey, {
@@ -110,20 +141,22 @@ export function loadSessionWorkspace(
         search: workspace.browserSearch,
         agentId,
       });
-      const artifacts = await state.client?.request<{
+      if (!isCurrentSessionWorkspace(state, workspace)) {
+        return;
+      }
+      const artifacts = await client.request<{
         artifacts?: SessionWorkspaceListResult["artifacts"];
       } | null>("artifacts.list", {
         sessionKey,
         ...(agentId ? { agentId } : {}),
       });
-      const current = currentSessionWorkspace(state);
-      if (current !== workspace || current.requestId !== requestId) {
+      if (!isCurrentSessionWorkspace(state, workspace)) {
         return;
       }
       const fileItems = files?.files ?? [];
       const artifactItems = artifacts?.artifacts ?? [];
       const browserItems = files?.browser?.entries ?? [];
-      current.list = {
+      workspace.list = {
         sessionKey,
         ...(files?.root ? { root: files.root } : {}),
         ...(typeof files?.gitCheckout === "boolean" ? { gitCheckout: files.gitCheckout } : {}),
@@ -132,26 +165,24 @@ export function loadSessionWorkspace(
         artifacts: artifactItems,
       };
       if (
-        current.activeId &&
-        !fileItems.some((file) => `file:${file.path}` === current.activeId) &&
-        !browserItems.some((entry) => `file:${entry.path}` === current.activeId) &&
-        !artifactItems.some((artifact) => `artifact:${artifact.id}` === current.activeId)
+        workspace.activeId &&
+        !fileItems.some((file) => `file:${file.path}` === workspace.activeId) &&
+        !browserItems.some((entry) => `file:${entry.path}` === workspace.activeId) &&
+        !artifactItems.some((artifact) => `artifact:${artifact.id}` === workspace.activeId)
       ) {
-        current.activeId = null;
+        workspace.activeId = null;
       }
     } catch (error) {
-      const current = currentSessionWorkspace(state);
-      if (current === workspace && current.requestId === requestId) {
-        current.error = formatUiError(error);
+      if (isCurrentSessionWorkspace(state, workspace)) {
+        workspace.error = formatUiError(error);
       }
     } finally {
-      const current = currentSessionWorkspace(state);
-      if (current === workspace && current.requestId === requestId) {
-        current.loading = false;
-        const reload = current.pendingReload;
-        current.pendingReload = false;
+      if (isCurrentSessionWorkspace(state, workspace)) {
+        workspace.loading = false;
+        const reload = workspace.pendingReload;
+        workspace.pendingReload = false;
         if (reload) {
-          loadSessionWorkspace(state, current);
+          loadSessionWorkspace(state, workspace);
         }
       }
       requestWorkspaceUpdate(state);
@@ -160,14 +191,34 @@ export function loadSessionWorkspace(
 }
 
 /** Refresh workspace facts after a run, which may have created a git checkout. */
-export function refreshSessionWorkspace(state: SessionWorkspaceHost) {
+export function refreshSessionWorkspaceState(state: SessionWorkspaceHost): boolean {
   const workspace = state.sessionWorkspaceState;
   if (!workspace || workspace.sessionKey !== state.sessionKey) {
-    return;
+    return false;
   }
+  const diffOpen =
+    workspace.diffContent !== undefined && state.sidebarContent === workspace.diffContent;
+  delete workspace.diffContent;
   if (workspace.loading) {
     workspace.pendingReload = true;
   } else {
     loadSessionWorkspace(state, workspace);
   }
+  return diffOpen;
+}
+
+/** Retire facts owned by one checkout without disturbing panel layout or retained drafts. */
+export function retireSessionWorkspaceCheckout(state: SessionWorkspaceHost) {
+  const current = state.sessionWorkspaceState;
+  if (!current || current.sessionKey !== state.sessionKey) {
+    return;
+  }
+  clearSessionCheckoutSidebar(state);
+  clearWorkspaceTimer(current);
+  const next = createSessionWorkspaceState(state, current);
+  state.sessionWorkspaceState = next;
+  if (state.client && state.connected) {
+    loadSessionWorkspace(state, next);
+  }
+  requestWorkspaceUpdate(state);
 }

--- a/ui/src/pages/chat/components/chat-session-workspace-types.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-types.ts
@@ -38,23 +38,16 @@ export type SessionWorkspaceState = {
   browserSearch: string;
   browserSearchTimer: ReturnType<typeof globalThis.setTimeout> | null;
   collapsed: boolean;
+  connectionEpoch: number;
   dock: ChatWorkspaceDock;
+  diffContent?: SidebarContent;
   error: string | null;
   list: SessionWorkspaceListResult | null;
   loading: boolean;
+  openRequest?: object;
   pendingReload: boolean;
-  requestId: number;
   sessionKey: string;
 };
-
-type OpenRequest = {
-  agentId: string;
-  id: number;
-  itemId: string;
-  sessionKey: string;
-};
-
-export type WorkspaceOpenRequest = OpenRequest;
 
 // Re-renders must preserve the document identity or the mounted diff panel
 // treats its loader as new and requests sessions.diff again.
@@ -63,6 +56,7 @@ export type SessionWorkspaceHost = {
   sessions: SessionCapability;
   client: GatewayBrowserClient | null;
   connected: boolean;
+  connectionEpoch: number;
   hello: GatewayHelloOk | null;
   terminalAvailable?: boolean;
   browserPanelAvailable?: boolean;
@@ -70,8 +64,8 @@ export type SessionWorkspaceHost = {
   agentsList?: SessionScopeHost["agentsList"];
   settings?: UiSettings;
   sessionWorkspaceState?: SessionWorkspaceState;
-  sessionWorkspaceOpenRequest?: WorkspaceOpenRequest;
   sessionWorkspaceDraftScope?: string;
+  sidebarContent: SidebarContent | null;
   requestUpdate?: () => void;
   handleOpenSidebar: (content: SidebarContent | null) => void;
 };

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createSessionWorkspaceProps,
   openSessionWorkspaceFile,
+  refreshSessionWorkspace,
   renderSessionWorkspaceRail,
+  resolveSessionDiffSidebarContent,
   type SessionWorkspaceHost,
 } from "./chat-session-workspace.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -35,6 +37,7 @@ describe("session workspace state", () => {
       requestUpdate: vi.fn(),
       sessionKey: "agent:main:current",
       settings: { chatWorkspaceDock: "bottom" },
+      sidebarContent: null,
       sessions: {},
     } as unknown as SessionWorkspaceHost;
 
@@ -44,6 +47,151 @@ describe("session workspace state", () => {
     workspace.onSetDock("right");
     expect(createSessionWorkspaceProps(state).dock).toBe("right");
     expect(state.settings?.chatWorkspaceDock).toBe("right");
+  });
+
+  it("rotates Files and Review ownership across a same-client reconnect", async () => {
+    let resolveReplacementList!: (value: {
+      sessionKey: string;
+      root: string;
+      gitCheckout: boolean;
+      files: [];
+    }) => void;
+    const replacementList = new Promise<{
+      sessionKey: string;
+      root: string;
+      gitCheckout: boolean;
+      files: [];
+    }>((resolve) => {
+      resolveReplacementList = resolve;
+    });
+    let resolveOldFile!: (value: {
+      sessionKey: string;
+      root: string;
+      file: { path: string; name: string; kind: "read"; missing: false; content: string };
+    }) => void;
+    const oldFile = new Promise<{
+      sessionKey: string;
+      root: string;
+      file: { path: string; name: string; kind: "read"; missing: false; content: string };
+    }>((resolve) => {
+      resolveOldFile = resolve;
+    });
+    const listFiles = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionKey: "agent:main:current",
+        root: "/checkout/a",
+        gitCheckout: true,
+        files: [],
+      })
+      .mockReturnValueOnce(replacementList);
+    const getFile = vi.fn().mockReturnValue(oldFile);
+    const client = { request: vi.fn().mockResolvedValue({ artifacts: [] }) };
+    const state = {
+      client,
+      connected: true,
+      connectionEpoch: 1,
+      handleOpenSidebar: vi.fn(),
+      hello: gatewayHello(["sessions.diff"]),
+      agentsList: { agents: [] },
+      requestUpdate: vi.fn(),
+      sessionKey: "agent:main:current",
+      sidebarContent: null,
+      sessions: { getFile, listFiles },
+    } as unknown as SessionWorkspaceHost;
+    const handleOpenSidebar = vi.fn((content: SidebarContent | null) => {
+      state.sidebarContent = content;
+    });
+    state.handleOpenSidebar = handleOpenSidebar;
+
+    createSessionWorkspaceProps(state, { expanded: true });
+    await vi.waitFor(() =>
+      expect(createSessionWorkspaceProps(state).list?.root).toBe("/checkout/a"),
+    );
+    const oldDiff = resolveSessionDiffSidebarContent(state);
+    expect(oldDiff?.kind).toBe("session-diff");
+    createSessionWorkspaceProps(state, { expanded: true }).onOpenDiff?.();
+    expect(state.sidebarContent).toBe(oldDiff);
+    openSessionWorkspaceFile(state, { path: "README.md" });
+    expect(handleOpenSidebar).toHaveBeenLastCalledWith(null);
+
+    (state as SessionWorkspaceHost & { connectionEpoch: number }).connectionEpoch = 2;
+    const pending = createSessionWorkspaceProps(state, { expanded: true });
+
+    expect(pending.list).toBeNull();
+    expect(pending.onOpenDiff).toBeUndefined();
+    expect(listFiles).toHaveBeenCalledTimes(2);
+    expect(state.sidebarContent).toBeNull();
+
+    resolveOldFile({
+      sessionKey: "agent:main:current",
+      root: "/checkout/a",
+      file: {
+        path: "README.md",
+        name: "README.md",
+        kind: "read",
+        missing: false,
+        content: "old checkout",
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handleOpenSidebar).toHaveBeenCalledTimes(2);
+
+    resolveReplacementList({
+      sessionKey: "agent:main:current",
+      root: "/checkout/b",
+      gitCheckout: true,
+      files: [],
+    });
+    await vi.waitFor(() =>
+      expect(createSessionWorkspaceProps(state).list?.root).toBe("/checkout/b"),
+    );
+    expect(resolveSessionDiffSidebarContent(state)).not.toBe(oldDiff);
+  });
+
+  it("refreshes content in place while rotating an open default Review loader", async () => {
+    let resolveRefresh!: (value: unknown) => void;
+    const listFiles = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionKey: "agent:main:current",
+        root: "/checkout/a",
+        gitCheckout: true,
+        files: [],
+      })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+    const state = {
+      client: { request: vi.fn().mockResolvedValue({ artifacts: [] }) } as never,
+      connected: true,
+      connectionEpoch: 1,
+      handleOpenSidebar: vi.fn(),
+      hello: gatewayHello(["sessions.diff"]),
+      agentsList: { agents: [] },
+      requestUpdate: vi.fn(),
+      sessionKey: "agent:main:current",
+      sidebarContent: null,
+      sessions: { listFiles } as never,
+    } as SessionWorkspaceHost;
+    state.handleOpenSidebar = (content) => {
+      state.sidebarContent = content;
+    };
+    createSessionWorkspaceProps(state, { expanded: true });
+    await vi.waitFor(() => expect(createSessionWorkspaceProps(state).list).not.toBeNull());
+    const oldDiff = resolveSessionDiffSidebarContent(state)!;
+    createSessionWorkspaceProps(state, { expanded: true }).onOpenDiff?.();
+
+    refreshSessionWorkspace(state);
+
+    expect(createSessionWorkspaceProps(state).list?.root).toBe("/checkout/a");
+    expect(state.sidebarContent).toMatchObject({ kind: "session-diff" });
+    expect(state.sidebarContent).not.toBe(oldDiff);
+    expect(listFiles).toHaveBeenCalledTimes(2);
+    resolveRefresh({ sessionKey: state.sessionKey, files: [] });
   });
 });
 
@@ -65,6 +213,7 @@ describe("session workspace artifacts", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {},
     } as unknown as SessionWorkspaceHost;
     return { handleOpenSidebar, request, state };
@@ -156,6 +305,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: existingContent,
       sessions: { getFile },
     } as unknown as SessionWorkspaceHost;
 
@@ -189,6 +339,7 @@ describe("openSessionWorkspaceFile", () => {
       sessionKey: "agent:main:current",
       sessionWorkspaceDraftScope: "pane-left",
       settings: { gatewayUrl: "wss://gateway-a.example" },
+      sidebarContent: null,
       sessions: { getFile },
     } as unknown as SessionWorkspaceHost;
 
@@ -219,6 +370,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello(methods, scopes),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {
         getFile: vi.fn().mockResolvedValue({
           sessionKey: "agent:main:current",
@@ -276,6 +428,7 @@ describe("openSessionWorkspaceFile", () => {
         hello: gatewayHello([]),
         agentsList: [],
         sessionKey: "agent:main:current",
+        sidebarContent: null,
         sessions: { getFile, listFiles },
       } as unknown as SessionWorkspaceHost;
 
@@ -307,6 +460,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {
         getFile: vi.fn().mockResolvedValue({
           sessionKey: "agent:main:current",
@@ -345,6 +499,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {
         getFile: vi.fn().mockResolvedValue({
           sessionKey: "agent:main:current",
@@ -381,6 +536,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {
         getFile: vi.fn().mockResolvedValue({
           sessionKey: "agent:main:current",
@@ -414,6 +570,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {
         getFile: vi.fn().mockResolvedValue({
           sessionKey: "agent:main:current",
@@ -451,6 +608,7 @@ describe("openSessionWorkspaceFile", () => {
       handleOpenSidebar,
       hello: gatewayHello([]),
       sessionKey: "agent:main:current",
+      sidebarContent: null,
       sessions: {
         getFile: vi.fn().mockResolvedValue({
           sessionKey: "agent:main:current",

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -7,18 +7,18 @@ import { t } from "../../../i18n/index.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../../lib/gateway-methods.ts";
-import { scopedAgentParamsForSession } from "../../../lib/sessions/index.ts";
 import {
   clearWorkspaceTimer,
-  currentSessionWorkspace,
   getSessionWorkspace,
+  isCurrentSessionWorkspace,
   loadSessionWorkspace,
+  openSessionCheckoutSidebar,
+  refreshSessionWorkspaceState,
   requestWorkspaceUpdate,
-  resolvePaneAgent,
+  trackSessionCheckoutSidebar,
 } from "./chat-session-workspace-state.ts";
 import type {
   SessionWorkspaceHost,
-  WorkspaceOpenRequest,
   SessionWorkspaceProps,
   SessionWorkspaceState,
 } from "./chat-session-workspace-types.ts";
@@ -26,18 +26,13 @@ import { hasUniformLineEndings, type SidebarContent } from "./chat-sidebar.ts";
 
 export {
   clearSessionWorkspaceTimers,
-  refreshSessionWorkspace,
+  retireSessionWorkspaceCheckout,
 } from "./chat-session-workspace-state.ts";
 export { renderSessionWorkspaceRail } from "./chat-session-workspace-rail.ts";
 export type {
   SessionWorkspaceHost,
   SessionWorkspaceProps,
 } from "./chat-session-workspace-types.ts";
-
-const sessionDiffSidebarContentByHost = new WeakMap<
-  SessionWorkspaceHost,
-  { content: SidebarContent; sessionKey: string }
->();
 
 function languageForFile(name: string): string {
   const extension = name.match(/\.([a-z0-9_-]+)$/i)?.[1]?.toLowerCase() ?? "";
@@ -158,36 +153,27 @@ function artifactSidebarContent(params: {
   return { kind: "markdown", content, rawText: content };
 }
 
-function beginWorkspaceOpenRequest(
-  state: SessionWorkspaceHost,
-  workspace: SessionWorkspaceState,
-  itemId: string,
-): WorkspaceOpenRequest {
+export function refreshSessionWorkspace(state: SessionWorkspaceHost) {
+  if (refreshSessionWorkspaceState(state)) {
+    state.handleOpenSidebar(resolveSessionDiffSidebarContent(state));
+  }
+}
+
+function beginWorkspaceOpenRequest(workspace: SessionWorkspaceState, itemId: string): object {
   workspace.activeId = itemId;
-  const previous = state.sessionWorkspaceOpenRequest;
-  const request: WorkspaceOpenRequest = {
-    agentId: workspace.agentId,
-    id: (previous?.id ?? 0) + 1,
-    itemId,
-    sessionKey: state.sessionKey,
-  };
-  state.sessionWorkspaceOpenRequest = request;
-  return request;
+  return (workspace.openRequest = {});
 }
 
 function isCurrentWorkspaceOpenRequest(
   state: SessionWorkspaceHost,
-  request: WorkspaceOpenRequest,
+  workspace: SessionWorkspaceState,
+  request: object,
+  itemId: string,
 ): boolean {
-  const currentRequest = state.sessionWorkspaceOpenRequest;
-  const current = currentSessionWorkspace(state);
   return (
-    currentRequest?.id === request.id &&
-    currentRequest.agentId === resolvePaneAgent(state) &&
-    currentRequest.itemId === request.itemId &&
-    currentRequest.sessionKey === state.sessionKey &&
-    current?.agentId === request.agentId &&
-    current.activeId === request.itemId
+    workspace.openRequest === request &&
+    isCurrentSessionWorkspace(state, workspace) &&
+    workspace.activeId === itemId
   );
 }
 
@@ -195,11 +181,11 @@ function openWorkspaceItem<T>(
   state: SessionWorkspaceHost,
   workspace: SessionWorkspaceState,
   itemId: string,
-  load: (request: WorkspaceOpenRequest) => Promise<T | null | undefined>,
+  load: () => Promise<T | null | undefined>,
   render: (result: T) => SidebarContent | null,
   missingMessage: string,
 ) {
-  const request = beginWorkspaceOpenRequest(state, workspace, itemId);
+  const request = beginWorkspaceOpenRequest(workspace, itemId);
   void (async () => {
     if (!state.client || !state.connected) {
       return;
@@ -207,19 +193,19 @@ function openWorkspaceItem<T>(
     state.handleOpenSidebar(null);
     workspace.error = null;
     try {
-      const result = await load(request);
+      const result = await load();
       const content = result == null ? null : render(result);
       if (!content) {
-        if (isCurrentWorkspaceOpenRequest(state, request)) {
+        if (isCurrentWorkspaceOpenRequest(state, workspace, request, itemId)) {
           workspace.error = missingMessage;
         }
         return;
       }
-      if (isCurrentWorkspaceOpenRequest(state, request)) {
-        state.handleOpenSidebar(content);
+      if (isCurrentWorkspaceOpenRequest(state, workspace, request, itemId)) {
+        openSessionCheckoutSidebar(state, content);
       }
     } catch (error) {
-      if (isCurrentWorkspaceOpenRequest(state, request)) {
+      if (isCurrentWorkspaceOpenRequest(state, workspace, request, itemId)) {
         workspace.error = formatUiError(error);
       }
     } finally {
@@ -239,9 +225,9 @@ function openFile(
     state,
     workspace,
     `file:${path}`,
-    (request) =>
-      state.sessions.getFile(request.sessionKey, requestPath, {
-        agentId: request.agentId,
+    () =>
+      state.sessions.getFile(workspace.sessionKey, requestPath, {
+        agentId: workspace.agentId,
       }),
     (result) => {
       const file = result.file;
@@ -425,11 +411,11 @@ function openArtifact(
     state,
     workspace,
     `artifact:${artifactId}`,
-    (request) =>
+    () =>
       state.client!.request<ArtifactDownloadResult | null>("artifacts.download", {
-        sessionKey: request.sessionKey,
+        sessionKey: workspace.sessionKey,
         artifactId,
-        ...(request.agentId ? { agentId: request.agentId } : {}),
+        ...(workspace.agentId ? { agentId: workspace.agentId } : {}),
       }),
     (result) =>
       !result.artifact
@@ -505,7 +491,7 @@ export function createSessionWorkspaceProps(
       }, 160);
     },
     onOpenArtifact: (artifactId) => openArtifact(state, workspace, artifactId),
-    onOpenDiff: diffContent ? () => state.handleOpenSidebar(diffContent) : undefined,
+    onOpenDiff: diffContent ? () => openSessionCheckoutSidebar(state, diffContent) : undefined,
   };
 }
 
@@ -521,29 +507,34 @@ export function resolveSessionDiffSidebarContent(
   if (!canOpenDiff) {
     return null;
   }
-  const cached = sessionDiffSidebarContentByHost.get(state);
-  if (cached?.sessionKey === state.sessionKey) {
-    return cached.content;
+  if (workspace.diffContent) {
+    return workspace.diffContent;
   }
-  const content = buildSessionDiffSidebarContent(state);
-  sessionDiffSidebarContentByHost.set(state, { content, sessionKey: state.sessionKey });
+  const content = buildSessionDiffSidebarContent(state, workspace);
+  trackSessionCheckoutSidebar(content);
+  workspace.diffContent = content;
   return content;
 }
 
 /** Sidebar payload whose loader refetches sessions.diff for the pane's session. */
-function buildSessionDiffSidebarContent(state: SessionWorkspaceHost): SidebarContent {
+function buildSessionDiffSidebarContent(
+  state: SessionWorkspaceHost,
+  workspace: SessionWorkspaceState,
+): SidebarContent {
   const sessionKey = state.sessionKey;
+  const client = state.client;
+  const agentId = workspace.agentId;
   const canLoadFileText =
     isGatewayMethodAdvertised(state, "sessions.files.get") === true && Boolean(state.client);
   return {
     kind: "session-diff",
     load: async (scope) => {
-      if (!state.client) {
+      if (!client) {
         throw new Error(t("chat.sessionDiff.disconnected"));
       }
-      return await state.client.request<SessionsDiffResult>("sessions.diff", {
+      return await client.request<SessionsDiffResult>("sessions.diff", {
         sessionKey,
-        ...scopedAgentParamsForSession(state, sessionKey),
+        ...(agentId ? { agentId } : {}),
         ...scope,
       });
     },
@@ -551,7 +542,7 @@ function buildSessionDiffSidebarContent(state: SessionWorkspaceHost): SidebarCon
       ? async (path) => {
           try {
             const result = await state.sessions.getFile(sessionKey, path, {
-              agentId: scopedAgentParamsForSession(state, sessionKey).agentId,
+              agentId,
             });
             const file = result?.file;
             if (


### PR DESCRIPTION
Closes #125767

AI-assisted: yes. No agent transcript is included.

## What Problem This Solves

Fixes an issue where Control UI users could see stale Create PR, pull-request, Files, Review, and branch data after a structural session replacement reused the same session key or after the same browser client reconnected. It also fixes a transient sidebar chunk failure leaving the selected panel blank with no useful recovery action.

The stale state could point operators at the previous checkout while the chat session already belonged to its replacement. The blank-panel path made the chat look partially broken even though the primary conversation remained usable.

## Why This Change Was Made

The root cause was split across the owners of checkout-derived state:

- The PR snapshot store keyed reconnect behavior to client/hello identity instead of the logical Gateway connection epoch and ignored same-key structural `sessions.changed` events.
- Shared PR summary/epoch and branch presentation survived structural replacement events.
- Files state and the default Review loader were session-key-owned rather than connection/checkout-owned, so superseded async results could still target the current pane.
- Forced Gateway refresh bypassed the GitHub snapshot cache but not the bounded 10-second local Git context/fact caches.
- Lazy sidebar imports swallowed a rejection or retained the rejected promise, so the panel had no visible terminal outcome.

The repair establishes one canonical structural-replacement policy for the current producer reasons: `new`, `reset`, `branch-switch`, `fork`, and `rewind`. Those events retire only the matching checkout-owned state and force a fresh producer read. Logical reconnects rotate the same ownership through the existing connection lifecycle. Workspace loaders capture their checkout/client owner and ignore superseded results. Lazy sidebar modules now share a retryable runtime registry and render the existing actionable stale-chunk recovery UI without hiding chat.

There is no Gateway protocol, configuration, storage, migration, or compatibility change.

Production LOC: +384/-223 (net +161). Tests and test support: +565/-33 (net +532). The positive production delta is the concrete ownership machinery needed to replace client-object heuristics with logical connection ownership, retire checkout-scoped Files/Review/PR facts at their lifecycle boundary, bypass stale local Git facts on explicit structural refresh, and give chunk-load failure an actionable visible outcome. It does not add a second data path or new public surface; workspace ownership now lives in main's split state/types owners rather than the former monolith.

## User Impact

Create PR and pull-request indicators disappear immediately when the underlying checkout is replaced, then repopulate from the replacement checkout. Files, Review, and branch facts likewise rotate across reset/rewind/fork/branch-switch/new events and reconnects, even when the session key and browser client object are reused. If a sidebar chunk fails to load, chat stays usable and the panel explains that a newer UI is available with a Reload action; retry restores the Files panel.

Release note: Control UI checkout side panels now refresh reliably after session replacement and reconnect, and failed sidebar chunks can recover without leaving blank content.

## Evidence

Pre-fix owner-boundary failures were captured before production edits:

- PR snapshot store: 6/24 failed — reconnect plus all five structural reasons retained seeded PR state.
- Shared PR summary/epoch: 5/9 failed — each structural reason retained the previous open summary.
- Chat branch presentation: 5/63 failed — each structural reason left the old branch list rendered.
- Workspace ownership: 1/19 failed — checkout A's Files list survived a connection-epoch change.
- Chat PR pane: 1/7 failed — `branch-switch` left the old PR rendered while replacement was pending.
- Sidebar indicator: 1/4 failed — `rewind` left the old open state rendered.
- Gateway forced refresh: both focused cases failed — cached additions and branch identity were returned.
- Lazy sidebar: 1/1 failed — the panel had no alert after a rejected chunk import.

Post-fix validation on the rebased head:

- `node scripts/run-vitest.mjs ui/src/lib/session-pull-requests.test.ts ui/src/lib/sessions/pull-request-state.test.ts ui/src/pages/chat/chat-state.test.ts ui/src/pages/chat/chat-pane-pull-requests.test.ts ui/src/components/app-sidebar-session-pr-indicators.test.ts ui/src/pages/chat/components/chat-session-workspace.test.ts ui/src/pages/chat/chat-pane-sidebar-layout.test.ts ui/src/pages/chat/chat-pane-sidebar-layout.lazy.test.ts src/gateway/control-ui-session-prs.test.ts` — 143 tests passed across 3 shards.
- Changed-path gates for all 28 paths — passed core/UI formatting, typechecks, lint, import cycles, storage/schema guards, i18n verification, dependency/plugin boundaries, and dead-export analysis.
- `pnpm build` — passed, including Control UI sidecars/startup budgets and lazy-module output; no ineffective dynamic-import warning.
- Fresh Codex-backed autoreview on `origin/main...HEAD` — TruffleHog clean, no accepted/actionable findings.
- Initial exact-head CI exposed a Linux startup-JavaScript budget overage in `build-artifacts`. The final owner refactor keeps structural policy in the PR snapshot store, retires derived summaries through fenced consumers, preserves canonical summary identity, and removes duplicate session-event parsing. On the latest main base, `pnpm ui:build` measures 343,573 bytes locally against the healed 345,451-byte limit, without changing this PR's budget configuration.
- The next CI run exposed the service-worker E2E's pre-repair ordering assumption: stale sidebar chunks can now refresh the document before worker activation. The scenario now advances mock Gateway build identity with replacement assets, as production does, and proves the queued catalog terminal intent survives both refresh owners exactly once. The exact E2E passes 2/2 locally; the original 146-test suite remains green.

Mocked Gateway + browser runtime proof:

Checkout A starts with Create PR and Review data:

![Checkout A with Create PR and Review](https://github.com/user-attachments/assets/408b71a8-fc56-41b9-8347-0f4ad23450a0)

The same-key reset immediately removes Create PR while Review advances to checkout B:

![Reset invalidates checkout A state](https://github.com/user-attachments/assets/7edec2d5-6e6a-4f3c-8348-b11447d59d37)

Replacement Create PR state arrives for checkout B:

![Checkout B replacement state](https://github.com/user-attachments/assets/6104dbef-4cf0-4124-b7a5-243fe0753a46)

A same-client reconnect clears the old PR state and advances Review to checkout C:

![Reconnect advances to checkout C](https://github.com/user-attachments/assets/9794f3b6-9214-4197-8395-f48e02cfa5a9)

An aborted sidebar chunk shows a visible Reload action while chat remains usable:

![Sidebar chunk failure with actionable reload](https://github.com/user-attachments/assets/89e4b92e-1d0f-4a0a-9c4d-3551f79aa4f0)

Reload recovers the Files panel:

![Files panel recovered after reload](https://github.com/user-attachments/assets/f8b4bd58-f392-41c0-ac92-eec25a778e82)
