### PR TITLE
test(ui): stabilize markdown table dialog reopen

### DIFF
--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -176,7 +176,7 @@ describe("Markdown table interactions", () => {
     expect(document.querySelector(".markdown-table-dialog")).toBeNull();
     expect(document.activeElement).toBe(expand);
 
-    expand.click();
+    handleMarkdownTableInteraction(markdownTableInteractionEvent(expand));
     const reopenedDialog = document.querySelector<HTMLDialogElement>(".markdown-table-dialog")!;
 
     reopenedDialog.querySelector<HTMLButtonElement>(".markdown-table-dialog__close")!.click();


### PR DESCRIPTION
## What Problem This Solves

Resolves a red-`main` failure in `ui/src/components/markdown-tables.test.ts` where the dialog-reopen assertion dereferences a missing dialog after backdrop dismissal. The failure was introduced by `40597e25b51490d334488da0f78c50cf11b4b8c0` (#125692), which added the backdrop-close/reopen sequence to the isolated jsdom test.

## Why This Change Was Made

This is a stale-test fix, not a product fix. The real Chromium E2E already performs open → backdrop close → focus restoration → reopen and passes on the unmodified product code. The isolated unit fixture has no chat-thread or Custodian delegated click listener, so its raw `expand.click()` cannot reach `handleMarkdownTableInteraction`; reopening through the same interaction owner used for the first open tests the intended unit boundary without changing production behavior.

Production LOC is unchanged. Tests are +1/-1. AI-assisted.

## User Impact

There is no user-visible behavior change: operators can already reopen a fullscreen Markdown table after dismissing it via the backdrop. Landing this correction restores green CI on `main` and unblocks unrelated pull requests while preserving backdrop dismissal and focus restoration coverage.

## Evidence

- Before the fix, `pnpm test ui/src/components/markdown-tables.test.ts` fails at line 182 with `TypeError: Cannot read properties of null (reading 'querySelector')` after 3/4 tests pass.
- On unchanged product code, `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts` passes 1/1 in Chromium. That test explicitly closes via the backdrop, verifies focus restoration, reopens via the expand button, and verifies the dialog is open.
- After the test-boundary correction, `pnpm test ui/src/components/markdown-tables.test.ts` passes all 4 tests.
- The same focused Chromium E2E passes after the correction.
- `pnpm format ui/src/components/markdown-tables.test.ts` completed cleanly.
- `pnpm check:changed` passed.
- Autoreview completed cleanly with no accepted or actionable findings.
