### PR TITLE
perf(ui): coalesce New Session draft writes

### DIFF
--- a/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
@@ -1,4 +1,6 @@
+import { Buffer } from "node:buffer";
 import path from "node:path";
+import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import {
   createNewSessionPageE2eSuite,
@@ -6,8 +8,116 @@ import {
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
+const DURABLE_ATTACHMENT_CAP_BYTES = 25 * 1024 * 1024;
+
+async function rawDraftMatches(
+  page: Page,
+  expectedText: string,
+  expectedAttachmentCount: number,
+): Promise<boolean> {
+  return page.evaluate(
+    async ({ attachmentCount, text }) => {
+      const databases = await indexedDB.databases();
+      if (!databases.some((database) => database.name === "openclaw-control-ui")) {
+        return false;
+      }
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open("openclaw-control-ui");
+        request.addEventListener("success", () => resolve(request.result), { once: true });
+        request.addEventListener(
+          "error",
+          () => reject(request.error ?? new Error("IndexedDB open failed")),
+          { once: true },
+        );
+      });
+      try {
+        const transaction = database.transaction("composerDrafts", "readonly");
+        const records = await new Promise<unknown[]>((resolve, reject) => {
+          const request = transaction.objectStore("composerDrafts").getAll();
+          request.addEventListener("success", () => resolve(request.result), { once: true });
+          request.addEventListener(
+            "error",
+            () => reject(request.error ?? new Error("IndexedDB read failed")),
+            { once: true },
+          );
+        });
+        return records.some((value) => {
+          if (!value || typeof value !== "object") {
+            return false;
+          }
+          const record = value as { attachments?: unknown; text?: unknown };
+          return (
+            record.text === text &&
+            Array.isArray(record.attachments) &&
+            record.attachments.length === attachmentCount
+          );
+        });
+      } finally {
+        database.close();
+      }
+    },
+    { attachmentCount: expectedAttachmentCount, text: expectedText },
+  );
+}
 
 suite.define(() => {
+  it("coalesces a burst of near-limit attachment draft mutations into one write", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    try {
+      const page = await context.newPage();
+      await page.addInitScript(() => {
+        const originalTransaction = Object.getOwnPropertyDescriptor(
+          IDBDatabase.prototype,
+          "transaction",
+        )?.value as IDBDatabase["transaction"];
+        const state = globalThis as typeof globalThis & {
+          composerDraftReadwriteTransactions: number;
+        };
+        state.composerDraftReadwriteTransactions = 0;
+        IDBDatabase.prototype.transaction = function (
+          this: IDBDatabase,
+          ...args: Parameters<IDBDatabase["transaction"]>
+        ) {
+          const [storeNames, mode] = args;
+          const names = typeof storeNames === "string" ? [storeNames] : Array.from(storeNames);
+          if (mode === "readwrite" && names.includes("composerDrafts")) {
+            state.composerDraftReadwriteTransactions += 1;
+          }
+          return originalTransaction.apply(this, args);
+        } as IDBDatabase["transaction"];
+      });
+      await installMockGateway(page, { attachmentMaxBytes: DURABLE_ATTACHMENT_CAP_BYTES });
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.locator(".agent-chat__file-input").setInputFiles({
+        name: "near-durable-cap.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.alloc(DURABLE_ATTACHMENT_CAP_BYTES - 64 * 1024, 0x61),
+      });
+      await expect.poll(() => rawDraftMatches(page, "", 1)).toBe(true);
+      await page.evaluate(() => {
+        (
+          globalThis as typeof globalThis & { composerDraftReadwriteTransactions: number }
+        ).composerDraftReadwriteTransactions = 0;
+      });
+
+      const message = page.locator(".new-session-page__message");
+      await message.pressSequentially("burst", { delay: 20 });
+      await expect.poll(() => rawDraftMatches(page, "burst", 1)).toBe(true);
+      const transactionCount = await page.evaluate(
+        () =>
+          (globalThis as typeof globalThis & { composerDraftReadwriteTransactions: number })
+            .composerDraftReadwriteTransactions,
+      );
+      expect(transactionCount).toBe(1);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("starts an attachment write while an earlier text write is still pending", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
@@ -49,6 +159,9 @@ suite.define(() => {
         .locator(".agent-chat__photo-input")
         .setInputFiles(path.join(process.cwd(), "ui/public/favicon-32.png"));
       await firstPage.getByRole("button", { name: `Open image ${fileName}` }).waitFor();
+      await firstPage.evaluate(() => {
+        document.querySelector("openclaw-new-session-page")?.remove();
+      });
       await firstPage.close();
 
       const restoredPage = await context.newPage();

--- a/ui/src/pages/new-session/draft-persistence.ts
+++ b/ui/src/pages/new-session/draft-persistence.ts
@@ -35,6 +35,7 @@ type DraftSnapshot = {
 
 const durableComposerStore = import("../../lib/chat/composer-draft-store.runtime.ts");
 const loadDurableComposerStore = () => durableComposerStore;
+const NEW_SESSION_DRAFT_PERSIST_DELAY_MS = 200;
 
 export class NewSessionDraftPersistence {
   private gatewayOwner = "";
@@ -45,6 +46,7 @@ export class NewSessionDraftPersistence {
   private restoreGeneration = 0;
   private restoredIdentity = "";
   private pending: DraftSnapshot | null = null;
+  private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private incognitoRetirement: Promise<void> = Promise.resolve();
   private readonly committedByScope = new Map<string, number>();
   private readonly committedWriteIdByScope = new Map<string, string>();
@@ -102,9 +104,9 @@ export class NewSessionDraftPersistence {
       return;
     }
     if (this.routeKey !== routeKey) {
+      this.persistNow();
       this.routeKey = routeKey;
       this.revision = 0;
-      this.pending = null;
     }
   }
 
@@ -136,19 +138,20 @@ export class NewSessionDraftPersistence {
     if (this.read().incognito) {
       return;
     }
+    this.discardPending();
     const snapshot = this.snapshot();
     if (!snapshot) {
       return;
     }
     this.pending = snapshot;
-    this.persistNow();
+    this.timer = globalThis.setTimeout(() => this.persistNow(), NEW_SESSION_DRAFT_PERSIST_DELAY_MS);
   }
 
   retireActive(): Promise<void> {
     this.mutationGeneration += 1;
+    this.discardPending();
     const requestedRevision = nextDraftRevision(this.revision);
     this.revision = requestedRevision;
-    this.pending = null;
     const scope = this.scope();
     if (!scope) {
       return Promise.resolve();
@@ -168,8 +171,8 @@ export class NewSessionDraftPersistence {
   }
 
   clearSubmittedDraft(): Promise<void> {
+    this.persistNow();
     this.mutationGeneration += 1;
-    this.pending = null;
     const scope = this.scope();
     if (!scope) {
       return Promise.resolve();
@@ -235,11 +238,16 @@ export class NewSessionDraftPersistence {
   }
 
   persistNow() {
+    this.clearTimer();
     const snapshot = this.pending;
-    this.pending = null;
-    if (!snapshot || this.read().incognito) {
+    if (!snapshot) {
       return;
     }
+    if (this.read().incognito) {
+      this.discardPending();
+      return;
+    }
+    this.pending = null;
     void this.enqueueWrite(async () => {
       const identity = durableComposerScopeIdentity(snapshot.scope);
       try {
@@ -288,6 +296,7 @@ export class NewSessionDraftPersistence {
   }
 
   disconnect() {
+    this.persistNow();
     this.restoreGeneration += 1;
   }
 
@@ -400,9 +409,32 @@ export class NewSessionDraftPersistence {
   }
 
   private enqueueWrite(run: () => Promise<void>): Promise<void> {
-    // Register each IndexedDB transaction before page teardown. Store ordering and
-    // revision CAS serialize snapshots without delaying attachments behind text.
+    // Flush timers before teardown, then start each IndexedDB transaction independently.
+    // Store ordering and revision CAS serialize writes without promise-chain delays.
     return run();
+  }
+
+  private clearTimer() {
+    if (this.timer === null) {
+      return;
+    }
+    globalThis.clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private discardPending() {
+    this.clearTimer();
+    const snapshot = this.pending;
+    this.pending = null;
+    if (!snapshot) {
+      return;
+    }
+    const identity = durableComposerScopeIdentity(snapshot.scope);
+    const localWriteIds = this.localWriteIdsByScope.get(identity);
+    localWriteIds?.delete(snapshot.writeId);
+    if (localWriteIds?.size === 0) {
+      this.localWriteIdsByScope.delete(identity);
+    }
   }
 
   private rememberLocalWriteId(identity: string, writeId: string) {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -74,6 +74,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private readonly place: DraftPlaceState;
   private readonly submission: DraftSubmissionFlow;
   private readonly subscriptions: SubscriptionsController;
+  private readonly flushDraft = () => this.submission.draftPersistence.persistNow();
 
   constructor() {
     super();
@@ -223,11 +224,13 @@ export class NewSessionPage extends OpenClawLightDomElement {
     super.connectedCallback();
     document.addEventListener("keydown", this, true);
     document.addEventListener("pointerdown", this, true);
+    window.addEventListener("beforeunload", this.flushDraft);
   }
 
   override disconnectedCallback() {
     document.removeEventListener("keydown", this, true);
     document.removeEventListener("pointerdown", this, true);
+    window.removeEventListener("beforeunload", this.flushDraft);
     retainDraft(this.context, this.submission, this.openedFor, this.messageOwnerKey);
     this.subscriptions.clear();
     this.gateway.invalidateDiscovery(
@@ -266,7 +269,6 @@ export class NewSessionPage extends OpenClawLightDomElement {
     const resolvedAgentId = this.data?.agentId ?? "";
     const groupDefaults = catalog.groupDefaultsKey(this.data);
     if (this.openedFor !== openKey) {
-      this.submission.draftPersistence.persistNow();
       const ownedMessage = this.messageOwnerKey === openKey ? this.submission.message : "";
       this.openedFor = openKey;
       this.openedGroupDefaults = groupDefaults;


### PR DESCRIPTION
Related: #125332, #125665

AI-assisted: yes. The implementation and evidence were reviewed before publication. No agent transcript is attached.

## What Problem This Solves

Fixes an issue where typing in New Session immediately started one IndexedDB readwrite transaction per input event. With a 24.94 MiB staged attachment, five input events produced five transactions and repeatedly staged the large Blob even though only the latest never-started draft snapshot mattered.

## Why This Change Was Made

The New Session persistence owner now applies a 200 ms trailing coalescing window. Every mutation still synchronously captures and registers the latest immutable draft snapshot, but a newer mutation replaces only pending work that has not started. In-flight write IDs remain valid CAS predecessors, and every started IndexedDB transaction remains independent rather than waiting on a promise chain.

Lifecycle boundaries preserve durability: route and owner changes, component disconnect, and `beforeunload` flush pending work; submit starts the pending snapshot before clearing it; and entering Incognito discards pending private content before starting the retirement fence. The route transition now relies on `selectRoute()` as the single flush owner.

This follows up the durable-draft feature in #125332 and its authoritative deletion cleanup in #125665. There are no Gateway API, protocol, config, dependency, release, or storage-schema changes.

## User Impact

Typing in New Session no longer rewrites a large staged draft attachment on every keystroke. Restart, route-change, submit, teardown, and Incognito durability behavior remains intact.

Release-note context: New Session typing no longer rewrites large draft attachments per keystroke while restart, Incognito, and submit durability remain intact.

## Evidence

Real Chromium with the mocked Gateway exercises the actual IndexedDB boundary and native Blob payload:

- Before on the exact parent: five `pressSequentially` input events with a Blob sized to 25 MiB minus 64 KiB started 5 `composerDrafts` readwrite transactions. The regression failed exactly `expected 5 to be 1`.
- After: the same burst starts exactly 1 `composerDrafts` readwrite transaction and restores the final text plus attachment from durable storage.

Exact rebased head `dd1520c1113af1ba9b0044cf606b10f0e5e2ff69`:

- `node scripts/run-vitest.mjs ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts ui/src/e2e/composer-draft-store.e2e.test.ts` — 4 files, 21 tests passed.
- `pnpm tsgo:ui` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh branch-mode P1 autoreview — clean; no accepted/actionable findings.

The patch retained stable patch ID `cf04fd805570b7f5cc25b8c9c4b428d667aa9ba3` across the rebase. The patch-identical pre-rebase tree also passed:

- `pnpm test:ui` — 692 files, 9,923 passed, 1 skipped.
- `pnpm build` — passed.
- `node scripts/check-changed.mjs` — passed, including dead-export scans, formatting, i18n, core/UI typechecks, and lint.
- The same focused Chromium suite — 4 files, 21 tests passed.
- Fresh P1 autoreview — clean.

LOC classification: production +43/-9 (net +34); tests +113/-0. The production growth is the owner-level coalescing state and explicit lifecycle flush/discard ownership; it does not add a second persistence path or compatibility fallback.

There is no visible pixel delta. Before/after screenshots would be identical and therefore misleading; transaction-count instrumentation plus the real Chromium restart, handoff, teardown, submit, and Incognito lifecycle proof is the meaningful user-surface evidence.
