### PR TITLE
fix(claws): keep project artifacts deterministic

### DIFF
--- a/src/claws/project-build.ts
+++ b/src/claws/project-build.ts
@@ -12,7 +12,6 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { constants as zlibConstants } from "node:zlib";
 import * as tar from "tar";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import {
@@ -25,6 +24,9 @@ import { isSafeClawRelativePath } from "./schema-portability.js";
 import { MAX_MANAGED_FILE_BYTES } from "./source-limits.js";
 
 export const CLAW_BUILD_RESULT_SCHEMA_VERSION = "openclaw.clawBuild.v1" as const;
+
+// zlib's public numeric API defines Z_FILTERED as strategy 1.
+const ZLIB_FILTERED_STRATEGY = 1;
 
 type ClawBuildResult = {
   schemaVersion: typeof CLAW_BUILD_RESULT_SCHEMA_VERSION;
@@ -186,7 +188,7 @@ export async function buildClawProject(
         cwd: stagingRoot,
         file: temporaryArtifact,
         // Stabilize supported zlib output without disabling normal match compression.
-        gzip: { level: 9, portable: true, strategy: zlibConstants.Z_FILTERED },
+        gzip: { level: 9, portable: true, strategy: ZLIB_FILTERED_STRATEGY },
         mtime: new Date(0),
         portable: true,
         prefix: "package",

--- a/src/claws/project-build.ts
+++ b/src/claws/project-build.ts
@@ -185,8 +185,8 @@ export async function buildClawProject(
       {
         cwd: stagingRoot,
         file: temporaryArtifact,
-        // Disable version-dependent string matching so supported zlib builds emit identical bytes.
-        gzip: { level: 9, portable: true, strategy: zlibConstants.Z_HUFFMAN_ONLY },
+        // Stabilize supported zlib output without disabling normal match compression.
+        gzip: { level: 9, portable: true, strategy: zlibConstants.Z_FILTERED },
         mtime: new Date(0),
         portable: true,
         prefix: "package",

--- a/src/claws/project-build.ts
+++ b/src/claws/project-build.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { constants as zlibConstants } from "node:zlib";
 import * as tar from "tar";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import {
@@ -184,7 +185,8 @@ export async function buildClawProject(
       {
         cwd: stagingRoot,
         file: temporaryArtifact,
-        gzip: { level: 9, portable: true },
+        // Disable version-dependent string matching so supported zlib builds emit identical bytes.
+        gzip: { level: 9, portable: true, strategy: zlibConstants.Z_HUFFMAN_ONLY },
         mtime: new Date(0),
         portable: true,
         prefix: "package",

--- a/src/claws/project.test.ts
+++ b/src/claws/project.test.ts
@@ -8,6 +8,8 @@ import { buildClawProject } from "./project-build.js";
 import { ClawProjectError, createClawProject, validateClawProject } from "./project.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const GOLDEN_ARTIFACT_INTEGRITY =
+  "sha256:5fba54933e519f4fc12422a3d555d076ce373be993eed3f6b3575a89aaa62618";
 
 async function writeRichProject(root: string): Promise<void> {
   await mkdir(join(root, "workspace"), { recursive: true });
@@ -50,9 +52,7 @@ describe("Claw projects", () => {
       output,
     );
 
-    expect(result.integrity).toBe(
-      "sha256:f7377ae66679a8d1088ac2d259b8567d19f584dbc4357949d3d4e0cc09d05874",
-    );
+    expect(result.integrity).toBe(GOLDEN_ARTIFACT_INTEGRITY);
   });
 
   it("matches the golden artifact digest under a restrictive umask", () => {
@@ -85,9 +85,7 @@ describe("Claw projects", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toBe(
-      "sha256:f7377ae66679a8d1088ac2d259b8567d19f584dbc4357949d3d4e0cc09d05874",
-    );
+    expect(result.stdout).toBe(GOLDEN_ARTIFACT_INTEGRITY);
   });
 
   it("creates a minimal project that validates through the canonical reader", async () => {
@@ -434,11 +432,11 @@ describe("Claw projects", () => {
       const project = tempDirs.make("openclaw-claw-manifest-case-collision-");
       await writeRichProject(project);
       const manifest = await readFile(join(project, "CLAW.md"), "utf8");
+      await writeFile(join(project, "claw.md"), "# Conflicting source\n");
       await writeFile(
         join(project, "CLAW.md"),
         manifest.replace("workspace/reference.md", "claw.md"),
       );
-      await writeFile(join(project, "claw.md"), "# Conflicting source\n");
 
       await expect(validateClawProject(project)).resolves.toMatchObject({
         ok: false,

--- a/src/claws/project.test.ts
+++ b/src/claws/project.test.ts
@@ -9,7 +9,7 @@ import { ClawProjectError, createClawProject, validateClawProject } from "./proj
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const GOLDEN_ARTIFACT_INTEGRITY =
-  "sha256:5fba54933e519f4fc12422a3d555d076ce373be993eed3f6b3575a89aaa62618";
+  "sha256:10b8890c5e5b062c94ff79b1d424859c6a5572548535eec6e31ee0c6d7c08a3b";
 
 async function writeRichProject(root: string): Promise<void> {
   await mkdir(join(root, "workspace"), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves
Current main's Claw project suite was red on supported runtimes. Node 22/zlib 1.3 and Node 24/26/zlib 1.2.12 emitted different gzip bytes for the same canonical tar, breaking cross-platform artifact integrity. Separately, the portable case-collision regression wrote lowercase `claw.md` after `CLAW.md`; on case-insensitive filesystems it overwrote the manifest and tested parse failure instead of collision policy.

## Why This Change Was Made
Use zlib's documented `Z_FILTERED` strategy for Claw artifact gzip. It emits identical bytes across the supported Node/zlib versions tested while retaining normal LZ match compression: the canonical fixture is 511 bytes (default 504; rejected Huffman-only 1,354). Reorder the test fixture so the canonical manifest remains intact and the existing portable selected-path collision owner returns `project_path_collision` on both case-sensitive and case-insensitive filesystems.

## User Impact
Claw project builds regain stable cross-runtime/umask integrity without artifact bloat, and project validation consistently rejects paths that portably collide with `CLAW.md`.

## Evidence
- Latest-main pre-fix: 3 failed, 24 passed, 1 skipped in isolation.
- Post-fix project suite: 27 passed, 1 skipped; sibling Claw CLI: 39 passed.
- Actual builder output: 511 bytes, byte-identical SHA-256 10b889... on Node 22.13/zlib1.3, Node24.19, Node26.7; normal/restrictive umasks identical.
- Core tsgo, test types, oxfmt, oxlint, diff check clean.
- Startup-budget follow-up removes the static `node:zlib` import while preserving `Z_FILTERED = 1`; project 27 passed/1 skipped, sibling Claw CLI 39 passed, `build:ci-artifacts` and `check:changed` clean.
- Combined branch net zero LOC; final autoreview clean 0.99.
