### PR TITLE
refactor(agents): prepare provider route facts at model-route build

### DIFF
--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -15,9 +15,6 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
   fetchWithSsrFGuard: fetchGuardMock,
 }));
 
-function createMockRequestConfig() {
-  return {} as ReturnType<typeof providerHttp.resolveProviderHttpRequestConfig>["requestConfig"];
-}
 describe("fal video generation provider", () => {
   function mockFalProviderRuntime() {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
@@ -33,7 +30,6 @@ describe("fal video generation provider", () => {
         "Content-Type": "application/json",
       }),
       dispatcherPolicy: undefined,
-      requestConfig: createMockRequestConfig(),
     });
     vi.spyOn(providerHttp, "assertOkOrThrowHttpError").mockResolvedValue(undefined);
   }

--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -26,6 +26,7 @@ export interface AiProviderRequestPolicyInput {
   transport?: "stream" | "websocket" | "http" | "media-understanding";
   modelId?: string | null;
   compat?: unknown;
+  model?: object;
 }
 
 /** Context shared by plugin-owned provider stream hooks. */
@@ -157,8 +158,6 @@ export interface AiTransportHost {
   plugin: AiTransportPluginHost;
   /** Builds provider-owned Copilot compatibility headers for one message turn. */
   buildCopilotDynamicHeaders(messages: Context["messages"]): Record<string, string>;
-  /** Resolves endpoint classification without importing core provider registries. */
-  resolveProviderEndpointClass(baseUrl?: string): string;
   /** Resolves provider capability flags used by payload compatibility policy. */
   resolveProviderRequestCapabilities(
     input: AiProviderRequestPolicyInput,
@@ -171,6 +170,7 @@ export interface AiTransportHost {
     providerHeaders?: Record<string, string>;
     callerHeaders?: Record<string, string>;
     precedence?: "caller-wins" | "defaults-win";
+    model?: object;
   }): Record<string, string> | undefined;
   /** Returns the host-configured request timeout attached to a model. */
   resolveModelRequestTimeoutMs(model: Model): number | undefined;
@@ -242,7 +242,6 @@ const inertAiTransportHost: ActiveAiTransportHost = {
     },
   },
   buildCopilotDynamicHeaders: () => ({}),
-  resolveProviderEndpointClass: () => "default",
   resolveProviderRequestCapabilities: () => ({
     endpointClass: "default",
     knownProviderFamily: "",

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -1,3 +1,4 @@
+import type { Model } from "@openclaw/llm-core";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
@@ -79,7 +80,7 @@ export function resolveAnthropicServerCompactionPlan(
 ): { enabled: boolean; threshold?: number } {
   const provider = normalizeOptionalLowercaseString(model.provider);
   const api = normalizeOptionalLowercaseString(model.api);
-  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  const endpointClass = resolveProviderEndpoint(model).endpointClass;
   const enabled =
     extraParams?.anthropicServerCompaction === true &&
     provider === "anthropic" &&
@@ -297,14 +298,18 @@ function countAnthropicCacheControlMarkers(blocks: unknown): number {
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export function resolveAnthropicPayloadPolicy(
   input: AnthropicPayloadPolicyInput,
+  model?: Model,
 ): AnthropicPayloadPolicy {
-  const capabilities = resolveProviderRequestCapabilities({
-    provider: input.provider,
-    api: input.api,
-    baseUrl: input.baseUrl,
-    capability: "llm",
-    transport: "stream",
-  });
+  const capabilities = resolveProviderRequestCapabilities(
+    {
+      provider: input.provider,
+      api: input.api,
+      baseUrl: input.baseUrl,
+      capability: "llm",
+      transport: "stream",
+    },
+    model,
+  );
   const serverCompactionPlan = resolveAnthropicServerCompactionPlan(input, input.extraParams);
 
   return {

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -340,7 +340,6 @@ describe("anthropic transport stream", () => {
       ...coreTransportHost,
       buildModelFetch: buildGuardedModelFetchMock,
       redactSecrets: redactTestSecrets,
-      resolveProviderEndpointClass: resolveTestEndpointClass,
       resolveProviderRequestCapabilities: (input) => {
         const endpointClass = resolveTestEndpointClass(input.baseUrl);
         return {

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -228,7 +228,7 @@ function isDirectAnthropicModel(model: Pick<AnthropicTransportModel, "provider" 
   if (normalizeLowercaseStringOrEmpty(model.provider) !== "anthropic") {
     return false;
   }
-  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  const endpointClass = resolveProviderEndpoint(model).endpointClass;
   return endpointClass === "default" || endpointClass === "anthropic-public";
 }
 
@@ -252,7 +252,7 @@ function useAnthropicServerSideFallback(model: AnthropicTransportModel): boolean
 function supportsReasoningContentReplay(
   model: Pick<AnthropicTransportModel, "provider" | "baseUrl">,
 ): boolean {
-  return resolveProviderEndpoint(model.baseUrl).endpointClass === "xiaomi-native";
+  return resolveProviderEndpoint(model).endpointClass === "xiaomi-native";
 }
 
 function buildAnthropicBetaHeader(
@@ -934,13 +934,16 @@ async function buildAnthropicParams(
       `Anthropic Messages transport requires a positive maxTokens value for ${model.provider}/${model.id}`,
     );
   }
-  const payloadPolicy = resolveAnthropicPayloadPolicy({
-    provider: model.provider,
-    api: model.api,
-    baseUrl: model.baseUrl,
-    cacheRetention: options?.cacheRetention,
-    enableCacheControl: true,
-  });
+  const payloadPolicy = resolveAnthropicPayloadPolicy(
+    {
+      provider: model.provider,
+      api: model.api,
+      baseUrl: model.baseUrl,
+      cacheRetention: options?.cacheRetention,
+      enableCacheControl: true,
+    },
+    model,
+  );
   // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
   // stays on the last stable user turn; conversion-to-policy must not splice messages.
   const cacheBreakpointOptOutMessageIndexes = new Set<number>();

--- a/packages/ai/src/transports/host-policy.ts
+++ b/packages/ai/src/transports/host-policy.ts
@@ -16,25 +16,36 @@ export function buildGuardedModelFetch(
   return host.buildModelFetch(model) ?? globalThis.fetch;
 }
 
-export function resolveProviderEndpoint(baseUrl?: string): { endpointClass: string } {
-  return { endpointClass: getAiTransportHost().resolveProviderEndpointClass(baseUrl) };
+export function resolveProviderEndpoint(model: { baseUrl?: string }): { endpointClass: string } {
+  return {
+    endpointClass: getAiTransportHost().resolveProviderRequestCapabilities({
+      baseUrl: model.baseUrl,
+      model,
+    }).endpointClass,
+  };
 }
 
-export function resolveProviderRequestCapabilities(input: AiProviderRequestPolicyInput) {
-  return getAiTransportHost().resolveProviderRequestCapabilities(input);
+export function resolveProviderRequestCapabilities(
+  input: AiProviderRequestPolicyInput,
+  model?: object,
+) {
+  return getAiTransportHost().resolveProviderRequestCapabilities({ ...input, model });
 }
 
-export function resolveProviderRequestPolicyConfig(input: {
-  provider?: string;
-  api?: string;
-  baseUrl?: string;
-  capability?: string;
-  transport?: string;
-  providerHeaders?: Record<string, string>;
-  callerHeaders?: Record<string, string>;
-  precedence?: "caller-wins" | "defaults-win";
-}): { headers?: Record<string, string> } {
-  return { headers: getAiTransportHost().resolveProviderRequestHeaders(input) };
+export function resolveProviderRequestPolicyConfig(
+  model: Model,
+  input: {
+    provider?: string;
+    api?: string;
+    baseUrl?: string;
+    capability?: string;
+    transport?: string;
+    providerHeaders?: Record<string, string>;
+    callerHeaders?: Record<string, string>;
+    precedence?: "caller-wins" | "defaults-win";
+  },
+): { headers?: Record<string, string> } {
+  return { headers: getAiTransportHost().resolveProviderRequestHeaders({ ...input, model }) };
 }
 
 export function resolveModelRequestTimeoutMs(model: Model, timeoutMs?: number): number | undefined {

--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -7,7 +7,7 @@
 import type { Model, OpenAICompletionsCompat } from "@openclaw/llm-core";
 import type { AiProviderRequestCapabilities, AiProviderRequestPolicyInput } from "../host.js";
 import { isKnownOpenAIJsonSchemaModelId } from "../providers/openai-response-format.js";
-import { resolveProviderRequestCapabilities } from "./host-policy.js";
+import { resolveProviderRequestCapabilities as resolveModelProviderRequestCapabilities } from "./host-policy.js";
 
 type ProviderEndpointClass = string;
 type ProviderRequestCapabilities = AiProviderRequestCapabilities;
@@ -196,11 +196,11 @@ export function detectOpenAICompletionsCompat(
   model: Pick<Model<"openai-completions">, "provider" | "baseUrl" | "id"> & {
     compat?: { supportsStore?: boolean } | null;
   },
-  resolveCapabilities: (
-    input: AiProviderRequestPolicyInput,
-  ) => ProviderRequestCapabilities = resolveProviderRequestCapabilities,
+  resolveCapabilities?: (input: AiProviderRequestPolicyInput) => ProviderRequestCapabilities,
 ): DetectedOpenAICompletionsCompat {
-  const capabilities = resolveCapabilities({
+  const capabilities = (
+    resolveCapabilities ?? ((input) => resolveModelProviderRequestCapabilities(input, model))
+  )({
     provider: model.provider,
     api: "openai-completions",
     baseUrl: model.baseUrl,
@@ -243,9 +243,7 @@ function resolveSessionAffinity(
 /** Applies explicit model overrides once on top of the canonical transport defaults. */
 export function resolveOpenAICompletionsCompat(
   model: Model<"openai-completions">,
-  resolveCapabilities: (
-    input: AiProviderRequestPolicyInput,
-  ) => ProviderRequestCapabilities = resolveProviderRequestCapabilities,
+  resolveCapabilities?: (input: AiProviderRequestPolicyInput) => ProviderRequestCapabilities,
 ): ResolvedOpenAICompletionsCompat {
   const { defaults } = detectOpenAICompletionsCompat(model, resolveCapabilities);
   const configured = model.compat;

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -53,7 +53,7 @@ function isKnownOpenAICompletionsEndpoint(model: Pick<Model, "baseUrl">): boolea
   if (!model.baseUrl.trim()) {
     return true;
   }
-  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  const endpointClass = resolveProviderEndpoint(model).endpointClass;
   if (endpointClass === "openai-public" || endpointClass === "azure-openai") {
     return true;
   }

--- a/packages/ai/src/transports/openai-completions.test-support.ts
+++ b/packages/ai/src/transports/openai-completions.test-support.ts
@@ -125,7 +125,6 @@ configureAiTransportHost({
   },
   resolveOpenAIStrictToolSetting: (_model, options) =>
     options?.supportsStrictMode ? true : undefined,
-  resolveProviderEndpointClass: resolveTestEndpointClass,
   resolveProviderRequestCapabilities: resolveTestCapabilities,
   resolveModelRequestTimeoutMs: (model) => {
     const value = (model as { requestTimeoutMs?: unknown }).requestTimeoutMs;

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -358,7 +358,7 @@ export function buildOpenAIClientHeaders(
     );
   }
   const callerHeaders = { ...optionHeaders, ...turnHeaders };
-  const headers = resolveProviderRequestPolicyConfig({
+  const headers = resolveProviderRequestPolicyConfig(model, {
     provider: model.provider,
     api: model.api,
     baseUrl: model.baseUrl,

--- a/src/agents/ai-transport-runtime-host.test.ts
+++ b/src/agents/ai-transport-runtime-host.test.ts
@@ -1,0 +1,96 @@
+// Verifies package transports consume the route generation prepared on the model.
+import { getAiTransportHost } from "@openclaw/ai";
+import { describe, expect, it } from "vitest";
+import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.types.js";
+import "./ai-transport-runtime-host.js";
+import {
+  attachModelProviderRequestRouteFacts,
+  getModelProviderRequestRouteFacts,
+  resolveProviderRequestPolicyConfig,
+} from "./provider-request-config.js";
+import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
+
+function buildOwners(): PluginMetadataSnapshotOwnerMaps {
+  const empty = new Map<string, readonly string[]>();
+  return {
+    channels: empty,
+    channelConfigs: empty,
+    providers: empty,
+    modelCatalogProviders: empty,
+    cliBackends: empty,
+    setupProviders: empty,
+    commandAliases: empty,
+    contracts: empty,
+    providerEndpoints: [
+      { endpointClass: "openai-public", hosts: ["prepared.example"] },
+      { endpointClass: "anthropic-public", hosts: ["projected.example"] },
+    ],
+    providerRequests: new Map([["openai", { family: "prepared-openai-family" }]]),
+  };
+}
+
+describe("AI transport prepared provider routes", () => {
+  it("keeps headers, capabilities, and SSRF posture on the prepared metadata generation", () => {
+    const model = attachModelProviderRequestRouteFacts(
+      makeProviderModelFixture<"openai-responses">({
+        id: "gpt-5.6-luna",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://prepared.example/v1",
+      }),
+      buildOwners(),
+    );
+    const host = getAiTransportHost();
+    const headers = host.resolveProviderRequestHeaders({
+      model,
+      provider: model.provider,
+      api: model.api,
+      baseUrl: model.baseUrl,
+    });
+    const capabilities = host.resolveProviderRequestCapabilities({
+      model,
+      provider: model.provider,
+      api: model.api,
+      baseUrl: model.baseUrl,
+      capability: "llm",
+      transport: "stream",
+    });
+    const requestPolicy = resolveProviderRequestPolicyConfig({
+      provider: model.provider,
+      api: model.api,
+      baseUrl: model.baseUrl,
+      routeFacts: getModelProviderRequestRouteFacts(model),
+      capability: "llm",
+      transport: "stream",
+    });
+
+    expect(headers).toMatchObject({ originator: "openclaw" });
+    expect(capabilities).toMatchObject({
+      endpointClass: "openai-public",
+      knownProviderFamily: "prepared-openai-family",
+    });
+    expect(requestPolicy.trustConfiguredBaseUrlOrigin).toBe(false);
+  });
+
+  it("re-resolves projected transport routes against the same metadata generation", () => {
+    const owners = buildOwners();
+    const source = attachModelProviderRequestRouteFacts(
+      makeProviderModelFixture<"openai-responses">({
+        id: "gpt-5.6-luna",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://prepared.example/v1",
+      }),
+      owners,
+    );
+    const projected = getAiTransportHost().inheritManagedTransport(source, {
+      ...source,
+      baseUrl: "https://projected.example/v1",
+    });
+    const routeFacts = getModelProviderRequestRouteFacts(projected);
+
+    expect(routeFacts?.providerMetadataOwners).toBe(owners);
+    expect(routeFacts?.capabilities.endpointClass).toBe("anthropic-public");
+    expect(routeFacts?.providerOwner).toBe("anthropic-public");
+  });
+});

--- a/src/agents/ai-transport-runtime-host.ts
+++ b/src/agents/ai-transport-runtime-host.ts
@@ -15,10 +15,7 @@ import {
 import { createAnthropicVertexStreamFnForModel } from "./anthropic-vertex-stream.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
-import {
-  resolveProviderRequestCapabilities,
-  resolveProviderEndpoint,
-} from "./provider-attribution.js";
+import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
 import {
   attachModelProviderLocalService,
   getModelProviderLocalService,
@@ -26,7 +23,8 @@ import {
 import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,
-  inheritModelProviderMetadataOwners,
+  getModelProviderRequestRouteFacts,
+  inheritModelProviderRequestRouteFacts,
   resolveProviderRequestPolicyConfig,
 } from "./provider-request-config.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
@@ -77,12 +75,13 @@ export function configureAiTransportRuntimeHost(): void {
     },
     buildCopilotDynamicHeaders: (messages) =>
       buildCopilotDynamicHeaders({ messages, hasImages: hasCopilotVisionInput(messages) }),
-    resolveProviderEndpointClass: (baseUrl) => resolveProviderEndpoint(baseUrl).endpointClass,
     resolveProviderRequestCapabilities: (input) =>
-      resolveProviderRequestCapabilities(input) as AiProviderRequestCapabilities,
+      (getModelProviderRequestRouteFacts(input.model ?? {})?.capabilities ??
+        resolveProviderRequestCapabilities(input)) as AiProviderRequestCapabilities,
     resolveProviderRequestHeaders: (input) =>
       resolveProviderRequestPolicyConfig({
         ...input,
+        routeFacts: getModelProviderRequestRouteFacts(input.model ?? {}),
         capability: "llm",
         transport: "stream",
       }).headers,
@@ -91,7 +90,7 @@ export function configureAiTransportRuntimeHost(): void {
       return Boolean(request?.proxy || request?.tls || getModelProviderLocalService(model));
     },
     inheritManagedTransport: (source, target) =>
-      inheritModelProviderMetadataOwners(
+      inheritModelProviderRequestRouteFacts(
         source,
         attachModelProviderLocalService(
           attachModelProviderRequestTransport(target, getModelProviderRequestTransport(source)),

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -38,7 +38,10 @@ import {
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveModelExtraParamSources } from "../model-extra-params.js";
-import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
+import {
+  getModelProviderRequestRouteFacts,
+  resolveProviderRequestPolicyConfig,
+} from "../provider-request-config.js";
 import type { AgentRuntimeTransport } from "../runtime-plan/types.js";
 import type { StreamFn } from "../runtime/index.js";
 import type { SettingsManager } from "../sessions/index.js";
@@ -706,14 +709,16 @@ function shouldStripOpenAICompletionsStore(model: ProviderRuntimeModel): boolean
     model.compat && typeof model.compat === "object"
       ? (model.compat as Record<string, unknown>)
       : undefined;
-  const capabilities = resolveProviderRequestPolicyConfig({
-    provider: typeof model.provider === "string" ? model.provider : undefined,
-    api: model.api,
-    baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
-    compat,
-    capability: "llm",
-    transport: "stream",
-  }).capabilities;
+  const capabilities =
+    getModelProviderRequestRouteFacts(model)?.capabilities ??
+    resolveProviderRequestPolicyConfig({
+      provider: typeof model.provider === "string" ? model.provider : undefined,
+      api: model.api,
+      baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
+      compat,
+      capability: "llm",
+      transport: "stream",
+    }).capabilities;
   return !capabilities.usesKnownNativeOpenAIRoute;
 }
 

--- a/src/agents/embedded-agent-runner/model.configured-fallback.ts
+++ b/src/agents/embedded-agent-runner/model.configured-fallback.ts
@@ -5,7 +5,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { resolveCatalogOwnedModelCompat } from "../model-compat-catalog.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
-  attachModelProviderMetadataOwners,
+  attachModelProviderRequestRouteFacts,
   attachModelProviderRequestTransport,
   resolveProviderRequestConfig,
   sanitizeConfiguredModelProviderRequest,
@@ -165,7 +165,7 @@ export function buildConfiguredFallbackModel(params: {
     cfg,
     agentDir,
     workspaceDir,
-    model: attachModelProviderMetadataOwners(
+    model: attachModelProviderRequestRouteFacts(
       attachModelProviderLocalService(
         attachModelProviderRequestTransport(
           {

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -13,7 +13,7 @@ import {
 } from "../model-suppression.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
-  attachModelProviderMetadataOwners,
+  attachModelProviderRequestRouteFacts,
   attachModelProviderRequestTransport,
   resolveProviderRequestConfig,
   sanitizeConfiguredModelProviderRequest,
@@ -327,7 +327,7 @@ export function applyConfiguredProviderOverrides(params: {
   workspaceDir?: string;
 }): ProviderRuntimeModel {
   const { providerConfig, modelId } = params;
-  const discoveredModel = attachModelProviderMetadataOwners(
+  const discoveredModel = attachModelProviderRequestRouteFacts(
     markDiscoveredMaxTokensSource(params.discoveredModel),
     params.providerMetadataOwners,
   );
@@ -563,7 +563,7 @@ export function applyConfiguredProviderOverrides(params: {
     capability: "llm",
     transport: "stream",
   });
-  return attachModelProviderMetadataOwners(
+  return attachModelProviderRequestRouteFacts(
     attachModelProviderLocalService(
       attachModelProviderRequestTransport(
         {

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -9,7 +9,7 @@ import type { PluginMetadataSnapshotOwnerMaps } from "../../plugins/plugin-metad
 import { isSecretRefHeaderValueMarker } from "../model-auth-markers.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
-  attachModelProviderMetadataOwners,
+  attachModelProviderRequestRouteFacts,
   attachModelProviderRequestTransport,
   resolveProviderRequestConfig,
   sanitizeConfiguredModelProviderRequest,
@@ -176,7 +176,7 @@ export function buildInlineProviderModels(
         transport: "stream",
       });
       const maxTokens = model.maxTokens ?? entry?.maxTokens;
-      return attachModelProviderMetadataOwners(
+      return attachModelProviderRequestRouteFacts(
         attachModelProviderLocalService(
           attachModelProviderRequestTransport(
             {

--- a/src/agents/embedded-agent-runner/model.provider-hooks.ts
+++ b/src/agents/embedded-agent-runner/model.provider-hooks.ts
@@ -13,7 +13,7 @@ import {
   shouldPreferProviderRuntimeResolvedModel,
 } from "../../plugins/provider-runtime.js";
 import { canonicalizeOpenAIModelId } from "../openai-routing.js";
-import { inheritModelProviderMetadataOwners } from "../provider-request-config.js";
+import { inheritModelProviderRequestRouteFacts } from "../provider-request-config.js";
 import {
   normalizeResolvedTransportApi,
   resolveProviderModelInput,
@@ -233,7 +233,7 @@ export function normalizeResolvedModel(params: {
     normalizedInputModel.requestTimeoutMs !== undefined
       ? { ...normalizedModel, requestTimeoutMs: normalizedInputModel.requestTimeoutMs }
       : normalizedModel;
-  return inheritModelProviderMetadataOwners(
+  return inheritModelProviderRequestRouteFacts(
     params.model,
     canonicalizeLegacyResolvedModel({
       provider: params.provider,

--- a/src/agents/embedded-agent-runner/model.static-catalog.prepared.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.prepared.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { getModelProviderMetadataOwners } from "../provider-request-config.js";
+import { getModelProviderRequestRouteFacts } from "../provider-request-config.js";
 
 const mocks = vi.hoisted(() => ({
   loadPluginManifestRegistryCore: vi.fn(),
@@ -224,7 +224,9 @@ describe("prepared bundled provider static catalogs", () => {
         contextWindow: 1_048_576,
       }),
     ]);
-    expect(getModelProviderMetadataOwners(models[0]!)).toBe(metadataSnapshot.owners);
+    expect(getModelProviderRequestRouteFacts(models[0]!)?.providerMetadataOwners).toBe(
+      metadataSnapshot.owners,
+    );
     expect(mocks.resolveRuntimePluginDiscoveryProviders).toHaveBeenCalledOnce();
     expect(mocks.runProviderStaticCatalog).not.toHaveBeenCalled();
   });

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -8,6 +8,7 @@ import { isProfileInCooldown } from "../../auth-profiles.js";
 import type { ResolvedProviderAuth } from "../../model-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../prepared-model-runtime.js";
 import { resolveProviderEndpoint } from "../../provider-attribution.js";
+import { getModelProviderRequestRouteFacts } from "../../provider-request-config.js";
 import {
   hasPreparedAuthAttemptModelMetadata,
   resolveCredentialScopedAuthAttemptModelDecision,
@@ -494,13 +495,17 @@ export async function prepareEmbeddedRunRuntime(input: {
     })
       ? pluginMetadataSnapshot
       : undefined;
-  const endpointClass = resolveProviderEndpoint(
-    effectiveModel.baseUrl,
-    compatibleMetadataSnapshot?.owners,
-  ).endpointClass;
-  const providerOwner = ["default", "invalid", "local", "custom"].includes(endpointClass)
+  const routeFacts = getModelProviderRequestRouteFacts(effectiveModel);
+  const fallbackEndpointClass = routeFacts
     ? undefined
-    : endpointClass;
+    : resolveProviderEndpoint(effectiveModel.baseUrl, compatibleMetadataSnapshot?.owners)
+        .endpointClass;
+  const providerOwner =
+    routeFacts?.providerOwner ??
+    (fallbackEndpointClass &&
+    !["default", "invalid", "local", "custom"].includes(fallbackEndpointClass)
+      ? fallbackEndpointClass
+      : undefined);
   const providerRuntimeHandle = {
     ...resolveProviderRuntimePluginHandle({
       provider,

--- a/src/agents/openai-strict-tool-setting.ts
+++ b/src/agents/openai-strict-tool-setting.ts
@@ -5,6 +5,7 @@
  */
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
+import { getModelProviderRequestRouteFacts } from "./provider-request-config.js";
 
 // Resolves OpenAI strict-tool schema defaults. Native OpenAI routes require
 // strict=true, while compatible providers that merely support strict mode get
@@ -23,15 +24,17 @@ function resolvesToNativeOpenAIStrictTools(
   model: OpenAIStrictToolModel,
   transport: OpenAITransportKind,
 ): boolean {
-  const capabilities = resolveProviderRequestCapabilities({
-    provider: readStringValue(model.provider),
-    api: readStringValue(model.api),
-    baseUrl: readStringValue(model.baseUrl),
-    capability: "llm",
-    transport,
-    modelId: readStringValue(model.id),
-    compat: model.compat,
-  });
+  const capabilities =
+    getModelProviderRequestRouteFacts(model)?.capabilities ??
+    resolveProviderRequestCapabilities({
+      provider: readStringValue(model.provider),
+      api: readStringValue(model.api),
+      baseUrl: readStringValue(model.baseUrl),
+      capability: "llm",
+      transport,
+      modelId: readStringValue(model.id),
+      compat: model.compat,
+    });
   if (!capabilities.usesKnownNativeOpenAIRoute) {
     return false;
   }

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -2,12 +2,13 @@
 import { describe, expect, it } from "vitest";
 import type { ConfiguredProviderRequest } from "../config/types.provider-request.js";
 import type { SecretRef } from "../config/types.secrets.js";
+import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   applyPreparedRuntimeAuthToModel,
-  attachModelProviderMetadataOwners,
+  attachModelProviderRequestRouteFacts,
   buildProviderRequestDispatcherPolicy,
-  getModelProviderMetadataOwners,
-  inheritModelProviderMetadataOwners,
+  getModelProviderRequestRouteFacts,
+  inheritModelProviderRequestRouteFacts,
   mergeModelProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
   resolveProviderRequestConfig,
@@ -15,6 +16,27 @@ import {
   sanitizeConfiguredModelProviderRequest,
   sanitizeConfiguredProviderRequest,
 } from "./provider-request-config.js";
+import { resolveProviderTransportSsrFPolicy } from "./provider-transport-fetch.js";
+import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
+
+function buildProviderMetadataOwners(
+  endpoints: NonNullable<PluginMetadataSnapshotOwnerMaps["providerEndpoints"]> = [],
+  requests: NonNullable<PluginMetadataSnapshotOwnerMaps["providerRequests"]> = new Map(),
+): PluginMetadataSnapshotOwnerMaps {
+  const empty = new Map<string, readonly string[]>();
+  return {
+    channels: empty,
+    channelConfigs: empty,
+    providers: empty,
+    modelCatalogProviders: empty,
+    cliBackends: empty,
+    setupProviders: empty,
+    commandAliases: empty,
+    contracts: empty,
+    providerEndpoints: endpoints,
+    providerRequests: requests,
+  };
+}
 
 describe("provider request config", () => {
   it("carries lifecycle plugin metadata ownership through model projections", () => {
@@ -30,20 +52,25 @@ describe("provider request config", () => {
       providerEndpoints: [],
       providerRequests: new Map([["prepared", { family: "prepared-family" }]]),
     };
-    const prepared = attachModelProviderMetadataOwners({ id: "prepared-model" }, owners);
-    const projected = inheritModelProviderMetadataOwners(prepared, {
+    const prepared = attachModelProviderRequestRouteFacts(
+      makeProviderModelFixture<"openai-completions">({
+        provider: "prepared",
+        api: "openai-completions",
+        baseUrl: "https://prepared.example/v1",
+        id: "prepared-model",
+      }),
+      owners,
+    );
+    const projected = inheritModelProviderRequestRouteFacts(prepared, {
       ...prepared,
       id: "projected-model",
     });
 
-    expect(getModelProviderMetadataOwners(prepared)).toBe(owners);
-    expect(getModelProviderMetadataOwners(projected)).toBe(owners);
-    expect(
-      resolveProviderRequestPolicyConfig({
-        provider: "prepared",
-        providerMetadataOwners: getModelProviderMetadataOwners(projected),
-      }).policy.knownProviderFamily,
-    ).toBe("prepared-family");
+    expect(getModelProviderRequestRouteFacts(prepared)?.providerMetadataOwners).toBe(owners);
+    expect(getModelProviderRequestRouteFacts(projected)?.providerMetadataOwners).toBe(owners);
+    expect(getModelProviderRequestRouteFacts(projected)?.capabilities.knownProviderFamily).toBe(
+      "prepared-family",
+    );
   });
 
   it("applies prepared runtime auth without retaining stale credential headers", () => {
@@ -132,8 +159,6 @@ describe("provider request config", () => {
 
     expect(resolved.proxy).toEqual({ configured: false });
     expect(resolved.tls).toEqual({ configured: false });
-    expect(resolved.policy.endpointClass).toBe("openrouter");
-    expect(resolved.policy.attributionProvider).toBe("openrouter");
     expect(resolved.extraHeaders).toEqual({
       configured: false,
       headers: undefined,
@@ -623,14 +648,87 @@ describe("provider request config", () => {
 
     expect(resolved.baseUrl).toBe("https://api.openai.com/v1");
     expect(resolved.allowPrivateNetwork).toBe(false);
-    expect(resolved.privateNetworkExplicitlyDenied).toBe(false);
-    expect(resolved.policy.endpointClass).toBe("openai-public");
+    expect(resolved.trustConfiguredBaseUrlOrigin).toBe(false);
+    expect(resolved.capabilities.endpointClass).toBe("openai-public");
     expect(resolved.capabilities.allowsResponsesStore).toBe(true);
     expect(resolved.headers?.authorization).toBe("Bearer test-key");
     expect(resolved.headers?.originator).toBe("openclaw");
     expect(typeof resolved.headers?.version).toBe("string");
     expect(resolved.headers?.["User-Agent"]).toMatch(/^openclaw\//);
     expect(resolved.headers?.["X-Custom"]).toBe("1");
+  });
+
+  it.each([
+    {
+      name: "OpenAI core",
+      provider: "openai",
+      api: "openai-responses" as const,
+      baseUrl: "https://prepared-openai.example/v1",
+      owners: buildProviderMetadataOwners([
+        { endpointClass: "openai-public", hosts: ["prepared-openai.example"] },
+      ]),
+    },
+    {
+      name: "Anthropic core",
+      provider: "anthropic",
+      api: "anthropic-messages" as const,
+      baseUrl: "https://prepared-anthropic.example/v1",
+      owners: buildProviderMetadataOwners([
+        { endpointClass: "anthropic-public", hosts: ["prepared-anthropic.example"] },
+      ]),
+    },
+    {
+      name: "plugin provider",
+      provider: "acme-plugin",
+      api: "openai-completions" as const,
+      baseUrl: "https://inference.acme.example/v1",
+      owners: buildProviderMetadataOwners(
+        [{ endpointClass: "nvidia-native", hosts: ["inference.acme.example"] }],
+        new Map([["acme-plugin", { family: "acme-family" }]]),
+      ),
+    },
+    {
+      name: "manifest fallback",
+      provider: "openrouter",
+      api: "openai-completions" as const,
+      baseUrl: "https://openrouter.ai/api/v1",
+      owners: undefined,
+    },
+  ])("keeps $name outbound headers and SSRF policy byte-identical", (testCase) => {
+    const model = makeProviderModelFixture({
+      provider: testCase.provider,
+      api: testCase.api,
+      baseUrl: testCase.baseUrl,
+      id: `${testCase.provider}-model`,
+    });
+    const preparedModel = attachModelProviderRequestRouteFacts(model, testCase.owners);
+    const common = {
+      provider: testCase.provider,
+      api: testCase.api,
+      baseUrl: testCase.baseUrl,
+      capability: "llm" as const,
+      transport: "stream" as const,
+      callerHeaders: { "X-Caller": "same" },
+      providerHeaders: { Authorization: "Bearer redacted" },
+    };
+    const before = resolveProviderRequestPolicyConfig({
+      ...common,
+      ...(testCase.owners ? { providerMetadataOwners: testCase.owners } : {}),
+    });
+    const after = resolveProviderRequestPolicyConfig({
+      ...common,
+      routeFacts: getModelProviderRequestRouteFacts(preparedModel),
+    });
+    const ssrfPolicy = (resolved: typeof before) =>
+      resolveProviderTransportSsrFPolicy({
+        baseUrl: testCase.baseUrl,
+        url: `${testCase.baseUrl}/responses`,
+        allowPrivateNetwork: resolved.allowPrivateNetwork,
+        trustConfiguredBaseUrlOrigin: resolved.trustConfiguredBaseUrlOrigin,
+      });
+
+    expect(JSON.stringify(after.headers)).toBe(JSON.stringify(before.headers));
+    expect(JSON.stringify(ssrfPolicy(after))).toBe(JSON.stringify(ssrfPolicy(before)));
   });
 
   it("does not convert implicit loopback model requests into broad private-network trust", () => {
@@ -643,7 +741,7 @@ describe("provider request config", () => {
     });
 
     expect(resolved.allowPrivateNetwork).toBe(false);
-    expect(resolved.privateNetworkExplicitlyDenied).toBe(false);
+    expect(resolved.trustConfiguredBaseUrlOrigin).toBe(true);
   });
 
   it("keeps explicit private-network denial for loopback model requests", () => {
@@ -657,7 +755,7 @@ describe("provider request config", () => {
     });
 
     expect(resolved.allowPrivateNetwork).toBe(false);
-    expect(resolved.privateNetworkExplicitlyDenied).toBe(true);
+    expect(resolved.trustConfiguredBaseUrlOrigin).toBe(false);
   });
 
   it("does not auto-allow non-loopback private model-provider hosts", () => {
@@ -670,7 +768,7 @@ describe("provider request config", () => {
     });
 
     expect(resolved.allowPrivateNetwork).toBe(false);
-    expect(resolved.privateNetworkExplicitlyDenied).toBe(false);
+    expect(resolved.trustConfiguredBaseUrlOrigin).toBe(true);
   });
 
   it.each([
@@ -704,7 +802,7 @@ describe("provider request config", () => {
       transport: "stream",
     });
 
-    expect(resolved.policy.endpointClass).toBe(entry.expectedEndpointClass);
-    expect(resolved.privateNetworkExplicitlyDenied).toBe(false);
+    expect(resolved.capabilities.endpointClass).toBe(entry.expectedEndpointClass);
+    expect(resolved.trustConfiguredBaseUrlOrigin).toBe(true);
   });
 });

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -18,8 +18,6 @@ import {
   type ProviderRequestCapability,
   type ProviderRequestTransport,
   resolveProviderRequestCapabilities,
-  resolveProviderRequestPolicy,
-  type ProviderRequestPolicyResolution,
 } from "./provider-attribution.js";
 
 type RequestApi = Api | ModelDefinitionConfig["api"];
@@ -134,7 +132,7 @@ type ResolvedProviderRequestExtraHeadersConfig = {
   headers?: Record<string, string>;
 };
 
-export type ResolvedProviderRequestConfig = {
+type ResolvedProviderRequestConfig = {
   api?: RequestApi;
   baseUrl?: string;
   headers?: Record<string, string>;
@@ -142,7 +140,6 @@ export type ResolvedProviderRequestConfig = {
   auth: ResolvedProviderRequestAuthConfig;
   proxy: ResolvedProviderRequestProxyConfig;
   tls: ResolvedProviderRequestTlsConfig;
-  policy: ProviderRequestPolicyResolution;
 };
 
 type ProviderRequestHeaderPrecedence = "caller-wins" | "defaults-win";
@@ -151,7 +148,7 @@ type ProviderRequestHeaderPrecedence = "caller-wins" | "defaults-win";
 // required before a provider request can be attached to a model call.
 type ResolvedProviderRequestPolicyConfig = ResolvedProviderRequestConfig & {
   allowPrivateNetwork: boolean;
-  privateNetworkExplicitlyDenied: boolean;
+  trustConfiguredBaseUrlOrigin: boolean;
   capabilities: ProviderRequestCapabilities;
 };
 
@@ -181,6 +178,7 @@ type ResolveProviderRequestPolicyConfigParams = {
   modelId?: string | null;
   allowPrivateNetwork?: boolean;
   request?: ModelProviderRequestTransportOverrides;
+  routeFacts?: ProviderRequestRouteFacts;
 };
 
 function resolvePrivateNetworkAccess(params: ResolveProviderRequestPolicyConfigParams): {
@@ -569,11 +567,15 @@ export function applyPreparedRuntimeAuthToModel<
     capability: "llm",
     transport: "stream",
   });
-  return {
+  const next = {
     ...model,
     ...(preparedAuth.baseUrl ? { baseUrl: preparedAuth.baseUrl } : {}),
     headers: requestConfig.headers,
   };
+  const routeFacts = getModelProviderRequestRouteFacts(model);
+  return routeFacts
+    ? attachModelProviderRequestRouteFacts(next, routeFacts.providerMetadataOwners)
+    : next;
 }
 
 function resolveProxyOverride(
@@ -694,13 +696,14 @@ export function resolveProviderRequestPolicyConfig(
       : {}),
     capability,
     transport,
-  } satisfies Parameters<typeof resolveProviderRequestPolicy>[0];
-  const policy = resolveProviderRequestPolicy(policyInput);
-  const capabilities = resolveProviderRequestCapabilities({
-    ...policyInput,
-    compat: params.compat,
-    modelId: params.modelId,
-  });
+  };
+  const capabilities =
+    params.routeFacts?.capabilities ??
+    resolveProviderRequestCapabilities({
+      ...policyInput,
+      compat: params.compat,
+      modelId: params.modelId,
+    });
   const auth = resolveAuthOverride({
     authHeader: params.authHeader,
     request: params.request,
@@ -715,7 +718,9 @@ export function resolveProviderRequestPolicyConfig(
     auth,
   );
   const protectedAttributionKeys = new Set(
-    Object.keys(policy.attributionHeaders ?? {}).map((key) => normalizeLowercaseStringOrEmpty(key)),
+    Object.keys(capabilities.attributionHeaders ?? {}).map((key) =>
+      normalizeLowercaseStringOrEmpty(key),
+    ),
   );
   const unprotectedCallerHeaders = params.callerHeaders
     ? Object.fromEntries(
@@ -724,7 +729,7 @@ export function resolveProviderRequestPolicyConfig(
         ),
       )
     : undefined;
-  const mergedDefaults = mergeProviderRequestHeaders(extraHeaders, policy.attributionHeaders);
+  const mergedDefaults = mergeProviderRequestHeaders(extraHeaders, capabilities.attributionHeaders);
   const headers =
     params.precedence === "caller-wins"
       ? mergeProviderRequestHeaders(mergedDefaults, unprotectedCallerHeaders)
@@ -742,10 +747,11 @@ export function resolveProviderRequestPolicyConfig(
     auth,
     proxy: resolveProxyOverride(params.request),
     tls: resolveTlsOverride(params.request?.tls),
-    policy,
     capabilities,
     allowPrivateNetwork: privateNetworkAccess.allowPrivateNetwork,
-    privateNetworkExplicitlyDenied: privateNetworkAccess.explicitlyDenied,
+    trustConfiguredBaseUrlOrigin:
+      !privateNetworkAccess.explicitlyDenied &&
+      (capabilities.endpointClass === "custom" || capabilities.endpointClass === "local"),
   };
 }
 
@@ -775,7 +781,6 @@ export function resolveProviderRequestConfig(params: {
     auth: resolved.auth,
     proxy: resolved.proxy,
     tls: resolved.tls,
-    policy: resolved.policy,
   };
 }
 
@@ -807,13 +812,28 @@ export function resolveProviderRequestHeaders(params: {
 const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
   "openclaw.modelProviderRequestTransport",
 );
-const MODEL_PROVIDER_METADATA_OWNERS_SYMBOL = Symbol.for("openclaw.modelProviderMetadataOwners");
+const MODEL_PROVIDER_REQUEST_ROUTE_FACTS_SYMBOL = Symbol.for(
+  "openclaw.modelProviderRequestRouteFacts",
+);
+
+type ProviderRequestRouteFacts = {
+  providerMetadataOwners: PluginMetadataSnapshotOwnerMaps;
+  capabilities: ProviderRequestCapabilities;
+  providerOwner?: string;
+};
+type ProviderRequestRouteModel = {
+  provider?: string;
+  api?: RequestApi;
+  baseUrl?: string;
+  id?: string;
+  compat?: unknown;
+};
 
 type ModelWithProviderRequestTransport = {
   [MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL]?: ModelProviderRequestTransportOverrides;
 };
-type ModelWithProviderMetadataOwners = {
-  [MODEL_PROVIDER_METADATA_OWNERS_SYMBOL]?: PluginMetadataSnapshotOwnerMaps;
+type ModelWithProviderRequestRouteFacts = {
+  [MODEL_PROVIDER_REQUEST_ROUTE_FACTS_SYMBOL]?: ProviderRequestRouteFacts;
 };
 
 /** Attaches model-scoped provider request transport metadata without mutating the model. */
@@ -836,31 +856,50 @@ export function getModelProviderRequestTransport(
   return (model as ModelWithProviderRequestTransport)[MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL];
 }
 
-/** Attaches the lifecycle-owned plugin metadata generation used for request policy. */
-export function attachModelProviderMetadataOwners<TModel extends object>(
+/** Resolves and attaches the final provider route against one lifecycle-owned metadata generation. */
+export function attachModelProviderRequestRouteFacts<TModel extends ProviderRequestRouteModel>(
   model: TModel,
-  owners: PluginMetadataSnapshotOwnerMaps | undefined,
+  providerMetadataOwners: PluginMetadataSnapshotOwnerMaps | undefined,
 ): TModel {
-  if (!owners) {
+  if (!providerMetadataOwners || !model.provider) {
     return model;
   }
-  const next = { ...model } as TModel & ModelWithProviderMetadataOwners;
-  next[MODEL_PROVIDER_METADATA_OWNERS_SYMBOL] = owners;
+  const next = { ...model } as TModel & ModelWithProviderRequestRouteFacts;
+  const capabilities = resolveProviderRequestCapabilities({
+    provider: model.provider,
+    api: model.api,
+    baseUrl: normalizeBaseUrl(model.baseUrl),
+    providerMetadataOwners,
+    capability: "llm",
+    transport: "stream",
+    modelId: model.id,
+    compat: model.compat,
+  });
+  next[MODEL_PROVIDER_REQUEST_ROUTE_FACTS_SYMBOL] = {
+    providerMetadataOwners,
+    capabilities,
+    ...(!["default", "invalid", "local", "custom"].includes(capabilities.endpointClass)
+      ? { providerOwner: capabilities.endpointClass }
+      : {}),
+  };
   return next;
 }
 
-/** Reads the plugin metadata generation attached to a prepared model. */
-export function getModelProviderMetadataOwners(
+/** Reads the prepared provider route attached to a transport model. */
+export function getModelProviderRequestRouteFacts(
   model: object,
-): PluginMetadataSnapshotOwnerMaps | undefined {
-  return (model as ModelWithProviderMetadataOwners)[MODEL_PROVIDER_METADATA_OWNERS_SYMBOL];
+): ProviderRequestRouteFacts | undefined {
+  return (model as ModelWithProviderRequestRouteFacts)[MODEL_PROVIDER_REQUEST_ROUTE_FACTS_SYMBOL];
 }
 
-/** Carries request-policy ownership across provider/transport model projections. */
-export function inheritModelProviderMetadataOwners<TModel extends object>(
+/** Re-resolves a projected transport model against the source model's metadata generation. */
+export function inheritModelProviderRequestRouteFacts<TModel extends ProviderRequestRouteModel>(
   source: object,
   target: TModel,
 ): TModel {
-  return attachModelProviderMetadataOwners(target, getModelProviderMetadataOwners(source));
+  return attachModelProviderRequestRouteFacts(
+    target,
+    getModelProviderRequestRouteFacts(source)?.providerMetadataOwners,
+  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -9,7 +9,7 @@ import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.
 
 type ProviderRequestPolicyConfigMockResult = {
   allowPrivateNetwork: boolean;
-  privateNetworkExplicitlyDenied?: boolean;
+  trustConfiguredBaseUrlOrigin?: boolean;
   policy?: {
     endpointClass?: string;
   };
@@ -94,7 +94,7 @@ vi.mock("./provider-local-service.js", () => ({
 
 vi.mock("./provider-request-config.js", () => ({
   buildProviderRequestDispatcherPolicy: buildProviderRequestDispatcherPolicyMock,
-  getModelProviderMetadataOwners: vi.fn(() => undefined),
+  getModelProviderRequestRouteFacts: vi.fn(() => undefined),
   getModelProviderRequestTransport: vi.fn(() => undefined),
   mergeModelProviderRequestOverrides: mergeModelProviderRequestOverridesMock,
   resolveProviderRequestPolicyConfig: resolveProviderRequestPolicyConfigMock,
@@ -797,6 +797,7 @@ describe("buildGuardedModelFetch", () => {
   it("trusts exact configured custom provider hosts without broad private-network opt-in", async () => {
     resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
       allowPrivateNetwork: false,
+      trustConfiguredBaseUrlOrigin: true,
       policy: { endpointClass: "custom" },
     });
     const model = makeProviderModelFixture<"openai-completions">({
@@ -820,6 +821,7 @@ describe("buildGuardedModelFetch", () => {
   it("trusts exact configured HTTPS custom provider origins", async () => {
     resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
       allowPrivateNetwork: false,
+      trustConfiguredBaseUrlOrigin: true,
       policy: { endpointClass: "custom" },
     });
     const model = makeProviderModelFixture<"openai-completions">({
@@ -841,7 +843,7 @@ describe("buildGuardedModelFetch", () => {
   it("keeps explicit private-network denial ahead of configured custom origin trust", async () => {
     resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
       allowPrivateNetwork: false,
-      privateNetworkExplicitlyDenied: true,
+      trustConfiguredBaseUrlOrigin: false,
       policy: { endpointClass: "custom" },
     });
     const model = makeProviderModelFixture<"openai-completions">({
@@ -861,6 +863,7 @@ describe("buildGuardedModelFetch", () => {
   it("trusts exact configured local provider origins", async () => {
     resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
       allowPrivateNetwork: false,
+      trustConfiguredBaseUrlOrigin: true,
       policy: { endpointClass: "local" },
     });
     const model = makeProviderModelFixture<"openai-completions">({
@@ -1015,6 +1018,7 @@ describe("buildGuardedModelFetch", () => {
   it("merges explicit private-network opt-in into the provider-host policies", async () => {
     resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
       allowPrivateNetwork: true,
+      trustConfiguredBaseUrlOrigin: true,
       policy: { endpointClass: "custom" },
     });
     const model = makeProviderModelFixture<"ollama">({

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -44,7 +44,7 @@ import {
 } from "./provider-local-service.js";
 import {
   buildProviderRequestDispatcherPolicy,
-  getModelProviderMetadataOwners,
+  getModelProviderRequestRouteFacts,
   getModelProviderRequestTransport,
   mergeModelProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
@@ -591,12 +591,12 @@ function resolveModelRequestPolicy(model: Model) {
         }
       : undefined,
   });
-  const providerMetadataOwners = getModelProviderMetadataOwners(model);
+  const routeFacts = getModelProviderRequestRouteFacts(model);
   return resolveProviderRequestPolicyConfig({
     provider: model.provider,
     api: model.api,
     baseUrl: model.baseUrl,
-    ...(providerMetadataOwners ? { providerMetadataOwners } : {}),
+    ...(routeFacts ? { routeFacts } : {}),
     capability: "llm",
     transport: "stream",
     request,
@@ -831,10 +831,7 @@ export function buildGuardedModelFetch(
       allowPrivateNetwork: requestConfig.allowPrivateNetwork,
       // Only operator-configured custom/local endpoints get exact-origin trust;
       // known public/native providers keep the default rebinding checks.
-      trustConfiguredBaseUrlOrigin:
-        !requestConfig.privateNetworkExplicitlyDenied &&
-        (requestConfig.policy?.endpointClass === "custom" ||
-          requestConfig.policy?.endpointClass === "local"),
+      trustConfiguredBaseUrlOrigin: requestConfig.trustConfiguredBaseUrlOrigin,
     });
     const requestInit =
       request &&

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -30,7 +30,10 @@ import {
   type OpenAITextVerbosity,
 } from "../../../agents/openai-text-verbosity.js";
 import { createOpenAIResponsesTransportStreamFn } from "../../../agents/openai-transport-stream.js";
-import { resolveProviderRequestPolicyConfig } from "../../../agents/provider-request-config.js";
+import {
+  getModelProviderRequestRouteFacts,
+  resolveProviderRequestPolicyConfig,
+} from "../../../agents/provider-request-config.js";
 import type { StreamFn } from "../../../agents/runtime/index.js";
 import type { SandboxToolPolicy } from "../../../agents/sandbox.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
@@ -88,6 +91,7 @@ function resolveOpenAIRequestCapabilities(model: {
     compat,
     capability: "llm",
     transport: "stream",
+    routeFacts: getModelProviderRequestRouteFacts(model),
   }).capabilities;
 }
 
@@ -818,6 +822,7 @@ export function createOpenAIAttributionHeadersWrapper(
         baseUrl: readStringValue(model.baseUrl),
         capability: "llm",
         transport: "stream",
+        routeFacts: getModelProviderRequestRouteFacts(model),
         callerHeaders: options?.headers,
         precedence: "defaults-win",
       }).headers,

--- a/src/llm/providers/stream-wrappers/proxy.ts
+++ b/src/llm/providers/stream-wrappers/proxy.ts
@@ -5,7 +5,10 @@ import {
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveProviderRequestPolicy } from "../../../agents/provider-attribution.js";
-import { resolveProviderRequestPolicyConfig } from "../../../agents/provider-request-config.js";
+import {
+  getModelProviderRequestRouteFacts,
+  resolveProviderRequestPolicyConfig,
+} from "../../../agents/provider-request-config.js";
 import type { StreamFn } from "../../../agents/runtime/index.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import { normalizeOpenAICompatibleReasoningPayload } from "../../../plugin-sdk/provider-stream-shared.js";
@@ -28,6 +31,19 @@ const BOOLEAN_PARAM_PARSE_OPTIONS = {
 function resolveKilocodeAppHeaders(): Record<string, string> {
   const feature = process.env[KILOCODE_FEATURE_ENV_VAR]?.trim() || KILOCODE_FEATURE_DEFAULT;
   return { [KILOCODE_FEATURE_HEADER]: feature };
+}
+
+function resolveModelEndpointClass(model: Parameters<StreamFn>[0]) {
+  return (
+    getModelProviderRequestRouteFacts(model)?.capabilities.endpointClass ??
+    resolveProviderRequestPolicy({
+      provider: readStringValue(model.provider),
+      api: readStringValue(model.api),
+      baseUrl: readStringValue(model.baseUrl),
+      capability: "llm",
+      transport: "stream",
+    }).endpointClass
+  );
 }
 
 function readExtraParam(
@@ -60,13 +76,7 @@ function resolveOpenRouterResponseCacheTtlSeconds(value: unknown): string | unde
 
 function shouldApplyOpenRouterResponseCacheHeaders(model: Parameters<StreamFn>[0]): boolean {
   const provider = readStringValue(model.provider);
-  const endpointClass = resolveProviderRequestPolicy({
-    provider,
-    api: readStringValue(model.api),
-    baseUrl: readStringValue(model.baseUrl),
-    capability: "llm",
-    transport: "stream",
-  }).endpointClass;
+  const endpointClass = resolveModelEndpointClass(model);
   return (
     endpointClass === "openrouter" ||
     (endpointClass === "default" && normalizeOptionalLowercaseString(provider) === "openrouter")
@@ -128,13 +138,7 @@ export function createOpenRouterSystemCacheWrapper(
     const modelId = readStringValue(model.id);
     // Keep OpenRouter-specific cache markers on verified OpenRouter routes
     // (or the provider's default route), but not on arbitrary OpenAI proxies.
-    const endpointClass = resolveProviderRequestPolicy({
-      provider,
-      api: readStringValue(model.api),
-      baseUrl: readStringValue(model.baseUrl),
-      capability: "llm",
-      transport: "stream",
-    }).endpointClass;
+    const endpointClass = resolveModelEndpointClass(model);
     if (
       !modelId ||
       !isAnthropicModelRef(modelId) ||
@@ -192,6 +196,7 @@ export function createOpenRouterWrapper(
       baseUrl: readStringValue(model.baseUrl),
       capability: "llm",
       transport: "stream",
+      routeFacts: getModelProviderRequestRouteFacts(model),
       callerHeaders: options?.headers,
       providerHeaders,
       precedence: "caller-wins",
@@ -231,6 +236,7 @@ export function createKilocodeWrapper(
       baseUrl: readStringValue(model.baseUrl),
       capability: "llm",
       transport: "stream",
+      routeFacts: getModelProviderRequestRouteFacts(model),
       callerHeaders: options?.headers,
       providerHeaders: resolveKilocodeAppHeaders(),
       precedence: "defaults-win",

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -8,6 +8,7 @@ import { isMinimaxVlmModel, minimaxUnderstandImage } from "../agents/minimax-vlm
 import { requireApiKey, resolveApiKeyForProviderCore } from "../agents/model-auth.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
 import {
+  getModelProviderRequestRouteFacts,
   getModelProviderRequestTransport,
   type ModelProviderRequestTransportOverrides,
 } from "../agents/provider-request-config.js";
@@ -56,6 +57,7 @@ function isNativeResponsesReasoningPayload(model: Model): boolean {
     baseUrl: model.baseUrl,
     capability: "image",
     transport: "media-understanding",
+    providerMetadataOwners: getModelProviderRequestRouteFacts(model)?.providerMetadataOwners,
   }).usesKnownNativeOpenAIRoute;
 }
 
@@ -162,6 +164,7 @@ function shouldPlaceImagePromptInUserContent(model: Model): boolean {
     baseUrl: model.baseUrl,
     capability: "image",
     transport: "media-understanding",
+    providerMetadataOwners: getModelProviderRequestRouteFacts(model)?.providerMetadataOwners,
   });
   return (
     capabilities.endpointClass === "openrouter" ||

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -20,7 +20,6 @@ import {
   buildProviderRequestDispatcherPolicy,
   resolveProviderRequestPolicyConfig,
   type ModelProviderRequestTransportOverrides,
-  type ResolvedProviderRequestConfig,
 } from "../agents/provider-request-config.js";
 import type { GuardedFetchMode, GuardedFetchResult } from "../infra/net/fetch-guard.js";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
@@ -386,7 +385,6 @@ type ResolvedProviderHttpRequestConfig = {
   allowPrivateNetwork: boolean;
   headers: Headers;
   dispatcherPolicy?: PinnedDispatcherPolicy;
-  requestConfig: ResolvedProviderRequestConfig;
 };
 
 type ResolvedProviderHttpRequestConfigWithOriginTrust = ResolvedProviderHttpRequestConfig & {
@@ -430,11 +428,7 @@ function resolveProviderHttpRequestConfigWithOriginTrustInternal(params: {
     allowPrivateNetwork: requestConfig.allowPrivateNetwork,
     headers,
     dispatcherPolicy: buildProviderRequestDispatcherPolicy(requestConfig),
-    requestConfig,
-    trustConfiguredBaseUrlOrigin:
-      !requestConfig.privateNetworkExplicitlyDenied &&
-      (requestConfig.policy.endpointClass === "custom" ||
-        requestConfig.policy.endpointClass === "local"),
+    trustConfiguredBaseUrlOrigin: requestConfig.trustConfiguredBaseUrlOrigin,
   };
 }
 
@@ -447,7 +441,6 @@ export function resolveProviderHttpRequestConfig(
     allowPrivateNetwork: resolved.allowPrivateNetwork,
     headers: resolved.headers,
     dispatcherPolicy: resolved.dispatcherPolicy,
-    requestConfig: resolved.requestConfig,
   };
 }
 

--- a/src/plugins/provider-model-compat.prepared.test.ts
+++ b/src/plugins/provider-model-compat.prepared.test.ts
@@ -58,9 +58,13 @@ describe("normalizeModelCompat prepared metadata", () => {
   it("uses the exact owner generation supplied by its registry", () => {
     const firstOwners = makeOwners("first");
     const secondOwners = makeOwners("second");
+    const firstModel = attachModelProviderRequestRouteFacts(model, firstOwners);
+    const secondModel = attachModelProviderRequestRouteFacts(model, secondOwners);
 
-    normalizeModelCompat(attachModelProviderRequestRouteFacts(model, firstOwners));
-    normalizeModelCompat(attachModelProviderRequestRouteFacts(model, secondOwners));
+    resolveProviderRequestCapabilities.mockClear();
+
+    normalizeModelCompat(firstModel);
+    normalizeModelCompat(secondModel);
 
     expect(resolveProviderRequestCapabilities).toHaveBeenNthCalledWith(
       1,

--- a/src/plugins/provider-model-compat.prepared.test.ts
+++ b/src/plugins/provider-model-compat.prepared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { attachModelProviderMetadataOwners } from "../agents/provider-request-config.js";
+import { attachModelProviderRequestRouteFacts } from "../agents/provider-request-config.js";
 import type { Model } from "../llm/types.js";
 import type { PluginMetadataSnapshotOwnerMaps } from "./plugin-metadata-snapshot.types.js";
 
@@ -59,8 +59,8 @@ describe("normalizeModelCompat prepared metadata", () => {
     const firstOwners = makeOwners("first");
     const secondOwners = makeOwners("second");
 
-    normalizeModelCompat(attachModelProviderMetadataOwners(model, firstOwners));
-    normalizeModelCompat(attachModelProviderMetadataOwners(model, secondOwners));
+    normalizeModelCompat(attachModelProviderRequestRouteFacts(model, firstOwners));
+    normalizeModelCompat(attachModelProviderRequestRouteFacts(model, secondOwners));
 
     expect(resolveProviderRequestCapabilities).toHaveBeenNthCalledWith(
       1,

--- a/src/plugins/provider-model-compat.ts
+++ b/src/plugins/provider-model-compat.ts
@@ -2,7 +2,7 @@
 import { resolveUnsupportedToolSchemaKeywords } from "@openclaw/ai/internal/openai";
 import { resolveOpenAICompletionsCompat } from "@openclaw/ai/transports";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
-import { getModelProviderMetadataOwners } from "../agents/provider-request-config.js";
+import { getModelProviderRequestRouteFacts } from "../agents/provider-request-config.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
 import "../llm/ai-transport-host.js";
 import type { Model } from "../llm/types.js";
@@ -91,7 +91,7 @@ export function normalizeModelCompat(
     return model;
   }
   const resolvedProviderMetadataOwners =
-    providerMetadataOwners ?? getModelProviderMetadataOwners(model);
+    providerMetadataOwners ?? getModelProviderRequestRouteFacts(model)?.providerMetadataOwners;
   const resolved = resolveOpenAICompletionsCompat(model, (input) =>
     resolveProviderRequestCapabilities({
       ...input,


### PR DESCRIPTION
## What Problem This Solves

Provider routing was resolved independently at several outbound-request consumers. Headers could classify a model from current raw route inputs while guarded fetch used the plugin-metadata generation captured during model preparation, leaving attribution and SSRF posture able to diverge when registry generations or projected model routes differed.

## Why This Change Was Made

The model-route build now prepares one route fact containing the captured metadata owners, endpoint class, provider family/owner, attribution eligibility, and capabilities. Model projections and auth overlays re-resolve that fact against the same captured generation, while headers, payload policy, guarded fetch, and runtime ownership consume it.

Resolution graph before:

```text
headers ── raw route ── resolve policy ── endpoint
capabilities ───────── resolve policy ── endpoint (duplicate)
SSRF ── prepared owners ── resolve policy ── endpoint
```

Resolution graph after:

```text
model-route build
  └─ prepared route fact
       {owners, endpoint class, family, provider owner,
        attribution eligibility, capabilities}
          ├─ headers/payload
          ├─ SSRF
          └─ runtime owner

Projections/auth overlays re-resolve once against the same captured owners.
```

net +71 production is APPROVED under the Repair Doctrine security-invariant exception — headers and SSRF policy now derive from one prepared route fact, making divergent resolution unrepresentable

Production LOC: +224/-153 (net +71). Tests and test support: +234/-36 (net +198). The test total includes the post-rebase correction that isolates normalization assertions from the intentional capability-resolution work performed while preparing the fact, plus removal of the retired Fal provider-HTTP mock field.

No protocol, config, storage, or public plugin API contract changes.

### Remaining resolver call sites

Every remaining production invocation of `resolveProviderRequestPolicy*` is listed below. Prepared model paths pass or read the route fact first; the fallback remains only where a model fact cannot yet be guaranteed.

| Call site | Fallback class | Why resolution remains here |
| --- | --- | --- |
| `packages/ai/src/transports/openai-transport-params.ts:361` | unprepared wrapper | The package transport accepts direct package models; the model-aware host consumes a prepared fact when present and resolves only for unprepared callers. |
| `src/agents/ai-transport-runtime-host.ts:82` | unprepared wrapper | This is the package/core host bridge. It passes the model fact into header resolution and retains raw-input resolution for models not built by the prepared route pipeline. |
| `src/agents/embedded-agent-runner/extra-params.ts:714` | unprepared wrapper | Store compatibility reads prepared capabilities first; externally supplied runtime models without a fact still need a bounded compatibility decision. |
| `src/agents/provider-transport-fetch.ts:595` | unprepared wrapper | Guarded model fetch consumes the prepared fact; the fallback preserves direct model-fetch callers that did not pass through model-route preparation. |
| `src/llm/providers/stream-wrappers/openai.ts:87` | unprepared wrapper | Capability shaping prefers the fact attached to the wrapper model and resolves only for direct wrapper models. |
| `src/llm/providers/stream-wrappers/openai.ts:819` | unprepared wrapper | Attribution header wrapping passes the prepared fact and retains the same direct-wrapper fallback. |
| `src/llm/providers/stream-wrappers/proxy.ts:39` | unprepared wrapper | Endpoint classification explicitly short-circuits to prepared capabilities; the raw policy call is only the fallback for direct proxy-wrapper models. |
| `src/llm/providers/stream-wrappers/proxy.ts:193` | unprepared wrapper | OpenRouter headers pass the prepared fact; direct wrapper construction can still lack one. |
| `src/llm/providers/stream-wrappers/proxy.ts:233` | unprepared wrapper | Kilocode headers pass the prepared fact; direct wrapper construction can still lack one. |
| `src/agents/provider-request-config.ts:772` | catalog | Catalog/config assembly happens before the final transport model exists, so it resolves raw setup inputs and intentionally excludes attribution headers. |
| `src/agents/provider-request-config.ts:799` | unprepared wrapper | The generic model-less header helper is retained for direct callers that have no model object on which to carry a fact. |
| `src/media-understanding/shared.ts:406` | media | Generic media HTTP helpers can be called with provider/API/base URL fields but no prepared model; model-aware image capability paths separately reuse prepared owners. |
| `src/agents/provider-attribution.ts:590` | catalog | This is the canonical raw capability resolver used to construct prepared facts and by pre-model catalog/config paths; it cannot consume the fact it is producing. |
| `src/agents/provider-attribution.ts:729` | diagnostic | The route-summary formatter is a URL/input diagnostic utility with no model object or outbound request authority. |

### Codex transport contract

Verified against Codex commit `92cbfb4d`: `../codex/codex-rs/login/src/auth/default_client.rs:217` documents that the default client sets `originator` and `User-Agent`, and `:330` inserts those headers. The prepared route fact preserves that native-route attribution contract while keeping native endpoints under the existing SSRF rebinding policy.

## User Impact

There is no new user-facing option. Operators get one consistent provider-route decision for attribution headers, payload compatibility, private-network trust, and provider runtime ownership, including plugin-owned endpoints and projected transport models.

## Evidence

The differential snapshots legacy header and SSRF outputs for OpenAI core, Anthropic core, a plugin-owned provider, and the manifest fallback, then feeds the corresponding prepared fact through the new path and requires byte-identical headers plus identical guarded-fetch policy.

- Exact provider/transport differential: the same 13-file selection recorded as 462/462 before rebase now passes 557/557 tests across five Vitest shards on current `main`.
- Focused changed-test suites: 266/266 tests passed across six touched test files and five Vitest shards.
- Fal provider suite: 18/18 tests passed with the retired mock field removed.
- `node scripts/check-changed.mjs`: passed all selected formatting, typecheck, lint, dead-export, plugin-boundary, import-cycle, database-first, and safety guards in 518 seconds.
- Final branch Codex autoreview: clean; no accepted/actionable findings. TruffleHog clean.
- `git diff --check`: passed.

An exploratory broad `test:changed` run selected effectively the full unit graph and exposed unrelated current-main failures in `src/claws/project.test.ts` plus a rollback-race assertion in `src/state/openclaw-state-ownership.test.ts`; neither imports nor exercises this provider-route patch. The exact requested differential and touched owner/sibling suites above are green, and exact-head CI remains the merge gate.

AI-assisted: yes (Codex).
