### PR TITLE
fix(ollama): stop response handling after abort

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1762,6 +1762,58 @@ describe("createOllamaStreamFn streaming events", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("does not resume response handling after the hook resolves concurrently with abort", async () => {
+    let markHookStarted: () => void = () => undefined;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+    let settleHook: () => void = () => undefined;
+    const hookPending = new Promise<void>((resolve) => {
+      settleHook = resolve;
+    });
+    const getReader = vi.fn(() => ({
+      read: vi.fn(async () => ({ done: true as const, value: undefined })),
+      cancel: vi.fn(async () => undefined),
+      releaseLock: vi.fn(),
+    }));
+    const cancel = vi.fn(async () => undefined);
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: {
+        status: 200,
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/x-ndjson" }),
+        body: { getReader, cancel },
+      } as unknown as Response,
+      release,
+    });
+    const abortController = new AbortController();
+
+    const eventsPromise = collectStreamEvents(
+      await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        options: {
+          onResponse: () => {
+            markHookStarted();
+            return hookPending;
+          },
+          signal: abortController.signal,
+        },
+      }),
+    );
+    await hookStarted;
+    await Promise.resolve();
+    void hookPending.then(() => abortController.abort());
+    settleHook();
+    const events = await eventsPromise;
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "error", reason: "aborted" });
+    expect(getReader).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("emits start, text_start, text_delta, text_end, done for text responses", async () => {
     const events = await collectMockedOllamaEvents([
       '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Hello"},"done":false}',

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -102,6 +102,7 @@ async function runOllamaResponseHook(params: {
       signal.removeEventListener("abort", onAbort);
     }
   }
+  throwIfOllamaStreamAborted(signal);
 }
 
 function createOllamaStreamCooperativeScheduler(


### PR DESCRIPTION
Follow-up to #125834. Related to #125802.

## What Problem This Solves

The Ollama response-hook repair can finish awaiting an asynchronous hook in the same microtask turn that the request becomes aborted. Without a final signal check, the transport can enter response-body handling with an already-aborted request before the next stream guard stops it.

## Why This Change Was Made

The response-hook owner now rechecks the request signal after the hook race and abort-listener cleanup, matching the established provider lifecycle pattern.

A boundary regression resolves the hook and aborts the request concurrently, then proves that Ollama:

- emits one terminal `aborted` event;
- never acquires the response body reader;
- cancels the unread body; and
- releases the guarded request exactly once.

This keeps the repair local to Ollama rather than adding a new Plugin SDK helper for a single consumer.

## User Impact

Canceled Ollama requests no longer resume response-body processing after an asynchronous response hook settles. Successful response reporting, HTTP status/header observation, payloads, and model output are unchanged.

## Evidence

The new regression failed against the merged #125834 implementation for the intended reason:

```text
expected getReader not to be called, received 1 call
1 failed, 145 skipped
```

After the fix:

```text
node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts
146 passed

node scripts/check-changed.mjs -- extensions/ollama/src/stream.runtime.ts extensions/ollama/src/stream-runtime.test.ts
all selected checks passed

.claude/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
```

Live Ollama proof against `https://ollama.com` with `glm-5.2:cloud`:

```text
callbackCount=1
status=200
callbackBeforeFirstEvent=true
events=start,text_start,text_delta,text_end,done
stopReason=stop
text=OK
```

Production LOC: +1/-0. Tests: +52/-0.
