### PR TITLE
fix(gateway): avoid session-store reads during streamed responses

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2463,6 +2463,21 @@ describe("agent event handler", () => {
     },
   );
 
+  it("loads restart-recovery state only for recognized lifecycle phases", () => {
+    const { handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+    });
+
+    emitAgentEvent(handler, "run-recovery", "assistant", { text: "streaming" });
+    emitAgentEvent(handler, "run-recovery", "lifecycle", { phase: "retry" }, { seq: 2 });
+
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+
+    emitAgentEvent(handler, "run-recovery", "lifecycle", { phase: "start" }, { seq: 3 });
+
+    expect(loadSessionEntry).toHaveBeenCalledOnce();
+  });
+
   it("suppresses late interrupted pre-restart lifecycle events from live projections", () => {
     mockSessionEntry(
       {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -94,6 +94,7 @@ const CHAT_STATE_BY_TERMINAL_CLASSIFICATION = {
   cancellation: "aborted",
   failure: "error",
 } as const;
+const RESTART_RECOVERY_LIFECYCLE_PHASES = new Set(["start", "end", "error"]);
 
 function readChatRunStartupPhase(value: unknown): ChatRunStartupPhase | undefined {
   switch (value) {
@@ -1398,7 +1399,9 @@ export function createAgentEventHandler({
     const projectSessionLifecycle =
       evt.projectSessionLifecycle ?? runContext?.projectSessionLifecycle ?? true;
     const isHeartbeat = runContext?.isHeartbeat;
-    const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
+    const restartRecoverySessionKey = RESTART_RECOVERY_LIFECYCLE_PHASES.has(lifecyclePhase ?? "")
+      ? (eventSessionKey ?? sessionKey)
+      : undefined;
     const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;
     const eventRunId = chatLink?.clientRunId ?? evt.runId;


### PR DESCRIPTION
Closes #120378

## What Problem This Solves

Fixes an issue where users running multi-agent workloads could experience Gateway stalls that scaled with streamed response length because every agent stream event performed restart-recovery session-store discovery.

## Why This Change Was Made

Restart-recovery state is now resolved only for the recognized lifecycle phases that consume it: `start`, `end`, and `error`. Assistant, thinking, tool, and fallback lifecycle events keep their existing delivery behavior without touching this durable-state path.

## User Impact

Streaming longer answers no longer adds restart-recovery session-store lookups per event, while restart suppression and terminal lifecycle handling remain unchanged.

## Evidence

A V8 precise-call-coverage probe ran the production event bus through an isolated real Gateway with 20 assistant/thinking events, one fallback lifecycle event, and `start`/`end` lifecycle events. On current `main`, the restart-recovery resolver ran 23 times. With this change, it ran 2 times, exactly for `start` and `end`. Plugins were disabled for isolation; no external provider was required.

The focused regression failed before the fix with two unexpected session-entry reads from an assistant event and a fallback lifecycle event, then passed after the fix while confirming lifecycle `start` still performs one read.

Validation:

- `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts` (146 tests)
- `node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-recovery-state.test.ts src/agents/main-session-recovery/main-session-recovery-run-ownership.test.ts src/gateway/server-runtime-subscriptions.test.ts` (60 tests)
- `pnpm check:changed -- src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts`

Disclosure: AI was used to understand the codebase and review the fix.