### PR TITLE
fix(sessions): preserve committed results across reconnects

### DIFF
--- a/extensions/sms/src/ingress-spool.test.ts
+++ b/extensions/sms/src/ingress-spool.test.ts
@@ -96,6 +96,9 @@ afterEach(async () => {
 describe("createSmsIngressSpool", () => {
   it("retries acknowledged MMS provider outages before adopting later same-sender messages", async () => {
     const stateDir = await createStateDir();
+    let now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    disposers.push(() => nowSpy.mockRestore());
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     disposers.push(() => {
       vi.unstubAllEnvs();
@@ -232,14 +235,14 @@ describe("createSmsIngressSpool", () => {
     const firstResponse = await postSignedCallback(mediaCallback);
     expect(firstResponse.status).toBe(200);
     expect(firstResponse.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
-    await vi.waitFor(async () => {
-      expect(mediaRequests).toBe(1);
-      expect(await queue.listPending()).toEqual([
-        expect.objectContaining({ id: messageSid, lastError: expect.stringContaining("HTTP 429") }),
-      ]);
-    });
+    await spool.waitForIdle();
+    expect(mediaRequests).toBe(1);
+    expect(await queue.listPending()).toEqual([
+      expect.objectContaining({ id: messageSid, lastError: expect.stringContaining("HTTP 429") }),
+    ]);
     expect(deliveries).toEqual([]);
 
+    now += 1_000;
     const secondSid = `SM${"d".repeat(32)}`;
     const secondResponse = await postSignedCallback({
       ...form(secondSid),
@@ -247,7 +250,7 @@ describe("createSmsIngressSpool", () => {
       Body: "the later message",
     });
     expect(secondResponse.status).toBe(200);
-    await vi.waitFor(() => expect(deliveries).toHaveLength(2), { timeout: 5_000 });
+    await spool.waitForIdle();
     expect(deliveries).toEqual([
       { id: messageSid, body: "keep this attachment", attachments: 1 },
       { id: secondSid, body: "the later message", attachments: 0 },

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -629,6 +629,9 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       respond(false, undefined, created.error);
       return;
     }
+    if (created.postCommit.status === "failed") {
+      runError = errorShape(ErrorCodes.UNAVAILABLE, formatErrorMessage(created.postCommit.error));
+    }
     registerCreatedSessionCategory(normalizeOptionalString(p.category), context);
     const createdWorktree = sessionWorktree
       ? {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1686,19 +1686,34 @@ test("sessions.create preserves a committed worktree when initial-turn setup fai
     new Error("synthetic post-commit initial-turn failure"),
   );
   try {
-    await expect(
-      directSessionReq(
-        "sessions.create",
-        {
-          agentId: "main",
-          key,
-          message: "start the committed session",
-          worktree: true,
-          worktreeName: "post-commit-worktree",
+    const created = await directSessionReq<{
+      key: string;
+      runError: { code: string; message: string };
+      runStarted: boolean;
+      sessionId: string;
+    }>(
+      "sessions.create",
+      {
+        agentId: "main",
+        key,
+        message: "start the committed session",
+        worktree: true,
+        worktreeName: "post-commit-worktree",
+      },
+      { client: { connect: { scopes: ["operator.admin"] } } as never },
+    );
+    expect(created).toMatchObject({
+      ok: true,
+      payload: {
+        key,
+        runError: {
+          code: "UNAVAILABLE",
+          message: "synthetic post-commit initial-turn failure",
         },
-        { client: { connect: { scopes: ["operator.admin"] } } as never },
-      ),
-    ).rejects.toThrow("synthetic post-commit initial-turn failure");
+        runStarted: false,
+        sessionId: expect.any(String),
+      },
+    });
 
     expect(loadSessionEntry({ sessionKey: key, storePath })).toMatchObject({
       sessionId: expect.any(String),

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -255,7 +255,7 @@ type TrustedInitialSessionEntry = {
   pluginExtensions?: SessionEntry["pluginExtensions"];
 };
 
-type CreateGatewaySessionResult =
+type GatewaySessionCommitResult =
   | {
       ok: true;
       key: string;
@@ -265,6 +265,12 @@ type CreateGatewaySessionResult =
       resetExisting: boolean;
     }
   | { ok: false; error: ErrorShape };
+
+type CreateGatewaySessionResult =
+  | (Extract<GatewaySessionCommitResult, { ok: true }> & {
+      postCommit: { status: "completed" } | { status: "failed"; error: unknown };
+    })
+  | Extract<GatewaySessionCommitResult, { ok: false }>;
 
 export async function createGatewaySession(params: {
   cfg: OpenClawConfig;
@@ -740,6 +746,7 @@ export async function createGatewaySession(params: {
         entry: projectPublicSessionEntry(resetResult.entry),
         resolved: resetResult.resolved,
         resetExisting: true,
+        postCommit: { status: "completed" },
       };
     }
   }
@@ -759,7 +766,7 @@ export async function createGatewaySession(params: {
           parentSessionKey: canonicalParentSessionKey,
         }
       : undefined;
-  const createChildSession = async (): Promise<CreateGatewaySessionResult> => {
+  const createChildSession = async (): Promise<GatewaySessionCommitResult> => {
     params.commitGuard?.();
     let currentParentSessionEntry = parentSessionEntry;
     if (
@@ -1345,9 +1352,20 @@ export async function createGatewaySession(params: {
       }
     },
   });
-  if (result.ok && !result.resetExisting && createdContext) {
-    await params.afterCreate?.(createdContext);
+  if (!result.ok) {
+    return result;
   }
-  return result;
+  if (result.resetExisting || !createdContext || !params.afterCreate) {
+    return { ...result, postCommit: { status: "completed" } };
+  }
+  // The row, transcript, and prepared lifecycle are already durable here. A
+  // fallible initializer must report that committed identity instead of making
+  // callers infer that creation never happened and retry the key.
+  try {
+    await params.afterCreate(createdContext);
+    return { ...result, postCommit: { status: "completed" } };
+  } catch (error) {
+    return { ...result, postCommit: { status: "failed", error } };
+  }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -418,6 +418,11 @@ async function createSessionEntry(
           if (!result.ok) {
             throw new Error(result.error.message);
           }
+          if (result.postCommit.status === "failed") {
+            // Plugin initialization owns guarded rollback and recovery. Do not
+            // finalize an initializationPending row whose callback failed.
+            throw result.postCommit.error;
+          }
           created = result;
         }
         if (recovered && !finalEntryPatch) {

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -223,10 +223,12 @@ suite.define(() => {
           app.runtime?.context.navigate("activity");
         });
         await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
-        await page.locator(".activity-feed__people-trigger").click();
+        const activityPage = page.locator("openclaw-activity-page");
+        await expect.poll(() => activityPage.count()).toBe(1);
+        await activityPage.locator(".activity-feed__people-trigger").click();
         await expect
           .poll(() =>
-            page
+            activityPage
               .locator(
                 '.activity-feed__people-row[data-activity-person]:not([data-activity-person=""])',
               )
@@ -234,16 +236,17 @@ suite.define(() => {
           )
           .toBe(3);
         await page.keyboard.press("Escape");
-        const automationGroup = page.locator("[data-activity-automation-group]");
+        const automationGroup = activityPage.locator("[data-activity-automation-group]");
+        const sessionRows = activityPage.locator("[data-activity-session]");
         await expect.poll(() => automationGroup.count()).toBe(1);
         await expect.poll(() => automationGroup.getAttribute("aria-expanded")).toBe("false");
-        await expect.poll(() => page.locator("[data-activity-session]").count()).toBe(2);
+        await expect.poll(() => sessionRows.count()).toBe(2);
         await automationGroup.click();
-        await expect.poll(() => page.locator("[data-activity-session]").count()).toBe(5);
+        await expect.poll(() => sessionRows.count()).toBe(5);
         await automationGroup.click();
-        await expect.poll(() => page.locator("[data-activity-session]").count()).toBe(2);
+        await expect.poll(() => sessionRows.count()).toBe(2);
 
-        const liveRow = page.locator(`[data-activity-session="${releaseKey}"]`);
+        const liveRow = activityPage.locator(`[data-activity-session="${releaseKey}"]`);
         await expect.poll(() => liveRow.locator(".activity-feed__run-dot").count()).toBe(1);
         await expect
           .poll(() => liveRow.locator(".activity-feed__session-headline").textContent())
@@ -270,10 +273,12 @@ suite.define(() => {
           .poll(() => new URL(page.url()).searchParams.get("person"))
           .toBe("profile-alice");
         await expect
-          .poll(() => page.locator('[data-activity-identity="profile-alice"]').isVisible())
+          .poll(() => activityPage.locator('[data-activity-identity="profile-alice"]').isVisible())
           .toBe(true);
         await expect
-          .poll(() => page.locator(".activity-feed__viewing-list .activity-feed__session").count())
+          .poll(() =>
+            activityPage.locator(".activity-feed__viewing-list .activity-feed__session").count(),
+          )
           .toBe(2);
         await page.screenshot({
           animations: "disabled",

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -240,6 +240,7 @@ suite.define(() => {
         sessionKey,
       );
       expect(startupError).toContain("send outcome unknown");
+      await waitForCommittedChatRoute(page);
       const startupErrorAlert = page.locator(".chat-cloud-startup-error");
       await startupErrorAlert.waitFor({ state: "visible" });
       expect(await startupErrorAlert.textContent()).toContain("send outcome unknown");

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -201,9 +201,48 @@ suite.define(() => {
         code: "UNAVAILABLE",
         message: "send outcome unknown",
       });
-      await pollLocatorText(page.locator(".chat-cloud-startup-error")).toContain(
-        "send outcome unknown",
+      const startupError = await page.evaluate(
+        (key) =>
+          new Promise<string>((resolve, reject) => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: {
+                context: {
+                  cloudStartup: {
+                    get: (sessionKey: string) => { error?: string; phase: string } | null;
+                    subscribe: (listener: () => void) => () => void;
+                  };
+                };
+              };
+            };
+            const cloudStartup = app.runtime?.context.cloudStartup;
+            if (!cloudStartup) {
+              reject(new Error("cloud startup runtime unavailable"));
+              return;
+            }
+            let settled = false;
+            const subscription: { stop?: () => void } = {};
+            const resolveFailed = () => {
+              const status = cloudStartup.get(key);
+              if (settled || status?.phase !== "failed") {
+                return;
+              }
+              settled = true;
+              subscription.stop?.();
+              resolve(status.error ?? "");
+            };
+            subscription.stop = cloudStartup.subscribe(resolveFailed);
+            if (settled) {
+              subscription.stop();
+            } else {
+              resolveFailed();
+            }
+          }),
+        sessionKey,
       );
+      expect(startupError).toContain("send outcome unknown");
+      const startupErrorAlert = page.locator(".chat-cloud-startup-error");
+      await startupErrorAlert.waitFor({ state: "visible" });
+      expect(await startupErrorAlert.textContent()).toContain("send outcome unknown");
       await gateway.setMethodResponse("sessions.send", {
         runId: "run-reload-recovery",
         status: "started",

--- a/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
@@ -5,10 +5,21 @@ import { expect, it } from "vitest";
 import {
   createNewSessionPageE2eSuite,
   installMockGateway,
+  waitForCommittedNewSessionDraft,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
 const DURABLE_ATTACHMENT_CAP_BYTES = 25 * 1024 * 1024;
+
+type DurableWriteTeardownGlobal = typeof globalThis & {
+  durableWriteTeardown: {
+    blockNextRead: boolean;
+    blockedRead: boolean;
+    completedReads: number;
+    teardownActive: boolean;
+    teardownStartedWrite: boolean;
+  };
+};
 
 async function rawDraftMatches(
   page: Page,
@@ -129,28 +140,72 @@ suite.define(() => {
       const fileName = "favicon-32.png";
       const firstPage = await context.newPage();
       await firstPage.addInitScript(() => {
+        const originalTransaction = Object.getOwnPropertyDescriptor(
+          IDBDatabase.prototype,
+          "transaction",
+        )?.value as IDBDatabase["transaction"];
         const originalGet = Object.getOwnPropertyDescriptor(IDBObjectStore.prototype, "get")
           ?.value as IDBObjectStore["get"];
-        let blocked = false;
+        const state = globalThis as DurableWriteTeardownGlobal;
+        state.durableWriteTeardown = {
+          blockNextRead: false,
+          blockedRead: false,
+          completedReads: 0,
+          teardownActive: false,
+          teardownStartedWrite: false,
+        };
+        IDBDatabase.prototype.transaction = function (
+          this: IDBDatabase,
+          ...args: Parameters<IDBDatabase["transaction"]>
+        ) {
+          const [storeNames, mode] = args;
+          const names = typeof storeNames === "string" ? [storeNames] : Array.from(storeNames);
+          if (
+            state.durableWriteTeardown.teardownActive &&
+            mode === "readwrite" &&
+            names.includes("composerDrafts")
+          ) {
+            state.durableWriteTeardown.teardownStartedWrite = true;
+          }
+          return originalTransaction.apply(this, args);
+        } as IDBDatabase["transaction"];
         IDBObjectStore.prototype.get = function (query: IDBValidKey | IDBKeyRange) {
-          if (!blocked && this.name === "composerDrafts") {
-            blocked = true;
-            (globalThis as unknown as { firstDraftReadBlocked: boolean }).firstDraftReadBlocked =
-              true;
+          if (this.name !== "composerDrafts") {
+            return originalGet.call(this, query);
+          }
+          if (state.durableWriteTeardown.blockNextRead) {
+            state.durableWriteTeardown.blockNextRead = false;
+            state.durableWriteTeardown.blockedRead = true;
             return new EventTarget() as IDBRequest;
           }
-          return originalGet.call(this, query);
+          const request = originalGet.call(this, query);
+          request.addEventListener(
+            "success",
+            () => {
+              state.durableWriteTeardown.completedReads += 1;
+            },
+            { once: true },
+          );
+          return request;
         };
       });
       await installMockGateway(firstPage);
       await firstPage.goto(`${suite.server.baseUrl}new`);
+      await expect
+        .poll(() =>
+          firstPage.evaluate(
+            () => (globalThis as DurableWriteTeardownGlobal).durableWriteTeardown.completedReads,
+          ),
+        )
+        .toBeGreaterThan(0);
+      await firstPage.evaluate(() => {
+        (globalThis as DurableWriteTeardownGlobal).durableWriteTeardown.blockNextRead = true;
+      });
       await firstPage.locator(".new-session-page__message").fill(text);
       await expect
         .poll(() =>
           firstPage.evaluate(
-            () =>
-              (globalThis as unknown as { firstDraftReadBlocked?: boolean })
-                .firstDraftReadBlocked === true,
+            () => (globalThis as DurableWriteTeardownGlobal).durableWriteTeardown.blockedRead,
           ),
         )
         .toBe(true);
@@ -160,8 +215,23 @@ suite.define(() => {
         .setInputFiles(path.join(process.cwd(), "ui/public/favicon-32.png"));
       await firstPage.getByRole("button", { name: `Open image ${fileName}` }).waitFor();
       await firstPage.evaluate(() => {
+        const state = (globalThis as DurableWriteTeardownGlobal).durableWriteTeardown;
+        state.teardownActive = true;
+        // The next task closes this window before the 200 ms debounce can start a write.
+        globalThis.setTimeout(() => {
+          state.teardownActive = false;
+        }, 0);
         document.querySelector("openclaw-new-session-page")?.remove();
       });
+      await expect
+        .poll(() =>
+          firstPage.evaluate(
+            () =>
+              (globalThis as DurableWriteTeardownGlobal).durableWriteTeardown.teardownStartedWrite,
+          ),
+        )
+        .toBe(true);
+      await waitForCommittedNewSessionDraft(firstPage, text, 1);
       await firstPage.close();
 
       const restoredPage = await context.newPage();

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -687,12 +687,17 @@ suite.define(() => {
       await whereTrigger.click();
       await whereSelect.getByRole("button", { name: "Old node" }).click();
       expect(await page.locator("#new-session-detail-trigger").count()).toBe(0);
+      await expect
+        .poll(() => page.evaluate(() => document.activeElement?.id))
+        .toBe("new-session-where-trigger");
       await projectTrigger.click();
       const nodeCwd = projectSelect.getByLabel("Working directory");
+      await nodeCwd.waitFor({ state: "visible" });
       await expect.poll(() => nodeCwd.inputValue()).toBe("");
       await nodeCwd.fill(EXEC_ONLY_PICKED);
       await captureProjectUiProof(page, "node-path-picker.png");
       await nodeCwd.press("Enter");
+      await pollLocatorText(projectLabel).toBe("repo");
       expect(
         (await gateway.getRequests("fs.listDir")).filter(
           (request) => (request.params as { nodeId?: string } | undefined)?.nodeId === "old-node",

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -778,11 +778,16 @@ suite.define(() => {
       await whereTrigger.click();
       await whereSelect.getByRole("button", { name: "Old node" }).click();
       expect(await page.locator("#new-session-detail-trigger").count()).toBe(0);
+      await expect
+        .poll(() => page.evaluate(() => document.activeElement?.id))
+        .toBe("new-session-where-trigger");
       await projectTrigger.click();
       const nodeCwd = projectSelect.getByLabel("Working directory");
+      await nodeCwd.waitFor({ state: "visible" });
       await expect.poll(() => nodeCwd.inputValue()).toBe("");
       await nodeCwd.fill(EXEC_ONLY_PICKED);
       await nodeCwd.press("Enter");
+      await pollLocatorText(projectLabel).toBe("repo");
       expect(
         (await gateway.getRequests("fs.listDir")).filter(
           (request) => (request.params as { nodeId?: string } | undefined)?.nodeId === "old-node",

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -728,6 +728,7 @@ suite.define(() => {
 
       await pastePng(composer);
       await page.locator('.chat-attachment-thumb img[alt="Attachment preview"]').waitFor();
+      await waitForCommittedNewSessionDraft(page, "", 1);
       const agentDropdown = page.locator(".new-session-page__select--agent wa-dropdown");
       await page.locator(".new-session-page__select--agent .agent-select__trigger").click();
       await expect

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -43,6 +43,7 @@ export const NODE_HOME = "/Users/peter";
 export const NODE_PICKED = "/Users/peter/Projects";
 export const NODE_UNC = "\\\\server\\share\\repo";
 export const EXEC_ONLY_PICKED = "C:\\Users\\peter\\repo";
+const LOCATOR_TEXT_READ_TIMEOUT_MS = 500;
 const LOCATOR_TEXT_POLL_TIMEOUT_MS = 10_000;
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
@@ -87,16 +88,9 @@ export const SESSION_LIST_DEFAULTS = {
 type LocatorTextPoll = ReturnType<typeof expect.poll<Promise<string | null>>>;
 
 export function pollLocatorText(locator: Locator): LocatorTextPoll {
-  return expect.poll(
-    () =>
-      locator.evaluateAll((elements) => {
-        if (elements.length > 1) {
-          throw new Error(`Expected at most one text target, found ${elements.length}`);
-        }
-        return elements[0]?.textContent ?? null;
-      }),
-    { timeout: LOCATOR_TEXT_POLL_TIMEOUT_MS },
-  );
+  return expect.poll(() => locator.textContent({ timeout: LOCATOR_TEXT_READ_TIMEOUT_MS }), {
+    timeout: LOCATOR_TEXT_POLL_TIMEOUT_MS,
+  });
 }
 
 export function createNewSessionPageE2eSuite() {

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -43,7 +43,6 @@ export const NODE_HOME = "/Users/peter";
 export const NODE_PICKED = "/Users/peter/Projects";
 export const NODE_UNC = "\\\\server\\share\\repo";
 export const EXEC_ONLY_PICKED = "C:\\Users\\peter\\repo";
-const LOCATOR_TEXT_READ_TIMEOUT_MS = 500;
 const LOCATOR_TEXT_POLL_TIMEOUT_MS = 10_000;
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
@@ -88,9 +87,16 @@ export const SESSION_LIST_DEFAULTS = {
 type LocatorTextPoll = ReturnType<typeof expect.poll<Promise<string | null>>>;
 
 export function pollLocatorText(locator: Locator): LocatorTextPoll {
-  return expect.poll(() => locator.textContent({ timeout: LOCATOR_TEXT_READ_TIMEOUT_MS }), {
-    timeout: LOCATOR_TEXT_POLL_TIMEOUT_MS,
-  });
+  return expect.poll(
+    () =>
+      locator.evaluateAll((elements) => {
+        if (elements.length > 1) {
+          throw new Error(`Expected at most one text target, found ${elements.length}`);
+        }
+        return elements[0]?.textContent ?? null;
+      }),
+    { timeout: LOCATOR_TEXT_POLL_TIMEOUT_MS },
+  );
 }
 
 export function createNewSessionPageE2eSuite() {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4082,6 +4082,8 @@ export const en: TranslationMap = {
     reconnecting: "Reconnecting…",
     retryNow: "Retry now",
     actionsUnavailable: "Actions are unavailable while the Gateway reconnects.",
+    sessionOperationCompletedPreviousConnection:
+      "The session operation completed on the previous connection. Check the current session list before continuing.",
     scopeUpgrade: {
       limited: "This browser has limited access.",
       guidance:

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4084,6 +4084,8 @@ export const en: TranslationMap = {
     actionsUnavailable: "Actions are unavailable while the Gateway reconnects.",
     sessionOperationCompletedPreviousConnection:
       "The session operation completed on the previous connection. Check the current session list before continuing.",
+    sessionOperationCompletedPreviousConnectionWithRefreshError:
+      "The session operation completed on the previous connection, but refreshing the current session list failed: {error}",
     scopeUpgrade: {
       limited: "This browser has limited access.",
       guidance:

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -493,36 +493,6 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
-  it("does not publish a created session from a retired same-client epoch", async () => {
-    const staleCreate = createDeferred<{ key: string }>();
-    const request = vi.fn(async (method: string) => {
-      if (method === "sessions.create") {
-        return await staleCreate.promise;
-      }
-      if (method === "sessions.subscribe") {
-        return { subscribed: true };
-      }
-      if (method === "sessions.list") {
-        return sessionsResult([], 2);
-      }
-      throw new Error(`Unexpected request: ${method}`);
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const { gateway, publish } = createGatewayHarness(client);
-    const sessions = createSessionCapability(gateway);
-    const created = vi.fn();
-    sessions.subscribeCreated(created);
-
-    const operation = sessions.create({ agentId: "main" });
-    publish(false);
-    publish(true);
-    staleCreate.resolve({ key: "agent:main:stale" });
-
-    await expect(operation).resolves.toBeNull();
-    expect(created).not.toHaveBeenCalled();
-    sessions.dispose();
-  });
-
   it("creates a session while a list refresh is in flight", async () => {
     const pendingList = createDeferred<SessionsListResult>();
     let listCalls = 0;

--- a/ui/src/lib/sessions/session-model-override.test.ts
+++ b/ui/src/lib/sessions/session-model-override.test.ts
@@ -8,7 +8,7 @@ import { createSessionCapability } from "./index.ts";
 import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
 
 describe("session model override lifecycle", () => {
-  it("clears optimistic and settled model overrides when its connection epoch retires", async () => {
+  it("retains a confirmed patch without publishing its retired optimistic state", async () => {
     const stalePatch = createDeferred<unknown>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.patch") {
@@ -36,10 +36,14 @@ describe("session model override lifecycle", () => {
     publish(false);
     expect(sessions.state.modelOverrides).toEqual({});
     publish(true);
-    stalePatch.resolve({});
+    stalePatch.resolve({ ok: true, path: "", key, entry: {} });
 
-    await expect(operation).resolves.toBeNull();
+    await expect(operation).resolves.toMatchObject({ ok: true, key });
     expect(sessions.state.modelOverrides).toEqual({});
+    expect(sessions.state.error).toContain("completed on the previous connection");
+    expect(
+      request.mock.calls.filter(([method]) => method === "sessions.list").length,
+    ).toBeGreaterThan(0);
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/session-mutations-reconnect.test.ts
+++ b/ui/src/lib/sessions/session-mutations-reconnect.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createSessionCapability } from "./index.ts";
+import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
+
+type RpcHandler = () => unknown;
+
+function createMutationHarness(handlers: Record<string, RpcHandler>) {
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.subscribe") {
+      return { subscribed: true };
+    }
+    const handler = handlers[method];
+    if (handler) {
+      return await handler();
+    }
+    if (method === "sessions.list") {
+      return sessionsResult([], 2);
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const client = { request } as unknown as GatewayBrowserClient;
+  const gatewayHarness = createGatewayHarness(client);
+  return {
+    ...gatewayHarness,
+    client,
+    request,
+    sessions: createSessionCapability(gatewayHarness.gateway),
+  };
+}
+
+function reconnectSameClient(publish: (connected: boolean) => void) {
+  publish(false);
+  publish(true);
+}
+
+describe("session mutation reconnect truth", () => {
+  it.each(["before-response", "after-response"] as const)(
+    "retains a confirmed create across a same-client reconnect %s without stale publication",
+    async (reconnectOrder) => {
+      const createResponse = createDeferred<{ key: string }>();
+      const { publish, request, sessions } = createMutationHarness({
+        "sessions.create": () => createResponse.promise,
+      });
+      const created = vi.fn();
+      sessions.subscribeCreated(created);
+
+      const operation = sessions.create({ agentId: "main" });
+      if (reconnectOrder === "before-response") {
+        reconnectSameClient(publish);
+        createResponse.resolve({ key: "agent:main:stale" });
+      } else {
+        // Resolving queues the RPC continuation; retire its epoch before that microtask runs.
+        createResponse.resolve({ key: "agent:main:stale" });
+        reconnectSameClient(publish);
+      }
+
+      await expect(operation).resolves.toBe("agent:main:stale");
+      expect(created).not.toHaveBeenCalled();
+      expect(sessions.state.error).toContain("completed on the previous connection");
+      expect(
+        request.mock.calls.filter(([method]) => method === "sessions.list").length,
+      ).toBeGreaterThan(0);
+      sessions.dispose();
+    },
+  );
+
+  it("does not carry a confirmed create into a different client owner", async () => {
+    const createResponse = createDeferred<{ key: string }>();
+    const { publish, request, sessions } = createMutationHarness({
+      "sessions.create": () => createResponse.promise,
+    });
+    const created = vi.fn();
+    sessions.subscribeCreated(created);
+
+    const operation = sessions.create({ agentId: "main" });
+    publish(false);
+    publish(true, { request } as unknown as GatewayBrowserClient);
+    createResponse.resolve({ key: "agent:main:other-gateway" });
+
+    await expect(operation).resolves.toBeNull();
+    expect(created).not.toHaveBeenCalled();
+    expect(sessions.state.error).toBeNull();
+    sessions.dispose();
+  });
+
+  it("revalidates the same-client owner after replacement reconciliation", async () => {
+    const createResponse = createDeferred<{ key: string }>();
+    const reconciliation = createDeferred<ReturnType<typeof sessionsResult>>();
+    let listCalls = 0;
+    const { publish, request, sessions } = createMutationHarness({
+      "sessions.create": () => createResponse.promise,
+      "sessions.list": () => {
+        listCalls += 1;
+        return listCalls === 2 ? reconciliation.promise : sessionsResult([], listCalls);
+      },
+    });
+    const created = vi.fn();
+    sessions.subscribeCreated(created);
+
+    const operation = sessions.create({ agentId: "main" });
+    reconnectSameClient(publish);
+    await waitForFast(() => expect(listCalls).toBe(1));
+    createResponse.resolve({ key: "agent:main:stale-owner" });
+    await waitForFast(() => expect(listCalls).toBe(2));
+    publish(false);
+    publish(true, { request } as unknown as GatewayBrowserClient);
+    reconciliation.resolve(sessionsResult([], 2));
+
+    await expect(operation).resolves.toBeNull();
+    expect(created).not.toHaveBeenCalled();
+    expect(sessions.state.error).toBeNull();
+    sessions.dispose();
+  });
+
+  it("keeps a rejected create uncertain across a same-client reconnect", async () => {
+    const createResponse = createDeferred<{ key: string }>();
+    const { publish, sessions } = createMutationHarness({
+      "sessions.create": () => createResponse.promise,
+    });
+
+    const operation = sessions.create({ agentId: "main" });
+    reconnectSameClient(publish);
+    createResponse.reject(new Error("transport closed before response"));
+
+    await expect(operation).resolves.toBeNull();
+    expect(sessions.state.error).toBeNull();
+    sessions.dispose();
+  });
+
+  it.each(["delete", "deleteMany"] as const)(
+    "retains a confirmed %s across a same-client reconnect without stale deletion publication",
+    async (operationName) => {
+      const deleteResponse = createDeferred<{ deleted: boolean }>();
+      const { publish, request, sessions } = createMutationHarness({
+        "sessions.delete": () => deleteResponse.promise,
+      });
+      const key = "agent:main:deleted-on-previous-connection";
+
+      const operation =
+        operationName === "delete" ? sessions.delete(key) : sessions.deleteMany([{ key }]);
+      reconnectSameClient(publish);
+      deleteResponse.resolve({ deleted: true });
+
+      await expect(operation).resolves.toEqual(
+        operationName === "delete"
+          ? { deleted: true }
+          : { deleted: [key], errors: [], preservedWorktrees: [] },
+      );
+      expect(sessions.state.deletedSessions).toEqual([]);
+      expect(sessions.state.error).toContain("completed on the previous connection");
+      expect(
+        request.mock.calls.filter(([method]) => method === "sessions.list").length,
+      ).toBeGreaterThan(0);
+      sessions.dispose();
+    },
+  );
+
+  it.each([
+    { laterOutcome: "no-op", errors: [] },
+    { laterOutcome: "transport rejection", errors: ["transport closed before response"] },
+  ] as const)(
+    "keeps earlier confirmed batch deletions when a later $laterOutcome follows reconnect",
+    async ({ laterOutcome, errors }) => {
+      const laterDelete = createDeferred<{ deleted: boolean }>();
+      let deleteCalls = 0;
+      const { publish, sessions } = createMutationHarness({
+        "sessions.delete": () => {
+          deleteCalls += 1;
+          return deleteCalls === 1 ? { deleted: true } : laterDelete.promise;
+        },
+      });
+
+      const operation = sessions.deleteMany([
+        { key: "agent:main:confirmed" },
+        { key: "agent:main:unchanged" },
+      ]);
+      await waitForFast(() => expect(deleteCalls).toBe(2));
+      reconnectSameClient(publish);
+      if (laterOutcome === "no-op") {
+        laterDelete.resolve({ deleted: false });
+      } else {
+        laterDelete.reject(new Error("transport closed before response"));
+      }
+
+      await expect(operation).resolves.toEqual({
+        deleted: ["agent:main:confirmed"],
+        errors: [...errors],
+        preservedWorktrees: [],
+      });
+      expect(sessions.state.deletedSessions).toEqual([]);
+      expect(sessions.state.error).toContain("completed on the previous connection");
+      sessions.dispose();
+    },
+  );
+});

--- a/ui/src/lib/sessions/session-mutations-reconnect.test.ts
+++ b/ui/src/lib/sessions/session-mutations-reconnect.test.ts
@@ -68,6 +68,31 @@ describe("session mutation reconnect truth", () => {
     },
   );
 
+  it("reports both confirmed completion and replacement refresh failure", async () => {
+    const createResponse = createDeferred<{ key: string }>();
+    let failRefresh = false;
+    const { publish, sessions } = createMutationHarness({
+      "sessions.create": () => createResponse.promise,
+      "sessions.list": () => {
+        if (failRefresh) {
+          throw new Error("replacement roster unavailable");
+        }
+        return sessionsResult([], 1);
+      },
+    });
+
+    const operation = sessions.create({ agentId: "main" });
+    reconnectSameClient(publish);
+    await waitForFast(() => expect(sessions.state.result).not.toBeNull());
+    failRefresh = true;
+    createResponse.resolve({ key: "agent:main:refresh-failed" });
+
+    await expect(operation).resolves.toBe("agent:main:refresh-failed");
+    expect(sessions.state.error).toContain("completed on the previous connection");
+    expect(sessions.state.error).toContain("replacement roster unavailable");
+    sessions.dispose();
+  });
+
   it("does not carry a confirmed create into a different client owner", async () => {
     const createResponse = createDeferred<{ key: string }>();
     const { publish, request, sessions } = createMutationHarness({

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -138,14 +138,24 @@ export function createSessionMutations(host: SessionMutationsHost) {
     if (!replacement || replacement.client !== scope.client) {
       return false;
     }
-    await host.refreshReplacement(agentId).catch(() => undefined);
+    let refreshError: string | undefined;
+    try {
+      await host.refreshReplacement(agentId);
+      refreshError = host.readState().error ?? undefined;
+    } catch (error) {
+      refreshError = formatUiError(error);
+    }
     if (!host.connection.isCurrent(replacement)) {
       return false;
     }
     host.publish(
       {
         ...host.readState(),
-        error: t("connection.sessionOperationCompletedPreviousConnection"),
+        error: refreshError
+          ? t("connection.sessionOperationCompletedPreviousConnectionWithRefreshError", {
+              error: refreshError,
+            })
+          : t("connection.sessionOperationCompletedPreviousConnection"),
       },
       "operation",
     );

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -8,6 +8,7 @@ import type {
   SessionsListResult,
   SessionsPatchResult,
 } from "../../api/types.ts";
+import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../format-error.ts";
 import {
   requestSessionCreate,
@@ -18,6 +19,7 @@ import type { SessionPatch, SessionPatchOptions } from "./patch.ts";
 import { requestSessionRecovery } from "./recover.ts";
 import type {
   SessionConnectionOwner,
+  SessionConnectionScope,
   SessionCreateReconciliation,
   SessionDeleteBatchResult,
   SessionDeleteOptions,
@@ -128,6 +130,28 @@ export function createSessionMutations(host: SessionMutationsHost) {
     setModelOverride(normalizedKey, undefined);
   };
 
+  const reconcileConfirmedPreviousConnection = async (
+    scope: SessionConnectionScope,
+    agentId?: string | null,
+  ): Promise<boolean> => {
+    const replacement = host.connection.capture();
+    if (!replacement || replacement.client !== scope.client) {
+      return false;
+    }
+    await host.refreshReplacement(agentId).catch(() => undefined);
+    if (!host.connection.isCurrent(replacement)) {
+      return false;
+    }
+    host.publish(
+      {
+        ...host.readState(),
+        error: t("connection.sessionOperationCompletedPreviousConnection"),
+      },
+      "operation",
+    );
+    return true;
+  };
+
   const createResult = async (
     params: SessionCreateParams = {},
     options: { reconciliation?: SessionCreateReconciliation } = {},
@@ -143,7 +167,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         ...resolveSessionCreateParams(currentSessionKey, params.agentId),
       });
       if (!host.connection.isCurrent(scope)) {
-        return null;
+        return (await reconcileConfirmedPreviousConnection(scope, params.agentId)) ? result : null;
       }
       // Creation precedes canonical rows; claim placement before any event or
       // list publication can assign this key an ordinary roster position.
@@ -166,7 +190,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
       } else {
         await reconciliation;
         if (!host.connection.isCurrent(scope)) {
-          return null;
+          return (await reconcileConfirmedPreviousConnection(scope, params.agentId))
+            ? result
+            : null;
         }
       }
       return result;
@@ -341,7 +367,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       const result = await requestSessionPatch(scope.client, key, patchParams, options);
       if (!host.connection.isCurrent(scope)) {
         settleOptimisticPatch(false);
-        return null;
+        return (await reconcileConfirmedPreviousConnection(scope, options.agentId)) ? result : null;
       }
       if (archivedPresentationRow) {
         const archivedAt = result.entry?.archivedAt ?? Date.now();
@@ -383,7 +409,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
         await host.refreshReplacement(options.agentId);
         if (!host.connection.isCurrent(scope)) {
           settleOptimisticPatch(false);
-          return null;
+          return (await reconcileConfirmedPreviousConnection(scope, options.agentId))
+            ? result
+            : null;
         }
       }
       settleOptimisticPatch(true);
@@ -410,8 +438,18 @@ export function createSessionMutations(host: SessionMutationsHost) {
     }
     try {
       const response = await requestSessionDelete(scope.client, key, options);
-      if (!host.connection.isCurrent(scope) || !confirmsSessionDeletion(response)) {
+      if (!confirmsSessionDeletion(response)) {
         return { deleted: false };
+      }
+      if (!host.connection.isCurrent(scope)) {
+        return (await reconcileConfirmedPreviousConnection(scope, options.agentId))
+          ? {
+              deleted: true,
+              ...(response.worktreePreserved
+                ? { worktreePreserved: response.worktreePreserved }
+                : {}),
+            }
+          : { deleted: false };
       }
       const retireBeforeRevision = Date.now();
       host.retirePullRequestSummary(key);
@@ -425,8 +463,18 @@ export function createSessionMutations(host: SessionMutationsHost) {
       });
       setModelOverride(key, undefined);
       await host.refreshReplacement(options.agentId);
+      if (!host.connection.isCurrent(scope)) {
+        return (await reconcileConfirmedPreviousConnection(scope, options.agentId))
+          ? {
+              deleted: true,
+              ...(response.worktreePreserved
+                ? { worktreePreserved: response.worktreePreserved }
+                : {}),
+            }
+          : { deleted: false };
+      }
       return {
-        deleted: host.connection.isCurrent(scope),
+        deleted: true,
         ...(response.worktreePreserved ? { worktreePreserved: response.worktreePreserved } : {}),
       };
     } catch (error) {
@@ -456,7 +504,15 @@ export function createSessionMutations(host: SessionMutationsHost) {
       try {
         const response = await requestSessionDelete(scope.client, target.key, target);
         if (!host.connection.isCurrent(scope)) {
-          break;
+          if (confirmsSessionDeletion(response)) {
+            deleted.push(target.key);
+            if (response.worktreePreserved) {
+              preservedWorktrees.push(response.worktreePreserved);
+            }
+          }
+          return deleted.length > 0 && (await reconcileConfirmedPreviousConnection(scope))
+            ? { deleted, errors, preservedWorktrees }
+            : { deleted: [], errors: [], preservedWorktrees: [] };
         }
         if (confirmsSessionDeletion(response)) {
           const retireBeforeRevision = Date.now();
@@ -474,7 +530,12 @@ export function createSessionMutations(host: SessionMutationsHost) {
         errors.push(formatUiError(error));
       }
     }
-    if (deleted.length > 0 && host.connection.isCurrent(scope)) {
+    if (!host.connection.isCurrent(scope)) {
+      return deleted.length > 0 && (await reconcileConfirmedPreviousConnection(scope))
+        ? { deleted, errors, preservedWorktrees }
+        : { deleted: [], errors: [], preservedWorktrees: [] };
+    }
+    if (deleted.length > 0) {
       for (const key of deleted) {
         host.retirePullRequestSummary(key);
         confirmedArchives.delete(key.trim());
@@ -488,10 +549,13 @@ export function createSessionMutations(host: SessionMutationsHost) {
         setModelOverride(key, undefined);
       }
       await host.refreshReplacement();
+      if (!host.connection.isCurrent(scope)) {
+        return (await reconcileConfirmedPreviousConnection(scope))
+          ? { deleted, errors, preservedWorktrees }
+          : { deleted: [], errors: [], preservedWorktrees: [] };
+      }
     }
-    return host.connection.isCurrent(scope)
-      ? { deleted, errors, preservedWorktrees }
-      : { deleted: [], errors: [], preservedWorktrees: [] };
+    return { deleted, errors, preservedWorktrees };
   };
 
   const reset = async (


### PR DESCRIPTION
Closes #125903

## What Problem This Solves

Fixes an issue where users creating or mutating sessions could see a total failure after the Gateway had already committed the operation. A post-create title/transcript/send failure could reject `sessions.create`, encouraging a duplicate retry, while a same-client Control UI reconnect could discard confirmed create, patch, delete, or partial batch-delete results.

## Why This Change Was Made

The Gateway now returns a closed post-commit outcome from its session lifecycle owner and maps initializer failures onto the existing successful `SessionsCreateResult.runError` field. The Control UI preserves confirmed results only across a verified same-client replacement, refreshes canonical session state, reports that the operation completed on the previous connection, and revalidates ownership after the refresh so a different client can never inherit the old result.

No protocol version, request shape, idempotency contract, or SQLite schema changes are introduced. Plugin initialization retains its existing guarded rollback/recovery behavior.

## User Impact

Operators no longer receive a misleading total failure for a session that already exists. Confirmed same-client mutations survive reconnects without publishing stale optimistic state, earlier confirmed batch deletions remain truthful when a later row is a no-op or loses transport, and different Gateway/client owners remain isolated.

Production LOC: +120/-16 (net +104) | Tests: +414/-72 (net +342)

The production growth is the explicit owner-boundary result contract plus same-client reconciliation and ownership fencing across create, patch, delete, and batch-delete operations. Duplicate page/controller feedback paths were removed during review so the policy remains in one session-mutation owner.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts` — 106 passed
- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-agent.test.ts` — 26 passed
- `node scripts/run-vitest.mjs ui/src/lib/sessions/index.test.ts ui/src/lib/sessions/session-mutations-reconnect.test.ts ui/src/lib/sessions/session-model-override.test.ts` — 43 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.places.e2e.test.ts ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts` — 20 passed after exact-head CI exposed two unrelated async-ownership flakes
- Each repaired E2E case passed three additional focused serial repetitions; the waits bind to focus restoration, visible input ownership, committed repository selection, and durable attachment draft state without increasing timeouts. After `main` consolidated the place suites, the same waits were added to the canonical `projects-places` scenario and passed four focused runs
- The activity-feed capture waits for one authoritative route owner and scopes all exact row/group/person assertions to it. Its fixture clock is anchored to recent previous-day 16:00 UTC so automation grouping is identical across UTC−12 through UTC+14 while remaining inside the seven-day filter; default, UTC−12, and UTC+14 runs passed
- Current `main` also carried a teardown E2E that intermittently closed Chromium after a CAS read but before its conditional IndexedDB `put`; the corrected behavioral contract now proves component teardown starts an independent transaction before debounce, waits for raw durable state, then closes/reopens. The exact case passed three independent repetitions plus the full 2-test file, and fresh autoreview was clean
- Exact-head CI later exposed cloud-startup failure handling that could settle before the chat route owner rendered its alert. The recovery E2E subscribes to the authoritative `cloudStartup` state until the exact session reaches `failed`, waits for committed chat-route ownership, then verifies the visible alert; the full file and three focused repetitions passed
- ClawSweeper's stale-head rank-up move was applied: a confirmed previous-connection result now preserves and combines a roster-refresh failure instead of replacing it with the generic completion notice, with focused same-client coverage
- A later changed-tests shard exposed an unrelated SMS spool timing assumption after 5,264 extension tests passed. The case now freezes its wall clock, waits for the spool's authoritative idle boundary, advances retry eligibility causally, and passed the full 22-test file plus three focused repetitions
- While this PR was in flight, current `main` landed the canonical Gateway fixes in #125985, #126040, and #125946 for retaining chat roots through error persistence, binding detached lifecycle dispatch, and routing retained announcements to the exact instance. The branch was rebased onto those fixes and duplicate local patches were skipped; the exact 24-file Gateway shard passed 395/395 on Testbox
- Focused final reconnect suite — 10 passed, including:
  - response before/after same-client reconnect
  - transport rejection remains uncertain
  - different-client replacement is rejected
  - replacement ownership is revalidated after awaited reconciliation
  - partial batch deletion preserves earlier confirmed results across later no-op/rejection
- `pnpm tsgo:ui` — passed
- targeted oxlint and `pnpm format:check` — passed
- `pnpm lint:ui:i18n` — passed
- `git diff --check` — passed
- Blacksmith Testbox `tbx_01m0aqmd6f1n7e8xyay9e2rxw4`: Gateway, UI, app-sidebar, and plugin suites passed; workflow run https://github.com/openclaw/openclaw/actions/runs/32154362541
- Blacksmith Testbox `tbx_01m0aszaym4zbjmahvfnsmb239`: final reconnect ownership and UI type/lint proof passed; workflow run https://github.com/openclaw/openclaw/actions/runs/32158441845
- Final Codex autoreview: clean, no accepted P0/P1 findings
- Rebased onto current main after #126032 independently landed the canonical previous-day local-noon activity fixture. The duplicate clock hunk was dropped while the route-owner scoping remained. Post-rebase proof passed 107 Gateway tests, 26 plugin-runtime tests, 44 UI session tests, and the activity capture at UTC, UTC−12, and UTC+14; fresh autoreview was clean
- Source-blind behavior validation passed the committed-create, same-client result preservation, transport uncertainty, stale-publication, and partial-delete contracts

Visual proof gap: the existing mocked Control UI Gateway can reconnect or resolve a deferred RPC, but it cannot atomically deliver an old-connection response and replace the connection between Promise resolution and the mutation continuation. Either ordering resolves fully before disconnect or becomes uncertain transport loss, so a truthful screenshot/video of this exact microtask race is not currently capturable without adding a test-only Gateway scheduling seam. The visible copy is still asserted at the session capability boundary, and the surrounding real reconnect/sidebar flows remain covered by existing browser E2E.

`check:changed` also encountered unrelated assertion-safety ratchet drift in `extensions/browser/src/browser/chrome.ts` and `src/state/user-profiles.ts`; neither path is touched here. All proportional touched-surface checks above are green.

AI-assisted: yes. I reviewed the full lifecycle and connection-owner paths, iterated on independent autoreview findings, and verified the final code and tests.