### PR TITLE
fix(gateway): remove orphaned media after sessionless agent runs

### DIFF
--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -71,6 +71,7 @@ export type PreparedAgentRunDispatch = {
   lifecycleStorePath: string;
   resolvedThreadId?: string | number;
   dispatchTaskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
+  unpersistedOffloadedRefs: OffloadedRef[];
   userTurn: PreparedAgentRunUserTurn;
   restoreAdmittedRestartRecoveryInterrupted?: () => Promise<
     MainSessionRecoveryPendingTarget | undefined
@@ -559,6 +560,7 @@ export async function prepareAgentRunDispatch(params: {
     lifecycleStorePath,
     resolvedThreadId,
     dispatchTaskTrackingMode,
+    unpersistedOffloadedRefs: userTurn.recorder ? [] : params.offloadedRefs,
     userTurn,
     restoreAdmittedRestartRecoveryInterrupted,
   };

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -28,6 +28,7 @@ import {
   annotateInterSessionPromptText,
   type InputProvenance,
 } from "../../sessions/input-provenance.js";
+import { discardPreparedInboundMedia } from "../chat-attachments.js";
 import { getGatewayLocalUserIngress } from "../local-user-ingress.js";
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import { createAgentRunModelSelectionHandler } from "../server-methods/agent-run-model-selection.js";
@@ -104,12 +105,16 @@ export function startAgentRunExecution(params: {
   ) => Promise<boolean>;
 }): void {
   const { prepared } = params;
+  let unpersistedOffloadedRefs = prepared.unpersistedOffloadedRefs;
   let releaseGatewayRootContinuation = retainGatewayRootWorkAdmissionContinuation() ?? undefined;
   const cleanupAdmittedRun: typeof prepared.activeRunAbort.cleanup = (options) => {
+    const refsToDiscard = unpersistedOffloadedRefs;
+    unpersistedOffloadedRefs = [];
     prepared.activeRunAbort.cleanup(options);
     prepared.activeGatewayWorkAdmission.release();
     releaseGatewayRootContinuation?.();
     releaseGatewayRootContinuation = undefined;
+    void discardPreparedInboundMedia(refsToDiscard, params.context.logGateway);
   };
   void prepared.activeGatewayWorkAdmission.run(async () => {
     await yieldAfterAgentAcceptedAck();

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -565,8 +565,8 @@ export function createAgentTurnService({
         return;
       }
       resolvedSessionId = admittedSessionId;
-      // Sessionless and persistence-suppressed runs transfer prepared media to
-      // execution only after dispatch is fully admitted.
+      // The prepared dispatch now owns either transcript-persisted media or its
+      // closed unpersisted ref set; admission must not retain a second owner.
       preparedOffloadedRefs = [];
       gatewayAdmissionTransferred = true;
       // This captures ambient root admission synchronously, then settles the final

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -39,6 +39,7 @@ import {
 } from "./chat-attachment-policy.js";
 import {
   type ChatAttachment,
+  discardPreparedInboundMedia,
   parseMessageWithAttachments,
   persistInboundImagesForTranscript,
   stripImageMediaMarkers,
@@ -153,6 +154,38 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("discardPreparedInboundMedia", () => {
+  it("deletes only the managed inbound id and reports cleanup failures", async () => {
+    const error = new Error("unlink denied");
+    deleteMediaBufferMock.mockRejectedValueOnce(error);
+    const warn = vi.fn();
+
+    await expect(
+      discardPreparedInboundMedia(
+        [
+          {
+            mediaRef: "media://inbound/managed-id",
+            id: "managed-id",
+            path: "/external/user-owned.png",
+            kind: "image",
+            mimeType: "image/png",
+            label: "user-owned.png",
+            sizeBytes: 42,
+            sourceIndex: 0,
+          },
+        ],
+        { warn },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(deleteMediaBufferMock).toHaveBeenCalledOnce();
+    expect(deleteMediaBufferMock).toHaveBeenCalledWith("managed-id", "inbound");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to discard prepared inbound media managed-id: unlink denied"),
+    );
+  });
 });
 
 describe("persistInboundImagesForTranscript", () => {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -49,8 +49,18 @@ export type OffloadedRef = {
 };
 
 /** Deletes prepared inbound files that never reached a durable owner. */
-export async function discardPreparedInboundMedia(refs: readonly OffloadedRef[]): Promise<void> {
-  await Promise.allSettled(refs.map((ref) => deleteMediaBuffer(ref.id, "inbound")));
+export async function discardPreparedInboundMedia(
+  refs: readonly OffloadedRef[],
+  log?: { warn: (message: string) => void },
+): Promise<void> {
+  const results = await Promise.allSettled(refs.map((ref) => deleteMediaBuffer(ref.id, "inbound")));
+  for (const [index, result] of results.entries()) {
+    if (result.status === "rejected" && log) {
+      log.warn(
+        `failed to discard prepared inbound media ${refs[index]?.id}: ${formatErrorMessage(result.reason)}`,
+      );
+    }
+  }
 }
 
 type ParsedMessageWithImages = {

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -12,11 +12,12 @@ import {
 } from "../agents/admitted-run-context.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { createAbortError } from "../infra/abort-signal.js";
 import {
   type AgentRunDelegatedAuthority,
   validateAgentRunDelegatedAuthority,
 } from "../infra/agent-run-registry.js";
-import { getMediaDir } from "../media/store.js";
+import * as mediaStore from "../media/store.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -30,6 +31,7 @@ import { waitForAgentCommandCall } from "./agent-command.test-helpers.js";
 import { resetPreparedModelCatalogStateForTest } from "./server-model-catalog.js";
 import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
 import { createRegistry } from "./server.e2e-registry-helpers.js";
+import { readSessionMessagesAsync } from "./session-transcript-readers.js";
 import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
 import {
   agentCommandMock,
@@ -41,7 +43,14 @@ import {
 
 installGatewayTestHooks({ scope: "suite" });
 
-const gatewaySuite = installConnectedSessionStoreGatewaySuite("openclaw-gw-session-");
+const gatewaySuite = installConnectedSessionStoreGatewaySuite("openclaw-gw-session-", {
+  client: {
+    id: "gateway-client",
+    version: "1.0.0",
+    platform: "test",
+    mode: "backend",
+  },
+});
 
 const BASE_IMAGE_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X3mIAAAAASUVORK5CYII=";
@@ -163,7 +172,7 @@ const offloadedImageAttachment = () => ({
 });
 
 async function listInboundMedia(): Promise<Set<string>> {
-  const entries = await fs.readdir(path.join(getMediaDir(), "inbound")).catch(() => []);
+  const entries = await fs.readdir(path.join(mediaStore.getMediaDir(), "inbound")).catch(() => []);
   return new Set(entries);
 }
 
@@ -602,6 +611,125 @@ describe("gateway server agent", () => {
     },
   );
 
+  test.each(["success", "error"] as const)(
+    "sessionless %s discards offloaded inbound media without a transcript owner",
+    async (outcome) => {
+      vi.mocked(agentCommandMock).mockImplementationOnce(async () => {
+        if (outcome === "error") {
+          throw new Error("forced provider failure");
+        }
+        return undefined;
+      });
+      const inboundBefore = await listInboundMedia();
+      const runId = `sessionless-media-${outcome}`;
+      const attachments =
+        outcome === "success"
+          ? [
+              { ...offloadedImageAttachment(), fileName: "large-a.png" },
+              baseImageAttachment(),
+              { ...offloadedImageAttachment(), fileName: "large-b.png" },
+            ]
+          : [offloadedImageAttachment()];
+      const res = await rpcReq(gatewaySuite.ws, "agent", {
+        message: "inspect media",
+        groupId: "group-sessionless-media",
+        groupChannel: "discord",
+        attachments,
+        idempotencyKey: runId,
+      });
+      expect(res.ok, JSON.stringify(res)).toBe(true);
+      const call = await waitForAgentCommandCall(runId);
+      expect(call.sessionKey).toBeUndefined();
+      if (outcome === "success") {
+        expect(call.media).toHaveLength(2);
+        expect(call.images).toHaveLength(1);
+      }
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await expectNoNewInboundMedia(inboundBefore);
+    },
+  );
+
+  test("prompt-persistence suppression discards offloaded media without a transcript row", async () => {
+    vi.mocked(agentCommandMock).mockImplementationOnce(async () => {});
+    testState.agentConfig = { model: { primary: "ollama-cloud/gemma4:31b" } };
+    await setGatewayModelCatalogForTest([VISION_AGENT_MODEL]);
+    await setTestSessionStore({
+      entries: { main: { sessionId: "suppressed-media-session", updatedAt: Date.now() } },
+    });
+    const inboundBefore = await listInboundMedia();
+    const runId = "suppressed-media";
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
+      message: "inspect media privately",
+      sessionKey: "main",
+      suppressPromptPersistence: true,
+      attachments: [offloadedImageAttachment()],
+      idempotencyKey: runId,
+    });
+    expect(res.ok, JSON.stringify(res)).toBe(true);
+    const call = await waitForAgentCommandCall(runId);
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await expect(
+      readSessionMessagesAsync(
+        {
+          agentId: "main",
+          sessionId: "suppressed-media-session",
+          sessionKey: String(call.sessionKey),
+          storePath: gatewaySuite.sessionStorePath,
+        },
+        { mode: "full", reason: "prompt-suppressed media leak reproduction" },
+      ),
+    ).resolves.toEqual([]);
+    await expectNoNewInboundMedia(inboundBefore);
+  });
+
+  test("prompt-suppressed abort discards each managed offload once after early run cleanup", async () => {
+    testState.agentConfig = { model: { primary: "ollama-cloud/gemma4:31b" } };
+    await setGatewayModelCatalogForTest([VISION_AGENT_MODEL]);
+    await setTestSessionStore({
+      entries: { main: { sessionId: "aborted-media-session", updatedAt: Date.now() } },
+    });
+    vi.mocked(agentCommandMock).mockImplementationOnce(
+      async (rawOpts) =>
+        await new Promise<void>((_resolve, reject) => {
+          (rawOpts as { abortSignal?: AbortSignal }).abortSignal?.addEventListener(
+            "abort",
+            () => reject(createAbortError("forced provider abort")),
+            { once: true },
+          );
+        }),
+    );
+    const deleteSpy = vi.spyOn(mediaStore, "deleteMediaBuffer");
+    const inboundBefore = await listInboundMedia();
+    const runId = "prompt-suppressed-media-abort";
+    try {
+      const res = await rpcReq(gatewaySuite.ws, "agent", {
+        message: "abort after admission",
+        sessionKey: "main",
+        suppressPromptPersistence: true,
+        attachments: [offloadedImageAttachment()],
+        idempotencyKey: runId,
+      });
+      expect(res.ok, JSON.stringify(res)).toBe(true);
+      const call = await waitForAgentCommandCall(runId);
+      const abortRes = await rpcReq(gatewaySuite.ws, "chat.abort", {
+        sessionKey: call.sessionKey,
+        runId,
+      });
+      expect(abortRes.ok, JSON.stringify(abortRes)).toBe(true);
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await expectNoNewInboundMedia(inboundBefore);
+
+      const mediaRef = (call.media as Array<{ url: string }>)[0]?.url;
+      const mediaId = mediaRef?.split("/").at(-1);
+      expect(mediaId).toBeTruthy();
+      expect(
+        deleteSpy.mock.calls.filter(([id, subdir]) => id === mediaId && subdir === "inbound"),
+      ).toHaveLength(1);
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
   test("agent rejects unknown reply channel", async () => {
     const inboundBefore = await listInboundMedia();
     const res = await rpcReq(gatewaySuite.ws, "agent", {
@@ -743,6 +871,7 @@ describe("gateway server agent", () => {
   test("agent retains image offload facts beside the claim-check line", async () => {
     testState.agentConfig = { model: { primary: "ollama-cloud/gemma4:31b" } };
     await setGatewayModelCatalogForTest([TEXT_ONLY_AGENT_MODEL, VISION_AGENT_MODEL]);
+    const inboundBefore = await listInboundMedia();
     const call = await runAgentImageRequest({
       idempotencyKey: "idem-agent-offloaded-media",
       sessionId: "sess-main-offloaded-media",
@@ -762,6 +891,20 @@ describe("gateway server agent", () => {
     await expect(fs.stat(media?.[0]?.path ?? "")).resolves.toMatchObject({
       isFile: expect.any(Function),
     });
+    const transcript = await readSessionMessagesAsync(
+      {
+        agentId: "main",
+        sessionId: "sess-main-offloaded-media",
+        sessionKey: String(call.sessionKey),
+        storePath: gatewaySuite.sessionStorePath,
+      },
+      { mode: "full", reason: "durable agent media custody regression" },
+    );
+    expect(
+      (transcript[0] as { __openclaw?: { media?: Array<{ url?: string }> } })["__openclaw"]?.media,
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ url: media?.[0]?.url })]));
+    const inboundAfter = await listInboundMedia();
+    expect([...inboundAfter].filter((entry) => !inboundBefore.has(entry))).toHaveLength(1);
   });
 
   test("agent validates first image attachment against per-agent model for fresh sessions", async () => {

--- a/src/gateway/test-helpers.connected-session-store.ts
+++ b/src/gateway/test-helpers.connected-session-store.ts
@@ -4,11 +4,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll } from "vitest";
-import { startConnectedServerWithClient } from "./test-helpers.js";
+import { connectOk, startServerWithClient } from "./test-helpers.js";
 
 // Suite-level connected Gateway fixture with isolated session store path.
 
-type ConnectedGateway = Awaited<ReturnType<typeof startConnectedServerWithClient>>;
+type ConnectedGateway = Awaited<ReturnType<typeof startServerWithClient>>;
 
 /** Return a required suite value or fail with a clear readiness label. */
 function requireValue<T>(value: T | undefined, label: string): T {
@@ -19,13 +19,17 @@ function requireValue<T>(value: T | undefined, label: string): T {
 }
 
 /** Install a shared connected Gateway and temp session store for a Vitest suite. */
-export function installConnectedSessionStoreGatewaySuite(prefix: string) {
+export function installConnectedSessionStoreGatewaySuite(
+  prefix: string,
+  connectOptions?: Parameters<typeof connectOk>[1],
+) {
   let started: ConnectedGateway | undefined;
   let sessionStoreDir: string | undefined;
   let sessionStorePath: string | undefined;
 
   beforeAll(async () => {
-    started = await startConnectedServerWithClient();
+    started = await startServerWithClient();
+    await connectOk(started.ws, connectOptions);
     sessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
     sessionStorePath = path.join(sessionStoreDir, "sessions.json");
   });


### PR DESCRIPTION
AI-assisted: yes.

## What Problem This Solves

Fixes an issue where sessionless or prompt-persistence-suppressed agent RPCs could leave inbound attachments larger than 2 MB in the managed media directory after the run completed. These files had no transcript owner and accumulated after successful, failed, or aborted runs.

## Why This Change Was Made

Agent-run admission now explicitly transfers only unpersisted offloaded media references to the execution lifecycle. The one-shot terminal cleanup owns and discards that closed set exactly once, while media recorded in a durable transcript remains owned by the transcript and is retained. Cleanup is lifecycle-driven rather than TTL-based.

The architectural owner is the admitted agent-run lifecycle: admission decides whether a transcript recorder owns each offload, and execution terminal cleanup disposes only the remainder. Downstream TTL cleanup or deleting every prepared reference would either defer an ownership leak or delete durable transcript media.

Production LOC: +21/-4 (net +17). Tests and test support: +187/-7 (net +180).

## User Impact

Operators no longer accumulate orphaned large inbound files from sessionless or non-persisted agent requests. Transcript-backed attachments remain available exactly as before.

## Evidence

- Current-main reproduction: successful, provider-error, and prompt-persistence-suppressed sessionless agent RPCs left a managed >2 MB inbound file with no transcript row owning it.
- Isolated Gateway validation covered success, provider error, abort, mixed inline/offloaded media, duplicate-cleanup protection, prompt suppression, and the durable transcript-owned control; terminal cleanup happened without waiting for a TTL.
- `node scripts/run-vitest.mjs src/gateway/chat-attachments.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts` — 80 tests passed after rebasing onto current `origin/main`.
- `node scripts/check-changed.mjs` — passed.
- `pnpm build` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

No changelog edit; release-note context is captured here.
