### PR TITLE
fix(gateway): enforce shutdown deadline during event-loop stalls

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -136,6 +136,12 @@ const gatewayLog = {
   error: vi.fn(),
 };
 const flushLogger = vi.fn(async () => {});
+const cancelShutdownHardExitWatchdog = vi.fn();
+const armShutdownHardExitWatchdog = vi.fn(
+  (_params: { delayMs: number; onError: (error: unknown) => void }) => ({
+    cancel: cancelShutdownHardExitWatchdog,
+  }),
+);
 
 vi.mock("../../infra/gateway-lock.js", () => ({
   acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
@@ -253,6 +259,11 @@ vi.mock("../../logging/logger.js", () => ({
 
 vi.mock("../../gateway/server-reload-contracts.js", () => ({
   abortPendingChannelReloads: () => abortPendingChannelReloads(),
+}));
+
+vi.mock("./shutdown-hard-exit.js", () => ({
+  armShutdownHardExitWatchdog: (params: { delayMs: number; onError: (error: unknown) => void }) =>
+    armShutdownHardExitWatchdog(params),
 }));
 
 const LOOP_SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
@@ -383,6 +394,7 @@ function createSignaledStart(close: GatewayCloseFn, startupSettled = Promise.res
 async function runLoopWithStart(params: {
   start: ReturnType<typeof vi.fn>;
   runtime: LoopRuntime;
+  ownsProcessLifecycle?: boolean;
   lockPort?: number;
   healthHost?: string;
   waitForHealthyChild?: (port: number, pid?: number, host?: string) => Promise<boolean>;
@@ -392,6 +404,7 @@ async function runLoopWithStart(params: {
   const loopPromise = runGatewayLoop({
     start: params.start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
     runtime: params.runtime,
+    ownsProcessLifecycle: params.ownsProcessLifecycle,
     lockPort: params.lockPort,
     healthHost: params.healthHost,
     waitForHealthyChild: params.waitForHealthyChild,
@@ -628,6 +641,7 @@ describe("runGatewayLoop", () => {
       });
       expect(runtime.exit).toHaveBeenCalledWith(0);
       expect(flushLogger).toHaveBeenCalledOnce();
+      expect(armShutdownHardExitWatchdog).not.toHaveBeenCalled();
     });
   });
 
@@ -2411,32 +2425,41 @@ describe("runGatewayLoop", () => {
       await withIsolatedSignals(async ({ captureSignal }) => {
         const { start, started } = createSignaledStart(close);
         const { runtime, exited } = createRuntimeWithExitSignal();
-        await runLoopWithStart({ start, runtime });
+        await runLoopWithStart({ start, runtime, ownsProcessLifecycle: true });
         await waitForStart(started);
         const sigusr1 = captureSignal("SIGUSR1");
 
-        sigusr1();
-        await waitForLoopCondition(
-          () => close.mock.calls.length === 1,
-          "restart close did not start",
-        );
-        sigusr1();
-        await waitForLoopCondition(
-          () =>
-            gatewayLog.info.mock.calls.some(([message]) =>
-              String(message).includes("upgrading to update.auto"),
-            ),
-          "accepted restart was not upgraded",
-        );
+        try {
+          sigusr1();
+          await waitForLoopCondition(
+            () => close.mock.calls.length === 1,
+            "restart close did not start",
+          );
+          expect(armShutdownHardExitWatchdog).toHaveBeenCalledTimes(1);
+          sigusr1();
+          await waitForLoopCondition(
+            () =>
+              gatewayLog.info.mock.calls.some(([message]) =>
+                String(message).includes("upgrading to update.auto"),
+              ),
+            "accepted restart was not upgraded",
+          );
+          expect(cancelShutdownHardExitWatchdog).toHaveBeenCalledTimes(1);
+          expect(armShutdownHardExitWatchdog).toHaveBeenCalledTimes(2);
 
-        releaseClose();
-        await expect(exited).resolves.toBe(0);
-        expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
-        expectRestartHandoffCall({
-          restartKind: "update-process",
-          reason: "update.auto",
-          supervisorMode: "external",
-        });
+          releaseClose();
+          await expect(exited).resolves.toBe(0);
+          expect(cancelShutdownHardExitWatchdog).toHaveBeenCalledTimes(2);
+          expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
+          expectRestartHandoffCall({
+            restartKind: "update-process",
+            reason: "update.auto",
+            supervisorMode: "external",
+          });
+        } finally {
+          releaseClose();
+          await exited;
+        }
       });
     } finally {
       if (originalPlatformDescriptor) {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -28,6 +28,10 @@ import {
   GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
 } from "../../state/openclaw-agent-db-migration-required.js";
 import { formatActiveTaskRestartBlocker } from "../../tasks/task-restart-blocker.js";
+import {
+  armShutdownHardExitWatchdog,
+  type ShutdownHardExitWatchdog,
+} from "./shutdown-hard-exit.js";
 const gatewayLog = createSubsystemLogger("gateway");
 const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
 const DEFAULT_RESTART_DRAIN_TIMEOUT_MS = 300_000;
@@ -36,6 +40,7 @@ const RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_TIMEOUT_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_POLL_MS = 200;
 const LOG_FLUSH_EXIT_TIMEOUT_MS = 4_000;
+const HARD_EXIT_WATCHDOG_GRACE_MS = 2_000;
 
 type GatewayRunSignalAction = "stop" | "restart";
 type RestartDrainTimeoutMs = number | undefined;
@@ -109,6 +114,8 @@ export async function runGatewayLoop(params: {
     requestHotReloadRecovery?: GatewayRestartEmitter;
   }) => Promise<Awaited<ReturnType<typeof startGatewayServer>>>;
   runtime: RuntimeEnv;
+  /** Grants this run-loop authority to hard-kill the process it exclusively owns. */
+  ownsProcessLifecycle?: boolean;
   lockPort?: number;
   healthHost?: string;
   waitForHealthyChild?: (port: number, pid?: number, host?: string) => Promise<boolean>;
@@ -502,6 +509,7 @@ export async function runGatewayLoop(params: {
       activeRestartRequest = acceptedRequest;
     }
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
+    let hardExitWatchdog: ShutdownHardExitWatchdog | null = null;
     const armForceExitTimer = (forceExitMs: number) => {
       if (forceExitTimer) {
         return;
@@ -524,13 +532,24 @@ export async function runGatewayLoop(params: {
           }
         })();
       }, forceExitMs);
+      if (params.ownsProcessLifecycle === true) {
+        hardExitWatchdog = armShutdownHardExitWatchdog({
+          delayMs: forceExitMs + HARD_EXIT_WATCHDOG_GRACE_MS,
+          onError: (error) => {
+            gatewayLog.warn(
+              `hard-exit watchdog failed; retaining main-thread shutdown timer: ${formatErrorMessage(error)}`,
+            );
+          },
+        });
+      }
     };
     const clearForceExitTimer = () => {
-      if (!forceExitTimer) {
-        return;
+      if (forceExitTimer) {
+        clearTimeout(forceExitTimer);
+        forceExitTimer = null;
       }
-      clearTimeout(forceExitTimer);
-      forceExitTimer = null;
+      hardExitWatchdog?.cancel();
+      hardExitWatchdog = null;
     };
     if (isRestart) {
       forceActiveRestartExit = () => {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -45,6 +45,8 @@ type GatewayLoopStart = (params?: { startupStartedAt?: number }) => Promise<unkn
 type GatewayLoopParams = {
   start: GatewayLoopStart;
   completeBoot?: (completion: unknown) => void;
+  ownsProcessLifecycle?: boolean;
+  runtime?: unknown;
 };
 const runGatewayLoop = vi.fn(async ({ start }: GatewayLoopParams) => {
   await start();
@@ -506,6 +508,9 @@ describe("gateway run option collisions", () => {
 
     expect(beforeRun).toHaveBeenCalledOnce();
     expect(callOrder).toEqual(["bootstrap", "normalize", "normalize", "start"]);
+    expect(runGatewayLoop).toHaveBeenCalledWith(
+      expect.objectContaining({ ownsProcessLifecycle: true, runtime: defaultRuntime }),
+    );
   });
 
   it("rejects invalid gateway ports before startup", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1182,6 +1182,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   const startLoop = async () =>
     await runGatewayLoop({
       runtime: defaultRuntime,
+      ownsProcessLifecycle: true,
       lockPort: port,
       healthHost,
       beginBoot,

--- a/src/cli/gateway-cli/shutdown-hard-exit.process.test.ts
+++ b/src/cli/gateway-cli/shutdown-hard-exit.process.test.ts
@@ -1,0 +1,67 @@
+// Process-boundary proof that the hard-exit watchdog survives main-thread starvation.
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const WATCHDOG_DELAY_MS = 100;
+const CHILD_TIMEOUT_MS = 3_000;
+const watchdogModuleUrl = pathToFileURL(
+  path.resolve("src/cli/gateway-cli/shutdown-hard-exit.ts"),
+).href;
+
+function runWatchdogChild(source: string) {
+  const script = `
+    import { armShutdownHardExitWatchdog } from ${JSON.stringify(watchdogModuleUrl)};
+    ${source}
+  `;
+  const startedAt = Date.now();
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script],
+    {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: { ...process.env, VITEST: undefined },
+      killSignal: "SIGKILL",
+      timeout: CHILD_TIMEOUT_MS,
+    },
+  );
+  return { elapsedMs: Date.now() - startedAt, result };
+}
+
+describe("shutdown hard-exit watchdog", () => {
+  it("kills a process whose main thread is synchronously blocked", () => {
+    const { elapsedMs, result } = runWatchdogChild(`
+      armShutdownHardExitWatchdog({
+        delayMs: ${WATCHDOG_DELAY_MS},
+        onError: (error) => console.error(error),
+      });
+      while (true) {}
+    `);
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBe("SIGKILL");
+    expect(elapsedMs).toBeLessThan(CHILD_TIMEOUT_MS);
+  });
+
+  it("lets a cancelled process survive beyond the deadline and exit cleanly", () => {
+    const { elapsedMs, result } = runWatchdogChild(`
+      const watchdog = armShutdownHardExitWatchdog({
+        delayMs: ${WATCHDOG_DELAY_MS},
+        onError: (error) => {
+          console.error(error);
+          process.exitCode = 2;
+        },
+      });
+      watchdog?.cancel();
+      await new Promise((resolve) => setTimeout(resolve, ${WATCHDOG_DELAY_MS * 2}));
+    `);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(elapsedMs).toBeGreaterThanOrEqual(WATCHDOG_DELAY_MS * 2);
+    expect(elapsedMs).toBeLessThan(CHILD_TIMEOUT_MS);
+  });
+});

--- a/src/cli/gateway-cli/shutdown-hard-exit.ts
+++ b/src/cli/gateway-cli/shutdown-hard-exit.ts
@@ -1,0 +1,56 @@
+import { Worker } from "node:worker_threads";
+
+export type ShutdownHardExitWatchdog = {
+  cancel: () => void;
+};
+
+export function armShutdownHardExitWatchdog(params: {
+  delayMs: number;
+  onError: (error: unknown) => void;
+}): ShutdownHardExitWatchdog | null {
+  const reportError = (error: unknown) => {
+    try {
+      params.onError(error);
+    } catch {
+      // Shutdown must retain the main-thread fallback even if warning delivery fails.
+    }
+  };
+  let worker: Worker;
+  try {
+    worker = new Worker(
+      `const { parentPort, workerData } = require("node:worker_threads");
+       const timer = setTimeout(() => process.kill(process.pid, "SIGKILL"), workerData.delayMs);
+       parentPort.once("message", () => {
+         clearTimeout(timer);
+         parentPort.close();
+       });`,
+      {
+        eval: true,
+        execArgv: [],
+        workerData: { delayMs: Math.max(0, Math.floor(params.delayMs)) },
+      },
+    );
+  } catch (error) {
+    reportError(error);
+    return null;
+  }
+
+  let active = true;
+  worker.once("error", (error) => {
+    if (active) {
+      active = false;
+      reportError(error);
+    }
+  });
+
+  return {
+    cancel: () => {
+      active = false;
+      try {
+        worker.postMessage("cancel", []);
+      } catch (error) {
+        reportError(error);
+      }
+    },
+  };
+}

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -39,6 +39,7 @@ const HTTP_CLOSE_GRACE_MS = 1_000;
 const HTTP_CLOSE_FORCE_WAIT_MS = 5_000;
 const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 5_000;
 const GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS = 10_000;
+const AGENT_HARNESS_CLOSE_GRACE_MS = 5_000;
 
 vi.mock("../channels/plugins/index.js", async () => ({
   ...(await vi.importActual<typeof import("../channels/plugins/index.js")>(
@@ -1686,6 +1687,44 @@ describe("createGatewayCloseHandler", () => {
       "tailscale",
       "embedding-providers",
     ]);
+  });
+
+  it("continues listener teardown when agent harness disposal never settles", async () => {
+    vi.useFakeTimers();
+    let releaseHarnessDisposal: (() => void) | undefined;
+    const harnessDisposal = new Promise<undefined>((resolve) => {
+      releaseHarnessDisposal = () => resolve(undefined);
+    });
+    mocks.disposeAgentHarnesses.mockReturnValue(harnessDisposal);
+    const httpClose = vi.fn((callback: (err?: Error | null) => void) => callback(null));
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        httpServer: {
+          close: httpClose,
+          closeIdleConnections: vi.fn(),
+        } as never,
+      }),
+    );
+    const closePromise = close({ reason: "test shutdown" });
+
+    try {
+      await vi.waitFor(() => expect(mocks.disposeAgentHarnesses).toHaveBeenCalledOnce());
+      expect(httpClose).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(AGENT_HARNESS_CLOSE_GRACE_MS);
+      const result = await closePromise;
+
+      expect(result.warnings).toContain("agent-harnesses");
+      expect(httpClose).toHaveBeenCalledOnce();
+      expect(
+        mocks.logWarn.mock.calls.some(([message]) =>
+          String(message).includes("agent-harnesses runtime disposal exceeded 5000ms"),
+        ),
+      ).toBe(true);
+    } finally {
+      releaseHarnessDisposal?.();
+      await closePromise;
+    }
   });
 
   it("starts bundle MCP and LSP runtime disposal concurrently", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -50,6 +50,7 @@ const HTTP_CLOSE_FORCE_WAIT_MS = 5_000;
 const MCP_RUNTIME_CLOSE_GRACE_MS = 5_000;
 const LSP_RUNTIME_CLOSE_GRACE_MS = 5_000;
 const EMBEDDING_PROVIDER_CLOSE_GRACE_MS = 5_000;
+const AGENT_HARNESS_CLOSE_GRACE_MS = 5_000;
 const RESTART_REPLY_DRAIN_POLL_MS = 100;
 const RESTART_REPLY_POST_ABORT_DRAIN_TIMEOUT_MS = 1_000;
 const RESTART_REPLY_POST_ABORT_DRAIN_POLL_MS = 50;
@@ -581,7 +582,12 @@ async function triggerGatewayLifecycleHookWithTimeout(params: {
 }
 
 async function disposeRuntimeWithShutdownGrace(params: {
-  label: "plugin-services" | "bundle-mcp" | "bundle-lsp" | "embedding-providers";
+  label:
+    | "plugin-services"
+    | "agent-harnesses"
+    | "bundle-mcp"
+    | "bundle-lsp"
+    | "embedding-providers";
   dispose: () => Promise<void>;
   graceMs: number;
   warnings: string[];
@@ -861,7 +867,12 @@ export function createGatewayCloseHandler(
         }
       });
       await shutdownStep("code-mode-runs", () => params.disposeAllCodeModeRuns(), warnings);
-      await shutdownStep("agent-harnesses", () => disposeRegisteredAgentHarnesses(), warnings);
+      await disposeRuntimeWithShutdownGrace({
+        label: "agent-harnesses",
+        dispose: disposeRegisteredAgentHarnesses,
+        graceMs: AGENT_HARNESS_CLOSE_GRACE_MS,
+        warnings,
+      });
       await shutdownStep("ai-session-resources", () => cleanupSessionResources(), warnings);
       await shutdownStep(
         "provider-transport-dispatchers",


### PR DESCRIPTION
Closes #125840

AI-assisted: yes. I understand the shutdown ownership and timeout behavior changed here.

## What Problem This Solves

Fixes an issue where a managed Gateway restart could remain unavailable indefinitely after an embedded run exceeded the drain deadline. The process closed admission but could stay alive with health/control traffic timing out and runtime children still attached until an external service restart.

## Why This Change Was Made

The existing forced-exit deadline was another main-event-loop timer. If embedded-run abort or teardown entered synchronous CPU-bound work, the timer responsible for terminating that work could not run.

The Gateway's sole production runner now explicitly grants process-lifecycle authority to a small Worker-thread watchdog. Graceful cleanup and the existing diagnostic exit path still run first; if the main thread remains wedged, the Worker sends `SIGKILL` two seconds later so the service supervisor can restart the process and reap its cgroup. Injected/non-process-owning runtimes remain unable to kill their host.

Agent-harness disposal now also uses the existing five-second shutdown-grace mechanism. A nonsettling harness records an `agent-harnesses` warning and no longer prevents later WebSocket/HTTP listener teardown.

Codex transport behavior is unchanged. Direct inspection of pinned Codex `rust-v0.147.0` confirmed stdio EOF is the graceful app-server shutdown boundary; OpenClaw's existing transport close already escalates and waits separately.

Provenance: the same-event-loop watchdog was introduced in #71465 on 2026-04-25 by PR author and merger @vincentkoc. It correctly bounded asynchronous shutdown, but could not enforce its own deadline during main-thread starvation. The embedded-run drain added in #40324 and budgeted in #85708 behaved as designed and exposed the ownership gap.

## User Impact

Managed restarts now regain service even when an embedded run's abort path or another shutdown step starves the Gateway event loop. Normal graceful shutdown remains unchanged when cleanup succeeds, while one stalled harness can no longer strand listener closure.

There is no config, protocol, storage, plugin SDK, or provider behavior change.

## Evidence

Production was evidence-only: it was not used for reproduction and was not stopped or restarted during this repair.

**Before fix, isolated current-main run-loop reproduction:**

```json
{"aliveAfterMs":28000,"reachedAbort":true,"forcedExitLogSeen":false}
{"code":null,"signal":"SIGKILL","elapsedMs":28006}
```

The second line is the parent harness cleaning up the still-live child.

**After fix, one-time full run-loop process proof:**

```text
manual run-loop proof: signal=SIGKILL elapsedMs=27166
```

The real `runGatewayLoop`, restart-intent store, and embedded-run registry reached the timeout and entered a synchronous CPU spin inside `abort()`. The independent watchdog killed the process before the 30-second parent deadline.

**Focused tests:**

```text
node scripts/run-vitest.mjs src/cli/gateway-cli/shutdown-hard-exit.process.test.ts src/cli/gateway-cli/run-loop.test.ts src/cli/gateway-cli/run.option-collisions.test.ts src/gateway/server-close.test.ts
Test Files: 4 passed
Tests: 189 passed
```

The committed process test proves both CPU-spin termination and cancellation with a short independent deadline. Run-loop tests prove authorized arm/rearm/cancel behavior and that injected runtimes do not arm the watchdog. The production-caller test proves only the real Gateway runner grants process authority. Server-close coverage proves a stalled harness records a warning and listener teardown continues.

**Checks:**

```text
node scripts/check-changed.mjs -- <8 changed files>
passed: format, core/core-test typechecks, oxlint, import cycles, architecture and repository guards

pnpm build
passed

git diff --check
passed

.claude/skills/autoreview/scripts/autoreview --mode uncommitted
clean: no accepted/actionable findings reported
```

**LOC:** production `+93/-6` (net `+87`); tests `+156/-22`. The production growth is the new independent process-lifecycle owner plus the explicit authority handoff; the harness timeout reuses existing shutdown machinery.

**Known proof gap:** no live systemd stop/restart was performed because the production Gateway was explicitly excluded from reproduction and restart without fresh approval. The changed boundary is covered by the real child-process proof, current-main failing reproduction, focused lifecycle suites, build, and exact-head CI.