### PR TITLE
fix: resume turns settled during gateway restart drain

### DIFF
--- a/src/agents/main-session-recovery/main-session-recovery-lifecycle.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-lifecycle.ts
@@ -195,6 +195,15 @@ export function projectMainSessionRecoveryLifecycle(params: {
       lifecycleGeneration,
       params.currentLifecycleGeneration,
     );
+    if (
+      params.entry?.abortedLastRun === true &&
+      !foreground.claimId &&
+      !foreground.hasCurrentOwner
+    ) {
+      // The restart marker won the session transaction before this normal terminal.
+      // Retire the old fence, but only a fresh owner may settle the handoff itself.
+      return apply({ restartRecoveryRuns: remaining?.length ? remaining : undefined });
+    }
     if (foreground.hasCurrentOwner) {
       // A terminal event may consume its own claim. Another owner still keeps
       // the aggregate live until that owner's terminal event or release.
@@ -212,9 +221,6 @@ export function projectMainSessionRecoveryLifecycle(params: {
       // active. Its terminal snapshot is authoritative and consumes the cycle.
       Object.assign(patch, buildMainSessionRecoveryClearPatch(params.entry));
       return apply(patch);
-    }
-    if (params.entry?.abortedLastRun === true && (remaining?.length ?? 0) > 0) {
-      return apply({ restartRecoveryRuns: remaining });
     }
     const recoveryDeliveryRunId =
       typeof params.entry?.restartRecoveryDeliveryRunId === "string"

--- a/src/agents/main-session-recovery/main-session-recovery-run-ownership.test.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-run-ownership.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import { projectMainSessionRecoveryLifecycle } from "./main-session-recovery-lifecycle.js";
+import { transitionMainSessionRecovery } from "./main-session-recovery-state.js";
 
 function recoveryEntry(params?: {
   hasCurrentOwner?: boolean;
@@ -33,6 +34,56 @@ function recoveryEntry(params?: {
 }
 
 describe("main-session recovery run ownership", () => {
+  it("transfers process-owned recovery leases to a restart marker", () => {
+    const entry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 100,
+      status: "running",
+      abortedLastRun: true,
+      restartRecoveryRuns: [{ runId: "drain-run", lifecycleGeneration: "generation-current" }],
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 4,
+        chargedAttempts: 2,
+        reservation: {
+          runId: "reserved-run",
+          attempt: 2,
+          lifecycleGeneration: "generation-current",
+        },
+        foregroundClaims: {
+          lifecycleGeneration: "generation-current",
+          tokens: ["foreground-1"],
+          runIdsByClaimId: { "foreground-1": "drain-run" },
+        },
+      },
+    };
+
+    transitionMainSessionRecovery(entry, {
+      kind: "mark_interrupted",
+      cycleId: "unused-cycle",
+      now: 200,
+      runs: [{ runId: "drain-run", lifecycleGeneration: "generation-current" }],
+    });
+
+    expect(entry.mainRestartRecovery).toEqual({
+      cycleId: "cycle-1",
+      revision: 5,
+      chargedAttempts: 2,
+    });
+    expect(
+      projectMainSessionRecoveryLifecycle({
+        currentLifecycleGeneration: "generation-current",
+        entry,
+        event: {
+          runId: "drain-run",
+          lifecycleGeneration: "generation-current",
+          data: { phase: "end" },
+        },
+        snapshotPatch: { status: "done", abortedLastRun: false },
+      }),
+    ).toEqual({ action: "apply", patch: { restartRecoveryRuns: undefined } });
+  });
+
   it("settles a resumed run once when older generations retain the same run id", () => {
     expect(
       projectMainSessionRecoveryLifecycle({

--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -294,8 +294,16 @@ export function transitionMainSessionRecovery(
 ): MainSessionRecoveryTransitionResult {
   switch (command.kind) {
     case "mark_interrupted": {
-      if (!entry.mainRestartRecovery) {
+      const state = entry.mainRestartRecovery;
+      if (!state) {
         entry.mainRestartRecovery = createCycle(command.cycleId);
+      } else if (state.foregroundClaims || state.reservation) {
+        // Restart owns continuation now. Process-bound foreground and reservation
+        // leases cannot authorize the old lifecycle after this durable handoff.
+        updateRecoveryState(entry, state, {
+          foregroundClaims: undefined,
+          reservation: undefined,
+        });
       }
       entry.status = "running";
       entry.lifecycleRunId = undefined;

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -23,6 +23,7 @@ import {
 import { resolveAgentRestartRecoveryExecutionIdentityAdmission } from "../../gateway/agent-turn/agent-restart-recovery-context.js";
 import { callGateway } from "../../gateway/call.js";
 import type { GatewayRecoveryRuntime } from "../../gateway/server-instance-runtime.types.js";
+import { persistGatewaySessionLifecycleEvent } from "../../gateway/session-lifecycle-state.js";
 import * as gatewaySessionUtils from "../../gateway/session-utils.js";
 import {
   getAgentEventLifecycleGeneration,
@@ -41,9 +42,13 @@ import { addTestHook } from "../../plugins/hooks.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
+  GatewayDrainingError,
   getActiveGatewayRootWorkCount,
+  markGatewayRestartDraining,
   resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
+  tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import {
   interruptSessionWorkAdmissions,
@@ -57,6 +62,7 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { deliverAgentCommandResult } from "../command/delivery.js";
 import { setActiveEmbeddedRunLifecycleGeneration } from "../embedded-agent-runner/run-state.js";
 import {
@@ -1039,6 +1045,89 @@ describe("main-session-restart-recovery", () => {
               ?.source === "segment",
         ),
     ).toHaveLength(2);
+  });
+
+  it("resumes a drain-marked turn that settles normally before the replacement starts", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const runId = "drain-overlap-run";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    await writeStore(sessionsDir, {
+      [sessionKey]: runningSessionEntry("main-session"),
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "finish the admitted work after the restart" },
+    ]);
+
+    const rootAdmission = tryBeginGatewayRootWorkAdmission();
+    expect(rootAdmission).not.toBeNull();
+    await rootAdmission?.run(async () => {
+      await expect(
+        markRestartAbortedMainSessions({
+          stateDir: tmpDir,
+          sessionKeys: [sessionKey],
+          sessionIds: ["main-session"],
+          activeRuns: [{ runId, lifecycleGeneration, sessionKey, sessionId: "main-session" }],
+          reason: "gateway restart drain",
+        }),
+      ).resolves.toEqual({ marked: 1, skipped: 0 });
+      markGatewayRestartDraining();
+      await expect(
+        runWithGatewayIndependentRootWorkAdmission(async () => undefined),
+      ).rejects.toBeInstanceOf(GatewayDrainingError);
+      await writeTranscript(sessionsDir, "main-session", [
+        {
+          role: "toolResult",
+          toolName: "sessions_spawn",
+          isError: true,
+          content: [{ type: "text", text: "Gateway restart admission is closed." }],
+        },
+        makeAssistantTextMessage("The Gateway is restarting; retry after it comes back."),
+      ]);
+      await withEnvAsync({ OPENCLAW_STATE_DIR: tmpDir }, async () => {
+        await persistGatewaySessionLifecycleEvent({
+          sessionKey,
+          agentId: "main",
+          event: {
+            ts: Date.now(),
+            sessionId: "main-session",
+            runId,
+            lifecycleGeneration,
+            data: { phase: "end", stopReason: "stop" },
+          },
+        });
+      });
+    });
+    rootAdmission?.release();
+
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      status: "running",
+      abortedLastRun: true,
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })?.restartRecoveryRuns).toBeUndefined();
+
+    resetGatewayWorkAdmission();
+    rotateAgentEventLifecycleGeneration();
+    const recovery = scheduleRestartAbortedMainSessionRecovery({
+      delayMs: 0,
+      getConfig: () => ({}),
+      maxRetries: 1,
+      stateDir: tmpDir,
+    });
+    await waitForFast(() => expect(callGateway).toHaveBeenCalledOnce());
+    await recovery.stop();
+
+    expect(gatewayParams()).toMatchObject({
+      expectedExistingSessionId: "main-session",
+      inputProvenance: {
+        kind: "internal_system",
+        sourceSessionKey: sessionKey,
+        sourceTool: "main_session_restart_recovery",
+      },
+      sessionKey,
+    });
+    expect(gatewayParams().idempotencyKey).not.toBe(runId);
   });
 
   it.each([

--- a/src/config/sessions/session-snapshot-merge.test.ts
+++ b/src/config/sessions/session-snapshot-merge.test.ts
@@ -402,7 +402,7 @@ describe("session snapshot merge", () => {
     expect(merged.mainRestartRecovery).toEqual(current.mainRestartRecovery);
   });
 
-  it("marks a claimed recovery healthy without erasing its owner aggregate", () => {
+  it("keeps a claimed recovery interrupted until its lifecycle owner settles", () => {
     const initialRecovery: SessionEntry = {
       ...initial,
       abortedLastRun: true,
@@ -433,7 +433,7 @@ describe("session snapshot merge", () => {
 
     const merged = mergeSessionSnapshotChanges({ initial: initialRecovery, next, current });
 
-    expect(merged.abortedLastRun).toBe(false);
+    expect(merged.abortedLastRun).toBe(true);
     expect(merged.restartRecoveryRuns).toBeUndefined();
     expect(merged.mainRestartRecovery).toEqual(current.mainRestartRecovery);
   });
@@ -473,7 +473,7 @@ describe("session snapshot merge", () => {
     expect(merged.mainRestartRecovery).toBeUndefined();
   });
 
-  it("preserves every concurrent owner while marking a recovered session healthy", () => {
+  it("preserves every concurrent owner and interruption until lifecycle settlement", () => {
     const initialRecovery: SessionEntry = {
       ...initial,
       abortedLastRun: true,
@@ -504,7 +504,7 @@ describe("session snapshot merge", () => {
 
     const merged = mergeSessionSnapshotChanges({ initial: initialRecovery, next, current });
 
-    expect(merged.abortedLastRun).toBe(false);
+    expect(merged.abortedLastRun).toBe(true);
     expect(merged.mainRestartRecovery?.foregroundClaims?.tokens).toEqual(["owner-1", "owner-2"]);
   });
 

--- a/src/config/sessions/session-snapshot-merge.ts
+++ b/src/config/sessions/session-snapshot-merge.ts
@@ -225,20 +225,13 @@ export function projectSessionSnapshotChanges(params: {
     restartRecoveryRunsOnlyConsumed(params.initial, params.current);
   if (
     mainRecoveryChanged &&
+    !mainRecoveryOwnershipChangedConcurrently &&
     (!mainRecoveryChangedConcurrently || currentOnlyConsumedLifecycleFences)
   ) {
-    // Apply all three fields together: a stale healthy flag can otherwise hide a newer marker.
-    // A healthy run first marks its claim non-interrupted; token-scoped release
-    // removes the aggregate only after the final concurrent owner exits.
-    if (
-      mainRecoveryOwnershipChangedConcurrently &&
-      isCanonicalMainSessionRecoveryClear(params.next)
-    ) {
-      patch.abortedLastRun = false;
-    } else if (!mainRecoveryOwnershipChangedConcurrently) {
-      for (const field of MAIN_SESSION_RECOVERY_TRANSACTION_FIELDS) {
-        patchRecord[field] = Object.hasOwn(params.next, field) ? next[field] : undefined;
-      }
+    // Apply all three fields together. Concurrent ownership changes settle through
+    // their lifecycle/release owner, never through an older run-local snapshot.
+    for (const field of MAIN_SESSION_RECOVERY_TRANSACTION_FIELDS) {
+      patchRecord[field] = Object.hasOwn(params.next, field) ? next[field] : undefined;
     }
   }
 


### PR DESCRIPTION
Related: #57425

## What Problem This Solves

Fixes an issue where users had to manually resend or type `retry` when an admitted agent turn overlapped a planned Gateway restart. If restart-only tool admission failures caused the old run to emit a normal final response before shutdown, that settlement erased the durable restart marker and the replacement Gateway had nothing to continue.

## Why This Change Was Made

Restart drain now transfers continuation ownership away from process-local claims and reservations. A late terminal event from the old lifecycle can retire only its stale run fence; it cannot clear the restart-owned recovery state, and a stale session snapshot cannot overwrite that ownership transfer. Startup still creates a fresh recovery run and revalidates current authority rather than reviving stale execution claims.

This deliberately keeps the existing at-least-once contract: a turn that completed ambiguously during drain can produce a duplicate response or action after restart, which is preferable to dropping the admitted request. No schema, config, queue, provider, channel, or tool-specific behavior was added.

## User Impact

Planned Gateway restarts no longer turn an unfinished request into a manual `retry` step when the pre-restart model happens to settle normally during drain. The replacement Gateway automatically continues the original session.

## Evidence

- Sanitized live trace reproduced the failure order: admitted turn → restart marker persisted → restart-only task admission rejected → model returned a normal final requesting retry → replacement startup did not dispatch recovery.
- Pre-fix regression: the focused scenario failed because the session became terminal with recovery disabled.
- Post-fix focused proof: 3 Vitest shards, 183 tests passed.
- Complete restart-recovery file: 160/160 tests passed.
- Source-blind behavior validation: focused scenario passed; complete 160-test recovery file passed.
- `node scripts/check-changed.mjs -- <six changed paths>` passed typecheck, lint, formatting, database/schema guards, dead-export checks, and import-cycle checks.
- `git diff --check` passed.
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +23/-16 (net +7). Tests: +144/-4.

AI-assisted: yes. The implementation and tests were independently reviewed and behavior-validated.