### PR TITLE
perf(test): narrow harness differential mock

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-model-selection-differential.test.ts
@@ -20,13 +20,9 @@ import { buildTestCtx } from "./test-ctx.js";
 
 const selectAgentHarnessMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../agents/harness/selection.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../agents/harness/selection.js")>();
-  return {
-    ...actual,
-    selectAgentHarness: (...args: unknown[]) => selectAgentHarnessMock(...args),
-  };
-});
+vi.mock("../../agents/harness/selection.js", () => ({
+  selectAgentHarness: (...args: unknown[]) => selectAgentHarnessMock(...args),
+}));
 
 const { resolveVisibleRepliesPolicy } = await import("./dispatch-from-config.harness-defaults.js");
 


### PR DESCRIPTION
## What Problem This Solves

This differential test spent most of its runtime and memory importing the real agent-harness selection graph even though the test only observes the `selectAgentHarness` boundary. On the same controlled Testbox, import time accounted for nearly all of the test's wall time while the eight differential cases themselves completed in roughly 1.5 seconds.

## Why This Change Was Made

Replace the partial-real `vi.mock` for `../../agents/harness/selection.js` with a complete narrow mock exporting only `selectAgentHarness`, the sole binding consumed by the imported owner under test. The SQLite session fixtures, plugin registry setup, and all eight model-selection differential cases remain unchanged.

This is test-only: production LOC is +0/-0; test LOC is +3/-7.

## User Impact

There is no product behavior change. Developers and CI get a substantially faster, lower-memory differential test without weakening its production-boundary coverage.

## Evidence

Controlled same-Testbox A/B benchmark with an excluded warmup, two retained samples, one worker, distinct module caches, import diagnostics, and `/usr/bin/time -v`:

- Wall time: 26.87/31.42s (mean 29.145s) -> 12.93/12.68s (mean 12.805s), -16.34s / -56.1%.
- Vitest time: 22.72/27.54s (mean 25.13s) -> 9.31/8.92s (mean 9.115s), -63.7%.
- Test body: 1.48/1.59s (mean 1.535s) -> 1.52/1.42s (mean 1.47s), -4.2%.
- Import time: 19.80/24.40s (mean 22.10s) -> 6.86/6.39s (mean 6.625s), -70.0%.
- Max RSS: mean 1,382,536KB -> 897,794KB, -35.1%.

Benchmark Testbox: `tbx_01m0av8e40j26sr0azrgx1t5ew` (stopped). Associated run: https://github.com/openclaw/openclaw/actions/runs/32160518134.

Behavioral proof:

- Fault injection temporarily prioritizing `channelModelCandidate` caused 4/8 intended differential failures; the production mutation was fully restored.
- Focused test: 8/8 passed.
- An initial reused-box changed gate exited 144 during core test typechecking after the focused test and all early guards passed; this was infrastructure timeout, not a code failure.
- A fresh full changed gate passed on Testbox `tbx_01m0awwg0v45b05z41z768cz26` (stopped).
- Fresh post-rebase Codex autoreview: clean, no accepted/actionable findings, 0.99.
- Stable patch ID was unchanged by the rebase.

No screenshots are included because this only changes a test module mock boundary and has no UI behavior. Changelog is not required for a test-only performance change.
