### PR TITLE
fix(memory): scope Dream Diary requests to the active agent

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -7809,9 +7809,11 @@ class NodeRuntime private constructor(
       disconnectedSummary = GatewayDreamingSummary(),
       failureText = nativeText("Could not load dreaming."),
     ) { gatewayScope ->
-      val statusResponse = requestGatewayData(gatewayScope, "doctor.memory.status", "{}")
+      val agentId = resolveActiveAgentId().takeIf { it.isNotEmpty() } ?: error("No active agent")
+      val paramsJson = buildJsonObject { put("agentId", JsonPrimitive(agentId)) }.toString()
+      val statusResponse = requestGatewayData(gatewayScope, "doctor.memory.status", paramsJson)
       val statusRoot = json.parseToJsonElement(statusResponse).asObjectOrNull()
-      val diaryResponse = requestGatewayData(gatewayScope, "doctor.memory.dreamDiary", "{}")
+      val diaryResponse = requestGatewayData(gatewayScope, "doctor.memory.dreamDiary", paramsJson)
       val diaryRoot = json.parseToJsonElement(diaryResponse).asObjectOrNull()
       parseDreamingSummary(dreaming = statusRoot?.get("dreaming").asObjectOrNull(), diary = diaryRoot)
     }

--- a/apps/ios/Sources/Design/AgentProTab+GatewayData.swift
+++ b/apps/ios/Sources/Design/AgentProTab+GatewayData.swift
@@ -133,8 +133,14 @@ extension AgentProTab {
         async let presence = self.requestOptional([PresenceEntry].self, method: "system-presence")
         async let cronStatus = self.requestOptional(CronStatusLite.self, method: "cron.status")
         async let cronJobs = self.requestAllCronJobs()
-        async let dreaming = self.requestOptional(DreamingStatusEnvelope.self, method: "doctor.memory.status")
-        async let dreamDiary = self.requestOptional(DreamDiaryLite.self, method: "doctor.memory.dreamDiary")
+        async let dreaming = self.requestOptional(
+            DreamingStatusEnvelope.self,
+            method: "doctor.memory.status",
+            paramsJSON: skillsParams)
+        async let dreamDiary = self.requestOptional(
+            DreamDiaryLite.self,
+            method: "doctor.memory.dreamDiary",
+            paramsJSON: skillsParams)
         async let usage = self.requestOptional(
             CostUsageSummaryLite.self,
             method: "usage.cost",

--- a/ui/src/pages/agents/memory/dreaming.test.ts
+++ b/ui/src/pages/agents/memory/dreaming.test.ts
@@ -79,7 +79,7 @@ afterAll(() => {
 function createState(): { state: DreamingState; request: ReturnType<typeof vi.fn<TestRequest>> } {
   const request = vi.fn<TestRequest>();
   const state: DreamingState = {
-    ...createDreamingState(),
+    ...createDreamingState({ selectedAgentId: "main" }),
     client: {
       request,
     } as unknown as DreamingState["client"],
@@ -247,7 +247,7 @@ describe("dreaming controller", () => {
 
     await loadDreamingStatus(state);
 
-    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", { agentId: "main" });
     const status = state.dreamingStatus;
     expect(status).toBe(payload.dreaming);
     expect(status?.enabled).toBe(true);
@@ -288,6 +288,25 @@ describe("dreaming controller", () => {
     expect(request).toHaveBeenCalledWith("doctor.memory.status", {
       agentId: "research-analyst",
     });
+  });
+
+  it("does not request agent-scoped resources or actions without a selected agent", async () => {
+    const { state, request } = createState();
+    state.selectedAgentId = null;
+    state.hello = gatewayHelloForMethods(
+      ["wiki.importInsights", "wiki.overview", "doctor.memory.backfillDreamDiary"],
+      ["operator.write"],
+    );
+
+    await Promise.all([
+      loadDreamingStatus(state),
+      loadDreamDiary(state),
+      loadWikiImportInsights(state),
+      loadWikiOverview(state),
+    ]);
+
+    await expect(backfillDreamDiary(state)).resolves.toBe(false);
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("starts a new selected-agent status load and ignores stale completions", async () => {
@@ -473,7 +492,7 @@ describe("dreaming controller", () => {
 
     await loadWikiImportInsights(state);
 
-    expect(request).toHaveBeenCalledWith("wiki.importInsights", {});
+    expect(request).toHaveBeenCalledWith("wiki.importInsights", { agentId: "main" });
     expect(state.wikiImportInsights?.totalItems).toBe(2);
     expect(state.wikiImportInsights?.totalClusters).toBe(1);
     expect(state.wikiImportInsights?.clusters).toHaveLength(1);
@@ -548,7 +567,7 @@ describe("dreaming controller", () => {
 
     await loadWikiImportInsights(state);
 
-    expect(request).toHaveBeenCalledWith("wiki.importInsights", {});
+    expect(request).toHaveBeenCalledWith("wiki.importInsights", { agentId: "main" });
     expect(state.wikiImportInsights?.totalItems).toBe(1);
     expect(state.wikiImportInsights?.totalClusters).toBe(1);
     expect(state.wikiImportInsightsError).toBeNull();
@@ -666,7 +685,7 @@ describe("dreaming controller", () => {
 
     await loadWikiOverview(state);
 
-    expect(request).toHaveBeenCalledWith("wiki.overview", {});
+    expect(request).toHaveBeenCalledWith("wiki.overview", { agentId: "main" });
     expect(state.wikiOverview?.totalItems).toBe(1);
     expect(state.wikiOverview?.totalPages).toBe(2);
     expect(state.wikiOverview?.pageCounts.source).toBe(1);
@@ -749,7 +768,7 @@ describe("dreaming controller", () => {
 
     await loadWikiOverview(state);
 
-    expect(request).toHaveBeenCalledWith("wiki.overview", {});
+    expect(request).toHaveBeenCalledWith("wiki.overview", { agentId: "main" });
     expect(state.wikiOverview?.totalItems).toBe(0);
     expect(state.wikiOverview?.totalPages).toBe(0);
     expect(state.wikiOverview?.pageCounts).toEqual({
@@ -1074,7 +1093,7 @@ describe("dreaming controller", () => {
 
     await loadDreamDiary(state);
 
-    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", { agentId: "main" });
     expect(state.dreamDiaryPath).toBe("DREAMS.md");
     expect(state.dreamDiaryContent).toBe("## Dream Diary\n- recurring glacier thoughts");
     expect(state.dreamDiaryError).toBeNull();
@@ -1253,9 +1272,9 @@ describe("dreaming controller", () => {
     const ok = await backfillDreamDiary(state);
 
     expect(ok).toBe(true);
-    expect(request).toHaveBeenCalledWith("doctor.memory.backfillDreamDiary", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.backfillDreamDiary", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", { agentId: "main" });
     expect(state.dreamDiaryContent).toBe("backfilled diary");
     expect(state.dreamDiaryActionLoading).toBe(false);
   });
@@ -1318,9 +1337,9 @@ describe("dreaming controller", () => {
     const ok = await resetDreamDiary(state);
 
     expect(ok).toBe(true);
-    expect(request).toHaveBeenCalledWith("doctor.memory.resetDreamDiary", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.resetDreamDiary", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", { agentId: "main" });
     expect(state.dreamDiaryContent).toBeNull();
     expect(state.dreamDiaryActionLoading).toBe(false);
   });
@@ -1345,9 +1364,11 @@ describe("dreaming controller", () => {
     const ok = await resetGroundedShortTerm(state);
 
     expect(ok).toBe(true);
-    expect(request).toHaveBeenCalledWith("doctor.memory.resetGroundedShortTerm", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
-    expect(request).not.toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.resetGroundedShortTerm", {
+      agentId: "main",
+    });
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", { agentId: "main" });
+    expect(request).not.toHaveBeenCalledWith("doctor.memory.dreamDiary", { agentId: "main" });
     expect(state.dreamDiaryContent).toBe("keep existing diary");
     expect(state.dreamDiaryActionLoading).toBe(false);
   });
@@ -1378,9 +1399,11 @@ describe("dreaming controller", () => {
     const ok = await repairDreamingArtifacts(state);
 
     expect(ok).toBe(true);
-    expect(request).toHaveBeenCalledWith("doctor.memory.repairDreamingArtifacts", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
-    expect(request).not.toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.repairDreamingArtifacts", {
+      agentId: "main",
+    });
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", { agentId: "main" });
+    expect(request).not.toHaveBeenCalledWith("doctor.memory.dreamDiary", { agentId: "main" });
     expect(state.dreamDiaryContent).toBe("keep existing diary");
     expect(state.dreamDiaryActionMessage).toEqual({
       kind: "success",
@@ -1415,9 +1438,9 @@ describe("dreaming controller", () => {
     const ok = await dedupeDreamDiary(state);
 
     expect(ok).toBe(true);
-    expect(request).toHaveBeenCalledWith("doctor.memory.dedupeDreamDiary", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
-    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.dedupeDreamDiary", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", { agentId: "main" });
     expect(state.dreamDiaryContent).toBe("deduped diary");
     expect(state.dreamDiaryActionMessage).toEqual({
       kind: "success",

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -105,7 +105,7 @@ export type WikiOverview = {
 };
 
 type DreamingResourceKey = "dreamingStatus" | "dreamDiary" | "wikiImportInsights" | "wikiOverview";
-type DreamingResourceRequest = { agentId: string | null };
+type DreamingResourceRequest = { agentId: string };
 
 export type DreamingState = {
   client: GatewayBrowserClient | null;
@@ -292,18 +292,6 @@ function resolveSelectedAgentId(state: DreamingState): string | null {
   return normalizeTrimmedString(state.selectedAgentId) ?? null;
 }
 
-function buildSelectedAgentPayloadForAgentId(
-  agentId: string | null,
-): { agentId: string } | Record<string, never> {
-  return agentId ? { agentId } : {};
-}
-
-function buildSelectedAgentPayload(
-  state: DreamingState,
-): { agentId: string } | Record<string, never> {
-  return buildSelectedAgentPayloadForAgentId(resolveSelectedAgentId(state));
-}
-
 export function resolveConfiguredDreaming(configValue: Record<string, unknown> | null): {
   pluginId: string;
   enabled: boolean;
@@ -389,15 +377,17 @@ async function loadDreamingResource<Key extends DreamingResourceKey>(
   key: Key,
   spec: DreamingResourceSpec<Key> = DREAMING_RESOURCE_SPECS[key],
 ): Promise<void> {
-  const client = state.client;
-  if (!client || !state.connected) {
-    return;
-  }
-
   const agentId = resolveSelectedAgentId(state);
   const loadingKey = `${key}Loading` as const;
   const errorKey = `${key}Error` as const;
   const agentKey = `${key}AgentId` as const;
+  if (!agentId) {
+    return;
+  }
+  const client = state.client;
+  if (!client || !state.connected) {
+    return;
+  }
   if (state[agentKey] !== agentId) {
     spec.clear(state);
   }
@@ -423,10 +413,7 @@ async function loadDreamingResource<Key extends DreamingResourceKey>(
   state[loadingKey] = true;
   state[errorKey] = null;
   try {
-    const payload = await client.request<DreamingResourcePayloads[Key]>(
-      spec.method,
-      buildSelectedAgentPayloadForAgentId(agentId),
-    );
+    const payload = await client.request<DreamingResourcePayloads[Key]>(spec.method, { agentId });
     if (state.resourceRequests[key] !== request || resolveSelectedAgentId(state) !== agentId) {
       return;
     }
@@ -473,8 +460,10 @@ async function runDreamDiaryAction(
   },
 ): Promise<boolean> {
   const client = state.client;
+  const agentId = resolveSelectedAgentId(state);
   if (
     !client ||
+    !agentId ||
     !canCallDreamingMethod(state, method, "operator.write") ||
     state.dreamDiaryActionLoading
   ) {
@@ -486,10 +475,7 @@ async function runDreamDiaryAction(
   state.dreamDiaryActionMessage = null;
   state.dreamDiaryActionArchivePath = null;
   try {
-    const payload = await client.request<DoctorMemoryDreamActionPayload>(
-      method,
-      buildSelectedAgentPayload(state),
-    );
+    const payload = await client.request<DoctorMemoryDreamActionPayload>(method, { agentId });
     if (options?.reloadDiary !== false) {
       await loadDreamDiary(state);
     }

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -102,6 +102,7 @@ function contextWithGateway(
     },
     runtimeConfig: {
       state: { configForm, configSnapshot: null },
+      ensureLoaded: vi.fn(async () => undefined),
       refresh: vi.fn(async () => undefined),
       removeFormValue: vi.fn(),
       waitForPendingWrites: vi.fn(async () => undefined),
@@ -134,6 +135,40 @@ afterEach(() => {
 });
 
 describe("AgentMemoryPanel gateway lifecycle", () => {
+  it("waits for a committed agent before loading agent-scoped memory", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "doctor.memory.status") {
+        return { dreaming: null };
+      }
+      if (method === "doctor.memory.dreamDiary") {
+        return { found: false, path: "DREAMS.md" };
+      }
+      return {};
+    });
+    const page = document.createElement("openclaw-agent-memory-panel") as TestMemoryPanel;
+    page.context = contextWithGateway({ request } as unknown as GatewayBrowserClient, true);
+
+    document.body.append(page);
+    await page.updateComplete;
+    await page.updateComplete;
+    await Promise.resolve();
+    await expect(page.openWikiPage("unowned.md")).resolves.toBeNull();
+
+    expect(request).not.toHaveBeenCalled();
+
+    page.agentId = "support";
+    await page.updateComplete;
+    await vi.waitFor(() => {
+      expect(request.mock.calls.filter(([method]) => method === "doctor.memory.status")).toEqual([
+        ["doctor.memory.status", { agentId: "support" }],
+      ]);
+      expect(
+        request.mock.calls.filter(([method]) => method === "doctor.memory.dreamDiary"),
+      ).toEqual([["doctor.memory.dreamDiary", { agentId: "support" }]]);
+      expect(request).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("does not run a confirmed dreaming action after the selected agent changes", async () => {
     const confirmation = deferred<boolean>();
     vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
@@ -176,6 +211,13 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
 
     expect(page.dreaming).not.toBe(previousState);
     expect(page.dreaming.selectedAgentId).toBe("support");
+    expect(page.dreaming.dreamDiaryContent).toBeNull();
+
+    page.dreaming.dreamDiaryContent = "support-only";
+    page.agentId = "";
+    await page.updateComplete;
+
+    expect(page.dreaming.selectedAgentId).toBeNull();
     expect(page.dreaming.dreamDiaryContent).toBeNull();
   });
 

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -125,6 +125,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
   private gatewayBindingEpoch = 0;
   private gatewayEpoch = 0;
   private hasBoundGatewaySource = false;
+  private selectedAgentId: string | null = null;
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
       () => this.context?.gateway,
@@ -154,7 +155,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
       },
     );
 
-  override willUpdate(changed: PropertyValues<this>) {
+  override updated(changed: PropertyValues<this>) {
     if (changed.has("agentId")) {
       this.applyAgentId();
     }
@@ -211,7 +212,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
       hello: snapshot.hello,
       configSnapshot: this.context.runtimeConfig.state.configSnapshot,
       applySessionKey: snapshot.sessionKey,
-      selectedAgentId: this.agentId.trim() || null,
+      selectedAgentId: this.selectedAgentId,
     });
   }
 
@@ -236,21 +237,26 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
       this.dreaming.hello = snapshot.hello;
       this.dreaming.applySessionKey = snapshot.sessionKey;
     }
-    if (snapshot.phase === "connected" && (replaceState || becameConnected)) {
+    if (
+      snapshot.phase === "connected" &&
+      this.selectedAgentId &&
+      (replaceState || becameConnected)
+    ) {
       void this.loadAll();
     }
     this.requestUpdate();
   }
 
   private applyAgentId() {
-    const agentId = this.agentId.trim();
-    if (!agentId || this.dreaming.selectedAgentId === agentId) {
+    const agentId = this.agentId.trim() || null;
+    if (this.selectedAgentId === agentId) {
       return;
     }
+    this.selectedAgentId = agentId;
     this.gatewayEpoch += 1;
     this.resetTransientState();
     this.dreaming = this.createGatewayState();
-    if (this.dreaming.connected) {
+    if (agentId && this.dreaming.connected) {
       void this.loadAll();
     }
   }
@@ -291,7 +297,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
 
   private async loadAll(refreshConfig = false) {
     const scope = this.captureTaskScope();
-    if (!scope || !scope.state.client || !scope.state.connected) {
+    if (!scope || !scope.state.client || !scope.state.connected || !scope.state.selectedAgentId) {
       return;
     }
     const runtimeConfig = this.context.runtimeConfig;
@@ -459,20 +465,17 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
   private async openWikiPage(lookup: string): Promise<WikiPagePreview | null> {
     const scope = this.captureTaskScope();
     const client = scope?.state.client;
-    if (!scope || !client || !scope.state.connected) {
+    const agentId = scope?.state.selectedAgentId;
+    if (!scope || !client || !scope.state.connected || !agentId) {
       return null;
     }
-    const agentId = scope.state.selectedAgentId?.trim() || null;
     const payload = await client.request("wiki.get", {
       lookup,
       fromLine: 1,
       lineCount: 5000,
-      ...(agentId ? { agentId } : {}),
+      agentId,
     });
-    if (
-      !this.isTaskScopeCurrent(scope) ||
-      (scope.state.selectedAgentId?.trim() || null) !== agentId
-    ) {
+    if (!this.isTaskScopeCurrent(scope) || scope.state.selectedAgentId !== agentId) {
       return null;
     }
     return readWikiPagePreview(payload, lookup);
@@ -480,7 +483,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
 
   private async refreshWikiData(task: (state: DreamingState) => Promise<void>) {
     const scope = this.captureTaskScope();
-    if (!scope) {
+    if (!scope?.state.selectedAgentId) {
       return;
     }
     const runtimeConfig = this.context.runtimeConfig;
@@ -509,7 +512,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
       onReset: () => void this.resetEnabledOverride(configuredDreaming),
     });
     const refreshLoading = dreaming.dreamingStatusLoading || dreaming.dreamDiaryLoading;
-    const selectedAgentId = dreaming.selectedAgentId ?? this.agentId;
+    const selectedAgentId = dreaming.selectedAgentId ?? "";
 
     return html`
       <section class="content-header content-header--page agent-memory-panel__header">


### PR DESCRIPTION
Closes #125935

## What Problem This Solves

Fixes an issue where multi-agent operators opening Dream Diary surfaces could receive the default agent's memory status or diary when the active agent had not yet been attached to the request. Control UI emitted its initial status and diary requests before Lit committed `agentId`; iOS and Android omitted the active agent from the same agent-owned methods.

## Why This Change Was Made

Control UI now waits for `updated()` to commit a normalized non-empty owner, performs one scoped initial load, preserves reconnect/agent-change dedupe and stale-completion fencing, and refuses memory/wiki reads or actions without an owner. iOS and Android pass their already-known active canonical agent IDs. Gateway behavior and its fail-closed semantics are unchanged; aggregate system-health and QA callers remain intentionally unscoped.

## User Impact

Dream Diary, memory, and wiki data/actions now stay attached to the active agent across Control UI, iOS, and Android instead of falling through to the default agent. There is no visual-layout change.

## Evidence

Exact request trace:

```text
Before:
doctor.memory.status {}
doctor.memory.dreamDiary {}

After (active agent `support`):
doctor.memory.status {"agentId":"support"}
doctor.memory.dreamDiary {"agentId":"support"}
```

The pre-fix Control UI regression failed one test (16 passed, 1 skipped) because both requests were sent before agent assignment:

```text
node scripts/run-vitest.mjs ui/src/pages/agents/memory/memory-panel.test.ts
```

Post-rebase proof on `f2c53dcb616b95e6adcc44b0b7db2ca49e000450`:

- `node scripts/run-vitest.mjs ui/src/pages/agents/memory/memory-panel.test.ts ui/src/pages/agents/memory/dreaming.test.ts` — 62 passed, 1 skipped.
- `node scripts/run-vitest.mjs src/gateway/server-methods/doctor.test.ts` — 45 passed.
- `node scripts/check-changed.mjs --dry-run -- <six changed files>` — selected `coreTests`, `ui`, and `apps`.
- `node scripts/check-changed.mjs -- <six changed files>` — passed core/UI typechecks, core/app lint, Control UI i18n verification, SwiftLint (366 iOS files, 0 violations), and native state schema v9.
- `git diff --check origin/main...HEAD` — clean.

Cross-platform proof on the exact code patch before its clean conflict-free rebase:

- `pnpm ios:build` — Debug generic iOS Simulator, 36-target graph, `BUILD SUCCEEDED`.
- Android Play and ThirdParty unit tests — 4,435 passed total, 0 skipped/failures/errors, `BUILD SUCCESSFUL`, 89 tasks.
- None of the rebased upstream commits touched the six changed files, so the native builds were not repeated locally; exact-head PR CI covers rebased platform integration.

Production LOC is **+43/-46 (net -3)**. Tests are **+87/-22 (net +65)**.

Fresh branch autoreview against `origin/main` used the request-owner invariant and completed clean: TruffleHog clean, one integrated pass, no accepted/actionable findings, overall patch score 0.98.

This is request ownership with no visual-layout delta, so before/after screenshots would be identical. The observable behavior proof is the exact RPC trace and lifecycle regression above.

Proof gap: no new local native rebuild was run after the conflict-free rebase for the reason above, and no visual capture was taken because rendered output does not change.

AI-assisted: Codex helped verify the existing repair, run the post-rebase gates and autoreview, audit related callers/issues/PRs, and prepare this issue/PR. The maintainer reviewed the root cause, ownership boundary, diff, and evidence and understands the change.
