### PR TITLE
fix(ui): retry CLI agent catalog discovery

### DIFF
--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -1,4 +1,6 @@
 // Covers model-catalog metadata failure and recovery on the new-session page.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   createNewSessionPageE2eSuite,
@@ -6,6 +8,25 @@ import {
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
+const captureCatalogRetryProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const catalogRetryProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "new-session-catalog-retry",
+);
+
+function catalogDiscoveryRequests(
+  requests: Array<{ params?: unknown }>,
+): Array<{ params?: unknown }> {
+  return requests.filter(
+    ({ params }) =>
+      params !== null &&
+      typeof params === "object" &&
+      !Array.isArray(params) &&
+      (params as { limitPerHost?: unknown }).limitPerHost === 1,
+  );
+}
 
 suite.define(() => {
   it("shows metadata failure truthfully and recovers when the picker opens", async () => {
@@ -127,6 +148,130 @@ suite.define(() => {
         expect.objectContaining({ params: { agentId: "main" } }),
         expect.objectContaining({ params: { agentId: "main" } }),
       ]);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows a retryable CLI-agent failure and recovers both picker catalogs", async () => {
+    if (captureCatalogRetryProof) {
+      await mkdir(catalogRetryProofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureCatalogRetryProof
+        ? { recordVideo: { dir: catalogRetryProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const models = [
+      {
+        available: true,
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+      },
+    ];
+    const unavailable = {
+      __mockError: {
+        code: "UNAVAILABLE",
+        message: "CLI-agent catalog is warming",
+      },
+    };
+    const discoveryMatch = { agentId: "main", limitPerHost: 1 };
+    const gateway = await installMockGateway(page, {
+      cliAgentsEnabled: true,
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "sessions.create",
+        "sessions.dispatch",
+        "sessions.catalog.list",
+      ],
+      methodResponses: {
+        "sessions.catalog.list": {
+          cases: [
+            { match: discoveryMatch, response: unavailable },
+            { match: {}, response: { catalogs: [] } },
+          ],
+        },
+      },
+      models,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await expect
+        .poll(async () =>
+          catalogDiscoveryRequests(await gateway.getRequests("sessions.catalog.list")),
+        )
+        .toHaveLength(1);
+
+      await page.locator('[data-chat-model-select="true"]').click();
+
+      await expect
+        .poll(async () =>
+          catalogDiscoveryRequests(await gateway.getRequests("sessions.catalog.list")),
+        )
+        .toHaveLength(2);
+      const errorState = page.locator(
+        '[data-chat-model-target-group="cliAgents"] [data-chat-model-catalog-state="error"]',
+      );
+      await expect.poll(() => errorState.isVisible()).toBe(true);
+      const retry = page.locator('[data-chat-model-target-retry="cliAgents"]');
+      await expect.poll(() => retry.isEnabled()).toBe(true);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      if (captureCatalogRetryProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(catalogRetryProofDir, "01-cli-agents-retry.png"),
+        });
+      }
+
+      await gateway.setMethodResponse("sessions.catalog.list", {
+        cases: [
+          {
+            match: discoveryMatch,
+            response: {
+              catalogs: [
+                {
+                  id: "anthropic",
+                  label: "Claude Code",
+                  capabilities: {
+                    continueSession: false,
+                    archive: false,
+                    createSession: { model: "anthropic/claude-sonnet-4-6" },
+                  },
+                  hosts: [],
+                },
+              ],
+            },
+          },
+          { match: {}, response: { catalogs: [] } },
+        ],
+      });
+      await retry.click();
+
+      await expect
+        .poll(async () =>
+          catalogDiscoveryRequests(await gateway.getRequests("sessions.catalog.list")),
+        )
+        .toHaveLength(3);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(3);
+      await expect
+        .poll(() => page.locator('[data-chat-model-target="anthropic"]').isVisible())
+        .toBe(true);
+      expect(await errorState.count()).toBe(0);
+      if (captureCatalogRetryProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(catalogRetryProofDir, "02-cli-agents-recovered.png"),
+        });
+      }
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -5,6 +5,7 @@ import { expect, it } from "vitest";
 import {
   createNewSessionPageE2eSuite,
   installMockGateway,
+  pollLocatorText,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -79,8 +80,11 @@ suite.define(() => {
       await gateway.waitForRequest("chat.metadata");
 
       const modelSelect = page.locator('[data-chat-model-select="true"]');
-      await expect.poll(() => modelSelect.textContent()).toContain("Models unavailable");
-      expect(await page.locator('[data-chat-model-catalog-state="error"]').count()).toBe(1);
+      const errorState = page.locator('[data-chat-model-catalog-state="error"]');
+      await pollLocatorText(
+        errorState.locator(".chat-controls__model-catalog-state-label > span"),
+      ).toBe("Models unavailable");
+      expect(await errorState.count()).toBe(1);
       expect(await page.locator("[data-chat-model-option]").count()).toBe(0);
 
       await modelSelect.click();
@@ -220,8 +224,18 @@ suite.define(() => {
         '[data-chat-model-target-group="cliAgents"] [data-chat-model-catalog-state="error"]',
       );
       await expect.poll(() => errorState.isVisible()).toBe(true);
+      await pollLocatorText(
+        errorState.locator(".chat-controls__model-catalog-state-label > span"),
+      ).toBe("CLI agents unavailable");
       const retry = page.locator('[data-chat-model-target-retry="cliAgents"]');
       await expect.poll(() => retry.isEnabled()).toBe(true);
+      await pollLocatorText(retry).toContain("Retry");
+      await pollLocatorText(
+        page.locator(
+          '[data-chat-model-option="openai/gpt-5.6-luna"] .chat-controls__model-option-name',
+        ),
+      ).toBe("GPT-5.6 Luna");
+      expect(await page.getByText("Models unavailable", { exact: true }).count()).toBe(0);
       await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
       if (captureCatalogRetryProof) {
         await page.screenshot({
@@ -264,6 +278,14 @@ suite.define(() => {
       await expect
         .poll(() => page.locator('[data-chat-model-target="anthropic"]').isVisible())
         .toBe(true);
+      await pollLocatorText(
+        page.locator(
+          '[data-chat-model-target-group="cliAgents"] .chat-controls__provider-heading > span:last-child',
+        ),
+      ).toBe("CLI agents");
+      await pollLocatorText(
+        page.locator('[data-chat-model-target="anthropic"] .chat-controls__model-option-name'),
+      ).toBe("Claude Code");
       expect(await errorState.count()).toBe(0);
       if (captureCatalogRetryProof) {
         await page.screenshot({

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -870,6 +870,7 @@ export const en: TranslationMap = {
     createOutcomeUnknown:
       "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
     cliAgentsGroup: "CLI agents",
+    cliAgentsUnavailable: "CLI agents unavailable",
     cloudSetupInterrupted:
       "This cloud session's setup was interrupted. Check recent sessions before starting this task again.",
     catalogUnavailable: "This session target is unavailable.",

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -52,6 +52,7 @@ type ChatModelControlsProps = {
   onModelSetup?: () => void;
   onModelPickerOpen?: () => unknown;
   onModelSelect?: (value: string, sessionKey: string) => unknown;
+  onModelPickerTargetRetry?: (groupId: string) => unknown;
   onModelPickerTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
   onThinkingSelect?: (value: string, sessionKey: string) => unknown;
@@ -387,6 +388,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
         onOpen: props.onModelPickerOpen,
         onModelSelect: async (next, targetSessionKey) =>
           props.onModelSelect?.(next, targetSessionKey),
+        onTargetRetry: props.onModelPickerTargetRetry,
         onTargetSelect: props.onModelPickerTargetSelect,
         onRequestUpdate: props.onRequestUpdate,
       })}

--- a/ui/src/pages/chat/components/chat-model-picker-options.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-options.ts
@@ -37,6 +37,7 @@ export type ChatModelPickerTargetGroup = {
   id: string;
   label: string;
   options: readonly { label: string; value: string }[];
+  status: "loading" | "ready" | "error";
 };
 
 // Known models.list runtime ids; mirrors src/status/agent-runtime-label.ts,

--- a/ui/src/pages/chat/components/chat-model-picker-options.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-options.ts
@@ -34,6 +34,7 @@ function formatModelContextMeta(option: ChatModelPickerOption): string {
 }
 
 export type ChatModelPickerTargetGroup = {
+  errorLabel: string;
   id: string;
   label: string;
   options: readonly { label: string; value: string }[];

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -33,6 +33,7 @@ type ChatModelPickerParams = {
   onModelSetup?: () => void;
   onOpen?: () => unknown;
   onModelSelect: (value: string, sessionKey: string) => Promise<unknown>;
+  onTargetRetry?: (groupId: string) => unknown;
   onTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
 };
@@ -229,6 +230,7 @@ function renderCatalogState(
   hasOptions: boolean,
   hasSelectableOptions: boolean,
   onModelSetup?: () => void,
+  retryTarget?: { disabled: boolean; groupId: string; onRetry: (groupId: string) => unknown },
 ) {
   if (!state || (state.status === "ready" && hasSelectableOptions)) {
     return nothing;
@@ -260,6 +262,22 @@ function renderCatalogState(
         ${state.status === "error" ? icons.alertTriangle : nothing}
         <span>${label}</span>
       </span>
+      ${state.status === "error" && retryTarget
+        ? html`
+            <button
+              class="chat-controls__model-catalog-action"
+              data-chat-model-target-retry=${retryTarget.groupId}
+              type="button"
+              ?disabled=${retryTarget.disabled}
+              @click=${(event: MouseEvent) => {
+                event.stopPropagation();
+                retryTarget.onRetry(retryTarget.groupId);
+              }}
+            >
+              ${t("common.retry")}
+            </button>
+          `
+        : nothing}
       ${state.status === "ready" && !hasSelectableOptions && onModelSetup
         ? html`
             <button
@@ -315,7 +333,9 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   const optionIndex = new Map(orderedOptions.map((option, index) => [option.value, index]));
   const targetGroups = params.targetGroups ?? [];
   const targetOptionCount = targetGroups.reduce((count, group) => count + group.options.length, 0);
-  const hasOptions = params.modelOptions.length + targetOptionCount > 0;
+  const hasOptions =
+    params.modelOptions.length + targetOptionCount > 0 ||
+    targetGroups.some((group) => group.status !== "ready");
   const hasSelectableModelOptions = params.modelOptions.some((option) => !option.disabled);
   const commitModel = (value: string) => {
     if (params.modelSelectionLocked) {
@@ -515,6 +535,21 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                                 >
                                 <span>${group.label}</span>
                               </div>
+                              ${group.status === "ready"
+                                ? nothing
+                                : renderCatalogState(
+                                    { hasSnapshot: false, status: group.status },
+                                    false,
+                                    false,
+                                    undefined,
+                                    params.onTargetRetry
+                                      ? {
+                                          disabled: params.disabled,
+                                          groupId: group.id,
+                                          onRetry: params.onTargetRetry,
+                                        }
+                                      : undefined,
+                                  )}
                               ${repeat(
                                 group.options,
                                 (entry) => entry.value,

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -230,6 +230,7 @@ function renderCatalogState(
   hasOptions: boolean,
   hasSelectableOptions: boolean,
   onModelSetup?: () => void,
+  errorLabel = t("chat.modelControls.modelsUnavailable"),
   retryTarget?: { disabled: boolean; groupId: string; onRetry: (groupId: string) => unknown },
 ) {
   if (!state || (state.status === "ready" && hasSelectableOptions)) {
@@ -244,7 +245,7 @@ function renderCatalogState(
       : state.status === "refreshing"
         ? t("chat.modelControls.refreshingModels")
         : state.status === "error"
-          ? t("chat.modelControls.modelsUnavailable")
+          ? errorLabel
           : state.status === "ready"
             ? hasOptions
               ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
@@ -542,6 +543,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                                     false,
                                     false,
                                     undefined,
+                                    group.errorLabel,
                                     params.onTargetRetry
                                       ? {
                                           disabled: params.disabled,

--- a/ui/src/pages/new-session/model-control.catalog-targets.test.ts
+++ b/ui/src/pages/new-session/model-control.catalog-targets.test.ts
@@ -160,4 +160,55 @@ describe("new-session CLI-agent model targets", () => {
     expect(container.querySelector('[data-chat-model-target="new-owner"]')).not.toBeNull();
     expect(container.querySelector('[data-chat-model-target="stale-owner"]')).toBeNull();
   });
+
+  it("ignores a stale response after the same client switches agent owners", async () => {
+    const mainCatalog = deferred<{ catalogs: Array<Record<string, unknown>> }>();
+    const researchCatalog = deferred<{ catalogs: Array<Record<string, unknown>> }>();
+    const { context, request } = contextWith(models, "openclaw", ["sessions.catalog.list"]);
+    request.mockImplementation((method: string, params?: { agentId?: string }) => {
+      if (method !== "sessions.catalog.list") {
+        return Promise.resolve({ models });
+      }
+      return params?.agentId === "research" ? researchCatalog.promise : mainCatalog.promise;
+    });
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.loadCatalogTargets(context, "main", true);
+    await vi.waitFor(() => expect(catalogCalls(request)).toHaveLength(1));
+    control.loadCatalogTargets(context, "research", true);
+    await vi.waitFor(() => expect(catalogCalls(request)).toHaveLength(2));
+
+    researchCatalog.resolve({
+      catalogs: [
+        {
+          id: "research-owner",
+          label: "Research owner",
+          capabilities: { createSession: { model: "openai/gpt-5.6-luna" } },
+          hosts: [],
+        },
+      ],
+    });
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-target="research-owner"]'),
+      ).not.toBeNull(),
+    );
+
+    mainCatalog.resolve({
+      catalogs: [
+        {
+          id: "main-owner",
+          label: "Main owner",
+          capabilities: { createSession: { model: "anthropic/claude-sonnet-4-6" } },
+          hosts: [],
+        },
+      ],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const container = renderControl(control, context);
+    expect(container.querySelector('[data-chat-model-target="research-owner"]')).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-target="main-owner"]')).toBeNull();
+  });
 });

--- a/ui/src/pages/new-session/model-control.catalog-targets.test.ts
+++ b/ui/src/pages/new-session/model-control.catalog-targets.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../../api/types.ts";
+import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
+import { NewSessionModelControl } from "./model-control.ts";
+
+const models: ModelCatalogEntry[] = [
+  { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+];
+
+function catalogCalls(request: ReturnType<typeof vi.fn>) {
+  return request.mock.calls.filter(([method]) => method === "sessions.catalog.list");
+}
+
+describe("new-session CLI-agent model targets", () => {
+  it("retries failed discovery with model metadata when the picker reopens", async () => {
+    const { context, request } = contextWith(models, "openclaw", ["sessions.catalog.list"]);
+    request.mockImplementation((method: string) => {
+      if (method === "sessions.catalog.list") {
+        return catalogCalls(request).length === 1
+          ? Promise.reject(new Error("catalog temporarily unavailable"))
+          : Promise.resolve({
+              catalogs: [
+                {
+                  id: "anthropic",
+                  label: "Claude Code",
+                  capabilities: { createSession: { model: "anthropic/claude-sonnet-4-6" } },
+                  hosts: [],
+                },
+              ],
+            });
+      }
+      return Promise.resolve({ models });
+    });
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    control.loadCatalogTargets(context, "main", true);
+
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-target-group="cliAgents"] [data-chat-model-catalog-state="error"]',
+        ),
+      ).not.toBeNull(),
+    );
+    control.loadCatalogTargets(context, "main", true);
+    await Promise.resolve();
+    expect(catalogCalls(request)).toHaveLength(1);
+
+    const picker = renderControl(control, context).querySelector<HTMLDetailsElement>(
+      ".chat-controls__model-picker",
+    );
+    picker!.open = true;
+    picker!.dispatchEvent(new Event("toggle"));
+
+    await vi.waitFor(() => {
+      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(2);
+      expect(catalogCalls(request)).toHaveLength(2);
+    });
+    await vi.waitFor(() => {
+      const recovered = renderControl(control, context);
+      expect(recovered.querySelector('[data-chat-model-target="anthropic"]')).not.toBeNull();
+      expect(
+        recovered.querySelector(
+          '[data-chat-model-target-group="cliAgents"] [data-chat-model-catalog-state="error"]',
+        ),
+      ).toBeNull();
+    });
+
+    control.loadCatalogTargets(context, "main", true);
+    await Promise.resolve();
+    expect(catalogCalls(request)).toHaveLength(2);
+  });
+
+  it("retries both catalogs from the visible discovery error action", async () => {
+    const { context, request } = contextWith(models, "openclaw", ["sessions.catalog.list"]);
+    request.mockImplementation((method: string) => {
+      if (method === "sessions.catalog.list") {
+        return catalogCalls(request).length === 1
+          ? Promise.reject(new Error("catalog temporarily unavailable"))
+          : Promise.resolve({ catalogs: [] });
+      }
+      return Promise.resolve({ models });
+    });
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    control.loadCatalogTargets(context, "main", true);
+
+    await vi.waitFor(() => {
+      const retry = renderControl(control, context).querySelector<HTMLButtonElement>(
+        '[data-chat-model-target-retry="cliAgents"]',
+      );
+      expect(retry).not.toBeNull();
+      retry?.click();
+    });
+
+    await vi.waitFor(() => {
+      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(2);
+      expect(catalogCalls(request)).toHaveLength(2);
+    });
+    expect(
+      renderControl(control, context).querySelector(
+        '[data-chat-model-target-group="cliAgents"] [data-chat-model-catalog-state="error"]',
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores a stale response after reconnect replaces its owner", async () => {
+    const oldCatalog = deferred<{ catalogs: Array<Record<string, unknown>> }>();
+    const { context: oldContext, request: oldRequest } = contextWith(models, "openclaw", [
+      "sessions.catalog.list",
+    ]);
+    oldRequest.mockImplementation((method: string) =>
+      method === "sessions.catalog.list" ? oldCatalog.promise : Promise.resolve({ models }),
+    );
+    const { context: newContext, request: newRequest } = contextWith(models, "openclaw", [
+      "sessions.catalog.list",
+    ]);
+    newRequest.mockImplementation((method: string) =>
+      method === "sessions.catalog.list"
+        ? Promise.resolve({
+            catalogs: [
+              {
+                id: "new-owner",
+                label: "New owner",
+                capabilities: { createSession: { model: "openai/gpt-5.6-luna" } },
+                hosts: [],
+              },
+            ],
+          })
+        : Promise.resolve({ models }),
+    );
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.loadCatalogTargets(oldContext, "main", true);
+    await vi.waitFor(() => expect(catalogCalls(oldRequest)).toHaveLength(1));
+    control.invalidate(false);
+    control.loadCatalogTargets(newContext, "main", true);
+
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, newContext).querySelector('[data-chat-model-target="new-owner"]'),
+      ).not.toBeNull(),
+    );
+    oldCatalog.resolve({
+      catalogs: [
+        {
+          id: "stale-owner",
+          label: "Stale owner",
+          capabilities: { createSession: { model: "anthropic/claude-sonnet-4-6" } },
+          hosts: [],
+        },
+      ],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const container = renderControl(control, newContext);
+    expect(container.querySelector('[data-chat-model-target="new-owner"]')).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-target="stale-owner"]')).toBeNull();
+  });
+});

--- a/ui/src/pages/new-session/model-control.test-support.ts
+++ b/ui/src/pages/new-session/model-control.test-support.ts
@@ -1,0 +1,75 @@
+import { render } from "lit";
+import { vi } from "vitest";
+import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { NewSessionModelControl } from "./model-control.ts";
+
+export function contextWith(
+  models: ModelCatalogEntry[],
+  runtime = "openclaw",
+  featureMethods: string[] = [],
+  cloudPlacementSupported?: boolean,
+) {
+  const request = vi.fn().mockResolvedValue({ models });
+  const navigate = vi.fn();
+  const context = {
+    navigate,
+    gateway: {
+      snapshot: {
+        phase: "connected",
+        client: { request },
+        hello: { features: { methods: featureMethods } },
+      },
+    },
+    sessions: {
+      state: {
+        result: {
+          defaults: {
+            model: "openai/gpt-5.6-luna",
+            modelProvider: "openai",
+            agentRuntime: {
+              id: runtime,
+              ...(cloudPlacementSupported === undefined ? {} : { cloudPlacementSupported }),
+              source: "defaults",
+            },
+          },
+          sessions: [],
+        },
+      },
+    },
+  } as unknown as ApplicationContext;
+  return { context, navigate, request };
+}
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+export function renderControl(
+  control: NewSessionModelControl,
+  context: ApplicationContext,
+  agentId = "main",
+  agent: GatewayAgentRow | null = {
+    id: "main",
+    model: { primary: "openai/gpt-5.6-luna" },
+    thinkingDefault: "medium",
+  },
+) {
+  const container = document.createElement("div");
+  render(
+    control.render({
+      ...(agent ? { agent } : {}),
+      agentId,
+      context,
+      sending: false,
+    }),
+    container,
+  );
+  return container;
+}

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,78 +1,8 @@
-import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
 import { NewSessionModelControl } from "./model-control.ts";
-
-function contextWith(
-  models: ModelCatalogEntry[],
-  runtime = "openclaw",
-  featureMethods: string[] = [],
-  cloudPlacementSupported?: boolean,
-) {
-  const request = vi.fn().mockResolvedValue({ models });
-  const navigate = vi.fn();
-  const context = {
-    navigate,
-    gateway: {
-      snapshot: {
-        phase: "connected",
-        client: { request },
-        hello: { features: { methods: featureMethods } },
-      },
-    },
-    sessions: {
-      state: {
-        result: {
-          defaults: {
-            model: "openai/gpt-5.6-luna",
-            modelProvider: "openai",
-            agentRuntime: {
-              id: runtime,
-              ...(cloudPlacementSupported === undefined ? {} : { cloudPlacementSupported }),
-              source: "defaults",
-            },
-          },
-          sessions: [],
-        },
-      },
-    },
-  } as unknown as ApplicationContext;
-  return { context, navigate, request };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
-
-function renderControl(
-  control: NewSessionModelControl,
-  context: ApplicationContext,
-  agentId = "main",
-  agent: GatewayAgentRow | null = {
-    id: "main",
-    model: { primary: "openai/gpt-5.6-luna" },
-    thinkingDefault: "medium",
-  },
-) {
-  const container = document.createElement("div");
-  render(
-    control.render({
-      ...(agent ? { agent } : {}),
-      agentId,
-      context,
-      sending: false,
-    }),
-    container,
-  );
-  return container;
-}
 
 afterEach(() => {
   vi.useRealTimers();
@@ -163,10 +93,19 @@ describe("new-session model runtime", () => {
     ]);
     const control = new NewSessionModelControl(() => undefined);
 
+    control.load(context, "main", true);
     control.loadCatalogTargets(context, "main", true);
-    await Promise.resolve();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
 
-    expect(request).not.toHaveBeenCalled();
+    const container = renderControl(control, context);
+    const picker = container.querySelector<HTMLDetailsElement>(".chat-controls__model-picker");
+    picker!.open = true;
+    picker!.dispatchEvent(new Event("toggle"));
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+
+    expect(request.mock.calls.some(([method]) => method === "sessions.catalog.list")).toBe(false);
+    expect(container.querySelector("[data-chat-model-target-group]")).toBeNull();
   });
 
   it("preserves a browser preference when an older server omits thinking profiles", async () => {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -19,6 +19,7 @@ import {
   renderChatModelControls,
   type ChatModelCatalogState,
 } from "../chat/components/chat-model-controls.ts";
+import type { ChatModelPickerTargetGroup } from "../chat/components/chat-model-picker-options.ts";
 import type { NewSessionPreference } from "./preferences.ts";
 
 type NewSessionMetadataClient = NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
@@ -37,6 +38,17 @@ type NewSessionMetadataLoadOptions = {
 };
 
 type CatalogCreateTarget = Pick<SessionCatalog, "id" | "label">;
+type CatalogTargetOwner = { agentId: string; client: NewSessionMetadataClient };
+type CatalogTargetDiscoveryState =
+  | { status: "idle" }
+  | {
+      status: "loading";
+      owner: CatalogTargetOwner;
+      controller: AbortController;
+      requestId: number;
+    }
+  | { status: "ready"; owner: CatalogTargetOwner; targets: CatalogCreateTarget[] }
+  | { status: "error"; owner: CatalogTargetOwner };
 type ReconciledNewSessionSelection = {
   model: string;
   thinkingLevel: string;
@@ -105,19 +117,8 @@ export class NewSessionModelControl {
   private pendingAgent: GatewayAgentRow | undefined;
   private pendingContext: ApplicationContext | undefined;
   private pendingSelectionGeneration = 0;
-  private catalogTargets: CatalogCreateTarget[] = [];
   private catalogTargetRequestId = 0;
-  private activeCatalogTargetRequest:
-    | {
-        agentId: string;
-        client: NewSessionMetadataClient;
-        controller: AbortController;
-        id: number;
-      }
-    | undefined;
-  private catalogTargetOwner:
-    | { agentId: string; client: NewSessionMetadataClient; loaded: boolean }
-    | undefined;
+  private catalogTargetDiscovery: CatalogTargetDiscoveryState = { status: "idle" };
   selected = "";
   thinkingLevel = "";
 
@@ -143,16 +144,52 @@ export class NewSessionModelControl {
   }
 
   private clearCatalogTargets() {
-    const active = this.activeCatalogTargetRequest;
-    this.activeCatalogTargetRequest = undefined;
+    const previous = this.catalogTargetDiscovery;
+    this.catalogTargetDiscovery = { status: "idle" };
     this.catalogTargetRequestId += 1;
-    active?.controller.abort();
-    const changed = this.catalogTargets.length > 0 || this.catalogTargetOwner !== undefined;
-    this.catalogTargets = [];
-    this.catalogTargetOwner = undefined;
-    if (changed) {
+    if (previous.status === "loading") {
+      previous.controller.abort();
+    }
+    if (previous.status !== "idle") {
       this.notify();
     }
+  }
+
+  private startCatalogTargetRequest(owner: CatalogTargetOwner) {
+    const controller = new AbortController();
+    const requestId = ++this.catalogTargetRequestId;
+    this.catalogTargetDiscovery = { status: "loading", owner, controller, requestId };
+    this.notify();
+    void owner.client
+      .request<SessionsCatalogListResult>(
+        "sessions.catalog.list",
+        { agentId: owner.agentId, limitPerHost: 1 },
+        { signal: controller.signal },
+      )
+      .then(
+        (result) => {
+          const active = this.catalogTargetDiscovery;
+          if (active.status !== "loading" || active.requestId !== requestId) {
+            return;
+          }
+          this.catalogTargetDiscovery = {
+            status: "ready",
+            owner,
+            targets: result.catalogs
+              .filter((catalog) => catalog.capabilities.createSession !== undefined)
+              .map(({ id, label }) => ({ id, label })),
+          };
+          this.notify();
+        },
+        () => {
+          const active = this.catalogTargetDiscovery;
+          if (active.status !== "loading" || active.requestId !== requestId) {
+            return;
+          }
+          this.catalogTargetDiscovery = { status: "error", owner };
+          this.notify();
+        },
+      );
   }
 
   loadCatalogTargets(context: ApplicationContext | undefined, agentId: string, enabled: boolean) {
@@ -169,52 +206,18 @@ export class NewSessionModelControl {
       this.clearCatalogTargets();
       return;
     }
+    const owner = { agentId: normalizedAgentId, client };
+    const current = this.catalogTargetDiscovery;
     if (
-      this.catalogTargetOwner?.client === client &&
-      this.catalogTargetOwner.agentId === normalizedAgentId &&
-      (this.catalogTargetOwner.loaded || this.activeCatalogTargetRequest)
+      current.status !== "idle" &&
+      current.owner.client === owner.client &&
+      current.owner.agentId === owner.agentId
     ) {
       return;
     }
 
     this.clearCatalogTargets();
-    const controller = new AbortController();
-    const requestId = ++this.catalogTargetRequestId;
-    this.catalogTargetOwner = { agentId: normalizedAgentId, client, loaded: false };
-    this.activeCatalogTargetRequest = {
-      agentId: normalizedAgentId,
-      client,
-      controller,
-      id: requestId,
-    };
-    void client
-      .request<SessionsCatalogListResult>(
-        "sessions.catalog.list",
-        { agentId: normalizedAgentId, limitPerHost: 1 },
-        { signal: controller.signal },
-      )
-      .then(
-        (result) => {
-          if (this.activeCatalogTargetRequest?.id !== requestId) {
-            return;
-          }
-          this.activeCatalogTargetRequest = undefined;
-          this.catalogTargetOwner = { agentId: normalizedAgentId, client, loaded: true };
-          this.catalogTargets = result.catalogs
-            .filter((catalog) => catalog.capabilities.createSession !== undefined)
-            .map(({ id, label }) => ({ id, label }));
-          this.notify();
-        },
-        () => {
-          if (this.activeCatalogTargetRequest?.id !== requestId) {
-            return;
-          }
-          this.activeCatalogTargetRequest = undefined;
-          this.catalogTargetOwner = { agentId: normalizedAgentId, client, loaded: true };
-          this.catalogTargets = [];
-          this.notify();
-        },
-      );
+    this.startCatalogTargetRequest(owner);
   }
 
   private updateMetadataState(next: NewSessionMetadataState) {
@@ -286,12 +289,41 @@ export class NewSessionModelControl {
     );
   }
 
-  refreshMetadataOnPickerOpen() {
-    if (!this.metadataClient || !this.agentId) {
-      return;
+  private refreshPickerCatalogs() {
+    const metadataClient = this.metadataClient;
+    if (metadataClient && this.agentId) {
+      // Picker open is the retry; start directly so preference restoration is not re-armed.
+      this.startMetadataRequest(metadataClient, this.agentId);
     }
-    // Picker open is the retry; start directly so preference restoration is not re-armed.
-    this.startMetadataRequest(this.metadataClient, this.agentId);
+    const targetDiscovery = this.catalogTargetDiscovery;
+    if (
+      targetDiscovery.status === "error" &&
+      targetDiscovery.owner.client === metadataClient &&
+      targetDiscovery.owner.agentId === this.agentId
+    ) {
+      this.startCatalogTargetRequest(targetDiscovery.owner);
+    }
+  }
+
+  private catalogTargetGroups(): readonly ChatModelPickerTargetGroup[] | undefined {
+    const discovery = this.catalogTargetDiscovery;
+    if (
+      discovery.status === "idle" ||
+      (discovery.status === "ready" && !discovery.targets.length)
+    ) {
+      return undefined;
+    }
+    return [
+      {
+        id: "cliAgents",
+        label: t("newSession.cliAgentsGroup"),
+        options:
+          discovery.status === "ready"
+            ? discovery.targets.map(({ id, label }) => ({ value: id, label }))
+            : [],
+        status: discovery.status,
+      },
+    ];
   }
 
   invalidate(resetSelection = false) {
@@ -528,16 +560,7 @@ export class NewSessionModelControl {
             : this.metadataState.status,
       },
       modelOverrides: { [sessionKey]: this.selected },
-      modelPickerTargetGroups:
-        this.catalogTargets.length > 0
-          ? [
-              {
-                id: "cliAgents",
-                label: t("newSession.cliAgentsGroup"),
-                options: this.catalogTargets.map(({ id, label }) => ({ value: id, label })),
-              },
-            ]
-          : undefined,
+      modelPickerTargetGroups: this.catalogTargetGroups(),
       modelSwitching: false,
       sending: options.sending,
       sessionKey,
@@ -559,6 +582,11 @@ export class NewSessionModelControl {
           this.onCatalogTargetSelect(catalogId);
         }
       },
+      onModelPickerTargetRetry: (groupId) => {
+        if (groupId === "cliAgents") {
+          this.refreshPickerCatalogs();
+        }
+      },
       onThinkingSelect: (value) => {
         this.selectionGeneration += 1;
         this.restoringPreference = false;
@@ -566,7 +594,7 @@ export class NewSessionModelControl {
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
       },
       onModelSetup: () => options.context?.navigate("model-setup"),
-      onModelPickerOpen: () => this.refreshMetadataOnPickerOpen(),
+      onModelPickerOpen: () => this.refreshPickerCatalogs(),
       onRequestUpdate: this.notify,
     });
   }

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -315,6 +315,7 @@ export class NewSessionModelControl {
     }
     return [
       {
+        errorLabel: t("newSession.cliAgentsUnavailable"),
         id: "cliAgents",
         label: t("newSession.cliAgentsGroup"),
         options:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a transient `sessions.catalog.list` failure permanently hid CLI-agent session targets on the New Session page. The discovery owner marked the request as loaded even after failure, so reopening the model picker could never recover without a full page/client reset.

## Why This Change Was Made

CLI-agent target discovery now uses one closed `idle | loading | ready | error` state that owns request identity, agent/client provenance, abort, caching, and retry. Successful results remain cached for the same owner; failed discovery stays explicitly retryable from the picker or a later open; stale responses cannot overwrite a newer agent or client.

Target groups now own their error copy, so a CLI-agent failure says `CLI agents unavailable` beside an otherwise healthy model catalog instead of the misleading `Models unavailable`. The shared model-catalog wording remains unchanged. AI-assisted; the final code and browser flow were independently reviewed.

Provenance: the sticky `loaded` state was introduced with the labs-gated CLI-agent target picker in #120949 on 2026-08-09.

## User Impact

Operators can recover from temporary CLI-agent catalog failures without reloading the page. The picker keeps healthy model choices visible, clearly identifies only the failed CLI-agent section, offers Retry, and reveals recovered targets when the request succeeds.

## Evidence

### Failure and retry

![CLI agent catalog failure with healthy model list and Retry](https://github.com/user-attachments/assets/a4fd6862-9a3f-4009-966b-eb825ee3c391)

### Recovery

![Recovered CLI agent target](https://github.com/user-attachments/assets/36c89cbd-a3ba-430c-a1c1-7c1ac63caccb)

- Pre-fix regression: two intended unit failures proved transient discovery was sticky.
- Final rebased focused proof: 37 unit assertions and 3 Chromium mocked-Gateway E2E scenarios passed.
- Coverage includes retry on open and explicit Retry, success caching, method-advertisement gating, same-client agent-owner switching, reconnect/client replacement, abort and stale-response rejection, and recovered target rendering.
- Full `pnpm check:changed` passed; final `git diff --check` passed.
- Fresh final-head autoreview: clean, no accepted/actionable findings.
- Direct Codex contract inspection covered `model/list` and catalog processing; CLI session-target discovery remains an independent Gateway catalog capability.
- Production LOC: +148/-77 (net +71). Tests/test support: +470/-75. The production growth replaces parallel nullable request/owner/loaded fields with one discriminated lifecycle state and adds the shared target-group recovery UI.
- Gap: no live Gateway/provider run; deterministic mocked-Gateway Chromium exercised the complete visible failure and recovery flow.
