### PR TITLE
fix(ci): heal red main dialog-reopen isolation and startup baseline

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 343289,
-  "reason": "Typed update recovery state, failure projection, and sidebar review routing",
+  "startupJsGzipBytes": 344395,
+  "reason": "Absorb accumulated startup creep from landed PRs to current main CI bytes (main red at 344395 B vs 343289 B baseline; run 32131816085)",
   "updatedAt": "2026-08-18"
 }

--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -176,7 +176,10 @@ describe("Markdown table interactions", () => {
     expect(document.querySelector(".markdown-table-dialog")).toBeNull();
     expect(document.activeElement).toBe(expand);
 
-    expand.click();
+    // Reopen through the handler like every other interaction here: the file
+    // runs in the isolated lane, so no shared-graph document listener exists
+    // to service a raw click().
+    handleMarkdownTableInteraction(markdownTableInteractionEvent(expand));
     const reopenedDialog = document.querySelector<HTMLDialogElement>(".markdown-table-dialog")!;
 
     reopenedDialog.querySelector<HTMLButtonElement>(".markdown-table-dialog__close")!.click();


### PR DESCRIPTION
## What Problem This Solves

Main is red (run 32131816085: `checks-ui`, `checks-node-compact-large-5`, `build-artifacts`) from two independent landed-PR races:

1. #125692 rewrote the markdown-tables dialog test to drive every interaction through direct `handleMarkdownTableInteraction(...)` calls — except the reopen step, which used a raw `expand.click()`. That click was only ever serviced by a leaked cross-file document listener in the shared `isolate: false` lane. #125766 (landed in the same window) moved the file to the canonical isolated lane, where no such listener exists, so the reopen deterministically finds no dialog. Neither PR saw the combination in its own CI.
2. Accumulated startup-JS creep from recently landed features put main 50 B over its gzip budget (344395 B measured vs 343289 B baseline + 1056 B tolerance) — failing `build-artifacts` on main itself.

## Why This Change Was Made

- The reopen step now uses the file's own handler idiom, matching every other interaction in the test; the protected behavior (reopen after light-dismiss, focus restore) is unchanged.
- The startup baseline is updated to main's CI-measured bytes via the script's `--update-baseline --startup-js-bytes` contract, with the reason recorded in the baseline file.

## User Impact

None at runtime. Restores green main.

## Evidence

- Pre-fix: `vitest --project unit-mock-registry src/components/markdown-tables.test.ts` fails on pure origin/main at the reopen assertion; post-fix: 4/4 green.
- Budget numbers from main run 32131816085's build-artifacts log; baseline update via the script's own mechanism.
