### PR TITLE
fix(ui): never restore a stored draft over typed new-session composer text

### DIFF
--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -29,6 +29,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/pages/config/config-page.custom-theme.test.ts",
   "ui/src/pages/config/memory-mutation-owner.test.ts",
   "ui/src/pages/config/memory-page.test.ts",
+  "ui/src/pages/new-session/draft-persistence.test.ts",
   "ui/src/pages/sessions/sessions-page.archived.test.ts",
   "ui/src/pages/workboard/view.test.ts",
 ];

--- a/ui/src/pages/new-session/draft-persistence.test.ts
+++ b/ui/src/pages/new-session/draft-persistence.test.ts
@@ -24,6 +24,10 @@ const store = vi.hoisted(() => {
     ),
     writeDurableComposerDraft: vi.fn(async () => ({ status: "persisted" as const })),
     retireDurableComposerDraft: vi.fn(async () => ({ status: "persisted" as const })),
+    writeDurableComposerSnapshot: vi.fn(async (_snapshot: unknown) => ({
+      result: { status: "persisted" as const },
+      payloadUnavailable: false,
+    })),
   };
 });
 
@@ -32,6 +36,17 @@ vi.mock("../../lib/chat/composer-draft-store.runtime.ts", () => ({
   writeDurableComposerDraft: store.writeDurableComposerDraft,
   retireDurableComposerDraft: store.retireDurableComposerDraft,
 }));
+
+// The store runtime above is only dynamically imported, so a shared module
+// graph could reuse a draft-persistence.ts evaluated without the mock.
+// Mocking this statically imported helper forces a fresh evaluation and gives
+// a deterministic write seam; the file also runs in the isolated ui lane
+// (vitest.ui-isolated-paths.mjs) so the re-evaluation cannot perturb sibling
+// files' module singletons.
+vi.mock("../chat/durable-composer-persistence.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../chat/durable-composer-persistence.ts")>();
+  return { ...actual, writeDurableComposerSnapshot: store.writeDurableComposerSnapshot };
+});
 
 async function resolvePendingRead(result: StoreReadResult) {
   // The read is issued behind the store's lazy import; wait for it to land.
@@ -81,11 +96,11 @@ describe("NewSessionDraftPersistence restore race", () => {
     expect(flow.message).toBe("typed before restore");
     // The typed text also wins persistence: local-wins writes it above the
     // stored revision instead of leaving the stale draft in place.
-    const write = store.writeDurableComposerDraft.mock.calls.at(-1) as
-      | [unknown, { revision: number; text: string }, unknown]
+    const write = store.writeDurableComposerSnapshot.mock.calls.at(-1)?.[0] as
+      | { revision: number; text: string }
       | undefined;
-    expect(write?.[1].text).toBe("typed before restore");
-    expect(write?.[1].revision).toBeGreaterThan(7);
+    expect(write?.text).toBe("typed before restore");
+    expect(write?.revision).toBeGreaterThan(7);
   });
 
   it("persists text typed before activation even when no stored draft exists", async () => {
@@ -96,10 +111,10 @@ describe("NewSessionDraftPersistence restore race", () => {
     await resolvePendingRead({ status: "not-found" });
     await settle();
     expect(flow.message).toBe("typed before restore");
-    const write = store.writeDurableComposerDraft.mock.calls.at(-1) as
-      | [unknown, { text: string }, unknown]
+    const write = store.writeDurableComposerSnapshot.mock.calls.at(-1)?.[0] as
+      | { text: string }
       | undefined;
-    expect(write?.[1].text).toBe("typed before restore");
+    expect(write?.text).toBe("typed before restore");
   });
 
   it("restores a stored draft into a pristine composer", async () => {

--- a/ui/src/pages/new-session/draft-persistence.test.ts
+++ b/ui/src/pages/new-session/draft-persistence.test.ts
@@ -1,0 +1,135 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DraftGatewayState } from "./draft-gateway-state.ts";
+import type { DraftPlaceState } from "./draft-place-state.ts";
+import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
+
+type StoreReadResult =
+  | {
+      status: "found";
+      draft: { revision: number; text: string; attachments: unknown[]; writeId: string };
+    }
+  | { status: "not-found"; revision?: number; writeId?: string };
+
+const store = vi.hoisted(() => {
+  const pendingReads: Array<(result: unknown) => void> = [];
+  return {
+    pendingReads,
+    readDurableComposerDraft: vi.fn(
+      () =>
+        new Promise((resolve) => {
+          pendingReads.push(resolve as (result: unknown) => void);
+        }),
+    ),
+    writeDurableComposerDraft: vi.fn(async () => ({ status: "persisted" as const })),
+    retireDurableComposerDraft: vi.fn(async () => ({ status: "persisted" as const })),
+  };
+});
+
+vi.mock("../../lib/chat/composer-draft-store.runtime.ts", () => ({
+  readDurableComposerDraft: store.readDurableComposerDraft,
+  writeDurableComposerDraft: store.writeDurableComposerDraft,
+  retireDurableComposerDraft: store.retireDurableComposerDraft,
+}));
+
+async function resolvePendingRead(result: StoreReadResult) {
+  // The read is issued behind the store's lazy import; wait for it to land.
+  await vi.waitFor(() => {
+    if (store.pendingReads.length === 0) {
+      throw new Error("no pending durable draft read");
+    }
+  });
+  store.pendingReads.shift()?.(result);
+}
+
+// Drain the restore's promise chain (store load, read, write) in one macrotask.
+function settle() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+// The gateway/place states are untouched by draft persistence and typing paths.
+function createFlow() {
+  return new DraftSubmissionFlow(
+    {} as DraftGatewayState,
+    {} as DraftPlaceState,
+    () => ({ context: undefined, data: undefined, isConnected: false }),
+    { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
+  );
+}
+
+afterEach(() => {
+  store.pendingReads.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("NewSessionDraftPersistence restore race", () => {
+  it("never applies a stored draft over text typed before the restore resolves", async () => {
+    const flow = createFlow();
+    // Reload flow: the composer renders and the user types before the gateway
+    // recovery scope arrives, so the route activates after the mutation.
+    flow.setMessage("typed before restore");
+    flow.draftPersistence.setOwner("ws://gateway.test", "recovery-a");
+    flow.draftPersistence.activateRoute("agent:main");
+    await resolvePendingRead({
+      status: "found",
+      draft: { revision: 7, text: "stored draft", attachments: [], writeId: "w-1" },
+    });
+    await settle();
+    expect(flow.message).toBe("typed before restore");
+    // The typed text also wins persistence: local-wins writes it above the
+    // stored revision instead of leaving the stale draft in place.
+    const write = store.writeDurableComposerDraft.mock.calls.at(-1) as
+      | [unknown, { revision: number; text: string }, unknown]
+      | undefined;
+    expect(write?.[1].text).toBe("typed before restore");
+    expect(write?.[1].revision).toBeGreaterThan(7);
+  });
+
+  it("persists text typed before activation even when no stored draft exists", async () => {
+    const flow = createFlow();
+    flow.setMessage("typed before restore");
+    flow.draftPersistence.setOwner("ws://gateway.test", "recovery-a");
+    flow.draftPersistence.activateRoute("agent:main");
+    await resolvePendingRead({ status: "not-found" });
+    await settle();
+    expect(flow.message).toBe("typed before restore");
+    const write = store.writeDurableComposerDraft.mock.calls.at(-1) as
+      | [unknown, { text: string }, unknown]
+      | undefined;
+    expect(write?.[1].text).toBe("typed before restore");
+  });
+
+  it("restores a stored draft into a pristine composer", async () => {
+    const flow = createFlow();
+    flow.draftPersistence.setOwner("ws://gateway.test", "recovery-a");
+    flow.draftPersistence.activateRoute("agent:main");
+    await resolvePendingRead({
+      status: "found",
+      draft: { revision: 7, text: "stored draft", attachments: [], writeId: "w-1" },
+    });
+    await settle();
+    expect(flow.message).toBe("stored draft");
+  });
+
+  it("re-arms restore for the next route once the page resets the draft", async () => {
+    const flow = createFlow();
+    flow.draftPersistence.setOwner("ws://gateway.test", "recovery-a");
+    flow.draftPersistence.activateRoute("agent:route-a");
+    await resolvePendingRead({ status: "not-found" });
+    await settle();
+    flow.setMessage("typed on route a");
+    // Route switch: the page persists, resets the composer, then activates.
+    flow.draftPersistence.persistNow();
+    flow.resetDraft();
+    flow.draftPersistence.activateRoute("agent:route-b");
+    await resolvePendingRead({
+      status: "found",
+      draft: { revision: 9, text: "route b draft", attachments: [], writeId: "w-2" },
+    });
+    await settle();
+    expect(flow.message).toBe("route b draft");
+  });
+});

--- a/ui/src/pages/new-session/draft-persistence.ts
+++ b/ui/src/pages/new-session/draft-persistence.ts
@@ -43,6 +43,11 @@ export class NewSessionDraftPersistence {
   private routeKey = "";
   private revision = 0;
   private mutationGeneration = 0;
+  // Mutation counter at the last programmatic content replacement (reset,
+  // handoff, restore). A generation beyond it means the composer holds text
+  // the user typed; a restore must never apply over that, and `revision`
+  // cannot arbitrate because `selectRoute` zeroes it after late owner setup.
+  private pristineMutationBaseline = 0;
   private restoreGeneration = 0;
   private restoredIdentity = "";
   private pending: DraftSnapshot | null = null;
@@ -135,6 +140,10 @@ export class NewSessionDraftPersistence {
     const baseline = this.read();
     const signature = chatAttachmentDraftSignature(baseline.message, baseline.attachments);
     void this.restoreScope(scope, generation, mutationGeneration, signature);
+  }
+
+  noteDraftReplaced() {
+    this.pristineMutationBaseline = this.mutationGeneration;
   }
 
   noteUserMutation() {
@@ -375,13 +384,21 @@ export class NewSessionDraftPersistence {
     ) {
       return;
     }
+    // Restore only into a pristine composer: anything the user typed on this
+    // route wins over the stored draft, even when the stored revision is
+    // higher (after a reload `revision` restarts at 0, so revision order
+    // cannot arbitrate against live input).
     if (
       storedRevision === undefined ||
       storedRevision < this.revision ||
-      (mutationGeneration > 0 && storedRevision <= this.revision)
+      mutationGeneration > this.pristineMutationBaseline
     ) {
       if (storedRevision !== undefined && storedRevision >= this.revision) {
         this.revision = nextDraftRevision(storedRevision);
+      } else if (this.revision <= 0 && mutationGeneration > this.pristineMutationBaseline) {
+        // Text typed before route activation: selectRoute zeroed its revision,
+        // so mint one or the snapshot below is empty and the draft never lands.
+        this.revision = nextDraftRevision(0);
       }
       this.pending = this.snapshot();
       this.persistNow();

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -106,6 +106,7 @@ export class DraftSubmissionFlow {
   }
 
   restoreMessage(message: string) {
+    this.draftPersistence.noteDraftReplaced();
     this.messageValue = message;
     this.callbacks.requestUpdate();
   }
@@ -115,6 +116,7 @@ export class DraftSubmissionFlow {
     attachments: ChatAttachment[];
     visibility: NewSessionVisibility;
   }) {
+    this.draftPersistence.noteDraftReplaced();
     this.messageValue = state.message;
     this.visibilityValue = state.visibility;
     this.attachmentDraft.restore(state.attachments);
@@ -143,8 +145,7 @@ export class DraftSubmissionFlow {
 
   clearErrorIf(error: string) {
     if (this.error === error) {
-      this.error = null;
-      this.callbacks.requestUpdate();
+      this.clearError();
     }
   }
 
@@ -357,6 +358,7 @@ export class DraftSubmissionFlow {
       this.pendingCloud.restored = false;
     } else {
       this.clearPendingCloudRecovery();
+      this.draftPersistence.noteDraftReplaced();
       this.messageValue = "";
     }
     this.error = null;


### PR DESCRIPTION
## What Problem This Solves

The new-session composer restores a persisted draft asynchronously after a reload. Text typed before that restore resolved could be overwritten by the stored draft — or, when input interleaved with the restore's DOM commit, appended to it, leaving the field with the content doubled. CI evidence: PR #125690, checks-ui-e2e shard 5/12, run 32122284238 attempts 1-2 (`"keep both remembered choiceskeep both remembered choices"`). That PR deflaked the e2e by waiting for the restore, but the product race remained.

## Why This Change Was Made

Root cause: draft revisions are timestamp-minted, so typed text normally outranks a pre-reload stored draft — but on `/new` the composer renders before the gateway recovery scope arrives, and when the scope lands, `selectRoute` zeroes `revision` for the fresh route binding. Text typed in that window loses its revision fence, and the stored draft's higher revision won the restore decision in `NewSessionDraftPersistence.restoreScope`.

Fix at the producer: the owner now records a `pristineMutationBaseline` at every programmatic content replacement (page route-reset, navigation handoff, restore apply — via the new `noteDraftReplaced()`), and a restore applies only when no user mutation happened past that baseline. Otherwise the typed text wins and is persisted above the stored revision, including minting a revision for text typed before route activation (previously that draft silently never persisted). The chat-composer sibling is unaffected by construction: its revision lineage persists synchronously to localStorage, so a typed draft always outranks the stored durable revision there.

## User Impact

Draft restoration never appends to or overwrites text the user has already typed; restore fills only a pristine composer. Text typed immediately after a reload now also survives as the persisted draft.

## Evidence

- New boundary regression test `ui/src/pages/new-session/draft-persistence.test.ts` drives the real flow (typing via `DraftSubmissionFlow.setMessage`, storage mocked at the store-runtime boundary with a deferred read). The two race tests fail on pre-fix code for the intended reason (stored draft overwrites typed text; typed-before-activation draft never persisted) and pass post-fix; two more pin pristine restore and route-switch re-arming.
- `node scripts/run-vitest.mjs ui/src/pages/new-session`: 25 files, 250 tests green.
- `node scripts/run-vitest.mjs ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts`: 13 tests green (covers the reload-restore path live in the mocked-gateway browser harness).
- `node scripts/check-changed.mjs`: exit 0 (format, oxlint, tsgo core+UI, guards).
- Autoreview (Codex gpt-5.6-sol, high): clean, "no accepted/actionable findings", overall "patch is correct (0.98)".
- Production LOC +19/-3, of which 11 added lines are invariant comments; code delta is the baseline field, one method, three producer call sites, and the restore-decision change, partially offset by a `clearErrorIf` simplification. Tests +138.

### Real Control UI proof (before/after)

Deterministic two-tab scenario on a real browser (Playwright Chromium against the mocked-gateway Control UI server): tab B commits a draft whose stored revision outranks later typing (clock-skew model — draft revisions are wall-clock timestamps, so a fast-clock device produces exactly this state; it is also the deterministic surrogate for the nondeterministic input-interleaving seen in the CI evidence). Tab A then types; its persist CAS-conflicts and re-arms restore.

Tab A after typing (both builds identical):

![tab A typed](https://github.com/user-attachments/assets/b3d8c45d-6f50-4552-bf17-dafa669c50dc)

**Before** (pre-fix `main`): the conflicted persist re-arms restore and the stored draft replaces the typed text:

![before: typed text replaced](https://github.com/user-attachments/assets/1487c9e0-f1e4-4b26-a10d-5e537c0c6c41)

**After** (this PR): the typed text survives and wins persistence:

![after: typed text kept](https://github.com/user-attachments/assets/c1c10db8-4aa8-4500-8664-46381286fdfd)

### Composition with #125637

The branch is rebased onto current `main` including 9a5b808f1182 ("restore drafts after owner discovery", #125637). That change composes cleanly: `selectRoute` now records the route pre-owner and `setOwner` activates immediately; the pristine baseline here is orthogonal to that activation path, and the regression tests still fail pre-fix on the composed tree (route-key assignment after typing still zeroes the revision fence). Full new-session suite green on the rebased head; exact-head CI validates the composed tree.
