### PR TITLE
perf(test): reuse command differential temp root

### DIFF
--- a/src/agents/command/model-selection.turn-model-differential.test.ts
+++ b/src/agents/command/model-selection.turn-model-differential.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -151,7 +151,12 @@ vi.mock("./runtime-loaders.js", () => ({
 
 const { resolveEmbeddedModelSelection } = await import("./model-selection.js");
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+let suiteTempRoot = "";
+
+beforeAll(() => {
+  suiteTempRoot = tempDirs.make("turn-model-command-");
+});
 
 function createConfig(fixture: TurnModelDifferentialFixture): OpenClawConfig {
   return {
@@ -161,6 +166,7 @@ function createConfig(fixture: TurnModelDifferentialFixture): OpenClawConfig {
 }
 
 async function observeCommandSelection(fixture: TurnModelDifferentialFixture) {
+  const fixtureIndex = TURN_MODEL_DIFFERENTIAL_FIXTURES.indexOf(fixture);
   const sessionKey = "agent:main:telegram:group:selection";
   const sessionStore: Record<string, SessionEntry> = { [sessionKey]: fixture.child };
   if (fixture.parent) {
@@ -194,9 +200,9 @@ async function observeCommandSelection(fixture: TurnModelDifferentialFixture) {
     sessionStore,
     sessionKey,
     sessionId: fixture.child.sessionId,
-    storePath: path.join(tempDirs.make("turn-model-command-"), "sessions.json"),
+    storePath: path.join(suiteTempRoot, `sessions-${fixtureIndex}.json`),
     sessionAgentId: "main",
-    workspaceDir: tempDirs.make("turn-model-command-workspace-"),
+    workspaceDir: suiteTempRoot,
     pluginsEnabled: false,
     modelManifestContext: {},
     configuredThinkingCatalog: [],


### PR DESCRIPTION
## What Problem This Solves

The command-path turn-model differential suite created separate temporary directories for every fixture. Across eight fixtures, that meant sixteen per-case directory creations even though the session stores only need unique inert paths and the workspace can be shared safely within the suite.

## Why This Change Was Made

Reuse one suite-owned temporary root, give all eight fixtures unique `sessions-<index>.json` store paths beneath it, and share that root as the workspace. The fixtures, mocks, session data, verdicts, and `suppressVisibleSessionEffects` behavior are unchanged. Suite cleanup remains registered through the existing automatic temp-directory tracker.

## User Impact

This is a test-only lifecycle optimization. It reduces focused-suite runtime without changing production behavior.

- Production LOC: +0/-0
- Tests: +10/-4
- Screenshots: not applicable; no UI or user-visible behavior changed
- Changelog: not required; test-only change

## Evidence

Controlled same-Testbox A/B run: https://github.com/openclaw/openclaw/actions/runs/32166257065

The benchmark used one excluded warmup, two retained measurements, one worker, distinct module caches, import diagnostics, and `/usr/bin/time -v`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall mean | 31.765s | 28.200s | -3.565s (-11.22%) |
| Vitest | 28.295s | 25.005s | -3.290s |
| Test body | 26.050s | 22.905s | -3.145s |
| Import | 1.425s | 1.310s | -0.115s |
| Maximum RSS | 1,275,584KB | 1,255,120KB | -20,464KB |

Mean CPU time improved by 4.33s user and 0.15s system.

- Focused suite: 8/8 passed.
- Mutation proof: temporarily making channel selection outrank stored selection failed the intended current-session, locked, and parent cases; production was then restored byte-identically.
- Complete changed gate: green on Testbox `tbx_01m0ayzh3bvv7cz2f203jba6pp` (stopped).
- Fresh post-rebase autoreview: clean, no accepted/actionable findings, overall 0.99.
- Stable patch-id before and after rebase: `f66777cfe55cabf8aeab247c1737da86d9970fc7`.
