### PR TITLE
fix(codex): explain timed-out MCP approvals

### DIFF
--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -356,6 +356,28 @@ describe("Codex app-server elicitation bridge", () => {
     ]);
   });
 
+  it("declines timed-out MCP approvals with explanatory metadata", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-timeout", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-timeout",
+        decision: "deny",
+        terminalReason: "timeout",
+      });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildApprovalElicitation(),
+      paramsForRun: createParams(),
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({
+      action: "decline",
+      content: null,
+      _meta: { message: "Approval timed out before an operator responded." },
+    });
+  });
+
   it("does not treat inherited request-time MCP decisions as final", async () => {
     const inheritedDecisionResult = Object.assign(Object.create({ decision: null }), {
       id: "plugin:approval-inherited",

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -7,6 +7,7 @@ import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
 import {
   approvalRequestExplicitlyUnavailable,
+  codexApprovalTimeoutText,
   mapExecDecisionToOutcome,
   requestPluginApproval,
   sanitizeCodexApprovalVisibleText,
@@ -36,6 +37,8 @@ type BridgeableApprovalElicitation = {
   persistHintsMode?: "legacy" | "explicit";
   allowedDecisions?: ExecApprovalDecision[];
 };
+
+type ElicitationApprovalOutcome = AppServerApprovalOutcome | "timed-out";
 
 type PluginElicitationResolution =
   | { kind: "not_plugin" }
@@ -309,7 +312,7 @@ async function buildPluginPolicyElicitationResponse(params: {
     });
     return buildElicitationResponse(
       approvalPrompt,
-      oneShotPluginPolicyApprovalOutcome(mode, outcome),
+      mode === "ask" && outcome === "approved-session" ? "approved-once" : outcome,
     );
   }
   logPluginElicitationDecline("unmappable_schema", params.requestParams);
@@ -331,13 +334,6 @@ function allowedPluginPolicyApprovalDecisions(
     return allowedDecisions;
   }
   return allowedDecisions.filter((decision) => decision !== "allow-always");
-}
-
-function oneShotPluginPolicyApprovalOutcome(
-  mode: "allow" | "deny" | "auto" | "ask",
-  outcome: AppServerApprovalOutcome,
-): AppServerApprovalOutcome {
-  return mode === "ask" && outcome === "approved-session" ? "approved-once" : outcome;
 }
 
 function readPluginApprovalElicitation(
@@ -408,8 +404,8 @@ function canMapPersistentApproval(requestedSchema: JsonObject, meta: JsonObject)
   });
 }
 
-function declineElicitationResponse(): JsonValue {
-  return { action: "decline", content: null, _meta: null };
+function declineElicitationResponse(message?: string): JsonValue {
+  return { action: "decline", content: null, _meta: message ? { message } : null };
 }
 
 function logPluginElicitationDecline(reason: string, requestParams: JsonObject | undefined): void {
@@ -655,7 +651,7 @@ async function requestPluginApprovalOutcome(params: {
   description: string;
   allowedDecisions?: ExecApprovalDecision[];
   signal?: AbortSignal;
-}): Promise<AppServerApprovalOutcome> {
+}): Promise<ElicitationApprovalOutcome> {
   try {
     const requestResult = await requestPluginApproval({
       hostCapabilities: params.paramsForRun.hostCapabilities,
@@ -678,6 +674,12 @@ async function requestPluginApprovalOutcome(params: {
           approvalId,
           signal: params.signal,
         });
+    if (params.signal?.aborted) {
+      return "cancelled";
+    }
+    if (approvalResult?.terminalReason === "timeout") {
+      return "timed-out";
+    }
     return mapExecDecisionToOutcome(approvalResult?.decision);
   } catch {
     return params.signal?.aborted ? "cancelled" : "denied";
@@ -689,14 +691,17 @@ function buildElicitationResponse(
     BridgeableApprovalElicitation,
     "requestedSchema" | "meta" | "persistHintsMode"
   >,
-  outcome: AppServerApprovalOutcome,
+  outcome: ElicitationApprovalOutcome,
 ): JsonValue {
   const { requestedSchema, meta } = approvalPrompt;
   if (outcome === "cancelled") {
     return { action: "cancel", content: null, _meta: null };
   }
+  if (outcome === "timed-out") {
+    return declineElicitationResponse(codexApprovalTimeoutText("other"));
+  }
   if (outcome === "denied" || outcome === "unavailable") {
-    return { action: "decline", content: null, _meta: null };
+    return declineElicitationResponse();
   }
 
   const content = buildAcceptedContent(approvalPrompt, outcome);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MCP, plugin-app, and Computer Use approvals that timed out would correctly decline the action and continue the Codex flow, but lose the explicit timeout explanation before the result reached the external MCP server.

## Why This Change Was Made

The elicitation bridge now preserves the timeout as a local closed outcome and maps it to Codex `decline` with bounded `_meta.message` evidence. Actual turn aborts remain `cancel`, while ordinary operator denial or an unavailable approval route remain metadata-free declines. The mapping stays local to the elicitation protocol boundary; the already-correct native approval sibling and public host capability contract are unchanged.

AI-assisted. The final diff was independently reviewed with the repository autoreview workflow.

Provenance: the structured approval result landed in #125671 on 2026-08-18, but its elicitation sibling projected only `decision` and dropped `terminalReason`.

Production LOC: +18/-13 (net +5) | Tests: +22/-0

The five production lines add the timeout outcome and explanation while deleting the one-use policy-normalization helper.

## User Impact

Timed-out Codex MCP/plugin approvals remain non-aborting declines, and the external MCP server now receives `Approval timed out before an operator responded.` instead of an unexplained generic decline. This gives plugin apps and Computer Use integrations enough context to explain the non-action and continue safely.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs extensions/codex/src/app-server/elicitation-bridge.test.ts` failed with 1 failed / 55 passed because the response had `_meta: null` instead of the timeout message.
- Focused post-fix proof: `node scripts/run-vitest.mjs extensions/codex/src/app-server/elicitation-bridge.test.ts extensions/codex/src/app-server/approval-bridge.test.ts` — 151/151 passed.
- `node scripts/check-changed.mjs` — passed all extension production/test typecheck, lint, formatting, boundary, dead-export, and import-cycle gates.
- `pnpm build` — passed; total 11m 3.7s.
- Authenticated real-behavior proof: an isolated API-key-backed managed Codex app-server registered a local stdio MCP server, discovered its tool through `mcpServerStatus/list`, and invoked it through the real `mcpServer/tool/call` RPC. The external MCP server observed exactly `{ "action": "decline", "_meta": { "message": "Approval timed out before an operator responded." } }`; the RPC returned a normal non-error tool result, proving timeout decline did not cancel the transport. The probe completed in 14.1s and its isolated state was removed.
- Direct upstream Codex source inspection confirmed the contract: `mcpServer/elicitation/request` exposes `accept | decline | cancel` plus opaque `_meta`; Guardian timeout maps to `decline` with `_meta.message`, while abort maps to `cancel` (`codex-rs/app-server-protocol/src/protocol/v2/mcp.rs`, `codex-rs/core/src/session/mcp.rs`, `codex-rs/app-server/src/bespoke_event_handling.rs`).
- Final Codex autoreview: clean, no accepted/actionable findings.
