### PR TITLE
test(ui): wait for the outbox retry drain instead of the timer tick

### DIFF
--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6678,9 +6678,13 @@ describe("handleSendChat", () => {
       });
       expect(sendAttempts).toBe(1);
       await vi.advanceTimersByTimeAsync(100);
-      expect(sendAttempts).toBe(2);
+      // The retry timer only kicks off a fire-and-forget drain, so the resend
+      // lands after the tick returns. Wait for the outcome, not the tick.
+      await waitForFast(() => {
+        expect(sendAttempts).toBe(2);
+        expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+      });
       expect(sendRunIds[1]).toBe(sendRunIds[0]);
-      expect(listStoredChatOutboxes(host)).toStrictEqual([]);
     } finally {
       vi.useRealTimers();
     }
@@ -6727,9 +6731,12 @@ describe("handleSendChat", () => {
       expect(historyAttempts).toBe(1);
       expect(sendAttempts).toBe(0);
       await vi.advanceTimersByTimeAsync(100);
-      expect(sendAttempts).toBe(1);
-      expect(historyAttempts).toBeGreaterThanOrEqual(2);
-      expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+      // Same fire-and-forget retry hand-off as the send-rejection case above.
+      await waitForFast(() => {
+        expect(sendAttempts).toBe(1);
+        expect(historyAttempts).toBeGreaterThanOrEqual(2);
+        expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+      });
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## What Problem This Solves

`ui/src/pages/chat/chat-send.test.ts` > "retries an explicitly retryable send rejection while still connected" fails intermittently in CI with `AssertionError: expected 1 to be 2` (observed in run 32153016319, job `checks-node-compact-large-9`, shard `core-runtime-media-ui-2`). A red merge gate that nobody can reproduce locally costs every contributor a rerun.

## Why This Change Was Made

The test asserted the resend side effect immediately after `await vi.advanceTimersByTimeAsync(100)`. That assertion has **exactly zero macrotask slack**, which is why it looks fine locally and dies under CI contention:

- After `handleSendChat`, three fake timers are pending: two rAF frames (16ms, 32ms from `scheduleChatScroll`) and the retry timer at 100ms, which fires last.
- Sinon's `tickAsync` fires each timer and yields exactly one real macrotask (`originalSetTimeout`) before re-entering; after the final timer there is exactly **one** such yield before the promise resolves.
- The retry chain is fire-and-forget: `scheduleStoredChatOutboxRetry`'s callback does `void scheduleStoredChatOutboxDrain(...)`, which then awaits `chat.history` and `chat.send`. Measured, it consumes exactly **one** macrotask boundary on the healthy path.

One needed, one available. Any single extra async hop tips it over.

The fix waits for the outcome with `waitForFast` (the repo's 1ms-interval `vi.waitFor` wrapper), which polls on real timers and gives the drain unbounded turns. The pre-tick `expect(sendAttempts).toBe(1)` still proves the retry does not fire early, so the timing contract is unchanged. `expect(listStoredChatOutboxes(host)).toStrictEqual([])` moved inside the wait because queue retirement lands after the `chat.send` call and had the same zero-slack problem.

The sibling test "retries reconnect history after a retryable response without a socket close" carried the identical latent flake and is fixed the same way.

No production change: `scheduleStoredChatOutboxRetry` schedules at the gateway-requested delay and the drain does resend with the same idempotency key. The chain is simply asynchronous, which is correct for a UI outbox.

## User Impact

No user-visible change. Removes a flaky merge-gate failure for contributors.

## Evidence

**Reproduced first.** Full-file loop with 40 CPU burners on a 16-core box hit the exact CI failure on run 2 of 8:

```
FAIL  |ui| ui/src/pages/chat/chat-send.test.ts > handleSendChat > retries an explicitly retryable send rejection while still connected
AssertionError: expected 1 to be 2 // Object.is equality
```

**Instrumented the mechanism.** Stepping the fake clock one timer at a time:

```
[DIAG] afterSend timers=3
[DIAG] step=0 elapsed=16  timers=2 sendAttempts=1
[DIAG] step=1 elapsed=32  timers=1 sendAttempts=1
[DIAG] step=2 elapsed=100 timers=0 sendAttempts=2
```

Five real macrotask turns *without* advancing fake time leave `sendAttempts` at 1, so the retry timer is genuinely required; after it fires, the chain needs exactly one macrotask boundary.

**Deterministic proof.** Injecting a single extra macrotask hop into the retry chain's `chat.history` handler reproduces the failure 100% of the time on the pre-fix assertions, and passes on the fixed ones:

| Test | Extra hop, pre-fix | Extra hop, post-fix |
| --- | --- | --- |
| retryable send rejection | `AssertionError: expected 1 to be 2` | pass |
| retryable history response | `AssertionError: expected +0 to be 1` | pass |

**Validation.**

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts` — 276/276 pass
- `node scripts/check-changed.mjs` — exit 0 (typecheck, lint, knip dead-export scan, i18n catalog)
- Codex autoreview (`gpt-5.6-sol`, xhigh) — clean, no accepted findings

**Known gap:** `advanceTimersByTimeAsync` is used in ~20 other UI test files. I did not audit them for this shape; that is a separate sweep.
