### PR TITLE
refactor: consolidate small shared helpers

### DIFF
--- a/scripts/check-gateway-watch-regression.mts
+++ b/scripts/check-gateway-watch-regression.mts
@@ -9,6 +9,7 @@ import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
+import { readProcessTreeCpuMs } from "./lib/gateway-bench-probes.ts";
 import {
   BUILD_STAMP_FILE,
   writeBuildStamp,
@@ -445,79 +446,6 @@ function runCheckedCommand(command: string, args: string[]) {
     return;
   }
   throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? "unknown"}`);
-}
-
-function parsePsCpuTimeMs(timeText: string): number | null {
-  const [maybeDays, clockText] = timeText.includes("-") ? timeText.split("-", 2) : ["0", timeText];
-  const days = Number(maybeDays);
-  const parts = clockText!.split(":");
-  if (!Number.isFinite(days) || parts.length < 2 || parts.length > 3) {
-    return null;
-  }
-  const seconds = Number(parts.at(-1));
-  const minutes = Number(parts.at(-2));
-  const hours = parts.length === 3 ? Number(parts[0]) : 0;
-  if (![seconds, minutes, hours].every(Number.isFinite)) {
-    return null;
-  }
-  return Math.round(((days * 24 + hours) * 60 * 60 + minutes * 60 + seconds) * 1000);
-}
-
-function readProcessTreeCpuMs(rootPid: number): number | null {
-  if (!Number.isInteger(rootPid) || rootPid <= 0) {
-    return null;
-  }
-  const result = spawnSync("ps", ["-eo", "pid=,ppid=,time="], {
-    cwd: process.cwd(),
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  if (result.status !== 0) {
-    return null;
-  }
-
-  const rows: Array<{ pid: number; ppid: number; cpuMs: number }> = [];
-  for (const line of result.stdout.split("\n")) {
-    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)$/);
-    if (!match) {
-      continue;
-    }
-    const pid = Number(match[1]);
-    const ppid = Number(match[2]);
-    const cpuMs = parsePsCpuTimeMs(match[3]!);
-    if (!Number.isInteger(pid) || !Number.isInteger(ppid) || cpuMs == null) {
-      continue;
-    }
-    rows.push({ pid, ppid, cpuMs });
-  }
-
-  const childrenByParent = new Map<number, number[]>();
-  const cpuByPid = new Map<number, number>();
-  for (const row of rows) {
-    cpuByPid.set(row.pid, row.cpuMs);
-    const children = childrenByParent.get(row.ppid) ?? [];
-    children.push(row.pid);
-    childrenByParent.set(row.ppid, children);
-  }
-  if (!cpuByPid.has(rootPid)) {
-    return null;
-  }
-
-  let totalCpuMs = 0;
-  const seen = new Set<number>();
-  const stack = [rootPid];
-  while (stack.length > 0) {
-    const pid = stack.pop();
-    if (!pid || seen.has(pid)) {
-      continue;
-    }
-    seen.add(pid);
-    totalCpuMs += cpuByPid.get(pid) ?? 0;
-    for (const childPid of childrenByParent.get(pid) ?? []) {
-      stack.push(childPid);
-    }
-  }
-  return totalCpuMs;
 }
 
 /**

--- a/scripts/control-ui-i18n-verify.ts
+++ b/scripts/control-ui-i18n-verify.ts
@@ -1,13 +1,15 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as ts from "typescript";
 import {
   loadControlUiTranslationMemory,
+  loadControlUiLocaleCatalog,
+  loadControlUiSourceCatalog,
   materializeControlUiLocaleCatalog,
-  mergeControlUiTranslationMaps,
+  readControlUiSourceCatalog,
 } from "./lib/control-ui-i18n-catalog.ts";
 import { CONTROL_UI_LOCALE_ENTRIES } from "./lib/control-ui-i18n-config.ts";
 import { syncControlUiRawCopyBaseline } from "./lib/control-ui-i18n-raw-copy.ts";
@@ -44,37 +46,12 @@ export function formatControlUiCatalogFallbackDriftError(): string {
   ].join("\n");
 }
 
-async function importLocaleModule<T>(filePath: string): Promise<T> {
-  const stats = await stat(filePath);
-  return (await import(`${pathToFileURL(filePath).href}?ts=${stats.mtimeMs}`)) as T;
-}
-
-async function loadLocaleMap(filePath: string, exportName: string): Promise<TranslationMap | null> {
-  if (!existsSync(filePath)) {
-    return null;
-  }
-  const mod = await importLocaleModule<Record<string, TranslationMap>>(filePath);
-  return mod[exportName] ?? null;
-}
-
 async function loadSourceLocaleMap(): Promise<TranslationMap> {
-  const source = await loadLocaleMap(SOURCE_LOCALE_PATH, "en");
-  const activitySource = (
-    await importLocaleModule<{
-      registerActivityEnglish: { catalog: TranslationMap };
-    }>(ACTIVITY_SOURCE_LOCALE_PATH)
-  ).registerActivityEnglish.catalog;
-  if (!source || !activitySource) {
-    throw new Error("Control UI English source catalogs are incomplete");
-  }
-  return mergeControlUiTranslationMaps(source, activitySource);
+  return await loadControlUiSourceCatalog(SOURCE_LOCALE_PATH, ACTIVITY_SOURCE_LOCALE_PATH);
 }
 
 async function readSourceLocaleRaw(): Promise<string> {
-  const sources = await Promise.all(
-    [SOURCE_LOCALE_PATH, ACTIVITY_SOURCE_LOCALE_PATH].map((filePath) => readFile(filePath, "utf8")),
-  );
-  return sources.join("\n");
+  return await readControlUiSourceCatalog(SOURCE_LOCALE_PATH, ACTIVITY_SOURCE_LOCALE_PATH);
 }
 
 function extractPlaceholders(text: string): string[] {
@@ -328,7 +305,7 @@ export async function verifyRuntimeLocaleConfig() {
     }
   }
 
-  const enMap = (await loadLocaleMap(SOURCE_LOCALE_PATH, "en")) ?? {};
+  const enMap = (await loadControlUiLocaleCatalog(SOURCE_LOCALE_PATH, "en")) ?? {};
   const languageMap = enMap.languages;
   const languageKeys =
     languageMap && typeof languageMap === "object"

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -2,7 +2,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { completeSimple, type AssistantMessage, type Model } from "openclaw/plugin-sdk/llm";
@@ -17,9 +17,10 @@ import {
 import { isStrictAffirmativeValue } from "./lib/arg-utils.mts";
 import {
   hashControlUiTranslationText,
+  loadControlUiSourceCatalog,
   loadControlUiTranslationMemory,
   materializeControlUiLocaleCatalog,
-  mergeControlUiTranslationMaps,
+  readControlUiSourceCatalog,
 } from "./lib/control-ui-i18n-catalog.ts";
 import { CONTROL_UI_LOCALE_ENTRIES } from "./lib/control-ui-i18n-config.ts";
 import { syncControlUiRawCopyBaseline } from "./lib/control-ui-i18n-raw-copy.ts";
@@ -280,38 +281,12 @@ function tmPath(entry: LocaleEntry): string {
   return path.join(I18N_ASSETS_DIR, `${entry.locale}.tm.jsonl`);
 }
 
-async function importLocaleModule<T>(filePath: string): Promise<T> {
-  const stats = await stat(filePath);
-  const href = `${pathToFileURL(filePath).href}?ts=${stats.mtimeMs}`;
-  return (await import(href)) as T;
-}
-
-async function loadLocaleMap(filePath: string, exportName: string): Promise<TranslationMap | null> {
-  if (!existsSync(filePath)) {
-    return null;
-  }
-  const mod = await importLocaleModule<Record<string, TranslationMap>>(filePath);
-  return mod[exportName] ?? null;
-}
-
 async function loadSourceLocaleMap(): Promise<TranslationMap> {
-  const source = await loadLocaleMap(SOURCE_LOCALE_PATH, "en");
-  const activitySource = (
-    await importLocaleModule<{
-      registerActivityEnglish: { catalog: TranslationMap };
-    }>(ACTIVITY_SOURCE_LOCALE_PATH)
-  ).registerActivityEnglish.catalog;
-  if (!source || !activitySource) {
-    throw new Error("Control UI English source catalogs are incomplete");
-  }
-  return mergeControlUiTranslationMaps(source, activitySource);
+  return await loadControlUiSourceCatalog(SOURCE_LOCALE_PATH, ACTIVITY_SOURCE_LOCALE_PATH);
 }
 
 async function readSourceLocaleRaw(): Promise<string> {
-  const sources = await Promise.all(
-    [SOURCE_LOCALE_PATH, ACTIVITY_SOURCE_LOCALE_PATH].map((filePath) => readFile(filePath, "utf8")),
-  );
-  return sources.join("\n");
+  return await readControlUiSourceCatalog(SOURCE_LOCALE_PATH, ACTIVITY_SOURCE_LOCALE_PATH);
 }
 
 type PlaceholderMismatch = {

--- a/scripts/e2e/parallels/linux-smoke.ts
+++ b/scripts/e2e/parallels/linux-smoke.ts
@@ -3,17 +3,12 @@
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
 import { posixAgentWorkspaceScript } from "./agent-workspace.ts";
 import {
   die,
-  ensureValue,
   currentRunningSnapshotInfo,
   makeTempDir,
   parseBoolEnv,
-  parseMode,
-  parseTcpPort,
-  parseProvider,
   readPositiveIntEnv,
   modelProviderConfigBatchJson,
   posixCodexPlatformPackageRepairFunction,
@@ -48,9 +43,9 @@ import {
   extractLastOpenClawVersion,
   packAndServeSmokeArtifact,
   printSmokeTargetSummary,
+  parseSmokeCliArgs,
   SmokeRunController,
-  type SmokeHostOptions,
-  type SmokeRunOptions,
+  type SmokeCliOptions,
 } from "./smoke-common.ts";
 
 // Older published baselines predate this warning, but still need update coverage.
@@ -86,13 +81,8 @@ function compareOpenClawPackageVersions(left: string, right: string): number {
   return 0;
 }
 
-interface LinuxOptions extends SmokeHostOptions, SmokeRunOptions {
-  vmName: string;
+interface LinuxOptions extends SmokeCliOptions {
   vmNameExplicit: boolean;
-  apiKeyEnv?: string;
-  modelId?: string;
-  installUrl: string;
-  latestVersion?: string;
 }
 
 interface LinuxSummary {
@@ -170,83 +160,16 @@ Options:
 }
 
 export function parseArgs(argv: string[]): LinuxOptions {
-  const args = stripLeadingPackageManagerSeparator(argv);
   const options = defaultOptions();
-  parseArgv: for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    switch (arg) {
-      case "--":
-        break parseArgv;
-      case "--vm":
-        options.vmName = ensureValue(args, i, arg);
-        options.vmNameExplicit = true;
-        i++;
-        break;
-      case "--snapshot-hint":
-        options.snapshotHint = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--mode":
-        options.mode = parseMode(ensureValue(args, i, arg));
-        i++;
-        break;
-      case "--provider":
-        options.provider = parseProvider(ensureValue(args, i, arg));
-        i++;
-        break;
-      case "--model":
-        options.modelId = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--api-key-env":
-      case "--openai-api-key-env":
-        options.apiKeyEnv = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--install-url":
-        options.installUrl = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--host-port":
-        options.hostPort = parseTcpPort(ensureValue(args, i, arg), arg);
-        options.hostPortExplicit = true;
-        i++;
-        break;
-      case "--host-ip":
-        options.hostIp = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--latest-version":
-        options.latestVersion = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--install-version":
-        options.installVersion = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--target-package-spec":
-        options.targetPackageSpec = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--npm-registry":
-        options.npmRegistry = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--keep-server":
-        options.keepServer = true;
-        break;
-      case "--json":
-        options.json = true;
-        break;
-      case "-h":
-      case "--help":
-        process.stdout.write(usage());
-        process.exit(0);
-      default:
-        die(`unknown arg: ${arg}`);
-    }
-  }
-  return options;
+  return parseSmokeCliArgs(argv, options, {
+    usage,
+    valueHandlers: {
+      "--vm": (parsed, value) => {
+        parsed.vmName = value;
+        parsed.vmNameExplicit = true;
+      },
+    },
+  });
 }
 
 class LinuxSmoke extends SmokeRunController<LinuxOptions> {

--- a/scripts/e2e/parallels/macos-smoke.ts
+++ b/scripts/e2e/parallels/macos-smoke.ts
@@ -3,11 +3,9 @@
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
 import { posixAgentWorkspaceScript } from "./agent-workspace.ts";
 import {
   die,
-  ensureValue,
   currentRunningSnapshotInfo,
   extractLastOpenClawVersionFromLog,
   makeTempDir,
@@ -16,12 +14,9 @@ import {
   packageVersionFromTgz,
   parseMacosDsclUserHomeLine,
   packOpenClaw,
-  parseMode,
-  parseProvider,
   modelProviderConfigBatchJson,
   posixCodexPlatformPackageRepairFunction,
   posixProviderOnlyPluginIsolationScript,
-  parseTcpPort,
   readGitCommitEnv,
   readPositiveIntEnv,
   resolveParallelsModelTimeoutSeconds,
@@ -52,26 +47,11 @@ import { runSmokeLane, type SmokeLane, type SmokeLaneStatus } from "./lane-runne
 import { MacosDiscordSmoke } from "./macos-discord.ts";
 import { resolveMacosVmName, waitForVmStatus } from "./parallels-vm.ts";
 import { PhaseRunner } from "./phase-runner.ts";
+import { parseSmokeCliArgs, type SmokeCliOptions } from "./smoke-common.ts";
 
-interface MacosOptions {
-  vmName: string;
+interface MacosOptions extends SmokeCliOptions {
   vmNameExplicit: boolean;
-  snapshotHint: string;
-  mode: Mode;
-  provider: Provider;
-  apiKeyEnv?: string;
-  modelId?: string;
-  installUrl: string;
-  hostPort: number;
-  hostPortExplicit: boolean;
-  hostIp?: string;
-  latestVersion?: string;
-  installVersion?: string;
-  npmRegistry?: string;
-  targetPackageSpec?: string;
   skipLatestRefCheck: boolean;
-  keepServer: boolean;
-  json: boolean;
   discordTokenEnv?: string;
   discordGuildId?: string;
   discordChannelId?: string;
@@ -175,98 +155,22 @@ Environment:
 }
 
 export function parseArgs(argv: string[]): MacosOptions {
-  const args = stripLeadingPackageManagerSeparator(argv);
   const options = defaultOptions();
-  parseArgv: for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    switch (arg) {
-      case "--":
-        break parseArgv;
-      case "--vm":
-        options.vmName = ensureValue(args, i, arg);
-        options.vmNameExplicit = true;
-        i++;
-        break;
-      case "--snapshot-hint":
-        options.snapshotHint = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--mode":
-        options.mode = parseMode(ensureValue(args, i, arg));
-        i++;
-        break;
-      case "--provider":
-        options.provider = parseProvider(ensureValue(args, i, arg));
-        i++;
-        break;
-      case "--model":
-        options.modelId = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--api-key-env":
-      case "--openai-api-key-env":
-        options.apiKeyEnv = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--install-url":
-        options.installUrl = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--host-port":
-        options.hostPort = parseTcpPort(ensureValue(args, i, arg), arg);
-        options.hostPortExplicit = true;
-        i++;
-        break;
-      case "--host-ip":
-        options.hostIp = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--latest-version":
-        options.latestVersion = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--install-version":
-        options.installVersion = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--target-package-spec":
-        options.targetPackageSpec = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--npm-registry":
-        options.npmRegistry = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--skip-latest-ref-check":
-        options.skipLatestRefCheck = true;
-        break;
-      case "--keep-server":
-        options.keepServer = true;
-        break;
-      case "--discord-token-env":
-        options.discordTokenEnv = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--discord-guild-id":
-        options.discordGuildId = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--discord-channel-id":
-        options.discordChannelId = ensureValue(args, i, arg);
-        i++;
-        break;
-      case "--json":
-        options.json = true;
-        break;
-      case "-h":
-      case "--help":
-        process.stdout.write(usage());
-        process.exit(0);
-      default:
-        die(`unknown arg: ${arg}`);
-    }
-  }
-  return options;
+  return parseSmokeCliArgs(argv, options, {
+    flagHandlers: {
+      "--skip-latest-ref-check": (parsed) => (parsed.skipLatestRefCheck = true),
+    },
+    usage,
+    valueHandlers: {
+      "--discord-channel-id": (parsed, value) => (parsed.discordChannelId = value),
+      "--discord-guild-id": (parsed, value) => (parsed.discordGuildId = value),
+      "--discord-token-env": (parsed, value) => (parsed.discordTokenEnv = value),
+      "--vm": (parsed, value) => {
+        parsed.vmName = value;
+        parsed.vmNameExplicit = true;
+      },
+    },
+  });
 }
 
 class MacosSmoke {

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -90,13 +90,13 @@ export function parseSmokeCliArgs<TOptions extends SmokeCliOptions>(
     if (arg === "--") {
       break;
     }
-    const valueHandler = valueHandlers[arg];
+    const valueHandler = Object.hasOwn(valueHandlers, arg) ? valueHandlers[arg] : undefined;
     if (valueHandler) {
       valueHandler(ensureValue(args, index, arg));
       index += 1;
       continue;
     }
-    const flagHandler = flagHandlers[arg];
+    const flagHandler = Object.hasOwn(flagHandlers, arg) ? flagHandlers[arg] : undefined;
     if (flagHandler) {
       flagHandler();
       continue;

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -1,8 +1,10 @@
 // Smoke Common helper supports OpenClaw script workflows.
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
+import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
+import { parseTcpPort } from "./env-limits.ts";
 import { extractLastOpenClawVersionFromLog } from "./filesystem.ts";
-import { run, say } from "./host-command.ts";
+import { run, say, die } from "./host-command.ts";
 import { resolveHostIp, resolveHostPort, startHostServer } from "./host-server.ts";
 import { runSmokeLane, type SmokeLane, type SmokeLaneStatus } from "./lane-runner.ts";
 import {
@@ -10,15 +12,16 @@ import {
   packageVersionFromTgz,
   packOpenClaw,
 } from "./package-artifact.ts";
+import { ensureValue, parseMode, parseProvider } from "./provider-auth.ts";
 import type { HostServer, Mode, PackageArtifact, Provider, SnapshotInfo } from "./types.ts";
 
-export interface SmokeHostOptions {
+interface SmokeHostOptions {
   hostIp?: string;
   hostPort: number;
   hostPortExplicit: boolean;
 }
 
-export interface SmokeRunOptions {
+interface SmokeRunOptions {
   installVersion?: string;
   json: boolean;
   keepServer: boolean;
@@ -27,6 +30,84 @@ export interface SmokeRunOptions {
   provider: Provider;
   snapshotHint: string;
   targetPackageSpec?: string;
+}
+
+export interface SmokeCliOptions extends SmokeHostOptions, SmokeRunOptions {
+  apiKeyEnv?: string;
+  installUrl: string;
+  latestVersion?: string;
+  modelId?: string;
+  vmName: string;
+}
+
+type SmokeCliParserConfig<TOptions extends SmokeCliOptions> = {
+  flagHandlers?: Record<string, (options: TOptions) => void>;
+  usage: () => string;
+  valueHandlers?: Record<string, (options: TOptions, value: string) => void>;
+};
+
+export function parseSmokeCliArgs<TOptions extends SmokeCliOptions>(
+  argv: string[],
+  options: TOptions,
+  config: SmokeCliParserConfig<TOptions>,
+): TOptions {
+  const args = stripLeadingPackageManagerSeparator(argv);
+  const valueHandlers: Record<string, (value: string) => void> = {
+    "--api-key-env": (value) => (options.apiKeyEnv = value),
+    "--host-ip": (value) => (options.hostIp = value),
+    "--host-port": (value) => {
+      options.hostPort = parseTcpPort(value, "--host-port");
+      options.hostPortExplicit = true;
+    },
+    "--install-url": (value) => (options.installUrl = value),
+    "--install-version": (value) => (options.installVersion = value),
+    "--latest-version": (value) => (options.latestVersion = value),
+    "--mode": (value) => (options.mode = parseMode(value)),
+    "--model": (value) => (options.modelId = value),
+    "--npm-registry": (value) => (options.npmRegistry = value),
+    "--openai-api-key-env": (value) => (options.apiKeyEnv = value),
+    "--provider": (value) => (options.provider = parseProvider(value)),
+    "--snapshot-hint": (value) => (options.snapshotHint = value),
+    "--target-package-spec": (value) => (options.targetPackageSpec = value),
+    "--vm": (value) => (options.vmName = value),
+  };
+  for (const [flag, handler] of Object.entries(config.valueHandlers ?? {})) {
+    valueHandlers[flag] = (value) => handler(options, value);
+  }
+  const flagHandlers: Record<string, () => void> = {
+    "--json": () => (options.json = true),
+    "--keep-server": () => (options.keepServer = true),
+  };
+  for (const [flag, handler] of Object.entries(config.flagHandlers ?? {})) {
+    flagHandlers[flag] = () => handler(options);
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === undefined) {
+      die(`missing argument at index ${index}`);
+    }
+    if (arg === "--") {
+      break;
+    }
+    const valueHandler = valueHandlers[arg];
+    if (valueHandler) {
+      valueHandler(ensureValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+    const flagHandler = flagHandlers[arg];
+    if (flagHandler) {
+      flagHandler();
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      process.stdout.write(config.usage());
+      process.exit(0);
+    }
+    die(`unknown arg: ${arg}`);
+  }
+  return options;
 }
 
 interface SmokeLaneStatuses {

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -2,16 +2,11 @@
 // Windows Smoke script supports OpenClaw repository automation.
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
 import { windowsAgentWorkspaceScript } from "./agent-workspace.ts";
 import {
   die,
-  ensureValue,
   currentRunningSnapshotInfo,
   makeTempDir,
-  parseMode,
-  parseTcpPort,
-  parseProvider,
   readGitCommitEnv,
   readPositiveIntEnv,
   resolveLatestVersion,
@@ -52,19 +47,14 @@ import {
   expectedPackageTargetVersion,
   extractLastOpenClawVersion,
   packAndServeSmokeArtifact,
+  parseSmokeCliArgs,
   printSmokeTargetSummary,
   SmokeRunController,
-  type SmokeHostOptions,
-  type SmokeRunOptions,
+  type SmokeCliOptions,
 } from "./smoke-common.ts";
 import { ensureGuestGit, prepareMinGitZip } from "./windows-git.ts";
 
-interface WindowsOptions extends SmokeHostOptions, SmokeRunOptions {
-  vmName: string;
-  apiKeyEnv?: string;
-  modelId?: string;
-  installUrl: string;
-  latestVersion?: string;
+interface WindowsOptions extends SmokeCliOptions {
   upgradeFromPackedMain: boolean;
   skipLatestRefCheck: boolean;
 }
@@ -158,93 +148,14 @@ Environment:
 }
 
 export function parseArgs(argv: string[]): WindowsOptions {
-  const args = stripLeadingPackageManagerSeparator(argv);
   const options = defaultOptions();
-  const valueHandlers: Record<string, (value: string) => void> = {
-    "--api-key-env": (value) => {
-      options.apiKeyEnv = value;
+  return parseSmokeCliArgs(argv, options, {
+    flagHandlers: {
+      "--skip-latest-ref-check": (parsed) => (parsed.skipLatestRefCheck = true),
+      "--upgrade-from-packed-main": (parsed) => (parsed.upgradeFromPackedMain = true),
     },
-    "--host-ip": (value) => {
-      options.hostIp = value;
-    },
-    "--host-port": (value) => {
-      options.hostPort = parseTcpPort(value, "--host-port");
-      options.hostPortExplicit = true;
-    },
-    "--install-url": (value) => {
-      options.installUrl = value;
-    },
-    "--install-version": (value) => {
-      options.installVersion = value;
-    },
-    "--latest-version": (value) => {
-      options.latestVersion = value;
-    },
-    "--model": (value) => {
-      options.modelId = value;
-    },
-    "--npm-registry": (value) => {
-      options.npmRegistry = value;
-    },
-    "--openai-api-key-env": (value) => {
-      options.apiKeyEnv = value;
-    },
-    "--provider": (value) => {
-      options.provider = parseProvider(value);
-    },
-    "--snapshot-hint": (value) => {
-      options.snapshotHint = value;
-    },
-    "--target-package-spec": (value) => {
-      options.targetPackageSpec = value;
-    },
-    "--vm": (value) => {
-      options.vmName = value;
-    },
-    "--mode": (value) => {
-      options.mode = parseMode(value);
-    },
-  };
-  const flagHandlers: Record<string, () => void> = {
-    "--json": () => {
-      options.json = true;
-    },
-    "--keep-server": () => {
-      options.keepServer = true;
-    },
-    "--skip-latest-ref-check": () => {
-      options.skipLatestRefCheck = true;
-    },
-    "--upgrade-from-packed-main": () => {
-      options.upgradeFromPackedMain = true;
-    },
-  };
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === undefined) {
-      die(`missing argument at index ${i}`);
-    }
-    if (arg === "--") {
-      break;
-    }
-    const valueHandler = valueHandlers[arg];
-    if (valueHandler) {
-      valueHandler(ensureValue(args, i, arg));
-      i++;
-      continue;
-    }
-    const flagHandler = flagHandlers[arg];
-    if (flagHandler) {
-      flagHandler();
-      continue;
-    }
-    if (arg === "-h" || arg === "--help") {
-      process.stdout.write(usage());
-      process.exit(0);
-    }
-    die(`unknown arg: ${arg}`);
-  }
-  return options;
+    usage,
+  });
 }
 
 class WindowsSmoke extends SmokeRunController<WindowsOptions> {

--- a/scripts/lib/control-ui-i18n-catalog.ts
+++ b/scripts/lib/control-ui-i18n-catalog.ts
@@ -1,6 +1,50 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 import type { TranslationMap, TranslationMemoryEntry } from "./control-ui-i18n-sync-plan.ts";
+
+async function importControlUiLocaleModule<T>(filePath: string): Promise<T> {
+  const stats = await stat(filePath);
+  return (await import(`${pathToFileURL(filePath).href}?ts=${stats.mtimeMs}`)) as T;
+}
+
+export async function loadControlUiLocaleCatalog(
+  filePath: string,
+  exportName: string,
+): Promise<TranslationMap | null> {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  const module = await importControlUiLocaleModule<Record<string, TranslationMap>>(filePath);
+  return module[exportName] ?? null;
+}
+
+export async function loadControlUiSourceCatalog(
+  sourceLocalePath: string,
+  activitySourceLocalePath: string,
+): Promise<TranslationMap> {
+  const source = await loadControlUiLocaleCatalog(sourceLocalePath, "en");
+  const activitySource = (
+    await importControlUiLocaleModule<{
+      registerActivityEnglish: { catalog: TranslationMap };
+    }>(activitySourceLocalePath)
+  ).registerActivityEnglish.catalog;
+  if (!source || !activitySource) {
+    throw new Error("Control UI English source catalogs are incomplete");
+  }
+  return mergeControlUiTranslationMaps(source, activitySource);
+}
+
+export async function readControlUiSourceCatalog(
+  sourceLocalePath: string,
+  activitySourceLocalePath: string,
+): Promise<string> {
+  const sources = await Promise.all(
+    [sourceLocalePath, activitySourceLocalePath].map((filePath) => readFile(filePath, "utf8")),
+  );
+  return sources.join("\n");
+}
 
 export function hashControlUiTranslationText(text: string): string {
   return createHash("sha256").update(text.trim().split(/\s+/).join(" ")).digest("hex");

--- a/scripts/lib/gateway-bench-probes.ts
+++ b/scripts/lib/gateway-bench-probes.ts
@@ -162,14 +162,22 @@ function requestStatus(port: number, pathname: string): Promise<number> {
 }
 
 function parsePsCpuTimeMs(raw: string): number | null {
-  const parts = raw.trim().split(":").map(Number);
-  if (parts.some((part) => !Number.isFinite(part) || part < 0)) {
+  const value = raw.trim();
+  const [dayText, clockText] = value.includes("-") ? value.split("-", 2) : ["0", value];
+  const days = Number(dayText);
+  const parts = expectDefined(clockText, "process CPU clock").split(":").map(Number);
+  if (
+    !Number.isFinite(days) ||
+    days < 0 ||
+    parts.some((part) => !Number.isFinite(part) || part < 0)
+  ) {
     return null;
   }
   if (parts.length === 2) {
     const [minutes, seconds] = parts;
     return Math.round(
-      (expectDefined(minutes, "process CPU minutes") * 60 +
+      (days * 24 * 60 * 60 +
+        expectDefined(minutes, "process CPU minutes") * 60 +
         expectDefined(seconds, "process CPU seconds")) *
         1000,
     );
@@ -177,7 +185,8 @@ function parsePsCpuTimeMs(raw: string): number | null {
   if (parts.length === 3) {
     const [hours, minutes, seconds] = parts;
     return Math.round(
-      (expectDefined(hours, "process CPU hours") * 60 * 60 +
+      (days * 24 * 60 * 60 +
+        expectDefined(hours, "process CPU hours") * 60 * 60 +
         expectDefined(minutes, "process CPU minutes") * 60 +
         expectDefined(seconds, "process CPU seconds")) *
         1000,

--- a/scripts/lib/sqlite-benchmark-cli.ts
+++ b/scripts/lib/sqlite-benchmark-cli.ts
@@ -1,0 +1,56 @@
+export type SqliteBenchmarkProfileId = "smoke" | "default" | "large";
+
+export class CliUsageError extends Error {
+  override name = "CliUsageError";
+}
+
+function parseProfile(raw: string | undefined): SqliteBenchmarkProfileId {
+  if (!raw) {
+    return "default";
+  }
+  if (raw === "smoke" || raw === "default" || raw === "large") {
+    return raw;
+  }
+  throw new CliUsageError(
+    `--profile must be one of smoke, default, large; got ${JSON.stringify(raw)}`,
+  );
+}
+
+export function parseSqliteBenchmarkCli(
+  argv: string[],
+  valueFlags: ReadonlySet<string>,
+):
+  | { help: true }
+  | {
+      help: false;
+      profile: SqliteBenchmarkProfileId;
+      values: ReadonlyMap<string, string>;
+    } {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index] ?? "";
+    if (arg === "--help") {
+      continue;
+    }
+    if (!valueFlags.has(arg)) {
+      throw new CliUsageError(`Unknown argument: ${arg}`);
+    }
+    if (values.has(arg)) {
+      throw new CliUsageError(`${arg} was provided more than once`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("-")) {
+      throw new CliUsageError(`${arg} requires a value`);
+    }
+    values.set(arg, value);
+    index += 1;
+  }
+  if (argv.includes("--help")) {
+    return { help: true };
+  }
+  return {
+    help: false,
+    profile: parseProfile(values.get("--profile")),
+    values,
+  };
+}

--- a/scripts/lib/sqlite-reliability-cli.ts
+++ b/scripts/lib/sqlite-reliability-cli.ts
@@ -1,73 +1,26 @@
-import type { CliOptions, ProfileId } from "./sqlite-reliability-contract.js";
+import { CliUsageError, parseSqliteBenchmarkCli } from "./sqlite-benchmark-cli.js";
+import type { CliOptions } from "./sqlite-reliability-contract.js";
 
-const BOOLEAN_FLAGS = new Set(["--help"]);
 const VALUE_FLAGS = new Set(["--agent", "--output", "--profile", "--repository", "--state-dir"]);
 
-export class CliUsageError extends Error {
-  override name = "CliUsageError";
-}
-
-function parseFlagValue(flag: string, argv: string[]): string | undefined {
-  const index = argv.indexOf(flag);
-  if (index === -1) {
-    return undefined;
-  }
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new CliUsageError(`${flag} requires a value`);
-  }
-  return value;
-}
-
-function validateArgs(argv: string[]): void {
-  const seenValueFlags = new Set<string>();
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index] ?? "";
-    if (BOOLEAN_FLAGS.has(arg)) {
-      continue;
-    }
-    if (!VALUE_FLAGS.has(arg)) {
-      throw new CliUsageError(`Unknown argument: ${arg}`);
-    }
-    if (seenValueFlags.has(arg)) {
-      throw new CliUsageError(`${arg} was provided more than once`);
-    }
-    seenValueFlags.add(arg);
-    const value = argv[index + 1];
-    if (!value || value.startsWith("-")) {
-      throw new CliUsageError(`${arg} requires a value`);
-    }
-    index += 1;
-  }
-}
-
-function parseProfile(raw: string | undefined): ProfileId {
-  if (!raw) {
-    return "default";
-  }
-  if (raw === "smoke" || raw === "default" || raw === "large") {
-    return raw;
-  }
-  throw new CliUsageError(
-    `--profile must be one of smoke, default, large; got ${JSON.stringify(raw)}`,
-  );
-}
+export { CliUsageError };
 
 export function parseSqliteReliabilityCli(
   argv: string[],
 ): { help: true } | { help: false; options: CliOptions } {
-  validateArgs(argv);
-  if (argv.includes("--help")) {
-    return { help: true };
+  const parsed = parseSqliteBenchmarkCli(argv, VALUE_FLAGS);
+  if (parsed.help) {
+    return parsed;
   }
+  const value = (flag: string) => parsed.values.get(flag) ?? null;
   return {
     help: false,
     options: {
-      agentId: parseFlagValue("--agent", argv) ?? null,
-      output: parseFlagValue("--output", argv) ?? null,
-      profile: parseProfile(parseFlagValue("--profile", argv)),
-      repository: parseFlagValue("--repository", argv) ?? null,
-      stateDir: parseFlagValue("--state-dir", argv) ?? null,
+      agentId: value("--agent"),
+      output: value("--output"),
+      profile: parsed.profile,
+      repository: value("--repository"),
+      stateDir: value("--state-dir"),
     },
   };
 }

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -1,4 +1,4 @@
-export type ProfileId = "smoke" | "default" | "large";
+type ProfileId = "smoke" | "default" | "large";
 
 export type IndexRepairJournalMode = "delete" | "wal";
 

--- a/scripts/lib/sqlite-state-benchmark-cli.ts
+++ b/scripts/lib/sqlite-state-benchmark-cli.ts
@@ -1,4 +1,10 @@
-export type ProfileId = "smoke" | "default" | "large";
+import {
+  CliUsageError,
+  parseSqliteBenchmarkCli,
+  type SqliteBenchmarkProfileId,
+} from "./sqlite-benchmark-cli.js";
+
+export type ProfileId = SqliteBenchmarkProfileId;
 
 type CliOptions = {
   output: string | null;
@@ -6,72 +12,24 @@ type CliOptions = {
   stateDir: string | null;
 };
 
-const BOOLEAN_FLAGS = new Set(["--help"]);
 const VALUE_FLAGS = new Set(["--output", "--profile", "--state-dir"]);
 
-export class CliUsageError extends Error {
-  override name = "CliUsageError";
-}
-
-function parseFlagValue(flag: string, argv: string[]): string | undefined {
-  const index = argv.indexOf(flag);
-  if (index === -1) {
-    return undefined;
-  }
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new CliUsageError(`${flag} requires a value`);
-  }
-  return value;
-}
-
-function validateArgs(argv: string[]): void {
-  const seenValueFlags = new Set<string>();
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index] ?? "";
-    if (BOOLEAN_FLAGS.has(arg)) {
-      continue;
-    }
-    if (!VALUE_FLAGS.has(arg)) {
-      throw new CliUsageError(`Unknown argument: ${arg}`);
-    }
-    if (seenValueFlags.has(arg)) {
-      throw new CliUsageError(`${arg} was provided more than once`);
-    }
-    seenValueFlags.add(arg);
-    const value = argv[index + 1];
-    if (!value || value.startsWith("-")) {
-      throw new CliUsageError(`${arg} requires a value`);
-    }
-    index += 1;
-  }
-}
-
-function parseProfile(raw: string | undefined): ProfileId {
-  if (!raw) {
-    return "default";
-  }
-  if (raw === "smoke" || raw === "default" || raw === "large") {
-    return raw;
-  }
-  throw new CliUsageError(
-    `--profile must be one of smoke, default, large; got ${JSON.stringify(raw)}`,
-  );
-}
+export { CliUsageError };
 
 export function parseSqliteStateBenchmarkCli(
   argv: string[],
 ): { help: true } | { help: false; options: CliOptions } {
-  validateArgs(argv);
-  if (argv.includes("--help")) {
-    return { help: true };
+  const parsed = parseSqliteBenchmarkCli(argv, VALUE_FLAGS);
+  if (parsed.help) {
+    return parsed;
   }
+  const value = (flag: string) => parsed.values.get(flag) ?? null;
   return {
     help: false,
     options: {
-      output: parseFlagValue("--output", argv) ?? null,
-      profile: parseProfile(parseFlagValue("--profile", argv)),
-      stateDir: parseFlagValue("--state-dir", argv) ?? null,
+      output: value("--output"),
+      profile: parsed.profile,
+      stateDir: value("--state-dir"),
     },
   };
 }

--- a/src/gateway/worker-environments/provider-lifecycle.types.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.types.ts
@@ -18,7 +18,7 @@ import type {
 } from "./store.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
 
-export type WorkerProviderLifecycleOptions = {
+export type WorkerProviderLifecycleInputOptions = {
   store: WorkerEnvironmentStore;
   getConfig: () => OpenClawConfig;
   resolveProvider: (providerId: string) => WorkerProvider | undefined;
@@ -42,6 +42,9 @@ export type WorkerProviderLifecycleOptions = {
   prepareNodeEnrollment?: (record: WorkerEnvironmentRecord) => Promise<WorkerNodeEnrollment>;
   retireNodeEnrollment?: (record: WorkerEnvironmentRecord) => Promise<void>;
   providerCallTimeoutMs?: number;
+};
+
+export type WorkerProviderLifecycleOptions = WorkerProviderLifecycleInputOptions & {
   tunnelManager?: Pick<WorkerTunnelManager, "stop">;
   credentialBroker: WorkerCredentialBroker;
   callBootstrap: <T>(

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -1,5 +1,4 @@
 import type {
-  WorkerAdmissionHandshake,
   WorkerSessionsSendParams,
   WorkerSessionsSpawnParams,
   WorkerSessionToolResult,
@@ -8,18 +7,9 @@ import type {
   WorkerTranscriptCommitResult,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { onSessionIdentityMutation } from "../../config/sessions/session-accessor.js";
-import type { OpenClawConfig } from "../../config/types.js";
-import type { SecretRef } from "../../config/types.secrets.js";
 import { withTimeout } from "../../infra/fs-safe.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
-import type {
-  WorkerExecutionMode,
-  WorkerNodeEnrollment,
-  WorkerProfile,
-  WorkerProvider,
-  WorkerSshEndpoint,
-  WorkerSshIdentity,
-} from "../../plugins/types.js";
+import type { WorkerExecutionMode, WorkerProfile } from "../../plugins/types.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import type { WorkerConnectionIdentity } from "./admission.js";
 import { workerBootstrapOperationTimeoutMs } from "./bootstrap.js";
@@ -36,10 +26,10 @@ import type { WorkerLiveEventReceiver } from "./live-events.js";
 import type { NodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import type { WorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import { createWorkerProviderLifecycle } from "./provider-lifecycle.js";
+import type { WorkerProviderLifecycleInputOptions } from "./provider-lifecycle.types.js";
 import type { WorkerEnvironmentState } from "./state.js";
 import type {
   WorkerEnvironmentRecord,
-  WorkerEnvironmentStore,
   WorkerEnvironmentTransitionPatch as TransitionPatch,
 } from "./store.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
@@ -70,34 +60,11 @@ class WorkerEnvironmentServiceError extends Error {
 const serviceError = (code: WorkerEnvironmentServiceErrorCode, message: string) =>
   new WorkerEnvironmentServiceError(code, message);
 
-type WorkerEnvironmentServiceOptions = {
-  store: WorkerEnvironmentStore;
-  getConfig: () => OpenClawConfig;
-  resolveProvider: (providerId: string) => WorkerProvider | undefined;
-  prepareInstallation: (
-    install: WorkerInstallationArtifact["install"],
-  ) => Promise<WorkerInstallationArtifact>;
-  bootstrapWorker: (params: {
-    operationId: string;
-    sshEndpoint: WorkerSshEndpoint;
-    installation: WorkerInstallationArtifact;
-    resolveIdentity: (keyRef: SecretRef) => Promise<WorkerSshIdentity>;
-    signal: AbortSignal;
-  }) => Promise<WorkerAdmissionHandshake>;
-  resolveSshIdentity?: (params: {
-    provider: WorkerProvider;
-    leaseId: string;
-    profile: WorkerProfile;
-    keyRef: SecretRef;
-  }) => Promise<WorkerSshIdentity>;
-  ensureNodeWorkerBundle?: (deviceId: string) => Promise<WorkerAdmissionHandshake>;
-  prepareNodeEnrollment?: (record: WorkerEnvironmentRecord) => Promise<WorkerNodeEnrollment>;
-  retireNodeEnrollment?: (record: WorkerEnvironmentRecord) => Promise<void>;
+type WorkerEnvironmentServiceOptions = WorkerProviderLifecycleInputOptions & {
   tunnelManager?: WorkerTunnelManager;
   nodeTunnelManager?: NodeWorkerTunnelManager;
   stopNodeWorkerBundleTransfers?: () => void;
   reconcileIntervalMs?: number;
-  providerCallTimeoutMs?: number;
   bootstrapCallTimeoutMs?: number;
   workerCredentialTtlMs?: number;
   generateWorkerCredential?: (bytes: number) => string;

--- a/test/scripts/gateway-bench-probes.test.ts
+++ b/test/scripts/gateway-bench-probes.test.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { readProcessTreeCpuMs } from "../../scripts/lib/gateway-bench-probes.ts";
+
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }));
+
+describe("gateway benchmark process probes", () => {
+  it.skipIf(process.platform === "win32")("parses day-prefixed process-tree CPU times", () => {
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: "123 1 1-02:03:04\n124 123 01:02\n",
+    } as never);
+
+    expect(readProcessTreeCpuMs(123)).toBe(93_846_000);
+  });
+});

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -634,6 +634,14 @@ describe("Parallels smoke model selection", () => {
     }
   });
 
+  it("rejects inherited object keys as unknown Parallels smoke arguments", () => {
+    for (const parseArgs of [parseMacosSmokeArgs, parseLinuxSmokeArgs, parseWindowsSmokeArgs]) {
+      for (const arg of ["constructor", "toString"]) {
+        expectFatalError(() => parseArgs([arg, "ignored"]), `unknown arg: ${arg}`);
+      }
+    }
+  });
+
   it("keeps provider auth and model defaults in the shared TypeScript helper", () => {
     expect(providerAuth).toContain("OPENCLAW_PARALLELS_OPENAI_MODEL");
     expect(providerAuth).toContain("OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL");


### PR DESCRIPTION
<!-- No linked issue: this is the maintainer-requested small-candidates tail from the third audit. -->

## What Problem This Solves

Several internal tooling and worker-lifecycle surfaces had independently accumulated copies of the same parsing, loading, process-probing, or option-shape logic. Keeping those copies synchronized increased maintenance risk and had already left five small consolidation candidates spread across otherwise unrelated files.

## Why This Change Was Made

This consolidates only the verified common contracts at their existing owner seams:

- the Linux, macOS, and Windows Parallels smoke CLIs now use one shared scalar/flag parser;
- the two SQLite benchmark CLIs use one shared argument/profile parser;
- gateway-watch reuses the existing gateway benchmark process-tree CPU probe;
- Control UI generation and verification reuse one lazy locale-catalog loader while the static Vite loader remains separate;
- worker environment service options reuse the provider-lifecycle input type while preserving the service-only and lifecycle-only tunnel distinctions.

The Parallels npm-update parser was explicitly left local: it has optional-value `--beta-validation`, repeatable tarball options, platform aliases, and cross-option validation that do not match the shared scalar/flag contract. Folding it in would add callbacks and policy to the common parser instead of removing duplication. Likewise, the Vite locale loader stays static because bundler discovery is a different contract, and worker tunnel fields stay in their owning layers rather than widening the shared input type.

History showed these copies grew independently as each script or lifecycle surface evolved. The consolidation therefore extracts the exact overlapping behavior instead of introducing a repo-wide generic abstraction. The first consolidation pass briefly used inherited object lookup for Parallels handler tables, which made keys such as `constructor` and `toString` callable instead of unknown. The follow-up commit switched both handler tables to own-property lookup and added the three-OS regression.

## User Impact

There is no user-visible behavior change. Operators and maintainers get one canonical implementation for each genuinely shared internal contract, with 287 fewer lines overall and explicit regression coverage for Parallels argument rejection and long-running process CPU accounting.

LOC by bucket:

- tooling/scripts: +276/-557 (net -281)
- production: +7/-37 (net -30)
- tests: +24/-0 (net +24)
- docs/generated: +0/-0
- total: +307/-594 (net -287)

No changelog entry is needed for this internal refactor.

## Evidence

Exact reviewed head: `59030b23ff663fb930ef633d65dea2727c78dd22` (base `641c9c1943265c9a1f5f040ed247a28754dd84c4`).

Focused behavior proof:

- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts` — 99/99 passed. Before the own-property fix, the new `constructor`/`toString` case failed because all three parsers did not throw; after the fix, direct Linux/macOS/Windows probes reject `constructor` with exit 1.
- Final post-rebase Parallels parser regression — 1/1 passed. A full local rerun also encountered two untouched process-reaping waits that failed identically when filtered; they are outside this parser refactor and are left to exact-head CI.
- `node scripts/run-vitest.mjs test/scripts/bench-sqlite-state.test.ts test/scripts/bench-sqlite-reliability.test.ts` — 10/10 passed.
- Final post-rebase SQLite CLI regression selection — 6/6 passed across both benchmark parsers.
- `node scripts/run-vitest.mjs test/scripts/check-gateway-watch-regression.test.ts test/scripts/bench-gateway-startup.test.ts test/scripts/bench-gateway-restart.test.ts` — 81/81 passed.
- `node scripts/run-vitest.mjs test/scripts/gateway-bench-probes.test.ts` — the day-prefixed process-tree case failed before the fix (`null` instead of `93846000`), then passed after the shared parser restored `D-HH:MM:SS` support.
- `node scripts/run-vitest.mjs test/scripts/gateway-bench-probes.test.ts test/scripts/check-gateway-watch-regression.test.ts test/scripts/bench-gateway-startup.test.ts test/scripts/bench-gateway-restart.test.ts` — 82/82 passed after the day-prefix repair.
- `pnpm ui:i18n:verify` — passed (raw-copy baseline 78, source keys 5384, literal refs 6111, template-prefix refs 57).
- `pnpm ui:i18n:check` — passed (fallback keys/pairs 0/0; all 20 locales clean).
- `pnpm test test/scripts/control-ui-i18n.test.ts test/scripts/control-ui-i18n-sync-plan.test.ts src/scripts/control-ui-i18n.test.ts ui/src/app/vite-config.node.test.ts` — 51/51 passed.
- `pnpm test src/gateway/worker-environments/provider-provisioning.test.ts src/gateway/worker-environments/provider-reconciliation.test.ts src/gateway/worker-environments/service-lifetime.test.ts` — 52/52 passed.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts` — 143/143 passed after base PR #125784 removed the independently broken over-scoped test; no Codex path is part of this PR.
- `pnpm check:changed` — exit 0 across core, core tests, scripts, root tests, and tooling; formatting 17/17, typechecks, lints, dead-code, erasability, i18n, database, import-cycle, and pairing guards all green; import cycles 0.
- `git diff --check origin/main..HEAD` — exit 0.

The original two independent reviews were clean: the repository autoreview completed one clean TruffleHog-scanned pass with no accepted/actionable findings, and a separate read-only exact-OID review found no blocking issue and independently confirmed the prototype-key rejection behavior. After ClawSweeper identified the missing day-prefix contract, the canonical shared-parser repair was independently reviewed and both rank-up moves were addressed. The final rebased head then passed a fresh structured review and a separate exact-head read-only review with no blocking findings. #125774 repaired the initial upstream generated locale baseline; after later source drift, #125871 refreshed the current-main baseline before the final zero-fallback proof.

AI-assisted; the implementation and evidence above were reviewed against the exact committed diff. No transcript is included.
