### PR TITLE
[AI-assisted] docs(oauth): point login-flow pointer at the real oauth homes

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -116,7 +116,7 @@ and [Z.AI / GLM Coding Plan](/providers/zai).
 
 ## OAuth exchange (how login works)
 
-OpenClaw's interactive login flows are implemented in `openclaw/plugin-sdk/llm.ts` and wired into the wizards/commands.
+OpenClaw's interactive login flows live in `src/llm/utils/oauth/` — login and token refresh for the built-in Anthropic OAuth flow (Claude Pro/Max), plus a ChatGPT/Codex adapter that delegates login to the bundled OpenAI OAuth plugin (`src/plugins/provider-openai-chatgpt-oauth.ts`) — on top of the shared runtime in `src/plugin-sdk/provider-oauth-runtime.ts` and `src/plugin-sdk/provider-auth-runtime.ts`. The auth wizards/commands such as `openclaw models auth` (`src/commands/models/auth.ts`) drive these flows and persist the returned credentials into the credential store.
 
 ### Anthropic setup-token
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -116,7 +116,7 @@ and [Z.AI / GLM Coding Plan](/providers/zai).
 
 ## OAuth exchange (how login works)
 
-OpenClaw's interactive login flows live in `src/llm/utils/oauth/` — login and token refresh for the built-in Anthropic OAuth flow (Claude Pro/Max), plus a ChatGPT/Codex adapter that delegates login to the bundled OpenAI OAuth plugin (`src/plugins/provider-openai-chatgpt-oauth.ts`) — on top of the shared runtime in `src/plugin-sdk/provider-oauth-runtime.ts` and `src/plugin-sdk/provider-auth-runtime.ts`. The auth wizards/commands such as `openclaw models auth` (`src/commands/models/auth.ts`) drive these flows and persist the returned credentials into the credential store.
+OpenClaw's OAuth registry and adapters live in `src/llm/utils/oauth/`. Shared provider helpers live in `src/plugin-sdk/provider-oauth-runtime.ts` and `src/plugin-sdk/provider-auth-runtime.ts`. The auth commands in `src/commands/models/auth.ts` run the selected provider method and persist the returned profiles.
 
 ### Anthropic setup-token
 


### PR DESCRIPTION
## What Problem This Solves

The OAuth guide sends readers investigating login behavior to an implementation path that no longer exists.

## Why This Change Was Made

Replace the stale pointer with the current OAuth registry and adapters, shared provider helpers, and auth commands. Keep the ownership distinction clear: provider methods return profiles, and the command flow persists them.

## User Impact

Readers can find the existing login implementation and storage owner. This changes documentation only; login commands, provider selection, protocol, and credential behavior remain unchanged. Thanks @santhiprakash for correcting the pointer.

## Evidence

- Read the complete OAuth guide, registry/adapters, provider bridge, shared OAuth/auth helper modules, and models-auth command. The command invokes the selected provider method and persists the returned profiles through the auth-profile owner.
- The old `openclaw/plugin-sdk/llm.ts` path is absent; the replacement paths exist on current main. Existing tests cover plugin-owned login routing and returned-profile persistence.
- Personally checked the sibling Codex login source: `codex-rs/login/src/lib.rs` and `server.rs` callback, exchange, and persistence boundaries. No live authenticated login is claimed for a source-pointer-only change.
- Trusted main docs tooling passed docs listing, MDX compilation, canonical formatting, internal links (6,524 checked; zero broken), and whitespace for the final candidate.
- Full candidate Codex autoreview passed with no accepted P0 findings. Documentation delta: +1/-1.
- Production and test code are unchanged. The correction removes one stale implementation pointer without creating another compatibility path.

Public documentation: [OAuth](https://docs.openclaw.ai/concepts/oauth).
