### PR TITLE
fix(cli): report broadcast delivery failures

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -153,7 +153,7 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
       if (descendantPid === undefined) {
         throw new Error("scenario command descendant did not expose its pid");
       }
-      expect(isProcessRunning(descendantPid)).toBe(false);
+      await waitForProcessExit(descendantPid);
     } finally {
       if (descendantPid && isProcessRunning(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -1,5 +1,5 @@
 // Process coverage for CLI help exits and route-first fallback validation.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -395,6 +395,70 @@ describe("rejected CLI process state isolation", () => {
     await expect(fs.access(path.join(result.root, `.openclaw-${profile}`))).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+});
+
+describe("message broadcast process exit", () => {
+  it("exits nonzero after a structured target failure", async () => {
+    const root = tempDirs.make("openclaw-message-broadcast-exit-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const entryPath = path.join(root, "run-message-broadcast.mjs");
+    await fs.writeFile(
+      entryPath,
+      `import { registerHooks } from "node:module";
+const messageModule = "data:text/javascript," + encodeURIComponent(\`export async function messageCommand() {
+  return ${JSON.stringify({
+    kind: "broadcast",
+    channel: "fixture",
+    action: "broadcast",
+    handledBy: "core",
+    payload: {
+      results: [
+        { channel: "fixture", to: "ok-target", ok: true },
+        { channel: "fixture", to: "failed-target", ok: false, error: "delivery failed" },
+      ],
+    },
+    dryRun: false,
+  })};
+}\`);
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    return specifier === "../../../commands/message.js"
+      ? { shortCircuit: true, url: messageModule }
+      : nextResolve(specifier, context);
+  },
+});
+const { createMessageCliHelpers } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/cli/program/message/helpers.ts")).href)});
+const { runMessageAction } = createMessageCliHelpers({}, "fixture");
+await runMessageAction("broadcast", {
+  channel: "fixture",
+  targets: ["ok-target", "failed-target"],
+  message: "hello",
+});
+`,
+    );
+
+    const child = spawnSync(process.execPath, ["--import", "tsx", entryPath], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: root,
+        NODE_ENV: undefined,
+        NODE_OPTIONS: undefined,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_NO_RESPAWN: "1",
+        OPENCLAW_STATE_DIR: stateDir,
+        VITEST: undefined,
+      },
+      timeout: DEFAULT_CHILD_PROCESS_TIMEOUT_MS,
+    });
+
+    expect(child.error).toBeUndefined();
+    expect(child.signal).toBeNull();
+    expect(child.status, child.stderr).toBe(1);
   });
 });
 

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -2,7 +2,7 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const messageCommandMock = vi.fn(async () => {});
+const messageCommandMock = vi.fn(async (): Promise<unknown> => undefined);
 vi.mock("../../../commands/message.js", () => ({
   messageCommand: messageCommandMock,
 }));
@@ -52,7 +52,7 @@ vi.mock("../../../plugins/hook-runner-global.js", () => ({
   runGlobalGatewayStopSafely: runGlobalGatewayStopSafelyMock,
 }));
 
-const exitMock = vi.fn((): never => {
+const exitMock = vi.fn((_code: number): never => {
   throw new Error("exit");
 });
 const errorMock = vi.fn();
@@ -137,7 +137,7 @@ describe("runMessageAction", () => {
     hasHooksMock.mockClear().mockReturnValue(false);
     runGatewayStopMock.mockClear().mockResolvedValue(undefined);
     runGlobalGatewayStopSafelyMock.mockClear();
-    exitMock.mockClear().mockImplementation((): never => {
+    exitMock.mockClear().mockImplementation((_code: number): never => {
       throw new Error("exit");
     });
   });
@@ -508,6 +508,43 @@ describe("runMessageAction", () => {
 
     expect(runGatewayStopMock).toHaveBeenCalledWith({ reason: "cli message action complete" }, {});
     expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it("runs gateway_stop hooks before exit(1) for a failed broadcast result", async () => {
+    const order: string[] = [];
+    hasHooksMock.mockReturnValueOnce(true);
+    messageCommandMock.mockResolvedValueOnce({
+      kind: "broadcast",
+      channel: "telegram",
+      action: "broadcast",
+      handledBy: "core",
+      payload: {
+        results: [
+          { channel: "telegram", to: "123", ok: true },
+          { channel: "telegram", to: "456", ok: false, error: "delivery failed" },
+        ],
+      },
+      dryRun: false,
+    });
+    runGatewayStopMock.mockImplementationOnce(async () => {
+      order.push("stop");
+    });
+    exitMock.mockImplementationOnce((code: number): never => {
+      order.push(`exit:${code}`);
+      throw new Error("exit");
+    });
+    const runMessageAction = createRunMessageAction();
+
+    await expect(
+      runMessageAction("broadcast", {
+        channel: "telegram",
+        targets: ["123", "456"],
+        message: "hi",
+      }),
+    ).rejects.toThrow("exit");
+
+    expect(order).toEqual(["stop", "exit:1"]);
+    expect(exitMock).not.toHaveBeenCalledWith(0);
   });
 
   it("logs gateway_stop failure and still exits with success code", async () => {

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -15,6 +15,7 @@ import { getRuntimeConfig } from "../../../config/config.js";
 import { danger, setVerbose } from "../../../globals.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-target.js";
+import { isMessageBroadcastSuccessful } from "../../../infra/outbound/message-action-contracts.js";
 import { withActivatedPluginIds } from "../../../plugins/activation-context.js";
 import {
   resolveConfiguredChannelPluginIds,
@@ -167,6 +168,7 @@ export function createMessageCliHelpers(
   const runMessageAction = async (action: string, opts: Record<string, unknown>) => {
     setVerbose(Boolean(opts.verbose));
     let failed = false;
+    let result: Awaited<ReturnType<typeof messageCommand>> | undefined;
     let pluginRegistry: PluginRegistry | undefined;
     await runCommandWithRuntime(
       defaultRuntime,
@@ -208,7 +210,7 @@ export function createMessageCliHelpers(
             deps,
             defaultRuntime,
           );
-        await withPluginRuntimeRegistryScope(pluginRegistry, run);
+        result = await withPluginRuntimeRegistryScope(pluginRegistry, run);
       },
       (err) => {
         failed = true;
@@ -219,6 +221,7 @@ export function createMessageCliHelpers(
     if (!ACTIONS_WITHOUT_STOP_HOOKS.has(action)) {
       await withPluginRuntimeRegistryScope(pluginRegistry, runPluginStopHooks);
     }
+    failed ||= result?.kind === "broadcast" && !isMessageBroadcastSuccessful(result);
     defaultRuntime.exit(failed ? 1 : 0);
   };
 

--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -248,3 +248,47 @@ describe("formatMessageCliText poll results", () => {
     ]);
   });
 });
+
+describe("formatMessageCliText broadcast results", () => {
+  it("reports aggregate failure while preserving every target row", () => {
+    const result = {
+      kind: "broadcast",
+      action: "broadcast",
+      channel: "directchat",
+      handledBy: "core",
+      payload: {
+        results: [
+          ...Array.from({ length: 51 }, (_, index) => ({
+            channel: "directchat" as const,
+            to: `room-ok-${index}`,
+            ok: true as const,
+          })),
+          {
+            channel: "directchat",
+            to: "room-suppressed",
+            ok: false,
+            error: "Broadcast send suppressed: cancelled_by_message_sending_hook.",
+          },
+          {
+            channel: "directchat",
+            to: "room-partial",
+            ok: false,
+            error: "second payload failed",
+            sentBeforeError: true,
+          },
+        ],
+      },
+      dryRun: false,
+    } satisfies MessageActionResult;
+
+    const output = textJoined(formatMessageCliText(result));
+
+    expect(output).toContain("Broadcast failed (51/53 succeeded, 2 failed)");
+    expect(output).not.toContain("Broadcast complete");
+    expect(output).toContain("room-ok-50");
+    expect(output).toContain("room-suppressed");
+    expect(output).toContain("room-partial");
+    expect(output).toContain("Broadcast send suppressed");
+    expect(output).toContain("second payload failed");
+  });
+});

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -7,7 +7,10 @@ import { getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 import { formatGatewaySummary, formatOutboundDeliverySummary } from "../infra/outbound/format.js";
-import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
+import {
+  isMessageBroadcastSuccessful,
+  type MessageActionResult,
+} from "../infra/outbound/message-action-contracts.js";
 import { formatTargetDisplay } from "../infra/outbound/target-resolver.js";
 import { shortenText } from "./text-format.js";
 
@@ -274,6 +277,7 @@ export function formatMessageCliText(
 ): string[] {
   const rich = isRich();
   const ok = (text: string) => (rich ? theme.success(text) : text);
+  const fail = (text: string) => (rich ? theme.error(text) : text);
   const muted = (text: string) => (rich ? theme.muted(text) : text);
   const heading = (text: string) => (rich ? theme.heading(text) : text);
 
@@ -295,8 +299,9 @@ export function formatMessageCliText(
     }));
     const okCount = results.filter((entry) => entry.ok).length;
     const total = results.length;
-    const headingLine = ok(
-      `✅ Broadcast complete (${okCount}/${total} succeeded, ${total - okCount} failed)`,
+    const successful = isMessageBroadcastSuccessful(result);
+    const headingLine = (successful ? ok : fail)(
+      `${successful ? "✅ Broadcast complete" : "❌ Broadcast failed"} (${okCount}/${total} succeeded, ${total - okCount} failed)`,
     );
     return [
       headingLine,
@@ -308,7 +313,7 @@ export function formatMessageCliText(
           { key: "Status", header: "Status", minWidth: 6 },
           { key: "Error", header: "Error", minWidth: 20, flex: true },
         ],
-        rows: rows.slice(0, 50),
+        rows,
       }).trimEnd(),
     ];
   }

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { CliDeps } from "../cli/deps.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
+import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv } from "../test-utils/env.js";
 
@@ -97,15 +98,18 @@ vi.mock("../cli/command-secret-targets.js", () => ({
 }));
 
 const runMessageActionMock = vi.hoisted(() =>
-  vi.fn(async ({ action, params }: RunMessageActionParams) => ({
-    kind: action === "poll" ? "poll" : "send",
-    channel: typeof params.channel === "string" ? params.channel : "telegram",
-    action: action === "poll" ? "poll" : "send",
-    to: typeof params.target === "string" ? params.target : "123456",
-    handledBy: "plugin",
-    payload: { ok: true },
-    dryRun: false,
-  })),
+  vi.fn(async ({ action, params }: RunMessageActionParams): Promise<MessageActionResult> => {
+    const base = {
+      channel: typeof params.channel === "string" ? params.channel : "telegram",
+      to: typeof params.target === "string" ? params.target : "123456",
+      handledBy: "plugin" as const,
+      payload: { ok: true },
+      dryRun: false,
+    };
+    return action === "poll"
+      ? { ...base, kind: "poll", action: "poll" }
+      : { ...base, kind: "send", action: "send" };
+  }),
 );
 
 vi.mock("../infra/outbound/message-action-runner.js", () => ({
@@ -253,6 +257,34 @@ async function runMessageCommand(opts: Record<string, unknown> = {}) {
 }
 
 describe("messageCommand", () => {
+  it("includes aggregate broadcast failure and every target row in JSON output", async () => {
+    const results: Extract<MessageActionResult, { kind: "broadcast" }>["payload"]["results"] = [
+      { channel: "telegram", to: "123", ok: true },
+      { channel: "telegram", to: "456", ok: false, error: "provider rejected the message" },
+    ];
+    runMessageActionMock.mockResolvedValueOnce({
+      kind: "broadcast",
+      channel: "telegram",
+      action: "broadcast",
+      handledBy: "core",
+      payload: { results },
+      dryRun: false,
+    });
+
+    await runMessageCommand({
+      action: "broadcast",
+      target: undefined,
+      targets: ["123", "456"],
+    });
+
+    const output = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+      ok?: boolean;
+      payload?: { results?: unknown[] };
+    };
+    expect(output.ok).toBe(false);
+    expect(output.payload?.results).toEqual(results);
+  });
+
   it("rejects a malformed explicit account before resolving secrets", async () => {
     await expect(runMessageCommand({ accountId: "!!!" })).rejects.toThrow("Invalid account ID");
 

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -24,6 +24,7 @@ import {
   resolveMessageBroadcastAccountPlan,
   validateExplicitMessageAccountSelection,
 } from "../infra/outbound/message-account-selection.js";
+import { isMessageBroadcastSuccessful } from "../infra/outbound/message-action-contracts.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
@@ -49,6 +50,7 @@ function extractMessageId(payload: unknown): string | undefined {
 function buildMessageCliJson(result: Awaited<ReturnType<typeof runMessageAction>>) {
   const messageId = extractMessageId(result.payload);
   return {
+    ...(result.kind === "broadcast" ? { ok: isMessageBroadcastSuccessful(result) } : {}),
     action: result.action,
     channel: result.channel,
     dryRun: result.dryRun,
@@ -158,7 +160,7 @@ export async function messageCommand(
 
   if (json) {
     writeRuntimeJson(runtime, buildMessageCliJson(result));
-    return;
+    return result;
   }
 
   const { formatMessageCliText } = await import("./message-format.js");
@@ -166,4 +168,5 @@ export async function messageCommand(
   for (const line of formatMessageCliText(result, { displayLimit })) {
     runtime.log(line);
   }
+  return result;
 }

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -169,6 +169,10 @@ export type MessageActionResult =
       dryRun: boolean;
     };
 
+export const isMessageBroadcastSuccessful = (
+  result: Extract<MessageActionResult, { kind: "broadcast" }>,
+): boolean => result.payload.results.every((entry) => entry.ok);
+
 export type ResolvedActionContext = {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `openclaw message broadcast` received a successful process outcome even when one or every target failed, was suppressed, or only partially delivered. Text output always said `Broadcast complete`, JSON omitted aggregate success, and the command exited 0 because only thrown exceptions reached the CLI failure path.

## Why This Change Was Made

The CLI now carries the message action's structured result through its helper and evaluates the existing per-target `ok` facts after plugin stop hooks complete. Broadcast text and JSON share one broadcast-specific aggregate predicate, every target row is preserved, and provider/channel delivery identity logic remains unchanged.

This PR is AI-assisted. The implementation and existing delivery contracts were manually inspected, and the complete diff was independently reviewed.

## User Impact

Broadcast automation can now trust both JSON and the process exit code: any failed, suppressed, or partially failed target produces `ok: false` and exit 1 while retaining the full per-target report. Fully successful broadcasts continue to report completion and exit 0.

## Evidence

- Focused Vitest: 116 tests passed across the message formatter, command JSON, CLI helper, process-exit, and broadcast status-producer suites.
- Source-blind CLI validation: successful two-target text and JSON dry runs reported both rows, top-level `ok: true`, and exit 0; structured failure fixtures reported `Broadcast failed`, `ok: false`, preserved all rows, ran stop hooks before exit, and exited 1.
- Exact-head CI exposed asynchronous Linux reaping lag in the QA lifecycle test's immediate descendant process-state assertion; the test now uses its existing bounded exit wait without changing production lifecycle code or timing constants.
- QA lifecycle proof: the focused file passed 8/8 tests and the exact formerly failing case passed 10/10 repetitions.
- `node scripts/check-changed.mjs -- <changed paths>` passed for both the broadcast patch and the isolated QA repair.
- `git diff --check` passed.
- Autoreview reported no accepted/actionable findings.
- Production LOC: +21/-6 (net +15). Tests/test-support: +191/-14 (net +177).
