### PR TITLE
fix(codex): preserve trajectory persistence through harness

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -219,7 +219,7 @@ extensions/codex/src/app-server/remote-workspace-media.ts	6
 extensions/codex/src/app-server/request.ts	2
 extensions/codex/src/app-server/run-attempt-context.ts	2
 extensions/codex/src/app-server/run-attempt-prompt.ts	2
-extensions/codex/src/app-server/run-attempt-resources.ts	14
+extensions/codex/src/app-server/run-attempt-resources.ts	13
 extensions/codex/src/app-server/run-attempt-runtime.ts	1
 extensions/codex/src/app-server/run-attempt-server-requests.ts	2
 extensions/codex/src/app-server/run-attempt-tool-setup.ts	1

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -384,6 +384,14 @@ binds the host-resolved run, sandbox, requester, route, and approval identity;
 plugins must not reconstruct those fields or retain the capability after the
 attempt returns. Calls made after attempt settlement fail closed.
 
+When trajectory capture has a valid host-owned session target,
+`params.hostCapabilities.trajectory` provides closure-bound `recordEvent(...)`
+and `flush()` operations. The host adds session attribution, bounds and redacts
+event data, and persists it through the canonical trajectory store. Treat the
+capability as optional, send only structured non-secret facts, and await
+`flush()` before the attempt settles; do not infer storage paths or create a
+plugin-side fallback when the capability is absent.
+
 New harnesses should implement `AgentHarnessV2` and type prepared attempts as
 `AgentHarnessAttemptParamsV2`, `EmbeddedRunAttemptParamsV2`, and
 `AgentHarnessSideQuestionParamsV2`; those contracts require

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -28,7 +28,7 @@ import {
   retainSharedCodexAppServerClientIfCurrent,
 } from "./shared-client.js";
 import type { CodexAppServerThreadLifecycleBinding } from "./thread-lifecycle.js";
-import { createCodexTrajectoryRecorder, type CodexHostTrajectoryRecorder } from "./trajectory.js";
+import { createCodexTrajectoryRecorder } from "./trajectory.js";
 import type { CodexAppServerTurnRouter, CodexThreadRouteReservation } from "./turn-router.js";
 
 export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
@@ -47,17 +47,13 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     nativeHookRelayEvents,
   } = connection;
   const { toolBridge } = attemptTools;
-  const hostTrajectoryRecorder = (
-    params as typeof params & { trajectoryRecorder?: CodexHostTrajectoryRecorder | null }
-  ).trajectoryRecorder;
   const trajectoryRecorder = createCodexTrajectoryRecorder({
     attempt: params,
     cwd: effectiveCwd,
     developerInstructions: buildRenderedCodexDeveloperInstructions(),
     prompt: turnState.codexTurnPromptText,
-    trajectoryRecorder: hostTrajectoryRecorder,
+    trajectory: params.hostCapabilities.trajectory,
     tools: toolBridge.availableSpecs,
-    warn: (message, fields) => embeddedAgentLog.warn(message, fields),
   });
   const state = {
     client: undefined as unknown as CodexAppServerClient,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1716,13 +1716,14 @@ describe("runCodexAppServerAttempt", () => {
       data?: { prompt?: string; systemPrompt?: string };
       type: string;
     }> = [];
-    Object.assign(params, {
-      trajectoryRecorder: {
+    params.hostCapabilities = Object.freeze({
+      ...params.hostCapabilities,
+      trajectory: Object.freeze({
         recordEvent: (type: string, data?: { prompt?: string; systemPrompt?: string }) => {
           trajectoryEvents.push({ type, data });
         },
         flush: async () => undefined,
-      },
+      }),
     });
     params.skillsSnapshot = {
       prompt: "<available_skills><skill><name>demo</name></skill></available_skills>",

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -12,15 +12,17 @@ import {
   tempWorkspaceSync,
   type TempWorkspaceSync,
 } from "openclaw/plugin-sdk/temp-path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  type CodexHostTrajectoryRecorder,
   createCodexTrajectoryRecorder,
   recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
 } from "./trajectory.js";
 
 type CodexTrajectoryRecorder = NonNullable<ReturnType<typeof createCodexTrajectoryRecorder>>;
+type CodexTrajectoryFacade = NonNullable<
+  Parameters<typeof createCodexTrajectoryRecorder>[0]["trajectory"]
+>;
 
 let testWorkspace: TempWorkspaceSync;
 
@@ -44,14 +46,14 @@ function expectTrajectoryRecorder(
   return recorder;
 }
 
-function createMemoryHostTrajectoryRecorder(): {
+function createMemoryTrajectoryFacade(): {
   events: Array<{ type: string; data?: Record<string, unknown> }>;
-  recorder: CodexHostTrajectoryRecorder;
+  trajectory: CodexTrajectoryFacade;
 } {
   const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
   return {
     events,
-    recorder: {
+    trajectory: {
       recordEvent: (type, data) => events.push({ type, data }),
       flush: async () => undefined,
     },
@@ -67,7 +69,7 @@ function createMemoryBackedRecorder(params: {
   recorder: CodexTrajectoryRecorder;
 } {
   const sessionId = (params.attempt?.sessionId as string | undefined) ?? "session-1";
-  const host = createMemoryHostTrajectoryRecorder();
+  const host = createMemoryTrajectoryFacade();
   const recorder = createCodexTrajectoryRecorder({
     cwd: params.tmpDir,
     attempt: {
@@ -80,18 +82,18 @@ function createMemoryBackedRecorder(params: {
       model: { api: "responses" },
       ...params.attempt,
     } as never,
-    trajectoryRecorder: host.recorder,
+    trajectory: host.trajectory,
     tools: params.tools,
     env: {},
   });
   return { events: host.events, recorder: expectTrajectoryRecorder(recorder) };
 }
 
-function createSqliteHostTrajectoryRecorder(params: {
+function createSqliteTrajectoryFacade(params: {
   agentId: string;
   sessionId: string;
   storePath: string;
-}): CodexHostTrajectoryRecorder {
+}): CodexTrajectoryFacade {
   const events: SqliteTrajectoryRuntimeEventForTest[] = [];
   let seq = 0;
   return {
@@ -117,41 +119,18 @@ function createSqliteHostTrajectoryRecorder(params: {
 }
 
 describe("Codex trajectory recorder", () => {
-  it("warns once per session when the SQLite host recorder is unavailable", async () => {
-    // Import a fresh module instance so the process-wide dedupe set starts
-    // clean without a test-only reset export in production code.
-    vi.resetModules();
-    const { createCodexTrajectoryRecorder: createFreshRecorder } = await import("./trajectory.js");
-    const warn = vi.fn();
-    const makeRecorder = (sessionId: string) =>
-      createFreshRecorder({
+  it("returns null when the host trajectory facade is unavailable", () => {
+    expect(
+      createCodexTrajectoryRecorder({
         cwd: testWorkspace.dir,
         attempt: {
-          sessionFile: `agent:main:${sessionId}`,
-          sessionId,
+          sessionFile: "agent:main:session-1",
+          sessionId: "session-1",
           model: { api: "responses" },
         } as never,
         env: {},
-        warn,
-      });
-
-    expect(makeRecorder("session-1")).toBeNull();
-    // Retried attempts for the same session must not repeat the warn.
-    expect(makeRecorder("session-1")).toBeNull();
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(
-      "codex trajectory capture requires the SQLite host recorder",
-      { sessionId: "session-1", reason: "sqlite-recorder-unavailable" },
-    );
-
-    // A later distinct session's recorder loss stays visible: the host can
-    // reject per-session (target-mapping conflicts), not only per-process.
-    expect(makeRecorder("session-2")).toBeNull();
-    expect(warn).toHaveBeenCalledTimes(2);
-    expect(warn).toHaveBeenLastCalledWith(
-      "codex trajectory capture requires the SQLite host recorder",
-      { sessionId: "session-2", reason: "sqlite-recorder-unavailable" },
-    );
+      }),
+    ).toBeNull();
   });
 
   it("stores SQLite-backed captures for the canonical session-key target", async () => {
@@ -173,7 +152,7 @@ describe("Codex trajectory recorder", () => {
         sessionId: "session-1",
         model: { api: "responses" },
       } as never,
-      trajectoryRecorder: createSqliteHostTrajectoryRecorder({
+      trajectory: createSqliteTrajectoryFacade({
         agentId: "main",
         sessionId: "session-1",
         storePath,
@@ -239,8 +218,8 @@ describe("Codex trajectory recorder", () => {
     ]);
   });
 
-  it("honors explicit disablement without warning", () => {
-    const warn = vi.fn();
+  it("honors explicit disablement", () => {
+    const host = createMemoryTrajectoryFacade();
     const recorder = createCodexTrajectoryRecorder({
       cwd: testWorkspace.dir,
       attempt: {
@@ -249,11 +228,11 @@ describe("Codex trajectory recorder", () => {
         model: { api: "responses" },
       } as never,
       env: { OPENCLAW_TRAJECTORY: "0" },
-      warn,
+      trajectory: host.trajectory,
     });
 
     expect(recorder).toBeNull();
-    expect(warn).not.toHaveBeenCalled();
+    expect(host.events).toEqual([]);
   });
 
   it("preserves usage when truncating oversized model completion events", async () => {

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -19,10 +19,9 @@ type CodexTrajectoryInit = {
   cwd: string;
   developerInstructions?: string;
   prompt?: string;
-  trajectoryRecorder?: CodexHostTrajectoryRecorder | null;
+  trajectory?: NonNullable<EmbeddedRunAttemptParams["hostCapabilities"]["trajectory"]> | null;
   tools?: CodexDynamicToolSpec[];
   env?: NodeJS.ProcessEnv;
-  warn?: (message: string, fields: Record<string, unknown>) => void;
 };
 
 const SENSITIVE_FIELD_RE = /(?:authorization|cookie|credential|key|password|passwd|secret|token)/iu;
@@ -32,16 +31,6 @@ const JWT_VALUE_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]
 const COOKIE_PAIR_RE = /\b([A-Za-z][A-Za-z0-9_.-]{1,64})=([A-Za-z0-9+/._~%=-]{16,})(?=;|\s|$)/gu;
 const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
 const TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS = ["usage", "promptCache"] as const;
-
-type CodexTrajectorySink = {
-  flush: () => Promise<void>;
-  write: (event: CodexTrajectoryEvent) => void;
-};
-
-export type CodexHostTrajectoryRecorder = {
-  recordEvent: (type: string, data?: Record<string, unknown>) => void;
-  flush: () => Promise<void>;
-};
 
 type CodexTrajectoryEvent = Record<string, unknown> & {
   data?: Record<string, unknown>;
@@ -108,26 +97,6 @@ function boundedTrajectoryEvent(event: Record<string, unknown>): CodexTrajectory
   return best;
 }
 
-function createCodexHostTrajectorySink(params: {
-  recorder: CodexHostTrajectoryRecorder;
-}): CodexTrajectorySink {
-  return {
-    write: (event) => {
-      params.recorder.recordEvent(event.type, event.data);
-    },
-    flush: async () => {
-      await params.recorder.flush();
-    },
-  };
-}
-
-// The host recorder can be absent per session (target-mapping conflicts), not
-// only per process, so dedupe the warn by session: repeated attempts for one
-// session stay quiet while a later distinct session still records its loss.
-// Bounded: cleared past the cap so a pathological session churn cannot grow it.
-const warnedRecorderUnavailableSessions = new Set<string>();
-const WARNED_RECORDER_SESSIONS_CAP = 64;
-
 /** Creates a trajectory recorder when trajectory capture is enabled for the environment. */
 export function createCodexTrajectoryRecorder(
   params: CodexTrajectoryInit,
@@ -138,26 +107,10 @@ export function createCodexTrajectoryRecorder(
     return null;
   }
 
-  // The host owns SQLite target resolution and identity validation; it hands
-  // back a recorder only for a committed session row. Re-deriving that here
-  // from a session-file string silently drops every capture once the host
-  // stops emitting the legacy `sqlite:` marker.
-  if (!params.trajectoryRecorder) {
-    // Per-attempt repeats for one session bury real diagnostics; warn once per
-    // session so retries stay quiet but each newly affected session is visible.
-    if (!warnedRecorderUnavailableSessions.has(params.attempt.sessionId)) {
-      if (warnedRecorderUnavailableSessions.size >= WARNED_RECORDER_SESSIONS_CAP) {
-        warnedRecorderUnavailableSessions.clear();
-      }
-      warnedRecorderUnavailableSessions.add(params.attempt.sessionId);
-      params.warn?.("codex trajectory capture requires the SQLite host recorder", {
-        sessionId: params.attempt.sessionId,
-        reason: "sqlite-recorder-unavailable",
-      });
-    }
+  if (!params.trajectory) {
     return null;
   }
-  const sink = createCodexHostTrajectorySink({ recorder: params.trajectoryRecorder });
+  const trajectory = params.trajectory;
   let seq = 0;
   const attribution = resolveCodexLocalRuntimeAttribution(params.attempt);
 
@@ -182,10 +135,10 @@ export function createCodexTrajectoryRecorder(
         data: data ? sanitizeValue(data) : undefined,
       });
       if (event) {
-        sink.write(event);
+        trajectory.recordEvent(event.type, event.data);
       }
     },
-    flush: sink.flush,
+    flush: trajectory.flush,
   };
 }
 

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -28,6 +28,11 @@ export type AgentHarnessHostCapabilities = Readonly<{
   version: 1;
   /** Fails closed unless this exact admitted run capability remains active. */
   assertActive: () => void;
+  /** Closure-bound event sink backed by the host-owned trajectory recorder. */
+  trajectory?: Readonly<{
+    recordEvent: (type: string, data?: Record<string, unknown>) => void;
+    flush: () => Promise<void>;
+  }>;
   /** Closure-bound non-secret maps prepared before harness placement. */
   preparedEnvironment?: () => AgentHarnessPreparedEnvironment;
   /** Applies the exact host caller binding to a plugin-built tool surface. */

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -241,6 +241,37 @@ describe("agent harness host capability", () => {
     expect(() => host.capabilities.preparedEnvironment?.()).toThrow("no longer active");
   });
 
+  it("delegates trajectory events and rejects a flush that outlives the capability", async () => {
+    const flushStarted = createDeferred();
+    const flushResult = createDeferred();
+    const recordEvent = vi.fn();
+    const flush = vi.fn(async () => {
+      flushStarted.resolve();
+      await flushResult.promise;
+    });
+    const { attempt } = await admittedAttempt("run-trajectory", {
+      trajectoryRecorder: {
+        recordEvent,
+        flush,
+      },
+    });
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    const trajectory = host.capabilities.trajectory;
+    if (!trajectory) {
+      throw new Error("expected trajectory capability");
+    }
+
+    trajectory.recordEvent("plugin.event", { ok: true });
+    expect(recordEvent).toHaveBeenCalledWith("plugin.event", { ok: true });
+    const pending = trajectory.flush();
+    await flushStarted.promise;
+    host.close();
+    flushResult.resolve();
+
+    await expect(pending).rejects.toThrow("no longer active");
+    expect(() => trajectory.recordEvent("late.event")).toThrow("no longer active");
+  });
+
   it("preserves ambient GitHub service tokens for a native local identity", async () => {
     vi.stubEnv("GH_TOKEN", "ambient-service-token");
     vi.stubEnv("GITHUB_TOKEN", "ambient-fallback-token");

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -288,10 +288,26 @@ export function createAgentHarnessHostCapabilities(params: {
     });
   });
 
+  const trajectoryRecorder = attempt.trajectoryRecorder;
   const capabilities: AgentHarnessHostCapabilities = Object.freeze({
     kind: "agent-harness-host-capability" as const,
     version: 1 as const,
     assertActive,
+    ...(trajectoryRecorder
+      ? {
+          trajectory: Object.freeze({
+            recordEvent: (type: string, data?: Record<string, unknown>) => {
+              assertActive();
+              trajectoryRecorder.recordEvent(type, data);
+            },
+            flush: async () => {
+              assertActive();
+              await trajectoryRecorder.flush();
+              assertActive();
+            },
+          }),
+        }
+      : {}),
     preparedEnvironment: () => {
       assertActive();
       return Object.freeze({

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1,7 +1,10 @@
 // Covers agent harness selection, fallback behavior, and compaction routing.
+import path from "node:path";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { TranscriptEntryAnchor } from "../../config/sessions/transcript-entry-anchor.js";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
 import type { ContextEngine } from "../../context-engine/types.js";
@@ -10,6 +13,10 @@ import { createOpenClawCodingTools } from "../../plugin-sdk/agent-harness.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { mintSecretSentinel } from "../../secrets/sentinel.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { loadSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
+import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
 import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
@@ -157,6 +164,7 @@ vi.mock("../tools/gateway.js", () => ({ callGatewayTool: vi.fn() }));
 const mockCallGatewayTool = vi.mocked(callGatewayTool);
 
 const originalRuntime = process.env.OPENCLAW_AGENT_RUNTIME;
+const trajectoryTempDirs = createTempDirTracker();
 let selectionAdmission: PreparedAgentRunAdmission;
 let selectionAdmittedRunContext: AdmittedRunContext;
 
@@ -218,6 +226,9 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  trajectoryTempDirs.cleanup();
   selectionAdmission.close();
   resetAgentRunRegistryForTest();
   clearAgentHarnesses();
@@ -691,6 +702,47 @@ describe("runAgentHarnessAttempt", () => {
 
     expect((params as unknown as Record<string, unknown>)[internalKey]).toBeDefined();
     expect(handedOffRuntime).toBeUndefined();
+  });
+
+  it("persists plugin trajectory events through the selected harness host capability", async () => {
+    const tempDir = trajectoryTempDirs.make("openclaw-harness-trajectory-");
+    const storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
+    const sessionKey = "agent:main:main";
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId: "session-1", updatedAt: 10 });
+    const trajectoryRecorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionKey,
+      sessionTarget: { agentId: "main", sessionId: "session-1", sessionKey, storePath },
+    });
+    if (!trajectoryRecorder) {
+      throw new Error("Expected SQLite trajectory recorder");
+    }
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: async (attempt) => {
+          const trajectory = attempt.hostCapabilities?.trajectory;
+          if (!trajectory) {
+            throw new Error("Expected host trajectory capability");
+          }
+          trajectory.recordEvent("plugin.selected");
+          await trajectory.flush();
+          return createAttemptResult("codex");
+        },
+      },
+      { ownerPluginId: "codex" },
+    );
+    const params = createAttemptParams(providerRuntimeConfig("codex", "codex"));
+    params.sessionKey = sessionKey;
+    params.trajectoryRecorder = trajectoryRecorder;
+
+    await runAgentHarnessAttempt(params);
+
+    expect(await loadSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath })).toEqual([
+      expect.objectContaining({ source: "runtime", type: "plugin.selected" }),
+    ]);
   });
 
   it.each(["heartbeat"] as const)(


### PR DESCRIPTION
Closes #125940

## What Problem This Solves

Fixes an issue where operators using the Codex harness would lose all default-on runtime trajectory persistence even though the agent turn completed successfully. The host created a valid SQLite-backed recorder, but the plugin handoff removed it before Codex could record prompt, context, usage, cache, tool, and completion events.

## Why This Change Was Made

Core now projects the existing host-owned recorder through an optional, closure-bound `hostCapabilities.trajectory` facade after harness selection. Core continues to own session attribution, redaction, bounds, SQLite persistence, and attempt lifetime; the Codex plugin only records and flushes through the facade, with no storage-path inference, cast, warning dedupe, or plugin-side fallback.

This keeps the ownership boundary narrow and fail-closed: retained recorders reject calls after the admitted attempt settles, including a flush that races capability closure.

## User Impact

Codex harness runs with a valid trajectory target once again persist their runtime flight-recorder events. Operators regain the diagnostic evidence needed to investigate prompt/context construction, token and cache behavior, tool execution, provider behavior, and terminal outcomes without changing configuration.

## Evidence

- `node scripts/run-vitest.mjs src/agents/harness/host-capability.test.ts src/agents/harness/selection.test.ts` — 2 files, 155 tests passed. This includes selection through the plugin harness into the real SQLite trajectory store and closure-race rejection.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/trajectory.test.ts` — 2 files, 150 tests passed.
- `node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt docs/plugins/sdk-agent-harness.md extensions/codex/src/app-server/run-attempt-resources.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/trajectory.test.ts extensions/codex/src/app-server/trajectory.ts src/agents/harness/host-capability-types.ts src/agents/harness/host-capability.test.ts src/agents/harness/host-capability.ts src/agents/harness/selection.test.ts` — passed core, core-test, plugin, plugin-test, docs, and tooling gates. The assertion ratchet correctly decreased from 14 to 13 for the changed Codex resource file.
- `pnpm plugin-sdk:surface:check` — passed: 332 entrypoints, 7,241 exports, 0 forbidden package-exported subpaths.
- `pnpm build` — passed, including plugin SDK declarations/exports, 61 local plugin builds, runtime postbuild checks, and Control UI build.
- `git diff --check origin/main...HEAD` — clean.
- Fresh autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high --stream-engine-output` — clean, no accepted/actionable findings; patch correct at 0.97 confidence.
- Upstream Codex protocol/runtime checked at `b5ea64a203ce1b04629010d3ef0a0d18c3c870a9`: notification registration, turn/item payloads, app-server completion emission, and core terminal-event construction align with the recorded lifecycle.

LOC split:

- Production: +28/-58, net -30.
- Tests: +110/-47, net +63.
- Docs: +8/-0.
- Assertion ratchet: +1/-1, net 0.

AI-assisted: yes. The repair and tests were reviewed against the complete owner path and the pinned upstream Codex source. No `CHANGELOG.md` edit is included, per repository policy.
