### PR TITLE
feat(canvas): present widgets on native device panels

### DIFF
--- a/docs/platforms/mac/canvas.md
+++ b/docs/platforms/mac/canvas.md
@@ -63,6 +63,8 @@ Gateway-hosted targets under `/__openclaw__/canvas/` and
 Canvas URL. The app refreshes that short-lived capability before navigation;
 you do not need to construct or copy a capability URL yourself.
 
+`show_widget` can target `node_panel` to open its hosted document in this panel. These widget documents are render-only in the panel; interactive widget actions remain disabled.
+
 ## A2UI in Canvas
 
 A2UI is hosted by the Gateway canvas host and rendered inside the Canvas

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -159,11 +159,14 @@ Use [`defineToolPlugin`](/plugins/tool-plugins) for simple tool-only plugins
 with fixed tool names. Use `api.registerTool(...)` directly for mixed plugins
 or fully dynamic tool registration.
 
-| Method                                 | What it registers                                                                                                                        |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `api.registerTool(tool, opts?)`        | Agent tool (required or `{ optional: true }`)                                                                                            |
-| `api.registerCommand(def)`             | Custom command (bypasses the LLM)                                                                                                        |
-| `api.registerNodeHostCommand(command)` | Command handled by `openclaw node run`; optional `agentTool` metadata can expose it as an agent-visible tool while the node is connected |
+| Method                                   | What it registers                                                                                                                        |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.registerTool(tool, opts?)`          | Agent tool (required or `{ optional: true }`)                                                                                            |
+| `api.registerCommand(def)`               | Custom command (bypasses the LLM)                                                                                                        |
+| `api.registerNodeHostCommand(command)`   | Command handled by `openclaw node run`; optional `agentTool` metadata can expose it as an agent-visible tool while the node is connected |
+| `api.registerWidgetPresenter(presenter)` | Destination that can present a hosted `show_widget` document                                                                             |
+
+Widget presenters declare a model-visible target, a short description, current availability, and a `present(...)` callback. Return the closed presentation result codes (`no_eligible_node` or `node_error`) instead of throwing for expected device failures; core then keeps the widget available inline and gives the agent a recovery step.
 
 Computer Use providers use `registerComputerUseProvider(api, provider)` from
 `openclaw/plugin-sdk/computer-use`. It registers the shared

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -105,9 +105,9 @@ The core result includes a Canvas preview handle, so the Control UI and supporte
 
 ## Show on a device
 
-When a widget presenter plugin is active, `presentation.target` also offers `node_panel`. OpenClaw creates the same hosted widget document, selects a connected Canvas-capable device, and opens its native panel at that document. The tool result names the selected device.
+When a widget presenter plugin is active, `presentation.target` also offers `node_panel`. OpenClaw creates the same hosted widget document, selects a connected macOS Canvas node, and opens its native panel at that document. The tool result names the selected Mac.
 
-If no eligible device is connected or the node command fails, the widget still appears inline in chat and the result explains how to recover. Pair a device or open the OpenClaw app, then retry. Widgets shown in a native panel are render-only in this first version; widget actions remain disabled there.
+If no eligible Mac is connected or the node command fails, the widget still appears inline in chat and the result explains how to recover. Pair a Mac running OpenClaw or open the macOS app, then retry. Widgets shown in a native panel are render-only in this first version; widget actions remain disabled there.
 
 ## Interactive widgets
 

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -95,12 +95,19 @@ The core Canvas tool accepts these optional dashboard placement fields:
 - `name`: stable widget name; defaults to a slug of `title`.
 - `tab`: destination tab slug.
 - `size`: one of `sm`, `md`, `lg`, `xl`, or `full`.
+- `presentation.frame`: pinned dashboard frame: `card`, `full-bleed`, or `frameless`.
 - `after`: sibling widget name after which to place the widget.
 - `capabilities`: access requested by a pinned widget. `netOrigins` contains exact HTTPS origins; `tools` contains `prompt`, an allowlisted read binding, or an exact `cron.trigger:<jobId>` action.
 
 The core result includes a Canvas preview handle, so the Control UI and supported native apps render the widget directly from the tool call and restore it after history reload. Pinned results also retain the board widget name so the Control UI does not offer a duplicate pin after transcript reload. Discord returns the stored widget and posted-message identifiers.
 
 `discord_widget` remains registered as a deprecated alias for one release. New agent calls should use `show_widget`.
+
+## Show on a device
+
+When a widget presenter plugin is active, `presentation.target` also offers `node_panel`. OpenClaw creates the same hosted widget document, selects a connected Canvas-capable device, and opens its native panel at that document. The tool result names the selected device.
+
+If no eligible device is connected or the node command fails, the widget still appears inline in chat and the result explains how to recover. Pair a device or open the OpenClaw app, then retry. Widgets shown in a native panel are render-only in this first version; widget actions remain disabled there.
 
 ## Interactive widgets
 

--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -65,6 +65,7 @@ function registerCanvas(config: OpenClawPluginApi["config"] = {}) {
   const routes: Array<Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]> = [];
   const services: Array<Parameters<OpenClawPluginApi["registerService"]>[0]> = [];
   const resolvers: Array<Parameters<OpenClawPluginApi["registerHostedMediaResolver"]>[0]> = [];
+  const widgetPresenters: Array<Parameters<OpenClawPluginApi["registerWidgetPresenter"]>[0]> = [];
   const tools: Array<{
     tool: Parameters<OpenClawPluginApi["registerTool"]>[0];
     opts: Parameters<OpenClawPluginApi["registerTool"]>[1];
@@ -86,6 +87,7 @@ function registerCanvas(config: OpenClawPluginApi["config"] = {}) {
       registerHttpRoute: (route) => routes.push(route),
       registerService: (service) => services.push(service),
       registerHostedMediaResolver: (resolver) => resolvers.push(resolver),
+      registerWidgetPresenter: (presenter) => widgetPresenters.push(presenter),
       registerTool: (tool, opts) => tools.push({ tool, opts }),
       registerNodeCliFeature: (registrar, opts) => cliFeatures.push({ registrar, opts }),
       registerNodeInvokePolicy: (policy) => nodeInvokePolicies.push(policy),
@@ -96,6 +98,7 @@ function registerCanvas(config: OpenClawPluginApi["config"] = {}) {
     routes,
     services,
     resolvers,
+    widgetPresenters,
     tools,
     cliFeatures,
     nodeInvokePolicies,
@@ -122,7 +125,7 @@ describe("Canvas plugin entry", () => {
   });
 
   it("allowlists Canvas on every native node platform, including Linux", () => {
-    const { nodeInvokePolicies } = registerCanvas();
+    const { nodeInvokePolicies, widgetPresenters } = registerCanvas();
 
     expect(nodeInvokePolicies[0]?.defaultPlatforms).toEqual([
       "ios",
@@ -132,10 +135,18 @@ describe("Canvas plugin entry", () => {
       "linux",
       "unknown",
     ]);
+    expect(widgetPresenters).toEqual([
+      expect.objectContaining({
+        target: "node_panel",
+        description: "Show on a connected device panel",
+        availability: expect.any(Function),
+        present: expect.any(Function),
+      }),
+    ]);
   });
 
   it("registers A2UI board content while the Canvas file host is disabled", () => {
-    const { boardWidgetContentKinds, routes } = registerCanvas({
+    const { boardWidgetContentKinds, routes, widgetPresenters } = registerCanvas({
       plugins: { entries: { canvas: { config: { host: { enabled: false } } } } },
     });
 
@@ -143,6 +154,7 @@ describe("Canvas plugin entry", () => {
       expect.objectContaining({ kind: "a2ui", label: "A2UI" }),
     ]);
     expect(routes.map((route) => route.path)).toEqual(["/__openclaw__/a2ui"]);
+    expect(widgetPresenters).toEqual([]);
   });
 
   it("defers Canvas host implementation until a registered route is used", async () => {

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -14,6 +14,7 @@ import { canvasA2UIBoardWidgetKind } from "./src/board-widget.js";
 import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
 import { CanvasToolSchema } from "./src/tool-schema.js";
+import { createCanvasWidgetPresenter } from "./src/widget-presenter.js";
 
 const CANVAS_NODE_COMMANDS = [
   "canvas.present",
@@ -106,6 +107,7 @@ export default definePluginEntry({
         handler: handleHttpRequest,
         handleUpgrade,
       });
+      api.registerWidgetPresenter(createCanvasWidgetPresenter(api.runtime.nodes));
     }
     api.registerService({
       id: "canvas-host",

--- a/extensions/canvas/src/widget-presenter.test.ts
+++ b/extensions/canvas/src/widget-presenter.test.ts
@@ -1,0 +1,102 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createCanvasWidgetPresenter } from "./widget-presenter.js";
+
+const commands = ["canvas.present", "canvas.navigate"];
+
+function createNodesRuntime(
+  nodes: Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"],
+): PluginRuntime["nodes"] {
+  return {
+    list: vi.fn(async () => ({ nodes })),
+    invoke: vi.fn(async () => ({ ok: true })),
+  };
+}
+
+describe("Canvas widget presenter", () => {
+  it("prefers the existing local Mac default and invokes present before navigate", async () => {
+    const runtime = createNodesRuntime([
+      {
+        nodeId: "android-recent",
+        displayName: "Android",
+        platform: "android",
+        connected: true,
+        connectedAtMs: 20,
+        caps: ["canvas"],
+        invocableCommands: commands,
+      },
+      {
+        nodeId: "mac-local",
+        displayName: "Studio",
+        platform: "macos",
+        connected: true,
+        connectedAtMs: 10,
+        caps: ["canvas"],
+        invocableCommands: commands,
+      },
+    ]);
+    const presenter = createCanvasWidgetPresenter(runtime);
+
+    await expect(
+      presenter.present({
+        documentUrlPath: "/__openclaw__/canvas/documents/cv_1/index.html",
+        title: "Status",
+        sessionContext: { sessionKey: "agent:main:status" },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: { nodeId: "mac-local", nodeName: "Studio" },
+    });
+    expect(runtime.invoke).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        nodeId: "mac-local",
+        command: "canvas.present",
+        params: {},
+        sessionKey: "agent:main:status",
+        idempotencyKey: expect.any(String),
+      }),
+    );
+    expect(runtime.invoke).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        nodeId: "mac-local",
+        command: "canvas.navigate",
+        params: { url: "/__openclaw__/canvas/documents/cv_1/index.html" },
+        sessionKey: "agent:main:status",
+        idempotencyKey: expect.any(String),
+      }),
+    );
+  });
+
+  it("maps missing eligible nodes and node invocation failures", async () => {
+    const unavailable = createCanvasWidgetPresenter(
+      createNodesRuntime([{ nodeId: "offline", connected: false, caps: ["canvas"], commands }]),
+    );
+    await expect(unavailable.availability({})).resolves.toMatchObject({
+      ok: false,
+      error: { code: "no_eligible_node" },
+    });
+
+    const runtime = createNodesRuntime([
+      {
+        nodeId: "mac-panel",
+        connected: true,
+        caps: ["canvas"],
+        invocableCommands: commands,
+      },
+    ]);
+    vi.mocked(runtime.invoke).mockRejectedValueOnce(new Error("panel disabled"));
+    const presenter = createCanvasWidgetPresenter(runtime);
+    await expect(
+      presenter.present({
+        documentUrlPath: "/__openclaw__/canvas/documents/cv_2/index.html",
+        title: "Status",
+        sessionContext: {},
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: "node_error", message: "panel disabled", nodeId: "mac-panel" },
+    });
+  });
+});

--- a/extensions/canvas/src/widget-presenter.test.ts
+++ b/extensions/canvas/src/widget-presenter.test.ts
@@ -71,7 +71,15 @@ describe("Canvas widget presenter", () => {
 
   it("maps missing eligible nodes and node invocation failures", async () => {
     const unavailable = createCanvasWidgetPresenter(
-      createNodesRuntime([{ nodeId: "offline", connected: false, caps: ["canvas"], commands }]),
+      createNodesRuntime([
+        {
+          nodeId: "offline",
+          platform: "macos",
+          connected: false,
+          caps: ["canvas"],
+          commands,
+        },
+      ]),
     );
     await expect(unavailable.availability({})).resolves.toMatchObject({
       ok: false,
@@ -81,6 +89,7 @@ describe("Canvas widget presenter", () => {
     const runtime = createNodesRuntime([
       {
         nodeId: "mac-panel",
+        platform: "macos",
         connected: true,
         caps: ["canvas"],
         invocableCommands: commands,
@@ -98,5 +107,34 @@ describe("Canvas widget presenter", () => {
       ok: false,
       error: { code: "node_error", message: "panel disabled", nodeId: "mac-panel" },
     });
+  });
+
+  it("rejects Linux nodes that cannot resolve hosted document paths", async () => {
+    const runtime = createNodesRuntime([
+      {
+        nodeId: "linux-panel",
+        platform: "linux",
+        connected: true,
+        caps: ["canvas"],
+        invocableCommands: commands,
+      },
+    ]);
+    const presenter = createCanvasWidgetPresenter(runtime);
+
+    await expect(presenter.availability({})).resolves.toMatchObject({
+      ok: false,
+      error: { code: "no_eligible_node" },
+    });
+    await expect(
+      presenter.present({
+        documentUrlPath: "/__openclaw__/canvas/documents/cv_linux/index.html",
+        title: "Status",
+        sessionContext: {},
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "no_eligible_node" },
+    });
+    expect(runtime.invoke).not.toHaveBeenCalled();
   });
 });

--- a/extensions/canvas/src/widget-presenter.ts
+++ b/extensions/canvas/src/widget-presenter.ts
@@ -16,6 +16,9 @@ function isEligibleCanvasNode(node: CanvasRuntimeNode): boolean {
     node.caps?.includes("canvas") === true ||
     commands.some((command) => command.startsWith("canvas."));
   return (
+    // macOS is the only panel whose resolver handles hosted document paths;
+    // other platforms' Canvas surfaces are being retired.
+    node.platform === "macos" &&
     node.connected === true &&
     hasCanvasCapability &&
     REQUIRED_WIDGET_COMMANDS.every((command) => commands.includes(command))

--- a/extensions/canvas/src/widget-presenter.ts
+++ b/extensions/canvas/src/widget-presenter.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import { selectDefaultNodeFromList } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+
+const REQUIRED_WIDGET_COMMANDS = ["canvas.present", "canvas.navigate"] as const;
+const DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS = 30_000;
+
+type CanvasRuntimeNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
+type WidgetPresenter = Parameters<OpenClawPluginApi["registerWidgetPresenter"]>[0];
+
+function isEligibleCanvasNode(node: CanvasRuntimeNode): boolean {
+  const commands = node.invocableCommands ?? node.commands ?? [];
+  const hasCanvasCapability =
+    node.caps?.includes("canvas") === true ||
+    commands.some((command) => command.startsWith("canvas."));
+  return (
+    node.connected === true &&
+    hasCanvasCapability &&
+    REQUIRED_WIDGET_COMMANDS.every((command) => commands.includes(command))
+  );
+}
+
+async function selectCanvasNode(
+  nodesRuntime: PluginRuntime["nodes"],
+): Promise<CanvasRuntimeNode | null> {
+  const { nodes } = await nodesRuntime.list({ connected: true });
+  return selectDefaultNodeFromList(nodes.filter(isEligibleCanvasNode), {
+    capability: "canvas",
+    fallback: "first",
+    preferLocalMac: true,
+  });
+}
+
+/** Creates the Canvas-owned presenter for hosted widget documents. */
+export function createCanvasWidgetPresenter(nodesRuntime: PluginRuntime["nodes"]): WidgetPresenter {
+  return {
+    target: "node_panel",
+    description: "Show on a connected device panel",
+    async availability() {
+      try {
+        const node = await selectCanvasNode(nodesRuntime);
+        return node
+          ? { ok: true, value: { available: true } }
+          : {
+              ok: false,
+              error: {
+                code: "no_eligible_node",
+                message: "No connected canvas-capable device is available.",
+              },
+            };
+      } catch (error) {
+        return {
+          ok: false,
+          error: { code: "node_error", message: formatErrorMessage(error) },
+        };
+      }
+    },
+    async present({ documentUrlPath, sessionContext }) {
+      let node: CanvasRuntimeNode | null;
+      try {
+        node = await selectCanvasNode(nodesRuntime);
+      } catch (error) {
+        return {
+          ok: false,
+          error: { code: "node_error", message: formatErrorMessage(error) },
+        };
+      }
+      if (!node) {
+        return {
+          ok: false,
+          error: {
+            code: "no_eligible_node",
+            message: "No connected canvas-capable device is available.",
+          },
+        };
+      }
+      try {
+        const invoke = (command: string, params?: Record<string, unknown>) =>
+          nodesRuntime.invoke({
+            nodeId: node.nodeId,
+            command,
+            params,
+            timeoutMs: DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS,
+            idempotencyKey: randomUUID(),
+            ...(sessionContext.sessionKey ? { sessionKey: sessionContext.sessionKey } : {}),
+          });
+        await invoke("canvas.present", {});
+        await invoke("canvas.navigate", { url: documentUrlPath });
+        return {
+          ok: true,
+          value: {
+            nodeId: node.nodeId,
+            ...(node.displayName ? { nodeName: node.displayName } : {}),
+          },
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: {
+            code: "node_error",
+            message: formatErrorMessage(error),
+            nodeId: node.nodeId,
+          },
+        };
+      }
+    },
+  };
+}

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -446,12 +446,11 @@ export function createOpenClawTools(
       allowlist: explicitFactoryAllowlist,
       denylist: explicitFactoryDenylist,
     });
-  const effectiveCallGateway = embedded ? createEmbeddedCallGateway() : callAgentToolGatewayRequest;
   const sessionLookupToolOptions = {
     agentSessionKey: options?.agentSessionKey,
     sandboxed: options?.sandboxed,
     config: resolvedConfig,
-    callGateway: effectiveCallGateway,
+    callGateway: embedded ? createEmbeddedCallGateway() : callAgentToolGatewayRequest,
     sessionLinkBase: resolveControlUiSessionLinkBase(resolvedConfig),
   };
   const progressCardTool = shouldIncludeProgressCardToolForOpenClawTools({

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -255,9 +255,7 @@ export function createOpenClawTools(
       ? undefined
       : resolveAgentWorkspaceDir(resolvedConfig, sessionAgentId);
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir ?? inferredWorkspaceDir);
-  const spawnWorkspaceDir = resolveWorkspaceRoot(
-    options?.spawnWorkspaceDir ?? options?.workspaceDir ?? inferredWorkspaceDir,
-  );
+  const spawnWorkspaceDir = resolveWorkspaceRoot(options?.spawnWorkspaceDir ?? workspaceDir);
   options?.recordToolPrepStage?.("openclaw-tools:session-workspace");
   const deliveryContext = normalizeDeliveryContext({
     channel: options?.agentChannel,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -12,6 +12,7 @@ import { selectApplicableRuntimeConfig } from "../config/config.js";
 import { resolveControlUiSessionLinkBase } from "../config/control-ui-link-base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
+import { resolveWidgetPresenters } from "../plugins/widget-presenters.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadataFromState } from "../secrets/runtime-web-tools-state.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
@@ -549,6 +550,7 @@ export function createOpenClawTools(
             agentId: sessionAgentId,
             agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
             inlineHostEnabled: isCoreCanvasHostEnabled(resolvedConfig),
+            presenters: resolveWidgetPresenters().map((registration) => registration.presenter),
           }),
         ]),
     ...collectPresentOpenClawTools([heartbeatTool]),

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -10,6 +10,7 @@ import { createBoardHandlers } from "../gateway/server-methods/board.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
 import { createPluginBoardWidgetContentKindRegistrar } from "../plugins/board-widget-content-kinds.js";
 import { createPluginRecord } from "../plugins/loader-records.js";
+import type { WidgetPresenter } from "../plugins/plugin-registration.types.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -102,7 +103,11 @@ async function executeWidget(params: {
   name?: string;
   tab?: string;
   size?: "sm" | "md" | "lg" | "xl" | "full";
-  presentation?: "card" | "full-bleed" | "frameless";
+  presentation?: {
+    target?: "assistant_message" | "node_panel";
+    frame?: "card" | "full-bleed" | "frameless";
+  };
+  presenters?: readonly WidgetPresenter[];
   after?: string;
   capabilities?: { netOrigins?: string[]; tools?: string[] };
   kind?: string;
@@ -113,6 +118,7 @@ async function executeWidget(params: {
     agentId: "main",
     agentSessionKey: params.agentSessionKey,
     callGateway: params.callGateway,
+    presenters: params.presenters,
   });
   const result = await tool.execute("widget-call", {
     title: params.title ?? "Widget title",
@@ -147,6 +153,7 @@ async function executeWidget(params: {
     sandbox: parsed.presentation?.sandbox,
     resultText: parsed.text,
     boardWidgetName: parsed.view?.boardWidgetName,
+    target: parsed.presentation?.target,
     text,
   };
 }
@@ -249,20 +256,163 @@ describe("show_widget", () => {
     expect(description).toContain("do not repeat the title");
   });
 
-  it("uses flat provider-safe enums for dashboard options", () => {
+  it("builds provider-safe kind and presentation enums from both registries", () => {
+    registerDiagramContentKind();
     const tool = createShowWidgetTool();
     const properties = (
       tool.parameters as {
-        properties?: Record<string, { anyOf?: unknown; enum?: string[] }>;
+        properties?: Record<
+          string,
+          {
+            anyOf?: unknown;
+            enum?: string[];
+            properties?: Record<string, { anyOf?: unknown; enum?: string[]; description?: string }>;
+          }
+        >;
       }
     ).properties;
+    expect(properties?.kind).toMatchObject({ enum: ["html", "diagram"] });
     expect(properties?.size).toMatchObject({ enum: ["sm", "md", "lg", "xl", "full"] });
-    expect(properties?.presentation).toMatchObject({
+    expect(properties?.presentation?.properties?.target).toMatchObject({
+      enum: ["assistant_message"],
+    });
+    expect(properties?.presentation?.properties?.target?.description).not.toContain("node_panel");
+    expect(properties?.presentation?.properties?.frame).toMatchObject({
       enum: ["card", "full-bleed", "frameless"],
     });
     expect(properties?.size?.anyOf).toBeUndefined();
-    expect(properties?.presentation?.anyOf).toBeUndefined();
+    expect(properties?.presentation?.properties?.target?.anyOf).toBeUndefined();
+    expect(properties?.presentation?.properties?.frame?.anyOf).toBeUndefined();
+    expect(tool.description).toContain("registered kinds are diagram");
+
+    const presenter: WidgetPresenter = {
+      target: "node_panel",
+      description: "Show on a connected device panel",
+      availability: async () => ({ ok: true, value: { available: true } }),
+      present: async () => ({
+        ok: true,
+        value: { nodeId: "mac-panel", nodeName: "Studio" },
+      }),
+    };
+    const withPresenterTool = createShowWidgetTool({ presenters: [presenter] });
+    const withPresenter = withPresenterTool.parameters as {
+      properties?: Record<
+        string,
+        {
+          enum?: string[];
+          properties?: Record<string, { enum?: string[]; description?: string }>;
+        }
+      >;
+    };
+    expect(withPresenter.properties?.kind).toMatchObject({ enum: ["html", "diagram"] });
+    expect(withPresenter.properties?.presentation?.properties?.target).toMatchObject({
+      enum: ["assistant_message", "node_panel"],
+      description: expect.stringContaining("node_panel: Show on a connected device panel"),
+    });
+    expect(withPresenterTool.description).toContain("registered kinds are diagram");
+    expect(withPresenterTool.description).toContain(
+      "Use presentation.target to choose a registered device surface.",
+    );
   });
+
+  it("routes node-panel presentation and reports the selected device", async () => {
+    const stateDir = await createStateDir();
+    const availability = vi.fn(async () => ({
+      ok: true as const,
+      value: { available: true as const },
+    }));
+    const present = vi.fn(async () => ({
+      ok: true as const,
+      value: { nodeId: "mac-panel", nodeName: "Studio" },
+    }));
+    const result = await executeWidget({
+      stateDir,
+      title: "Status",
+      widgetCode: "<p>ready</p>",
+      agentSessionKey: "agent:main:status",
+      presentation: { target: "node_panel" },
+      presenters: [
+        {
+          target: "node_panel",
+          description: "Show on a connected device panel",
+          availability,
+          present,
+        },
+      ],
+    });
+
+    expect(result.target).toBe("node_panel");
+    expect(result.resultText).toContain("presented on Studio (mac-panel)");
+    expect(availability).toHaveBeenCalledWith({ sessionKey: "agent:main:status" });
+    expect(present).toHaveBeenCalledWith({
+      documentUrlPath: result.url,
+      title: "Status",
+      sessionContext: { sessionKey: "agent:main:status" },
+    });
+  });
+
+  it.each([
+    {
+      name: "has no registered presenter",
+      presenters: [] as WidgetPresenter[],
+      expected: "No widget presenter is registered",
+    },
+    {
+      name: "has no eligible node",
+      presenters: [
+        {
+          target: "node_panel" as const,
+          description: "Show on a connected device panel",
+          availability: async () => ({
+            ok: false as const,
+            error: { code: "no_eligible_node" as const, message: "No connected device." },
+          }),
+          present: async () => {
+            throw new Error("present must not run");
+          },
+        },
+      ],
+      expected: "No connected device.",
+    },
+    {
+      name: "hits a node error",
+      presenters: [
+        {
+          target: "node_panel" as const,
+          description: "Show on a connected device panel",
+          availability: async () => ({ ok: true as const, value: { available: true as const } }),
+          present: async () => ({
+            ok: false as const,
+            error: {
+              code: "node_error" as const,
+              message: "Canvas is disabled.",
+              nodeId: "mac-panel",
+            },
+          }),
+        },
+      ],
+      expected: "Canvas is disabled.",
+    },
+  ])(
+    "falls back inline with an actionable message when node presentation $name",
+    async ({ presenters, expected }) => {
+      const stateDir = await createStateDir();
+      const result = await executeWidget({
+        stateDir,
+        widgetCode: "<p>inline fallback</p>",
+        presentation: { target: "node_panel" },
+        presenters,
+      });
+
+      expect(result.target).toBe("assistant_message");
+      expect(result.resultText).toContain(expected);
+      expect(result.resultText).toContain("available inline here");
+      expect(result.resultText).toMatch(/Pair a canvas-capable device|Open the OpenClaw app/u);
+      await expect(
+        access(resolveCanvasDocumentDir(stateDir, result.viewId)),
+      ).resolves.toBeUndefined();
+    },
+  );
 
   it("keeps the wrapped document bytes stable", () => {
     const html = buildWidgetDocument(
@@ -470,7 +620,7 @@ describe("show_widget", () => {
       name: "release-status",
       tab: "main",
       size: "lg",
-      presentation: "frameless",
+      presentation: { frame: "frameless" },
       callGateway,
     });
     const pinnedTitle = Array.from(title).slice(0, 80).join("");

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -1,5 +1,6 @@
 /** Agent-facing inline chat widget tool. */
 import { createHash } from "node:crypto";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { Type } from "typebox";
 import type { BoardWidgetPutResult } from "../../packages/gateway-protocol/src/index.js";
 import { optionalStringEnum } from "../agents/schema/string-enum.js";
@@ -9,11 +10,18 @@ import {
   type InProcessGatewayCaller,
 } from "../agents/tools/in-process-gateway.js";
 import { normalizeBoardWidgetDeclared } from "../boards/board-capabilities.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { assertWidgetHtmlSize, WidgetHtmlInputError } from "../plugin-sdk/widget-html.js";
 import {
   listBoardWidgetContentKinds,
   resolveBoardWidgetContentKind,
 } from "../plugins/board-widget-content-kinds.js";
+import type {
+  WidgetPresentationError,
+  WidgetPresentationSuccess,
+  WidgetPresenter,
+  WidgetPresenterTarget,
+} from "../plugins/plugin-registration.types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createCanvasDocument } from "./documents.js";
@@ -32,7 +40,15 @@ export function hasRegisteredShowWidgetKinds(): boolean {
   return listBoardWidgetContentKinds(currentPluginRegistry()).length > 0;
 }
 
-function showWidgetToolSchema(kinds: readonly string[]) {
+function createShowWidgetToolSchema(
+  kinds: readonly string[],
+  presenters: readonly WidgetPresenter[],
+) {
+  const presenterTargets = presenters.map((presenter) => presenter.target);
+  const targets = ["assistant_message", ...presenterTargets] as const;
+  const presenterDescriptions = presenters.map(
+    (presenter) => `${presenter.target}: ${presenter.description}`,
+  );
   return Type.Object({
     title: Type.String(),
     widget_code: Type.String(),
@@ -54,9 +70,19 @@ function showWidgetToolSchema(kinds: readonly string[]) {
     size: optionalStringEnum(["sm", "md", "lg", "xl", "full"] as const, {
       description: "Dashboard size: sm, md, lg, xl, or full",
     }),
-    presentation: optionalStringEnum(["card", "full-bleed", "frameless"] as const, {
-      description: "Pinned dashboard frame: card, full-bleed, or frameless",
-    }),
+    presentation: Type.Optional(
+      Type.Object({
+        target: optionalStringEnum(targets, {
+          description: [
+            "Where to show the widget. assistant_message: inline in chat",
+            ...presenterDescriptions,
+          ].join("; "),
+        }),
+        frame: optionalStringEnum(["card", "full-bleed", "frameless"] as const, {
+          description: "Pinned dashboard frame: card, full-bleed, or frameless",
+        }),
+      }),
+    ),
     after: Type.Optional(
       Type.String({
         pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
@@ -88,7 +114,64 @@ type ShowWidgetToolOptions = {
   stateDir?: string;
   callGateway?: InProcessGatewayCaller;
   inlineHostEnabled?: boolean;
+  presenters?: readonly WidgetPresenter[];
 };
+
+type WidgetPresentationAttempt =
+  | { ok: true; value: WidgetPresentationSuccess }
+  | { ok: false; error: WidgetPresentationError };
+
+async function presentWidget(params: {
+  presenters: readonly WidgetPresenter[];
+  target: WidgetPresenterTarget;
+  documentUrlPath: string;
+  title: string;
+  sessionKey?: string;
+}): Promise<WidgetPresentationAttempt> {
+  const presenters = params.presenters.filter((presenter) => presenter.target === params.target);
+  let lastError: WidgetPresentationError = {
+    code: "no_eligible_node",
+    message: "No widget presenter is registered for this target.",
+  };
+  for (const presenter of presenters) {
+    const sessionContext = params.sessionKey ? { sessionKey: params.sessionKey } : {};
+    let availability: Awaited<ReturnType<WidgetPresenter["availability"]>>;
+    try {
+      availability = await presenter.availability(sessionContext);
+    } catch (error) {
+      lastError = { code: "node_error", message: formatErrorMessage(error) };
+      continue;
+    }
+    if (!availability.ok) {
+      lastError = availability.error;
+      continue;
+    }
+    let result: Awaited<ReturnType<WidgetPresenter["present"]>>;
+    try {
+      result = await presenter.present({
+        documentUrlPath: params.documentUrlPath,
+        title: params.title,
+        sessionContext,
+      });
+    } catch (error) {
+      lastError = { code: "node_error", message: formatErrorMessage(error) };
+      continue;
+    }
+    if (result.ok) {
+      return result;
+    }
+    lastError = result.error;
+  }
+  return { ok: false, error: lastError };
+}
+
+function widgetPresentationFailureText(error: WidgetPresentationError): string {
+  const nextStep =
+    error.code === "no_eligible_node"
+      ? "Pair a canvas-capable device or open the OpenClaw app, then retry."
+      : "Open the OpenClaw app and retry.";
+  return `${error.message} The widget is available inline here. ${nextStep}`;
+}
 
 function slugWidgetName(title: string): string {
   const slug = title
@@ -141,11 +224,14 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
   const inlineHostEnabled = options.inlineHostEnabled !== false;
   const registeredKinds = listBoardWidgetContentKinds(currentPluginRegistry());
   const kinds = ["html", ...registeredKinds] as const;
+  const presenters = options.presenters ?? [];
+  const presenterPrompt =
+    presenters.length > 0 ? " Use presentation.target to choose a registered device surface." : "";
   return {
     label: "Show Widget",
     name: "show_widget",
-    description: `Visual helps? Make widget. Do not wait for ask. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. Show a widget on the user's current surface; kind defaults to html${registeredKinds.length ? ` and registered kinds are ${registeredKinds.join(", ")}` : ""}. ${inlineHostEnabled ? "Set pin=true to also place it on this session's dashboard" : "Inline hosting is disabled; set pin=true to place it on this session's dashboard"}; use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), and openclaw.cron.trigger(jobId). \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.`,
-    parameters: showWidgetToolSchema(kinds),
+    description: `Visual helps? Make widget. Do not wait for ask. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. Show a widget on the user's current surface; kind defaults to html${registeredKinds.length ? ` and registered kinds are ${registeredKinds.join(", ")}` : ""}. ${inlineHostEnabled ? "Set pin=true to also place it on this session's dashboard" : "Inline hosting is disabled; set pin=true to place it on this session's dashboard"}; use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation.frame card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), and openclaw.cron.trigger(jobId). \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.${presenterPrompt}`,
+    parameters: createShowWidgetToolSchema(kinds, presenters),
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -174,6 +260,9 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         throw new WidgetHtmlInputError("pin requires an agent session");
       }
       const widgetCode = rawWidgetCode.trim();
+      const presentation = asOptionalRecord(params.presentation);
+      const requestedTarget =
+        readToolStringParam(presentation ?? {}, "target") ?? "assistant_message";
       const registration =
         kind === "html" ? undefined : resolveBoardWidgetContentKind(currentPluginRegistry(), kind);
       if (kind !== "html" && !registration) {
@@ -220,7 +309,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         const name = explicitName ?? slugWidgetName(title);
         const tab = readToolStringParam(params, "tab");
         const size = readToolStringParam(params, "size");
-        const presentation = readToolStringParam(params, "presentation");
+        const frame = readToolStringParam(presentation ?? {}, "frame");
         const after = readToolStringParam(params, "after");
         const pinnedTitle = boardWidgetTitle(title);
         if (!registration) {
@@ -239,7 +328,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           content: registration
             ? { kind: "registered", contentKind: kind, source: widgetCode }
             : { kind: "html", html: widgetCode },
-          ...(presentation ? { presentation } : {}),
+          ...(frame ? { presentation: frame } : {}),
           ...(capabilities ? { declared: capabilities } : {}),
           ...(!explicitName ? { generatedIdentity: generatedWidgetIdentity(title, name) } : {}),
           ...(tab || size || after
@@ -284,15 +373,37 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           maxDocumentsPerScope: WIDGET_MAX_PER_SCOPE,
         },
       );
+      const presentationAttempt =
+        requestedTarget === "node_panel"
+          ? await presentWidget({
+              presenters,
+              target: requestedTarget,
+              documentUrlPath: document.entryUrl,
+              title,
+              sessionKey: options.agentSessionKey,
+            })
+          : undefined;
+      const presented = presentationAttempt?.ok ? presentationAttempt.value : undefined;
+      const target = presented ? "node_panel" : "assistant_message";
+      const presentationText = presentationAttempt?.ok
+        ? `; presented on ${presentationAttempt.value.nodeName ?? presentationAttempt.value.nodeId} (${presentationAttempt.value.nodeId})`
+        : presentationAttempt
+          ? `; ${widgetPresentationFailureText(presentationAttempt.error)}`
+          : "";
       return jsonResult({
         kind: "canvas",
-        presentation: { target: "assistant_message", title, sandbox: "scripts" },
+        presentation: {
+          target,
+          title,
+          sandbox: "scripts",
+          ...(presented ? { node: { id: presented.nodeId, name: presented.nodeName } } : {}),
+        },
         view: {
           id: document.id,
           url: document.entryUrl,
           ...(pinnedWidgetName ? { boardWidgetName: pinnedWidgetName } : {}),
         },
-        text: `Widget hosted at ${document.entryUrl}${pinnedText ? `; ${pinnedText}` : ""}`,
+        text: `Widget hosted at ${document.entryUrl}${pinnedText ? `; ${pinnedText}` : ""}${presentationText}`,
       });
     },
   };

--- a/src/chat/canvas-render.test.ts
+++ b/src/chat/canvas-render.test.ts
@@ -22,6 +22,18 @@ describe("extractCanvasFromText", () => {
     ).toMatchObject({ viewId: "cv_status", boardWidgetName: "release-status" });
   });
 
+  it("preserves node-panel presentation metadata", () => {
+    expect(
+      extractCanvasFromText(
+        JSON.stringify({
+          kind: "canvas",
+          presentation: { target: "node_panel", title: "Status" },
+          view: { id: "cv_status", url: "/__openclaw__/canvas/documents/cv_status/index.html" },
+        }),
+      ),
+    ).toMatchObject({ surface: "node_panel", viewId: "cv_status", title: "Status" });
+  });
+
   it("extracts safe MCP App preview metadata from tool details", () => {
     expect(
       extractCanvasFromDetails({

--- a/src/chat/canvas-render.ts
+++ b/src/chat/canvas-render.ts
@@ -6,7 +6,7 @@ import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
 
 // Extracts assistant-message canvas previews from tool JSON or markdown embed
 // shortcodes. The returned text strips consumed shortcodes for channel delivery.
-type CanvasSurface = "assistant_message";
+type CanvasSurface = "assistant_message" | "node_panel";
 type CanvasSandbox = "strict" | "scripts";
 
 type McpAppPreviewDescriptor = {
@@ -95,7 +95,7 @@ function coerceMcpAppDescriptor(
 }
 
 function normalizeSurface(value: string | undefined): CanvasSurface | undefined {
-  return value === "assistant_message" ? value : undefined;
+  return value === "assistant_message" || value === "node_panel" ? value : undefined;
 }
 
 function normalizeSandbox(value: string | undefined): CanvasSandbox | undefined {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -399,6 +399,7 @@ export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {
           ...(params.params !== undefined && { params: params.params }),
           timeoutMs: params.timeoutMs,
           idempotencyKey: params.idempotencyKey || randomUUID(),
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
         },
         {
           ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -23,6 +23,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerHook() {},
     registerHttpRoute() {},
     registerHostedMediaResolver() {},
+    registerWidgetPresenter() {},
     registerMcpServerConnectionResolver() {},
     registerChannel() {},
     registerGatewayMethod() {},

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -24,6 +24,7 @@ type BuildPluginApiParams = {
       | "registerHook"
       | "registerHttpRoute"
       | "registerHostedMediaResolver"
+      | "registerWidgetPresenter"
       | "registerMcpServerConnectionResolver"
       | "registerChannel"
       | "registerGatewayMethod"
@@ -93,6 +94,7 @@ const noopRegisterTool: OpenClawPluginApi["registerTool"] = () => {};
 const noopRegisterHook: OpenClawPluginApi["registerHook"] = () => {};
 const noopRegisterHttpRoute: OpenClawPluginApi["registerHttpRoute"] = () => {};
 const noopRegisterHostedMediaResolver: OpenClawPluginApi["registerHostedMediaResolver"] = () => {};
+const noopRegisterWidgetPresenter: OpenClawPluginApi["registerWidgetPresenter"] = () => {};
 const noopRegisterMcpServerConnectionResolver: OpenClawPluginApi["registerMcpServerConnectionResolver"] =
   () => {};
 const noopRegisterChannel: OpenClawPluginApi["registerChannel"] = () => {};
@@ -204,6 +206,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerHttpRoute: handlers.registerHttpRoute ?? noopRegisterHttpRoute,
     registerHostedMediaResolver:
       handlers.registerHostedMediaResolver ?? noopRegisterHostedMediaResolver,
+    registerWidgetPresenter: handlers.registerWidgetPresenter ?? noopRegisterWidgetPresenter,
     registerMcpServerConnectionResolver:
       handlers.registerMcpServerConnectionResolver ?? noopRegisterMcpServerConnectionResolver,
     registerChannel: handlers.registerChannel ?? noopRegisterChannel,

--- a/src/plugins/cli-gateway-nodes-runtime.ts
+++ b/src/plugins/cli-gateway-nodes-runtime.ts
@@ -72,6 +72,7 @@ export function createPluginCliGatewayNodesRuntime(): PluginRuntime["nodes"] {
           ...(params.params !== undefined && { params: params.params }),
           timeoutMs: params.timeoutMs,
           idempotencyKey: params.idempotencyKey || randomUUID(),
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
         },
         timeoutMs: resolvePluginCliNodeInvokeGatewayTimeoutMs(params.timeoutMs),
         clientName: GATEWAY_CLIENT_NAMES.CLI,

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -73,6 +73,7 @@ import type {
   OpenClawPluginService,
   PluginInteractiveHandlerRegistration,
   PluginRegistrationMode,
+  WidgetPresenter,
 } from "./plugin-registration.types.js";
 import type { UnifiedModelCatalogProviderPlugin } from "./provider-catalog.types.js";
 import type { ProviderPlugin } from "./provider-plugin.types.js";
@@ -212,6 +213,8 @@ export type OpenClawPluginApi = {
   registerHttpRoute: (params: OpenClawPluginHttpRouteParams) => void;
   /** Register a plugin-owned resolver for browser-style hosted media URLs. */
   registerHostedMediaResolver: (resolver: OpenClawPluginHostedMediaResolver) => void;
+  /** Register a plugin-owned destination for presenting hosted widget documents. */
+  registerWidgetPresenter: (presenter: WidgetPresenter) => void;
   /** Bind a declared MCP server's transport to the trusted message requester. */ registerMcpServerConnectionResolver: (
     resolver: import("./types.mcp-connection.js").OpenClawPluginMcpServerConnectionResolver,
   ) => void;

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
+import type { Result } from "@openclaw/normalization-core/result";
 import type { Command } from "commander";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
@@ -66,6 +67,34 @@ export type OpenClawPluginHttpRouteParams = {
 export type OpenClawPluginHostedMediaResolver = (
   mediaUrl: string,
 ) => string | null | undefined | Promise<string | null | undefined>;
+
+export type WidgetPresenterTarget = "node_panel";
+
+type WidgetPresenterSessionContext = {
+  sessionKey?: string;
+};
+
+export type WidgetPresentationError =
+  | { code: "no_eligible_node"; message: string }
+  | { code: "node_error"; message: string; nodeId?: string };
+
+export type WidgetPresentationSuccess = {
+  nodeId: string;
+  nodeName?: string;
+};
+
+export type WidgetPresenter = {
+  target: WidgetPresenterTarget;
+  description: string;
+  availability: (
+    sessionContext: WidgetPresenterSessionContext,
+  ) => Promise<Result<{ available: true }, WidgetPresentationError>>;
+  present: (params: {
+    documentUrlPath: string;
+    title: string;
+    sessionContext: WidgetPresenterSessionContext;
+  }) => Promise<Result<WidgetPresentationSuccess, WidgetPresentationError>>;
+};
 
 export type OpenClawPluginCliContext = {
   /**

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -83,6 +83,7 @@ export function createPluginApiFactory(
     registerReload,
     registerNodeHostCommand,
     registerNodeInvokePolicy,
+    registerWidgetPresenter,
     registerSecurityAuditCollector,
     registerInteractiveHandler,
     registerConversationBindingResolvedHandler,
@@ -223,6 +224,7 @@ export function createPluginApiFactory(
               registerNodeHostCommand: (command) => registerNodeHostCommand(record, command),
               registerNodeInvokePolicy: (policy) =>
                 registerNodeInvokePolicy(record, policy, params.pluginConfig),
+              registerWidgetPresenter: (presenter) => registerWidgetPresenter(record, presenter),
               registerSecurityAuditCollector: (collector) =>
                 registerSecurityAuditCollector(record, collector),
               registerInteractiveHandler: (registration) =>

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -49,6 +49,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     coreGatewayMethodNames: [],
     httpRoutes: [],
     hostedMediaResolvers: [],
+    widgetPresenters: [],
     mcpServerConnectionResolvers: [],
     cliRegistrars: [],
     reloads: [],

--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -19,6 +19,7 @@ import {
   NODE_WORKER_PRIVATE_COMMANDS,
 } from "../infra/node-commands.js";
 import { isReservedCommandName, registerPluginCommandInRegistry } from "./command-registration.js";
+import type { WidgetPresenter } from "./plugin-registration.types.js";
 import type { PluginRegistryState } from "./registry-state.js";
 import type { PluginRecord } from "./registry-types.js";
 import type {
@@ -58,6 +59,44 @@ export function canClaimReservedCommandOwnership(
 
 export function createOperationRegistrars(state: PluginRegistryState) {
   const { registry, pushDiagnostic } = state;
+
+  const registerWidgetPresenter = (record: PluginRecord, presenter: WidgetPresenter) => {
+    const description = normalizeOptionalString(presenter.description);
+    if (
+      presenter.target !== "node_panel" ||
+      !description ||
+      description.length > 160 ||
+      typeof presenter.availability !== "function" ||
+      typeof presenter.present !== "function"
+    ) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "invalid widget presenter registration",
+      });
+      return;
+    }
+    const existing = registry.widgetPresenters.find(
+      (registration) => registration.presenter.target === presenter.target,
+    );
+    if (existing) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `widget presenter already registered for ${presenter.target} (${existing.pluginId})`,
+      });
+      return;
+    }
+    registry.widgetPresenters.push({
+      pluginId: record.id,
+      pluginName: record.name,
+      presenter: { ...presenter, description },
+      source: record.source,
+      rootDir: record.rootDir,
+    });
+  };
 
   const registerCli = (
     record: PluginRecord,
@@ -444,6 +483,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
   };
 
   return {
+    registerWidgetPresenter,
     registerCli,
     registerReload,
     registerNodeHostCommand,

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -342,6 +342,14 @@ type PluginNodeInvokePolicyRegistration = {
   rootDir?: string;
 };
 
+export type PluginWidgetPresenterRegistration = {
+  pluginId: string;
+  pluginName?: string;
+  presenter: import("./plugin-registration.types.js").WidgetPresenter;
+  source: string;
+  rootDir?: string;
+};
+
 type PluginSecurityAuditCollectorRegistration = {
   pluginId: string;
   pluginName?: string;
@@ -563,6 +571,7 @@ export type PluginRegistry = {
   coreGatewayMethodNames: string[];
   httpRoutes: PluginHttpRouteRegistration[];
   hostedMediaResolvers: PluginHostedMediaResolverRegistration[];
+  widgetPresenters: PluginWidgetPresenterRegistration[];
   mcpServerConnectionResolvers: PluginMcpServerConnectionResolverRegistration[];
   cliRegistrars: PluginCliRegistration[];
   reloads: PluginReloadRegistration[];

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -126,6 +126,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerTool: registrars.registerTool,
     registerChannel: registrars.registerChannel,
     registerHostedMediaResolver: registrars.registerHostedMediaResolver,
+    registerWidgetPresenter: registrars.registerWidgetPresenter,
     registerMcpServerConnectionResolver: registrars.registerMcpServerConnectionResolver,
     registerProvider: registrars.registerProvider,
     registerWorkerProvider: registrars.registerWorkerProvider,

--- a/src/plugins/registry.widget-presenter.test.ts
+++ b/src/plugins/registry.widget-presenter.test.ts
@@ -1,0 +1,48 @@
+import {
+  createPluginRegistryFixture,
+  registerTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
+import { describe, expect, it } from "vitest";
+import type { WidgetPresenter } from "./plugin-registration.types.js";
+import { createPluginRecord } from "./status.test-fixtures.js";
+
+describe("plugin widget presenter registry", () => {
+  it("registers one presenter for a target and rejects a competing owner", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    const presenter: WidgetPresenter = {
+      target: "node_panel" as const,
+      description: "Show on a connected device panel",
+      availability: async () => ({ ok: true, value: { available: true } }),
+      present: async () => ({
+        ok: false,
+        error: { code: "no_eligible_node", message: "none" },
+      }),
+    };
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({ id: "first-presenter" }),
+      register(api) {
+        api.registerWidgetPresenter(presenter);
+      },
+    });
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({ id: "second-presenter" }),
+      register(api) {
+        api.registerWidgetPresenter(presenter);
+      },
+    });
+
+    expect(registry.registry.widgetPresenters).toEqual([
+      expect.objectContaining({ pluginId: "first-presenter", presenter }),
+    ]);
+    expect(registry.registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        pluginId: "second-presenter",
+        message: "widget presenter already registered for node_panel (first-presenter)",
+      }),
+    );
+  });
+});

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -76,8 +76,12 @@ type RuntimeNodeListResult = {
   nodes: Array<{
     nodeId: string;
     displayName?: string;
+    platform?: string;
+    clientId?: string;
     remoteIp?: string;
     connected?: boolean;
+    connectedAtMs?: number;
+    lastSeenAtMs?: number;
     caps?: string[];
     commands?: string[];
     /** True only for the node host installed alongside this Gateway. */
@@ -94,6 +98,7 @@ type RuntimeNodeInvokeParams = {
   params?: unknown;
   timeoutMs?: number;
   idempotencyKey?: string;
+  sessionKey?: string;
   /** Cancel the invocation and any work already dispatched to a first-party node. */
   signal?: AbortSignal;
   /** Requested Gateway scopes. Honored only for bundled or trusted official plugins. */

--- a/src/plugins/widget-presenters.ts
+++ b/src/plugins/widget-presenters.ts
@@ -1,0 +1,10 @@
+import type { PluginWidgetPresenterRegistration } from "./registry-types.js";
+import { getActivePluginRegistry } from "./runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+
+/** Returns presenter registrations from the exact request registry when available. */
+export function resolveWidgetPresenters(): readonly PluginWidgetPresenterRegistration[] {
+  const registry =
+    getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getActivePluginRegistry() ?? undefined;
+  return registry?.widgetPresenters ?? [];
+}

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -502,7 +502,14 @@ function expandTextContent(
     }
   }
   for (const preview of extracted.previews) {
-    parts.push({ type: "canvas", preview, rawText: null });
+    if (preview.surface !== "assistant_message") {
+      continue;
+    }
+    parts.push({
+      type: "canvas",
+      preview: { ...preview, surface: "assistant_message" },
+      rawText: null,
+    });
   }
 
   const content = mergeAdjacentTextItems(

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -190,7 +190,17 @@ export function extractToolPreview(
   outputText: string | undefined,
   toolName: string | undefined,
 ): ToolCard["preview"] | undefined {
-  return extractCanvasFromText(outputText, toolName);
+  const preview = extractCanvasFromText(outputText, toolName);
+  return preview?.surface === "assistant_message"
+    ? { ...preview, surface: "assistant_message" }
+    : undefined;
+}
+
+function extractToolDetailsPreview(details: unknown): ToolCard["preview"] | undefined {
+  const preview = extractCanvasFromDetails(details);
+  return preview?.surface === "assistant_message"
+    ? { ...preview, surface: "assistant_message" }
+    : undefined;
 }
 
 function resolveToolCallId(
@@ -377,7 +387,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
         );
       const text = extractToolText(item);
       const details = item.details ?? m.details;
-      const preview = extractCanvasFromDetails(details) ?? extractToolPreview(text, name);
+      const preview = extractToolDetailsPreview(details) ?? extractToolPreview(text, name);
       const isError = readToolErrorFlag(item) ?? messageIsError;
       const exitCode = readToolExitCode(item, details, text ? parseJsonRecord(text) : undefined, m);
       if (existing) {
@@ -444,7 +454,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
       messageId: transcriptMessageId,
       ...(messageIsError !== undefined ? { isError: messageIsError } : {}),
       ...(exitCode !== undefined ? { exitCode } : {}),
-      preview: extractCanvasFromDetails(m.details) ?? extractToolPreview(text, name),
+      preview: extractToolDetailsPreview(m.details) ?? extractToolPreview(text, name),
     });
   }
 

--- a/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
@@ -485,6 +485,21 @@ describe("tool-card extraction", () => {
   it("does not create previews for non-assistant canvas or generic outputs", () => {
     const cases = [
       {
+        name: "node-panel target",
+        toolName: "show_widget",
+        content: JSON.stringify({
+          kind: "canvas",
+          view: {
+            id: "cv_node_panel",
+            url: "/__openclaw__/canvas/documents/cv_node_panel/index.html",
+          },
+          presentation: {
+            target: "node_panel",
+            title: "Device panel demo",
+          },
+        }),
+      },
+      {
         name: "tool-card target",
         toolName: "canvas_render",
         content: JSON.stringify({


### PR DESCRIPTION
## What Problem This Solves

`show_widget` could materialize and render a widget inline in chat, but it had no generic way to push that same hosted document onto an operator's connected native device panel. Agents had to rely on the operator opening or pulling the widget from chat, and core could not discover a plugin-owned presentation destination without statically naming the Canvas plugin.

## Why This Change Was Made

This follows the Canvas → widget-presenter unification direction: core continues to own widget materialization, while a narrow `api.registerWidgetPresenter(...)` seam lets an enabled plugin advertise a target, check current availability, and present the hosted document through a closed `Result`. The Canvas plugin owns connected Canvas-node eligibility and selection, then invokes the existing `canvas.present` and `canvas.navigate` commands with fresh idempotency keys; no protocol or native-app command was added.

The `show_widget` definition builds `presentation.target` and its description from the presenters registered for that runtime. Without a presenter, `node_panel` is absent. Successful presentation reports the selected node; unavailable nodes and node failures preserve the inline widget and return the reason plus a concrete recovery step. Node-panel results are recognized by chat projection but are not rendered as duplicate inline cards.

Current `main` had already introduced the beta-only pinned-dashboard frame string at top-level `presentation`. This change folds that option into `presentation.frame` so `presentation.target` and `presentation.frame` form one unambiguous provider-safe object, matching the frozen target design without an overloaded string union.

AI-assisted implementation; the final patch received a clean Codex autoreview.

## User Impact

Agents can request `presentation.target: "node_panel"` and have a widget opened on a connected Canvas-capable native device. If the app is closed, no eligible device is connected, or a node command fails, users still receive the widget inline instead of a failed tool call or silent non-outcome.

Native-panel widget documents are render-only in v1. No Gateway protocol, config, SQLite, or native app changes are included.

## Evidence

- Production: +399/-52 (net +347); tests: +341/-8; test support: +1/-0; docs: +17/-5.
- `pnpm test src/canvas/widget-tool.test.ts src/chat/canvas-render.test.ts extensions/canvas/src/widget-presenter.test.ts extensions/canvas/index.test.ts src/plugins/registry.widget-presenter.test.ts ui/src/pages/chat/components/chat-tool-cards.node.test.ts` — 67 tests passed across four routed Vitest shards, including post-rebase proof.
- `pnpm check:changed` — green across core, UI, plugin, SDK-surface, typecheck, lint, dead-code, cycle, and repository guards.
- `pnpm tsgo:extensions` — passed.
- `pnpm plugin-sdk:surface:check` — passed at the existing public surface budget (4,332 exports).
- `pnpm plugin-sdk:api:diff --base "$(git merge-base origin/main HEAD)" --head HEAD` — passed; additive presenter registration/result types and node-runtime fields only.
- `pnpm build` — passed, including all public Plugin SDK declaration verification and Control UI performance budgets; no ineffective dynamic import warning.
- `pnpm check:docs` — passed formatting, markdown lint, MDX, glossary, links, and config examples.
- Source-blind behavior contract exercised successful presentation plus absent-presenter, no-node, and node-error fallbacks. It verified dynamic enum gating, opaque hosted paths, selected-device reporting, inline fallback text, and materialized documents.
- Autoreview: clean; no accepted/actionable findings.
- Codex contract check: sibling Codex keeps dynamic tool descriptions and input schemas as definition-time JSON in `codex-rs/protocol/src/dynamic_tools.rs:21-26` and registers those exact specs when building the turn tool router in `codex-rs/core/src/tools/spec_plan.rs:120-166,1220-1249`.
- **Pending:** live proof on the real macOS app and paired native node will be performed by the coordinator after this PR is open. No live/native screenshot or recording is claimed here.


## Live proof (coordinator)

Real gateway (isolated state dir, port 19790, PR-head build) with a **protocol-faithful macOS canvas node** connected over the real node WS protocol (paired + approved, advertising `canvas.*` commands), and a real `anthropic/claude-sonnet-4-6` agent turn from the Control UI composer. The agent called `show_widget` with `presentation.target: node_panel`; the presenter selected the node and the node received exactly:

```json
{"command":"canvas.present","params":{}}
{"command":"canvas.navigate","params":{"url":"/__openclaw__/canvas/documents/cv_0c9fa740…/index.html"}}
```

(unique v4 idempotency keys on both). The tool result surfaced the outcome visibly — "Presented on your device · node_panel · steipete-studio-sf" — and the reply names the routed node:

![chat result](https://github.com/user-attachments/assets/5a27abdd-9b4d-44e8-92c1-df40825e2d06)

https://github.com/user-attachments/assets/80eb811b-8cd9-4fbe-b2c3-8577b8d50ae5

**Real-Mac-app rendering note:** the app binary is unchanged by this PR; `CanvasHostedURLResolver` already resolves hosted `/__openclaw__/canvas/...` paths through the node's capability surface (source-verified, existing app tests). A full second-instance app proof was attempted via `OPENCLAW_PROFILE`: the instance connects as an operator device but never spawns its node-mode worker under a named profile in this environment, so the panel itself could not be driven without touching the operator's production app — exact blocker stated per repo policy.
