### PR TITLE
fix(tui): show interrupted runs after reconnect

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -178,7 +178,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     const setActivityStatus = vi.fn();
     const loadHistory = vi.fn<() => Promise<TuiHistoryLoadResult>>(async () => ({
       loaded: true,
-      inFlightRunId: null,
+      runOutcome: { state: "completed" },
     }));
     const localRunIds = new Set<string>();
     const localBtwRunIds = new Set<string>();
@@ -275,7 +275,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   it("preserves an in-flight run when gap-recovery history reports it is still active", async () => {
     const { state, loadHistory, reconcileHistoryAfterGap, setActivityStatus } =
       createHandlersHarness({ state: { activeChatRunId: "run-gap" } });
-    loadHistory.mockResolvedValue({ loaded: true, inFlightRunId: "run-gap" });
+    loadHistory.mockResolvedValue({
+      loaded: true,
+      runOutcome: { state: "active", runId: "run-gap" },
+    });
 
     reconcileHistoryAfterGap();
 
@@ -324,13 +327,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.startTool).not.toHaveBeenCalled();
   });
 
-  it("retires a reconnect run immediately when history proves it is absent", () => {
+  it("renders one reconnect interruption and ignores repeated or late terminal output", () => {
     const { state, reconnectStreamingWatchdog, handleChatEvent, chatLog, setActivityStatus } =
       createHandlersHarness({
         state: { activeChatRunId: "run-stale", activityStatus: "streaming" },
       });
 
-    reconnectStreamingWatchdog(null);
+    reconnectStreamingWatchdog({ state: "interrupted" });
+    reconnectStreamingWatchdog({ state: "interrupted" });
     handleChatEvent({
       runId: "run-stale",
       message: { role: "assistant", content: "late stale output" },
@@ -338,7 +342,44 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(state.activeChatRunId).toBeNull();
     expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(chatLog.addSystem).toHaveBeenCalledTimes(1);
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run aborted");
     expect(chatLog.updateAssistant).not.toHaveBeenCalled();
+  });
+
+  it("renders a reconnect failure through the terminal error presenter", () => {
+    const { state, reconnectStreamingWatchdog, chatLog, setActivityStatus } = createHandlersHarness(
+      {
+        state: { activeChatRunId: "run-failed", activityStatus: "streaming" },
+      },
+    );
+
+    reconnectStreamingWatchdog({ state: "failed", errorMessage: "provider failed" });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider failed");
+  });
+
+  it.each([
+    { name: "completed", outcome: { state: "completed" } as const },
+    { name: "active", outcome: { state: "active", runId: "run-current" } as const },
+  ])("reconciles a $name reconnect outcome without an interruption", ({ outcome }) => {
+    const { state, reconnectStreamingWatchdog, handleChatEvent, chatLog, setActivityStatus } =
+      createHandlersHarness({
+        state: { activeChatRunId: "run-current", activityStatus: "streaming" },
+      });
+    handleChatEvent({ runId: "run-current", message: { content: "partial" } });
+    chatLog.addSystem.mockClear();
+    setActivityStatus.mockClear();
+
+    reconnectStreamingWatchdog(outcome);
+
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run aborted");
+    expect(state.activeChatRunId).toBe(outcome.state === "active" ? "run-current" : null);
+    expect(setActivityStatus).toHaveBeenLastCalledWith(
+      outcome.state === "active" ? "streaming" : "idle",
+    );
   });
 
   it("processes tool events when runId matches activeChatRunId (even if sessionId differs)", () => {
@@ -2291,7 +2332,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     loadHistory.mockImplementation(async () => {
       expect(state.activeChatRunId).toBeNull();
       expect(state.activityStatus).toBe("idle");
-      return { loaded: true, inFlightRunId: null };
+      return { loaded: true, runOutcome: { state: "completed" } };
     });
 
     handleChatEvent({
@@ -3172,7 +3213,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       expect(loadHistory).toHaveBeenCalledTimes(1);
       expect(state.sessionInfo.updatedAt).toBe(249);
 
-      resolveFirstHistory?.({ loaded: true, inFlightRunId: null });
+      resolveFirstHistory?.({
+        loaded: true,
+        runOutcome: { state: "completed" },
+      });
       await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
     });
 
@@ -3265,7 +3309,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
       loadHistory.mockReturnValueOnce(result);
       return (loaded: boolean, inFlightRunId: string | null = null) =>
-        resolveHistory(loaded ? { loaded: true, inFlightRunId } : { loaded: false });
+        resolveHistory(
+          loaded
+            ? {
+                loaded: true,
+                runOutcome: inFlightRunId
+                  ? { state: "active", runId: inFlightRunId }
+                  : { state: "completed" },
+              }
+            : { loaded: false },
+        );
     };
 
     it("waits for terminal persistence before rebuilding an active external run", async () => {
@@ -3440,7 +3493,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       loadHistory.mockImplementationOnce(async () => {
         state.activeChatRunId = "run-reset";
         state.activityStatus = "streaming";
-        return { loaded: true as const, inFlightRunId: "run-reset" };
+        return {
+          loaded: true as const,
+          runOutcome: { state: "active" as const, runId: "run-reset" },
+        };
       });
 
       handleSessionsChangedEvent({
@@ -3723,7 +3779,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     handlers.dispose?.();
   });
 
-  it("resets to idle when reconnect drops an active run that is no longer tracked", () => {
+  it("keeps an untracked reconnect run visible until history resolves it", () => {
     const { state, setActivityStatus, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
@@ -3732,9 +3788,9 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.reconnectStreamingWatchdog();
 
-    expect(state.activeChatRunId).toBeNull();
-    expect(state.activityStatus).toBe("idle");
-    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+    expect(state.activeChatRunId).toBe("run-stale");
+    expect(state.activityStatus).toBe("streaming");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
 
     handlers.dispose?.();
   });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -176,6 +176,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (!matchesSelectedTuiSession(state, evt)) {
       return;
     }
+    if (runCoordinator.isHistoryTerminalDiagnosticRun(evt.runId)) {
+      return;
+    }
     const isSequencedGatewayEvent = Number.isSafeInteger(evt.seq) && (evt.seq ?? -1) >= 0;
     if (
       runCoordinator.isRetiredOrphanRun(evt.runId) &&

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -9,6 +9,7 @@ import {
   waitForFixtureLogEntry,
   type FixtureLogEntry,
 } from "./tui-pty-harness-assertion-test-support.js";
+import { TUI_PTY_RECONNECT_FIXTURE } from "./tui-pty-reconnect-fixture-test-support.js";
 import { TUI_PTY_RENDERING_FIXTURE_SCRIPT } from "./tui-pty-rendering-test-support.js";
 import { TUI_PTY_RESET_FIXTURE } from "./tui-pty-reset-fixture-test-support.js";
 import { TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT } from "./tui-pty-subscription-fixture-test-support.js";
@@ -98,8 +99,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         ...(thinkingLabel ? [{ id: "fixture-thinking", label: thinkingLabel }] : []),
         ...(safeThinkingLabel ? [{ id: "fixture-thinking-safe", label: safeThinkingLabel }] : []),
       ];
-      const disconnectReason = process.env.OPENCLAW_TUI_PTY_DISCONNECT_REASON;
-      let disconnectPending = disconnectReason !== undefined;
+      ${TUI_PTY_RECONNECT_FIXTURE.variables}
       const enablePickerFixture = process.env.OPENCLAW_TUI_PTY_PICKER_FIXTURE === "1";
       const pickerModelValue = process.env.OPENCLAW_TUI_PTY_PICKER_MODEL_VALUE ?? "fixture-provider/fixture-model-2";
       const pickerModelName = process.env.OPENCLAW_TUI_PTY_PICKER_MODEL_NAME ?? "Fixture 2";
@@ -194,14 +194,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         onDisconnected?: TuiBackend["onDisconnected"];
         onGap?: TuiBackend["onGap"];
 
-        emitDisconnect() {
-          if (!disconnectPending || disconnectReason === undefined) {
-            return;
-          }
-          disconnectPending = false;
-          record("disconnect");
-          this.onDisconnected?.(disconnectReason);
-        }
+        ${TUI_PTY_RECONNECT_FIXTURE.disconnect}
 
         start() {
           if (pendingPluginApproval) {
@@ -224,6 +217,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
             thinking: opts.thinking,
           });
           const runId = opts.runId ?? "run-pty-fixture";
+          ${TUI_PTY_RECONNECT_FIXTURE.sendChat}
           if (opts.message.startsWith("live reply dedupe proof: ")) {
             const reply = opts.message.endsWith("first") ? "TUI_LIVE_FIRST" : "TUI_LIVE_SECOND";
             const userSequence = ++liveReplySequence;
@@ -463,6 +457,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           record("loadHistory", { sessionKey });
           const gapHistory = loadGapHistory(sessionKey);
           if (gapHistory) { return gapHistory; }
+          ${TUI_PTY_RECONNECT_FIXTURE.loadHistory}
           if (liveReplyHistory.length > 0) {
             return { messages: [...liveReplyHistory] };
           }

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -15,6 +15,7 @@ import {
   waitForSynchronizedFrameRows,
   type FixtureLogEntry,
 } from "./tui-pty-harness-fixture-test-support.js";
+import { exerciseTuiReconnectOutcomes } from "./tui-pty-reconnect-test-support.js";
 import {
   exerciseStreamingRendering,
   exerciseToolCardRendering,
@@ -235,6 +236,12 @@ describe.sequential("TUI PTY harness", () => {
       expect(output.indexOf("starting up")).toBeGreaterThanOrEqual(0);
       expect(output.indexOf("starting up")).toBeLessThan(output.indexOf("local ready | idle"));
     },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "reconciles active and terminal runs after reconnect history",
+    () => exerciseTuiReconnectOutcomes(STARTUP_TIMEOUT_MS),
     STARTUP_TEST_TIMEOUT_MS,
   );
 

--- a/src/tui/tui-pty-reconnect-fixture-test-support.ts
+++ b/src/tui/tui-pty-reconnect-fixture-test-support.ts
@@ -1,0 +1,69 @@
+// Injects reconnect terminal outcomes into the generated real-runTui PTY backend.
+export const TUI_PTY_RECONNECT_FIXTURE = {
+  variables: `
+      const disconnectReason = process.env.OPENCLAW_TUI_PTY_DISCONNECT_REASON;
+      const reconnectOutcome = process.env.OPENCLAW_TUI_PTY_RECONNECT_OUTCOME;
+      let disconnectPending = disconnectReason === undefined
+        ? 0
+        : Number(process.env.OPENCLAW_TUI_PTY_DISCONNECT_COUNT ?? 1);
+      let reconnectHistoryReady = false;
+      let reconnectRunId = "run-reconnect-fixture";
+  `,
+  disconnect: `
+        emitDisconnect() {
+          if (disconnectPending <= 0 || disconnectReason === undefined) return;
+          disconnectPending -= 1;
+          reconnectHistoryReady = true;
+          record("disconnect");
+          this.onDisconnected?.(disconnectReason);
+          setTimeout(() => this.onConnected?.(), 50);
+        }
+  `,
+  sendChat: `
+          if (reconnectOutcome && opts.message === "reconnect terminal proof") {
+            reconnectRunId = runId;
+            queueMicrotask(() => this.onEvent?.({
+              event: "chat",
+              payload: {
+                runId,
+                sessionKey: opts.sessionKey,
+                state: "delta",
+                message: { role: "assistant", content: "PTY_RECONNECT_PARTIAL" },
+              },
+            }));
+            if (reconnectOutcome === "interrupted" || reconnectOutcome === "failed") {
+              setTimeout(() => this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  state: "final",
+                  message: { role: "assistant", content: "PTY_LATE_RECONNECT_FINAL" },
+                },
+              }), 400);
+            }
+            return { runId };
+          }
+  `,
+  loadHistory: `
+          if (reconnectHistoryReady && reconnectOutcome) {
+            const sessionInfo = {
+              ...sessionEntry(sessionKey),
+              ...(reconnectOutcome === "interrupted"
+                ? { status: "killed", abortedLastRun: true }
+                : reconnectOutcome === "failed"
+                  ? { status: "failed", lastRunError: "fixture provider failed" }
+                  : { status: reconnectOutcome === "completed" ? "done" : "running" }),
+            };
+            return {
+              sessionInfo,
+              messages: reconnectOutcome === "completed"
+                ? [{ role: "assistant", content: "PTY_RECONNECT_COMPLETED" }]
+                : [],
+              ...(reconnectOutcome === "active"
+                ? { inFlightRun: { runId: reconnectRunId, text: "PTY_RECONNECT_PARTIAL" } }
+                : {}),
+            };
+          }
+  `,
+} as const;

--- a/src/tui/tui-pty-reconnect-test-support.ts
+++ b/src/tui/tui-pty-reconnect-test-support.ts
@@ -1,0 +1,50 @@
+import { expect } from "vitest";
+import { sleep } from "../utils/sleep.js";
+import {
+  startTuiFixture,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-fixture-test-support.js";
+
+const RECONNECT_CASES = [
+  { outcome: "interrupted", marker: "run aborted", activity: "idle" },
+  { outcome: "failed", marker: "run error: fixture provider failed", activity: "error" },
+  { outcome: "completed", marker: "PTY_RECONNECT_COMPLETED", activity: "idle" },
+  { outcome: "active", marker: "PTY_RECONNECT_PARTIAL", activity: "streaming" },
+] as const;
+
+export async function exerciseTuiReconnectOutcomes(timeoutMs: number): Promise<void> {
+  await Promise.all(
+    RECONNECT_CASES.map(async ({ outcome, marker, activity }) => {
+      const fixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_DISCONNECT_REASON: "fixture transport loss",
+          OPENCLAW_TUI_PTY_RECONNECT_OUTCOME: outcome,
+        },
+      });
+      try {
+        await fixture.run.waitForOutput("local ready", timeoutMs);
+        await fixture.run.write("reconnect terminal proof\r", { delay: false });
+        await fixture.run.waitForOutput("PTY_RECONNECT_PARTIAL", timeoutMs);
+        await fixture.run.write("/gateway-status\r", { delay: false });
+        await fixture.run.waitForOutput("gateway reconnected after transport loss", timeoutMs);
+        await waitForSynchronizedFrameRows(
+          fixture.run,
+          (rows) =>
+            rows.some((row) => row.includes(marker)) &&
+            rows.some((row) => row.includes(`| ${activity}`) || row.includes(`${activity} •`)),
+          timeoutMs,
+        );
+        await sleep(500);
+        const frame = await waitForSynchronizedFrameRows(
+          fixture.run,
+          (rows) => rows.some((row) => row.includes(marker)),
+          timeoutMs,
+        );
+        expect(frame.join("\n")).not.toContain("PTY_LATE_RECONNECT_FINAL");
+        expect(frame.join("\n").includes("run aborted")).toBe(outcome === "interrupted");
+      } finally {
+        await fixture.cleanup();
+      }
+    }),
+  );
+}

--- a/src/tui/tui-run-lifecycle.ts
+++ b/src/tui/tui-run-lifecycle.ts
@@ -9,7 +9,7 @@ import {
   getPendingSubmitAcceptedRunId,
   hasPendingSubmit,
 } from "./tui-submit-state.js";
-import type { AgentEvent, TuiStateAccess } from "./tui-types.js";
+import type { AgentEvent, TuiHistoryRunOutcome, TuiStateAccess } from "./tui-types.js";
 
 const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
 const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
@@ -244,7 +244,7 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
     flushPendingHistoryRefreshIfIdle();
   };
 
-  const reconnectStreamingWatchdog = (historyInFlightRunId?: string | null) => {
+  const reconnectStreamingWatchdog = (runOutcome?: TuiHistoryRunOutcome) => {
     clearStreamingWatchdog();
     const activeRunId = state.activeChatRunId;
     if (!activeRunId) {
@@ -252,20 +252,24 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
       clearStaleStreamingIfNoTrackedRunRemains();
       return;
     }
-    if (historyInFlightRunId === null) {
-      runCoordinator.noteFinalizedRun(activeRunId, { displayedFinal: true });
-      state.activeChatRunId = null;
+    if (runOutcome && runOutcome.state !== "active") {
+      if (runOutcome.state === "failed") {
+        runCoordinator.notePersistedRun(activeRunId);
+        renderTerminalRunError({ runId: activeRunId, errorMessage: runOutcome.errorMessage });
+        return;
+      }
+      if (runOutcome.state === "interrupted") {
+        chatLog.addSystem("run aborted");
+        liveTerminalErrorMessages.set(activeRunId, "run aborted");
+      }
+      runCoordinator.notePersistedRun(activeRunId);
       clearPendingTerminalLifecycleError(activeRunId);
-      setActivityStatus("idle");
-      flushPendingHistoryRefreshIfIdle();
-      return;
-    }
-    if (!sessionRuns.has(activeRunId)) {
-      reconnectPendingRunId = null;
-      state.activeChatRunId = null;
-      state.activityStatus = "idle";
-      setActivityStatus("idle");
-      flushPendingHistoryRefreshIfIdle();
+      finalizeRun({
+        runId: activeRunId,
+        wasActiveRun: true,
+        status: "idle",
+        displayedFinal: runOutcome.state === "interrupted",
+      });
       return;
     }
     reconnectPendingRunId = activeRunId;

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -2502,7 +2502,36 @@ describe("tui session actions", () => {
     expect(chatLog.addUser).toHaveBeenCalledWith("persisted");
     expect(chatLog.addPendingUser).toHaveBeenCalledWith("optimistic-run", "optimistic prompt");
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("reply");
-    expect(result).toEqual({ loaded: true, inFlightRunId: null });
+    expect(result).toEqual({
+      loaded: true,
+      runOutcome: { state: "completed" },
+    });
+  });
+
+  it.each([
+    {
+      name: "interrupted",
+      sessionInfo: { status: "killed", abortedLastRun: true },
+      runOutcome: { state: "interrupted" },
+    },
+    {
+      name: "failed",
+      sessionInfo: { status: "failed", lastRunError: "provider failed" },
+      runOutcome: { state: "failed", errorMessage: "provider failed" },
+    },
+  ])("projects a closed $name history outcome", async ({ sessionInfo, runOutcome }) => {
+    const { loadHistory } = createTestSessionActions({
+      client: makeTuiBackend({
+        listSessions: vi.fn(),
+        loadHistory: vi.fn().mockResolvedValue({
+          sessionId: "session-main",
+          sessionInfo,
+          messages: [],
+        }),
+      }),
+    });
+
+    await expect(loadHistory()).resolves.toEqual({ loaded: true, runOutcome });
   });
 
   it("restores attachment-only assistant rows from history without exposing references", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -3,6 +3,7 @@ import type { TUI } from "@earendil-works/pi-tui";
 import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { resolveSessionInfoModelSelection } from "../agents/model-selection-display.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import {
   agentSessionKeysMatchByRequestKey,
   normalizeAgentId,
@@ -427,7 +428,8 @@ export function createSessionActions(context: SessionActionContext) {
       const record = history as {
         messages?: unknown[];
         sessionId?: string;
-        sessionInfo?: SessionInfoEntry;
+        sessionInfo?: SessionInfoEntry &
+          Partial<Pick<SessionEntry, "abortedLastRun" | "lastRunError" | "status">>;
         defaults?: SessionInfoDefaults;
         thinkingLevel?: string;
         fastMode?: FastMode;
@@ -557,20 +559,12 @@ export function createSessionActions(context: SessionActionContext) {
             : [],
         ),
       );
-      // Restore a run still streaming for this session+agent that the gateway
-      // reports as in-flight. Its live deltas were delivered to a per-agent key
-      // we stopped watching after switching away, so the persisted history above
-      // does not contain it; render the partial and re-adopt the run so further
-      // deltas (now that this session is active again) continue it.
       const inFlightRunId = formatPrimitiveString(record.inFlightRun?.runId, "");
       const inFlightText = formatPrimitiveString(record.inFlightRun?.text, "");
       if (inFlightRunId) {
-        // Render any buffered partial (embedded runtimes); Codex has none mid-run.
         if (inFlightText) {
           chatLog.updateAssistant(inFlightText, inFlightRunId);
         }
-        // Adopt the run regardless so its status shows `streaming` (not idle) and
-        // its completion is handled here instead of an unowned error path.
         state.activeChatRunId = inFlightRunId;
         setActivityStatus("streaming");
       }
@@ -582,7 +576,18 @@ export function createSessionActions(context: SessionActionContext) {
       }
       void rememberSessionKey?.(state.currentSessionKey);
       tui.requestRender(true);
-      return { loaded: true, inFlightRunId: inFlightRunId || null };
+      const status = sessionInfo?.status;
+      const runOutcome = inFlightRunId
+        ? ({ state: "active", runId: inFlightRunId } as const)
+        : status === "failed" || status === "timeout"
+          ? ({
+              state: "failed",
+              errorMessage: sessionInfo?.lastRunError ?? `session run ${status}`,
+            } as const)
+          : status === "killed" || sessionInfo?.abortedLastRun === true
+            ? ({ state: "interrupted" } as const)
+            : ({ state: "completed" } as const);
+      return { loaded: true, runOutcome };
     } catch (err) {
       if (!isCurrentLoad()) {
         return { loaded: false };

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it, vi } from "vitest";
 import { createTuiRunIdTracker, TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
 import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
 
+const completedHistory = {
+  loaded: true,
+  runOutcome: { state: "completed" },
+} as const;
+const activeHistory = (runId: string): TuiHistoryLoadResult => ({
+  loaded: true,
+  runOutcome: { state: "active", runId },
+});
+
 function makeState(overrides?: Partial<TuiStateAccess>): TuiStateAccess {
   return {
     agentDefaultId: "main",
@@ -37,8 +46,7 @@ function createCoordinator(overrides?: {
   const loadHistory = vi.fn<() => Promise<TuiHistoryLoadResult>>(
     overrides?.loadHistory ??
       (async () => ({
-        loaded: true,
-        inFlightRunId: null,
+        ...completedHistory,
       })),
   );
   const finalizeHistoryOwnedRun = vi.fn();
@@ -202,16 +210,16 @@ describe("TuiSessionRunCoordinator", () => {
     coordinator.queueHistoryReload();
     expect(loadHistory).toHaveBeenCalledTimes(1);
 
-    resolveHistory?.({ loaded: true, inFlightRunId: null });
+    resolveHistory?.(completedHistory);
     await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
     expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
       runId: "run-first",
-      result: { loaded: true, inFlightRunId: null },
+      result: completedHistory,
       previouslyDisplayed: false,
     });
     expect(replayHistoryRunEvent).toHaveBeenCalledWith(deferredEvent);
 
-    resolveHistory?.({ loaded: true, inFlightRunId: null });
+    resolveHistory?.(completedHistory);
   });
 
   it("does not finalize a gap-recovery run when authoritative history fails", async () => {
@@ -236,12 +244,12 @@ describe("TuiSessionRunCoordinator", () => {
     await vi.waitFor(() => expect(finalizeHistoryOwnedRun).toHaveBeenCalledTimes(2));
     expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
       runId: "run-first",
-      result: { loaded: true, inFlightRunId: null },
+      result: completedHistory,
       previouslyDisplayed: false,
     });
     expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
       runId: "run-second",
-      result: { loaded: true, inFlightRunId: null },
+      result: completedHistory,
       previouslyDisplayed: false,
     });
   });
@@ -264,15 +272,15 @@ describe("TuiSessionRunCoordinator", () => {
       coordinator.queueGapHistoryReload(["run-gap"]);
       expect(loadHistory).toHaveBeenCalledTimes(1);
 
-      resolveHistory?.({ loaded: true, inFlightRunId });
+      resolveHistory?.(inFlightRunId ? activeHistory(inFlightRunId) : completedHistory);
       await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
       expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
 
-      resolveHistory?.({ loaded: true, inFlightRunId: null });
+      resolveHistory?.(completedHistory);
       await vi.waitFor(() => expect(finalizeHistoryOwnedRun).toHaveBeenCalledTimes(1));
       expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
         runId: "run-gap",
-        result: { loaded: true, inFlightRunId: null },
+        result: completedHistory,
         previouslyDisplayed: false,
       });
     },
@@ -289,7 +297,7 @@ describe("TuiSessionRunCoordinator", () => {
 
     coordinator.queueHistoryReload(["run-stale"], ["run-stale"]);
     coordinator.clear();
-    resolveHistory?.({ loaded: true, inFlightRunId: null });
+    resolveHistory?.(completedHistory);
 
     await vi.waitFor(() => {
       expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -147,6 +147,14 @@ export class TuiSessionRunCoordinator {
     );
   }
 
+  isHistoryTerminalDiagnosticRun(runId: string): boolean {
+    return (
+      this.finalizedRuns.has(runId) &&
+      this.persistedTerminalRunIds.has(runId) &&
+      this.liveTerminalErrorMessages.has(runId)
+    );
+  }
+
   resolveMostRecentPromotableRun(): string | undefined {
     const pendingRunId = getPendingSubmitAcceptedRunId(this.context.state);
     let nextRunId: string | undefined;
@@ -308,7 +316,10 @@ export class TuiSessionRunCoordinator {
         const historyOwned = Boolean(flags & HISTORY_RELOAD_OWNED);
         const previouslyDisplayed = Boolean(flags & HISTORY_RELOAD_DISPLAYED);
         const gapRecovery = Boolean(flags & HISTORY_RELOAD_GAP_RECOVERY);
-        const restoredInFlight = result.loaded && result.inFlightRunId === runId;
+        const restoredInFlight =
+          result.loaded &&
+          result.runOutcome.state === "active" &&
+          result.runOutcome.runId === runId;
 
         if (historyOwned && !restoredInFlight && (result.loaded || !gapRecovery)) {
           this.context.finalizeHistoryOwnedRun({ runId, result, previouslyDisplayed });

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -31,8 +31,13 @@ export type TuiResult = {
   systemAgentMessage?: string;
 };
 
+export type TuiHistoryRunOutcome =
+  | { state: "active"; runId: string }
+  | { state: "completed" | "interrupted" }
+  | { state: "failed"; errorMessage: string };
+
 export type TuiHistoryLoadResult =
-  | { loaded: true; inFlightRunId: string | null }
+  | { loaded: true; runOutcome: TuiHistoryRunOutcome }
   | { loaded: false };
 
 export type ChatEvent = {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -81,6 +81,7 @@ import { createTuiTaskSuggestionController } from "./tui-task-suggestions.js";
 import type {
   SessionInfo,
   SessionScope,
+  TuiHistoryRunOutcome,
   TuiOptions,
   TuiResult,
   TuiStateAccess,
@@ -804,7 +805,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   let lastActivityStatus = "idle";
   let invalidateSessionRunOwnership: () => void = () => undefined;
   let notifySessionChanged: () => void = () => undefined;
-  let retireHistoryAbsentRun: (_runId: string) => void = () => undefined;
+  let reconcileReconnectRun: (_outcome: TuiHistoryRunOutcome) => void = () => undefined;
 
   const state: TuiStateAccess & {
     sessionGeneration: number;
@@ -1448,17 +1449,12 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     setSession,
     abortActive,
   } = sessionActions;
-  const loadHistory = async (options?: { retireMissingReconnectRun?: boolean }) => {
+  const loadHistory = async (reconcileReconnect = false) => {
     const activeRunAtStart = state.activeChatRunId;
     const result = await loadHistorySnapshot();
     if (result.loaded) {
-      if (
-        options?.retireMissingReconnectRun === true &&
-        activeRunAtStart &&
-        !result.inFlightRunId &&
-        activeRunAtStart === state.activeChatRunId
-      ) {
-        retireHistoryAbsentRun(activeRunAtStart);
+      if (reconcileReconnect && activeRunAtStart && activeRunAtStart === state.activeChatRunId) {
+        reconcileReconnectRun(result.runOutcome);
       }
       restoreConnectionNotices();
       tui.requestRender();
@@ -1510,7 +1506,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     forgetLocalBtwRunId: localBtwRunIds.forget,
     clearLocalBtwRunIds: localBtwRunIds.clear,
   });
-  retireHistoryAbsentRun = () => reconnectStreamingWatchdog(null);
+  reconcileReconnectRun = reconnectStreamingWatchdog;
   invalidateSessionRunOwnership = () => {
     disposeEventHandlers();
     state.activeChatRunId = null;
@@ -1825,7 +1821,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       if (!ownsConnection()) {
         return;
       }
-      await loadHistory({ retireMissingReconnectRun: reconnected });
+      await loadHistory(reconnected);
       if (!ownsConnection()) {
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a TUI run interrupted during a transport restart could silently return to idle after reconnect, without telling the operator that the durable run was killed or aborted.

Before this change, missing `inFlightRun` history was treated as a completed run and marked already displayed; a late final event could then replace the partial output. After this change, reconnect history returns a closed active/completed/interrupted/failed outcome, and the TUI renders the durable terminal result while ignoring late events from the retired run.

## Why This Change Was Made

Session history is the owner of the durable run outcome after reconnect. The history loader now returns that typed outcome to the existing run lifecycle, which performs one canonical reconciliation and records terminal diagnostics so later events cannot overwrite them. This removes the previous null-as-completed inference rather than adding a downstream guard or retry path.

Production LOC: +62/-38 (net +24) | Tests/test support: +248/-34

The runtime growth expresses the closed reconnect outcome and its lifecycle handoff. Test-support growth adds the deterministic real-`runTui()` backend matrix for active, completed, interrupted, and failed history.

## User Impact

After a reconnect, operators now see `run aborted` for interrupted work or the durable error for a failed run. Completed history restores normally, active history remains streaming, and late terminal events from a retired run do not erase the visible outcome.

## Evidence

Rebased onto `6629ca32dfcd1b008890440161bda9f551bf3ff1`.

### Before

Current main reconnects to idle with no abort diagnostic and accepts the late final event:

![Before: reconnect idles without an abort diagnostic and shows the late final](https://github.com/user-attachments/assets/6622dc3a-f263-4ddc-9648-179a235000f4)

### After

The rebased head renders the durable interrupted outcome and suppresses the late final:

![After: reconnect renders run aborted and remains idle](https://github.com/user-attachments/assets/8edca1c0-50e2-4b7e-9753-4843cab978b1)

Both images are inspected synchronized frames from the same deterministic real-`runTui()` PTY fixture. They contain fixture-only data and were uploaded through GitHub's attachment API.

- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-session-run-coordinator.test.ts` — 249 lifecycle tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` — 65 real-terminal tests passed, including the active/completed/interrupted/failed reconnect matrix and late-final suppression.
- Source-blind behavior contract `/tmp/openclaw-pr3-behavior-contract.md` — every user task and anti-cheat probe passed; live Gateway/provider behavior is explicitly out of scope for this deterministic fake-backend proof.
- `node scripts/check-changed.mjs` — formatting, typechecks, type-aware lint, dead-code, database-first, architecture, and import-cycle gates passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.
