### PR TITLE
fix(providers): report request acceptance consistently

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -716,6 +716,8 @@ catalog, API-key auth, and dynamic model resolution.
       | `validateReplayTurns` | Strict replay-turn validation before the embedded runner |
       | `onModelSelected` | Post-selection callback (e.g. telemetry) |
 
+      Custom `createStreamFn` transports must report provider acceptance before exposing the first stream event. Use `notifyProviderHttpResponse` from `openclaw/plugin-sdk/provider-transport-runtime` when the transport owns a real `Response`. Use `notifyProviderStreamOpened` when an SDK returns an open stream but hides HTTP metadata. The first helper also runs the compatibility `onResponse` callback with the real status and headers; the second never invents them. Stream wrappers must forward `onProviderAccepted` and `onResponse` unchanged.
+
       Runtime fallback notes:
 
       - `normalizeConfig` resolves one owning plugin per provider id (bundled providers first, then the matched runtime plugin) and calls only that hook - there is no scan across other providers. Google's own `normalizeConfig` hook is what normalizes `google` / `google-vertex` / `google-antigravity` config entries; it is not a separate core fallback.

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -716,7 +716,7 @@ catalog, API-key auth, and dynamic model resolution.
       | `validateReplayTurns` | Strict replay-turn validation before the embedded runner |
       | `onModelSelected` | Post-selection callback (e.g. telemetry) |
 
-      Custom `createStreamFn` transports must report provider acceptance before exposing the first stream event. Use `notifyProviderHttpResponse` from `openclaw/plugin-sdk/provider-transport-runtime` when the transport owns a real `Response`, or `notifyProviderHttpMetadata` when an SDK exposes the real status and headers without the response body. Both helpers also run the compatibility `onResponse` callback. Use `notifyProviderStreamOpened` when an SDK returns an open stream but hides HTTP metadata; it never invents status or headers. Stream wrappers must forward `onProviderAccepted` and `onResponse` unchanged.
+      Custom `createStreamFn` transports must report provider acceptance before exposing the first stream event. Import the lifecycle helpers from `openclaw/plugin-sdk/provider-lifecycle`. Use `notifyProviderHttpResponse` when the transport owns a real `Response`, or `notifyProviderHttpMetadata` when an SDK exposes the real status and headers without the response body. Both helpers also run the compatibility `onResponse` callback. Use `notifyProviderStreamOpened` when an SDK returns an open stream but hides HTTP metadata; it never invents status or headers. Stream wrappers must forward `onProviderAccepted` and `onResponse` unchanged.
 
       Runtime fallback notes:
 

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -716,7 +716,7 @@ catalog, API-key auth, and dynamic model resolution.
       | `validateReplayTurns` | Strict replay-turn validation before the embedded runner |
       | `onModelSelected` | Post-selection callback (e.g. telemetry) |
 
-      Custom `createStreamFn` transports must report provider acceptance before exposing the first stream event. Use `notifyProviderHttpResponse` from `openclaw/plugin-sdk/provider-transport-runtime` when the transport owns a real `Response`. Use `notifyProviderStreamOpened` when an SDK returns an open stream but hides HTTP metadata. The first helper also runs the compatibility `onResponse` callback with the real status and headers; the second never invents them. Stream wrappers must forward `onProviderAccepted` and `onResponse` unchanged.
+      Custom `createStreamFn` transports must report provider acceptance before exposing the first stream event. Use `notifyProviderHttpResponse` from `openclaw/plugin-sdk/provider-transport-runtime` when the transport owns a real `Response`, or `notifyProviderHttpMetadata` when an SDK exposes the real status and headers without the response body. Both helpers also run the compatibility `onResponse` callback. Use `notifyProviderStreamOpened` when an SDK returns an open stream but hides HTTP metadata; it never invents status or headers. Stream wrappers must forward `onProviderAccepted` and `onResponse` unchanged.
 
       Runtime fallback notes:
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -149,6 +149,7 @@ are private-local.
     | `plugin-sdk/provider-catalog-runtime` | Provider catalog augmentation runtime hook and plugin-provider registry seams for contract tests |
     | `plugin-sdk/provider-catalog-shared` | Private-local after July 2026; `findCatalogTemplate`, `buildSingleProviderApiKeyCatalog`, `buildManifestModelProviderConfig`, `supportsNativeStreamingUsageCompat`, `applyProviderNativeStreamingUsageCompat` |
     | `plugin-sdk/provider-http` | Private-local after July 2026; Generic provider HTTP/endpoint capability helpers, provider HTTP errors, and audio transcription multipart form helpers |
+    | `plugin-sdk/provider-lifecycle` | Supported provider request-acceptance types and helpers for real HTTP metadata and metadata-free SDK or WebSocket streams |
     | `plugin-sdk/provider-binary-stream` | Direct-reader bounded binary streams with fitting-prefix delivery and explicit overflow/release errors |
     | `plugin-sdk/provider-web-fetch-contract` | Private-local after July 2026; Narrow web-fetch config/selection contract helpers such as `enablePluginInConfig` and `WebFetchProviderPlugin` |
     | `plugin-sdk/provider-web-fetch` | Private-local after July 2026; Web-fetch provider registration/cache helpers |

--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
@@ -60,9 +60,13 @@ describe("createMantleAnthropicStreamFn", () => {
     const context = { messages: [] };
     const deps = createTestDeps();
     deps.stream.mockReturnValue(stream as never);
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
 
     const result = createMantleAnthropicStreamFn(deps)(model, context, {
       apiKey: "bedrock-bearer-token",
+      onProviderAccepted,
+      onResponse,
       headers: {
         "X-Caller": "caller-header",
       },
@@ -87,6 +91,8 @@ describe("createMantleAnthropicStreamFn", () => {
       "bedrock-bearer-token",
     );
     expect(streamOptions.thinkingEnabled).toBe(false);
+    expect(streamOptions.onProviderAccepted).toBe(onProviderAccepted);
+    expect(streamOptions.onResponse).toBe(onResponse);
   });
 
   it("omits unsupported Opus 4.7 sampling and reasoning overrides", () => {

--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts
@@ -136,6 +136,8 @@ function buildMantleAnthropicBaseOptions(
     cacheRetention: options?.cacheRetention,
     sessionId: options?.sessionId,
     onPayload: options?.onPayload,
+    onProviderAccepted: options?.onProviderAccepted,
+    onResponse: options?.onResponse,
     maxRetryDelayMs: options?.maxRetryDelayMs,
     metadata: options?.metadata,
   };

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -119,12 +119,17 @@ describe("Bedrock stream client lifecycle", () => {
       yield { messageStop: { stopReason: BedrockStopReason.END_TURN } };
     }
     const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
-      $metadata: { httpStatusCode: 200 },
+      $metadata: { httpStatusCode: 200, requestId: "bedrock-request-1" },
       stream: successfulStream(),
     } as never);
     const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
 
-    const resultPromise = streamBedrockForTest(bedrockModel({}), context).result();
+    const resultPromise = streamBedrockForTest(bedrockModel({}), context, {
+      onProviderAccepted,
+      onResponse,
+    }).result();
     await streamBlocked;
     expect(destroy).not.toHaveBeenCalled();
 
@@ -132,6 +137,18 @@ describe("Bedrock stream client lifecycle", () => {
     const result = await resultPromise;
 
     expect(result.stopReason).toBe("stop");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      {
+        kind: "http_response",
+        status: 200,
+        headers: { "x-amzn-requestid": "bedrock-request-1" },
+      },
+      expect.objectContaining({ provider: "amazon-bedrock" }),
+    );
+    expect(onResponse).toHaveBeenCalledWith(
+      { status: 200, headers: { "x-amzn-requestid": "bedrock-request-1" } },
+      expect.objectContaining({ provider: "amazon-bedrock" }),
+    );
     expectDestroyedClient(send, destroy);
   });
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -283,10 +283,12 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
         if (response.$metadata.requestId) {
           responseHeaders["x-amzn-requestid"] = response.$metadata.requestId;
         }
-        await options?.onResponse?.(
-          { status: response.$metadata.httpStatusCode, headers: responseHeaders },
+        const status = response.$metadata.httpStatusCode;
+        await options?.onProviderAccepted?.(
+          { kind: "http_response", status, headers: responseHeaders },
           model,
         );
+        await options?.onResponse?.({ status, headers: responseHeaders }, model);
       }
 
       let sawMessageStop = false;

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -70,7 +70,10 @@ import {
   createDeferredEventBuffer,
   notifyLlmRequestActivity,
 } from "openclaw/plugin-sdk/provider-stream-shared";
-import { describeToolResultMediaPlaceholder } from "openclaw/plugin-sdk/provider-transport-runtime";
+import {
+  describeToolResultMediaPlaceholder,
+  notifyProviderHttpMetadata,
+} from "openclaw/plugin-sdk/provider-transport-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { supportsBedrockPromptCaching, type BedrockOptions } from "./bedrock-options.js";
 import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
@@ -283,12 +286,11 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
         if (response.$metadata.requestId) {
           responseHeaders["x-amzn-requestid"] = response.$metadata.requestId;
         }
-        const status = response.$metadata.httpStatusCode;
-        await options?.onProviderAccepted?.(
-          { kind: "http_response", status, headers: responseHeaders },
+        await notifyProviderHttpMetadata({
+          options,
+          response: { status: response.$metadata.httpStatusCode, headers: responseHeaders },
           model,
-        );
-        await options?.onResponse?.({ status, headers: responseHeaders }, model);
+        });
       }
 
       let sawMessageStop = false;

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -55,6 +55,7 @@ import {
   type ToolResultMessage,
 } from "openclaw/plugin-sdk/llm";
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
+import { notifyProviderHttpMetadata } from "openclaw/plugin-sdk/provider-lifecycle";
 import {
   resolveClaudeFable5ModelIdentity,
   resolveClaudeModelIdentity,
@@ -70,10 +71,7 @@ import {
   createDeferredEventBuffer,
   notifyLlmRequestActivity,
 } from "openclaw/plugin-sdk/provider-stream-shared";
-import {
-  describeToolResultMediaPlaceholder,
-  notifyProviderHttpMetadata,
-} from "openclaw/plugin-sdk/provider-transport-runtime";
+import { describeToolResultMediaPlaceholder } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { supportsBedrockPromptCaching, type BedrockOptions } from "./bedrock-options.js";
 import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";

--- a/extensions/anthropic-vertex/stream-runtime.test.ts
+++ b/extensions/anthropic-vertex/stream-runtime.test.ts
@@ -541,6 +541,26 @@ describe("createAnthropicVertexStreamFn", () => {
     expect(transportOptions).not.toHaveProperty("temperature");
   });
 
+  it("forwards provider acceptance hooks to the shared Anthropic transport", () => {
+    const { deps, streamAnthropicMock } = createStreamDeps();
+    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
+
+    void streamFn(
+      makeModel({ id: "claude-sonnet-4-6" }),
+      { messages: [] },
+      {
+        onProviderAccepted,
+        onResponse,
+      },
+    );
+
+    const transportOptions = streamTransportOptions(streamAnthropicMock);
+    expect(transportOptions.onProviderAccepted).toBe(onProviderAccepted);
+    expect(transportOptions.onResponse).toBe(onResponse);
+  });
+
   it("keeps already-budgeted cache_control markers intact when forwarding payload hooks", async () => {
     const { deps, streamAnthropicMock } = createStreamDeps();
     const onPayload = vi.fn(async (payload: unknown) => payload);

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -231,6 +231,8 @@ export function createAnthropicVertexStreamFn(
       // cache boundary and budgets all cache_control markers; re-applying the
       // payload policy here marked the uncached suffix and breached the 4-marker cap.
       onPayload: options?.onPayload,
+      onProviderAccepted: options?.onProviderAccepted,
+      onResponse: options?.onResponse,
       maxRetryDelayMs: options?.maxRetryDelayMs,
       metadata: options?.metadata,
     };

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1476,6 +1476,26 @@ describe("google transport stream", () => {
     expect(cancelCalled).toBe(true);
   });
 
+  it("does not count provider acceptance callback time against the retry deadline", async () => {
+    vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
+    mockGoogleTextResponse("accepted");
+
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({ id: "gemini-3.1-pro-preview" }),
+      options: {
+        reasoning: "high",
+        onProviderAccepted: async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 25);
+          });
+        },
+      },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "accepted" }]);
+    expect(guardedFetchMock).toHaveBeenCalledOnce();
+  });
+
   it("keeps oversized-video shedding in the Gemini 3 retry payload", async () => {
     vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
     guardedFetchMock

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1443,6 +1443,37 @@ describe("google transport stream", () => {
     },
   );
 
+  it("does not retry when a slow provider acceptance callback rejects", async () => {
+    vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      buildOpenRawSseResponse({
+        sse: 'data: {"candidates":[{"finishReason":"STOP"}]}\n\n',
+        onCancel: () => {
+          cancelCalled = true;
+        },
+      }),
+    );
+
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({ id: "gemini-3.1-pro-preview" }),
+      options: {
+        reasoning: "high",
+        onProviderAccepted: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          throw new Error("acceptance callback failed");
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "acceptance callback failed",
+    });
+    expect(guardedFetchMock).toHaveBeenCalledOnce();
+    expect(cancelCalled).toBe(true);
+  });
+
   it("keeps oversized-video shedding in the Gemini 3 retry payload", async () => {
     vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
     guardedFetchMock

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -654,6 +654,34 @@ describe("google transport stream", () => {
     );
   });
 
+  it("reports rejected HTTP responses without marking them accepted", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response('{"error":{"message":"rate limited"}}', {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "req-rejected",
+        },
+      }),
+    );
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
+
+    const result = await runGeminiStreamResult({
+      options: { onProviderAccepted, onResponse },
+    });
+
+    expect(result.stopReason).toBe("error");
+    expect(onProviderAccepted).not.toHaveBeenCalled();
+    expect(onResponse).toHaveBeenCalledWith(
+      {
+        status: 429,
+        headers: expect.objectContaining({ "x-request-id": "req-rejected" }),
+      },
+      expect.objectContaining({ provider: "google" }),
+    );
+  });
+
   it("uses the guarded fetch transport and parses Gemini SSE output", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1476,6 +1476,53 @@ describe("google transport stream", () => {
     expect(cancelCalled).toBe(true);
   });
 
+  it.each(["onProviderAccepted", "onResponse"] as const)(
+    "aborts a pending %s callback without retrying",
+    async (hookName) => {
+      vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "1000");
+      const controller = new AbortController();
+      const cancel = vi.fn();
+      guardedFetchMock.mockResolvedValueOnce(
+        buildOpenRawSseResponse({
+          sse: 'data: {"candidates":[{"finishReason":"STOP"}]}\n\n',
+          onCancel: cancel,
+        }),
+      );
+      let markHookStarted!: () => void;
+      const hookStarted = new Promise<void>((resolve) => {
+        markHookStarted = resolve;
+      });
+      const hook = vi.fn(() => {
+        markHookStarted();
+        return new Promise<void>(() => {});
+      });
+
+      const resultPromise = runGeminiStreamResult({
+        model: buildGeminiModel({ id: "gemini-3.1-pro-preview" }),
+        options: {
+          reasoning: "high",
+          signal: controller.signal,
+          [hookName]: hook,
+        },
+      });
+      await hookStarted;
+      controller.abort(
+        Object.assign(new Error("operator canceled the request"), {
+          code: "OPERATOR_CANCELLED",
+        }),
+      );
+
+      await expect(resultPromise).resolves.toMatchObject({
+        stopReason: "aborted",
+        errorCode: "OPERATOR_CANCELLED",
+        errorMessage: "operator canceled the request",
+      });
+      expect(hook).toHaveBeenCalledOnce();
+      expect(guardedFetchMock).toHaveBeenCalledOnce();
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
   it("does not count provider acceptance callback time against the retry deadline", async () => {
     vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
     mockGoogleTextResponse("accepted");

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -630,6 +630,30 @@ describe("google transport stream", () => {
     expect(guardedFetchMock).not.toHaveBeenCalled();
   });
 
+  it("reports the real HTTP response before consuming Gemini SSE output", async () => {
+    mockGoogleTextResponse();
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
+
+    const result = await runGeminiStreamResult({
+      options: { onProviderAccepted, onResponse },
+    });
+
+    expect(result.stopReason).toBe("stop");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      {
+        kind: "http_response",
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      },
+      expect.objectContaining({ provider: "google" }),
+    );
+    expect(onResponse).toHaveBeenCalledWith(
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+      expect.objectContaining({ provider: "google" }),
+    );
+  });
+
   it("uses the guarded fetch transport and parses Gemini SSE output", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1460,7 +1460,9 @@ describe("google transport stream", () => {
       options: {
         reasoning: "high",
         onProviderAccepted: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 25));
+          await new Promise((resolve) => {
+            setTimeout(resolve, 25);
+          });
           throw new Error("acceptance callback failed");
         },
       },

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1177,16 +1177,16 @@ async function openGoogleSseAttempt(params: {
   } catch (error) {
     return handleTimedOperationError(error);
   }
-  if (!response.ok) {
-    attemptSignal?.cleanup();
-    throw await createProviderHttpError(response, params.errorPrefix);
-  }
   attemptSignal?.pauseDeadline();
   try {
     await notifyGoogleTransportHttpResponse(params.model, params.options, response, signal);
   } catch (error) {
     attemptSignal?.cleanup();
     throw error;
+  }
+  if (!response.ok) {
+    attemptSignal?.cleanup();
+    throw await createProviderHttpError(response, params.errorPrefix);
   }
   attemptSignal?.resumeDeadline();
   const chunks = parseGoogleSseChunks(response, signal);
@@ -1232,15 +1232,15 @@ async function openGoogleSseChunks(params: {
       body: serializeGoogleRequest(params.request, params.videoSlots),
       signal: params.options?.signal,
     });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
     await notifyGoogleTransportHttpResponse(
       params.model,
       params.options,
       response,
       params.options?.signal,
     );
+    if (!response.ok) {
+      throw await createProviderHttpError(response, errorPrefix);
+    }
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1255,15 +1255,15 @@ async function openGoogleSseChunks(params: {
       body: serializeGoogleRequest(params.request, params.videoSlots),
       signal: params.options?.signal,
     });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
     await notifyGoogleTransportHttpResponse(
       params.model,
       params.options,
       response,
       params.options?.signal,
     );
+    if (!response.ok) {
+      throw await createProviderHttpError(response, errorPrefix);
+    }
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1042,9 +1042,42 @@ function buildGoogleGemini3FirstResponseRetryParams(params: {
 function createChildSignal(parent: AbortSignal | undefined, timeoutMs: number) {
   const controller = new AbortController();
   let timedOut = false;
+  let remainingMs = timeoutMs;
+  let deadlineStartedAt: number | undefined;
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const abortFromParent = () => {
     controller.abort(parent?.reason);
+  };
+  const abortForTimeout = () => {
+    timedOut = true;
+    timeout = undefined;
+    deadlineStartedAt = undefined;
+    controller.abort(new Error("Google Gemini first response retry deadline reached"));
+  };
+  const startDeadline = () => {
+    if (timeout || controller.signal.aborted || timeoutMs <= 0) {
+      return;
+    }
+    if (remainingMs <= 0) {
+      abortForTimeout();
+      return;
+    }
+    deadlineStartedAt = Date.now();
+    timeout = setTimeout(abortForTimeout, remainingMs);
+    timeout.unref?.();
+  };
+  const clearDeadline = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+    deadlineStartedAt = undefined;
+  };
+  const pauseDeadline = () => {
+    if (deadlineStartedAt !== undefined) {
+      remainingMs = Math.max(0, remainingMs - (Date.now() - deadlineStartedAt));
+    }
+    clearDeadline();
   };
   if (parent) {
     if (parent.aborted) {
@@ -1053,22 +1086,12 @@ function createChildSignal(parent: AbortSignal | undefined, timeoutMs: number) {
       parent.addEventListener("abort", abortFromParent, { once: true });
     }
   }
-  if (timeoutMs > 0) {
-    timeout = setTimeout(() => {
-      timedOut = true;
-      controller.abort(new Error("Google Gemini first response retry deadline reached"));
-    }, timeoutMs);
-    timeout.unref?.();
-  }
-  const clearDeadline = () => {
-    if (timeout) {
-      clearTimeout(timeout);
-      timeout = undefined;
-    }
-  };
+  startDeadline();
   return {
     signal: controller.signal,
     timedOut: () => timedOut,
+    pauseDeadline,
+    resumeDeadline: startDeadline,
     clearDeadline,
     cleanup: () => {
       clearDeadline();
@@ -1152,12 +1175,14 @@ async function openGoogleSseAttempt(params: {
     attemptSignal?.cleanup();
     throw await createProviderHttpError(response, params.errorPrefix);
   }
+  attemptSignal?.pauseDeadline();
   try {
     await notifyGoogleTransportHttpResponse(params.model, params.options, response);
   } catch (error) {
     attemptSignal?.cleanup();
     throw error;
   }
+  attemptSignal?.resumeDeadline();
   const chunks = parseGoogleSseChunks(response, signal);
   const iterator = chunks[Symbol.asyncIterator]();
   let first: IteratorResult<GoogleSseChunk>;

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -24,6 +24,7 @@ import {
   providerOperationRetryConfig,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
+import { notifyProviderHttpResponse } from "openclaw/plugin-sdk/provider-lifecycle";
 import {
   buildGuardedModelFetch,
   coerceTransportToolCallArguments,
@@ -34,7 +35,6 @@ import {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
-  notifyProviderHttpResponse,
   sanitizeTransportPayloadText,
   sortPromptCacheToolsByName,
   stripSystemPromptCacheBoundary,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -34,6 +34,7 @@ import {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
+  notifyProviderHttpResponse,
   sanitizeTransportPayloadText,
   sortPromptCacheToolsByName,
   stripSystemPromptCacheBoundary,
@@ -1104,6 +1105,14 @@ type GoogleSseAttempt =
     }
   | { type: "timeout" };
 
+async function notifyGoogleTransportHttpResponse(
+  model: GoogleTransportModel,
+  options: GoogleTransportOptions | undefined,
+  response: Response,
+): Promise<void> {
+  await notifyProviderHttpResponse({ options, response, model: canonicalGoogleModel(model) });
+}
+
 async function openGoogleSseAttempt(params: {
   guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
   url: string;
@@ -1113,6 +1122,8 @@ async function openGoogleSseAttempt(params: {
   parentSignal?: AbortSignal;
   firstResponseTimeoutMs: number;
   errorPrefix: string;
+  model: GoogleTransportModel;
+  options: GoogleTransportOptions | undefined;
 }): Promise<GoogleSseAttempt> {
   const attemptSignal =
     params.firstResponseTimeoutMs > 0
@@ -1129,6 +1140,7 @@ async function openGoogleSseAttempt(params: {
     if (!response.ok) {
       throw await createProviderHttpError(response, params.errorPrefix);
     }
+    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
     const chunks = parseGoogleSseChunks(response, signal);
     const iterator = chunks[Symbol.asyncIterator]();
     const first = await iterator.next();
@@ -1177,6 +1189,7 @@ async function openGoogleSseChunks(params: {
     if (!response.ok) {
       throw await createProviderHttpError(response, errorPrefix);
     }
+    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1194,6 +1207,7 @@ async function openGoogleSseChunks(params: {
     if (!response.ok) {
       throw await createProviderHttpError(response, errorPrefix);
     }
+    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1209,6 +1223,8 @@ async function openGoogleSseChunks(params: {
     parentSignal: params.options?.signal,
     firstResponseTimeoutMs: retryMs,
     errorPrefix,
+    model: params.model,
+    options: params.options,
   });
   if (firstAttempt.type === "ready") {
     return firstAttempt;
@@ -1229,6 +1245,8 @@ async function openGoogleSseChunks(params: {
     parentSignal: params.options?.signal,
     firstResponseTimeoutMs: 0,
     errorPrefix,
+    model: params.model,
+    options: params.options,
   });
   if (retryAttempt.type === "timeout") {
     throw new Error("Google Gemini first response retry timed out unexpectedly");

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1130,39 +1130,54 @@ async function openGoogleSseAttempt(params: {
       ? createChildSignal(params.parentSignal, params.firstResponseTimeoutMs)
       : undefined;
   const signal = attemptSignal?.signal ?? params.parentSignal;
-  try {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
-      headers: params.headers,
-      body: serializeGoogleRequest(params.request, params.videoSlots),
-      signal,
-    });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, params.errorPrefix);
-    }
-    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
-    const chunks = parseGoogleSseChunks(response, signal);
-    const iterator = chunks[Symbol.asyncIterator]();
-    const first = await iterator.next();
-    attemptSignal?.clearDeadline();
-    if (first.done) {
-      return {
-        type: "ready",
-        chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
-      };
-    }
-    return {
-      type: "ready",
-      firstChunk: first.value,
-      chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
-    };
-  } catch (error) {
+  const handleTimedOperationError = (error: unknown): GoogleSseAttempt => {
     attemptSignal?.cleanup();
     if (attemptSignal?.timedOut() && !params.parentSignal?.aborted) {
       return { type: "timeout" };
     }
     throw error;
+  };
+  let response: Response;
+  try {
+    response = await params.guardedFetch(params.url, {
+      method: "POST",
+      headers: params.headers,
+      body: serializeGoogleRequest(params.request, params.videoSlots),
+      signal,
+    });
+  } catch (error) {
+    return handleTimedOperationError(error);
   }
+  if (!response.ok) {
+    attemptSignal?.cleanup();
+    throw await createProviderHttpError(response, params.errorPrefix);
+  }
+  try {
+    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
+  } catch (error) {
+    attemptSignal?.cleanup();
+    throw error;
+  }
+  const chunks = parseGoogleSseChunks(response, signal);
+  const iterator = chunks[Symbol.asyncIterator]();
+  let first: IteratorResult<GoogleSseChunk>;
+  try {
+    first = await iterator.next();
+  } catch (error) {
+    return handleTimedOperationError(error);
+  }
+  attemptSignal?.clearDeadline();
+  if (first.done) {
+    return {
+      type: "ready",
+      chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
+    };
+  }
+  return {
+    type: "ready",
+    firstChunk: first.value,
+    chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
+  };
 }
 
 async function openGoogleSseChunks(params: {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1132,8 +1132,14 @@ async function notifyGoogleTransportHttpResponse(
   model: GoogleTransportModel,
   options: GoogleTransportOptions | undefined,
   response: Response,
+  signal?: AbortSignal,
 ): Promise<void> {
-  await notifyProviderHttpResponse({ options, response, model: canonicalGoogleModel(model) });
+  await notifyProviderHttpResponse({
+    options,
+    response,
+    model: canonicalGoogleModel(model),
+    signal,
+  });
 }
 
 async function openGoogleSseAttempt(params: {
@@ -1177,7 +1183,7 @@ async function openGoogleSseAttempt(params: {
   }
   attemptSignal?.pauseDeadline();
   try {
-    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
+    await notifyGoogleTransportHttpResponse(params.model, params.options, response, signal);
   } catch (error) {
     attemptSignal?.cleanup();
     throw error;
@@ -1229,7 +1235,12 @@ async function openGoogleSseChunks(params: {
     if (!response.ok) {
       throw await createProviderHttpError(response, errorPrefix);
     }
-    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
+    await notifyGoogleTransportHttpResponse(
+      params.model,
+      params.options,
+      response,
+      params.options?.signal,
+    );
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1247,7 +1258,12 @@ async function openGoogleSseChunks(params: {
     if (!response.ok) {
       throw await createProviderHttpError(response, errorPrefix);
     }
-    await notifyGoogleTransportHttpResponse(params.model, params.options, response);
+    await notifyGoogleTransportHttpResponse(
+      params.model,
+      params.options,
+      response,
+      params.options?.signal,
+    );
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -456,6 +456,32 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     },
   );
 
+  it("reports the real HTTP response before consuming native Ollama output", async () => {
+    await withSuccessfulOllamaFetch(async () => {
+      const onProviderAccepted = vi.fn();
+      const onResponse = vi.fn();
+      const stream = await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        options: { onProviderAccepted, onResponse },
+      });
+
+      await collectStreamEvents(stream);
+
+      expect(onProviderAccepted).toHaveBeenCalledWith(
+        {
+          kind: "http_response",
+          status: 200,
+          headers: { "content-type": "application/x-ndjson" },
+        },
+        expect.objectContaining({ provider: "custom-ollama" }),
+      );
+      expect(onResponse).toHaveBeenCalledWith(
+        { status: 200, headers: { "content-type": "application/x-ndjson" } },
+        expect.objectContaining({ provider: "custom-ollama" }),
+      );
+    });
+  });
+
   it("passes resolved provider request timeouts to native Ollama chat fetches", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -76,36 +76,6 @@ function throwIfOllamaStreamAborted(signal?: AbortSignal): void {
   }
 }
 
-async function runOllamaResponseHook(params: {
-  hook: (() => void | Promise<void>) | undefined;
-  signal: AbortSignal | undefined;
-}): Promise<void> {
-  const { hook, signal } = params;
-  if (!hook) {
-    return;
-  }
-  throwIfOllamaStreamAborted(signal);
-  if (!signal) {
-    await hook();
-    return;
-  }
-  let onAbort: (() => void) | undefined;
-  try {
-    await Promise.race([
-      Promise.resolve().then(hook),
-      new Promise<never>((_resolve, reject) => {
-        onAbort = () => reject(new Error("Request was aborted"));
-        signal.addEventListener("abort", onAbort, { once: true });
-      }),
-    ]);
-  } finally {
-    if (onAbort) {
-      signal.removeEventListener("abort", onAbort);
-    }
-  }
-  throwIfOllamaStreamAborted(signal);
-}
-
 function createOllamaStreamCooperativeScheduler(
   signal?: AbortSignal,
 ): OllamaStreamCooperativeScheduler {
@@ -1056,26 +1026,7 @@ function createRawOllamaStreamFn(
         });
 
         try {
-          const responseHook = options?.onResponse;
-          try {
-            await runOllamaResponseHook({
-              hook: responseHook
-                ? () =>
-                    responseHook(
-                      {
-                        status: response.status,
-                        headers: Object.fromEntries(response.headers.entries()),
-                      },
-                      model,
-                    )
-                : undefined,
-              signal: options?.signal,
-            });
-          } catch (error) {
-            // A pending body cancel must not stall release or the terminal error.
-            void response.body?.cancel().catch(() => undefined);
-            throw error;
-          }
+          await notifyProviderHttpResponse({ options, response, model });
           if (!response.ok) {
             const errorText = await readResponseTextLimited(
               response,
@@ -1083,7 +1034,6 @@ function createRawOllamaStreamFn(
             ).catch(() => "unknown error");
             throw new Error(`${response.status} ${errorText}`);
           }
-          await notifyProviderHttpResponse({ options, response, model });
           if (!response.body) {
             throw new Error("Ollama API returned empty response body");
           }

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -19,8 +19,8 @@ import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { notifyProviderHttpResponse } from "openclaw/plugin-sdk/provider-lifecycle";
 import { createPlainTextToolCallCompatWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
-import { notifyProviderHttpResponse } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -20,6 +20,7 @@ import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { createPlainTextToolCallCompatWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import { notifyProviderHttpResponse } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -1082,6 +1083,7 @@ function createRawOllamaStreamFn(
             ).catch(() => "unknown error");
             throw new Error(`${response.status} ${errorText}`);
           }
+          await notifyProviderHttpResponse({ options, response, model });
           if (!response.body) {
             throw new Error("Ollama API returned empty response body");
           }

--- a/package.json
+++ b/package.json
@@ -1319,6 +1319,10 @@
     "./plugin-sdk/provider-http": {
       "default": "./dist/plugin-sdk/provider-http.js"
     },
+    "./plugin-sdk/provider-lifecycle": {
+      "types": "./dist/plugin-sdk/provider-lifecycle.d.ts",
+      "default": "./dist/plugin-sdk/provider-lifecycle.js"
+    },
     "./plugin-sdk/provider-binary-stream": {
       "types": "./dist/plugin-sdk/provider-binary-stream.d.ts",
       "default": "./dist/plugin-sdk/provider-binary-stream.js"

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -118,6 +118,8 @@ export interface AgentOptions {
   getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
   /** Inspect the provider payload before it is sent. */
   onPayload?: SimpleStreamOptions["onPayload"];
+  /** Observe when the provider accepts the request. */
+  onProviderAccepted?: SimpleStreamOptions["onProviderAccepted"];
   /** Inspect the provider response after it returns. */
   onResponse?: SimpleStreamOptions["onResponse"];
   /** Hook that may short-circuit or alter a tool call before execution. */
@@ -229,6 +231,7 @@ export class Agent {
   public streamFn: StreamFn;
   public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
   public onPayload?: SimpleStreamOptions["onPayload"];
+  public onProviderAccepted?: SimpleStreamOptions["onProviderAccepted"];
   public onResponse?: SimpleStreamOptions["onResponse"];
   public beforeToolCall?: (
     context: BeforeToolCallContext,
@@ -270,6 +273,7 @@ export class Agent {
     this.streamFn = resolveAgentCoreStreamFn(options.runtime, options.streamFn);
     this.getApiKey = options.getApiKey;
     this.onPayload = options.onPayload;
+    this.onProviderAccepted = options.onProviderAccepted;
     this.onResponse = options.onResponse;
     this.beforeToolCall = options.beforeToolCall;
     this.resolveDeferredTool = options.resolveDeferredTool;
@@ -521,6 +525,7 @@ export class Agent {
       ),
       sessionId: this.sessionId,
       onPayload: this.onPayload,
+      onProviderAccepted: this.onProviderAccepted,
       onResponse: this.onResponse,
       transport: this.transport,
       thinkingBudgets: this.thinkingBudgets,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -29,7 +29,10 @@ import {
   type AnthropicCompactionBlock,
 } from "../transports/anthropic-compaction-replay.js";
 import { applyAnthropicCacheControlToMessages } from "../transports/anthropic-payload-policy.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import {
+  notifyProviderHttpResponse,
+  transportAbortError,
+} from "../transports/transport-stream-shared.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type {
   AnthropicMessagesCompat,
@@ -49,7 +52,6 @@ import type {
 } from "../types.js";
 import { createDeferredEventBuffer } from "../utils/deferred-event-buffer.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { projectProviderError } from "../utils/provider-error.js";
@@ -422,10 +424,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
       const response = await client.messages
         .create({ ...params, stream: true }, sdkRequestOptions)
         .asResponse();
-      await requestOptions?.onResponse?.(
-        { status: response.status, headers: headersToRecord(response.headers) },
-        model,
-      );
+      await notifyProviderHttpResponse({ options: requestOptions, response, model });
 
       type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & {
         index: number;

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -599,10 +599,32 @@ describe("runGoogleGenerateContentLifecycle", () => {
     );
 
     expect(result.stopReason).toBe("stop");
-    expect(onProviderAccepted).toHaveBeenCalledWith(
-      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-      model,
-    );
+    expect(onProviderAccepted).toHaveBeenCalledWith({ kind: "provider_stream_opened" }, model);
+  });
+
+  it("closes an unread SDK stream without waiting when acceptance fails", async () => {
+    const close = vi.fn(() => new Promise<IteratorResult<GenerateContentResponse>>(() => {}));
+    const googleStream = {
+      next: vi.fn(),
+      return: close,
+      throw: vi.fn(),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    } as unknown as AsyncGenerator<GenerateContentResponse>;
+
+    const { result } = await runGoogleFixture([], {
+      options: {
+        onProviderAccepted: () => Promise.reject(new Error("acceptance callback failed")),
+      },
+      generateContentStream: async () => googleStream,
+    });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "acceptance callback failed",
+    });
+    expect(close).toHaveBeenCalledOnce();
   });
 
   it.each(["google-generative-ai", "google-vertex"] as const)(

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -590,6 +590,21 @@ describe("consumeGoogleGenerateContentStream", () => {
 });
 
 describe("runGoogleGenerateContentLifecycle", () => {
+  it("reports SDK stream acceptance without fabricated HTTP metadata", async () => {
+    const onProviderAccepted = vi.fn();
+
+    const { result } = await runGoogleFixture(
+      [googleResponse({ parts: [{ text: "ok" }], finishReason: FinishReason.STOP })],
+      { options: { onProviderAccepted } },
+    );
+
+    expect(result.stopReason).toBe("stop");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+      model,
+    );
+  });
+
   it.each(["google-generative-ai", "google-vertex"] as const)(
     "rejects an unfinished %s stream instead of silently completing partial output",
     async (api) => {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -437,9 +437,16 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       requestParams = nextParams as GenerateContentParameters;
     }
     const googleStream = await client.models.generateContentStream(requestParams);
-    await notifyProviderStreamOpened({ options, model });
+    const googleIterator = googleStream[Symbol.asyncIterator]();
+    try {
+      await notifyProviderStreamOpened({ options, model });
+    } catch (error) {
+      // Cleanup is best effort; callback failure must not wait on an unread SDK stream.
+      void Promise.resolve(googleIterator.return?.()).catch(() => undefined);
+      throw error;
+    }
     await consumeGoogleGenerateContentStream({
-      chunks: googleStream,
+      chunks: { [Symbol.asyncIterator]: () => googleIterator },
       model,
       output,
       stream,

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -19,6 +19,7 @@ import { googleFlashSupportsMinimalThinking } from "../transports/google-thinkin
 import {
   assignTransportErrorDetails,
   coerceTransportToolCallArguments,
+  notifyProviderStreamOpened,
   transportAbortError,
 } from "../transports/transport-stream-shared.js";
 import type {
@@ -421,7 +422,7 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
   stream: AssistantMessageEventStream;
   model: Model<T>;
   output: AssistantMessage;
-  options?: Pick<StreamOptions, "signal" | "onPayload">;
+  options?: Pick<StreamOptions, "signal" | "onPayload" | "onProviderAccepted">;
   createClient: () => GoogleGenerateContentClient;
   buildParams: () => GenerateContentParameters;
   nextToolCallId: (name: string | undefined) => string;
@@ -436,6 +437,7 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       requestParams = nextParams as GenerateContentParameters;
     }
     const googleStream = await client.models.generateContentStream(requestParams);
+    await notifyProviderStreamOpened({ options, model });
     await consumeGoogleGenerateContentStream({
       chunks: googleStream,
       model,

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -45,7 +45,12 @@ vi.mock("@mistralai/mistralai", async () => {
                 httpClient?: { request(request: Request): Promise<Response> };
               }
             ).httpClient;
-            await httpClient?.request(new Request("https://api.mistral.ai/chat"));
+            const response = await httpClient?.request(new Request("https://api.mistral.ai/chat"));
+            if (response && !response.ok) {
+              throw Object.assign(new Error(`Mistral HTTP ${response.status}`), {
+                statusCode: response.status,
+              });
+            }
           }
           if (mistralMockState.streamResult !== undefined) {
             return mistralMockState.streamResult;
@@ -311,6 +316,36 @@ describe("Mistral provider", () => {
       {
         status: 200,
         headers: expect.objectContaining({ "x-mistral-request-id": "req-1" }),
+      },
+      expect.objectContaining({ provider: "mistral" }),
+    );
+    expect(hostFetch).toHaveBeenCalledOnce();
+  });
+
+  it("reports a rejected HTTP response without marking it accepted", async () => {
+    mistralMockState.requestThroughHttpClient = true;
+    const hostFetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response("rate limited", {
+          status: 429,
+          headers: { "x-mistral-request-id": "req-rejected" },
+        }),
+    );
+    configureAiTransportHost({ buildModelFetch: () => hostFetch });
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
+
+    const result = await runSimpleMistralFixture(context, {
+      onProviderAccepted,
+      onResponse,
+    });
+
+    expect(result.stopReason).toBe("error");
+    expect(onProviderAccepted).not.toHaveBeenCalled();
+    expect(onResponse).toHaveBeenCalledWith(
+      {
+        status: 429,
+        headers: expect.objectContaining({ "x-mistral-request-id": "req-rejected" }),
       },
       expect.objectContaining({ provider: "mistral" }),
     );

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -245,30 +245,7 @@ describe("Mistral provider", () => {
     configureAiTransportHost({});
   });
 
-  it("reports SDK stream acceptance without fabricated HTTP metadata", async () => {
-    mistralMockState.streamResult = {
-      async *[Symbol.asyncIterator]() {
-        yield {
-          data: {
-            id: "resp-ack",
-            model: "mistral-large-latest",
-            choices: [{ finishReason: "stop", delta: { content: "ok" } }],
-          },
-        };
-      },
-    };
-    const onProviderAccepted = vi.fn();
-
-    const result = await runSimpleMistralFixture(context, { onProviderAccepted });
-
-    expect(result.stopReason).toBe("stop");
-    expect(onProviderAccepted).toHaveBeenCalledWith(
-      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-      expect.objectContaining({ provider: "mistral" }),
-    );
-  });
-
-  it("reports the real HTTP response captured at the Mistral fetcher boundary", async () => {
+  it("reports the real HTTP response captured by the Mistral HTTPClient hook", async () => {
     mistralMockState.requestThroughHttpClient = true;
     mistralMockState.streamResult = {
       async *[Symbol.asyncIterator]() {

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -227,6 +227,38 @@ describe("Mistral provider", () => {
     configureAiTransportHost({});
   });
 
+  it("reports SDK stream acceptance without fabricated HTTP metadata", async () => {
+    mistralMockState.streamResult = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          data: {
+            id: "resp-ack",
+            model: "mistral-large-latest",
+            choices: [{ finishReason: "stop", delta: { content: "ok" } }],
+          },
+        };
+      },
+    };
+    const onProviderAccepted = vi.fn();
+
+    const result = await runSimpleMistralFixture(context, { onProviderAccepted });
+
+    expect(result.stopReason).toBe("stop");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+      expect.objectContaining({ provider: "mistral" }),
+    );
+  });
+
+  it("does not report acceptance when SDK stream setup fails", async () => {
+    const onProviderAccepted = vi.fn();
+
+    const result = await runSimpleMistralFixture(context, { onProviderAccepted });
+
+    expect(result.stopReason).toBe("error");
+    expect(onProviderAccepted).not.toHaveBeenCalled();
+  });
+
   it("forwards simple stop sequences to Mistral stop", async () => {
     const result = await runSimpleMistralFixture(context, {
       stop: ["STOP"],

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -9,6 +9,7 @@ const mistralMockState = vi.hoisted(() => ({
   payloads: [] as unknown[],
   requestOptions: [] as unknown[],
   randomUUIDs: [] as string[],
+  requestThroughHttpClient: false,
   streamError: new Error("stop before network") as unknown,
   streamResult: undefined as unknown,
 }));
@@ -27,7 +28,10 @@ vi.mock("@mistralai/mistralai", async () => {
   return {
     ...actual,
     Mistral: class MockMistral {
+      private readonly config: unknown;
+
       constructor(config: unknown) {
+        this.config = config;
         mistralMockState.configs.push(config);
       }
 
@@ -35,6 +39,14 @@ vi.mock("@mistralai/mistralai", async () => {
         stream: vi.fn(async (payload: unknown, requestOptions: unknown) => {
           mistralMockState.payloads.push(payload);
           mistralMockState.requestOptions.push(requestOptions);
+          if (mistralMockState.requestThroughHttpClient) {
+            const httpClient = (
+              this.config as {
+                httpClient?: { request(request: Request): Promise<Response> };
+              }
+            ).httpClient;
+            await httpClient?.request(new Request("https://api.mistral.ai/chat"));
+          }
           if (mistralMockState.streamResult !== undefined) {
             return mistralMockState.streamResult;
           }
@@ -219,6 +231,7 @@ describe("Mistral provider", () => {
     mistralMockState.payloads = [];
     mistralMockState.requestOptions = [];
     mistralMockState.randomUUIDs = [];
+    mistralMockState.requestThroughHttpClient = false;
     mistralMockState.streamError = new Error("stop before network");
     mistralMockState.streamResult = undefined;
   });
@@ -248,6 +261,60 @@ describe("Mistral provider", () => {
       { kind: "provider_stream_opened", httpMetadata: "unavailable" },
       expect.objectContaining({ provider: "mistral" }),
     );
+  });
+
+  it("reports the real HTTP response captured at the Mistral fetcher boundary", async () => {
+    mistralMockState.requestThroughHttpClient = true;
+    mistralMockState.streamResult = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          data: {
+            id: "resp-http-ack",
+            model: "mistral-large-latest",
+            choices: [{ finishReason: "stop", delta: { content: "ok" } }],
+          },
+        };
+      },
+    };
+    const hostFetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response("stream", {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+            "x-mistral-request-id": "req-1",
+          },
+        }),
+    );
+    configureAiTransportHost({ buildModelFetch: () => hostFetch });
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
+
+    const result = await runSimpleMistralFixture(context, {
+      onProviderAccepted,
+      onResponse,
+    });
+
+    expect(result.stopReason).toBe("stop");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      {
+        kind: "http_response",
+        status: 200,
+        headers: expect.objectContaining({
+          "content-type": "text/event-stream",
+          "x-mistral-request-id": "req-1",
+        }),
+      },
+      expect.objectContaining({ provider: "mistral" }),
+    );
+    expect(onResponse).toHaveBeenCalledWith(
+      {
+        status: 200,
+        headers: expect.objectContaining({ "x-mistral-request-id": "req-1" }),
+      },
+      expect.objectContaining({ provider: "mistral" }),
+    );
+    expect(hostFetch).toHaveBeenCalledOnce();
   });
 
   it("does not report acceptance when SDK stream setup fails", async () => {

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -299,6 +299,37 @@ describe("Mistral provider", () => {
     expect(hostFetch).toHaveBeenCalledOnce();
   });
 
+  it("cancels an unread Mistral stream when provider acceptance fails", async () => {
+    mistralMockState.requestThroughHttpClient = true;
+    const cancel = vi.fn(async () => undefined);
+    mistralMockState.streamResult = {
+      cancel,
+      async *[Symbol.asyncIterator]() {
+        yield {
+          data: {
+            id: "resp-http-ack",
+            model: "mistral-large-latest",
+            choices: [{ finishReason: "stop", delta: { content: "ok" } }],
+          },
+        };
+      },
+    };
+    configureAiTransportHost({
+      buildModelFetch: () => async () => new Response("stream", { status: 200 }),
+    });
+    const hookError = new Error("acceptance callback failed");
+
+    const result = await runSimpleMistralFixture(context, {
+      onProviderAccepted: () => Promise.reject(hookError),
+    });
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "acceptance callback failed",
+    });
+    expect(cancel).toHaveBeenCalledWith(hookError);
+  });
+
   it("reports a rejected HTTP response without marking it accepted", async () => {
     mistralMockState.requestThroughHttpClient = true;
     const hostFetch = vi.fn<typeof fetch>(

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -186,7 +186,14 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         signal: options?.signal,
       });
       if (mistralResponse && mistralResponse !== reportedResponse) {
-        await notifyProviderHttpResponse({ options, response: mistralResponse, model });
+        try {
+          await notifyProviderHttpResponse({ options, response: mistralResponse, model });
+        } catch (error) {
+          // The SDK EventStream owns the locked response reader after chat.stream resolves.
+          // Cancellation is best effort and must not delay the lifecycle callback failure.
+          void mistralStream.cancel(error).catch(() => undefined);
+          throw error;
+        }
       }
       stream.push({ type: "start", partial: output });
       await consumeChatStream(model, output, stream, mistralStream);

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -15,7 +15,6 @@ import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import { transformProviderMessages as transformMessages } from "../provider-transcript-transform.js";
 import {
   notifyProviderHttpResponse,
-  notifyProviderStreamOpened,
   transportAbortError,
 } from "../transports/transport-stream-shared.js";
 import type {
@@ -148,29 +147,22 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
       );
       let mistralResponse: Response | undefined;
       let reportedResponse: Response | undefined;
-      const responseCapturingFetcher: Fetcher = async (input, init) => {
-        const response =
-          init == null ? await boundedFetcher(input) : await boundedFetcher(input, init);
+      const httpClient = new HTTPClient({ fetcher: boundedFetcher });
+      httpClient.addHook("response", async (response) => {
         mistralResponse = response;
         if (!response.ok) {
           await notifyProviderHttpResponse({ options, response, model });
           reportedResponse = response;
         }
-        return response;
-      };
+      });
       // Intentionally per-request: avoids shared SDK mutable state across concurrent consumers.
       const mistral = new Mistral({
         apiKey,
         serverURL: model.baseUrl,
         // Bound the streamed Mistral response body at 16 MiB so a hostile or
-        // malfunctioning endpoint cannot exhaust memory. The fetcher is
-        // injected via the SDK's `HTTPClient` (see
-        // `@mistralai/mistralai/lib/sdks.ts` `ClientSDK` constructor: when
-        // `httpClient` is passed, `ClientSDK.#httpClient` is set from it and
-        // every `chat.stream` / `complete` call routes through
-        // `HTTPClient.request` → `this.fetcher(req)`).
-        // Mistral accepts HTTPClient.fetcher, so compose guarded egress with the byte cap.
-        httpClient: new HTTPClient({ fetcher: responseCapturingFetcher }),
+        // malfunctioning endpoint cannot exhaust memory. The HTTPClient is the
+        // SDK's public fetch and response-hook boundary for every chat.stream attempt.
+        httpClient,
       });
 
       const normalizeMistralToolCallId = createMistralToolCallIdNormalizer();
@@ -195,8 +187,6 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
       });
       if (mistralResponse && mistralResponse !== reportedResponse) {
         await notifyProviderHttpResponse({ options, response: mistralResponse, model });
-      } else if (!mistralResponse) {
-        await notifyProviderStreamOpened({ options, model });
       }
       stream.push({ type: "start", partial: output });
       await consumeChatStream(model, output, stream, mistralStream);

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -14,6 +14,7 @@ import { getAiTransportHost } from "../host.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import { transformProviderMessages as transformMessages } from "../provider-transcript-transform.js";
 import {
+  notifyProviderHttpResponse,
   notifyProviderStreamOpened,
   transportAbortError,
 } from "../transports/transport-stream-shared.js";
@@ -141,6 +142,17 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         throw new Error(`No API key for provider: ${model.provider}`);
       }
 
+      const boundedFetcher = createBoundedMistralFetcher(
+        MISTRAL_STREAM_BODY_MAX_BYTES,
+        getAiTransportHost().buildModelFetch(model) ?? fetch,
+      );
+      let mistralResponse: Response | undefined;
+      const responseCapturingFetcher: Fetcher = async (input, init) => {
+        const response =
+          init == null ? await boundedFetcher(input) : await boundedFetcher(input, init);
+        mistralResponse = response;
+        return response;
+      };
       // Intentionally per-request: avoids shared SDK mutable state across concurrent consumers.
       const mistral = new Mistral({
         apiKey,
@@ -153,12 +165,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         // every `chat.stream` / `complete` call routes through
         // `HTTPClient.request` → `this.fetcher(req)`).
         // Mistral accepts HTTPClient.fetcher, so compose guarded egress with the byte cap.
-        httpClient: new HTTPClient({
-          fetcher: createBoundedMistralFetcher(
-            MISTRAL_STREAM_BODY_MAX_BYTES,
-            getAiTransportHost().buildModelFetch(model) ?? fetch,
-          ),
-        }),
+        httpClient: new HTTPClient({ fetcher: responseCapturingFetcher }),
       });
 
       const normalizeMistralToolCallId = createMistralToolCallIdNormalizer();
@@ -181,7 +188,11 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         headers,
         signal: options?.signal,
       });
-      await notifyProviderStreamOpened({ options, model });
+      if (mistralResponse) {
+        await notifyProviderHttpResponse({ options, response: mistralResponse, model });
+      } else {
+        await notifyProviderStreamOpened({ options, model });
+      }
       stream.push({ type: "start", partial: output });
       await consumeChatStream(model, output, stream, mistralStream);
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -147,10 +147,20 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         getAiTransportHost().buildModelFetch(model) ?? fetch,
       );
       let mistralResponse: Response | undefined;
+      let reportedResponse: Response | undefined;
       const responseCapturingFetcher: Fetcher = async (input, init) => {
         const response =
           init == null ? await boundedFetcher(input) : await boundedFetcher(input, init);
         mistralResponse = response;
+        if (!response.ok) {
+          await notifyProviderHttpResponse({
+            options,
+            response,
+            model,
+            accepted: false,
+          });
+          reportedResponse = response;
+        }
         return response;
       };
       // Intentionally per-request: avoids shared SDK mutable state across concurrent consumers.
@@ -188,9 +198,9 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         headers,
         signal: options?.signal,
       });
-      if (mistralResponse) {
+      if (mistralResponse && mistralResponse !== reportedResponse) {
         await notifyProviderHttpResponse({ options, response: mistralResponse, model });
-      } else {
+      } else if (!mistralResponse) {
         await notifyProviderStreamOpened({ options, model });
       }
       stream.push({ type: "start", partial: output });

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -153,12 +153,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
           init == null ? await boundedFetcher(input) : await boundedFetcher(input, init);
         mistralResponse = response;
         if (!response.ok) {
-          await notifyProviderHttpResponse({
-            options,
-            response,
-            model,
-            accepted: false,
-          });
+          await notifyProviderHttpResponse({ options, response, model });
           reportedResponse = response;
         }
         return response;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -13,7 +13,10 @@ import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import { transformProviderMessages as transformMessages } from "../provider-transcript-transform.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import {
+  notifyProviderStreamOpened,
+  transportAbortError,
+} from "../transports/transport-stream-shared.js";
 import type {
   AssistantMessage,
   Context,
@@ -178,6 +181,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         headers,
         signal: options?.signal,
       });
+      await notifyProviderStreamOpened({ options, model });
       stream.push({ type: "start", partial: output });
       await consumeChatStream(model, output, stream, mistralStream);
 

--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -151,6 +151,63 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
     });
   });
 
+  it("reports acceptance before the default WebSocket stream starts", async () => {
+    class AcceptedWebSocket extends EventTarget {
+      constructor() {
+        super();
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      send(): void {
+        queueMicrotask(() => {
+          this.dispatchEvent(
+            Object.assign(new Event("message"), {
+              data: JSON.stringify({
+                type: "response.completed",
+                response: {
+                  id: "resp_ws_accepted",
+                  status: "completed",
+                  output: [],
+                  usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+                },
+              }),
+            }),
+          );
+        });
+      }
+
+      close(): void {}
+    }
+
+    const order: string[] = [];
+    const onProviderAccepted = vi.fn(async () => {
+      order.push("accepted");
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("WebSocket", AcceptedWebSocket);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+      }),
+      onProviderAccepted,
+    });
+    for await (const event of stream) {
+      order.push(event.type);
+    }
+
+    expect(order).toEqual(["accepted", "start", "done"]);
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      {
+        kind: "provider_stream_opened",
+        httpMetadata: "unavailable",
+      },
+      model,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("emits an error for a content-filtered incomplete WebSocket turn", async () => {
     class ContentFilteredWebSocket extends EventTarget {
       constructor() {

--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -198,13 +198,7 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
     }
 
     expect(order).toEqual(["accepted", "start", "done"]);
-    expect(onProviderAccepted).toHaveBeenCalledWith(
-      {
-        kind: "provider_stream_opened",
-        httpMetadata: "unavailable",
-      },
-      model,
-    );
+    expect(onProviderAccepted).toHaveBeenCalledWith({ kind: "provider_stream_opened" }, model);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
@@ -544,6 +544,47 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     expect(onCompactionRejected).toHaveBeenCalledOnce();
   });
 
+  it("WebSocket commits stripped compaction before a provider acceptance callback fails", async () => {
+    const context = createReplayContext("compaction");
+    const onCompactionRejected = vi.fn();
+    const observations: ResponsesPromptObservation[] = [];
+    const scripted = installScriptedWebSocket([
+      { events: [invalidEncryptedEvent()] },
+      { events: [completionEvent("resp_ws_hook_failure")] },
+    ]);
+    const onProviderAccepted = vi.fn(async () => {
+      if (scripted.requests.length >= 2) {
+        throw new Error("acceptance callback failed");
+      }
+    });
+    const options = createObservedOptions(
+      {
+        apiKey: createJwt(),
+        transport: "websocket" as const,
+        onCompactionRejected,
+        onProviderAccepted,
+        ...REPLAY_IDENTITY,
+      },
+      observations,
+    );
+
+    const result = await streamOpenAICodexResponses(model, context, options).result();
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "acceptance callback failed",
+      providerReplay: { type: "openai-responses-compaction-suppression" },
+    });
+    expect(scripted.requests).toHaveLength(2);
+    expect(hasInputType(requireItem(scripted.requests, 0), "compaction")).toBe(true);
+    expect(hasInputType(requireItem(scripted.requests, 1), "compaction")).toBe(false);
+    expect(observations.map((entry) => entry.payloadVariant)).toEqual([
+      "initial",
+      "compaction-stripped",
+    ]);
+    expect(onCompactionRejected).toHaveBeenCalledOnce();
+  });
+
   it("WebSocket preserves compaction when reasoning-stripped recovery succeeds", async () => {
     const context = createReplayContext("mixed");
     const observations: ResponsesPromptObservation[] = [];

--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -92,9 +92,13 @@ describe("streamOpenAICodexResponses retry classification", () => {
       return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
     const options = {
       apiKey: jwt,
       transport: "sse" as const,
+      onProviderAccepted,
+      onResponse,
     };
     responsesPromptObserver.set(options, (observation) => observations.push(observation));
 
@@ -106,6 +110,8 @@ describe("streamOpenAICodexResponses retry classification", () => {
 
     expect(result.stopReason).toBe("error");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onProviderAccepted).not.toHaveBeenCalled();
+    expect(onResponse.mock.calls.map(([response]) => response.status)).toEqual([503, 401]);
     expect(observations).toHaveLength(2);
     expect(observations.every((entry) => entry.egress === "native-codex-sse")).toBe(true);
     expect(observations.every((entry) => entry.payloadVariant === "initial")).toBe(true);

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -1468,8 +1468,8 @@ async function* startWebSocketOutputOnFirstEvent(
     if (!started) {
       started = true;
       onFirstProviderEvent();
-      await onProviderAccepted();
       onStart();
+      await onProviderAccepted();
       stream.push({ type: "start", partial: output });
     }
     yield event;

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -33,7 +33,7 @@ import {
   type ResponsesEncryptedContentAttempt,
 } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
-import { createOpenAIResponseHook } from "../transports/openai-transport-shared.js";
+import { createOpenAIProviderAcceptanceHook } from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
   withProviderResponseHook,
@@ -520,7 +520,7 @@ export const streamOpenAICodexResponses: StreamFunction<
             withProviderResponseHook({
               signal: firstEventAbort.signal,
               abort: firstEventAbort.abort,
-              hook: createOpenAIResponseHook(options?.onResponse, attemptResponse, model),
+              hook: createOpenAIProviderAcceptanceHook(options, attemptResponse, model),
             }),
             {
               provider: model.provider,
@@ -582,7 +582,7 @@ export const streamOpenAICodexResponses: StreamFunction<
         stream: mapCodexEvents(parseOpenAIChatGptResponsesSse(response)),
         signal: firstEventAbort.signal,
         abort: firstEventAbort.abort,
-        hook: createOpenAIResponseHook(options?.onResponse, response, model),
+        hook: createOpenAIProviderAcceptanceHook(options, response, model),
         onReady: () => stream.push({ type: "start", partial: output }),
       });
       await processResponsesStream(hookedResponseStream, output, stream, model, {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -33,7 +33,10 @@ import {
   type ResponsesEncryptedContentAttempt,
 } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
-import { createOpenAIProviderAcceptanceHook } from "../transports/openai-transport-shared.js";
+import {
+  createOpenAIProviderAcceptanceHook,
+  createOpenAIResponseHook,
+} from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
   withProviderResponseHook,
@@ -520,7 +523,7 @@ export const streamOpenAICodexResponses: StreamFunction<
             withProviderResponseHook({
               signal: firstEventAbort.signal,
               abort: firstEventAbort.abort,
-              hook: createOpenAIProviderAcceptanceHook(options, attemptResponse, model),
+              hook: createOpenAIResponseHook(options?.onResponse, attemptResponse, model),
             }),
             {
               provider: model.provider,

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -38,6 +38,7 @@ import {
   createOpenAIResponseHook,
 } from "../transports/openai-transport-shared.js";
 import {
+  notifyProviderStreamOpened,
   transportAbortError,
   withProviderResponseHook,
 } from "../transports/transport-stream-shared.js";
@@ -363,8 +364,10 @@ export const streamOpenAICodexResponses: StreamFunction<
               stream,
               model,
               () => {
-                commitSemanticAttempt(activeAttempt);
                 websocketStarted = true;
+              },
+              () => {
+                commitSemanticAttempt(activeAttempt);
               },
               requestOptions,
               firstEventAbort.abort,
@@ -1456,12 +1459,16 @@ async function* startWebSocketOutputOnFirstEvent(
   events: AsyncIterable<ResponseStreamEvent>,
   output: AssistantMessage,
   stream: AssistantMessageEventStream,
+  onFirstProviderEvent: () => void,
+  onProviderAccepted: () => Promise<void>,
   onStart: () => void,
 ): AsyncGenerator<ResponseStreamEvent> {
   let started = false;
   for await (const event of events) {
     if (!started) {
       started = true;
+      onFirstProviderEvent();
+      await onProviderAccepted();
       onStart();
       stream.push({ type: "start", partial: output });
     }
@@ -1476,6 +1483,7 @@ async function processWebSocketStream(
   output: AssistantMessage,
   stream: AssistantMessageEventStream,
   model: Model<"openai-chatgpt-responses">,
+  onFirstProviderEvent: () => void,
   onStart: () => void,
   options?: OpenAICodexResponsesOptions,
   abortFirstEventStream?: (reason: Error) => void,
@@ -1512,6 +1520,8 @@ async function processWebSocketStream(
         mapCodexEvents(parseWebSocket(socket, options?.signal)),
         output,
         stream,
+        onFirstProviderEvent,
+        () => notifyProviderStreamOpened({ options, model }),
         onStart,
       ),
       output,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -19,7 +19,7 @@ import {
 } from "../transports/openai-completions-compat.js";
 import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-compat.js";
 import {
-  createOpenAIResponseHook,
+  createOpenAIProviderAcceptanceHook,
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
@@ -184,7 +184,7 @@ export const streamOpenAICompletions: StreamFunction<
         stream: openaiStream,
         signal: firstEventAbort.signal,
         abort: firstEventAbort.abort,
-        hook: createOpenAIResponseHook(options?.onResponse, response, model),
+        hook: createOpenAIProviderAcceptanceHook(options, response, model),
         onReady: () => stream.push({ type: "start", partial: output }),
       });
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -92,7 +92,13 @@ type ResponsesStreamClient = {
 
 type ResponsesLifecycleStreamOptions = Pick<
   StreamOptions,
-  "signal" | "timeoutMs" | "maxRetries" | "onPayload" | "onResponse" | "sessionId"
+  | "signal"
+  | "timeoutMs"
+  | "maxRetries"
+  | "onPayload"
+  | "onProviderAccepted"
+  | "onResponse"
+  | "sessionId"
 > &
   Pick<BaseOpenAIStreamOptions, "authProfileId" | "onCompactionRejected"> &
   FirstStreamEventInternalOptions;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -18,7 +18,7 @@ import {
   convertProviderResponsesMessages,
 } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
-import { createOpenAIResponseHook } from "../transports/openai-transport-shared.js";
+import { createOpenAIProviderAcceptanceHook } from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
   withProviderResponseHook,
@@ -296,7 +296,7 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
       stream: openaiStream,
       signal: firstEventAbort.signal,
       abort: firstEventAbort.abort,
-      hook: createOpenAIResponseHook(options?.onResponse, response, model),
+      hook: createOpenAIProviderAcceptanceHook(options, response, model),
       onReady: () => stream.push({ type: "start", partial: output }),
     });
 

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -31,6 +31,7 @@ export function buildBaseOptions(
     promptCacheKey: options?.promptCacheKey,
     headers: options?.headers,
     onPayload: options?.onPayload,
+    onProviderAccepted: options?.onProviderAccepted,
     onResponse: options?.onResponse,
     timeoutMs: options?.timeoutMs,
     firstEventTimeoutMs: firstEventOptions?.firstEventTimeoutMs,

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -4333,10 +4333,12 @@ describe("anthropic transport stream", () => {
       ]),
     );
     const streamFn = createAnthropicMessagesTransportStreamFn();
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
     const stream = streamFn(
       makeAnthropicTransportModel(),
       { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
-      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+      { apiKey: "sk-ant-api", onProviderAccepted, onResponse } as AnthropicStreamOptions,
     );
 
     const eventTypes: string[] = [];
@@ -4347,6 +4349,11 @@ describe("anthropic transport stream", () => {
     const startIndex = eventTypes.indexOf("start");
     expect(startIndex).toBeGreaterThanOrEqual(0);
     expect(eventTypes.slice(0, startIndex).some((t) => t === "error")).toBe(false);
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+      expect.objectContaining({ provider: "anthropic" }),
+    );
+    expect(onResponse).not.toHaveBeenCalled();
   });
 
   it("emits error without a preceding start event when SSE error arrives before message_start", async () => {

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1129,17 +1129,24 @@ describe("anthropic transport stream", () => {
       ),
     );
 
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
     const result = await runTransportStream(
       makeAnthropicTransportModel(),
       {
         messages: [{ role: "user", content: "hello" }],
       } as AnthropicStreamContext,
-      { apiKey: "test-api-key" } as AnthropicStreamOptions,
+      { apiKey: "test-api-key", onProviderAccepted, onResponse } as AnthropicStreamOptions,
     );
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe(
       'HTTP 429: {"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens exceeded the per-minute rate limit."}}; Retry-After: 30 seconds',
+    );
+    expect(onProviderAccepted).not.toHaveBeenCalled();
+    expect(onResponse).toHaveBeenCalledWith(
+      { status: 429, headers: { "content-type": "text/plain;charset=UTF-8", "retry-after": "30" } },
+      expect.objectContaining({ provider: "anthropic" }),
     );
   });
 

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -4350,7 +4350,7 @@ describe("anthropic transport stream", () => {
     expect(startIndex).toBeGreaterThanOrEqual(0);
     expect(eventTypes.slice(0, startIndex).some((t) => t === "error")).toBe(false);
     expect(onProviderAccepted).toHaveBeenCalledWith(
-      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+      { kind: "provider_stream_opened" },
       expect.objectContaining({ provider: "anthropic" }),
     );
     expect(onResponse).not.toHaveBeenCalled();

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -3794,6 +3794,33 @@ describe("anthropic transport stream", () => {
     expect(cancelReason).toBe(abortReason);
   });
 
+  it("cancels an unread SSE body when provider acceptance fails", async () => {
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      createOpenRawSseResponse({
+        body: "",
+        onCancel: () => {
+          cancelCalled = true;
+        },
+      }),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        onProviderAccepted: () => Promise.reject(new Error("acceptance callback failed")),
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "acceptance callback failed",
+    });
+    await vi.waitFor(() => expect(cancelCalled).toBe(true));
+  });
+
   it("cancels open SSE bodies when Anthropic stream consumers throw", async () => {
     let cancelCalled = false;
     guardedFetchMock.mockResolvedValueOnce(
@@ -4350,10 +4377,17 @@ describe("anthropic transport stream", () => {
     expect(startIndex).toBeGreaterThanOrEqual(0);
     expect(eventTypes.slice(0, startIndex).some((t) => t === "error")).toBe(false);
     expect(onProviderAccepted).toHaveBeenCalledWith(
-      { kind: "provider_stream_opened" },
+      {
+        kind: "http_response",
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      },
       expect.objectContaining({ provider: "anthropic" }),
     );
-    expect(onResponse).not.toHaveBeenCalled();
+    expect(onResponse).toHaveBeenCalledWith(
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+      expect.objectContaining({ provider: "anthropic" }),
+    );
   });
 
   it("emits error without a preceding start event when SSE error arrives before message_start", async () => {
@@ -4368,10 +4402,12 @@ describe("anthropic transport stream", () => {
       ),
     );
     const streamFn = createAnthropicMessagesTransportStreamFn();
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
     const stream = streamFn(
       makeAnthropicTransportModel(),
       { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
-      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+      { apiKey: "sk-ant-api", onProviderAccepted, onResponse } as AnthropicStreamOptions,
     );
 
     const eventTypes: string[] = [];
@@ -4383,6 +4419,18 @@ describe("anthropic transport stream", () => {
     // surfaces the SSE error as an explicit "error" event or silently ends the
     // stream (a timing artefact of synchronous mock SSE delivery).
     expect(eventTypes).not.toContain("start");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      {
+        kind: "http_response",
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      },
+      expect.objectContaining({ provider: "anthropic" }),
+    );
+    expect(onResponse).toHaveBeenCalledWith(
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+      expect.objectContaining({ provider: "anthropic" }),
+    );
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -107,6 +107,7 @@ import {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
+  notifyProviderStreamOpened,
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
   transportAbortError,
@@ -1094,6 +1095,8 @@ function resolveAnthropicTransportOptions(
     sessionId: options?.sessionId,
     headers: options?.headers,
     onPayload: options?.onPayload,
+    onProviderAccepted: options?.onProviderAccepted,
+    onResponse: options?.onResponse,
     maxRetryDelayMs: options?.maxRetryDelayMs,
     metadata: options?.metadata,
     interleavedThinking: options?.interleavedThinking,
@@ -1326,10 +1329,15 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             });
           }
         };
+        let providerAccepted = false;
         for await (const event of anthropicStream) {
           if (event.type === "error") {
             const error = event.error as { message?: string } | undefined;
             throw new Error(error?.message || "Anthropic Messages stream failed");
+          }
+          if (!providerAccepted) {
+            providerAccepted = true;
+            await notifyProviderStreamOpened({ options: transportOptions, model });
           }
           if (event.type === "message_start") {
             const message = event.message as

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -761,10 +761,6 @@ function createAnthropicMessagesClient(params: {
           body: JSON.stringify(body),
           signal: options?.signal,
         });
-        if (!response.ok) {
-          const detail = await readAnthropicMessagesErrorBodySnippet(response);
-          throw new Error(formatAnthropicMessagesHttpError(response, detail));
-        }
         return {
           response,
           stream: response.body ? parseAnthropicSseBody(response.body, options?.signal) : [],
@@ -1202,6 +1198,10 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           transportOptions.signal ? { signal: transportOptions.signal } : undefined,
         );
         await notifyProviderHttpResponse({ options: transportOptions, response, model });
+        if (!response.ok) {
+          const detail = await readAnthropicMessagesErrorBodySnippet(response);
+          throw new Error(formatAnthropicMessagesHttpError(response, detail));
+        }
         const blocks = output.content;
         const blockIndexes = new Map<number, number>();
         const compactionCapture = createCompactionCapture(output, model, transportOptions);

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -107,7 +107,7 @@ import {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
-  notifyProviderStreamOpened,
+  notifyProviderHttpResponse,
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
   transportAbortError,
@@ -144,7 +144,10 @@ type AnthropicMessagesClient = {
     stream(
       params: Record<string, unknown>,
       options?: { signal?: AbortSignal },
-    ): AsyncIterable<Record<string, unknown>>;
+    ): Promise<{
+      response: Response;
+      stream: AsyncIterable<Record<string, unknown>> | Iterable<Record<string, unknown>>;
+    }>;
   };
 };
 
@@ -742,7 +745,7 @@ function createAnthropicMessagesClient(params: {
   const url = resolveAnthropicMessagesUrl(params.baseURL);
   return {
     messages: {
-      async *stream(body: Record<string, unknown>, options?: { signal?: AbortSignal }) {
+      async stream(body: Record<string, unknown>, options?: { signal?: AbortSignal }) {
         const headers = mergeTransportHeaders(
           {
             "content-type": "application/json",
@@ -762,10 +765,10 @@ function createAnthropicMessagesClient(params: {
           const detail = await readAnthropicMessagesErrorBodySnippet(response);
           throw new Error(formatAnthropicMessagesHttpError(response, detail));
         }
-        if (!response.body) {
-          return;
-        }
-        yield* parseAnthropicSseBody(response.body, options?.signal);
+        return {
+          response,
+          stream: response.body ? parseAnthropicSseBody(response.body, options?.signal) : [],
+        };
       },
     },
   };
@@ -1194,10 +1197,11 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           params = nextParams as Record<string, unknown>;
         }
         applyClaudeRequestContract(params, model);
-        const anthropicStream = client.messages.stream(
+        const { response, stream: anthropicStream } = await client.messages.stream(
           { ...params, stream: true },
           transportOptions.signal ? { signal: transportOptions.signal } : undefined,
         );
+        await notifyProviderHttpResponse({ options: transportOptions, response, model });
         const blocks = output.content;
         const blockIndexes = new Map<number, number>();
         const compactionCapture = createCompactionCapture(output, model, transportOptions);
@@ -1329,15 +1333,10 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             });
           }
         };
-        let providerAccepted = false;
         for await (const event of anthropicStream) {
           if (event.type === "error") {
             const error = event.error as { message?: string } | undefined;
             throw new Error(error?.message || "Anthropic Messages stream failed");
-          }
-          if (!providerAccepted) {
-            providerAccepted = true;
-            await notifyProviderStreamOpened({ options: transportOptions, model });
           }
           if (event.type === "message_start") {
             const message = event.message as

--- a/packages/ai/src/transports/openai-completions-transport.response-hook.test.ts
+++ b/packages/ai/src/transports/openai-completions-transport.response-hook.test.ts
@@ -116,12 +116,21 @@ describe.each([
     const hookCompleted = new Promise<void>((resolve) => {
       continueHook = resolve;
     });
+    const onProviderAccepted = vi.fn<NonNullable<StreamOptions["onProviderAccepted"]>>(
+      (acceptance) => {
+        order.push(`accepted:${acceptance.kind}`);
+      },
+    );
     const onResponse = vi.fn<NonNullable<StreamOptions["onResponse"]>>(async () => {
       order.push("hook:start");
       await hookCompleted;
       order.push("hook:end");
     });
-    const stream = createStream(model, context, { apiKey: "fixture-token", onResponse });
+    const stream = createStream(model, context, {
+      apiKey: "fixture-token",
+      onProviderAccepted,
+      onResponse,
+    });
     const consume = (async () => {
       for await (const event of stream) {
         order.push(event.type);
@@ -129,7 +138,19 @@ describe.each([
     })();
 
     await vi.waitFor(() => expect(onResponse).toHaveBeenCalledOnce());
-    expect(order).toEqual(["hook:start"]);
+    expect(order).toEqual(["accepted:http_response", "hook:start"]);
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      {
+        kind: "http_response",
+        status: 202,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-ratelimit-remaining-requests": "42",
+          "x-request-id": "req_observable",
+        },
+      },
+      model,
+    );
     expect(onResponse).toHaveBeenCalledWith(
       {
         status: 202,
@@ -145,7 +166,12 @@ describe.each([
     continueHook();
     await consume;
     expect((await stream.result()).stopReason).toBe("stop");
-    expect(order.slice(0, 3)).toEqual(["hook:start", "hook:end", "start"]);
+    expect(order.slice(0, 4)).toEqual([
+      "accepted:http_response",
+      "hook:start",
+      "hook:end",
+      "start",
+    ]);
   });
 
   it.each(["throw", "reject"] as const)(
@@ -176,6 +202,32 @@ describe.each([
       lifecycle.assertListenersRemoved();
     },
   );
+
+  it("preserves an acceptance hook failure and closes the unread request", async () => {
+    const lifecycle = installResponse();
+    const hookError = new Error("provider acceptance hook failed");
+    const onProviderAccepted = vi.fn(() => Promise.reject(hookError));
+    const onResponse = vi.fn();
+    const stream = createStream(model, context, {
+      apiKey: "fixture-token",
+      onProviderAccepted,
+      onResponse,
+    });
+    const eventTypes: string[] = [];
+
+    for await (const event of stream) {
+      eventTypes.push(event.type);
+    }
+
+    expect(await stream.result()).toMatchObject({
+      stopReason: "error",
+      errorMessage: "provider acceptance hook failed",
+    });
+    expect(onProviderAccepted).toHaveBeenCalledOnce();
+    expect(onResponse).not.toHaveBeenCalled();
+    expect(eventTypes).toEqual(["error"]);
+    expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+  });
 
   it("applies the first-event timeout while the hook is pending", async () => {
     const lifecycle = installResponse();

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -27,7 +27,7 @@ import {
   resolveCodeModeResponsesVisibleToolNames,
 } from "./openai-transport-params.js";
 import {
-  createOpenAIResponseHook,
+  createOpenAIProviderAcceptanceHook,
   type MutableAssistantOutput,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
@@ -271,7 +271,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           stream: responseStream,
           signal: firstEventAbort.signal,
           abort: firstEventAbort.abort,
-          hook: createOpenAIResponseHook(options?.onResponse, response, model),
+          hook: createOpenAIProviderAcceptanceHook(options, response, model),
           onReady: () => stream.push({ type: "start", partial: output }),
         });
         await processCompletionsStream(hookedResponseStream, output, model, stream, {

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -28,6 +28,7 @@ import {
 } from "./openai-transport-params.js";
 import {
   createOpenAIProviderAcceptanceHook,
+  createOpenAIResponseHook,
   type MutableAssistantOutput,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
@@ -271,7 +272,9 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           stream: responseStream,
           signal: firstEventAbort.signal,
           abort: firstEventAbort.abort,
-          hook: createOpenAIProviderAcceptanceHook(options, response, model),
+          hook: options?.onProviderAccepted
+            ? createOpenAIProviderAcceptanceHook(options, response, model)
+            : createOpenAIResponseHook(options?.onResponse, response, model),
           onReady: () => stream.push({ type: "start", partial: output }),
         });
         await processCompletionsStream(hookedResponseStream, output, model, stream, {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -70,13 +70,14 @@ import {
   isOpenAICodexResponsesModel,
   resolveCodeModeResponsesVisibleToolNames,
 } from "./openai-transport-params.js";
-import { createOpenAIResponseHook, log } from "./openai-transport-shared.js";
+import { createOpenAIProviderAcceptanceHook, log } from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
 import {
   createWritableTransportEventStream,
   failTransportStream,
   finalizeTransportStream,
   mergeTransportMetadata,
+  notifyProviderStreamOpened,
   transportAbortError,
   withProviderResponseHook,
 } from "./transport-stream-shared.js";
@@ -448,7 +449,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             stream: observeResponsesStream(rawResponseStream, model, requestStartedAt),
             signal: firstEvent.signal,
             abort: firstEvent.abort,
-            hook: createOpenAIResponseHook(options?.onResponse, response, model),
+            hook: createOpenAIProviderAcceptanceHook(options, response, model),
             onReady: () => {
               emitModelTransportDebug(
                 log,
@@ -503,8 +504,13 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             );
             responseStream = {
               async *[Symbol.asyncIterator]() {
+                let providerAccepted = false;
                 try {
                   for await (const event of websocket.stream) {
+                    if (!providerAccepted) {
+                      providerAccepted = true;
+                      await notifyProviderStreamOpened({ options, model });
+                    }
                     startStream();
                     yield event;
                   }

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -3,6 +3,7 @@ import {
   type AssistantMessage,
   type Context,
   type Model,
+  type StreamOptions,
 } from "@openclaw/llm-core";
 import { WebSocketError } from "openai/resources/responses/internal-base.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -268,6 +269,7 @@ async function run(
     headers?: Record<string, string>;
     observations?: ResponsesPromptObservation[];
     onCompactionRejected?: () => void;
+    onProviderAccepted?: NonNullable<StreamOptions["onProviderAccepted"]>;
   } = {},
 ): Promise<AssistantMessage> {
   const options = {
@@ -278,6 +280,7 @@ async function run(
     timeoutMs: overrides.timeoutMs,
     headers: overrides.headers,
     onCompactionRejected: overrides.onCompactionRejected,
+    onProviderAccepted: overrides.onProviderAccepted,
   };
   if (overrides.observations) {
     responsesPromptObserver.set(options, (observation) =>
@@ -339,6 +342,22 @@ describe("native OpenAI Responses WebSocket client integration", () => {
   afterEach(() => {
     cleanupSessionResources();
     configureAiTransportHost(initialHost);
+  });
+
+  it("reports WebSocket acceptance without fabricated HTTP metadata", async () => {
+    transportState.responseBatches.push([message(completedEvent("resp_accepted", "ok"))]);
+    const onProviderAccepted = vi.fn();
+
+    const result = await run(
+      { messages: [userMessage("hello", 1)], tools: [] },
+      { onProviderAccepted },
+    );
+
+    expect(result.stopReason).toBe("stop");
+    expect(onProviderAccepted).toHaveBeenCalledWith(
+      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+      model,
+    );
   });
 
   it("continues past provider-only output metadata with one socket and only new input", async () => {

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -354,10 +354,7 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     );
 
     expect(result.stopReason).toBe("stop");
-    expect(onProviderAccepted).toHaveBeenCalledWith(
-      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-      model,
-    );
+    expect(onProviderAccepted).toHaveBeenCalledWith({ kind: "provider_stream_opened" }, model);
   });
 
   it("continues past provider-only output metadata with one socket and only new input", async () => {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -15,7 +15,6 @@ import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 /** Shared options, usage shape, cache identity, ordering, and stream scheduling for OpenAI APIs. */
 import { clampOpenAIPromptCacheKey } from "../providers/openai-prompt-cache.js";
 import { headersToRecord } from "../utils/headers.js";
-import { notifyProviderHttpResponse } from "./transport-stream-shared.js";
 import { transportAbortError } from "./transport-stream-shared.js";
 
 export { sortPromptCacheToolsByName as sortTransportToolsByName } from "../utils/prompt-cache-stability.js";
@@ -235,10 +234,17 @@ export function createOpenAIProviderAcceptanceHook(
   options: Pick<BaseOpenAIStreamOptions, "onProviderAccepted" | "onResponse"> | undefined,
   response: Response,
   model: Model,
-): (() => Promise<void>) | undefined {
-  return options?.onProviderAccepted || options?.onResponse
-    ? () => notifyProviderHttpResponse({ options, response, model })
-    : undefined;
+): (() => void | Promise<void>) | undefined {
+  const responseHook = createOpenAIResponseHook(options?.onResponse, response, model);
+  if (!options?.onProviderAccepted) {
+    return responseHook;
+  }
+  return async () => {
+    const status = response.status;
+    const headers = headersToRecord(response.headers);
+    await options.onProviderAccepted?.({ kind: "http_response", status, headers }, model);
+    await responseHook?.();
+  };
 }
 
 type ModelStreamCooperativeScheduler = {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -15,6 +15,7 @@ import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 /** Shared options, usage shape, cache identity, ordering, and stream scheduling for OpenAI APIs. */
 import { clampOpenAIPromptCacheKey } from "../providers/openai-prompt-cache.js";
 import { headersToRecord } from "../utils/headers.js";
+import { notifyProviderHttpResponse } from "./transport-stream-shared.js";
 import { transportAbortError } from "./transport-stream-shared.js";
 
 export { sortPromptCacheToolsByName as sortTransportToolsByName } from "../utils/prompt-cache-stability.js";
@@ -227,6 +228,16 @@ export function createOpenAIResponseHook(
   return onResponse
     ? () =>
         onResponse({ status: response.status, headers: headersToRecord(response.headers) }, model)
+    : undefined;
+}
+
+export function createOpenAIProviderAcceptanceHook(
+  options: Pick<BaseOpenAIStreamOptions, "onProviderAccepted" | "onResponse"> | undefined,
+  response: Response,
+  model: Model,
+): (() => Promise<void>) | undefined {
+  return options?.onProviderAccepted || options?.onResponse
+    ? () => notifyProviderHttpResponse({ options, response, model })
     : undefined;
 }
 

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -15,7 +15,7 @@ import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 /** Shared options, usage shape, cache identity, ordering, and stream scheduling for OpenAI APIs. */
 import { clampOpenAIPromptCacheKey } from "../providers/openai-prompt-cache.js";
 import { headersToRecord } from "../utils/headers.js";
-import { transportAbortError } from "./transport-stream-shared.js";
+import { notifyProviderHttpMetadata, transportAbortError } from "./transport-stream-shared.js";
 
 export { sortPromptCacheToolsByName as sortTransportToolsByName } from "../utils/prompt-cache-stability.js";
 
@@ -235,16 +235,15 @@ export function createOpenAIProviderAcceptanceHook(
   response: Response,
   model: Model,
 ): (() => void | Promise<void>) | undefined {
-  const responseHook = createOpenAIResponseHook(options?.onResponse, response, model);
   if (!options?.onProviderAccepted) {
-    return responseHook;
+    return createOpenAIResponseHook(options?.onResponse, response, model);
   }
-  return async () => {
-    const status = response.status;
-    const headers = headersToRecord(response.headers);
-    await options.onProviderAccepted?.({ kind: "http_response", status, headers }, model);
-    await responseHook?.();
-  };
+  return () =>
+    notifyProviderHttpMetadata({
+      options,
+      response: { status: response.status, headers: headersToRecord(response.headers) },
+      model,
+    });
 }
 
 type ModelStreamCooperativeScheduler = {

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -1,0 +1,30 @@
+import type { Model, StreamOptions } from "@openclaw/llm-core";
+import { describe, expect, it, vi } from "vitest";
+import { notifyProviderHttpResponse } from "./transport-stream-shared.js";
+
+const model = { id: "acceptance-test", provider: "test" } as Model;
+
+describe("notifyProviderHttpResponse", () => {
+  it.each(["onProviderAccepted", "onResponse"] as const)(
+    "cancels an unread response when %s fails",
+    async (hookName) => {
+      const hookError = new Error(`${hookName} failed`);
+      const cancel = vi.fn();
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          cancel,
+        }),
+        { status: 200 },
+      );
+      const options: StreamOptions = {
+        [hookName]: vi.fn(() => Promise.reject(hookError)),
+      };
+
+      await expect(notifyProviderHttpResponse({ options, response, model })).rejects.toBe(
+        hookError,
+      );
+
+      expect(cancel).toHaveBeenCalledWith(hookError);
+    },
+  );
+});

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -1,6 +1,9 @@
 import type { Model, StreamOptions } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
-import { notifyProviderHttpResponse } from "./transport-stream-shared.js";
+import {
+  notifyProviderHttpResponse,
+  notifyProviderStreamOpened,
+} from "./transport-stream-shared.js";
 
 const model = { id: "acceptance-test", provider: "test" } as Model;
 
@@ -27,4 +30,57 @@ describe("notifyProviderHttpResponse", () => {
       expect(cancel).toHaveBeenCalledWith(hookError);
     },
   );
+
+  it("uses the option signal to abort a pending HTTP acceptance callback", async () => {
+    const controller = new AbortController();
+    const abortReason = Object.assign(new Error("operator canceled"), {
+      code: "OPERATOR_CANCELLED",
+    });
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream<Uint8Array>({ cancel }), { status: 200 });
+    let markHookStarted!: () => void;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+    const options: StreamOptions = {
+      signal: controller.signal,
+      onProviderAccepted: () => {
+        markHookStarted();
+        return new Promise<void>(() => {});
+      },
+    };
+
+    const notification = notifyProviderHttpResponse({ options, response, model });
+    await hookStarted;
+    controller.abort(abortReason);
+
+    await expect(notification).rejects.toBe(abortReason);
+    expect(cancel).toHaveBeenCalledWith(abortReason);
+  });
+});
+
+describe("notifyProviderStreamOpened", () => {
+  it("uses the option signal to abort a pending SDK acceptance callback", async () => {
+    const controller = new AbortController();
+    const abortReason = Object.assign(new Error("operator canceled"), {
+      code: "OPERATOR_CANCELLED",
+    });
+    let markHookStarted!: () => void;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+    const options: StreamOptions = {
+      signal: controller.signal,
+      onProviderAccepted: () => {
+        markHookStarted();
+        return new Promise<void>(() => {});
+      },
+    };
+
+    const notification = notifyProviderStreamOpened({ options, model });
+    await hookStarted;
+    controller.abort(abortReason);
+
+    await expect(notification).rejects.toBe(abortReason);
+  });
 });

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -31,6 +31,31 @@ describe("notifyProviderHttpResponse", () => {
     },
   );
 
+  it("does not wait for unread response cancellation after a callback fails", async () => {
+    const hookError = new Error("acceptance failed");
+    let markCancelStarted!: () => void;
+    const cancelStarted = new Promise<void>((resolve) => {
+      markCancelStarted = resolve;
+    });
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          markCancelStarted();
+          return new Promise<void>(() => {});
+        },
+      }),
+      { status: 200 },
+    );
+    const notification = notifyProviderHttpResponse({
+      options: { onProviderAccepted: () => Promise.reject(hookError) },
+      response,
+      model,
+    });
+
+    await cancelStarted;
+    await expect(notification).rejects.toBe(hookError);
+  });
+
   it("reports a rejected HTTP response without marking it accepted", async () => {
     const onProviderAccepted = vi.fn();
     const onResponse = vi.fn();

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -31,6 +31,23 @@ describe("notifyProviderHttpResponse", () => {
     },
   );
 
+  it("reports a rejected HTTP response without marking it accepted", async () => {
+    const onProviderAccepted = vi.fn();
+    const onResponse = vi.fn();
+    const options: StreamOptions = { onProviderAccepted, onResponse };
+    const response = new Response("rejected", { status: 429 });
+
+    await notifyProviderHttpResponse({
+      options,
+      response,
+      model,
+      accepted: false,
+    });
+
+    expect(onProviderAccepted).not.toHaveBeenCalled();
+    expect(onResponse).toHaveBeenCalledWith(expect.objectContaining({ status: 429 }), model);
+  });
+
   it("uses the option signal to abort a pending HTTP acceptance callback", async () => {
     const controller = new AbortController();
     const abortReason = Object.assign(new Error("operator canceled"), {

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -37,12 +37,7 @@ describe("notifyProviderHttpResponse", () => {
     const options: StreamOptions = { onProviderAccepted, onResponse };
     const response = new Response("rejected", { status: 429 });
 
-    await notifyProviderHttpResponse({
-      options,
-      response,
-      model,
-      accepted: false,
-    });
+    await notifyProviderHttpResponse({ options, response, model });
 
     expect(onProviderAccepted).not.toHaveBeenCalled();
     expect(onResponse).toHaveBeenCalledWith(expect.objectContaining({ status: 429 }), model);

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -68,6 +68,27 @@ describe("notifyProviderHttpResponse", () => {
     expect(onResponse).toHaveBeenCalledWith(expect.objectContaining({ status: 429 }), model);
   });
 
+  it("does not resume response handling when a callback aborts its signal", async () => {
+    const controller = new AbortController();
+    const abortReason = Object.assign(new Error("operator canceled"), {
+      code: "OPERATOR_CANCELLED",
+    });
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream<Uint8Array>({ cancel }), { status: 200 });
+
+    await expect(
+      notifyProviderHttpResponse({
+        options: {
+          signal: controller.signal,
+          onProviderAccepted: () => controller.abort(abortReason),
+        },
+        response,
+        model,
+      }),
+    ).rejects.toBe(abortReason);
+    expect(cancel).toHaveBeenCalledWith(abortReason);
+  });
+
   it("uses the option signal to abort a pending HTTP acceptance callback", async () => {
     const controller = new AbortController();
     const abortReason = Object.assign(new Error("operator canceled"), {

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -160,12 +160,13 @@ async function awaitProviderLifecycleCallback(
   }
 }
 
-/** Report a real HTTP response before its body stream is consumed. */
+/** Report a real HTTP response before body consumption; rejected responses use only onResponse. */
 export async function notifyProviderHttpResponse(params: {
   options?: ProviderAcceptanceOptions;
   response: Response;
   model: Model;
   signal?: AbortSignal;
+  accepted?: boolean;
 }): Promise<void> {
   if (!params.options?.onProviderAccepted && !params.options?.onResponse) {
     return;
@@ -175,7 +176,7 @@ export async function notifyProviderHttpResponse(params: {
   const signal = params.signal ?? params.options?.signal;
   try {
     await awaitProviderLifecycleCallback(
-      params.options.onProviderAccepted
+      params.accepted !== false && params.options.onProviderAccepted
         ? () =>
             params.options?.onProviderAccepted?.(
               { kind: "http_response", status, headers },

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -126,11 +126,43 @@ export function transportAbortError(signal?: AbortSignal): Error {
 
 type ProviderAcceptanceOptions = Pick<StreamOptions, "onProviderAccepted" | "onResponse">;
 
+async function awaitProviderLifecycleCallback(
+  callback: (() => void | Promise<void>) | undefined,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal?.aborted) {
+    throw transportAbortError(signal);
+  }
+  if (!callback) {
+    return;
+  }
+  const callbackPromise = Promise.resolve().then(callback);
+  if (!signal) {
+    await callbackPromise;
+    return;
+  }
+  let onAbort: (() => void) | undefined;
+  try {
+    await Promise.race([
+      callbackPromise,
+      new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(transportAbortError(signal));
+        signal.addEventListener("abort", onAbort, { once: true });
+      }),
+    ]);
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
 /** Report a real HTTP response before its body stream is consumed. */
 export async function notifyProviderHttpResponse(params: {
   options?: ProviderAcceptanceOptions;
   response: Response;
   model: Model;
+  signal?: AbortSignal;
 }): Promise<void> {
   if (!params.options?.onProviderAccepted && !params.options?.onResponse) {
     return;
@@ -138,11 +170,22 @@ export async function notifyProviderHttpResponse(params: {
   const status = params.response.status;
   const headers = headersToRecord(params.response.headers);
   try {
-    await params.options.onProviderAccepted?.(
-      { kind: "http_response", status, headers },
-      params.model,
+    await awaitProviderLifecycleCallback(
+      params.options.onProviderAccepted
+        ? () =>
+            params.options?.onProviderAccepted?.(
+              { kind: "http_response", status, headers },
+              params.model,
+            )
+        : undefined,
+      params.signal,
     );
-    await params.options.onResponse?.({ status, headers }, params.model);
+    await awaitProviderLifecycleCallback(
+      params.options.onResponse
+        ? () => params.options?.onResponse?.({ status, headers }, params.model)
+        : undefined,
+      params.signal,
+    );
   } catch (error) {
     await params.response.body?.cancel(error).catch(() => undefined);
     throw error;
@@ -170,27 +213,11 @@ export function withProviderResponseHook<T = never>(params: {
 }): AsyncIterable<T> {
   return {
     async *[Symbol.asyncIterator]() {
-      let onAbort: (() => void) | undefined;
       try {
-        if (params.signal.aborted) {
-          throw transportAbortError(params.signal);
-        }
-        if (params.hook) {
-          await Promise.race([
-            Promise.resolve().then(params.hook),
-            new Promise<never>((_resolve, reject) => {
-              onAbort = () => reject(transportAbortError(params.signal));
-              params.signal.addEventListener("abort", onAbort, { once: true });
-            }),
-          ]);
-        }
+        await awaitProviderLifecycleCallback(params.hook, params.signal);
       } catch (error) {
         params.abort(error instanceof Error ? error : new Error(String(error)));
         throw error;
-      } finally {
-        if (onAbort) {
-          params.signal.removeEventListener("abort", onAbort);
-        }
       }
       if (params.signal.aborted) {
         throw transportAbortError(params.signal);

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -164,6 +164,9 @@ async function awaitProviderLifecycleCallback(
       signal.removeEventListener("abort", onAbort);
     }
   }
+  if (signal.aborted) {
+    throw transportAbortError(signal);
+  }
 }
 
 /** Report observed HTTP metadata; rejected responses use only onResponse. */

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -124,7 +124,10 @@ export function transportAbortError(signal?: AbortSignal): Error {
     : new Error("Request was aborted");
 }
 
-type ProviderAcceptanceOptions = Pick<StreamOptions, "onProviderAccepted" | "onResponse">;
+type ProviderAcceptanceOptions = Pick<
+  StreamOptions,
+  "onProviderAccepted" | "onResponse" | "signal"
+>;
 
 async function awaitProviderLifecycleCallback(
   callback: (() => void | Promise<void>) | undefined,
@@ -169,6 +172,7 @@ export async function notifyProviderHttpResponse(params: {
   }
   const status = params.response.status;
   const headers = headersToRecord(params.response.headers);
+  const signal = params.signal ?? params.options?.signal;
   try {
     await awaitProviderLifecycleCallback(
       params.options.onProviderAccepted
@@ -178,13 +182,13 @@ export async function notifyProviderHttpResponse(params: {
               params.model,
             )
         : undefined,
-      params.signal,
+      signal,
     );
     await awaitProviderLifecycleCallback(
       params.options.onResponse
         ? () => params.options?.onResponse?.({ status, headers }, params.model)
         : undefined,
-      params.signal,
+      signal,
     );
   } catch (error) {
     await params.response.body?.cancel(error).catch(() => undefined);
@@ -194,12 +198,19 @@ export async function notifyProviderHttpResponse(params: {
 
 /** Report an accepted SDK stream when the SDK does not expose HTTP metadata. */
 export async function notifyProviderStreamOpened(params: {
-  options?: Pick<StreamOptions, "onProviderAccepted">;
+  options?: Pick<StreamOptions, "onProviderAccepted" | "signal">;
   model: Model;
+  signal?: AbortSignal;
 }): Promise<void> {
-  await params.options?.onProviderAccepted?.(
-    { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-    params.model,
+  await awaitProviderLifecycleCallback(
+    params.options?.onProviderAccepted
+      ? () =>
+          params.options?.onProviderAccepted?.(
+            { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+            params.model,
+          )
+      : undefined,
+    params.signal ?? params.options?.signal,
   );
 }
 

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -3,7 +3,13 @@
  *
  * Sanitizes provider payloads, merges metadata, and formats streamed assistant events.
  */
-import type { AssistantMessage, Model, StreamOptions, Usage } from "@openclaw/llm-core";
+import type {
+  AssistantMessage,
+  Model,
+  ProviderResponse,
+  StreamOptions,
+  Usage,
+} from "@openclaw/llm-core";
 import { asNonArrayRecord, asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
@@ -160,38 +166,58 @@ async function awaitProviderLifecycleCallback(
   }
 }
 
-/** Report a real HTTP response before body consumption; rejected responses use only onResponse. */
-export async function notifyProviderHttpResponse(params: {
+/** Report observed HTTP metadata; rejected responses use only onResponse. */
+export async function notifyProviderHttpMetadata(params: {
   options?: ProviderAcceptanceOptions;
-  response: Response;
+  response: ProviderResponse;
   model: Model;
   signal?: AbortSignal;
 }): Promise<void> {
   if (!params.options?.onProviderAccepted && !params.options?.onResponse) {
     return;
   }
-  const status = params.response.status;
-  const headers = headersToRecord(params.response.headers);
+  const { status, headers } = params.response;
   const signal = params.signal ?? params.options?.signal;
+  const accepted = status >= 200 && status < 300;
+  await awaitProviderLifecycleCallback(
+    accepted && params.options.onProviderAccepted
+      ? () =>
+          params.options?.onProviderAccepted?.(
+            { kind: "http_response", status, headers },
+            params.model,
+          )
+      : undefined,
+    signal,
+  );
+  await awaitProviderLifecycleCallback(
+    params.options.onResponse
+      ? () => params.options?.onResponse?.({ status, headers }, params.model)
+      : undefined,
+    signal,
+  );
+}
+
+/** Report a real HTTP response before body consumption. */
+export async function notifyProviderHttpResponse(params: {
+  options?: ProviderAcceptanceOptions;
+  response: Response;
+  model: Model;
+  signal?: AbortSignal;
+}): Promise<void> {
   try {
-    await awaitProviderLifecycleCallback(
-      params.response.ok && params.options.onProviderAccepted
-        ? () =>
-            params.options?.onProviderAccepted?.(
-              { kind: "http_response", status, headers },
-              params.model,
-            )
-        : undefined,
-      signal,
-    );
-    await awaitProviderLifecycleCallback(
-      params.options.onResponse
-        ? () => params.options?.onResponse?.({ status, headers }, params.model)
-        : undefined,
-      signal,
-    );
+    await notifyProviderHttpMetadata({
+      options: params.options,
+      response: {
+        status: params.response.status,
+        headers: headersToRecord(params.response.headers),
+      },
+      model: params.model,
+      signal: params.signal,
+    });
   } catch (error) {
-    await params.response.body?.cancel(error).catch(() => undefined);
+    // Cancellation is best-effort cleanup; a stalled body must not retain the request owner
+    // or delay the callback failure that made the body unreadable.
+    void params.response.body?.cancel(error).catch(() => undefined);
     throw error;
   }
 }
@@ -204,11 +230,7 @@ export async function notifyProviderStreamOpened(params: {
 }): Promise<void> {
   await awaitProviderLifecycleCallback(
     params.options?.onProviderAccepted
-      ? () =>
-          params.options?.onProviderAccepted?.(
-            { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-            params.model,
-          )
+      ? () => params.options?.onProviderAccepted?.({ kind: "provider_stream_opened" }, params.model)
       : undefined,
     params.signal ?? params.options?.signal,
   );

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -3,9 +3,10 @@
  *
  * Sanitizes provider payloads, merges metadata, and formats streamed assistant events.
  */
-import type { AssistantMessage, Usage } from "@openclaw/llm-core";
+import type { AssistantMessage, Model, StreamOptions, Usage } from "@openclaw/llm-core";
 import { asNonArrayRecord, asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
+import { headersToRecord } from "../utils/headers.js";
 import { projectProviderError, type ProviderErrorProjection } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
@@ -121,6 +122,37 @@ export function transportAbortError(signal?: AbortSignal): Error {
   return reason instanceof Error && typeof (reason as { code?: unknown }).code === "string"
     ? reason
     : new Error("Request was aborted");
+}
+
+type ProviderAcceptanceOptions = Pick<StreamOptions, "onProviderAccepted" | "onResponse">;
+
+/** Report a real HTTP response before its body stream is consumed. */
+export async function notifyProviderHttpResponse(params: {
+  options?: ProviderAcceptanceOptions;
+  response: Response;
+  model: Model;
+}): Promise<void> {
+  if (!params.options?.onProviderAccepted && !params.options?.onResponse) {
+    return;
+  }
+  const status = params.response.status;
+  const headers = headersToRecord(params.response.headers);
+  await params.options.onProviderAccepted?.(
+    { kind: "http_response", status, headers },
+    params.model,
+  );
+  await params.options.onResponse?.({ status, headers }, params.model);
+}
+
+/** Report an accepted SDK stream when the SDK does not expose HTTP metadata. */
+export async function notifyProviderStreamOpened(params: {
+  options?: Pick<StreamOptions, "onProviderAccepted">;
+  model: Model;
+}): Promise<void> {
+  await params.options?.onProviderAccepted?.(
+    { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+    params.model,
+  );
 }
 
 /** Run a provider-response hook before start/body consumption inside the first-event deadline. */

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -137,11 +137,16 @@ export async function notifyProviderHttpResponse(params: {
   }
   const status = params.response.status;
   const headers = headersToRecord(params.response.headers);
-  await params.options.onProviderAccepted?.(
-    { kind: "http_response", status, headers },
-    params.model,
-  );
-  await params.options.onResponse?.({ status, headers }, params.model);
+  try {
+    await params.options.onProviderAccepted?.(
+      { kind: "http_response", status, headers },
+      params.model,
+    );
+    await params.options.onResponse?.({ status, headers }, params.model);
+  } catch (error) {
+    await params.response.body?.cancel(error).catch(() => undefined);
+    throw error;
+  }
 }
 
 /** Report an accepted SDK stream when the SDK does not expose HTTP metadata. */

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -166,7 +166,6 @@ export async function notifyProviderHttpResponse(params: {
   response: Response;
   model: Model;
   signal?: AbortSignal;
-  accepted?: boolean;
 }): Promise<void> {
   if (!params.options?.onProviderAccepted && !params.options?.onResponse) {
     return;
@@ -176,7 +175,7 @@ export async function notifyProviderHttpResponse(params: {
   const signal = params.signal ?? params.options?.signal;
   try {
     await awaitProviderLifecycleCallback(
-      params.accepted !== false && params.options.onProviderAccepted
+      params.response.ok && params.options.onProviderAccepted
         ? () =>
             params.options?.onProviderAccepted?.(
               { kind: "http_response", status, headers },

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -71,10 +71,7 @@ export type ProviderAcceptance =
       status: number;
       headers: Record<string, string>;
     }
-  | {
-      kind: "provider_stream_opened";
-      httpMetadata: "unavailable";
-    };
+  | { kind: "provider_stream_opened" };
 
 /** Request options shared by text streaming providers. */
 export interface StreamOptions {

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -64,6 +64,18 @@ export interface ProviderResponse {
   headers: Record<string, string>;
 }
 
+/** Evidence that a text provider accepted a request. */
+export type ProviderAcceptance =
+  | {
+      kind: "http_response";
+      status: number;
+      headers: Record<string, string>;
+    }
+  | {
+      kind: "provider_stream_opened";
+      httpMetadata: "unavailable";
+    };
+
 /** Request options shared by text streaming providers. */
 export interface StreamOptions {
   temperature?: number;
@@ -113,8 +125,13 @@ export interface StreamOptions {
    */
   onPayload?: (payload: unknown, model: Model) => MaybePromise<unknown>;
   /**
-   * Optional callback invoked after an HTTP response is received and before
-   * its body stream is consumed.
+   * Optional callback invoked after the provider accepts the request and before
+   * its body stream is consumed. HTTP metadata is included only when the transport sees it.
+   */
+  onProviderAccepted?: (acceptance: ProviderAcceptance, model: Model) => void | Promise<void>;
+  /**
+   * Optional compatibility callback invoked after a transport receives a real
+   * HTTP response and before its body stream is consumed.
    */
   onResponse?: (response: ProviderResponse, model: Model) => void | Promise<void>;
   /**

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -136,6 +136,10 @@
       "types": "./dist/src/plugin-sdk/provider-http.d.ts",
       "default": "./src/provider-http.ts"
     },
+    "./provider-lifecycle": {
+      "types": "./dist/src/plugin-sdk/provider-lifecycle.d.ts",
+      "default": "./src/provider-lifecycle.ts"
+    },
     "./provider-model-shared": {
       "types": "./dist/src/plugin-sdk/provider-model-shared.d.ts",
       "default": "./src/provider-model-shared.ts"

--- a/packages/plugin-sdk/src/provider-lifecycle.ts
+++ b/packages/plugin-sdk/src/provider-lifecycle.ts
@@ -1,0 +1,2 @@
+/** Workspace facade for the public provider acceptance lifecycle API. */
+export * from "../../../src/plugin-sdk/provider-lifecycle.js";

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -287,6 +287,7 @@
   "provider-entry",
   "provider-env-vars",
   "provider-http",
+  "provider-lifecycle",
   "provider-binary-stream",
   "provider-model-types",
   "provider-model-shared",

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -195,7 +195,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical Computer Use wire contract and node-host provider seam.
       // -1: retire the deprecated messaging-targets subpath.
       // +2: bounded provider streams and read-only SecretRef resolution.
-      146,
+      // +1: supported provider request-acceptance lifecycle seam.
+      147,
       env,
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
@@ -300,7 +301,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: account-scoped model catalog discovery for native agent harnesses.
       // +2: shared delegation policy (mode resolver + section builder) so harness
       //     runtimes render the same guidance instead of diverging prompt copies.
-      4334,
+      // +5: provider acceptance receipt/response types and three lifecycle helpers.
+      4339,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -385,7 +387,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical sensitive-URL redactor so plugin CLI errors never print URL userinfo.
       // +2: shared delegation policy (mode resolver + section builder) so harness
       //     runtimes render the same guidance instead of diverging prompt copies.
-      2577,
+      // +3: provider acceptance lifecycle helpers for HTTP and metadata-free streams.
+      2580,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
@@ -226,16 +226,13 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
         _context: Parameters<StreamFn>[1],
         options: Parameters<StreamFn>[2],
       ) => {
-        return options?.onProviderAccepted?.(
-          { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-          model,
-        );
+        return options?.onProviderAccepted?.({ kind: "provider_stream_opened" }, model);
       }) as unknown as StreamFn,
       {
         runId: "run-timeline-accepted",
-        provider: "mistral",
-        model: "mistral-large-latest",
-        api: "mistral-conversations",
+        provider: "google",
+        model: "gemini-2.5-pro",
+        api: "google-generative-ai",
         trace: createDiagnosticTraceContext(),
         nextCallId: () => "call-timeline-accepted",
       },
@@ -243,15 +240,15 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
 
     const events = await collectProviderTimelineEvents(async () => {
       await wrapped(
-        { id: "mistral-large-latest" } as never,
+        { id: "gemini-2.5-pro" } as never,
         {} as never,
         { onProviderAccepted: originalOnProviderAccepted } as never,
       );
     });
 
     expect(originalOnProviderAccepted).toHaveBeenCalledWith(
-      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
-      { id: "mistral-large-latest" },
+      { kind: "provider_stream_opened" },
+      { id: "gemini-2.5-pro" },
     );
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
@@ -212,7 +212,58 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
       type: "provider.request",
       ok: true,
       status: 200,
+      attributes: {
+        providerAccepted: true,
+        providerAcceptanceKind: "http_response",
+      },
     });
+  });
+
+  it("records provider acceptance when an SDK hides HTTP metadata", async () => {
+    const originalOnProviderAccepted = vi.fn(async () => undefined);
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      ((
+        model: Parameters<StreamFn>[0],
+        _context: Parameters<StreamFn>[1],
+        options: Parameters<StreamFn>[2],
+      ) => {
+        return options?.onProviderAccepted?.(
+          { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+          model,
+        );
+      }) as unknown as StreamFn,
+      {
+        runId: "run-timeline-accepted",
+        provider: "mistral",
+        model: "mistral-large-latest",
+        api: "mistral-conversations",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-timeline-accepted",
+      },
+    );
+
+    const events = await collectProviderTimelineEvents(async () => {
+      await wrapped(
+        { id: "mistral-large-latest" } as never,
+        {} as never,
+        { onProviderAccepted: originalOnProviderAccepted } as never,
+      );
+    });
+
+    expect(originalOnProviderAccepted).toHaveBeenCalledWith(
+      { kind: "provider_stream_opened", httpMetadata: "unavailable" },
+      { id: "mistral-large-latest" },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "provider.request",
+      ok: true,
+      attributes: {
+        providerAccepted: true,
+        providerAcceptanceKind: "provider_stream_opened",
+      },
+    });
+    expect(events[0]?.status).toBeUndefined();
   });
 
   it("writes Unicode-safe bounded attributes to the provider timeline JSONL", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
@@ -172,7 +172,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
     expect(events[0]?.status).toBeUndefined();
   });
 
-  it("records provider response status and preserves the original response callback", async () => {
+  it("records legacy response status without inferring provider acceptance", async () => {
     const originalOnResponse = vi.fn(async () => undefined);
     const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
       ((
@@ -213,8 +213,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
       ok: true,
       status: 200,
       attributes: {
-        providerAccepted: true,
-        providerAcceptanceKind: "http_response",
+        providerAccepted: false,
       },
     });
   });

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -402,7 +402,6 @@ function withDiagnosticRequestContext(
   const onResponse: NonNullable<ModelCallStreamOptions>["onResponse"] = (response, model) => {
     // Retrying providers can expose several responses; the terminal request status
     // is the latest response observed before the model call completes or fails.
-    observer.state.providerAcceptanceKind ??= "http_response";
     observer.state.responseStatus = response.status;
     return originalOnResponse?.(response, model);
   };

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -1,3 +1,4 @@
+import type { ProviderAcceptance } from "@openclaw/llm-core";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { fireAndForgetBoundedHook } from "../../../hooks/fire-and-forget.js";
@@ -85,7 +86,7 @@ export type ModelCallUsage = NonNullable<
 >;
 export type ModelCallObservationState = {
   requestPayloadBytes?: number;
-  providerAcceptanceKind?: "http_response" | "provider_stream_opened";
+  providerAcceptanceKind?: ProviderAcceptance["kind"];
   responseStatus?: number;
   responseStreamBytes: number;
   timeToFirstByteMs?: number;

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -85,6 +85,7 @@ export type ModelCallUsage = NonNullable<
 >;
 export type ModelCallObservationState = {
   requestPayloadBytes?: number;
+  providerAcceptanceKind?: "http_response" | "provider_stream_opened";
   responseStatus?: number;
   responseStreamBytes: number;
   timeToFirstByteMs?: number;
@@ -154,6 +155,7 @@ function emitProviderRequestTimelineEvent(
   durationMs: number,
   ok: boolean,
   responseStatus: number | undefined,
+  providerAcceptanceKind: ModelCallObservationState["providerAcceptanceKind"],
 ): void {
   const provider = boundedTimelineAttribute(eventBase.provider);
   const model = boundedTimelineAttribute(eventBase.model);
@@ -174,6 +176,8 @@ function emitProviderRequestTimelineEvent(
       ...(model ? { model } : {}),
       ...(api ? { api } : {}),
       ...(transport ? { transport } : {}),
+      providerAccepted: providerAcceptanceKind !== undefined,
+      ...(providerAcceptanceKind ? { providerAcceptanceKind } : {}),
     },
   });
 }
@@ -291,6 +295,7 @@ function emitModelCallCompleted(
     durationMs,
     true,
     observer.state.responseStatus,
+    observer.state.providerAcceptanceKind,
   );
   emitCoreModelRequestEndedDiagnosticEvent(
     {
@@ -329,7 +334,14 @@ function emitModelCallError(
   const errorStatus = diagnosticHttpStatusCode(err);
   const responseStatus =
     observer.state.responseStatus ?? (errorStatus === undefined ? undefined : Number(errorStatus));
-  emitProviderRequestTimelineEvent(eventBase, startedAt, durationMs, false, responseStatus);
+  emitProviderRequestTimelineEvent(
+    eventBase,
+    startedAt,
+    durationMs,
+    false,
+    responseStatus,
+    observer.state.providerAcceptanceKind,
+  );
   emitCoreModelRequestEndedDiagnosticEvent(
     {
       type: "model.call.error",
@@ -360,6 +372,7 @@ function withDiagnosticRequestContext(
 ): ModelCallStreamOptions {
   const traceparent = formatPropagatedDiagnosticTraceparent(trace);
   const originalOnPayload = options?.onPayload;
+  const originalOnProviderAccepted = options?.onProviderAccepted;
   const originalOnResponse = options?.onResponse;
   const onPayload: NonNullable<ModelCallStreamOptions>["onPayload"] = (payload, model) => {
     if (!originalOnPayload) {
@@ -376,9 +389,20 @@ function withDiagnosticRequestContext(
     observer.assignRequestPayloadBytes(result ?? payload);
     return result;
   };
+  const onProviderAccepted: NonNullable<ModelCallStreamOptions>["onProviderAccepted"] = (
+    acceptance,
+    model,
+  ) => {
+    observer.state.providerAcceptanceKind = acceptance.kind;
+    if (acceptance.kind === "http_response") {
+      observer.state.responseStatus = acceptance.status;
+    }
+    return originalOnProviderAccepted?.(acceptance, model);
+  };
   const onResponse: NonNullable<ModelCallStreamOptions>["onResponse"] = (response, model) => {
     // Retrying providers can expose several responses; the terminal request status
     // is the latest response observed before the model call completes or fails.
+    observer.state.providerAcceptanceKind ??= "http_response";
     observer.state.responseStatus = response.status;
     return originalOnResponse?.(response, model);
   };
@@ -398,6 +422,7 @@ function withDiagnosticRequestContext(
     requestId: callId,
     ...((options?.headers || traceparent) && { headers }),
     onPayload,
+    onProviderAccepted,
     onResponse,
   };
 }

--- a/src/plugin-sdk/llm.ts
+++ b/src/plugin-sdk/llm.ts
@@ -37,6 +37,7 @@ export type {
   Message,
   Model,
   ModelThinkingLevel,
+  ProviderAcceptance,
   ProviderResponse,
   ProviderStreamOptions,
   SimpleStreamOptions,

--- a/src/plugin-sdk/provider-lifecycle.ts
+++ b/src/plugin-sdk/provider-lifecycle.ts
@@ -1,0 +1,7 @@
+/** Public provider request-acceptance lifecycle types and helpers. */
+export type { ProviderAcceptance, ProviderResponse } from "@openclaw/llm-core";
+export {
+  notifyProviderHttpMetadata,
+  notifyProviderHttpResponse,
+  notifyProviderStreamOpened,
+} from "@openclaw/ai/transports";

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -19,6 +19,7 @@ export {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
+  notifyProviderHttpMetadata,
   notifyProviderHttpResponse,
   notifyProviderStreamOpened,
   sanitizeTransportPayloadText,

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -19,6 +19,8 @@ export {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
+  notifyProviderHttpResponse,
+  notifyProviderStreamOpened,
   sanitizeTransportPayloadText,
   type WritableTransportStream,
 } from "@openclaw/ai/transports";

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -19,9 +19,6 @@ export {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
-  notifyProviderHttpMetadata,
-  notifyProviderHttpResponse,
-  notifyProviderStreamOpened,
   sanitizeTransportPayloadText,
   type WritableTransportStream,
 } from "@openclaw/ai/transports";


### PR DESCRIPTION
> Opened on behalf of Onur Solmaz (`osolmaz`). Work is in progress.
>
> AI-assisted. I reviewed the transport owners, dependency contracts, deterministic and live reproductions, focused tests, repository gates, and independent review findings.

Closes #125802

## What Problem This Solves

Successful provider streams could complete without reporting that the provider accepted the request.
Model diagnostics and plugin hooks could not distinguish a request that reached the provider from one that failed before acceptance.
Some wrappers also dropped the existing HTTP response callback.

## Why This Change Was Made

Provider acceptance is now one shared lifecycle fact across HTTP, SDK, and WebSocket transports.
Real HTTP paths report observed status and headers, while transports that cannot see HTTP metadata report only that the provider stream opened.

- Adds the additive `ProviderAcceptance` type and `onProviderAccepted` callback, with three lifecycle helpers on the supported `openclaw/plugin-sdk/provider-lifecycle` subpath.
- Centralizes HTTP acceptance, legacy `onResponse` delivery, abort handling, and unread-body cleanup in provider transport helpers.
- Converts Anthropic, Amazon Bedrock, Google, Mistral, Ollama, and OpenAI HTTP and WebSocket boundaries.
- Forwards both lifecycle callbacks through Anthropic Vertex and Bedrock Mantle.
- Records the acceptance kind in the canonical model-call diagnostic lifecycle without inferring acceptance from a legacy response callback.
- Keeps rejected HTTP responses on `onResponse` without marking them accepted.
- Cancels unread HTTP or SDK streams when lifecycle callbacks fail, without waiting on stalled cleanup.

Maintainer decision: Onur requested the complete remaining provider-acceptance work in one PR, including the additive Plugin SDK contract and diagnostic migration.

Dependency contracts were checked directly:

- Mistral SDK 2.5.0 exposes each real `Response` through the public `HTTPClient` response hook. Acceptance is emitted only after `chat.stream()` succeeds.
- Google Gen AI SDK 2.13.0 returns an opened async stream but does not expose a complete status-and-headers pair for streamed responses, so it reports `provider_stream_opened` without fabricated HTTP data.
- Codex WebSocket source at `openai/codex@d6ea5991e7f91eec5bad1fb4cb36f6be638878bc` sends `response.create`, rejects wrapped error events, and then forwards parsed provider events in `codex-rs/codex-api/src/endpoint/responses_websocket.rs:675-795`. OpenClaw reports acceptance on that first forwarded event before exposing it downstream.

## User Impact

Operators get truthful provider-acceptance diagnostics across the built-in transport families.
Plugin developers can observe successful non-HTTP streams without inventing an HTTP status, while existing HTTP response hooks keep their real status and headers.

No configuration, authentication, persistence, request payload, or database contract changes.

## Evidence

The original deterministic reproduction showed Mistral completing with `onResponse=0`, Anthropic Vertex and Bedrock Mantle dropping the callback, and OpenAI HTTP calling it once before `start`.
A live native Ollama run also completed with `onResponse=0` before the repair and with one acceptance plus one HTTP response callback after it.

Focused exact-branch tests:

```text
node scripts/run-vitest.mjs \
  packages/ai/src/transports/transport-stream-shared.acceptance.test.ts \
  extensions/ollama/src/stream-runtime.test.ts \
  extensions/amazon-bedrock/stream.runtime.test.ts \
  extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts \
  extensions/anthropic-vertex/stream-runtime.test.ts \
  extensions/google/transport-stream.test.ts \
  packages/ai/src/providers/google-shared.test.ts \
  packages/ai/src/providers/mistral.test.ts \
  packages/ai/src/providers/mistral.bounded-stream.test.ts \
  packages/ai/src/transports/anthropic-transport-stream.test.ts \
  packages/ai/src/transports/openai-completions-transport.response-hook.test.ts \
  packages/ai/src/transports/openai-responses-websocket-client.test.ts \
  packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts \
  packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts \
  packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts \
  src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
# 16 files passed, 691 tests passed

node scripts/check-changed.mjs --base upstream/main --timed
pnpm tsgo:prod
pnpm tsgo:test
pnpm plugin-sdk:surface:check
pnpm build
pnpm docs:check-mdx
pnpm docs:check-links
# passed

node scripts/check-changed.mjs --base upstream/main -- \
  packages/ai/src/transports/anthropic-transport-stream.ts \
  packages/ai/src/transports/anthropic-transport-stream.test.ts
# passed after the final Anthropic response-boundary repair

pi-reviewer --base upstream/main
# patch is correct; no findings
```

Production/tooling LOC: +430/-155 (net +275) | Tests: +828/-9 (net +819) | Docs: +3/-0.
The production growth establishes one public lifecycle contract, adapts the affected built-in transport families, and centralizes callback cancellation and response cleanup. Removing Ollama's local response-hook implementation offsets part of that growth.

## Risks

The main risk is callback ordering at provider boundaries.
Tests cover success, rejection, retries, first-event ordering, callback failure, aborts, wrapper forwarding, WebSocket state, and unread-stream cleanup.

The new Plugin SDK callback is optional and additive.
The existing `onResponse` callback remains the compatibility contract for paths with real HTTP metadata.

<!-- agent-transcript:start -->
## Agent transcript

<details>
<summary>Redacted agent session transcript</summary>

```text
source: local session
redaction: local paths, credentials, raw tool output, and environment details omitted

[user]
Reproduce the provider response hook issue on current upstream main. Use deterministic mocked provider clients. Cover a direct transport, a forwarding wrapper, and a working OpenAI control.

[assistant]
Confirmed. Mistral completed with onResponse=0; Anthropic Vertex and Bedrock Mantle did not forward the callback; OpenAI completed with onResponse=1 before start.

[user]
Can we use something other than Mistral?

[assistant]
Ollama is a better first direct transport because it owns the real HTTP Response and has no SDK ambiguity.

[user]
Ollama is logged in locally. Continue to verify.

[assistant]
Before the fix, native Ollama completed glm-5.2:cloud with text OK and onResponse=0.

[user]
Open the tracking issue, then autoimplement the pull request with the regression test.

[assistant]
Opened #125802. Added the initial provider-acceptance contract and deterministic coverage.

[user]
Autoimplement all remaining provider-acceptance work in one PR.

[assistant]
Reused the existing broad PR, rebased it onto current main, removed the duplicated Ollama hook path, completed the HTTP, SDK, WebSocket, wrapper, and diagnostic boundaries, and ran focused tests, changed gates, build checks, and independent review.
```

</details>
<!-- agent-transcript:end -->


