### PR TITLE
perf(test): consolidate shutdown watchdog proof

### DIFF
--- a/src/cli/gateway-cli/shutdown-hard-exit.process.test.ts
+++ b/src/cli/gateway-cli/shutdown-hard-exit.process.test.ts
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 
 const WATCHDOG_DELAY_MS = 100;
 const CHILD_TIMEOUT_MS = 3_000;
@@ -10,10 +10,39 @@ const watchdogModuleUrl = pathToFileURL(
   path.resolve("src/cli/gateway-cli/shutdown-hard-exit.ts"),
 ).href;
 
-function runWatchdogChild(source: string) {
+function runWatchdogChild() {
   const script = `
+    import { writeSync } from "node:fs";
     import { armShutdownHardExitWatchdog } from ${JSON.stringify(watchdogModuleUrl)};
-    ${source}
+
+    const fail = (message) => {
+      writeSync(2, \`error:\${message}\\n\`);
+      process.exit(2);
+    };
+    const firstWatchdog = armShutdownHardExitWatchdog({
+      delayMs: ${WATCHDOG_DELAY_MS},
+      onError: (error) => fail(String(error)),
+    });
+    if (firstWatchdog === null) {
+      fail("first-watchdog-not-armed");
+    }
+    firstWatchdog.cancel();
+    await new Promise((resolve) => setTimeout(resolve, ${WATCHDOG_DELAY_MS * 2}));
+    writeSync(1, "cancelled-watchdog-deadline-survived\\n");
+
+    process.once("beforeExit", () => {
+      // Reaching beforeExit proves the cancelled worker no longer retains process liveness.
+      writeSync(1, "cancelled-watchdog-released-liveness\\n");
+      const secondWatchdog = armShutdownHardExitWatchdog({
+        delayMs: ${WATCHDOG_DELAY_MS},
+        onError: (error) => fail(String(error)),
+      });
+      if (secondWatchdog === null) {
+        fail("second-watchdog-not-armed");
+      }
+      writeSync(1, "second-watchdog-armed\\n");
+      while (true) {}
+    });
   `;
   const startedAt = Date.now();
   const result = spawnSync(
@@ -30,38 +59,34 @@ function runWatchdogChild(source: string) {
   return { elapsedMs: Date.now() - startedAt, result };
 }
 
-describe("shutdown hard-exit watchdog", () => {
-  it("kills a process whose main thread is synchronously blocked", () => {
-    const { elapsedMs, result } = runWatchdogChild(`
-      armShutdownHardExitWatchdog({
-        delayMs: ${WATCHDOG_DELAY_MS},
-        onError: (error) => console.error(error),
-      });
-      while (true) {}
-    `);
+it("cancels one watchdog before another kills a blocked main thread", () => {
+  const { elapsedMs, result } = runWatchdogChild();
+  const diagnostics = JSON.stringify(
+    {
+      elapsedMs,
+      status: result.status,
+      signal: result.signal,
+      error: result.error ? String(result.error) : undefined,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    },
+    null,
+    2,
+  );
+  const markers = [
+    "cancelled-watchdog-deadline-survived",
+    "cancelled-watchdog-released-liveness",
+    "second-watchdog-armed",
+  ];
+  let previousMarkerIndex = -1;
+  for (const marker of markers) {
+    const markerIndex = result.stdout.indexOf(marker);
+    expect(markerIndex, diagnostics).toBeGreaterThan(previousMarkerIndex);
+    previousMarkerIndex = markerIndex;
+  }
 
-    expect(result.error).toBeUndefined();
-    expect(result.signal).toBe("SIGKILL");
-    expect(elapsedMs).toBeLessThan(CHILD_TIMEOUT_MS);
-  });
-
-  it("lets a cancelled process survive beyond the deadline and exit cleanly", () => {
-    const { elapsedMs, result } = runWatchdogChild(`
-      const watchdog = armShutdownHardExitWatchdog({
-        delayMs: ${WATCHDOG_DELAY_MS},
-        onError: (error) => {
-          console.error(error);
-          process.exitCode = 2;
-        },
-      });
-      watchdog?.cancel();
-      await new Promise((resolve) => setTimeout(resolve, ${WATCHDOG_DELAY_MS * 2}));
-    `);
-
-    expect(result.error).toBeUndefined();
-    expect(result.status).toBe(0);
-    expect(result.signal).toBeNull();
-    expect(elapsedMs).toBeGreaterThanOrEqual(WATCHDOG_DELAY_MS * 2);
-    expect(elapsedMs).toBeLessThan(CHILD_TIMEOUT_MS);
-  });
+  expect(result.error, diagnostics).toBeUndefined();
+  expect(result.status, diagnostics).toBeNull();
+  expect(result.signal, diagnostics).toBe("SIGKILL");
+  expect(elapsedMs, diagnostics).toBeLessThan(CHILD_TIMEOUT_MS);
 });

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -3,6 +3,7 @@
 export const cliProcessTestFiles = [
   "src/cli/acp-cli-exit.process.test.ts",
   "src/cli/gateway-backed-exit.process.test.ts",
+  "src/cli/gateway-cli/shutdown-hard-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",
 ];


### PR DESCRIPTION
## What Problem This Solves

The new shutdown watchdog process coverage cold-started Node+tsx twice and was accidentally routed through the shared non-isolated `unit-fast` graph, despite exercising real child processes and deadline-sensitive worker behavior.

## Why This Change Was Made

Run the cancellation and starvation contracts sequentially in one real child. Synchronous markers prove the first watchdog survives its deadline and releases process liveness before a second watchdog arms and kills a synchronously blocked main thread. Register the file in the existing CLI process-owned list so focused and full runs use the intended isolated lane.

## User Impact

There is no product behavior change. The real watchdog lifecycle proof is stronger, correctly isolated, and materially faster at the repository test entrypoint.

## Evidence

- Controlled same-Testbox A/B on https://github.com/openclaw/openclaw/actions/runs/32156735860 with one excluded warmup, two retained samples per state, one Vitest worker, distinct module caches, import diagnostics, and `/usr/bin/time -v`.
- Retained wall mean: 6.50 s → 4.36 s, -2.14 s (-32.9%).
- Retained test-body mean: 0.435 s → 0.412 s (-5.3%).
- Vitest mean: 0.594 s → 1.175 s because the test now pays the correct isolated `cli-process` setup instead of running in shared `unit-fast`; total scoped wall still falls substantially.
- Fault proof: cancelling the second watchdog made the child hit the 3 s outer timeout instead of receiving the expected SIGKILL; the mutation was restored.
- Focused proof: 1 watchdog process test, 111 routing/config tests, and 2 targeted test-project routing tests passed.
- Complete changed gate passed on Blacksmith Testbox `tbx_01m0arzj8b5v9kt3m4a1s0ektn`.
- Fresh post-rebase Codex autoreview: clean, 0.99.
- Production LOC: +0/-0. Tests/test support: +62/-36 (net +26).
