### PR TITLE
test(ui): stabilize widget hover proof

### DIFF
--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -329,7 +329,8 @@ suite.define(() => {
     await page.locator(".board-session-surface").waitFor();
 
     const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
-    await preview.hover();
+    const previewBubble = page.locator(".chat-bubble", { has: preview });
+    const widgetActions = preview.locator("[data-widget-actions]");
     await expect.poll(() => preview.locator(".chat-tool-card__preview-header").count()).toBe(0);
     await expect
       .poll(() =>
@@ -356,14 +357,13 @@ suite.define(() => {
       )
       .toBe("0px");
     if (recordProof) {
+      await widgetActions.hover();
       await expect
-        .poll(() =>
-          preview
-            .locator("[data-widget-actions]")
-            .evaluate((element) => getComputedStyle(element).opacity),
-        )
+        .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
-      await preview.screenshot({ path: path.join(workboardPinProofDir, "01-pin-hover.png") });
+      await previewBubble.screenshot({
+        path: path.join(workboardPinProofDir, "01-pin-hover.png"),
+      });
     }
     await preview.getByRole("button", { name: "Pin to dashboard" }).click();
     await expect.poll(async () => (await gateway.getRequests("board.widget.put")).length).toBe(1);
@@ -377,7 +377,7 @@ suite.define(() => {
       .poll(() => preview.getByRole("button", { name: "Pinned" }).isDisabled())
       .toBe(true);
     if (recordProof) {
-      await preview.screenshot({ path: path.join(workboardPinProofDir, "02-pinned.png") });
+      await previewBubble.screenshot({ path: path.join(workboardPinProofDir, "02-pinned.png") });
     }
     await gateway.setMethodResponse("board.get", resizablePinnedBoardSnapshot);
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the full recorded session-dashboard E2E could fail before capturing Canvas pin proof because its stale hover target left the widget action rail at partial opacity.

## Why This Change Was Made

The widget preview chrome refactor removed the old header hover target and moved actions above the preview, while the recording-only proof still hovered the iframe-centered preview and screenshot only the preview bounds. The proof now hovers the actual action rail and captures the enclosing chat bubble. Production behavior and the network widget grant alert flow are unchanged.

## User Impact

No runtime product behavior changes. Maintainers get deterministic recorded dashboard proof whose screenshots include the pin and overflow action controls.

## Evidence

- Pre-fix exact recorded full-file run: 1 failed / 7 passed; expected opacity 1, received 0.45.
- Post-fix exact recorded full-file run: three consecutive runs, 8/8 passed each.
- Focused non-recorded pin scenario: 1 passed / 7 skipped.
- Recorded session-dashboard.grant-failure.e2e.test.ts: 1/1 passed independently.
- Changed-file checks and git diff --check passed.
- Codex autoreview: no accepted/actionable findings.
- Visual captures under .artifacts/control-ui-e2e/workboard-pin were inspected and include the action controls.
- Production LOC: +0/-0. Tests: +8/-8.

AI-assisted: yes. The change and generated proof were reviewed and understood.
