### PR TITLE
fix(cli): guard against NaN timeout in health route

### DIFF
--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -158,4 +158,32 @@ describe("runGatewayHealthJsonRoute", () => {
     expect(runtime.writeJson).toHaveBeenCalledWith(payload, 2);
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
+
+  it("falls back to default timeout when rpc.timeout produces NaN", async () => {
+    const runtime = createRuntime();
+    const error = new Error("gateway unavailable");
+    const callGateway = vi.fn(async () => {
+      throw error;
+    });
+    const emitReachableGatewayAuthDiagnostic = vi.fn(async () => false);
+
+    await runGatewayHealthJsonRoute(
+      { rpc: { json: true, timeout: "not-a-number" } },
+      runtime as never,
+      {
+        callGateway,
+        readBestEffortConfig: async () => ({}),
+        emitReachableGatewayAuthDiagnostic: emitReachableGatewayAuthDiagnostic as never,
+        formatGatewayAuthErrorJson: vi.fn(() => null) as never,
+        formatGatewayClientRequestErrorJson: vi.fn(() => null) as never,
+        formatGatewayTransportErrorJson: vi.fn(() => null) as never,
+      },
+    );
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 10_000,
+      }),
+    );
+  });
 });

--- a/src/cli/gateway-cli/health-route.ts
+++ b/src/cli/gateway-cli/health-route.ts
@@ -90,7 +90,7 @@ export async function runGatewayHealthJsonRoute(
       error,
       config: rpc.config ?? (await readNonObservingHealthConfig()),
       runtime,
-      timeoutMs: Number(rpc.timeout ?? "10000"),
+      timeoutMs: Number.isNaN(Number(rpc.timeout ?? "10000")) ? 10_000 : Number(rpc.timeout ?? "10000"),
       token: rpc.token,
       password: rpc.password,
       localPortOverride: rpc.localPortOverride,


### PR DESCRIPTION
## Summary

- **Problem:** Number(rpc.timeout) can produce NaN when the timeout string is not a valid number, which is then passed to emitReachableGatewayAuthDiagnostic without validation.
- **Solution:** Add Number.isNaN check and fall back to 10_000 default when the parsed timeout is NaN.
- **What changed:** Added NaN guard in the health route error handler.
- **What did NOT change:** No other components were affected.

## Real behavior proof

- **Behavior or issue addressed:** An invalid timeout string could produce NaN passed to the diagnostic function.
- **Real environment tested:** Unit test.
- **Exact steps or command run after this patch:**
  ```
  npx vitest run src/cli/gateway-cli/health-route.test.ts
  ```
- **Evidence after fix:** The regression test passes confirming the fix is effective.
- **Observed result after fix:** Invalid timeout strings fall back to the default 10_000 ms.
- **What was not tested:** No known gaps.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: {TEST_FILE}
- Scenario locked in: When rpc.timeout is "not-a-number", emitReachableGatewayAuthDiagnostic receives timeoutMs: 10_000.

## Root Cause

- Root cause: Number() was called without checking for NaN result.
- Missing detection / guardrail: No NaN validation on the parsed timeout value.