### PR TITLE
fix(skills): report execution-directory skill precedence collisions

### DIFF
--- a/src/skills/loading/workspace-precedence.test.ts
+++ b/src/skills/loading/workspace-precedence.test.ts
@@ -1,4 +1,5 @@
 // Workspace precedence tests cover precedence between workspace, plugin, and bundled skills.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
@@ -8,6 +9,7 @@ import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import type { OpenClawSkillMetadata, SkillEntry } from "../types.js";
 import { createSyntheticSourceInfo } from "./skill-contract.js";
+import { loadMergedWorkspaceSkills } from "./workspace-skill-loader.js";
 import { buildSkillSnapshot } from "./workspace-skill-prompt.js";
 
 const buildWorkspaceSkillsPrompt = (
@@ -37,6 +39,18 @@ afterEach(() => {
 
 function captureWarningLogger() {
   setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+  const warn = vi.fn();
+  loggingState.rawConsole = {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn,
+    error: vi.fn(),
+  };
+  return warn;
+}
+
+function captureJsonWarningLogger() {
+  setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "json" });
   const warn = vi.fn();
   loggingState.rawConsole = {
     log: vi.fn(),
@@ -141,6 +155,72 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(warningText).toContain('skill="demo-skill"');
     expect(warningText).toContain("winner=openclaw-bundled:~/.bundled/demo-skill/SKILL.md");
     expect(warningText).toContain("loser=openclaw-extra:~/.extra/demo-skill/SKILL.md");
+  });
+
+  it("reports execution-directory collisions while keeping workspace precedence", async () => {
+    const agentWorkspaceDir = await fixtureSuite.createCaseDir("agent-workspace-collision");
+    const executionWorkspaceDir = await fixtureSuite.createCaseDir("execution-workspace-collision");
+    const workspaceSkillFile = path.join(agentWorkspaceDir, "skills", "demo-skill", "SKILL.md");
+    const executionSkillFile = path.join(executionWorkspaceDir, "skills", "demo-skill", "SKILL.md");
+    await writeSkill({
+      dir: path.dirname(workspaceSkillFile),
+      name: "demo-skill",
+      description: "Workspace version",
+    });
+    await writeSkill({
+      dir: path.dirname(executionSkillFile),
+      name: "demo-skill",
+      description: "Execution version",
+    });
+    const warn = captureJsonWarningLogger();
+
+    const entries = loadMergedWorkspaceSkills({
+      agentWorkspaceDir,
+      executionSkillsDir: path.join(executionWorkspaceDir, "skills"),
+      managedSkillsDir: path.join(agentWorkspaceDir, ".managed"),
+      bundledSkillsDir: "",
+      pluginSkillsDir: path.join(agentWorkspaceDir, ".plugin-skills"),
+    });
+    const warning = JSON.parse(String(warn.mock.calls[0]?.[0])) as Record<string, unknown>;
+
+    expect(entries.find((entry) => entry.skill.name === "demo-skill")?.skill.description).toBe(
+      "Workspace version",
+    );
+    expect(warning).toMatchObject({
+      message: "Skill precedence collision resolved.",
+      skill: "demo-skill",
+      winnerPath: workspaceSkillFile,
+      loserPath: executionSkillFile,
+    });
+  });
+
+  it("does not report execution-directory collisions for the same canonical skill file", async () => {
+    const agentWorkspaceDir = await fixtureSuite.createCaseDir("agent-workspace-symlink");
+    const executionWorkspaceDir = await fixtureSuite.createCaseDir("execution-workspace-symlink");
+    const workspaceSkillsDir = path.join(agentWorkspaceDir, "skills");
+    await writeSkill({
+      dir: path.join(workspaceSkillsDir, "demo-skill"),
+      name: "demo-skill",
+      description: "Workspace version",
+    });
+    const executionSkillsDir = path.join(executionWorkspaceDir, "skills");
+    await fs.symlink(
+      workspaceSkillsDir,
+      executionSkillsDir,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const warn = captureWarningLogger();
+
+    const entries = loadMergedWorkspaceSkills({
+      agentWorkspaceDir,
+      executionSkillsDir,
+      managedSkillsDir: path.join(agentWorkspaceDir, ".managed"),
+      bundledSkillsDir: "",
+      pluginSkillsDir: path.join(agentWorkspaceDir, ".plugin-skills"),
+    });
+
+    expect(entries.filter((entry) => entry.skill.name === "demo-skill")).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
   });
   it("gates by bins, config, and always", async () => {
     const workspaceDir = await fixtureSuite.createCaseDir("workspace");

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -97,6 +97,29 @@ function warnInvalidSkill(source: string, diagnostic: LocalSkillLoadDiagnostic):
   });
 }
 
+// Shared by both merge paths so a dropped skill is never silent: the by-name merge in
+// loadSkillEntries and the execution-directory filter in loadMergedWorkspaceSkills.
+function warnSkillPrecedenceCollision(winner: Skill, loser: Skill): void {
+  // One file reachable through two roots is not a collision. normalizeWorkspaceSkillRoots only
+  // rejects the literal <agentWorkspaceDir>/skills path, so a symlinked execution dir still
+  // arrives here with both sides naming the same skill.
+  if (canonicalizePath(winner.filePath) === canonicalizePath(loser.filePath)) {
+    return;
+  }
+  const collisionName = winner.name.slice(0, 128);
+  skillsLogger.warn("Skill precedence collision resolved.", {
+    skill: collisionName,
+    winnerSource: winner.source,
+    loserSource: loser.source,
+    winnerPath: winner.filePath,
+    loserPath: loser.filePath,
+    consoleMessage:
+      `Skill precedence collision: skill="${collisionName}" ` +
+      `winner=${winner.source}:${compactSkillPath(winner.filePath)} ` +
+      `loser=${loser.source}:${compactSkillPath(loser.filePath)}`,
+  });
+}
+
 function filterSkillEntries(
   entries: SkillEntry[],
   config?: OpenClawConfig,
@@ -370,22 +393,8 @@ function loadSkillEntries(
       return;
     }
     const replaced = merged.get(record.skill.name);
-    if (
-      replaced &&
-      canonicalizePath(replaced.skill.filePath) !== canonicalizePath(record.skill.filePath)
-    ) {
-      const collisionName = record.skill.name.slice(0, 128);
-      skillsLogger.warn("Skill precedence collision resolved.", {
-        skill: collisionName,
-        winnerSource: record.skill.source,
-        loserSource: replaced.skill.source,
-        winnerPath: record.skill.filePath,
-        loserPath: replaced.skill.filePath,
-        consoleMessage:
-          `Skill precedence collision: skill="${collisionName}" ` +
-          `winner=${record.skill.source}:${compactSkillPath(record.skill.filePath)} ` +
-          `loser=${replaced.skill.source}:${compactSkillPath(replaced.skill.filePath)}`,
-      });
+    if (replaced) {
+      warnSkillPrecedenceCollision(record.skill, replaced.skill);
     }
     merged.set(record.skill.name, record);
   };
@@ -531,12 +540,19 @@ export function loadMergedWorkspaceSkills(
     canExec: params.eligibility?.nodeSkills?.canExec,
     node: params.eligibility?.nodeSkills?.node,
   });
-  const agentNames = new Set(agentEntries.map((entry) => entry.skill.name));
+  const agentEntriesByName = new Map(agentEntries.map((entry) => [entry.skill.name, entry]));
   const executionEntries = loadSkillEntries(agentWorkspaceDir, {
     ...params,
     workspaceOnly: true,
     workspaceSkillsDir: executionSkillsDir,
-  }).filter((entry) => !agentNames.has(entry.skill.name));
+  }).filter((entry) => {
+    const agentEntry = agentEntriesByName.get(entry.skill.name);
+    if (!agentEntry) {
+      return true;
+    }
+    warnSkillPrecedenceCollision(agentEntry.skill, entry.skill);
+    return false;
+  });
   const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(params);
   return filterSkillEntries(
     [...agentEntries, ...executionEntries],


### PR DESCRIPTION
## What Problem This Solves

`src/skills/loading/workspace-skill-loader.ts` has two skill-merge paths, and only one of them told
anybody when a skill lost a name collision.

`loadSkillEntries` merges every skill root into a single map and, on each collision between distinct
files, warns through `skillsLogger` naming the winner and loser source and path.

`loadMergedWorkspaceSkills` — the agent-workspace/execution-directory merge used by agent session
assembly — calls `loadSkillEntries` **twice**, so each call builds its own private map and the
existing warning can never observe a cross-root collision. It then dropped the losers with a bare
name filter:

```ts
const agentNames = new Set(agentEntries.map((entry) => entry.skill.name));
const executionEntries = loadSkillEntries(/* execution dir */).filter(
  (entry) => !agentNames.has(entry.skill.name),
);
```

No log, no diagnostic, no record. An operator's execution-directory skill simply did not load into
the session and nothing anywhere said why. That is the silent-failure class this repo ranks above
crashes.

Reached through `src/skills/runtime/session-snapshot.ts:95`,
`src/skills/runtime/embedded-run-entries.ts:52`, and
`src/skills/loading/workspace-skill-sync.runtime.ts:197`.

## Why This Change Was Made

The repo has already decided what a skill precedence collision looks like; the execution-directory
merge just did not participate. Rather than invent a second diagnostic, the existing warning moved
into `warnSkillPrecedenceCollision(winner, loser)` and both merge paths now call it, so both emit one
grep-able shape with identical fields and the same 128-character name clamp.

The canonical-path equality guard moved into the helper with it. `normalizeWorkspaceSkillRoots` only
rejects the literal `<agentWorkspaceDir>/skills` path, so an execution dir that is a *symlink* to the
workspace skills dir still reaches this code with both sides naming the same file — that is one file
seen through two roots, not a collision, and it stays silent.

Precedence is unchanged: the agent workspace still wins, matching the behaviour established in
#125786. Only the loss became visible.

## User Impact

Operators who keep skills in an execution directory now get a warning naming the shadowed file
instead of a skill that silently does not exist. No behaviour, config, or precedence change.

## Evidence

**A/B on the same input through the real production function**, `loadMergedWorkspaceSkills` imported
from each build's `dist/workspace-skill-loader-*.js`, with a workspace/execution `dup-skill`
collision plus a non-colliding execution-only skill. Isolated `OPENCLAW_STATE_DIR`,
`OPENCLAW_SKIP_CHANNELS=1`, channel/Twilio env unset, no provider calls:

| build | stderr |
| --- | --- |
| `main` (unfixed) | **0 bytes** — silent drop |
| this branch | `[skills] Skill precedence collision: skill="dup-skill" winner=openclaw-workspace:/tmp/r32proof/ws/skills/dup-skill/SKILL.md loser=openclaw-workspace:/tmp/r32proof/exec/skills/dup-skill/SKILL.md` |

Both builds returned an identical entry list — `dup-skill` resolving to the workspace file with
description `WORKSPACE winner`, and the non-colliding `execonly` execution-directory skill still
present — confirming precedence is untouched and the filter does not over-drop.

Sibling check: `plugin-skills.ts:317` also drops by name, but that is keep-set semantics for stale
generated symlink cleanup, a different invariant, and is already commented. `loadMergedWorkspaceSkills`
was the only sibling sharing the silent-drop shape.

**Tests** — extended `src/skills/loading/workspace-precedence.test.ts` beside the existing warning
assertion rather than adding a near-duplicate file:
- execution-directory collision warns with the workspace `winnerPath` and execution `loserPath`, and
  the workspace description still wins;
- an execution skills dir symlinked to the workspace skills dir stays silent and yields one entry.

Reverting only the production file makes the new assertion fail (1 failed / 6 passed) and restoring
it passes 7/7 — the test proves the behaviour rather than restating it.

**Validation** — focused `workspace-precedence.test.ts` green; `node scripts/check-changed.mjs`;
branch-mode autoreview clean (`patch is correct`, no accepted or actionable findings).

Production LOC `+34/-18` in one file (the warning block moved rather than duplicated; the growth is
the shared helper, its guard comment, and the winner lookup needed to name the losing path). Test LOC
`+80`.
