### PR TITLE
test(e2e): keep recovery proof alive

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { writeSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { startQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
@@ -55,6 +56,7 @@ const QUEUED_PROMPT =
 const QUEUED_REPLY_MARKER = "GATEWAY_REPEATED_REQUEST_QUEUED_OK";
 const RECOVERY_REASON = "repeated_model_requests_without_progress";
 const PRODUCTION_RECOVERY_BOUND_MS = 360_000;
+const RECOVERY_PROGRESS_INTERVAL_MS = 60_000;
 const HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const HISTORY_RETRY_INTERVAL_MS = 250;
 
@@ -83,11 +85,22 @@ async function waitForStability(
   timeoutMs: number,
 ): Promise<StabilityEvent[]> {
   const startedAt = Date.now();
+  let nextProgressAt = RECOVERY_PROGRESS_INTERVAL_MS;
   let latest: StabilityEvent[] = [];
   while (Date.now() - startedAt < timeoutMs) {
     latest = (await readStability(gateway, sinceSeq)).events ?? [];
     if (predicate(latest)) {
       return latest;
+    }
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= nextProgressAt) {
+      // Vitest suppresses test console output; write to the worker fd so the outer
+      // no-output watchdog can distinguish this production-length poll from a stalled worker.
+      writeSync(
+        2,
+        `[gateway-repeated-request-recovery] waiting for stability evidence (${elapsedMs}ms, ${latest.length} events)\n`,
+      );
+      nextProgressAt += RECOVERY_PROGRESS_INTERVAL_MS;
     }
     await sleep(1_000);
   }


### PR DESCRIPTION
## Summary

- keep the real repeated-request recovery proof observable during its production-length polling window
- bypass Vitest console suppression only for one bounded liveness line per minute
- preserve the 360-second production recovery bound, the 350-second evidence wait, and all assertions

## Root cause

`gateway-repeated-request-recovery.e2e.test.ts` intentionally waits up to 350 seconds for the real 360-second stale-session recovery policy. The repo E2E wrapper terminates the Vitest process after 300 seconds without child output. Vitest runs this config with `silent: true`, so ordinary test console output cannot prove that the worker is still polling. The full repo E2E therefore dies anonymously after the preceding Telegram test even though the recovery worker is active.

Vitest 4.1.10 runs uncached files by descending file size, which places this test immediately after the last reported Telegram test. The same ordering and anonymous 300-second termination is present in historical run 31626760595, job 94215788330, and exact-head run 32113064535, job 95637173419.

## Verification

- No local tests or validation were run, per release-validation policy.
- Exact-head GitHub repo E2E attempts: https://github.com/openclaw/openclaw/actions/runs/32135733228. Attempts 1 and 2 never reached tests because this older PR head carries the pre-#125800 Control UI startup baseline (repo build 344400 B and OpenShell build 344371 B versus the stale 344345 B limit).
- The unrelated budget owner was already repaired on current main by merged #125800; no duplicate baseline change is included here.
- Current-main merge-candidate proof: https://github.com/openclaw/openclaw/actions/runs/32137415599 at base-repo SHA `534e92d337139e0bce0b11c2059f0eb76e5f6c85`. That branch is current main `e8044fdffef35faa908f7f1521ee9a4217ddd349` plus this PR's unchanged test patch; its stable patch-id matches PR head exactly (`ac4b7a11c522492c81d7301d38f07add6c5be2ef`).
- In that proof, the worker emitted recovery liveness at 60, 120, 180, and 240 seconds and the unchanged target assertion passed in 398.857 seconds. The suite continued beyond the historical watchdog point. Its terminal job failure came from unrelated OTel evidence timeout and hosted-web registry timing, neither touched by this PR; hosted-web is covered by #125814.
- Static: the change writes directly to worker fd 2 once per minute while `waitForStability` remains active; this output reaches the outer process without changing any behavioral deadline or assertion.

## Scope

Test-only: +13/-0. No production behavior, config, public contract, or changelog change.
