### PR TITLE
fix(agents): reject unusable explicit spawn models

### DIFF
--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -4,7 +4,13 @@ import { isIncognitoSessionKey } from "../../../routing/session-key.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveAgentDir } from "../../agent-scope-config.js";
 import { findModelCatalogEntry } from "../../model-catalog-lookup.js";
-import { resolveDefaultModelForAgent } from "../../model-selection.js";
+import type { ModelCatalogEntry } from "../../model-catalog.types.js";
+import {
+  findNormalizedProviderValue,
+  getModelRefStatus,
+  resolveAllowedModelRef,
+  resolveDefaultModelForAgent,
+} from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
 import { summarizeSpawnError } from "../../spawn-pipeline.js";
 import { resolveSpawnSandboxError, mintSpawnSessionKey } from "../../spawn-plan.js";
@@ -26,7 +32,6 @@ import {
   readRequesterThinkingLevel,
 } from "./subagent-spawn-requester-prefs.js";
 import {
-  loadPreparedModelCatalog,
   normalizeDeliveryContext,
   resolveAgentConfig,
   resolveSandboxRuntimeStatus,
@@ -47,24 +52,23 @@ function buildResolvedSubagentModelMetadata(resolvedModel?: string): {
   };
 }
 
-async function resolveCollectorOutputModelError(params: {
+async function resolveSpawnModelError(params: {
   cfg: OpenClawConfig;
   targetAgentId: string;
   targetAgentDir: string;
   workspaceDir?: string;
+  request: SpawnSubagentParams;
   resolvedModel?: string;
 }): Promise<string | undefined> {
-  const selected = splitModelRef(params.resolvedModel);
-  const fallback = resolveDefaultModelForAgent({
-    cfg: params.cfg,
-    agentId: params.targetAgentId,
-  });
-  const provider = selected.provider ?? fallback.provider;
-  const model = selected.model ?? fallback.model;
-  if (!provider || !model) {
+  const { cfg, targetAgentId } = params;
+  const requestedModel = normalizeOptionalString(params.request.model);
+  if (!requestedModel && !params.request.outputSchema) {
     return undefined;
   }
-  let catalog: Awaited<ReturnType<typeof loadPreparedModelCatalog>>;
+  const defaults = resolveDefaultModelForAgent({ cfg, agentId: targetAgentId });
+  const selected = splitModelRef(params.resolvedModel);
+  const provider = selected.provider ?? defaults.provider;
+  let catalog: ModelCatalogEntry[];
   try {
     catalog = await getSubagentSpawnDeps().loadPreparedModelCatalog({
       config: params.cfg,
@@ -75,13 +79,59 @@ async function resolveCollectorOutputModelError(params: {
       scopedLiveProviderDiscovery: true,
     });
   } catch (error) {
-    return `sessions_spawn could not verify outputSchema model capabilities: ${summarizeSpawnError(error)}`;
+    return `sessions_spawn could not verify ${requestedModel ? "the requested model" : "outputSchema model capabilities"}: ${summarizeSpawnError(error)}`;
   }
-  const entry = findModelCatalogEntry(catalog, { provider, modelId: model });
-  if (!entry || supportsModelTools(entry)) {
-    return undefined;
+
+  if (!requestedModel) {
+    const model = selected.model ?? defaults.model;
+    const entry = model && findModelCatalogEntry(catalog, { provider, modelId: model });
+    return entry && !supportsModelTools(entry)
+      ? `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`
+      : undefined;
   }
-  return `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`;
+  const selection = {
+    cfg,
+    catalog,
+    defaultProvider: defaults.provider,
+    defaultModel: defaults.model,
+    agentId: targetAgentId,
+  };
+  const resolved = resolveAllowedModelRef({
+    ...selection,
+    raw: requestedModel,
+  });
+  if ("error" in resolved) {
+    return `sessions_spawn model "${requestedModel}" is not usable: ${resolved.error}`;
+  }
+
+  const status = getModelRefStatus({
+    ...selection,
+    ref: resolved.ref,
+  });
+  if (status.allowAny && !status.inCatalog) {
+    const resolvedProvider = resolved.ref.provider;
+    const knownProvider =
+      findNormalizedProviderValue(cfg.models?.providers, resolvedProvider) ||
+      catalog.some((entry) => entry.provider === resolvedProvider) ||
+      getSubagentSpawnDeps().resolveProviderRefOwnership({
+        provider: resolvedProvider,
+        config: cfg,
+        workspaceDir: params.workspaceDir,
+      }).status === "owned";
+    if (!knownProvider) {
+      return `sessions_spawn model "${requestedModel}" is not usable: unknown model provider "${resolvedProvider}"`;
+    }
+  }
+  if (params.request.outputSchema) {
+    const entry = findModelCatalogEntry(catalog, {
+      provider: resolved.ref.provider,
+      modelId: resolved.ref.model,
+    });
+    if (entry && !supportsModelTools(entry)) {
+      return `sessions_spawn outputSchema requires a tool-capable target model; "${resolved.ref.provider}/${resolved.ref.model}" declares compat.supportsTools=false.`;
+    }
+  }
+  return undefined;
 }
 
 type ResolvedSubagentChildPlan = {
@@ -221,6 +271,24 @@ export async function resolveSubagentChildPlan(params: {
     };
   }
   const { resolvedModel } = modelPlan;
+  const modelError = await resolveSpawnModelError({
+    cfg: params.cfg,
+    targetAgentId: params.targetAgentId,
+    targetAgentDir,
+    workspaceDir: spawnedWorkspaceDir,
+    request: params.request,
+    resolvedModel,
+  });
+  if (modelError) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: modelError,
+        ...(params.request.outputSchema ? { childSessionKey } : {}),
+      },
+    };
+  }
   const resolvedLaunchModel = splitModelRef(resolvedModel);
   const launchAuthorization: SubagentLaunchAuthorization | undefined =
     params.request.model?.trim() && resolvedLaunchModel.model
@@ -231,21 +299,6 @@ export async function resolveSubagentChildPlan(params: {
           },
         }
       : undefined;
-  if (params.request.outputSchema) {
-    const outputModelError = await resolveCollectorOutputModelError({
-      cfg: params.cfg,
-      targetAgentId: params.targetAgentId,
-      targetAgentDir,
-      workspaceDir: spawnedWorkspaceDir,
-      resolvedModel,
-    });
-    if (outputModelError) {
-      return {
-        ok: false,
-        result: { status: "error", error: outputModelError, childSessionKey },
-      };
-    }
-  }
   return {
     ok: true,
     resolved: {

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -7,7 +7,6 @@ import { findModelCatalogEntry } from "../../model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "../../model-catalog.types.js";
 import {
   findNormalizedProviderValue,
-  getModelRefStatus,
   resolveAllowedModelRef,
   resolveDefaultModelForAgent,
 } from "../../model-selection.js";
@@ -104,15 +103,15 @@ async function resolveSpawnModelError(params: {
     return `sessions_spawn model "${requestedModel}" is not usable: ${resolved.error}`;
   }
 
-  const status = getModelRefStatus({
-    ...selection,
-    ref: resolved.ref,
+  const entry = findModelCatalogEntry(catalog, {
+    provider: resolved.ref.provider,
+    modelId: resolved.ref.model,
   });
-  if (status.allowAny && !status.inCatalog) {
+  if (!entry) {
     const resolvedProvider = resolved.ref.provider;
     const knownProvider =
       findNormalizedProviderValue(cfg.models?.providers, resolvedProvider) ||
-      catalog.some((entry) => entry.provider === resolvedProvider) ||
+      catalog.some((catalogEntry) => catalogEntry.provider === resolvedProvider) ||
       getSubagentSpawnDeps().resolveProviderRefOwnership({
         provider: resolvedProvider,
         config: cfg,
@@ -122,14 +121,8 @@ async function resolveSpawnModelError(params: {
       return `sessions_spawn model "${requestedModel}" is not usable: unknown model provider "${resolvedProvider}"`;
     }
   }
-  if (params.request.outputSchema) {
-    const entry = findModelCatalogEntry(catalog, {
-      provider: resolved.ref.provider,
-      modelId: resolved.ref.model,
-    });
-    if (entry && !supportsModelTools(entry)) {
-      return `sessions_spawn outputSchema requires a tool-capable target model; "${resolved.ref.provider}/${resolved.ref.model}" declares compat.supportsTools=false.`;
-    }
+  if (params.request.outputSchema && entry && !supportsModelTools(entry)) {
+    return `sessions_spawn outputSchema requires a tool-capable target model; "${resolved.ref.provider}/${resolved.ref.model}" declares compat.supportsTools=false.`;
   }
   return undefined;
 }

--- a/src/agents/subagents/spawn/subagent-spawn-deps.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-deps.ts
@@ -8,6 +8,7 @@ import {
   getRuntimeConfig,
   hasInProcessGatewayContext,
   loadPreparedModelCatalog,
+  resolveProviderRefOwnership,
   resolveContextEngine,
 } from "./subagent-spawn.runtime.js";
 
@@ -20,6 +21,7 @@ type SubagentSpawnDeps = {
   hasInProcessGatewayContext: typeof hasInProcessGatewayContext;
   ensureContextEnginesInitialized: typeof ensureContextEnginesInitialized;
   loadPreparedModelCatalog: typeof loadPreparedModelCatalog;
+  resolveProviderRefOwnership: typeof resolveProviderRefOwnership;
   resolveContextEngine: typeof resolveContextEngine;
 };
 
@@ -32,6 +34,7 @@ const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
   hasInProcessGatewayContext,
   ensureContextEnginesInitialized,
   loadPreparedModelCatalog,
+  resolveProviderRefOwnership,
   resolveContextEngine,
 };
 

--- a/src/agents/subagents/spawn/subagent-spawn.runtime.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.runtime.ts
@@ -23,6 +23,7 @@ export {
 export { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 export { resolveGatewaySessionStoreTarget } from "../../../gateway/session-utils.js";
 export { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+export { resolveProviderRefOwnership } from "../../../plugins/providers.js";
 export { emitSessionLifecycleEvent } from "../../../sessions/session-lifecycle-events.js";
 export {
   mergeDeliveryContext,

--- a/src/agents/subagents/spawn/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test-helpers.ts
@@ -134,6 +134,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
   getRuntimeConfig?: () => Record<string, unknown>;
   loadSessionStoreMock?: MockFn;
   loadPreparedModelCatalogMock?: MockFn;
+  resolveProviderRefOwnershipMock?: MockFn;
   ensureContextEnginesInitializedMock?: MockFn;
   updateSessionStoreMock?: MockFn;
   forkSessionEntryFromParentMock?: MockFn;
@@ -268,6 +269,11 @@ export async function loadSubagentSpawnModuleForTest(params: {
       createSubagentSpawnTestConfig(params.workspaceDir ?? os.tmpdir()),
     loadPreparedModelCatalog: (...args: unknown[]) =>
       params.loadPreparedModelCatalogMock?.(...args) ?? [],
+    resolveProviderRefOwnership: (...args: unknown[]) =>
+      params.resolveProviderRefOwnershipMock?.(...args) ?? {
+        status: "owned",
+        pluginIds: ["test-provider"],
+      },
     loadSessionEntry: (scope: { storePath?: string; sessionKey: string }) =>
       ((params.loadSessionStoreMock?.(scope.storePath) ?? {}) as SessionStore)[scope.sessionKey],
     loadSessionStore: params.loadSessionStoreMock ?? (() => ({})),

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -656,12 +656,15 @@ describe("spawnSubagentDirect seam flow", () => {
     });
   });
 
-  it("accepts an explicitly allowlisted catalog-missing custom ref", async () => {
+  it.each([
+    { policy: "exact", allow: ["future-provider/new-model"] },
+    { policy: "provider wildcard", allow: ["future-provider/*"] },
+  ])("rejects an unowned catalog-missing ref under a strict $policy policy", async ({ allow }) => {
     hoisted.configOverride = createConfigOverride({
       agents: {
         defaults: {
           workspace: os.tmpdir(),
-          modelPolicy: { allow: ["future-provider/new-model"] },
+          modelPolicy: { allow },
         },
         list: [{ id: "main", workspace: "/tmp/workspace-main" }],
       },
@@ -669,42 +672,18 @@ describe("spawnSubagentDirect seam flow", () => {
     hoisted.resolveProviderRefOwnershipMock.mockReturnValue({ status: "unowned" });
 
     const result = await spawnSubagentDirect(
-      { task: "use the explicit custom ref", model: "future-provider/new-model" },
+      { task: "do not launch an unowned provider", model: "future-provider/new-model" },
       { agentSessionKey: "agent:main:main" },
     );
 
-    expect(result).toMatchObject({
-      status: "accepted",
-      modelApplied: true,
-      resolvedModel: "future-provider/new-model",
-      resolvedProvider: "future-provider",
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('unknown model provider "future-provider"');
+    expect(hoisted.resolveProviderRefOwnershipMock).toHaveBeenCalledWith({
+      provider: "future-provider",
+      config: hoisted.configOverride,
+      workspaceDir: resolveUserPath("/tmp/workspace-main"),
     });
-    expect(hoisted.resolveProviderRefOwnershipMock).not.toHaveBeenCalled();
-  });
-
-  it("accepts a provider-wildcard catalog-missing ref without provider ownership", async () => {
-    hoisted.configOverride = createConfigOverride({
-      agents: {
-        defaults: {
-          workspace: os.tmpdir(),
-          modelPolicy: { allow: ["future-provider/*"] },
-        },
-        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
-      },
-    });
-    hoisted.resolveProviderRefOwnershipMock.mockReturnValue({ status: "unowned" });
-
-    const result = await spawnSubagentDirect(
-      { task: "use a wildcard-authorized ref", model: "future-provider/new-model" },
-      { agentSessionKey: "agent:main:main" },
-    );
-
-    expect(result).toMatchObject({
-      status: "accepted",
-      resolvedModel: "future-provider/new-model",
-      resolvedProvider: "future-provider",
-    });
-    expect(hoisted.resolveProviderRefOwnershipMock).not.toHaveBeenCalled();
+    expectNoChildSpawnSideEffects();
   });
 
   it.each([

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -5,6 +5,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../../../state/openclaw-agent-db.paths.js";
+import { resolveUserPath } from "../../../utils.js";
 import { installAcceptedSubagentGatewayMock } from "../../test-helpers/subagent-gateway.js";
 import { testing as swarmSchedulerTesting } from "../swarm/swarm-scheduler.test-support.js";
 import {
@@ -21,6 +22,7 @@ const hoisted = vi.hoisted(() => ({
     throw new Error("full model catalog should not materialize");
   }),
   loadPreparedModelCatalogMock: vi.fn(),
+  resolveProviderRefOwnershipMock: vi.fn(),
   updateSessionStoreMock: vi.fn(),
   registerSubagentRunMock: vi.fn(),
   startQueuedSubagentRunMock: vi.fn(),
@@ -71,6 +73,13 @@ function gatewayRequest(method: string): Record<string, unknown> {
 
 function firstRegisteredSubagentRun(): Record<string, unknown> {
   return requireRecord(hoisted.registerSubagentRunMock.mock.calls[0]?.[0]);
+}
+
+function expectNoChildSpawnSideEffects(): void {
+  expect(hoisted.updateSessionStoreMock).not.toHaveBeenCalled();
+  expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
+  expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+  expect(hoisted.emitSessionLifecycleEventMock).not.toHaveBeenCalled();
 }
 
 type InheritedSpawnPreferenceCase = {
@@ -164,6 +173,7 @@ describe("spawnSubagentDirect seam flow", () => {
       getRuntimeConfig: () => hoisted.configOverride,
       loadSessionStoreMock: hoisted.loadSessionStoreMock,
       loadPreparedModelCatalogMock: hoisted.loadPreparedModelCatalogMock,
+      resolveProviderRefOwnershipMock: hoisted.resolveProviderRefOwnershipMock,
       updateSessionStoreMock: hoisted.updateSessionStoreMock,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
       startQueuedSubagentRunMock: hoisted.startQueuedSubagentRunMock,
@@ -187,6 +197,10 @@ describe("spawnSubagentDirect seam flow", () => {
     hoisted.loadSessionStoreMock.mockReset();
     hoisted.loadFullModelCatalogMock.mockClear();
     hoisted.loadPreparedModelCatalogMock.mockReset().mockResolvedValue([]);
+    hoisted.resolveProviderRefOwnershipMock.mockReset().mockReturnValue({
+      status: "owned",
+      pluginIds: ["test-provider"],
+    });
     hoisted.updateSessionStoreMock.mockReset();
     hoisted.registerSubagentRunMock.mockReset();
     hoisted.startQueuedSubagentRunMock.mockReset().mockReturnValue(true);
@@ -513,6 +527,240 @@ describe("spawnSubagentDirect seam flow", () => {
       scopes: ["operator.admin"],
       params: { provider: "openai", model: "gpt-5.4" },
     });
+  });
+
+  it("rejects an explicit non-allowlisted model before creating child state", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          modelPolicy: { allow: ["openai/gpt-5.4"] },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+    hoisted.loadPreparedModelCatalogMock.mockResolvedValue([
+      { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+      },
+    ]);
+
+    const result = await spawnSubagentDirect(
+      { task: "must honor model policy", model: "anthropic/claude-sonnet-4-6" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("model not allowed: anthropic/claude-sonnet-4-6");
+    expectNoChildSpawnSideEffects();
+  });
+
+  it("rejects an unknown-provider model under unrestricted policy before creating child state", async () => {
+    hoisted.resolveProviderRefOwnershipMock.mockReturnValue({ status: "unowned" });
+    hoisted.loadPreparedModelCatalogMock.mockResolvedValue([
+      { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
+    ]);
+
+    const result = await spawnSubagentDirect(
+      { task: "do not substitute an unknown provider", model: "unknown-provider/gpt-5.4" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('unknown model provider "unknown-provider"');
+    expectNoChildSpawnSideEffects();
+  });
+
+  it("does not treat ambiguous provider ownership as runnable", async () => {
+    hoisted.resolveProviderRefOwnershipMock.mockReturnValue({
+      status: "ambiguous",
+      pluginIds: ["provider-a", "provider-b"],
+    });
+
+    const result = await spawnSubagentDirect(
+      { task: "do not guess an owner", model: "ambiguous-provider/gpt-5.4" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('unknown model provider "ambiguous-provider"');
+    expectNoChildSpawnSideEffects();
+  });
+
+  it("accepts a catalog-missing model from a known provider under unrestricted policy", async () => {
+    hoisted.loadPreparedModelCatalogMock.mockResolvedValue([
+      { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
+    ]);
+
+    const result = await spawnSubagentDirect(
+      { task: "use a newly released model", model: "openai/gpt-new" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+      resolvedModel: "openai/gpt-new",
+      resolvedProvider: "openai",
+    });
+    expect(hoisted.resolveProviderRefOwnershipMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a catalog-missing model known only through provider ownership", async () => {
+    hoisted.loadPreparedModelCatalogMock.mockResolvedValue([]);
+
+    const result = await spawnSubagentDirect(
+      { task: "use a plugin-owned provider", model: "plugin-provider/new-model" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      resolvedModel: "plugin-provider/new-model",
+      resolvedProvider: "plugin-provider",
+    });
+    expect(hoisted.resolveProviderRefOwnershipMock).toHaveBeenCalledWith({
+      provider: "plugin-provider",
+      config: hoisted.configOverride,
+      workspaceDir: resolveUserPath("/tmp/workspace-main"),
+    });
+  });
+
+  it("accepts a catalog-missing model from a configured custom provider", async () => {
+    hoisted.configOverride = createConfigOverride({
+      models: {
+        providers: {
+          loopback: {
+            api: "openai-completions",
+            baseUrl: "http://127.0.0.1:43123/v1",
+            models: [],
+          },
+        },
+      },
+    });
+    hoisted.resolveProviderRefOwnershipMock.mockReturnValue({ status: "unowned" });
+
+    const result = await spawnSubagentDirect(
+      { task: "use the configured loopback provider", model: "loopback/new-model" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+      resolvedModel: "loopback/new-model",
+      resolvedProvider: "loopback",
+    });
+  });
+
+  it("accepts an explicitly allowlisted catalog-missing custom ref", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          modelPolicy: { allow: ["future-provider/new-model"] },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+    hoisted.resolveProviderRefOwnershipMock.mockReturnValue({ status: "unowned" });
+
+    const result = await spawnSubagentDirect(
+      { task: "use the explicit custom ref", model: "future-provider/new-model" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+      resolvedModel: "future-provider/new-model",
+      resolvedProvider: "future-provider",
+    });
+    expect(hoisted.resolveProviderRefOwnershipMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a provider-wildcard catalog-missing ref without provider ownership", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          modelPolicy: { allow: ["future-provider/*"] },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+    hoisted.resolveProviderRefOwnershipMock.mockReturnValue({ status: "unowned" });
+
+    const result = await spawnSubagentDirect(
+      { task: "use a wildcard-authorized ref", model: "future-provider/new-model" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      resolvedModel: "future-provider/new-model",
+      resolvedProvider: "future-provider",
+    });
+    expect(hoisted.resolveProviderRefOwnershipMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "alias",
+      model: "fast",
+      models: { "openai/gpt-5.4": { alias: "fast" } },
+    },
+    {
+      name: "bare model ref",
+      model: "gpt-5.4",
+      models: { "openai/gpt-5.4": {} },
+    },
+  ])("validates an explicit $name through the target policy", async ({ model, models }) => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: { workspace: os.tmpdir(), models },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+    hoisted.loadPreparedModelCatalogMock.mockResolvedValue([
+      { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
+    ]);
+
+    const result = await spawnSubagentDirect(
+      { task: `use ${model}`, model },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({ status: "accepted", modelApplied: true });
+  });
+
+  it("does not load the model catalog for an implicit default", async () => {
+    const result = await spawnSubagentDirect(
+      { task: "inherit the default model" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.loadPreparedModelCatalogMock).not.toHaveBeenCalled();
+    expect(hoisted.resolveProviderRefOwnershipMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit model when catalog validation fails without creating child state", async () => {
+    hoisted.loadPreparedModelCatalogMock.mockRejectedValue(new Error("catalog unavailable"));
+
+    const result = await spawnSubagentDirect(
+      { task: "validate before launch", model: "openai/gpt-5.4" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain(
+      "sessions_spawn could not verify the requested model: catalog unavailable",
+    );
+    expectNoChildSpawnSideEffects();
   });
 
   it("aborts a collector cancelled while its gateway launch is in flight", async () => {
@@ -1062,10 +1310,11 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(rejected.status).toBe("error");
     expect(rejected.error).toContain("requires a tool-capable target model");
     expect(hoisted.loadFullModelCatalogMock).not.toHaveBeenCalled();
+    expect(hoisted.loadPreparedModelCatalogMock).toHaveBeenCalledTimes(1);
     expect(hoisted.loadPreparedModelCatalogMock).toHaveBeenCalledWith({
       config: hoisted.configOverride,
       agentDir: expect.any(String),
-      workspaceDir: "/tmp/workspace-main",
+      workspaceDir: resolveUserPath("/tmp/workspace-main"),
       readOnly: true,
       providerDiscoveryProviderIds: ["openai"],
       scopedLiveProviderDiscovery: true,
@@ -1710,7 +1959,7 @@ describe("spawnSubagentDirect seam flow", () => {
     const childSessionKey = result.childSessionKey as string;
     const childEntry = persistedStore?.[childSessionKey];
     expect(childEntry?.spawnedWorkspaceDir).toBe("/tmp/requester-workspace");
-    expect(childEntry?.spawnedCwd).toBe("/tmp/task-repo");
+    expect(childEntry?.spawnedCwd).toBe(resolveUserPath("/tmp/task-repo"));
 
     const agentRequest = gatewayRequest("agent");
     const agentParams = requireRecord(agentRequest.params);


### PR DESCRIPTION
## What Problem This Solves

An explicit `sessions_spawn.model` was resolved and persisted without the model-policy check used by normal session model changes. A policy miss could therefore be acknowledged with `modelApplied: true`, then silently reset to the default model when the child ran. A catalog-missing model could also create child state when its provider was neither configured, catalog-known, nor uniquely plugin-owned.

Fixes #123601.

## Root Cause and Fix

The child planner trusted resolved explicit model text as launch authorization. It did not validate target-agent model policy before session persistence, and the first repair applied provider-ownership validation only under unrestricted policy.

The planner now validates every explicit spawn model before launch authorization, session-store mutation, run registration, gateway launch, or lifecycle emission:

- Reuses the target-agent allowlist resolver, including aliases, bare refs, exact entries, wildcards, and automatic fallbacks.
- Requires every catalog-missing explicit ref to use a provider known through prepared catalog rows, `models.providers`, or unique plugin ownership.
- Rejects unowned and ambiguously owned providers under unrestricted, exact, and wildcard policies.
- Preserves newly released and self-hosted models on known providers.
- Shares one scoped prepared-catalog read and one catalog lookup with `outputSchema` capability validation.
- Leaves implicit/default spawns off the catalog-loading path.

This is the child-planning owner boundary: a rejected request cannot leave partial child state behind.

## User Impact

Typos, policy misses, and unregistered providers in explicit `sessions_spawn` requests now return a visible error instead of silently running the child on another model. Valid custom/new models on known providers continue to work.

## Evidence

[AI-assisted]

### Regression proof

On pre-fix `f95b5a00622`, the owner-boundary policy test failed as expected:

```text
rejects an explicit non-allowlisted model before creating child state
Expected: "error"
Received: "accepted"
1 failed
```

On previous PR head `d0472634e46`, the strict-provider cases failed as expected:

```text
rejects an unowned catalog-missing ref under a strict 'exact' policy
rejects an unowned catalog-missing ref under a strict 'provider wildcard' policy
Expected: "error"
Received: "accepted"
2 failed
```

The regression assertions require zero session-store writes, subagent-run registrations, gateway calls, and lifecycle events.

### Exact-head local proof

Exact head: `8ad28feb432c6bebbfe263ce4fd6f0ad272d8292`

```text
node scripts/run-vitest.mjs src/agents/subagents/spawn
  13 files passed; 257 tests passed

pnpm tsgo:prod
pnpm check:test-types
pnpm build
targeted oxfmt + oxlint
git diff --check
  all passed
```

The spawn matrix includes accepted catalog-missing models from catalog-known,
configured custom, and uniquely plugin-owned providers, plus rejected unowned
providers under unrestricted, exact, and wildcard policies.

### ClawSweeper

Local exact-head review with `gpt-5.6-terra` high reasoning:

```text
correctness: patch is correct
findings: 0
security: cleared (0 concerns)
maintainer decision required: no
rank-up moves: 0
```

### Telegram E2E

`telegram-e2e-userbot` exercised the changed path through a real Telegram DM on the exact head:

```text
requested child model: openai/policy-blocked
allowed model: openai/gpt-5.5
Telegram verdict: SPAWN_MODEL_REJECTED
tool result: status=error; model not allowed: openai/policy-blocked
provider requests: 2 root requests on gpt-5.5; 0 requests on policy-blocked
recording: complete (messages, typing, deletion captured)
```

### CI

[Exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/32343765689) passed on retry attempt 2. The first attempt's `security-fast` failure was a 120-second fetch timeout before scanning; the exact failed job passed on rerun. OpenGrep's exact-head retry also passed.

### ClawSweeper checklist disposition

- Configured and uniquely plugin-owned routes: covered by the exact-head spawn matrix above.
- Production growth: one pre-persistence validation boundary; the follow-up repair removed seven production lines and two duplicate lookups.
- Optional rebase rank-up: skipped. GitHub reports the PR mergeable, required CI passed the synthetic merge against current `main`, and OpenClaw fast-lane policy treats behind-base status alone as advisory. No force-push was used.

## Surface

- Production: `+82/-32` (net `+50`)
- Tests/test support: `+236/-2` (net `+234`)

The production growth establishes the missing validation boundary and injected provider-ownership seam. The follow-up repair removed a duplicate policy-status build and duplicate catalog lookup, reducing the original production delta by seven lines.

## Runtime Contract Check

OpenAI Codex validates explicit subagent model overrides before spawn and returns a visible error for unknown models (`codex-rs/core/src/tools/handlers/multi_agents_common.rs:257-287,416-440`; coverage in `codex-rs/core/src/tools/handlers/multi_agents_tests.rs:395`). OpenClaw remains responsible for its own provider-policy and catalog compatibility rules.
