### PR TITLE
fix(cli): migrate legacy state when --agent selects an owner

### DIFF
--- a/src/cli/command-options.test.ts
+++ b/src/cli/command-options.test.ts
@@ -139,6 +139,17 @@ describe("inheritOptionFromParent", () => {
     expect(inheritOptionFromParent<string>(run, "token")).toBe("gateway-env-token");
   });
 
+  it("can restrict inherited values to an explicit CLI source", () => {
+    const gateway = new Command().option("--token <token>", "Gateway token");
+    const run = gateway.command("run").option("--token <token>", "Run token");
+
+    gateway.setOptionValueWithSource("token", "gateway-env-token", "env");
+    expect(inheritOptionFromParent<string>(run, "token", "cli")).toBeUndefined();
+
+    gateway.setOptionValueWithSource("token", "gateway-cli-token", "cli");
+    expect(inheritOptionFromParent<string>(run, "token", "cli")).toBe("gateway-cli-token");
+  });
+
   it("skips default-valued ancestor options and keeps traversing", async () => {
     const program = new Command().option("--token <token>", "Root token");
     const gateway = program

--- a/src/cli/command-options.ts
+++ b/src/cli/command-options.ts
@@ -1,5 +1,5 @@
 // Commander option-source helpers for explicit flags and bounded parent inheritance.
-import type { Command } from "commander";
+import type { Command, OptionValueSource } from "commander";
 
 export function hasExplicitOptions(command: Command, names: readonly string[]): boolean {
   return names.some((name) => command.getOptionValueSource(name) === "cli");
@@ -12,6 +12,7 @@ const MAX_INHERIT_DEPTH = 2;
 export function inheritOptionFromParent<T = unknown>(
   command: Command | undefined,
   name: string,
+  requiredSource?: OptionValueSource,
 ): T | undefined {
   if (!command) {
     return undefined;
@@ -27,6 +28,9 @@ export function inheritOptionFromParent<T = unknown>(
   while (ancestor && depth < MAX_INHERIT_DEPTH) {
     const source = ancestor.getOptionValueSource(name);
     if (source && source !== "default") {
+      if (requiredSource && source !== requiredSource) {
+        return undefined;
+      }
       return ancestor.getOptionValue(name) as T | undefined;
     }
     depth += 1;

--- a/src/cli/program/preaction-agent-owner.test.ts
+++ b/src/cli/program/preaction-agent-owner.test.ts
@@ -1,0 +1,83 @@
+// Preaction parser coverage for explicit legacy migration ownership.
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tryResolveLegacyCompatibilityAgentId } from "../../agents/agent-scope-config.js";
+import { createDoctorConfigSnapshot } from "../../commands/doctor-config-snapshot.test-helpers.js";
+import type { ConfigFileSnapshot } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  ensureConfigReady:
+    vi.fn<
+      (options: {
+        beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
+      }) => Promise<void>
+    >(),
+}));
+
+vi.mock("../../globals.js", () => ({ setVerbose: vi.fn() }));
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+}));
+vi.mock("../../logging/console.js", () => ({ routeLogsToStderr: vi.fn() }));
+vi.mock("../banner.js", () => ({ emitCliBanner: vi.fn() }));
+vi.mock("../cli-name.js", () => ({ resolveCliName: () => "openclaw" }));
+vi.mock("./config-guard.js", () => ({ ensureConfigReady: mocks.ensureConfigReady }));
+vi.mock("../plugin-registry.js", () => ({ ensurePluginRegistryLoaded: vi.fn() }));
+
+const originalArgv = [...process.argv];
+const originalTitle = process.title;
+
+function createProgram(): Command {
+  const program = new Command().name("openclaw").enablePositionalOptions();
+  const models = program.command("models").option("--agent <id>");
+  const auth = models.command("auth").option("--agent <id>");
+  auth
+    .command("setup-token")
+    .option("--agent <id>")
+    .action(() => {});
+  return program;
+}
+
+describe("preaction migration agent owner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.title = originalTitle;
+  });
+
+  it.each([
+    ["leaf", ["models", "auth", "setup-token", "--agent", "main"], "main"],
+    ["parent", ["models", "auth", "--agent", "main", "setup-token"], "main"],
+    ["grandparent", ["models", "--agent", "main", "auth", "setup-token"], "main"],
+    [
+      "leaf over parent",
+      ["models", "auth", "--agent", "main", "setup-token", "--agent", "work"],
+      "work",
+    ],
+    ["omitted", ["models", "auth", "setup-token"], undefined],
+    ["unknown", ["models", "auth", "setup-token", "--agent", "missing"], undefined],
+    ["invalid", ["models", "auth", "setup-token", "--agent", "main!"], undefined],
+  ])(
+    "retains only a valid explicit owner from the %s placement",
+    async (_label, argv, expected) => {
+      const config = {
+        agents: { ownership: "explicit", entries: { main: {}, work: {} } },
+      } satisfies OpenClawConfig;
+      mocks.ensureConfigReady.mockImplementationOnce(async (options) => {
+        await options.beforeStateMigrations?.(createDoctorConfigSnapshot({ config }));
+      });
+      const program = createProgram();
+      const { registerPreActionHooks } = await import("./preaction.js");
+      registerPreActionHooks(program, "test");
+      process.argv = ["node", "openclaw", ...argv];
+
+      await program.parseAsync(process.argv);
+
+      expect(tryResolveLegacyCompatibilityAgentId(config)).toBe(expected);
+    },
+  );
+});

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -158,6 +158,7 @@ describe("registerPreActionHooks", () => {
       .command("agent")
       .argument("[note]")
       .requiredOption("-m, --message <text>")
+      .option("--agent <id>")
       .option("--local")
       .option("--json")
       .action(() => {});
@@ -505,7 +506,7 @@ describe("registerPreActionHooks", () => {
   it("bypasses operator config and plugin startup for agent exec", async () => {
     await runPreAction({
       parseArgv: ["agent", "exec", "fix it"],
-      processArgv: ["node", "openclaw", "agent", "exec", "fix it"],
+      processArgv: ["node", "openclaw", "agent", "--agent", "main", "exec", "fix it"],
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -12,6 +12,7 @@ import {
   ensureCliExecutionBootstrap,
   resolveCliExecutionStartupContext,
 } from "../command-execution-startup.js";
+import { inheritOptionFromParent } from "../command-options.js";
 import { applyResolvedCommandOutputMode } from "../json-output-mode.js";
 import {
   resolvePluginInstallInvalidConfigPolicy,
@@ -55,6 +56,17 @@ function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
   }
   const logLevel = actionCommand.optsWithGlobals<{ logLevel?: unknown }>().logLevel;
   return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
+}
+
+function getStateMigrationAgentId(actionCommand: Command): string | undefined {
+  if (!actionCommand.options.some((option) => option.attributeName() === "agent")) {
+    return undefined;
+  }
+  const value =
+    actionCommand.getOptionValueSource("agent") === "cli"
+      ? actionCommand.getOptionValue("agent")
+      : inheritOptionFromParent(actionCommand, "agent", "cli");
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function isBareParentDefaultHelpInvocation(actionCommand: Command, argv: string[]): boolean {
@@ -182,6 +194,27 @@ export function registerPreActionHooks(program: Command, programVersion: string)
           ...(snapshot ? { snapshot } : {}),
         });
     }
+    const stateMigrationAgentId = getStateMigrationAgentId(actionCommand);
+    if (stateMigrationAgentId) {
+      const existingGuard = beforeStateMigrations;
+      beforeStateMigrations = async (snapshot) => {
+        if (snapshot) {
+          const { isValidAgentId, normalizeAgentId } =
+            await import("@openclaw/normalization-core/agent-id");
+          if (isValidAgentId(stateMigrationAgentId)) {
+            const [{ listAgentIds }, { retainLegacyDefaultAgentId }] = await Promise.all([
+              import("../../agents/agent-scope-config.js"),
+              import("../../config/legacy.default-agent-owner.js"),
+            ]);
+            const agentId = normalizeAgentId(stateMigrationAgentId);
+            if (listAgentIds(snapshot.sourceConfig).includes(agentId)) {
+              retainLegacyDefaultAgentId(snapshot.sourceConfig, agentId);
+            }
+          }
+        }
+        return (await existingGuard?.(snapshot)) ?? true;
+      };
+    }
     await ensureCliExecutionBootstrap({
       runtime: defaultRuntime,
       commandPath,
@@ -191,7 +224,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
       ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
     });
-    if (beforeStateMigrations) {
+    if (beforeStateMigrations && isGatewayRunAction(actionCommand)) {
       const { reloadTrustedGatewayRunEnvironment } =
         await import("../gateway-cli/pre-bootstrap.js");
       await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators selecting an agent with `--agent` could still have legacy startup state migration deferred in multi-agent configurations. The CLI action knew the explicit owner, but startup migration received only the command path, so the owner was lost before migration ran and legacy state could remain unmigrated.

## Why This Change Was Made

Commander pre-action now carries the applicable parsed `--agent` selection into the existing migration guard. It reads agent semantics only from leaves that declare the option, accepts inherited parent or grandparent values only when Commander marks them as explicit CLI input, normalizes and validates the id against the loaded roster, and retains it for that in-process migration pass.

This does not add an argv parser, write config, force migration, change schemas or public APIs, add runtime fallback behavior, or change `agent exec`. AI-assisted implementation and review were used; no transcript is included.

## User Impact

Operators can place `--agent <id>` on an applicable leaf, parent, or grandparent command and have legacy state migrate under that selected owner instead of being falsely deferred. Omitted, invalid, and unknown owners remain non-authoritative, and isolated `agent exec` behavior is unchanged.

## Evidence

- Pre-fix process/parser reproduction: applicable leaf and parent forms emitted the deferred legacy-agent/session migration result and left the legacy state in place.
- Post-fix parser/owner coverage includes leaf, parent, grandparent, leaf precedence, omitted, unknown, invalid, and `agent exec` exclusion cases.
- `pnpm test src/cli/command-options.test.ts src/cli/program/preaction.test.ts src/cli/program/preaction-agent-owner.test.ts` — 82/82 tests passed across two Vitest shards after rebasing onto current `main`.
- `pnpm check:changed` — passed all selected core and core-test formatting, type, lint, architecture, database-first, and guard lanes.
- Full `pnpm build` passed before rebase; the public CLI wrapper also rebuilt the rebased dirty tree successfully during isolated CLI verification.
- Fresh P1 autoreview reported no accepted or actionable findings (correctness 0.90).
- `git diff --check` — clean.
- Direct Codex CLI contract inspection at `92cbfb4d2431`: `codex-rs/cli/src/main.rs:128`, `codex-rs/cli/src/main.rs:1034`, `codex-rs/exec/src/cli.rs:9`, and `codex-rs/utils/cli/src/shared_options.rs:10` show `exec` owns model/profile/cwd-style controls, not an OpenClaw roster-agent selector.
- Production LOC: +39/-2 (net +37). Tests: +96/-1. Production growth establishes the missing ownership handoff plus CLI-source and roster validation; it does not add a second migration path.

Proof gap: no live operator state was mutated. OpenClaw has no public command that creates the retired legacy agent/session fixture, so post-rebase proof uses the prior isolated process reproduction plus focused parser/owner regression coverage rather than describing a synthetic fixture as live validation.
