### PR TITLE
fix(build): rebuild incomplete managed-update cache hits

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -234,7 +234,8 @@ describe("qa scenario catalog channel contracts", () => {
     expect(flow).toContain("env.gateway.call('tasks.list'");
     expect(flow).toContain("task.title === `qa-terminal-${caseName}`");
     expect(flow).toContain("terminalTask.status === 'completed'");
-    expect(flow).toContain("emptyTask.status === 'failed'");
+    expect(flow).toContain("emptyTask.status === 'completed'");
+    expect(flow).toContain("emptyTask.terminalOutcome === 'blocked'");
     expect(flow).toContain("task.deliveryStatus === 'delivered'");
     expect(flow).toContain("readSettledTerminalTask('restart')");
     expect(flow).toContain("readSettledTerminalTask('empty')");

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -23,7 +23,7 @@ scenario:
   successCriteria:
     - Visible completion output reaches the originating QA DM exactly once.
     - Exact worker NO_REPLY stays private while required parent completion represents missing child output visibly exactly once.
-    - Empty output after a side effect remains a failed execution while its terminal representation is delivered exactly once.
+    - Empty output after a side effect settles as a blocked completion while its terminal representation is delivered exactly once.
     - Gateway restart does not replay prior terminal payloads or synthesize interruption notices for already-settled handoffs, and a post-restart completion is delivered exactly once.
     - Direct fallback strips protected internal metadata before one channel delivery.
   docsRefs:
@@ -265,8 +265,8 @@ flow:
               ref: emptyConversationId
             senderName: QA Empty Reply Operator
             text: "Subagent terminal reply QA check: empty. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
-        # Empty output after one side effect is an incomplete turn, but its
-        # failed execution still owns one visible terminal representation.
+        # Subagent lifecycle owns empty completion classification, while its
+        # blocked completion still owns one visible terminal representation.
         - call: waitForCondition
           saveAs: emptyTask
           args:
@@ -297,7 +297,7 @@ flow:
             message:
               expr: "`empty completion did not exercise native spawn/direct-fallback: ${JSON.stringify(emptyRequests)}`"
         - assert:
-            expr: "emptyTask.title === 'qa-terminal-empty' && emptyTask.status === 'failed' && emptyTask.deliveryStatus === 'delivered' && emptyTask.toolUseCount === 1 && emptyTask.lastToolName === 'write'"
+            expr: "emptyTask.title === 'qa-terminal-empty' && emptyTask.status === 'completed' && emptyTask.terminalOutcome === 'blocked' && emptyTask.deliveryStatus === 'delivered' && emptyTask.toolUseCount === 1 && emptyTask.lastToolName === 'write'"
             message:
               expr: "`empty completion execution and delivery did not settle independently; task=${JSON.stringify(emptyTask)}`"
         - set: appendEmptyVerdict

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -11,6 +11,7 @@ import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import prettyMilliseconds from "pretty-ms";
 import { resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
 import {
+  listPluginSdkDistArtifacts,
   listPluginSdkDeclarationOutputs,
   pluginSdkEntrypoints,
 } from "./lib/plugin-sdk-entries.mts";
@@ -38,6 +39,7 @@ type BuildCache = {
   inputs: BuildCacheEntry[];
   outputs: BuildCacheEntry[];
   requiredOutputs?: string[] | ((env: NodeJS.ProcessEnv) => string[]);
+  requiredCacheHitOutputs?: string[];
   restore?: "always";
   runOnHit?: { env?: NodeJS.ProcessEnv; finalize?: "refresh" };
 };
@@ -229,6 +231,9 @@ export const BUILD_ALL_STEPS: BuildAllStep[] = [
         env.OPENCLAW_BUILD_PRIVATE_QA === "1"
           ? listPluginSdkDeclarationOutputs(pluginSdkEntrypoints)
           : listPluginSdkDeclarationOutputs(),
+      // Shared declaration snapshots cannot make a replaced live dist complete.
+      // Rebuild the unified unit when its package artifacts are no longer intact.
+      requiredCacheHitOutputs: listPluginSdkDistArtifacts(),
       restore: "always",
       runOnHit: {
         env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
@@ -763,11 +768,13 @@ export function resolveBuildAllStepCacheState(
     stampedOutputs.length > 0 && hasAllFiles(rootDir, stampedOutputs, fsImpl);
   const cachedOutputsPresent =
     stampedOutputs.length > 0 && hasAllFiles(outputRoot, stampedOutputs, fsImpl);
+  const cacheHitContractMatches =
+    stampMatches && hasAllFiles(rootDir, step.cache.requiredCacheHitOutputs ?? [], fsImpl);
   const alwaysRestore = step.cache.restore === "always";
   const actualOutputsAcceptable = actualOutputsPresent && !alwaysRestore;
   const restorable =
-    stampMatches && cachedOutputsPresent && (alwaysRestore || !actualOutputsPresent);
-  const fresh = stampMatches && (actualOutputsAcceptable || cachedOutputsPresent);
+    cacheHitContractMatches && cachedOutputsPresent && (alwaysRestore || !actualOutputsPresent);
+  const fresh = cacheHitContractMatches && (actualOutputsAcceptable || cachedOutputsPresent);
   return {
     cacheable: true,
     fresh,

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -23,6 +23,7 @@ import {
   writeBuildAllStepCacheStamp,
 } from "../../scripts/build-all.mts";
 import {
+  listPluginSdkDistArtifacts,
   listPluginSdkDeclarationOutputs,
   pluginSdkEntrypoints,
 } from "../../scripts/lib/plugin-sdk-entries.mts";
@@ -62,6 +63,7 @@ function withBuildCacheFixture(
             }
         >;
         requiredOutputs?: string[] | ((env: NodeJS.ProcessEnv) => string[]);
+        requiredCacheHitOutputs?: string[];
         restore?: "always";
         runOnHit?: {
           env?: NodeJS.ProcessEnv;
@@ -431,6 +433,7 @@ describe("resolveBuildAllSteps", () => {
     expect(productionOutputs).toContain("dist/plugin-sdk/provider-auth-runtime.d.ts");
     expect(productionOutputs).not.toContain("dist/plugin-sdk/test-fixtures.d.ts");
     expect(privateQaOutputs).toContain("dist/plugin-sdk/test-fixtures.d.ts");
+    expect(unified.cache?.requiredCacheHitOutputs).toEqual(listPluginSdkDistArtifacts());
   });
 
   it("uses a runtime artifact plus plugin SDK export profile for ci artifacts", () => {
@@ -979,6 +982,36 @@ describe("resolveBuildAllStepCacheState", () => {
         stampedOutputs: ["dist/output.js"],
       });
       expect(restoreBuildAllStepCacheOutputs(stale, { rootDir })).toBe(false);
+    });
+  });
+
+  it("rejects a cache hit when a required live output was removed", () => {
+    withBuildCacheFixture(({ rootDir, outputPath, step }) => {
+      const declarationPath = path.join(rootDir, "dist/output.d.ts");
+      fs.writeFileSync(declarationPath, "export declare const output: true;");
+      const guardedStep = {
+        ...step,
+        cache: {
+          ...step.cache,
+          outputs: [{ path: "dist", extensions: [".d.ts"] }],
+          requiredCacheHitOutputs: ["dist/output.js"],
+          restore: "always" as const,
+        },
+      };
+      const cacheState = resolveBuildAllStepCacheState(guardedStep, { rootDir });
+      writeBuildAllStepCacheStamp(guardedStep, cacheState, { rootDir });
+
+      expect(resolveBuildAllStepCacheState(guardedStep, { rootDir })).toMatchObject({
+        fresh: true,
+        restorable: true,
+      });
+      fs.rmSync(outputPath);
+
+      expect(resolveBuildAllStepCacheState(guardedStep, { rootDir })).toMatchObject({
+        fresh: false,
+        reason: "stale",
+        restorable: false,
+      });
     });
   });
 


### PR DESCRIPTION
Closes #125952

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled through the same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where managed dev-channel source updates could fail both activation and rollback when a matching declaration cache was reused after the live Plugin SDK output tree had been replaced or cleaned.

On 2026-08-18, Team attempted to update from exact `0684f501`. The target build failed after 39.6 seconds with 146 missing public Plugin SDK JS subpaths. Rollback to exact `0684f501` reused the cache again and failed with 293 missing JS/DTS dependencies. The restart sentinel recorded `build-failed`, Team stayed on `0684f501`, and the pending ingress repair could not deploy until the preserved release restored service health.

## Why This Change Was Made

The build-cache owner now includes the existing canonical Plugin SDK package artifact manifest in the unified cache-hit contract. A healthy live output tree keeps the fast declaration reuse path; a moved, cleaned, or outdated tree makes that unit stale and runs the existing full unified build.

This is the narrow owner-boundary repair. It adds no updater retry, fallback build, timeout increase, downstream artifact workaround, or second build path.

The final current-main merge result also exposed a stale QA assertion after main made empty subagent replies lifecycle-owned. The test-only follow-up now asserts the authoritative independent facts observed in CI: completed with a blocked terminal outcome, delivered representation, and one write side effect. It changes no runtime behavior.

## User Impact

Managed source updates and rollback recovery no longer trust a declaration snapshot when the live runtime/package outputs needed by that build unit are incomplete. Healthy cache hits remain unchanged and fast.

No runtime product, configuration, dependency, protocol, or storage contract changes.

AI-assisted: yes. The cache owner, tsdown cleanup/configuration, Plugin SDK manifest/export gate, updater preflight/live/rollback calls, dependency source, related history, and the current-main QA lifecycle contract were inspected. Fresh Codex autoreview reported no actionable findings.

## Evidence

Current-main pre-fix reproduction at `2ffbff0547312054fb6f5a47868686165b44ea8e`:

1. Seeded a complete `pnpm build` and shared build cache.
2. Moved `dist/plugin-sdk` while preserving `.artifacts/build-all-cache`.
3. The unified cache still reported `fresh=true`, `restorable=true`, `reason=fresh-cache` with a 1,946-file declaration stamp.
4. Restore produced 0 Plugin SDK JS entrypoints and 312 declaration entrypoints.
5. `check-plugin-sdk-exports` failed with exactly 146 missing public JS subpaths.

Post-fix injected-output proof:

1. Moved the same authoritative output tree while retaining the cache.
2. The unified cache reported `fresh=false`, `restorable=false`, `reason=stale`.
3. The existing unified build regenerated all nine runtime/declaration invocations.
4. The result contained 312 JS and 312 declaration entrypoints; all 146 public subpaths passed the export gate.
5. A subsequent healthy `pnpm build` retained cache hits for AI, package, and unified declaration groups and passed the same export gate.

Current-main QA reconciliation:

- Exact merge-head artifact from superseded run `32219073366` showed `qa-terminal-empty` as `status=completed`, `terminalOutcome=blocked`, `deliveryStatus=delivered`, `toolUseCount=1`, `lastToolName=write` after main commit `baefd067bb2` made subagent-lane terminal replies lifecycle-owned.
- The updated real mock-gateway scenario passes locally with those facts.
- Final exact-head CI run `32222372265` is green, including QA Smoke CI profile 3/6 and the aggregate `openclaw/ci-gate`.

Validation:

- `node scripts/run-vitest.mjs test/scripts/build-all.test.ts test/scripts/tsdown-build.test.ts extensions/qa-lab/src/scenario-catalog-channels.test.ts` — 110 tooling tests and 16 QA contract tests passed.
- `node scripts/run-vitest.mjs src/infra/update-runner.test.ts -t "shares the build cache|rebuilds and verifies the original runtime"` — 2 tests passed.
- `node --import tsx scripts/check-plugin-sdk-exports.mts` — all 146 public subpaths verified.
- `openclaw qa run --qa-profile smoke-ci --scenario subagent-completion-direct-fallback` through the private QA wrapper — passed on current main.
- `pnpm build` — passed; all nine unified declaration builds and the Plugin SDK export gate completed.
- `node scripts/check-changed.mjs -- scripts/build-all.mts test/scripts/build-all.test.ts extensions/qa-lab/src/scenario-catalog-channels.test.ts qa/scenarios/agents/subagent-completion-direct-fallback.yaml` — passed all selected repository gates.
- `git diff --check` — passed.
- Fresh Codex autoreview of the full two-commit branch — clean, no accepted/actionable findings.

Production tooling LOC: +9/-2 (net +7). Tests and QA test support: +39/-5 (net +34).

The small production growth is the cache ownership invariant: one optional required-live-output manifest plus one hit-predicate check, using the existing `listPluginSdkDistArtifacts()` source of truth. Related cache work #117246, #120961, and #122837 remains intact.
