### PR TITLE
perf(test): await session hovercard arbitration

### DIFF
--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -471,29 +471,38 @@ suite.define(() => {
         });
 
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
+        const sidebarTrigger = page.locator(
+          `.sidebar-recent-session[data-session-key="${selectedSessionKey}"] .sidebar-recent-session__link`,
+        );
+        await sidebarTrigger.focus();
+        await expect
+          .poll(
+            async () =>
+              (await gateway.getRequests("progressCard.get")).filter(
+                (request) =>
+                  isRecord(request.params) && request.params.sessionKey === selectedSessionKey,
+              ).length,
+          )
+          .toBe(1);
+        const sidebarProgress = page.locator(".session-progress-hovercard");
+        await sidebarProgress.waitFor({ state: "visible" });
+        await page.keyboard.press("Escape");
+        await expect.poll(() => sidebarProgress.count()).toBe(0);
+
         const link = page.locator(`.markdown-session-link[data-session-key="${linkedSessionKey}"]`);
         await link.waitFor({ state: "visible" });
         await link.focus();
 
         const preview = page.locator(".session-link-hovercard");
-        await preview.waitFor({ state: "visible" });
+        await expect.poll(() => preview.getAttribute("data-loading")).toBe("false");
         expect(await preview.getAttribute("role")).toBe("dialog");
         expect(await link.getAttribute("aria-controls")).toBe(await preview.getAttribute("id"));
-        await expect
-          .poll(
-            async () => {
-              await new Promise<void>((resolve) => {
-                setTimeout(resolve, 700);
-              });
-              return (await gateway.getRequests("progressCard.get")).filter(
-                (request) =>
-                  isRecord(request.params) && request.params.sessionKey === linkedSessionKey,
-              ).length;
-            },
-            { timeout: 2_000 },
-          )
-          .toBe(0);
-        expect(await page.locator(".session-progress-hovercard").count()).toBe(0);
+        expect(
+          (await gateway.getRequests("progressCard.get")).filter(
+            (request) => isRecord(request.params) && request.params.sessionKey === linkedSessionKey,
+          ),
+        ).toHaveLength(0);
+        expect(await sidebarProgress.count()).toBe(0);
       },
     );
   });


### PR DESCRIPTION
## What Problem This Solves

The session hovercard E2E path spent 700 ms proving a negative after the linked-session preview opened, while a broad sidebar intercept could hide stale sidebar traffic and make the dedicated completion signal unreliable.

## Why This Change Was Made

The prior 700 ms negative poll is replaced by explicit sidebar provider warmup and dismissal, followed by the dedicated hovercard's data-loading completion. The assertion then proves zero linked-session progress requests and no stale sidebar hovercard.

## User Impact

There is no user-visible behavior change. This makes the existing E2E coverage faster and more precise. No changelog entry or screenshots are needed for this test-only change.

## Evidence

- Fault: broad sidebar request interception and broken dedicated completion made the negative assertion both slower and less specific.
- A/B performance run: https://github.com/openclaw/openclaw/actions/runs/32148101771 — target 1.540 s to 0.925 s (-615 ms, -40%); full body -770 ms (-7.5%).
- Exact-head proof: https://github.com/openclaw/openclaw/actions/runs/32151143813 — target x3, 28 unit tests, 11 E2E tests, and the changed gate all green in 10m25s.
- Production LOC: +0/-0. Tests: +25/-16.
