### PR TITLE
fix(voice-call): preserve caller ownership context

### DIFF
--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -41,6 +41,7 @@ type EmbeddedAgentArgs = {
   agentId?: string;
   workspaceDir?: string;
   sessionFile?: string;
+  senderIsOwner?: boolean;
   toolsAllow?: string[];
   blockReplyBreak?: "text_end" | "message_end";
   onBlockReply?: (
@@ -196,6 +197,7 @@ async function runGenerateVoiceResponse(
     runtime?: OpenClawPluginApi["runtime"]["agent"];
     transcript?: Array<{ speaker: "user" | "bot"; text: string }>;
     onEarlyText?: (text: string) => Promise<boolean>;
+    senderIsOwner?: boolean;
   },
 ) {
   const voiceConfig = VoiceCallConfigSchema.parse({
@@ -210,6 +212,7 @@ async function runGenerateVoiceResponse(
     agentRuntime: runtime,
     callId: "call-123",
     from: "+15550001111",
+    senderIsOwner: overrides?.senderIsOwner,
     transcript: overrides?.transcript ?? [{ speaker: "user", text: "hello there" }],
     userMessage: "hello there",
     onEarlyText: overrides?.onEarlyText,
@@ -219,6 +222,22 @@ async function runGenerateVoiceResponse(
 }
 
 describe("generateVoiceResponse", () => {
+  it("marks classic inbound callers as non-owners", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+
+    await runGenerateVoiceResponse([], { runtime, senderIsOwner: false });
+
+    expect(requireEmbeddedAgentArgs(runEmbeddedAgent).senderIsOwner).toBe(false);
+  });
+
+  it("preserves delegated authority for outbound conversations", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+
+    await runGenerateVoiceResponse([], { runtime });
+
+    expect(requireEmbeddedAgentArgs(runEmbeddedAgent).senderIsOwner).toBeUndefined();
+  });
+
   it("suppresses reasoning payloads and reads structured spoken output", async () => {
     const { runtime, runEmbeddedAgent, runWithWorkAdmission } = createAgentRuntime([
       { text: "Reasoning: hidden", isReasoning: true },
@@ -536,6 +555,7 @@ describe("generateVoiceResponse", () => {
       agentRuntime: runtime,
       callId: "call-123",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [{ speaker: "user", text: "hello there" }],
       userMessage: "hello there",
     });
@@ -585,6 +605,7 @@ describe("generateVoiceResponse", () => {
       agentRuntime: runtime,
       callId: "call-123",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [{ speaker: "user", text: "hello there" }],
       userMessage: "hello there",
     });
@@ -632,6 +653,7 @@ describe("generateVoiceResponse", () => {
       callId: "call-123",
       sessionKey,
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [{ speaker: "user", text: "continue" }],
       userMessage: "continue",
     });
@@ -663,6 +685,7 @@ describe("generateVoiceResponse", () => {
       callId: "call-123",
       sessionKey: "voice:call:call-123",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [{ speaker: "user", text: "hello there" }],
       userMessage: "hello there",
     });
@@ -693,6 +716,7 @@ describe("generateVoiceResponse", () => {
       callId: "call-123",
       sessionKey: "meet-room-1",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [],
       userMessage: "hello there",
     });
@@ -719,6 +743,7 @@ describe("generateVoiceResponse", () => {
         callId: "call-123",
         sessionKey,
         from: "+15550001111",
+        senderIsOwner: undefined,
         transcript: [],
         userMessage: "hello there",
       });
@@ -756,6 +781,7 @@ describe("generateVoiceResponse", () => {
       callId: "call-123",
       sessionKey: "agent:voice:main",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [],
       userMessage: "hello there",
     });
@@ -782,6 +808,7 @@ describe("generateVoiceResponse", () => {
       agentRuntime: runtime,
       callId: "call-123",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [],
       userMessage: "hello there",
     });
@@ -830,6 +857,7 @@ describe("generateVoiceResponse", () => {
       agentRuntime: runtime,
       callId: "call-123",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [],
       userMessage: "hello there",
     });
@@ -871,6 +899,7 @@ describe("generateVoiceResponse", () => {
       agentId: "support",
       sessionKey: "agent:support:google-meet:meet-1",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [],
       userMessage: "hello there",
     });
@@ -906,6 +935,7 @@ describe("generateVoiceResponse", () => {
       agentRuntime: runtime,
       callId: "call-123",
       from: "+15550001111",
+      senderIsOwner: undefined,
       transcript: [],
       userMessage: "hello there",
     });

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -36,6 +36,8 @@ type VoiceResponseParams = {
   sessionKey?: string;
   /** Caller's phone number */
   from: string;
+  /** Caller ownership prepared by the call boundary. */
+  senderIsOwner: boolean | undefined;
   /** Agent frozen on the call record. */
   agentId?: string;
   /** Conversation transcript */
@@ -245,6 +247,7 @@ export async function generateVoiceResponse(
     callId,
     sessionKey,
     from,
+    senderIsOwner,
     transcript,
     userMessage,
     coreConfig,
@@ -407,6 +410,7 @@ export async function generateVoiceResponse(
           lane: "voice",
           extraSystemPrompt,
           agentDir,
+          senderIsOwner,
           toolsAllow,
           abortSignal,
           blockReplyBreak: "text_end",

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -2234,16 +2234,20 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     const params = requireFirstMockCall(
       mocks.generateVoiceResponse.mock.calls,
       "classic voice response",
-    )[0] as { agentId?: string; voiceConfig?: VoiceCallConfig } | undefined;
+    )[0] as
+      | { agentId?: string; senderIsOwner?: boolean; voiceConfig?: VoiceCallConfig }
+      | undefined;
     expect(params?.voiceConfig?.agentId).toBe("top");
     expect(params?.agentId).toBe("support");
+    expect(params).toHaveProperty("senderIsOwner", undefined);
     expect(speak).toHaveBeenCalledWith(call.callId, "Hello back", {
       listenAfterPlayback: true,
     });
   });
 
-  it("does not replay a completed response after early playback", async () => {
+  it("marks inbound calls as non-owners and does not replay an early response", async () => {
     const call = createCall(Date.now());
+    call.direction = "inbound";
     const speak = vi.fn(async () => ({ success: true }));
     const manager = {
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
@@ -2274,6 +2278,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     expect(speak.mock.calls).toEqual([
       [call.callId, "Spoken before compaction. Final detail.", { listenAfterPlayback: true }],
     ]);
+    expect(mocks.generateVoiceResponse.mock.calls[0]?.[0]).toHaveProperty("senderIsOwner", false);
   });
 
   it("logs only char counts for inbound user text, early AI text, and final AI text", async () => {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -1058,6 +1058,7 @@ export class VoiceCallWebhookServer {
         callId,
         sessionKey: call.sessionKey,
         from: call.from,
+        senderIsOwner: call.direction === "inbound" ? false : undefined,
         agentId: resolveCallAgentId(call, effectiveConfig),
         transcript: call.transcript,
         userMessage,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where accepted classic inbound voice callers could reach the configured agent without an explicit non-owner identity, leaving owner-only control-plane tools available to that call.

## Why This Change Was Made

The voice-call webhook now prepares caller ownership from the stored call direction and requires the response generator to carry that decision to the embedded-agent boundary. Inbound calls are explicit non-owners; operator-initiated outbound conversations retain their existing delegated authority.

## User Impact

Classic inbound voice callers continue to use the agent's normal configured tools but can no longer access tools reserved for an owner. Existing outbound conversation workflows are unchanged.

## Evidence

- Pre-fix focused regression failed because the embedded-agent invocation received `undefined` instead of `false` for an inbound caller.
- `node scripts/run-vitest.mjs extensions/voice-call/src/response-generator.test.ts extensions/voice-call/src/webhook.test.ts` — 87 tests passed.
- `node scripts/check-changed.mjs -- extensions/voice-call/src/response-generator.ts extensions/voice-call/src/webhook.ts extensions/voice-call/src/response-generator.test.ts extensions/voice-call/src/webhook.test.ts` — passed.
- Local autoreview completed with no accepted or actionable findings.
