### PR TITLE
fix(ui): restore startup budget margin

### DIFF
--- a/ui/src/components/github-link-target.ts
+++ b/ui/src/components/github-link-target.ts
@@ -13,7 +13,7 @@ export type GitHubLinkTarget = GitHubItemTarget & {
   href: string;
 };
 
-function decodePathSegment(value: string): string | null {
+export function decodeGitHubPathSegment(value: string): string | null {
   try {
     const decoded = decodeURIComponent(value).trim();
     return decoded && decoded !== "." && decoded !== ".." ? decoded : null;
@@ -22,10 +22,10 @@ function decodePathSegment(value: string): string | null {
   }
 }
 
-function parseGitHubItemPath(url: URL): GitHubItemTarget | null {
+export function parseGitHubItemPath(url: URL): GitHubItemTarget | null {
   const segments = url.pathname.split("/").filter(Boolean);
-  const owner = decodePathSegment(segments[0] ?? "");
-  const repo = decodePathSegment(segments[1] ?? "");
+  const owner = decodeGitHubPathSegment(segments[0] ?? "");
+  const repo = decodeGitHubPathSegment(segments[1] ?? "");
   const surface = segments[2];
   const numberText = segments[3] ?? "";
   if (!owner || !repo || !/^[1-9]\d{0,9}$/.test(numberText)) {
@@ -52,35 +52,12 @@ export function parseGitHubLinkTarget(href: string): GitHubLinkTarget | null {
   return target ? { ...target, href: url.href } : null;
 }
 
-export function formatGitHubLinkLabel(url: URL): string {
-  const segments = url.pathname.split("/").filter(Boolean);
-  const item = parseGitHubItemPath(url);
-  if (item && segments.length === 4 && !url.search && !url.hash) {
-    return `#${item.number}`;
-  }
-  if (item) {
-    return url.href;
-  }
-  if (segments.length === 2) {
-    return segments.map((segment) => decodePathSegment(segment) ?? segment).join("/");
-  }
-  if (segments[2] === "blob" && segments.length > 4) {
-    const filename = decodePathSegment(segments.at(-1) ?? "");
-    if (filename) {
-      return filename;
-    }
-  }
-  const fallbackSegments = segments.length > 2 ? segments.slice(2) : segments;
-  const path = fallbackSegments.map((segment) => decodePathSegment(segment) ?? segment);
-  return ["github.com", ...path].join("/");
-}
-
 export function gitHubProfileUrl(login: string): string {
   return `https://${GITHUB_HOST}/${encodeURIComponent(login)}`;
 }
 
-// Built from the parsed parts rather than the source href, which isGitHubItemRootPath
-// shows may already carry its own sub-path, query, or comment fragment.
+// Build from parsed parts because the source href may already carry its own
+// sub-path, query, or comment fragment.
 export function gitHubFilesChangedUrl(target: GitHubItemTarget): string {
   const repoPath = `${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
   return `https://${GITHUB_HOST}/${repoPath}/pull/${target.number}/files`;

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -3,7 +3,7 @@ import markdownItTaskLists from "markdown-it-task-lists";
 import type Token from "markdown-it/lib/token.mjs";
 import { t } from "../i18n/index.ts";
 import { fileKindForPath, shortestFileLabels } from "./file-kind.ts";
-import { formatGitHubLinkLabel } from "./github-link-target.ts";
+import { decodeGitHubPathSegment, parseGitHubItemPath } from "./github-link-target.ts";
 import {
   installAssistantTranscriptRoleImageRenderer,
   installAssistantTranscriptRoleMarkdown,
@@ -106,6 +106,26 @@ function parseWebLinkHref(href: string): URL | null {
     return null;
   }
   return url.protocol === "https:" || url.protocol === "http:" ? url : null;
+}
+
+function formatGitHubLinkLabel(url: URL): string {
+  const segments = url.pathname.split("/").filter(Boolean);
+  const item = parseGitHubItemPath(url);
+  if (item) {
+    return segments.length === 4 && !url.search && !url.hash ? `#${item.number}` : url.href;
+  }
+  if (segments.length === 2) {
+    return segments.map((segment) => decodeGitHubPathSegment(segment) ?? segment).join("/");
+  }
+  if (segments[2] === "blob" && segments.length > 4) {
+    const filename = decodeGitHubPathSegment(segments.at(-1) ?? "");
+    if (filename) {
+      return filename;
+    }
+  }
+  const fallbackSegments = segments.length > 2 ? segments.slice(2) : segments;
+  const path = fallbackSegments.map((segment) => decodeGitHubPathSegment(segment) ?? segment);
+  return ["github.com", ...path].join("/");
 }
 
 function isFileLinkBoundaryBefore(value: string, index: number): boolean {

--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -77,14 +77,9 @@ function interactiveOwner(): {
     scrollLeft: { configurable: true, value: 0, writable: true },
     scrollWidth: { configurable: true, value: 300 },
   });
+  owner.addEventListener("click", handleMarkdownTableInteraction);
   enhanceMarkdownTables(owner);
   return { owner, shell, viewport };
-}
-
-function markdownTableInteractionEvent(target: Element): Event {
-  const event = new MouseEvent("click", { bubbles: true });
-  Object.defineProperty(event, "target", { value: target });
-  return event;
 }
 
 describe("Markdown table interactions", () => {
@@ -174,8 +169,7 @@ describe("Markdown table interactions", () => {
     vi.useFakeTimers();
     const { owner } = interactiveOwner();
     const copy = owner.querySelector<HTMLButtonElement>(".markdown-table__copy")!;
-
-    handleMarkdownTableInteraction(markdownTableInteractionEvent(copy));
+    copy.click();
 
     expect(writeText).toHaveBeenCalledWith("Name\tValue\nAlpha\tOne");
     await vi.advanceTimersByTimeAsync(0);
@@ -190,8 +184,7 @@ describe("Markdown table interactions", () => {
     const { owner } = interactiveOwner();
     const expand = owner.querySelector<HTMLButtonElement>(".markdown-table__expand")!;
     expand.focus();
-
-    handleMarkdownTableInteraction(markdownTableInteractionEvent(expand));
+    expand.click();
 
     const dialog = document.querySelector<HTMLDialogElement>(".markdown-table-dialog")!;
     expect(dialog.hasAttribute("open")).toBe(true);
@@ -212,10 +205,7 @@ describe("Markdown table interactions", () => {
     expect(document.querySelector(".markdown-table-dialog")).toBeNull();
     expect(document.activeElement).toBe(expand);
 
-    // Reopen through the handler like every other interaction here: the file
-    // runs in the isolated lane, so no shared-graph document listener exists
-    // to service a raw click().
-    handleMarkdownTableInteraction(markdownTableInteractionEvent(expand));
+    expand.click();
     const reopenedDialog = document.querySelector<HTMLDialogElement>(".markdown-table-dialog")!;
 
     reopenedDialog.querySelector<HTMLButtonElement>(".markdown-table-dialog__close")!.click();


### PR DESCRIPTION
Related: #125753

## What Problem This Solves

Resolves two persistent Control UI CI regressions first visible in [main run 32129796108](https://github.com/openclaw/openclaw/actions/runs/32129796108) and [PR run 32129658101](https://github.com/openclaw/openclaw/actions/runs/32129658101): startup JavaScript exceeded the pre-regression gzip ceiling, and the isolated Markdown-table test could not reopen its dialog because its raw click had no owner-local delegated listener.

#125800 made `main` green by directly calling the table handler and raising the recorded startup baseline. Current Linux `main` still measured 344,406 B, 61 B above the earlier 344,345 B ceiling. This PR restores real startup margin without changing the committed baseline and replaces the test-only direct call with the production click ownership boundary.

## Why This Change Was Made

GitHub Markdown label formatting now lives with the Markdown parser that consumes it instead of the eagerly loaded hovercard target module. Markdown-table tests install the same owner-level click delegation used by chat and Custodian surfaces, then drive copy, expand, dismiss, reopen, close, and focus restoration through bubbling clicks.

No config repair, budget, tolerance, or baseline file is changed. AI-assisted; the complete diff and behavior were independently inspected and verified.

## User Impact

No visible behavior changes. The Control UI retains GitHub link labels and Markdown-table interactions while shipping a smaller startup graph and deterministic isolated tests.

## Evidence

- Original failures: [main build/test run 32129796108](https://github.com/openclaw/openclaw/actions/runs/32129796108), [blocking PR run 32129658101](https://github.com/openclaw/openclaw/actions/runs/32129658101)
- Current-main Linux measurement before this repair: 344,406 B startup JS gzip in [run 32142493672](https://github.com/openclaw/openclaw/actions/runs/32142493672)
- Local exact-main build before/after: 343,652 B → 343,524 B (−128 B), 12 startup JS requests unchanged
- `node scripts/run-vitest.mjs ui/src/components/markdown-tables.test.ts ui/src/components/markdown-links.test.ts ui/src/components/github-link-hovercard.test.ts` — 112 passed
- `pnpm test:ui` — 694 files, 9,947 passed, 1 skipped
- `pnpm ui:build` plus `node --import tsx scripts/check-control-ui-performance.mts --json` — no violations
- `node scripts/check-changed.mjs -- ui/src/components/github-link-target.ts ui/src/components/markdown-parser.ts ui/src/components/markdown-tables.test.ts` — passed
- Fresh Codex autoreview (`--mode uncommitted`) — no accepted/actionable findings
- `config/control-ui-startup-budget-baseline.json` unchanged (`sha256 04f9e4194aef1ff4107372f6afb9cab9edaacd602281f19372eb0e4d21a38f90`)
- Production LOC: +27/−30 (net −3); tests: +4/−12 (net −8)

Visual proof is not applicable: rendered UI behavior and styling are unchanged.
