### PR TITLE
fix(ui): stop truncated Workshop diffs showing zero totals

### DIFF
--- a/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
@@ -149,12 +149,16 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
     }
   });
 
-  it("directs late-only changes to the full body without showing zero totals", async () => {
+  it.each([
+    { label: "late-only", changedIndex: 650, hasVisibleChange: false },
+    { label: "visible-only", changedIndex: 500, hasVisibleChange: true },
+  ])("directs $label changes to the full body without exact totals", async (scenario) => {
     const previous = appliedProposal("proposal-long-v1", "2026-08-16T10:00:00.000Z");
     const latest = appliedProposal("proposal-long-v2", "2026-08-17T10:00:00.000Z");
     const previousLines = Array.from({ length: 700 }, (_, index) => `Procedure line ${index}`);
     const latestLines = [...previousLines];
-    latestLines[650] = "Changed procedure outside preview";
+    const changedText = `Changed procedure at line ${scenario.changedIndex}`;
+    latestLines[scenario.changedIndex] = changedText;
     const context = await browser.newContext({
       locale: "en-US",
       recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
@@ -193,19 +197,20 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
 
       const notice = page.locator(".sw-diff__notice");
       await notice.waitFor();
-      expect(await notice.textContent()).toContain("The changed region is outside this preview.");
+      expect(await notice.textContent()).toContain("This comparison is truncated.");
       expect(await notice.textContent()).toContain("Switch to Full body");
       expect(await page.locator(".sw-diff__stat").count()).toBe(0);
+      expect((await page.locator(".sw-diff__row--add").count()) > 0).toBe(
+        scenario.hasVisibleChange,
+      );
       await page.screenshot({
         animations: "disabled",
         fullPage: true,
-        path: path.join(artifactDir, "03-late-change.png"),
+        path: path.join(artifactDir, `03-${scenario.label}-change.png`),
       });
 
       await page.getByRole("button", { name: "Full body", exact: true }).click();
-      await expect
-        .poll(() => page.locator(".sw-body-card").textContent())
-        .toContain("Changed procedure outside preview");
+      await expect.poll(() => page.locator(".sw-body-card").textContent()).toContain(changedText);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
@@ -120,6 +120,9 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
       await expect.poll(() => changes.getAttribute("aria-pressed")).toBe("true");
       await page.locator(".sw-diff__row--add", { hasText: "Publish package." }).waitFor();
       await page.locator(".sw-diff__row--del", { hasText: "Publish release." }).waitFor();
+      expect((await page.locator(".sw-diff__stat").textContent())?.replace(/\s+/gu, "")).toBe(
+        "+1-1",
+      );
       const inspectRequests = await gateway.getRequests("skills.proposals.inspect");
       expect(new Set(inspectRequests.map(inspectedProposalId))).toEqual(
         new Set([latest.id, previous.id]),
@@ -141,6 +144,68 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
         fullPage: true,
         path: path.join(artifactDir, "02-full-body.png"),
       });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("directs late-only changes to the full body without showing zero totals", async () => {
+    const previous = appliedProposal("proposal-long-v1", "2026-08-16T10:00:00.000Z");
+    const latest = appliedProposal("proposal-long-v2", "2026-08-17T10:00:00.000Z");
+    const previousLines = Array.from({ length: 700 }, (_, index) => `Procedure line ${index}`);
+    const latestLines = [...previousLines];
+    latestLines[650] = "Changed procedure outside preview";
+    const context = await browser.newContext({
+      locale: "en-US",
+      recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "skills.proposals.inspect": {
+          cases: [
+            {
+              match: { proposalId: latest.id },
+              response: inspectResponse(latest, latestLines.join("\n"), "v2"),
+            },
+            {
+              match: { proposalId: previous.id },
+              response: inspectResponse(previous, previousLines.join("\n"), "v1"),
+            },
+          ],
+        },
+        "skills.proposals.list": {
+          proposals: [latest, previous],
+          schema: "openclaw.skill-workshop.proposals-manifest.v1",
+          updatedAt: latest.updatedAt,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}skills/workshop`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("skills.proposals.list");
+      await page.locator("#skill-workshop-mode-tab-board").click();
+      await page.locator(".sw-lifecycle-tab", { hasText: "Applied" }).click();
+
+      const notice = page.locator(".sw-diff__notice");
+      await notice.waitFor();
+      expect(await notice.textContent()).toContain("The changed region is outside this preview.");
+      expect(await notice.textContent()).toContain("Switch to Full body");
+      expect(await page.locator(".sw-diff__stat").count()).toBe(0);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(artifactDir, "03-late-change.png"),
+      });
+
+      await page.getByRole("button", { name: "Full body", exact: true }).click();
+      await expect
+        .poll(() => page.locator(".sw-body-card").textContent())
+        .toContain("Changed procedure outside preview");
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3500,6 +3500,10 @@ export const en: TranslationMap = {
       loadingPrevious: "Loading the previous revision\u2026",
       previousUnavailable: "The previous revision is unavailable, so this is the full body.",
       tooLarge: "This comparison is too large to show here. Switch to Full body to read it.",
+      outsidePreview:
+        "The changed region is outside this preview. Statistics are incomplete. Switch to Full body to review it.",
+      partialPreview:
+        "Some changed regions are outside this preview. Statistics are incomplete. Switch to Full body to review every change.",
     },
     applied: {
       history: "History",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3500,10 +3500,8 @@ export const en: TranslationMap = {
       loadingPrevious: "Loading the previous revision\u2026",
       previousUnavailable: "The previous revision is unavailable, so this is the full body.",
       tooLarge: "This comparison is too large to show here. Switch to Full body to read it.",
-      outsidePreview:
-        "The changed region is outside this preview. Statistics are incomplete. Switch to Full body to review it.",
-      partialPreview:
-        "Some changed regions are outside this preview. Statistics are incomplete. Switch to Full body to review every change.",
+      truncated:
+        "This comparison is truncated. Changes and statistics may be incomplete. Switch to Full body to review the complete revision.",
     },
     applied: {
       history: "History",

--- a/ui/src/lib/chat/tool-call-diff.test.ts
+++ b/ui/src/lib/chat/tool-call-diff.test.ts
@@ -5,7 +5,6 @@ import {
   buildWriteDiffLines,
   computeLineDiff,
   countTextLines,
-  diffStat,
   joinDiffSections,
   parseDiffDetailsString,
   type DiffLine,
@@ -17,20 +16,27 @@ describe("parseDiffDetailsString", () => {
       "\n",
     );
 
-    expect(parseDiffDetailsString(diff)).toEqual([
-      { kind: "ctx", lineNo: 455, text: "before" },
-      { kind: "del", lineNo: 456, text: "old line" },
-      { kind: "add", lineNo: 456, text: "new line" },
-      { kind: "skip", text: "" },
-      { kind: "ctx", lineNo: 460, text: "after" },
-    ]);
+    expect(parseDiffDetailsString(diff)).toEqual({
+      kind: "complete",
+      lines: [
+        { kind: "ctx", lineNo: 455, text: "before" },
+        { kind: "del", lineNo: 456, text: "old line" },
+        { kind: "add", lineNo: 456, text: "new line" },
+        { kind: "skip", text: "" },
+        { kind: "ctx", lineNo: 460, text: "after" },
+      ],
+      stat: { added: 1, removed: 1 },
+    });
   });
 
   it("accepts the persisted history truncation marker", () => {
-    expect(parseDiffDetailsString("+12 kept line\n...(truncated)...")).toEqual([
-      { kind: "add", lineNo: 12, text: "kept line" },
-      { kind: "skip", text: "" },
-    ]);
+    expect(parseDiffDetailsString("+12 kept line\n...(truncated)...")).toEqual({
+      kind: "truncated",
+      lines: [
+        { kind: "add", lineNo: 12, text: "kept line" },
+        { kind: "skip", text: "" },
+      ],
+    });
   });
 
   it.each([
@@ -47,30 +53,75 @@ describe("parseDiffDetailsString", () => {
 
     const lines = parseDiffDetailsString(diff);
 
-    expect(lines).toHaveLength(402);
-    expect(lines?.at(-1)).toEqual({ kind: "skip", text: "" });
+    expect(lines).toMatchObject({ kind: "truncated" });
+    expect(lines?.lines).toHaveLength(402);
+    expect(lines?.lines.at(-1)).toEqual({ kind: "skip", text: "" });
   });
 });
 
 describe("computeLineDiff", () => {
-  it("diffs changed lines with surrounding context", () => {
-    expect(computeLineDiff("a\nb\nc", "a\nx\nc")).toEqual([
-      { kind: "ctx", text: "a" },
-      { kind: "del", text: "b" },
-      { kind: "add", text: "x" },
-      { kind: "ctx", text: "c" },
-    ]);
+  it("reports an incomplete comparison when the only change is beyond the work budget", () => {
+    const oldLines = Array.from({ length: 700 }, (_, index) => `line ${index}`);
+    const newLines = [...oldLines];
+    newLines[650] = "outside budget";
+
+    expect(computeLineDiff(oldLines.join("\n"), newLines.join("\n"))).toMatchObject({
+      kind: "truncated",
+      lines: [{ kind: "skip", text: "" }],
+    });
+  });
+
+  it("reports an incomplete comparison when visible changes precede a truncated tail", () => {
+    const oldLines = Array.from({ length: 700 }, (_, index) => `line ${index}`);
+    const newLines = [...oldLines];
+    newLines[500] = "visible change";
+    newLines[650] = "outside budget";
+
+    expect(computeLineDiff(oldLines.join("\n"), newLines.join("\n"))).toMatchObject({
+      kind: "truncated",
+      lines: expect.arrayContaining([
+        { kind: "del", text: "line 500" },
+        { kind: "add", text: "visible change" },
+      ]),
+    });
+  });
+
+  it("returns exact zero statistics for a normal unchanged comparison", () => {
+    expect(computeLineDiff("alpha\nbeta", "alpha\nbeta", { compactUnchanged: true })).toEqual({
+      kind: "complete",
+      lines: [],
+      stat: { added: 0, removed: 0 },
+    });
+
+    const longBody = Array.from({ length: 700 }, (_, index) => `line ${index}`).join("\n");
+    expect(computeLineDiff(longBody, longBody, { compactUnchanged: true })).toEqual({
+      kind: "complete",
+      lines: [],
+      stat: { added: 0, removed: 0 },
+    });
+  });
+
+  it("returns exact statistics for a normal changed comparison", () => {
+    expect(computeLineDiff("alpha\nbeta", "alpha\ngamma")).toEqual({
+      kind: "complete",
+      lines: [
+        { kind: "ctx", text: "alpha" },
+        { kind: "del", text: "beta" },
+        { kind: "add", text: "gamma" },
+      ],
+      stat: { added: 1, removed: 1 },
+    });
   });
 
   it("treats a trailing newline as no extra line", () => {
-    expect(computeLineDiff("foo\n", "bar\n")).toEqual([
+    expect(computeLineDiff("foo\n", "bar\n").lines).toEqual([
       { kind: "del", text: "foo" },
       { kind: "add", text: "bar" },
     ]);
   });
 
   it("normalizes CRLF endings before diffing", () => {
-    expect(computeLineDiff("a\r\nb", "a\nb")).toEqual([
+    expect(computeLineDiff("a\r\nb", "a\nb").lines).toEqual([
       { kind: "ctx", text: "a" },
       { kind: "ctx", text: "b" },
     ]);
@@ -79,7 +130,7 @@ describe("computeLineDiff", () => {
   it("caps rendered output with a trailing skip line", () => {
     const newText = Array.from({ length: 500 }, (_, i) => `line ${i}`).join("\n");
 
-    const lines = computeLineDiff("only old line", newText);
+    const lines = computeLineDiff("only old line", newText).lines;
 
     expect(lines).toHaveLength(401);
     expect(lines.at(-1)).toEqual({ kind: "skip", text: "" });
@@ -90,21 +141,11 @@ describe("computeLineDiff", () => {
     const newLines = [...oldLines];
     newLines[450] = "changed late";
 
-    const lines = computeLineDiff(oldLines.join("\n"), newLines.join("\n"));
+    const lines = computeLineDiff(oldLines.join("\n"), newLines.join("\n")).lines;
 
     expect(lines).toContainEqual({ kind: "add", text: "changed late" });
     expect(lines).toContainEqual({ kind: "del", text: "line 450" });
     expect(lines.length).toBeLessThanOrEqual(401);
-  });
-
-  it("shows only truncation when the change is beyond the input work budget", () => {
-    const oldLines = Array.from({ length: 700 }, (_, index) => `line ${index}`);
-    const newLines = [...oldLines];
-    newLines[650] = "outside budget";
-
-    expect(computeLineDiff(oldLines.join("\n"), newLines.join("\n"))).toEqual([
-      { kind: "skip", text: "" },
-    ]);
   });
 
   it("collapses unchanged runs to three context lines when asked", () => {
@@ -117,8 +158,8 @@ describe("computeLineDiff", () => {
       compactUnchanged: true,
     });
 
-    expect(full).toHaveLength(41);
-    expect(compact.filter((line) => line.kind === "ctx").map((line) => line.text)).toEqual([
+    expect(full.lines).toHaveLength(41);
+    expect(compact.lines.filter((line) => line.kind === "ctx").map((line) => line.text)).toEqual([
       "line 17",
       "line 18",
       "line 19",
@@ -126,14 +167,14 @@ describe("computeLineDiff", () => {
       "line 22",
       "line 23",
     ]);
-    expect(compact.filter((line) => line.kind === "skip")).toHaveLength(2);
+    expect(compact.lines.filter((line) => line.kind === "skip")).toHaveLength(2);
   });
 
   it("compacts an identical pair to nothing so callers can say unchanged", () => {
     const text = "alpha\nbeta\ngamma";
 
-    expect(computeLineDiff(text, text, { compactUnchanged: true })).toEqual([]);
-    expect(computeLineDiff(text, text)).toHaveLength(3);
+    expect(computeLineDiff(text, text, { compactUnchanged: true }).lines).toEqual([]);
+    expect(computeLineDiff(text, text).lines).toHaveLength(3);
   });
 });
 
@@ -155,30 +196,26 @@ describe("buildWriteDiffLines", () => {
   });
 });
 
-describe("diffStat", () => {
-  it("counts only added and removed lines", () => {
-    const lines: DiffLine[] = [
-      { kind: "add", text: "a" },
-      { kind: "add", text: "b" },
-      { kind: "del", text: "c" },
-      { kind: "ctx", text: "d" },
-      { kind: "skip", text: "" },
-    ];
-
-    expect(diffStat(lines)).toEqual({ added: 2, removed: 1 });
-  });
-});
-
 describe("joinDiffSections", () => {
   it("separates non-empty sections with skip lines and drops empty ones", () => {
     const first: DiffLine[] = [{ kind: "del", text: "old" }];
     const second: DiffLine[] = [{ kind: "add", text: "new" }];
 
-    expect(joinDiffSections([first, [], second])).toEqual([
-      { kind: "del", text: "old" },
-      { kind: "skip", text: "" },
-      { kind: "add", text: "new" },
-    ]);
+    expect(
+      joinDiffSections([
+        { kind: "complete", lines: first, stat: { added: 0, removed: 1 } },
+        { kind: "complete", lines: [], stat: { added: 0, removed: 0 } },
+        { kind: "complete", lines: second, stat: { added: 1, removed: 0 } },
+      ]),
+    ).toEqual({
+      kind: "complete",
+      lines: [
+        { kind: "del", text: "old" },
+        { kind: "skip", text: "" },
+        { kind: "add", text: "new" },
+      ],
+      stat: { added: 1, removed: 1 },
+    });
   });
 
   it("enforces one render-row budget across every section", () => {
@@ -191,10 +228,14 @@ describe("joinDiffSections", () => {
       text: `second ${index}`,
     }));
 
-    const joined = joinDiffSections([first, second]);
+    const joined = joinDiffSections([
+      { kind: "complete", lines: first, stat: { added: 250, removed: 0 } },
+      { kind: "complete", lines: second, stat: { added: 0, removed: 250 } },
+    ]);
 
-    expect(joined).toHaveLength(401);
-    expect(joined.at(-1)).toEqual({ kind: "skip", text: "" });
+    expect(joined).toMatchObject({ kind: "complete", stat: { added: 250, removed: 250 } });
+    expect(joined.lines).toHaveLength(401);
+    expect(joined.lines.at(-1)).toEqual({ kind: "skip", text: "" });
   });
 });
 

--- a/ui/src/lib/chat/tool-call-diff.ts
+++ b/ui/src/lib/chat/tool-call-diff.ts
@@ -26,11 +26,15 @@ export type DiffLine = {
 
 export type DiffStat = { added: number; removed: number };
 
+type LineDiffResult =
+  | { kind: "complete"; lines: DiffLine[]; stat: DiffStat }
+  | { kind: "truncated"; lines: DiffLine[] };
+
 /** Bound diff rendering work; oversized inputs degrade to a truncation marker. */
 const MAX_DIFF_INPUT_LINES = 600;
 export const MAX_DIFF_RENDER_LINES = 400;
 
-export function diffStat(lines: readonly DiffLine[]): DiffStat {
+function diffStat(lines: readonly DiffLine[]): DiffStat {
   let added = 0;
   let removed = 0;
   for (const line of lines) {
@@ -47,18 +51,23 @@ export function diffStat(lines: readonly DiffLine[]): DiffStat {
  * Parse the edit tool's display diff (`generateDiffString` output):
  * `+457 text`, `-455 text`, ` 456 text`, and `     ...` skip markers.
  */
-export function parseDiffDetailsString(diff: string): DiffLine[] | null {
+export function parseDiffDetailsString(diff: string): LineDiffResult | null {
   const trimmed = diff.trim();
   if (!trimmed) {
     return null;
   }
   const lines: DiffLine[] = [];
+  let truncated = false;
   for (const raw of diff.split("\n")) {
     if (!raw) {
       continue;
     }
-    const skipMatch = raw.match(/^\s*\.\.\.(?:\(truncated\)\.\.\.)?\s*$/);
-    if (skipMatch) {
+    if (/^\s*\.\.\.\(truncated\)\.\.\.\s*$/.test(raw)) {
+      truncated = true;
+      lines.push({ kind: "skip", text: "" });
+      continue;
+    }
+    if (/^\s*\.\.\.\s*$/.test(raw)) {
       lines.push({ kind: "skip", text: "" });
       continue;
     }
@@ -78,10 +87,16 @@ export function parseDiffDetailsString(diff: string): DiffLine[] | null {
     });
     if (lines.length > MAX_DIFF_RENDER_LINES) {
       lines.push({ kind: "skip", text: "" });
+      truncated = true;
       break;
     }
   }
-  return lines.some((line) => line.kind === "add" || line.kind === "del") ? lines : null;
+  if (!lines.some((line) => line.kind === "add" || line.kind === "del")) {
+    return null;
+  }
+  return truncated
+    ? { kind: "truncated", lines }
+    : { kind: "complete", lines, stat: diffStat(lines) };
 }
 
 function splitDiffLines(text: string): string[] {
@@ -165,11 +180,15 @@ export function computeLineDiff(
   oldText: string,
   newText: string,
   options?: { compactUnchanged?: boolean },
-): DiffLine[] {
+): LineDiffResult {
   const allOldLines = splitDiffLines(oldText);
   const allNewLines = splitDiffLines(newText);
   const inputTruncated =
     allOldLines.length > MAX_DIFF_INPUT_LINES || allNewLines.length > MAX_DIFF_INPUT_LINES;
+  const inputsEqual =
+    allOldLines.length === allNewLines.length &&
+    allOldLines.every((line, index) => line === allNewLines[index]);
+  const comparisonTruncated = inputTruncated && !inputsEqual;
   const oldLines = allOldLines.slice(0, MAX_DIFF_INPUT_LINES);
   const newLines = allNewLines.slice(0, MAX_DIFF_INPUT_LINES);
   const n = oldLines.length;
@@ -226,7 +245,10 @@ export function computeLineDiff(
     }
     j++;
   }
-  return compactLineDiff(lines, inputTruncated, options?.compactUnchanged === true);
+  const preview = compactLineDiff(lines, comparisonTruncated, options?.compactUnchanged === true);
+  return comparisonTruncated
+    ? { kind: "truncated", lines: preview }
+    : { kind: "complete", lines: preview, stat: diffStat(lines) };
 }
 
 /** All-added preview for freshly written files, numbered from line 1. */
@@ -251,33 +273,45 @@ export function countTextLines(content: string): number {
  * where each `edits[i]` produced its own local diff.
  */
 export function joinDiffSections(
-  sections: ReadonlyArray<DiffLine[]>,
+  sections: ReadonlyArray<LineDiffResult>,
   options?: { truncated?: boolean; maxLines?: number },
-): DiffLine[] {
+): LineDiffResult {
   const maxLines = options?.maxLines ?? MAX_DIFF_RENDER_LINES;
   const joined: DiffLine[] = [];
-  let truncated = options?.truncated === true;
+  const comparisonTruncated =
+    options?.truncated === true || sections.some((section) => section.kind === "truncated");
+  let previewTruncated = comparisonTruncated;
   for (const section of sections) {
-    if (section.length === 0) {
+    if (section.lines.length === 0) {
       continue;
     }
     if (joined.length > 0) {
       if (joined.length >= maxLines) {
-        truncated = true;
+        previewTruncated = true;
         break;
       }
       joined.push({ kind: "skip", text: "" });
     }
     const remaining = maxLines - joined.length;
-    if (section.length > remaining) {
-      joined.push(...section.slice(0, remaining));
-      truncated = true;
+    if (section.lines.length > remaining) {
+      joined.push(...section.lines.slice(0, remaining));
+      previewTruncated = true;
       break;
     }
-    joined.push(...section);
+    joined.push(...section.lines);
   }
-  if (truncated && joined.at(-1)?.kind !== "skip") {
+  if (previewTruncated && joined.at(-1)?.kind !== "skip") {
     joined.push({ kind: "skip", text: "" });
   }
-  return joined;
+  if (comparisonTruncated) {
+    return { kind: "truncated", lines: joined };
+  }
+  const stat = sections.reduce(
+    (sum, section) => ({
+      added: sum.added + (section.kind === "complete" ? section.stat.added : 0),
+      removed: sum.removed + (section.kind === "complete" ? section.stat.removed : 0),
+    }),
+    { added: 0, removed: 0 },
+  );
+  return { kind: "complete", lines: joined, stat };
 }

--- a/ui/src/lib/chat/tool-call-view.ts
+++ b/ui/src/lib/chat/tool-call-view.ts
@@ -12,9 +12,7 @@ import {
   buildWriteDiffLines,
   computeLineDiff,
   countTextLines,
-  diffStat,
   joinDiffSections,
-  MAX_DIFF_RENDER_LINES,
   parseDiffDetailsString,
   type DiffLine,
   type DiffStat,
@@ -143,17 +141,10 @@ function readDetailsDiff(details: unknown): ResolvedEditDiff | null {
   if (!lines) {
     return null;
   }
-  const stat = { added: 0, removed: 0 };
-  for (const match of diffText.matchAll(/^([+-])\s*\d+/gm)) {
-    if (match[1] === "+") {
-      stat.added += 1;
-    } else {
-      stat.removed += 1;
-    }
-  }
-  const truncated =
-    /^\s*\.\.\.\(truncated\)\.\.\.\s*$/m.test(diffText) || lines.length > MAX_DIFF_RENDER_LINES + 1;
-  return { lines, ...(truncated ? {} : { stat }) };
+  return {
+    lines: lines.lines,
+    ...(lines.kind === "complete" ? { stat: lines.stat } : {}),
+  };
 }
 
 function resolveEditDiff(source: ToolCallViewSource): ResolvedEditDiff | null {
@@ -170,25 +161,14 @@ function resolveEditDiff(source: ToolCallViewSource): ResolvedEditDiff | null {
     return truncated ? { lines: [{ kind: "skip", text: "" }] } : null;
   }
   const sections = pairs.map((pair) => computeLineDiff(pair.oldText, pair.newText));
-  const sectionTruncated = sections.some((section) => section.at(-1)?.kind === "skip");
-  const lines = joinDiffSections(sections, { truncated });
-  if (lines.length === 0) {
+  const result = joinDiffSections(sections, { truncated });
+  if (result.lines.length === 0) {
     return null;
   }
-  const stat =
-    truncated || sectionTruncated
-      ? undefined
-      : sections.reduce(
-          (sum, section) => {
-            const sectionStat = diffStat(section);
-            return {
-              added: sum.added + sectionStat.added,
-              removed: sum.removed + sectionStat.removed,
-            };
-          },
-          { added: 0, removed: 0 },
-        );
-  return { lines, ...(stat ? { stat } : {}) };
+  return {
+    lines: result.lines,
+    ...(result.kind === "complete" ? { stat: result.stat } : {}),
+  };
 }
 
 function resolveInsertionDiff(
@@ -203,7 +183,7 @@ function resolveInsertionDiff(
   if (!insertText) {
     return null;
   }
-  const lines = computeLineDiff("", insertText);
+  const lines = computeLineDiff("", insertText).lines;
   // The text is known, but its surrounding file context is not. Omit an exact
   // stat rather than implying this preview represents the final placement.
   return lines.length > 0 ? { lines } : null;

--- a/ui/src/pages/skill-workshop/applied-history.runtime.ts
+++ b/ui/src/pages/skill-workshop/applied-history.runtime.ts
@@ -26,7 +26,6 @@ export function renderAppliedRevisionDiff(previousBody: string, body: string) {
   if (result.kind === "complete" && result.lines.length === 0) {
     return html`<p class="sw-muted">${t("skillWorkshop.diff.unchanged")}</p>`;
   }
-  const hasVisibleChange = result.lines.some((line) => line.kind === "add" || line.kind === "del");
   return html`
     <div class="sw-diff">
       ${result.kind === "complete"
@@ -34,13 +33,7 @@ export function renderAppliedRevisionDiff(previousBody: string, body: string) {
             <span class="sw-diff__stat-add">+${result.stat.added}</span>
             <span class="sw-diff__stat-del">-${result.stat.removed}</span>
           </p>`
-        : html`<p class="sw-muted sw-diff__notice">
-            ${t(
-              hasVisibleChange
-                ? "skillWorkshop.diff.partialPreview"
-                : "skillWorkshop.diff.outsidePreview",
-            )}
-          </p>`}
+        : html`<p class="sw-muted sw-diff__notice">${t("skillWorkshop.diff.truncated")}</p>`}
       <div class="sw-diff__rows">${result.lines.map(renderDiffRow)}</div>
     </div>
   `;

--- a/ui/src/pages/skill-workshop/applied-history.runtime.ts
+++ b/ui/src/pages/skill-workshop/applied-history.runtime.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { t } from "../../i18n/index.ts";
-import { computeLineDiff, type DiffLine, diffStat } from "../../lib/chat/tool-call-diff.ts";
+import { computeLineDiff, type DiffLine } from "../../lib/chat/tool-call-diff.ts";
 import type { SkillWorkshopAppliedSkill } from "../../lib/skill-workshop/index.ts";
 import type { SkillWorkshopProps } from "./view-types.ts";
 
@@ -22,18 +22,26 @@ function renderDiffRow(line: DiffLine) {
 }
 
 export function renderAppliedRevisionDiff(previousBody: string, body: string) {
-  const lines = computeLineDiff(previousBody, body, { compactUnchanged: true });
-  if (lines.length === 0) {
+  const result = computeLineDiff(previousBody, body, { compactUnchanged: true });
+  if (result.kind === "complete" && result.lines.length === 0) {
     return html`<p class="sw-muted">${t("skillWorkshop.diff.unchanged")}</p>`;
   }
-  const { added, removed } = diffStat(lines);
+  const hasVisibleChange = result.lines.some((line) => line.kind === "add" || line.kind === "del");
   return html`
     <div class="sw-diff">
-      <p class="sw-diff__stat">
-        <span class="sw-diff__stat-add">+${added}</span>
-        <span class="sw-diff__stat-del">-${removed}</span>
-      </p>
-      <div class="sw-diff__rows">${lines.map(renderDiffRow)}</div>
+      ${result.kind === "complete"
+        ? html`<p class="sw-diff__stat">
+            <span class="sw-diff__stat-add">+${result.stat.added}</span>
+            <span class="sw-diff__stat-del">-${result.stat.removed}</span>
+          </p>`
+        : html`<p class="sw-muted sw-diff__notice">
+            ${t(
+              hasVisibleChange
+                ? "skillWorkshop.diff.partialPreview"
+                : "skillWorkshop.diff.outsidePreview",
+            )}
+          </p>`}
+      <div class="sw-diff__rows">${result.lines.map(renderDiffRow)}</div>
     </div>
   `;
 }

--- a/ui/src/pages/skill-workshop/skill-workshop-page.applied.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.applied.test.ts
@@ -207,6 +207,32 @@ describe("Skill Workshop applied history", () => {
     expect(modeButton(page, "Changes")?.getAttribute("aria-pressed")).toBe("false");
   });
 
+  it.each([
+    ["late-only", null, "The changed region is outside this preview."],
+    ["partial", 500, "Some changed regions are outside this preview."],
+  ])("labels %s revision comparisons as incomplete", async (_label, visibleIndex, message) => {
+    const previousBody = Array.from({ length: 700 }, (_, index) => `line ${index}`);
+    const latestBody = [...previousBody];
+    if (visibleIndex !== null) {
+      latestBody[visibleIndex] = "changed inside preview";
+    }
+    latestBody[650] = "changed outside preview";
+    const proposals = appliedProposals();
+    proposals[2]!.body = previousBody.join("\n");
+    proposals[3]!.body = latestBody.join("\n");
+
+    const page = await mountAppliedPage(inspectRequest(), proposals);
+    await vi.waitFor(
+      () => {
+        expect(page.querySelector(".sw-diff__notice")?.textContent).toContain(message);
+      },
+      { interval: 1 },
+    );
+
+    expect(page.querySelector(".sw-diff__stat")).toBeNull();
+    expect(page.querySelector(".sw-body-card")?.textContent).toContain("Full body");
+  });
+
   it("shows the oldest revision as a full body with no diff toggle", async () => {
     const page = await mountAppliedPage(inspectRequest(), appliedProposals());
     await vi.waitFor(() => expect(historyItems(page)).toHaveLength(4), { interval: 1 });

--- a/ui/src/pages/skill-workshop/skill-workshop-page.applied.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.applied.test.ts
@@ -208,30 +208,36 @@ describe("Skill Workshop applied history", () => {
   });
 
   it.each([
-    ["late-only", null, "The changed region is outside this preview."],
-    ["partial", 500, "Some changed regions are outside this preview."],
-  ])("labels %s revision comparisons as incomplete", async (_label, visibleIndex, message) => {
-    const previousBody = Array.from({ length: 700 }, (_, index) => `line ${index}`);
-    const latestBody = [...previousBody];
-    if (visibleIndex !== null) {
-      latestBody[visibleIndex] = "changed inside preview";
-    }
-    latestBody[650] = "changed outside preview";
-    const proposals = appliedProposals();
-    proposals[2]!.body = previousBody.join("\n");
-    proposals[3]!.body = latestBody.join("\n");
+    { label: "late-only", changedIndexes: [650], hasVisibleChange: false },
+    { label: "visible-only", changedIndexes: [500], hasVisibleChange: true },
+    { label: "visible-and-late", changedIndexes: [500, 650], hasVisibleChange: true },
+  ])(
+    "labels $label revision comparisons as incomplete",
+    async ({ changedIndexes, hasVisibleChange }) => {
+      const previousBody = Array.from({ length: 700 }, (_, index) => `line ${index}`);
+      const latestBody = [...previousBody];
+      for (const changedIndex of changedIndexes) {
+        latestBody[changedIndex] = `changed line ${changedIndex}`;
+      }
+      const proposals = appliedProposals();
+      proposals[2]!.body = previousBody.join("\n");
+      proposals[3]!.body = latestBody.join("\n");
 
-    const page = await mountAppliedPage(inspectRequest(), proposals);
-    await vi.waitFor(
-      () => {
-        expect(page.querySelector(".sw-diff__notice")?.textContent).toContain(message);
-      },
-      { interval: 1 },
-    );
+      const page = await mountAppliedPage(inspectRequest(), proposals);
+      await vi.waitFor(
+        () => {
+          expect(page.querySelector(".sw-diff__notice")?.textContent).toContain(
+            "This comparison is truncated.",
+          );
+        },
+        { interval: 1 },
+      );
 
-    expect(page.querySelector(".sw-diff__stat")).toBeNull();
-    expect(page.querySelector(".sw-body-card")?.textContent).toContain("Full body");
-  });
+      expect(page.querySelector(".sw-diff__stat")).toBeNull();
+      expect(page.querySelector(".sw-diff__row--add") !== null).toBe(hasVisibleChange);
+      expect(page.querySelector(".sw-body-card")?.textContent).toContain("Full body");
+    },
+  );
 
   it("shows the oldest revision as a full body with no diff toggle", async () => {
     const page = await mountAppliedPage(inspectRequest(), appliedProposals());


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Skill Workshop applied-revision comparisons could show `+0 −0` when the actual change occurred beyond the bounded 600-line preview. That falsely told operators there was no change even though the comparison was incomplete.

## Why This Change Was Made

The shared diff owner now returns a closed `complete | truncated` result. Exact statistics exist only for complete comparisons; truncated comparisons retain any visible rows but show one neutral notice that changes and totals may be incomplete, with Full body as the authoritative escape hatch. Ordinary chat tool-call diff consumers use the same completeness contract.

The notice intentionally does not claim a hidden region changed: a long comparison can be incomplete even when its only change is visible inside the preview. AI-assisted; the final behavior and screenshots were independently reviewed and manually inspected.

Provenance: the Applied revision Changes view was introduced by #125854 on 2026-08-18. The original shared diff bound predated it, but the new consumer interpreted a bounded preview as exact.

## User Impact

Operators no longer see misleading zero totals for long Skill Workshop revisions. They get truthful incomplete-comparison guidance, visible changed rows when available, and a direct Full body path to the complete revision.

## Evidence

### Before

The real mocked-Gateway UI showed `+0 −0` for a late-only change:

![Before: truncated comparison shows zero totals](https://github.com/user-attachments/assets/3d2b37d9-3108-4190-8672-acc69b878ef2)

### After

The same flow omits false totals and explains that the comparison is truncated:

![After: truncated comparison shows truthful guidance](https://github.com/user-attachments/assets/c1429c8d-d1ec-466d-a5e3-1fa54ff0b135)

- Pre-fix regression: five intended failures around incomplete statistics and late-only changes.
- Focused final rebased head: 104 UI unit assertions and 3 Chromium mocked-Gateway E2E scenarios passed.
- Browser coverage includes late-only, visible-only, ordinary compact diff, and Full body recovery.
- Full `pnpm check:changed` passed before the final conflict-free rebase; final `git diff --check` passed.
- Fresh final-head autoreview: clean, no accepted/actionable findings.
- Production LOC: +75/-58 (net +17). Tests: +205/-62. The production growth replaces ambiguous array semantics with a shared completeness boundary and one truthful UI state.
- Gap: no live Gateway/provider run; this behavior is local diff computation and was exercised through real Chromium with a deterministic mocked Gateway.
