### PR TITLE
feat(skills): merge execution-dir skills after agent workspace skills

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3818,7 +3818,7 @@ src/skills/loading/config.ts	1
 src/skills/loading/frontmatter.ts	1
 src/skills/loading/source.ts	1
 src/skills/loading/workspace-skill-loader.ts	2
-src/skills/loading/workspace-skill-sync.runtime.ts	2
+src/skills/loading/workspace-skill-sync.runtime.ts	1
 src/skills/runtime/refresh.ts	3
 src/skills/runtime/remote-probe-utils.ts	2
 src/skills/runtime/remote-skills.ts	1

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1,4 +1,5 @@
 /** Main agent command orchestration for sessions, model selection, delivery, and attempts. */
+import path from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
@@ -442,6 +443,7 @@ async function agentCommandInternal(
             lifecycleGeneration,
             runId,
             workspaceDir,
+            executionSkillsDir: path.join(cwd ?? workspaceDir, "skills"),
             isNewSession,
             isSubagentLaneTurn,
             suppressVisibleSessionEffects,

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -443,7 +443,10 @@ async function agentCommandInternal(
             lifecycleGeneration,
             runId,
             workspaceDir,
-            executionSkillsDir: path.join(cwd ?? workspaceDir, "skills"),
+            executionSkillsDir: path.join(
+              sessionEntry?.worktree?.canonicalWorkspaceDir ?? cwd ?? workspaceDir,
+              "skills",
+            ),
             isNewSession,
             isSubagentLaneTurn,
             suppressVisibleSessionEffects,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -260,7 +260,7 @@ async function resolveCliSkillsPrompt(params: {
     workspaceDir: params.workspaceDir,
   });
   if (!sandboxWorkspace) {
-    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries } =
+    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries, preserveEntryOrder } =
       resolveEmbeddedRunSkillEntries({
         workspaceDir: params.workspaceDir,
         config: params.config,
@@ -274,6 +274,7 @@ async function resolveCliSkillsPrompt(params: {
       workspaceDir: params.workspaceDir,
       config: params.config,
       agentId: params.agentId,
+      preserveEntryOrder,
     });
   }
 
@@ -302,14 +303,15 @@ async function resolveCliSkillsPrompt(params: {
     skillsAnchorWorkspace: sandboxWorkspace.workspaceDir,
     skillsSnapshot: params.skillsSnapshot,
   });
-  const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-    workspaceDir: skillsWorkspaceDir,
-    config: params.config,
-    agentId: params.agentId,
-    eligibility: skillsEligibility,
-    skillsSnapshot: skillsSnapshotForRun,
-    workspaceOnly,
-  });
+  const { shouldLoadSkillEntries, skillEntries, preserveEntryOrder } =
+    resolveEmbeddedRunSkillEntries({
+      workspaceDir: skillsWorkspaceDir,
+      config: params.config,
+      agentId: params.agentId,
+      eligibility: skillsEligibility,
+      skillsSnapshot: skillsSnapshotForRun,
+      workspaceOnly,
+    });
   const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
     entries: shouldLoadSkillEntries ? skillEntries : undefined,
     skillsWorkspaceDir,
@@ -322,6 +324,7 @@ async function resolveCliSkillsPrompt(params: {
     config: params.config,
     agentId: params.agentId,
     eligibility: skillsEligibility,
+    preserveEntryOrder,
   });
 }
 

--- a/src/agents/command/session-preparation.ts
+++ b/src/agents/command/session-preparation.ts
@@ -23,6 +23,7 @@ export async function prepareEmbeddedSessionState(params: {
   lifecycleGeneration: string;
   runId: string;
   workspaceDir: string;
+  executionSkillsDir: string;
   isNewSession: boolean;
   isSubagentLaneTurn: boolean;
   suppressVisibleSessionEffects: boolean;
@@ -64,6 +65,7 @@ export async function prepareEmbeddedSessionState(params: {
   });
   const skillSnapshotState = resolveReusableWorkspaceSkillSnapshot({
     workspaceDir: params.workspaceDir,
+    executionSkillsDir: params.executionSkillsDir,
     config: params.cfg,
     agentId: params.sessionAgentId,
     existingSnapshot: params.isNewSession ? undefined : currentSkillsSnapshot,

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -986,9 +986,16 @@ export async function loadCompactHooksHarness(): Promise<{
     applySkillEnvOverridesFromSnapshot: vi.fn(() => () => {}),
   }));
 
-  vi.doMock("../../skills/loading/workspace-skill-loader.js", () => ({
-    loadWorkspaceSkills: vi.fn(() => []),
-  }));
+  vi.doMock("../../skills/loading/workspace-skill-loader.js", async () => {
+    const actual = await vi.importActual<
+      typeof import("../../skills/loading/workspace-skill-loader.js")
+    >("../../skills/loading/workspace-skill-loader.js");
+    return {
+      loadMergedWorkspaceSkills: vi.fn(() => []),
+      loadWorkspaceSkills: vi.fn(() => []),
+      normalizeWorkspaceSkillRoots: actual.normalizeWorkspaceSkillRoots,
+    };
+  });
 
   vi.doMock("../../skills/loading/workspace-skill-prompt.js", () => ({
     resolveSkillsPrompt: vi.fn(() => undefined),

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -3,6 +3,7 @@
  * prepared direct compaction attempt.
  */
 import os from "node:os";
+import path from "node:path";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import {
@@ -152,6 +153,11 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
         agentId: effectiveSkillAgentId,
         eligibility: skillsEligibility,
         skillsSnapshot: skillsSnapshotForRun,
+        // Sandbox fallbacks stay inside their sandbox skill workspace;
+        // host execution skills are not mounted there.
+        ...(sandbox?.enabled === true
+          ? {}
+          : { executionSkillsDir: path.join(effectiveWorkspace, "skills") }),
         workspaceOnly: loadSkillsWorkspaceOnly,
       });
     restoreSkillEnv = skillsSnapshotForRun

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -146,7 +146,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       skillsAnchorWorkspace: params.bootstrapWorkspaceDir ?? effectiveWorkspace,
       skillsSnapshot: params.skillsSnapshot,
     });
-    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries } =
+    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries, preserveEntryOrder } =
       resolveEmbeddedRunSkillEntries({
         workspaceDir: effectiveSkillsWorkspace,
         config: params.config,
@@ -191,6 +191,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       workspaceDir: effectiveSkillsPromptWorkspace,
       agentId: effectiveSkillAgentId,
       eligibility: skillsEligibility,
+      preserveEntryOrder,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
@@ -228,7 +228,7 @@ describe("prepareEmbeddedAttemptSetup", () => {
 });
 
 describe("prepareEmbeddedAttemptSkills", () => {
-  it("discovers fallback skills from the configured agent workspace", async () => {
+  it("discovers fallback skills from the agent and execution workspaces", async () => {
     const agentWorkspace = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-skills-")),
     );
@@ -258,7 +258,7 @@ describe("prepareEmbeddedAttemptSkills", () => {
       });
       try {
         expect(prepared.skillsPrompt).toContain("agent-workspace-skill");
-        expect(prepared.skillsPrompt).not.toContain("execution-workspace-skill");
+        expect(prepared.skillsPrompt).toContain("execution-workspace-skill");
       } finally {
         prepared.restoreSkillEnv();
       }

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -513,8 +513,8 @@ export function prepareEmbeddedAttemptSkills(params: {
     skillsAnchorWorkspace: params.attempt.bootstrapWorkspaceDir ?? params.effectiveWorkspace,
     skillsSnapshot: params.attempt.skillsSnapshot,
   });
-  const { shouldLoadSkillEntries, skillEntries, loadSkillEntries } = resolveEmbeddedRunSkillEntries(
-    {
+  const { shouldLoadSkillEntries, skillEntries, loadSkillEntries, preserveEntryOrder } =
+    resolveEmbeddedRunSkillEntries({
       workspaceDir: skillsWorkspaceDir,
       config: params.attempt.config,
       agentId: params.sessionAgentId,
@@ -526,8 +526,7 @@ export function prepareEmbeddedAttemptSkills(params: {
         ? {}
         : { executionSkillsDir: path.join(params.effectiveWorkspace, "skills") }),
       workspaceOnly,
-    },
-  );
+    });
   const restoreSkillEnv = skillsSnapshot
     ? applySkillEnvOverridesFromSnapshot({
         snapshot: skillsSnapshot,
@@ -560,6 +559,7 @@ export function prepareEmbeddedAttemptSkills(params: {
       workspaceDir: skillsPromptWorkspaceDir,
       agentId: params.sessionAgentId,
       eligibility: skillsEligibility,
+      preserveEntryOrder,
     });
     const sandbox = params.sandbox;
     const sandboxSkillReader: CodeModeSkillReader | undefined = sandbox?.enabled

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -520,6 +520,11 @@ export function prepareEmbeddedAttemptSkills(params: {
       agentId: params.sessionAgentId,
       eligibility: skillsEligibility,
       skillsSnapshot,
+      // Sandbox fallbacks stay inside their sandbox skill workspace;
+      // host execution skills are not mounted there.
+      ...(params.sandbox?.enabled === true
+        ? {}
+        : { executionSkillsDir: path.join(params.effectiveWorkspace, "skills") }),
       workspaceOnly,
     },
   );

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -114,14 +114,15 @@ async function resolveCommandSkillsPrompt(params: {
           },
           skillsAnchorWorkspace: sandboxWorkspace.workspaceDir,
         });
-        const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-          workspaceDir: skillsWorkspaceDir,
-          config: params.config,
-          agentId: params.agentId,
-          eligibility: skillsEligibility,
-          skillsSnapshot: skillsSnapshotForRun,
-          workspaceOnly,
-        });
+        const { shouldLoadSkillEntries, skillEntries, preserveEntryOrder } =
+          resolveEmbeddedRunSkillEntries({
+            workspaceDir: skillsWorkspaceDir,
+            config: params.config,
+            agentId: params.agentId,
+            eligibility: skillsEligibility,
+            skillsSnapshot: skillsSnapshotForRun,
+            workspaceOnly,
+          });
         const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
           entries: shouldLoadSkillEntries ? skillEntries : undefined,
           skillsWorkspaceDir,
@@ -134,6 +135,7 @@ async function resolveCommandSkillsPrompt(params: {
           workspaceDir: skillsPromptWorkspaceDir,
           agentId: params.agentId,
           eligibility: skillsEligibility,
+          preserveEntryOrder,
         });
       }
       // Existing third-party backends may not expose the optional workdir

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { clearAutoFallbackPrimaryProbeSelection } from "../../agents/agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
@@ -196,6 +197,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
           sessionId,
           isFirstTurnInSession,
           workspaceDir: context.skillsWorkspaceDir,
+          executionSkillsDir: path.join(context.workspaceDir, "skills"),
           cfg,
           execOverrides: params.execOverrides,
           skillFilter: opts?.skillFilter,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -197,7 +197,10 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
           sessionId,
           isFirstTurnInSession,
           workspaceDir: context.skillsWorkspaceDir,
-          executionSkillsDir: path.join(context.workspaceDir, "skills"),
+          executionSkillsDir: path.join(
+            sessionEntry?.worktree?.canonicalWorkspaceDir ?? context.workspaceDir,
+            "skills",
+          ),
           cfg,
           execOverrides: params.execOverrides,
           skillFilter: opts?.skillFilter,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -66,6 +66,12 @@ vi.mock("../../agents/harness/hook-helpers.js", () => ({
 const preparedReplyMockState = vi.hoisted(() => ({
   unexpectedCalls: [] as string[],
 }));
+const envMockState = vi.hoisted(() => ({ fastTestRuntime: true }));
+
+vi.mock("../../infra/env.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/env.js")>()),
+  isFastTestRuntimeEnv: () => envMockState.fastTestRuntime,
+}));
 
 vi.mock("../../agents/main-session-recovery/main-session-recovery-owner-release.js", () => ({
   scheduleMainSessionRecoveryPendingTarget: vi.fn(),
@@ -502,13 +508,19 @@ describe("runPreparedReply media-only handling", () => {
     ]);
   });
 
-  it("loads skills from the configured agent workspace for sessions running elsewhere", async () => {
+  it("loads configured and canonical workspace skills for managed-worktree sessions", async () => {
     const params = baseParams({
       workspaceDir: "/tmp/agent-workspace",
       sessionEntry: {
         sessionId: "session-1",
         updatedAt: Date.now(),
         spawnedCwd: "/tmp/session-worktree",
+        worktree: {
+          id: "worktree-1",
+          branch: "openclaw/worktree-1",
+          repoRoot: "/tmp/project",
+          canonicalWorkspaceDir: "/tmp/project/packages/app",
+        },
       },
     });
     const context = await prepareReplyRunContext(params);
@@ -518,7 +530,19 @@ describe("runPreparedReply media-only handling", () => {
       skillsWorkspaceDir: "/tmp/agent-workspace",
     });
 
-    await runPreparedReply(params);
+    envMockState.fastTestRuntime = false;
+    try {
+      await runPreparedReply(params);
+      const { ensureSkillSnapshot } = await loadSessionUpdatesRuntime();
+      expect(ensureSkillSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceDir: "/tmp/agent-workspace",
+          executionSkillsDir: "/tmp/project/packages/app/skills",
+        }),
+      );
+    } finally {
+      envMockState.fastTestRuntime = true;
+    }
     expect(requireRunReplyAgentCall().followupRun.run.workspaceDir).toBe("/tmp/session-worktree");
   });
 

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -172,6 +172,7 @@ export async function ensureSkillSnapshot(params: {
   sessionId?: string;
   isFirstTurnInSession: boolean;
   workspaceDir: string;
+  executionSkillsDir?: string;
   cfg: OpenClawConfig;
   execOverrides?: ExecPolicyOverrides;
   /** If provided, only load skills with these names (for per-channel skill filtering) */
@@ -223,6 +224,7 @@ export async function ensureSkillSnapshot(params: {
   const resolveSnapshot = (snapshot: SessionEntry["skillsSnapshot"]) =>
     resolveReusableWorkspaceSkillSnapshot({
       workspaceDir,
+      ...(params.executionSkillsDir ? { executionSkillsDir: params.executionSkillsDir } : {}),
       config: cfg,
       agentId: sessionAgentId,
       skillFilter,

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -301,11 +301,18 @@ vi.mock("../skills/loading/workspace-skill-prompt.js", () => ({
   buildSkillSnapshot: vi.fn(() => undefined),
 }));
 
-vi.mock("../skills/loading/workspace-skill-loader.js", () => ({
-  filterWorkspaceSkills: (entries: unknown[]) => entries,
-  loadVisibleSkills: vi.fn(() => []),
-  loadWorkspaceSkills: vi.fn(() => []),
-}));
+vi.mock("../skills/loading/workspace-skill-loader.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../skills/loading/workspace-skill-loader.js")
+  >("../skills/loading/workspace-skill-loader.js");
+  return {
+    filterWorkspaceSkills: (entries: unknown[]) => entries,
+    loadMergedWorkspaceSkills: vi.fn(() => []),
+    loadVisibleSkills: vi.fn(() => []),
+    loadWorkspaceSkills: vi.fn(() => []),
+    normalizeWorkspaceSkillRoots: actual.normalizeWorkspaceSkillRoots,
+  };
+});
 
 vi.mock("../skills/runtime/remote.js", () => ({
   getRemoteSkillEligibility: vi.fn(() => undefined),

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -1,4 +1,5 @@
 // Agent command tests cover local agent runs, session routing, and command runtime behavior.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -19,6 +20,7 @@ import * as modelSelectionModule from "../agents/model-selection.js";
 import { loadPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
+import { managedWorktrees } from "../agents/worktrees/service.js";
 import { BASE_THINKING_LEVELS } from "../auto-reply/thinking.shared.js";
 import * as runtimeSnapshotModule from "../config/runtime-snapshot.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
@@ -596,6 +598,61 @@ describe("agentCommand", () => {
       expect(resolveReusableWorkspaceSkillSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({
           executionSkillsDir: path.join(executionWorkspace, "skills"),
+        }),
+      );
+    });
+  });
+
+  it("uses the recorded canonical workspace for a managed-worktree skill snapshot", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const sessionKey = "agent:main:dashboard:managed-worktree";
+      const canonicalWorkspace = path.join(home, "project");
+      fs.mkdirSync(canonicalWorkspace, { recursive: true });
+      execFileSync("git", ["-C", canonicalWorkspace, "init", "-b", "main"]);
+      execFileSync("git", ["-C", canonicalWorkspace, "config", "user.name", "OpenClaw Test"]);
+      execFileSync("git", [
+        "-C",
+        canonicalWorkspace,
+        "config",
+        "user.email",
+        "openclaw-test@example.invalid",
+      ]);
+      fs.writeFileSync(path.join(canonicalWorkspace, "README.md"), "base\n");
+      execFileSync("git", ["-C", canonicalWorkspace, "add", "README.md"]);
+      execFileSync("git", ["-C", canonicalWorkspace, "commit", "-m", "initial"]);
+      mockConfig(home, store);
+      const worktree = await managedWorktrees.create({
+        repoRoot: canonicalWorkspace,
+        name: "managed",
+        ownerKind: "session",
+        ownerId: sessionKey,
+      });
+      await writeSessionStoreSeed(store, {
+        [sessionKey]: {
+          sessionId: "managed-worktree-session",
+          spawnedCwd: worktree.path,
+          worktree: {
+            id: worktree.id,
+            branch: worktree.branch,
+            repoRoot: worktree.repoRoot,
+            canonicalWorkspaceDir: canonicalWorkspace,
+          },
+        },
+      });
+
+      await agentCommandFromIngress(
+        {
+          message: "inspect this repo",
+          sessionKey,
+          allowModelOverride: false,
+        },
+        runtime,
+      );
+
+      expect(resolveReusableWorkspaceSkillSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionSkillsDir: path.join(canonicalWorkspace, "skills"),
         }),
       );
     });

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -44,6 +44,7 @@ import {
   loadVisibleSkills,
   loadWorkspaceSkills,
 } from "../skills/loading/workspace-skill-loader.js";
+import { resolveReusableWorkspaceSkillSnapshot } from "../skills/runtime/session-snapshot.js";
 import type { SkillEntry } from "../skills/types.js";
 import {
   createDirectOutboundTestAdapter,
@@ -577,6 +578,29 @@ beforeEach(() => {
 });
 
 describe("agentCommand", () => {
+  it("carries an external cwd into the direct agent session skill snapshot", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const executionWorkspace = path.join(home, "external-repo");
+      mockConfig(home, store);
+
+      await agentCommand(
+        {
+          message: "inspect this repo",
+          agentId: "main",
+          cwd: executionWorkspace,
+        },
+        runtime,
+      );
+
+      expect(resolveReusableWorkspaceSkillSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionSkillsDir: path.join(executionWorkspace, "skills"),
+        }),
+      );
+    });
+  });
+
   it.each(["Echo $PATH exactly.", String.raw`Keep \$release_notes literal.`])(
     "does not discover skills for literal dollar input: %s",
     async (message) => {

--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -11,8 +11,11 @@ import {
   collectStateDeepFilesystemFindings,
 } from "./audit-extra.async.js";
 
-vi.mock("../skills/loading/workspace-skill-loader.js", () => ({
-  loadWorkspaceSkills: (workspaceDir: string) => {
+vi.mock("../skills/loading/workspace-skill-loader.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../skills/loading/workspace-skill-loader.js")
+  >("../skills/loading/workspace-skill-loader.js");
+  const loadWorkspaceSkills = (workspaceDir: string) => {
     const sep = workspaceDir.includes("\\") ? "\\" : "/";
     const baseDir = `${workspaceDir}${sep}skills${sep}evil-skill`;
     return [
@@ -27,8 +30,14 @@ vi.mock("../skills/loading/workspace-skill-loader.js", () => ({
         frontmatter: {},
       },
     ];
-  },
-}));
+  };
+  return {
+    loadMergedWorkspaceSkills: (params: Parameters<typeof actual.loadMergedWorkspaceSkills>[0]) =>
+      loadWorkspaceSkills(params.agentWorkspaceDir),
+    loadWorkspaceSkills,
+    normalizeWorkspaceSkillRoots: actual.normalizeWorkspaceSkillRoots,
+  };
+});
 
 describe("audit-extra async code safety", () => {
   let fixtureRoot = "";

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -26,10 +26,17 @@ vi.mock("../../plugins/bundle-commands.js", () => ({
   loadEnabledClaudeBundleCommands: () => bundleCommandState.entries,
 }));
 
-vi.mock("../loading/workspace-skill-loader.js", () => ({
-  filterWorkspaceSkills: (entries: SkillEntry[]) => entries,
-  loadVisibleSkills: () => [],
-}));
+vi.mock("../loading/workspace-skill-loader.js", async () => {
+  const actual = await vi.importActual<typeof import("../loading/workspace-skill-loader.js")>(
+    "../loading/workspace-skill-loader.js",
+  );
+  return {
+    filterWorkspaceSkills: (entries: SkillEntry[]) => entries,
+    loadMergedWorkspaceSkills: () => [],
+    loadVisibleSkills: () => [],
+    normalizeWorkspaceSkillRoots: actual.normalizeWorkspaceSkillRoots,
+  };
+});
 
 beforeEach(() => {
   vi.resetModules();

--- a/src/skills/lifecycle/install-fallback.test.ts
+++ b/src/skills/lifecycle/install-fallback.test.ts
@@ -19,9 +19,16 @@ vi.mock("../../plugins/install-security-scan.js", () => ({
   evaluateSkillInstallPolicy: vi.fn(async () => undefined),
 }));
 
-vi.mock("../loading/workspace-skill-loader.js", () => ({
-  loadWorkspaceSkills: skillsMocks.loadWorkspaceSkills,
-}));
+vi.mock("../loading/workspace-skill-loader.js", async () => {
+  const actual = await vi.importActual<typeof import("../loading/workspace-skill-loader.js")>(
+    "../loading/workspace-skill-loader.js",
+  );
+  return {
+    loadMergedWorkspaceSkills: skillsMocks.loadWorkspaceSkills,
+    loadWorkspaceSkills: skillsMocks.loadWorkspaceSkills,
+    normalizeWorkspaceSkillRoots: actual.normalizeWorkspaceSkillRoots,
+  };
+});
 
 let installSkill: typeof import("./install.js").installSkill;
 let resolveInstallerKindReadiness: typeof import("./install.js").resolveInstallerKindReadiness;

--- a/src/skills/loading/skill-prompt-limits.ts
+++ b/src/skills/loading/skill-prompt-limits.ts
@@ -67,10 +67,13 @@ export function formatSkillsForPromptBounded(params: {
   maxSkillsInPrompt?: number;
   maxSkillsPromptChars?: number;
   remoteNote?: string;
+  preserveOrder?: boolean;
 }): string {
   const maxSkillsInPrompt = params.maxSkillsInPrompt ?? DEFAULT_MAX_SKILLS_IN_PROMPT;
   const maxSkillsPromptChars = params.maxSkillsPromptChars ?? DEFAULT_MAX_SKILLS_PROMPT_CHARS;
-  const orderedSkills = params.skills.toSorted((a, b) => a.name.localeCompare(b.name, "en"));
+  const orderedSkills = params.preserveOrder
+    ? params.skills
+    : params.skills.toSorted((a, b) => a.name.localeCompare(b.name, "en"));
   const total = orderedSkills.length;
   const byCount = orderedSkills.slice(0, Math.max(0, maxSkillsInPrompt));
   let skillsForPrompt = byCount;

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -58,6 +58,34 @@ type LoadedSkillRecord = {
   syncDirName?: string;
 };
 
+export type WorkspaceSkillRoots = {
+  agentWorkspaceDir: string;
+  executionSkillsDir?: string;
+};
+
+type WorkspaceSkillLoadOptions = {
+  config?: OpenClawConfig;
+  managedSkillsDir?: string;
+  bundledSkillsDir?: string;
+  pluginSkillsDir?: string;
+  skillFilter?: string[];
+  skillOverrides?: Record<string, boolean>;
+  agentId?: string;
+  eligibility?: SkillEligibilityContext;
+  workspaceOnly?: boolean;
+  includeArchived?: boolean;
+};
+
+export function normalizeWorkspaceSkillRoots(roots: WorkspaceSkillRoots): WorkspaceSkillRoots {
+  const agentWorkspaceDir = path.resolve(roots.agentWorkspaceDir);
+  const executionSkillsDir = roots.executionSkillsDir
+    ? path.resolve(roots.executionSkillsDir)
+    : undefined;
+  return executionSkillsDir && executionSkillsDir !== path.join(agentWorkspaceDir, "skills")
+    ? { agentWorkspaceDir, executionSkillsDir }
+    : { agentWorkspaceDir };
+}
+
 function warnInvalidSkill(source: string, diagnostic: LocalSkillLoadDiagnostic): void {
   skillsLogger.warn("Skipping invalid skill.", {
     source,
@@ -280,6 +308,7 @@ function loadSkillEntries(
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
     pluginSkillsDir?: string;
+    workspaceSkillsDir?: string;
     workspaceOnly?: boolean;
     includeArchived?: boolean;
   },
@@ -291,7 +320,7 @@ function loadSkillEntries(
 
   const workspaceOnly = opts?.workspaceOnly === true;
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
-  const workspaceSkillsDir = path.resolve(workspaceDir, "skills");
+  const workspaceSkillsDir = opts?.workspaceSkillsDir ?? path.resolve(workspaceDir, "skills");
   const bundledSkillsDir = workspaceOnly
     ? undefined
     : (opts?.bundledSkillsDir ?? resolveBundledSkillsDir());
@@ -466,18 +495,7 @@ export function resolveWorkspaceSkillPromptEntries(
 
 export function loadWorkspaceSkills(
   workspaceDir: string,
-  opts?: {
-    config?: OpenClawConfig;
-    managedSkillsDir?: string;
-    bundledSkillsDir?: string;
-    pluginSkillsDir?: string;
-    skillFilter?: string[];
-    skillOverrides?: Record<string, boolean>;
-    agentId?: string;
-    eligibility?: SkillEligibilityContext;
-    workspaceOnly?: boolean;
-    includeArchived?: boolean;
-  },
+  opts?: WorkspaceSkillLoadOptions,
 ): SkillEntry[] {
   const entries = mergeRemoteNodeSkillEntries(loadSkillEntries(workspaceDir, opts), {
     canExec: opts?.eligibility?.nodeSkills?.canExec,
@@ -497,6 +515,35 @@ export function loadWorkspaceSkills(
     effectiveSkillFilter,
     opts?.skillOverrides,
     opts?.eligibility,
+  );
+}
+
+/** Loads agent-workspace skills first, then execution-directory OpenClaw skills. */
+export function loadMergedWorkspaceSkills(
+  params: WorkspaceSkillRoots & WorkspaceSkillLoadOptions,
+): SkillEntry[] {
+  const { agentWorkspaceDir, executionSkillsDir } = normalizeWorkspaceSkillRoots(params);
+  if (!executionSkillsDir) {
+    return loadWorkspaceSkills(agentWorkspaceDir, params);
+  }
+
+  const agentEntries = mergeRemoteNodeSkillEntries(loadSkillEntries(agentWorkspaceDir, params), {
+    canExec: params.eligibility?.nodeSkills?.canExec,
+    node: params.eligibility?.nodeSkills?.node,
+  });
+  const agentNames = new Set(agentEntries.map((entry) => entry.skill.name));
+  const executionEntries = loadSkillEntries(agentWorkspaceDir, {
+    ...params,
+    workspaceOnly: true,
+    workspaceSkillsDir: executionSkillsDir,
+  }).filter((entry) => !agentNames.has(entry.skill.name));
+  const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(params);
+  return filterSkillEntries(
+    [...agentEntries, ...executionEntries],
+    params.config,
+    effectiveSkillFilter,
+    params.skillOverrides,
+    params.eligibility,
   );
 }
 

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -58,7 +58,7 @@ type LoadedSkillRecord = {
   syncDirName?: string;
 };
 
-export type WorkspaceSkillRoots = {
+type WorkspaceSkillRoots = {
   agentWorkspaceDir: string;
   executionSkillsDir?: string;
 };

--- a/src/skills/loading/workspace-skill-prompt.ts
+++ b/src/skills/loading/workspace-skill-prompt.ts
@@ -23,6 +23,7 @@ type WorkspaceSkillBuildOptions = {
   skillFilter?: string[];
   skillOverrides?: Record<string, boolean>;
   eligibility?: SkillEligibilityContext;
+  preserveEntryOrder?: boolean;
 };
 
 function resolveWorkspaceSkillPromptState(
@@ -40,6 +41,7 @@ function resolveWorkspaceSkillPromptState(
     maxSkillsInPrompt: limits?.maxSkillsInPrompt,
     maxSkillsPromptChars: agentLimits?.maxSkillsPromptChars ?? limits?.maxSkillsPromptChars,
     remoteNote,
+    preserveOrder: opts?.preserveEntryOrder,
   });
   return { eligible, prompt, resolvedSkills, skillFilter };
 }

--- a/src/skills/loading/workspace-skill-prompt.ts
+++ b/src/skills/loading/workspace-skill-prompt.ts
@@ -81,6 +81,7 @@ type ResolveSkillsPromptParams = {
   agentId?: string;
   eligibility?: SkillEligibilityContext;
   loadEntries?: () => SkillEntry[];
+  preserveEntryOrder?: boolean;
 };
 
 function buildSkillsPromptFromEntries(
@@ -95,6 +96,7 @@ function buildSkillsPromptFromEntries(
     config: params.config,
     agentId: params.agentId,
     eligibility: params.eligibility,
+    preserveEntryOrder: params.preserveEntryOrder,
   }).prompt;
   return prompt.trim() ? prompt : "";
 }

--- a/src/skills/loading/workspace-skill-snapshot.test.ts
+++ b/src/skills/loading/workspace-skill-snapshot.test.ts
@@ -5,6 +5,8 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { withEnv, withPathResolutionEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
+import { resolveEmbeddedRunSkillEntries } from "../runtime/embedded-run-entries.js";
+import { resolveReusableWorkspaceSkillSnapshot } from "../runtime/session-snapshot.js";
 import { writeSkill, writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
 import {
   restoreMockSkillsHomeEnv,
@@ -71,6 +73,39 @@ async function cloneTemplateDir(templateDir: string, prefix: string): Promise<st
   return cloned;
 }
 
+async function createMultiRootFixture() {
+  const agentWorkspaceDir = await fixtureSuite.createCaseDir("agent-workspace");
+  const executionWorkspaceDir = await fixtureSuite.createCaseDir("execution-workspace");
+  for (const [workspaceDir, name, description] of [
+    [agentWorkspaceDir, "middle", "Agent middle"],
+    [agentWorkspaceDir, "shared", "Agent shared"],
+    [executionWorkspaceDir, "aardvark", "Execution aardvark"],
+    [executionWorkspaceDir, "shared", "Execution shared"],
+    [executionWorkspaceDir, "zulu", "Execution zulu"],
+  ] as const) {
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", name),
+      name,
+      description,
+    });
+  }
+  const skillFilter = ["aardvark", "middle", "shared", "zulu"];
+  const executionSkillsDir = path.join(executionWorkspaceDir, "skills");
+  const snapshot = withWorkspaceHome(
+    agentWorkspaceDir,
+    () =>
+      resolveReusableWorkspaceSkillSnapshot({
+        workspaceDir: agentWorkspaceDir,
+        executionSkillsDir,
+        config: {},
+        skillFilter,
+        watch: false,
+        snapshotVersion: 1,
+      }).snapshot,
+  );
+  return { agentWorkspaceDir, executionSkillsDir, skillFilter, snapshot };
+}
+
 function expectSnapshotNamesAndPrompt(
   snapshot: ReturnType<typeof buildSkillSnapshot>,
   params: { contains?: string[]; omits?: string[] },
@@ -86,6 +121,72 @@ function expectSnapshotNamesAndPrompt(
 }
 
 describe("buildSkillSnapshot", () => {
+  it("orders agent skills before execution skills with lexical order inside each root", async () => {
+    const { snapshot } = await createMultiRootFixture();
+
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual([
+      "middle",
+      "shared",
+      "aardvark",
+      "zulu",
+    ]);
+    expect(
+      [...snapshot.prompt.matchAll(/<name>([^<]+)<\/name>/g)].map((match) => match[1]),
+    ).toEqual(["middle", "shared", "aardvark", "zulu"]);
+  });
+
+  it("keeps the agent-workspace skill when the execution root has the same name", async () => {
+    const { agentWorkspaceDir, snapshot } = await createMultiRootFixture();
+    const shared = snapshot.resolvedSkills?.find((skill) => skill.name === "shared");
+
+    expect(shared?.description).toBe("Agent shared");
+    expect(shared?.filePath).toBe(path.join(agentWorkspaceDir, "skills", "shared", "SKILL.md"));
+  });
+
+  it("keeps canonical same-root snapshots byte-identical", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("canonical-workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "canonical"),
+      name: "canonical",
+      description: "Canonical",
+    });
+    const build = (executionSkillsDir?: string) =>
+      withWorkspaceHome(
+        workspaceDir,
+        () =>
+          resolveReusableWorkspaceSkillSnapshot({
+            workspaceDir,
+            ...(executionSkillsDir ? { executionSkillsDir } : {}),
+            config: {},
+            skillFilter: ["canonical"],
+            watch: false,
+            snapshotVersion: 1,
+          }).snapshot,
+      );
+
+    expect(JSON.stringify(build(path.join(workspaceDir, "skills")))).toBe(JSON.stringify(build()));
+  });
+
+  it("returns identical sets from snapshot and cold embedded fallback paths", async () => {
+    const { agentWorkspaceDir, snapshot } = await createMultiRootFixture();
+    const coldSnapshot = { ...snapshot };
+    delete coldSnapshot.resolvedSkills;
+    const fallback = withWorkspaceHome(agentWorkspaceDir, () =>
+      resolveEmbeddedRunSkillEntries({
+        workspaceDir: agentWorkspaceDir,
+        config: {},
+        skillsSnapshot: coldSnapshot,
+      }),
+    );
+
+    expect(fallback.skillEntries.map((entry) => entry.skill.name)).toEqual(
+      snapshot.skills.map((skill) => skill.name),
+    );
+    expect(fallback.skillEntries.map((entry) => entry.skill.filePath)).toEqual(
+      snapshot.resolvedSkills?.map((skill) => skill.filePath),
+    );
+  });
+
   it("returns an empty snapshot when skills dirs are missing", async () => {
     const workspaceDir = await fixtureSuite.createCaseDir("workspace");
 

--- a/src/skills/loading/workspace-skill-sync.runtime.test.ts
+++ b/src/skills/loading/workspace-skill-sync.runtime.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../../test-utils/env.js";
 import { bumpSkillsSnapshotVersion, getSkillsSnapshotVersion } from "../runtime/refresh-state.js";
+import { resolveReusableWorkspaceSkillSnapshot } from "../runtime/session-snapshot.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { buildSkillSnapshot } from "./workspace-skill-prompt.js";
 import { syncWorkspaceSkills } from "./workspace-skill-sync.runtime.js";
@@ -209,6 +210,51 @@ describe("syncWorkspaceSkills", () => {
     expect(copyCount).toBe(0);
     expect(await pathExists(path.join(targetWorkspace, "skills", "alpha", "SKILL.md"))).toBe(true);
     expect(await pathExists(path.join(targetWorkspace, "skills", "hidden", "SKILL.md"))).toBe(true);
+  });
+
+  it("replaces same-name execution skills when the execution root changes", async () => {
+    const agentWorkspace = await createCaseDir("agent-workspace");
+    const firstExecutionWorkspace = await createCaseDir("execution-a");
+    const secondExecutionWorkspace = await createCaseDir("execution-b");
+    const targetWorkspace = await createCaseDir("target");
+    const skillName = "shared-execution-skill";
+    await writeSkill({
+      dir: path.join(firstExecutionWorkspace, "skills", skillName),
+      name: skillName,
+      description: "Execution root A",
+    });
+    await writeSkill({
+      dir: path.join(secondExecutionWorkspace, "skills", skillName),
+      name: skillName,
+      description: "Execution root B",
+    });
+    const resolveSnapshot = (executionWorkspace: string) =>
+      resolveReusableWorkspaceSkillSnapshot({
+        workspaceDir: agentWorkspace,
+        executionSkillsDir: path.join(executionWorkspace, "skills"),
+        config: {},
+        skillFilter: [skillName],
+        snapshotVersion: getSkillsSnapshotVersion(agentWorkspace),
+        watch: false,
+      }).snapshot;
+    const syncSnapshot = async (executionWorkspace: string) =>
+      await syncWorkspaceSkills({
+        sourceWorkspaceDir: agentWorkspace,
+        targetWorkspaceDir: targetWorkspace,
+        bundledSkillsDir: path.join(agentWorkspace, ".bundled"),
+        managedSkillsDir: path.join(agentWorkspace, ".managed"),
+        skillsSnapshot: resolveSnapshot(executionWorkspace),
+      });
+
+    await syncSnapshot(firstExecutionWorkspace);
+    await syncSnapshot(secondExecutionWorkspace);
+
+    const materializedSkill = await fs.readFile(
+      path.join(targetWorkspace, "skills", skillName, "SKILL.md"),
+      "utf8",
+    );
+    expect(materializedSkill).toContain("Execution root B");
+    expect(materializedSkill).not.toContain("Execution root A");
   });
 
   it("rejects path-like tampering without deriving read paths from the manifest", async () => {

--- a/src/skills/loading/workspace-skill-sync.runtime.ts
+++ b/src/skills/loading/workspace-skill-sync.runtime.ts
@@ -19,7 +19,7 @@ import type {
 import { resolveSkillKey } from "./frontmatter.js";
 import { serializeByKey } from "./serialize.js";
 import { resolveSkillTelemetrySource } from "./source.js";
-import { loadWorkspaceSkills } from "./workspace-skill-loader.js";
+import { loadMergedWorkspaceSkills, loadWorkspaceSkills } from "./workspace-skill-loader.js";
 
 const fsp = fs.promises;
 const skillsLogger = createSubsystemLogger("skills");
@@ -129,8 +129,9 @@ export async function syncWorkspaceSkills(params: {
   return await serializeByKey(`syncSkills:${targetDir}`, async () => {
     const targetSkillsDir = path.join(targetDir, "skills");
     const manifestPath = path.join(targetSkillsDir, SYNCED_SKILLS_MANIFEST_NAME);
-    const skillsVersion = getSkillsSnapshotVersion(sourceDir);
     const skillsSnapshot = params.skillsSnapshot;
+    const skillRoots = skillsSnapshot?.skillRoots;
+    const skillsVersion = getSkillsSnapshotVersion(skillRoots?.agentWorkspaceDir ?? sourceDir);
 
     await ensureSyncedSkillsDirectory(targetSkillsDir);
     const manifest = parseSyncedSkillsManifest(await tryReadJson<unknown>(manifestPath));
@@ -155,7 +156,7 @@ export async function syncWorkspaceSkills(params: {
       return cachedUsage.skillUsagePaths.map((entry) => ({ ...entry }));
     }
 
-    const entries = loadWorkspaceSkills(sourceDir, {
+    const loadOptions = {
       config: params.config,
       skillFilter: params.skillFilter,
       agentId: params.agentId,
@@ -163,7 +164,12 @@ export async function syncWorkspaceSkills(params: {
       managedSkillsDir: params.managedSkillsDir,
       bundledSkillsDir: params.bundledSkillsDir,
       pluginSkillsDir: params.pluginSkillsDir,
-    });
+      ...(skillsSnapshot?.skillFilter ? { skillFilter: skillsSnapshot.skillFilter } : {}),
+      ...(skillsSnapshot?.skillOverrides ? { skillOverrides: skillsSnapshot.skillOverrides } : {}),
+    };
+    const entries = skillRoots
+      ? loadMergedWorkspaceSkills({ ...skillRoots, ...loadOptions })
+      : loadWorkspaceSkills(sourceDir, loadOptions);
 
     const usedDirNames = new Set<string>();
     const plans: Array<{ destinationPath?: string; entry: SkillEntry; identity: string }> = [];

--- a/src/skills/loading/workspace-skill-sync.runtime.ts
+++ b/src/skills/loading/workspace-skill-sync.runtime.ts
@@ -5,6 +5,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveSandboxPath } from "../../agents/sandbox-paths.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { sha256Hex } from "../../infra/crypto-digest.js";
 import { tryReadJson, writeJson } from "../../infra/json-files.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -42,6 +43,7 @@ const SYNCED_SKILLS_MANIFEST_NAME = ".openclaw-sync.json";
 
 type SyncedSkillsManifest = {
   entryKeys: string[];
+  skillRootsFingerprint?: string;
   skillsVersion: number;
 };
 
@@ -68,7 +70,27 @@ function parseSyncedSkillsManifest(value: unknown): SyncedSkillsManifest | null 
   ) {
     return null;
   }
-  return { entryKeys: value.entryKeys, skillsVersion: value.skillsVersion } as SyncedSkillsManifest;
+  if (
+    value.skillRootsFingerprint !== undefined &&
+    typeof value.skillRootsFingerprint !== "string"
+  ) {
+    return null;
+  }
+  return {
+    entryKeys: value.entryKeys,
+    ...(value.skillRootsFingerprint === undefined
+      ? {}
+      : { skillRootsFingerprint: value.skillRootsFingerprint }),
+    skillsVersion: value.skillsVersion,
+  };
+}
+
+function resolveSyncedSkillsManifestKey(manifest: SyncedSkillsManifest): string {
+  return JSON.stringify([
+    manifest.skillsVersion,
+    manifest.skillRootsFingerprint,
+    manifest.entryKeys,
+  ]);
 }
 
 function resolveSyncedSkillDestinationPath(params: {
@@ -131,23 +153,27 @@ export async function syncWorkspaceSkills(params: {
     const manifestPath = path.join(targetSkillsDir, SYNCED_SKILLS_MANIFEST_NAME);
     const skillsSnapshot = params.skillsSnapshot;
     const skillRoots = skillsSnapshot?.skillRoots;
+    // Same-named skills from different execution roots share entry identities.
+    // Bind roots to the cache so shared sandboxes recopy when sessions change repos.
+    const skillRootsFingerprint = skillRoots
+      ? sha256Hex(JSON.stringify([skillRoots.agentWorkspaceDir, skillRoots.executionSkillsDir]))
+      : undefined;
     const skillsVersion = getSkillsSnapshotVersion(skillRoots?.agentWorkspaceDir ?? sourceDir);
 
     await ensureSyncedSkillsDirectory(targetSkillsDir);
     const manifest = parseSyncedSkillsManifest(await tryReadJson<unknown>(manifestPath));
     const expectedManifestKey =
       skillsSnapshot?.version === skillsVersion
-        ? JSON.stringify([
-            skillsVersion,
-            skillsSnapshot.skills
+        ? resolveSyncedSkillsManifestKey({
+            entryKeys: skillsSnapshot.skills
               .map((skill) => resolveSyncedSkillIdentity(skill.skillKey ?? skill.name, skill.name))
               .toSorted(),
-          ])
+            ...(skillRootsFingerprint ? { skillRootsFingerprint } : {}),
+            skillsVersion,
+          })
         : undefined;
     const cachedUsage = syncedSkillsUsageCache.get(targetSkillsDir);
-    const manifestKey = manifest
-      ? JSON.stringify([manifest.skillsVersion, manifest.entryKeys])
-      : undefined;
+    const manifestKey = manifest ? resolveSyncedSkillsManifestKey(manifest) : undefined;
     if (
       expectedManifestKey &&
       manifestKey === expectedManifestKey &&
@@ -205,7 +231,9 @@ export async function syncWorkspaceSkills(params: {
 
     await fsp.rm(manifestPath, { force: true });
     const previousUsage =
-      manifest?.skillsVersion === skillsVersion && cachedUsage?.manifestKey === manifestKey
+      manifest?.skillsVersion === skillsVersion &&
+      manifest.skillRootsFingerprint === skillRootsFingerprint &&
+      cachedUsage?.manifestKey === manifestKey
         ? cachedUsage
         : undefined;
     syncedSkillsUsageCache.delete(targetSkillsDir);
@@ -263,6 +291,7 @@ export async function syncWorkspaceSkills(params: {
     if (!copyFailed) {
       const nextManifest: SyncedSkillsManifest = {
         entryKeys: plans.map((plan) => plan.identity).toSorted(),
+        ...(skillRootsFingerprint ? { skillRootsFingerprint } : {}),
         skillsVersion,
       };
       await writeJson(manifestPath, nextManifest, { trailingNewline: true });
@@ -274,7 +303,7 @@ export async function syncWorkspaceSkills(params: {
               : [],
           ),
         ),
-        manifestKey: JSON.stringify([skillsVersion, nextManifest.entryKeys]),
+        manifestKey: resolveSyncedSkillsManifestKey(nextManifest),
         skillUsagePaths,
       });
       pruneMapToMaxSize(syncedSkillsUsageCache, 100);

--- a/src/skills/runtime/embedded-run-entries.integration.test.ts
+++ b/src/skills/runtime/embedded-run-entries.integration.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveSkillsPrompt } from "../loading/workspace-skill-prompt.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { writePluginWithSkill } from "../test-support/skill-plugin-fixtures.test-support.js";
 import { resolveEmbeddedRunSkillEntries } from "./embedded-run-entries.js";
@@ -91,6 +92,49 @@ describe("resolveEmbeddedRunSkillEntries (integration)", () => {
       description: "Agent wins",
       filePath: path.join(agentWorkspaceDir, "skills", "fallback-shared", "SKILL.md"),
     });
+  });
+
+  it("keeps agent skills ahead of execution skills in a constrained fallback prompt", async () => {
+    const agentWorkspaceDir = tempDirs.make("openclaw-agent-workspace-");
+    const executionWorkspaceDir = tempDirs.make("openclaw-execution-workspace-");
+    const executionSkillsDir = path.join(executionWorkspaceDir, "skills");
+    const agentSkillName = "z-agent-priority";
+    const executionSkillName = "a-execution-priority";
+    await writeSkill({
+      dir: path.join(agentWorkspaceDir, "skills", agentSkillName),
+      name: agentSkillName,
+      description: "Agent priority",
+    });
+    await writeSkill({
+      dir: path.join(executionSkillsDir, executionSkillName),
+      name: executionSkillName,
+      description: "Execution priority",
+    });
+    const config: OpenClawConfig = { skills: { limits: { maxSkillsInPrompt: 1 } } };
+    const snapshotPrompt = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: agentWorkspaceDir,
+      executionSkillsDir,
+      config,
+      skillFilter: [agentSkillName, executionSkillName],
+      watch: false,
+      snapshotVersion: 1,
+    }).snapshot.prompt;
+    const fallback = resolveEmbeddedRunSkillEntries({
+      workspaceDir: agentWorkspaceDir,
+      executionSkillsDir,
+      config,
+      workspaceOnly: true,
+    });
+    const fallbackPrompt = resolveSkillsPrompt({
+      entries: fallback.skillEntries,
+      workspaceDir: agentWorkspaceDir,
+      config,
+      preserveEntryOrder: fallback.preserveEntryOrder,
+    });
+
+    expect(fallbackPrompt).toBe(snapshotPrompt);
+    expect(fallbackPrompt).toContain(agentSkillName);
+    expect(fallbackPrompt).not.toContain(executionSkillName);
   });
 
   it("loads bundled diffs skill when explicitly enabled in config", async () => {

--- a/src/skills/runtime/embedded-run-entries.integration.test.ts
+++ b/src/skills/runtime/embedded-run-entries.integration.test.ts
@@ -3,8 +3,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { writePluginWithSkill } from "../test-support/skill-plugin-fixtures.test-support.js";
 import { resolveEmbeddedRunSkillEntries } from "./embedded-run-entries.js";
+import { resolveReusableWorkspaceSkillSnapshot } from "./session-snapshot.js";
 
 const tempDirs = createTempDirTracker();
 const originalBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -45,6 +47,52 @@ afterEach(() => {
 });
 
 describe("resolveEmbeddedRunSkillEntries (integration)", () => {
+  it("matches snapshot skill roots when a snapshot-less run uses a different execution directory", async () => {
+    const agentWorkspaceDir = tempDirs.make("openclaw-agent-workspace-");
+    const executionWorkspaceDir = tempDirs.make("openclaw-execution-workspace-");
+    const executionSkillsDir = path.join(executionWorkspaceDir, "skills");
+    for (const [workspaceDir, name, description] of [
+      [agentWorkspaceDir, "fallback-agent", "Agent only"],
+      [agentWorkspaceDir, "fallback-shared", "Agent wins"],
+      [executionWorkspaceDir, "fallback-execution", "Execution only"],
+      [executionWorkspaceDir, "fallback-shared", "Execution loses"],
+    ] as const) {
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", name),
+        name,
+        description,
+      });
+    }
+    const skillNames = ["fallback-agent", "fallback-shared", "fallback-execution"];
+    const snapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: agentWorkspaceDir,
+      executionSkillsDir,
+      config: {},
+      skillFilter: skillNames,
+      watch: false,
+      snapshotVersion: 1,
+    }).snapshot;
+
+    const fallback = resolveEmbeddedRunSkillEntries({
+      workspaceDir: agentWorkspaceDir,
+      executionSkillsDir,
+      config: {},
+    });
+    const fallbackSkills = fallback.skillEntries.filter((entry) =>
+      skillNames.includes(entry.skill.name),
+    );
+
+    expect(fallbackSkills.map((entry) => entry.skill.name)).toEqual(
+      snapshot.skills.map((skill) => skill.name),
+    );
+    expect(
+      fallbackSkills.find((entry) => entry.skill.name === "fallback-shared")?.skill,
+    ).toMatchObject({
+      description: "Agent wins",
+      filePath: path.join(agentWorkspaceDir, "skills", "fallback-shared", "SKILL.md"),
+    });
+  });
+
   it("loads bundled diffs skill when explicitly enabled in config", async () => {
     const config: OpenClawConfig = {
       plugins: {

--- a/src/skills/runtime/embedded-run-entries.ts
+++ b/src/skills/runtime/embedded-run-entries.ts
@@ -1,12 +1,17 @@
 // Embedded run entry helpers serialize runtime skill metadata for agent run records.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveSkillRuntimeConfig } from "../loading/runtime-config.js";
-import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
+import {
+  loadMergedWorkspaceSkills,
+  loadWorkspaceSkills,
+  normalizeWorkspaceSkillRoots,
+} from "../loading/workspace-skill-loader.js";
 import type { SkillEligibilityContext, SkillEntry, SkillSnapshot } from "../types.js";
 
 /** Resolves skill entries embedded into a run payload into runtime-visible entries. */
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
+  executionSkillsDir?: string;
   config?: OpenClawConfig;
   agentId?: string;
   eligibility?: SkillEligibilityContext;
@@ -24,12 +29,26 @@ export function resolveEmbeddedRunSkillEntries(params: {
     if (cachedSkillEntries) {
       return cachedSkillEntries;
     }
-    cachedSkillEntries = loadWorkspaceSkills(params.workspaceDir, {
+    const options = {
       config,
       agentId: params.agentId,
       ...(params.eligibility ? { eligibility: params.eligibility } : {}),
+      ...(params.skillsSnapshot?.skillFilter
+        ? { skillFilter: params.skillsSnapshot.skillFilter }
+        : {}),
+      ...(params.skillsSnapshot?.skillOverrides
+        ? { skillOverrides: params.skillsSnapshot.skillOverrides }
+        : {}),
       ...(params.workspaceOnly === true ? { workspaceOnly: true } : {}),
+    };
+    const liveSkillRoots = normalizeWorkspaceSkillRoots({
+      agentWorkspaceDir: params.workspaceDir,
+      ...(params.executionSkillsDir ? { executionSkillsDir: params.executionSkillsDir } : {}),
     });
+    const skillRoots = params.skillsSnapshot?.skillRoots ?? liveSkillRoots;
+    cachedSkillEntries = skillRoots.executionSkillsDir
+      ? loadMergedWorkspaceSkills({ ...skillRoots, ...options })
+      : loadWorkspaceSkills(params.workspaceDir, options);
     return cachedSkillEntries;
   };
   return {

--- a/src/skills/runtime/embedded-run-entries.ts
+++ b/src/skills/runtime/embedded-run-entries.ts
@@ -21,9 +21,16 @@ export function resolveEmbeddedRunSkillEntries(params: {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
   loadSkillEntries: () => SkillEntry[];
+  preserveEntryOrder: boolean;
 } {
   const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
   const config = resolveSkillRuntimeConfig(params.config);
+  const skillRoots =
+    params.skillsSnapshot?.skillRoots ??
+    normalizeWorkspaceSkillRoots({
+      agentWorkspaceDir: params.workspaceDir,
+      ...(params.executionSkillsDir ? { executionSkillsDir: params.executionSkillsDir } : {}),
+    });
   let cachedSkillEntries: SkillEntry[] | undefined;
   const loadSkillEntries = (): SkillEntry[] => {
     if (cachedSkillEntries) {
@@ -41,11 +48,6 @@ export function resolveEmbeddedRunSkillEntries(params: {
         : {}),
       ...(params.workspaceOnly === true ? { workspaceOnly: true } : {}),
     };
-    const liveSkillRoots = normalizeWorkspaceSkillRoots({
-      agentWorkspaceDir: params.workspaceDir,
-      ...(params.executionSkillsDir ? { executionSkillsDir: params.executionSkillsDir } : {}),
-    });
-    const skillRoots = params.skillsSnapshot?.skillRoots ?? liveSkillRoots;
     cachedSkillEntries = skillRoots.executionSkillsDir
       ? loadMergedWorkspaceSkills({ ...skillRoots, ...options })
       : loadWorkspaceSkills(params.workspaceDir, options);
@@ -55,5 +57,7 @@ export function resolveEmbeddedRunSkillEntries(params: {
     shouldLoadSkillEntries,
     skillEntries: shouldLoadSkillEntries ? loadSkillEntries() : [],
     loadSkillEntries,
+    // Merged loading orders agent skills first so prompt caps keep their priority.
+    preserveEntryOrder: skillRoots.executionSkillsDir !== undefined,
   };
 }

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -764,6 +764,38 @@ describe("ensureSkillsWatcher", () => {
     },
   );
 
+  it.each(["add", "change", "unlink"] as const)(
+    "refreshes the owning snapshot when an execution-directory skill emits %s",
+    async (event) => {
+      vi.useFakeTimers();
+      const workspaceDir = "/tmp/agent-workspace";
+      const executionSkillsDir = "/tmp/execution-workspace/skills";
+      const seen: SkillsChangeEvent[] = [];
+      refreshModule.registerSkillsChangeListener((change) => {
+        seen.push(change);
+      });
+      refreshModule.ensureSkillsWatcher({ workspaceDir, executionSkillsDir });
+      const versionBefore = getSkillsSnapshotVersion(workspaceDir);
+      const callPaths = (watchMock.mock.calls as unknown as Array<[string]>).map(([target]) =>
+        target.replaceAll("\\", "/"),
+      );
+      const executionWatcherIndex = callPaths.indexOf(executionSkillsDir);
+      const changedPath = `${executionSkillsDir}/demo/SKILL.md`;
+
+      expect(executionWatcherIndex).toBeGreaterThanOrEqual(0);
+      createdWatchers[executionWatcherIndex]?.emit("all", event, changedPath);
+      await vi.advanceTimersByTimeAsync(250);
+
+      const versionAfter = getSkillsSnapshotVersion(workspaceDir);
+      expect(shouldRefreshSnapshotForVersion(versionBefore, versionAfter)).toBe(true);
+      expect(seen).toContainEqual({
+        workspaceDir,
+        reason: "watch",
+        changedPath,
+      });
+    },
+  );
+
   it("refreshes skills snapshots when watched skill roots change", () => {
     const seen: SkillsChangeEvent[] = [];
     refreshModule.registerSkillsChangeListener((change) => {

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -63,6 +63,9 @@ const pathWatchers = new Map<string, SkillsPathWatchState>();
 // Watch targets each workspace is currently subscribed to, used to reconcile
 // subscriptions and to detect watch-target changes across calls.
 const workspaceWatchTargets = new Map<string, WatchTarget[]>();
+// A watcher key may include an execution root, but refresh events and versions
+// retain the configured agent workspace as their stable public identity.
+const workspaceWatchOwnerDirs = new Map<string, string>();
 // Resolved nested skill watch roots are filesystem-derived. Cache them so the
 // per-turn watcher reconciliation path stays cheap until config or watched
 // filesystem changes require a fresh root scan.
@@ -91,7 +94,12 @@ const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.cache([\\/]|$)/,
 ];
 
-function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): WatchTarget[] {
+function resolveWatchTargets(
+  workspaceDir: string,
+  config: OpenClawConfig | undefined,
+  executionSkillsDir: string | undefined,
+  watcherKey: string,
+): WatchTarget[] {
   const baseRoots: Array<{ path: string; source: string }> = [];
   if (workspaceDir.trim()) {
     baseRoots.push({ path: path.join(workspaceDir, "skills"), source: "openclaw-workspace" });
@@ -99,6 +107,9 @@ function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): Wat
       path: path.join(workspaceDir, ".agents", "skills"),
       source: "agents-skills-project",
     });
+  }
+  if (executionSkillsDir) {
+    baseRoots.push({ path: executionSkillsDir, source: "openclaw-workspace" });
   }
   baseRoots.push({ path: path.join(CONFIG_DIR, "skills"), source: "openclaw-managed" });
   if (isDefaultStateDir()) {
@@ -120,7 +131,7 @@ function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): Wat
     pluginSkillDirs: pluginSkillDirs.map(toWatchRoot),
     allowSymlinkTargets: allowedSymlinkTargetRealPaths,
   });
-  const cached = workspaceWatchTargetCache.get(workspaceDir);
+  const cached = workspaceWatchTargetCache.get(watcherKey);
   if (cached?.signature === signature) {
     return cached.targets;
   }
@@ -190,7 +201,7 @@ function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): Wat
     );
   }
   const sortedTargets = Array.from(targets.values()).toSorted((a, b) => a.key.localeCompare(b.key));
-  workspaceWatchTargetCache.set(workspaceDir, { signature, targets: sortedTargets });
+  workspaceWatchTargetCache.set(watcherKey, { signature, targets: sortedTargets });
   return sortedTargets;
 }
 
@@ -527,10 +538,10 @@ function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
       state.timer = undefined;
       // Fan the change out to every workspace subscribed to this directory so a
       // shared skill root refreshes the snapshot for all agents that use it.
-      for (const workspaceDir of state.subscribers) {
-        workspaceWatchTargetCache.delete(workspaceDir);
+      for (const watcherKey of state.subscribers) {
+        workspaceWatchTargetCache.delete(watcherKey);
         bumpSkillsSnapshotVersion({
-          workspaceDir,
+          workspaceDir: workspaceWatchOwnerDirs.get(watcherKey) ?? watcherKey,
           reason: "watch",
           changedPath: pendingPath,
         });
@@ -615,16 +626,18 @@ function unsubscribeWorkspaceFromPath(workspaceDir: string, watchTarget: WatchTa
 }
 
 function disposeWorkspaceWatchState(
-  workspaceDir: string,
-  watchTargets: readonly WatchTarget[] = workspaceWatchTargets.get(workspaceDir) ?? [],
+  watcherKey: string,
+  watchTargets: readonly WatchTarget[] = workspaceWatchTargets.get(watcherKey) ?? [],
 ): void {
+  const workspaceDir = workspaceWatchOwnerDirs.get(watcherKey) ?? watcherKey;
   const hadWatchTargets = watchTargets.length > 0;
   for (const watchTarget of watchTargets) {
-    unsubscribeWorkspaceFromPath(workspaceDir, watchTarget);
+    unsubscribeWorkspaceFromPath(watcherKey, watchTarget);
   }
-  workspaceWatchTargets.delete(workspaceDir);
-  workspaceWatchTargetCache.delete(workspaceDir);
-  workspaceWatchLastEnsuredAt.delete(workspaceDir);
+  workspaceWatchTargets.delete(watcherKey);
+  workspaceWatchOwnerDirs.delete(watcherKey);
+  workspaceWatchTargetCache.delete(watcherKey);
+  workspaceWatchLastEnsuredAt.delete(watcherKey);
   if (hadWatchTargets) {
     // Watcher disposal creates an unwatched interval; mark the workspace dirty
     // so the next turn rebuilds skills even if file events were missed.
@@ -642,23 +655,46 @@ function evictIdleWorkspaceWatchStates(now: number): void {
   }
 }
 
-export function ensureSkillsWatcher(params: { workspaceDir: string; config?: OpenClawConfig }) {
+export function resolveSkillsWatcherKey(params: {
+  workspaceDir: string;
+  executionSkillsDir?: string;
+}): string {
+  return params.executionSkillsDir
+    ? JSON.stringify([params.workspaceDir, params.executionSkillsDir])
+    : params.workspaceDir;
+}
+
+export function ensureSkillsWatcher(params: {
+  workspaceDir: string;
+  executionSkillsDir?: string;
+  config?: OpenClawConfig;
+}) {
   const workspaceDir = params.workspaceDir.trim();
   if (!workspaceDir) {
     return;
   }
+  const watcherKey = resolveSkillsWatcherKey({
+    workspaceDir,
+    ...(params.executionSkillsDir ? { executionSkillsDir: params.executionSkillsDir } : {}),
+  });
+  workspaceWatchOwnerDirs.set(watcherKey, workspaceDir);
   const now = Date.now();
   const watchEnabled = params.config?.skills?.load?.watch !== false;
-  const previousTargets = workspaceWatchTargets.get(workspaceDir) ?? [];
+  const previousTargets = workspaceWatchTargets.get(watcherKey) ?? [];
 
   if (!watchEnabled) {
-    disposeWorkspaceWatchState(workspaceDir, previousTargets);
+    disposeWorkspaceWatchState(watcherKey, previousTargets);
     evictIdleWorkspaceWatchStates(now);
     return;
   }
 
-  workspaceWatchLastEnsuredAt.set(workspaceDir, now);
-  const watchTargets = resolveWatchTargets(workspaceDir, params.config);
+  workspaceWatchLastEnsuredAt.set(watcherKey, now);
+  const watchTargets = resolveWatchTargets(
+    workspaceDir,
+    params.config,
+    params.executionSkillsDir,
+    watcherKey,
+  );
   const targetsUnchanged = sameWatchTargets(previousTargets, watchTargets);
   const watcherDepthsCoverTargets = watchTargets.every(
     (watchTarget) => (pathWatchers.get(watchTarget.key)?.depth ?? -1) >= watchTarget.depth,
@@ -672,13 +708,13 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   const nextTargetKeys = new Set(watchTargets.map((target) => target.key));
   for (const watchTarget of previousTargets) {
     if (!nextTargetKeys.has(watchTarget.key)) {
-      unsubscribeWorkspaceFromPath(workspaceDir, watchTarget);
+      unsubscribeWorkspaceFromPath(watcherKey, watchTarget);
     }
   }
   for (const watchTarget of watchTargets) {
-    subscribeWorkspaceToPath(workspaceDir, watchTarget);
+    subscribeWorkspaceToPath(watcherKey, watchTarget);
   }
-  workspaceWatchTargets.set(workspaceDir, watchTargets);
+  workspaceWatchTargets.set(watcherKey, watchTargets);
 
   if (watchTargetsChanged) {
     bumpSkillsSnapshotVersion({
@@ -696,6 +732,7 @@ async function resetSkillsRefreshForTest(): Promise<void> {
   const active = Array.from(pathWatchers.values());
   pathWatchers.clear();
   workspaceWatchTargets.clear();
+  workspaceWatchOwnerDirs.clear();
   workspaceWatchTargetCache.clear();
   workspaceWatchLastEnsuredAt.clear();
   await Promise.all(

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -655,7 +655,7 @@ function evictIdleWorkspaceWatchStates(now: number): void {
   }
 }
 
-export function resolveSkillsWatcherKey(params: {
+function resolveSkillsWatcherKey(params: {
   workspaceDir: string;
   executionSkillsDir?: string;
 }): string {

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -3,6 +3,10 @@ import { stableStringify } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { matchesSkillFilter } from "../discovery/filter.js";
+import {
+  loadMergedWorkspaceSkills,
+  normalizeWorkspaceSkillRoots,
+} from "../loading/workspace-skill-loader.js";
 import { buildSkillSnapshot } from "../loading/workspace-skill-prompt.js";
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import type { SkillEligibilityContext, SkillSnapshot } from "../types.js";
@@ -19,6 +23,7 @@ const RESOLVED_SKILLS_CACHE_MAX = 10;
 /** Inputs that make a resolved skill snapshot reusable within a process. */
 type ReusableSkillSnapshotParams = {
   workspaceDir: string;
+  executionSkillsDir?: string;
   config: OpenClawConfig;
   agentId?: string;
   skillFilter?: string[];
@@ -45,10 +50,25 @@ function cacheResolvedSkills(cacheKey: string, snapshot: SkillSnapshot): SkillSn
 export function resolveReusableWorkspaceSkillSnapshot(
   params: ReusableSkillSnapshotParams,
 ): ReusableSkillSnapshotResult {
+  const normalizedRoots = normalizeWorkspaceSkillRoots({
+    agentWorkspaceDir: params.workspaceDir,
+    ...(params.executionSkillsDir ? { executionSkillsDir: params.executionSkillsDir } : {}),
+  });
+  const skillRoots = normalizedRoots.executionSkillsDir
+    ? {
+        agentWorkspaceDir: normalizedRoots.agentWorkspaceDir,
+        executionSkillsDir: normalizedRoots.executionSkillsDir,
+      }
+    : undefined;
+  const watcherWorkspaceDir = skillRoots?.agentWorkspaceDir ?? params.workspaceDir;
   if (params.watch !== false) {
-    ensureSkillsWatcher({ workspaceDir: params.workspaceDir, config: params.config });
+    ensureSkillsWatcher({
+      workspaceDir: watcherWorkspaceDir,
+      ...(skillRoots ? { executionSkillsDir: skillRoots.executionSkillsDir } : {}),
+      config: params.config,
+    });
   }
-  const snapshotVersion = params.snapshotVersion ?? getSkillsSnapshotVersion(params.workspaceDir);
+  const snapshotVersion = params.snapshotVersion ?? getSkillsSnapshotVersion(watcherWorkspaceDir);
   const promptFormatChanged =
     params.existingSnapshot?.promptFormatVersion !== WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION;
   const skillVersionChanged = shouldRefreshSnapshotForVersion(
@@ -61,26 +81,42 @@ export function resolveReusableWorkspaceSkillSnapshot(
   const skillOverridesChanged =
     stableStringify(params.existingSnapshot?.skillOverrides) !==
     stableStringify(params.skillOverrides);
+  const skillRootsChanged =
+    stableStringify(params.existingSnapshot?.skillRoots) !== stableStringify(skillRoots);
   const shouldRefresh =
     promptFormatChanged ||
     skillVersionChanged ||
     nodeSkillsEligibilityChanged ||
+    skillRootsChanged ||
     !matchesSkillFilter(params.existingSnapshot?.skillFilter, params.skillFilter) ||
     skillOverridesChanged;
   const buildSnapshot = () => {
-    return buildSkillSnapshot(params.workspaceDir, {
+    const entries = skillRoots
+      ? loadMergedWorkspaceSkills({
+          ...skillRoots,
+          config: params.config,
+          agentId: params.agentId,
+          skillFilter: params.skillFilter,
+          skillOverrides: params.skillOverrides,
+          eligibility: params.eligibility,
+        })
+      : undefined;
+    const snapshot = buildSkillSnapshot(params.workspaceDir, {
       config: params.config,
+      ...(entries ? { entries, preserveEntryOrder: true } : {}),
       agentId: params.agentId,
       skillFilter: params.skillFilter,
       skillOverrides: params.skillOverrides,
       eligibility: params.eligibility,
       snapshotVersion,
     });
+    return skillRoots ? { ...snapshot, skillRoots } : snapshot;
   };
 
   const buildSnapshotCacheKey = () =>
     JSON.stringify([
       params.workspaceDir,
+      skillRoots,
       snapshotVersion,
       params.skillFilter,
       params.skillOverrides,

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -143,6 +143,11 @@ export type SkillSnapshot = {
   /** Effective node-exec eligibility used to select connected node-hosted skills. */
   nodeSkillsEligibility?: SkillEligibilityContext["nodeSkills"];
   resolvedSkills?: Skill[];
+  /** Present only when a session merges skills from distinct agent and execution roots. */
+  skillRoots?: {
+    agentWorkspaceDir: string;
+    executionSkillsDir: string;
+  };
   version?: number;
   promptFormatVersion?: number;
 };


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #125675. Sessions executing outside the configured agent workspace loaded skills only from the agent workspace — a visited repo's OpenClaw `skills/` directory was invisible, while native Codex sessions did see repo `.agents/skills`, leaving the generic harness behind.

## Why This Change Was Made

Adds a two-root merge at the skill-snapshot owner (`loadMergedWorkspaceSkills` in `src/skills/loading/workspace-skill-loader.ts`): agent-workspace skills first, execution-directory skills appended, name collisions resolved agent-wins, each group lexicographically sorted (deterministic for prompt cache). Key properties:

- **Single merge owner** — snapshot path, snapshot-less embedded fallback (attempt + compaction), and Codex skills-collaboration path all consume the same merged set; `skillRoots` is recorded on the snapshot so fallback and snapshot answers agree.
- **Refresh identity covers both roots** — composite watcher key with the agent workspace retained as the stable version identity; adding/removing/editing execution-dir skills bumps the snapshot; persisted `skillRoots` forces refresh when roots change across restarts. No new freshness polling; existing watcher mechanics only.
- **Canonical sessions byte-identical** — `normalizeWorkspaceSkillRoots` drops the execution root when it equals the agent workspace's own `skills/` dir; regression-tested.
- **Sandbox boundary respected** — sandboxed fallbacks stay inside their materialized skill workspace (host execution skills are not mounted); commented at the seam.
- No new config surface, no SQLite schema change (optional JSON field on the session skill snapshot only).

## User Impact

Agents working in a repo with its own `skills/` directory can now use those skills on every harness, while the agent's own skills always win name conflicts. Same-folder sessions are unchanged.

## Evidence

- Focused Vitest: 173 + 12 passed across snapshot, refresh, loader, embedded-run-entries, media-only suites; new regressions confirmed failing pre-fix (missing `fallback-execution` skill).
- `pnpm tsgo` + `pnpm check:test-types`: pass.
- Structured autoreview (codex/gpt-5.6-sol, high): clean, 0 findings, 0.94.
- Determinism: loader sorts per root (`workspace-skill-loader.ts:265,297,412`); merged prompt order is sorted(agent) ++ sorted(execution−collisions).

Production delta +216/−46, tests +183/−2; growth carries the multi-root capability at one owner instead of scattered dual-root conditionals.


### Review follow-ups (2026-08-18)

All three ClawSweeper findings verified real and fixed with pre-fix-failing regressions: CLI session snapshots carry the execution root; sandbox skill sync invalidates on a hashed two-root fingerprint; snapshot-less prompt rebuilds preserve merged order under caps.

**Maintainer acceptance:** execution-directory skill discovery (visited repo's `skills/` merged after agent skills, agent-wins) is the intended default, accepted by the maintainer (@obviyus) who requested this feature — matching native Codex behavior for repo `.agents/skills`.
