### PR TITLE
perf(test): reuse plugin load-context modules

### DIFF
--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -1,5 +1,5 @@
 // Load context tests cover agent and workspace context resolution for plugin runtimes.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const loadConfigMock = vi.fn<typeof import("../../config/config.js").loadConfig>();
@@ -69,13 +69,15 @@ vi.mock("../plugin-metadata-snapshot.js", () => ({
 }));
 
 describe("resolvePluginRuntimeLoadContext", () => {
-  beforeEach(async () => {
-    vi.resetModules();
+  beforeAll(async () => {
     ({ clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
       await import("../../config/runtime-snapshot.js"));
     ({ clearPluginMetadataLifecycleCaches } = await import("../plugin-metadata-lifecycle.js"));
     ({ resolvePluginRuntimeLoadContext, buildPluginRuntimeLoadOptions } =
       await import("./load-context.js"));
+  });
+
+  beforeEach(() => {
     loadConfigMock.mockReset();
     applyPluginAutoEnableMock.mockReset();
     fingerprintPluginAutoEnableConfigMock.mockClear();
@@ -94,6 +96,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       autoEnabledReasons: {},
     }));
     clearRuntimeConfigSnapshot();
+    clearPluginMetadataLifecycleCaches();
   });
 
   it("builds the runtime plugin load context from the auto-enabled config", () => {


### PR DESCRIPTION
## What Problem This Solves

The plugin load-context test suite repeatedly reset the Vitest module graph and dynamically re-imported the same three modules for each of ten tests. That made this focused suite substantially slower and more memory-intensive than its assertions required.

## Why This Change Was Made

The suite now imports the three modules once at suite scope and reuses them across all ten tests. Each test still starts from the two canonical mutable-state owners being cleared in `beforeEach`: `clearRuntimeConfigSnapshot()` resets the runtime configuration snapshot, and `clearPluginMetadataLifecycleCaches()` resets plugin metadata lifecycle caches.

This preserves every test and every mid-test invalidation assertion. The cache boundary is required: a fault-injection run that omitted the lifecycle clear made the reference-fast-path test fail because `applyPluginAutoEnable` ran once instead of the expected twice; restoring the lifecycle clear restored the intended behavior.

Production LOC: +0/-0. Tests: +6/-3.

## User Impact

There is no product behavior change. Maintainers get a faster, lower-memory plugin load-context test suite without reducing coverage.

## Evidence

Controlled A/B on the same Testbox run, based on `ab2bd4faa87ed68aba00615317f8ea4587795289`: https://github.com/openclaw/openclaw/actions/runs/32172442197

The comparison excluded warmup and retained two measured runs per side, using one worker, distinct caches, import diagnostics, and `time -v`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall mean | 5.940s | 4.205s | -1.735s / -29.2% |
| Vitest | 1.800s | 0.593s | -67.1% |
| Test body | 0.3815s | 0.1195s | -68.7% |
| Imports | 0.0275s | 0.0075s | -72.7% |
| Max RSS | 544,224 KB | 320,724 KB | -41.1% |
| CPU total mean | — | — | -32.6% |

- Focused suite: 10/10 passed.
- Complete changed gate: passed on Testbox `tbx_01m0b2w03z0b9a6ht3wbr0w000`; the box was stopped after completion.
- Fresh post-rebase autoreview: clean, 0.99, with no accepted/actionable findings.
- Stable patch ID across the rebase: `d61390fe0d33675f8ecd14e08a5141f19fa9819f`.
- Screenshots: N/A; this is a test-only performance change with no visual surface.
- Changelog: not required for a test-only performance change.
