### PR TITLE
fix(tui): block sends until session events are subscribed

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -580,6 +580,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
 
         async getGatewayStatus() {
           record("getGatewayStatus");
+          this.reconnectSessionSubscription();
           this.emitDisconnect();
           return gatewayStatus;
         }

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -26,6 +26,60 @@ const STARTUP_TIMEOUT_MS = 20_000;
 const TEST_TIMEOUT_MS = 5_000;
 const STARTUP_TEST_TIMEOUT_MS = 25_000;
 
+it(
+  "blocks submits after subscription exhaustion until reconnect succeeds",
+  async () => {
+    const subscriptionFixture = await startTuiFixture({
+      env: {
+        OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES: "5",
+        OPENCLAW_TUI_PTY_SUBSCRIBE_RECONNECT: "1",
+      },
+    });
+    try {
+      await subscriptionFixture.run.waitForOutput(
+        "session event subscribe failed",
+        STARTUP_TIMEOUT_MS,
+      );
+      const entries = await readFixtureLog(subscriptionFixture.logPath);
+      expect(entries.filter((entry) => entry.method === "subscribeSessionEvents")).toHaveLength(5);
+      expect(entries.filter((entry) => entry.method === "subscribeSessionFailure")).toHaveLength(5);
+      expect(entries.some((entry) => entry.method === "loadHistory")).toBe(false);
+      expect(subscriptionFixture.run.visibleOutput()).not.toContain("local ready | idle");
+
+      const message = "after subscription reconnect proof";
+      await subscriptionFixture.run.write(`${message}\r`, { delay: false });
+      await subscriptionFixture.run.waitForOutput(
+        "local runtime not ready — message not sent",
+        STARTUP_TIMEOUT_MS,
+      );
+      expect(
+        (await readFixtureLog(subscriptionFixture.logPath)).some(
+          (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+        ),
+      ).toBe(false);
+
+      await subscriptionFixture.run.write("\x03", { delay: false });
+      await subscriptionFixture.run.waitForOutput("cleared input", STARTUP_TIMEOUT_MS);
+      await subscriptionFixture.run.write("/gateway-status\r", { delay: false });
+      await subscriptionFixture.waitForLogEntry(
+        (entry) => entry.method === "subscriptionReconnect",
+        STARTUP_TIMEOUT_MS,
+      );
+      await subscriptionFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
+      await subscriptionFixture.run.write(`${message}\r`, { delay: false });
+      await subscriptionFixture.run.waitForOutput(`PTY_RESPONSE: ${message}`, STARTUP_TIMEOUT_MS);
+      expect(
+        (await readFixtureLog(subscriptionFixture.logPath)).filter(
+          (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await subscriptionFixture.cleanup();
+    }
+  },
+  STARTUP_TEST_TIMEOUT_MS,
+);
+
 it("rejects rendering oracle false positives", () => {
   const tokens = Array.from({ length: 64 }, (_, i) => `T${String(i).padStart(3, "0")}`);
   const promptFrame = [`burst streaming proof ${tokens.join(" ")}`, "local ready | idle"];
@@ -266,33 +320,6 @@ describe.sequential("TUI PTY harness", () => {
           "PTY_RESPONSE: after subscription recovery proof",
           STARTUP_TIMEOUT_MS,
         );
-      } finally {
-        await subscriptionFixture.cleanup();
-      }
-    },
-    STARTUP_TEST_TIMEOUT_MS,
-  );
-
-  it(
-    "never reports ready after exhausting session subscription recovery",
-    async () => {
-      const subscriptionFixture = await startTuiFixture({
-        env: { OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES: "5" },
-      });
-      try {
-        await subscriptionFixture.run.waitForOutput(
-          "session event subscribe failed",
-          STARTUP_TIMEOUT_MS,
-        );
-        const entries = await readFixtureLog(subscriptionFixture.logPath);
-        expect(entries.filter((entry) => entry.method === "subscribeSessionEvents")).toHaveLength(
-          5,
-        );
-        expect(entries.filter((entry) => entry.method === "subscribeSessionFailure")).toHaveLength(
-          5,
-        );
-        expect(entries.some((entry) => entry.method === "loadHistory")).toBe(false);
-        expect(subscriptionFixture.run.visibleOutput()).not.toContain("local ready | idle");
       } finally {
         await subscriptionFixture.cleanup();
       }

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -26,59 +26,13 @@ const STARTUP_TIMEOUT_MS = 20_000;
 const TEST_TIMEOUT_MS = 5_000;
 const STARTUP_TEST_TIMEOUT_MS = 25_000;
 
-it(
-  "blocks submits after subscription exhaustion until reconnect succeeds",
-  async () => {
-    const subscriptionFixture = await startTuiFixture({
-      env: {
-        OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES: "5",
-        OPENCLAW_TUI_PTY_SUBSCRIBE_RECONNECT: "1",
-      },
-    });
-    try {
-      await subscriptionFixture.run.waitForOutput(
-        "session event subscribe failed",
-        STARTUP_TIMEOUT_MS,
-      );
-      const entries = await readFixtureLog(subscriptionFixture.logPath);
-      expect(entries.filter((entry) => entry.method === "subscribeSessionEvents")).toHaveLength(5);
-      expect(entries.filter((entry) => entry.method === "subscribeSessionFailure")).toHaveLength(5);
-      expect(entries.some((entry) => entry.method === "loadHistory")).toBe(false);
-      expect(subscriptionFixture.run.visibleOutput()).not.toContain("local ready | idle");
+const countFixtureCalls = (entries: FixtureLogEntry[], method: string) =>
+  entries.filter((entry) => entry.method === method).length;
 
-      const message = "after subscription reconnect proof";
-      await subscriptionFixture.run.write(`${message}\r`, { delay: false });
-      await subscriptionFixture.run.waitForOutput(
-        "local runtime not ready — message not sent",
-        STARTUP_TIMEOUT_MS,
-      );
-      expect(
-        (await readFixtureLog(subscriptionFixture.logPath)).some(
-          (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
-        ),
-      ).toBe(false);
-
-      await subscriptionFixture.run.write("\x03", { delay: false });
-      await subscriptionFixture.run.waitForOutput("cleared input", STARTUP_TIMEOUT_MS);
-      await subscriptionFixture.run.write("/gateway-status\r", { delay: false });
-      await subscriptionFixture.waitForLogEntry(
-        (entry) => entry.method === "subscriptionReconnect",
-        STARTUP_TIMEOUT_MS,
-      );
-      await subscriptionFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
-      await subscriptionFixture.run.write(`${message}\r`, { delay: false });
-      await subscriptionFixture.run.waitForOutput(`PTY_RESPONSE: ${message}`, STARTUP_TIMEOUT_MS);
-      expect(
-        (await readFixtureLog(subscriptionFixture.logPath)).filter(
-          (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
-        ),
-      ).toHaveLength(1);
-    } finally {
-      await subscriptionFixture.cleanup();
-    }
-  },
-  STARTUP_TEST_TIMEOUT_MS,
-);
+const countFixtureMessages = (entries: FixtureLogEntry[], message: string) =>
+  entries.filter(
+    (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+  ).length;
 
 it("rejects rendering oracle false positives", () => {
   const tokens = Array.from({ length: 64 }, (_, i) => `T${String(i).padStart(3, "0")}`);
@@ -308,18 +262,62 @@ describe.sequential("TUI PTY harness", () => {
       try {
         await subscriptionFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
         const entries = await readFixtureLog(subscriptionFixture.logPath);
-        expect(entries.filter((entry) => entry.method === "subscribeSessionEvents")).toHaveLength(
-          failures + 1,
-        );
-        expect(entries.filter((entry) => entry.method === "subscribeSessionFailure")).toHaveLength(
-          failures,
-        );
+        expect(countFixtureCalls(entries, "subscribeSessionEvents")).toBe(failures + 1);
+        expect(countFixtureCalls(entries, "subscribeSessionFailure")).toBe(failures);
 
         await subscriptionFixture.run.write("after subscription recovery proof\r");
         await subscriptionFixture.run.waitForOutput(
           "PTY_RESPONSE: after subscription recovery proof",
           STARTUP_TIMEOUT_MS,
         );
+      } finally {
+        await subscriptionFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "blocks submits after subscription exhaustion until reconnect succeeds",
+    async () => {
+      const subscriptionFixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES: "5",
+          OPENCLAW_TUI_PTY_SUBSCRIBE_RECONNECT: "1",
+        },
+      });
+      try {
+        await subscriptionFixture.run.waitForOutput(
+          "session event subscribe failed",
+          STARTUP_TIMEOUT_MS,
+        );
+        const entries = await readFixtureLog(subscriptionFixture.logPath);
+        expect(countFixtureCalls(entries, "subscribeSessionEvents")).toBe(5);
+        expect(countFixtureCalls(entries, "subscribeSessionFailure")).toBe(5);
+        expect(entries.some((entry) => entry.method === "loadHistory")).toBe(false);
+        expect(subscriptionFixture.run.visibleOutput()).not.toContain("local ready | idle");
+
+        const message = "after subscription reconnect proof";
+        await subscriptionFixture.run.write(`${message}\r`, { delay: false });
+        await subscriptionFixture.run.waitForOutput(
+          "local runtime not ready — message not sent",
+          STARTUP_TIMEOUT_MS,
+        );
+        const blockedEntries = await readFixtureLog(subscriptionFixture.logPath);
+        expect(countFixtureMessages(blockedEntries, message)).toBe(0);
+
+        await subscriptionFixture.run.write("\x03", { delay: false });
+        await subscriptionFixture.run.waitForOutput("cleared input", STARTUP_TIMEOUT_MS);
+        await subscriptionFixture.run.write("/gateway-status\r", { delay: false });
+        await subscriptionFixture.waitForLogEntry(
+          (entry) => entry.method === "subscriptionReconnect",
+          STARTUP_TIMEOUT_MS,
+        );
+        await subscriptionFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
+        await subscriptionFixture.run.write(`${message}\r`, { delay: false });
+        await subscriptionFixture.run.waitForOutput(`PTY_RESPONSE: ${message}`, STARTUP_TIMEOUT_MS);
+        const reconnectedEntries = await readFixtureLog(subscriptionFixture.logPath);
+        expect(countFixtureMessages(reconnectedEntries, message)).toBe(1);
       } finally {
         await subscriptionFixture.cleanup();
       }

--- a/src/tui/tui-pty-subscription-fixture-test-support.ts
+++ b/src/tui/tui-pty-subscription-fixture-test-support.ts
@@ -2,6 +2,16 @@
 export const TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT = `
   private sessionSubscriptionAttempts = 0;
 
+  reconnectSessionSubscription() {
+    if (process.env.OPENCLAW_TUI_PTY_SUBSCRIBE_RECONNECT !== "1") {
+      return;
+    }
+    process.env.OPENCLAW_TUI_PTY_SUBSCRIBE_RECONNECT = "0";
+    record("subscriptionReconnect");
+    this.onDisconnected?.("fixture subscription reconnect");
+    queueMicrotask(() => this.onConnected?.());
+  }
+
   async subscribeSessionEvents() {
     record("subscribeSessionEvents");
     const configuredFailures = Number(process.env.OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES ?? 0);

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1746,15 +1746,10 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     const connectedGeneration = ++connectionGeneration;
-    const ownsConnection = () =>
-      connectedGeneration === connectionGeneration && state.isConnected && !exitRequested;
-    state.isConnected = true;
+    const ownsConnection = () => connectedGeneration === connectionGeneration && !exitRequested;
+    state.isConnected = false;
     remediationShown = false;
-    const reconnected = connectionLineage.connect();
-    if (reconnected) {
-      reconnectStreamingWatchdog();
-    }
-    setConnectionStatus(isLocalMode ? "local ready" : "connected");
+    setConnectionStatus("subscribing to session events");
     // A reconnect may already have restored a live run's busy status. Only
     // claim the status line when startup owns it, then release that exact state.
     if (!isTuiBusyActivityStatus(state.activityStatus)) {
@@ -1788,6 +1783,11 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       }
       if (!ownsConnection()) {
         return;
+      }
+      state.isConnected = true;
+      const reconnected = connectionLineage.connect();
+      if (reconnected) {
+        reconnectStreamingWatchdog();
       }
       await refreshAgents();
       if (!ownsConnection()) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the terminal UI marked itself connected before `sessions.subscribe` succeeded. If subscription recovery exhausted, users could submit a message even though the TUI would miss every subsequent session event and peer message.

## Why This Change Was Made

Connection admission now stays closed until the current connection generation successfully subscribes to session events. Only then does the TUI mark itself connected, resume reconnect lineage/watchdogs, and continue startup. Retry exhaustion remains visibly blocked; a later transport reconnect can subscribe and reopen admission normally.

The repair keeps the existing generation fence, history/catalog ordering, disconnect cleanup, retry count, and timeouts. Production is a net-zero ownership move. AI-assisted; the final lifecycle and PTY proof were independently reviewed.

Provenance: the premature `state.isConnected = true` assignment was introduced by #117368 on 2026-08-01 while consolidating TUI runtime ownership.

## User Impact

The TUI no longer accepts chat input while it is connected to transport but not subscribed to session events. After a successful reconnect, the same input path becomes available again and sends exactly once.

## Evidence

- Pre-fix order-faithful regression: five subscription failures still left message admission open.
- Initial cold-start placement exposed a test-harness timeout before fixture startup; the regression was moved into the existing warmed sequential PTY owner without increasing timeouts or weakening assertions.
- Final exact scenario: five subscribe failures, no history load, rejected pre-ready submit with zero `sendChat`, explicit reconnect, readiness, then exactly one matching send and response.
- Final rebased PTY regression passed in 5.5 seconds under the unchanged 20-second output budget.
- Earlier focused TUI suites: 247 tests passed; core/test types and changed gate passed.
- Fresh final-head autoreview: clean, no accepted/actionable findings.
- Production LOC: +8/-8 (net 0). Tests/test support: +50/-14.
- Visual-proof gap: this is a terminal admission/lifecycle fix exercised by the real PTY loop; the harness does not emit a sanitized image/video artifact. The order-faithful PTY transcript and backend call log provide the boundary proof.
