### PR TITLE
fix(config): fail config unset on a missing path again

### DIFF
--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -562,34 +562,45 @@ describe("config cli integration", () => {
     );
   });
 
-  it.each([
-    {
-      name: "setting an authored value to itself",
-      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
-        runConfigSet({
-          path: "gateway.port",
-          value: "18789",
-          cliOptions: { strictJson: true },
-          runtime,
-        }),
-    },
-    {
-      name: "unsetting an absent authored value",
-      run: (runtime: ReturnType<typeof createTestRuntime>["runtime"]) =>
-        runConfigUnset({ path: "gateway.bind", runtime }),
-    },
-  ])("preserves exact JSON5 bytes when $name is a no-op", async (testCase) => {
+  it("preserves exact JSON5 bytes when setting an authored value to itself", async () => {
     const raw =
       '{\n  // preserve this comment and order\n  gateway: { port: 18789 },\n  logging: { level: "info" },\n}\n';
     await withConfigFileHarness("openclaw-config-cli-noop-", raw, async ({ configPath }) => {
       const output = createTestRuntime();
 
-      await testCase.run(output.runtime);
+      await runConfigSet({
+        path: "gateway.port",
+        value: "18789",
+        cliOptions: { strictJson: true },
+        runtime: output.runtime,
+      });
 
       expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
       expect(output.errors).toStrictEqual([]);
       expect(output.logs).toStrictEqual(["No change"]);
     });
+  });
+
+  it("preserves exact JSON5 bytes while rejecting an absent authored unset", async () => {
+    const raw =
+      '{\n  // preserve this comment and order\n  gateway: { port: 18789 },\n  logging: { level: "info" },\n}\n';
+    await withConfigFileHarness(
+      "openclaw-config-cli-missing-unset-",
+      raw,
+      async ({ configPath }) => {
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigUnset({ path: "gateway.bind", runtime: output.runtime }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        expect(output.logs).toStrictEqual([]);
+        expect(output.errors.join("\n")).toContain(
+          "Config path not found: gateway.bind. Nothing was changed. Run openclaw config get <path> first if you are unsure of the path.",
+        );
+      },
+    );
   });
 
   it("writes an absent key even when its value equals the resolved default", async () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -4151,7 +4151,7 @@ describe("config cli", () => {
       ]);
     });
 
-    it("treats unsetting a runtime-only default shown by config get as an authored no-op", async () => {
+    it("fails when unsetting a runtime-only default shown by config get", async () => {
       const resolved = {
         agents: {
           defaults: {
@@ -4179,10 +4179,12 @@ describe("config cli", () => {
       mockLog.mockClear();
       setSnapshot(resolved, runtimeMerged);
 
-      await runConfigCommand(["config", "unset", aliasPath]);
+      await expect(runConfigCommand(["config", "unset", aliasPath])).rejects.toThrow(ExitError);
 
-      expectLogIncludes("No change");
-      expect(mockError).not.toHaveBeenCalled();
+      expectLogExcludes("No change");
+      expectErrorIncludes(
+        `Config path not found in authored config: ${aliasPath}. It only exists after runtime defaults are applied, so there is nothing for config unset to remove. Use openclaw config set <path> <value> to override the inherited value.`,
+      );
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
 
       setSnapshot(resolved, runtimeMerged);
@@ -4202,6 +4204,28 @@ describe("config cli", () => {
         ],
       });
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("reports No change when removing a normalized duplicate leaves config unchanged", async () => {
+      const retired = "google/gemini-3-pro-preview";
+      const canonical = "google/gemini-3.1-pro-preview";
+      const resolved: OpenClawConfig = {
+        agents: {
+          defaults: {
+            models: {
+              [retired]: { alias: "gemini" },
+              [canonical]: { alias: "gemini" },
+            },
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", `agents.defaults.models["${retired}"]`]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
+      expectLogIncludes("No change");
     });
 
     it("validates existing refs when unset dry-run removes all secret providers", async () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -265,16 +265,14 @@ export async function runConfigUnset(opts: {
           ],
         });
       }
-      if (cliOptions.dryRun) {
-        runtime.error(danger(missingPathMessage));
-        runtime.exit(1);
-        return;
+      if (!cliOptions.dryRun) {
+        assertStrictConfigForMutation(
+          currentConfig,
+          mutationStart.writeOptions.basePluginMetadataSnapshot,
+        );
       }
-      assertStrictConfigForMutation(
-        currentConfig,
-        mutationStart.writeOptions.basePluginMetadataSnapshot,
-      );
-      runtime.log(info("No change"));
+      runtime.error(danger(missingPathMessage));
+      runtime.exit(1);
       return;
     }
     const operation = buildUnsetOperation(parsedPath);


### PR DESCRIPTION
## What Problem This Solves

`openclaw config unset <missing-path>` reports success, while `--dry-run` on the exact same input
fails. Measured on a built CLI with an isolated state dir:

```
$ openclaw config unset bogus.typo.path
No change
[exit 0]

$ openclaw config unset bogus.typo.path --dry-run
Config path not found: bogus.typo.path. Nothing was changed. Run openclaw config get <path> first if you are unsure of the path.
[exit 1]
```

The mode that actually mutates config is the only one that treats a typo as success. Dry-run exists
to predict the real run, and here it predicts the opposite. `openclaw config unset some.path && echo
removed` prints `removed` while nothing was removed, and `runConfigUnset` computes the specific
`missingPathMessage` on the real path and then discards it.

## Why This Change Was Made

**This reverses one specific outcome that #125753 intended, so it deserves an explicit callout.**
That PR's body lists "absent-authored-value unset printed exactly `No change`" among its results, and
it added coverage for that. Its actual stated goal, though, was that authored no-op commands must not
"destructively reserialize JSON5" — preserving bytes, comments, and ordering.

That goal is fully preserved here. The new integration test asserts the failing unset leaves the
config file byte-identical, so nothing reserializes. What changes is only the exit code and the
message on a path that does not exist.

Restoring the failure is the coherent side of the contradiction, because everything else already
expects it: `--dry-run` fails with this message today, `config get <missing>` exits 1, the behaviour
before #125753 exited 1 for both modes, and the `missingPathMessage` — including its `runtimeOnly`
variant explaining that a runtime-default-only path has nothing to remove and pointing at
`config set` — exists solely for this case and is otherwise unreachable on the real path.

The strict-validation call #125753 added is load-bearing and stays: a real missing-path unset still
runs `assertStrictConfigForMutation` first, so an unrelated strict validation error still wins.

Sibling mutation paths were checked and deliberately left alone, because they are declarative rather
than imperative about a target that must exist — their desired end state already holds, and their
dry-runs agree:

| path | absent/no-op input | verdict |
| --- | --- | --- |
| `config set` same value | `No change`, exit 0 | consistent, unchanged |
| `config patch` null-delete of absent leaf | applies, exit 0 | consistent, unchanged |
| batch `config set` | no unset/delete operation exists | cannot share the shape |
| `config unset` deep-equal after normalization | `No change`, exit 0 | genuinely no change, unchanged |

Only `runConfigUnset`'s `!unsetResult.removed` branch changed.

## User Impact

`config unset` on a path that does not exist now fails with the specific message it already had,
instead of reporting success. Scripts that relied on the ~one-day-old lenient behaviour will now see
a nonzero exit — intended, since that is the bug. Unreleased: `git tag --contains 8dd0434f86f`
returns nothing, so no shipped release carries the lenient behaviour.

## Evidence

**Live proof on the built CLI**, isolated `OPENCLAW_STATE_DIR`, `OPENCLAW_SKIP_CHANNELS=1`, free
port, channel/Twilio env unset, no gateway bound and no provider calls. Config SHA-256 captured
before and after each case:

| case | exit | output | config bytes |
| --- | --- | --- | --- |
| real, missing path | 1 | specific missing-path message on stderr | unchanged |
| `--dry-run`, missing path | 1 | same message | unchanged |
| `--json` without `--dry-run` | 1 | `--json can only be used with --dry-run.` | unchanged |
| real unset of an existing path | 0 | `Removed gateway.port. Restart the gateway to apply.` | changed, key gone |

**Tests** — `src/cli/config-cli.test.ts` and `src/cli/config-cli.integration.test.ts`: 210 passed.
Reverting only `src/cli/config-cli.ts` fails exactly 2 targeted tests (208 pass), so the coverage is
load-bearing rather than restating the implementation.

Two existing tests encoded the regression and were corrected rather than worked around:
- the unit test asserting a runtime-only default unset was "an authored no-op" now asserts exit 1, no
  write, and the full runtime-only guidance;
- the byte-preservation table case for "unsetting an absent authored value" was split, so same-value
  `set` keeps its byte-preserving success while absent unset asserts exit 1 *and* identical file
  bytes.

New coverage was added for the legitimate deep-equal `No change` path (two model-map keys that
normalize to the same canonical key), which previously had no explicit test.

**Validation** — focused config CLI tests: 210 passed; `node scripts/check-changed.mjs` (Testbox
`tbx_01m0ba9t4qwecnmcfwdv86f7q9`, run `32184618340`, exit 0); `pnpm docs:check-mdx`
(777 files); docs formatting; `git diff --check`; branch-mode autoreview clean (`patch is correct`,
no accepted or actionable findings). The original code head also passed `pnpm build`.

Production LOC `+7/-9` (net **−2**) in one file. Test LOC `+57/-22`. Docs LOC `+1/-1`.

