### PR TITLE
fix(status): show Gateway runtime degradation

### DIFF
--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   resolveNodeExecEligibility: vi.fn(() => ({ canExec: false })),
   loadExecApprovalsReadOnly: vi.fn(() => ({ version: 1, agents: {} })),
   buildWorkspaceSkillStatus: vi.fn(() => null),
+  resolveStatusSummaryFromOverview: vi.fn(async () => ({})),
 }));
 
 vi.mock("../../agents/exec-defaults.js", () => ({
@@ -53,6 +54,9 @@ vi.mock("../status-update-restart.ts", () => ({
 vi.mock("../status.gateway-connection.ts", () => ({
   resolveStatusAllConnectionDetails: () => [],
 }));
+vi.mock("../status.scan-overview.ts", () => ({
+  resolveStatusSummaryFromOverview: mocks.resolveStatusSummaryFromOverview,
+}));
 
 import { buildStatusAllReportData } from "./report-data.js";
 
@@ -94,6 +98,7 @@ describe("buildStatusAllReportData", () => {
     expect(mocks.inspectPortUsage).toHaveBeenCalledWith(18789, {
       probeHosts: ["127.0.0.1"],
     });
+    expect(mocks.resolveStatusSummaryFromOverview).toHaveBeenCalledOnce();
   });
 
   it("collects delivery and exporter stability projections in parallel", async () => {
@@ -113,6 +118,7 @@ describe("buildStatusAllReportData", () => {
         agentStatus: { agents: [], defaultId: null },
         channels: { rows: [], details: [] },
         channelIssues: [],
+        runtimeDegradation: { degradedSecretOwners: [], degradedPlugins: [] },
         osSummary: { label: "test" },
       } as never,
       daemon: {} as never,
@@ -134,6 +140,7 @@ describe("buildStatusAllReportData", () => {
         }),
       ],
     ]);
+    expect(mocks.resolveStatusSummaryFromOverview).not.toHaveBeenCalled();
   });
 
   it("uses the configured system agent for workspace skill diagnosis", async () => {

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -25,7 +25,10 @@ import {
 import { formatUpdateRestartStatusValue } from "../status-update-restart.ts";
 import { resolveStatusAllConnectionDetails } from "../status.gateway-connection.ts";
 import type { NodeOnlyGatewayInfo } from "../status.node-mode.js";
-import type { StatusScanOverviewResult } from "../status.scan-overview.ts";
+import {
+  resolveStatusSummaryFromOverview,
+  type StatusScanOverviewResult,
+} from "../status.scan-overview.ts";
 
 type StatusServiceSummaries = Awaited<ReturnType<typeof resolveStatusServiceSummaries>>;
 type StatusGatewayServiceSummary = StatusServiceSummaries[0];
@@ -198,15 +201,19 @@ export async function buildStatusAllReportData(params: {
   timeoutMs?: number;
 }) {
   const gatewaySnapshot = params.overview.gatewaySnapshot;
-  const { configPath, health, diagnosis } = await resolveStatusAllLocalDiagnosis({
-    overview: params.overview,
-    progress: params.progress,
-    gatewayReachable: gatewaySnapshot.gatewayReachable,
-    gatewayProbe: gatewaySnapshot.gatewayProbe,
-    gatewayCallOverrides: gatewaySnapshot.gatewayCallOverrides,
-    nodeOnlyGateway: params.nodeOnlyGateway,
-    timeoutMs: params.timeoutMs,
-  });
+  const [{ configPath, health, diagnosis }, summary] = await Promise.all([
+    resolveStatusAllLocalDiagnosis({
+      overview: params.overview,
+      progress: params.progress,
+      gatewayReachable: gatewaySnapshot.gatewayReachable,
+      gatewayProbe: gatewaySnapshot.gatewayProbe,
+      gatewayCallOverrides: gatewaySnapshot.gatewayCallOverrides,
+      nodeOnlyGateway: params.nodeOnlyGateway,
+      timeoutMs: params.timeoutMs,
+    }),
+    params.overview.runtimeDegradation ??
+      resolveStatusSummaryFromOverview({ overview: params.overview }),
+  ]);
 
   const overviewSurface: StatusOverviewSurface = buildStatusOverviewSurfaceFromOverview({
     overview: params.overview,
@@ -218,6 +225,7 @@ export async function buildStatusAllReportData(params: {
     surface: overviewSurface,
     osLabel: params.overview.osSummary.label,
     configPath,
+    summary,
     secretDiagnosticsCount: params.overview.secretDiagnostics.length,
     updateRestartValue: formatUpdateRestartStatusValue(diagnosis.sentinel?.payload),
     agentStatus: params.overview.agentStatus,

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -98,12 +98,36 @@ describe("status-overview-rows", () => {
   });
 
   it("builds status-all overview rows from the shared surface", () => {
+    const summary = createStatusCommandOverviewRowsParams().summary;
     const rows = buildStatusAllOverviewRows({
       surface: {
         ...baseStatusOverviewSurface,
         tailscaleMode: "off",
         tailscaleHttpsUrl: null,
         gatewayConnection: { url: "wss://gateway.example.com", urlSource: "config" },
+      },
+      summary: {
+        ...summary,
+        degradedSecretOwners: [
+          {
+            ownerKind: "capability",
+            ownerId: "tts",
+            state: "unavailable",
+            paths: ["tts.providers.elevenlabs.apiKey"],
+            reason: "secret reference was not found",
+          },
+        ],
+        degradedPlugins: [
+          {
+            pluginId: "discord",
+            state: "configured-unavailable",
+            diagnostic: {
+              kind: "plugin-verification",
+              reason: "unreadable-package-json",
+              detail: "permission denied",
+            },
+          },
+        ],
       },
       osLabel: "macOS",
       configPath: "/tmp/openclaw.json",
@@ -122,6 +146,8 @@ describe("status-overview-rows", () => {
     expect(findRowValue(rows, "Config")).toBe("/tmp/openclaw.json");
     expect(findRowValue(rows, "Update restart")).toBe("restart pending health verification");
     expect(findRowValue(rows, "Security")).toBe("Run: openclaw security audit --deep");
+    expect(findRowValue(rows, "Degraded secrets")).toBe("1 degraded · capability:tts");
+    expect(findRowValue(rows, "Degraded plugins")).toBe("1 configured-unavailable · discord");
     expect(findRowValue(rows, "Secrets")).toBe("2 diagnostics");
   });
 });

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -31,6 +31,34 @@ import {
 } from "./status.command-sections.js";
 import type { MemoryPluginStatus, MemoryStatusSnapshot } from "./status.scan.shared.js";
 
+type StatusDegradationSummary = Pick<StatusSummary, "degradedSecretOwners" | "degradedPlugins">;
+
+function buildStatusDegradationRows(
+  summary: StatusDegradationSummary,
+  decorate = (value: string) => value,
+) {
+  const rows: Array<{ Item: string; Value: string }> = [];
+  const secretOwners = summary.degradedSecretOwners ?? [];
+  if (secretOwners.length > 0) {
+    rows.push({
+      Item: "Degraded secrets",
+      Value: decorate(
+        `${secretOwners.length} degraded · ${secretOwners.map((owner) => `${owner.ownerKind}:${owner.ownerId}`).join(", ")}`,
+      ),
+    });
+  }
+  const plugins = summary.degradedPlugins ?? [];
+  if (plugins.length > 0) {
+    rows.push({
+      Item: "Degraded plugins",
+      Value: decorate(
+        `${plugins.length} configured-unavailable · ${plugins.map((plugin) => plugin.pluginId).join(", ")}`,
+      ),
+    });
+  }
+  return rows;
+}
+
 /** Builds the default `openclaw status` overview rows from scan, health, memory, and session inputs. */
 export function buildStatusCommandOverviewRows(
   params: {
@@ -68,24 +96,6 @@ export function buildStatusCommandOverviewRows(
   const eventsValue = buildStatusEventsValue({
     queuedSystemEvents: params.summary.queuedSystemEvents,
   });
-  const degradedSecretOwners = params.summary.degradedSecretOwners ?? [];
-  const degradedSecretsValue =
-    degradedSecretOwners.length > 0
-      ? params.warn(
-          `${degradedSecretOwners.length} degraded · ${degradedSecretOwners
-            .map((owner) => `${owner.ownerKind}:${owner.ownerId}`)
-            .join(", ")}`,
-        )
-      : null;
-  const degradedPlugins = params.summary.degradedPlugins ?? [];
-  const degradedPluginsValue =
-    degradedPlugins.length > 0
-      ? params.warn(
-          `${degradedPlugins.length} configured-unavailable · ${degradedPlugins
-            .map((plugin) => plugin.pluginId)
-            .join(", ")}`,
-        )
-      : null;
   const tasksValue = buildStatusTasksValue({
     summary: params.summary,
     warn: params.warn,
@@ -153,8 +163,7 @@ export function buildStatusCommandOverviewRows(
         : []),
       { Item: "Memory", Value: memoryValue },
       { Item: "Host desktop", Value: hostDesktopValue },
-      ...(degradedSecretsValue ? [{ Item: "Degraded secrets", Value: degradedSecretsValue }] : []),
-      ...(degradedPluginsValue ? [{ Item: "Degraded plugins", Value: degradedPluginsValue }] : []),
+      ...buildStatusDegradationRows(params.summary, params.warn),
       { Item: "Plugin compatibility", Value: pluginCompatibilityValue },
       { Item: "Probes", Value: probesValue },
       { Item: "Events", Value: eventsValue },
@@ -185,6 +194,7 @@ export function buildStatusCommandOverviewRows(
 /** Builds the expanded status-all overview rows, including config and security hints. */
 export function buildStatusAllOverviewRows(params: {
   surface: StatusOverviewSurface;
+  summary: StatusDegradationSummary;
   osLabel: string;
   configPath: string;
   secretDiagnosticsCount: number;
@@ -216,6 +226,7 @@ export function buildStatusAllOverviewRows(params: {
         ? [{ Item: "Update restart", Value: params.updateRestartValue }]
         : []),
       { Item: "Security", Value: `Run: ${formatCliCommand("openclaw security audit --deep")}` },
+      ...buildStatusDegradationRows(params.summary),
     ],
     agentsValue: buildStatusAllAgentsValue({
       agentStatus: params.agentStatus,

--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -59,6 +59,14 @@ function firstGatewayRequest(): { method?: string; url?: string; token?: string 
   return call[0] as { method?: string; url?: string; token?: string };
 }
 
+function gatewayRequest(method: string): { method?: string; url?: string; token?: string } {
+  const call = mocks.callGateway.mock.calls.find(([request]) => request?.method === method);
+  if (!call) {
+    throw new Error(`expected ${method} gateway call`);
+  }
+  return call[0] as { method?: string; url?: string; token?: string };
+}
+
 type ChannelsTableCall = [
   unknown,
   {
@@ -121,7 +129,11 @@ describe("collectStatusScanOverview", () => {
       resolveTailscaleHttpsUrl: vi.fn(async () => "https://box.tail.ts.net"),
       skipColdStartNetworkChecks: false,
     });
-    mocks.callGateway.mockResolvedValue({ channelAccounts: {} });
+    mocks.callGateway.mockImplementation(async ({ method }: { method?: string }) =>
+      method === "status"
+        ? { degradedSecretOwners: [], degradedPlugins: [] }
+        : { channelAccounts: {} },
+    );
     mocks.collectChannelStatusIssues.mockReturnValue([{ channel: "quietchat", message: "boom" }]);
     mocks.buildChannelsTable.mockResolvedValue({ rows: [], details: [] });
   });
@@ -138,11 +150,10 @@ describe("collectStatusScanOverview", () => {
       observe: false,
       skipPluginValidation: undefined,
     });
-    expect(mocks.callGateway).toHaveBeenCalledOnce();
-    const gatewayRequest = firstGatewayRequest();
-    expect(gatewayRequest?.method).toBe("channels.status");
-    expect(gatewayRequest?.url).toBe("ws://127.0.0.1:18789");
-    expect(gatewayRequest?.token).toBe("tok");
+    expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+    const channelsRequest = gatewayRequest("channels.status");
+    expect(channelsRequest?.url).toBe("ws://127.0.0.1:18789");
+    expect(channelsRequest?.token).toBe("tok");
     expect(mocks.buildChannelsTable).toHaveBeenCalledOnce();
     const channelTableCall = firstChannelsTableCall();
     expect(typeof channelTableCall?.[0]).toBe("object");
@@ -161,7 +172,8 @@ describe("collectStatusScanOverview", () => {
       includeChannelSetupRuntimeFallback: false,
     });
 
-    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.callGateway).toHaveBeenCalledOnce();
+    expect(firstGatewayRequest().method).toBe("status");
     expect(mocks.buildChannelsTable).toHaveBeenCalledOnce();
     const channelTableCall = firstChannelsTableCall();
     expect(typeof channelTableCall?.[0]).toBe("object");

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -7,6 +7,7 @@ import { resolveOsSummary } from "../infra/os-summary.js";
 import type { UpdateCheckResult } from "../infra/update-check.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import type { StatusSummary } from "../status/types.js";
 import type { buildChannelsTable as buildChannelsTableFn } from "./status-all/channels.js";
 import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
 import {
@@ -94,6 +95,7 @@ export type StatusScanOverviewResult = {
     | "gatewaySelf"
     | "gatewayCallOverrides"
   >;
+  runtimeDegradation: Pick<StatusSummary, "degradedSecretOwners" | "degradedPlugins"> | null;
   channelsStatus: unknown;
   channelIssues: ReturnType<typeof collectChannelStatusIssuesFn>;
   channels: Awaited<ReturnType<typeof buildChannelsTableFn>>;
@@ -236,6 +238,22 @@ export async function collectStatusScanOverview(params: {
   }
   const gatewaySnapshot = await bootstrap.gatewayProbePromise;
   params.progress?.tick();
+  let runtimeDegradation: StatusScanOverviewResult["runtimeDegradation"] = null;
+  if (gatewaySnapshot.gatewayReachable) {
+    const status = await gatewayCallModuleLoader.load().then(({ callGateway }) =>
+      callGateway<StatusSummary>({
+        config: cfg,
+        method: "status",
+        params: { includeChannelSummary: false },
+        timeoutMs: Math.min(5000, params.opts.timeoutMs ?? 10_000),
+        ...gatewaySnapshot.gatewayCallOverrides,
+      }),
+    );
+    runtimeDegradation = {
+      degradedSecretOwners: status.degradedSecretOwners ?? [],
+      degradedPlugins: status.degradedPlugins ?? [],
+    };
+  }
 
   const tailscaleHttpsUrl = await bootstrap.resolveTailscaleHttpsUrl();
   const advertisedControlUiLinks =
@@ -316,6 +334,7 @@ export async function collectStatusScanOverview(params: {
     ...(advertisedControlUiLinks ? { advertisedControlUiLinks } : {}),
     update,
     gatewaySnapshot,
+    runtimeDegradation,
     channelsStatus,
     channelIssues,
     channels,
@@ -325,12 +344,15 @@ export async function collectStatusScanOverview(params: {
 
 /** Resolves the summary object from overview data, preserving cold-start fast-path behavior. */
 export async function resolveStatusSummaryFromOverview(params: {
-  overview: Pick<StatusScanOverviewResult, "skipColdStartNetworkChecks" | "cfg" | "sourceConfig">;
+  overview: Pick<
+    StatusScanOverviewResult,
+    "skipColdStartNetworkChecks" | "cfg" | "sourceConfig" | "runtimeDegradation"
+  >;
 }) {
   if (params.overview.skipColdStartNetworkChecks) {
     return buildColdStartStatusSummary();
   }
-  return await statusSummaryModuleLoader.load().then(({ getStatusSummary }) =>
+  const summary = await statusSummaryModuleLoader.load().then(({ getStatusSummary }) =>
     getStatusSummary({
       config: params.overview.cfg,
       sourceConfig: params.overview.sourceConfig,
@@ -338,4 +360,7 @@ export async function resolveStatusSummaryFromOverview(params: {
       includeChannelSummary: false,
     }),
   );
+  return params.overview.runtimeDegradation
+    ? { ...summary, ...params.overview.runtimeDegradation }
+    : summary;
 }

--- a/src/commands/status.scan-result.ts
+++ b/src/commands/status.scan-result.ts
@@ -18,6 +18,7 @@ export type StatusScanResult = Omit<
   | "skipColdStartNetworkChecks"
   | "gatewaySnapshot"
   | "channelsStatus"
+  | "runtimeDegradation"
 > &
   StatusScanGatewayResult & {
     summary: Awaited<ReturnType<typeof getStatusSummaryFn>>;

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -70,7 +70,9 @@ function configureScanStatus(
     rows: [],
     details: [],
   });
-  mocks.callGateway.mockResolvedValue(null);
+  mocks.callGateway.mockImplementation(async ({ method }: { method?: string }) =>
+    method === "status" ? { degradedSecretOwners: [], degradedPlugins: [] } : null,
+  );
   mocks.getStatusCommandSecretTargetIds.mockReturnValue(new Set<string>());
 }
 
@@ -187,7 +189,9 @@ describe("scanStatus", () => {
       sourceConfig: cfg,
       resolvedConfig: cfg,
     });
-    mocks.callGateway.mockResolvedValue(liveChannelStatus);
+    mocks.callGateway.mockImplementation(async ({ method }: { method?: string }) =>
+      method === "status" ? { degradedSecretOwners: [], degradedPlugins: [] } : liveChannelStatus,
+    );
     mocks.probeGateway.mockResolvedValue({
       ok: true,
       url: "ws://127.0.0.1:18789",
@@ -202,8 +206,10 @@ describe("scanStatus", () => {
 
     await scanStatus({ json: false, deep: true, timeoutMs: 5000 }, {} as never);
 
-    expect(mocks.callGateway).toHaveBeenCalledOnce();
-    expect(firstCallArg(mocks.callGateway, "callGateway args")).toStrictEqual({
+    expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.callGateway.mock.calls.find(([call]) => call?.method === "channels.status")?.[0],
+    ).toStrictEqual({
       config: cfg,
       method: "channels.status",
       params: {

--- a/test/status-shared-state-readonly.e2e.test.ts
+++ b/test/status-shared-state-readonly.e2e.test.ts
@@ -1,10 +1,38 @@
 // Status shared-state E2E tests enforce the CLI/Gateway SQLite ownership boundary.
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
+import { writePersistedInstalledPluginIndexInstallRecords } from "../src/plugins/installed-plugin-index-records.js";
 import { createOpenClawTestInstance } from "./helpers/openclaw-test-instance.js";
+
+const DEGRADED_PLUGIN_ID = "status-degraded-plugin";
+
+function createUnavailablePluginFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-status-degraded-plugin-"));
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: DEGRADED_PLUGIN_ID,
+      version: "1.0.0",
+      type: "module",
+      main: "./missing-main.js",
+      openclaw: { extensions: ["./index.js"] },
+      peerDependencies: { openclaw: ">=2026.1.1" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(root, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: DEGRADED_PLUGIN_ID,
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  fs.writeFileSync(path.join(root, "index.js"), "export default { register() {} };\n");
+  return root;
+}
 
 function seedInspectableTask(db: DatabaseSync): void {
   const now = Date.now();
@@ -36,6 +64,121 @@ function seedInspectableTask(db: DatabaseSync): void {
 }
 
 describe("status shared-state ownership", () => {
+  it("projects Gateway-owned runtime degradation across status processes", async () => {
+    const pluginRoot = createUnavailablePluginFixture();
+    const instance = await createOpenClawTestInstance({
+      name: "status-runtime-degradation",
+      env: {
+        STATUS_E2E_MISSING_SECRET: undefined,
+        VITEST: undefined,
+        VITEST_POOL_ID: undefined,
+        VITEST_WORKER_ID: undefined,
+      },
+      config: {
+        tts: {
+          providers: {
+            elevenlabs: {
+              apiKey: {
+                source: "env",
+                provider: "default",
+                id: "STATUS_E2E_MISSING_SECRET",
+              },
+            },
+          },
+        },
+        plugins: {
+          enabled: true,
+          allow: [DEGRADED_PLUGIN_ID],
+          load: { paths: [pluginRoot] },
+          entries: { [DEGRADED_PLUGIN_ID]: { enabled: true } },
+        },
+      },
+    });
+    try {
+      await writePersistedInstalledPluginIndexInstallRecords(
+        {
+          [DEGRADED_PLUGIN_ID]: {
+            source: "npm",
+            spec: DEGRADED_PLUGIN_ID,
+            installPath: pluginRoot,
+          },
+        },
+        { env: instance.env },
+      );
+      await instance.startGateway();
+
+      const rpc = await instance.cli(["gateway", "call", "status", "--json"]);
+      expect(rpc.code, rpc.stderr).toBe(0);
+      const gatewayStatus = JSON.parse(rpc.stdout) as {
+        degradedSecretOwners: unknown[];
+        degradedPlugins: unknown[];
+      };
+      expect(gatewayStatus.degradedSecretOwners).toEqual([
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "tts",
+          paths: ["tts.providers.elevenlabs.apiKey"],
+          reason: "secret reference was not found",
+        }),
+      ]);
+      expect(gatewayStatus.degradedPlugins).toEqual([
+        expect.objectContaining({
+          pluginId: DEGRADED_PLUGIN_ID,
+          state: "configured-unavailable",
+          diagnostic: expect.objectContaining({ reason: "missing-openclaw-peer-link" }),
+        }),
+      ]);
+
+      for (const args of [["status"], ["status", "--all"], ["status", "--json"]]) {
+        const status = await instance.cli(args, { timeoutMs: 60_000 });
+        expect(status.code, status.stderr).toBe(0);
+        if (args.includes("--json")) {
+          const payload = JSON.parse(status.stdout) as typeof gatewayStatus;
+          expect(payload.degradedSecretOwners).toEqual(gatewayStatus.degradedSecretOwners);
+          expect(payload.degradedPlugins).toEqual(gatewayStatus.degradedPlugins);
+        } else {
+          expect(status.stdout).toContain("Degraded secrets");
+          expect(status.stdout).toContain("capability:tts");
+          expect(status.stdout).toContain("Degraded plugins");
+          expect(status.stdout).toContain(DEGRADED_PLUGIN_ID);
+        }
+        expect(`${status.stdout}\n${status.stderr}`).not.toContain("STATUS_E2E_MISSING_SECRET");
+        expect(`${status.stdout}\n${status.stderr}`).not.toContain(pluginRoot);
+      }
+
+      const logs = instance.logs();
+      expect(logs).toContain("Secret owner capability:tts is configured-unavailable");
+      expect(logs).toContain(`Plugin \"${DEGRADED_PLUGIN_ID}\"`);
+      expect(logs).not.toContain("STATUS_E2E_MISSING_SECRET");
+    } finally {
+      await instance.cleanup();
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it("keeps healthy and unreachable Gateway degradation summaries empty", async () => {
+    const instance = await createOpenClawTestInstance({ name: "status-runtime-healthy" });
+    try {
+      await instance.startGateway();
+      const healthy = await instance.cli(["status", "--json"]);
+      expect(healthy.code, healthy.stderr).toBe(0);
+      expect(JSON.parse(healthy.stdout)).toMatchObject({
+        degradedSecretOwners: [],
+        degradedPlugins: [],
+      });
+
+      await instance.stopGateway();
+      const unreachable = await instance.cli(["status", "--json"]);
+      expect(unreachable.code, unreachable.stderr).toBe(0);
+      expect(JSON.parse(unreachable.stdout)).toMatchObject({
+        degradedSecretOwners: [],
+        degradedPlugins: [],
+      });
+    } finally {
+      await instance.cleanup();
+    }
+  }, 120_000);
+
   it.each([
     { name: "text status", args: ["status"] },
     { name: "JSON status", args: ["status", "--json"] },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw status`, `openclaw status --all`, or `openclaw status --json` from a separate CLI process could miss a plugin or SecretRef owner that the running Gateway had marked degraded.

Before this change, the CLI read process-local degradation registries, which are empty in a separate process. After this change, status projects the authoritative redacted degradation summary returned by the Gateway, while healthy and unreachable controls remain distinct.

## Why This Change Was Made

The Gateway status response is the owner of live runtime degradation. The status scan now carries that existing response fact into the shared overview/report projection, and the text and JSON presenters read the same canonical shape. This avoids trying to reconstruct Gateway runtime state from CLI-local registries or adding a second state path.

Production LOC: +77/-32 (net +45) | Tests: +205/-11

The production growth carries one previously missing authoritative status fact through existing shared result/report shapes and renders it in the default/all views; it does not add config, persistence, or a fallback registry.

## User Impact

Operators can now see which configured plugin or SecretRef owner is unavailable in default, all, and JSON status output even when the CLI is a separate process from the Gateway. Diagnostics remain exactly redacted; healthy Gateways do not show degradation, and unreachable Gateways keep their existing unavailable behavior.

## Evidence

Rebased onto `8de2679a5e85749d9420aa5e62ec4f78e18c3ea2`.

- `node scripts/run-vitest.mjs src/commands/status.scan.test.ts src/commands/status.scan-overview.test.ts src/commands/status-overview-rows.test.ts src/commands/status-all/report-data.test.ts test/status-shared-state-readonly.e2e.test.ts --reporter=verbose` — 25 focused status tests plus 7 built-artifact cross-process Gateway/CLI tests passed.
- Source-blind behavior contract `/tmp/openclaw-pr2-behavior-contract.md` — default/all/JSON degradation projection, exact redaction, changed-owner observation, healthy control, and unreachable control all passed through the process-level fixture.
- `node scripts/check-changed.mjs` — formatting, core/test typechecks, type-aware lint, dead-code, database-first, architecture, and import-cycle gates passed. It emitted one warning-only suggestion to modernize the new E2E fixture's self-cleaned temporary directory.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.

The process-level regression starts a Gateway with runtime degradation, invokes status from separate CLI processes, verifies text/all/JSON output and redaction, and covers healthy and unreachable controls.
