### PR TITLE
fix(gateway): settle hosted registry before QA route registration

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-hosted-web.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-hosted-web.e2e.test.ts
@@ -167,6 +167,9 @@ describe("Gateway hosted web surfaces", () => {
             controlUiEnabled: true,
             sidecarStartup: "defer",
           });
+          // Deferred startup replaces the bootstrap registry; register routes only after the
+          // server publishes the settled runtime so requests do not target a retired registry.
+          await server.startupSettled;
           const registry = getActivePluginRegistry();
           if (!registry) {
             throw new Error("gateway did not publish an active plugin registry");


### PR DESCRIPTION
## What Problem This Solves

Fixes the full-release repo E2E hosted-web scenario, which deterministically received route-level `404` for an invalid Canvas capability instead of exercising the registered route's `401` authentication response.

The failure was made visible by `6c027ad5e1f1` (#124309): deferred startup now returns before startup-plugin loading and exposes `startupSettled`. The scenario still captured and mutated the bootstrap plugin registry immediately, so deferred startup replaced that registry before the later capability requests.

## Why This Change Was Made

Wait for the Gateway's published `startupSettled` lifecycle handle before capturing the active registry and registering the hosted test routes. This keeps the deferred-start contract explicit and preserves the strict `401` assertion; it adds no retry, timeout, fallback, or production behavior change.

## User Impact

No user-visible runtime change. Full release validation now tests hosted Control UI, admin RPC, Canvas, and A2UI routes against the authoritative settled plugin registry.

Production LOC: +0/-0 (net 0) | Tests: +3/-0

## Evidence

- Known-good repo E2E at `16540e2b8859`: [run 31626760595 / job 94215788330](https://github.com/openclaw/openclaw/actions/runs/31626760595/job/94215788330) passed hosted-web in 853 ms while startup-plugin loading still settled before return.
- Pre-regression midpoint `860aeed8f672`: [run 32137635372 / job 95713349797](https://github.com/openclaw/openclaw/actions/runs/32137635372/job/95713349797) passed hosted-web in 1.367 s.
- Current behavior at `c94b673e46ee`: [run 32134707496 / job 95703950719](https://github.com/openclaw/openclaw/actions/runs/32134707496/job/95703950719) failed hosted-web with expected `401`, received `404`.
- Source/history proof: first-bad `6c027ad5e1f1` removed the pre-return `await startupPluginsResident.start()` and moved it behind deferred sidecar startup; `server.startupSettled` is the corresponding public completion handle.
- Exact head `a9a2eb12220ae82a72304f16e49bbf0debc9b7b1`: [GitHub repo-E2E proof 32139099095 / job 95718095696](https://github.com/openclaw/openclaw/actions/runs/32139099095/job/95718095696) passed the modified hosted-web scenario in 1.491 s. The terminal job failure came from an unrelated OTel evidence timeout and the unmodified recovery watchdog; the latter is covered by #125804.
- PR CI is terminal: 113 success, 43 skipped, no failures or pending checks; required `openclaw/ci-gate` passed.
- No local tests or builds were run, per the release-validation instruction.
