### PR TITLE
fix(ui): defer syntax highlighting for open streaming fences (AI-assisted)

### DIFF
--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -55,6 +55,10 @@ function shouldRenderCodeBlockCopy(env: unknown): boolean {
   return codeBlockRenderEnv(env)?.codeBlockChrome !== "none";
 }
 
+function shouldHighlightCodeBlock(env: unknown): boolean {
+  return codeBlockRenderEnv(env)?.codeBlockSyntaxHighlighting !== "deferred";
+}
+
 function shouldRenderCodeBlockInteraction(env: unknown): boolean {
   return codeBlockRenderEnv(env)?.codeBlockInteraction === "interactive";
 }
@@ -268,12 +272,13 @@ function codeClassAttribute(lang: string, highlighted: string): string {
 function renderCodeElement(
   text: string,
   lang: string,
-  options: { blockArt?: boolean } = {},
+  options: { blockArt?: boolean; highlight?: boolean } = {},
 ): string {
   if (options.blockArt || isMarkdownBlockArtText(text)) {
     return `<pre><code class="markdown-block-art">${escapeMarkdownHtml(text)}</code></pre>`;
   }
-  const highlighted = highlightCodeHtml(text, lang);
+  const highlighted =
+    options.highlight === false ? escapeMarkdownHtml(text) : highlightCodeHtml(text, lang);
   const classAttr = codeClassAttribute(lang, highlighted);
   return `<pre><code${classAttr}>${highlighted}</code></pre>`;
 }
@@ -304,7 +309,10 @@ export function renderMarkdownCodeBlock(
   options: { blockArt?: boolean; copyText?: string } = {},
 ): string {
   const blockArt = options.blockArt || isMarkdownBlockArtText(text);
-  const codeBlock = renderCodeElement(text, lang, { blockArt });
+  const codeBlock = renderCodeElement(text, lang, {
+    blockArt,
+    highlight: shouldHighlightCodeBlock(env),
+  });
   if (!shouldRenderCodeBlockCopy(env) && !shouldRenderCodeBlockInteraction(env)) {
     return codeBlock;
   }

--- a/ui/src/components/markdown-render-options.ts
+++ b/ui/src/components/markdown-render-options.ts
@@ -2,11 +2,13 @@ type MarkdownCodeBlockChrome = "copy" | "none";
 type MarkdownCodeBlockInteraction = "interactive" | "static";
 type MarkdownTableInteractions = "enabled" | "none";
 type MarkdownRenderMode = "document" | "message";
+type MarkdownCodeBlockSyntaxHighlighting = "live" | "deferred";
 
 export type MarkdownRenderOptions = {
   assistantTranscriptRoleHeaders?: boolean;
   codeBlockChrome?: MarkdownCodeBlockChrome;
   codeBlockInteraction?: MarkdownCodeBlockInteraction;
+  codeBlockSyntaxHighlighting?: MarkdownCodeBlockSyntaxHighlighting;
   fileLinks?: boolean;
   interactiveImages?: boolean;
   progressBars?: boolean;
@@ -24,6 +26,7 @@ export function normalizeMarkdownRenderOptions(
     assistantTranscriptRoleHeaders: options.assistantTranscriptRoleHeaders ?? false,
     codeBlockChrome: options.codeBlockChrome ?? "copy",
     codeBlockInteraction: options.codeBlockInteraction ?? "static",
+    codeBlockSyntaxHighlighting: options.codeBlockSyntaxHighlighting ?? "live",
     fileLinks: options.fileLinks ?? false,
     interactiveImages: options.interactiveImages ?? false,
     progressBars: options.progressBars ?? false,

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -936,12 +936,15 @@ describe("toStreamingMarkdownHtml", () => {
     expect(html).toBe("<p>prices are $$50 and</p>\n");
   });
 
-  it("streams an open code fence as a live-highlighted code block", () => {
+  it("defers syntax highlighting for an open streaming code fence", () => {
     const html = toStreamingMarkdownHtml("Intro\n\n```ts\nconst x = 1 < 2");
     const fragment = htmlFragment(html);
 
     expect(fragment.querySelector("p")?.textContent).toBe("Intro");
-    expect(fragment.querySelector("code.language-ts")?.textContent).toContain("const x = 1 < 2");
+    const code = fragment.querySelector("code.language-ts");
+    expect(code?.textContent).toContain("const x = 1 < 2");
+    expect(code?.classList.contains("hljs")).toBe(false);
+    expect(html).not.toContain("hljs-");
     expect(html).not.toContain("markdown-plain-text-fallback");
   });
 

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -409,6 +409,33 @@ PY
       );
     });
 
+    it("keeps deferred code highlighting separate from live rendering", () => {
+      const renderings = [
+        {
+          markdown: "```typescript\nconst liveFirst = 42;\n```",
+          first: { codeBlockSyntaxHighlighting: "live" as const },
+          second: { codeBlockSyntaxHighlighting: "deferred" as const },
+        },
+        {
+          markdown: "```typescript\nconst deferredFirst = 42;\n```",
+          first: { codeBlockSyntaxHighlighting: "deferred" as const },
+          second: { codeBlockSyntaxHighlighting: "live" as const },
+        },
+      ];
+
+      for (const { markdown, first, second } of renderings) {
+        const firstHtml = htmlFragment(toSanitizedMarkdownHtml(markdown, first));
+        const secondHtml = htmlFragment(toSanitizedMarkdownHtml(markdown, second));
+
+        expect(firstHtml.querySelector("pre code")?.classList.contains("hljs")).toBe(
+          first.codeBlockSyntaxHighlighting === "live",
+        );
+        expect(secondHtml.querySelector("pre code")?.classList.contains("hljs")).toBe(
+          second.codeBlockSyntaxHighlighting === "live",
+        );
+      }
+    });
+
     it("keeps short code blocks fully visible in interactive hosts", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(jsonBlock(7), { codeBlockInteraction: "interactive" }),

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -559,7 +559,7 @@ export function toSanitizedMarkdownHtml(
   }
   const renderInput = isMarkdownBlockArtText(rawInput) ? rawInput : input;
   const cacheable = input.length <= MARKDOWN_CACHE_MAX_CHARS;
-  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.codeBlockInteraction}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.progressBars}\0${renderOptions.mode}\0${renderOptions.sessionLinks}\0${renderOptions.tableInteractions}\0${renderInput}`;
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.codeBlockInteraction}\0${renderOptions.codeBlockSyntaxHighlighting}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.progressBars}\0${renderOptions.mode}\0${renderOptions.sessionLinks}\0${renderOptions.tableInteractions}\0${renderInput}`;
   if (cacheable) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -609,7 +609,10 @@ export function toStreamingMarkdownHtml(
   }
   const tailHtml =
     tailRepairStart === null
-      ? renderSanitizedMarkdown(streamingTail, renderOptions)
+      ? renderSanitizedMarkdown(streamingTail, {
+          ...renderOptions,
+          codeBlockSyntaxHighlighting: "deferred",
+        })
       : renderSanitizedMarkdown(
           repairStreamingMarkdownTail(streamingTail, tailRepairStart - boundary),
           renderOptions,

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -311,6 +311,85 @@ suite.define(() => {
     }
   });
 
+  it("defers and restores code highlighting across a streamed fence", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      ...(artifactDir
+        ? {
+            recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } },
+          }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.locator(".agent-chat__composer-combobox textarea").fill("stream a code fence");
+      await page.getByRole("button", { name: "Send message" }).click();
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const runId = requireString(
+        requireRecord(sendRequest.params).idempotencyKey,
+        "chat send idempotency key",
+      );
+      const openFence = "```typescript\nconst answer = 42;";
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: openFence,
+        message: {
+          content: [{ text: openFence, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId,
+        seq: 1,
+        sessionKey: "main",
+        state: "delta",
+      });
+
+      const streamingCode = page.locator(".chat-bubble.streaming code");
+      await expect(streamingCode).toContainText("const answer = 42;");
+      const openState = await streamingCode.evaluate((element) => ({
+        className: element.className,
+        hasHljsClass: element.classList.contains("hljs"),
+      }));
+      expect(openState.hasHljsClass).toBe(false);
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "markdown-open-fence.png"),
+        });
+      }
+
+      await gateway.emitChatFinal({ runId, text: `${openFence}\n\n\`\`\`` });
+      const committedCode = page.locator(".chat-bubble:not(.streaming) code").last();
+      await expect(committedCode).toContainText("const answer = 42;");
+      await expect
+        .poll(() => committedCode.evaluate((element) => element.classList.contains("hljs")))
+        .toBe(true);
+      const closedState = await committedCode.evaluate((element) => ({
+        className: element.className,
+        hasHljsClass: element.classList.contains("hljs"),
+      }));
+      console.log(
+        `[markdown-stream-proof] ${JSON.stringify({
+          openFence: openState,
+          closedFence: closedState,
+        })}`,
+      );
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "markdown-closed-fence.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("normalizes Unicode line separators in streaming and final chat DOM", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Closes #112136

## What Problem This Solves

Fixes an issue where users viewing a streaming Markdown response with an unfinished fenced code block could trigger repeated syntax-highlighting work on every permitted render, causing avoidable CPU usage and UI friction.

## Why This Change Was Made

Completed code fences continue to receive normal syntax highlighting. While a fence is still open during streaming, rendering defers highlighting and keeps the code as escaped plaintext until the fence closes. This preserves the completed-message presentation while avoiding repeated parsing of content that is still changing.

## User Impact

Streaming code blocks should consume less CPU and remain more responsive while they are being generated. Once the closing fence arrives, the existing highlighted rendering is restored.

## Evidence

- Regression test fails before the fix and passes after it:
  - `ui/src/components/markdown.test.ts`
  - Open streaming fences remain plaintext without `hljs` classes.
  - Completed fences retain syntax highlighting.
  - Deferred/live cache-order coverage passes in both call orders; without the cache-key field the regression fails because the second render reuses the first mode's HTML.
- Focused UI tests pass:
  - `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/components/markdown.test.ts ui/src/components/markdown-details.test.ts ui/src/components/markdown-code-blocks.test.ts`
  - 143 tests passed.
- UI typecheck passes: `pnpm tsgo:ui`
- Targeted lint passes for the four touched UI files: oxlint and stylelint.
- Formatting check passes for the four touched UI files: `oxfmt --check`.
- `git diff --check` passes.
- Added a real Control UI mocked-Gateway E2E at `ui/src/e2e/chat-flow.streaming.e2e.test.ts`; it logs the open/closed DOM class state and optionally records screenshots/video through `OPENCLAW_UI_E2E_ARTIFACT_DIR`.
- Production delta: `+19/-5` (net +14); tests: `+111/-2` (net +109). The production increase consists of the explicit highlighting-mode cache dimension and the owner-boundary render option; the test growth covers both cache call orders and the real Control UI streaming transition.
- ClawSweeper's actionable cache finding is addressed: `codeBlockSyntaxHighlighting` is now part of the static Markdown cache key, with regression coverage for deferred-first and live-first calls.
- A local run of the browser harness was attempted, but the host ran out of disk while building the temporary Control UI bundle (`ENOSPC`) before the browser test executed. No local screenshot or recording is claimed; the new E2E test is queued for exact-head CI proof.

AI-assisted: implemented and validated with Codex; the author understands the change and its tradeoffs. The autoreview skill was attempted, but its Codex backend could not connect to refresh models in this environment; no automated review findings were returned.
