### PR TITLE
fix: thinking controls update after dynamic model discovery

### DIFF
--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -209,6 +209,14 @@ export function getPreparedModelCatalogSnapshot(
   return getPreparedModelCatalogOwnerSnapshot(params)?.modelCatalog;
 }
 
+/** Returns the newest completed catalog for the current generation without starting discovery. */
+export function getAvailablePreparedModelCatalogSnapshot(
+  params: LoadPreparedModelCatalogParams = {},
+): ModelCatalogSnapshot | undefined {
+  const owner = getPreparedModelCatalogOwnerSnapshot(params);
+  return owner?.readFullModelCatalog?.() ?? owner?.modelCatalog;
+}
+
 async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -211,6 +211,7 @@ vi.mock("../logging/subsystem.js", () => ({
 
 const { getPreparedModelRuntimeSnapshot, refreshPreparedModelRuntimeSnapshots } =
   await import("./prepared-model-runtime.js");
+const { getAvailablePreparedModelCatalogSnapshot } = await import("./prepared-model-catalog.js");
 const { prepareScopedReadOnlyLiveModelCatalog, prepareScopedReadOnlyModelCatalog } =
   await import("./prepared-model-runtime.scoped-catalog.js");
 const { resetPreparedModelRuntimeSnapshotsForTest } =
@@ -416,6 +417,14 @@ describe("prepared model runtime Gateway catalog mode", () => {
       inheritedAuthDir: "/tmp/prepared-static-agent",
       workspaceDir: "/tmp/prepared-static-workspace",
     });
+    expect(
+      getAvailablePreparedModelCatalogSnapshot({
+        agentId: "default",
+        config,
+        agentDir: "/tmp/prepared-static-agent",
+        workspaceDir: "/tmp/prepared-static-workspace",
+      }),
+    ).toBe(snapshot?.modelCatalog);
     expect(snapshot?.configuredRuntimeModels).toHaveLength(1);
     expect(snapshot?.pluginRegistry).toBeDefined();
     expect(snapshot?.messageToolCatalog).toBeUndefined();
@@ -432,6 +441,15 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     expect(snapshot?.readFullModelCatalog?.()).toEqual({ entries: [], routeVariants: [] });
+    expect(
+      getAvailablePreparedModelCatalogSnapshot({
+        agentId: "default",
+        config,
+        agentDir: "/tmp/prepared-static-agent",
+        workspaceDir: "/tmp/prepared-static-workspace",
+      }),
+    ).toEqual({ entries: [], routeVariants: [] });
+    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
 
     await snapshot?.loadFullModelCatalog?.({ refresh: true });
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);

--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -12,7 +12,7 @@ import { readSessionAutomationVersion } from "../session-automation-index.js";
 import { readSessionLifecyclePersistenceVersion } from "../session-lifecycle-state.js";
 import { isGatewayAdmin } from "../session-sharing.js";
 import { readSessionTitleProjectionUnavailableVersion } from "../session-transcript-title-reader.js";
-import type { SessionsListResult } from "../session-utils.types.js";
+import type { SessionListModelCatalog, SessionsListResult } from "../session-utils.types.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { readSessionsMutationVersion } from "./session-change-event.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
@@ -22,7 +22,7 @@ type SessionListFence = {
   agentDatabaseRegistryToken: symbol;
   incognitoDatabaseGeneration: number;
   lifecyclePersistenceVersion: number;
-  modelCatalogRevision: number;
+  modelCatalogRevision: string;
   sessionAutomationVersion: number;
   sessionIdentityMutationVersion: number;
   sessionsMutationVersion: number;
@@ -56,16 +56,33 @@ function readModelCatalogRevision(modelCatalog: readonly ModelCatalogEntry[] | u
   return revision;
 }
 
+/**
+ * Serializes the per-agent catalog revision set so the cache fence advances
+ * when any row owner's catalog changes. The revision identity of each distinct
+ * catalog array is monotonic; the string join is stable per sorted agent set.
+ */
+function readSessionListModelCatalogFence(
+  modelCatalog: SessionListModelCatalog | undefined,
+): string {
+  if (!modelCatalog || modelCatalog.size === 0) {
+    return "none";
+  }
+  return [...modelCatalog.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([agentId, entries]) => `${agentId}:${readModelCatalogRevision(entries)}`)
+    .join(",");
+}
+
 function readSessionListFence(
   context: GatewayRequestContext,
-  modelCatalog: readonly ModelCatalogEntry[] | undefined,
+  modelCatalog: SessionListModelCatalog | undefined,
 ): SessionListFence {
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
     agentDatabaseRegistryToken: readOpenClawAgentDatabaseRegistryToken(),
     incognitoDatabaseGeneration: readOpenIncognitoAgentDatabaseGeneration(),
     lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
-    modelCatalogRevision: readModelCatalogRevision(modelCatalog),
+    modelCatalogRevision: readSessionListModelCatalogFence(modelCatalog),
     sessionAutomationVersion: readSessionAutomationVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
@@ -159,7 +176,7 @@ export async function respondWithCachedSessionList(params: {
   client: GatewayClient | null;
   config: OpenClawConfig;
   context: GatewayRequestContext;
-  modelCatalog?: readonly ModelCatalogEntry[];
+  modelCatalog?: SessionListModelCatalog;
   request: SessionsListParams;
   respond: RespondFn;
   run: () => Promise<SessionsListResult>;

--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -1,4 +1,5 @@
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
@@ -21,6 +22,7 @@ type SessionListFence = {
   agentDatabaseRegistryToken: symbol;
   incognitoDatabaseGeneration: number;
   lifecyclePersistenceVersion: number;
+  modelCatalogRevision: number;
   sessionAutomationVersion: number;
   sessionIdentityMutationVersion: number;
   sessionsMutationVersion: number;
@@ -38,13 +40,32 @@ type SessionListState = {
 
 const SESSIONS_LIST_COMPLETED_CACHE_LIMIT = 64;
 const sessionListsByContext = new WeakMap<GatewayRequestContext, SessionListState>();
+const modelCatalogRevisions = new WeakMap<readonly ModelCatalogEntry[], number>();
+let nextModelCatalogRevision = 1;
 
-function readSessionListFence(context: GatewayRequestContext): SessionListFence {
+function readModelCatalogRevision(modelCatalog: readonly ModelCatalogEntry[] | undefined): number {
+  if (!modelCatalog) {
+    return 0;
+  }
+  const existing = modelCatalogRevisions.get(modelCatalog);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const revision = nextModelCatalogRevision++;
+  modelCatalogRevisions.set(modelCatalog, revision);
+  return revision;
+}
+
+function readSessionListFence(
+  context: GatewayRequestContext,
+  modelCatalog: readonly ModelCatalogEntry[] | undefined,
+): SessionListFence {
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
     agentDatabaseRegistryToken: readOpenClawAgentDatabaseRegistryToken(),
     incognitoDatabaseGeneration: readOpenIncognitoAgentDatabaseGeneration(),
     lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
+    modelCatalogRevision: readModelCatalogRevision(modelCatalog),
     sessionAutomationVersion: readSessionAutomationVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
@@ -62,6 +83,7 @@ function matchesSessionListFence(value: SessionListFence, fence: SessionListFenc
     value.agentDatabaseRegistryToken === fence.agentDatabaseRegistryToken &&
     value.incognitoDatabaseGeneration === fence.incognitoDatabaseGeneration &&
     value.lifecyclePersistenceVersion === fence.lifecyclePersistenceVersion &&
+    value.modelCatalogRevision === fence.modelCatalogRevision &&
     value.sessionAutomationVersion === fence.sessionAutomationVersion &&
     value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&
     value.sessionsMutationVersion === fence.sessionsMutationVersion &&
@@ -137,6 +159,7 @@ export async function respondWithCachedSessionList(params: {
   client: GatewayClient | null;
   config: OpenClawConfig;
   context: GatewayRequestContext;
+  modelCatalog?: readonly ModelCatalogEntry[];
   request: SessionsListParams;
   respond: RespondFn;
   run: () => Promise<SessionsListResult>;
@@ -145,7 +168,7 @@ export async function respondWithCachedSessionList(params: {
   const state = sessionListState(params.context, params.config);
   // Every input that can change a projected row must fence reuse. Session identity,
   // Gateway projection, and live-run mutations have separate monotonic owners.
-  const fence = readSessionListFence(params.context);
+  const fence = readSessionListFence(params.context, params.modelCatalog);
   // Activity windows and child retention expire without mutations; hidden paginated rows
   // prevent deriving a safe deadline, so only concurrent temporal requests share work.
   const cacheCompleted = params.request.activeMinutes === undefined && !params.request.spawnedBy;
@@ -169,7 +192,10 @@ export async function respondWithCachedSessionList(params: {
   const promise = Promise.resolve()
     .then(params.run)
     .then((result) => {
-      if (cacheCompleted && matchesSessionListFence(readSessionListFence(params.context), fence)) {
+      if (
+        cacheCompleted &&
+        matchesSessionListFence(readSessionListFence(params.context, params.modelCatalog), fence)
+      ) {
         const expiresAt = resolveSessionListExpiration(result);
         if (expiresAt !== null && (expiresAt === undefined || expiresAt > Date.now())) {
           rememberCompletedSessionList(state, workKey, { ...fence, result, expiresAt });

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -266,6 +267,55 @@ describe("sessions.list single-flight", () => {
       emitSessionsChanged(context, { reason: "test", sessionKey: "agent:main:active" });
       await listSessions({ client, context, request });
       expect(loader.calls).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("reprojects a cached list when a completed model catalog replaces startup metadata", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      config.agents = {
+        ...config.agents,
+        defaults: { model: { primary: "dynamic-router/reasoner" } },
+      };
+      const startupCatalog: ModelCatalogEntry[] = [
+        {
+          provider: "dynamic-router",
+          id: "reasoner",
+          name: "Reasoner",
+          reasoning: false,
+        },
+      ];
+      const fullCatalog: ModelCatalogEntry[] = [
+        {
+          provider: "dynamic-router",
+          id: "reasoner",
+          name: "Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["low", "high", "max"] },
+        },
+      ];
+      let catalog = startupCatalog;
+      const context = {
+        ...requestContext(config),
+        readPreparedGatewayModelCatalog: vi.fn(async () => catalog),
+      };
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+
+      const first = await listSessions({ client, context, request });
+      expect(first.sessions.find((session) => session.agentId === "main")?.thinkingOptions).toEqual(
+        ["off"],
+      );
+      expect(await listSessions({ client, context, request })).toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+
+      catalog = fullCatalog;
+      const refreshed = await listSessions({ client, context, request });
+      expect(refreshed).not.toBe(first);
+      expect(
+        refreshed.sessions.find((session) => session.agentId === "main")?.thinkingOptions,
+      ).toEqual(expect.arrayContaining(["off", "low", "high", "max"]));
+      expect(loader.calls).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
+++ b/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { GatewaySessionRow } from "../session-utils.types.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+
+const { sessionReadHandlers } = await import("./sessions-read.js");
+
+function identifiedClient(profileId: string): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+    },
+    authenticatedUserProfile: {
+      profileId,
+      displayName: profileId,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+function requestContext(config: OpenClawConfig): GatewayRequestContext {
+  return {
+    chatAbortControllers: new Map(),
+    getRuntimeConfig: () => config,
+    getSessionEventSubscriberConnIds: () => new Set(),
+    loadGatewayModelCatalog: async () => [],
+    logGateway: { debug: vi.fn() },
+  } as unknown as GatewayRequestContext;
+}
+
+async function listSessions(params: {
+  client: GatewayClient;
+  context: GatewayRequestContext;
+  request: SessionsListParams;
+}) {
+  const responses: Parameters<RespondFn>[] = [];
+  await sessionReadHandlers["sessions.list"]?.({
+    params: params.request,
+    client: params.client,
+    context: params.context,
+    respond: (...response: Parameters<RespondFn>) => responses.push(response),
+  } as never);
+  expect(responses).toHaveLength(1);
+  expect(responses[0]?.[0]).toBe(true);
+  return responses[0]?.[1] as {
+    count: number;
+    nextOffset: number | null;
+    sessions: GatewaySessionRow[];
+    totalCount: number;
+  };
+}
+
+async function seedSessions(): Promise<OpenClawConfig> {
+  const config: OpenClawConfig = {
+    agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+  };
+  await upsertSessionEntryCore(
+    { agentId: "main", sessionKey: "agent:main:active" },
+    {
+      sessionId: "main-active",
+      updatedAt: 400,
+      createdActor: { type: "human", id: "owner@example.com" },
+      visibility: "shared",
+    },
+  );
+  await upsertSessionEntryCore(
+    { agentId: "work", sessionKey: "agent:work:active" },
+    {
+      sessionId: "work-active",
+      updatedAt: 100,
+      createdActor: { type: "human", id: "viewer@example.com" },
+      visibility: "shared",
+    },
+  );
+  return config;
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+});
+
+afterEach(() => {
+  resetAgentEventsForTest();
+  vi.restoreAllMocks();
+});
+
+describe("sessions.list catalog scoping", () => {
+  it("keeps unscoped listings owner-scoped when agents have distinct completed catalogs", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      config.agents = {
+        ...config.agents,
+        defaults: { model: { primary: "dynamic-router/reasoner" } },
+      };
+      const mainCatalog: ModelCatalogEntry[] = [
+        {
+          provider: "dynamic-router",
+          id: "reasoner",
+          name: "Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["low", "high", "max"] },
+        },
+      ];
+      const workCatalog: ModelCatalogEntry[] = [
+        {
+          provider: "dynamic-router",
+          id: "reasoner",
+          name: "Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["medium"] },
+        },
+      ];
+      const context = {
+        ...requestContext(config),
+        readPreparedGatewayModelCatalog: vi.fn(async (options?: { agentId?: string }) =>
+          options?.agentId === "work" ? workCatalog : mainCatalog,
+        ),
+      };
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+
+      const result = await listSessions({ client, context, request });
+
+      const mainRow = result.sessions.find((session) => session.agentId === "main");
+      const workRow = result.sessions.find((session) => session.agentId === "work");
+      expect(mainRow).toBeDefined();
+      expect(workRow).toBeDefined();
+      expect(mainRow?.thinkingOptions).toEqual(
+        expect.arrayContaining(["off", "low", "high", "max"]),
+      );
+      expect(workRow?.thinkingOptions).toEqual(expect.arrayContaining(["off", "medium"]));
+      expect(workRow?.thinkingOptions).not.toEqual(expect.arrayContaining(["low", "high", "max"]));
+      expect(context.readPreparedGatewayModelCatalog).toHaveBeenCalledWith({
+        agentId: "main",
+      });
+      expect(context.readPreparedGatewayModelCatalog).toHaveBeenCalledWith({
+        agentId: "work",
+      });
+    });
+  });
+
+  it("uses only the requested agent's catalog for scoped listings", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      config.agents = {
+        ...config.agents,
+        defaults: { model: { primary: "dynamic-router/reasoner" } },
+      };
+      const mainCatalog: ModelCatalogEntry[] = [
+        {
+          provider: "dynamic-router",
+          id: "reasoner",
+          name: "Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["low", "high", "max"] },
+        },
+      ];
+      const context = {
+        ...requestContext(config),
+        readPreparedGatewayModelCatalog: vi.fn(async () => mainCatalog),
+      };
+      const client = identifiedClient("owner@example.com");
+
+      const result = await listSessions({
+        client,
+        context,
+        request: { agentId: "main", archived: "all" as const, limit: 100 },
+      });
+
+      expect(result.sessions.every((session) => session.agentId === "main")).toBe(true);
+      expect(result.sessions[0]?.thinkingOptions).toEqual(
+        expect.arrayContaining(["off", "low", "high", "max"]),
+      );
+      expect(context.readPreparedGatewayModelCatalog).toHaveBeenCalledTimes(1);
+      expect(context.readPreparedGatewayModelCatalog).toHaveBeenCalledWith({
+        agentId: "main",
+      });
+    });
+  });
+});

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -211,6 +211,18 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     const cfg = context.getRuntimeConfig();
     const configuredAgentsOnly = p.configuredAgentsOnly === true;
     const identityId = gatewayClientSessionCreator(client)?.id;
+    const preparedModelCatalog = await measureDiagnosticsTimelineSpan(
+      "gateway.sessions.list.model_catalog",
+      () =>
+        readPreparedServerMethodModelCatalog(
+          context,
+          p.agentId ? { agentId: p.agentId } : undefined,
+        ),
+      {
+        config: cfg,
+        phase: "sessions.list",
+      },
+    );
     const run = () =>
       measureDiagnosticsTimelineSpan(
         "gateway.sessions.list",
@@ -226,18 +238,6 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
         ): Promise<Awaited<ReturnType<typeof listSessionsFromStoreAsync>>> {
           let loaded = options.loaded;
           if (!loaded) {
-            const modelCatalog = await measureDiagnosticsTimelineSpan(
-              "gateway.sessions.list.model_catalog",
-              () =>
-                readPreparedServerMethodModelCatalog(
-                  context,
-                  p.agentId ? { agentId: p.agentId } : undefined,
-                ),
-              {
-                config: cfg,
-                phase: "sessions.list",
-              },
-            );
             const loadedStore = measureDiagnosticsTimelineSpanSync(
               "gateway.sessions.list.store_load",
               () =>
@@ -255,7 +255,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 },
               },
             );
-            loaded = { ...loadedStore, modelCatalog };
+            loaded = { ...loadedStore, modelCatalog: preparedModelCatalog };
           }
           if (!loaded) {
             throw new Error("sessions.list store input was not loaded");
@@ -473,7 +473,15 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           },
         },
       );
-    await respondWithCachedSessionList({ client, config: cfg, context, request: p, respond, run });
+    await respondWithCachedSessionList({
+      client,
+      config: cfg,
+      context,
+      modelCatalog: preparedModelCatalog,
+      request: p,
+      respond,
+      run,
+    });
   },
   "sessions.cleanup": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateSessionsCleanupParams, "sessions.cleanup", respond)) {

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -11,6 +11,7 @@ import {
   validateSessionsResolveParams,
   validateSessionsSearchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { listAgentIds } from "../../agents/agent-scope-config.js";
 import {
   isPerAgentSessionStoreConfig,
   listSessionMembershipKeys,
@@ -211,13 +212,31 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     const cfg = context.getRuntimeConfig();
     const configuredAgentsOnly = p.configuredAgentsOnly === true;
     const identityId = gatewayClientSessionCreator(client)?.id;
-    const preparedModelCatalog = await measureDiagnosticsTimelineSpan(
+    const preparedModelCatalogByAgent = await measureDiagnosticsTimelineSpan(
       "gateway.sessions.list.model_catalog",
-      () =>
-        readPreparedServerMethodModelCatalog(
-          context,
-          p.agentId ? { agentId: p.agentId } : undefined,
-        ),
+      async () => {
+        // Scoped listings use exactly the requested agent's completed catalog.
+        // Unscoped listings must not apply one agent's catalog to rows owned by
+        // another agent; resolve each configured agent's completed snapshot
+        // (read-only, never starts discovery) so row projections stay
+        // owner-scoped while cache reuse stays fenced per agent.
+        if (p.agentId) {
+          const agentId = normalizeAgentId(p.agentId);
+          const catalog = await readPreparedServerMethodModelCatalog(context, { agentId });
+          return new Map([[agentId, catalog]]);
+        }
+        const catalogByAgent = new Map<
+          string,
+          Awaited<ReturnType<typeof readPreparedServerMethodModelCatalog>>
+        >();
+        for (const agentId of listAgentIds(cfg)) {
+          catalogByAgent.set(
+            agentId,
+            await readPreparedServerMethodModelCatalog(context, { agentId }),
+          );
+        }
+        return catalogByAgent;
+      },
       {
         config: cfg,
         phase: "sessions.list",
@@ -231,7 +250,10 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             allowFullReload?: boolean;
             excludedKeys?: ReadonlySet<string>;
             loaded?: ReturnType<typeof loadCombinedSessionStoreForGatewayCore> & {
-              modelCatalog: Awaited<ReturnType<typeof readPreparedServerMethodModelCatalog>>;
+              modelCatalogByAgent: Map<
+                string,
+                Awaited<ReturnType<typeof readPreparedServerMethodModelCatalog>>
+              >;
             };
             rowRepairAttempted?: boolean;
           } = {},
@@ -255,12 +277,12 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 },
               },
             );
-            loaded = { ...loadedStore, modelCatalog: preparedModelCatalog };
+            loaded = { ...loadedStore, modelCatalogByAgent: preparedModelCatalogByAgent };
           }
           if (!loaded) {
             throw new Error("sessions.list store input was not loaded");
           }
-          const { durableStorePath, durableTargets, modelCatalog, storePath } = loaded;
+          const { durableStorePath, durableTargets, modelCatalogByAgent, storePath } = loaded;
           const visibilityFilter = createSessionListEntryFilter({ client });
           const entryFilter =
             visibilityFilter || options.excludedKeys?.size
@@ -276,7 +298,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 ...(entryFilter ? { entryFilter } : {}),
                 storePath,
                 store: loaded.store,
-                modelCatalog,
+                modelCatalog: modelCatalogByAgent,
                 opts: p,
                 ...(p.involvingMe === true && identityId ? { involvingActorId: identityId } : {}),
               }),
@@ -477,7 +499,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
       client,
       config: cfg,
       context,
-      modelCatalog: preparedModelCatalog,
+      modelCatalog: preparedModelCatalogByAgent,
       request: p,
       respond,
       run,

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -167,13 +167,14 @@ export async function loadGatewayModelCatalog(
   return (await loadGatewayModelCatalogSnapshot(params)).entries;
 }
 
-/** Reads the already-published startup catalog without starting provider discovery. */
+/** Reads the newest completed published catalog without starting provider discovery. */
 export async function readPreparedGatewayModelCatalog(
   params?: LoadGatewayModelCatalogParams,
 ): Promise<GatewayModelChoice[] | undefined> {
-  const { getPreparedModelCatalogSnapshot } = await import("../agents/prepared-model-catalog.js");
+  const { getAvailablePreparedModelCatalogSnapshot } =
+    await import("../agents/prepared-model-catalog.js");
   const config = (params?.getConfig ?? getRuntimeConfig)();
-  return getPreparedModelCatalogSnapshot({
+  return getAvailablePreparedModelCatalogSnapshot({
     ...(params?.agentId ? { agentId: params.agentId } : {}),
     ...(params?.agentDir ? { agentDir: params.agentDir } : {}),
     config,

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -12,11 +12,13 @@ import {
   getSessionDisplaySubagentRunByChildSessionKey,
 } from "../agents/subagents/registry/subagent-registry-read.js";
 import { shouldKeepSubagentRunChildLink } from "../agents/subagents/registry/subagent-run-liveness.js";
+import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
 import {
   isIncognitoSessionKey,
+  LEGACY_IMPLICIT_AGENT_ID,
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
@@ -54,7 +56,11 @@ import {
   resolveSessionListSearchModelFields,
   shouldResolveDerivedSessionModelSearchFields,
 } from "./session-utils-search.js";
-import type { GatewaySessionRow, SessionsListResult } from "./session-utils.types.js";
+import type {
+  GatewaySessionRow,
+  SessionListModelCatalog,
+  SessionsListResult,
+} from "./session-utils.types.js";
 
 /**
  * Number of session rows to build per batch before yielding to the event loop.
@@ -73,7 +79,7 @@ type ListSessionsFromStoreParams = {
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
   storePath: string;
   store: Record<string, SessionEntry>;
-  modelCatalog?: ModelCatalogEntry[];
+  modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
   lightweightListRows?: boolean;
   opts: SessionsListParams;
   involvingActorId?: string;
@@ -466,10 +472,24 @@ function buildSessionsListResult(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   list: ReturnType<typeof prepareSessionList>;
-  modelCatalog?: ModelCatalogEntry[];
+  modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
   sessions: GatewaySessionRow[];
 }): SessionsListResult {
   const { list, sessions } = params;
+  // The defaults projection uses the same agent identity as getSessionDefaults:
+  // the requested agent when scoped, otherwise the legacy compatibility agent.
+  // Legacy plain-array catalogs (direct listSessionsFromStore callers) pass through
+  // unchanged; per-agent maps resolve by the same identity.
+  const defaultsCatalog =
+    params.modelCatalog instanceof Map
+      ? params.modelCatalog.get(
+          params.agentId
+            ? normalizeAgentId(params.agentId)
+            : normalizeAgentId(
+                tryResolveLegacyCompatibilityAgentId(params.cfg) ?? LEGACY_IMPLICIT_AGENT_ID,
+              ),
+        )
+      : params.modelCatalog;
   return {
     ts: list.now,
     path: list.storePath,
@@ -480,7 +500,7 @@ function buildSessionsListResult(params: {
     nextOffset: list.nextOffset,
     hasMore: list.hasMore,
     owners: list.ownerFacet,
-    defaults: getSessionDefaults(params.cfg, params.modelCatalog, {
+    defaults: getSessionDefaults(params.cfg, defaultsCatalog, {
       ...(params.agentId ? { agentId: params.agentId } : {}),
       allowPluginNormalization: false,
     }),

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -316,11 +316,19 @@ export function getSessionDefaults(
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: options?.allowPluginNormalization,
       });
+  const catalogEntry = modelCatalog
+    ? findModelCatalogEntry(modelCatalog, {
+        provider: resolved.provider,
+        modelId: resolved.model,
+      })
+    : undefined;
   const contextTokens =
     resolveContextTokensForModel({
       cfg,
       provider: resolved.provider,
       model: resolved.model,
+      modelContextTokens: catalogEntry?.contextTokens,
+      modelContextWindow: catalogEntry?.contextWindow,
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS;
   const sessionKey = resolveAgentMainSessionKey({ cfg, agentId });

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -11,7 +11,7 @@ import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveAgentIdentity } from "../agents/identity.js";
-import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { findModelCatalogEntry, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import { resolveSessionModelIdentityRef } from "../agents/session-model-ref.js";
 import {
   countActiveDescendantRuns,
@@ -472,11 +472,20 @@ export function buildGatewaySessionRow(params: {
     rowContext,
     providerPolicySource: lightweight ? "active" : undefined,
   });
+  const catalogEntry =
+    params.modelCatalog && rowModelProvider && rowModel
+      ? findModelCatalogEntry(params.modelCatalog, {
+          provider: rowModelProvider,
+          modelId: rowModel,
+        })
+      : undefined;
   const resolvedCurrentContextTokens = resolvePositiveNumber(
     resolveContextTokensForModel({
       cfg,
       provider: rowModelProvider,
       model: rowModel,
+      modelContextTokens: catalogEntry?.contextTokens,
+      modelContextWindow: catalogEntry?.contextWindow,
       allowAsyncLoad: false,
     }),
   );

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -81,7 +81,7 @@ import {
   resolveTranscriptUsageFallback,
 } from "./session-utils-projection.js";
 import { isGroupOrChannelDisplaySession, parseGroupKey } from "./session-utils-store.js";
-import type { GatewaySessionRow } from "./session-utils.types.js";
+import type { GatewaySessionRow, SessionListModelCatalog } from "./session-utils.types.js";
 import { projectWorkerPlacementAgentRuntime } from "./worker-environments/placement-session-runtime.js";
 
 /** Adds current actor display data without persisting rename-prone metadata. */
@@ -209,7 +209,7 @@ export function buildGatewaySessionRow(params: {
   store: Record<string, SessionEntry>;
   key: string;
   entry?: SessionEntry;
-  modelCatalog?: ModelCatalogEntry[];
+  modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
   now?: number;
   includeDerivedTitles?: boolean;
   includeLastMessage?: boolean;
@@ -457,10 +457,16 @@ export function buildGatewaySessionRow(params: {
 
   const thinkingProvider = rowModelProvider ?? DEFAULT_PROVIDER;
   const thinkingModel = rowModel ?? DEFAULT_MODEL;
+  // A per-agent catalog map keeps unscoped listings owner-scoped: each row uses
+  // its own agent's completed catalog instead of a shared default-agent catalog.
+  const rowModelCatalog =
+    params.modelCatalog instanceof Map
+      ? params.modelCatalog.get(sessionAgentId)
+      : params.modelCatalog;
   // Event/list rows must not rediscover plugin-backed configured catalog metadata.
   // Lightweight projections may use an already-active provider policy, but must
   // not fall through to public artifacts that reload the manifest registry.
-  const thinkingModelCatalog = params.modelCatalog ?? (lightweight ? [] : undefined);
+  const thinkingModelCatalog = rowModelCatalog ?? (lightweight ? [] : undefined);
   const thinkingProjection = resolveGatewaySessionThinkingProjectionInternal({
     cfg,
     agentId: sessionAgentId,
@@ -473,8 +479,8 @@ export function buildGatewaySessionRow(params: {
     providerPolicySource: lightweight ? "active" : undefined,
   });
   const catalogEntry =
-    params.modelCatalog && rowModelProvider && rowModel
-      ? findModelCatalogEntry(params.modelCatalog, {
+    rowModelCatalog && rowModelProvider && rowModel
+      ? findModelCatalogEntry(rowModelCatalog, {
           provider: rowModelProvider,
           modelId: rowModel,
         })

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -811,6 +811,51 @@ describe("gateway session utils", () => {
     expect(row.thinkingDefault).toBe("medium");
   });
 
+  test("session defaults and rows use dynamic catalog context limits with authored caps", () => {
+    const catalog = [
+      {
+        provider: "dynamic-router",
+        id: "reasoner",
+        name: "Reasoner",
+        contextWindow: 256_000,
+        contextTokens: 200_000,
+      },
+    ];
+    const cfg = createModelDefaultsConfig({ primary: "dynamic-router/reasoner" });
+
+    expect(getSessionDefaults(cfg, catalog).contextTokens).toBe(200_000);
+    expect(
+      buildGatewaySessionRow({
+        cfg,
+        storePath: "",
+        store: {},
+        key: "agent:main:main",
+        modelCatalog: catalog,
+      }).contextTokens,
+    ).toBe(200_000);
+
+    const capped = {
+      ...cfg,
+      models: {
+        providers: {
+          "dynamic-router": {
+            models: [{ id: "reasoner", contextWindow: 128_000 }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(getSessionDefaults(capped, catalog).contextTokens).toBe(128_000);
+    expect(
+      buildGatewaySessionRow({
+        cfg: capped,
+        storePath: "",
+        store: {},
+        key: "agent:main:main",
+        modelCatalog: catalog,
+      }).contextTokens,
+    ).toBe(128_000);
+  });
+
   test("session rows project automation bindings and event fields forward them", () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     registerSessionAutomationSource({

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../packages/gateway-protocol/src/index.js";
 import type { QueueMode } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import type { ChatType } from "../channels/chat-type.js";
 import type {
   SessionCompactionCheckpoint,
@@ -222,6 +223,13 @@ export type SessionsPreviewResult = {
 };
 
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;
+
+/**
+ * Per-agent completed model catalogs for a session listing. Scoped listings
+ * carry exactly one agent's catalog; unscoped listings carry one per configured
+ * agent so row projections stay owner-scoped.
+ */
+export type SessionListModelCatalog = ReadonlyMap<string, ModelCatalogEntry[] | undefined>;
 
 export type SessionsPatchResult = SessionsPatchResultBase<SessionEntry> & {
   entry: SessionEntry;

--- a/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
@@ -1,0 +1,150 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const dynamicCatalogProofDir =
+  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dynamic-catalog-convergence")
+    : null;
+
+suite.define(() => {
+  it("converges Chat reasoning and context metadata after dynamic catalog discovery", async () => {
+    if (dynamicCatalogProofDir) {
+      await mkdir(dynamicCatalogProofDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(dynamicCatalogProofDir
+        ? { recordVideo: { dir: dynamicCatalogProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:dynamic-catalog";
+    const preparedLevels = [{ id: "off", label: "off" }];
+    const discoveredLevels = ["off", "low", "medium", "high", "xhigh"].map((id) => ({
+      id,
+      label: id,
+    }));
+    const preparedModel = {
+      available: true,
+      id: "deepseekv4flash-equivalent",
+      name: "DeepSeek V4 Flash",
+      provider: "omniroute",
+      reasoning: true,
+    };
+    const discoveredModel = {
+      ...preparedModel,
+      compat: { supportedReasoningEfforts: discoveredLevels.map((level) => level.id) },
+      contextWindow: 262_144,
+    };
+    const agentsList = {
+      agents: [
+        {
+          id: "main",
+          model: { primary: "omniroute/deepseekv4flash-equivalent" },
+          name: "Main",
+        },
+      ],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+    const sessionResponse = (levels: typeof preparedLevels, contextTokens: number) => ({
+      count: 1,
+      defaults: {
+        contextTokens,
+        model: "deepseekv4flash-equivalent",
+        modelProvider: "omniroute",
+        thinkingDefault: "off",
+        thinkingLevels: levels,
+      },
+      path: "",
+      sessions: [
+        {
+          contextTokens,
+          key: sessionKey,
+          kind: "direct",
+          label: "Dynamic catalog",
+          model: "deepseekv4flash-equivalent",
+          modelProvider: "omniroute",
+          thinkingDefault: "off",
+          thinkingLevels: levels,
+          updatedAt: 2,
+        },
+      ],
+      ts: Date.now(),
+    });
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.startup": {
+          agentsList,
+          messages: [],
+          metadata: { models: [preparedModel] },
+          sessionId: "control-ui-dynamic-catalog-convergence",
+          thinkingLevel: null,
+        },
+        "sessions.list": sessionResponse(preparedLevels, 8_192),
+      },
+      models: [discoveredModel],
+      sessionKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const main = page.getByRole("main");
+      const modelSelect = main.locator('[data-chat-model-select="true"]');
+      const effortSelect = main.locator('[data-chat-thinking-select="true"]');
+
+      await effortSelect.click();
+      await expect.poll(() => main.locator('[data-chat-thinking-option="off"]').count()).toBe(1);
+      expect(await main.locator('[data-chat-thinking-slider="true"]').count()).toBe(0);
+      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "01-prepared-off-only.png"),
+        });
+      }
+
+      await page.keyboard.press("Escape");
+      await gateway.setMethodResponse("sessions.list", sessionResponse(discoveredLevels, 65_536));
+      const sessionListCount = (await gateway.getRequests("sessions.list")).length;
+      await modelSelect.click();
+      const modelsRequest = await gateway.waitForRequest("models.list");
+      expect(modelsRequest.params).toEqual({ view: "configured", agentId: "main" });
+      const refreshedSessionsRequest = await gateway.waitForRequest("sessions.list", {
+        after: sessionListCount,
+      });
+      expect(refreshedSessionsRequest.params).toMatchObject({ agentId: "main" });
+      const modelOption = main.locator(
+        '[data-chat-model-option="omniroute/deepseekv4flash-equivalent"]',
+      );
+      await expect.poll(() => modelOption.textContent()).toContain("262.1k");
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "02-discovered-context.png"),
+        });
+      }
+
+      await page.keyboard.press("Escape");
+      await effortSelect.click();
+      const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
+      await expect
+        .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
+        .toBe("off,low,medium,high,xhigh");
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "03-discovered-thinking-levels.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,5 +1,3 @@
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
 import { expect, it } from "vitest";
 import {
   chatSessionListResponse,
@@ -11,10 +9,6 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const dynamicCatalogProofDir =
-  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
-    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dynamic-catalog-convergence")
-    : null;
 
 suite.define(() => {
   it("patches the session permission mode and reflects sessions.changed", async () => {
@@ -606,144 +600,6 @@ suite.define(() => {
       }
 
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
-  });
-
-  it("converges Chat reasoning and context metadata after dynamic catalog discovery", async () => {
-    if (dynamicCatalogProofDir) {
-      await mkdir(dynamicCatalogProofDir, { recursive: true });
-    }
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-      ...(dynamicCatalogProofDir
-        ? { recordVideo: { dir: dynamicCatalogProofDir, size: { height: 900, width: 1280 } } }
-        : {}),
-    });
-    const page = await context.newPage();
-    const sessionKey = "agent:main:dynamic-catalog";
-    const preparedLevels = [{ id: "off", label: "off" }];
-    const discoveredLevels = ["off", "low", "medium", "high", "xhigh"].map((id) => ({
-      id,
-      label: id,
-    }));
-    const preparedModel = {
-      available: true,
-      id: "deepseekv4flash-equivalent",
-      name: "DeepSeek V4 Flash",
-      provider: "omniroute",
-      reasoning: true,
-    };
-    const discoveredModel = {
-      ...preparedModel,
-      compat: { supportedReasoningEfforts: discoveredLevels.map((level) => level.id) },
-      contextWindow: 262_144,
-    };
-    const agentsList = {
-      agents: [
-        {
-          id: "main",
-          model: { primary: "omniroute/deepseekv4flash-equivalent" },
-          name: "Main",
-        },
-      ],
-      defaultId: "main",
-      mainKey: "main",
-      scope: "agent",
-    };
-    const sessionResponse = (levels: typeof preparedLevels, contextTokens: number) => ({
-      count: 1,
-      defaults: {
-        contextTokens,
-        model: "deepseekv4flash-equivalent",
-        modelProvider: "omniroute",
-        thinkingDefault: "off",
-        thinkingLevels: levels,
-      },
-      path: "",
-      sessions: [
-        {
-          contextTokens,
-          key: sessionKey,
-          kind: "direct",
-          label: "Dynamic catalog",
-          model: "deepseekv4flash-equivalent",
-          modelProvider: "omniroute",
-          thinkingDefault: "off",
-          thinkingLevels: levels,
-          updatedAt: 2,
-        },
-      ],
-      ts: Date.now(),
-    });
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "chat.startup": {
-          agentsList,
-          messages: [],
-          metadata: { models: [preparedModel] },
-          sessionId: "control-ui-dynamic-catalog-convergence",
-          thinkingLevel: null,
-        },
-        "sessions.list": sessionResponse(preparedLevels, 8_192),
-      },
-      models: [discoveredModel],
-      sessionKey,
-    });
-
-    try {
-      await page.goto(`${suite.server.baseUrl}chat`);
-      const main = page.getByRole("main");
-      const modelSelect = main.locator('[data-chat-model-select="true"]');
-      const effortSelect = main.locator('[data-chat-thinking-select="true"]');
-
-      await effortSelect.click();
-      await expect.poll(() => main.locator('[data-chat-thinking-option="off"]').count()).toBe(1);
-      expect(await main.locator('[data-chat-thinking-slider="true"]').count()).toBe(0);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
-      if (dynamicCatalogProofDir) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(dynamicCatalogProofDir, "01-prepared-off-only.png"),
-        });
-      }
-
-      await page.keyboard.press("Escape");
-      await gateway.setMethodResponse("sessions.list", sessionResponse(discoveredLevels, 65_536));
-      const sessionListCount = (await gateway.getRequests("sessions.list")).length;
-      await modelSelect.click();
-      const modelsRequest = await gateway.waitForRequest("models.list");
-      expect(modelsRequest.params).toEqual({ view: "configured", agentId: "main" });
-      const refreshedSessionsRequest = await gateway.waitForRequest("sessions.list", {
-        after: sessionListCount,
-      });
-      expect(refreshedSessionsRequest.params).toMatchObject({ agentId: "main" });
-      const modelOption = main.locator(
-        '[data-chat-model-option="omniroute/deepseekv4flash-equivalent"]',
-      );
-      await expect.poll(() => modelOption.textContent()).toContain("262.1k");
-      if (dynamicCatalogProofDir) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(dynamicCatalogProofDir, "02-discovered-context.png"),
-        });
-      }
-
-      await page.keyboard.press("Escape");
-      await effortSelect.click();
-      const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
-      await expect
-        .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
-        .toBe("off,low,medium,high,xhigh");
-      if (dynamicCatalogProofDir) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(dynamicCatalogProofDir, "03-discovered-thinking-levels.png"),
-        });
-      }
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,3 +1,5 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   chatSessionListResponse,
@@ -9,6 +11,10 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+const dynamicCatalogProofDir =
+  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dynamic-catalog-convergence")
+    : null;
 
 suite.define(() => {
   it("patches the session permission mode and reflects sessions.changed", async () => {
@@ -600,6 +606,144 @@ suite.define(() => {
       }
 
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("converges Chat reasoning and context metadata after dynamic catalog discovery", async () => {
+    if (dynamicCatalogProofDir) {
+      await mkdir(dynamicCatalogProofDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(dynamicCatalogProofDir
+        ? { recordVideo: { dir: dynamicCatalogProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:dynamic-catalog";
+    const preparedLevels = [{ id: "off", label: "off" }];
+    const discoveredLevels = ["off", "low", "medium", "high", "xhigh"].map((id) => ({
+      id,
+      label: id,
+    }));
+    const preparedModel = {
+      available: true,
+      id: "deepseekv4flash-equivalent",
+      name: "DeepSeek V4 Flash",
+      provider: "omniroute",
+      reasoning: true,
+    };
+    const discoveredModel = {
+      ...preparedModel,
+      compat: { supportedReasoningEfforts: discoveredLevels.map((level) => level.id) },
+      contextWindow: 262_144,
+    };
+    const agentsList = {
+      agents: [
+        {
+          id: "main",
+          model: { primary: "omniroute/deepseekv4flash-equivalent" },
+          name: "Main",
+        },
+      ],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+    const sessionResponse = (levels: typeof preparedLevels, contextTokens: number) => ({
+      count: 1,
+      defaults: {
+        contextTokens,
+        model: "deepseekv4flash-equivalent",
+        modelProvider: "omniroute",
+        thinkingDefault: "off",
+        thinkingLevels: levels,
+      },
+      path: "",
+      sessions: [
+        {
+          contextTokens,
+          key: sessionKey,
+          kind: "direct",
+          label: "Dynamic catalog",
+          model: "deepseekv4flash-equivalent",
+          modelProvider: "omniroute",
+          thinkingDefault: "off",
+          thinkingLevels: levels,
+          updatedAt: 2,
+        },
+      ],
+      ts: Date.now(),
+    });
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.startup": {
+          agentsList,
+          messages: [],
+          metadata: { models: [preparedModel] },
+          sessionId: "control-ui-dynamic-catalog-convergence",
+          thinkingLevel: null,
+        },
+        "sessions.list": sessionResponse(preparedLevels, 8_192),
+      },
+      models: [discoveredModel],
+      sessionKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const main = page.getByRole("main");
+      const modelSelect = main.locator('[data-chat-model-select="true"]');
+      const effortSelect = main.locator('[data-chat-thinking-select="true"]');
+
+      await effortSelect.click();
+      await expect.poll(() => main.locator('[data-chat-thinking-option="off"]').count()).toBe(1);
+      expect(await main.locator('[data-chat-thinking-slider="true"]').count()).toBe(0);
+      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "01-prepared-off-only.png"),
+        });
+      }
+
+      await page.keyboard.press("Escape");
+      await gateway.setMethodResponse("sessions.list", sessionResponse(discoveredLevels, 65_536));
+      const sessionListCount = (await gateway.getRequests("sessions.list")).length;
+      await modelSelect.click();
+      const modelsRequest = await gateway.waitForRequest("models.list");
+      expect(modelsRequest.params).toEqual({ view: "configured", agentId: "main" });
+      const refreshedSessionsRequest = await gateway.waitForRequest("sessions.list", {
+        after: sessionListCount,
+      });
+      expect(refreshedSessionsRequest.params).toMatchObject({ agentId: "main" });
+      const modelOption = main.locator(
+        '[data-chat-model-option="omniroute/deepseekv4flash-equivalent"]',
+      );
+      await expect.poll(() => modelOption.textContent()).toContain("262.1k");
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "02-discovered-context.png"),
+        });
+      }
+
+      await page.keyboard.press("Escape");
+      await effortSelect.click();
+      const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
+      await expect
+        .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
+        .toBe("off,low,medium,high,xhigh");
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "03-discovered-thinking-levels.png"),
+        });
+      }
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -14,7 +14,10 @@ import { refreshChatAvatar, resolveAgentIdForSession } from "./chat-avatar.ts";
 import { applyRemoteSlashCommandsResult, refreshSlashCommands } from "./chat-commands.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import { flushChatQueueForEvent } from "./chat-send-actions.ts";
-import { flushChatQueueAfterIdleSessionReconciliation } from "./chat-session.ts";
+import {
+  flushChatQueueAfterIdleSessionReconciliation,
+  refreshCurrentChatSessionList,
+} from "./chat-session.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
 import { loadModels } from "./models.ts";
@@ -194,6 +197,10 @@ export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promi
     if (ownsRequest()) {
       host.chatModelCatalog = models;
       host.chatModelCatalogError = null;
+      // Full model discovery can complete after the session projection used at mount time.
+      // Refresh through the normal session owner so thinking/context metadata converges without
+      // letting the UI guess which provider- or runtime-specific levels are valid.
+      await refreshCurrentChatSessionList(host).catch(() => undefined);
     }
   } catch (error) {
     if (ownsRequest()) {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -18,6 +18,7 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
 import {
   refreshChatMetadata,
+  refreshChatModelCatalogOnDemand,
   refreshChatModelAuthStatus,
   retireChatMetadataRequests,
 } from "./chat-state-refresh.ts";
@@ -2117,6 +2118,42 @@ describe("refreshChatMetadata", () => {
       ...overrides,
     } as unknown as ChatPageHost;
   }
+
+  it("refreshes session metadata after full model discovery completes", async () => {
+    const refreshSessions = vi.fn().mockResolvedValue(undefined);
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      expect(method).toBe("models.list");
+      expect(params).toEqual({ view: "configured", agentId: "work" });
+      return {
+        models: [
+          {
+            id: "reasoner",
+            name: "Reasoner",
+            provider: "dynamic-router",
+            reasoning: true,
+          },
+        ],
+      };
+    });
+    const state = createMetadataState(request, {
+      sessions: { refresh: refreshSessions } as never,
+    });
+
+    await refreshChatModelCatalogOnDemand(state);
+
+    expect(state.chatModelCatalog).toEqual([
+      {
+        id: "reasoner",
+        name: "Reasoner",
+        provider: "dynamic-router",
+        reasoning: true,
+      },
+    ]);
+    expect(refreshSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "work", force: true }),
+    );
+    expect(state.chatModelCatalogError).toBeNull();
+  });
 
   it("applies agent-scoped metadata after a same-agent session switch", async () => {
     let resolveMetadata:


### PR DESCRIPTION
Closes #125845

Related: #124008 (New Session follow-up in #126013).

## What Problem This Solves

A dynamic provider can finish loading richer model metadata after sessions.list has already cached rows built from the startup catalog. The picker then has the provider's capabilities, while existing session controls can still show stale thinking options and omit the provider-advertised context limit.

## Scope

This PR makes a completed catalog converge into session projections without starting discovery from a session read:

- reads the lifecycle owner's already-completed catalog when present;
- fences sessions.list reuse on the catalog snapshot;
- after Chat's existing on-demand catalog load succeeds, refreshes through the existing session owner.

Provider thinking semantics and configured context caps remain authoritative. There are no provider-specific fallbacks or model heuristics.

## Explicit non-scope: New Session inventory

This leaves chat.metadata prepared-only and does not change New Session's catalog request. #124008 is handled by #126013, which owns the shared New Session catalog path.

The two PRs are complementary but independently scoped: this PR repairs an existing-session projection/cache path; #126013 repairs New Session inventory and provider metadata preservation. Neither needs to absorb the other's ownership.

## Evidence status

- Provider-neutral regressions cover cache reprojection when a completed catalog replaces startup metadata, dynamic thinking levels, and configured context caps.
- The Chat regression covers refreshing session controls after existing on-demand catalog discovery.
- The prior screenshot/video set exercised the intended Control UI transition in a test harness. It is not used here as evidence of a completed provider/Gateway session-flow run.

## Completed isolated runtime proof

The original contributor head was run against an isolated loopback Gateway with the external OmniRoute plugin and an authenticated local GET /v1/models fixture. The completed catalog was discovered once and reprojected into the existing session row:

- Catalog views configured, default, and all returned deepseekv4flash-equivalent at context 262144 with thinking levels off, low, medium, high, xhigh.
- The existing row was startup-only before discovery; after discovery it reported context 262144, the same supported levels, and default medium.
- Chat startup stayed prepared-only with an empty metadata list, preserving #126013 New Session ownership.
- The fixture received one authenticated request. The sanitized RPC artifact is retained locally at pr125847-existing-session-proof-20260819/rpc-existing-session-proof.json.

Companion plugin repair: https://github.com/ekinnee/omniroute-openclaw/pull/7. It preserves configured credential discovery and recognizes OmniRoute documented OpenAI chat endpoint values.

## Maintainer exact-head validation (2026-08-20)

The guarded current-main rebase preserved Erick Kinnee's authorship on all four commits. Exact head: `6702178e8ac9647736f556371bc74e8e5b7a967b`.

- Provider: Crabbox AWS coordinator, fresh GitHub PR checkout; lease `cbx_fd0334442408`, run `run_509d8bfe9fd3`.
- Command: `corepack pnpm install --frozen-lockfile` followed by the Gateway cache/scope suites, Chat state suite, and `ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts`.
- Observed: 30 Gateway tests, 63 Chat state tests, and 1 browser E2E passed. The E2E exercised Chat's completed-catalog control convergence; the isolated Gateway proof above remains the live provider/catalog evidence.
- Limits: Docker Desktop's Linux engine was unavailable after the maintainer host restart, and the configured delegated Testbox client was not installed; neither is a product-test failure. The exact-head hosted CI and CodeQL runs remain the broad validation gate.
