### PR TITLE
test(ui): fix CI-flaky model-menu geometry baseline in new-session-page e2e

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -270,12 +270,40 @@ suite.define(() => {
         .toBe(true);
       const secondShortcut = secondModel.locator('[data-chat-model-shortcut-number="2"]');
       await expect.poll(() => secondShortcut.count()).toBe(1);
-      const menuBoxBeforeFocus = await page.locator(".chat-controls__model-menu").boundingBox();
-      const actionBoxBeforeFocus = await secondModel
-        .locator(".chat-controls__model-option-action")
-        .boundingBox();
-      expect(menuBoxBeforeFocus).not.toBeNull();
-      expect(actionBoxBeforeFocus).not.toBeNull();
+      // wa-popup positions asynchronously: a freshly opened menu can rest at a
+      // stale offset for several frames before autoUpdate applies the anchored
+      // position, so raw boundingBox baselines race that settlement under CI
+      // load. Measure geometry relative to the trigger and gate the baseline on
+      // the anchored-overlay contract (menu bottom sits `distance` = 6px above
+      // its anchor; see syncAnchoredOverlay).
+      const modelMenu = page.locator(".chat-controls__model-menu");
+      const menuGeometry = async () => {
+        const [menuBox, triggerBox, actionBox] = await Promise.all([
+          modelMenu.boundingBox(),
+          modelSelect.boundingBox(),
+          secondModel.locator(".chat-controls__model-option-action").boundingBox(),
+        ]);
+        if (!menuBox || !triggerBox || !actionBox) {
+          return null;
+        }
+        return {
+          anchorGap: Math.round(triggerBox.y - (menuBox.y + menuBox.height)),
+          menu: {
+            width: menuBox.width,
+            height: menuBox.height,
+            left: menuBox.x - triggerBox.x,
+          },
+          action: {
+            width: actionBox.width,
+            height: actionBox.height,
+            left: actionBox.x - menuBox.x,
+            top: actionBox.y - menuBox.y,
+          },
+        };
+      };
+      await expect.poll(async () => (await menuGeometry())?.anchorGap).toBe(6);
+      const geometryBeforeFocus = await menuGeometry();
+      expect(geometryBeforeFocus).not.toBeNull();
       await expect
         .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
@@ -287,12 +315,9 @@ suite.define(() => {
       await expect
         .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("0");
-      expect(await page.locator(".chat-controls__model-menu").boundingBox()).toEqual(
-        menuBoxBeforeFocus,
-      );
-      expect(
-        await secondModel.locator(".chat-controls__model-option-action").boundingBox(),
-      ).toEqual(actionBoxBeforeFocus);
+      // Hiding the shortcut badges is opacity-only: the menu must not move or
+      // resize relative to its anchor, and the action cell must hold its slot.
+      expect(await menuGeometry()).toEqual(geometryBeforeFocus);
       await search.press("1");
       await expect.poll(() => search.inputValue()).toBe("1");
       await expect.poll(() => picker.getAttribute("open")).toBe("");


### PR DESCRIPTION
## What Problem This Solves

`ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts` had two CI-flaky tests flagged against shard 5/12 of run 32122284238 (PR #125690, a sidebar-only change that does not touch the new-session page), while passing 13/13 locally.

## Why This Change Was Made

Investigated both failures by reproducing under CI-equivalent load (CPU throttling + concurrent shard runs) rather than guessing from the stack trace alone.

**"blocks an immediate submit until remembered model and worktree choices validate"** — the CI run's merge base (`b8ff4fe3d`) predates commit dfca085063539a4afebc4568b2d89b7ef4a03ccc ("test(ui): wait for remembered draft before reload"), which already fixed this exact race: the pre-fix test called `.fill()` immediately after `page.reload()`, racing the IndexedDB draft restore's `.value` commit. When the restore's assignment lands between `fill()`'s select-all and its insertText, the selection collapses and the insert appends instead of replacing — producing the observed `"...choiceskeep both remembered choices"` doubling. No production code can concatenate a message (verified by reading every write path: `setMessage`, `restoreMessage`, `restoreDraftState`, the durable draft store's CAS write). Current `main` already carries the fix; no change needed here. 15/15 focused runs and ~60 file-level runs (including under 20x CPU throttle and 3-way concurrency) pass on the current shape.

**"separates model shortcuts from numeric search input by focus"** — reproduced twice locally under concurrent load with the exact CI signature (menu box y 139→175, a 36px vertical shift). Root cause: the model menu is a `wa-popup` (floating-ui) that positions asynchronously. It can render at a stale offset for several frames — computed against a pre-settle content height — before `autoUpdate` applies the corrected anchored position, and that correction lags further under CPU starvation. The test sampled a `boundingBox()` baseline before the popup had settled, then compared it against the post-settle position, so the two samples were never actually the same "moment" in the popup's lifecycle. The fix gates the baseline on the anchored-overlay contract itself (menu bottom rests `distance: 6px` above its trigger, per `syncAnchoredOverlay`) and compares trigger-relative geometry instead of raw viewport coordinates, so it fails hard only if the real protected behavior — that focusing the search input doesn't move or resize the menu — is violated.

## User Impact

Test-only change. Removes a CI flake source without weakening any assertion; both checks remain exact-equality gates on the actual protected behavior.

## Evidence

- Root cause for the doubling test: `git merge-base --is-ancestor dfca085063539a4afebc4568b2d89b7ef4a03ccc b8ff4fe3d7d687620ce5b4a4785832daca94a74d` → not an ancestor, confirming the CI run tested a pre-fix tree.
- Reproduced the geometry flake locally (`ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts:289`) with matching failure signature under 3-way concurrent `node scripts/run-vitest.mjs` runs.
- Post-fix verification: 9/9 green across 3 rounds of 3-way concurrent full-file runs, plus a clean serial 13/13 run.
- `node scripts/check-changed.mjs` — format/lint/typecheck/knip/i18n all pass on the changed file.

## Follow-up

PR #125690 itself should rebase onto current `main` so its next CI run picks up dfca085063539a4afebc4568b2d89b7ef4a03ccc and stops hitting the doubling flake on a stale merge ref.
