### PR TITLE
refactor(providers): remove JSON reader test facades

### DIFF
--- a/extensions/minimax/src/minimax-web-search-provider.runtime.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.runtime.ts
@@ -279,5 +279,4 @@ export const testing = {
   resolveMiniMaxApiKey,
   resolveMiniMaxEndpoint,
   resolveMiniMaxRegion,
-  readMiniMaxSearchJsonResponse: readProviderJsonResponse<MiniMaxSearchResponse>,
 } as const;

--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -9,7 +9,6 @@ const {
   resolveMiniMaxApiKey,
   resolveMiniMaxEndpoint,
   resolveMiniMaxRegion,
-  readMiniMaxSearchJsonResponse,
 } = minimaxWebSearchTesting;
 
 function restoreEnvValue(key: string, value: string | undefined) {
@@ -240,11 +239,5 @@ describe("minimax web search provider", () => {
     it("uses correct CN endpoint", () => {
       expect(MINIMAX_SEARCH_ENDPOINT_CN).toBe("https://api.minimaxi.com/v1/coding_plan/search");
     });
-  });
-
-  it("reports malformed Search API JSON with a stable provider error", async () => {
-    await expect(
-      readMiniMaxSearchJsonResponse(new Response("{ nope"), "MiniMax Search API error"),
-    ).rejects.toThrow("MiniMax Search API error: malformed JSON response");
   });
 });

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -140,10 +140,6 @@ function buildPerplexityRequestHeaders(apiKey: string, acceptJson = false): Reco
   };
 }
 
-async function readPerplexityJsonResponse<T>(response: Response, label: string): Promise<T> {
-  return await readProviderJsonResponse<T>(response, label);
-}
-
 function resolvePerplexityTransport(perplexity?: PerplexityConfig): {
   apiKey?: string;
   source: "config" | "perplexity_env" | "openrouter_env" | "none";
@@ -253,7 +249,7 @@ async function runPerplexitySearchApi(params: {
       if (!res.ok) {
         return await throwWebSearchApiError(res, "Perplexity Search");
       }
-      const data = await readPerplexityJsonResponse<PerplexitySearchApiResponse>(
+      const data = await readProviderJsonResponse<PerplexitySearchApiResponse>(
         res,
         "Perplexity Search",
       );
@@ -301,7 +297,7 @@ async function runPerplexitySearch(params: {
       if (!res.ok) {
         return await throwWebSearchApiError(res, "Perplexity");
       }
-      const data = await readPerplexityJsonResponse<PerplexitySearchResponse>(res, "Perplexity");
+      const data = await readProviderJsonResponse<PerplexitySearchResponse>(res, "Perplexity");
       return {
         content: data.choices?.[0]?.message?.content ?? "No response",
         citations: extractPerplexityCitations(data),
@@ -558,5 +554,4 @@ export const testing = {
   resolvePerplexityTransport,
   resolvePerplexityRequestModel,
   resolvePerplexityApiKey,
-  readPerplexityJsonResponse,
 } as const;

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -1,7 +1,6 @@
 // Perplexity tests cover perplexity web search provider plugin behavior.
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
-import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
 
 const withTrustedWebSearchEndpointMock = vi.hoisted(() => vi.fn());
 
@@ -274,35 +273,5 @@ describe("perplexity web search provider", () => {
         );
       },
     );
-  });
-
-  it("reports malformed Search API JSON with a stable provider error", async () => {
-    await expect(
-      testing.readPerplexityJsonResponse(new Response("{ nope"), "Perplexity Search"),
-    ).rejects.toThrow("Perplexity Search: malformed JSON response");
-  });
-
-  it("reports malformed chat completion JSON with a stable provider error", async () => {
-    await expect(
-      testing.readPerplexityJsonResponse(new Response("{ nope"), "Perplexity"),
-    ).rejects.toThrow("Perplexity: malformed JSON response");
-  });
-
-  it("bounds successful Perplexity JSON bodies before parsing", async () => {
-    const streamed = createStreamingResponse({
-      chunkCount: 32,
-      chunkSize: 1024 * 1024,
-      text: "x",
-      headers: { "content-type": "application/json" },
-    });
-    const jsonSpy = vi.spyOn(streamed.response, "json").mockRejectedValue(new Error("unbounded"));
-
-    await expect(
-      testing.readPerplexityJsonResponse(streamed.response, "Perplexity Search"),
-    ).rejects.toThrow("Perplexity Search: JSON response exceeds 16777216 bytes");
-
-    expect(streamed.getReadCount()).toBeLessThan(32);
-    expect(streamed.wasCanceled()).toBe(true);
-    expect(jsonSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

MiniMax and Perplexity retained provider-local tests that invoked aliases or wrappers around the shared bounded JSON response reader directly. Those tests replayed the shared helper rather than exercising production provider composition, and they preserved test-only runtime seams without detecting a production callsite reverting to `Response.json()`.

## Why This Change Was Made

Remove the provider-local direct-wrapper tests and the test-only exports they required. MiniMax production continues to call `readProviderJsonResponse` directly; both Perplexity Search API and chat-completions paths now call the same canonical helper directly with unchanged response types and labels.

Shared owner coverage remains in `src/agents/provider-http-errors.test.ts` for labeled malformed JSON, valid JSON, byte caps, and invalid UTF-8, and in `src/infra/http-body.response.test.ts` for bounded-read early termination and cancellation. Real provider-boundary transport, cancellation, date-filter, config, registration, and replay-policy tests remain intact.

## User Impact

No user-visible behavior changes. This removes low-value duplicate test coverage and six production lines of provider-local facade surface while preserving the canonical bounded JSON reader at every production callsite.

No docs or changelog update is needed. There is no schema, protocol, config, dependency, lockfile, external API, operator-state, or Gateway behavior change.

## Evidence

- Focused owner suites: `node scripts/run-vitest.mjs extensions/minimax/src/minimax-web-search-provider.test.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts src/agents/provider-http-errors.test.ts src/infra/http-body.response.test.ts extensions/minimax/index.test.ts` — 5 files, 106 tests passed across 4 routed shards.
- Changed gate: `node scripts/check-changed.mjs -- extensions/minimax/src/minimax-web-search-provider.runtime.ts extensions/minimax/src/minimax-web-search-provider.test.ts extensions/perplexity/src/perplexity-web-search-provider.runtime.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts` — passed.
- Formatting: repo `oxfmt` on all four changed files — passed.
- Patch checks: `git diff --check` — passed.
- Codex-backed autoreview: no accepted/actionable findings; patch rated correct (0.99 confidence).
- Judged LOC: production `+2/-8` (net `-6`); tests `+0/-38` (net `-38`). The two production additions replace wrapper calls with direct canonical-helper calls.

AI-assisted: implemented and validated with Codex; the author reviewed the source, ownership boundaries, history, diff, and proof results.
