### PR TITLE
fix(skills): back off failed collection reviews instead of retrying every tick

### DIFF
--- a/src/skills/workshop/collection-review-state.ts
+++ b/src/skills/workshop/collection-review-state.ts
@@ -23,6 +23,7 @@ import {
 
 const CURATOR_STATE_ID = 1;
 const REVIEW_INTERVAL_MS = 24 * 60 * 60_000;
+const REVIEW_FAILURE_RETRY_MS = 60 * 60_000;
 const REVIEW_CLAIM_MS = 11 * 60_000;
 // Bound per-workspace history so unattended daily maintenance cannot grow state forever.
 const SKILL_COLLECTION_REVIEW_RETENTION_COUNT = 90;
@@ -63,25 +64,30 @@ export async function withSkillCollectionReviewClaim<T>(
   );
 }
 
-function parseReviewTimes(value: string | null | undefined): Record<string, number> {
+function parseReviewState(value: string | null | undefined): Record<string, unknown> {
   if (!value) {
     return {};
   }
   try {
-    const reviews = asNullableRecord(JSON.parse(value))?.collectionReviewSuccess;
-    const record = asNullableRecord(reviews);
-    if (!record) {
-      return {};
-    }
-    return Object.fromEntries(
-      Object.entries(record).filter(
-        (entry): entry is [string, number] =>
-          typeof entry[1] === "number" && Number.isFinite(entry[1]),
-      ),
-    );
+    return { ...asNullableRecord(JSON.parse(value)) };
   } catch {
     return {};
   }
+}
+
+function parseReviewTimes(
+  state: Record<string, unknown>,
+  field: "collectionReviewAttempts" | "collectionReviewSuccess",
+): Record<string, number> {
+  const record = asNullableRecord(state[field]);
+  return record
+    ? Object.fromEntries(
+        Object.entries(record).filter(
+          (entry): entry is [string, number] =>
+            typeof entry[1] === "number" && Number.isFinite(entry[1]),
+        ),
+      )
+    : {};
 }
 
 export function isSkillCollectionReviewDue(
@@ -98,8 +104,14 @@ export function isSkillCollectionReviewDue(
       .select("last_result_json")
       .where("id", "=", CURATOR_STATE_ID),
   );
-  const lastSuccess = parseReviewTimes(state?.last_result_json)[workspaceKey(workspaceDir)];
-  return lastSuccess === undefined || nowMs - lastSuccess >= REVIEW_INTERVAL_MS;
+  const reviewState = parseReviewState(state?.last_result_json);
+  const key = workspaceKey(workspaceDir);
+  const lastSuccess = parseReviewTimes(reviewState, "collectionReviewSuccess")[key];
+  if (lastSuccess !== undefined && nowMs - lastSuccess < REVIEW_INTERVAL_MS) {
+    return false;
+  }
+  const lastAttempt = parseReviewTimes(reviewState, "collectionReviewAttempts")[key];
+  return lastAttempt === undefined || nowMs - lastAttempt >= REVIEW_FAILURE_RETRY_MS;
 }
 
 function parseStoredNames(value: string, field: string): string[] {
@@ -168,9 +180,17 @@ export function recordSkillCollectionReviewSuccess(
         .select("last_result_json")
         .where("id", "=", CURATOR_STATE_ID),
     );
-    const reviews = parseReviewTimes(current?.last_result_json);
-    reviews[workspaceKey(workspaceDir)] = nowMs;
-    const lastResultJson = JSON.stringify({ collectionReviewSuccess: reviews });
+    const reviewState = parseReviewState(current?.last_result_json);
+    const key = workspaceKey(workspaceDir);
+    const successes = parseReviewTimes(reviewState, "collectionReviewSuccess");
+    const attempts = parseReviewTimes(reviewState, "collectionReviewAttempts");
+    successes[key] = nowMs;
+    attempts[key] = nowMs;
+    const lastResultJson = JSON.stringify({
+      ...reviewState,
+      collectionReviewAttempts: attempts,
+      collectionReviewSuccess: successes,
+    });
     executeSqliteQuerySync(
       db,
       kysely
@@ -219,4 +239,49 @@ export function recordSkillCollectionReviewSuccess(
         .where("review_id", "not in", retainedReviewIds),
     );
   }, databaseOptions(options));
+}
+
+export function recordSkillCollectionReviewFailure(
+  workspaceDir: string,
+  nowMs: number,
+  error: unknown,
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<CollectionReviewDatabase>(db);
+    const current = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("skill_curator_state")
+        .select("last_result_json")
+        .where("id", "=", CURATOR_STATE_ID),
+    );
+    const reviewState = parseReviewState(current?.last_result_json);
+    const attempts = parseReviewTimes(reviewState, "collectionReviewAttempts");
+    attempts[workspaceKey(workspaceDir)] = nowMs;
+    const lastResultJson = JSON.stringify({
+      ...reviewState,
+      collectionReviewAttempts: attempts,
+    });
+    const lastError = String(error).slice(0, 2_000);
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .insertInto("skill_curator_state")
+        .values({
+          id: CURATOR_STATE_ID,
+          last_attempt_at_ms: nowMs,
+          last_success_at_ms: null,
+          last_error: lastError,
+          last_result_json: lastResultJson,
+        })
+        .onConflict((conflict) =>
+          conflict.column("id").doUpdateSet({
+            last_attempt_at_ms: nowMs,
+            last_error: lastError,
+            last_result_json: lastResultJson,
+          }),
+        ),
+    );
+  }, options);
 }

--- a/src/skills/workshop/collection-review-state.ts
+++ b/src/skills/workshop/collection-review-state.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import {
@@ -69,7 +70,7 @@ function parseReviewState(value: string | null | undefined): Record<string, unkn
     return {};
   }
   try {
-    return { ...asNullableRecord(JSON.parse(value)) };
+    return asNullableRecord(JSON.parse(value)) ?? {};
   } catch {
     return {};
   }
@@ -88,6 +89,53 @@ function parseReviewTimes(
         ),
       )
     : {};
+}
+
+function recordCollectionReviewState(
+  db: DatabaseSync,
+  workspaceDir: string,
+  nowMs: number,
+  lastError: string | null,
+) {
+  const kysely = getNodeSqliteKysely<CollectionReviewDatabase>(db);
+  const current = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("skill_curator_state")
+      .select("last_result_json")
+      .where("id", "=", CURATOR_STATE_ID),
+  );
+  const reviewState = parseReviewState(current?.last_result_json);
+  const key = workspaceKey(workspaceDir);
+  const lastResultJson = JSON.stringify({
+    ...reviewState,
+    collectionReviewAttempts: {
+      ...parseReviewTimes(reviewState, "collectionReviewAttempts"),
+      [key]: nowMs,
+    },
+    ...(lastError === null
+      ? {
+          collectionReviewSuccess: {
+            ...parseReviewTimes(reviewState, "collectionReviewSuccess"),
+            [key]: nowMs,
+          },
+        }
+      : {}),
+  });
+  const updatedState = {
+    last_attempt_at_ms: nowMs,
+    last_error: lastError,
+    last_result_json: lastResultJson,
+    ...(lastError === null ? { last_success_at_ms: nowMs } : {}),
+  };
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .insertInto("skill_curator_state")
+      .values({ id: CURATOR_STATE_ID, last_success_at_ms: null, ...updatedState })
+      .onConflict((conflict) => conflict.column("id").doUpdateSet(updatedState)),
+  );
+  return kysely;
 }
 
 export function isSkillCollectionReviewDue(
@@ -172,45 +220,7 @@ export function recordSkillCollectionReviewSuccess(
 ): void {
   ensureSkillWorkshopSchema(options);
   runOpenClawStateWriteTransaction(({ db }) => {
-    const kysely = getNodeSqliteKysely<CollectionReviewDatabase>(db);
-    const current = executeSqliteQueryTakeFirstSync(
-      db,
-      kysely
-        .selectFrom("skill_curator_state")
-        .select("last_result_json")
-        .where("id", "=", CURATOR_STATE_ID),
-    );
-    const reviewState = parseReviewState(current?.last_result_json);
-    const key = workspaceKey(workspaceDir);
-    const successes = parseReviewTimes(reviewState, "collectionReviewSuccess");
-    const attempts = parseReviewTimes(reviewState, "collectionReviewAttempts");
-    successes[key] = nowMs;
-    attempts[key] = nowMs;
-    const lastResultJson = JSON.stringify({
-      ...reviewState,
-      collectionReviewAttempts: attempts,
-      collectionReviewSuccess: successes,
-    });
-    executeSqliteQuerySync(
-      db,
-      kysely
-        .insertInto("skill_curator_state")
-        .values({
-          id: CURATOR_STATE_ID,
-          last_attempt_at_ms: nowMs,
-          last_success_at_ms: nowMs,
-          last_error: null,
-          last_result_json: lastResultJson,
-        })
-        .onConflict((conflict) =>
-          conflict.column("id").doUpdateSet({
-            last_attempt_at_ms: nowMs,
-            last_success_at_ms: nowMs,
-            last_error: null,
-            last_result_json: lastResultJson,
-          }),
-        ),
-    );
+    const kysely = recordCollectionReviewState(db, workspaceDir, nowMs, null);
     const resolvedWorkspaceDir = path.resolve(workspaceDir);
     executeSqliteQuerySync(
       db,
@@ -248,40 +258,6 @@ export function recordSkillCollectionReviewFailure(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    const kysely = getNodeSqliteKysely<CollectionReviewDatabase>(db);
-    const current = executeSqliteQueryTakeFirstSync(
-      db,
-      kysely
-        .selectFrom("skill_curator_state")
-        .select("last_result_json")
-        .where("id", "=", CURATOR_STATE_ID),
-    );
-    const reviewState = parseReviewState(current?.last_result_json);
-    const attempts = parseReviewTimes(reviewState, "collectionReviewAttempts");
-    attempts[workspaceKey(workspaceDir)] = nowMs;
-    const lastResultJson = JSON.stringify({
-      ...reviewState,
-      collectionReviewAttempts: attempts,
-    });
-    const lastError = String(error).slice(0, 2_000);
-    executeSqliteQuerySync(
-      db,
-      kysely
-        .insertInto("skill_curator_state")
-        .values({
-          id: CURATOR_STATE_ID,
-          last_attempt_at_ms: nowMs,
-          last_success_at_ms: null,
-          last_error: lastError,
-          last_result_json: lastResultJson,
-        })
-        .onConflict((conflict) =>
-          conflict.column("id").doUpdateSet({
-            last_attempt_at_ms: nowMs,
-            last_error: lastError,
-            last_result_json: lastResultJson,
-          }),
-        ),
-    );
+    recordCollectionReviewState(db, workspaceDir, nowMs, String(error).slice(0, 2_000));
   }, options);
 }

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -219,10 +219,44 @@ describe("skill collection review", () => {
 
   it("backs failed reviews off for one hour without delaying a later success", async () => {
     const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-backoff-");
+    const otherWorkspaceDir = await makeWorkspaceDir("openclaw-collection-review-other-");
     const nowMs = Date.UTC(2026, 7, 10);
+    const database = openOpenClawStateDatabase({ env: testState.env }).db;
 
-    recordSkillCollectionReviewFailure(workspaceDir, nowMs, new Error("oversized"), {
+    recordSkillCollectionReviewSuccess(
+      otherWorkspaceDir,
+      nowMs - 1,
+      { backupId: "other-workspace-backup", kept: [], written: [], dropped: [] },
+      { env: testState.env },
+    );
+    const otherWorkspaceState = database
+      .prepare("SELECT last_result_json FROM skill_curator_state WHERE id = 1")
+      .get() as { last_result_json: string };
+    database.prepare("UPDATE skill_curator_state SET last_result_json = ? WHERE id = 1").run(
+      JSON.stringify({
+        ...JSON.parse(otherWorkspaceState.last_result_json),
+        unrelated: { preserved: true },
+      }),
+    );
+
+    recordSkillCollectionReviewFailure(workspaceDir, nowMs, new Error("x".repeat(2_000)), {
       env: testState.env,
+    });
+    const failedState = database
+      .prepare("SELECT * FROM skill_curator_state WHERE id = 1")
+      .get() as {
+      last_attempt_at_ms: number;
+      last_error: string;
+      last_result_json: string;
+      last_success_at_ms: number;
+    };
+    expect(failedState.last_attempt_at_ms).toBe(nowMs);
+    expect(failedState.last_success_at_ms).toBe(nowMs - 1);
+    expect(failedState.last_error).toHaveLength(2_000);
+    expect(JSON.parse(failedState.last_result_json)).toMatchObject({
+      unrelated: { preserved: true },
+      collectionReviewSuccess: JSON.parse(otherWorkspaceState.last_result_json)
+        .collectionReviewSuccess,
     });
     expect(
       isSkillCollectionReviewDue(workspaceDir, nowMs + 59 * 60_000, { env: testState.env }),
@@ -230,6 +264,9 @@ describe("skill collection review", () => {
     expect(
       isSkillCollectionReviewDue(workspaceDir, nowMs + 60 * 60_000, { env: testState.env }),
     ).toBe(true);
+    expect(
+      isSkillCollectionReviewDue(otherWorkspaceDir, nowMs + 60 * 60_000, { env: testState.env }),
+    ).toBe(false);
 
     recordSkillCollectionReviewSuccess(
       workspaceDir,
@@ -242,6 +279,13 @@ describe("skill collection review", () => {
         env: testState.env,
       }),
     ).toBe(false);
+    const successfulState = database
+      .prepare("SELECT last_error, last_result_json FROM skill_curator_state WHERE id = 1")
+      .get() as { last_error: string | null; last_result_json: string };
+    expect(successfulState.last_error).toBeNull();
+    expect(JSON.parse(successfulState.last_result_json)).toMatchObject({
+      unrelated: { preserved: true },
+    });
   });
 
   it("leaves disabled and agent-filtered skills outside the editable collection", async () => {
@@ -540,6 +584,22 @@ describe("skill collection review", () => {
   it("claims a due workspace before dispatching the model", async () => {
     const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-claim-");
     await writeWorkspaceSkills(workspaceDir, [{ name: "useful", description: "Useful procedure" }]);
+    const database = openOpenClawStateDatabase({ env: testState.env }).db;
+    database
+      .prepare(
+        "INSERT INTO skill_curator_state (id, last_attempt_at_ms, last_success_at_ms, last_error, last_result_json) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(
+        1,
+        41,
+        23,
+        null,
+        JSON.stringify({
+          unrelated: { preserved: true },
+          collectionReviewAttempts: { "other-workspace": 41 },
+          collectionReviewSuccess: { "other-workspace": 23 },
+        }),
+      );
     let releaseReview: (() => void) | undefined;
     let markStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {
@@ -571,13 +631,33 @@ describe("skill collection review", () => {
     const first = runScheduledSkillCollectionReviews({ config, env: testState.env });
     await started;
     const secondError = vi.fn();
+    const reviewStateBeforeContention = database
+      .prepare("SELECT * FROM skill_curator_state WHERE id = 1")
+      .get();
 
-    await runScheduledSkillCollectionReviews({ config, env: testState.env, onError: secondError });
+    try {
+      await runScheduledSkillCollectionReviews({
+        config,
+        env: testState.env,
+        onError: secondError,
+      });
 
-    expect(secondError).toHaveBeenCalledOnce();
-    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
-    releaseReview?.();
-    await first;
+      expect(secondError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "OPENCLAW_STATE_LEASE_TIMEOUT" }),
+        workspaceDir,
+      );
+      expect(runWithGatewayIndependentRootWorkAdmission).toHaveBeenCalledOnce();
+      expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+      expect(database.prepare("SELECT * FROM skill_curator_state WHERE id = 1").get()).toEqual(
+        reviewStateBeforeContention,
+      );
+      expect(isSkillCollectionReviewDue(workspaceDir, Date.now(), { env: testState.env })).toBe(
+        true,
+      );
+    } finally {
+      releaseReview?.();
+      await first;
+    }
   });
 
   it("admits and reports each workspace independently", async () => {
@@ -652,6 +732,40 @@ describe("skill collection review", () => {
       expect.objectContaining({ message: expect.stringContaining("review limit") }),
       workspaceDir,
     );
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("reports both a review failure and a failed attempt-state write", async () => {
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-state-failure-");
+    await writeWorkspaceSkills(workspaceDir, [
+      { name: "oversized", description: "Oversized procedure", body: "x".repeat(240_001) },
+    ]);
+    openOpenClawStateDatabase({ env: testState.env }).db.exec(`
+      CREATE TRIGGER reject_collection_review_state
+      BEFORE INSERT ON skill_curator_state
+      BEGIN
+        SELECT RAISE(FAIL, 'collection review state unavailable');
+      END
+    `);
+    const onError = vi.fn();
+
+    await runScheduledSkillCollectionReviews({
+      config: {
+        agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
+      env: testState.env,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    const [error, failedWorkspaceDir] = onError.mock.calls[0]!;
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(error.errors).toEqual([
+      expect.objectContaining({ message: expect.stringContaining("review limit") }),
+      expect.objectContaining({ message: expect.stringContaining("state unavailable") }),
+    ]);
+    expect(failedWorkspaceDir).toBe(workspaceDir);
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -16,6 +16,7 @@ import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
 import {
   isSkillCollectionReviewDue,
+  recordSkillCollectionReviewFailure,
   recordSkillCollectionReviewSuccess,
 } from "./collection-review-state.js";
 import { runScheduledSkillCollectionReviews } from "./collection-review.js";
@@ -214,6 +215,33 @@ describe("skill collection review", () => {
         )
         .get(path.resolve(workspaceDir)),
     ).toEqual({ count: 90, oldest: 1 });
+  });
+
+  it("backs failed reviews off for one hour without delaying a later success", async () => {
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-backoff-");
+    const nowMs = Date.UTC(2026, 7, 10);
+
+    recordSkillCollectionReviewFailure(workspaceDir, nowMs, new Error("oversized"), {
+      env: testState.env,
+    });
+    expect(
+      isSkillCollectionReviewDue(workspaceDir, nowMs + 59 * 60_000, { env: testState.env }),
+    ).toBe(false);
+    expect(
+      isSkillCollectionReviewDue(workspaceDir, nowMs + 60 * 60_000, { env: testState.env }),
+    ).toBe(true);
+
+    recordSkillCollectionReviewSuccess(
+      workspaceDir,
+      nowMs + 60 * 60_000,
+      { backupId: "backup-after-retry", kept: [], written: [], dropped: [] },
+      { env: testState.env },
+    );
+    expect(
+      isSkillCollectionReviewDue(workspaceDir, nowMs + 24 * 60 * 60_000, {
+        env: testState.env,
+      }),
+    ).toBe(false);
   });
 
   it("leaves disabled and agent-filtered skills outside the editable collection", async () => {
@@ -608,15 +636,18 @@ describe("skill collection review", () => {
     ]);
 
     const onError = vi.fn();
-    await runScheduledSkillCollectionReviews({
+    const params = {
       config: {
         agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
-        skills: { workshop: { autonomous: { mode: "auto" } } },
+        skills: { workshop: { autonomous: { mode: "auto" as const } } },
       },
       env: testState.env,
       onError,
-    });
+    };
+    await runScheduledSkillCollectionReviews(params);
+    await runScheduledSkillCollectionReviews(params);
 
+    expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("review limit") }),
       workspaceDir,

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -29,6 +29,7 @@ import {
 import { listWritableSkillCollection } from "./collection-reconcile.js";
 import {
   isSkillCollectionReviewDue,
+  recordSkillCollectionReviewFailure,
   withSkillCollectionReviewClaim,
 } from "./collection-review-state.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
@@ -219,6 +220,18 @@ export async function runScheduledSkillCollectionReviews(params: {
         stateOptions,
       );
     } catch (error) {
+      try {
+        recordSkillCollectionReviewFailure(workspaceDir, Date.now(), error, stateOptions);
+      } catch (recordError) {
+        reportError(
+          new AggregateError(
+            [error, recordError],
+            `Skill collection review failed and its retry backoff could not be recorded for ${workspaceDir}.`,
+          ),
+          workspaceDir,
+        );
+        continue;
+      }
       reportError(error, workspaceDir);
     }
   }

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -199,39 +199,48 @@ export async function runScheduledSkillCollectionReviews(params: {
           if (!isSkillCollectionReviewDue(workspaceDir, nowMs, stateOptions)) {
             return;
           }
-          const reviewModels = agentIds.map((id) =>
-            resolveCollectionReviewIdentity(params.config, id, params.env),
-          );
-          const reviewModel = reviewModels[0]!;
-          if (
-            reviewModels.some(
-              (candidate) =>
-                candidate.provider !== reviewModel.provider ||
-                candidate.model !== reviewModel.model ||
-                candidate.authIdentity !== reviewModel.authIdentity,
-            )
-          ) {
-            throw new Error("Shared workspace agents use different collection-review identities.");
+          // Persist failures before releasing the claim; acquisition failures
+          // never enter this callback and must not count as review attempts.
+          try {
+            const reviewModels = agentIds.map((id) =>
+              resolveCollectionReviewIdentity(params.config, id, params.env),
+            );
+            const reviewModel = reviewModels[0]!;
+            if (
+              reviewModels.some(
+                (candidate) =>
+                  candidate.provider !== reviewModel.provider ||
+                  candidate.model !== reviewModel.model ||
+                  candidate.authIdentity !== reviewModel.authIdentity,
+              )
+            ) {
+              throw new Error(
+                "Shared workspace agents use different collection-review identities.",
+              );
+            }
+            await runWithGatewayIndependentRootWorkAdmission(async () => {
+              await runSkillCollectionReview({ ...params, agentId, agentIds, workspaceDir });
+            });
+          } catch (error) {
+            try {
+              recordSkillCollectionReviewFailure(workspaceDir, Date.now(), error, stateOptions);
+            } catch (recordError) {
+              reportError(
+                new AggregateError(
+                  [error, recordError],
+                  `Skill collection review failed and its retry backoff could not be recorded for ${workspaceDir}.`,
+                  { cause: error },
+                ),
+                workspaceDir,
+              );
+              return;
+            }
+            throw error;
           }
-          await runWithGatewayIndependentRootWorkAdmission(async () => {
-            await runSkillCollectionReview({ ...params, agentId, agentIds, workspaceDir });
-          });
         },
         stateOptions,
       );
     } catch (error) {
-      try {
-        recordSkillCollectionReviewFailure(workspaceDir, Date.now(), error, stateOptions);
-      } catch (recordError) {
-        reportError(
-          new AggregateError(
-            [error, recordError],
-            `Skill collection review failed and its retry backoff could not be recorded for ${workspaceDir}.`,
-          ),
-          workspaceDir,
-        );
-        continue;
-      }
       reportError(error, workspaceDir);
     }
   }


### PR DESCRIPTION
Closes #125307

## What Problem This Solves

`isSkillCollectionReviewDue` is driven purely by recorded successes. A collection review that throws (bad workspace, provider/model error, I/O) records nothing, so the workspace stays permanently due and the scheduler retries it on every tick — a hot loop of repeated model spend, error-log spam, and claim-lease churn until a run happens to succeed. The success writer also serialized only its own key into `last_result_json`, clobbering unrelated fields.

## Why This Change Was Made

Failure attempts are now recorded (`collectionReviewAttempts` alongside `collectionReviewSuccess`, plus a 2000-character-bounded `last_error`), and due-ness requires both the existing 24-hour success interval and a one-hour failure retry backoff. A single state-owner writer preserves previously parsed state, so unrelated curator fields and other workspaces' review history survive both failure and success.

Crucially, failure persistence happens only inside an acquired review claim, before that claim is released. A second scheduler pass that loses the existing zero-wait SQLite lease reports `OPENCLAW_STATE_LEASE_TIMEOUT` without calling the provider/model, writing an attempt or `last_error`, changing the existing curator row, or suppressing the later legitimate review. If recording an actual review failure also fails, the runner reports an `AggregateError` containing both failures.

## User Impact

A persistently failing skills workspace becomes eligible for another review after about an hour instead of immediately on every scheduler pass; successful reviews retain their existing 24-hour cadence. `skill_curator_state` carries bounded evidence for genuine review failures, while ordinary concurrent-claim contention leaves persisted curator state unchanged. No config or database-schema changes.

This PR is AI-assisted. I reviewed the implementation and understand the shipped behavior.

## Evidence

- Exact concurrent-claim regression was first applied to the original contributor head and failed because the losing scheduler changed `last_attempt_at_ms`, `last_error`, and the raw curator JSON; the identical regression passes on the maintainer follow-up and proves one model call, unchanged complete SQLite state, and continued review eligibility.
- `node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts` — **15 passed**, covering zero-wait claim contention, 59-/60-minute failure eligibility, the 24-hour success cadence, independent workspaces, unrelated JSON preservation, bounded errors, and aggregate write failures.
- `node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts src/skills/workshop/collection-reconcile.test.ts src/skills/workshop/curator.test.ts src/state/openclaw-state-lease.test.ts src/gateway/server-maintenance.test.ts` — **70 passed** across the scheduler, review owner, reconciliation siblings, curator state, and real SQLite lease.
- `node scripts/run-vitest.mjs src/skills/workshop` — **234 passed** across 21 Workshop test files.
- `node scripts/check-changed.mjs -- src/skills/workshop/collection-review-state.ts src/skills/workshop/collection-review.ts src/skills/workshop/collection-review.test.ts` — full changed-file formatting, production/test typechecking, lint, schema, database-first, sidecar, import-cycle, and auth guards passed on an isolated Linux runner.
- `git diff --check` — passed. Fresh global Codex autoreview in branch mode against `origin/main` — clean; TruffleHog preflight passed.
- Production: **+124/-61 (net +63)**; tests: **+153/-8 (net +145)**. The new durable bounded-backoff capability accounts for cumulative production growth; the maintainer follow-up consolidates state ownership and is itself **production +88/-103 (net -15)**.

## Runtime proof (2026-08-19) — live dev gateway, three-phase backoff demonstration

Isolated dev gateway built from the original contributor head (`b12301d47c7`), scratch `OPENCLAW_STATE_DIR`, port 19796 — never the operator's gateway. `skills.workshop.autonomous.mode: "auto"`, one seeded workspace skill (verified discoverable via `openclaw skills list` before the tick), and the review model pointed at a local logging mock so **every provider request is independently recorded** — "no review ran" is proven by an empty request log, not by absence of gateway log lines.

**Phase 1 — failure recorded at the owner.** The +5min scheduled review ran, hit the mock (3 attempts), failed, and recorded the failure in `skill_curator_state`:

```
requests.log: 3× POST /chat/completions → HTTP 500
[health] skill collection review failed for /tmp/oc-skills-state/workspace: HTTP 500: mock upstream failure
skill_curator_state: last_attempt_at_ms=1787084784138 last_success_at_ms=None
  last_error=FailoverError: HTTP 500: mock upstream failure
  last_result_json={"collectionReviewAttempts":{"5575c66e…":1787084784138}}
```

**Phase 2 — backoff holds.** A fresh gateway started inside the 1-hour retry window; its +5min review tick issued **zero provider requests** (request log empty through the full window) and the state row is byte-identical — the failed review was not re-run. On pre-fix `main`, due-ness keys solely off `lastSuccess`, so this tick would have re-run the failing review.

**Phase 3 — eligibility returns.** `collectionReviewAttempts` wound back 2h (beyond `REVIEW_FAILURE_RETRY_MS`), gateway restarted: the +5min tick ran the review again (3 fresh mock requests) and recorded the new attempt (`last_attempt_at_ms=1787085605019`), proving failed workspaces are retried after the backoff rather than abandoned.

The three-phase isolated-gateway trace was recorded on the original contributor head; the maintainer follow-up's additional zero-wait contention contract is proven separately by the deterministic real-SQLite scheduler-boundary regression above, not by a new two-gateway live recording.
