### PR TITLE
fix(ui): stop completed chats staying in progress

### DIFF
--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import {
   ONE_PIXEL_PNG_B64,
   SESSION_LIST_DEFAULTS,
@@ -50,6 +51,7 @@ suite.define(() => {
       await firstMessage.fill(text);
       await waitForCommittedNewSessionDraft(firstPage, text, 0);
       await firstPage.reload();
+      await waitForControlUiGatewayReady(firstPage);
       await expect.poll(() => firstMessage.inputValue()).toBe(text);
       await firstPage.close();
 

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -106,7 +106,13 @@ function seedChatSnapshot(
 type SessionTestState = ChatState & {
   [key: string]: unknown;
   chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
-  lastLocalTerminalReconcile?: { sessionStatus: string } | null;
+  knownAgentRunIds: Set<string>;
+  lastLocalTerminalReconcile?: {
+    phase: string;
+    runId: string | null;
+    sessionKey: string;
+    sessionStatus: string;
+  } | null;
   sessionsResult: {
     [key: string]: unknown;
     sessions: Array<Record<string, unknown>>;
@@ -827,6 +833,54 @@ describe("handleChatGatewayEvent", () => {
     ).toMatchObject({
       status: "completed",
       acceptedFinalMessageIdentities: [expect.any(String)],
+    });
+  });
+
+  it("settles an active run when its terminal reply was already accepted", () => {
+    const runId = "run-1";
+    const final = createTextChatMessage("assistant", "Delivered answer");
+    const state = createStateWithRunningSession({
+      sessionKey: "main",
+      chatRunId: runId,
+      chatStream: "Delivered answer",
+      chatStreamStartedAt: 123,
+      chatRunStartup: { state: "activity", runId },
+    }) as SessionTestState & { chatStreamSegments: HistoryToolSegment[] };
+    state.chatStreamSegments = [{ text: "Retained commentary", ts: 122, toolCallId: "call-1" }];
+    state.knownAgentRunIds = new Set([runId]);
+    const scope = { sessionKey: state.sessionKey };
+    const projection = reduceSessionProjection(
+      getChatSessionProjection(state, state.chatMessages, scope),
+      { type: "runTerminal", runId, status: "completed", message: final, scope },
+    );
+    setChatSessionProjection(state, projection);
+    state.chatMessages = [final];
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId,
+        sessionKey: "main",
+        state: "final",
+        message: final,
+      }),
+    ).toBe("final");
+
+    expect(state.chatMessages).toEqual([final]);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.chatRunStartup).toBeNull();
+    expect(state.knownAgentRunIds.has(runId)).toBe(false);
+    expect(state.sessionsResult.sessions[0]).toMatchObject({
+      status: "done",
+      hasActiveRun: false,
+      activeRunIds: [],
+    });
+    expect(state.lastLocalTerminalReconcile).toMatchObject({
+      runId,
+      sessionKey: "main",
+      phase: "done",
+      sessionStatus: "done",
     });
   });
 

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -106,7 +106,13 @@ function seedChatSnapshot(
 type SessionTestState = ChatState & {
   [key: string]: unknown;
   chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
-  lastLocalTerminalReconcile?: { sessionStatus: string } | null;
+  knownAgentRunIds: Set<string>;
+  lastLocalTerminalReconcile?: {
+    phase: string;
+    runId: string | null;
+    sessionKey: string;
+    sessionStatus: string;
+  } | null;
   sessionsResult: {
     [key: string]: unknown;
     sessions: Array<Record<string, unknown>>;
@@ -827,6 +833,52 @@ describe("handleChatGatewayEvent", () => {
     ).toMatchObject({
       status: "completed",
       acceptedFinalMessageIdentities: [expect.any(String)],
+    });
+  });
+
+  it("settles an active run when its terminal reply was already accepted", () => {
+    const runId = "run-1";
+    const final = createTextChatMessage("assistant", "Delivered answer");
+    const state = createStateWithRunningSession({
+      sessionKey: "main",
+      chatRunId: runId,
+      chatStream: "Delivered answer",
+      chatStreamStartedAt: 123,
+      chatRunStartup: { state: "activity", runId },
+    });
+    state.knownAgentRunIds = new Set([runId]);
+    const scope = { sessionKey: state.sessionKey };
+    const projection = reduceSessionProjection(
+      getChatSessionProjection(state, state.chatMessages, scope),
+      { type: "runTerminal", runId, status: "completed", message: final, scope },
+    );
+    setChatSessionProjection(state, projection);
+    state.chatMessages = [final];
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId,
+        sessionKey: "main",
+        state: "final",
+        message: final,
+      }),
+    ).toBe("final");
+
+    expect(state.chatMessages).toEqual([final]);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatRunStartup).toBeNull();
+    expect(state.knownAgentRunIds.has(runId)).toBe(false);
+    expect(state.sessionsResult.sessions[0]).toMatchObject({
+      status: "done",
+      hasActiveRun: false,
+      activeRunIds: [],
+    });
+    expect(state.lastLocalTerminalReconcile).toMatchObject({
+      runId,
+      sessionKey: "main",
+      phase: "done",
+      sessionStatus: "done",
     });
   });
 

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -264,6 +264,49 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (projectedRun) {
     setChatSessionProjection(state, projectedRun.projection);
   }
+  const terminalRunId = payload.runId ?? state.chatRunId;
+  const reconcileOwnedTerminalRun = () => {
+    const terminalStatus = projectedRun?.currentRun?.status;
+    if (
+      !payload.runId ||
+      payload.runId !== state.chatRunId ||
+      !terminalStatus ||
+      terminalStatus === "streaming"
+    ) {
+      return;
+    }
+    clearToolStreamSegments(state);
+    const sessionKeys = sessionMatches ? [state.sessionKey, payload.sessionKey] : [];
+    if (terminalStatus === "yielded") {
+      reconcileChatRunLifecycle(state, {
+        yielded: true,
+        runId: terminalRunId,
+        sessionKey: state.sessionKey,
+        sessionKeys,
+        clearLocalRun: true,
+        clearChatStream: true,
+      });
+      return;
+    }
+    const sessionStatus =
+      terminalStatus === "completed"
+        ? ("done" as const)
+        : terminalStatus === "aborted"
+          ? ("killed" as const)
+          : terminalStatus === "timeout"
+            ? ("timeout" as const)
+            : ("failed" as const);
+    reconcileChatRunLifecycle(state, {
+      outcome: terminalStatus === "completed" ? "done" : "interrupted",
+      sessionStatus,
+      runId: terminalRunId,
+      sessionKey: state.sessionKey,
+      sessionKeys,
+      clearLocalRun: true,
+      clearChatStream: true,
+      armLocalTerminalReconcile: hadActiveRunBeforeEvent && activeRunMatches,
+    });
+  };
   const previousTerminalRun = projectedRun?.previousRun;
   if (previousTerminalRun && previousTerminalRun.status !== "streaming") {
     if (payload.state === "delta") {
@@ -285,6 +328,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         setChatRunError(state, resolveGatewayErrorText(payload, null));
       }
       if (payload.state === "error") {
+        reconcileOwnedTerminalRun();
         return "error";
       }
     }
@@ -296,6 +340,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
           shouldHideAssistantChatMessage(incomingFinal) ||
           hasSessionProjectionAcceptedFinal(previousTerminalRun, incomingFinal)))
     ) {
+      reconcileOwnedTerminalRun();
       return payload.state;
     }
   }
@@ -325,7 +370,6 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     return null;
   }
 
-  const terminalRunId = payload.runId ?? state.chatRunId;
   const terminalAfterBoundaryRunId = latestStreamBoundaryRunId(state);
   const materializeVisibleStream = (
     materializeOpts: Parameters<typeof materializeVisibleAssistantStreamMessages>[2] = {},
@@ -333,21 +377,6 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
       ...materializeOpts,
     });
-  const reconcileTerminalRun = (
-    outcome: "done" | "interrupted",
-    sessionStatus: "done" | "failed" | "killed" | "timeout",
-  ) =>
-    reconcileChatRunLifecycle(state, {
-      outcome,
-      sessionStatus,
-      runId: terminalRunId,
-      sessionKey: state.sessionKey,
-      sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
-      clearLocalRun: true,
-      clearChatStream: true,
-      armLocalTerminalReconcile: hadActiveRunBeforeEvent && activeRunMatches,
-    });
-
   if (payload.state === "status") {
     if (!payload.runId || payload.runId !== state.chatRunId) {
       return null;
@@ -424,18 +453,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         state.chatMessages = materializeVisibleStream();
       }
     }
-    if (payload.yielded === true && payload.stopReason === "end_turn") {
-      reconcileChatRunLifecycle(state, {
-        yielded: true,
-        runId: terminalRunId,
-        sessionKey: state.sessionKey,
-        sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
-        clearLocalRun: true,
-        clearChatStream: true,
-      });
-    } else {
-      reconcileTerminalRun("done", "done");
-    }
+    reconcileOwnedTerminalRun();
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
@@ -460,7 +478,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     if (payload.errorMessage?.trim()) {
       setChatRunError(state, resolveGatewayErrorText(payload, null));
     }
-    reconcileTerminalRun("interrupted", "killed");
+    reconcileOwnedTerminalRun();
   } else if (payload.state === "error") {
     const payloadMessage = normalizeFinalAssistantMessage(payload.message);
     const visiblePayloadMessage =
@@ -523,10 +541,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
     // The shared Gateway projection owns timeout classification; preserve it
     // when publishing selected-session and sidebar terminal status.
-    reconcileTerminalRun(
-      "interrupted",
-      projectedRun?.currentRun?.status === "timeout" ? "timeout" : "failed",
-    );
+    reconcileOwnedTerminalRun();
     setChatRunError(
       state,
       resolveGatewayErrorText(payload, projectedErrorMessage ? visiblePayloadMessage : null),

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -263,6 +263,48 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (projectedRun) {
     setChatSessionProjection(state, projectedRun.projection);
   }
+  const terminalRunId = payload.runId ?? state.chatRunId;
+  const reconcileOwnedTerminalRun = () => {
+    const terminalStatus = projectedRun?.currentRun?.status;
+    if (
+      !payload.runId ||
+      payload.runId !== state.chatRunId ||
+      !terminalStatus ||
+      terminalStatus === "streaming"
+    ) {
+      return;
+    }
+    const sessionKeys = sessionMatches ? [state.sessionKey, payload.sessionKey] : [];
+    if (terminalStatus === "yielded") {
+      reconcileChatRunLifecycle(state, {
+        yielded: true,
+        runId: terminalRunId,
+        sessionKey: state.sessionKey,
+        sessionKeys,
+        clearLocalRun: true,
+        clearChatStream: true,
+      });
+      return;
+    }
+    const sessionStatus =
+      terminalStatus === "completed"
+        ? ("done" as const)
+        : terminalStatus === "aborted"
+          ? ("killed" as const)
+          : terminalStatus === "timeout"
+            ? ("timeout" as const)
+            : ("failed" as const);
+    reconcileChatRunLifecycle(state, {
+      outcome: terminalStatus === "completed" ? "done" : "interrupted",
+      sessionStatus,
+      runId: terminalRunId,
+      sessionKey: state.sessionKey,
+      sessionKeys,
+      clearLocalRun: true,
+      clearChatStream: true,
+      armLocalTerminalReconcile: hadActiveRunBeforeEvent && activeRunMatches,
+    });
+  };
   const previousTerminalRun = projectedRun?.previousRun;
   if (previousTerminalRun && previousTerminalRun.status !== "streaming") {
     if (payload.state === "delta") {
@@ -284,6 +326,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         setChatRunError(state, resolveGatewayErrorText(payload, null));
       }
       if (payload.state === "error") {
+        reconcileOwnedTerminalRun();
         return "error";
       }
     }
@@ -295,6 +338,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
           shouldHideAssistantChatMessage(incomingFinal) ||
           hasSessionProjectionAcceptedFinal(previousTerminalRun, incomingFinal)))
     ) {
+      reconcileOwnedTerminalRun();
       return payload.state;
     }
   }
@@ -324,7 +368,6 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     return null;
   }
 
-  const terminalRunId = payload.runId ?? state.chatRunId;
   const terminalAfterBoundaryRunId = latestStreamBoundaryRunId(state);
   const materializeVisibleStream = (
     materializeOpts: Parameters<typeof materializeVisibleAssistantStreamMessages>[2] = {},
@@ -332,21 +375,6 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
       ...materializeOpts,
     });
-  const reconcileTerminalRun = (
-    outcome: "done" | "interrupted",
-    sessionStatus: "done" | "failed" | "killed" | "timeout",
-  ) =>
-    reconcileChatRunLifecycle(state, {
-      outcome,
-      sessionStatus,
-      runId: terminalRunId,
-      sessionKey: state.sessionKey,
-      sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
-      clearLocalRun: true,
-      clearChatStream: true,
-      armLocalTerminalReconcile: hadActiveRunBeforeEvent && activeRunMatches,
-    });
-
   if (payload.state === "status") {
     if (!payload.runId || payload.runId !== state.chatRunId) {
       return null;
@@ -423,18 +451,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         state.chatMessages = materializeVisibleStream();
       }
     }
-    if (payload.yielded === true && payload.stopReason === "end_turn") {
-      reconcileChatRunLifecycle(state, {
-        yielded: true,
-        runId: terminalRunId,
-        sessionKey: state.sessionKey,
-        sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
-        clearLocalRun: true,
-        clearChatStream: true,
-      });
-    } else {
-      reconcileTerminalRun("done", "done");
-    }
+    reconcileOwnedTerminalRun();
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
@@ -458,7 +475,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     if (payload.errorMessage?.trim()) {
       setChatRunError(state, resolveGatewayErrorText(payload, null));
     }
-    reconcileTerminalRun("interrupted", "killed");
+    reconcileOwnedTerminalRun();
   } else if (payload.state === "error") {
     const payloadMessage = normalizeFinalAssistantMessage(payload.message);
     const visiblePayloadMessage =
@@ -503,10 +520,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
     // The shared Gateway projection owns timeout classification; preserve it
     // when publishing selected-session and sidebar terminal status.
-    reconcileTerminalRun(
-      "interrupted",
-      projectedRun?.currentRun?.status === "timeout" ? "timeout" : "failed",
-    );
+    reconcileOwnedTerminalRun();
     setChatRunError(
       state,
       resolveGatewayErrorText(payload, projectedErrorMessage ? visiblePayloadMessage : null),


### PR DESCRIPTION
Related: #87875

WebChat could show a complete assistant reply while leaving the chat marked as Working with the Stop control still active. That made a finished turn look stuck and could block the next message. This PR keeps duplicate reply text suppressed but always completes the matching run's lifecycle. The composer now returns to idle without duplicating the final answer or clearing a newer run.

## What Problem This Solves

The shared chat state could already contain the final reply before the matching terminal event was replayed. The duplicate-content path returned early and skipped run cleanup.

## Why This Change Was Made

Terminal events owned by the active run now use one settlement path for completed, yielded, aborted, failed, and timed-out outcomes. Existing exact-run protection still prevents an older terminal event from clearing newer work.

## User Impact

Completed chats reliably leave Working state and restore the normal composer, while the final reply remains visible exactly once.

## Proof

Same accepted final reply and active-run state, executed through the production chat event handler on both revisions:

**Before — direct base**

```text
visibleFinals: 1
chatRunId: "run-1"
chatStream: "Delivered answer"
knownAgentRunIds: ["run-1"]
session: { status: "running", hasActiveRun: true, activeRunIds: ["run-1"] }
```

**After — PR**

```text
visibleFinals: 1
chatRunId: null
chatStream: null
knownAgentRunIds: []
session: { status: "done", hasActiveRun: false, activeRunIds: [] }
```

## How to verify

1. Start a WebChat run and accept its final reply into shared chat state.
2. Replay the matching terminal event while the local run still appears active.
3. Confirm the reply remains single, the Stop control disappears, and the session becomes done.

## Implementation notes

Provenance: the early terminal deduplication return was introduced in #115377 (`18ecde3d9f8`) and carried forward by #115429 (`ad3f74f296e`). Production LOC: +47/-33. Tests: +53/-1.

Supporting checks: 265 focused UI tests, 6 browser lifecycle tests, the exact changed-file gate, the Control UI production build and performance budgets, autoreview, and independent P0/P1 review all passed.
