### PR TITLE
perf(test): remove duplicate hovercard waits

### DIFF
--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -118,7 +118,6 @@ suite.define(() => {
         await row.waitFor({ state: "visible" });
         await row.hover();
         const card = page.locator(".session-progress-hovercard");
-        await page.waitForTimeout(450);
         expect(await card.count()).toBe(0);
         expect(
           (await gateway.getRequests("progressCard.get")).filter(
@@ -338,7 +337,6 @@ suite.define(() => {
         expect(await row.getAttribute("title")).toBeNull();
         expect(await row.locator(".sidebar-recent-session__link").getAttribute("title")).toBeNull();
         await row.hover();
-        await page.waitForTimeout(450);
         expect(await page.locator(".session-progress-hovercard").count()).toBe(0);
 
         const link = page.locator(


### PR DESCRIPTION
## What Problem This Solves

The rewritten session progress hovercard E2E suite paid two fixed 450 ms delays to prove sidebar rows do not open progress cards, even though sidebar ownership is already enforced by the target matcher unit test and both cases retain immediate negative assertions.

## Why This Change Was Made

Remove the duplicate elapsed-time waits while preserving the assertions that sidebar hover mounts no progress card. The first E2E still verifies zero sidebar `progressCard.get` requests, and the focused matcher unit test independently rejects sidebar anchors.

## User Impact

There is no user-visible behavior change. The hovercard E2E suite is faster while retaining the same owner and integration contracts.

## Evidence

- Same-Testbox controlled A/B with one excluded warmup, two retained samples per state, one Vitest worker, distinct module caches, import diagnostics, and `/usr/bin/time -v`.
- Retained wall mean: 10.37 s → 9.28 s, -1.10 s (-10.6%).
- Retained Vitest mean: 8.85 s → 7.76 s, -1.09 s (-12.3%).
- Retained test-body mean: 3.37 s → 2.60 s, -0.77 s (-22.9%).
- Mutation broadening the target selector to include sidebar anchors failed `session-progress-hovercard-target.test.ts` as expected.
- Focused proof: 4 matcher unit tests and 3 browser E2E tests passed.
- Complete changed gate passed on Blacksmith Testbox `tbx_01m0aqa1vs3xdt3x3h559d8538`.
- Fresh post-rebase Codex autoreview: clean, 0.99.
- Production LOC: +0/-0. Tests: +0/-2.
