### PR TITLE
fix: preserve channel messages during gateway restart drain

### DIFF
--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -6,6 +6,7 @@
  */
 import { sleepWithAbort } from "@openclaw/retry";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { GatewayDrainingError } from "../../process/gateway-work-admission.js";
 import {
   createIngressDrainOwnerId,
   deregisterLiveIngressDrainInstance,
@@ -319,6 +320,10 @@ export function createChannelIngressDrain<
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
     err: unknown,
   ) => {
+    if (err instanceof GatewayDrainingError) {
+      await releaseClaim(claim, { recordAttempt: false });
+      return;
+    }
     const disposition = resolveIngressFailureDisposition({
       err,
       event: claim,

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  GatewayDrainingError,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { sleep } from "../../utils/sleep.js";
 import {
@@ -97,6 +103,7 @@ function createMonitor(
 }
 
 afterEach(() => {
+  resetGatewayWorkAdmission();
   closeOpenClawStateDatabaseForTest();
   vi.restoreAllMocks();
 });
@@ -514,6 +521,110 @@ describe("channel ingress monitor", () => {
 
       await expect(monitor.waitForIdle()).resolves.toBeUndefined();
       await monitor.stop();
+    });
+  });
+
+  it("preserves restart-drained ingress for a fresh monitor without consuming retry budget", async () => {
+    await withQueue(async (queue) => {
+      resetGatewayWorkAdmission();
+      let markPruneStarted = () => {};
+      const pruneStarted = new Promise<void>((resolve) => {
+        markPruneStarted = resolve;
+      });
+      let releasePrune = () => {};
+      const pruneGate = new Promise<void>((resolve) => {
+        releasePrune = resolve;
+      });
+      const prune = queue.prune.bind(queue);
+      let pruneCalls = 0;
+      queue.prune = async (...args) => {
+        if (pruneCalls++ === 0) {
+          markPruneStarted();
+          await pruneGate;
+        }
+        return await prune(...args);
+      };
+
+      const observedErrors: unknown[] = [];
+      const createRestartMonitor = (deliver: Parameters<typeof createMonitor>[1]) =>
+        createChannelIngressMonitor<RawEvent, string, StoredEvent>({
+          queue,
+          inspect: (raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
+          payload: {
+            storage: "raw-event",
+            version: 1,
+            serialize: (raw) => JSON.stringify(raw),
+            deserialize: (body) => JSON.parse(body) as RawEvent,
+            createClaimError: (kind) => new PermanentIngressError(kind),
+          },
+          deliver,
+          pollIntervalMs: 60_000,
+          retention: { pruneIntervalMs: 0 },
+          drain: {
+            adoptionStallTimeoutMs: 5_000,
+            retryPolicy: {
+              maxAttempts: 8,
+              deadLetterMinAgeMs: 0,
+              baseMs: 0,
+              maxMs: 0,
+            },
+          },
+        });
+
+      const original = createRestartMonitor(async (_raw, lifecycle) => {
+        try {
+          await runWithGatewayIndependentRootWorkAdmission(async () => {
+            await lifecycle.onAdopted();
+          });
+        } catch (error) {
+          observedErrors.push(error);
+          throw error;
+        }
+      });
+      let successor: ReturnType<typeof createRestartMonitor> | undefined;
+      original.start();
+      try {
+        await pruneStarted;
+        markGatewayRestartDraining();
+        await original.admit({ id: "event-restart", lane: "a", text: "during drain" });
+        releasePrune();
+
+        await vi.waitFor(() => expect(observedErrors.length).toBeGreaterThan(0));
+        expect(observedErrors[0]).toBeInstanceOf(GatewayDrainingError);
+        await vi.waitFor(async () => {
+          expect(await queue.listPending()).toEqual([
+            expect.objectContaining({
+              id: "event-restart",
+              attempts: 0,
+            }),
+          ]);
+        });
+        const [pending] = await queue.listPending();
+        expect(observedErrors).toHaveLength(1);
+        expect(pending).not.toHaveProperty("lastAttemptAt");
+        expect(pending).not.toHaveProperty("lastError");
+        await expect(queue.listFailed?.()).resolves.toEqual([]);
+
+        await original.stop();
+        resetGatewayWorkAdmission();
+        const delivered = vi.fn(
+          async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+            await lifecycle.onAdopted();
+          },
+        );
+        successor = createRestartMonitor(delivered);
+        successor.start();
+        await successor.waitForIdle();
+
+        expect(delivered).toHaveBeenCalledOnce();
+        await expect(
+          queue.enqueue("event-restart", { version: 1, rawEvent: "duplicate" }),
+        ).resolves.toMatchObject({ kind: "completed" });
+      } finally {
+        releasePrune();
+        await Promise.allSettled([original.stop(), successor?.stop()]);
+        resetGatewayWorkAdmission();
+      }
     });
   });
 

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -1,5 +1,6 @@
 /** Shared durable channel-ingress admission, pump, retention, and shutdown lifecycle. */
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { isGatewayRestartDraining } from "../../process/gateway-work-admission.js";
 import { sleep } from "../../utils/sleep.js";
 import {
   createChannelIngressDrain,
@@ -544,7 +545,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   };
 
   const requestDrain = (): void => {
-    if (!running || isAborted()) {
+    if (!running || isAborted() || isGatewayRestartDraining()) {
       publishActivity();
       return;
     }


### PR DESCRIPTION
Related: #51620

## What Problem This Solves
Fixes an issue where durable channel messages arriving during a planned Gateway restart drain could reach root dispatch after admission closed, throw `GatewayDrainingError`, consume the full ingress retry budget, and be dead-lettered before the successor Gateway started. Discord's current policy makes this immediate after 8 attempts because `deadLetterMinAgeMs` is `0`.

## Why This Change Was Made
The shared channel-ingress monitor now avoids starting new pumps while Gateway restart admission is draining. If an already-claimed event hits the exact typed `GatewayDrainingError` race, the generic drain releases it with `recordAttempt: false`. Durable transport append remains open so the successor can claim the pending row. This adds no Discord-specific production check, retry/timeout increase, parallel retry path, config surface, protocol change, or schema change.

## User Impact
Messages that were durably accepted during a planned restart remain pending and recoverable, and a fresh successor monitor dispatches them after admission reopens. Genuine retryable, non-retryable, and retry-limit failures still consume their normal budget and dead-letter normally; cancellation preserves prior retry facts.

## Evidence
- Pre-fix on current-main base `b9d0e13b5d084f085c669a000b98223de95ceed6`: the focused order regression observed all 8 typed drain failures and failed because the expected pending row with `attempts: 0` was gone/dead-lettered (1 failed test, 22 skipped).
- `node scripts/run-vitest.mjs src/channels/message/ingress-monitor.test.ts -t "defers a claimed event across restart drain without consuming retry budget"` — 1 passed, 22 skipped.
- `node scripts/run-vitest.mjs src/channels/message/ingress-monitor.test.ts` — 23 passed.
- `node scripts/run-vitest.mjs src/channels/message/ingress-drain.cancellation.test.ts` — 1 passed.
- Generic ingress drain suite — 27 passed.
- Ingress retry-policy suite — 12 passed.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/ingress.test.ts` — 6 passed.
- IRC sibling durable-ingress suite — 9 passed.
- Targeted `oxfmt` and `git diff --check` — clean.
- `node scripts/check-changed.mjs` — passed for `core, coreTests`, including production/test types, lint, guards, dead-code checks, and 0 import cycles.
- Codex autoreview — clean in 1 iteration with no accepted/actionable findings.
- Production LOC: +7/-1 (net +6). Tests: +111/-0.
- Build not run: no build-output, package, lazy/dynamic-import, or published boundary changed.
- Remaining gap: no live Discord restart E2E. Normal remote PR CI remains pending while this PR is draft.

AI-assisted; the owner path, diff, and evidence were reviewed before publication.
