### PR TITLE
fix(channels): preserve ingress during gateway restarts

### DIFF
--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -6,6 +6,7 @@
  */
 import { sleepWithAbort } from "@openclaw/retry";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { GatewayDrainingError } from "../../process/gateway-work-admission.js";
 import {
   createIngressDrainOwnerId,
   deregisterLiveIngressDrainInstance,
@@ -319,6 +320,12 @@ export function createChannelIngressDrain<
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
     err: unknown,
   ) => {
+    if (err instanceof GatewayDrainingError) {
+      // Root dispatch closes before durable transport admission during restart.
+      // Preserve the row for the successor without spending its failure budget.
+      await releaseClaim(claim, { recordAttempt: false });
+      return;
+    }
     const disposition = resolveIngressFailureDisposition({
       err,
       event: claim,

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  GatewayDrainingError,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { sleep } from "../../utils/sleep.js";
 import {
@@ -10,6 +16,7 @@ import {
   type ChannelIngressMonitorLifecycle,
 } from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
+import type { IngressRetryPolicyConfig } from "./ingress-retry-policy.js";
 import {
   ChannelIngressUnavailableError,
   isChannelIngressUnavailableError,
@@ -58,6 +65,7 @@ function createMonitor(
             }>;
         waitForDeliveryIdleBeforeRepump?: boolean;
         waitForDeliveryIdleOnStop?: boolean;
+        retryPolicy?: IngressRetryPolicyConfig;
       },
   onError?: (error: unknown) => void,
   abortSignal?: AbortSignal,
@@ -68,6 +76,7 @@ function createMonitor(
     typeof activityOrMonitorOptions === "function" ? activityOrMonitorOptions : undefined;
   const monitorOptions =
     typeof activityOrMonitorOptions === "object" ? activityOrMonitorOptions : {};
+  const { retryPolicy, ...baseMonitorOptions } = monitorOptions;
   return createChannelIngressMonitor<RawEvent, string, StoredEvent>({
     queue,
     inspect: (raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
@@ -81,10 +90,10 @@ function createMonitor(
     deliver,
     pollIntervalMs,
     retention: { pruneIntervalMs: 60_000 },
-    ...monitorOptions,
+    ...baseMonitorOptions,
     drain: {
       adoptionStallTimeoutMs: 5_000,
-      retryPolicy: { baseMs: retryBaseMs, maxMs: retryBaseMs },
+      retryPolicy: retryPolicy ?? { baseMs: retryBaseMs, maxMs: retryBaseMs },
       resolveNonRetryableFailure: (error) =>
         error instanceof PermanentIngressError
           ? { reason: "invalid-event", message: error.message }
@@ -97,6 +106,7 @@ function createMonitor(
 }
 
 afterEach(() => {
+  resetGatewayWorkAdmission();
   closeOpenClawStateDatabaseForTest();
   vi.restoreAllMocks();
 });
@@ -363,6 +373,124 @@ describe("channel ingress monitor", () => {
       await monitor.waitForIdle();
 
       await monitor.stop();
+    });
+  });
+
+  it("defers a claimed event across restart drain without consuming retry budget", async () => {
+    await withQueue(async (queue) => {
+      const event = {
+        id: "event-restart-drain",
+        lane: "a",
+        text: "recover me",
+      } satisfies RawEvent;
+      const storedEvent = {
+        version: 1,
+        rawEvent: JSON.stringify(event),
+      } satisfies StoredEvent;
+      const drainErrors: unknown[] = [];
+      const oldDeliver = vi.fn(
+        async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+          try {
+            await runWithGatewayIndependentRootWorkAdmission(async () => {
+              await lifecycle.onAdopted();
+            });
+          } catch (error) {
+            drainErrors.push(error);
+            throw error;
+          }
+        },
+      );
+      const monitorOptions = {
+        retryPolicy: {
+          maxAttempts: 8,
+          deadLetterMinAgeMs: 0,
+          baseMs: 0,
+          maxMs: 0,
+        },
+      } as const;
+      const oldMonitor = createMonitor(
+        queue,
+        oldDeliver,
+        monitorOptions,
+        undefined,
+        undefined,
+        60_000,
+      );
+      let successorMonitor: ReturnType<typeof createMonitor> | undefined;
+      oldMonitor.start();
+      try {
+        await oldMonitor.waitForIdle();
+
+        let markPendingScanStarted = () => {};
+        const pendingScanStarted = new Promise<void>((resolve) => {
+          markPendingScanStarted = resolve;
+        });
+        let releasePendingScan = () => {};
+        const pendingScanGate = new Promise<void>((resolve) => {
+          releasePendingScan = resolve;
+        });
+        const listPending = queue.listPending.bind(queue);
+        let gateNextPendingScan = true;
+        queue.listPending = async (...args) => {
+          if (gateNextPendingScan) {
+            gateNextPendingScan = false;
+            markPendingScanStarted();
+            await pendingScanGate;
+          }
+          return await listPending(...args);
+        };
+
+        oldMonitor.requestDrain();
+        await pendingScanStarted;
+        markGatewayRestartDraining();
+        await queue.enqueue(event.id, storedEvent, { laneKey: "lane:a" });
+        releasePendingScan();
+        await vi.waitFor(() => expect(drainErrors.length).toBeGreaterThan(0));
+
+        for (let cycle = 0; cycle < 8; cycle += 1) {
+          oldMonitor.requestDrain();
+          await oldMonitor.waitForIdle();
+        }
+
+        expect(drainErrors[0]).toBeInstanceOf(GatewayDrainingError);
+        expect(drainErrors).toHaveLength(1);
+        expect(oldDeliver).toHaveBeenCalledOnce();
+        await expect(queue.listClaims()).resolves.toEqual([]);
+        await expect(queue.listPending()).resolves.toEqual([
+          expect.objectContaining({ id: event.id, attempts: 0 }),
+        ]);
+        await expect(queue.listFailed?.()).resolves.toEqual([]);
+
+        await oldMonitor.stop();
+        resetGatewayWorkAdmission();
+        const successorDeliver = vi.fn(
+          async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+            await runWithGatewayIndependentRootWorkAdmission(async () => {
+              await lifecycle.onAdopted();
+            });
+          },
+        );
+        successorMonitor = createMonitor(
+          queue,
+          successorDeliver,
+          monitorOptions,
+          undefined,
+          undefined,
+          60_000,
+        );
+        successorMonitor.start();
+        await successorMonitor.waitForIdle();
+
+        expect(successorDeliver).toHaveBeenCalledOnce();
+        expect(oldDeliver).toHaveBeenCalledOnce();
+        await expect(
+          queue.enqueue(event.id, { version: 1, rawEvent: "duplicate" }),
+        ).resolves.toMatchObject({ kind: "completed" });
+      } finally {
+        await successorMonitor?.stop();
+        await oldMonitor.stop();
+        resetGatewayWorkAdmission();
+      }
     });
   });
 

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -1,5 +1,6 @@
 /** Shared durable channel-ingress admission, pump, retention, and shutdown lifecycle. */
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { isGatewayRestartDraining } from "../../process/gateway-work-admission.js";
 import { sleep } from "../../utils/sleep.js";
 import {
   createChannelIngressDrain,
@@ -544,7 +545,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   };
 
   const requestDrain = (): void => {
-    if (!running || isAborted()) {
+    if (!running || isAborted() || isGatewayRestartDraining()) {
       publishActivity();
       return;
     }


### PR DESCRIPTION
Closes #125918

## What Problem This Solves

Fixes an issue where a durably accepted channel event could exhaust its delivery retry budget and be dead-lettered while the Gateway was intentionally draining for a managed restart. The successor Gateway then had no pending event left to recover, so an accepted message could be permanently missed.

AI-assisted implementation; the resulting owner boundary and tests were reviewed directly.

## Why This Change Was Made

The generic ingress drain now treats the typed `GatewayDrainingError` as a lifecycle deferral: it releases the claim without recording an attempt. Channel monitors also stop starting new drains while restart admission is closed. Other retryable and non-retryable failures continue through the existing failure policy unchanged.

The regression models the real process transition using one durable queue: the old monitor releases the claim during drain, then a newly started successor monitor claims and completes it after admission reopens.

## User Impact

Messages accepted by durable channel ingress during a planned Gateway restart remain recoverable instead of being dead-lettered by the restart itself. This applies generically to durable channel monitors; it does not increase retry counts or weaken handling for real delivery failures.

## Evidence

Pre-fix owner-boundary regression failed because the drain exception consumed retry attempts.

Focused verification after the repair:

- `node scripts/run-vitest.mjs src/channels/message/ingress-monitor.test.ts src/channels/message/ingress-drain.test.ts src/channels/message/ingress-drain.cancellation.test.ts src/channels/message/ingress-drain-lanes.test.ts src/channels/message/ingress-retry-policy.test.ts src/channels/message/ingress-queue.test.ts extensions/discord/src/monitor/ingress.test.ts`
  - 3 Vitest shards passed
  - 7 files passed
  - 104 tests passed
- `node scripts/check-changed.mjs -- src/channels/message/ingress-drain.ts src/channels/message/ingress-monitor.ts src/channels/message/ingress-monitor.test.ts`
  - core/coreTests typecheck, lint, format, dead-export, import-cycle, architecture, and repository guards passed
- `git diff --check`
  - passed
- Codex autoreview
  - clean, no accepted/actionable findings

Production LOC: +9 / -1. Test LOC: +130 / -2. The production growth records the restart-lifecycle deferral at the generic ingress owner and prevents new pumps while the same fence is active.
