### PR TITLE
chore: canonicalize update test fixture roots on macOS

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -551,7 +551,7 @@ describe("update-cli", () => {
   };
 
   const createTrackedTempDir = async (prefix: string) => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
     tempDirsToCleanup.add(dir);
     return dir;
   };


### PR DESCRIPTION
## What Problem This Solves

Resolves a macOS-only test-harness failure where three update CLI tests created temporary checkout roots under the `/var/folders/...` alias while production correctly returned the canonical `/private/var/folders/...` path. The stale fixture identity made the tests fail even though the runtime behavior was correct.

## Why This Change Was Made

The shared `createTrackedTempDir` fixture now canonicalizes the directory returned by `fs.mkdtemp` before tracking and returning it. This repairs the identity at the fixture producer boundary, keeps every consumer and assertion on the same canonical path, and avoids weakening assertions or changing production path logic.

Related history: #78408 introduced `createTrackedTempDir`; #125171 canonicalized the suite-level `fixtureRoot` but not this helper; #124872 made published checkout roots canonical and exposed the stale fixture identity. #125721 merely surfaced these failures during diagnostics and is unrelated to managed-worktree garbage collection.

## User Impact

No runtime or package behavior changes. macOS contributors and CI can run the affected update CLI tests without false `/var` versus `/private/var` path failures.

Production LOC: +0/-0 | Tests: +1/-1

## Evidence

- Pre-fix: the exact three affected tests failed 3/3 on macOS because expected roots used `/var/folders/...` while production returned `/private/var/folders/...`.
- Focused regression proof: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t 'stops a managed gateway rooted at the git checkout when switching package installs to dev|stops a managed gateway rooted at the package install when switching package installs to dev|continues package-to-Git updates from the published checkout after its alias is retargeted'` — 3 passed, 238 skipped.
- Full file: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts` — 241 passed.
- Formatting: `./node_modules/.bin/oxfmt --check src/cli/update-cli.test.ts` — passed.
- Whitespace: `git diff --check` and `git diff --check origin/main...HEAD` — passed.
- Changed gate: `node scripts/check-changed.mjs -- src/cli/update-cli.test.ts` — passed, lane `coreTests`.
- Codex autoreview: branch mode against `origin/main` — TruffleHog clean; no accepted/actionable findings.

This is deterministic test-harness proof only. No live package install was run or needed because production and package behavior are unchanged.

AI-assisted change; the author reviewed the patch and proof.
