### PR TITLE
fix(ci): stop the codex lane hanging on a cold real-tool graph

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -475,6 +475,10 @@ async function runSideQuestionWithManagedWebSearchCall(
   } = {},
 ) {
   const client = createFakeClient();
+  let resolveTurnStarted!: () => void;
+  const turnStarted = new Promise<void>((resolve) => {
+    resolveTurnStarted = resolve;
+  });
   if (!options.preserveToolFactory) {
     createOpenClawCodingToolsMock.mockReturnValue([
       {
@@ -493,6 +497,7 @@ async function runSideQuestionWithManagedWebSearchCall(
       return {};
     }
     if (method === "turn/start") {
+      queueMicrotask(resolveTurnStarted);
       return turnStartResult("turn-1");
     }
     if (method === "thread/unsubscribe" || method === "turn/interrupt") {
@@ -503,7 +508,8 @@ async function runSideQuestionWithManagedWebSearchCall(
   getSharedCodexAppServerClientMock.mockResolvedValue(client);
 
   const run = runCodexAppServerSideQuestion(params);
-  const toolResponse = await handleClientRequestWhenReady(client, {
+  await turnStarted;
+  const toolResponse = await client.handleRequest({
     id: 42,
     method: "item/tool/call",
     params: {
@@ -513,6 +519,7 @@ async function runSideQuestionWithManagedWebSearchCall(
       arguments: options.toolArguments ?? { query: "service providers" },
     },
   });
+  expect(toolResponse).not.toBeUndefined();
   client.emit(turnCompleted("side-thread", "turn-1", "Search answer."));
   const result = await run;
   const forkCall = client.request.mock.calls.find(([method]) => method === "thread/fork");
@@ -1276,14 +1283,31 @@ describe("runCodexAppServerSideQuestion", () => {
       success: true,
     },
   ])("applies native search domains to side-question web_fetch and $name", async (testCase) => {
-    const actualAgentHarness = await vi.importActual<
-      typeof import("openclaw/plugin-sdk/agent-harness")
-    >("openclaw/plugin-sdk/agent-harness");
-    createOpenClawCodingToolsMock.mockImplementation((options) =>
-      actualAgentHarness
-        .createOpenClawCodingTools(options as never)
-        .filter((tool) => tool.name === "web_search" || tool.name === "web_fetch"),
-    );
+    const { createWebFetchTool } = await vi.importActual<
+      typeof import("../../../../src/agents/tools/web-fetch.js")
+    >("../../../../src/agents/tools/web-fetch.js");
+    createOpenClawCodingToolsMock.mockImplementation((options) => {
+      const toolOptions = options as NonNullable<
+        Parameters<
+          (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"]
+        >[0]
+      >;
+      const webFetchTool = createWebFetchTool({
+        config: toolOptions.config,
+        sandboxed: toolOptions.sandbox?.enabled === true,
+        lateBindRuntimeConfig: true,
+        hostnameAllowlistRef: toolOptions.webFetchHostnameAllowlistRef,
+      });
+      return [
+        {
+          name: "web_search",
+          description: "Search the web",
+          parameters: { type: "object", properties: {}, additionalProperties: true },
+          execute: toolExecuteMock,
+        },
+        ...(webFetchTool ? [webFetchTool] : []),
+      ];
+    });
     const fetchMock = vi.fn(
       async () =>
         new Response("permitted", { status: 200, headers: { "content-type": "text/plain" } }),

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -12,7 +12,10 @@ import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
-import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  createMockPluginRegistry,
+  loadWebFetchToolFactoryForTest,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   codexTestTurnIds,
@@ -1283,9 +1286,7 @@ describe("runCodexAppServerSideQuestion", () => {
       success: true,
     },
   ])("applies native search domains to side-question web_fetch and $name", async (testCase) => {
-    const { createWebFetchTool } = await vi.importActual<
-      typeof import("../../../../src/agents/tools/web-fetch.js")
-    >("../../../../src/agents/tools/web-fetch.js");
+    const createWebFetchTool = await loadWebFetchToolFactoryForTest();
     createOpenClawCodingToolsMock.mockImplementation((options) => {
       const toolOptions = options as NonNullable<
         Parameters<

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -89,9 +89,9 @@ const EXTENSION_TEST_COST_MULTIPLIERS: Record<string, number> = {
   // overstates its real wall-clock cost during CI shard planning.
   "test/vitest/vitest.extensions.config.ts": 1.1,
 };
-// A 34-file changed shard starved real-time watches on 4-vCPU CI while the same
-// inventory completed normally when split or run without host contention (#125768).
-const CODEX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 20;
+// A 34-file changed shard starved real-time watches and the no-output watchdog.
+// Keep serial, non-isolated Codex processes small enough for prompt output (#125768, #125839).
+const CODEX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 12;
 const MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT = 1;
 const TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT = 10;

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -139,6 +139,9 @@ export {
 } from "../test-utils/plugin-setup-wizard.js";
 export { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 export { createAdmittedHostCapabilityTestFixture } from "../agents/harness/host-capability.test-support.js";
+export async function loadWebFetchToolFactoryForTest() {
+  return (await import("../agents/tools/web-fetch.js")).createWebFetchTool;
+}
 export { buildPluginApi } from "../plugins/api-builder.js";
 export {
   createCapturedPluginRegistration,

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -20,7 +20,7 @@ import { hasImportGraphImpactOnTargets } from "../../scripts/test-projects.test-
 import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
 
-const CODEX_TEST_PROCESS_FILE_LIMIT = 20;
+const CODEX_TEST_PROCESS_FILE_LIMIT = 12;
 
 function expectBoundedCodexFallback(
   shards: ReturnType<typeof createChangedExtensionFallbackShards>,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -39,7 +39,7 @@ import {
 } from "../vitest/vitest.contracts-shared.ts";
 
 const normalizeRepoPath = toRepoPath;
-const CODEX_TEST_PROCESS_FILE_LIMIT = 20;
+const CODEX_TEST_PROCESS_FILE_LIMIT = 12;
 const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_TEST_PROCESS_FILE_LIMIT = 1;
 


### PR DESCRIPTION
Closes #125839

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where every pull request selecting the Codex extension lane could remain silent until the no-output watchdog terminated it. The affected side-question test paid for a cold, whole-agent-tool graph while racing a one-second readiness poll, and the planner could place all 34 Codex files in one serial, non-isolated process.

## Why This Change Was Made

The domain-policy cases now load the narrow real `web_fetch` implementation on demand through the local-only Plugin SDK test runtime and retain a lightweight `web_search` policy marker, so they still exercise permitted-host fetches, blocked outside hosts, network call counts, and the exact error payload without evaluating the unrelated agent-harness graph. The helper also synchronizes on the actual side-turn start before issuing the tool request instead of relying on a retry timeout.

As defense in depth, Codex extension processes are capped at 12 files. Existing full-runner and changed-extension planner tests now enforce that bound, which limits time-to-first-output even if future test imports grow.

## User Impact

Contributors can land extension-touching pull requests again without the Codex test lane hanging. There is no production runtime or user-visible behavior change.

## Evidence

- Planner contracts: `test/scripts/test-projects.test.ts` and `test/scripts/ci-changed-node-test-plan.test.ts` passed, 308/308 tests. Direct plan inspection produced 15 Codex processes, each containing 11 or 12 files; maximum 12.
- Heavy CI-shaped chunk containing `side-question.test.ts`, 12 files / 422 tests, 300-second watchdog:
  - final run 1: first `✓` at 15.249s, wall 102.63s
  - final run 2: first `✓` at 20.678s, wall 115.34s
  - post-rebase conflict check: first `✓` at 19.494s, wall 106.53s
- Remaining original shard inventory:
  - 12 files / 371 tests passed, wall 30.83s
  - 10 files / 237 tests passed, wall 24.37s
- `side-question.test.ts` alone passed twice, 67/67 tests, in 63.49s and 65.38s.
- `node scripts/check-changed.mjs` passed.
- `pnpm build` passed; all 146 public Plugin SDK subpaths verified, with no ineffective dynamic-import warning.
- `pnpm run lint:plugins:no-extension-test-core-imports` passed after routing the narrow loader through the local-only test runtime.
- Structured autoreview passed with no accepted/actionable findings.
- Direct Codex contract check: `item/tool/call` maps to the dynamic tool request/response contract in `../codex/codex-rs/app-server-protocol/src/protocol/common.rs:1627` and `../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs:1551`; app-server response handling is in `../codex/codex-rs/app-server/src/dynamic_tools.rs:20`.
