### PR TITLE
fix(agents): keep the skills catalog when toolsAllow is not a narrow grant

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.skills-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.skills-catalog.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { skillsCatalogIsActionable } from "./attempt-system-prompt-prepare.js";
+
+/**
+ * Regression cover for a run losing `<available_skills>` because a runtime
+ * `toolsAllow` list was attached. Cron persists an explicit `["*"]` to record
+ * "unrestricted", and agent-created jobs persist a mirror of the creating
+ * turn's own tools — both non-empty, both fully privileged.
+ */
+describe("skillsCatalogIsActionable", () => {
+  it("keeps the catalog when no allowlist is set", () => {
+    expect(skillsCatalogIsActionable(undefined)).toBe(true);
+  });
+
+  it("keeps the catalog for an empty allowlist", () => {
+    expect(skillsCatalogIsActionable([])).toBe(true);
+  });
+
+  it("keeps the catalog for an explicit wildcard, which means unrestricted", () => {
+    expect(skillsCatalogIsActionable(["*"])).toBe(true);
+  });
+
+  it("normalizes wildcard entries before matching", () => {
+    expect(skillsCatalogIsActionable(["read", " * "])).toBe(true);
+  });
+
+  it("keeps the catalog for a cron creator cap that carries read", () => {
+    // A real agent-created cron payload: no wildcard, but full read access.
+    expect(
+      skillsCatalogIsActionable([
+        "read",
+        "edit",
+        "write",
+        "exec",
+        "process",
+        "web_search",
+        "web_fetch",
+        "memory_search",
+      ]),
+    ).toBe(true);
+  });
+
+  it("drops the catalog for a narrow single-purpose allowlist", () => {
+    expect(skillsCatalogIsActionable(["openclaw"])).toBe(false);
+  });
+
+  it("drops the catalog when the run cannot read a skill body", () => {
+    expect(skillsCatalogIsActionable(["exec", "process"])).toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -32,6 +32,7 @@ import type { SandboxContext } from "../../sandbox/types.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
+import { normalizeToolName } from "../../tool-policy-shared.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import { buildToolSchemaDirectoryPrompt } from "../../tool-search.js";
 import { buildEmbeddedMessageActionDiscoveryInput } from "../message-action-discovery-input.js";
@@ -47,6 +48,30 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 
 type PreparedBootstrap = Awaited<ReturnType<typeof prepareEmbeddedAttemptBootstrap>>;
 type PromptTools = Parameters<typeof buildEmbeddedSystemPrompt>[0]["tools"];
+
+/**
+ * Whether the run can act on the skills catalog at all.
+ *
+ * A runtime `toolsAllow` list is not on its own evidence of a narrow run. Cron
+ * stores an explicit `["*"]` to record "unrestricted" (see
+ * `applyDefaultCronToolsAllow`), and agent-created jobs persist a mirror of the
+ * creating turn's own tools; both are non-empty while granting full access.
+ * Treating either as "narrow" removed `<available_skills>` from the prompt, so
+ * the model was never told which skills exist or where their SKILL.md files
+ * are, and could only rediscover them by searching the filesystem.
+ *
+ * A skill body is loaded by calling the read tool on the catalog's
+ * `<location>`, so the catalog is actionable exactly when the run may call
+ * `read`, or when the allowlist says unrestricted. Genuinely narrow helper
+ * turns (`["openclaw"]`, `[]`, read-less tool sets) still skip it.
+ */
+export function skillsCatalogIsActionable(toolsAllow: string[] | undefined): boolean {
+  if (!toolsAllow?.length) return true;
+  return toolsAllow.some((entry) => {
+    const name = normalizeToolName(entry);
+    return name === "*" || name === "read";
+  });
+}
 
 export async function prepareEmbeddedAttemptSystemPrompt(params: {
   activeContextEngine: EmbeddedRunAttemptParams["contextEngine"];
@@ -179,7 +204,9 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
     (params.isRawModelRun ? "none" : resolvePromptModeForSession(attempt.sessionKey));
   const promptSurface = resolveAgentPromptSurfaceForSessionKey(attempt.sessionKey);
   const effectivePromptMode = attempt.toolsAllow?.length ? ("minimal" as const) : promptMode;
-  const effectiveSkillsPrompt = attempt.toolsAllow?.length ? undefined : params.skillsPrompt;
+  const effectiveSkillsPrompt = skillsCatalogIsActionable(attempt.toolsAllow)
+    ? params.skillsPrompt
+    : undefined;
   const openClawReferences = await resolveOpenClawReferencePaths({
     workspaceDir: params.effectiveWorkspace,
     argv1: process.argv[1],


### PR DESCRIPTION
## Severity: high — silent, fleet-wide, and invisible in telemetry

Every cron `agentTurn` job that carries a `toolsAllow` runs **without `<available_skills>` in its system prompt**. The model is never told which skills exist or where their `SKILL.md` files are, so it cannot deliberately use one — it can only rediscover a skill by searching the filesystem, or answer from priors. There is no error, no warning, and no log line.

Three things make this worth prioritising:

1. **On the 2026.7.2 line it hits every box.** Since #112483, `applyDefaultCronToolsAllow` stamps `toolsAllow = ["*"]` on **every** tool-using cron job, to record "unrestricted" as an explicit fact. `["*"].length` is truthy, so on that line *every cron job everywhere* loses its skills catalog.
2. **The failure is silent and plausible.** In our measurements an affected run did not say "I could not check" — one fabricated a confident, well-formatted answer for a capability it never queried.
3. **Telemetry reports the opposite.** `buildSystemPromptReport` is handed the **un-gated** `skillsPrompt` while the prompt is built from the gated one, so `systemPromptReport` shows the catalog as present in exactly the runs where the model never received it — identical hash and char count in a failing cron run and a passing chat run. Anyone diagnosing this from telemetry gets a confident false negative. (Not fixed here; flagged so it does not mislead the next person.)

## The bug

`prepareEmbeddedAttemptSystemPrompt`:

```ts
const effectiveSkillsPrompt = attempt.toolsAllow?.length ? undefined : params.skillsPrompt;
```

A non-empty `toolsAllow` is treated as proof of a narrow run. It is not.

`toolsAllow` is three-valued in this codebase — `undefined` unrestricted, a short array restricted, `["*"]` **explicitly** unrestricted — and the rest of the code honours that:

- `hasWildcardToolAllowlist` in `attempt-tool-construction-plan.ts` (sibling file, same directory);
- `cli-runner/prepare.ts` normalising a wildcard back to `undefined`, covered by `does not restrict CLI-backed announce runs when toolsAllow contains a wildcard`.

Only this gate uses a bare `.length` check. It also cannot consult `toolsAllowIsDefault`, because `EmbeddedRunAttemptParams` does not carry it.

**Timeline** — the gate is not wrong for the callers it was written for. It predates cron's stamping by about a day, when every non-empty `toolsAllow` came from a genuinely narrow helper turn (realtime-voice consult, system-agent `["openclaw"]` / `[]`). Those still behave exactly as before after this change. Cron later walked into a gate built for something else.

## Evidence

Controlled harness, 20 runs per cell. Same agent, same five-section prompt, same model, same tool set, same skill; the **only** difference is whether the cron job carried an explicit tool list:

| cell | correct | skill body read | attempts at the capability |
|---|---|---|---|
| cron, tool list set | 8/20 | 5/20 | `{0:12, 1:2, 2:6}` |
| cron, no tool list | 20/20 | 20/20 | `{1:20}` |

Fisher exact: **p = 4.5e-05** on outcome, **p = 7.7e-07** on whether the skill body was read. Twelve of twenty affected runs made **zero** attempts at the capability.

## The fix

Rather than special-casing the wildcard, the predicate asks what the gate was approximating: *can this run open a skill body?* A skill is loaded by calling the read tool on the catalog's `<location>`, so the catalog is kept when `toolsAllow` grants `read` or is explicitly unrestricted, and still dropped otherwise.

A wildcard-only check would **not** be sufficient: agent-created jobs persist a mirror of the creating turn's own tools, which is a long, fully-privileged list with no wildcard in it. That is the shape that hit us in production.

`promptMode` is deliberately left untouched — this change is scoped to the skills catalog.

## Tests

`attempt-system-prompt-prepare.skills-catalog.test.ts` covers seven cases: unset, empty, explicit wildcard, wildcard needing normalization, a creator-cap list carrying `read`, and two genuinely narrow lists that must still skip the catalog.

Negative-controlled: with the predicate reverted to the current behaviour, exactly the three cases this PR fixes go red and the four that must not change stay green.

I could not find any existing test asserting the current coupling, nor a doc or CHANGELOG entry describing it — `docs/concepts/system-prompt.md` says Skills "stay available" under `minimal` mode, which is what this restores.
