### PR TITLE
fix(diagnostics): defer watchdog abort during preflight

### DIFF
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -18,10 +18,8 @@ import {
   resolveActiveReplyOperationForSessionId,
   resolveActiveReplyRunSessionId,
   resolveReplyBackendQueueMessageMismatch,
-  resolveReplyRunPhaseForSessionId,
   supersedeReplyRunByRunId,
   type ReplyOperation,
-  type ReplyOperationPhase,
   waitForReplyOperationOwnerSettlement,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
@@ -802,10 +800,13 @@ export function isEmbeddedAgentRunInProgress(sessionId: string): boolean {
   return resolveEmbeddedAgentRunProgressState(sessionId) !== undefined;
 }
 
-export function resolveEmbeddedAgentReplyRunPhase(
+export function resolveEmbeddedReplyActivity(
   sessionId: string,
-): ReplyOperationPhase | undefined {
-  return resolveReplyRunPhaseForSessionId(sessionId);
+): Pick<ReplyOperation, "phase" | "lastActivityAtMs"> | undefined {
+  const operation = resolveActiveReplyOperationForSessionId(sessionId);
+  return operation
+    ? { phase: operation.phase, lastActivityAtMs: operation.lastActivityAtMs }
+    : undefined;
 }
 
 export function isEmbeddedAgentRunHandleActive(sessionId: string): boolean {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2651,6 +2651,11 @@ describe("runMemoryFlushIfNeeded", () => {
     const compactCall = requireCompactEmbeddedAgentSessionCall();
     expect(compactCall.contextTokenBudget).toBe(200_000);
     expect(replyOperation.setPhase).toHaveBeenCalledWith("preflight_compacting");
+    expect(
+      replyOperation.setPhase.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    ).toBeLessThan(
+      compactEmbeddedAgentSessionMock.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+    );
     expect(replyOperation.updateSessionId).not.toHaveBeenCalled();
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
     expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/reply-run-registry.registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.registry.ts
@@ -11,7 +11,6 @@ import {
   replyMessageInjectionTargetOperation,
   replyRunInterruptTargetOperation,
   type ReplyOperation,
-  type ReplyOperationPhase,
   type ReplyRunInterruptTarget,
   type ReplyRunRegistry,
 } from "./reply-run-registry.contracts.js";
@@ -230,12 +229,6 @@ export function resolveActiveReplyRunThreadId(sessionKey: string): string | numb
 
 export function isReplyRunActiveForSessionId(sessionId: string): boolean {
   return resolveReplyRunForCurrentSessionId(sessionId) !== undefined;
-}
-
-export function resolveReplyRunPhaseForSessionId(
-  sessionId: string,
-): ReplyOperationPhase | undefined {
-  return resolveReplyRunForCurrentSessionId(sessionId)?.phase;
 }
 
 export function isReplyRunAbortableForCompaction(sessionId: string): boolean {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -42,7 +42,6 @@ import {
   runAfterReplyOperationClear,
   resolveActiveReplyRunSessionId,
   resolveActiveReplyOperationForSessionId,
-  resolveReplyRunPhaseForSessionId,
   waitForReplyOperationOwnerSettlement,
   waitForReplyRunEndBySessionId,
   waitForReplyRunSuccessorAdmission,
@@ -342,9 +341,6 @@ describe("reply run registry", () => {
     operation.markWaitingForDeferredMaintenance();
 
     expect(operation.phase).toBe("waiting_for_deferred_maintenance");
-    expect(resolveReplyRunPhaseForSessionId("session-wait")).toBe(
-      "waiting_for_deferred_maintenance",
-    );
     expect(
       getDiagnosticSessionActivitySnapshot({
         sessionId: "session-wait",

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -13,7 +13,6 @@ export type {
   ReplyMessageInjectionAttempt,
   ReplyMessageInjectionTarget,
   ReplyOperation,
-  ReplyOperationPhase,
   ReplyTurnKind,
 } from "./reply-run-registry.contracts.js";
 export {
@@ -44,7 +43,6 @@ export {
   resolveActiveReplyOperationForSessionId,
   resolveActiveReplyRunSessionId,
   resolveActiveReplyRunThreadId,
-  resolveReplyRunPhaseForSessionId,
   supersedeReplyRunByRunId,
   waitForReplyOperationOwnerSettlement,
   waitForReplyRunEndBySessionId,

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -14,6 +14,7 @@ import { testing as replyRunTesting } from "../auto-reply/reply/reply-run-regist
 import {
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
+  setDiagnosticsEnabledForProcess,
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { enqueueCommandInLane, getQueueSize, resetCommandLane } from "../process/command-queue.js";
@@ -25,6 +26,7 @@ import {
   markDiagnosticRunProgress,
 } from "./diagnostic-run-activity.js";
 import { markDiagnosticModelStartedForTest } from "./diagnostic-run-activity.test-support.js";
+import { logMessageQueuedWithBacklogPolicy } from "./diagnostic-runtime.js";
 import { recoverStuckDiagnosticSession } from "./diagnostic-stuck-session-recovery.runtime.js";
 import { logSessionStateChange, startDiagnosticHeartbeat } from "./diagnostic.js";
 import { resetDiagnosticStateForTest } from "./diagnostic.test-support.js";
@@ -338,6 +340,184 @@ describe("stuck session recovery integration", () => {
     await expect(queued).resolves.toBe("drained");
     expect(outcome.status).toBe("aborted");
     expect(getQueueSize(lane)).toBe(0);
+  });
+
+  it("keeps queued preflight compaction alive until its configured safety timeout", async () => {
+    const sessionKey = "agent:main:active-preflight";
+    const sessionId = "active-preflight-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    operation.setPhase("preflight_compacting");
+    let markActiveStarted!: () => void;
+    const activeStarted = new Promise<void>((resolve) => {
+      markActiveStarted = resolve;
+    });
+    const active = enqueueCommandInLane(
+      lane,
+      () =>
+        new Promise<"aborted">((resolve) => {
+          markActiveStarted();
+          operation.abortSignal.addEventListener(
+            "abort",
+            () => {
+              operation.complete();
+              resolve("aborted");
+            },
+            { once: true },
+          );
+        }),
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    const queued = enqueueCommandInLane(lane, async () => "drained", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    await activeStarted;
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      // The session can be old even though it only just entered preflight.
+      ageMs: 30 * 60_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+      compactionSafetyTimeoutMs: 10 * 60_000,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_reply_work",
+      activeSessionId: sessionId,
+    });
+    expect(operation.abortSignal.aborted).toBe(false);
+    await expectPendingAfterEventLoopTurn(active);
+    await expectPendingAfterEventLoopTurn(queued);
+    expect(getQueueSize(lane)).toBe(2);
+
+    // Intentional cancellation remains owned by the reply operation.
+    expect(operation.abortByUser()).toBe(true);
+    await expect(active).resolves.toBe("aborted");
+    await expect(queued).resolves.toBe("drained");
+  });
+
+  it("keeps fresh preflight compaction through the queued-session heartbeat watchdog", async () => {
+    vi.useFakeTimers();
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
+    try {
+      const sessionKey = "agent:main:heartbeat-preflight";
+      const sessionId = "heartbeat-preflight-session";
+      const lane = resolveEmbeddedSessionLane(sessionKey);
+      const startMs = Date.parse("2026-08-18T12:00:00Z");
+      vi.setSystemTime(startMs);
+      setDiagnosticsEnabledForProcess(true);
+      logSessionStateChange({ sessionId, sessionKey, state: "processing" });
+      logMessageQueuedWithBacklogPolicy({ sessionId, sessionKey, source: "test" }, true);
+      markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+
+      // The diagnostic owner is old, but preflight starts only now.
+      vi.setSystemTime(startMs + 12 * 60_000);
+      const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+      operation.setPhase("preflight_compacting");
+      let markActiveStarted!: () => void;
+      const activeStarted = new Promise<void>((resolve) => {
+        markActiveStarted = resolve;
+      });
+      const active = enqueueCommandInLane(
+        lane,
+        () =>
+          new Promise<"aborted">((resolve) => {
+            markActiveStarted();
+            operation.abortSignal.addEventListener(
+              "abort",
+              () => {
+                operation.complete();
+                resolve("aborted");
+              },
+              { once: true },
+            );
+          }),
+        { warnAfterMs: Number.MAX_SAFE_INTEGER },
+      );
+      const queued = enqueueCommandInLane(lane, async () => "drained", {
+        warnAfterMs: Number.MAX_SAFE_INTEGER,
+      });
+      await activeStarted;
+
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: { enabled: true },
+          agents: { defaults: { compaction: { timeoutSeconds: 600 } } },
+        },
+        {
+          recoverStuckSession: recoverStuckDiagnosticSession,
+          testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 90_000 },
+        },
+      );
+      await vi.advanceTimersByTimeAsync(90_000);
+      await Promise.resolve();
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "session.recovery.requested",
+          sessionId,
+          sessionKey,
+          queueDepth: 1,
+          allowActiveAbort: true,
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "session.recovery.completed",
+          sessionId,
+          sessionKey,
+          status: "skipped",
+          action: "keep_lane",
+          outcomeReason: "active_reply_work",
+        }),
+      );
+      expect(operation.abortSignal.aborted).toBe(false);
+      expect(getQueueSize(lane)).toBe(2);
+
+      // Restart remains an intentional, immediate cancellation source.
+      expect(operation.abortForRestart()).toBe(true);
+      await expect(active).resolves.toBe("aborted");
+      await expect(queued).resolves.toBe("drained");
+    } finally {
+      unsubscribe();
+      resetDiagnosticStateForTest();
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps supersession cancellation immediate during protected preflight", async () => {
+    const sessionKey = "agent:main:superseded-preflight";
+    const sessionId = "superseded-preflight-session";
+    const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    operation.setPhase("preflight_compacting");
+
+    await expect(
+      recoverStuckDiagnosticSession({
+        sessionId,
+        sessionKey,
+        ageMs: 30 * 60_000,
+        queueDepth: 1,
+        allowActiveAbort: true,
+        compactionSafetyTimeoutMs: 10 * 60_000,
+      }),
+    ).resolves.toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_reply_work",
+    });
+
+    expect(operation.supersede()).toBe(true);
+    expect(operation.abortSignal.aborted).toBe(true);
+    expect(operation.result).toEqual({
+      kind: "aborted",
+      code: "aborted_for_supersession",
+    });
   });
 
   it("keeps queued lane work behind reply-only force-clear settlement", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   resolveActiveEmbeddedRunSessionIdBySessionFile: vi.fn(),
   resolveActiveEmbeddedRunHandleSessionId: vi.fn(),
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile: vi.fn(),
-  resolveEmbeddedAgentReplyRunPhase: vi.fn(),
+  resolveEmbeddedReplyActivity: vi.fn(),
   resolveEmbeddedSessionLane: vi.fn((key: string) => `session:${key}`),
   waitForEmbeddedAgentRunEnd: vi.fn(),
   getDiagnosticSessionActivitySnapshot: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock("../agents/embedded-agent-runner/runs.js", () => ({
   resolveActiveEmbeddedRunHandleSessionId: mocks.resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile:
     mocks.resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
-  resolveEmbeddedAgentReplyRunPhase: mocks.resolveEmbeddedAgentReplyRunPhase,
+  resolveEmbeddedReplyActivity: mocks.resolveEmbeddedReplyActivity,
   waitForEmbeddedAgentRunEnd: mocks.waitForEmbeddedAgentRunEnd,
 }));
 
@@ -103,7 +103,7 @@ function resetMocks() {
   mocks.resolveActiveEmbeddedRunSessionIdBySessionFile.mockReset();
   mocks.resolveActiveEmbeddedRunHandleSessionId.mockReset();
   mocks.resolveActiveEmbeddedRunHandleSessionIdBySessionFile.mockReset();
-  mocks.resolveEmbeddedAgentReplyRunPhase.mockReset();
+  mocks.resolveEmbeddedReplyActivity.mockReset();
   mocks.resolveEmbeddedSessionLane.mockClear();
   mocks.waitForEmbeddedAgentRunEnd.mockReset();
   mocks.getDiagnosticSessionActivitySnapshot.mockReset();
@@ -401,7 +401,10 @@ describe("stuck session recovery", () => {
   it("keeps the lane while reply work waits for deferred maintenance", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
-    mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue("waiting_for_deferred_maintenance");
+    mocks.resolveEmbeddedReplyActivity.mockReturnValue({
+      phase: "waiting_for_deferred_maintenance",
+      lastActivityAtMs: Date.now(),
+    });
     mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
 
@@ -430,7 +433,10 @@ describe("stuck session recovery", () => {
   it("keeps a reply queued on the global lane instead of reclaiming it", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
-    mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue("waiting_for_global_lane");
+    mocks.resolveEmbeddedReplyActivity.mockReturnValue({
+      phase: "waiting_for_global_lane",
+      lastActivityAtMs: Date.now(),
+    });
     mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
 
     const outcome = await recoverStuckDiagnosticSession({
@@ -494,7 +500,10 @@ describe("stuck session recovery", () => {
       mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
       mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
       mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
-      mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue(phase);
+      mocks.resolveEmbeddedReplyActivity.mockReturnValue({
+        phase,
+        lastActivityAtMs: Date.now(),
+      });
       mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
         lastProgressAgeMs: 720_000,
       });
@@ -556,7 +565,10 @@ describe("stuck session recovery", () => {
       );
       mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
       mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(hasEmbeddedHandle);
-      mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue(phase);
+      mocks.resolveEmbeddedReplyActivity.mockReturnValue({
+        phase,
+        lastActivityAtMs: Date.now() - ageMs,
+      });
       mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: ageMs });
       mocks.abortEmbeddedAgentRun.mockReturnValue(true);
       mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
@@ -578,6 +590,130 @@ describe("stuck session recovery", () => {
       );
     },
   );
+
+  it.each([
+    {
+      name: "keeps fresh queued preflight despite an old session attention age",
+      replyActivityAgeMs: 1_000,
+      queueDepth: 1,
+      compactionSafetyTimeoutMs: 600_000,
+      expectedAbort: false,
+    },
+    {
+      name: "clamps a future preflight activity clock instead of treating it as stale",
+      replyActivityAgeMs: -1_000,
+      queueDepth: 1,
+      compactionSafetyTimeoutMs: 600_000,
+      expectedAbort: false,
+    },
+    {
+      name: "keeps zero-backlog preflight one millisecond before timeout plus settle",
+      replyActivityAgeMs: 614_999,
+      queueDepth: 0,
+      compactionSafetyTimeoutMs: 600_000,
+      expectedAbort: false,
+    },
+    {
+      name: "recovers queued preflight exactly at timeout plus settle",
+      replyActivityAgeMs: 615_000,
+      queueDepth: 1,
+      compactionSafetyTimeoutMs: 600_000,
+      expectedAbort: true,
+    },
+    {
+      name: "recovers queued preflight after timeout plus settle",
+      replyActivityAgeMs: 615_001,
+      queueDepth: 1,
+      compactionSafetyTimeoutMs: 600_000,
+      expectedAbort: true,
+    },
+    {
+      name: "keeps preflight before the default stale recovery floor",
+      replyActivityAgeMs: 299_999,
+      queueDepth: 1,
+      expectedAbort: false,
+    },
+    {
+      name: "recovers preflight at the default stale recovery floor",
+      replyActivityAgeMs: 300_000,
+      queueDepth: 1,
+      expectedAbort: true,
+    },
+    {
+      name: "uses the default stale recovery floor for an invalid compaction timeout",
+      replyActivityAgeMs: 299_999,
+      queueDepth: 1,
+      compactionSafetyTimeoutMs: 0,
+      expectedAbort: false,
+    },
+  ])(
+    "$name",
+    async ({ replyActivityAgeMs, queueDepth, compactionSafetyTimeoutMs, expectedAbort }) => {
+      const now = 1_800_000;
+      const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
+      try {
+        mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("preflight-session");
+        mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+        mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+        mocks.resolveEmbeddedReplyActivity.mockReturnValue({
+          phase: "preflight_compacting",
+          lastActivityAtMs: now - replyActivityAgeMs,
+        });
+        mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+        mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+        mocks.resetCommandLane.mockReturnValue(0);
+
+        const outcome = await recoverStuckDiagnosticSession({
+          sessionId: "preflight-session",
+          sessionKey: "agent:main:main",
+          // Deliberately older than every preflight clock in this table.
+          ageMs: 30 * 60_000,
+          queueDepth,
+          allowActiveAbort: true,
+          compactionSafetyTimeoutMs,
+        });
+
+        expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledTimes(expectedAbort ? 1 : 0);
+        expect(outcome).toMatchObject(
+          expectedAbort
+            ? { status: "aborted", action: "abort_embedded_run" }
+            : { status: "skipped", action: "keep_lane", reason: "active_reply_work" },
+        );
+      } finally {
+        dateNow.mockRestore();
+      }
+    },
+  );
+
+  it("uses reply activity rather than session age for memory flushing", async () => {
+    const now = Date.now();
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("memory-flush-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.resolveEmbeddedReplyActivity.mockReturnValue({
+      phase: "memory_flushing",
+      lastActivityAtMs: now,
+    });
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(0);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "memory-flush-session",
+      sessionKey: "agent:main:main",
+      ageMs: 30 * 60_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+      compactionSafetyTimeoutMs: 600_000,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_reply_work",
+    });
+  });
 
   it("keeps reply-only ownership with recent progress even with zero queued backlog", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("live-reply-session");

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -4,7 +4,7 @@ import {
   abortAndDrainEmbeddedAgentRun,
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunHandleActive,
-  resolveEmbeddedAgentReplyRunPhase,
+  resolveEmbeddedReplyActivity,
   resolveActiveEmbeddedRunSessionId,
   resolveActiveEmbeddedRunSessionIdBySessionFile,
   resolveActiveEmbeddedRunHandleSessionId,
@@ -177,22 +177,29 @@ export async function recoverStuckDiagnosticSession(
     let forceCleared = false;
     const staleActiveProgressAbortMs = resolveStaleActiveProgressAbortMs(params);
     const staleActiveLaneTaskReleaseMs = resolveStaleActiveLaneTaskReleaseMs(params);
-    const activeReplyPhase = activeWorkSessionId
-      ? resolveEmbeddedAgentReplyRunPhase(activeWorkSessionId)
+    const activeReplyActivity = activeWorkSessionId
+      ? resolveEmbeddedReplyActivity(activeWorkSessionId)
+      : undefined;
+    const activeReplyPhase = activeReplyActivity?.phase;
+    // Phase changes refresh the reply operation's activity clock. Session
+    // attention age may predate maintenance, so it cannot own this timeout.
+    const activeReplyAgeMs = activeReplyActivity
+      ? Math.max(0, Date.now() - activeReplyActivity.lastActivityAtMs)
       : undefined;
     const maintenancePhase =
       activeReplyPhase === "preflight_compacting" || activeReplyPhase === "memory_flushing";
+    const activeMaintenanceProtected =
+      maintenancePhase &&
+      activeReplyAgeMs !== undefined &&
+      activeReplyAgeMs < staleActiveLaneTaskReleaseMs;
 
-    if (
-      activeReplyPhase === "waiting_for_global_lane" ||
-      (maintenancePhase && params.ageMs < staleActiveLaneTaskReleaseMs)
-    ) {
+    if (activeReplyPhase === "waiting_for_global_lane" || activeMaintenanceProtected) {
       // Queued replies and configured maintenance own their lane until their
       // producer finishes or the existing compaction safety window expires.
       return reportRecoveryOutcome({
         status: "skipped",
         action: "keep_lane",
-        reason: maintenancePhase ? "active_reply_work" : "global_lane_wait",
+        reason: activeMaintenanceProtected ? "active_reply_work" : "global_lane_wait",
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         activeSessionId: activeWorkSessionId,


### PR DESCRIPTION
## What Problem This Solves

The diagnostic heartbeat can promote a queued stalled session to `allowActiveAbort: true`. During mandatory budget preflight compaction, that recovery path could abort the active `ReplyOperation` before the configured compaction safety timeout, even though the session had only just entered preflight. The diagnostic request age can predate preflight by many minutes, so it is not a valid preflight clock.

Fixes #95553.

## Why This Change Was Made

The repair stays at the watchdog/recovery owner instead of filtering the shared reply abort signal:

- Recovery reads one active reply snapshot containing `phase` and owner `lastActivityAtMs`.
- A reply-only `preflight_compacting` operation is protected while its owner activity age is below the existing lane-release window: `max(5 minutes, compaction timeout + 15 seconds)`.
- Phase entry refreshes that owner clock; stale session-attention age is deliberately ignored.
- A future clock is clamped to age zero, and equality at the release boundary permits recovery.
- Ordinary running work keeps its existing recovery behavior; the upstream-recognized `preflight_compacting` and `memory_flushing` maintenance phases both use their own operation clock.
- User abort, restart, and supersession still cancel the same `ReplyOperation` immediately.

The old phase-only registry facade is removed; the embedded-run facade now exposes only the two fields recovery needs.

## User Impact

Legitimate preflight compaction is no longer killed by the queued-session watchdog shortly after it begins. Its own configured safety timeout remains the primary bound, while genuinely stale work is still reclaimed and intentional cancellation remains immediate.

## Evidence

[AI-assisted]

### Pre-fix reproduction

The production recovery/queue/`ReplyOperation` integration failed on the pre-fix tree:

```text
node scripts/run-vitest.mjs \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts \
  -t "keeps queued preflight compaction alive until its configured safety timeout"

actual:   { status: "aborted", action: "abort_embedded_run" }
expected: { status: "skipped", action: "keep_lane", reason: "active_reply_work" }
```

The scenario uses `allowActiveAbort: true`, queued backlog, a 10-minute compaction timeout, an 18-minute-old diagnostic session, and a freshly entered preflight phase.

### Post-fix production-path proof

The integration suite drives the real diagnostic heartbeat, command lane, reply registry, and abort/drain path. It observes a queued recovery request with `allowActiveAbort: true`, followed by `keep_lane`; the same operation then aborts immediately through restart. Separate real-operation coverage proves user abort and supersession remain immediate.

A temporary, uncommitted production-boundary harness then connected the real `runPreflightCompactionIfNeeded` producer, `ReplyOperation`, command lane/backlog, diagnostic heartbeat, and recovery runtime. Only the compact backend was a controlled slow seam. The harness emitted this redacted terminal proof and was removed afterward:

```text
OPENCLAW_95553_PROOF {
  "config":{"compactionSafetyTimeoutMs":600000,"settleAllowanceMs":15000,"releaseBoundaryMs":615000},
  "producer":{"module":"runPreflightCompactionIfNeeded","producerPhase":"preflight_compacting","oldDiagnosticAgeMsAtPhaseEntry":720000,"freshOwnerAgeMsAtPhaseEntry":0,"controlledSlowCompactionObservedAbortSignal":true},
  "beforeBoundary":{"trigger":"diagnostic_heartbeat","ownerAgeMs":90000,"diagnosticAgeMs":810000,"outcome":{"status":"skipped","action":"keep_lane","reason":"active_reply_work"},"signalAborted":false,"laneSize":2},
  "atBoundary":{"trigger":"diagnostic_heartbeat","ownerAgeMs":615000,"diagnosticAgeMs":1335000,"recoveryMode":"stale_reclaim","outcome":{"status":"aborted","action":"abort_embedded_run","released":0},"activeResult":"aborted","queuedResult":"drained","laneSize":0},
  "intentionalCancellation":[
    {"source":"user","independentOperation":true,"accepted":true,"signalAbortedSynchronously":true,"resultCode":"aborted_by_user"},
    {"source":"restart","independentOperation":true,"accepted":true,"signalAbortedSynchronously":true,"resultCode":"aborted_for_restart"},
    {"source":"supersede","independentOperation":true,"accepted":true,"signalAbortedSynchronously":true,"resultCode":"aborted_for_supersession"}
  ]
}
production-boundary proof: 1 passed
```

`released: 0` is the lane-reset release counter; `queuedResult: "drained"` plus `laneSize: 0` proves the backlog completed through normal drain after the active operation aborted.

The committed, rerunnable focused proof also passes:

```text
node scripts/run-vitest.mjs \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts \
  -t "keeps fresh preflight compaction through the queued-session heartbeat watchdog" \
  --reporter=verbose

keeps fresh preflight compaction through the queued-session heartbeat watchdog 26ms
Test Files 1 passed (1)
Tests 1 passed | 11 skipped (12)
```

Runtime boundary coverage includes:

- old diagnostic age + fresh preflight owner clock;
- future-clock rollback clamp;
- configured `600s`: protected at `614999ms`, recoverable at `615000ms`;
- default/invalid timeout floor: protected at `299999ms`, recoverable at `300000ms`;
- queue depth `0` and `1`;
- ordinary running sibling behavior plus upstream-recognized memory-flushing maintenance;
- user, restart, and supersession cancellation;
- producer ordering: `setPhase("preflight_compacting")` occurs before compaction starts.

### Validation

```text
node scripts/run-vitest.mjs \
  src/logging/diagnostic-stuck-session-recovery.runtime.test.ts \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts \
  src/auto-reply/reply/reply-run-registry.test.ts

logging/recovery: 63 passed
reply registry:   85 passed
```

After rebasing onto `6cb08cb8ee`, the current focused set passed 148/148. The conflict resolution preserves the queued-reply ownership changes from #127510 while replacing session attention age with the owning reply-operation activity clock.

Current-head changed-surface gates passed: oxfmt, changed-file oxlint, production tsgo, messaging test tsgo, logging test tsgo, and `git diff --check`. Exact-head CI is rerunning the repository-wide gates.

On Windows, the focused `agent-runner-memory` test reaches its assertions and then fails deleting an open temporary SQLite/WAL/SHM file. The identical test on a clean detached worktree at the exact base SHA fails at the same `afterEach` unlink with `EBUSY`; this is a baseline teardown lock, not a behavior failure introduced here.

### Surface

- Production: `+21/-22` (net `-1`)
- Tests: `+328/-11` (net `+317`)

The owner snapshot and guarded recovery decision are fully absorbed by removing the obsolete phase-only facade, leaving production code net-negative.

### Runtime contract check

OpenAI Codex runs compaction as `CompactTask` and propagates explicit aborts through the task lifecycle (`codex-rs/core/src/tasks/compact.rs`, `codex-rs/core/src/tasks/mod.rs`, `codex-rs/core/src/tasks/lifecycle.rs`; inspected at `9b9b614b02ba`). The OpenClaw diagnostic watchdog is therefore the correct owner for distinguishing recovery from intentional cancellation.


