### PR TITLE
fix(cli): stop claiming a write when approvals mutations are no-ops

### DIFF
--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -141,6 +141,10 @@ function expectGatewayCall(index: number, method: string, params: unknown) {
   expect(call[2]).toEqual(params);
 }
 
+function loggedOutput(): string {
+  return defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
+}
+
 function writtenJson(): Record<string, unknown> {
   const value = firstMockArg(vi.mocked(defaultRuntime.writeJson));
   return requireRecord(value, "written json");
@@ -311,7 +315,7 @@ describe("exec approvals CLI", () => {
 
     await runApprovalsCommand(["approvals", "get"]);
 
-    const output = defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
+    const output = loggedOutput();
     expect(output).toContain("State");
     expect(output).toContain("defaults (no stored overrides)");
     expect(output).not.toContain("Exists");
@@ -326,7 +330,7 @@ describe("exec approvals CLI", () => {
 
     await runApprovalsCommand(["approvals", "get"]);
 
-    const output = defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
+    const output = loggedOutput();
     const hasUnsafeControl = Array.from(output).some((char) => {
       const codePoint = char.codePointAt(0) ?? -1;
       return (
@@ -888,6 +892,37 @@ describe("exec approvals CLI", () => {
     if (requireRecord(saved.agents, "saved agents")["*"] === undefined) {
       throw new Error("Expected wildcard exec approval agent entry");
     }
+    expect(loggedOutput()).toContain("Writing local approvals.");
+  });
+
+  it.each([
+    {
+      label: "an already-allowlisted add",
+      args: ["add", "/usr/bin/uptime"],
+      outcome: "Already allowlisted.",
+    },
+    {
+      label: "a remove of an absent pattern",
+      args: ["remove", "/usr/bin/never-added"],
+      outcome: "Pattern not found.",
+    },
+  ])("reports $label without announcing a local write", async ({ args, outcome }) => {
+    localSnapshot.file = {
+      version: 1,
+      agents: { "*": { allowlist: [{ pattern: "/usr/bin/uptime", lastUsedAt: Date.now() }] } },
+    };
+    const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
+    updateExecApprovals.mockClear();
+
+    await runApprovalsCommand(["approvals", "allowlist", ...args]);
+
+    const output = loggedOutput();
+    expect(output).toContain(outcome);
+    expect(output).not.toContain("Writing local approvals.");
+    expect(updateExecApprovals).not.toHaveBeenCalled();
+    // Idempotent add/remove leave the requested end state satisfied: no failure exit.
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("removes wildcard allowlist entry and prunes empty agent", async () => {
@@ -913,6 +948,7 @@ describe("exec approvals CLI", () => {
       version: 1,
       agents: {},
     });
+    expect(loggedOutput()).toContain("Writing local approvals.");
     expect(runtimeErrors).toHaveLength(0);
   });
 

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -324,9 +324,6 @@ async function loadWritableSnapshotTarget(opts: ExecApprovalsCliOpts): Promise<{
 }> {
   // Writes carry the base hash so gateway/node updates can reject stale snapshots.
   const { snapshot, nodeId, source } = await loadSnapshotTarget(opts);
-  if (source === "local") {
-    defaultRuntime.log(theme.muted("Writing local approvals."));
-  }
   const targetLabel = source === "local" ? "local" : nodeId ? `node:${nodeId}` : "gateway";
   if (isNativeApprovalsSnapshot(snapshot) && !snapshot.enabled) {
     exitWithError(
@@ -362,6 +359,9 @@ async function saveSnapshotTargeted(params: SaveSnapshotTargetedParams): Promise
     });
     next = await loadSnapshot(params.opts, params.nodeId);
   } else if (params.source === "local") {
+    // Announced at the write, not at target resolution: no-op allowlist edits and
+    // rejected `set` input never reach here and must not claim a write happened.
+    defaultRuntime.log(theme.muted("Writing local approvals."));
     next = await saveSnapshotLocal(params.file, params.baseHash);
   } else {
     next = await saveSnapshot(params.opts, params.nodeId, params.file, params.baseHash);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw approvals allowlist add` or `remove` would be told the CLI wrote their approvals file when it did not. Both idempotent paths print the write announcement and then a no-op outcome:

```
$ openclaw approvals allowlist remove "/usr/bin/never-added"
Writing local approvals.
Pattern not found.

$ openclaw approvals allowlist add "/usr/bin/uptime"   # already present
Writing local approvals.
Already allowlisted.
```

`openclaw approvals set` shares the same seam and had the same problem: it announced the write, then rejected unparseable input with `Failed to parse approvals JSON: ...`.

## Why This Change Was Made

The announcement was emitted by `loadWritableSnapshotTarget`, the target-resolution helper, which by construction cannot know whether a mutation will follow — the decision happens later in `runAllowlistMutation`, and when the mutation callback returns false the save is skipped entirely. Moving the line into the local branch of `saveSnapshotTargeted`, the function that owns the write, records the fact where it happens and fixes every caller of the shared seam at once.

Exit codes are deliberately unchanged. An idempotent add and an idempotent remove both leave the operator's requested end state satisfied, so exit 0 remains correct; this PR is only about the CLI stating a write it did not perform.

Production diff is net zero (+3/-3).

## User Impact

The write announcement is now truthful. Operators and scripts see `Writing local approvals.` only when approvals were actually persisted; no-op allowlist edits and rejected `set` input report their outcome alone. Gateway- and node-targeted writes are unaffected, and `approvals get`'s `Showing local approvals.` was already accurate.

## Evidence

Live-verified against a freshly built CLI with an isolated `OPENCLAW_STATE_DIR` under `/tmp` (no gateway involved):

```
--- allowlist add /usr/bin/uptime (exit=0) ---
Writing local approvals.
Target: local
--- allowlist add /usr/bin/uptime (exit=0) ---
Already allowlisted.
--- allowlist remove /usr/bin/never-added (exit=0) ---
Pattern not found.
--- allowlist remove /usr/bin/uptime (exit=0) ---
Writing local approvals.
Target: local
```

Sibling `approvals set` on the same seam: invalid stdin/file input now prints only `Failed to parse approvals JSON: ...` (exit 1), valid input prints `Writing local approvals.` + `Target: local`.

Regression coverage extends the existing suite in `src/cli/exec-approvals-cli.test.ts`: an `it.each` pair asserts each no-op reports its outcome, never emits the announcement, never calls `updateExecApprovals`, and never triggers a failure exit; the two existing write tests now assert the announcement is still emitted. Both new cases fail on pre-fix code for the intended reason:

```
AssertionError: expected 'Writing local approvals.\nAlready all...' not to contain 'Writing local approvals.'
AssertionError: expected 'Writing local approvals.\nPattern not...' not to contain 'Writing local approvals.'
```

Local gates: `node scripts/run-vitest.mjs src/cli/exec-approvals-cli.test.ts` — 29 passed. `node scripts/check-changed.mjs` — exit 0. Fresh Codex autoreview on the diff — clean, no accepted findings.
