### PR TITLE
fix(agents): record the final-call context fact on cumulative provider usage (#125333)

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -42,12 +42,50 @@ import {
 } from "./embedded-agent-utils.js";
 import type { AgentEvent, AgentMessage } from "./runtime/index.js";
 import {
+  derivePromptTokens,
   hasNonzeroUsage,
   makeZeroUsageSnapshot,
   normalizeUsage,
   type NormalizedUsage,
   type UsageLike,
 } from "./usage.js";
+
+/**
+ * Records the call-scoped context fact on an assistant message that already carries provider
+ * token totals.
+ *
+ * Provider totals win for the message's own buckets, but for a tool-loop run those totals can
+ * cover every model call in the attempt instead of the final one. The message then reaches the
+ * transcript with no `contextUsage`, so every later reader -- the session context snapshot and
+ * the memory-flush prompt estimate -- has to infer the prompt size from cumulative buckets and
+ * overstates it by roughly one multiple per tool-call round trip.
+ *
+ * `pendingUsage` is the stream-captured snapshot for this assistant message and is still the
+ * final-call value at this point: `handleMessageEnd` only replaces it with the message's own
+ * usage after this function runs. Stamping it leaves the provider's buckets untouched and
+ * mirrors how the CLI path fills `contextUsage` in `resolveCliTranscriptUsage`.
+ */
+function stampCallScopedContextUsage(
+  message: AssistantMessage,
+  messageUsage: NormalizedUsage,
+  pendingUsage: NormalizedUsage,
+): void {
+  if (messageUsage.contextUsage !== undefined) {
+    return;
+  }
+  const promptTokens = derivePromptTokens(pendingUsage);
+  if (promptTokens === undefined) {
+    return;
+  }
+  message.usage = {
+    ...message.usage,
+    contextUsage: {
+      state: "available",
+      promptTokens,
+      totalTokens: promptTokens + (pendingUsage.output ?? 0),
+    },
+  };
+}
 
 export function preservePendingAssistantUsage(
   message: AssistantMessage,
@@ -61,6 +99,7 @@ export function preservePendingAssistantUsage(
   }
   const messageUsage = normalizeUsage((message as { usage?: UsageLike }).usage);
   if (hasNonzeroUsage(messageUsage)) {
+    stampCallScopedContextUsage(message, messageUsage, pendingUsage);
     return message;
   }
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.usage.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.usage.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Usage } from "../llm/types.js";
+import { preservePendingAssistantUsage } from "./embedded-agent-subscribe.handlers.messages.lifecycle.js";
+import { deriveContextPromptTokens, normalizeUsage, type NormalizedUsage } from "./usage.js";
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } as const;
+
+/**
+ * Shapes taken from the #125333 report: a non-CLI provider reported attempt-cumulative totals on
+ * the assistant message, while the final model call of that turn was two orders smaller.
+ */
+const CUMULATIVE_TOTALS: Usage = {
+  input: 82_123,
+  output: 3_000,
+  cacheRead: 525_824,
+  cacheWrite: 0,
+  totalTokens: 610_947,
+  cost: { ...ZERO_COST },
+};
+
+const FINAL_CALL_USAGE: NormalizedUsage = {
+  input: 12_400,
+  output: 3_000,
+  cacheRead: 18_900,
+  total: 34_300,
+};
+
+function makeAssistant(usage: Usage): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "final reply" }],
+    api: "openai-completions",
+    provider: "openai-sub2api",
+    model: "gpt-5.6-sol",
+    usage,
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+const contextSnapshotOf = (message: AssistantMessage): number | undefined =>
+  deriveContextPromptTokens({ lastCallUsage: normalizeUsage(message.usage) });
+
+describe("preservePendingAssistantUsage context fact", () => {
+  it("records the final-call context fact when provider totals are attempt-cumulative", () => {
+    const message = makeAssistant({ ...CUMULATIVE_TOTALS });
+
+    preservePendingAssistantUsage(message, { ...FINAL_CALL_USAGE });
+
+    expect(message.usage.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 31_300,
+      totalTokens: 34_300,
+    });
+    // Without the fact, readers derive the prompt size from the cumulative buckets instead.
+    expect(contextSnapshotOf(message)).toBe(31_300);
+    expect(contextSnapshotOf(makeAssistant({ ...CUMULATIVE_TOTALS }))).toBe(607_947);
+  });
+
+  it("leaves the provider's own token buckets untouched", () => {
+    const message = makeAssistant({ ...CUMULATIVE_TOTALS });
+
+    preservePendingAssistantUsage(message, { ...FINAL_CALL_USAGE });
+
+    expect(message.usage).toMatchObject({
+      input: 82_123,
+      output: 3_000,
+      cacheRead: 525_824,
+      totalTokens: 610_947,
+    });
+  });
+
+  it("never overwrites a context fact the provider already supplied", () => {
+    const supplied = { state: "available", promptTokens: 99_000, totalTokens: 99_500 } as const;
+    const message = makeAssistant({ ...CUMULATIVE_TOTALS, contextUsage: { ...supplied } });
+
+    preservePendingAssistantUsage(message, { ...FINAL_CALL_USAGE });
+
+    expect(message.usage.contextUsage).toEqual(supplied);
+  });
+
+  it("never overwrites an unavailable-context barrier", () => {
+    const message = makeAssistant({
+      ...CUMULATIVE_TOTALS,
+      contextUsage: { state: "unavailable" },
+    });
+
+    preservePendingAssistantUsage(message, { ...FINAL_CALL_USAGE });
+
+    expect(message.usage.contextUsage).toEqual({ state: "unavailable" });
+  });
+
+  it("records nothing when the pending snapshot carries no prompt tokens", () => {
+    const message = makeAssistant({ ...CUMULATIVE_TOTALS });
+
+    preservePendingAssistantUsage(message, { output: 3_000, total: 3_000 });
+
+    expect(message.usage.contextUsage).toBeUndefined();
+    expect(message.usage).toEqual({ ...CUMULATIVE_TOTALS });
+  });
+
+  it("still fills missing usage from the pending snapshot", () => {
+    const message = makeAssistant({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { ...ZERO_COST },
+    });
+
+    preservePendingAssistantUsage(message, { ...FINAL_CALL_USAGE });
+
+    expect(message.usage).toMatchObject({
+      input: 12_400,
+      output: 3_000,
+      cacheRead: 18_900,
+      totalTokens: 34_300,
+    });
+  });
+});


### PR DESCRIPTION
Refs #125333.

## What Problem This Solves

On providers that report attempt-cumulative usage on the assistant message, the persisted context snapshot overstates the real prompt size, which trips compaction early. #125333 measured `totalTokens` climbing 455,917 → 607,947 on one session, where 607,947 is exactly `usage.input` 82,123 + `usage.cacheRead` 525,824 summed across a tool loop rather than the prompt of the final model call.

The transcript side has a root cause that is separate from candidate ordering: in `preservePendingAssistantUsage`, when the message already carries provider totals, the function returns early and the message reaches the transcript **with no `contextUsage` at all**. `Usage.contextUsage` is documented as "Exact context snapshot for the final provider iteration", and the CLI path fills it in `resolveCliTranscriptUsage` — but nothing fills it for other APIs. So every later reader (the session context snapshot, the memory-flush prompt estimate) has to infer the prompt size from cumulative token buckets, and overstates it by roughly one multiple per tool-call round trip.

## Why This Change Was Made

`ctx.state.pendingAssistantUsage` is the stream-captured snapshot for the assistant message, and at the point `preservePendingAssistantUsage` runs it is still the **final-call** value: `handleMessageEnd` only replaces it with the message's own usage afterwards, via `recordAssistantUsage(assistantMessage.usage)` on the next line. That makes it the authoritative call-scoped fact, available exactly where the transcript record is being finalized.

So this stamps it as `contextUsage` and leaves the provider's own token buckets untouched:

- the prompt figure comes from the existing exported `derivePromptTokens`, not a new formula;
- the shape mirrors `resolveCliTranscriptUsage` so both paths produce the same contract;
- an existing `contextUsage` — `available` or the `unavailable` barrier — is never overwritten;
- a pending snapshot with no prompt tokens stamps nothing;
- the pre-existing "fill in missing/zero usage" path is unchanged.

Deliberately kept out of scope so this does not collide with #125479, which is already open on the same issue:

- No change to `deriveContextPromptTokens` or to `agent-runner-memory.ts`. #125479's context-window bound and this change are complementary: with a call-scoped fact present in the transcript, that bound becomes a backstop against impossible values rather than the primary defense — which matters because a window bound cannot reject inflation that stays under the window (e.g. a true 30k prompt reported as 150k against a 200k window).
- No treatment of sessions that **already** persisted an inflated `totalTokens`. Those stay authoritative through `resolveFreshSessionTotalTokens` until either `SESSION_TOTAL_TOKENS_VERSION` is bumped or the persisted read is bounded; both are separable decisions, noted in my review on #125479.

## User Impact

Sessions on non-CLI providers stop accumulating an inflated context snapshot from tool-loop turns, so compaction and memory flush fire against the real prompt size instead of a multiple of it. No user-visible surface changes; the provider's reported token counts and costs are byte-identical.

## Evidence

New test file `src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.usage.test.ts` (6 cases) uses the shapes from the report. The first case is an A/B on the same cumulative message: with the fact recorded the derived snapshot is the true final-call prompt `31,300`; constructed without it, the same message still derives `607,947` — the figure from the issue.

Local validation on this branch:

| Check | Result |
| --- | --- |
| new test file | 6/6 passed |
| regression: `embedded-agent-subscribe.handlers.messages*` + usage suites (7 files) | 165/165 passed |
| `pnpm tsgo:core` | exit 0 |
| `pnpm tsgo:test:src` | exit 0 |
| `pnpm check:assertion-safety` | OK — 4312 files, no new uncommented assertions |
| `pnpm check:max-lines-ratchet` | OK — 901 grandfathered suppressions, none added |
| `oxlint` (changed files) / `oxfmt --check` | exit 0 / correctly formatted |

Not run locally: the full `pnpm build && pnpm check && pnpm test` suite — leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
