### PR TITLE
fix(models): Web UI provider probe fails for direct-credential providers

### DIFF
--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -13,6 +13,7 @@ import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   acquireAgentRunPreparedModelRuntime,
+  acquireReadOnlyPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
   loadPublishedGatewayReplyDispatchRuntime,
   loadPreparedModelRuntimeSnapshot,
@@ -152,6 +153,25 @@ describe("prepared model runtime owner selection", () => {
         allowGatewaySubagentBinding: true,
       }),
     ).rejects.toThrow("prepared model runtime owner was not published");
+  });
+
+  it("keeps a caller-pinned agent dir for isolated read-only leases on an active gateway", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+
+    // Run-provenance leases rebind a pinned agentDir to the committed configured
+    // owner; isolated read-only leases keep the pinned dir so synthetic probe
+    // credentials stay resolvable from that generation's auth store.
+    const lease = await acquireReadOnlyPreparedModelRuntime({
+      agentId: "default",
+      config,
+      agentDir: "/tmp/isolated-probe-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/isolated-probe-workspace",
+    });
+    expect(lease.snapshot.agentDir).toBe("/tmp/isolated-probe-agent");
+    lease.release();
   });
 
   it("publishes provider selections kept on the core runtime by request parameters", async () => {

--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -179,6 +179,7 @@ describe("runAuthProbes", () => {
         authProfileId?: string;
         authProfileIdSource?: string;
         config?: OpenClawConfig;
+        preparedModelRuntimeMode?: string;
       }): Promise<AgentRunResultView> => {
         if (params.agentHarnessRuntimeOverride !== "openclaw") {
           throw new Error(
@@ -262,6 +263,9 @@ describe("runAuthProbes", () => {
           authProfileIdSource: "user",
         }),
       );
+      // Profile targets reuse the committed configured generation: no isolated
+      // runtime mode is requested.
+      expect(runEmbeddedAgent.mock.calls[0]?.[0].preparedModelRuntimeMode).toBeUndefined();
 
       runEmbeddedAgent.mockResolvedValueOnce({
         payloads: [{ text: "LLM request timed out.", isError: true }],
@@ -308,6 +312,7 @@ describe("runAuthProbes", () => {
         authProfileId?: string;
         authProfileIdSource?: string;
         config?: OpenClawConfig;
+        preparedModelRuntimeMode?: string;
       }) => ({ payloads: [{ text: "OK" }] }),
     );
     vi.doMock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
@@ -386,6 +391,7 @@ describe("runAuthProbes", () => {
       );
       expect(configKeyCall?.[0].agentDir).not.toBe("/tmp/openclaw-probe-agent");
       expect(configKeyCall?.[0].authProfileIdSource).toBe("user");
+      expect(configKeyCall?.[0].preparedModelRuntimeMode).toBe("isolated-read-only");
       expect(configKeyCall?.[0].config).toMatchObject({
         models: {
           providers: {
@@ -421,7 +427,12 @@ describe("runAuthProbes", () => {
 
   it("isolates marker credentials from stored profiles without pinning a synthetic one", async () => {
     const runEmbeddedAgent = vi.fn(
-      async (_params: { agentDir?: string; authProfileId?: string; config?: OpenClawConfig }) => ({
+      async (_params: {
+        agentDir?: string;
+        authProfileId?: string;
+        config?: OpenClawConfig;
+        preparedModelRuntimeMode?: string;
+      }) => ({
         payloads: [{ text: "OK" }],
       }),
     );
@@ -490,6 +501,7 @@ describe("runAuthProbes", () => {
       const call = runEmbeddedAgent.mock.calls[0]?.[0];
       expect(call?.agentDir).not.toBe("/tmp/openclaw-probe-agent");
       expect(call?.agentDir).toContain("openclaw-auth-probe-");
+      expect(call?.preparedModelRuntimeMode).toBe("isolated-read-only");
       expect(call?.config?.auth?.order?.openai).toEqual([]);
       expect(call?.config?.models?.providers?.openai?.apiKey).toBe(
         cfg.models.providers.openai.apiKey,

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -75,14 +75,6 @@ export function redactAuthProbeError(error: string): string {
   return redactStatusSecrets(error);
 }
 
-const embeddedRunnerModuleLoader = createLazyImportLoader(
-  () => import("../../agents/embedded-agent.js"),
-);
-
-function loadEmbeddedRunnerModule() {
-  return embeddedRunnerModuleLoader.load();
-}
-
 /** Widened runner call shape for isolated auth probe generations (see setup-inference-core). */
 type ProbeRunEmbeddedAgentParams = Parameters<
   (typeof import("../../agents/embedded-agent.js"))["runEmbeddedAgent"]
@@ -93,6 +85,16 @@ type ProbeRunEmbeddedAgentParams = Parameters<
 type ProbeRunEmbeddedAgent = (
   params: ProbeRunEmbeddedAgentParams,
 ) => ReturnType<(typeof import("../../agents/embedded-agent.js"))["runEmbeddedAgent"]>;
+
+// The probe only calls runEmbeddedAgent; the widened loader type lets the call
+// request the isolated-read-only runtime generation without a call-site cast.
+const embeddedRunnerModuleLoader = createLazyImportLoader<{
+  runEmbeddedAgent: ProbeRunEmbeddedAgent;
+}>(() => import("../../agents/embedded-agent.js"));
+
+function loadEmbeddedRunnerModule() {
+  return embeddedRunnerModuleLoader.load();
+}
 
 /** Normalized probe status bucket for auth/model diagnostics. */
 export type AuthProbeStatus =
@@ -856,8 +858,7 @@ async function probeTarget(params: {
         throw new Error("Could not prepare isolated auth probe profile");
       }
     }
-    const runEmbeddedAgent = (await loadEmbeddedRunnerModule())
-      .runEmbeddedAgent as ProbeRunEmbeddedAgent;
+    const { runEmbeddedAgent } = await loadEmbeddedRunnerModule();
     preparedRunAdmission = prepareSystemAgentRunAdmission(
       probeConfig,
       runId,

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -83,6 +83,17 @@ function loadEmbeddedRunnerModule() {
   return embeddedRunnerModuleLoader.load();
 }
 
+/** Widened runner call shape for isolated auth probe generations (see setup-inference-core). */
+type ProbeRunEmbeddedAgentParams = Parameters<
+  (typeof import("../../agents/embedded-agent.js"))["runEmbeddedAgent"]
+>[0] & {
+  preparedModelRuntimeMode?: "isolated-read-only";
+};
+
+type ProbeRunEmbeddedAgent = (
+  params: ProbeRunEmbeddedAgentParams,
+) => ReturnType<(typeof import("../../agents/embedded-agent.js"))["runEmbeddedAgent"]>;
+
 /** Normalized probe status bucket for auth/model diagnostics. */
 export type AuthProbeStatus =
   | "ok"
@@ -808,7 +819,10 @@ async function probeTarget(params: {
     // Any bound-value target runs in an empty agent dir so stored profiles are
     // absent and cannot satisfy the probe via failover. Direct values pin a
     // synthetic profile; marker values are resolved by the runtime from the
-    // profile-order-cleared config.
+    // profile-order-cleared config. Inside a Gateway, the isolated-read-only
+    // runtime mode set on the runner call keeps this pinned generation
+    // authoritative: a run-provenance lease would rebind it to the committed
+    // configured owner and lose the synthetic profile.
     if (target.boundValue || target.useRuntimeAuth) {
       // Canonicalize so the isolated agent DB registers and unregisters under
       // one path. os.tmpdir() is a symlink on macOS (/var -> /private/var), and
@@ -842,7 +856,8 @@ async function probeTarget(params: {
         throw new Error("Could not prepare isolated auth probe profile");
       }
     }
-    const { runEmbeddedAgent } = await loadEmbeddedRunnerModule();
+    const runEmbeddedAgent = (await loadEmbeddedRunnerModule())
+      .runEmbeddedAgent as ProbeRunEmbeddedAgent;
     preparedRunAdmission = prepareSystemAgentRunAdmission(
       probeConfig,
       runId,
@@ -875,6 +890,10 @@ async function probeTarget(params: {
       disableTools: true,
       modelRun: true,
       cleanupBundleMcpOnRunEnd: true,
+      // Keep the isolated generation outside configured Gateway ownership: a
+      // run-provenance lease rebinds the pinned agentDir to the committed
+      // configured owner, losing the synthetic probe profile below.
+      ...(isolatedAgentDir ? { preparedModelRuntimeMode: "isolated-read-only" as const } : {}),
       abortSignal: params.abortSignal,
     })) as AgentRunResultView;
     const terminalError = extractAgentRunTerminalError(runResult);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users who configure a model provider with a direct credential (`models.providers.<id>.apiKey` or an environment variable like `DEEPSEEK_API_KEY`) would see the Web UI "test provider" probe fail with `Auth profile "<provider>:probe-<uuid>" is not configured for <provider>.`, even though normal agent chat with the same provider works. The same probe succeeds from the CLI, so the false failure only appears in the Gateway-served Settings → Model Providers flow.

Fixes #125745

## Why This Change Was Made

The probe pins a synthetic auth profile into a temporary isolated agent directory and passes that directory to `runEmbeddedAgent`. Inside a running Gateway, the run-provenance prepared-runtime lease rebinds the pinned agent directory to the committed configured owner's canonical directory, so the synthetic profile is no longer found when the auth plan validates the pinned profile id. The fix opts isolated probe targets (direct config keys, env credentials, and marker credentials) into the existing `preparedModelRuntimeMode: "isolated-read-only"` generation seam — the same one setup inference already uses for isolated probe runs — whose ephemeral provenance keeps the pinned directory and the probe config authoritative. Profile-based probe targets are unchanged and keep reusing the committed generation, so that path keeps its no-rebuild behavior.

## User Impact

Users with direct-credential providers (literal `apiKey`, environment variable, or marker reference) now get accurate reachability results from the Web UI provider probe instead of a false "connection probe failed". Marker credential probes also no longer risk being satisfied by an unrelated stored profile inside a Gateway.

## Evidence

### Before fix

The regression assertions added in `src/commands/models/list.probe.test.ts` fail against the pre-fix production code — the probe call does not request an isolated runtime generation:

```
 FAIL  |commands| src/commands/models/list.probe.test.ts > runAuthProbes > preserves provider config while suppressing profiles for a config-key target
AssertionError: expected undefined to be 'isolated-read-only' // Object.is equality
 FAIL  |commands| src/commands/models/list.probe.test.ts > runAuthProbes > isolates marker credentials from stored profiles without pinning a synthetic one
AssertionError: expected undefined to be 'isolated-read-only' // Object.is equality
 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
```

The issue's Gateway log shows the user-visible failure: `lane task error: ... error="Auth profile \"zte:probe-06ddb42e-...\" is not configured for zte."`

### After fix

Unit and boundary tests:

```
 ✓ |commands| src/commands/models/list.probe.test.ts (8 tests) — all pass
 ✓ |agents-core| src/agents/prepared-model-runtime.owner-selection.test.ts (23 tests) — all pass
```

- `tsgo:core` and `tsgo:core:test` pass.
- oxlint on the changed files: 0 warnings, 0 errors.
- `pnpm check:max-lines-ratchet --base origin/main`: OK.
- `pnpm check:import-cycles`: 0 runtime cycles.
- Assertion-safety ratchet: OK. The widened runner params are declared on the lazy loader type instead of a call-site cast, so the file stays at its grandfathered baseline.

### Real Gateway + Web UI proof (direct credential)

Live run on a dev Gateway with a real direct credential, exercising the exact issue-125745 flow (Web UI Settings → Model Providers → test provider). Credentials come from an environment variable and are not present in any output below.

Setup:

- Isolated state dir (`OPENCLAW_STATE_DIR=/tmp/openclaw-pr125816-proof`), Gateway on loopback port `19009`, auth mode `none` — the operator's real Gateway/state is never touched.
- Config: `models.providers.deepseek.apiKey = { "source": "env", "provider": "default", "id": "DEEPSEEK_API_KEY" }`, default model `deepseek/deepseek-v4-flash`.
- Gateway boot log: `[gateway] deepseek/deepseek-v4-flash model configured, enabled automatically.` → `http server listening … 6.4s`.

Flow: open the Control UI at `http://127.0.0.1:19009/settings/model-providers`, wait for the `deepseek` provider card, click **Test connection**, and observe the probe result.

Result — probe reported **Connected**:

```
PROBE_RESULT: "Connected 1896 ms Configured credential · deepseek/deepseek-v4-flash Connected · 1896 ms"
```

Gateway log for the same request — the `models.probe` RPC succeeds, and the log contains no `Auth profile … is not configured` error:

```
2026-08-19T02:16:44.262+08:00 [ws] ⇄ res ✓ models.probe 3300ms conn=480ced24…b513 id=461177ae…39e1
```

Initial state:

![Model Providers before probe](https://github.com/user-attachments/assets/cd4506cf-ed8f-4c69-b816-6a6830dc2cd0)

After clicking Test connection:

![Probe result: Connected](https://github.com/user-attachments/assets/1355f3f5-8c12-4e6b-964a-432ec163bdf3)

Screen recording of the full flow:

https://github.com/user-attachments/assets/7b5395e2-4e21-4b47-a9e8-57e27b456933

### CI notes

- `checks-fast-baseline-ratchets` failed on the first head (`list.probe.ts: 3 > 2` uncommented type assertions); fixed in 4185921f6de by typing the lazy loader instead of casting at the call site.
- `checks-node-changed-extensions-config-10` failed with a 120s timeout in `extensions/codex/src/app-server/run-attempt.test.ts` — a file this PR does not touch. Ran locally: 141/141 tests pass (122s), confirming an unrelated shard-loading flake.
