### PR TITLE
fix(cli): preserve plugin overlays in immutable deployments

### DIFF
--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -328,6 +328,23 @@ const readRuntimePostBuildStamp = (deps: RunNodeRuntimeRequirementDeps) => {
   return readJsonStamp(deps.runtimePostBuildStampPath, deps);
 };
 
+const isImmutableGitDeployment = (deps: RunNodeRequirementDeps) => {
+  try {
+    const deployment = JSON.parse(
+      deps.fs.readFileSync(path.join(deps.cwd, "deployment.json"), "utf8"),
+    );
+    // Deployment ownership outranks source-checkout freshness. A mismatched
+    // checkout must fail closed instead of repairing manager-owned artifacts.
+    return (
+      deployment?.kind === "git" &&
+      typeof deployment.sourceHead === "string" &&
+      deployment.sourceHead.trim().length > 0
+    );
+  } catch {
+    return false;
+  }
+};
+
 const hasSourceMtimeChanged = (stampMtime: number, deps: RunNodeRequirementDeps) => {
   let latestSourceMtime: number | null = null;
   for (const sourceRoot of deps.sourceRoots) {
@@ -770,6 +787,19 @@ const RUNTIME_POSTBUILD_REASON_LABELS = {
 const formatBuildReason = (reason: BuildRequirement["reason"]) => BUILD_REASON_LABELS[reason];
 const formatRuntimePostBuildReason = (reason: RuntimePostBuildRequirement["reason"]) =>
   RUNTIME_POSTBUILD_REASON_LABELS[reason];
+
+const refuseImmutableDeploymentMutation = async (
+  deps: RunNodeDeps,
+  artifactKind: "build" | "runtime",
+  reason: string,
+) => {
+  const message =
+    `[openclaw] Cannot regenerate ${artifactKind} artifacts in an immutable deployment (${reason}). ` +
+    "Replace this deployment with a complete release, then use its installed `openclaw` command or run `node openclaw.mjs ...` from that release.\n";
+  deps.stderr.write(message);
+  deps.outputTee?.write(message);
+  return await closeRunNodeOutputTee(deps, 1);
+};
 
 const SIGNAL_EXIT_CODES = {
   SIGINT: 130,
@@ -1597,6 +1627,14 @@ export async function runNodeMain(params: RunNodeMainParams = {}): Promise<numbe
       return await closeRunNodeOutputTee(deps, exitCode);
     }
     const buildRequirement = resolveBuildRequirement(deps);
+    const immutableDeployment = isImmutableGitDeployment(deps);
+    if (immutableDeployment && buildRequirement.shouldBuild) {
+      return await refuseImmutableDeploymentMutation(
+        deps,
+        "build",
+        formatBuildReason(buildRequirement.reason),
+      );
+    }
     const qaReportScript = resolveQaReportSourceScript(deps, buildRequirement);
     if (qaReportScript) {
       const reportName = qaReportScript === "qa-parity-report.ts" ? "parity" : "coverage";
@@ -1609,6 +1647,13 @@ export async function runNodeMain(params: RunNodeMainParams = {}): Promise<numbe
     }
     if (!buildRequirement.shouldBuild) {
       const runtimePostBuildRequirement = resolveRuntimePostBuildRequirement(deps);
+      if (immutableDeployment && runtimePostBuildRequirement.shouldSync) {
+        return await refuseImmutableDeploymentMutation(
+          deps,
+          "runtime",
+          formatRuntimePostBuildReason(runtimePostBuildRequirement.reason),
+        );
+      }
       if (
         runtimePostBuildRequirement.shouldSync &&
         !shouldSkipWatchRuntimeSync(deps, runtimePostBuildRequirement)

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -33,6 +33,7 @@ const ROOT_SRC = "src/index.ts";
 const ROOT_TSCONFIG = "tsconfig.json";
 const ROOT_PACKAGE = "package.json";
 const ROOT_TSDOWN = "tsdown.config.ts";
+const DEPLOYMENT_MANIFEST = "deployment.json";
 const GENERATED_PLUGIN_ASSET_BUNDLE = "extensions/demo/src/host/assets/view.bundle.js";
 const GENERATED_PLUGIN_ASSET_BUNDLE_HASH = "extensions/demo/src/host/assets/.bundle.hash";
 const DIST_ENTRY = "dist/entry.js";
@@ -191,6 +192,18 @@ function statusCommandSpawn() {
   return [process.execPath, "openclaw.mjs", "status"];
 }
 
+function gatewayStatusCommandSpawn() {
+  return [
+    process.execPath,
+    "openclaw.mjs",
+    "gateway",
+    "status",
+    "--deep",
+    "--require-rpc",
+    "--json",
+  ];
+}
+
 function resolvePath(tmp: string, relativePath: string) {
   return path.join(tmp, relativePath);
 }
@@ -276,6 +289,12 @@ async function setupStampedProject(
   });
 }
 
+async function writeImmutableDeploymentManifest(tmp: string): Promise<void> {
+  await writeProjectFiles(tmp, {
+    [DEPLOYMENT_MANIFEST]: `${JSON.stringify({ kind: "git", sourceHead: "a".repeat(40) })}\n`,
+  });
+}
+
 function createSpawnRecorder(
   options: {
     gitHead?: string;
@@ -356,6 +375,7 @@ type RunCommandParams = {
   args?: string[];
   spawn: (cmd: string, args: string[]) => ReturnType<typeof createExitedProcess>;
   spawnSync?: (cmd: string, args: string[]) => { status: number; stdout: string };
+  stderr?: NodeJS.WriteStream;
   env?: Record<string, string>;
   runRuntimePostBuild?: (params?: {
     cwd?: string;
@@ -1120,6 +1140,74 @@ describe("run-node script", () => {
     expect(spawnCalls).toEqual([statusCommandSpawn()]);
     expect(runRuntimePostBuild).not.toHaveBeenCalled();
   });
+
+  it("runs current immutable deployment artifacts without refreshing them", async ({ tmp }) => {
+    await setupStampedProject(tmp, {
+      files: { [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n' },
+      oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+    });
+    await writeImmutableDeploymentManifest(tmp);
+
+    const runRuntimePostBuild = vi.fn();
+    const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder();
+    const exitCode = await runStatusCommand({
+      tmp,
+      args: ["gateway", "status", "--deep", "--require-rpc", "--json"],
+      spawn,
+      spawnSync,
+      runRuntimePostBuild,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(spawnCalls).toEqual([gatewayStatusCommandSpawn()]);
+    expect(runRuntimePostBuild).not.toHaveBeenCalled();
+  });
+
+  for (const { label, missingPath, expectedReason } of [
+    {
+      label: "build output",
+      missingPath: BUILD_STAMP,
+      expectedReason: "build stamp missing",
+    },
+    {
+      label: "runtime postbuild output",
+      missingPath: DIST_OPENCLAW_ALIAS_PACKAGE,
+      expectedReason: "required runtime postbuild output missing",
+    },
+  ]) {
+    it(`refuses to regenerate missing ${label} in an immutable deployment`, async ({ tmp }) => {
+      await setupStampedProject(tmp, {
+        files: { [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n' },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+      });
+      await writeImmutableDeploymentManifest(tmp);
+      await fs.rm(resolvePath(tmp, missingPath));
+
+      const stderrChunks: string[] = [];
+      const stderr = {
+        write: (chunk: string | Buffer) => {
+          stderrChunks.push(String(chunk));
+          return true;
+        },
+      } as unknown as NodeJS.WriteStream;
+      const runRuntimePostBuild = vi.fn();
+      const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder();
+      const exitCode = await runStatusCommand({
+        tmp,
+        args: ["gateway", "status", "--deep", "--require-rpc", "--json"],
+        spawn,
+        spawnSync,
+        stderr,
+        runRuntimePostBuild,
+      });
+
+      expect(exitCode).toBe(1);
+      expect(spawnCalls).toEqual([]);
+      expect(runRuntimePostBuild).not.toHaveBeenCalled();
+      expect(stderrChunks.join("")).toContain(expectedReason);
+      expect(stderrChunks.join("")).toContain("node openclaw.mjs");
+    });
+  }
 
   it("restages runtime artifacts when runtime metadata is dirty", async ({ tmp }) => {
     await setupStampedProject(tmp, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an immutable, manager-owned git deployment could have its packed external plugin overlays destroyed when a CLI probe encountered stale or missing build/runtime artifacts.

The concrete incident occurred during a Clawstudio deployment: a gateway status probe entered the development runner, which treated the deployed tree as a mutable source checkout and admitted runtime-postbuild regeneration. That regeneration replaced deployment-owned plugin artifacts instead of preserving the release exactly as installed.

## Why This Change Was Made

The runner now treats generic git deployment metadata (`deployment.json` with `kind: "git"` and a non-empty `sourceHead`) as the authoritative ownership boundary. Complete immutable deployments run without modification; incomplete ones fail visibly before any build or runtime sync. Ordinary developer checkouts keep their existing automatic repair behavior.

## User Impact

Operators can run CLI and gateway status commands against immutable deployments without risking mutation of packed plugin overlays. Damaged immutable releases now produce a clear replacement instruction instead of attempting an unsafe in-place repair.

## Evidence

- Regression proof: the pre-fix test failed because the runner admitted the destructive mutation path.
- `pnpm test src/infra/run-node.test.ts`: 74/74 passed after rebasing onto current `origin/main`.
- Source-blind isolated CLI validation: 3/3 passed — complete immutable unchanged/succeeded, damaged immutable unchanged/refused, damaged mutable checkout repaired.
- `pnpm build`: passed on the verified patch content.
- `pnpm check:changed`: all selected guards, formatting, script erasability, core-test typecheck, script typecheck, and core-test lint passed. The final targeted script lint hit the known unrelated `typescript(no-redundant-type-constituents)` gap on unchanged `NodeJS.Signals`/`NodeJS.Timeout` lines in `scripts/run-node.mts`; the same diagnostic reproduces in untouched `scripts/test-docker-all.mts:85,88`.
- Fresh autoreview through P1: no accepted/actionable findings; correctness 0.87.
- `git diff --check`: clean.
- Production/tooling: +45/-0. Tests: +88/-0.

AI-assisted; the implementation and evidence were reviewed before publication.
