### PR TITLE
test(cron): await durable owner subprocesses

### DIFF
--- a/src/cron/service/owner-hardening.test.ts
+++ b/src/cron/service/owner-hardening.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -34,7 +34,7 @@ const { makeStorePath } = createCronStoreHarness({ prefix: "cron-owner-hardening
 const children = new Set<ChildProcess>();
 let scriptRoot = "";
 let runnerScript = "";
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = createTempDirTracker();
 
 beforeEach(async () => {
   scriptRoot = tempDirs.make("cron-owner-hardening-script-", os.tmpdir());
@@ -113,12 +113,15 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  for (const child of children) {
-    if (child.exitCode === null && child.signalCode === null) {
-      child.kill("SIGKILL");
-    }
+  const activeChildren = [...children].filter(
+    (child) => child.exitCode === null && child.signalCode === null,
+  );
+  for (const child of activeChildren) {
+    child.kill("SIGKILL");
   }
+  await Promise.all(activeChildren.map(waitForExit));
   children.clear();
+  tempDirs.cleanup();
 });
 
 function makeCommandJob(id: string, nextRunAtMs: number, trigger = false): CronJob {
@@ -175,42 +178,29 @@ function spawnRunner(params: {
   return child;
 }
 
+// Wait on the child protocol itself; cold TypeScript imports are not part of
+// the cron ownership contract this fixture exercises.
 async function waitForLine(child: ChildProcess, expected: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
-    const cleanup = () => {
-      child.stdout?.off("data", onStdout);
-      child.stderr?.off("data", onStderr);
-      child.off("error", onError);
-      child.off("exit", onExit);
-    };
-    const onStdout = (chunk: unknown) => {
+  let stdout = "";
+  let stderr = "";
+  const onStderr = (chunk: unknown) => {
+    stderr += String(chunk);
+  };
+  if (!child.stdout) {
+    throw new Error(`cron child has no stdout while waiting for ${expected}`);
+  }
+  child.stderr?.on("data", onStderr);
+  try {
+    for await (const chunk of child.stdout.iterator({ destroyOnReturn: false })) {
       stdout += String(chunk);
       if (stdout.split("\n").includes(expected)) {
-        cleanup();
-        resolve();
+        return;
       }
-    };
-    const onStderr = (chunk: unknown) => {
-      stderr += String(chunk);
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const onExit = () => {
-      cleanup();
-      reject(new Error(`cron child exited before ${expected}: ${stderr || stdout}`));
-    };
-    child.stdout?.on("data", onStdout);
-    child.stderr?.on("data", onStderr);
-    child.once("error", onError);
-    child.once("exit", onExit);
-    if (child.exitCode !== null || child.signalCode !== null) {
-      onExit();
     }
-  });
+    throw new Error(`cron child exited before ${expected}: ${stderr || stdout}`);
+  } finally {
+    child.stderr?.off("data", onStderr);
+  }
 }
 
 async function waitForExit(child: ChildProcess): Promise<void> {

--- a/src/cron/service/owner-hardening.test.ts
+++ b/src/cron/service/owner-hardening.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -30,11 +30,25 @@ import type { CronServiceState } from "./state.js";
 import { findCronTaskRunRecoveryInDatabase } from "./task-runs.js";
 import { stopTimer } from "./timer.js";
 
-const { makeStorePath } = createCronStoreHarness({ prefix: "cron-owner-hardening-" });
 const children = new Set<ChildProcess>();
 let scriptRoot = "";
 let runnerScript = "";
-const tempDirs = createTempDirTracker();
+
+// Register this before the temp and store hooks because children can retain
+// both filesystem and SQLite ownership until their exit event is observed.
+afterEach(async () => {
+  const activeChildren = [...children].filter(
+    (child) => child.exitCode === null && child.signalCode === null,
+  );
+  for (const child of activeChildren) {
+    child.kill("SIGKILL");
+  }
+  await Promise.all(activeChildren.map(waitForExit));
+  children.clear();
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const { makeStorePath } = createCronStoreHarness({ prefix: "cron-owner-hardening-" });
 
 beforeEach(async () => {
   scriptRoot = tempDirs.make("cron-owner-hardening-script-", os.tmpdir());
@@ -112,18 +126,6 @@ beforeEach(async () => {
   );
 });
 
-afterEach(async () => {
-  const activeChildren = [...children].filter(
-    (child) => child.exitCode === null && child.signalCode === null,
-  );
-  for (const child of activeChildren) {
-    child.kill("SIGKILL");
-  }
-  await Promise.all(activeChildren.map(waitForExit));
-  children.clear();
-  tempDirs.cleanup();
-});
-
 function makeCommandJob(id: string, nextRunAtMs: number, trigger = false): CronJob {
   return {
     id,
@@ -183,13 +185,37 @@ function spawnRunner(params: {
 async function waitForLine(child: ChildProcess, expected: string): Promise<void> {
   let stdout = "";
   let stderr = "";
+  let protocolFailure: Error | undefined;
   const onStderr = (chunk: unknown) => {
     stderr += String(chunk);
   };
   if (!child.stdout) {
     throw new Error(`cron child has no stdout while waiting for ${expected}`);
   }
+  const failure = (reason: string, cause?: Error) =>
+    new Error(`cron child ${reason} before ${expected}: ${stderr || stdout}`, { cause });
+  const onExit = () => {
+    protocolFailure = failure("exited");
+    child.stdout?.destroy(protocolFailure);
+  };
+  const onChildError = (error: Error) => {
+    protocolFailure = failure("failed", error);
+    child.stdout?.destroy(protocolFailure);
+  };
+  const onStdoutClose = () => {
+    protocolFailure ??= failure("closed stdout");
+  };
+  const onStdoutError = (error: Error) => {
+    protocolFailure ??= failure("failed to read stdout", error);
+  };
+  if (child.exitCode !== null || child.signalCode !== null) {
+    throw failure("exited");
+  }
   child.stderr?.on("data", onStderr);
+  child.once("exit", onExit);
+  child.once("error", onChildError);
+  child.stdout.once("close", onStdoutClose);
+  child.stdout.once("error", onStdoutError);
   try {
     for await (const chunk of child.stdout.iterator({ destroyOnReturn: false })) {
       stdout += String(chunk);
@@ -197,9 +223,15 @@ async function waitForLine(child: ChildProcess, expected: string): Promise<void>
         return;
       }
     }
-    throw new Error(`cron child exited before ${expected}: ${stderr || stdout}`);
+    throw protocolFailure ?? failure("closed stdout");
+  } catch (error) {
+    throw protocolFailure ?? error;
   } finally {
     child.stderr?.off("data", onStderr);
+    child.off("exit", onExit);
+    child.off("error", onChildError);
+    child.stdout.off("close", onStdoutClose);
+    child.stdout.off("error", onStdoutError);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Main CI intermittently fails two durable cron ownership tests before reaching their ownership assertions because the helper child does not emit the exact `started` protocol line within a hard-coded 10-second startup deadline. PR #126284 reproduced the same current-main failure in run 32252328739, job 96066372163: the helper remained alive with empty stdout until that deadline expired.

## Root Cause

The fixture counted cold TypeScript loader and source-import latency as part of the cron ownership contract. Under runner contention, the child can still be importing when the deadline expires. Cleanup also removed generated runner and cron-store state before ensuring every tracked child had exited, allowing a prior subprocess to retain filesystem or SQLite ownership into the next test.

## Fix

- Consume exact stdout protocol lines from the existing child stream with `destroyOnReturn: false`, preserving the stream for later `started` and `completed` waits.
- Capture stderr and reject immediately when stdout closes/errors or the child exits/errors before the expected line.
- Register child kill-and-await teardown before the repository temp-dir tracker and cron-store harness cleanup hooks.
- Keep the cross-process durable-owner behavior and exact protocol assertions unchanged.

Production delta: zero. Test-only delta: +22 lines (+63/-41) against the current base. No changelog entry is needed.

## Evidence

Exact head: `7a8949b6548bb108ae2b9e3fe8a8ac5a6dc903e7`

- Focused owner-hardening test passed 5 serial runs: 13/13 each, 65 assertions total (52.56s, 49.85s, 47.56s, 43.00s, 42.61s).
- Complete serial cron config passed: 179 files, 2,250 tests in 270.82s with `--reporter=verbose`.
- After current-main drift, the resolved fixture remained byte-for-byte identical; the rebased exact head passed another focused 13/13 run in 48.30s.
- The same full command with the default silent reporter first reached the repository wrapper's generic 120-second no-output watchdog; verbose reporting supplied progress without changing any timeout or test behavior.
- `node scripts/check-changed.mjs -- src/cron/service/owner-hardening.test.ts` — passed on the rebased exact head, including core test types, lint, dead-export checks, and temp-dir migration audit.
- `node_modules/.bin/oxfmt --check src/cron/service/owner-hardening.test.ts` — passed.
- `git diff --check` — passed.
- Fresh branch autoreview against the current exact base — clean, no accepted/actionable findings.
