### PR TITLE
fix(llama-cpp): cap the managed embedding server context so it stops reserving the model's full training context

### DIFF
--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -40,7 +40,9 @@ The default chat model remains:
 Gemma 4 E4B IT Q4_K_M is about 5.0 GB. OpenClaw offers that download only on
 machines with at least 16 GiB of RAM. The default context cap is 65,536 tokens,
 which the full agent system prompt requires. The bundled EmbeddingGemma model is
-about 0.3 GB.
+about 0.3 GB. The managed embedding server runs with its own 2,048-token
+context, matching the memory host's local embedding input bound, so it does not
+reserve the embedding model's full training context per slot.
 
 Discovery is read-only. It reports a prepared choice only when the managed
 binary, server preset, and selected model already exist; it never installs or

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -40,9 +40,9 @@ The default chat model remains:
 Gemma 4 E4B IT Q4_K_M is about 5.0 GB. OpenClaw offers that download only on
 machines with at least 16 GiB of RAM. The default context cap is 65,536 tokens,
 which the full agent system prompt requires. The bundled EmbeddingGemma model is
-about 0.3 GB. The managed embedding server runs with its own 2,048-token
-context, matching the memory host's local embedding input bound, so it does not
-reserve the embedding model's full training context per slot.
+about 0.3 GB. The managed embedding server runs with its own 8,192-token
+context rather than the embedding model's full training context, which keeps
+its memory bounded while covering the Gateway's largest accepted embedding input.
 
 Discovery is read-only. It reports a prepared choice only when the managed
 binary, server preset, and selected model already exist; it never installs or

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -31,6 +31,12 @@ export const DEFAULT_LLAMA_CPP_MODEL_SHA256 =
 // the first turn. 64K leaves real headroom for history and tool output; Gemma 4
 // supports far more, and the 16 GiB offer floor already bounds weaker machines.
 export const DEFAULT_LLAMA_CPP_CONTEXT_SIZE = 65536;
+// The managed embedding server gets its own, much smaller context. The memory
+// host bounds local embedding inputs at 2,048 tokens before they reach the
+// server, so any larger KV reservation is pure waste: without a cap llama.cpp
+// falls back to the model's full training context (32K on Qwen3-Embedding) per
+// slot, which reserved ~5 GB and OOM-killed 16 GB gateways (#125792).
+export const DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE = 2048;
 
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
   "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -31,12 +31,10 @@ export const DEFAULT_LLAMA_CPP_MODEL_SHA256 =
 // the first turn. 64K leaves real headroom for history and tool output; Gemma 4
 // supports far more, and the 16 GiB offer floor already bounds weaker machines.
 export const DEFAULT_LLAMA_CPP_CONTEXT_SIZE = 65536;
-// The managed embedding server gets its own, much smaller context. The memory
-// host bounds local embedding inputs at 2,048 tokens before they reach the
-// server, so any larger KV reservation is pure waste: without a cap llama.cpp
-// falls back to the model's full training context (32K on Qwen3-Embedding) per
-// slot, which reserved ~5 GB and OOM-killed 16 GB gateways (#125792).
-export const DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE = 2048;
+// Embedding server context. Uncapped, llama.cpp reserves the model's full
+// training context per slot; 8,192 covers the Gateway's per-input ceiling
+// (MAX_EMBEDDING_INPUT_CHARS, chars >= tokens) so no direct caller loses capacity.
+export const DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE = 8192;
 
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
   "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -78,18 +78,18 @@ describe("managed llama-server", () => {
       await prepareManagedLlamaServer({
         chatModelId: "chat-model",
         chatModelPath: "/models/chat.gguf",
-        contextSize: 8192,
-        maxTokens: 2048,
+        contextSize: 16384,
+        maxTokens: 1024,
         embeddingModelPath: "/models/embedding.gguf",
         port: 19_432,
       });
       const preset = await fs.readFile(presetPath, "utf8");
-      expect(preset).toContain("[chat-model]\nmodel = /models/chat.gguf\nctx-size = 8192");
-      // The embedding stanza owns its own small ctx-size (memory host bounds local
-      // embedding inputs at 2,048); it must never inherit the chat context, which
-      // is what let llama.cpp reserve the model's full training context per slot.
+      expect(preset).toContain("[chat-model]\nmodel = /models/chat.gguf\nctx-size = 16384");
+      // The embedding stanza carries its own fixed ctx-size, distinct from both the
+      // chat ctx-size and n-predict; omitting it lets llama.cpp reserve the model's
+      // full training context per slot.
       expect(preset).toContain(
-        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nctx-size = 2048\nembedding = true",
+        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nctx-size = 8192\nembedding = true",
       );
       expect(preset).not.toMatch(/mmproj|draft/iu);
     } finally {
@@ -118,7 +118,7 @@ describe("managed llama-server", () => {
       });
       const preset = await fs.readFile(presetPath, "utf8");
       expect(preset).toBe(
-        "version = 1\n\n[embeddinggemma-300m-qat-q8_0]\nmodel = /models/custom-embedding.gguf\nctx-size = 2048\nembedding = true\n",
+        "version = 1\n\n[embeddinggemma-300m-qat-q8_0]\nmodel = /models/custom-embedding.gguf\nctx-size = 8192\nembedding = true\n",
       );
       expect(preset).not.toContain("jinja");
     } finally {

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -85,8 +85,11 @@ describe("managed llama-server", () => {
       });
       const preset = await fs.readFile(presetPath, "utf8");
       expect(preset).toContain("[chat-model]\nmodel = /models/chat.gguf\nctx-size = 8192");
+      // The embedding stanza owns its own small ctx-size (memory host bounds local
+      // embedding inputs at 2,048); it must never inherit the chat context, which
+      // is what let llama.cpp reserve the model's full training context per slot.
       expect(preset).toContain(
-        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nembedding = true",
+        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nctx-size = 2048\nembedding = true",
       );
       expect(preset).not.toMatch(/mmproj|draft/iu);
     } finally {
@@ -115,7 +118,7 @@ describe("managed llama-server", () => {
       });
       const preset = await fs.readFile(presetPath, "utf8");
       expect(preset).toBe(
-        "version = 1\n\n[embeddinggemma-300m-qat-q8_0]\nmodel = /models/custom-embedding.gguf\nembedding = true\n",
+        "version = 1\n\n[embeddinggemma-300m-qat-q8_0]\nmodel = /models/custom-embedding.gguf\nctx-size = 2048\nembedding = true\n",
       );
       expect(preset).not.toContain("jinja");
     } finally {

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -10,6 +10,7 @@ import { fetchConfiguredLocalOriginWithSsrFGuard } from "openclaw/plugin-sdk/ssr
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   DEFAULT_LLAMA_CPP_CONTEXT_SIZE,
+  DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE,
   DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
@@ -338,6 +339,9 @@ function renderLlamaServerPreset(params: {
   lines.push(
     `[${embeddingId}]`,
     `model = ${assertIniValue(params.embeddingModelPath, "llama.cpp embedding model path")}`,
+    // Per-stanza ctx-size stays independent of the chat stanza's; the router
+    // applies model-specific preset keys over any global default.
+    `ctx-size = ${DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE}`,
     "embedding = true",
     "",
   );

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -339,8 +339,8 @@ function renderLlamaServerPreset(params: {
   lines.push(
     `[${embeddingId}]`,
     `model = ${assertIniValue(params.embeddingModelPath, "llama.cpp embedding model path")}`,
-    // Per-stanza ctx-size stays independent of the chat stanza's; the router
-    // applies model-specific preset keys over any global default.
+    // Stanza-scoped: independent of the chat stanza's ctx-size. Never pass
+    // --ctx-size on the router command line; CLI args override preset keys.
     `ctx-size = ${DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE}`,
     "embedding = true",
     "",


### PR DESCRIPTION
Closes #125792

## What Problem This Solves

The managed llama.cpp **embedding** server was spawned with no context-size cap. The generated `models.ini` embedding stanza wrote only the model path and `embedding = true`, while the chat stanza right next to it already writes `ctx-size`. `llama-server`'s `--ctx-size` defaults to `0 = loaded from model`, so the embedding server reserved the model's full training context per slot — 32K on `Qwen3-Embedding-0.6B` × 4 auto slots. On the reporter's 16 GB host that was ~5.3 GB RSS for a 610 MB model, re-reserved every time `active-memory` restarted the server, and it got the gateway OOM-killed four times in two days.

## Why This Change Was Made

Fix the generated plugin preset, not a config knob — the shape recommended in the issue review:

- **`extensions/llama-cpp/src/defaults.ts`**: new plugin-owned `DEFAULT_LLAMA_CPP_EMBEDDING_CONTEXT_SIZE = 8192`, next to its chat sibling.
- **`extensions/llama-cpp/src/managed-server.ts`**: `renderLlamaServerPreset` emits `ctx-size = 8192` in the embedding stanza.

**Why 8,192 (and not the memory host's 2,048 chunk bound).** The generated preset serves three callers, and only memory indexing splits inputs at the host's 2,048-**byte** chunk bound. The Gateway `/v1/embeddings` endpoint admits inputs up to `MAX_EMBEDDING_INPUT_CHARS = 8_192` (`src/gateway/embeddings-http.ts:53`) and the inference CLI forwards texts directly. Since chars ≥ tokens for any tokenizer, an 8,192-token context can never reject an input the Gateway already accepts — **no direct caller loses capacity relative to `main`**, so no compatibility policy is being imposed. It still cuts the per-slot reservation 4× on the model that reproduces the issue. (The first revision of this PR used 2,048; ClawSweeper's P1 on shared callers was correct and this supersedes it.)

**Upstream contract verified at the pin.** llama.cpp `tools/server/README.md` and `server-context.cpp` at exactly `b10357`: preset keys are CLI args without dashes; per-model preset keys override globals; per-slot context is `n_ctx_slot = min(ctx-size, n_ctx_train)`. That last rule is why the default EmbeddingGemma (`n_ctx_train = 2048`) was never the OOM case and why the fix must be proven on a long-context model — see Evidence.

**No new config surface.** `memory.search.local.contextSize` is retired (runtime schema permits only `local.modelPath`; doctor removes the key; `dead-config-keys.test.ts` lists it). It is not revived. The stale `local.contextSize` TS type the issue review suggested deleting was already removed on current `main`.

**Sibling coverage:** both callers (`setup.ts`, `embedding-provider.ts`) route through the single `prepareManagedLlamaServer` → `renderLlamaServerPreset` writer. Slot count (`--parallel`, auto) is intentionally untouched: it also governs the chat server and is outside this invariant; the context is the lever.

**Production LOC:** +8 (constant, import, stanza key, invariant comments), tests +3, docs +2. Positive because it expresses a new bounded contract; there was no remaining stale code to absorb it into.

## User Impact

Operators using local memory embeddings on memory-constrained hosts no longer have the embedding server reserve the model's full training context. Chat context is untouched. No config change, migration, or reindex — the preset is regenerated on every start. Gateway and CLI embedding inputs keep their current capacity.

## Evidence

### Real behavior proof — pinned binary, live before/after (no mocks)

Ran the plugin's exact pinned `llama-server` (`b10357` macOS-arm64, SHA-256 `7f464a2d…` matches `llama-server-assets.ts`) with the plugin's exact argv (`--models-preset … --models-max 2 --metrics --no-ui`), against presets **generated by the real `prepareManagedLlamaServer` writer** — once from `main`'s renderer, once from this branch. Apple Silicon, 48 GiB, isolated scratch dir; nothing touched a live gateway.

**On the model that reproduces #125792 — `Qwen3-Embedding-0.6B-Q8_0.gguf` (609 MB, `n_ctx_train = 32768`), server's own log as ground truth:**

| | stanza `ctx-size` | server `n_ctx_slot` (×4 slots, kv_unified) | RSS router+child | `/v1/embeddings` |
|---|---|---|---|---|
| **Before** (`main`) | none | **32768** | **4,333 MB** | ✅ 1024-d |
| **After** (this PR) | 8192 | **8192** | **1,654 MB** | ✅ 1024-d |

That reproduces the reporter's exact numbers (`n_ctx_slot = 32768`, 4 slots, ~4–5 GB for a 610 MB model) and shows the fix: **−2.7 GB (−62%)** with embeddings still working. Log lines:
```
BEFORE: srv load_model: initializing, n_slots = 4, n_ctx_slot = 32768, kv_unified = 'true'
AFTER:  srv load_model: initializing, n_slots = 4, n_ctx_slot = 8192,  kv_unified = 'true'
```

**Direct-caller compatibility (the shared-caller P1):** an input at the Gateway's exact 8,192-char ceiling (3,013 tokens) embeds successfully on the after server, identical to before. **Concurrency across the shared unified KV:** 4 simultaneous requests × 2 Gateway-max inputs (8 inputs, 24,104 tokens in flight over the 4 slots) — all succeed. So no capacity regression, including under concurrent batch indexing.

**Default model (`EmbeddingGemma`, `n_ctx_train = 2048`):** before and after both report `n_ctx_slot = 2048` — llama-server caps at training context, so the default path is unchanged (and confirms why the default was never the OOM case).

### Regression coverage
Existing boundary tests read the real `models.ini` bytes; both updated to assert the cap and that chat (`16384`) and embedding (`8192`) contexts stay independent, with `maxTokens` deliberately distinct from the embedding ctx-size so a wrong-field regression cannot pass by coincidence. **Fails pre-fix, passes post-fix**: with only the production files reverted, both preset tests fail with `+ ctx-size = 8192`.

### Gates (all green locally on the head)
- `node scripts/run-vitest.mjs extensions/llama-cpp/src/managed-server.test.ts` — 11/11
- `node scripts/run-vitest.mjs src/config/dead-config-keys.test.ts` — 218/218
- `node scripts/check-changed.mjs -- extensions/llama-cpp/src/managed-server.ts extensions/llama-cpp/src/managed-server.test.ts` — exit 0
- `git diff --check` clean

**Remaining gap:** the live run is macOS-arm64 with 48 GiB, not the reporter's 16 GB Linux host, so the OOM-killer itself is not reproduced — the RSS delta and `n_ctx_slot` are the measured mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n5eSiz5Uy57civqEnUMAS
