### PR TITLE
refactor(macos): remove unused node encoding contract

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodesStore.swift
+++ b/apps/macos/Sources/OpenClaw/NodesStore.swift
@@ -3,7 +3,7 @@ import Observation
 import OpenClawKit
 import OSLog
 
-struct NodeInfo: Identifiable, Codable {
+struct NodeInfo: Identifiable, Decodable {
     let nodeId: String
     let displayName: String?
     let platform: String?
@@ -32,7 +32,7 @@ struct NodeInfo: Identifiable, Codable {
     }
 }
 
-private struct NodeListResponse: Codable {
+private struct NodeListResponse: Decodable {
     let ts: Double?
     let nodes: [NodeInfo]
 }

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -91,29 +91,6 @@ struct LowCoverageHelperTests {
         #expect(ContinuousClock.now - startedAt < .seconds(2))
     }
 
-    @Test func `node info codable round trip`() throws {
-        let info = NodeInfo(
-            nodeId: "node-1",
-            displayName: "Node One",
-            platform: "macOS",
-            version: "1.0",
-            coreVersion: "1.0-core",
-            uiVersion: "1.0-ui",
-            deviceFamily: "Mac",
-            modelIdentifier: "MacBookPro",
-            remoteIp: "192.168.1.2",
-            caps: ["chat"],
-            commands: ["send"],
-            permissions: ["send": true],
-            paired: true,
-            connected: false)
-        let data = try JSONEncoder().encode(info)
-        let decoded = try JSONDecoder().decode(NodeInfo.self, from: data)
-        #expect(decoded.nodeId == "node-1")
-        #expect(decoded.isPaired == true)
-        #expect(decoded.isConnected == false)
-    }
-
     @Test @MainActor func `presence reporter summary and privacy parameters`() {
         let summary = PresenceReporter._testComposePresenceSummary(mode: "local", reason: "test")
         #expect(summary.contains("mode local"))


### PR DESCRIPTION
## What Problem This Solves

Removes a self-generated macOS node-model round-trip test that could drift both its encoder and decoder together while uniquely forcing an unused encoding contract on the production response model.

## Why This Change Was Made

`NodeInfo` and the private `NodeListResponse` now conform only to `Decodable`, matching their production owner: `NodesStore` only decodes the gateway's `node.list` response. The self-encoded round-trip test is deleted; the real decoder path and independent visible node-status and sorting behavior remain covered.

## User Impact

No user-visible behavior changes. This is a focused test-audit cleanup with no schema, protocol, config, documentation, changelog, dependency, operator-state, or Gateway-state changes.

## Evidence

- `swift test --package-path apps/macos --filter 'LowCoverageHelperTests|MenuSessionsInjectorTests|NodesStoreTests'` — 29 tests in 3 suites passed on the rebased head.
- `./scripts/format-swift.sh macos` — clean; 0 files require formatting.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings; patch correct 0.99.
- Prior patch-identical proof: `./scripts/lint-swift.sh macos` — 0 violations.
- Prior patch-identical full changed gate: `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/NodesStore.swift apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift` — passed all selected lanes, including Swift lint, 7 Vitest shards / 483 tests, and native schema guard v9.
- Prior patch-identical local autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; patch correct 0.99.
- Production LOC: +2/-2 (net 0, conformance narrowing only). Tests: +0/-23.
- No screenshots: there is no UI-visible change.

AI-assisted: this cleanup and its evidence were prepared with Codex assistance and passed fresh Codex-backed autoreview.
