### PR TITLE
fix(gateway): block unauthorized session lifecycle sources

### DIFF
--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -38,6 +38,7 @@ type ForkSessionFromParentParams = {
   parentSessionKey: string;
   parentEntry: SessionEntry;
   agentId: string;
+  commitGuard?: () => void;
   config?: OpenClawConfig;
   sessionKey: string;
   storePath?: string;
@@ -119,6 +120,7 @@ export async function forkSessionFromParent(
   const storePath = resolveParentForkStorePath(params);
   const fork = await forkSessionFromParentTranscript({
     agentId: params.agentId,
+    ...(params.commitGuard ? { commitGuard: params.commitGuard } : {}),
     parentEntry: params.parentEntry,
     parentSessionKey: params.parentSessionKey,
     sessionKey: params.sessionKey,
@@ -135,6 +137,7 @@ export async function forkSessionFromParentWithDecision(
   assertParentSessionForkAllowed(params.parentEntry);
   return await forkSessionFromParentTranscript({
     agentId: params.agentId,
+    ...(params.commitGuard ? { commitGuard: params.commitGuard } : {}),
     enforceTokenLimit: true,
     parentEntry: params.parentEntry,
     parentSessionKey: params.parentSessionKey,

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -105,7 +105,6 @@ export async function createSessionEntryWithTranscript<TError = string>(
   }
 
   try {
-    options.commitGuard?.();
     await appendTranscriptEvent(
       {
         agentId,
@@ -114,8 +113,12 @@ export async function createSessionEntryWithTranscript<TError = string>(
         storePath,
       },
       createSessionTranscriptHeader({ cwd: options.cwd, sessionId: created.entry.sessionId }),
+      options.commitGuard ? { beforeCommitInTransaction: options.commitGuard } : undefined,
     );
   } catch (err) {
+    // Preserve authority errors from the commit guard instead of projecting
+    // them as transcript failures at the Gateway boundary.
+    options.commitGuard?.();
     return {
       ok: false,
       error: formatErrorMessage(err),

--- a/src/config/sessions/session-accessor.parent-fork.test.ts
+++ b/src/config/sessions/session-accessor.parent-fork.test.ts
@@ -72,6 +72,71 @@ afterEach(async () => {
 });
 
 describe("forkSessionFromParentTranscript", () => {
+  it("checks authority inside same- and cross-database transcript commits", async () => {
+    const root = await makeRoot("openclaw-parent-fork-guard-");
+    const storePath = path.join(root, "sessions.json");
+    const parentSessionId = "parent-guarded";
+    await seedParentTranscript({
+      storePath,
+      parentSessionId,
+      events: [
+        {
+          type: "session",
+          version: 3,
+          id: parentSessionId,
+          timestamp: "2026-08-18T00:00:00.000Z",
+          cwd: root,
+        },
+        {
+          type: "message",
+          id: "private-message",
+          parentId: null,
+          timestamp: "2026-08-18T00:00:01.000Z",
+          message: { role: "user", content: "private context" },
+        },
+      ],
+    });
+
+    for (const target of [
+      {
+        agentId: "main",
+        sessionId: "same-database-child",
+        sessionKey: "agent:main:guarded-child",
+        targetStorePath: undefined,
+      },
+      {
+        agentId: "work",
+        sessionId: "cross-database-child",
+        sessionKey: "agent:work:guarded-child",
+        targetStorePath: path.join(root, "work-sessions.json"),
+      },
+    ]) {
+      const commitGuard = () => {
+        throw new Error("session participation changed");
+      };
+      await expect(
+        forkSessionFromParentTranscript({
+          agentId: "main",
+          commitGuard,
+          parentEntry: { sessionId: parentSessionId, updatedAt: 1 },
+          parentSessionKey: "agent:main:main",
+          sessionKey: target.sessionKey,
+          storePath,
+          targetSessionId: target.sessionId,
+          ...(target.targetStorePath ? { targetStorePath: target.targetStorePath } : {}),
+        }),
+      ).rejects.toThrow("session participation changed");
+      await expect(
+        loadTranscriptEvents({
+          agentId: target.agentId,
+          sessionId: target.sessionId,
+          sessionKey: target.sessionKey,
+          storePath: target.targetStorePath ?? storePath,
+        }),
+      ).resolves.toEqual([]);
+    }
+  });
+
   it("forks the active branch without synchronously opening the session manager", async () => {
     const root = await makeRoot("openclaw-parent-fork-");
     const sessionsDir = path.join(root, "sessions");

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -80,6 +80,8 @@ export type SessionTranscriptInstance = SessionEntrySummary & {
 
 export type TranscriptEventAppendOptions = {
   appendIntent?: "active-branch";
+  /** Synchronous authority check run inside the append transaction. */
+  beforeCommitInTransaction?: () => void;
 };
 
 export type TranscriptEventAppendError =

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -70,6 +70,7 @@ export async function forkSessionTranscriptFromParent(
     return await runExclusiveSqliteSessionWrite(resolved, async () => {
       let result: ForkSessionFromParentTranscriptResult = { status: "failed" };
       runOpenClawAgentWriteTransaction((database) => {
+        params.commitGuard?.();
         result = forkSqliteParentTranscriptInTransaction(database, resolved, {
           enforceTokenLimit: params.enforceTokenLimit,
           parentEntry: params.parentEntry,
@@ -116,6 +117,7 @@ export async function forkSessionTranscriptFromParent(
     };
     const sessionFile = formatSqliteSessionReferenceForScope(targetScope);
     runOpenClawAgentWriteTransaction((database) => {
+      params.commitGuard?.();
       writeSqliteForkedChildTranscriptInTransaction(database, targetScope, {
         parentSessionFile,
         source,

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -256,6 +256,7 @@ export async function appendTranscriptEvent(
   const resolved = resolveSqliteTranscriptScope(scope);
   await runExclusiveSqliteSessionWrite(resolved, async () => {
     runOpenClawAgentWriteTransaction((database) => {
+      options.beforeCommitInTransaction?.();
       appendTranscriptEventInTransaction(
         database,
         resolved,
@@ -277,6 +278,7 @@ export function appendTranscriptEventSync(
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let result: Result<boolean, TranscriptEventAppendError> = ok(false);
   runOpenClawAgentWriteTransaction((database) => {
+    options.beforeCommitInTransaction?.();
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
     if (!fresh) {
       result = err({

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -617,6 +617,8 @@ export type ForkSessionFromParentTranscriptResult =
 
 export type ForkSessionFromParentTranscriptParams = {
   agentId?: string;
+  /** Synchronous authority check run inside each transcript commit transaction. */
+  commitGuard?: () => void;
   parentEntry: SessionEntry;
   parentSessionKey: string;
   sessionKey: string;

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -394,7 +394,7 @@ describe("gateway method authorization", () => {
         },
       );
 
-      const dispatch = async (
+      const dispatchRequest = async (
         method: "sessions.create" | "sessions.fork" | "sessions.recover",
         requestParams: Record<string, unknown>,
         profileId: string,
@@ -446,11 +446,11 @@ describe("gateway method authorization", () => {
         { method: "sessions.recover" as const, params: { key: sessionKey } },
       ];
       for (const testCase of cases) {
-        const owner = await dispatch(testCase.method, testCase.params, "owner");
+        const owner = await dispatchRequest(testCase.method, testCase.params, "owner");
         expect(owner.handler, testCase.method).toHaveBeenCalledOnce();
         expect(owner.respond, testCase.method).toHaveBeenCalledWith(true, { authorized: true });
 
-        const outsider = await dispatch(testCase.method, testCase.params, "outsider");
+        const outsider = await dispatchRequest(testCase.method, testCase.params, "outsider");
         expect(outsider.handler, testCase.method).not.toHaveBeenCalled();
         expect(outsider.respond, testCase.method).toHaveBeenCalledWith(
           false,

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -380,6 +380,88 @@ describe("gateway method authorization", () => {
       expect(loadSessionEntry({ agentId: "main", sessionKey })).not.toHaveProperty("label");
     });
   });
+
+  it("authorizes lifecycle targets from each method's protocol shape", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:lifecycle-authorization-target";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-lifecycle-authorization-target",
+          updatedAt: 1,
+          visibility: "read-only",
+          createdActor: { type: "human", id: "owner" },
+        },
+      );
+
+      const dispatch = async (
+        method: "sessions.create" | "sessions.fork" | "sessions.recover",
+        requestParams: Record<string, unknown>,
+        profileId: string,
+      ) => {
+        const handler = vi.fn<GatewayRequestHandler>(({ respond, sessionMutationAuthorization }) =>
+          respond(true, { authorized: sessionMutationAuthorization !== undefined }),
+        );
+        const respond = vi.fn();
+        await handleGatewayRequest({
+          req: { type: "req", id: `${method}-${profileId}`, method, params: requestParams },
+          respond,
+          client: {
+            connId: `${method}-${profileId}`,
+            authenticatedUserId: `${profileId}@example.com`,
+            authenticatedUserProfile: {
+              profileId,
+              displayName: profileId,
+              hasAvatar: false,
+              updatedAt: 1,
+            },
+            connect: {
+              role: "operator",
+              scopes: ["operator.write"],
+              client: { id: "test", version: "1", platform: "test", mode: "test" },
+              minProtocol: 1,
+              maxProtocol: 1,
+            },
+          } as Parameters<typeof handleGatewayRequest>[0]["client"],
+          isWebchatConnect: () => false,
+          context: {
+            chatAbortControllers: new Map(),
+            getRuntimeConfig: () => ({}),
+            logGateway: { warn: vi.fn() },
+          } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+          extraHandlers: { [method]: handler },
+        });
+        return { handler, respond };
+      };
+
+      const cases = [
+        {
+          method: "sessions.create" as const,
+          params: { parentSessionKey: sessionKey, fork: true },
+        },
+        {
+          method: "sessions.fork" as const,
+          params: { sessionKey, entryId: "user-entry" },
+        },
+        { method: "sessions.recover" as const, params: { key: sessionKey } },
+      ];
+      for (const testCase of cases) {
+        const owner = await dispatch(testCase.method, testCase.params, "owner");
+        expect(owner.handler, testCase.method).toHaveBeenCalledOnce();
+        expect(owner.respond, testCase.method).toHaveBeenCalledWith(true, { authorized: true });
+
+        const outsider = await dispatch(testCase.method, testCase.params, "outsider");
+        expect(outsider.handler, testCase.method).not.toHaveBeenCalled();
+        expect(outsider.respond, testCase.method).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({
+            details: expect.objectContaining({ code: "SESSION_PARTICIPATION_REQUIRED" }),
+          }),
+        );
+      }
+    });
+  });
 });
 
 describe("sessions.patchMany orchestration", () => {

--- a/src/gateway/server-methods/sessions-recover.ts
+++ b/src/gateway/server-methods/sessions-recover.ts
@@ -11,11 +11,25 @@ import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionRecoverHandlers: GatewayRequestHandlers = {
-  "sessions.recover": async ({ req, params, respond, client, context }) => {
+  "sessions.recover": async ({
+    req,
+    params,
+    respond,
+    client,
+    context,
+    sessionMutationAuthorization,
+  }) => {
     if (!assertValidParams(params, validateSessionsRecoverParams, "sessions.recover", respond)) {
       return;
     }
     const authority = createAgentRuntimeAuthorityGuard(client, context, respond);
+    const commitGuard =
+      authority.commitGuard || sessionMutationAuthorization
+        ? () => {
+            authority.commitGuard?.();
+            sessionMutationAuthorization?.assertCurrent();
+          }
+        : undefined;
     const creation = resolveOperatorSessionCreation(client);
     const recovered = await recoverGatewaySession({
       cfg: context.getRuntimeConfig(),
@@ -23,12 +37,12 @@ export const sessionRecoverHandlers: GatewayRequestHandlers = {
       ...(params.agentId ? { agentId: params.agentId } : {}),
       ...(creation.actor ? { actor: creation.actor } : {}),
       authorizedPluginId: client?.internal?.pluginRuntimeOwnerId,
-      ...(authority.commitGuard ? { commitGuard: authority.commitGuard } : {}),
+      ...(commitGuard ? { commitGuard } : {}),
       launchContinuation: async (continuation) =>
         await launchSessionRecoveryContinuation({
           ...continuation,
           client,
-          ...(authority.commitGuard ? { commitGuard: authority.commitGuard } : {}),
+          ...(commitGuard ? { commitGuard } : {}),
           context,
           req,
         }),

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -22,6 +22,11 @@ import {
   loadTranscriptEvents,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteStoreScope,
+  runExclusiveSqliteSessionWrite,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import { addSessionMember, removeSessionMember } from "../config/sessions/session-sharing-store.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
@@ -42,6 +47,10 @@ import {
   prepareGatewayLocalUserIngress,
 } from "./local-user-ingress.js";
 import { listSessionGroups } from "./session-groups.js";
+import {
+  resolveSessionMutationAuthorization,
+  SessionMutationAuthorizationChangedError,
+} from "./session-sharing.js";
 import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
 import {
   agentCommandMock,
@@ -271,6 +280,113 @@ test("sessions.create carries keyed adoption authorization through the durable c
   expect(adopted.ok).toBe(true);
   expect(assertCurrent).toHaveBeenCalled();
   expect(loadSessionEntry({ sessionKey: key, storePath })?.category).toBe("Projects");
+});
+
+test("sessions.create revalidates parent participation before committing a fork transcript", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const parentSessionKey = "agent:main:dashboard:participation-race-parent";
+  const parentSessionId = "participation-race-parent-session";
+  const childSessionKey = "agent:main:dashboard:participation-race-child";
+  await writeSessionStore({
+    entries: {
+      [parentSessionKey]: sessionStoreEntry(parentSessionId, {
+        visibility: "read-only",
+        createdActor: { type: "human", id: "owner" },
+      }),
+    },
+  });
+  await seedSessionTranscript({
+    agentId: "main",
+    sessionId: parentSessionId,
+    sessionKey: parentSessionKey,
+    storePath,
+    messages: [{ role: "user", content: "private parent context" }],
+  });
+  addSessionMember(
+    { agentId: "main", sessionKey: parentSessionKey, storePath },
+    { identityId: "member", addedBy: "owner", expectedSessionId: parentSessionId },
+  );
+  const client = {
+    authenticatedUserId: "member@example.com",
+    authenticatedUserProfile: {
+      profileId: "member",
+      displayName: "Member",
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+    connect: { role: "operator", scopes: ["operator.write"] },
+  } as never;
+  const requestParams = {
+    agentId: "main",
+    key: childSessionKey,
+    parentSessionKey,
+    fork: true,
+  };
+  const authorization = resolveSessionMutationAuthorization({
+    client,
+    method: "sessions.create",
+    requestParams,
+    context: { getRuntimeConfig } as never,
+  });
+  expect(authorization.error).toBeNull();
+  const assertCurrent = authorization.authorization?.assertCurrent;
+  if (!assertCurrent) {
+    throw new Error("sessions.create did not capture parent participation");
+  }
+
+  const writerEntered = createDeferredCore();
+  const releaseWriter = createDeferredCore();
+  const resolvedStore = resolveSqliteStoreScope(storePath, { agentId: "main" });
+  const heldWriter = runExclusiveSqliteSessionWrite(resolvedStore, async () => {
+    writerEntered.resolve();
+    await releaseWriter.promise;
+  });
+  await writerEntered.promise;
+  const database = openOpenClawAgentDatabase({
+    agentId: "main",
+    ...(resolvedStore.path ? { path: resolvedStore.path } : {}),
+  });
+  const transcriptCount = () =>
+    (
+      database.db.prepare("SELECT count(*) AS count FROM transcript_events").get() as {
+        count: number;
+      }
+    ).count;
+  const beforeTranscriptCount = transcriptCount();
+  const firstGuard = createDeferredCore();
+  let guardCalls = 0;
+  const { createGatewaySession } = await import("./session-create-service.js");
+  const creating = createGatewaySession({
+    cfg: getRuntimeConfig(),
+    ...requestParams,
+    commandSource: "test",
+    commitGuard: () => {
+      assertCurrent();
+      guardCalls += 1;
+      if (guardCalls === 1) {
+        firstGuard.resolve();
+      }
+    },
+  });
+
+  try {
+    await firstGuard.promise;
+    removeSessionMember(
+      { agentId: "main", sessionKey: parentSessionKey, storePath },
+      "member",
+      undefined,
+      parentSessionId,
+    );
+  } finally {
+    releaseWriter.resolve();
+    await heldWriter;
+  }
+
+  await expect(creating).rejects.toBeInstanceOf(SessionMutationAuthorizationChangedError);
+  expect(
+    loadSessionEntry({ agentId: "main", sessionKey: childSessionKey, storePath }),
+  ).toBeUndefined();
+  expect(transcriptCount()).toBe(beforeTranscriptCount);
 });
 
 test("sessions.create registers a category only after the session commit succeeds", async () => {

--- a/src/gateway/server.sessions.recover.test.ts
+++ b/src/gateway/server.sessions.recover.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from "vitest";
+import { getRuntimeConfig } from "../config/io.js";
 import { loadSessionEntry, loadTranscriptEvents } from "../config/sessions/session-accessor.js";
+import { addSessionMember, removeSessionMember } from "../config/sessions/session-sharing-store.js";
+import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  resolveSessionMutationAuthorization,
+  SessionMutationAuthorizationChangedError,
+} from "./session-sharing.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -142,6 +150,107 @@ test("sessions.recover rejects a healthy session", async () => {
     ok: false,
     error: { code: "INVALID_REQUEST", message: expect.stringContaining("tombstoned") },
   });
+});
+
+test("sessions.recover revalidates participation at the recovery writer commit", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sourceKey = "agent:main:dashboard:recovery-participation-race";
+  const sourceSessionId = "recovery-participation-race-source";
+  await writeSessionStore({
+    entries: {
+      [sourceKey]: sessionStoreEntry(sourceSessionId, {
+        status: "failed",
+        abortedLastRun: true,
+        visibility: "read-only",
+        createdActor: { type: "human", id: "owner" },
+        mainRestartRecovery: {
+          cycleId: "cycle-recovery-participation-race",
+          revision: 1,
+          chargedAttempts: 3,
+          tombstone: { reason: "automatic recovery exhausted" },
+        },
+      }),
+    },
+  });
+  await seedSessionTranscript({
+    agentId: "main",
+    sessionId: sourceSessionId,
+    sessionKey: sourceKey,
+    storePath,
+    messages: [{ role: "user", content: "recover this private session" }],
+  });
+  addSessionMember(
+    { agentId: "main", sessionKey: sourceKey, storePath },
+    { identityId: "member", addedBy: "owner", expectedSessionId: sourceSessionId },
+  );
+  const client = {
+    authenticatedUserId: "member@example.com",
+    authenticatedUserProfile: {
+      profileId: "member",
+      displayName: "Member",
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+    connect: { role: "operator", scopes: ["operator.write"] },
+  } as never;
+  // Use an already-registered single-key mutation to isolate handler/writer propagation from
+  // the separate sessions.recover registry regression covered at the router boundary.
+  const authorization = resolveSessionMutationAuthorization({
+    client,
+    method: "sessions.reset",
+    requestParams: { key: sourceKey, agentId: "main" },
+    context: { getRuntimeConfig } as never,
+  });
+  expect(authorization.error).toBeNull();
+  if (!authorization.authorization) {
+    throw new Error("failed to capture recovery source participation");
+  }
+
+  const mutationEntered = createDeferredCore();
+  const releaseMutation = createDeferredCore();
+  const heldMutation = runExclusiveSessionLifecycleMutation({
+    scope: storePath,
+    identities: [sourceKey, sourceSessionId],
+    run: async () => {
+      mutationEntered.resolve();
+      await releaseMutation.promise;
+    },
+  });
+  await mutationEntered.promise;
+  const requestStarted = createDeferredCore();
+  const recovering = directSessionReq(
+    "sessions.recover",
+    { agentId: "main", key: sourceKey },
+    {
+      client,
+      context: {
+        getRuntimeConfig: () => {
+          requestStarted.resolve();
+          return getRuntimeConfig();
+        },
+      },
+      sessionMutationAuthorization: authorization.authorization,
+    },
+  );
+
+  try {
+    await requestStarted.promise;
+    removeSessionMember(
+      { agentId: "main", sessionKey: sourceKey, storePath },
+      "member",
+      undefined,
+      sourceSessionId,
+    );
+  } finally {
+    releaseMutation.resolve();
+    await heldMutation;
+  }
+
+  await expect(recovering).rejects.toBeInstanceOf(SessionMutationAuthorizationChangedError);
+  const source = loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath });
+  expect(source?.archivedAt).toBeUndefined();
+  expect(source?.mainRestartRecovery?.tombstone).not.toHaveProperty("recoveredSessionKey");
+  expect(source?.mainRestartRecovery?.tombstone).not.toHaveProperty("recoveredSessionId");
 });
 
 test("sessions.recover rejects continuation launch after runtime authority closes", async () => {

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1190,6 +1190,7 @@ export async function createGatewaySession(params: {
         const forkResult = await forkSessionFromParentWithDecision({
           parentEntry: currentParentSessionEntry,
           agentId: parentSessionTarget.agentId,
+          ...(params.commitGuard ? { commitGuard: params.commitGuard } : {}),
           parentSessionKey: forkParentSessionKey,
           sessionKey: target.canonicalKey,
           storePath: parentSessionTarget.storePath,

--- a/src/gateway/session-sharing.test.ts
+++ b/src/gateway/session-sharing.test.ts
@@ -122,6 +122,40 @@ describe("session sharing policy", () => {
     });
   });
 
+  it("extracts every message-cut lifecycle target from sessionKey", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:message-cut-target";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-message-cut-target",
+          updatedAt: 1,
+          visibility: "read-only",
+          createdActor: { type: "human", id: "owner" },
+        },
+      );
+      const context = { getRuntimeConfig: () => ({}) } as GatewayRequestContext;
+      for (const method of ["sessions.fork", "sessions.rewind", "sessions.branches.switch"]) {
+        expect(
+          resolveSessionMutationAuthorization({
+            client: client({ user: "owner" }),
+            method,
+            requestParams: { sessionKey },
+            context,
+          }),
+        ).toMatchObject({ error: null, authorization: expect.any(Object) });
+        expect(
+          resolveSessionMutationAuthorization({
+            client: client({ user: "outsider" }),
+            method,
+            requestParams: { sessionKey },
+            context,
+          }).error,
+        ).toMatchObject({ details: { code: "SESSION_PARTICIPATION_REQUIRED" } });
+      }
+    });
+  });
+
   it("rechecks group members before committing a defaults update", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       putSessionGroups(["Race"]);

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -263,39 +263,42 @@ export function authorizeSessionSharingTarget(params: {
       });
 }
 
-const SESSION_KEY_PARAM_BY_METHOD = new Map<string, "key" | "sessionKey">([
-  ["agent", "sessionKey"],
-  ["board.event", "sessionKey"],
-  ["board.update", "sessionKey"],
-  ["board.widget.grant", "sessionKey"],
-  ["board.widget.put", "sessionKey"],
-  ["chat.abort", "sessionKey"],
-  ["chat.inject", "sessionKey"],
-  ["chat.send", "sessionKey"],
-  ["message.action", "sessionKey"],
-  ["plugins.sessionAction", "sessionKey"],
-  ["progressCard.get", "sessionKey"],
-  ["progressCard.put", "sessionKey"],
-  ["send", "sessionKey"],
-  ["session.discussion.open", "sessionKey"],
-  ["sessions.abort", "key"],
-  ["sessions.compaction.branch", "key"],
-  ["sessions.compaction.restore", "key"],
-  ["sessions.compact", "key"],
-  ["sessions.create", "key"],
-  ["sessions.delete", "key"],
-  ["sessions.dispatch", "key"],
-  ["sessions.files.set", "sessionKey"],
-  ["sessions.fork", "key"],
-  ["sessions.patch", "key"],
-  ["sessions.pluginPatch", "key"],
-  ["sessions.reclaim", "key"],
-  ["sessions.reset", "key"],
-  ["sessions.rewind", "key"],
-  ["sessions.send", "key"],
-  ["sessions.steer", "key"],
-  ["sessions.branches.switch", "key"],
-  ["tools.invoke", "sessionKey"],
+type SessionMutationTargetField = "key" | "parentSessionKey" | "sessionKey";
+
+const SESSION_TARGET_FIELDS_BY_METHOD = new Map<string, readonly SessionMutationTargetField[]>([
+  ["agent", ["sessionKey"]],
+  ["board.event", ["sessionKey"]],
+  ["board.update", ["sessionKey"]],
+  ["board.widget.grant", ["sessionKey"]],
+  ["board.widget.put", ["sessionKey"]],
+  ["chat.abort", ["sessionKey"]],
+  ["chat.inject", ["sessionKey"]],
+  ["chat.send", ["sessionKey"]],
+  ["message.action", ["sessionKey"]],
+  ["plugins.sessionAction", ["sessionKey"]],
+  ["progressCard.get", ["sessionKey"]],
+  ["progressCard.put", ["sessionKey"]],
+  ["send", ["sessionKey"]],
+  ["session.discussion.open", ["sessionKey"]],
+  ["sessions.abort", ["key"]],
+  ["sessions.compaction.branch", ["key"]],
+  ["sessions.compaction.restore", ["key"]],
+  ["sessions.compact", ["key"]],
+  ["sessions.create", ["key", "parentSessionKey"]],
+  ["sessions.delete", ["key"]],
+  ["sessions.dispatch", ["key"]],
+  ["sessions.files.set", ["sessionKey"]],
+  ["sessions.fork", ["sessionKey"]],
+  ["sessions.patch", ["key"]],
+  ["sessions.pluginPatch", ["key"]],
+  ["sessions.reclaim", ["key"]],
+  ["sessions.recover", ["key"]],
+  ["sessions.reset", ["key"]],
+  ["sessions.rewind", ["sessionKey"]],
+  ["sessions.send", ["key"]],
+  ["sessions.steer", ["key"]],
+  ["sessions.branches.switch", ["sessionKey"]],
+  ["tools.invoke", ["sessionKey"]],
 ]);
 
 const REQUIRED_SESSION_TARGET_METHODS = new Set([
@@ -325,6 +328,7 @@ const REQUIRED_SESSION_TARGET_METHODS = new Set([
   "sessions.patch",
   "sessions.pluginPatch",
   "sessions.reclaim",
+  "sessions.recover",
   "sessions.reset",
   "sessions.rewind",
   "sessions.send",
@@ -409,15 +413,34 @@ function resolveSessionMutationTargets(params: {
     );
     return target ? [target] : undefined;
   }
-  const field = SESSION_KEY_PARAM_BY_METHOD.get(params.method);
-  const directKey = field ? readStringParam(params.requestParams, field) : undefined;
-  if (!directKey && (params.method === "board.event" || params.method === "board.action")) {
+  const requestedAgentId = readStringParam(params.requestParams, "agentId");
+  const directTargets = SESSION_TARGET_FIELDS_BY_METHOD.get(params.method)?.flatMap(
+    (field): SessionMutationTarget[] => {
+      const sessionKey = readStringParam(params.requestParams, field);
+      if (!sessionKey) {
+        return [];
+      }
+      // sessions.create applies its selected agent to the parent only for the
+      // unqualified global sentinels; other parents resolve their own store.
+      const parentUsesRequestedAgent =
+        field !== "parentSessionKey" || ["global", "unknown"].includes(sessionKey.toLowerCase());
+      return [
+        {
+          sessionKey,
+          ...(requestedAgentId && parentUsesRequestedAgent ? { agentId: requestedAgentId } : {}),
+        },
+      ];
+    },
+  );
+  if (directTargets?.length) {
+    return directTargets;
+  }
+  if (params.method === "board.event" || params.method === "board.action") {
     const ticket = readStringParam(params.requestParams, "ticket");
     const claims = ticket ? verifyBoardViewTicket(ticket) : undefined;
     if (!claims) {
       return undefined;
     }
-    const requestedAgentId = readStringParam(params.requestParams, "agentId");
     if (requestedAgentId && requestedAgentId !== claims.agentId) {
       return undefined;
     }
@@ -428,16 +451,8 @@ function resolveSessionMutationTargets(params: {
       },
     ];
   }
-  if (directKey || params.method !== "sessions.abort") {
-    const agentId = readStringParam(params.requestParams, "agentId");
-    return directKey
-      ? [
-          {
-            sessionKey: directKey,
-            ...(agentId ? { agentId } : {}),
-          },
-        ]
-      : undefined;
+  if (params.method !== "sessions.abort") {
+    return undefined;
   }
   const runId = readStringParam(params.requestParams, "runId");
   const run = runId ? params.context.chatAbortControllers.get(runId) : undefined;

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -414,25 +414,22 @@ function resolveSessionMutationTargets(params: {
     return target ? [target] : undefined;
   }
   const requestedAgentId = readStringParam(params.requestParams, "agentId");
-  const directTargets = SESSION_TARGET_FIELDS_BY_METHOD.get(params.method)?.flatMap(
-    (field): SessionMutationTarget[] => {
-      const sessionKey = readStringParam(params.requestParams, field);
-      if (!sessionKey) {
-        return [];
-      }
-      // sessions.create applies its selected agent to the parent only for the
-      // unqualified global sentinels; other parents resolve their own store.
-      const parentUsesRequestedAgent =
-        field !== "parentSessionKey" || ["global", "unknown"].includes(sessionKey.toLowerCase());
-      return [
-        {
-          sessionKey,
-          ...(requestedAgentId && parentUsesRequestedAgent ? { agentId: requestedAgentId } : {}),
-        },
-      ];
-    },
-  );
-  if (directTargets?.length) {
+  const directTargets: SessionMutationTarget[] = [];
+  for (const field of SESSION_TARGET_FIELDS_BY_METHOD.get(params.method) ?? []) {
+    const sessionKey = readStringParam(params.requestParams, field);
+    if (!sessionKey) {
+      continue;
+    }
+    // sessions.create applies its selected agent to the parent only for the
+    // unqualified global sentinels; other parents resolve their own store.
+    const parentUsesRequestedAgent =
+      field !== "parentSessionKey" || ["global", "unknown"].includes(sessionKey.toLowerCase());
+    directTargets.push({
+      sessionKey,
+      ...(requestedAgentId && parentUsesRequestedAgent ? { agentId: requestedAgentId } : {}),
+    });
+  }
+  if (directTargets.length) {
     return directTargets;
   }
   if (params.method === "board.event" || params.method === "board.action") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where multi-profile operators with write scope could apply session lifecycle operations to source sessions they were not permitted to participate in. Legitimate message-cut fork operations could also be rejected because their protocol target was read from the wrong field.

## Why This Change Was Made

Session lifecycle authorization now uses method-specific protocol target extraction, includes recovery, and revalidates participation inside the exact SQLite create, fork, and recovery commit transactions after asynchronous work. Operator scopes, protocol shapes, storage schema, and compatibility behavior are unchanged.

This is AI-assisted work reviewed and understood by the author.

## User Impact

Multi-profile operators can expect session create, fork, rewind, branch-switch, and recovery flows to honor the source session's participation boundary consistently. Authorized message-cut forks continue to work, while lifecycle writes stop if participation changes before commit.

## Evidence

- Real-behavior proof: an isolated dev Gateway accepted two distinct trusted-proxy profiles over real WebSockets with no production credentials. After the owner changed the source session to read-only, the outsider was denied for `sessions.create`, `sessions.fork`, and `sessions.recover`, while the owner reached each handler. One temporary proof test passed on Blacksmith Testbox `tbx_01m0asx8fgmxt9t31cnwpqcd6c`: https://github.com/openclaw/openclaw/actions/runs/32158334652. The temporary test was removed before publication.
- Fresh focused Testbox proof passed 14 tests total (four changed-behavior cases plus all ten parent-fork storage tests) on `tbx_01m0at51bg4gmw2za55mqwcrk8`: https://github.com/openclaw/openclaw/actions/runs/32158747022.
- After CI exposed two branch lint defects, Testbox `tbx_01m0atjf37yhsjpb8d8639rk5r` passed formatting, the exact `check-lint-core-2` command, the same four focused behavior cases, and all ten parent-fork tests: https://github.com/openclaw/openclaw/actions/runs/32159438407.

  ```bash
  node scripts/run-vitest.mjs src/gateway/server-methods.authorization.test.ts src/gateway/session-sharing.test.ts src/gateway/server.sessions.recover.test.ts -t "authorizes lifecycle targets|extracts every message-cut|revalidates participation at the recovery writer commit"
  node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts -t "revalidates parent participation before committing a fork transcript"
  node scripts/run-vitest.mjs src/config/sessions/session-accessor.parent-fork.test.ts
  ```

- Earlier local focused proof passed 73 router/lifecycle tests and all 10 parent-fork storage tests.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` completed clean with no accepted/actionable findings on final head `6652b6e1881bb75dc5ec4d1ecd100d2ac320f7e0`.
- A broader earlier run of `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts` had one unrelated worktree fixture failure because that fixture's temporary workspace was not a Git checkout. The new create race test passes independently, as shown above.
- Production LOC: `+92/-51` (net `+41`). Tests: `+406/-0`. The production growth carries participation revalidation through distinct create, same-database fork, cross-database fork, transcript append, and recovery writer commit boundaries; collapsing those boundaries would weaken the transaction-local authority check.
- Security-owner review is required before merge and will be requested from `@openclaw/openclaw-secops` for this authorization boundary.
- No changelog edit: normal PR release-note context is captured here.
