### PR TITLE
chore(worker): stabilize inference cancellation tests

### DIFF
--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -36,6 +36,7 @@ import {
   type WorkerInferenceTerminalFrame,
   type WorkerInferenceTerminalOutcome,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { createOperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import { listRunningSessions } from "../agents/bash-process-registry.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
@@ -94,6 +95,7 @@ const WORKER_LOOP_REPLAY = {
 };
 const BUNDLE_HASH = Array.from({ length: 64 }, () => "a").join("");
 const CREDENTIAL = ["worker", "fixture", "admission"].join("-");
+const WORKER_INFERENCE_START_TIMEOUT_MS = 90_000;
 
 type InferencePlan =
   | "text"
@@ -165,6 +167,7 @@ class FakeWorkerGateway {
   private sentLiveResync = 0;
   private unavailable = false;
   private ignoredAdmission = false;
+  private readonly inferenceStarted = createDeferred();
 
   socketPath = "";
   connectionCount = 0;
@@ -175,6 +178,14 @@ class FakeWorkerGateway {
   readonly inferenceRequests: WorkerInferenceStartParams[] = [];
   readonly sessionSpawnRequests: WorkerSessionsSpawnParams[] = [];
   readonly applicationOrder: string[] = [];
+
+  waitForInferenceStart(): Promise<void> {
+    return withTestTimeout(
+      this.inferenceStarted.promise,
+      WORKER_INFERENCE_START_TIMEOUT_MS,
+      "worker inference start did not reach the fake Gateway",
+    );
+  }
 
   constructor(private readonly options: FakeGatewayOptions = {}) {
     this.httpServer = createServer();
@@ -468,6 +479,7 @@ class FakeWorkerGateway {
   private handleInference(socket: WebSocket, frame: WorkerInferenceStartRequestFrame): void {
     this.methods.push(frame.method);
     this.inferenceRequests.push(structuredClone(frame.params));
+    this.inferenceStarted.resolve();
     if (this.options.silenceFirstInference && !this.droppedInference) {
       this.droppedInference = true;
       return;
@@ -1168,7 +1180,7 @@ describe("worker runtime", () => {
     const { gateway, launch } = await setup({ inferencePlans: ["hold"] });
     const controller = new AbortController();
     const result = runWorkerDescriptor(launch, { signal: controller.signal });
-    await waitForFast(() => expect(gateway.inferenceRequests).toHaveLength(1));
+    await gateway.waitForInferenceStart();
 
     controller.abort(new Error("operator stopped worker"));
 
@@ -1187,7 +1199,7 @@ describe("worker runtime", () => {
     });
     const controller = new AbortController();
     const result = runWorkerDescriptor(launch, { signal: controller.signal });
-    await waitForFast(() => expect(gateway.inferenceRequests).toHaveLength(1));
+    await gateway.waitForInferenceStart();
 
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where two worker cancellation tests could fail in isolation before the fake Gateway observed any inference request. Both pre-fix reproductions expired in the one-second polling assertion with zero inference requests, so the tests never reached the cancellation behavior they were intended to verify.

## Why This Change Was Made

The fake Gateway now exposes a bounded, event-driven wait that resolves when it receives `worker.inference.start`. The two cancellation tests wait on that owner-boundary event before aborting the worker, avoiding a startup-speed assumption while preserving the production cancellation and one-second shutdown-grace behavior. No production code or approval-timeout behavior changed.

AI-assisted: yes. The complete diff was reviewed and the repository autoreview workflow reported no accepted or actionable findings.

## User Impact

There is no runtime or user-visible product behavior change. Developers and CI get deterministic coverage of worker inference cancellation and bounded shutdown.

Production LOC: +0/-0 (net 0) | Tests: +14/-2

## Evidence

Pre-fix, both named tests failed independently with zero inference requests.

- `node scripts/run-vitest.mjs src/worker/worker.runtime.test.ts -t 'sends remote inference cancellation before stopping an active worker|bounds shutdown when remote inference cancellation cannot settle'` -> 2 passed
- `node scripts/run-vitest.mjs src/worker/worker.runtime.test.ts` -> 45 passed
- `node scripts/check-changed.mjs -- src/worker/worker.runtime.test.ts` -> passed all gates
- `git diff --check` -> passed
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted` -> clean, no accepted/actionable findings

No live or user-visible proof is needed because this is a test-harness-only reliability fix. There are no known proof gaps.
