### PR TITLE
feat: add A2UI widgets to session boards

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -359,6 +359,7 @@ public struct BoardWidget: Codable, Sendable {
     public let sandboxurl: String?
     public let sandboxport: Int?
     public let sandboxorigin: String?
+    public let kindlabel: String?
 
     public init(
         name: String,
@@ -383,7 +384,8 @@ public struct BoardWidget: Codable, Sendable {
         viewgeneration: String? = nil,
         sandboxurl: String? = nil,
         sandboxport: Int? = nil,
-        sandboxorigin: String? = nil)
+        sandboxorigin: String? = nil,
+        kindlabel: String? = nil)
     {
         self.name = name
         self.tabid = tabid
@@ -408,6 +410,7 @@ public struct BoardWidget: Codable, Sendable {
         self.sandboxurl = sandboxurl
         self.sandboxport = sandboxport
         self.sandboxorigin = sandboxorigin
+        self.kindlabel = kindlabel
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -434,6 +437,7 @@ public struct BoardWidget: Codable, Sendable {
         case sandboxurl = "sandboxUrl"
         case sandboxport = "sandboxPort"
         case sandboxorigin = "sandboxOrigin"
+        case kindlabel = "kindLabel"
     }
 }
 
@@ -750,6 +754,28 @@ public struct BoardWidgetPluginContent: Codable, Sendable {
         case kind
         case pluginkind = "pluginKind"
         case props
+    }
+}
+
+public struct BoardWidgetRegisteredContent: Codable, Sendable {
+    public let kind: String
+    public let contentkind: String
+    public let source: String
+
+    public init(
+        kind: String,
+        contentkind: String,
+        source: String)
+    {
+        self.kind = kind
+        self.contentkind = contentkind
+        self.source = source
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case contentkind = "contentKind"
+        case source
     }
 }
 
@@ -20681,6 +20707,7 @@ public enum BoardWidgetContent: Codable, Sendable {
     case html(BoardWidgetHtmlContent)
     case mcpApp(BoardWidgetMcpAppContent)
     case plugin(BoardWidgetPluginContent)
+    case registered(BoardWidgetRegisteredContent)
 
     private enum CodingKeys: String, CodingKey {
         case discriminator = "kind"
@@ -20693,6 +20720,7 @@ public enum BoardWidgetContent: Codable, Sendable {
         case "html": self = try .html(BoardWidgetHtmlContent(from: decoder))
         case "mcp-app": self = try .mcpApp(BoardWidgetMcpAppContent(from: decoder))
         case "plugin": self = try .plugin(BoardWidgetPluginContent(from: decoder))
+        case "registered": self = try .registered(BoardWidgetRegisteredContent(from: decoder))
         default:
             throw DecodingError.dataCorruptedError(
                 forKey: .discriminator,
@@ -20707,6 +20735,7 @@ public enum BoardWidgetContent: Codable, Sendable {
         case .html(let value): try value.encode(to: encoder)
         case .mcpApp(let value): try value.encode(to: encoder)
         case .plugin(let value): try value.encode(to: encoder)
+        case .registered(let value): try value.encode(to: encoder)
         }
     }
 }
@@ -20715,6 +20744,7 @@ public enum BoardWidgetPutContent: Codable, Sendable {
     case html(BoardWidgetHtmlContent)
     case mcpApp(BoardWidgetMcpAppPutContent)
     case plugin(BoardWidgetPluginContent)
+    case registered(BoardWidgetRegisteredContent)
     case canvasDoc(BoardCanvasDocumentSource)
 
     private enum CodingKeys: String, CodingKey {
@@ -20728,6 +20758,7 @@ public enum BoardWidgetPutContent: Codable, Sendable {
         case "html": self = try .html(BoardWidgetHtmlContent(from: decoder))
         case "mcp-app": self = try .mcpApp(BoardWidgetMcpAppPutContent(from: decoder))
         case "plugin": self = try .plugin(BoardWidgetPluginContent(from: decoder))
+        case "registered": self = try .registered(BoardWidgetRegisteredContent(from: decoder))
         case "canvas-doc": self = try .canvasDoc(BoardCanvasDocumentSource(from: decoder))
         default:
             throw DecodingError.dataCorruptedError(
@@ -20743,6 +20774,7 @@ public enum BoardWidgetPutContent: Codable, Sendable {
         case .html(let value): try value.encode(to: encoder)
         case .mcpApp(let value): try value.encode(to: encoder)
         case .plugin(let value): try value.encode(to: encoder)
+        case .registered(let value): try value.encode(to: encoder)
         case .canvasDoc(let value): try value.encode(to: encoder)
         }
     }

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2292,8 +2292,8 @@ src/auto-reply/tokens.ts	1
 src/auto-reply/usage-bar/template.ts	1
 src/auto-reply/usage-bar/translator.ts	4
 src/boards/board-store.ts	1
-src/boards/sqlite-board-codec.ts	9
-src/boards/sqlite-board-store.ts	5
+src/boards/sqlite-board-codec.ts	7
+src/boards/sqlite-board-store.ts	3
 src/bootstrap/node-extra-ca-certs.ts	2
 src/bootstrap/node-startup-env.ts	1
 src/canvas/documents.ts	2

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -708,6 +708,7 @@ const config = {
       // Rolldown consumes this config and its browser bootstrap entry.
       "src/host/a2ui-app/rolldown.config.mjs!",
       "src/host/a2ui-app/bootstrap.js!",
+      "src/host/a2ui-app/bootstrap-v0.9.js!",
     ]),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/cloudflare-ai-gateway`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/chutes`]: bundledPluginWorkspace(),

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -388,6 +388,17 @@ plugins.
 | `api.session.workflow.sendSessionAttachment(...)`                                    | Bundled-only host-mediated file attachment delivery to the active direct-outbound session route                                                            |
 | `api.session.workflow.scheduleSessionTurn(...)` / `unscheduleSessionTurnsByTag(...)` | Bundled-only Cron-backed scheduled session turns plus tag-based cleanup                                                                                    |
 | `api.session.controls.registerSessionAction(...)`                                    | Typed session actions clients can dispatch through the Gateway                                                                                             |
+| `api.registerBoardWidgetContentKind(...)`                                            | Sandboxed board widget source validation, renderer resources, and document composition                                                                     |
+
+`registerBoardWidgetContentKind(...)` is for plugins that own a declarative
+widget source format. The registration supplies a globally unique lowercase
+`kind`, a short label, one capability-scoped plugin surface plus its renderer
+resource paths, a synchronous `validateSource(source)` callback, and a
+synchronous `composeDocument(...)` callback. Core adds the document shell,
+sandbox, theme, and ticket-bound action bridge. Registrations exist only while
+their plugin is active; invalid, reserved, or duplicate kinds fail plugin load.
+Use `dashboard.dataBindings` and `dashboard.actionVerbs` for host capabilities,
+not for renderer registration.
 
 A `surface: "tab"` descriptor adds a sidebar tab to the Control UI. Active
 plugins' tab descriptors are advertised to dashboard clients in the gateway

--- a/docs/refactor/canvas.md
+++ b/docs/refactor/canvas.md
@@ -43,6 +43,9 @@ Done:
 - Moved Canvas host URL and scoped capability helpers into `extensions/canvas/src`.
 - Moved Canvas node command defaults out of hardcoded core lists and into plugin `nodeInvokePolicies`.
 - Added plugin-owned Canvas host config at `plugins.entries.canvas.config.host`.
+- Registered A2UI as a sandboxed board widget source kind through the generic
+  Plugin SDK content-kind seam. The capability-scoped A2UI asset route remains
+  available when the optional Canvas file host is disabled.
 - Moved Canvas and A2UI HTTP serving behind Canvas plugin HTTP route registration.
 - Added generic plugin WebSocket upgrade dispatch for plugin-owned HTTP routes.
 - Replaced Canvas-specific gateway host URL and node capability auth with generic hosted plugin surface and node capability helpers.

--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -121,11 +121,29 @@ content kind:
 - `html` — agent-authored via `show_widget`, bytes in board storage.
 - `mcp-app` — a third-party MCP app view (`ui://` resource from a configured
   server) hosted inside the widget cell.
+- Registered plugin kinds — plugin-validated source rendered through the same
+  sandboxed document frame. The Canvas plugin registers `a2ui`; core discovers
+  the active registry and never hardcodes plugin kind names.
 
 MCP apps do not define the widget model; widgets gained the ability to host
 them. Identity, placement, pinning, grants, and the author-facing API stay
 OpenClaw's — so `show_widget` code stays as short as it is today and never
 needs to know the MCP Apps spec exists.
+
+Registered kinds use a small runtime Plugin SDK seam. A registration owns the
+agent-facing kind name, source validation, capability-scoped renderer
+resources, and document-body composition. The Gateway validates source again
+at `board.widget.put`, stores it in the existing generic `plugin` descriptor
+envelope, and composes the framed document only after a ticketed board read.
+This keeps stored source out of board snapshots and avoids a database CHECK or
+schema-version change. Disabled plugins are absent from the registry, so new
+puts fail with an enable-and-retry error and existing cells render as disabled.
+
+The A2UI implementation composes a small document that references the renderer
+bundle on the capability-scoped Gateway asset route. Core then adds the same
+CSP, theme bridge, size reporter, and private-port host bridge used by HTML
+widgets. v0.8 and v0.9 use separate renderer bundles because their Lit custom
+elements share tag names but their processors and action contracts differ.
 
 Shared infrastructure underneath (this is where the simplification lands):
 
@@ -320,8 +338,9 @@ Widget bytes are served over the authenticated HTTP surface, not the socket.
 Three tools total (core, always registered; rendering gated on the
 `inline-widgets` client cap as today):
 
-- `show_widget { title, widget_code, name?, pin?, size?, tab?, after?,
-capabilities? }` — create/update by name; `pin` places it on the board.
+- `show_widget { title, widget_code, kind?, name?, pin?, size?, tab?, after?,
+capabilities? }` — create/update by name; `kind` defaults to `html` and its enum
+  includes active registered kinds; `pin` places it on the board.
   Without `name`/`pin` it behaves exactly like today (inline, ephemeral).
 - `dashboard { action, ... }` — board management verbs: `read`, `tab_create`,
   `tab_update`, `tab_delete`, `tabs_reorder`, `widget_move`, `widget_remove`,

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -109,6 +109,20 @@ board with fresh sessions; by default they are display-only, and granting the
 widget its declared server tools makes it fully interactive — with the same
 one-tap, revision-bound approval as everything else.
 
+## A2UI widgets
+
+When the Canvas plugin is enabled, agents can render A2UI JSONL as a dashboard
+widget. A2UI widgets use the same stable name, tab, size, pinning, sandbox, and
+update-in-place behavior as HTML widgets. The renderer is loaded from the
+Gateway's capability-scoped A2UI asset route; the renderer bundle is not copied
+into each widget, and the Canvas file host does not need to be enabled.
+
+A2UI actions use the normal widget bridge. By default, clicks become quiet
+session notices that the agent sees on its next turn. If the widget declares
+and receives the `prompt` grant, its actions can instead send a visible prompt
+into the thread. Disabling the Canvas plugin removes the A2UI kind and leaves
+stored widgets visibly unavailable until the plugin is enabled again.
+
 ## Good to know
 
 - Resetting a thread that has a board asks for confirmation and keeps the

--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -61,7 +61,7 @@ vi.mock("./src/tool.js", () => ({
   createCanvasTool: mocks.createCanvasTool,
 }));
 
-function registerCanvas() {
+function registerCanvas(config: OpenClawPluginApi["config"] = {}) {
   const routes: Array<Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]> = [];
   const services: Array<Parameters<OpenClawPluginApi["registerService"]>[0]> = [];
   const resolvers: Array<Parameters<OpenClawPluginApi["registerHostedMediaResolver"]>[0]> = [];
@@ -75,20 +75,32 @@ function registerCanvas() {
   }> = [];
   const nodeInvokePolicies: Array<Parameters<OpenClawPluginApi["registerNodeInvokePolicy"]>[0]> =
     [];
+  const boardWidgetContentKinds: Array<
+    Parameters<OpenClawPluginApi["registerBoardWidgetContentKind"]>[0]
+  > = [];
   canvasPlugin.register?.(
     createTestPluginApi({
       id: "canvas",
       name: "Canvas",
-      config: {},
+      config,
       registerHttpRoute: (route) => routes.push(route),
       registerService: (service) => services.push(service),
       registerHostedMediaResolver: (resolver) => resolvers.push(resolver),
       registerTool: (tool, opts) => tools.push({ tool, opts }),
       registerNodeCliFeature: (registrar, opts) => cliFeatures.push({ registrar, opts }),
       registerNodeInvokePolicy: (policy) => nodeInvokePolicies.push(policy),
+      registerBoardWidgetContentKind: (kind) => boardWidgetContentKinds.push(kind),
     }),
   );
-  return { routes, services, resolvers, tools, cliFeatures, nodeInvokePolicies };
+  return {
+    routes,
+    services,
+    resolvers,
+    tools,
+    cliFeatures,
+    nodeInvokePolicies,
+    boardWidgetContentKinds,
+  };
 }
 
 function createNodeInvokeContext(
@@ -120,6 +132,17 @@ describe("Canvas plugin entry", () => {
       "linux",
       "unknown",
     ]);
+  });
+
+  it("registers A2UI board content while the Canvas file host is disabled", () => {
+    const { boardWidgetContentKinds, routes } = registerCanvas({
+      plugins: { entries: { canvas: { config: { host: { enabled: false } } } } },
+    });
+
+    expect(boardWidgetContentKinds).toEqual([
+      expect.objectContaining({ kind: "a2ui", label: "A2UI" }),
+    ]);
+    expect(routes.map((route) => route.path)).toEqual(["/__openclaw__/a2ui"]);
   });
 
   it("defers Canvas host implementation until a registered route is used", async () => {
@@ -282,13 +305,6 @@ describe("Canvas plugin entry", () => {
 
   it.each([
     ["malformed pushJSONL", "canvas.a2ui.pushJSONL", { jsonl: "{not-json}" }],
-    [
-      "versioned A2UI v0.9 pushJSONL",
-      "canvas.a2ui.pushJSONL",
-      {
-        jsonl: JSON.stringify({ version: "v0.9", deleteSurface: { surfaceId: "main" } }),
-      },
-    ],
     ["malformed legacy push JSONL fallback", "canvas.a2ui.push", { jsonl: "{not-json}" }],
   ])("rejects %s at the final Canvas node policy", async (_label, command, params) => {
     const { nodeInvokePolicies } = registerCanvas();
@@ -302,6 +318,30 @@ describe("Canvas plugin entry", () => {
 
     expect(result).toMatchObject({ ok: false, code: "INVALID_A2UI_JSONL" });
     expect(invokeNode).not.toHaveBeenCalled();
+  });
+
+  it("dispatches A2UI v0.9 JSONL unchanged through the final Canvas node policy", async () => {
+    const { nodeInvokePolicies } = registerCanvas();
+    const policy = nodeInvokePolicies[0];
+    if (!policy) {
+      throw new Error("Canvas node invoke policy was not registered");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const }));
+    const jsonl = JSON.stringify({
+      version: "v0.9",
+      deleteSurface: { surfaceId: "main" },
+    });
+
+    const result = await policy.handle(
+      createNodeInvokeContext({
+        command: "canvas.a2ui.pushJSONL",
+        params: { jsonl },
+        invokeNode,
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(invokeNode).toHaveBeenCalledOnce();
   });
 
   it("dispatches A2UI v0.8 JSONL unchanged through the final Canvas node policy", async () => {

--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -305,6 +305,13 @@ describe("Canvas plugin entry", () => {
 
   it.each([
     ["malformed pushJSONL", "canvas.a2ui.pushJSONL", { jsonl: "{not-json}" }],
+    [
+      "versioned A2UI v0.9 pushJSONL",
+      "canvas.a2ui.pushJSONL",
+      {
+        jsonl: JSON.stringify({ version: "v0.9", deleteSurface: { surfaceId: "main" } }),
+      },
+    ],
     ["malformed legacy push JSONL fallback", "canvas.a2ui.push", { jsonl: "{not-json}" }],
   ])("rejects %s at the final Canvas node policy", async (_label, command, params) => {
     const { nodeInvokePolicies } = registerCanvas();
@@ -318,30 +325,6 @@ describe("Canvas plugin entry", () => {
 
     expect(result).toMatchObject({ ok: false, code: "INVALID_A2UI_JSONL" });
     expect(invokeNode).not.toHaveBeenCalled();
-  });
-
-  it("dispatches A2UI v0.9 JSONL unchanged through the final Canvas node policy", async () => {
-    const { nodeInvokePolicies } = registerCanvas();
-    const policy = nodeInvokePolicies[0];
-    if (!policy) {
-      throw new Error("Canvas node invoke policy was not registered");
-    }
-    const invokeNode = vi.fn(async () => ({ ok: true as const }));
-    const jsonl = JSON.stringify({
-      version: "v0.9",
-      deleteSurface: { surfaceId: "main" },
-    });
-
-    const result = await policy.handle(
-      createNodeInvokeContext({
-        command: "canvas.a2ui.pushJSONL",
-        params: { jsonl },
-        invokeNode,
-      }),
-    );
-
-    expect(result).toEqual({ ok: true });
-    expect(invokeNode).toHaveBeenCalledOnce();
   });
 
   it("dispatches A2UI v0.8 JSONL unchanged through the final Canvas node policy", async () => {

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -10,6 +10,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { asNonArrayRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { validateSupportedA2UIJsonl } from "./src/a2ui-jsonl.js";
+import { canvasA2UIBoardWidgetKind } from "./src/board-widget.js";
 import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
 import { CanvasToolSchema } from "./src/tool-schema.js";
@@ -60,35 +61,36 @@ export default definePluginEntry({
     restartPrefixes: ["plugins.enabled", "plugins.allow", "plugins.deny", "plugins.entries.canvas"],
   },
   register(api) {
-    if (isCanvasHostEnabled(api.config)) {
-      const httpRouteHandlerLoader = createLazyRuntimeModule(() =>
-        import("./src/http-route.js").then(({ createCanvasHttpRouteHandler }) =>
-          createCanvasHttpRouteHandler({
-            config: api.config,
-            pluginConfig: api.pluginConfig,
-            runtime: {
-              log: (...args) => api.logger.info(args.map(String).join(" ")),
-              error: (...args) => api.logger.error(args.map(String).join(" ")),
-              exit: (code) => {
-                throw new Error(`canvas host requested process exit ${code}`);
-              },
+    const httpRouteHandlerLoader = createLazyRuntimeModule(() =>
+      import("./src/http-route.js").then(({ createCanvasHttpRouteHandler }) =>
+        createCanvasHttpRouteHandler({
+          config: api.config,
+          pluginConfig: api.pluginConfig,
+          runtime: {
+            log: (...args) => api.logger.info(args.map(String).join(" ")),
+            error: (...args) => api.logger.error(args.map(String).join(" ")),
+            exit: (code) => {
+              throw new Error(`canvas host requested process exit ${code}`);
             },
-          }),
-        ),
-      );
-      const loadHttpRouteHandler = httpRouteHandlerLoader;
-      const handleHttpRequest = async (req: IncomingMessage, res: ServerResponse) =>
-        await (await loadHttpRouteHandler()).handleHttpRequest(req, res);
+          },
+        }),
+      ),
+    );
+    const loadHttpRouteHandler = httpRouteHandlerLoader;
+    const handleHttpRequest = async (req: IncomingMessage, res: ServerResponse) =>
+      await (await loadHttpRouteHandler()).handleHttpRequest(req, res);
+    const nodeCapability = { surface: "canvas" };
+    api.registerHttpRoute({
+      path: A2UI_PATH,
+      auth: "plugin",
+      match: "prefix",
+      nodeCapability,
+      handler: handleHttpRequest,
+    });
+    api.registerBoardWidgetContentKind(canvasA2UIBoardWidgetKind);
+    if (isCanvasHostEnabled(api.config)) {
       const handleUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) =>
         await (await loadHttpRouteHandler()).handleUpgrade(req, socket, head);
-      const nodeCapability = { surface: "canvas" };
-      api.registerHttpRoute({
-        path: A2UI_PATH,
-        auth: "plugin",
-        match: "prefix",
-        nodeCapability,
-        handler: handleHttpRequest,
-      });
       api.registerHttpRoute({
         path: CANVAS_HOST_PATH,
         auth: "plugin",
@@ -104,15 +106,15 @@ export default definePluginEntry({
         handler: handleHttpRequest,
         handleUpgrade,
       });
-      api.registerService({
-        id: "canvas-host",
-        start: () => {},
-        stop: async () => {
-          const httpRouteHandler = await httpRouteHandlerLoader.peek();
-          await httpRouteHandler?.close();
-        },
-      });
     }
+    api.registerService({
+      id: "canvas-host",
+      start: () => {},
+      stop: async () => {
+        const httpRouteHandler = await httpRouteHandlerLoader.peek();
+        await httpRouteHandler?.close();
+      },
+    });
     api.registerNodeInvokePolicy({
       commands: CANVAS_NODE_COMMANDS,
       defaultPlatforms: ["ios", "android", "macos", "windows", "linux", "unknown"],

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -9,7 +9,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { asNonArrayRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { validateSupportedA2UIJsonl } from "./src/a2ui-jsonl.js";
+import { validateNativeA2UIJsonl } from "./src/a2ui-jsonl.js";
 import { canvasA2UIBoardWidgetKind } from "./src/board-widget.js";
 import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
@@ -131,7 +131,7 @@ export default definePluginEntry({
         if (usesJsonl) {
           const jsonl = typeof params.jsonl === "string" ? params.jsonl : "";
           try {
-            validateSupportedA2UIJsonl(jsonl);
+            validateNativeA2UIJsonl(jsonl);
           } catch (error) {
             return {
               ok: false,

--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -8,7 +8,8 @@
     "@openclaw/plugin-sdk": "workspace:*"
   },
   "dependencies": {
-    "@a2ui/lit": "0.10.2",
+    "@a2ui/lit": "0.10.3",
+    "@a2ui/web_core": "0.10.6",
     "@lit/context": "1.1.6",
     "chokidar": "5.0.0",
     "lit": "3.3.3",
@@ -23,7 +24,8 @@
       "build": "node scripts/bundle-a2ui.mjs",
       "buildOutputs": [
         "src/host/a2ui/.bundle.hash",
-        "src/host/a2ui/a2ui.bundle.js"
+        "src/host/a2ui/a2ui.bundle.js",
+        "src/host/a2ui/a2ui-v0.9.bundle.js"
       ],
       "copy": "node scripts/copy-a2ui.mjs"
     }

--- a/extensions/canvas/scripts/bundle-a2ui.mjs
+++ b/extensions/canvas/scripts/bundle-a2ui.mjs
@@ -21,6 +21,9 @@ const hashFile =
 const outputFile =
   process.env.OPENCLAW_A2UI_BUNDLE_OUT ??
   path.join(pluginDir, "src", "host", "a2ui", "a2ui.bundle.js");
+const outputV09File = process.env.OPENCLAW_A2UI_BUNDLE_OUT
+  ? `${process.env.OPENCLAW_A2UI_BUNDLE_OUT}.v0.9.js`
+  : path.join(pluginDir, "src", "host", "a2ui", "a2ui-v0.9.bundle.js");
 const a2uiAppDir = path.join(pluginDir, "src", "host", "a2ui-app");
 const GIT_INPUT_DISCOVERY_TIMEOUT_MS = 5_000;
 
@@ -176,6 +179,7 @@ function runPnpm(pnpmArgs) {
 async function main() {
   const hasAppDir = await pathExists(a2uiAppDir);
   const hasOutputFile = await pathExists(outputFile);
+  const hasV09OutputFile = await pathExists(outputV09File);
   let hasA2uiPackage = true;
   try {
     require.resolve("@a2ui/lit");
@@ -200,7 +204,7 @@ async function main() {
   const currentHash = await computeHash();
   if (await pathExists(hashFile)) {
     const previousHash = (await fs.readFile(hashFile, "utf8")).trim();
-    if (previousHash === currentHash && hasOutputFile) {
+    if (previousHash === currentHash && hasOutputFile && hasV09OutputFile) {
       console.log("A2UI bundle up to date; skipping.");
       return;
     }
@@ -216,13 +220,11 @@ async function main() {
   ).find(Boolean);
 
   if (localRolldownCli) {
-    runStep(process.execPath, [
-      localRolldownCli,
-      "-c",
-      path.join(a2uiAppDir, "rolldown.config.mjs"),
-    ]);
+    const configPath = path.join(a2uiAppDir, "rolldown.config.mjs");
+    runStep(process.execPath, [localRolldownCli, "-c", configPath]);
   } else {
-    runPnpm(["-s", "exec", "rolldown", "-c", path.join(a2uiAppDir, "rolldown.config.mjs")]);
+    const configPath = path.join(a2uiAppDir, "rolldown.config.mjs");
+    runPnpm(["-s", "exec", "rolldown", "-c", configPath]);
   }
 
   await fs.writeFile(hashFile, `${currentHash}\n`, "utf8");

--- a/extensions/canvas/scripts/copy-a2ui.mjs
+++ b/extensions/canvas/scripts/copy-a2ui.mjs
@@ -45,6 +45,7 @@ export async function copyA2uiAssets({ srcDir, outDir }) {
   try {
     await fs.stat(path.join(srcDir, "index.html"));
     await fs.stat(path.join(srcDir, "a2ui.bundle.js"));
+    await fs.stat(path.join(srcDir, "a2ui-v0.9.bundle.js"));
   } catch (err) {
     const message = 'Missing A2UI bundle assets. Run "pnpm canvas:a2ui:bundle" and retry.';
     if (skipMissing) {

--- a/extensions/canvas/scripts/copy-a2ui.test.ts
+++ b/extensions/canvas/scripts/copy-a2ui.test.ts
@@ -68,6 +68,7 @@ describe("canvas a2ui copy", () => {
       await fs.mkdir(srcDir, { recursive: true });
       await fs.writeFile(path.join(srcDir, "index.html"), "<html></html>", "utf8");
       await fs.writeFile(path.join(srcDir, "a2ui.bundle.js"), "console.log(1);", "utf8");
+      await fs.writeFile(path.join(srcDir, "a2ui-v0.9.bundle.js"), "console.log(2);", "utf8");
 
       await copyA2uiAssets({ srcDir, outDir });
 
@@ -76,6 +77,9 @@ describe("canvas a2ui copy", () => {
       );
       await expect(fs.readFile(path.join(outDir, "a2ui.bundle.js"), "utf8")).resolves.toBe(
         "console.log(1);",
+      );
+      await expect(fs.readFile(path.join(outDir, "a2ui-v0.9.bundle.js"), "utf8")).resolves.toBe(
+        "console.log(2);",
       );
     });
   });
@@ -89,6 +93,7 @@ describe("canvas a2ui copy", () => {
       await fs.mkdir(outDir, { recursive: true });
       await fs.writeFile(path.join(srcDir, "index.html"), "<html></html>", "utf8");
       await fs.writeFile(path.join(srcDir, "a2ui.bundle.js"), "console.log(1);", "utf8");
+      await fs.writeFile(path.join(srcDir, "a2ui-v0.9.bundle.js"), "console.log(2);", "utf8");
       await fs.writeFile(path.join(nestedAssetDir, "sample.txt"), "nested-asset", "utf8");
       await fs.writeFile(path.join(outDir, "stale.txt"), "stale-output", "utf8");
 
@@ -109,6 +114,7 @@ describe("canvas a2ui copy", () => {
       await fs.mkdir(srcDir, { recursive: true });
       await fs.writeFile(path.join(srcDir, "index.html"), "<html></html>", "utf8");
       await fs.writeFile(path.join(srcDir, "a2ui.bundle.js"), "console.log(1);", "utf8");
+      await fs.writeFile(path.join(srcDir, "a2ui-v0.9.bundle.js"), "console.log(2);", "utf8");
 
       await expect(copyA2uiAssets({ srcDir, outDir: srcDir })).rejects.toThrow("must not overlap");
       await expect(fs.readFile(path.join(srcDir, "index.html"), "utf8")).resolves.toBe(

--- a/extensions/canvas/src/a2ui-jsonl.test.ts
+++ b/extensions/canvas/src/a2ui-jsonl.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildA2UITextJsonl, validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
+
+const BASIC_CATALOG = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json";
+
+describe("Canvas A2UI JSONL validation", () => {
+  it("keeps unversioned v0.8 messages accepted", () => {
+    expect(validateSupportedA2UIJsonl(buildA2UITextJsonl("hello"))).toMatchObject({
+      version: "v0.8",
+      messageCount: 2,
+    });
+  });
+
+  it("accepts the v0.9 create, component, data, and delete message set", () => {
+    const messages = [
+      {
+        version: "v0.9",
+        createSurface: { surfaceId: "main", catalogId: BASIC_CATALOG },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "main",
+          components: [{ id: "root", component: "Text", text: "hello" }],
+        },
+      },
+      {
+        version: "v0.9",
+        updateDataModel: { surfaceId: "main", path: "/status", value: "ready" },
+      },
+      { version: "v0.9", deleteSurface: { surfaceId: "main" } },
+    ];
+    const jsonl = messages.map((message) => JSON.stringify(message)).join("\n");
+
+    expect(validateSupportedA2UIJsonl(jsonl)).toMatchObject({
+      version: "v0.9",
+      messageCount: 4,
+      messages,
+    });
+  });
+
+  it.each([
+    ["empty input", " \n ", "no JSONL messages"],
+    ["invalid JSON", "{", "line 1"],
+    [
+      "versioned v0.8 operation",
+      JSON.stringify({ version: "v0.9", surfaceUpdate: { surfaceId: "main", components: [] } }),
+      "v0.9 action key",
+    ],
+    [
+      "unversioned v0.9 operation",
+      JSON.stringify({ createSurface: { surfaceId: "main", catalogId: BASIC_CATALOG } }),
+      "v0.8 action key",
+    ],
+    [
+      "malformed createSurface",
+      JSON.stringify({ version: "v0.9", createSurface: { surfaceId: "main" } }),
+      "Invalid input",
+    ],
+    [
+      "mixed versions",
+      [
+        JSON.stringify({ deleteSurface: { surfaceId: "legacy" } }),
+        JSON.stringify({ version: "v0.9", deleteSurface: { surfaceId: "modern" } }),
+      ].join("\n"),
+      "mixed A2UI",
+    ],
+  ])("rejects $0", (_name, jsonl, expected) => {
+    expect(() => validateSupportedA2UIJsonl(jsonl)).toThrow(expected);
+  });
+});

--- a/extensions/canvas/src/a2ui-jsonl.test.ts
+++ b/extensions/canvas/src/a2ui-jsonl.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildA2UITextJsonl, validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
+import {
+  buildA2UITextJsonl,
+  validateNativeA2UIJsonl,
+  validateSupportedA2UIJsonl,
+} from "./a2ui-jsonl.js";
 
 const BASIC_CATALOG = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json";
 
@@ -37,6 +41,20 @@ describe("Canvas A2UI JSONL validation", () => {
       messageCount: 4,
       messages,
     });
+  });
+
+  it("keeps native Canvas pushes on v0.8", () => {
+    expect(validateNativeA2UIJsonl(buildA2UITextJsonl("hello"))).toMatchObject({
+      version: "v0.8",
+    });
+    expect(() =>
+      validateNativeA2UIJsonl(
+        JSON.stringify({
+          version: "v0.9",
+          createSurface: { surfaceId: "main", catalogId: BASIC_CATALOG },
+        }),
+      ),
+    ).toThrow("OpenClaw currently supports v0.8 only for native Canvas pushes");
   });
 
   it.each([

--- a/extensions/canvas/src/a2ui-jsonl.ts
+++ b/extensions/canvas/src/a2ui-jsonl.ts
@@ -1,12 +1,19 @@
 /**
  * A2UI JSONL helpers for Canvas text rendering and validation.
  */
-const A2UI_ACTION_KEYS = [
+import { A2uiMessageSchema as A2uiV09MessageSchema } from "@a2ui/web_core/v0_9";
+
+const A2UI_V08_ACTION_KEYS = [
   "beginRendering",
   "surfaceUpdate",
   "dataModelUpdate",
   "deleteSurface",
+] as const;
+const A2UI_V09_ACTION_KEYS = [
   "createSurface",
+  "updateComponents",
+  "updateDataModel",
+  "deleteSurface",
 ] as const;
 
 /** A2UI message dialects recognized by the Canvas validator. */
@@ -47,6 +54,7 @@ function validateA2UIJsonl(jsonl: string) {
   let sawV08 = false;
   let sawV09 = false;
   let messageCount = 0;
+  const messages: unknown[] = [];
 
   lines.forEach((line, idx) => {
     const trimmed = line.trim();
@@ -76,20 +84,40 @@ function validateA2UIJsonl(jsonl: string) {
       errors.push(`line ${idx + 1}: unsupported A2UI version: ${JSON.stringify(explicitVersion)}`);
       return;
     }
-    const actionKeys = A2UI_ACTION_KEYS.filter((key) => key in record);
+    const actionKeys = (
+      explicitVersion === "v0.9" ? A2UI_V09_ACTION_KEYS : A2UI_V08_ACTION_KEYS
+    ).filter((key) => key in record);
     if (actionKeys.length !== 1) {
       errors.push(
-        `line ${idx + 1}: expected exactly one action key (${A2UI_ACTION_KEYS.join(", ")})`,
+        `line ${idx + 1}: expected exactly one ${explicitVersion === "v0.9" ? "v0.9" : "v0.8"} action key`,
       );
       return;
     }
-    // v0.9 requires an explicit version, but keep recognizing legacy
-    // createSurface payloads so older generators still fail closed.
-    if (explicitVersion === "v0.9" || actionKeys[0] === "createSurface") {
+    const allowedTopLevelKeys = new Set(
+      explicitVersion === "v0.9" ? ["version", actionKeys[0]] : [actionKeys[0]],
+    );
+    if (Object.keys(record).some((key) => !allowedTopLevelKeys.has(key))) {
+      errors.push(`line ${idx + 1}: unexpected top-level A2UI field`);
+      return;
+    }
+    const payload = record[actionKeys[0]!];
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      errors.push(`line ${idx + 1}: action payload must be an object`);
+      return;
+    }
+    if (explicitVersion === "v0.9") {
+      const result = A2uiV09MessageSchema.safeParse(record);
+      if (!result.success) {
+        errors.push(
+          `line ${idx + 1}: ${result.error.issues[0]?.message ?? "invalid v0.9 message"}`,
+        );
+        return;
+      }
       sawV09 = true;
     } else {
       sawV08 = true;
     }
+    messages.push(record);
   });
 
   if (messageCount === 0) {
@@ -103,14 +131,10 @@ function validateA2UIJsonl(jsonl: string) {
   }
 
   const version: A2UIVersion = sawV09 ? "v0.9" : "v0.8";
-  return { version, messageCount };
+  return { version, messageCount, messages };
 }
 
 /** Validates A2UI JSONL against the Canvas runtime's currently supported dialect. */
 export function validateSupportedA2UIJsonl(jsonl: string) {
-  const result = validateA2UIJsonl(jsonl);
-  if (result.version !== "v0.8") {
-    throw new Error("Detected unsupported A2UI v0.9 JSONL. OpenClaw currently supports v0.8 only.");
-  }
-  return result;
+  return validateA2UIJsonl(jsonl);
 }

--- a/extensions/canvas/src/a2ui-jsonl.ts
+++ b/extensions/canvas/src/a2ui-jsonl.ts
@@ -138,3 +138,12 @@ function validateA2UIJsonl(jsonl: string) {
 export function validateSupportedA2UIJsonl(jsonl: string) {
   return validateA2UIJsonl(jsonl);
 }
+
+/** Keeps native Canvas pushes on the renderer generation shipped by node clients. */
+export function validateNativeA2UIJsonl(jsonl: string) {
+  const parsed = validateA2UIJsonl(jsonl);
+  if (parsed.version !== "v0.8") {
+    throw new Error("OpenClaw currently supports v0.8 only for native Canvas pushes");
+  }
+  return parsed;
+}

--- a/extensions/canvas/src/board-widget.ts
+++ b/extensions/canvas/src/board-widget.ts
@@ -1,0 +1,53 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
+
+const A2UI_V08_BUNDLE_PATH = "/__openclaw__/a2ui/a2ui.bundle.js";
+const A2UI_V09_BUNDLE_PATH = "/__openclaw__/a2ui/a2ui-v0.9.bundle.js";
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function bootScript(messages: unknown[], promptGranted: boolean): string {
+  const boot = JSON.stringify({ messages, actionTier: promptGranted ? "prompt" : "state" })
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+  return `<script>globalThis.__openclawA2UIBoot=${boot};</script>`;
+}
+
+function resourceScript(path: string, url: string): string {
+  if (url !== path) {
+    return `<script src="${escapeHtmlAttribute(url)}"></script>`;
+  }
+  const serializedPath = JSON.stringify(path).replaceAll("<", "\\u003c");
+  return `<script>(()=>{const match=location.pathname.match(/^\\/__openclaw__\\/cap\\/[^/]+/u);const script=document.createElement("script");script.src=(match?.[0]??"")+${serializedPath};document.head.appendChild(script);})();</script>`;
+}
+
+/** Canvas-owned A2UI source validation and document composition for boards. */
+export const canvasA2UIBoardWidgetKind: Parameters<
+  OpenClawPluginApi["registerBoardWidgetContentKind"]
+>[0] = {
+  kind: "a2ui",
+  label: "A2UI",
+  resources: {
+    surface: "canvas",
+    paths: [A2UI_V08_BUNDLE_PATH, A2UI_V09_BUNDLE_PATH],
+  },
+  validateSource(source) {
+    validateSupportedA2UIJsonl(source);
+  },
+  composeDocument({ source, resourceUrls, promptGranted }) {
+    const parsed = validateSupportedA2UIJsonl(source);
+    const bundlePath = parsed.version === "v0.9" ? A2UI_V09_BUNDLE_PATH : A2UI_V08_BUNDLE_PATH;
+    const bundleUrl = resourceUrls[bundlePath];
+    if (!bundleUrl) {
+      throw new Error(`A2UI renderer resource unavailable: ${bundlePath}`);
+    }
+    return `${bootScript(parsed.messages, promptGranted)}<style>html,body{height:100%;overflow:hidden;background:transparent}openclaw-a2ui-host{display:block;height:100%}</style><openclaw-a2ui-host></openclaw-a2ui-host>${resourceScript(bundlePath, bundleUrl)}`;
+  },
+};

--- a/extensions/canvas/src/board-widget.ts
+++ b/extensions/canvas/src/board-widget.ts
@@ -17,7 +17,7 @@ function bootScript(messages: unknown[], promptGranted: boolean): string {
     .replaceAll("<", "\\u003c")
     .replaceAll("\u2028", "\\u2028")
     .replaceAll("\u2029", "\\u2029");
-  return `<script>globalThis.__openclawA2UIBoot=${boot};</script>`;
+  return `<script>globalThis.openclawA2UIBoot=${boot};</script>`;
 }
 
 function resourceScript(path: string, url: string): string {

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -461,13 +461,13 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
           const jsonl = hasText
             ? buildA2UITextJsonl(opts.text ?? "")
             : await fs.readFile(String(opts.jsonl), "utf8");
-          const { messageCount } = validateSupportedA2UIJsonl(jsonl);
+          const { messageCount, version } = validateSupportedA2UIJsonl(jsonl);
           const result = await invokeCanvas(deps, opts, "canvas.a2ui.pushJSONL", { jsonl });
           writeCanvasInvokeResult(
             deps,
             opts,
             result,
-            `canvas a2ui push ok (v0.8, ${messageCount} message${messageCount === 1 ? "" : "s"})`,
+            `canvas a2ui push ok (${version}, ${messageCount} message${messageCount === 1 ? "" : "s"})`,
           );
         });
       }),

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -23,7 +23,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { shortenHomePath } from "openclaw/plugin-sdk/text-utility-runtime";
-import { buildA2UITextJsonl, validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
+import { buildA2UITextJsonl, validateNativeA2UIJsonl } from "./a2ui-jsonl.js";
 import { canvasSnapshotTempPath, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 
 /** Runtime output surface used by Canvas CLI commands. */
@@ -461,7 +461,7 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
           const jsonl = hasText
             ? buildA2UITextJsonl(opts.text ?? "")
             : await fs.readFile(String(opts.jsonl), "utf8");
-          const { messageCount, version } = validateSupportedA2UIJsonl(jsonl);
+          const { messageCount, version } = validateNativeA2UIJsonl(jsonl);
           const result = await invokeCanvas(deps, opts, "canvas.a2ui.pushJSONL", { jsonl });
           writeCanvasInvokeResult(
             deps,

--- a/extensions/canvas/src/host/a2ui-app/bootstrap-v0.9.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap-v0.9.js
@@ -1,7 +1,6 @@
 import { basicCatalog } from "@a2ui/lit/v0_9";
 /** A2UI v0.9 Lit host used by sandboxed board documents. */
 import { MessageProcessor } from "@a2ui/web_core/v0_9";
-import "@a2ui/lit/v0_9";
 import { css, html, LitElement } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 
@@ -18,7 +17,7 @@ const routeBoardAction = async (action) => {
   if (!api?.state?.emit) {
     return false;
   }
-  if (globalThis.__openclawA2UIBoot?.actionTier === "prompt" && api.prompt?.send) {
+  if (globalThis.openclawA2UIBoot?.actionTier === "prompt" && api.prompt?.send) {
     await api.prompt.send(actionText(action));
   } else {
     await api.state.emit({ eventType: "a2ui.action", action });
@@ -79,7 +78,7 @@ class OpenClawA2UIV09Host extends LitElement {
       reset: () => this.reset(),
       getSurfaces: () => this.surfaces.map(([id]) => id),
     };
-    const bootMessages = globalThis.__openclawA2UIBoot?.messages;
+    const bootMessages = globalThis.openclawA2UIBoot?.messages;
     if (Array.isArray(bootMessages)) {
       this.applyMessages(bootMessages);
     }

--- a/extensions/canvas/src/host/a2ui-app/bootstrap-v0.9.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap-v0.9.js
@@ -1,0 +1,135 @@
+import { basicCatalog } from "@a2ui/lit/v0_9";
+/** A2UI v0.9 Lit host used by sandboxed board documents. */
+import { MessageProcessor } from "@a2ui/web_core/v0_9";
+import "@a2ui/lit/v0_9";
+import { css, html, LitElement } from "lit";
+import { repeat } from "lit/directives/repeat.js";
+
+const actionText = (action) => {
+  const context =
+    action?.context && Object.keys(action.context).length ? action.context : undefined;
+  return context
+    ? `A2UI action ${action.name}: ${JSON.stringify(context)}`
+    : `A2UI action ${action?.name ?? "selected"}`;
+};
+
+const routeBoardAction = async (action) => {
+  const api = globalThis.openclaw;
+  if (!api?.state?.emit) {
+    return false;
+  }
+  if (globalThis.__openclawA2UIBoot?.actionTier === "prompt" && api.prompt?.send) {
+    await api.prompt.send(actionText(action));
+  } else {
+    await api.state.emit({ eventType: "a2ui.action", action });
+  }
+  return true;
+};
+
+class OpenClawA2UIV09Host extends LitElement {
+  static properties = { surfaces: { state: true }, error: { state: true } };
+
+  static styles = css`
+    :host {
+      display: block;
+      min-height: 100%;
+      color: var(--text);
+      background: transparent;
+    }
+    #surfaces {
+      display: grid;
+      gap: 12px;
+      min-height: 100%;
+    }
+    .error {
+      color: var(--danger);
+      padding: 12px;
+    }
+  `;
+
+  surfaces = [];
+  error = "";
+  #processor;
+  #subscriptions = [];
+
+  constructor() {
+    super();
+    this.#processor = this.#createProcessor();
+  }
+
+  #createProcessor() {
+    const processor = new MessageProcessor([basicCatalog], async (action) => {
+      try {
+        await routeBoardAction(action);
+      } catch (error) {
+        this.error = String(error?.message ?? error);
+      }
+    });
+    this.#subscriptions = [
+      processor.onSurfaceCreated(() => this.#syncSurfaces()),
+      processor.onSurfaceDeleted(() => this.#syncSurfaces()),
+    ];
+    return processor;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    globalThis.openclawA2UI = {
+      applyMessages: (messages) => this.applyMessages(messages),
+      reset: () => this.reset(),
+      getSurfaces: () => this.surfaces.map(([id]) => id),
+    };
+    const bootMessages = globalThis.__openclawA2UIBoot?.messages;
+    if (Array.isArray(bootMessages)) {
+      this.applyMessages(bootMessages);
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    for (const subscription of this.#subscriptions) {
+      subscription.unsubscribe();
+    }
+    this.#subscriptions = [];
+  }
+
+  applyMessages(messages) {
+    if (!Array.isArray(messages)) {
+      throw new Error("A2UI: expected messages array");
+    }
+    this.#processor.processMessages(messages);
+    this.#syncSurfaces();
+    return { ok: true, surfaces: this.surfaces.map(([id]) => id) };
+  }
+
+  reset() {
+    this.#processor.model.dispose();
+    for (const subscription of this.#subscriptions) {
+      subscription.unsubscribe();
+    }
+    this.#processor = this.#createProcessor();
+    this.surfaces = [];
+    this.error = "";
+    return { ok: true };
+  }
+
+  #syncSurfaces() {
+    this.surfaces = Array.from(this.#processor.model.surfacesMap.entries());
+    this.requestUpdate();
+  }
+
+  render() {
+    return html`${this.error ? html`<div class="error" role="alert">${this.error}</div>` : ""}
+      <section id="surfaces">
+        ${repeat(
+          this.surfaces,
+          ([surfaceId]) => surfaceId,
+          ([, surface]) => html`<a2ui-surface .surface=${surface}></a2ui-surface>`,
+        )}
+      </section>`;
+  }
+}
+
+if (!customElements.get("openclaw-a2ui-host")) {
+  customElements.define("openclaw-a2ui-host", OpenClawA2UIV09Host);
+}

--- a/extensions/canvas/src/host/a2ui-app/bootstrap.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap.js
@@ -381,6 +381,10 @@ class OpenClawA2UIHost extends LitElement {
       globalThis.addEventListener(eventName, this.#statusListener);
     }
     this.#syncSurfaces();
+    const bootMessages = globalThis.__openclawA2UIBoot?.messages;
+    if (Array.isArray(bootMessages)) {
+      this.applyMessages(bootMessages);
+    }
   }
 
   disconnectedCallback() {
@@ -502,6 +506,26 @@ class OpenClawA2UIHost extends LitElement {
     };
 
     globalThis["__openclawLastA2UIAction"] = userAction;
+
+    const boardApi = globalThis.openclaw;
+    if (boardApi?.state?.emit) {
+      const request =
+        globalThis.__openclawA2UIBoot?.actionTier === "prompt" && boardApi.prompt?.send
+          ? boardApi.prompt.send(
+              Object.keys(context).length
+                ? `A2UI action ${name}: ${JSON.stringify(context)}`
+                : `A2UI action ${name}`,
+            )
+          : boardApi.state.emit({ eventType: "a2ui.action", action: userAction });
+      void Promise.resolve(request).then(
+        () => this.#handleActionStatus({ detail: { id: actionId, ok: true } }),
+        (error) =>
+          this.#handleActionStatus({
+            detail: { id: actionId, ok: false, error: String(error?.message ?? error) },
+          }),
+      );
+      return;
+    }
 
     const handler =
       globalThis.webkit?.messageHandlers?.openclawCanvasA2UIAction ??

--- a/extensions/canvas/src/host/a2ui-app/bootstrap.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap.js
@@ -381,7 +381,7 @@ class OpenClawA2UIHost extends LitElement {
       globalThis.addEventListener(eventName, this.#statusListener);
     }
     this.#syncSurfaces();
-    const bootMessages = globalThis.__openclawA2UIBoot?.messages;
+    const bootMessages = globalThis.openclawA2UIBoot?.messages;
     if (Array.isArray(bootMessages)) {
       this.applyMessages(bootMessages);
     }
@@ -510,7 +510,7 @@ class OpenClawA2UIHost extends LitElement {
     const boardApi = globalThis.openclaw;
     if (boardApi?.state?.emit) {
       const request =
-        globalThis.__openclawA2UIBoot?.actionTier === "prompt" && boardApi.prompt?.send
+        globalThis.openclawA2UIBoot?.actionTier === "prompt" && boardApi.prompt?.send
           ? boardApi.prompt.send(
               Object.keys(context).length
                 ? `A2UI action ${name}: ${JSON.stringify(context)}`
@@ -519,7 +519,7 @@ class OpenClawA2UIHost extends LitElement {
           : boardApi.state.emit({ eventType: "a2ui.action", action: userAction });
       void Promise.resolve(request).then(
         () => this.#handleActionStatus({ detail: { id: actionId, ok: true } }),
-        (error) =>
+        (/** @type {unknown} */ error) =>
           this.#handleActionStatus({
             detail: { id: actionId, ok: false, error: String(error?.message ?? error) },
           }),

--- a/extensions/canvas/src/host/a2ui-app/rolldown.config.mjs
+++ b/extensions/canvas/src/host/a2ui-app/rolldown.config.mjs
@@ -14,9 +14,14 @@ const fromHere = (p) => path.resolve(here, p);
 const outputFile = process.env.OPENCLAW_A2UI_BUNDLE_OUT
   ? path.resolve(process.env.OPENCLAW_A2UI_BUNDLE_OUT)
   : path.resolve(here, "..", "a2ui", "a2ui.bundle.js");
+const outputV09File = process.env.OPENCLAW_A2UI_BUNDLE_OUT
+  ? `${outputFile}.v0.9.js`
+  : path.resolve(here, "..", "a2ui", "a2ui-v0.9.bundle.js");
 
 const a2uiLitIndex = require.resolve("@a2ui/lit");
 const a2uiLitUi = require.resolve("@a2ui/lit/ui");
+const a2uiLitV09 = require.resolve("@a2ui/lit/v0_9");
+const a2uiWebCoreV09 = require.resolve("@a2ui/web_core/v0_9");
 const a2uiThemeContext = path.resolve(path.dirname(a2uiLitUi), "context/theme.js");
 const uiNodeModules = path.resolve(uiRoot, "node_modules");
 const repoNodeModules = path.resolve(repoRoot, "node_modules");
@@ -39,8 +44,8 @@ function resolveUiDependency(moduleId) {
   );
 }
 
-export default {
-  input: fromHere("bootstrap.js"),
+const createConfig = (input, file) => ({
+  input,
   experimental: {
     attachDebugInfo: "none",
   },
@@ -49,6 +54,8 @@ export default {
     alias: {
       "@a2ui/lit": a2uiLitIndex,
       "@a2ui/lit/ui": a2uiLitUi,
+      "@a2ui/lit/v0_9": a2uiLitV09,
+      "@a2ui/web_core/v0_9": a2uiWebCoreV09,
       "@openclaw/a2ui-theme-context": a2uiThemeContext,
       "@lit/context": resolveUiDependency("@lit/context"),
       "@lit/context/": resolveUiDependency("@lit/context/"),
@@ -60,9 +67,14 @@ export default {
     },
   },
   output: {
-    file: outputFile,
+    file,
     format: "esm",
     codeSplitting: false,
     sourcemap: false,
   },
-};
+});
+
+export default [
+  createConfig(fromHere("bootstrap.js"), outputFile),
+  createConfig(fromHere("bootstrap-v0.9.js"), outputV09File),
+];

--- a/extensions/canvas/src/host/a2ui.ts
+++ b/extensions/canvas/src/host/a2ui.ts
@@ -46,8 +46,10 @@ async function resolveA2uiRoot(): Promise<string | null> {
     try {
       const indexPath = path.join(dir, "index.html");
       const bundlePath = path.join(dir, "a2ui.bundle.js");
+      const v09BundlePath = path.join(dir, "a2ui-v0.9.bundle.js");
       await fs.stat(indexPath);
       await fs.stat(bundlePath);
+      await fs.stat(v09BundlePath);
       return dir;
     } catch {
       // try next

--- a/extensions/canvas/src/http-route.ts
+++ b/extensions/canvas/src/http-route.ts
@@ -53,13 +53,15 @@ export function createCanvasHttpRouteHandler(params: {
 
   return {
     async handleHttpRequest(req, res) {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      if (url.pathname === A2UI_PATH || url.pathname.startsWith(`${A2UI_PATH}/`)) {
+        return handleA2uiHttpRequest(req, res, {
+          liveReload: isCanvasHostEnabled(params.config) ? getHostConfig().liveReload : false,
+        });
+      }
       const handler = await loadHostHandler();
       if (!handler) {
         return false;
-      }
-      const url = new URL(req.url ?? "/", "http://localhost");
-      if (url.pathname === A2UI_PATH || url.pathname.startsWith(`${A2UI_PATH}/`)) {
-        return handleA2uiHttpRequest(req, res, { liveReload: getHostConfig().liveReload });
       }
       return handler.handleHttpRequest(req, res);
     },

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -583,7 +583,7 @@ describe("Canvas tool", () => {
     [
       "legacy createSurface JSONL",
       JSON.stringify({ createSurface: { surfaceId: "main", root: "root" } }),
-      /OpenClaw currently supports v0\.8 only/,
+      /expected exactly one v0\.8 action key/,
     ],
     [
       "A2UI v0.9 deleteSurface JSONL",

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -28,7 +28,7 @@ import {
   wrapExternalContent,
 } from "openclaw/plugin-sdk/security-runtime";
 import { DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS } from "openclaw/plugin-sdk/text-utility-runtime";
-import { validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
+import { validateNativeA2UIJsonl } from "./a2ui-jsonl.js";
 import { normalizeCanvasSnapshotFileExtension, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 import { CanvasToolSchema } from "./tool-schema.js";
 
@@ -302,7 +302,7 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
           if (!jsonl.trim()) {
             throw new Error("jsonl or jsonlPath required");
           }
-          validateSupportedA2UIJsonl(jsonl);
+          validateNativeA2UIJsonl(jsonl);
           const { node } = await invoke("canvas.a2ui.pushJSONL", { jsonl });
           return jsonResult({ ok: true, node });
         }

--- a/package.json
+++ b/package.json
@@ -2067,7 +2067,8 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@a2ui/lit": "0.10.2",
+    "@a2ui/lit": "0.10.3",
+    "@a2ui/web_core": "0.10.6",
     "@copilotkit/aimock": "1.37.4",
     "@lit-labs/signals": "0.3.0",
     "@lit/context": "1.1.6",

--- a/packages/gateway-protocol/src/schema/board.ts
+++ b/packages/gateway-protocol/src/schema/board.ts
@@ -95,6 +95,7 @@ export const BoardWidgetSchema = closedObject({
   sandboxUrl: Type.Optional(Type.String()),
   sandboxPort: Type.Optional(Type.Integer({ minimum: 1, maximum: 65535 })),
   sandboxOrigin: Type.Optional(Type.String()),
+  kindLabel: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
 });
 export type BoardWidget = Static<typeof BoardWidgetSchema>;
 
@@ -195,16 +196,25 @@ export const BoardWidgetPluginContentSchema = closedObject({
   pluginKind: BoardWidgetPluginKindSchema,
   props: Type.Optional(BoardWidgetPluginPropsSchema),
 });
+export const BoardWidgetRegisteredContentSchema = closedObject({
+  kind: Type.Literal("registered"),
+  contentKind: Type.String({ pattern: "^[a-z][a-z0-9-]{0,31}$" }),
+  source: Type.String({ maxLength: 262_144 }),
+});
 export const BoardWidgetContentSchema = Type.Union([
   BoardWidgetHtmlContentSchema,
   BoardWidgetMcpAppContentSchema,
   BoardWidgetPluginContentSchema,
+  BoardWidgetRegisteredContentSchema,
 ]);
 export type BoardWidgetContent = Static<typeof BoardWidgetContentSchema>;
 export type BoardWidgetMaterializedContent =
   | Static<typeof BoardWidgetHtmlContentSchema>
   | (Static<typeof BoardWidgetMcpAppContentSchema> & { interactive: boolean })
   | Static<typeof BoardWidgetPluginContentSchema>;
+export type BoardWidgetRegisteredMaterializedContent = Static<
+  typeof BoardWidgetRegisteredContentSchema
+> & { pluginKind: string };
 
 export const BoardCanvasDocumentSourceSchema = closedObject({
   kind: Type.Literal("canvas-doc"),
@@ -216,6 +226,7 @@ export const BoardWidgetPutContentSchema = Type.Union([
   BoardWidgetHtmlContentSchema,
   BoardWidgetMcpAppPutContentSchema,
   BoardWidgetPluginContentSchema,
+  BoardWidgetRegisteredContentSchema,
   BoardCanvasDocumentSourceSchema,
 ]);
 export type BoardWidgetPutContent = Static<typeof BoardWidgetPutContentSchema>;
@@ -241,7 +252,7 @@ export const BoardWidgetPutParamsSchema = closedObject({
 export type BoardWidgetPutParams = Static<typeof BoardWidgetPutParamsSchema>;
 /** Materialized input accepted by the board store after gateway source resolution. */
 export type BoardWidgetMaterializedPutParams = Omit<BoardWidgetPutParams, "content"> & {
-  content: BoardWidgetMaterializedContent;
+  content: BoardWidgetMaterializedContent | BoardWidgetRegisteredMaterializedContent;
 };
 export const BoardWidgetPutResultSchema = closedObject({
   ...BoardSnapshotFields,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-board.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-board.ts
@@ -19,6 +19,7 @@ export const BoardProtocolSchemas = {
   BoardWidgetMcpAppContent: board.BoardWidgetMcpAppContentSchema,
   BoardWidgetMcpAppPutContent: board.BoardWidgetMcpAppPutContentSchema,
   BoardWidgetPluginContent: board.BoardWidgetPluginContentSchema,
+  BoardWidgetRegisteredContent: board.BoardWidgetRegisteredContentSchema,
   BoardCanvasDocumentSource: board.BoardCanvasDocumentSourceSchema,
   BoardWidgetContent: board.BoardWidgetContentSchema,
   BoardWidgetPutContent: board.BoardWidgetPutContentSchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,8 +239,11 @@ importers:
         version: 4.4.3
     devDependencies:
       '@a2ui/lit':
-        specifier: 0.10.2
-        version: 0.10.2(signal-polyfill@0.2.2)
+        specifier: 0.10.3
+        version: 0.10.3(signal-polyfill@0.2.2)
+      '@a2ui/web_core':
+        specifier: 0.10.6
+        version: 0.10.6
       '@copilotkit/aimock':
         specifier: 1.37.4
         version: 1.37.4(vitest@4.1.10)
@@ -574,8 +577,11 @@ importers:
   extensions/canvas:
     dependencies:
       '@a2ui/lit':
-        specifier: 0.10.2
-        version: 0.10.2(signal-polyfill@0.2.2)
+        specifier: 0.10.3
+        version: 0.10.3(signal-polyfill@0.2.2)
+      '@a2ui/web_core':
+        specifier: 0.10.6
+        version: 0.10.6
       '@lit/context':
         specifier: 1.1.6
         version: 1.1.6
@@ -2480,16 +2486,16 @@ importers:
 
 packages:
 
-  '@a2ui/lit@0.10.2':
-    resolution: {integrity: sha512-Jn/nlytHi0nXF6BRSEYPTJ27o4k8ozd+dTxeHZlNGG/ppVSw/EVWZ0N5uaxDoiCDhMNdQXQ3qZREMp9GsYXmMw==}
+  '@a2ui/lit@0.10.3':
+    resolution: {integrity: sha512-/kkL0BqJJfC6sn3XNKbo7QDWKE9K06blUVIoLHLU2PZQJalE1KBv/HLTpupBJ94SMhG+NaOUUu8yBUT+ACsm2Q==}
     peerDependencies:
       '@a2ui/markdown-it': '*'
     peerDependenciesMeta:
       '@a2ui/markdown-it':
         optional: true
 
-  '@a2ui/web_core@0.10.5':
-    resolution: {integrity: sha512-q+HyK1V/jM8l+/VmuXRbBNCS9yDguqdjsJ7/8aqY9O/WUdRE14FbhkFyQyGWQNqPJa9QbVfQyAjGQIK0B1aQtg==}
+  '@a2ui/web_core@0.10.6':
+    resolution: {integrity: sha512-kTwir93Fk5eupl4FZ6CkhJDrisR2fnQgEIlDCTp06uzx2PvUhItbq1E+h7hFyeHGTu/NMci9Tqn7Is1IVRpufw==}
 
   '@agentclientprotocol/claude-agent-acp@0.62.0':
     resolution: {integrity: sha512-8QRNmyk5Cfy4XVREeg5KCPoCDtmYS0xALY9WqI640PfopLMpeUzMByXbzLkBLbD819zB67DBhLG5ta98uOEPKg==}
@@ -9106,9 +9112,9 @@ packages:
 
 snapshots:
 
-  '@a2ui/lit@0.10.2(signal-polyfill@0.2.2)':
+  '@a2ui/lit@0.10.3(signal-polyfill@0.2.2)':
     dependencies:
-      '@a2ui/web_core': 0.10.5
+      '@a2ui/web_core': 0.10.6
       '@lit-labs/signals': 0.3.0
       '@lit/context': 1.1.6
       lit: 3.3.3
@@ -9117,7 +9123,7 @@ snapshots:
     transitivePeerDependencies:
       - signal-polyfill
 
-  '@a2ui/web_core@0.10.5':
+  '@a2ui/web_core@0.10.6':
     dependencies:
       '@preact/signals-core': 1.14.4
       date-fns: 4.4.0

--- a/scripts/check-database-first-legacy-stores.mts
+++ b/scripts/check-database-first-legacy-stores.mts
@@ -316,6 +316,7 @@ function isGeneratedAssetSourceFile(filePath: string) {
   const normalized = filePath.replaceAll(path.sep, "/");
   return (
     /(?:^|\/)extensions\/[^/]+\/(?:assets|dist)\/.+\.[cm]?js$/u.test(normalized) ||
+    /(?:^|\/)extensions\/canvas\/src\/host\/a2ui\/[^/]+\.bundle\.js$/u.test(normalized) ||
     /(?:^|\/)packages\/[^/]+\/dist\/.+\.[cm]?js$/u.test(normalized)
   );
 }

--- a/scripts/sync-native-a2ui.mts
+++ b/scripts/sync-native-a2ui.mts
@@ -234,6 +234,9 @@ async function withFreshBundleCheckSource(
       OPENCLAW_A2UI_BUNDLE_OUT: path.join(checkSourceDir, "a2ui.bundle.js"),
       OPENCLAW_A2UI_BUNDLE_HASH_FILE: path.join(tempDir, ".bundle.hash"),
     });
+    // Native node hosts still load the v0.8 page. The v0.9 bundle is board-only
+    // until native clients can select a renderer before applying their stream.
+    await fs.rm(path.join(checkSourceDir, "a2ui.bundle.js.v0.9.js"), { force: true });
     await run(checkSourceDir);
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -2,6 +2,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
+import { createPluginBoardWidgetContentKindRegistrar } from "../plugins/board-widget-content-kinds.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withEnv } from "../test-utils/env.js";
 import { isToolWrappedWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { applyToolAvailabilityDescriptions } from "./agent-tools.deferred-followup.js";
@@ -702,6 +706,44 @@ describe("gateway client capability tool filtering", () => {
         "show_widget",
       ),
     ).toBe(false);
+  });
+
+  it("keeps registered board widgets available without promising inline delivery", () => {
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({
+      id: "diagram",
+      source: "diagram-fixture",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+    createPluginBoardWidgetContentKindRegistrar(registry)(record, {
+      kind: "diagram",
+      label: "Diagram",
+      resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
+      validateSource() {},
+      composeDocument: ({ source }) => source,
+    });
+    setActivePluginRegistry(registry);
+
+    try {
+      const tool = expectToolNamed(
+        createOpenClawTools({
+          agentSessionKey: "agent:main:main",
+          clientCaps: ["inline-widgets"],
+          config: {
+            plugins: { entries: { canvas: { config: { host: { enabled: false } } } } },
+          },
+        }),
+        "show_widget",
+      );
+
+      expect(tool.description).toContain(
+        "Inline hosting is disabled; set pin=true to place it on this session's dashboard",
+      );
+    } finally {
+      resetPluginRuntimeStateForTest();
+    }
   });
 
   it("keeps the core widget tool out when OPENCLAW_SKIP_CANVAS_HOST is set", () => {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -4,7 +4,7 @@ import type {
   TaskSuggestionDeliveryMode,
 } from "../auto-reply/get-reply-options.types.js";
 import { isCoreCanvasHostEnabled } from "../canvas/config.js";
-import { createShowWidgetTool } from "../canvas/widget-tool.js";
+import { createShowWidgetTool, hasRegisteredShowWidgetKinds } from "../canvas/widget-tool.js";
 import type { ChatType } from "../channels/chat-type.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { ConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
@@ -541,7 +541,8 @@ export function createOpenClawTools(
       : []),
     ...(messageTool && includeMessageTool ? [messageTool] : []),
     // Discord owns show_widget; registering the core tool would collide.
-    ...(options?.agentChannel === "discord" || !isCoreCanvasHostEnabled(resolvedConfig)
+    ...(options?.agentChannel === "discord" ||
+    (!isCoreCanvasHostEnabled(resolvedConfig) && !hasRegisteredShowWidgetKinds())
       ? []
       : [
           createShowWidgetTool({

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -228,7 +228,6 @@ export function createOpenClawTools(
     ModelAwareToolContext,
 ): AnyAgentTool[] {
   const resolvedConfig = options?.config;
-  const sessionLinkBase = resolveControlUiSessionLinkBase(resolvedConfig);
   const activeProjectKeys = options?.preparedModelRuntime?.activeProjectKeys ?? [];
   const runtimeSnapshot = getActiveSecretsRuntimeConfigSnapshot();
   const availabilityConfig = selectApplicableRuntimeConfig({
@@ -452,7 +451,7 @@ export function createOpenClawTools(
     sandboxed: options?.sandboxed,
     config: resolvedConfig,
     callGateway: effectiveCallGateway,
-    sessionLinkBase,
+    sessionLinkBase: resolveControlUiSessionLinkBase(resolvedConfig),
   };
   const progressCardTool = shouldIncludeProgressCardToolForOpenClawTools({
     ...options,
@@ -549,6 +548,7 @@ export function createOpenClawTools(
             sessionId: options?.sessionId,
             agentId: sessionAgentId,
             agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
+            inlineHostEnabled: isCoreCanvasHostEnabled(resolvedConfig),
           }),
         ]),
     ...collectPresentOpenClawTools([heartbeatTool]),
@@ -719,13 +719,12 @@ export function createOpenClawTools(
   options?.recordToolPrepStage?.("openclaw-tools:core-tool-list");
   let allTools = tools;
   if (!options?.disablePluginTools) {
-    const existingToolNames = new Set(tools.map((tool) => tool.name));
     allTools = [
       ...tools,
       ...resolveOpenClawPluginToolsForOptions({
         options: { ...options, activeProjectKeys },
         resolvedConfig,
-        existingToolNames,
+        existingToolNames: new Set(tools.map((tool) => tool.name)),
       }),
     ];
     options?.recordToolPrepStage?.("openclaw-tools:plugin-tools");

--- a/src/boards/board-store.ts
+++ b/src/boards/board-store.ts
@@ -24,8 +24,19 @@ export type BoardWidgetHtmlDocument = {
   viewGeneration: string;
   grantState: "none" | "pending" | "granted" | "rejected";
   declared?: BoardWidgetDeclared;
+  resourceOrigins?: string[];
 };
 export type BoardWidgetHtmlViewMetadata = Omit<BoardWidgetHtmlDocument, "html">;
+export type BoardWidgetRegisteredDocument = {
+  pluginKind: string;
+  source: string;
+  title?: string;
+  revision: number;
+  sha256: string;
+  viewGeneration: string;
+  grantState: "none" | "pending" | "granted" | "rejected";
+  declared?: BoardWidgetDeclared;
+};
 export type BoardWidgetMcpAppDocument = {
   descriptor: BoardMcpAppDescriptor;
   revision: number;
@@ -34,7 +45,10 @@ export type BoardWidgetMcpAppDocument = {
   declaredTools: string[];
   interactive: boolean;
 };
-export type BoardWidgetDocument = BoardWidgetHtmlDocument | BoardWidgetMcpAppDocument;
+export type BoardWidgetDocument =
+  | BoardWidgetHtmlDocument
+  | BoardWidgetRegisteredDocument
+  | BoardWidgetMcpAppDocument;
 export type BoardSnapshotWithHtmlViewMetadata = {
   snapshot: BoardSnapshot;
   htmlViewMetadata: ReadonlyMap<string, BoardWidgetHtmlViewMetadata>;
@@ -53,6 +67,7 @@ export interface BoardStore {
     instanceId?: string,
   ): BoardSnapshot;
   readWidgetHtml(sessionKey: string, name: string): BoardWidgetHtmlDocument | undefined;
+  readWidgetRegistered(sessionKey: string, name: string): BoardWidgetRegisteredDocument | undefined;
   readWidgetMcpApp(sessionKey: string, name: string): BoardWidgetMcpAppDocument | undefined;
   listSessionsWithBoards(): string[];
 }
@@ -192,6 +207,18 @@ function validatePluginContent(params: BoardWidgetMaterializedPutParams): void {
   }
 }
 
+function validateRegisteredContent(params: BoardWidgetMaterializedPutParams): void {
+  if (params.content.kind !== "registered") {
+    return;
+  }
+  if (Buffer.byteLength(params.content.source, "utf8") > BOARD_MAX_WIDGET_HTML_BYTES) {
+    throw new BoardValidationError(
+      "invalid_operation",
+      `board registered widget source exceeds ${BOARD_MAX_WIDGET_HTML_BYTES} UTF-8 bytes`,
+    );
+  }
+}
+
 export function createBoardWidgetPutSnapshot(
   prior: BoardSnapshot,
   params: BoardWidgetMaterializedPutParams,
@@ -202,6 +229,7 @@ export function createBoardWidgetPutSnapshot(
   },
 ): BoardSnapshot {
   validatePluginContent(params);
+  validateRegisteredContent(params);
   if (
     params.content.kind === "html" &&
     Buffer.byteLength(params.content.html, "utf8") > BOARD_MAX_WIDGET_HTML_BYTES
@@ -234,7 +262,9 @@ export function createBoardWidgetPutSnapshot(
   const contentSha256 =
     params.content.kind === "html"
       ? createHash("sha256").update(params.content.html).digest("hex")
-      : undefined;
+      : params.content.kind === "registered"
+        ? createHash("sha256").update(params.content.source).digest("hex")
+        : undefined;
   // HTML grants are frozen to approved bytes. MCP App grants stay within the
   // source server. Either kind may narrow, but never widen, its declaration.
   const preservesGrant =
@@ -242,7 +272,9 @@ export function createBoardWidgetPutSnapshot(
     context.grantScopeMatches &&
     (params.content.kind !== "mcp-app" || params.content.interactive) &&
     existing?.grantState === "granted" &&
-    (params.content.kind === "html" ? contentSha256 === context.grantedSha256 : true) &&
+    (params.content.kind === "html" || params.content.kind === "registered"
+      ? contentSha256 === context.grantedSha256
+      : true) &&
     boardDeclarationIsSubset(declared, existing.declared);
   layout = insertBoardWidget(
     layout,
@@ -254,7 +286,7 @@ export function createBoardWidgetPutSnapshot(
         : existing?.title !== undefined
           ? { title: existing.title }
           : {}),
-      contentKind: params.content.kind,
+      contentKind: params.content.kind === "registered" ? "plugin" : params.content.kind,
       ...(params.presentation !== undefined
         ? { presentation: params.presentation }
         : existing?.presentation !== undefined
@@ -265,10 +297,10 @@ export function createBoardWidgetPutSnapshot(
         : existing?.heightMode !== undefined
           ? { heightMode: existing.heightMode }
           : {}),
-      ...(params.content.kind === "plugin"
+      ...(params.content.kind === "plugin" || params.content.kind === "registered"
         ? {
             pluginKind: params.content.pluginKind,
-            ...(params.content.props !== undefined
+            ...(params.content.kind === "plugin" && params.content.props !== undefined
               ? { props: structuredClone(params.content.props) }
               : {}),
           }

--- a/src/boards/sqlite-board-codec.ts
+++ b/src/boards/sqlite-board-codec.ts
@@ -19,6 +19,7 @@ import {
   resolveBoardWidgetPutParams,
   type BoardWidgetHtmlViewMetadata,
   type BoardWidgetNameIdentityMarker,
+  type BoardWidgetRegisteredDocument,
 } from "./board-store.js";
 
 export type SelectedBoardTabRow = Selectable<BoardTabRow>;
@@ -69,7 +70,7 @@ type ParsedRegisteredPluginContent = {
   pluginKind: string;
   source: string;
 };
-export type ParsedPluginContent = ParsedTrustedPluginContent | ParsedRegisteredPluginContent;
+type ParsedPluginContent = ParsedTrustedPluginContent | ParsedRegisteredPluginContent;
 
 export function parseManifest(value: string): ParsedBoardManifest {
   const parsed = JSON.parse(value) as {
@@ -353,6 +354,38 @@ export function parsePluginContent(value: string): ParsedPluginContent {
         pluginKind: parsed.pluginKind,
         ...(parsed.props !== undefined ? { props: parsed.props } : {}),
       };
+}
+
+export function rowToRegisteredDocument(
+  row: Pick<
+    SelectedBoardWidgetRow,
+    | "content_kind"
+    | "descriptor_json"
+    | "title"
+    | "revision"
+    | "sha256"
+    | "grant_state"
+    | "manifest"
+  >,
+): BoardWidgetRegisteredDocument | undefined {
+  if (row.content_kind !== "plugin" || row.descriptor_json === null) {
+    return undefined;
+  }
+  const content = parsePluginContent(row.descriptor_json);
+  const manifest = parseManifest(row.manifest);
+  if (!("source" in content) || !manifest.registeredInstanceId) {
+    return undefined;
+  }
+  return {
+    pluginKind: content.pluginKind,
+    source: content.source,
+    ...(row.title !== null ? { title: row.title } : {}),
+    revision: row.revision,
+    sha256: row.sha256,
+    viewGeneration: manifest.registeredInstanceId,
+    grantState: effectiveGrantState(row.grant_state, manifest),
+    ...(manifest.declared ? { declared: manifest.declared } : {}),
+  };
 }
 
 export function rowToTab(row: SelectedBoardTabRow): BoardTab {

--- a/src/boards/sqlite-board-codec.ts
+++ b/src/boards/sqlite-board-codec.ts
@@ -58,12 +58,18 @@ type ParsedBoardManifest = {
   nameIdentityInvalid?: true;
   mcpAppInteractive?: boolean;
   mcpAppInstanceId?: string;
+  registeredInstanceId?: string;
 };
 
-type ParsedPluginContent = {
+type ParsedTrustedPluginContent = {
   pluginKind: string;
   props?: Record<string, unknown>;
 };
+type ParsedRegisteredPluginContent = {
+  pluginKind: string;
+  source: string;
+};
+export type ParsedPluginContent = ParsedTrustedPluginContent | ParsedRegisteredPluginContent;
 
 export function parseManifest(value: string): ParsedBoardManifest {
   const parsed = JSON.parse(value) as {
@@ -75,6 +81,7 @@ export function parseManifest(value: string): ParsedBoardManifest {
     nameIdentity?: unknown;
     mcpAppInteractive?: unknown;
     mcpAppInstanceId?: unknown;
+    registeredInstanceId?: unknown;
   };
   const netOrigins = Array.isArray(parsed.netOrigins)
     ? parsed.netOrigins.filter((entry): entry is string => typeof entry === "string")
@@ -87,6 +94,11 @@ export function parseManifest(value: string): ParsedBoardManifest {
   const mcpAppInstanceId =
     typeof parsed.mcpAppInstanceId === "string" && /^[a-f0-9]{32}$/u.test(parsed.mcpAppInstanceId)
       ? parsed.mcpAppInstanceId
+      : undefined;
+  const registeredInstanceId =
+    typeof parsed.registeredInstanceId === "string" &&
+    /^[a-f0-9]{32}$/u.test(parsed.registeredInstanceId)
+      ? parsed.registeredInstanceId
       : undefined;
   const presentation =
     parsed.presentation === "card" ||
@@ -139,6 +151,7 @@ export function parseManifest(value: string): ParsedBoardManifest {
       ...(!nameIdentity && nameIdentityPresent ? { nameIdentityInvalid: true as const } : {}),
       ...(mcpAppInteractive !== undefined ? { mcpAppInteractive } : {}),
       ...(mcpAppInstanceId ? { mcpAppInstanceId } : {}),
+      ...(registeredInstanceId ? { registeredInstanceId } : {}),
     };
   } catch (error) {
     if (error instanceof BoardValidationError) {
@@ -153,7 +166,9 @@ export function parseManifest(value: string): ParsedBoardManifest {
 export function serializeManifest(
   declared: BoardWidgetDeclared | undefined,
   grantState: BoardWidget["grantState"],
-  mcpAppAuthority?: { interactive: boolean; instanceId: string },
+  frameAuthority?:
+    | { kind: "mcp-app"; interactive: boolean; instanceId: string }
+    | { kind: "registered"; instanceId: string },
   widgetOptions?: Pick<BoardWidget, "presentation" | "heightMode">,
   nameIdentity?: BoardWidgetNameIdentityMarker,
 ): string {
@@ -163,11 +178,14 @@ export function serializeManifest(
     ...(widgetOptions?.heightMode ? { heightMode: widgetOptions.heightMode } : {}),
     ...(nameIdentity ? { nameIdentity } : {}),
     ...(grantState === "granted" ? { grantSemanticsVersion: BOARD_GRANT_SEMANTICS_VERSION } : {}),
-    ...(mcpAppAuthority
+    ...(frameAuthority?.kind === "mcp-app"
       ? {
-          mcpAppInteractive: mcpAppAuthority.interactive,
-          mcpAppInstanceId: mcpAppAuthority.instanceId,
+          mcpAppInteractive: frameAuthority.interactive,
+          mcpAppInstanceId: frameAuthority.instanceId,
         }
+      : {}),
+    ...(frameAuthority?.kind === "registered"
+      ? { registeredInstanceId: frameAuthority.instanceId }
       : {}),
   });
 }
@@ -186,8 +204,10 @@ export function createBoardWidgetContentFields(
     params.declared,
     grantState,
     params.content.kind === "mcp-app"
-      ? { interactive: params.content.interactive, instanceId: viewGeneration }
-      : undefined,
+      ? { kind: "mcp-app", interactive: params.content.interactive, instanceId: viewGeneration }
+      : params.content.kind === "registered"
+        ? { kind: "registered", instanceId: viewGeneration }
+        : undefined,
     frame,
     params.generatedIdentity
       ? {
@@ -227,6 +247,25 @@ export function createBoardWidgetContentFields(
       manifest,
       grant_state: "none",
       granted_sha: null,
+      updated_at: now,
+    };
+  }
+  if (params.content.kind === "registered") {
+    const descriptorJson = JSON.stringify({
+      pluginKind: params.content.pluginKind,
+      source: params.content.source,
+    });
+    const sha256 = createHash("sha256").update(params.content.source).digest("hex");
+    return {
+      content_kind: "plugin",
+      html: null,
+      descriptor_json: descriptorJson,
+      sha256,
+      view_generation: null,
+      revision,
+      manifest,
+      grant_state: grantState,
+      granted_sha: grantState === "granted" ? sha256 : null,
       updated_at: now,
     };
   }
@@ -273,9 +312,15 @@ export function updateManifestHeightMode(
 }
 
 export function effectiveGrantState(
-  grantState: BoardWidget["grantState"],
+  storedGrantState: string,
   manifest: ParsedBoardManifest,
 ): BoardWidget["grantState"] {
+  const grantState: BoardWidget["grantState"] =
+    storedGrantState === "pending" ||
+    storedGrantState === "granted" ||
+    storedGrantState === "rejected"
+      ? storedGrantState
+      : "none";
   if (manifest.declarationInvalid || (!manifest.declared && manifest.mcpAppInteractive !== true)) {
     // Losing an invalid legacy declaration removes authority, never an
     // operator's explicit rejection of the widget document itself.
@@ -297,7 +342,17 @@ export function parseDescriptor(value: string): BoardMcpAppDescriptor {
 }
 
 export function parsePluginContent(value: string): ParsedPluginContent {
-  return JSON.parse(value) as ParsedPluginContent;
+  const parsed = JSON.parse(value) as Partial<ParsedRegisteredPluginContent> &
+    Partial<ParsedTrustedPluginContent>;
+  if (typeof parsed.pluginKind !== "string") {
+    throw new BoardValidationError("invalid_operation", "board plugin widget kind is invalid");
+  }
+  return typeof parsed.source === "string"
+    ? { pluginKind: parsed.pluginKind, source: parsed.source }
+    : {
+        pluginKind: parsed.pluginKind,
+        ...(parsed.props !== undefined ? { props: parsed.props } : {}),
+      };
 }
 
 export function rowToTab(row: SelectedBoardTabRow): BoardTab {
@@ -320,7 +375,11 @@ export function rowToWidget(
       ? parsePluginContent(row.descriptor_json)
       : undefined;
   const instanceId =
-    row.content_kind === "mcp-app" ? manifest.mcpAppInstanceId : row.view_generation;
+    row.content_kind === "mcp-app"
+      ? manifest.mcpAppInstanceId
+      : pluginContent && "source" in pluginContent
+        ? manifest.registeredInstanceId
+        : row.view_generation;
   return {
     name: row.name,
     tabId: row.tab_id,
@@ -331,13 +390,15 @@ export function rowToWidget(
     ...(pluginContent
       ? {
           pluginKind: pluginContent.pluginKind,
-          ...(pluginContent.props !== undefined ? { props: pluginContent.props } : {}),
+          ...("props" in pluginContent && pluginContent.props !== undefined
+            ? { props: pluginContent.props }
+            : {}),
         }
       : {}),
     sizeW: row.size_w,
     sizeH: row.size_h,
     position: row.position,
-    grantState: effectiveGrantState(row.grant_state as BoardWidget["grantState"], manifest),
+    grantState: effectiveGrantState(row.grant_state, manifest),
     revision: row.revision,
     ...(instanceId ? { instanceId } : {}),
     ...(declaredSummary ? { declaredSummary } : {}),
@@ -352,15 +413,17 @@ export function rowToHtmlViewMetadata(
   >,
   manifest: ReturnType<typeof parseManifest>,
 ): BoardWidgetHtmlViewMetadata | undefined {
-  if (row.content_kind !== "html" || row.view_generation === null) {
+  const viewGeneration =
+    row.content_kind === "html" ? row.view_generation : manifest.registeredInstanceId;
+  if (viewGeneration === null || viewGeneration === undefined) {
     return undefined;
   }
   const declared = manifest.declared;
   return {
     revision: row.revision,
     sha256: row.sha256,
-    viewGeneration: row.view_generation,
-    grantState: effectiveGrantState(row.grant_state as BoardWidget["grantState"], manifest),
+    viewGeneration,
+    grantState: effectiveGrantState(row.grant_state, manifest),
     ...(declared ? { declared } : {}),
   };
 }

--- a/src/boards/sqlite-board-store.ts
+++ b/src/boards/sqlite-board-store.ts
@@ -3,7 +3,6 @@ import type { DatabaseSync } from "node:sqlite";
 import type {
   BoardOp,
   BoardSnapshot,
-  BoardWidget,
   BoardWidgetMaterializedPutParams,
 } from "../../packages/gateway-protocol/src/index.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -43,6 +42,7 @@ import {
   parseManifest,
   parsePluginContent,
   resolveSqliteBoardWidgetPutParams,
+  rowToRegisteredDocument,
   rowToTab,
   rowToHtmlViewMetadata,
   rowToWidget,
@@ -199,38 +199,6 @@ function rowToHtmlDocument(
     viewGeneration: row.view_generation,
     grantState: effectiveGrantState(row.grant_state, manifest),
     ...(declared ? { declared } : {}),
-  };
-}
-
-function rowToRegisteredDocument(
-  row: Pick<
-    SelectedBoardWidgetRow,
-    | "content_kind"
-    | "descriptor_json"
-    | "title"
-    | "revision"
-    | "sha256"
-    | "grant_state"
-    | "manifest"
-  >,
-): BoardWidgetRegisteredDocument | undefined {
-  if (row.content_kind !== "plugin" || row.descriptor_json === null) {
-    return undefined;
-  }
-  const content = parsePluginContent(row.descriptor_json);
-  const manifest = parseManifest(row.manifest);
-  if (!("source" in content) || !manifest.registeredInstanceId) {
-    return undefined;
-  }
-  return {
-    pluginKind: content.pluginKind,
-    source: content.source,
-    ...(row.title !== null ? { title: row.title } : {}),
-    revision: row.revision,
-    sha256: row.sha256,
-    viewGeneration: manifest.registeredInstanceId,
-    grantState: effectiveGrantState(row.grant_state, manifest),
-    ...(manifest.declared ? { declared: manifest.declared } : {}),
   };
 }
 
@@ -652,7 +620,7 @@ export class SqliteBoardStore implements BoardStore {
     );
   }
 
-  readWidgetHtml(sessionKey: string, name: string): BoardWidgetHtmlDocument | undefined {
+  private readWidgetRow(sessionKey: string, name: string) {
     const resolved = this.resolve(sessionKey);
     const result = withOpenClawAgentDatabaseReadOnly(
       (database) => {
@@ -668,6 +636,7 @@ export class SqliteBoardStore implements BoardStore {
               "content_kind",
               "html",
               "descriptor_json",
+              "title",
               "revision",
               "sha256",
               "view_generation",
@@ -678,10 +647,7 @@ export class SqliteBoardStore implements BoardStore {
             .where("name", "=", name)
             .limit(1),
         ).rows[0];
-        if (!row) {
-          return undefined;
-        }
-        return rowToHtmlDocument(row);
+        return row;
       },
       {
         agentId: resolved.agentId,
@@ -692,85 +658,36 @@ export class SqliteBoardStore implements BoardStore {
     return result.found ? result.value : undefined;
   }
 
+  readWidgetHtml(sessionKey: string, name: string): BoardWidgetHtmlDocument | undefined {
+    const row = this.readWidgetRow(sessionKey, name);
+    return row ? rowToHtmlDocument(row) : undefined;
+  }
+
   readWidgetMcpApp(sessionKey: string, name: string): BoardWidgetMcpAppDocument | undefined {
-    const resolved = this.resolve(sessionKey);
-    const result = withOpenClawAgentDatabaseReadOnly(
-      (database) => {
-        if (!hasSession(database, resolved.sessionKey) || !boardTablesPresent(database)) {
-          return undefined;
-        }
-        const db = getNodeSqliteKysely<BoardDatabase>(database.db);
-        const row = executeSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("board_widgets")
-            .select(["content_kind", "descriptor_json", "revision", "grant_state", "manifest"])
-            .where("session_key", "=", resolved.sessionKey)
-            .where("name", "=", name)
-            .limit(1),
-        ).rows[0];
-        if (!row || row.content_kind !== "mcp-app" || row.descriptor_json === null) {
-          return undefined;
-        }
-        const manifest = parseManifest(row.manifest);
-        if (manifest.mcpAppInteractive === undefined || manifest.mcpAppInstanceId === undefined) {
-          return undefined;
-        }
-        return {
-          descriptor: parseDescriptor(row.descriptor_json),
-          revision: row.revision,
-          instanceId: manifest.mcpAppInstanceId,
-          grantState: effectiveGrantState(row.grant_state, manifest),
-          declaredTools: manifest.declared?.tools ?? [],
-          interactive: manifest.mcpAppInteractive,
-        };
-      },
-      {
-        agentId: resolved.agentId,
-        ...(resolved.path ? { path: resolved.path } : {}),
-        env: this.options.env,
-      },
-    );
-    return result.found ? result.value : undefined;
+    const row = this.readWidgetRow(sessionKey, name);
+    if (!row || row.content_kind !== "mcp-app" || row.descriptor_json === null) {
+      return undefined;
+    }
+    const manifest = parseManifest(row.manifest);
+    if (manifest.mcpAppInteractive === undefined || manifest.mcpAppInstanceId === undefined) {
+      return undefined;
+    }
+    return {
+      descriptor: parseDescriptor(row.descriptor_json),
+      revision: row.revision,
+      instanceId: manifest.mcpAppInstanceId,
+      grantState: effectiveGrantState(row.grant_state, manifest),
+      declaredTools: manifest.declared?.tools ?? [],
+      interactive: manifest.mcpAppInteractive,
+    };
   }
 
   readWidgetRegistered(
     sessionKey: string,
     name: string,
   ): BoardWidgetRegisteredDocument | undefined {
-    const resolved = this.resolve(sessionKey);
-    const result = withOpenClawAgentDatabaseReadOnly(
-      (database) => {
-        if (!hasSession(database, resolved.sessionKey) || !boardTablesPresent(database)) {
-          return undefined;
-        }
-        const db = getNodeSqliteKysely<BoardDatabase>(database.db);
-        const row = executeSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("board_widgets")
-            .select([
-              "content_kind",
-              "descriptor_json",
-              "title",
-              "revision",
-              "sha256",
-              "grant_state",
-              "manifest",
-            ])
-            .where("session_key", "=", resolved.sessionKey)
-            .where("name", "=", name)
-            .limit(1),
-        ).rows[0];
-        return row ? rowToRegisteredDocument(row) : undefined;
-      },
-      {
-        agentId: resolved.agentId,
-        ...(resolved.path ? { path: resolved.path } : {}),
-        env: this.options.env,
-      },
-    );
-    return result.found ? result.value : undefined;
+    const row = this.readWidgetRow(sessionKey, name);
+    return row ? rowToRegisteredDocument(row) : undefined;
   }
 
   listSessionsWithBoards(): string[] {

--- a/src/boards/sqlite-board-store.ts
+++ b/src/boards/sqlite-board-store.ts
@@ -33,6 +33,7 @@ import {
   type BoardWidgetHtmlDocument,
   type BoardWidgetHtmlViewMetadata,
   type BoardWidgetMcpAppDocument,
+  type BoardWidgetRegisteredDocument,
 } from "./board-store.js";
 import {
   BOARD_WIDGET_SNAPSHOT_COLUMNS,
@@ -196,8 +197,40 @@ function rowToHtmlDocument(
     revision: row.revision,
     sha256: row.sha256,
     viewGeneration: row.view_generation,
-    grantState: effectiveGrantState(row.grant_state as BoardWidget["grantState"], manifest),
+    grantState: effectiveGrantState(row.grant_state, manifest),
     ...(declared ? { declared } : {}),
+  };
+}
+
+function rowToRegisteredDocument(
+  row: Pick<
+    SelectedBoardWidgetRow,
+    | "content_kind"
+    | "descriptor_json"
+    | "title"
+    | "revision"
+    | "sha256"
+    | "grant_state"
+    | "manifest"
+  >,
+): BoardWidgetRegisteredDocument | undefined {
+  if (row.content_kind !== "plugin" || row.descriptor_json === null) {
+    return undefined;
+  }
+  const content = parsePluginContent(row.descriptor_json);
+  const manifest = parseManifest(row.manifest);
+  if (!("source" in content) || !manifest.registeredInstanceId) {
+    return undefined;
+  }
+  return {
+    pluginKind: content.pluginKind,
+    source: content.source,
+    ...(row.title !== null ? { title: row.title } : {}),
+    revision: row.revision,
+    sha256: row.sha256,
+    viewGeneration: manifest.registeredInstanceId,
+    grantState: effectiveGrantState(row.grant_state, manifest),
+    ...(manifest.declared ? { declared: manifest.declared } : {}),
   };
 }
 
@@ -496,7 +529,8 @@ export class SqliteBoardStore implements BoardStore {
                 parseDescriptor(existing.descriptor_json).serverName ===
                   canonicalParams.content.descriptor.serverName
               : existing.descriptor_json !== null &&
-                canonicalParams.content.kind === "plugin" &&
+                (canonicalParams.content.kind === "plugin" ||
+                  canonicalParams.content.kind === "registered") &&
                 parsePluginContent(existing.descriptor_json).pluginKind ===
                   canonicalParams.content.pluginKind
           : true;
@@ -593,10 +627,13 @@ export class SqliteBoardStore implements BoardStore {
                 decision,
                 manifest.mcpAppInteractive !== undefined && manifest.mcpAppInstanceId
                   ? {
+                      kind: "mcp-app" as const,
                       interactive: manifest.mcpAppInteractive,
                       instanceId: manifest.mcpAppInstanceId,
                     }
-                  : undefined,
+                  : manifest.registeredInstanceId
+                    ? { kind: "registered" as const, instanceId: manifest.registeredInstanceId }
+                    : undefined,
                 {
                   presentation: manifest.presentation,
                   heightMode: manifest.heightMode,
@@ -683,10 +720,49 @@ export class SqliteBoardStore implements BoardStore {
           descriptor: parseDescriptor(row.descriptor_json),
           revision: row.revision,
           instanceId: manifest.mcpAppInstanceId,
-          grantState: effectiveGrantState(row.grant_state as BoardWidget["grantState"], manifest),
+          grantState: effectiveGrantState(row.grant_state, manifest),
           declaredTools: manifest.declared?.tools ?? [],
           interactive: manifest.mcpAppInteractive,
         };
+      },
+      {
+        agentId: resolved.agentId,
+        ...(resolved.path ? { path: resolved.path } : {}),
+        env: this.options.env,
+      },
+    );
+    return result.found ? result.value : undefined;
+  }
+
+  readWidgetRegistered(
+    sessionKey: string,
+    name: string,
+  ): BoardWidgetRegisteredDocument | undefined {
+    const resolved = this.resolve(sessionKey);
+    const result = withOpenClawAgentDatabaseReadOnly(
+      (database) => {
+        if (!hasSession(database, resolved.sessionKey) || !boardTablesPresent(database)) {
+          return undefined;
+        }
+        const db = getNodeSqliteKysely<BoardDatabase>(database.db);
+        const row = executeSqliteQuerySync(
+          database.db,
+          db
+            .selectFrom("board_widgets")
+            .select([
+              "content_kind",
+              "descriptor_json",
+              "title",
+              "revision",
+              "sha256",
+              "grant_state",
+              "manifest",
+            ])
+            .where("session_key", "=", resolved.sessionKey)
+            .where("name", "=", name)
+            .limit(1),
+        ).rows[0];
+        return row ? rowToRegisteredDocument(row) : undefined;
       },
       {
         agentId: resolved.agentId,

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -8,7 +8,7 @@ import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.
 import { createTestBoardStore } from "../boards/board-store.test-support.js";
 import { createBoardHandlers } from "../gateway/server-methods/board.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
-import { registerPluginBoardWidgetContentKind } from "../plugins/board-widget-content-kinds.js";
+import { createPluginBoardWidgetContentKindRegistrar } from "../plugins/board-widget-content-kinds.js";
 import { createPluginRecord } from "../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
@@ -111,18 +111,16 @@ describe("show_widget", () => {
       enabled: true,
       configSchema: false,
     });
-    registerPluginBoardWidgetContentKind({
-      record,
-      registry,
-      definition: {
-        kind: "diagram",
-        label: "Diagram",
-        resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
-        validateSource(source) {
-          if (!source.startsWith("diagram:")) throw new Error("diagram prefix required");
-        },
-        composeDocument: ({ source }) => `<main>${source}</main>`,
+    createPluginBoardWidgetContentKindRegistrar(registry)(record, {
+      kind: "diagram",
+      label: "Diagram",
+      resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
+      validateSource(source) {
+        if (!source.startsWith("diagram:")) {
+          throw new Error("diagram prefix required");
+        }
       },
+      composeDocument: ({ source }) => `<main>${source}</main>`,
     });
     setActivePluginRegistry(registry);
     const stateDir = await createStateDir();

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -37,6 +37,56 @@ async function createStateDir(): Promise<string> {
   return stateDir;
 }
 
+function registerDiagramContentKind(): void {
+  const registry = createEmptyPluginRegistry();
+  const record = createPluginRecord({
+    id: "diagram",
+    source: "diagram-fixture",
+    origin: "bundled",
+    enabled: true,
+    configSchema: false,
+  });
+  createPluginBoardWidgetContentKindRegistrar(registry)(record, {
+    kind: "diagram",
+    label: "Diagram",
+    resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
+    validateSource(source) {
+      if (!source.startsWith("diagram:")) {
+        throw new Error("diagram prefix required");
+      }
+    },
+    composeDocument: ({ source }) => `<main>${source}</main>`,
+  });
+  setActivePluginRegistry(registry);
+}
+
+function createBoardPutCaller() {
+  const mock = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
+    sessionKey: params.sessionKey,
+    revision: 1,
+    tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+    widgets: [
+      {
+        name: params.name,
+        tabId: "main",
+        contentKind: "plugin",
+        pluginKind: "diagram:diagram",
+        sizeW: 6,
+        sizeH: 4,
+        position: 0,
+        grantState: "none",
+        revision: 1,
+      },
+    ],
+    resolvedWidgetName: params.name,
+  }));
+  const callGateway: InProcessGatewayCaller = async <T>(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<T> => (await mock(method, params)) as T;
+  return { mock, callGateway };
+}
+
 function resolveCanvasDocumentDir(stateDir: string, documentId: string): string {
   return path.join(resolveCanvasDocumentsDir(stateDir), documentId);
 }
@@ -103,50 +153,9 @@ async function executeWidget(params: {
 
 describe("show_widget", () => {
   it("builds a sorted kind enum and routes registered source through board put", async () => {
-    const registry = createEmptyPluginRegistry();
-    const record = createPluginRecord({
-      id: "diagram",
-      source: "diagram-fixture",
-      origin: "bundled",
-      enabled: true,
-      configSchema: false,
-    });
-    createPluginBoardWidgetContentKindRegistrar(registry)(record, {
-      kind: "diagram",
-      label: "Diagram",
-      resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
-      validateSource(source) {
-        if (!source.startsWith("diagram:")) {
-          throw new Error("diagram prefix required");
-        }
-      },
-      composeDocument: ({ source }) => `<main>${source}</main>`,
-    });
-    setActivePluginRegistry(registry);
+    registerDiagramContentKind();
     const stateDir = await createStateDir();
-    const callGatewayMock = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
-      sessionKey: params.sessionKey,
-      revision: 1,
-      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
-      widgets: [
-        {
-          name: params.name,
-          tabId: "main",
-          contentKind: "plugin",
-          pluginKind: "diagram:diagram",
-          sizeW: 6,
-          sizeH: 4,
-          position: 0,
-          grantState: "none",
-          revision: 1,
-        },
-      ],
-      resolvedWidgetName: params.name,
-    }));
-    const callGateway: InProcessGatewayCaller = async <T>(
-      method: string,
-      params: Record<string, unknown>,
-    ): Promise<T> => (await callGatewayMock(method, params)) as T;
+    const { mock: callGatewayMock, callGateway } = createBoardPutCaller();
     const tool = createShowWidgetTool({
       stateDir,
       sessionId: "registered",
@@ -180,6 +189,50 @@ describe("show_widget", () => {
     ).rejects.toThrow(
       'widget kind "diagram" is unavailable; enable the plugin that provides it and retry',
     );
+  });
+
+  it("uses board-only delivery when inline hosting is disabled", async () => {
+    registerDiagramContentKind();
+    const stateDir = await createStateDir();
+    const { mock: callGatewayMock, callGateway } = createBoardPutCaller();
+    const tool = createShowWidgetTool({
+      stateDir,
+      sessionId: "board-only",
+      agentSessionKey: "agent:main:board-only",
+      inlineHostEnabled: false,
+      callGateway,
+    });
+
+    await expect(
+      tool.execute("unpinned", {
+        title: "Diagram",
+        widget_code: "diagram:ready",
+        kind: "diagram",
+      }),
+    ).rejects.toThrow(
+      "inline widget hosting is disabled; set pin=true to place the widget on the session dashboard",
+    );
+    await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
+
+    const result = await tool.execute("pinned", {
+      title: "Diagram",
+      widget_code: "diagram:ready",
+      kind: "diagram",
+      pin: true,
+    });
+    const text = result.content.find((item) => item.type === "text")?.text;
+    expect(JSON.parse(text ?? "null")).toEqual({
+      status: "pinned",
+      boardWidgetName: "diagram",
+      text: "Widget pinned to dashboard tab main as diagram",
+    });
+    expect(callGatewayMock).toHaveBeenCalledExactlyOnceWith(
+      "board.widget.put",
+      expect.objectContaining({
+        content: { kind: "registered", contentKind: "diagram", source: "diagram:ready" },
+      }),
+    );
+    await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
   });
 
   it("tells the agent to use widgets proactively", () => {

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -8,6 +8,10 @@ import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.
 import { createTestBoardStore } from "../boards/board-store.test-support.js";
 import { createBoardHandlers } from "../gateway/server-methods/board.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
+import { registerPluginBoardWidgetContentKind } from "../plugins/board-widget-content-kinds.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveCanvasDocumentsDir } from "./documents.js";
@@ -23,6 +27,7 @@ afterEach(async () => {
   vi.useRealTimers();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
+  resetPluginRuntimeStateForTest();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -50,6 +55,7 @@ async function executeWidget(params: {
   presentation?: "card" | "full-bleed" | "frameless";
   after?: string;
   capabilities?: { netOrigins?: string[]; tools?: string[] };
+  kind?: string;
 }) {
   const tool = createShowWidgetTool({
     stateDir: params.stateDir,
@@ -68,6 +74,7 @@ async function executeWidget(params: {
     ...(params.presentation ? { presentation: params.presentation } : {}),
     ...(params.after ? { after: params.after } : {}),
     ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+    ...(params.kind ? { kind: params.kind } : {}),
   });
   const text = result.content.find((item) => item.type === "text")?.text;
   if (!text) {
@@ -95,6 +102,88 @@ async function executeWidget(params: {
 }
 
 describe("show_widget", () => {
+  it("builds a sorted kind enum and routes registered source through board put", async () => {
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({
+      id: "diagram",
+      source: "diagram-fixture",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+    registerPluginBoardWidgetContentKind({
+      record,
+      registry,
+      definition: {
+        kind: "diagram",
+        label: "Diagram",
+        resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
+        validateSource(source) {
+          if (!source.startsWith("diagram:")) throw new Error("diagram prefix required");
+        },
+        composeDocument: ({ source }) => `<main>${source}</main>`,
+      },
+    });
+    setActivePluginRegistry(registry);
+    const stateDir = await createStateDir();
+    const callGatewayMock = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
+      sessionKey: params.sessionKey,
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+      widgets: [
+        {
+          name: params.name,
+          tabId: "main",
+          contentKind: "plugin",
+          pluginKind: "diagram:diagram",
+          sizeW: 6,
+          sizeH: 4,
+          position: 0,
+          grantState: "none",
+          revision: 1,
+        },
+      ],
+      resolvedWidgetName: params.name,
+    }));
+    const callGateway: InProcessGatewayCaller = async <T>(
+      method: string,
+      params: Record<string, unknown>,
+    ): Promise<T> => (await callGatewayMock(method, params)) as T;
+    const tool = createShowWidgetTool({
+      stateDir,
+      sessionId: "registered",
+      agentSessionKey: "agent:main:registered",
+      callGateway,
+    });
+    const kindSchema = (tool.parameters as { properties?: { kind?: { enum?: string[] } } })
+      .properties?.kind;
+
+    expect(kindSchema?.enum).toEqual(["html", "diagram"]);
+    await tool.execute("registered", {
+      title: "Diagram",
+      widget_code: "diagram:ready",
+      kind: "diagram",
+      pin: true,
+    });
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      "board.widget.put",
+      expect.objectContaining({
+        content: { kind: "registered", contentKind: "diagram", source: "diagram:ready" },
+      }),
+    );
+
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    await expect(
+      tool.execute("stale", {
+        title: "Diagram",
+        widget_code: "diagram:ready",
+        kind: "diagram",
+      }),
+    ).rejects.toThrow(
+      'widget kind "diagram" is unavailable; enable the plugin that provides it and retry',
+    );
+  });
+
   it("tells the agent to use widgets proactively", () => {
     expect(createShowWidgetTool().description).toMatch(
       /^Visual helps\? Make widget\. Do not wait for ask\./,

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -87,6 +87,7 @@ type ShowWidgetToolOptions = {
   agentSessionKey?: string;
   stateDir?: string;
   callGateway?: InProcessGatewayCaller;
+  inlineHostEnabled?: boolean;
 };
 
 function slugWidgetName(title: string): string {
@@ -137,12 +138,13 @@ function assertPinnedWidgetDocumentSize(html: string): void {
 /** Creates a self-contained widget hosted by OpenClaw core. */
 export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAgentTool {
   const gatewayCall = options.callGateway ?? callInProcessGatewayTool;
+  const inlineHostEnabled = options.inlineHostEnabled !== false;
   const registeredKinds = listBoardWidgetContentKinds(currentPluginRegistry());
   const kinds = ["html", ...registeredKinds] as const;
   return {
     label: "Show Widget",
     name: "show_widget",
-    description: `Visual helps? Make widget. Do not wait for ask. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. Show a widget on the user's current surface; kind defaults to html${registeredKinds.length ? ` and registered kinds are ${registeredKinds.join(", ")}` : ""}. Set pin=true to also place it on this session's dashboard; use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), and openclaw.cron.trigger(jobId). \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.`,
+    description: `Visual helps? Make widget. Do not wait for ask. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. Show a widget on the user's current surface; kind defaults to html${registeredKinds.length ? ` and registered kinds are ${registeredKinds.join(", ")}` : ""}. ${inlineHostEnabled ? "Set pin=true to also place it on this session's dashboard" : "Inline hosting is disabled; set pin=true to place it on this session's dashboard"}; use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), and openclaw.cron.trigger(jobId). \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.`,
     parameters: showWidgetToolSchema(kinds),
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (_toolCallId, args) => {
@@ -186,24 +188,30 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           throw new WidgetHtmlInputError(`invalid ${kind} widget source: ${String(error)}`);
         }
       }
-      const inlineBody = registration
-        ? registration.definition.composeDocument({
-            source: widgetCode,
+      if (!inlineHostEnabled && !shouldPin) {
+        throw new WidgetHtmlInputError(
+          "inline widget hosting is disabled; set pin=true to place the widget on the session dashboard",
+        );
+      }
+      const wrappedDocument = inlineHostEnabled
+        ? buildWidgetDocument(
             title,
-            resourceUrls: Object.fromEntries(
-              registration.definition.resources.paths.map((resourcePath) => [
-                resourcePath,
-                resourcePath,
-              ]),
-            ),
-            promptGranted: false,
-          })
-        : widgetCode;
-      const wrappedDocument = buildWidgetDocument(
-        title,
-        inlineBody,
-        registration ? { scriptOrigins: ["'self'"] } : {},
-      );
+            registration
+              ? registration.definition.composeDocument({
+                  source: widgetCode,
+                  title,
+                  resourceUrls: Object.fromEntries(
+                    registration.definition.resources.paths.map((resourcePath) => [
+                      resourcePath,
+                      resourcePath,
+                    ]),
+                  ),
+                  promptGranted: false,
+                })
+              : widgetCode,
+            registration ? { scriptOrigins: ["'self'"] } : {},
+          )
+        : undefined;
       let pinnedText = "";
       let pinnedWidgetName: string | undefined;
       if (pinSessionKey) {
@@ -248,9 +256,16 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         const widget = snapshot.widgets.find(
           (candidate) => candidate.name === snapshot.resolvedWidgetName,
         );
-        pinnedText = `; pinned to dashboard tab ${widget?.tabId ?? tab ?? "main"} as ${
+        pinnedText = `pinned to dashboard tab ${widget?.tabId ?? tab ?? "main"} as ${
           snapshot.resolvedWidgetName
         }${size ? ` (${size})` : ""}`;
+      }
+      if (!wrappedDocument) {
+        return jsonResult({
+          status: "pinned",
+          boardWidgetName: pinnedWidgetName,
+          text: `Widget ${pinnedText}`,
+        });
       }
       // Pin first: placement validation can fail, and a rejected board write
       // must not materialize or prune the bounded inline-document store.
@@ -277,7 +292,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           url: document.entryUrl,
           ...(pinnedWidgetName ? { boardWidgetName: pinnedWidgetName } : {}),
         },
-        text: `Widget hosted at ${document.entryUrl}${pinnedText}`,
+        text: `Widget hosted at ${document.entryUrl}${pinnedText ? `; ${pinnedText}` : ""}`,
       });
     },
   };

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -199,9 +199,11 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
             promptGranted: false,
           })
         : widgetCode;
-      const wrappedDocument = buildWidgetDocument(title, inlineBody, {
-        ...(registration ? { scriptOrigins: ["'self'"] } : {}),
-      });
+      const wrappedDocument = buildWidgetDocument(
+        title,
+        inlineBody,
+        registration ? { scriptOrigins: ["'self'"] } : {},
+      );
       let pinnedText = "";
       let pinnedWidgetName: string | undefined;
       if (pinSessionKey) {

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -10,6 +10,12 @@ import {
 } from "../agents/tools/in-process-gateway.js";
 import { normalizeBoardWidgetDeclared } from "../boards/board-capabilities.js";
 import { assertWidgetHtmlSize, WidgetHtmlInputError } from "../plugin-sdk/widget-html.js";
+import {
+  listBoardWidgetContentKinds,
+  resolveBoardWidgetContentKind,
+} from "../plugins/board-widget-content-kinds.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createCanvasDocument } from "./documents.js";
 import { buildWidgetDocument } from "./wrap.js";
 
@@ -18,49 +24,62 @@ const WIDGET_CODE_MAX_CHARS = 262_144;
 const PINNED_WIDGET_MAX_UTF8_BYTES = 256 * 1024;
 const WIDGET_MAX_PER_SCOPE = 32;
 
-const ShowWidgetToolSchema = Type.Object({
-  title: Type.String(),
-  widget_code: Type.String(),
-  name: Type.Optional(
-    Type.String({
-      pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
-      description: "Stable dashboard widget name when pinning",
+function currentPluginRegistry() {
+  return getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getActivePluginRegistry();
+}
+
+export function hasRegisteredShowWidgetKinds(): boolean {
+  return listBoardWidgetContentKinds(currentPluginRegistry()).length > 0;
+}
+
+function showWidgetToolSchema(kinds: readonly string[]) {
+  return Type.Object({
+    title: Type.String(),
+    widget_code: Type.String(),
+    kind: optionalStringEnum(kinds, {
+      description: `Widget source kind: ${kinds.join(", ")}`,
     }),
-  ),
-  pin: Type.Optional(
-    Type.Boolean({ description: "Also pin this widget to the session dashboard" }),
-  ),
-  tab: Type.Optional(
-    Type.String({ pattern: "^[a-z0-9-]{1,40}$", description: "Dashboard tab slug" }),
-  ),
-  size: optionalStringEnum(["sm", "md", "lg", "xl", "full"] as const, {
-    description: "Dashboard size: sm, md, lg, xl, or full",
-  }),
-  presentation: optionalStringEnum(["card", "full-bleed", "frameless"] as const, {
-    description: "Pinned dashboard frame: card, full-bleed, or frameless",
-  }),
-  after: Type.Optional(
-    Type.String({
-      pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
-      description: "Place after this dashboard widget name",
+    name: Type.Optional(
+      Type.String({
+        pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
+        description: "Stable dashboard widget name when pinning",
+      }),
+    ),
+    pin: Type.Optional(
+      Type.Boolean({ description: "Also pin this widget to the session dashboard" }),
+    ),
+    tab: Type.Optional(
+      Type.String({ pattern: "^[a-z0-9-]{1,40}$", description: "Dashboard tab slug" }),
+    ),
+    size: optionalStringEnum(["sm", "md", "lg", "xl", "full"] as const, {
+      description: "Dashboard size: sm, md, lg, xl, or full",
     }),
-  ),
-  capabilities: Type.Optional(
-    Type.Object({
-      netOrigins: Type.Optional(
-        Type.Array(Type.String(), {
-          description: "Exact HTTPS origins the pinned widget may fetch after approval",
-        }),
-      ),
-      tools: Type.Optional(
-        Type.Array(Type.String(), {
-          description:
-            "Pinned widget host tools, such as prompt, sessions.list, or cron.trigger:<jobId>",
-        }),
-      ),
+    presentation: optionalStringEnum(["card", "full-bleed", "frameless"] as const, {
+      description: "Pinned dashboard frame: card, full-bleed, or frameless",
     }),
-  ),
-});
+    after: Type.Optional(
+      Type.String({
+        pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
+        description: "Place after this dashboard widget name",
+      }),
+    ),
+    capabilities: Type.Optional(
+      Type.Object({
+        netOrigins: Type.Optional(
+          Type.Array(Type.String(), {
+            description: "Exact HTTPS origins the pinned widget may fetch after approval",
+          }),
+        ),
+        tools: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              "Pinned widget host tools, such as prompt, sessions.list, or cron.trigger:<jobId>",
+          }),
+        ),
+      }),
+    ),
+  });
+}
 
 type ShowWidgetToolOptions = {
   sessionId?: string;
@@ -118,15 +137,17 @@ function assertPinnedWidgetDocumentSize(html: string): void {
 /** Creates a self-contained widget hosted by OpenClaw core. */
 export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAgentTool {
   const gatewayCall = options.callGateway ?? callInProcessGatewayTool;
+  const registeredKinds = listBoardWidgetContentKinds(currentPluginRegistry());
+  const kinds = ["html", ...registeredKinds] as const;
   return {
     label: "Show Widget",
     name: "show_widget",
-    description:
-      'Visual helps? Make widget. Do not wait for ask. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. Show interactive self-contained HTML or SVG widget on the user\'s current surface. Set pin=true to also place it on this session\'s dashboard; use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation card|full-bleed|frameless, and after for a sibling widget anchor. Dashboard widgets auto-fit their content height until the user resizes them. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. Inline everything; no external resources unless an exact HTTPS origin is declared and granted. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), and openclaw.cron.trigger(jobId). `title` is host metadata for the accessible chat preview, exports, pinning, and dashboard chrome. Start directly with content; do not repeat the title, add a generic widget header, or recreate pin/menu controls. Use internal headings only to label or control widget content. Pre-themed: bare button, input, select, textarea, table, code, h1-h3 already styled — write minimal HTML. Helper classes: .card, .badge (.ok/.warn/.danger/.info), .metric, .muted, .row; button.primary = the one main action. Theme vars (auto light/dark, live host sync): --surface --card --elevated --text --text-strong --muted --border --border-strong --accent (links/focus/highlight) --accent-fill (primary bg) --accent-fg --ok --warn --danger --info (each with -subtle tint) --radius --font-body --font-mono. Colors ONLY via these vars — never hex/rgb/hsl, no own color palette; layout-only custom vars fine. Page background stays transparent. Pattern: <div class="card"><div class="muted">Uptime</div><div class="metric">18d</div></div> <span class="badge ok">connected</span>. Web chat: sendPrompt(text) sends text as the user\'s message — wire to buttons, suffix label with ↗; works only after a real click inside the widget (never call automatically; slash commands rejected).',
-    parameters: ShowWidgetToolSchema,
+    description: `Visual helps? Make widget. Do not wait for ask. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. Show a widget on the user's current surface; kind defaults to html${registeredKinds.length ? ` and registered kinds are ${registeredKinds.join(", ")}` : ""}. Set pin=true to also place it on this session's dashboard; use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), and openclaw.cron.trigger(jobId). \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.`,
+    parameters: showWidgetToolSchema(kinds),
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
+      const kind = readToolStringParam(params, "kind") ?? "html";
       const title = readToolStringParam(params, "title", { required: true });
       const rawWidgetCode = readToolStringParam(params, "widget_code", {
         required: true,
@@ -151,7 +172,36 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         throw new WidgetHtmlInputError("pin requires an agent session");
       }
       const widgetCode = rawWidgetCode.trim();
-      const wrappedDocument = buildWidgetDocument(title, widgetCode);
+      const registration =
+        kind === "html" ? undefined : resolveBoardWidgetContentKind(currentPluginRegistry(), kind);
+      if (kind !== "html" && !registration) {
+        throw new WidgetHtmlInputError(
+          `widget kind ${JSON.stringify(kind)} is unavailable; enable the plugin that provides it and retry`,
+        );
+      }
+      if (registration) {
+        try {
+          registration.definition.validateSource(widgetCode);
+        } catch (error) {
+          throw new WidgetHtmlInputError(`invalid ${kind} widget source: ${String(error)}`);
+        }
+      }
+      const inlineBody = registration
+        ? registration.definition.composeDocument({
+            source: widgetCode,
+            title,
+            resourceUrls: Object.fromEntries(
+              registration.definition.resources.paths.map((resourcePath) => [
+                resourcePath,
+                resourcePath,
+              ]),
+            ),
+            promptGranted: false,
+          })
+        : widgetCode;
+      const wrappedDocument = buildWidgetDocument(title, inlineBody, {
+        ...(registration ? { scriptOrigins: ["'self'"] } : {}),
+      });
       let pinnedText = "";
       let pinnedWidgetName: string | undefined;
       if (pinSessionKey) {
@@ -163,18 +213,22 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         const presentation = readToolStringParam(params, "presentation");
         const after = readToolStringParam(params, "after");
         const pinnedTitle = boardWidgetTitle(title);
-        assertPinnedWidgetDocumentSize(
-          buildWidgetDocument(pinnedTitle ?? name, widgetCode, {
-            connectOrigins: capabilities?.netOrigins,
-          }),
-        );
+        if (!registration) {
+          assertPinnedWidgetDocumentSize(
+            buildWidgetDocument(pinnedTitle ?? name, widgetCode, {
+              connectOrigins: capabilities?.netOrigins,
+            }),
+          );
+        }
         const snapshot = await gatewayCall<BoardWidgetPutResult>("board.widget.put", {
           sessionKey,
           name,
           ...(pinnedTitle ? { title: pinnedTitle } : {}),
           // The Gateway owns the board document shell so agent-authored bytes
           // can never run before its user-activation and bridge bootstrap.
-          content: { kind: "html", html: widgetCode },
+          content: registration
+            ? { kind: "registered", contentKind: kind, source: widgetCode }
+            : { kind: "html", html: widgetCode },
           ...(presentation ? { presentation } : {}),
           ...(capabilities ? { declared: capabilities } : {}),
           ...(!explicitName ? { generatedIdentity: generatedWidgetIdentity(title, name) } : {}),

--- a/src/canvas/wrap.ts
+++ b/src/canvas/wrap.ts
@@ -81,6 +81,7 @@ code{padding:1px 5px}pre{padding:10px;overflow-x:auto}
 
 type WidgetDocumentOptions = {
   connectOrigins?: readonly string[];
+  scriptOrigins?: readonly string[];
 };
 
 /** Wraps agent-authored widget markup in the stable isolated Canvas document shell. */
@@ -237,6 +238,7 @@ export function buildWidgetDocument(
   const connectSources = options.connectOrigins?.length
     ? options.connectOrigins.join(" ")
     : "'none'";
+  const scriptSources = options.scriptOrigins?.length ? ` ${options.scriptOrigins.join(" ")}` : "";
   return `<!doctype html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src ${connectSources};"><title>${escapeHtml(title)}</title><style>${WIDGET_BASE_STYLES}</style></head><body${bodyClass}>${widgetBridge}${themeBridge}${snapshotBridge}${widgetCode}${sizeReporter}</body></html>`;
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'${scriptSources}; img-src data:; connect-src ${connectSources};"><title>${escapeHtml(title)}</title><style>${WIDGET_BASE_STYLES}</style></head><body${bodyClass}>${widgetBridge}${themeBridge}${snapshotBridge}${widgetCode}${sizeReporter}</body></html>`;
 }

--- a/src/gateway/board-sandbox.ts
+++ b/src/gateway/board-sandbox.ts
@@ -1,7 +1,9 @@
 import { buildSandboxHostPath } from "../agents/sandbox-host.js";
 import type { BoardWidgetHtmlViewMetadata } from "../boards/board-store.js";
 
-type BoardWidgetSandboxMetadata = Pick<BoardWidgetHtmlViewMetadata, "declared" | "grantState">;
+type BoardWidgetSandboxMetadata = Pick<BoardWidgetHtmlViewMetadata, "declared" | "grantState"> & {
+  resourceOrigins?: readonly string[];
+};
 
 function grantedConnectOrigins(document: BoardWidgetSandboxMetadata): string[] | undefined {
   if (document.grantState !== "granted") {
@@ -17,6 +19,7 @@ export function buildBoardWidgetSandboxPath(document: BoardWidgetSandboxMetadata
     // Best-effort hardening for the documented WebRTC residual; the DOM guard
     // reduces fresh descendant realms but is not an authorization boundary.
     blockDescendantFrames: true,
+    ...(document.resourceOrigins?.length ? { resourceDomains: [...document.resourceOrigins] } : {}),
     ...(connectDomains ? { connectDomains } : {}),
   });
 }
@@ -26,11 +29,13 @@ export function buildBoardWidgetContentSecurityPolicy(
   document: BoardWidgetSandboxMetadata,
 ): string {
   const connectSources = grantedConnectOrigins(document)?.join(" ") ?? "'none'";
+  const resourceSources = document.resourceOrigins?.join(" ") ?? "";
   return [
     "default-src 'none'",
-    "script-src 'unsafe-inline'",
+    `script-src 'unsafe-inline' ${resourceSources}`.trim(),
     "style-src 'unsafe-inline'",
-    "img-src data:",
+    `img-src data: ${resourceSources}`.trim(),
+    `media-src data: ${resourceSources}`.trim(),
     `connect-src ${connectSources}`,
     "webrtc 'block'",
     "base-uri 'none'",

--- a/src/gateway/board-view-ticket.ts
+++ b/src/gateway/board-view-ticket.ts
@@ -23,6 +23,10 @@ type BoardViewTicketClaims = {
   viewGeneration: string;
   expiresAtMs: number;
   nonce: string;
+  pluginFrame?: {
+    pluginKind: string;
+    scopedHostUrl: string;
+  };
 };
 
 function signTicketPayload(payload: string, secret: Buffer): string {
@@ -53,7 +57,13 @@ function isValidClaims(value: unknown): value is BoardViewTicketClaims {
     /^[a-f0-9]{32}$/u.test(claims.viewGeneration) &&
     Number.isSafeInteger(claims.expiresAtMs) &&
     typeof claims.nonce === "string" &&
-    /^[A-Za-z0-9_-]{32}$/u.test(claims.nonce)
+    /^[A-Za-z0-9_-]{32}$/u.test(claims.nonce) &&
+    (claims.pluginFrame === undefined ||
+      (typeof claims.pluginFrame === "object" &&
+        typeof claims.pluginFrame.pluginKind === "string" &&
+        claims.pluginFrame.pluginKind.length <= 128 &&
+        typeof claims.pluginFrame.scopedHostUrl === "string" &&
+        claims.pluginFrame.scopedHostUrl.length <= 1024))
   );
 }
 
@@ -64,6 +74,7 @@ export function createBoardViewTicket(params: {
   revision: number;
   viewGeneration: string;
   nowMs?: number;
+  pluginFrame?: BoardViewTicketClaims["pluginFrame"];
 }): BoardViewTicket {
   const nowMs = params.nowMs ?? Date.now();
   const claims: BoardViewTicketClaims = {
@@ -74,6 +85,7 @@ export function createBoardViewTicket(params: {
     viewGeneration: params.viewGeneration,
     expiresAtMs: nowMs + BOARD_VIEW_TICKET_TTL_MS,
     nonce: randomBytes(24).toString("base64url"),
+    ...(params.pluginFrame ? { pluginFrame: params.pluginFrame } : {}),
   };
   if (!Number.isSafeInteger(nowMs) || !isValidClaims(claims)) {
     throw new Error("invalid board view ticket binding");

--- a/src/gateway/board-widget-view.ts
+++ b/src/gateway/board-widget-view.ts
@@ -1,5 +1,11 @@
 import { BoardValidationError } from "../boards/board-layout.js";
 import type { BoardStore, BoardWidgetDocument } from "../boards/board-store.js";
+import { buildWidgetDocument } from "../canvas/wrap.js";
+import {
+  resolveBoardWidgetContentKindByPluginKind,
+  resolveBoardWidgetContentKindResourceUrls,
+} from "../plugins/board-widget-content-kinds.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { verifyBoardViewTicket } from "./board-view-ticket.js";
 
 type AuthorizedBoardWidgetView = {
@@ -17,14 +23,59 @@ export function resolveAuthorizedBoardWidgetView(
   if (!claims) {
     throw new BoardValidationError("invalid_operation", "board widget view ticket is invalid");
   }
-  const document = store.readWidgetHtml(claims.sessionKey, claims.name);
+  const document = claims.pluginFrame
+    ? store.readWidgetRegistered(claims.sessionKey, claims.name)
+    : store.readWidgetHtml(claims.sessionKey, claims.name);
   if (
     !document ||
-    !("html" in document) ||
     (document.grantState !== "none" && document.grantState !== "granted") ||
     document.revision !== claims.revision ||
     document.viewGeneration !== claims.viewGeneration
   ) {
+    throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
+  }
+  if (claims.pluginFrame) {
+    if (!("source" in document) || document.pluginKind !== claims.pluginFrame.pluginKind) {
+      throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
+    }
+    const registration = resolveBoardWidgetContentKindByPluginKind(
+      getActivePluginRegistry(),
+      document.pluginKind,
+    );
+    const resourceUrls = registration
+      ? resolveBoardWidgetContentKindResourceUrls(registration, claims.pluginFrame.scopedHostUrl)
+      : undefined;
+    if (!registration || !resourceUrls) {
+      throw new BoardValidationError(
+        "invalid_operation",
+        "board widget content kind is unavailable",
+      );
+    }
+    const resourceOrigins = [
+      ...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin)),
+    ];
+    const body = registration.definition.composeDocument({
+      source: document.source,
+      title: document.title ?? claims.name,
+      resourceUrls,
+      promptGranted:
+        document.grantState === "granted" && document.declared?.tools?.includes("prompt") === true,
+    });
+    const composed = {
+      html: buildWidgetDocument(document.title ?? claims.name, body, {
+        connectOrigins: document.declared?.netOrigins,
+        scriptOrigins: resourceOrigins,
+      }),
+      revision: document.revision,
+      sha256: document.sha256,
+      viewGeneration: document.viewGeneration,
+      grantState: document.grantState,
+      ...(document.declared ? { declared: document.declared } : {}),
+      resourceOrigins,
+    };
+    return { sessionKey: claims.sessionKey, name: claims.name, document: composed };
+  }
+  if (!("html" in document)) {
     throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
   }
   return { sessionKey: claims.sessionKey, name: claims.name, document };

--- a/src/gateway/server-methods/board.content-kinds.test.ts
+++ b/src/gateway/server-methods/board.content-kinds.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { registerPluginBoardWidgetContentKind } from "../../plugins/board-widget-content-kinds.js";
+import { createPluginRecord } from "../../plugins/loader-records.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { resolveAuthorizedBoardWidgetView } from "../board-widget-view.js";
+import { createBoardHarness } from "./board.test-support.js";
+
+function registeredWidgetRegistry() {
+  const registry = createEmptyPluginRegistry();
+  const record = createPluginRecord({
+    id: "diagram",
+    source: "diagram-fixture",
+    origin: "bundled",
+    enabled: true,
+    configSchema: false,
+  });
+  const validateSource = vi.fn((source: string) => {
+    if (!source.startsWith("diagram:")) {
+      throw new Error("diagram prefix required");
+    }
+  });
+  const composeDocument = vi.fn(
+    ({
+      source,
+      resourceUrls,
+    }: {
+      source: string;
+      resourceUrls: Readonly<Record<string, string>>;
+    }) =>
+      `<main>${source}</main><script src="${resourceUrls["/__openclaw__/diagram/app.js"]}"></script>`,
+  );
+  registerPluginBoardWidgetContentKind({
+    record,
+    registry,
+    definition: {
+      kind: "diagram",
+      label: "Diagram",
+      resources: {
+        surface: "diagram",
+        paths: ["/__openclaw__/diagram/app.js"],
+      },
+      validateSource,
+      composeDocument,
+    },
+  });
+  registry.plugins.push(record);
+  return { registry, validateSource, composeDocument };
+}
+
+afterEach(() => resetPluginRuntimeStateForTest());
+
+describe("board registered widget content kinds", () => {
+  it("validates, persists, composes, and updates registered source by name", async () => {
+    const previous = getActivePluginRegistry();
+    const { registry, validateSource, composeDocument } = registeredWidgetRegistry();
+    setActivePluginRegistry(registry);
+    const { invoke, store } = createBoardHarness(
+      undefined,
+      {},
+      undefined,
+      {},
+      {
+        connect: {} as never,
+        pluginSurfaceUrls: {
+          diagram: "https://gateway.test/__openclaw__/cap/diagram-token",
+        },
+      },
+    );
+    try {
+      await invoke("board.widget.put", {
+        sessionKey: "session",
+        name: "status",
+        content: { kind: "registered", contentKind: "diagram", source: "diagram:first" },
+      });
+      const updated = await invoke("board.widget.put", {
+        sessionKey: "session",
+        name: "status",
+        content: { kind: "registered", contentKind: "diagram", source: "diagram:second" },
+      });
+
+      expect(validateSource).toHaveBeenCalledTimes(2);
+      expect(updated.mock.calls[0]?.[1]).toMatchObject({
+        widgets: [
+          {
+            name: "status",
+            contentKind: "plugin",
+            pluginKind: "diagram:diagram",
+            revision: 2,
+          },
+        ],
+      });
+      expect(store.readWidgetRegistered("session", "status")).toMatchObject({
+        source: "diagram:second",
+        pluginKind: "diagram:diagram",
+        revision: 2,
+      });
+
+      const board = await invoke("board.get", { sessionKey: "session" });
+      const widget = (board.mock.calls[0]?.[1] as BoardSnapshot).widgets[0]!;
+      expect(widget).toMatchObject({
+        kindLabel: "Diagram",
+        frameUrl: expect.stringContaining("/__openclaw__/board/"),
+        sandboxUrl: expect.stringContaining("/mcp-app-sandbox"),
+      });
+      const authorized = resolveAuthorizedBoardWidgetView(store, widget.viewTicket!);
+      expect(authorized.document.html).toContain("<main>diagram:second</main>");
+      expect(authorized.document.html).toContain(
+        "https://gateway.test/__openclaw__/cap/diagram-token/__openclaw__/diagram/app.js",
+      );
+      expect(composeDocument).toHaveBeenCalledOnce();
+    } finally {
+      if (previous) setActivePluginRegistry(previous);
+      else resetPluginRuntimeStateForTest();
+    }
+  });
+
+  it("returns an actionable error when the providing plugin is unavailable", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const { invoke } = createBoardHarness();
+
+    const response = await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "status",
+      content: { kind: "registered", contentKind: "diagram", source: "diagram:first" },
+    });
+
+    expect(response.mock.calls[0]?.[0]).toBe(false);
+    expect(response.mock.calls[0]?.[2]?.message).toContain(
+      'widget kind "diagram" is unavailable; enable the plugin that provides it and retry',
+    );
+  });
+
+  it("composes visible prompt actions only after the prompt grant", async () => {
+    const { registry, composeDocument } = registeredWidgetRegistry();
+    setActivePluginRegistry(registry);
+    const { invoke, store } = createBoardHarness(
+      undefined,
+      {},
+      undefined,
+      {},
+      {
+        connect: {} as never,
+        pluginSurfaceUrls: {
+          diagram: "https://gateway.test/__openclaw__/cap/diagram-token",
+        },
+      },
+    );
+    const put = await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "prompting",
+      content: { kind: "registered", contentKind: "diagram", source: "diagram:prompt" },
+      declared: { tools: ["prompt"] },
+    });
+    const pending = (put.mock.calls[0]?.[1] as BoardSnapshot).widgets[0]!;
+    expect(pending.grantState).toBe("pending");
+    await invoke("board.widget.grant", {
+      sessionKey: "session",
+      name: "prompting",
+      decision: "granted",
+      revision: pending.revision,
+      instanceId: pending.instanceId,
+    });
+    const board = await invoke("board.get", { sessionKey: "session" });
+    const widget = (board.mock.calls[0]?.[1] as BoardSnapshot).widgets[0]!;
+
+    resolveAuthorizedBoardWidgetView(store, widget.viewTicket!);
+
+    expect(composeDocument).toHaveBeenCalledWith(expect.objectContaining({ promptGranted: true }));
+  });
+});

--- a/src/gateway/server-methods/board.content-kinds.test.ts
+++ b/src/gateway/server-methods/board.content-kinds.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
-import { registerPluginBoardWidgetContentKind } from "../../plugins/board-widget-content-kinds.js";
+import { createPluginBoardWidgetContentKindRegistrar } from "../../plugins/board-widget-content-kinds.js";
 import { createPluginRecord } from "../../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
@@ -35,19 +35,15 @@ function registeredWidgetRegistry() {
     }) =>
       `<main>${source}</main><script src="${resourceUrls["/__openclaw__/diagram/app.js"]}"></script>`,
   );
-  registerPluginBoardWidgetContentKind({
-    record,
-    registry,
-    definition: {
-      kind: "diagram",
-      label: "Diagram",
-      resources: {
-        surface: "diagram",
-        paths: ["/__openclaw__/diagram/app.js"],
-      },
-      validateSource,
-      composeDocument,
+  createPluginBoardWidgetContentKindRegistrar(registry)(record, {
+    kind: "diagram",
+    label: "Diagram",
+    resources: {
+      surface: "diagram",
+      paths: ["/__openclaw__/diagram/app.js"],
     },
+    validateSource,
+    composeDocument,
   });
   registry.plugins.push(record);
   return { registry, validateSource, composeDocument };
@@ -102,7 +98,11 @@ describe("board registered widget content kinds", () => {
       });
 
       const board = await invoke("board.get", { sessionKey: "session" });
-      const widget = (board.mock.calls[0]?.[1] as BoardSnapshot).widgets[0]!;
+      const snapshot = board.mock.calls[0]?.[1];
+      if (!snapshot) {
+        throw new Error("board.get did not return a snapshot");
+      }
+      const widget = (snapshot as BoardSnapshot).widgets[0]!;
       expect(widget).toMatchObject({
         kindLabel: "Diagram",
         frameUrl: expect.stringContaining("/__openclaw__/board/"),
@@ -115,8 +115,11 @@ describe("board registered widget content kinds", () => {
       );
       expect(composeDocument).toHaveBeenCalledOnce();
     } finally {
-      if (previous) setActivePluginRegistry(previous);
-      else resetPluginRuntimeStateForTest();
+      if (previous) {
+        setActivePluginRegistry(previous);
+      } else {
+        resetPluginRuntimeStateForTest();
+      }
     }
   });
 
@@ -157,7 +160,11 @@ describe("board registered widget content kinds", () => {
       content: { kind: "registered", contentKind: "diagram", source: "diagram:prompt" },
       declared: { tools: ["prompt"] },
     });
-    const pending = (put.mock.calls[0]?.[1] as BoardSnapshot).widgets[0]!;
+    const putSnapshot = put.mock.calls[0]?.[1];
+    if (!putSnapshot) {
+      throw new Error("board.widget.put did not return a snapshot");
+    }
+    const pending = (putSnapshot as BoardSnapshot).widgets[0]!;
     expect(pending.grantState).toBe("pending");
     await invoke("board.widget.grant", {
       sessionKey: "session",
@@ -167,7 +174,11 @@ describe("board registered widget content kinds", () => {
       instanceId: pending.instanceId,
     });
     const board = await invoke("board.get", { sessionKey: "session" });
-    const widget = (board.mock.calls[0]?.[1] as BoardSnapshot).widgets[0]!;
+    const snapshot = board.mock.calls[0]?.[1];
+    if (!snapshot) {
+      throw new Error("board.get did not return a snapshot");
+    }
+    const widget = (snapshot as BoardSnapshot).widgets[0]!;
 
     resolveAuthorizedBoardWidgetView(store, widget.viewTicket!);
 

--- a/src/gateway/server-methods/board.test-support.ts
+++ b/src/gateway/server-methods/board.test-support.ts
@@ -2,7 +2,7 @@ import { vi } from "vitest";
 import type { BoardStore } from "../../boards/board-store.js";
 import { createTestBoardStore } from "../../boards/board-store.test-support.js";
 import { createBoardHandlers } from "./board.js";
-import type { GatewayRequestContext, RespondFn } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 type BoardHandlerDependencies = NonNullable<Parameters<typeof createBoardHandlers>[3]>;
 type BoardMcpAppDependencies = {
@@ -46,6 +46,7 @@ export function createBoardHarness(
   dependencies: BoardHandlerDependencies = {},
   store: BoardStore = createTestBoardStore(),
   contextOverrides: Partial<GatewayRequestContext> = {},
+  client: GatewayClient | null = null,
 ) {
   const defaults = createMcpAppDependencies();
   const mcpApp: BoardHandlerDependencies & BoardMcpAppDependencies = {
@@ -62,7 +63,7 @@ export function createBoardHarness(
     await handlers[method]!({
       req: { type: "req", id: "test", method, params },
       params,
-      client: null,
+      client,
       isWebchatConnect: () => false,
       respond,
       context: {

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -33,6 +33,12 @@ import type { BoardStore } from "../../boards/board-store.js";
 import { readCanvasDocumentHtmlSource } from "../../canvas/documents.js";
 import { buildWidgetDocument } from "../../canvas/wrap.js";
 import {
+  resolveBoardWidgetContentKind,
+  resolveBoardWidgetContentKindByPluginKind,
+  resolveBoardWidgetContentKindResourceUrls,
+} from "../../plugins/board-widget-content-kinds.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import {
   readBoardDataBinding,
   runBoardActionVerb,
   triggerBoardCronJob,
@@ -153,7 +159,7 @@ export function createBoardHandlers(
   const runActionVerb = dependencies.runActionVerb ?? runBoardActionVerb;
   const triggerCronJob = dependencies.triggerCronJob ?? triggerBoardCronJob;
   return {
-    "board.get": async ({ params, respond, context }) => {
+    "board.get": async ({ params, respond, context, client }) => {
       if (!validateBoardGetParams(params)) {
         invalidParams("board.get", validateBoardGetParams.errors, respond);
         return;
@@ -175,6 +181,22 @@ export function createBoardHandlers(
         if (!viewMetadata || viewMetadata.revision !== widget.revision) {
           continue;
         }
+        const registration = widget.pluginKind
+          ? resolveBoardWidgetContentKindByPluginKind(getActivePluginRegistry(), widget.pluginKind)
+          : undefined;
+        const scopedHostUrl = registration
+          ? client?.pluginSurfaceUrls?.[registration.definition.resources.surface]
+          : undefined;
+        const resourceUrls =
+          registration && scopedHostUrl
+            ? resolveBoardWidgetContentKindResourceUrls(registration, scopedHostUrl)
+            : undefined;
+        if (widget.contentKind === "plugin" && (!registration || !resourceUrls || !scopedHostUrl)) {
+          continue;
+        }
+        const resourceOrigins = resourceUrls
+          ? [...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin))]
+          : undefined;
         if (sandboxPort === undefined && context.ensureSandboxHostPort) {
           try {
             sandboxPort = await context.ensureSandboxHostPort();
@@ -188,7 +210,18 @@ export function createBoardHandlers(
           name: widget.name,
           revision: widget.revision,
           viewGeneration: viewMetadata.viewGeneration,
+          ...(registration && scopedHostUrl
+            ? {
+                pluginFrame: {
+                  pluginKind: registration.pluginKind,
+                  scopedHostUrl,
+                },
+              }
+            : {}),
         });
+        if (registration) {
+          widget.kindLabel = registration.definition.label;
+        }
         widget.frameUrl = buildBoardWidgetFrameUrl({
           sessionKey: snapshot.sessionKey,
           name: widget.name,
@@ -198,7 +231,10 @@ export function createBoardHandlers(
         widget.viewTicketTtlMs = BOARD_VIEW_TICKET_TTL_MS;
         widget.viewGeneration = viewMetadata.viewGeneration;
         if (sandboxPort !== undefined) {
-          widget.sandboxUrl = buildBoardWidgetSandboxPath(viewMetadata);
+          widget.sandboxUrl = buildBoardWidgetSandboxPath({
+            ...viewMetadata,
+            ...(resourceOrigins ? { resourceOrigins } : {}),
+          });
           widget.sandboxPort = sandboxPort;
           if (!sandboxOriginResolved) {
             const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
@@ -295,13 +331,42 @@ export function createBoardHandlers(
             interactive,
           };
           declared = allowedTools.length > 0 ? { tools: allowedTools } : undefined;
+        } else if (requestParams.content.kind === "registered") {
+          const registration = resolveBoardWidgetContentKind(
+            getActivePluginRegistry(),
+            requestParams.content.contentKind,
+          );
+          if (!registration) {
+            throw new BoardValidationError(
+              "invalid_operation",
+              `widget kind ${JSON.stringify(requestParams.content.contentKind)} is unavailable; enable the plugin that provides it and retry`,
+            );
+          }
+          try {
+            registration.definition.validateSource(requestParams.content.source);
+          } catch (error) {
+            throw new BoardValidationError(
+              "invalid_operation",
+              `invalid ${requestParams.content.contentKind} widget source: ${String(error)}`,
+            );
+          }
+          content = {
+            ...requestParams.content,
+            pluginKind: registration.pluginKind,
+          };
         } else {
           content = requestParams.content;
         }
         const persistedContent =
           content.kind === "mcp-app"
             ? { kind: content.kind, descriptor: content.descriptor }
-            : content;
+            : content.kind === "registered"
+              ? {
+                  kind: content.kind,
+                  contentKind: content.contentKind,
+                  source: content.source,
+                }
+              : content;
         if (!validateBoardWidgetContent(persistedContent)) {
           invalidParams("board.widget.put content", validateBoardWidgetContent.errors, respond);
           return;

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -72,6 +72,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerTrustedToolPolicy() {},
     registerToolMetadata() {},
     registerControlUiDescriptor() {},
+    registerBoardWidgetContentKind() {},
     registerRuntimeLifecycle() {},
     registerAgentEventSubscription() {},
     emitAgentEvent: () => ({ emitted: false as const, reason: "test api" }),

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -67,6 +67,7 @@ type BuildPluginApiParams = {
       | "registerTrustedToolPolicy"
       | "registerToolMetadata"
       | "registerControlUiDescriptor"
+      | "registerBoardWidgetContentKind"
       | "registerRuntimeLifecycle"
       | "registerAgentEventSubscription"
       | "emitAgentEvent"
@@ -151,6 +152,8 @@ const noopEnqueueNextTurnInjection: OpenClawPluginApi["enqueueNextTurnInjection"
 const noopRegisterTrustedToolPolicy: OpenClawPluginApi["registerTrustedToolPolicy"] = () => {};
 const noopRegisterToolMetadata: OpenClawPluginApi["registerToolMetadata"] = () => {};
 const noopRegisterControlUiDescriptor: OpenClawPluginApi["registerControlUiDescriptor"] = () => {};
+const noopRegisterBoardWidgetContentKind: OpenClawPluginApi["registerBoardWidgetContentKind"] =
+  () => {};
 const noopRegisterRuntimeLifecycle: OpenClawPluginApi["registerRuntimeLifecycle"] = () => {};
 const noopRegisterAgentEventSubscription: OpenClawPluginApi["registerAgentEventSubscription"] =
   () => {};
@@ -266,6 +269,8 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerToolMetadata: handlers.registerToolMetadata ?? noopRegisterToolMetadata,
     registerControlUiDescriptor:
       handlers.registerControlUiDescriptor ?? noopRegisterControlUiDescriptor,
+    registerBoardWidgetContentKind:
+      handlers.registerBoardWidgetContentKind ?? noopRegisterBoardWidgetContentKind,
     registerRuntimeLifecycle: handlers.registerRuntimeLifecycle ?? noopRegisterRuntimeLifecycle,
     registerAgentEventSubscription:
       handlers.registerAgentEventSubscription ?? noopRegisterAgentEventSubscription,

--- a/src/plugins/board-widget-content-kind.types.ts
+++ b/src/plugins/board-widget-content-kind.types.ts
@@ -1,0 +1,21 @@
+/** Plugin-owned source kind rendered through the board's sandboxed document host. */
+export type PluginBoardWidgetContentKind = {
+  /** Agent-facing kind, for example `diagram`. Must be globally unique. */
+  kind: string;
+  /** Short label shown in dashboard chrome. */
+  label: string;
+  /** Capability-scoped static resources used by the composed document. */
+  resources: {
+    surface: string;
+    paths: string[];
+  };
+  /** Reject malformed or unsupported source before it reaches persistent storage. */
+  validateSource: (source: string) => void;
+  /** Build the untrusted document body; core adds the canonical bridge and CSP shell. */
+  composeDocument: (params: {
+    source: string;
+    title: string;
+    resourceUrls: Readonly<Record<string, string>>;
+    promptGranted: boolean;
+  }) => string;
+};

--- a/src/plugins/board-widget-content-kinds.ts
+++ b/src/plugins/board-widget-content-kinds.ts
@@ -1,0 +1,132 @@
+import type { PluginBoardWidgetContentKind } from "./board-widget-content-kind.types.js";
+import { PluginDashboardDeclarationError } from "./dashboard-capabilities.js";
+import type {
+  PluginBoardWidgetContentKindRegistration,
+  PluginRecord,
+  PluginRegistry,
+} from "./registry-types.js";
+
+const CONTENT_KIND_PATTERN = /^[a-z][a-z0-9-]{0,31}$/u;
+const SURFACE_PATTERN = /^[a-z][a-z0-9._-]{0,63}$/u;
+const RESERVED_CONTENT_KINDS = new Set(["html", "mcp-app", "plugin"]);
+
+function fail(pluginId: string, message: string): never {
+  throw new PluginDashboardDeclarationError(
+    `invalid board widget content kind for plugin ${JSON.stringify(pluginId)}: ${message}`,
+  );
+}
+
+function isGatewayLocalPath(value: string): boolean {
+  return value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\");
+}
+
+/** Validates and publishes one runtime board-widget content kind. */
+export function registerPluginBoardWidgetContentKind(params: {
+  record: PluginRecord;
+  registry: PluginRegistry;
+  definition: PluginBoardWidgetContentKind;
+}): void {
+  const { definition, record, registry } = params;
+  const kind = typeof definition.kind === "string" ? definition.kind.trim() : "";
+  const label = typeof definition.label === "string" ? definition.label.trim() : "";
+  const surface =
+    typeof definition.resources?.surface === "string" ? definition.resources.surface.trim() : "";
+  const paths = definition.resources?.paths;
+  if (!CONTENT_KIND_PATTERN.test(kind) || RESERVED_CONTENT_KINDS.has(kind)) {
+    fail(record.id, `kind ${JSON.stringify(kind)} is invalid or reserved`);
+  }
+  if (!label || label.length > 80) {
+    fail(record.id, "label must contain 1-80 characters");
+  }
+  if (!SURFACE_PATTERN.test(surface)) {
+    fail(record.id, `resource surface ${JSON.stringify(surface)} is invalid`);
+  }
+  if (
+    !Array.isArray(paths) ||
+    paths.length === 0 ||
+    paths.length > 8 ||
+    paths.some(
+      (resourcePath) =>
+        typeof resourcePath !== "string" ||
+        resourcePath.length > 256 ||
+        !isGatewayLocalPath(resourcePath),
+    ) ||
+    new Set(paths).size !== paths.length
+  ) {
+    fail(record.id, "resource paths must be 1-8 unique gateway-local absolute paths");
+  }
+  if (
+    typeof definition.validateSource !== "function" ||
+    typeof definition.composeDocument !== "function"
+  ) {
+    fail(record.id, "validateSource and composeDocument callbacks are required");
+  }
+  if (registry.boardWidgetContentKinds.has(kind)) {
+    fail(record.id, `duplicate kind ${JSON.stringify(kind)}`);
+  }
+  const pluginKind = `${record.id}:${kind}`;
+  if (!/^[a-z0-9][a-z0-9-]{0,63}:[a-z0-9][a-z0-9._-]{0,63}$/u.test(pluginKind)) {
+    fail(record.id, `persisted kind ${JSON.stringify(pluginKind)} is invalid`);
+  }
+  registry.boardWidgetContentKinds.set(kind, {
+    pluginId: record.id,
+    pluginKind,
+    definition: {
+      ...definition,
+      kind,
+      label,
+      resources: { surface, paths: [...paths] },
+    },
+  });
+}
+
+export function resolveBoardWidgetContentKind(
+  registry: PluginRegistry | null | undefined,
+  kind: string,
+): PluginBoardWidgetContentKindRegistration | undefined {
+  return registry?.boardWidgetContentKinds.get(kind);
+}
+
+export function resolveBoardWidgetContentKindByPluginKind(
+  registry: PluginRegistry | null | undefined,
+  pluginKind: string,
+): PluginBoardWidgetContentKindRegistration | undefined {
+  if (!registry) {
+    return undefined;
+  }
+  for (const registration of registry.boardWidgetContentKinds.values()) {
+    if (registration.pluginKind === pluginKind) {
+      return registration;
+    }
+  }
+  return undefined;
+}
+
+export function listBoardWidgetContentKinds(registry: PluginRegistry | null | undefined): string[] {
+  return [...(registry?.boardWidgetContentKinds.keys() ?? [])].toSorted();
+}
+
+/** Resolves registration resource paths below one connection-scoped plugin capability URL. */
+export function resolveBoardWidgetContentKindResourceUrls(
+  registration: PluginBoardWidgetContentKindRegistration,
+  scopedHostUrl: string,
+): Readonly<Record<string, string>> | undefined {
+  try {
+    const scoped = new URL(scopedHostUrl);
+    const prefix = scoped.pathname.replace(/\/+$/u, "");
+    if (!/^\/__openclaw__\/cap\/[^/]+$/u.test(prefix)) {
+      return undefined;
+    }
+    return Object.fromEntries(
+      registration.definition.resources.paths.map((resourcePath) => {
+        const url = new URL(scoped.toString());
+        url.pathname = `${prefix}${resourcePath}`;
+        url.search = "";
+        url.hash = "";
+        return [resourcePath, url.toString()];
+      }),
+    );
+  } catch {
+    return undefined;
+  }
+}

--- a/src/plugins/board-widget-content-kinds.ts
+++ b/src/plugins/board-widget-content-kinds.ts
@@ -21,7 +21,7 @@ function isGatewayLocalPath(value: string): boolean {
 }
 
 /** Validates and publishes one runtime board-widget content kind. */
-export function registerPluginBoardWidgetContentKind(params: {
+function registerPluginBoardWidgetContentKind(params: {
   record: PluginRecord;
   registry: PluginRegistry;
   definition: PluginBoardWidgetContentKind;
@@ -78,6 +78,11 @@ export function registerPluginBoardWidgetContentKind(params: {
       resources: { surface, paths: [...paths] },
     },
   });
+}
+
+export function createPluginBoardWidgetContentKindRegistrar(registry: PluginRegistry) {
+  return (record: PluginRecord, definition: PluginBoardWidgetContentKind) =>
+    registerPluginBoardWidgetContentKind({ record, registry, definition });
 }
 
 export function resolveBoardWidgetContentKind(

--- a/src/plugins/dashboard-capabilities.test.ts
+++ b/src/plugins/dashboard-capabilities.test.ts
@@ -35,6 +35,66 @@ function loadFixture(plugin: TempPlugin) {
 }
 
 describe("plugin dashboard declarations", () => {
+  it("publishes valid runtime board widget content kinds", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "diagram",
+      body: `module.exports = {
+        id: "diagram",
+        register(api) {
+          api.registerBoardWidgetContentKind({
+            kind: "diagram",
+            label: "Diagram",
+            resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
+            validateSource(source) { if (!source.trim()) throw new Error("source required"); },
+            composeDocument({ source }) { return "<main>" + source + "</main>"; },
+          });
+        },
+      };`,
+    });
+
+    const registry = loadFixture(plugin);
+
+    expect(registry.plugins.find((entry) => entry.id === plugin.id)?.status).toBe("loaded");
+    expect(registry.boardWidgetContentKinds.get("diagram")).toMatchObject({
+      pluginId: "diagram",
+      pluginKind: "diagram:diagram",
+      definition: { kind: "diagram", label: "Diagram" },
+    });
+  });
+
+  it("fails plugin load atomically for invalid board widget content kinds", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "invalid-widget-kind",
+      body: `module.exports = {
+        id: "invalid-widget-kind",
+        register(api) {
+          api.registerBoardWidgetContentKind({
+            kind: "html",
+            label: "Invalid",
+            resources: { surface: "canvas", paths: ["/__openclaw__/invalid/app.js"] },
+            validateSource() {},
+            composeDocument() { return ""; },
+          });
+        },
+      };`,
+    });
+
+    const registry = loadFixture(plugin);
+    const record = registry.plugins.find((entry) => entry.id === plugin.id);
+
+    expect(record).toMatchObject({ status: "error", failurePhase: "register" });
+    expect(record?.error).toContain('kind "html" is invalid or reserved');
+    expect(registry.boardWidgetContentKinds.size).toBe(0);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        pluginId: plugin.id,
+        code: "dashboard-declaration-invalid",
+      }),
+    );
+  });
+
   it("loads the Workboard bindings and dispatch action from its manifest", () => {
     const result = loadPluginManifest(path.join(process.cwd(), "extensions", "workboard"));
 

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -9,6 +9,7 @@ import type {
   AgentToolResultMiddleware,
   AgentToolResultMiddlewareOptions,
 } from "./agent-tool-result-middleware-types.js";
+import type { PluginBoardWidgetContentKind } from "./board-widget-content-kind.types.js";
 import type {
   ImageGenerationProviderPlugin,
   MediaUnderstandingProviderPlugin,
@@ -228,6 +229,8 @@ export type OpenClawPluginApi = {
     handler: GatewayRequestHandler,
     opts?: { scope?: OperatorScope },
   ) => void;
+  /** Register a sandboxed board widget source kind owned by this plugin. */
+  registerBoardWidgetContentKind: (definition: PluginBoardWidgetContentKind) => void;
   /** Register a read-only external-session catalog with optional native adoption actions. */
   registerSessionCatalog: (provider: SessionCatalogProvider) => void;
   registerCli: (

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -95,6 +95,7 @@ export function createPluginApiFactory(
     registerTrustedToolPolicy,
     registerToolMetadata,
     registerControlUiDescriptor,
+    registerBoardWidgetContentKind,
     registerRuntimeLifecycle,
     registerAgentEventSubscription,
     registerSessionSchedulerJob,
@@ -265,6 +266,8 @@ export function createPluginApiFactory(
               registerToolMetadata: (metadata) => registerToolMetadata(record, metadata),
               registerControlUiDescriptor: (descriptor) =>
                 registerControlUiDescriptor(record, descriptor),
+              registerBoardWidgetContentKind: (definition) =>
+                registerBoardWidgetContentKind(record, definition),
               registerRuntimeLifecycle: (lifecycle) => registerRuntimeLifecycle(record, lifecycle),
               registerAgentEventSubscription: (subscription) =>
                 registerAgentEventSubscription(record, subscription),

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -45,6 +45,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     gatewayMethodDescriptors: [],
     dashboardDataBindings: new Map(),
     dashboardActionVerbs: new Map(),
+    boardWidgetContentKinds: new Map(),
     coreGatewayMethodNames: [],
     httpRoutes: [],
     hostedMediaResolvers: [],

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -1,4 +1,6 @@
 import { isOperatorScope, type OperatorScope } from "../gateway/operator-scopes.js";
+import type { PluginBoardWidgetContentKind } from "./board-widget-content-kind.types.js";
+import { registerPluginBoardWidgetContentKind } from "./board-widget-content-kinds.js";
 import {
   getPluginSessionSchedulerJobGeneration,
   registerPluginSessionSchedulerJob,
@@ -460,6 +462,13 @@ export function createHostRegistrars(state: PluginRegistryState) {
     });
   };
 
+  const registerBoardWidgetContentKind = (
+    record: PluginRecord,
+    definition: PluginBoardWidgetContentKind,
+  ) => {
+    registerPluginBoardWidgetContentKind({ record, registry, definition });
+  };
+
   const registerRuntimeLifecycle = (
     record: PluginRecord,
     lifecycle: PluginRuntimeLifecycleRegistration,
@@ -708,6 +717,7 @@ export function createHostRegistrars(state: PluginRegistryState) {
     registerTrustedToolPolicy,
     registerToolMetadata,
     registerControlUiDescriptor,
+    registerBoardWidgetContentKind,
     registerRuntimeLifecycle,
     registerAgentEventSubscription,
     registerSessionSchedulerJob,

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -1,6 +1,5 @@
 import { isOperatorScope, type OperatorScope } from "../gateway/operator-scopes.js";
-import type { PluginBoardWidgetContentKind } from "./board-widget-content-kind.types.js";
-import { registerPluginBoardWidgetContentKind } from "./board-widget-content-kinds.js";
+import { createPluginBoardWidgetContentKindRegistrar } from "./board-widget-content-kinds.js";
 import {
   getPluginSessionSchedulerJobGeneration,
   registerPluginSessionSchedulerJob,
@@ -462,13 +461,6 @@ export function createHostRegistrars(state: PluginRegistryState) {
     });
   };
 
-  const registerBoardWidgetContentKind = (
-    record: PluginRecord,
-    definition: PluginBoardWidgetContentKind,
-  ) => {
-    registerPluginBoardWidgetContentKind({ record, registry, definition });
-  };
-
   const registerRuntimeLifecycle = (
     record: PluginRecord,
     lifecycle: PluginRuntimeLifecycleRegistration,
@@ -717,7 +709,7 @@ export function createHostRegistrars(state: PluginRegistryState) {
     registerTrustedToolPolicy,
     registerToolMetadata,
     registerControlUiDescriptor,
-    registerBoardWidgetContentKind,
+    registerBoardWidgetContentKind: createPluginBoardWidgetContentKindRegistrar(registry),
     registerRuntimeLifecycle,
     registerAgentEventSubscription,
     registerSessionSchedulerJob,

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -11,6 +11,7 @@ import type {
   AgentToolResultMiddlewareRuntime,
   AgentToolResultMiddlewareScope,
 } from "./agent-tool-result-middleware-types.js";
+import type { PluginBoardWidgetContentKind } from "./board-widget-content-kind.types.js";
 import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationSource } from "./config-state.js";
@@ -204,6 +205,12 @@ export type PluginDashboardActionVerbRegistration = PluginManifestDashboardActio
   pluginId: string;
   capabilityId: string;
   handler: GatewayRequestHandlers[string];
+};
+
+export type PluginBoardWidgetContentKindRegistration = {
+  pluginId: string;
+  pluginKind: string;
+  definition: PluginBoardWidgetContentKind;
 };
 
 type PluginCliBackendRegistration = {
@@ -552,6 +559,7 @@ export type PluginRegistry = {
   gatewayMethodDescriptors: GatewayMethodDescriptor[];
   dashboardDataBindings: Map<string, PluginDashboardDataBindingRegistration>;
   dashboardActionVerbs: Map<string, PluginDashboardActionVerbRegistration>;
+  boardWidgetContentKinds: Map<string, PluginBoardWidgetContentKindRegistration>;
   coreGatewayMethodNames: string[];
   httpRoutes: PluginHttpRouteRegistration[];
   hostedMediaResolvers: PluginHostedMediaResolverRegistration[];

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -156,6 +156,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerTrustedToolPolicy: registrars.registerTrustedToolPolicy,
     registerToolMetadata: registrars.registerToolMetadata,
     registerControlUiDescriptor: registrars.registerControlUiDescriptor,
+    registerBoardWidgetContentKind: registrars.registerBoardWidgetContentKind,
     registerRuntimeLifecycle: registrars.registerRuntimeLifecycle,
     registerAgentEventSubscription: registrars.registerAgentEventSubscription,
     registerSessionSchedulerJob: registrars.registerSessionSchedulerJob,

--- a/test/scripts/check-database-first-legacy-stores.test.ts
+++ b/test/scripts/check-database-first-legacy-stores.test.ts
@@ -131,7 +131,7 @@ describe("check-database-first-legacy-stores", () => {
     }
   });
 
-  it("skips generated extension asset and dist bundles", async () => {
+  it("skips generated extension asset, renderer, and dist bundles", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-db-first-guard-"));
     try {
       await fs.mkdir(path.join(root, "extensions", "diffs", "assets"), { recursive: true });
@@ -139,6 +139,9 @@ describe("check-database-first-legacy-stores", () => {
         recursive: true,
       });
       await fs.mkdir(path.join(root, "extensions", "diffs", "src"), { recursive: true });
+      await fs.mkdir(path.join(root, "extensions", "canvas", "src", "host", "a2ui"), {
+        recursive: true,
+      });
       await fs.mkdir(path.join(root, "packages", "plugin-sdk", "dist"), { recursive: true });
       await fs.mkdir(path.join(root, "packages", "plugin-sdk", "src"), { recursive: true });
       await fs.writeFile(
@@ -151,6 +154,14 @@ describe("check-database-first-legacy-stores", () => {
       );
       await fs.writeFile(
         path.join(root, "extensions", "diffs", "src", "runtime.js"),
+        "export const runtime = true;\n",
+      );
+      await fs.writeFile(
+        path.join(root, "extensions", "canvas", "src", "host", "a2ui", "a2ui.bundle.js"),
+        "export const bundled = true;\n",
+      );
+      await fs.writeFile(
+        path.join(root, "extensions", "canvas", "src", "host", "a2ui", "bootstrap.js"),
         "export const runtime = true;\n",
       );
       await fs.writeFile(
@@ -171,6 +182,7 @@ describe("check-database-first-legacy-stores", () => {
         .toSorted();
 
       expect(relativeFiles).toEqual([
+        "extensions/canvas/src/host/a2ui/bootstrap.js",
         "extensions/diffs/src/runtime.js",
         "packages/plugin-sdk/src/index.js",
       ]);

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -257,6 +257,9 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
         onRemove: () => void this.runAction(() => callbacks.remove(widget)),
       });
     }
+    if (widget.contentKind === "plugin" && widget.frameUrl) {
+      return this.frame.render(widget);
+    }
     if (widget.contentKind === "plugin") {
       if (this.pluginRendererError) {
         return renderBoardWidgetError(this.pluginRendererError, () => this.retryPluginRenderer());
@@ -288,7 +291,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     const widget = this.widget;
     const activeKinds = this.context?.gateway.snapshot.hello?.controlUiWidgetKinds ?? [];
     const contribution =
-      widget?.contentKind === "plugin"
+      widget?.contentKind === "plugin" && !widget.frameUrl
         ? getPluginWidgetKindContribution(widget.pluginKind, activeKinds)
         : null;
     if (!contribution) {
@@ -389,9 +392,13 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
       widget.grantState === "pending" ||
       widget.grantState === "rejected";
     const contentScrollable =
-      bodyScrollable || widget.contentKind === "mcp-app" || widget.contentKind === "plugin";
+      bodyScrollable ||
+      widget.contentKind === "mcp-app" ||
+      (widget.contentKind === "plugin" && !widget.frameUrl);
     const presentation =
-      widget.contentKind === "html" ? (widget.presentation ?? "card") : undefined;
+      widget.contentKind === "html" || widget.frameUrl
+        ? (widget.presentation ?? "card")
+        : undefined;
     // While a move/resize gesture runs, the card fills its (preview) cell so
     // the user manipulates the quantized rect they will actually commit.
     const exactHeightPx = this.dragging
@@ -429,7 +436,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
             >${widget.contentKind === "mcp-app"
               ? t("board.widget.kindMcp")
               : widget.contentKind === "plugin"
-                ? this.pluginRendererLabel || t("board.widget.kindPlugin")
+                ? widget.kindLabel || this.pluginRendererLabel || t("board.widget.kindPlugin")
                 : t("board.widget.kindHtml")}</span
           >
           ${renderBoardGrantedCapabilities(widget)}

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -6,6 +6,7 @@ import type { BoardWidgetFrameUrl } from "../../lib/board/view-types.ts";
 import { BoardWidgetSandboxHost } from "../../lib/board/widget-sandbox-host.ts";
 import { remainingBoardWidgetTicketTtlMs } from "../../lib/board/widget-ticket-lifetime.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { installWidgetThemeObserver, postWidgetTheme } from "../../lib/widget-theme.ts";
 import { resolveGatewayHttpOrigin, resolveSandboxHostUrl } from "../sandbox-host.ts";
 
 // Keep in sync with the identical literal in chat widget-card.ts: a shared
@@ -159,6 +160,9 @@ export class BoardWidgetFrameLifecycle {
       document.addEventListener("visibilitychange", this.handleVisibilityChange);
       this.visibilityListening = true;
     }
+    installWidgetThemeObserver(() =>
+      this.host.root().querySelectorAll<HTMLIFrameElement>(".board-widget__frame"),
+    );
   }
 
   disconnect(): void {
@@ -250,6 +254,7 @@ export class BoardWidgetFrameLifecycle {
               this.refreshFailedFrame(widget);
             }
           }}
+          @load=${(event: Event) => this.postTheme(event)}
         ></iframe>
       `;
     }
@@ -352,6 +357,13 @@ export class BoardWidgetFrameLifecycle {
           this.refreshFailedFrame(widget);
         }
       });
+  }
+
+  private postTheme(event: Event): void {
+    const frame = event.currentTarget;
+    if (frame instanceof HTMLIFrameElement) {
+      postWidgetTheme(frame, this.sandboxOrigin || "*");
+    }
   }
 
   private resolveSandboxFrameUrl(widget: BoardWidget): string | undefined {
@@ -489,5 +501,8 @@ export class BoardWidgetFrameLifecycle {
       this.sandboxHost.update(options);
     }
     this.sandboxHost.handleMessage(event);
+    if (event.data?.type === "openclaw:widget-bridge-ready") {
+      postWidgetTheme(frame, this.sandboxOrigin);
+    }
   };
 }

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -160,9 +160,7 @@ export class BoardWidgetFrameLifecycle {
       document.addEventListener("visibilitychange", this.handleVisibilityChange);
       this.visibilityListening = true;
     }
-    installWidgetThemeObserver(() =>
-      this.host.root().querySelectorAll<HTMLIFrameElement>(".board-widget__frame"),
-    );
+    installWidgetThemeObserver();
   }
 
   disconnect(): void {

--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -66,7 +66,9 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
       response.setHeader("Content-Type", "text/javascript; charset=utf-8");
       response.end(rendererBundle);
     });
-    await new Promise<void>((resolve) => rendererServer.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      rendererServer.listen(0, "127.0.0.1", resolve);
+    });
     const rendererAddress = rendererServer.address();
     if (!rendererAddress || typeof rendererAddress === "string") {
       throw new Error("A2UI renderer server did not bind");
@@ -82,13 +84,19 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
   }, 120_000);
 
   afterAll(async () => {
-    for (const context of contexts) await context.close();
+    for (const context of contexts) {
+      await context.close();
+    }
     await browser?.close();
     if (sandboxServer) {
-      await new Promise<void>((resolve) => sandboxServer.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        sandboxServer.close(() => resolve());
+      });
     }
     if (rendererServer) {
-      await new Promise<void>((resolve) => rendererServer.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        rendererServer.close(() => resolve());
+      });
     }
     await controlUi?.close();
   });
@@ -130,7 +138,7 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
     const boot = JSON.stringify({ messages, actionTier: "state" }).replaceAll("<", "\\u003c");
     const documentHtml = buildWidgetDocument(
       "A2UI controls",
-      `<script>globalThis.__openclawA2UIBoot=${boot};</script><style>html,body{height:100%;background:transparent}openclaw-a2ui-host{display:block;height:100%}</style><openclaw-a2ui-host></openclaw-a2ui-host><script src="${rendererUrl}"></script>`,
+      `<script>globalThis.openclawA2UIBoot=${boot};</script><style>html,body{height:100%;background:transparent}openclaw-a2ui-host{display:block;height:100%}</style><openclaw-a2ui-host></openclaw-a2ui-host><script src="${rendererUrl}"></script>`,
       { scriptOrigins: [rendererOrigin] },
     );
     const frameUrl = `${origin}/__openclaw__/board/${encodeURIComponent(sessionKey)}/a2ui-controls/index.html?bt=ticket`;
@@ -183,7 +191,9 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
       .poll(
         async () => {
           const child = outerFrame?.childFrames()[0];
-          if (!child) return false;
+          if (!child) {
+            return false;
+          }
           try {
             return await child.evaluate(() =>
               Boolean(

--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -1,0 +1,222 @@
+// Dashboard A2UI E2E covers the real renderer, sandbox proxy, and tier-1 board bridge.
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile } from "node:fs/promises";
+import { createServer, type Server as HttpServer } from "node:http";
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
+import { buildBoardWidgetSandboxPath } from "../../../src/gateway/board-sandbox.js";
+import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
+import { getGatewayE2ePortBlock } from "../../../src/gateway/test-helpers.e2e.js";
+import {
+  canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const sessionKey = "agent:main:board-a2ui";
+const screenshotPath = "/tmp/pr-b-shots/a2ui-board.png";
+const basicCatalog = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json";
+
+let browser: Browser;
+let controlUi: ControlUiE2eServer;
+let sandboxServer: HttpServer;
+let sandboxPort: number;
+let rendererServer: HttpServer;
+let rendererOrigin: string;
+let rendererBundle: Buffer;
+const contexts = new Set<BrowserContext>();
+
+async function openDashboard(page: Page): Promise<void> {
+  const settingsKey = controlUiBundledSettingsStorageKey(controlUi.baseUrl);
+  await page.addInitScript(
+    ({ key, storageKey }) => {
+      const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      settings.boardSessionViews = { [key]: { activeTabId: "main" } };
+      localStorage.setItem(storageKey, JSON.stringify(settings));
+    },
+    { key: sessionKey, storageKey: settingsKey },
+  );
+  await page.goto(`${controlUi.baseUrl}dashboard`);
+  await page.locator(".board-session-surface").waitFor();
+}
+
+describeControlUiE2e("Control UI dashboard A2UI", () => {
+  beforeAll(async () => {
+    execFileSync(process.execPath, ["extensions/canvas/scripts/bundle-a2ui.mjs"], {
+      cwd: process.cwd(),
+      stdio: "inherit",
+    });
+    rendererBundle = await readFile(
+      path.resolve("extensions/canvas/src/host/a2ui/a2ui-v0.9.bundle.js"),
+    );
+    rendererServer = createServer((_request, response) => {
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "text/javascript; charset=utf-8");
+      response.end(rendererBundle);
+    });
+    await new Promise<void>((resolve) => rendererServer.listen(0, "127.0.0.1", resolve));
+    const rendererAddress = rendererServer.address();
+    if (!rendererAddress || typeof rendererAddress === "string") {
+      throw new Error("A2UI renderer server did not bind");
+    }
+    rendererOrigin = `http://127.0.0.1:${rendererAddress.port}`;
+    controlUi = await startControlUiE2eServer();
+    sandboxPort = await getGatewayE2ePortBlock();
+    sandboxServer = createSandboxHostHttpServer();
+    await new Promise<void>((resolve) => {
+      sandboxServer.listen(sandboxPort, "127.0.0.1", resolve);
+    });
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  }, 120_000);
+
+  afterAll(async () => {
+    for (const context of contexts) await context.close();
+    await browser?.close();
+    if (sandboxServer) {
+      await new Promise<void>((resolve) => sandboxServer.close(() => resolve()));
+    }
+    if (rendererServer) {
+      await new Promise<void>((resolve) => rendererServer.close(() => resolve()));
+    }
+    await controlUi?.close();
+  });
+
+  it("renders a v0.9 widget and routes its action to a tier-1 state event", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      permissions: ["local-network-access"],
+      viewport: { width: 1280, height: 800 },
+    });
+    contexts.add(context);
+    const page = await context.newPage();
+    const origin = new URL(controlUi.baseUrl).origin;
+    const rendererUrl = `${rendererOrigin}/__openclaw__/cap/canvas-proof/__openclaw__/a2ui/a2ui-v0.9.bundle.js`;
+    const messages = [
+      {
+        version: "v0.9",
+        createSurface: { surfaceId: "main", catalogId: basicCatalog },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "main",
+          components: [
+            { id: "root", component: "Column", children: ["title", "action"] },
+            { id: "title", component: "Text", text: "A2UI board widget" },
+            {
+              id: "action",
+              component: "Button",
+              child: "action-label",
+              variant: "primary",
+              action: { event: { name: "refresh", context: {} } },
+            },
+            { id: "action-label", component: "Text", text: "Refresh data" },
+          ],
+        },
+      },
+    ];
+    const boot = JSON.stringify({ messages, actionTier: "state" }).replaceAll("<", "\\u003c");
+    const documentHtml = buildWidgetDocument(
+      "A2UI controls",
+      `<script>globalThis.__openclawA2UIBoot=${boot};</script><style>html,body{height:100%;background:transparent}openclaw-a2ui-host{display:block;height:100%}</style><openclaw-a2ui-host></openclaw-a2ui-host><script src="${rendererUrl}"></script>`,
+      { scriptOrigins: [rendererOrigin] },
+    );
+    const frameUrl = `${origin}/__openclaw__/board/${encodeURIComponent(sessionKey)}/a2ui-controls/index.html?bt=ticket`;
+    await page.route("**/__openclaw__/board/**", (route) =>
+      route.fulfill({ status: 200, contentType: "text/html", body: documentHtml }),
+    );
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      featureMethods: ["board.event", "board.get", "chat.metadata", "chat.startup"],
+      methodResponses: {
+        "board.get": {
+          sessionKey,
+          revision: 1,
+          tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+          widgets: [
+            {
+              name: "a2ui-controls",
+              tabId: "main",
+              title: "A2UI controls",
+              contentKind: "plugin",
+              pluginKind: "canvas:a2ui",
+              kindLabel: "A2UI",
+              sizeW: 8,
+              sizeH: 5,
+              position: 0,
+              grantState: "none",
+              revision: 1,
+              instanceId: "a2ui-instance",
+              frameUrl,
+              viewTicket: "ticket",
+              viewTicketTtlMs: 1_200_000,
+              viewGeneration: "0123456789abcdef0123456789abcdef",
+              sandboxUrl: buildBoardWidgetSandboxPath({
+                grantState: "none",
+                resourceOrigins: [rendererOrigin],
+              }),
+              sandboxPort,
+            },
+          ],
+        },
+        "board.event": { ok: true, appended: true },
+      },
+    });
+
+    await openDashboard(page);
+    const outer = page.locator(".board-widget__frame");
+    await outer.waitFor();
+    const outerFrame = await outer.elementHandle().then((handle) => handle?.contentFrame());
+    await expect
+      .poll(
+        async () => {
+          const child = outerFrame?.childFrames()[0];
+          if (!child) return false;
+          try {
+            return await child.evaluate(() =>
+              Boolean(
+                customElements.get("openclaw-a2ui-host") && Reflect.get(globalThis, "openclawA2UI"),
+              ),
+            );
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+    const widgetFrame = outerFrame!.childFrames()[0]!;
+    await widgetFrame.getByText("A2UI board widget").waitFor();
+    await widgetFrame.getByText("Refresh data").click();
+
+    await expect.poll(async () => (await gateway.getRequests("board.event")).length).toBe(1);
+    expect((await gateway.getRequests("board.event"))[0]?.params).toMatchObject({
+      ticket: "ticket",
+      payload: {
+        eventType: "a2ui.action",
+        action: { name: "refresh", surfaceId: "main", sourceComponentId: "action" },
+      },
+    });
+    await expect
+      .poll(() =>
+        widgetFrame.evaluate(() =>
+          getComputedStyle(document.documentElement).getPropertyValue("--surface"),
+        ),
+      )
+      .not.toBe("");
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+  });
+});

--- a/ui/src/lib/widget-theme.ts
+++ b/ui/src/lib/widget-theme.ts
@@ -72,9 +72,8 @@ export function postWidgetTheme(frame: HTMLIFrameElement, targetOrigin = "*"): v
 }
 
 const widgetThemeObserverWindows = new WeakSet<Window>();
-const widgetFrameProviders = new WeakMap<Window, Set<() => Iterable<HTMLIFrameElement>>>();
 
-export function installWidgetThemeObserver(getFrames: () => Iterable<HTMLIFrameElement>): void {
+export function installWidgetThemeObserver(): void {
   if (
     typeof window === "undefined" ||
     typeof document === "undefined" ||
@@ -82,21 +81,16 @@ export function installWidgetThemeObserver(getFrames: () => Iterable<HTMLIFrameE
   ) {
     return;
   }
-  const providers = widgetFrameProviders.get(window) ?? new Set();
-  providers.add(getFrames);
-  widgetFrameProviders.set(window, providers);
   if (widgetThemeObserverWindows.has(window)) {
     return;
   }
   widgetThemeObserverWindows.add(window);
   const root = document.documentElement;
   new MutationObserver(() => {
-    for (const provider of providers) {
-      for (const frame of provider()) {
-        if (frame.isConnected) {
-          postWidgetTheme(frame);
-        }
-      }
+    for (const frame of document.querySelectorAll<HTMLIFrameElement>(
+      ".chat-tool-card__preview-frame, .board-widget__frame",
+    )) {
+      postWidgetTheme(frame);
     }
   }).observe(root, {
     attributes: true,

--- a/ui/src/lib/widget-theme.ts
+++ b/ui/src/lib/widget-theme.ts
@@ -68,27 +68,34 @@ export function buildWidgetThemeMessage(): {
 }
 
 export function postWidgetTheme(frame: HTMLIFrameElement, targetOrigin = "*"): void {
-  // Canvas widgets have opaque origins and require "*". Authenticated
-  // cross-origin embeds instead supply their exact, validated origin.
   frame.contentWindow?.postMessage(buildWidgetThemeMessage(), targetOrigin);
 }
 
-let widgetThemeObserverInstalled = false;
+const widgetThemeObserverWindows = new WeakSet<Window>();
+const widgetFrameProviders = new WeakMap<Window, Set<() => Iterable<HTMLIFrameElement>>>();
 
 export function installWidgetThemeObserver(getFrames: () => Iterable<HTMLIFrameElement>): void {
   if (
-    widgetThemeObserverInstalled ||
+    typeof window === "undefined" ||
     typeof document === "undefined" ||
     typeof MutationObserver === "undefined"
   ) {
     return;
   }
-  widgetThemeObserverInstalled = true;
+  const providers = widgetFrameProviders.get(window) ?? new Set();
+  providers.add(getFrames);
+  widgetFrameProviders.set(window, providers);
+  if (widgetThemeObserverWindows.has(window)) {
+    return;
+  }
+  widgetThemeObserverWindows.add(window);
   const root = document.documentElement;
   new MutationObserver(() => {
-    for (const frame of getFrames()) {
-      if (frame.isConnected) {
-        postWidgetTheme(frame);
+    for (const provider of providers) {
+      for (const frame of provider()) {
+        if (frame.isConnected) {
+          postWidgetTheme(frame);
+        }
       }
     }
   }).observe(root, {

--- a/ui/src/pages/chat/components/session-discussion-panel.ts
+++ b/ui/src/pages/chat/components/session-discussion-panel.ts
@@ -9,8 +9,8 @@ import { icons } from "../../../components/icons.ts";
 import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
+import { buildWidgetThemeMessage, postWidgetTheme } from "../../../lib/widget-theme.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
-import { buildWidgetThemeMessage, postWidgetTheme } from "./widget-theme.ts";
 
 type SessionDiscussionInfoLoader = (sessionKey: string) => Promise<SessionDiscussionInfo>;
 type SessionDiscussionOpener = (sessionKey: string) => Promise<SessionDiscussionInfo>;

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -24,9 +24,9 @@ import {
   type EmbedSandboxMode,
 } from "../../../lib/chat/tool-display.ts";
 import { showToast } from "../../../lib/toast.ts";
+import { installWidgetThemeObserver, postWidgetTheme } from "../../../lib/widget-theme.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 import { exportWidget } from "./widget-export.ts";
-import { installWidgetThemeObserver, postWidgetTheme } from "./widget-theme.ts";
 
 export { WIDGET_PROMPT_EVENT };
 export type { WidgetPromptEventDetail };

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -309,7 +309,7 @@ function renderPreviewFrame(params: {
   promptCapable?: boolean;
 }) {
   installWidgetSizeListener();
-  installWidgetThemeObserver(() => widgetFrameRegistry);
+  installWidgetThemeObserver();
   const sandbox = params.sandbox ?? "";
   const src = params.src ?? "";
   const heightKey = params.frameKey || src;

--- a/ui/src/pages/chat/components/widget-theme.test.ts
+++ b/ui/src/pages/chat/components/widget-theme.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { installWidgetThemeObserver, postWidgetTheme } from "./widget-theme.ts";
+import { installWidgetThemeObserver, postWidgetTheme } from "../../../lib/widget-theme.ts";
 
 function stubComputedStyles(values: Record<string, string>) {
   vi.stubGlobal(

--- a/ui/src/pages/chat/components/widget-theme.test.ts
+++ b/ui/src/pages/chat/components/widget-theme.test.ts
@@ -111,20 +111,18 @@ describe("widget theme bridge", () => {
 
     vi.stubGlobal("MutationObserver", FakeMutationObserver);
     stubComputedStyles({ "--accent": "#c41e30" });
-    const connectedPost = vi.fn();
-    const detachedPost = vi.fn();
-    const connected = {
-      isConnected: true,
-      contentWindow: { postMessage: connectedPost },
-    } as unknown as HTMLIFrameElement;
-    const detached = {
-      isConnected: false,
-      contentWindow: { postMessage: detachedPost },
-    } as unknown as HTMLIFrameElement;
-    const getFrames = () => [connected, detached];
+    const chatFrame = document.createElement("iframe");
+    chatFrame.className = "chat-tool-card__preview-frame";
+    const boardFrame = document.createElement("iframe");
+    boardFrame.className = "board-widget__frame";
+    const unrelatedFrame = document.createElement("iframe");
+    document.body.append(chatFrame, boardFrame, unrelatedFrame);
+    const chatPost = vi.spyOn(chatFrame.contentWindow!, "postMessage");
+    const boardPost = vi.spyOn(boardFrame.contentWindow!, "postMessage");
+    const unrelatedPost = vi.spyOn(unrelatedFrame.contentWindow!, "postMessage");
 
-    installWidgetThemeObserver(getFrames);
-    installWidgetThemeObserver(getFrames);
+    installWidgetThemeObserver();
+    installWidgetThemeObserver();
 
     expect(FakeMutationObserver.instances).toHaveLength(1);
     expect(FakeMutationObserver.instances[0]?.observe).toHaveBeenCalledWith(
@@ -137,7 +135,8 @@ describe("widget theme bridge", () => {
     FakeMutationObserver.instances[0]?.trigger({
       attributeName: "data-theme",
     } as MutationRecord);
-    expect(connectedPost).toHaveBeenCalledOnce();
-    expect(detachedPost).not.toHaveBeenCalled();
+    expect(chatPost).toHaveBeenCalledOnce();
+    expect(boardPost).toHaveBeenCalledOnce();
+    expect(unrelatedPost).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #101823

Related: #68497 — this PR bridges A2UI actions for **board-hosted** widgets only. Standalone Canvas browser pages intentionally keep their current native-only action path: the campaign direction (see PR body below) retires the standalone canvas file host in a follow-up deletion PR, at which point #68497 will be resolved with that rationale rather than implemented.

## What Problem This Solves

Session boards could render HTML and MCP App widgets, but agents could not place Canvas A2UI applications on the board or receive their browser actions through the existing sandbox bridge. The Canvas validator and Lit host were also limited to the v0.8 message vocabulary, which rejected v0.9 `createSurface` streams.

## Why This Change Was Made

This adds a minimal runtime Plugin SDK seam:

```ts
api.registerBoardWidgetContentKind({
  kind,
  label,
  resources,
  validateSource,
  composeDocument,
});
```

The runtime hook is smaller and more consistent than manifest declarations because source validation and document composition are executable plugin-owned behavior. Core stores registered widgets through the existing generic `plugin` discrimination and discovers available kinds from the active registry; there are no Canvas- or A2UI-specific literals in core.

Rendering uses mechanism (b): the Canvas plugin composes a small sandbox document which references its capability-scoped renderer bundle from the Gateway origin. This preserves the existing board frame, ticket, CSP, theme, revision-reload, and private MessagePort bridge pipeline without adding another iframe host or an embed protocol for the full Canvas page. The A2UI asset route is independent of the Canvas file host.

The installed dependency contracts were checked directly. A2UI v0.9 defines `createSurface`, `updateComponents`, `updateDataModel`, and `deleteSurface` in `node_modules/@a2ui/web_core/src/v0_9/index.d.ts:40` and dispatches exactly those operations in `node_modules/@a2ui/web_core/src/v0_9/processing/message-processor.js:183`. The retained v0.8 vocabulary is defined in `node_modules/@a2ui/web_core/src/v0_8/schema/server-to-client.js:205`. `@a2ui/lit` is pinned to 0.10.3 and the direct v0.9 processor dependency `@a2ui/web_core` is pinned to 0.10.6.

There is no SQLite schema/version bump and no Gateway protocol version bump. Native node resource staging deliberately remains on the v0.8 renderer; v0.9 is board/web-only until native clients can select a renderer before applying a stream.

Issue #66983 proposes browser tabs registering as privileged Canvas nodes. This design answers the browser use case differently: A2UI runs as a capability-scoped, opaque board widget instead of widening node pairing or Canvas command authority. I recommend closing #66983 with that rationale, but this PR does not claim to close it.

The plugin inventory regeneration is an opportunistic pathfinder repair for pre-existing `cua-computer` staleness on `main`. Plugin-touching changes activate that latent gate, so the generated inventory and reference page are refreshed in a separate commit.

## User Impact

Agents can call `show_widget` with a dynamically registered A2UI kind, update the widget in place by name, and use the same pin, size, tab, and presentation semantics as HTML widgets. A2UI actions produce tier-1 session notices by default; granting the existing `prompt` capability enables visible prompt sends. If Canvas is disabled, the kind is absent from the tool schema and direct requests receive an actionable enable-the-plugin error.

## Evidence

- `pnpm plugins:inventory:check` — passed on the rebased head.
- `pnpm check:changed` — passed all formatting, ratchet, dependency, SDK, database-first, typecheck, lint, and import-cycle lanes on the rebased head.
- `pnpm plugin-sdk:surface:check` — passed.
- `pnpm plugin-sdk:api:diff --base "$(git merge-base origin/main HEAD)" --head HEAD` — intended additive board/plugin declarations only.
- `pnpm build` — passed.
- Canvas/A2UI focused tests — 31 passed.
- Board/store/widget/plugin focused tests — 66 passed.
- Database-first guard tests — 534 passed; generated A2UI renderer bundles are excluded as generated assets.
- Control UI Playwright E2E — a real v0.9 button rendered in the board sandbox, inherited theme tokens, and emitted `board.event`.
- Final structured review — clean, no accepted/actionable findings.
- Production/tooling LOC: +1004/-209 (net +795); tests: +710/-14; docs: +52/-5; metadata/generated: +25/-16. Production growth is the new generic Plugin SDK owner boundary, registered board-frame materialization path, and dual-generation Canvas renderer support.

![A2UI board widget rendering in the existing session board frame](https://github.com/user-attachments/assets/56726f93-6319-4deb-92ff-bd3c0c46f430)

AI-assisted: yes


## Live proof (coordinator)

Real gateway (isolated state dir, port 19789, PR-head build), real `anthropic/claude-sonnet-4-6` agent turn via the Control UI composer: the agent created and pinned an `a2ui` widget by name (`rig-proof`); the Dashboard face renders it; clicking its **Ping** button routes through the board bridge with a visible acknowledgment. Recorded fact verified server-side: `board_widgets` row `rig-proof` with `pluginKind: canvas:a2ui` and JSONL source, `grant_state: none` (capless → instant render).

Dashboard face with the pinned A2UI widget:

![dashboard face](https://github.com/user-attachments/assets/63b2619f-e7ac-44ff-bcad-a134ba512b90)

After clicking Ping inside the sandboxed frame:

![after ping](https://github.com/user-attachments/assets/93eb7e53-6f7b-4a7e-9ffc-80ceacefe19b)

Full flow video:

https://github.com/user-attachments/assets/6f89027f-e95a-478f-a162-9e03101a0405
