### PR TITLE
fix(claws): keep project builds reproducible across Node versions

### DIFF
--- a/src/claws/project-build.ts
+++ b/src/claws/project-build.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { constants as zlibConstants } from "node:zlib";
 import * as tar from "tar";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import {
@@ -24,9 +25,6 @@ import { isSafeClawRelativePath } from "./schema-portability.js";
 import { MAX_MANAGED_FILE_BYTES } from "./source-limits.js";
 
 export const CLAW_BUILD_RESULT_SCHEMA_VERSION = "openclaw.clawBuild.v1" as const;
-
-// zlib's public numeric API defines Z_FILTERED as strategy 1.
-const ZLIB_FILTERED_STRATEGY = 1;
 
 type ClawBuildResult = {
   schemaVersion: typeof CLAW_BUILD_RESULT_SCHEMA_VERSION;
@@ -187,8 +185,8 @@ export async function buildClawProject(
       {
         cwd: stagingRoot,
         file: temporaryArtifact,
-        // Stabilize supported zlib output without disabling normal match compression.
-        gzip: { level: 9, portable: true, strategy: ZLIB_FILTERED_STRATEGY },
+        // Native zlib match selection varies by version; Huffman-only keeps artifact bytes portable.
+        gzip: { level: 9, portable: true, strategy: zlibConstants.Z_HUFFMAN_ONLY },
         mtime: new Date(0),
         portable: true,
         prefix: "package",

--- a/src/claws/project.test.ts
+++ b/src/claws/project.test.ts
@@ -9,7 +9,18 @@ import { ClawProjectError, createClawProject, validateClawProject } from "./proj
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const GOLDEN_ARTIFACT_INTEGRITY =
-  "sha256:10b8890c5e5b062c94ff79b1d424859c6a5572548535eec6e31ee0c6d7c08a3b";
+  "sha256:5fba54933e519f4fc12422a3d555d076ce373be993eed3f6b3575a89aaa62618";
+
+async function writeCaseVariantIfDistinct(path: string, content: string): Promise<void> {
+  try {
+    await writeFile(path, content, { flag: "wx" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return;
+    }
+    throw error;
+  }
+}
 
 async function writeRichProject(root: string): Promise<void> {
   await mkdir(join(root, "workspace"), { recursive: true });
@@ -426,52 +437,49 @@ describe("Claw projects", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a workspace source that portably collides with CLAW.md",
-    async () => {
-      const project = tempDirs.make("openclaw-claw-manifest-case-collision-");
-      await writeRichProject(project);
-      const manifest = await readFile(join(project, "CLAW.md"), "utf8");
-      await writeFile(join(project, "claw.md"), "# Conflicting source\n");
-      await writeFile(
-        join(project, "CLAW.md"),
-        manifest.replace("workspace/reference.md", "claw.md"),
-      );
+  it("rejects a workspace source that portably collides with CLAW.md", async () => {
+    const project = tempDirs.make("openclaw-claw-manifest-case-collision-");
+    await writeRichProject(project);
+    const manifest = await readFile(join(project, "CLAW.md"), "utf8");
+    await writeFile(
+      join(project, "CLAW.md"),
+      manifest.replace("workspace/reference.md", "claw.md"),
+    );
+    await writeCaseVariantIfDistinct(join(project, "claw.md"), "# Conflicting source\n");
 
-      await expect(validateClawProject(project)).resolves.toMatchObject({
-        ok: false,
-        diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
-      });
-    },
-  );
+    await expect(validateClawProject(project)).resolves.toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
+    });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a workspace source that portably collides with a custom profile",
-    async () => {
-      const project = tempDirs.make("openclaw-claw-profile-case-collision-");
-      await writeRichProject(project);
-      await rename(
-        join(project, "profiles", "openclaw.yml"),
-        join(project, "profiles", "custom.yaml"),
-      );
-      await writeFile(join(project, "profiles", "CUSTOM.yaml"), "schemaVersion: 1\nagent: {}\n");
-      const manifest = await readFile(join(project, "CLAW.md"), "utf8");
-      await writeFile(
-        join(project, "CLAW.md"),
-        manifest
-          .replace(
-            "agent:\n  id: demo-claw",
-            "agent:\n  id: demo-claw\nmetadata:\n  openclaw.config: profiles/custom.yaml",
-          )
-          .replace("workspace/reference.md", "profiles/CUSTOM.yaml"),
-      );
+  it("rejects a workspace source that portably collides with a custom profile", async () => {
+    const project = tempDirs.make("openclaw-claw-profile-case-collision-");
+    await writeRichProject(project);
+    await rename(
+      join(project, "profiles", "openclaw.yml"),
+      join(project, "profiles", "custom.yaml"),
+    );
+    await writeCaseVariantIfDistinct(
+      join(project, "profiles", "CUSTOM.yaml"),
+      "schemaVersion: 1\nagent: {}\n",
+    );
+    const manifest = await readFile(join(project, "CLAW.md"), "utf8");
+    await writeFile(
+      join(project, "CLAW.md"),
+      manifest
+        .replace(
+          "agent:\n  id: demo-claw",
+          "agent:\n  id: demo-claw\nmetadata:\n  openclaw.config: profiles/custom.yaml",
+        )
+        .replace("workspace/reference.md", "profiles/CUSTOM.yaml"),
+    );
 
-      await expect(validateClawProject(project)).resolves.toMatchObject({
-        ok: false,
-        diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
-      });
-    },
-  );
+    await expect(validateClawProject(project)).resolves.toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "project_path_collision" })],
+    });
+  });
 
   it.runIf(process.platform !== "win32")(
     "rejects Unicode-normalization collisions between workspace sources",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where building the same canonical claw project on different supported Node versions could produce different `.tgz` bytes and integrity digests, making project artifacts non-reproducible across runtimes. It also makes the portable path-collision coverage reliable on both case-sensitive and case-insensitive filesystems.

## Why This Change Was Made

`buildClawProject` now uses zlib's `Z_HUFFMAN_ONLY` strategy so canonical archive bytes do not depend on native DEFLATE match-selection behavior. Before the fix, the same canonical tar input emitted `sha256:1a65cb...` (504 bytes) on Node 24/zlib 1.2.12 and `sha256:f7377...` (499 bytes) on Node 26/zlib 1.3.2.

The collision fixture now attempts an exclusive case-variant write. On case-insensitive APFS, writing `claw.md` previously overwrote `CLAW.md`, so `missing_claw_frontmatter` was the correct result instead of the intended `project_path_collision`. The revised fixture preserves the valid canonical file when the filesystem aliases the two paths, allowing both collision tests to run and assert `project_path_collision` on case-sensitive and case-insensitive filesystems.

## User Impact

Claw project builds now produce the same archive bytes and integrity digest across supported Node/zlib versions, improving reproducibility for generated artifacts. Portable path-collision validation remains covered consistently across filesystem types.

Release-note context: stabilize claw project artifact digests across Node versions and make case-collision validation portable.

AI-assisted: yes. The implementation and evidence were reviewed, and Codex autoreview reported no accepted/actionable findings.

No UI proof is needed because this changes generated archive behavior; exact digest plus extraction and contents tests cover the affected surface.

## Evidence

- Node 24, Node 26.5.0, and Node 26.5.1 all emitted `sha256:5fba54933e519f4fc12422a3d555d076ce373be993eed3f6b3575a89aaa62618` (1354 bytes).
- `node scripts/run-vitest.mjs src/claws/project.test.ts` on Node 24: 27 passed, 1 pre-existing skip.
- `node scripts/run-vitest.mjs src/claws/project.test.ts` on Node 26: 27 passed, 1 pre-existing skip.
- `node scripts/check-changed.mjs -- src/claws/project-build.ts src/claws/project.test.ts` passed.
- `git diff --check` passed.
- Codex autoreview: no accepted/actionable findings.
- LOC: production +3/-1 (net +2); tests +55/-49 (net +6).
