### PR TITLE
fix(qa): avoid survivor stop timeout on zombie processes

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -930,13 +930,15 @@ command="${filtered[0]:-status}"
 
 is_running() {
   [ -s "$pid_file" ] || return 1
-  local pid
-  local process_state
+  local pid stat_line stat_tail
   pid="$(cat "$pid_file" 2>/dev/null || true)"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" >/dev/null 2>&1 || return 1
-  process_state="$(awk '{ print $3 }' "/proc/$pid/stat" 2>/dev/null || true)"
-  [ "$process_state" != "Z" ]
+  stat_line="$(cat "/proc/$pid/stat" 2>/dev/null || true)"
+  stat_tail="${stat_line##*) }"
+  [[ "$stat_line" == "$pid ("*") $stat_tail" &&
+    "$stat_tail" =~ ^Z([[:space:]]+-?[0-9]+){49,}$ ]] && return 1
+  return 0
 }
 
 stop_gateway() {

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -41,13 +41,15 @@ command="${filtered[0]:-status}"
 
 is_running() {
   [ -s "$pid_file" ] || return 1
-  local pid
-  local process_state
+  local pid stat_line stat_tail
   pid="$(cat "$pid_file" 2>/dev/null || true)"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" >/dev/null 2>&1 || return 1
-  process_state="$(awk '{ print $3 }' "/proc/$pid/stat" 2>/dev/null || true)"
-  [ "$process_state" != "Z" ]
+  stat_line="$(cat "/proc/$pid/stat" 2>/dev/null || true)"
+  stat_tail="${stat_line##*) }"
+  [[ "$stat_line" == "$pid ("*") $stat_tail" &&
+    "$stat_tail" =~ ^Z([[:space:]]+-?[0-9]+){49,}$ ]] && return 1
+  return 0
 }
 
 stop_gateway() {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -216,6 +216,15 @@ function extractUpgradeSurvivorSupervisor(script: string): string {
   return source;
 }
 
+function extractUpgradeSurvivorSystemctlShim(script: string): string {
+  const match = script.match(/cat >"\$shim_dir\/systemctl" <<'SHIM'\n(?<source>[\s\S]*?)\nSHIM/u);
+  const source = match?.groups?.source;
+  if (!source) {
+    throw new Error("upgrade survivor systemctl shim source not found");
+  }
+  return source;
+}
+
 async function waitForProcessExit(child: ChildProcess, timeoutMs = 5_000): Promise<number | null> {
   if (child.exitCode !== null || child.signalCode !== null) {
     return child.exitCode;
@@ -252,6 +261,75 @@ setInterval(() => {}, 1_000);
 `,
   );
   return descendantPath;
+}
+
+async function forEachUpgradeSurvivorSystemctlShim(
+  callback: (fixture: {
+    pid: number;
+    run: (command: "is-active" | "stop", procStat?: string) => number | null;
+    scriptPath: string;
+  }) => void | Promise<void>,
+): Promise<void> {
+  for (const scriptPath of [
+    UPGRADE_SURVIVOR_RUN_SCRIPT,
+    UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH,
+  ]) {
+    const workDir = tempDirs.make("openclaw-systemctl-shim-");
+    const binDir = join(workDir, "bin");
+    const pidPath = join(workDir, "gateway.pid");
+    const childPidPath = join(workDir, "child.pid");
+    const child = spawn(process.execPath, [writeTermIgnoringDescendant(workDir)], {
+      env: { ...process.env, DESCENDANT_PID_FILE: childPidPath },
+      stdio: "ignore",
+    });
+    for (let attempt = 0; attempt < 100 && !existsSync(childPidPath); attempt += 1) {
+      await delay(10);
+    }
+    const pid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+    writeFileSync(pidPath, `${pid}\n`);
+    const shimPath = join(workDir, "systemctl");
+    writeFileSync(shimPath, extractUpgradeSurvivorSystemctlShim(readFileSync(scriptPath, "utf8")), {
+      mode: 0o755,
+    });
+    writeExecutables(binDir, {
+      awk: `#!/usr/bin/env bash
+[ "$FAKE_PROC_STAT_MODE" != "unreadable" ] || exit 1
+set -- $FAKE_PROC_STAT
+printf '%s\\n' "\${3:-}"
+`,
+      cat: `#!/usr/bin/env bash
+case "\${1:-}" in
+  /proc/*/stat)
+    [ "$FAKE_PROC_STAT_MODE" != "unreadable" ] || exit 1
+    printf '%s\\n' "$FAKE_PROC_STAT"
+    ;;
+  *) exec /bin/cat "$@" ;;
+esac
+`,
+      sleep: "#!/usr/bin/env bash\nexit 97\n",
+    });
+    const run = (command: "is-active" | "stop", procStat?: string) =>
+      spawnSync("bash", [shimPath, "--user", command, "openclaw-gateway.service"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_PROC_STAT: procStat ?? "",
+          FAKE_PROC_STAT_MODE: procStat === undefined ? "unreadable" : "readable",
+          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(workDir, "systemctl.log"),
+          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: pidPath,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      }).status;
+
+    try {
+      await callback({ pid, run, scriptPath });
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      await waitForProcessExit(child).catch(() => undefined);
+    }
+  }
 }
 
 function cleanupSmokeLogTailHelpers(): string {
@@ -3044,7 +3122,6 @@ fi
     for (const script of [publishedRunner, updateRestartAuth]) {
       expectTextToIncludeAll(script, [
         'supervisor_script="${pid_file}.supervisor.mjs"',
-        'process_state="$(awk \'{ print $3 }\' "/proc/$pid/stat" 2>/dev/null || true)"',
         'OPENCLAW_SYSTEMCTL_SHIM_EXEC_START="$exec_start"',
         'nohup node "$supervisor_script"',
         'if (key.startsWith("OPENCLAW_UPDATE_")) {',
@@ -3069,6 +3146,27 @@ fi
       expect(script).toContain("systemctl --user stop openclaw-gateway.service");
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "stops promptly when the systemctl target is a zombie with spaces and parentheses in comm",
+    async () => {
+      await forEachUpgradeSurvivorSystemctlShim(({ pid, run, scriptPath }) => {
+        const procTail = Array.from({ length: 49 }, (_, field) => field + 1).join(" ");
+        expect(run("stop", `${pid} (gateway (old) worker) Z ${procTail}`), scriptPath).toBe(0);
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "keeps a killable systemctl target active when proc stat is unreadable or malformed",
+    async () => {
+      await forEachUpgradeSurvivorSystemctlShim(({ pid, run, scriptPath }) => {
+        for (const procStat of [undefined, `${pid} (gateway) Z`]) {
+          expect(run("is-active", procStat), `${scriptPath}: ${procStat ?? "unreadable"}`).toBe(0);
+        }
+      });
+    },
+  );
 
   it("stops supervised gateway restarts after the systemd burst limit", async () => {
     const workDir = tempDirs.make("openclaw-update-restart-supervisor-");


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/120703

## What Problem This Solves

Fixes an issue where release upgrade-survivor checks could spend the full systemctl stop deadline waiting on a zombie process when its Linux process name contained spaces or parentheses.

## Why This Change Was Made

Linux emits `/proc/<pid>/stat` process names unescaped inside parentheses, so whitespace field splitting cannot reliably locate the process state. Both canonical upgrade-survivor systemctl shims now split at the final `) ` boundary and treat a process as stopped only when the PID, zombie state, and complete numeric stat tail are all valid. Unreadable, truncated, mismatched, or malformed stat data remains conservatively running.

The broader convergence work in #120703 remains independent; this PR repairs the currently shipped shim behavior without adopting that draft's larger process-group refactor.

## User Impact

Release and package-validation operators no longer wait roughly 35 seconds for the shim's stop deadline when the supervised process has already become a zombie. Product runtime behavior is unchanged.

## Evidence

- Pre-fix boundary harness: `awk '{ print $3 }'` returned `(old)` for a zombie named `gateway (old) worker`, entered the wait loop, and hit the test sleep sentinel with exit 97.
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts -t "systemctl target"` — 2 passed.
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` — 198 passed.
- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh` — passed.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/upgrade-survivor/run.sh scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh test/scripts/docker-build-helper.test.ts` — passed.
- Codex autoreview of the final uncommitted patch — no accepted/actionable findings.
- Production runtime LOC: unchanged. Release tooling: +12/-8. Tests: +99/-1.

AI-assisted: yes. The implementation and tests were reviewed and understood before publication.
