### PR TITLE
fix: Code Mode drain QA survives worker contention

### DIFF
--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -109,76 +109,110 @@ describe("headless Code Mode", () => {
   });
 
   it("keeps the headless race winner when the later-started tool settles first", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const events: string[] = [];
+    const firstStarted = createDeferred();
+    const firstRelease = createDeferred();
     let firstAborted = false;
     const first = fakeTool("headless_first_race", async (_toolCallId, _input, signal) => {
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(resolve, 25);
-        signal?.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(timer);
-            firstAborted = true;
-            reject(new Error("aborted"));
-          },
-          { once: true },
-        );
-      });
+      events.push("first:start");
+      firstStarted.resolve();
+      signal?.addEventListener(
+        "abort",
+        () => {
+          firstAborted = true;
+          firstRelease.reject(new Error("aborted"));
+        },
+        { once: true },
+      );
+      await firstRelease.promise;
+      events.push("first:done");
       return jsonResult({ winner: "first" });
     });
-    const second = fakeTool("headless_second_race", async () => jsonResult({ winner: "second" }));
+    const second = fakeTool("headless_second_race", async () => {
+      await firstStarted.promise;
+      events.push("second:win");
+      return jsonResult({ winner: "second" });
+    });
+    const release = fakeTool("headless_first_race_release", async () => {
+      events.push("first:release");
+      firstRelease.resolve();
+      return jsonResult({ released: true });
+    });
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([first, second]),
-        code: `return await Promise.race([
-          tools.callValue("openclaw:core:headless_first_race", {}),
-          tools.callValue("openclaw:core:headless_second_race", {}),
-        ]);`,
+        ctx: createHeadlessHarness([first, second, release]),
+        code: `const value = await Promise.race([
+            tools.callValue("openclaw:core:headless_first_race", {}),
+            tools.callValue("openclaw:core:headless_second_race", {}),
+          ]);
+          void tools.callValue("openclaw:core:headless_first_race_release", {});
+          return value;`,
         wallClockMs: 5_000,
       }),
     );
 
     expect(result.value).toEqual({ winner: "second" });
-    expect(result.toolCallCount).toBe(2);
+    expect(result.toolCallCount).toBe(3);
     expect(first.execute).toHaveBeenCalledOnce();
     expect(second.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual(["first:start", "second:win", "first:release", "first:done"]);
     expect(firstAborted).toBe(false);
   });
 
   it("drains a headless nested combinator after its outer race wins", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const events: string[] = [];
+    const nestedStarted = createDeferred();
+    const nestedRelease = createDeferred();
     let nestedAborted = false;
     const never = fakeTool("headless_nested_race_never", async (_toolCallId, _input, signal) => {
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(resolve, 25);
-        signal?.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(timer);
-            nestedAborted = true;
-            reject(new Error("aborted"));
-          },
-          { once: true },
-        );
-      });
+      events.push("nested:start");
+      nestedStarted.resolve();
+      signal?.addEventListener(
+        "abort",
+        () => {
+          nestedAborted = true;
+          nestedRelease.reject(new Error("aborted"));
+        },
+        { once: true },
+      );
+      await nestedRelease.promise;
+      events.push("nested:done");
       return jsonResult({ winner: "nested" });
     });
-    const fast = fakeTool("headless_nested_race_fast", async () => jsonResult({ winner: "fast" }));
+    const fast = fakeTool("headless_nested_race_fast", async () => {
+      await nestedStarted.promise;
+      events.push("fast:win");
+      return jsonResult({ winner: "fast" });
+    });
+    const release = fakeTool("headless_nested_race_release", async () => {
+      events.push("nested:release");
+      nestedRelease.resolve();
+      return jsonResult({ released: true });
+    });
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([never, fast]),
-        code: `return await Promise.race([
-          Promise.all([tools.callValue("openclaw:core:headless_nested_race_never", {})]),
-          tools.callValue("openclaw:core:headless_nested_race_fast", {}),
-        ]);`,
+        ctx: createHeadlessHarness([never, fast, release]),
+        code: `const value = await Promise.race([
+            Promise.all([tools.callValue("openclaw:core:headless_nested_race_never", {})]),
+            tools.callValue("openclaw:core:headless_nested_race_fast", {}),
+          ]);
+          void tools.callValue("openclaw:core:headless_nested_race_release", {});
+          return value;`,
         wallClockMs: 5_000,
       }),
     );
 
     expect(result.value).toEqual({ winner: "fast" });
-    expect(result.toolCallCount).toBe(2);
+    expect(result.toolCallCount).toBe(3);
     expect(never.execute).toHaveBeenCalledOnce();
     expect(fast.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual(["nested:start", "fast:win", "nested:release", "nested:done"]);
     expect(nestedAborted).toBe(false);
   });
 
@@ -212,80 +246,127 @@ describe("headless Code Mode", () => {
   ])(
     "drains a headless detached audit started $label before an awaited nested call",
     async ({ auditCode }) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+      const events: string[] = [];
       let auditCompleted = false;
       let auditAborted = false;
       const auditStarted = createDeferred();
       const auditRelease = createDeferred();
       const audit = fakeTool("headless_early_audit", async (_toolCallId, _input, signal) => {
+        events.push("audit:start");
         auditStarted.resolve();
-        signal?.addEventListener("abort", () => (auditAborted = true), { once: true });
+        signal?.addEventListener(
+          "abort",
+          () => {
+            auditAborted = true;
+            auditRelease.reject(new Error("aborted"));
+          },
+          { once: true },
+        );
         await auditRelease.promise;
+        events.push("audit:done");
         auditCompleted = true;
         return jsonResult({ recorded: true });
       });
       const fast = fakeTool("headless_awaited_fast", async () => {
         await auditStarted.promise;
-        setImmediate(() => auditRelease.resolve());
+        events.push("awaited:done");
         return jsonResult({ winner: "fast" });
+      });
+      const release = fakeTool("headless_early_audit_release", async () => {
+        events.push("audit:release");
+        auditRelease.resolve();
+        return jsonResult({ released: true });
       });
 
       const result = expectCompleted(
         await runCodeModeScriptHeadless({
-          ctx: createHeadlessHarness([audit, fast]),
+          ctx: createHeadlessHarness([audit, fast, release]),
           code: `${auditCode}
-          return await tools.callValue("openclaw:core:headless_awaited_fast", {});`,
+          const value = await tools.callValue("openclaw:core:headless_awaited_fast", {});
+          void tools.callValue("openclaw:core:headless_early_audit_release", {});
+          return value;`,
           wallClockMs: 5_000,
         }),
       );
 
       expect(result.value).toEqual({ winner: "fast" });
-      expect(result.toolCallCount).toBe(2);
+      expect(result.toolCallCount).toBe(3);
       expect(audit.execute).toHaveBeenCalledOnce();
       expect(fast.execute).toHaveBeenCalledOnce();
+      expect(release.execute).toHaveBeenCalledOnce();
+      expect(events).toEqual(["audit:start", "awaited:done", "audit:release", "audit:done"]);
       expect(auditCompleted).toBe(true);
       expect(auditAborted).toBe(false);
     },
   );
 
   it("drains a headless race winner's detached audit and its slower race branch", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const events: string[] = [];
+    const loserStarted = createDeferred();
+    const loserRelease = createDeferred();
+    const auditStarted = createDeferred();
     let loserAborted = false;
-    const winner = fakeTool("headless_race_winner", async () => jsonResult({ winner: "fast" }));
+    const winner = fakeTool("headless_race_winner", async () => {
+      await loserStarted.promise;
+      events.push("winner:win");
+      return jsonResult({ winner: "fast" });
+    });
     const loser = fakeTool("headless_race_loser", async (_toolCallId, _input, signal) => {
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(resolve, 25);
-        signal?.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(timer);
-            loserAborted = true;
-            reject(new Error("aborted"));
-          },
-          { once: true },
-        );
-      });
+      events.push("loser:start");
+      loserStarted.resolve();
+      signal?.addEventListener(
+        "abort",
+        () => {
+          loserAborted = true;
+          loserRelease.reject(new Error("aborted"));
+        },
+        { once: true },
+      );
+      await loserRelease.promise;
+      events.push("loser:done");
       return jsonResult({ winner: "slow" });
     });
-    const audit = fakeTool("headless_race_audit", async () => jsonResult({ recorded: true }));
+    const audit = fakeTool("headless_race_audit", async () => {
+      events.push("audit:done");
+      auditStarted.resolve();
+      return jsonResult({ recorded: true });
+    });
+    const release = fakeTool("headless_race_loser_release", async () => {
+      await auditStarted.promise;
+      events.push("loser:release");
+      loserRelease.resolve();
+      return jsonResult({ released: true });
+    });
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([winner, loser, audit]),
-        code: `return Promise.race([
-          tools.callValue("openclaw:core:headless_race_winner", {}),
-          tools.callValue("openclaw:core:headless_race_loser", {}),
-        ]).then((value) => {
+        ctx: createHeadlessHarness([winner, loser, audit, release]),
+        code: `const value = await Promise.race([
+            tools.callValue("openclaw:core:headless_race_winner", {}),
+            tools.callValue("openclaw:core:headless_race_loser", {}),
+          ]);
           void tools.callValue("openclaw:core:headless_race_audit", {});
-          return value;
-        });`,
+          void tools.callValue("openclaw:core:headless_race_loser_release", {});
+          return value;`,
         wallClockMs: 5_000,
       }),
     );
 
     expect(result.value).toEqual({ winner: "fast" });
-    expect(result.toolCallCount).toBe(3);
+    expect(result.toolCallCount).toBe(4);
     expect(winner.execute).toHaveBeenCalledOnce();
     expect(loser.execute).toHaveBeenCalledOnce();
     expect(audit.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual([
+      "loser:start",
+      "winner:win",
+      "audit:done",
+      "loser:release",
+      "loser:done",
+    ]);
     expect(loserAborted).toBe(false);
   });
 
@@ -312,72 +393,101 @@ describe("headless Code Mode", () => {
   it.each(["race", "any"] as const)(
     "preserves the headless Promise.%s winner while draining the slower nested tool",
     async (combinator) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+      const events: string[] = [];
+      const slowStarted = createDeferred();
+      const slowRelease = createDeferred();
       let slowAborted = false;
       let slowCompleted = false;
-      const fast = fakeTool("headless_fast", async () => jsonResult({ winner: "fast" }));
+      const fast = fakeTool("headless_fast", async () => {
+        await slowStarted.promise;
+        events.push("fast:win");
+        return jsonResult({ winner: "fast" });
+      });
       const slow = fakeTool("headless_slow", async (_toolCallId, _input, signal) => {
-        await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(resolve, 25);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              slowAborted = true;
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
-        });
+        events.push("slow:start");
+        slowStarted.resolve();
+        signal?.addEventListener(
+          "abort",
+          () => {
+            slowAborted = true;
+            slowRelease.reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+        await slowRelease.promise;
+        events.push("slow:done");
         slowCompleted = true;
         return jsonResult({ winner: "slow" });
+      });
+      const release = fakeTool("headless_slow_release", async () => {
+        events.push("slow:release");
+        slowRelease.resolve();
+        return jsonResult({ released: true });
       });
 
       const result = expectCompleted(
         await runCodeModeScriptHeadless({
-          ctx: createHeadlessHarness([fast, slow]),
-          code: `return await Promise.${combinator}([
-            tools.callValue("openclaw:core:headless_fast", {}),
-            tools.callValue("openclaw:core:headless_slow", {}),
-          ]);`,
+          ctx: createHeadlessHarness([fast, slow, release]),
+          code: `const value = await Promise.${combinator}([
+              tools.callValue("openclaw:core:headless_slow", {}),
+              tools.callValue("openclaw:core:headless_fast", {}),
+            ]);
+            void tools.callValue("openclaw:core:headless_slow_release", {});
+            return value;`,
           wallClockMs: 5_000,
         }),
       );
 
       expect(result.value).toEqual({ winner: "fast" });
-      expect(result.toolCallCount).toBe(2);
+      expect(result.toolCallCount).toBe(3);
       expect(fast.execute).toHaveBeenCalledOnce();
       expect(slow.execute).toHaveBeenCalledOnce();
+      expect(release.execute).toHaveBeenCalledOnce();
+      expect(events).toEqual(["slow:start", "fast:win", "slow:release", "slow:done"]);
       expect(slowCompleted).toBe(true);
       expect(slowAborted).toBe(false);
     },
   );
 
   it("preserves headless fail-fast Promise.all while draining the slower nested tool", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const events: string[] = [];
+    const slowStarted = createDeferred();
+    const slowRelease = createDeferred();
     let slowAborted = false;
     let slowCompleted = false;
     const failed = fakeTool("headless_failed", async () => {
+      events.push("failed:wait");
+      await slowStarted.promise;
+      events.push("failed:reject");
       throw new Error("fast failure");
     });
     const slow = fakeTool("headless_slow", async (_toolCallId, _input, signal) => {
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(resolve, 25);
-        signal?.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(timer);
-            slowAborted = true;
-            reject(new Error("aborted"));
-          },
-          { once: true },
-        );
-      });
+      events.push("slow:start");
+      slowStarted.resolve();
+      signal?.addEventListener(
+        "abort",
+        () => {
+          slowAborted = true;
+          slowRelease.reject(new Error("aborted"));
+        },
+        { once: true },
+      );
+      await slowRelease.promise;
+      events.push("slow:done");
       slowCompleted = true;
       return jsonResult({ winner: "slow" });
+    });
+    const release = fakeTool("headless_slow_release", async () => {
+      events.push("slow:release");
+      slowRelease.resolve();
+      return jsonResult({ released: true });
     });
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([failed, slow]),
+        ctx: createHeadlessHarness([failed, slow, release]),
         code: `try {
           await Promise.all([
             tools.callValue("openclaw:core:headless_failed", {}),
@@ -385,6 +495,7 @@ describe("headless Code Mode", () => {
           ]);
           return "unexpected success";
         } catch (error) {
+          void tools.callValue("openclaw:core:headless_slow_release", {});
           return error.message;
         }`,
         wallClockMs: 5_000,
@@ -392,9 +503,17 @@ describe("headless Code Mode", () => {
     );
 
     expect(result.value).toBe("fast failure");
-    expect(result.toolCallCount).toBe(2);
+    expect(result.toolCallCount).toBe(3);
     expect(failed.execute).toHaveBeenCalledOnce();
     expect(slow.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual([
+      "failed:wait",
+      "slow:start",
+      "failed:reject",
+      "slow:release",
+      "slow:done",
+    ]);
     expect(slowCompleted).toBe(true);
     expect(slowAborted).toBe(false);
   });

--- a/src/agents/code-mode.bridge.test.ts
+++ b/src/agents/code-mode.bridge.test.ts
@@ -29,34 +29,51 @@ describe("Code Mode bridge settlement and cancellation", () => {
   });
 
   it("drains a nested combinator after its outer race wins", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const events: string[] = [];
+    const nestedStarted = createDeferred();
+    const nestedRelease = createDeferred();
     let nestedAborted = false;
     const never = pluginToolWithExecute(
       "fake_nested_race_never",
       "Never-settling nested race helper",
       async (_toolCallId, _input, signal) => {
-        await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(resolve, 25);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              nestedAborted = true;
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
-        });
+        events.push("nested:start");
+        nestedStarted.resolve();
+        signal?.addEventListener(
+          "abort",
+          () => {
+            nestedAborted = true;
+            nestedRelease.reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+        await nestedRelease.promise;
+        events.push("nested:done");
         return jsonResult({ winner: "nested" });
       },
     );
     const fast = pluginToolWithExecute(
       "fake_nested_race_fast",
       "Fast nested race helper",
-      async () => jsonResult({ winner: "fast" }),
+      async () => {
+        await nestedStarted.promise;
+        events.push("fast:win");
+        return jsonResult({ winner: "fast" });
+      },
+    );
+    const release = pluginToolWithExecute(
+      "fake_nested_race_release",
+      "Release nested race helper",
+      async () => {
+        events.push("nested:release");
+        nestedRelease.resolve();
+        return jsonResult({ released: true });
+      },
     );
     applyCodeModeCatalog({
-      tools: [...codeModeTools, never, fast],
+      tools: [...codeModeTools, never, fast, release],
       config,
       sessionId: "session-code-mode",
       sessionKey: "agent:main:main",
@@ -68,10 +85,12 @@ describe("Code Mode bridge settlement and cancellation", () => {
       await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
         "code-call-nested-combinator-race",
         {
-          code: `return await Promise.race([
-            Promise.all([tools.callValue("fake_nested_race_never", {})]),
-            tools.callValue("fake_nested_race_fast", {}),
-          ]);`,
+          code: `const value = await Promise.race([
+              Promise.all([tools.callValue("fake_nested_race_never", {})]),
+              tools.callValue("fake_nested_race_fast", {}),
+            ]);
+            void tools.callValue("fake_nested_race_release", {});
+            return value;`,
         },
       ),
     );
@@ -79,6 +98,8 @@ describe("Code Mode bridge settlement and cancellation", () => {
     expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
     expect(never.execute).toHaveBeenCalledOnce();
     expect(fast.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual(["nested:start", "fast:win", "nested:release", "nested:done"]);
     expect(nestedAborted).toBe(false);
     expect(testing.activeRuns.size).toBe(0);
   });
@@ -184,32 +205,47 @@ describe("Code Mode bridge settlement and cancellation", () => {
   });
 
   it("keeps the actual winner when the later-started nested tool settles first", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const events: string[] = [];
+    const firstStarted = createDeferred();
+    const firstRelease = createDeferred();
     let firstAborted = false;
     const first = pluginToolWithExecute(
       "fake_first",
       "Earlier slow helper",
       async (_toolCallId, _input, signal) => {
-        await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(resolve, 25);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              firstAborted = true;
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
-        });
+        events.push("first:start");
+        firstStarted.resolve();
+        signal?.addEventListener(
+          "abort",
+          () => {
+            firstAborted = true;
+            firstRelease.reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+        await firstRelease.promise;
+        events.push("first:done");
         return jsonResult({ winner: "first" });
       },
     );
-    const second = pluginToolWithExecute("fake_second", "Later fast helper", async () =>
-      jsonResult({ winner: "second" }),
+    const second = pluginToolWithExecute("fake_second", "Later fast helper", async () => {
+      await firstStarted.promise;
+      events.push("second:win");
+      return jsonResult({ winner: "second" });
+    });
+    const release = pluginToolWithExecute(
+      "fake_first_release",
+      "Release earlier race helper",
+      async () => {
+        events.push("first:release");
+        firstRelease.resolve();
+        return jsonResult({ released: true });
+      },
     );
     applyCodeModeCatalog({
-      tools: [...codeModeTools, first, second],
+      tools: [...codeModeTools, first, second, release],
       config,
       sessionId: "session-code-mode",
       sessionKey: "agent:main:main",
@@ -221,10 +257,12 @@ describe("Code Mode bridge settlement and cancellation", () => {
       await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
         "code-call-later-winner",
         {
-          code: `return await Promise.race([
-            tools.callValue("fake_first", {}),
-            tools.callValue("fake_second", {}),
-          ]);`,
+          code: `const value = await Promise.race([
+              tools.callValue("fake_first", {}),
+              tools.callValue("fake_second", {}),
+            ]);
+            void tools.callValue("fake_first_release", {});
+            return value;`,
         },
       ),
     );
@@ -232,6 +270,8 @@ describe("Code Mode bridge settlement and cancellation", () => {
     expect(details).toMatchObject({ status: "completed", value: { winner: "second" } });
     expect(first.execute).toHaveBeenCalledOnce();
     expect(second.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual(["first:start", "second:win", "first:release", "first:done"]);
     expect(firstAborted).toBe(false);
     expect(testing.activeRuns.size).toBe(0);
   });
@@ -264,7 +304,9 @@ describe("Code Mode bridge settlement and cancellation", () => {
   ])(
     "drains a detached audit started $label before an awaited nested call",
     async ({ auditCode }) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
       const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+      const events: string[] = [];
       let auditCompleted = false;
       let auditAborted = false;
       const auditStarted = createDeferred();
@@ -273,20 +315,38 @@ describe("Code Mode bridge settlement and cancellation", () => {
         "fake_early_audit",
         "Early detached audit",
         async (_toolCallId, _input, signal) => {
+          events.push("audit:start");
           auditStarted.resolve();
-          signal?.addEventListener("abort", () => (auditAborted = true), { once: true });
+          signal?.addEventListener(
+            "abort",
+            () => {
+              auditAborted = true;
+              auditRelease.reject(new Error("aborted"));
+            },
+            { once: true },
+          );
           await auditRelease.promise;
+          events.push("audit:done");
           auditCompleted = true;
           return jsonResult({ recorded: true });
         },
       );
       const fast = pluginToolWithExecute("fake_awaited_fast", "Awaited fast helper", async () => {
         await auditStarted.promise;
-        setImmediate(() => auditRelease.resolve());
+        events.push("awaited:done");
         return jsonResult({ winner: "fast" });
       });
+      const release = pluginToolWithExecute(
+        "fake_early_audit_release",
+        "Release early detached audit",
+        async () => {
+          events.push("audit:release");
+          auditRelease.resolve();
+          return jsonResult({ released: true });
+        },
+      );
       applyCodeModeCatalog({
-        tools: [...codeModeTools, audit, fast],
+        tools: [...codeModeTools, audit, fast, release],
         config,
         sessionId: "session-code-mode",
         sessionKey: "agent:main:main",
@@ -299,7 +359,9 @@ describe("Code Mode bridge settlement and cancellation", () => {
           "code-call-early-detached-audit",
           {
             code: `${auditCode}
-            return await tools.callValue("fake_awaited_fast", {});`,
+            const value = await tools.callValue("fake_awaited_fast", {});
+            void tools.callValue("fake_early_audit_release", {});
+            return value;`,
           },
         ),
       );
@@ -307,6 +369,8 @@ describe("Code Mode bridge settlement and cancellation", () => {
       expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
       expect(audit.execute).toHaveBeenCalledOnce();
       expect(fast.execute).toHaveBeenCalledOnce();
+      expect(release.execute).toHaveBeenCalledOnce();
+      expect(events).toEqual(["audit:start", "awaited:done", "audit:release", "audit:done"]);
       expect(auditCompleted).toBe(true);
       expect(auditAborted).toBe(false);
       expect(testing.activeRuns.size).toBe(0);
@@ -314,35 +378,54 @@ describe("Code Mode bridge settlement and cancellation", () => {
   );
 
   it("drains a race winner's detached audit and its slower race branch", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const events: string[] = [];
+    const loserStarted = createDeferred();
+    const loserRelease = createDeferred();
+    const auditStarted = createDeferred();
     let loserAborted = false;
-    const winner = pluginToolWithExecute("fake_race_winner", "Race winner", async () =>
-      jsonResult({ winner: "fast" }),
-    );
+    const winner = pluginToolWithExecute("fake_race_winner", "Race winner", async () => {
+      await loserStarted.promise;
+      events.push("winner:win");
+      return jsonResult({ winner: "fast" });
+    });
     const loser = pluginToolWithExecute(
       "fake_race_loser",
       "Race loser",
       async (_toolCallId, _input, signal) => {
-        await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(resolve, 25);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              loserAborted = true;
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
-        });
+        events.push("loser:start");
+        loserStarted.resolve();
+        signal?.addEventListener(
+          "abort",
+          () => {
+            loserAborted = true;
+            loserRelease.reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+        await loserRelease.promise;
+        events.push("loser:done");
         return jsonResult({ winner: "slow" });
       },
     );
-    const audit = pluginToolWithExecute("fake_race_audit", "Detached audit", async () =>
-      jsonResult({ recorded: true }),
+    const audit = pluginToolWithExecute("fake_race_audit", "Detached audit", async () => {
+      events.push("audit:done");
+      auditStarted.resolve();
+      return jsonResult({ recorded: true });
+    });
+    const release = pluginToolWithExecute(
+      "fake_race_loser_release",
+      "Release race loser",
+      async () => {
+        await auditStarted.promise;
+        events.push("loser:release");
+        loserRelease.resolve();
+        return jsonResult({ released: true });
+      },
     );
     applyCodeModeCatalog({
-      tools: [...codeModeTools, winner, loser, audit],
+      tools: [...codeModeTools, winner, loser, audit, release],
       config,
       sessionId: "session-code-mode",
       sessionKey: "agent:main:main",
@@ -354,13 +437,13 @@ describe("Code Mode bridge settlement and cancellation", () => {
       await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
         "code-call-race-detached-audit",
         {
-          code: `return Promise.race([
-            tools.callValue("fake_race_winner", {}),
-            tools.callValue("fake_race_loser", {}),
-          ]).then((value) => {
+          code: `const value = await Promise.race([
+              tools.callValue("fake_race_winner", {}),
+              tools.callValue("fake_race_loser", {}),
+            ]);
             void tools.callValue("fake_race_audit", {});
-            return value;
-          });`,
+            void tools.callValue("fake_race_loser_release", {});
+            return value;`,
         },
       ),
     );
@@ -369,6 +452,14 @@ describe("Code Mode bridge settlement and cancellation", () => {
     expect(winner.execute).toHaveBeenCalledOnce();
     expect(loser.execute).toHaveBeenCalledOnce();
     expect(audit.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual([
+      "loser:start",
+      "winner:win",
+      "audit:done",
+      "loser:release",
+      "loser:done",
+    ]);
     expect(loserAborted).toBe(false);
     expect(testing.activeRuns.size).toBe(0);
   });
@@ -412,34 +503,49 @@ describe("Code Mode bridge settlement and cancellation", () => {
   it.each(["race", "any"] as const)(
     "preserves the Promise.%s winner while draining the slower nested tool",
     async (combinator) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
       const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+      const events: string[] = [];
+      const slowStarted = createDeferred();
+      const slowRelease = createDeferred();
       let slowAborted = false;
       let slowCompleted = false;
-      const fast = pluginToolWithExecute("fake_fast", "Fast helper", async () =>
-        jsonResult({ winner: "fast" }),
-      );
+      const fast = pluginToolWithExecute("fake_fast", "Fast helper", async () => {
+        await slowStarted.promise;
+        events.push("fast:win");
+        return jsonResult({ winner: "fast" });
+      });
       const slow = pluginToolWithExecute(
         "fake_slow",
         "Slow helper",
         async (_toolCallId, _input, signal) => {
-          await new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(resolve, 25);
-            signal?.addEventListener(
-              "abort",
-              () => {
-                clearTimeout(timer);
-                slowAborted = true;
-                reject(new Error("aborted"));
-              },
-              { once: true },
-            );
-          });
+          events.push("slow:start");
+          slowStarted.resolve();
+          signal?.addEventListener(
+            "abort",
+            () => {
+              slowAborted = true;
+              slowRelease.reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+          await slowRelease.promise;
+          events.push("slow:done");
           slowCompleted = true;
           return jsonResult({ winner: "slow" });
         },
       );
+      const release = pluginToolWithExecute(
+        "fake_slow_release",
+        "Release slow helper",
+        async () => {
+          events.push("slow:release");
+          slowRelease.resolve();
+          return jsonResult({ released: true });
+        },
+      );
       applyCodeModeCatalog({
-        tools: [...codeModeTools, fast, slow],
+        tools: [...codeModeTools, fast, slow, release],
         config,
         sessionId: "session-code-mode",
         sessionKey: "agent:main:main",
@@ -451,10 +557,12 @@ describe("Code Mode bridge settlement and cancellation", () => {
         await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
           `code-call-${combinator}-fast`,
           {
-            code: `return await Promise.${combinator}([
-              tools.callValue("fake_fast", {}),
-              tools.callValue("fake_slow", {}),
-            ]);`,
+            code: `const value = await Promise.${combinator}([
+                tools.callValue("fake_slow", {}),
+                tools.callValue("fake_fast", {}),
+              ]);
+              void tools.callValue("fake_slow_release", {});
+              return value;`,
           },
         ),
       );
@@ -462,6 +570,8 @@ describe("Code Mode bridge settlement and cancellation", () => {
       expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
       expect(fast.execute).toHaveBeenCalledOnce();
       expect(slow.execute).toHaveBeenCalledOnce();
+      expect(release.execute).toHaveBeenCalledOnce();
+      expect(events).toEqual(["slow:start", "fast:win", "slow:release", "slow:done"]);
       expect(slowCompleted).toBe(true);
       expect(slowAborted).toBe(false);
       expect(testing.activeRuns.size).toBe(0);
@@ -469,34 +579,46 @@ describe("Code Mode bridge settlement and cancellation", () => {
   );
 
   it("preserves fail-fast Promise.all while draining the slower nested tool", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const events: string[] = [];
+    const slowStarted = createDeferred();
+    const slowRelease = createDeferred();
     let slowAborted = false;
     let slowCompleted = false;
     const failed = pluginToolWithExecute("fake_failed", "Failed helper", async () => {
+      events.push("failed:wait");
+      await slowStarted.promise;
+      events.push("failed:reject");
       throw new Error("fast failure");
     });
     const slow = pluginToolWithExecute(
       "fake_slow",
       "Slow helper",
       async (_toolCallId, _input, signal) => {
-        await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(resolve, 25);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              slowAborted = true;
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
-        });
+        events.push("slow:start");
+        slowStarted.resolve();
+        signal?.addEventListener(
+          "abort",
+          () => {
+            slowAborted = true;
+            slowRelease.reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+        await slowRelease.promise;
+        events.push("slow:done");
         slowCompleted = true;
         return jsonResult({ winner: "slow" });
       },
     );
+    const release = pluginToolWithExecute("fake_slow_release", "Release slow helper", async () => {
+      events.push("slow:release");
+      slowRelease.resolve();
+      return jsonResult({ released: true });
+    });
     applyCodeModeCatalog({
-      tools: [...codeModeTools, failed, slow],
+      tools: [...codeModeTools, failed, slow, release],
       config,
       sessionId: "session-code-mode",
       sessionKey: "agent:main:main",
@@ -515,6 +637,7 @@ describe("Code Mode bridge settlement and cancellation", () => {
             ]);
             return "unexpected success";
           } catch (error) {
+            void tools.callValue("fake_slow_release", {});
             return error.message;
           }`,
         },
@@ -524,6 +647,14 @@ describe("Code Mode bridge settlement and cancellation", () => {
     expect(details).toMatchObject({ status: "completed", value: "fast failure" });
     expect(failed.execute).toHaveBeenCalledOnce();
     expect(slow.execute).toHaveBeenCalledOnce();
+    expect(release.execute).toHaveBeenCalledOnce();
+    expect(events).toEqual([
+      "failed:wait",
+      "slow:start",
+      "failed:reject",
+      "slow:release",
+      "slow:done",
+    ]);
     expect(slowCompleted).toBe(true);
     expect(slowAborted).toBe(false);
     expect(testing.activeRuns.size).toBe(0);


### PR DESCRIPTION
Related: #114884

## What Problem This Solves

Exhaustive headless Code Mode QA could report failed completion and aborted race losers under loaded-host worker contention even though the production lifecycle owner correctly drained nested and detached work. A representative exact case previously ended after 28.68 seconds with `status: failed`, which made the regression proof look like a Promise ownership failure.

## Why This Change Was Made

The semantic ownership tests mixed short real-time timers and parent wall-clock deadlines with real QuickJS worker scheduling. This change replaces timing guesses with deferred causal gates and guest-triggered release tools, and freezes only the parent host clock/timers in those semantic cases. QuickJS worker execution remains real, dedicated deadline tests are unchanged, and there is no production change or timeout increase.

## User Impact

There is no runtime behavior change. Maintainers get deterministic regression proof for detached `allSettled`, `race`/`any` losers, nested combinators, detached audit work, and fail-fast `all` drain semantics under host contention.

## Evidence

- Before: a loaded-host exact case completed after 28.68 seconds as `status: failed` because the test-owned deadline fired before worker scheduling caught up.
- Clean Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/32153947917. The two exact headless failure shapes passed 8/8 serial repetitions each (16 case executions total); the changed interactive boundary filter passed 12/12.
- The Testbox lease was stopped after the focused commands completed, so the workflow record is `cancelled` during cleanup. Its final broad changed check had only assertion-safety ratchet drift in untouched files against the stale pre-rebase baseline; fresh exact-head PR CI is the remaining gate.
- Structured autoreview: no accepted/actionable findings; correctness confidence 0.99.
- Patch identity survived the rebase onto current `main`; `git diff --check` is clean.
- Production LOC: +0/-0. Tests: +446/-196 across two files.

AI-assisted: yes. I reviewed the test ownership model, causal ordering, focused proof, and final diff. No transcript is included.
