### PR TITLE
fix(ui): prevent transcript overlap during MCP app teardown

### DIFF
--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -226,14 +226,12 @@ class OpenClawRouterOutlet<
   private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
 
   override render() {
-    if (!this.router) {
+    const router = this.router;
+    if (!router) {
       return nothing;
     }
     const snapshot = this.outlet.snapshot;
     const renderedMatch = selectRenderedRouteMatch(snapshot.active, snapshot.pending);
-    const rendered = renderRouterOutlet(this.router, snapshot, renderedMatch, {
-      retryContext: this.retryContext,
-    });
     const routeKey = renderedMatch ? `${renderedMatch.routeId}:${renderedMatch.status}` : "empty";
     const routeModule = renderedMatch?.module;
     const declaredOwnerKey =
@@ -245,9 +243,15 @@ class OpenClawRouterOutlet<
       explicitOwnerKey !== undefined &&
       renderedMatch?.status === "pending" &&
       renderedMatch.data === undefined;
-    return this.mcpAppUnmountGate.render(explicitOwnerKey ?? routeKey, rendered, () => [this], {
-      retainRenderedValue: retainCurrent,
-    });
+    return this.mcpAppUnmountGate.render(
+      explicitOwnerKey ?? routeKey,
+      () =>
+        renderRouterOutlet(router, snapshot, renderedMatch, {
+          retryContext: this.retryContext,
+        }),
+      () => [this],
+      { retainRenderedValue: retainCurrent },
+    );
   }
 }
 

--- a/ui/src/components/mcp-app-unmount.test.ts
+++ b/ui/src/components/mcp-app-unmount.test.ts
@@ -1,20 +1,8 @@
 import { LitElement, html, nothing } from "lit";
 import { html as staticHtml, unsafeStatic } from "lit/static-html.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { McpAppUnmountGate } from "./mcp-app-unmount.ts";
-
-type Deferred = {
-  promise: Promise<void>;
-  resolve: () => void;
-};
-
-function deferred(): Deferred {
-  let resolve!: () => void;
-  const promise = new Promise<void>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-  return { promise, resolve };
-}
 
 const targetTag = `test-mcp-app-unmount-target-${crypto.randomUUID()}`;
 const ownerTag = `test-mcp-app-unmount-owner-${crypto.randomUUID()}`;
@@ -39,6 +27,11 @@ class TestMcpAppUnmountOwner extends LitElement {
   valueKey = "initial";
   retainRenderedValue = false;
   private readonly gate = new McpAppUnmountGate(this, targetTag);
+  readonly renderValue = vi.fn(() =>
+    this.valueKey === "initial"
+      ? staticHtml`<${staticTargetTag}></${staticTargetTag}><span data-value="initial">initial</span>`
+      : html`<span data-value=${this.valueKey}>${this.valueKey}</span>`,
+  );
 
   show(key: string, valueKey = key, retainRenderedValue = false) {
     this.key = key;
@@ -48,11 +41,7 @@ class TestMcpAppUnmountOwner extends LitElement {
   }
 
   override render() {
-    const value =
-      this.valueKey === "initial"
-        ? staticHtml`<${staticTargetTag}></${staticTargetTag}><span data-value="initial">initial</span>`
-        : html`<span data-value=${this.valueKey}>${this.valueKey}</span>`;
-    return this.gate.render(this.key, value, () => [this.renderRoot], {
+    return this.gate.render(this.key, this.renderValue, () => [this.renderRoot], {
       retainRenderedValue: this.retainRenderedValue,
     });
   }
@@ -68,16 +57,17 @@ class TestMcpAppUnmountSiblingOwner extends LitElement {
   }
 
   override render() {
-    const value = staticHtml`
-      ${
-        this.includeLeaving
-          ? staticHtml`<div class="leaving"><${staticTargetTag}></${staticTargetTag}></div>`
-          : nothing
-      }
-      <${staticTargetTag} class="retained"></${staticTargetTag}>
-    `;
-    return this.gate.render(this.includeLeaving ? "both" : "retained", value, () =>
-      this.renderRoot.querySelectorAll(".leaving"),
+    return this.gate.render(
+      this.includeLeaving ? "both" : "retained",
+      () => staticHtml`
+        ${
+          this.includeLeaving
+            ? staticHtml`<div class="leaving"><${staticTargetTag}></${staticTargetTag}></div>`
+            : nothing
+        }
+        <${staticTargetTag} class="retained"></${staticTargetTag}>
+      `,
+      () => this.renderRoot.querySelectorAll(".leaving"),
     );
   }
 }
@@ -111,34 +101,38 @@ describe("McpAppUnmountGate", () => {
   });
 
   it("keeps the old subtree connected and coalesces replacements until teardown resolves", async () => {
-    const pending = deferred();
+    const pending = createDeferred();
     teardown.mockReturnValue(pending.promise);
     const owner = document.createElement(ownerTag) as TestMcpAppUnmountOwner;
     document.body.append(owner);
     await owner.updateComplete;
+    owner.renderValue.mockClear();
 
     const target = owner.shadowRoot!.querySelector(targetTag)!;
     owner.show("intermediate");
     await owner.updateComplete;
     expect(teardown).toHaveBeenCalledOnce();
+    expect(owner.renderValue).not.toHaveBeenCalled();
     expect(target.isConnected).toBe(true);
     expect(owner.shadowRoot!.querySelector("[data-value='initial']")).not.toBeNull();
 
     owner.show("latest");
     await owner.updateComplete;
     expect(teardown).toHaveBeenCalledOnce();
+    expect(owner.renderValue).not.toHaveBeenCalled();
     expect(owner.shadowRoot!.querySelector("[data-value='latest']")).toBeNull();
 
     pending.resolve();
     await expect
       .poll(() => owner.shadowRoot!.querySelector("[data-value='latest']"))
       .not.toBeNull();
+    expect(owner.renderValue).toHaveBeenCalledOnce();
     expect(owner.shadowRoot!.querySelector(targetTag)).toBeNull();
     expect(owner.shadowRoot!.querySelector("[data-value='intermediate']")).toBeNull();
   });
 
   it("restarts the original target when a pending transition rebounds", async () => {
-    const pending = deferred();
+    const pending = createDeferred();
     teardown.mockReturnValueOnce(pending.promise).mockResolvedValue(undefined);
     const owner = document.createElement(ownerTag) as TestMcpAppUnmountOwner;
     document.body.append(owner);
@@ -158,7 +152,7 @@ describe("McpAppUnmountGate", () => {
   });
 
   it("preserves retained siblings while removing a torn-down target", async () => {
-    const pending = deferred();
+    const pending = createDeferred();
     teardown.mockReturnValue(pending.promise);
     const owner = document.createElement(siblingOwnerTag) as TestMcpAppUnmountSiblingOwner;
     document.body.append(owner);

--- a/ui/src/components/mcp-app-unmount.ts
+++ b/ui/src/components/mcp-app-unmount.ts
@@ -4,6 +4,7 @@ type McpAppUnmountTarget = Element & {
   restartAfterTeardown(): void;
   teardown(): Promise<void>;
 };
+type McpAppUnmountKey = string | readonly string[];
 
 function isMcpAppUnmountTarget(value: Element): value is McpAppUnmountTarget {
   return (
@@ -30,12 +31,9 @@ function findMcpAppUnmountTargets(
   return [...targets];
 }
 
-/**
- * Keeps the currently rendered subtree connected while MCP Apps acknowledge teardown.
- * New renders coalesce behind one bounded component-owned teardown instead of queuing.
- */
+/** Keeps rendered DOM and owner state together until one coalesced MCP teardown completes. */
 export class McpAppUnmountGate {
-  private renderedKey: string | null = null;
+  private renderedKey: McpAppUnmountKey | null = null;
   private renderedValue: unknown;
   private pending = false;
   private restartTargets: McpAppUnmountTarget[] | null = null;
@@ -45,15 +43,15 @@ export class McpAppUnmountGate {
     private readonly selector = "mcp-app-view",
   ) {}
 
-  private apply(key: string, value: unknown): unknown {
+  private apply(key: McpAppUnmountKey, renderValue: () => unknown): unknown {
+    this.renderedValue = renderValue();
     this.renderedKey = key;
-    this.renderedValue = value;
     return this.renderedValue;
   }
 
   render(
-    key: string,
-    value: unknown,
+    key: McpAppUnmountKey,
+    renderValue: () => unknown,
     leavingRoots: () => Iterable<ParentNode>,
     options: { retainRenderedValue?: boolean } = {},
   ): unknown {
@@ -74,18 +72,18 @@ export class McpAppUnmountGate {
       });
       return this.renderedKey === key && options.retainRenderedValue
         ? this.renderedValue
-        : this.apply(key, value);
+        : this.apply(key, renderValue);
     }
     if (this.renderedKey === key && options.retainRenderedValue) {
       return this.renderedValue;
     }
     if (this.renderedKey === null || this.renderedKey === key) {
-      return this.apply(key, value);
+      return this.apply(key, renderValue);
     }
 
     const targets = findMcpAppUnmountTargets(leavingRoots(), this.selector);
     if (targets.length === 0) {
-      return this.apply(key, value);
+      return this.apply(key, renderValue);
     }
 
     this.pending = true;

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -706,7 +706,7 @@ export class ChatPage extends OpenClawLightDomElement {
         );
       }),
     );
-    const rendered = html`
+    const renderValue = () => html`
       <div class="chat-split-view__drop-container">
         ${this.renderSplitLayout(layout, Boolean(this.layout), retainedSessions)}
         ${indicator
@@ -725,7 +725,7 @@ export class ChatPage extends OpenClawLightDomElement {
           : nothing}
       </div>
     `;
-    return this.mcpAppUnmountGate.render(JSON.stringify([...nextPaneKeys]), rendered, () =>
+    return this.mcpAppUnmountGate.render(JSON.stringify([...nextPaneKeys]), renderValue, () =>
       [...this.querySelectorAll<ChatPaneElement>("openclaw-chat-pane")].filter(
         (pane) => !nextPaneKeys.has(pane.dataset.mcpAppOwnerKey ?? ""),
       ),

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -1,9 +1,12 @@
 /* @vitest-environment jsdom */
 
-import { nothing, render } from "lit";
+import { expectDefined } from "@openclaw/normalization-core";
+import { html, nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../../test/helpers/promise.js";
 import { createTestTranscript, stubAnimationFrames } from "../chat-view.test-helpers.ts";
 import { renderChatThread } from "./chat-thread.ts";
+import type { TranscriptRow } from "./chat-transcript-controller.ts";
 import {
   flushDeferredRowPrune,
   installTranscriptDomMocks,
@@ -14,6 +17,47 @@ import {
   transcriptDomState,
   transcriptRows,
 } from "./chat-transcript.test-support.ts";
+
+type TestContentRow = Extract<TranscriptRow, { kind: "content" }>;
+
+function stubMcpAppLifecycle(
+  container: ParentNode,
+  teardown: () => Promise<void> = () => Promise.resolve(),
+) {
+  const app = expectDefined(
+    container.querySelector<HTMLElement>("mcp-app-view"),
+    "mounted MCP app",
+  );
+  const lifecycle = {
+    restartAfterTeardown: vi.fn(),
+    teardown: vi.fn(teardown),
+  };
+  return { app: Object.assign(app, lifecycle), ...lifecycle };
+}
+
+async function mountTestTranscript(paneId: string, initialRows: readonly TestContentRow[]) {
+  const transcript = createTestTranscript();
+  const container = document.body.appendChild(document.createElement("div"));
+  const renderRows = (rows: readonly TestContentRow[]) => {
+    const view = transcript.renderSession(paneId, `agent:main:${paneId}`, (session) =>
+      session.render(rows, (row) => (row.kind === "content" ? row.content : nothing), null, false),
+    );
+    render(view, container);
+    transcript.hostUpdated();
+  };
+  transcript.hostConnected();
+  renderRows(initialRows);
+  await flushDeferredRowPrune();
+  return { container, renderRows, transcript };
+}
+
+function mcpRangeRows(appContent: unknown): TestContentRow[] {
+  return Array.from({ length: 24 }, (_, index) => ({
+    kind: "content" as const,
+    key: `row:${index}`,
+    content: index === 17 ? appContent : html`<div>row ${index}</div>`,
+  }));
+}
 
 describe("chat transcript controller", () => {
   beforeEach(installTranscriptDomMocks);
@@ -70,6 +114,101 @@ describe("chat transcript controller", () => {
     render(renderChatThread(props, transcript), container);
 
     expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(100px)");
+  });
+
+  it("keeps retained MCP rows and the virtual row model atomic through teardown", async () => {
+    const teardownPending = createDeferred();
+    transcriptDomState.measuredRowHeight = 180;
+    const initialRows = [
+      { kind: "content" as const, key: "app", content: html`<mcp-app-view></mcp-app-view>` },
+      { kind: "content" as const, key: "group:tool", content: html`<div>tool</div>` },
+      { kind: "content" as const, key: "group:reply", content: html`<div>reply</div>` },
+    ];
+    const regroupedRows = [
+      { kind: "content" as const, key: "history", content: html`<div>history</div>` },
+      {
+        kind: "content" as const,
+        key: "group:reply",
+        content: html`<div>regrouped</div>`,
+      },
+      { kind: "content" as const, key: "group:next", content: html`<div>next</div>` },
+    ];
+    const { container, renderRows } = await mountTestTranscript("pane-mcp-rows", initialRows);
+    stubMcpAppLifecycle(container, () => teardownPending.promise);
+
+    renderRows(regroupedRows);
+    const retainedRows = transcriptRows(container);
+    expect(retainedRows.map((row) => row.dataset.virtualRowKey)).toEqual([
+      "app",
+      "group:tool",
+      "group:reply",
+    ]);
+
+    // Deliver an old-tree resize while teardown keeps that tree connected.
+    // Its data-index values must still resolve through the old key model.
+    Object.defineProperty(retainedRows[1]!, "offsetHeight", { configurable: true, value: 40 });
+    for (const observer of resizeObservers) {
+      observer.emitTarget(retainedRows[1]!, 800, 40);
+    }
+    teardownPending.resolve();
+    await teardownPending.promise;
+    await Promise.resolve();
+    renderRows(regroupedRows);
+    await flushDeferredRowPrune();
+    renderRows(regroupedRows);
+
+    const committedRows = transcriptRows(container);
+    const overlaps = committedRows.slice(1).flatMap((row, index) => {
+      const previous = committedRows[index]!;
+      const previousStart = Number.parseFloat(previous.style.transform.slice(11));
+      const nextStart = Number.parseFloat(row.style.transform.slice(11));
+      return nextStart < previousStart + previous.offsetHeight
+        ? [`${previous.dataset.virtualRowKey}->${row.dataset.virtualRowKey}`]
+        : [];
+    });
+    expect(overlaps).toEqual([]);
+  });
+
+  it("does not teardown an MCP row retained by an append", async () => {
+    const initialRows = [
+      { kind: "content" as const, key: "app", content: html`<mcp-app-view></mcp-app-view>` },
+      { kind: "content" as const, key: "reply", content: html`<div>reply</div>` },
+    ];
+    const { container, renderRows } = await mountTestTranscript("pane-mcp-append", initialRows);
+    const { app, teardown } = stubMcpAppLifecycle(container);
+
+    renderRows([...initialRows, { kind: "content", key: "next", content: html`<div>next</div>` }]);
+
+    expect(teardown).not.toHaveBeenCalled();
+    expect(container.querySelector("mcp-app-view")).toBe(app);
+  });
+
+  it("tears down a retained MCP key that leaves the next virtual range", async () => {
+    const initialRows = mcpRangeRows(html`<mcp-app-view></mcp-app-view>`);
+    const { container, renderRows } = await mountTestTranscript("pane-mcp-range", initialRows);
+    const { app, teardown } = stubMcpAppLifecycle(container);
+
+    renderRows([initialRows[17]!, ...initialRows.slice(0, 17), ...initialRows.slice(18)]);
+
+    expect(teardown).toHaveBeenCalledOnce();
+    expect(app.isConnected).toBe(true);
+  });
+
+  it("keeps a focused MCP key at its next-model index", async () => {
+    const initialRows = mcpRangeRows(html`<mcp-app-view><button>focus app</button></mcp-app-view>`);
+    const { container, renderRows, transcript } = await mountTestTranscript(
+      "pane-mcp-focused-range",
+      initialRows,
+    );
+    const { app, teardown } = stubMcpAppLifecycle(container);
+    const button = expectDefined(container.querySelector("button"), "MCP app focus target");
+    container.addEventListener("focusin", (event) => transcript.handleFocusIn(event as FocusEvent));
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    renderRows([initialRows[17]!, ...initialRows.slice(0, 17), ...initialRows.slice(18)]);
+
+    expect(teardown).not.toHaveBeenCalled();
+    expect(app.isConnected).toBe(true);
   });
 
   it("reconciles an implicit end anchor when committed content has no scroll range", () => {

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -1,11 +1,8 @@
 // Session-owned virtualizer lifecycle for chat transcripts.
 import { VirtualizerController } from "@tanstack/lit-virtual";
 import {
-  defaultRangeExtractor,
   measureElement as measureVirtualElement,
   observeElementRect,
-  type Range,
-  Virtualizer,
 } from "@tanstack/virtual-core";
 import {
   html,
@@ -25,6 +22,7 @@ import {
   saveChatSessionScrollPosition,
   type ChatSessionScrollPosition,
 } from "../scroll.ts";
+import { extractTranscriptRange, previewTranscriptRowKeys } from "./chat-transcript-range.ts";
 
 export type TranscriptRow<T = unknown> =
   | { kind: "item"; key: string; item: T }
@@ -265,7 +263,8 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
           }
         }),
       measureElement: measureVirtualElement,
-      rangeExtractor: (range) => this.extractTranscriptRange(range, this.rowIndexesByKey),
+      rangeExtractor: (range) =>
+        extractTranscriptRange(range, this.rowIndexesByKey, this.focusedRowKey),
       scrollEndThreshold: CHAT_TRANSCRIPT_END_THRESHOLD_PX,
       overscan: CHAT_TRANSCRIPT_OVERSCAN,
     });
@@ -423,7 +422,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
           return [];
         }
         const nextRenderedKeys = rowModelChanged
-          ? this.previewVirtualRowKeys(nextKeys)
+          ? previewTranscriptRowKeys(virtualizer, nextKeys, this.focusedRowKey)
           : new Set(nextRowKeys);
         return [...appRows].filter((row) => !nextRenderedKeys.has(row.dataset.virtualRowKey ?? ""));
       },
@@ -540,46 +539,6 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
     this.currentAnnouncementText = announcement.text;
   }
 
-  private previewVirtualRowKeys(nextKeys: readonly string[]): Set<string> {
-    const virtualizer = this.virtualizerController.getVirtualizer();
-    const nextIndexes = new Map(nextKeys.map((key, index) => [key, index]));
-    const preview = new Virtualizer<HTMLDivElement, HTMLElement>({
-      ...virtualizer.options,
-      initialMeasurementsCache: virtualizer.takeSnapshot(),
-      initialOffset: virtualizer.scrollOffset ?? virtualizer.options.initialOffset,
-      initialRect: virtualizer.scrollRect ?? virtualizer.options.initialRect,
-      onChange: () => undefined,
-      rangeExtractor: (range) => this.extractTranscriptRange(range, nextIndexes),
-    });
-    preview.scrollElement = virtualizer.scrollElement;
-    // Apply the fork's key-anchor transition on isolated state so teardown
-    // selection is exact without advancing the model owned by connected DOM.
-    preview.setOptions({
-      ...preview.options,
-      count: nextKeys.length,
-      getItemKey: (index) => nextKeys[index] ?? `missing:${index}`,
-    });
-    return new Set(preview.getVirtualIndexes().flatMap((index) => nextKeys[index] ?? []));
-  }
-
-  private extractTranscriptRange(
-    range: Range,
-    rowIndexesByKey: ReadonlyMap<string, number>,
-  ): number[] {
-    const indexes = defaultRangeExtractor(range);
-    const focused =
-      this.focusedRowKey === null ? undefined : rowIndexesByKey.get(this.focusedRowKey);
-    if (
-      focused === undefined ||
-      focused < 0 ||
-      focused >= range.count ||
-      indexes.includes(focused)
-    ) {
-      return indexes;
-    }
-    return [...indexes, focused].toSorted((left, right) => left - right);
-  }
-
   private syncRows(nextKeys: string[]): void {
     const virtualizer = this.virtualizerController.getVirtualizer();
     const typingAdded =
@@ -599,7 +558,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
       count: keys.length,
       getItemKey: (index) => keys[index] ?? `missing:${index}`,
       followOnAppend: false,
-      rangeExtractor: (range) => this.extractTranscriptRange(range, rowIndexesByKey),
+      rangeExtractor: (range) => extractTranscriptRange(range, rowIndexesByKey, this.focusedRowKey),
     });
     if (followTyping) {
       virtualizer.scrollToIndex(this.rowIndexesByKey.get("presence:typing") ?? keys.length - 1, {

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -4,6 +4,8 @@ import {
   defaultRangeExtractor,
   measureElement as measureVirtualElement,
   observeElementRect,
+  type Range,
+  Virtualizer,
 } from "@tanstack/virtual-core";
 import {
   html,
@@ -263,20 +265,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
           }
         }),
       measureElement: measureVirtualElement,
-      rangeExtractor: (range) => {
-        const indexes = defaultRangeExtractor(range);
-        const focused =
-          this.focusedRowKey === null ? undefined : this.rowIndexesByKey.get(this.focusedRowKey);
-        if (
-          focused === undefined ||
-          focused < 0 ||
-          focused >= range.count ||
-          indexes.includes(focused)
-        ) {
-          return indexes;
-        }
-        return [...indexes, focused].toSorted((left, right) => left - right);
-      },
+      rangeExtractor: (range) => this.extractTranscriptRange(range, this.rowIndexesByKey),
       scrollEndThreshold: CHAT_TRANSCRIPT_END_THRESHOLD_PX,
       overscan: CHAT_TRANSCRIPT_OVERSCAN,
     });
@@ -368,61 +357,76 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
     announce: boolean,
     overlay: unknown = nothing,
   ): TemplateResult {
-    this.syncRows(rows);
-    this.syncAnnouncement(announcement, announce);
+    const nextKeys = rows.map((row) => row.key);
+    const rowModelChanged =
+      nextKeys.length !== this.rowKeys.length ||
+      nextKeys.some((key, index) => key !== this.rowKeys[index]);
     const virtualizer = this.virtualizerController.getVirtualizer();
-    const virtualRows = virtualizer.getVirtualItems();
-    const nextRowKeys = new Set(
-      virtualRows.flatMap((virtualRow) => {
-        const row = rows[virtualRow.index];
-        return row ? [row.key] : [];
-      }),
-    );
-    const rendered = html`
-      <div class="chat-thread-inner chat-thread-inner--virtual" ${ref(this.scrollElementRef)}>
-        <div
-          class="chat-virtual-sizer"
-          style=${styleMap({ height: `${virtualizer.getTotalSize()}px` })}
-        >
-          ${overlay}
-          ${repeat(
-            virtualRows,
-            (virtualRow) => virtualRow.key,
-            (virtualRow) => {
-              const row = rows[virtualRow.index];
-              if (!row) {
-                return nothing;
-              }
-              return html`
-                <div
-                  class="chat-virtual-row ${virtualRow.index === 0
-                    ? "chat-virtual-row--first"
-                    : ""}"
-                  style=${styleMap({
-                    transform: `translateY(${
-                      virtualRow.start - virtualizer.options.scrollMargin
-                    }px)`,
-                    // Keep skipped overscan rows at the virtualizer's known size.
-                    containIntrinsicBlockSize: `auto ${virtualRow.size}px`,
-                  })}
-                  data-index=${String(virtualRow.index)}
-                  data-virtual-row-key=${row.key}
-                  ${ref(this.measureRowRefFor(row.key))}
-                >
-                  ${renderRow(row)}
-                </div>
-              `;
-            },
-          )}
-        </div>
-      </div>
-    `;
-    return this.mcpAppUnmountGate.render(JSON.stringify([...nextRowKeys]), rendered, () =>
-      this.threadInnerElement
-        ? [...this.threadInnerElement.querySelectorAll<HTMLElement>(".chat-virtual-row")].filter(
-            (row) => !nextRowKeys.has(row.dataset.virtualRowKey ?? ""),
-          )
-        : [],
+    const nextRowKeys = rowModelChanged
+      ? nextKeys
+      : virtualizer.getVirtualItems().flatMap(({ index }) => rows[index]?.key ?? []);
+    return this.mcpAppUnmountGate.render(
+      rowModelChanged ? nextKeys : JSON.stringify(nextRowKeys),
+      () => {
+        if (rowModelChanged) {
+          this.syncRows(nextKeys);
+        }
+        this.syncAnnouncement(announcement, announce);
+        const virtualRows = virtualizer.getVirtualItems();
+        return html`
+          <div class="chat-thread-inner chat-thread-inner--virtual" ${ref(this.scrollElementRef)}>
+            <div
+              class="chat-virtual-sizer"
+              style=${styleMap({ height: `${virtualizer.getTotalSize()}px` })}
+            >
+              ${overlay}
+              ${repeat(
+                virtualRows,
+                (virtualRow) => virtualRow.key,
+                (virtualRow) => {
+                  const row = rows[virtualRow.index];
+                  if (!row) {
+                    return nothing;
+                  }
+                  return html`
+                    <div
+                      class="chat-virtual-row ${virtualRow.index === 0
+                        ? "chat-virtual-row--first"
+                        : ""}"
+                      style=${styleMap({
+                        transform: `translateY(${
+                          virtualRow.start - virtualizer.options.scrollMargin
+                        }px)`,
+                        // Keep skipped overscan rows at the virtualizer's known size.
+                        containIntrinsicBlockSize: `auto ${virtualRow.size}px`,
+                      })}
+                      data-index=${String(virtualRow.index)}
+                      data-virtual-row-key=${row.key}
+                      ${ref(this.measureRowRefFor(row.key))}
+                    >
+                      ${renderRow(row)}
+                    </div>
+                  `;
+                },
+              )}
+            </div>
+          </div>
+        `;
+      },
+      () => {
+        const appRows = new Set(
+          [
+            ...(this.threadInnerElement?.querySelectorAll<HTMLElement>("mcp-app-view") ?? []),
+          ].flatMap((app) => app.closest<HTMLElement>(".chat-virtual-row") ?? []),
+        );
+        if (appRows.size === 0) {
+          return [];
+        }
+        const nextRenderedKeys = rowModelChanged
+          ? this.previewVirtualRowKeys(nextKeys)
+          : new Set(nextRowKeys);
+        return [...appRows].filter((row) => !nextRenderedKeys.has(row.dataset.virtualRowKey ?? ""));
+      },
     ) as TemplateResult;
   }
 
@@ -536,20 +540,54 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
     this.currentAnnouncementText = announcement.text;
   }
 
-  private syncRows(rows: readonly TranscriptRow[]): void {
-    const nextKeys = rows.map((row) => row.key);
+  private previewVirtualRowKeys(nextKeys: readonly string[]): Set<string> {
+    const virtualizer = this.virtualizerController.getVirtualizer();
+    const nextIndexes = new Map(nextKeys.map((key, index) => [key, index]));
+    const preview = new Virtualizer<HTMLDivElement, HTMLElement>({
+      ...virtualizer.options,
+      initialMeasurementsCache: virtualizer.takeSnapshot(),
+      initialOffset: virtualizer.scrollOffset ?? virtualizer.options.initialOffset,
+      initialRect: virtualizer.scrollRect ?? virtualizer.options.initialRect,
+      onChange: () => undefined,
+      rangeExtractor: (range) => this.extractTranscriptRange(range, nextIndexes),
+    });
+    preview.scrollElement = virtualizer.scrollElement;
+    // Apply the fork's key-anchor transition on isolated state so teardown
+    // selection is exact without advancing the model owned by connected DOM.
+    preview.setOptions({
+      ...preview.options,
+      count: nextKeys.length,
+      getItemKey: (index) => nextKeys[index] ?? `missing:${index}`,
+    });
+    return new Set(preview.getVirtualIndexes().flatMap((index) => nextKeys[index] ?? []));
+  }
+
+  private extractTranscriptRange(
+    range: Range,
+    rowIndexesByKey: ReadonlyMap<string, number>,
+  ): number[] {
+    const indexes = defaultRangeExtractor(range);
+    const focused =
+      this.focusedRowKey === null ? undefined : rowIndexesByKey.get(this.focusedRowKey);
     if (
-      nextKeys.length === this.rowKeys.length &&
-      nextKeys.every((key, index) => key === this.rowKeys[index])
+      focused === undefined ||
+      focused < 0 ||
+      focused >= range.count ||
+      indexes.includes(focused)
     ) {
-      return;
+      return indexes;
     }
+    return [...indexes, focused].toSorted((left, right) => left - right);
+  }
+
+  private syncRows(nextKeys: string[]): void {
     const virtualizer = this.virtualizerController.getVirtualizer();
     const typingAdded =
       !this.rowIndexesByKey.has("presence:typing") && nextKeys.includes("presence:typing");
     const followTyping = typingAdded && virtualizer.isAtEnd();
     this.rowKeys = Object.freeze(nextKeys);
-    this.rowIndexesByKey = new Map(this.rowKeys.map((key, index) => [key, index]));
+    const rowIndexesByKey = new Map(this.rowKeys.map((key, index) => [key, index]));
+    this.rowIndexesByKey = rowIndexesByKey;
     for (const key of this.measureRowRefs.keys()) {
       if (!this.rowIndexesByKey.has(key)) {
         this.measureRowRefs.delete(key);
@@ -561,6 +599,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
       count: keys.length,
       getItemKey: (index) => keys[index] ?? `missing:${index}`,
       followOnAppend: false,
+      rangeExtractor: (range) => this.extractTranscriptRange(range, rowIndexesByKey),
     });
     if (followTyping) {
       virtualizer.scrollToIndex(this.rowIndexesByKey.get("presence:typing") ?? keys.length - 1, {

--- a/ui/src/pages/chat/components/chat-transcript-range.ts
+++ b/ui/src/pages/chat/components/chat-transcript-range.ts
@@ -1,0 +1,39 @@
+import { defaultRangeExtractor, type Range, Virtualizer } from "@tanstack/virtual-core";
+
+export function extractTranscriptRange(
+  range: Range,
+  rowIndexesByKey: ReadonlyMap<string, number>,
+  focusedRowKey: string | null,
+): number[] {
+  const indexes = defaultRangeExtractor(range);
+  const focused = focusedRowKey === null ? undefined : rowIndexesByKey.get(focusedRowKey);
+  if (focused === undefined || focused < 0 || focused >= range.count || indexes.includes(focused)) {
+    return indexes;
+  }
+  return [...indexes, focused].toSorted((left, right) => left - right);
+}
+
+export function previewTranscriptRowKeys(
+  virtualizer: Virtualizer<HTMLDivElement, HTMLElement>,
+  nextKeys: readonly string[],
+  focusedRowKey: string | null,
+): Set<string> {
+  const nextIndexes = new Map(nextKeys.map((key, index) => [key, index]));
+  const preview = new Virtualizer<HTMLDivElement, HTMLElement>({
+    ...virtualizer.options,
+    initialMeasurementsCache: virtualizer.takeSnapshot(),
+    initialOffset: virtualizer.scrollOffset ?? virtualizer.options.initialOffset,
+    initialRect: virtualizer.scrollRect ?? virtualizer.options.initialRect,
+    onChange: () => undefined,
+    rangeExtractor: (range) => extractTranscriptRange(range, nextIndexes, focusedRowKey),
+  });
+  preview.scrollElement = virtualizer.scrollElement;
+  // Isolate the fork's key-anchor transition so teardown selection cannot
+  // advance the model owned by connected DOM.
+  preview.setOptions({
+    ...preview.options,
+    count: nextKeys.length,
+    getItemKey: (index) => nextKeys[index] ?? `missing:${index}`,
+  });
+  return new Set(preview.getVirtualIndexes().flatMap((index) => nextKeys[index] ?? []));
+}

--- a/ui/src/pages/chat/components/chat-transcript.test-support.ts
+++ b/ui/src/pages/chat/components/chat-transcript.test-support.ts
@@ -32,20 +32,27 @@ class RecordingResizeObserver implements ResizeObserver {
   }
 
   emit(width: number, height: number): void {
-    const entries = [...this.targets].map(
-      (target) =>
-        ({
-          target,
-          borderBoxSize: [{ inlineSize: width, blockSize: height }],
-        }) as unknown as ResizeObserverEntry,
-    );
+    const entries = [...this.targets].map((target) => this.entry(target, width, height));
     if (entries.length > 0) {
       this.callback(entries, this);
     }
   }
 
+  emitTarget(target: Element, width: number, height: number): void {
+    if (this.targets.has(target)) {
+      this.callback([this.entry(target, width, height)], this);
+    }
+  }
+
   observes(target: Element): boolean {
     return this.targets.has(target);
+  }
+
+  private entry(target: Element, width: number, height: number): ResizeObserverEntry {
+    return {
+      target,
+      borderBoxSize: [{ inlineSize: width, blockSize: height }],
+    } as unknown as ResizeObserverEntry;
   }
 }
 


### PR DESCRIPTION
Closes #125836

## What Problem This Solves

Fixes an issue where users viewing tool-rich Control UI transcripts could see messages overlap after an MCP app row began asynchronous teardown while the virtualized row model changed.

The outgoing DOM intentionally remains connected until teardown finishes. Previously, the virtualizer could adopt the replacement row keys first, allowing a late ResizeObserver event from an old row index to overwrite a different replacement row's cached height.

## Why This Change Was Made

The MCP unmount gate now accepts a lazy render commit, so connected DOM and owner state advance together after teardown. The transcript previews the forked virtualizer's next rendered range from its public snapshot/remount contract, selecting only MCP rows that truly leave while keeping retained and focused rows mounted.

This is the owner-boundary repair rather than a downstream remeasure or retry: stale resize events continue to work, but they resolve through the row-key model belonging to the DOM that produced them. Router and split-pane callers preserve their existing teardown selection semantics.

Production LOC: +138/-99 (net +39) | Tests/support: +179/-39. The production growth is the isolated next-range preview and atomic commit boundary needed to preserve both exact virtual-range teardown and the fork's key-anchor behavior; the range policy lives in a dedicated module so the lifecycle controller remains below its line budget.

This is an AI-assisted change. I reproduced the failure, inspected the forked `@tanstack/virtual-core` measurement/anchor contract, reviewed the implementation, and ran the proof below.

## User Impact

Control UI transcripts remain readable through MCP app teardown, row regrouping, history insertion, focused-row retention, and virtual-range eviction. Adjacent messages no longer paint over one another because a late measurement was attributed to the wrong row key.

### Before

The deterministic pre-fix lifecycle reproduction reports a 140px overlap:

![Before: next message overlaps the reply by 140px](https://github.com/user-attachments/assets/7cbea52c-3aa7-4d10-b396-e7778b4ed363)

### After

The same row sequence and late measurement reports no overlap:

![After: row geometry commits atomically with no overlap](https://github.com/user-attachments/assets/0a150242-22c5-44a0-a1c1-26ce195f74d0)

## Evidence

- Pre-fix focused regression: `expected [] but received ["group:reply->group:next"]` for `[app, tool, reply] -> [history, reply, next]` with a late old-index measurement.
- Post-fix MCP gate + transcript controller: 18/18 passed.
- Rebase integration with current-main typing-follow behavior: 15/15 passed.
- Router and chat-page callers: 56/56 passed.
- Chromium resize/end-anchor E2E: 2/2 passed.
- `node scripts/check-changed.mjs -- <7 changed files>` passed formatting, core/UI types, i18n, lint, dead-export, package, assertion, and repository guards.
- `git diff --check` passed.
- Codex autoreview (`--mode uncommitted`, high reasoning): clean, no accepted/actionable findings; correctness 0.96.
- 180-row Chromium stress proof covered rapid scrolling, 440-760px width changes, and 480px late row growth without overlap; this ruled out `content-visibility: auto` as the cause:

https://github.com/user-attachments/assets/cf08a579-2060-4cfe-8caa-17616200bb79

The signed-in hosted MCP flow was not recorded because the authenticated Chrome extension relay was unavailable. The deterministic lifecycle regression, exact pre-fix browser geometry, post-fix browser geometry, caller suites, and real Chromium resize lane cover the available owner boundaries.

Provenance: clearly introduced by the transcript integration in #111124 (code and PR author/merger: @fuller-stack-dev, merged 2026-07-19); the later transcript-owner extraction in #122420 carried the ordering forward without changing it.
