### PR TITLE
fix: keep turns active when sessions_yield has no child

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -111,6 +111,7 @@ type DynamicToolBuildParams = {
   /** Host fact resolver; injectable only for focused plugin contract tests. */
   isHostScopedToolActive?: (toolName: string) => boolean;
   onYieldDetected: (acknowledgment?: string) => void;
+  claimYieldCompletion?: OpenClawCodingToolsOptions["claimYieldCompletion"];
   onCodexAppServerEvent?: (event: CodexDynamicToolBuildEvent) => void;
   onPersistentWebSearchPolicyResolved?: (allowed: boolean) => void;
   onWebSearchPolicyResolved?: (allowed: boolean) => void;
@@ -355,6 +356,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
             data: { name: "sessions_yield", message },
           });
         },
+        claimYieldCompletion: input.claimYieldCompletion,
         recordToolPrepStage: (name) => {
           toolBuildStages.mark(name);
         },

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -62,6 +62,7 @@ export type CodexNativePreToolUseFailure = {
 
 export type CodexNativeHookRelay = NativeHookRelayRegistrationHandle & {
   authorizeRetentionAfterSuccessfulYield: () => void;
+  hasClaimedDirectChild: () => boolean;
   claimDirectChild: (threadId: string) => () => void;
   rejectPendingDirectChild: (threadId: string, reason: string) => void;
 };
@@ -270,6 +271,7 @@ export function createCodexNativeHookRelay(params: {
     authorizeRetentionAfterSuccessfulYield: () => {
       successfulYieldRetentionAuthorized = true;
     },
+    hasClaimedDirectChild: () => directChildClaims.size > 0,
     rejectPendingDirectChild: (threadIdInput, reason) => {
       const threadId = threadIdInput.trim();
       const pending = threadId ? pendingDirectChildAdmissions.get(threadId) : undefined;

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -189,6 +189,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         runtimeAuthority?: NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
       }>)
     | undefined;
+  const runtimeYieldCompletionClaim: { current?: () => boolean } = {};
   const commonToolParams = {
     params: dynamicToolParams,
     resolvedWorkspace,
@@ -212,6 +213,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       toolState.yieldDetected = true;
       toolState.yieldAcknowledgment = acknowledgment;
     },
+    claimYieldCompletion: () => runtimeYieldCompletionClaim.current?.() ?? false,
     onCodexAppServerEvent: (event: Parameters<typeof emitCodexAppServerEvent>[1]) => {
       void emitCodexAppServerEvent(params, event);
     },
@@ -557,6 +559,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       suppressedDynamicToolOutcomeOrdinals,
       onCodexToolOutcome,
       allocateCodexToolOutcomeOrdinal,
+      runtimeYieldCompletionClaim,
     };
   } catch (error) {
     // Materialized runtimes are attempt-owned only after this function returns.

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -30,6 +30,8 @@ export async function runCodexAppServerAttempt(
   const attemptContext = await prepareCodexAttemptContext(runtime, attemptTools);
   const attemptPrompt = await prepareCodexAttemptPrompt(attemptContext);
   const resources = prepareCodexAttemptResources(attemptPrompt);
+  attemptTools.runtimeYieldCompletionClaim.current = () =>
+    resources.state.nativeHookRelay?.hasClaimedDirectChild() ?? false;
   await startCodexAttemptRuntime(resources);
 
   const turnRuntime = createCodexAttemptTurnState(resources);

--- a/src/agents/agent-tools.runtime.test.ts
+++ b/src/agents/agent-tools.runtime.test.ts
@@ -97,7 +97,10 @@ describe("wrapToolWithAbortSignal", () => {
     const wrapped = wrapToolWithAbortSignal(
       createSessionsYieldTool({
         sessionId: "requester",
-        onBeforeYield: beforeYield,
+        claimYield: () => {
+          beforeYield();
+          return true;
+        },
         onYield: () => {
           runAbort.abort(handoffReason);
         },
@@ -126,6 +129,7 @@ describe("wrapToolWithAbortSignal", () => {
     const yieldTool = wrapToolWithAbortSignal(
       createSessionsYieldTool({
         sessionId: "requester",
+        claimYield: () => true,
         onYield: () => {
           runAbort.abort(handoffReason);
         },
@@ -146,6 +150,7 @@ describe("wrapToolWithAbortSignal", () => {
     const wrapped = wrapToolWithAbortSignal(
       createSessionsYieldTool({
         sessionId: "requester",
+        claimYield: () => true,
         onYield: () => {
           runAbort.abort(handoffReason);
           callAbort.abort(handoffReason);
@@ -230,6 +235,7 @@ describe("wrapToolWithAbortSignal", () => {
     const wrapped = wrapToolWithAbortSignal(
       createSessionsYieldTool({
         sessionId: "requester",
+        claimYield: () => true,
         onYield: () => {
           runAbort.abort({ code: "sessions_yield", turnHandoff: true });
           throw yieldError;

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -352,6 +352,8 @@ type OpenClawCodingToolsOptions = {
   authProfileStore?: AuthProfileStore;
   /** Callback invoked when sessions_yield tool is called. */
   onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
+  /** Side-effect-free runtime completion claimant composed with the durable subagent claim. */
+  claimYieldCompletion?: () => boolean | Promise<boolean>;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
   /** Live observer called after wrapped tool outcomes are recorded. */
@@ -848,6 +850,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             inheritedToolAllowlist,
             inheritedToolDenylist,
             onYield: options?.onYield,
+            claimYieldCompletion: options?.claimYieldCompletion,
             allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
             recordToolPrepStage: options?.recordToolPrepStage,
           }),

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -699,6 +699,41 @@ describe("sessions_yield completion ownership", () => {
     }
   });
 
+  it("accepts a subagent self-yield without a pending child completion", async () => {
+    const registry = await import("./subagents/registry/subagent-registry.js");
+    const markRequesterTurnYielded = vi
+      .spyOn(registry, "markRequesterTurnYielded")
+      .mockReturnValue(0);
+    const onYield = vi.fn(async () => undefined);
+
+    try {
+      const tool = expectToolNamed(
+        createTestOpenClawTools({
+          agentSessionKey: "agent:main:subagent:worker",
+          sessionId: "subagent-session",
+          runId: "run-subagent",
+          onYield,
+          disableMessageTool: true,
+          disablePluginTools: true,
+          wrapBeforeToolCallHook: false,
+        }),
+        "sessions_yield",
+      );
+
+      await expect(tool.execute("yield-subagent", {})).resolves.toMatchObject({
+        details: { status: "yielded" },
+      });
+      expect(markRequesterTurnYielded).toHaveBeenCalledExactlyOnceWith({
+        requesterAgentId: "main",
+        requesterSessionKey: "agent:main:subagent:worker",
+        requesterTurnRunId: "run-subagent",
+      });
+      expect(onYield).toHaveBeenCalledOnce();
+    } finally {
+      markRequesterTurnYielded.mockRestore();
+    }
+  });
+
   it("accepts a runtime completion owner while recording the registry claim", async () => {
     const registry = await import("./subagents/registry/subagent-registry.js");
     const markRequesterTurnYielded = vi

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -698,6 +698,78 @@ describe("sessions_yield completion ownership", () => {
       markRequesterTurnYielded.mockRestore();
     }
   });
+
+  it("accepts a runtime completion owner while recording the registry claim", async () => {
+    const registry = await import("./subagents/registry/subagent-registry.js");
+    const markRequesterTurnYielded = vi
+      .spyOn(registry, "markRequesterTurnYielded")
+      .mockReturnValue(0);
+    const claimYieldCompletion = vi.fn(() => true);
+    const onYield = vi.fn(async () => undefined);
+
+    try {
+      const tool = expectToolNamed(
+        createTestOpenClawTools({
+          agentSessionKey: controllerSessionKey,
+          sessionId: "requester-session",
+          runId: "run-requester",
+          claimYieldCompletion,
+          onYield,
+          disableMessageTool: true,
+          disablePluginTools: true,
+          wrapBeforeToolCallHook: false,
+        }),
+        "sessions_yield",
+      );
+
+      await expect(tool.execute("yield-requester", {})).resolves.toMatchObject({
+        details: { status: "yielded" },
+      });
+      expect(markRequesterTurnYielded).toHaveBeenCalledOnce();
+      expect(claimYieldCompletion).toHaveBeenCalledOnce();
+      expect(onYield).toHaveBeenCalledOnce();
+      expect(claimYieldCompletion.mock.invocationCallOrder[0]).toBeLessThan(
+        markRequesterTurnYielded.mock.invocationCallOrder[0]!,
+      );
+    } finally {
+      markRequesterTurnYielded.mockRestore();
+    }
+  });
+
+  it("fails before registry side effects when the runtime completion claimant throws", async () => {
+    const registry = await import("./subagents/registry/subagent-registry.js");
+    const markRequesterTurnYielded = vi
+      .spyOn(registry, "markRequesterTurnYielded")
+      .mockReturnValue(1);
+    const failure = new Error("runtime completion owner failed");
+    const claimYieldCompletion = vi.fn(() => {
+      throw failure;
+    });
+    const onYield = vi.fn(async () => undefined);
+
+    try {
+      const tool = expectToolNamed(
+        createTestOpenClawTools({
+          agentSessionKey: controllerSessionKey,
+          sessionId: "requester-session",
+          runId: "run-requester",
+          claimYieldCompletion,
+          onYield,
+          disableMessageTool: true,
+          disablePluginTools: true,
+          wrapBeforeToolCallHook: false,
+        }),
+        "sessions_yield",
+      );
+
+      await expect(tool.execute("yield-requester", {})).rejects.toBe(failure);
+      expect(markRequesterTurnYielded).not.toHaveBeenCalled();
+      expect(claimYieldCompletion).toHaveBeenCalledOnce();
+      expect(onYield).not.toHaveBeenCalled();
+    } finally {
+      markRequesterTurnYielded.mockRestore();
+    }
+  });
 });
 
 function hasTool(tools: readonly { name: string }[], name: string): boolean {

--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -662,6 +662,42 @@ describe("sessions_yield completion ownership", () => {
       markRequesterTurnYielded.mockRestore();
     }
   });
+
+  it("keeps the turn active when it owns no pending child completion", async () => {
+    const registry = await import("./subagents/registry/subagent-registry.js");
+    const markRequesterTurnYielded = vi
+      .spyOn(registry, "markRequesterTurnYielded")
+      .mockReturnValue(0);
+    const onYield = vi.fn(async () => undefined);
+
+    try {
+      const tool = expectToolNamed(
+        createTestOpenClawTools({
+          agentSessionKey: controllerSessionKey,
+          runSessionKey: "agent:main:main",
+          sessionId: "requester-session",
+          runId: "run-requester",
+          onYield,
+          disableMessageTool: true,
+          disablePluginTools: true,
+          wrapBeforeToolCallHook: false,
+        }),
+        "sessions_yield",
+      );
+
+      const result = await tool.execute("yield-requester", {});
+
+      expect(result.details).toMatchObject({
+        status: "error",
+        error:
+          "No pending child completion is owned by this turn. Continue working because independent background operations complete separately.",
+      });
+      expect(markRequesterTurnYielded).toHaveBeenCalledOnce();
+      expect(onYield).not.toHaveBeenCalled();
+    } finally {
+      markRequesterTurnYielded.mockRestore();
+    }
+  });
 });
 
 function hasTool(tools: readonly { name: string }[], name: string): boolean {

--- a/src/agents/openclaw-tools.requester-yield.ts
+++ b/src/agents/openclaw-tools.requester-yield.ts
@@ -2,16 +2,18 @@ export function createRequesterYieldCallback(params: {
   requesterSessionKey?: string;
   requesterAgentId: string;
   requesterTurnRunId?: string;
-}): (() => Promise<void>) | undefined {
+}): (() => Promise<boolean>) | undefined {
   if (!params.requesterSessionKey || !params.requesterTurnRunId) {
     return undefined;
   }
   return async () => {
     const { markRequesterTurnYielded } = await import("./subagents/registry/subagent-registry.js");
-    markRequesterTurnYielded({
-      requesterSessionKey: params.requesterSessionKey as string,
-      requesterAgentId: params.requesterAgentId,
-      requesterTurnRunId: params.requesterTurnRunId as string,
-    });
+    return (
+      markRequesterTurnYielded({
+        requesterSessionKey: params.requesterSessionKey as string,
+        requesterAgentId: params.requesterAgentId,
+        requesterTurnRunId: params.requesterTurnRunId as string,
+      }) > 0
+    );
   };
 }

--- a/src/agents/openclaw-tools.requester-yield.ts
+++ b/src/agents/openclaw-tools.requester-yield.ts
@@ -1,3 +1,5 @@
+import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
+
 type YieldCompletionClaim = () => boolean | Promise<boolean>;
 
 export function createRequesterYieldCallback(params: {
@@ -6,8 +8,9 @@ export function createRequesterYieldCallback(params: {
   requesterTurnRunId?: string;
   claimYieldCompletion?: YieldCompletionClaim;
 }): YieldCompletionClaim | undefined {
+  const selfClaimed = isSubagentSessionKey(params.requesterSessionKey);
   const hasRegistryClaim = Boolean(params.requesterSessionKey && params.requesterTurnRunId);
-  if (!params.claimYieldCompletion && !hasRegistryClaim) {
+  if (!params.claimYieldCompletion && !selfClaimed && !hasRegistryClaim) {
     return undefined;
   }
   return async () => {
@@ -15,7 +18,7 @@ export function createRequesterYieldCallback(params: {
     // so a runtime failure cannot record a yield that never reaches onYield.
     const runtimeClaimed = (await params.claimYieldCompletion?.()) ?? false;
     if (!hasRegistryClaim) {
-      return runtimeClaimed;
+      return runtimeClaimed || selfClaimed;
     }
     const { markRequesterTurnYielded } = await import("./subagents/registry/subagent-registry.js");
     const registryClaimed =
@@ -24,6 +27,6 @@ export function createRequesterYieldCallback(params: {
         requesterAgentId: params.requesterAgentId,
         requesterTurnRunId: params.requesterTurnRunId as string,
       }) > 0;
-    return runtimeClaimed || registryClaimed;
+    return runtimeClaimed || selfClaimed || registryClaimed;
   };
 }

--- a/src/agents/openclaw-tools.requester-yield.ts
+++ b/src/agents/openclaw-tools.requester-yield.ts
@@ -1,19 +1,29 @@
+type YieldCompletionClaim = () => boolean | Promise<boolean>;
+
 export function createRequesterYieldCallback(params: {
   requesterSessionKey?: string;
   requesterAgentId: string;
   requesterTurnRunId?: string;
-}): (() => Promise<boolean>) | undefined {
-  if (!params.requesterSessionKey || !params.requesterTurnRunId) {
+  claimYieldCompletion?: YieldCompletionClaim;
+}): YieldCompletionClaim | undefined {
+  const hasRegistryClaim = Boolean(params.requesterSessionKey && params.requesterTurnRunId);
+  if (!params.claimYieldCompletion && !hasRegistryClaim) {
     return undefined;
   }
   return async () => {
+    // Runtime claims are observational. Check them before durable registry state
+    // so a runtime failure cannot record a yield that never reaches onYield.
+    const runtimeClaimed = (await params.claimYieldCompletion?.()) ?? false;
+    if (!hasRegistryClaim) {
+      return runtimeClaimed;
+    }
     const { markRequesterTurnYielded } = await import("./subagents/registry/subagent-registry.js");
-    return (
+    const registryClaimed =
       markRequesterTurnYielded({
         requesterSessionKey: params.requesterSessionKey as string,
         requesterAgentId: params.requesterAgentId,
         requesterTurnRunId: params.requesterTurnRunId as string,
-      }) > 0
-    );
+      }) > 0;
+    return runtimeClaimed || registryClaimed;
   };
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -445,12 +445,11 @@ export function createOpenClawTools(
       allowlist: explicitFactoryAllowlist,
       denylist: explicitFactoryDenylist,
     });
-  const effectiveCallGateway = embedded ? createEmbeddedCallGateway() : callAgentToolGatewayRequest;
   const sessionLookupToolOptions = {
     agentSessionKey: options?.agentSessionKey,
     sandboxed: options?.sandboxed,
     config: resolvedConfig,
-    callGateway: effectiveCallGateway,
+    callGateway: embedded ? createEmbeddedCallGateway() : callAgentToolGatewayRequest,
     sessionLinkBase: resolveControlUiSessionLinkBase(resolvedConfig),
   };
   const progressCardTool = shouldIncludeProgressCardToolForOpenClawTools({
@@ -461,11 +460,6 @@ export function createOpenClawTools(
         agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
       })
     : null;
-  const includeAskUserTool = shouldIncludeAskUserToolForOpenClawTools({
-    config: resolvedConfig,
-    agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
-    pluginToolDenylist: options?.pluginToolDenylist,
-  });
   const transcriptsTool = resolveTranscriptsTool(resolvedConfig, sessionAgentId, options);
   const tools: AnyAgentTool[] = [
     createDashboardTool({
@@ -603,7 +597,11 @@ export function createOpenClawTools(
         ]),
     ...collectPresentOpenClawTools([progressCardTool]),
     ...swarmToolGroups.structuredOutput,
-    ...(includeAskUserTool
+    ...(shouldIncludeAskUserToolForOpenClawTools({
+      config: resolvedConfig,
+      agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
+      pluginToolDenylist: options?.pluginToolDenylist,
+    })
       ? [
           createAskUserTool({
             agentId: sessionAgentId,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -220,8 +220,8 @@ export function createOpenClawTools(
     spawnWorkspaceDir?: string;
     /** Current runtime directory used as the default project for follow-up suggestions. */
     cwd?: string;
-    /** Callback invoked when sessions_yield tool is called. */
     onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
+    claimYieldCompletion?: () => boolean | Promise<boolean>;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
   } & SpawnedToolContext &
@@ -690,6 +690,7 @@ export function createOpenClawTools(
         requesterSessionKey: trimmedRunSessionKey || options?.agentSessionKey,
         requesterAgentId: sessionAgentId,
         requesterTurnRunId: options?.runId,
+        claimYieldCompletion: options?.claimYieldCompletion,
       }),
       onYield: options?.onYield,
     }),

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -686,7 +686,7 @@ export function createOpenClawTools(
     ...swarmToolGroups.agentsWait,
     createSessionsYieldTool({
       sessionId: options?.sessionId,
-      onBeforeYield: createRequesterYieldCallback({
+      claimYield: createRequesterYieldCallback({
         requesterSessionKey: trimmedRunSessionKey || options?.agentSessionKey,
         requesterAgentId: sessionAgentId,
         requesterTurnRunId: options?.runId,

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -23,7 +23,11 @@ describe("sessions_yield tool", () => {
 
   it("invokes onYield callback with default message", async () => {
     const onYield = vi.fn();
-    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      claimYield: () => true,
+      onYield,
+    });
     const result = await tool.execute("call-1", {});
     const details = result.details as SessionsYieldDetails;
     expect(details.status).toBe("yielded");
@@ -36,7 +40,11 @@ describe("sessions_yield tool", () => {
     // The callback message becomes operator-visible scheduler context, so the
     // tool must not replace a supplied reason with the default text.
     const onYield = vi.fn();
-    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      claimYield: () => true,
+      onYield,
+    });
     const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
     const details = result.details as SessionsYieldDetails;
     expect(details.status).toBe("yielded");
@@ -47,7 +55,11 @@ describe("sessions_yield tool", () => {
 
   it("keeps private context separate from the user-facing acknowledgment", async () => {
     const onYield = vi.fn();
-    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      claimYield: () => true,
+      onYield,
+    });
     const result = await tool.execute("call-1", {
       message: "Resume after the fact-checker replies",
       acknowledgment: "Research started; results will follow.",
@@ -65,12 +77,13 @@ describe("sessions_yield tool", () => {
     );
   });
 
-  it("persists yield intent before aborting the requester run", async () => {
+  it("claims completion ownership before aborting the requester run", async () => {
     const order: string[] = [];
     const tool = createSessionsYieldTool({
       sessionId: "test-session",
-      onBeforeYield: () => {
-        order.push("persist");
+      claimYield: () => {
+        order.push("claim");
+        return true;
       },
       onYield: () => {
         order.push("abort");
@@ -79,7 +92,7 @@ describe("sessions_yield tool", () => {
 
     await tool.execute("call-1", {});
 
-    expect(order).toEqual(["persist", "abort"]);
+    expect(order).toEqual(["claim", "abort"]);
   });
 
   it("does not abort the requester when yield intent cannot persist", async () => {
@@ -87,13 +100,34 @@ describe("sessions_yield tool", () => {
     const onYield = vi.fn();
     const tool = createSessionsYieldTool({
       sessionId: "test-session",
-      onBeforeYield: () => {
+      claimYield: () => {
         throw failure;
       },
       onYield,
     });
 
     await expect(tool.execute("call-1", {})).rejects.toThrow(failure);
+    expect(onYield).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "the claim callback is unavailable" },
+    { name: "the turn owns no pending child completion", claimYield: () => false },
+  ])("keeps the turn active when $name", async ({ claimYield }) => {
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      ...(claimYield ? { claimYield } : {}),
+      onYield,
+    });
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error:
+        "No pending child completion is owned by this turn. Continue working because independent background operations complete separately.",
+    });
     expect(onYield).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -7,6 +7,9 @@ import { Type } from "typebox";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readToolStringParam } from "./common.js";
 
+const NO_PENDING_CHILD_COMPLETION_ERROR =
+  "No pending child completion is owned by this turn. Continue working because independent background operations complete separately.";
+
 const SessionsYieldToolSchema = Type.Object({
   message: Type.Optional(
     Type.String({ description: "Private context for the resumed turn; not sent to the user." }),
@@ -21,7 +24,7 @@ const SessionsYieldToolSchema = Type.Object({
 /** Creates the sessions_yield tool for runtimes that support yield callbacks. */
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
-  onBeforeYield?: () => Promise<void> | void;
+  claimYield?: () => boolean | Promise<boolean>;
   onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
 }): AnyAgentTool {
   return {
@@ -43,7 +46,12 @@ export function createSessionsYieldTool(opts?: {
       if (!opts?.onYield) {
         return jsonResult({ status: "error", error: "Yield not supported in this context" });
       }
-      await opts.onBeforeYield?.();
+      if (!(await opts.claimYield?.())) {
+        return jsonResult({
+          status: "error",
+          error: NO_PENDING_CHILD_COMPLETION_ERROR,
+        });
+      }
       // The runtime owns the actual pause/end-turn behavior; this tool records intent.
       await opts.onYield(message, acknowledgment);
       return jsonResult({

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -226,29 +226,43 @@ describe("resolveGatewayScopedTools", () => {
   });
 
   it("passes loopback yield context into sessions_yield", async () => {
+    const registry = await import("../agents/subagents/registry/subagent-registry.js");
+    const markRequesterTurnYielded = vi
+      .spyOn(registry, "markRequesterTurnYielded")
+      .mockReturnValue(1);
     const onYield = vi.fn();
-    const result = resolveGatewayScopedTools({
-      cfg: { tools: { profile: "minimal", alsoAllow: ["sessions_yield"] } } as OpenClawConfig,
-      sessionKey: "agent:main:telegram:group:-100123",
-      sessionId: "session-123",
-      onYield,
-      surface: "loopback",
-    });
-    const yieldTool = result.tools.find((tool) => tool.name === "sessions_yield");
-    if (!yieldTool) {
-      throw new Error("expected sessions_yield tool");
+    try {
+      const result = resolveGatewayScopedTools({
+        cfg: { tools: { profile: "minimal", alsoAllow: ["sessions_yield"] } } as OpenClawConfig,
+        sessionKey: "agent:main:telegram:group:-100123",
+        sessionId: "session-123",
+        runId: "run-123",
+        onYield,
+        surface: "loopback",
+      });
+      const yieldTool = result.tools.find((tool) => tool.name === "sessions_yield");
+      if (!yieldTool) {
+        throw new Error("expected sessions_yield tool");
+      }
+
+      const toolResult = await yieldTool.execute("tool-call-1", {
+        message: "waiting on subagents",
+        acknowledgment: "I’m waiting on the subagents.",
+      });
+
+      expect(markRequesterTurnYielded).toHaveBeenCalledExactlyOnceWith({
+        requesterAgentId: "main",
+        requesterSessionKey: "agent:main:telegram:group:-100123",
+        requesterTurnRunId: "run-123",
+      });
+      expect(onYield).toHaveBeenCalledWith("waiting on subagents", "I’m waiting on the subagents.");
+      expect(toolResult.details).toEqual({
+        status: "yielded",
+        message: "waiting on subagents",
+        acknowledgment: "I’m waiting on the subagents.",
+      });
+    } finally {
+      markRequesterTurnYielded.mockRestore();
     }
-
-    const toolResult = await yieldTool.execute("tool-call-1", {
-      message: "waiting on subagents",
-      acknowledgment: "I’m waiting on the subagents.",
-    });
-
-    expect(onYield).toHaveBeenCalledWith("waiting on subagents", "I’m waiting on the subagents.");
-    expect(toolResult.details).toEqual({
-      status: "yielded",
-      message: "waiting on subagents",
-      acknowledgment: "I’m waiting on the subagents.",
-    });
   });
 });


### PR DESCRIPTION
Closes #125848

AI-assisted: yes

## What Problem This Solves

Fixes an issue where an interactive agent could call `sessions_yield` without owning any pending spawned-child completion, ending the turn and abandoning promised follow-up work behind an unrelated async completion event.

## Why This Change Was Made

`sessions_yield` now requires an explicit completion-ownership claim before the runtime may abort the requester turn. The claim composes the durable OpenClaw subagent registry with side-effect-free runtime owners such as Codex native direct children. Runtime claims run before durable registry mutation, so a runtime failure cannot record a yield that never happens.

A missing or zero-child claim returns an actionable tool error and keeps the turn active. Valid OpenClaw child yields, Codex-native child yields, persistence failures, acknowledgments, relay retention/revocation, heartbeat handling, and background-command completion policy remain intact.

This repairs the lifecycle owner rather than teaching exec-event heartbeats to recover an invalid yield.

## User Impact

Agents that accidentally call `sessions_yield` after unrelated background work now remain active and can finish or wait for that work normally. Valid subagent fan-out across the embedded and Codex runtimes continues to pause and resume as before.

Release-note context: prevent successful async work from becoming silently stranded when `sessions_yield` is called without a pending child completion.

Production LOC: +53/-19 (net +34) | Tests: +227/-30. The production growth adds one canonical multi-runtime completion-claim boundary; no fallback path, config, protocol, storage, or compatibility shim was added.

## Evidence

Before the production change, the composed-tool regression failed as intended: `markRequesterTurnYielded` returned `0`, but `sessions_yield` still returned `status: "yielded"` and invoked the runtime yield callback.

After the change:

- `node scripts/run-vitest.mjs src/gateway/tool-resolution.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts src/agents/tools/sessions-yield-tool.test.ts src/agents/openclaw-tools.registration.test.ts src/agents/agent-tools.runtime.test.ts` — 111 tests passed across 4 shards after rebasing onto current `main`.
- `node scripts/check-changed.mjs -- <all touched paths>` — passed (`core`, `coreTests`, `extensions`, `extensionTests`), including typecheck, lint, import-cycle, plugin-boundary, and database-first guards.
- `git diff --check` — passed.
- Fresh Codex autoreview (`--mode uncommitted`, high reasoning) — clean, no accepted/actionable findings.
- Isolated live agent proof against the built PR head with environment-only Anthropic credentials: the model called `sessions_yield` without spawning a child, received one failed tool result, stayed in the same turn, and returned exactly `YIELD_REJECTED_CONTINUED` plus `No pending child completion is owned by this turn.` (`assistantTurns: 2`, `toolSummary.calls: 1`, `toolSummary.failures: 1`).
- The first exact-head CI run correctly exposed two omitted sibling cases: Gateway loopback yield composition and Codex native direct-child retention. The repair now proves both authoritative owners while retaining the zero-child rejection.
- ClawSweeper's documented-self-yield finding was addressed: a host-identified subagent may still pause itself for plugin-managed external work. The composed-tool boundary regression passes, and the existing registry pause/adopt/announce lifecycle suite remains green.

Production logs established the original execution order: background exec running → unsupported `sessions_yield` accepted → exec completion wake handled independently → promised continuation not executed. No secrets, private channel identifiers, or transcript content are included here.
