### PR TITLE
fix(mcp): preserve recovery text with structured results

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1381,6 +1381,7 @@ describe("session MCP runtime", () => {
           type: "text",
           text: `structuredContent:\n${JSON.stringify(structuredContent, null, 2)}`,
         },
+        { type: "text", text: "captured screenshot" },
         { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
         { type: "text", text: "[Report] https://example.com/report" },
         { type: "text", text: "memo body" },

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -18,6 +18,7 @@ import type {
 import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
 import { getMcpAppViewLease } from "./mcp-ui-resource.js";
 import { testing as mcpUiResourceTesting } from "./mcp-ui-resource.test-support.js";
+import { isToolResultError } from "./tool-result-error.js";
 
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 
@@ -90,6 +91,18 @@ function makeToolRuntime(
       },
     dispose: async () => {},
   };
+}
+
+async function executeMcpToolResult(result: CallToolResult) {
+  const runtime = await materializeBundleMcpToolsForRun({
+    runtime: makeToolRuntime({ result }),
+  });
+  return await expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
+    "call-bundle-probe",
+    {},
+    undefined,
+    undefined,
+  );
 }
 
 describe("createBundleMcpToolRuntime", () => {
@@ -270,88 +283,109 @@ describe("createBundleMcpToolRuntime", () => {
     );
   });
 
-  it("keeps structuredContent visible when MCP tools also return text content", async () => {
-    const runtime = await materializeBundleMcpToolsForRun({
-      runtime: makeToolRuntime({
-        result: {
-          content: [{ type: "text", text: "pong" }],
-          structuredContent: {
-            threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
-            content: "pong",
-          },
-          isError: false,
-        },
-      }),
+  it("preserves recovery text alongside structuredContent", async () => {
+    const result = await executeMcpToolResult({
+      content: [{ type: "text", text: "authentication expired; run login" }],
+      structuredContent: { retryable: true },
+      isError: false,
     });
 
-    const result = await expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
-      "call-bundle-probe",
-      {},
-      undefined,
-      undefined,
-    );
-
-    expectTextContentBlock(
-      result.content[0],
-      `structuredContent:\n${JSON.stringify(
-        {
-          threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
-          content: "pong",
-        },
-        null,
-        2,
-      )}`,
-    );
-    expect(result.content).toHaveLength(1);
+    expect(result.content).toEqual([
+      { type: "text", text: 'structuredContent:\n{\n  "retryable": true\n}' },
+      { type: "text", text: "authentication expired; run login" },
+    ]);
     expect(result.details).toEqual({
       mcpServer: "bundleProbe",
       mcpTool: "bundle_probe",
-      structuredContent: {
-        threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
-        content: "pong",
-      },
+      structuredContent: { retryable: true },
     });
   });
 
-  it("preserves non-text MCP content alongside structuredContent without duplicating mirrored text", async () => {
+  it("preserves text and non-text MCP content alongside structuredContent", async () => {
     const structuredContent = { description: "captured screenshot" };
-    const runtime = await materializeBundleMcpToolsForRun({
-      runtime: makeToolRuntime({
-        result: {
-          content: [
-            { type: "text", text: "captured screenshot" },
-            { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
-            {
-              type: "resource_link",
-              uri: "https://example.com/report",
-              name: "report",
-              title: "Report",
-            },
-            { type: "resource", resource: { uri: "memo://one", text: "memo body" } },
-            { type: "audio", data: "AAAA", mimeType: "audio/mpeg" },
-          ],
-          structuredContent,
+    const result = await executeMcpToolResult({
+      content: [
+        { type: "text", text: "captured screenshot" },
+        { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+        {
+          type: "resource_link",
+          uri: "https://example.com/report",
+          name: "report",
+          title: "Report",
         },
-      }),
+        { type: "resource", resource: { uri: "memo://one", text: "memo body" } },
+        { type: "audio", data: "AAAA", mimeType: "audio/mpeg" },
+      ],
+      structuredContent,
     });
-
-    const result = await expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
-      "call-bundle-probe",
-      {},
-      undefined,
-      undefined,
-    );
 
     expect(result.content).toEqual([
       {
         type: "text",
         text: `structuredContent:\n${JSON.stringify(structuredContent, null, 2)}`,
       },
+      { type: "text", text: "captured screenshot" },
       { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
       { type: "text", text: "[Report] https://example.com/report" },
       { type: "text", text: "memo body" },
       { type: "text", text: "[audio audio/mpeg]" },
     ]);
+  });
+
+  it("deduplicates exact structured JSON mirrors without dropping near matches", async () => {
+    const structuredContent = { zeta: 2, alpha: 1 };
+    const result = await executeMcpToolResult({
+      content: [
+        { type: "text", text: JSON.stringify(structuredContent, null, 2) },
+        { type: "text", text: 'Result metadata: {"alpha":1,"zeta":2}' },
+      ],
+      structuredContent,
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: 'structuredContent:\n{\n  "alpha": 1,\n  "zeta": 2\n}',
+      },
+      { type: "text", text: 'Result metadata: {"alpha":1,"zeta":2}' },
+    ]);
+  });
+
+  it("marks isError through the tool-result owner while preserving recovery text", async () => {
+    const result = await executeMcpToolResult({
+      content: [{ type: "text", text: "authentication expired; run login" }],
+      structuredContent: { retryable: true },
+      isError: true,
+    });
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "authentication expired; run login",
+    });
+    expect(result.details).toMatchObject({
+      status: "error",
+      structuredContent: { retryable: true },
+    });
+    expect(isToolResultError(result)).toBe(true);
+  });
+
+  it("renders structured-only results in deterministic key order", async () => {
+    const result = await executeMcpToolResult({
+      content: [],
+      structuredContent: { zeta: 2, alpha: 1 },
+    });
+
+    expect(result.content).toEqual([
+      { type: "text", text: 'structuredContent:\n{\n  "alpha": 1,\n  "zeta": 2\n}' },
+    ]);
+  });
+
+  it("keeps text-only results unchanged", async () => {
+    const result = await executeMcpToolResult({
+      content: [{ type: "text", text: "plain result" }],
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "plain result" }]);
   });
 
   it("coerces non-text/image MCP tool-result blocks to text (resource_link/resource/audio)", async () => {

--- a/src/agents/mcp-content.ts
+++ b/src/agents/mcp-content.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentToolResult } from "./runtime/index.js";
 
@@ -61,13 +62,18 @@ function projectMcpCallToolResultContent(result: {
 }): AgentToolResult<unknown>["content"] {
   const sourceContent = Array.isArray(result.content) ? result.content : [];
   if (isRecord(result.structuredContent)) {
+    const mirroredText = JSON.stringify(result.structuredContent, null, 2);
+    const structuredJson = JSON.stringify(
+      JSON.parse(stableStringify(result.structuredContent)),
+      null,
+      2,
+    );
+    const structuredText = `structuredContent:\n${structuredJson}`;
     return [
-      {
-        type: "text",
-        text: `structuredContent:\n${JSON.stringify(result.structuredContent, null, 2)}`,
-      },
+      { type: "text", text: structuredText },
       ...sourceContent
-        .filter((block) => !isRecord(block) || block.type !== "text")
+        // Only the SDK's full pretty-JSON mirror is redundant; overlapping text can carry recovery guidance.
+        .filter((block) => !isRecord(block) || block.type !== "text" || block.text !== mirroredText)
         .map(mcpContentBlockToAgentContent),
     ];
   }

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -291,6 +291,8 @@ describe("createNodePluginTools", () => {
     expect(result.content).toEqual([
       { type: "text", text: 'structuredContent:\n{\n  "hits": 2\n}' },
       { type: "image", data: "aW1hZ2UtMQ==", mimeType: "image/png" },
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
       { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
       { type: "text", text: '{"type":"image","data":42,"mimeType":"image/png"}' },
     ]);

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -195,6 +195,44 @@ describe("mcp.tools.call.v1", () => {
     expect(payload.structuredContent).toBeUndefined();
   });
 
+  it("preserves structured content and recovery guidance when an exact JSON mirror is oversized", async () => {
+    const structuredContent = {
+      oversized: "S".repeat(Math.floor(testing.MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
+    };
+    const recovery = "authentication expired; run login";
+    const result = await invokeMcp(
+      managerWith(async () => ({
+        content: [
+          { type: "text", text: JSON.stringify(structuredContent, null, 2) },
+          {
+            type: "image",
+            data: "I".repeat(Math.floor(testing.MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
+            mimeType: "image/png",
+          },
+          { type: "text", text: recovery },
+        ],
+        structuredContent,
+        isError: true,
+      })),
+      { server: "docs", tool: "recover" },
+    );
+    const payload = result.payload as {
+      content: Array<{ type: string; text?: string }>;
+      structuredContent?: Record<string, unknown>;
+      isError?: boolean;
+    };
+    expect(payload.isError).toBe(true);
+    expect(payload.structuredContent).toBeDefined();
+    expect(payload.structuredContent?.oversized).toHaveLength(structuredContent.oversized.length);
+    expect(payload.content).toEqual([
+      { type: "text", text: recovery },
+      { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
+    ]);
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
+      testing.MCP_INVOKE_PAYLOAD_MAX_BYTES,
+    );
+  });
+
   it("sends MCP payloads as structured invoke data without double JSON escaping", async () => {
     const escaped = "\\".repeat(8 * 1024 * 1024);
     const result = await invokeMcp(

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -986,7 +986,16 @@ function boundMcpToolResultPayload(result: {
   structuredContent?: Record<string, unknown>;
   isError?: true;
 } {
-  const normalizedBlocks = result.content.filter(isRecord);
+  const mirroredStructuredContent = result.structuredContent
+    ? JSON.stringify(result.structuredContent, null, 2)
+    : undefined;
+  const normalizedBlocks = result.content.filter(
+    (block): block is McpInvokeContentBlock =>
+      isRecord(block) &&
+      (mirroredStructuredContent === undefined ||
+        block.type !== "text" ||
+        block.text !== mirroredStructuredContent),
+  );
   const totalTextBytes = normalizedBlocks.reduce<number>(
     (total, block) =>
       total +
@@ -1032,6 +1041,17 @@ function boundMcpToolResultPayload(result: {
   const isError = result.isError === true;
   let usedBytes = jsonUtf8Bytes({ content: [], ...(isError ? { isError } : {}) });
   let payloadTruncated = false;
+  let structuredContent: Record<string, unknown> | undefined;
+  if (result.structuredContent) {
+    const structuredBytes =
+      Buffer.byteLength(',"structuredContent":') + jsonUtf8Bytes(result.structuredContent);
+    if (usedBytes + structuredBytes + reservedMarkerBytes <= MCP_INVOKE_PAYLOAD_MAX_BYTES) {
+      structuredContent = result.structuredContent;
+      usedBytes += structuredBytes;
+    } else {
+      payloadTruncated = true;
+    }
+  }
   const content: McpInvokeContentBlock[] = [];
   for (const block of textBoundedContent) {
     const blockBytes = jsonUtf8Bytes(block) + (content.length > 0 ? 1 : 0);
@@ -1041,16 +1061,6 @@ function boundMcpToolResultPayload(result: {
     }
     content.push(block);
     usedBytes += blockBytes;
-  }
-  let structuredContent: Record<string, unknown> | undefined;
-  if (result.structuredContent) {
-    const structuredBytes =
-      Buffer.byteLength(',"structuredContent":') + jsonUtf8Bytes(result.structuredContent);
-    if (usedBytes + structuredBytes + reservedMarkerBytes <= MCP_INVOKE_PAYLOAD_MAX_BYTES) {
-      structuredContent = result.structuredContent;
-    } else {
-      payloadTruncated = true;
-    }
   }
   if (payloadTruncated) {
     content.push(payloadMarker);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MCP tools returning both `structuredContent` and useful text would lose all text, including recovery guidance. On remote node-host paths, an oversized exact JSON mirror could also consume the text budget and evict the canonical structured result or every later recovery message.

## Why This Change Was Made

The shared MCP projection now keeps ordered non-redundant text, images, and resources alongside deterministic structured JSON, removing only a byte-identical pretty-JSON mirror. The node-host producer applies the same mirror rule before text bounding and reserves a fitting structured payload before optional content, so transport caps cannot reverse the MCP result’s ownership priorities.

This preserves the independent MCP SDK fields (`content`, `structuredContent`, and `isError`), existing 1 MiB text and 20 MiB node payload caps, ordering, error status, and truncation markers. AI-assisted; the final diff was independently reviewed and manually verified.

Provenance: the text-dropping projection was introduced by #125092 and carried into the shared projection by #125564; both were authored and merged by @steipete on 2026-08-17/18.

## User Impact

Models can now see recovery instructions and mixed media/resource output from MCP tools without losing structured results. Large remote-node MCP results stay bounded while retaining the canonical structured payload and any trailing actionable guidance that fits.

## Evidence

- Pre-fix focused regression: 5 intended failures when structured results discarded text.
- Pre-fix node-host boundary reproduction: an oversized structured JSON mirror followed by `authentication expired; run login` produced no recovery text.
- Focused post-fix suites: 75 assertions passed across node-host MCP manager/recovery, agent MCP materialization, and node-plugin projection.
- Final rebased head: 45 focused assertions passed.
- `pnpm check:changed` passed for the complete six-file patch before the final conflict-free rebase; final `git diff --check` passed.
- Fresh structured autoreview on the final rebased head: clean, no accepted/actionable findings.
- Installed MCP SDK contract inspected at `node_modules/@modelcontextprotocol/sdk/dist/esm/types.js` and `client/index.js`; the SDK defines `content`, `structuredContent`, and `isError` independently and requires structured output for output-schema tools.
- The implementation worker also inspected the sibling Codex MCP adapters at `codex-rs/protocol/src/mcp.rs`, `codex-rs/codex-mcp/src/binding.rs`, and `codex-rs/mcp-server/src/codex_tool_runner.rs`; they preserve the same independent fields.
- Production LOC: +32/-16 (net +16). Tests: +135/-60. The production growth establishes the shared projection contract and enforces the same priority at the node-host payload owner.
- Gap: no external live-provider run; real stdio MCP and `mcp.tools.call.v1` node-host boundary tests cover the unchanged wire contract.
