### PR TITLE
fix(ui): restore session link hovercards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session hovercards:** restore owner, timing, pull-request checks, and diff details on chat session links, and show the latest turn when a session has no progress card.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session hovercards:** restore owner, timing, pull-request checks, and diff details on chat session links, and show the latest turn when a session has no progress card.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -1,0 +1,199 @@
+/* @vitest-environment jsdom */
+
+import type { ProgressCard } from "@openclaw/gateway-protocol";
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ControlUiSessionPullRequestSnapshot } from "../../../src/gateway/control-ui-contract.js";
+import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
+import { renderSessionHovercard } from "./session-hovercard.ts";
+
+function row(overrides: Partial<SidebarRecentSession> = {}): SidebarRecentSession {
+  return {
+    key: "agent:main:work",
+    label: "Ship the release",
+    startedAt: Date.now() - 2 * 60 * 60_000,
+    updatedAt: Date.now() - 5 * 60_000,
+    owner: { actor: { type: "human", id: "alice", label: "Alice Baker" } },
+    children: [],
+    ...overrides,
+  } as SidebarRecentSession;
+}
+
+function snapshot(
+  overrides: Partial<ControlUiSessionPullRequestSnapshot> = {},
+): ControlUiSessionPullRequestSnapshot {
+  return { status: "ready", pullRequests: [], rateLimited: false, ...overrides };
+}
+
+function progressCard(): ProgressCard {
+  return {
+    sessionKey: "agent:main:work",
+    revision: 1,
+    updatedAt: Date.now(),
+    markdown: "**Release** is ready.",
+    steps: [{ step: "Verify", status: "in_progress" }],
+  };
+}
+
+describe("renderSessionHovercard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders synchronous row metadata without inventing a progress section", () => {
+    const container = document.createElement("div");
+    render(renderSessionHovercard({ row: row() }), container);
+
+    expect(container.querySelector(".session-hovercard__title")?.textContent).toBe(
+      "Ship the release",
+    );
+    expect(container.querySelector(".session-hovercard__avatar")?.textContent).toBe("AB");
+    const metadata = container.querySelector(".session-hovercard__meta")?.textContent ?? "";
+    expect(metadata).toContain("Alice Baker");
+    expect(metadata).toContain("created");
+    expect(metadata).toContain("updated");
+    expect(container.querySelector(".session-progress-card")).toBeNull();
+    expect(container.querySelector(".session-hovercard__excerpt")).toBeNull();
+    expect(container.querySelector(".session-hovercard__divider")).toBeNull();
+  });
+
+  it("renders bounded linked PR chips with state, CI, and diff facts", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        pullRequests: snapshot({
+          pullRequests: [
+            {
+              number: 101,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "First",
+              url: "https://github.com/openclaw/openclaw/pull/101",
+              state: "open",
+              changedFiles: 2,
+              additions: 7,
+              deletions: 3,
+              checks: { state: "passing", passed: 2, failed: 0, skipped: 0, running: 0 },
+            },
+            {
+              number: 102,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "Second",
+              url: "https://github.com/openclaw/openclaw/pull/102",
+              state: "draft",
+            },
+            {
+              number: 103,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "Third",
+              url: "https://github.com/openclaw/openclaw/pull/103",
+              state: "merged",
+            },
+            {
+              number: 104,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "Fourth",
+              url: "https://github.com/openclaw/openclaw/pull/104",
+              state: "closed",
+            },
+          ],
+        }),
+      }),
+      container,
+    );
+
+    const links = [...container.querySelectorAll<HTMLAnchorElement>(".session-hovercard__pr-chip")];
+    expect(links).toHaveLength(3);
+    expect(links[0]?.href).toBe("https://github.com/openclaw/openclaw/pull/101");
+    expect(links[0]?.target).toBe("_blank");
+    expect(links[0]?.rel).toContain("noopener");
+    expect(links[0]?.querySelector(".session-hovercard__pr-number")?.textContent).toBe("#101");
+    expect(links[0]?.querySelector(".session-hovercard__pr-state")?.textContent).toBe("Open");
+    expect(links[0]?.querySelector("[data-checks='passing']")?.textContent).toBe("✓");
+    expect(links[0]?.querySelector(".session-hovercard__files")?.textContent).toBe("2 files");
+    expect(links[0]?.querySelector(".session-hovercard__additions")?.textContent).toBe("+7");
+    expect(links[0]?.querySelector(".session-hovercard__deletions")?.textContent).toBe("−3");
+    expect(container.querySelector(".session-hovercard__more")?.textContent).toBe("+1 more");
+  });
+
+  it("falls back to branch and diff chips with a create-PR link", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        row: row({ workSession: true, subtitle: "openclaw/openclaw · feature" }),
+        pullRequests: snapshot({
+          branch: {
+            owner: "openclaw",
+            repo: "openclaw",
+            branch: "feature",
+            changedFiles: 3,
+            additions: 12,
+            deletions: 4,
+            createUrl: "https://github.com/openclaw/openclaw/pull/new/feature",
+          },
+        }),
+      }),
+      container,
+    );
+
+    expect(container.querySelector(".session-hovercard__branch-chip")?.textContent).toBe(
+      "openclaw/openclaw · feature",
+    );
+    expect(container.querySelector(".session-hovercard__files")?.textContent).toBe("3 files");
+    expect(container.querySelector(".session-hovercard__additions")?.textContent).toBe("+12");
+    expect(container.querySelector(".session-hovercard__deletions")?.textContent).toBe("−4");
+    const createLink = container.querySelector<HTMLAnchorElement>(".session-hovercard__no-pr a");
+    expect(createLink?.textContent).toBe("No PR yet");
+    expect(createLink?.href).toBe("https://github.com/openclaw/openclaw/pull/new/feature");
+  });
+
+  it("renders the latest turn as plain text when progress is absent", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        row: row({ lastMessagePreview: "  Finished <strong>without markup</strong>.  " }),
+      }),
+      container,
+    );
+
+    expect(container.querySelector(".session-hovercard__excerpt")?.textContent).toBe(
+      "Finished <strong>without markup</strong>.",
+    );
+    expect(container.querySelector(".session-hovercard__excerpt strong")).toBeNull();
+    expect(container.querySelector(".session-progress-card")).toBeNull();
+  });
+
+  it("renders progress instead of the latest-turn excerpt", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        row: row({ lastMessagePreview: "This must not appear." }),
+        progressCard: progressCard(),
+      }),
+      container,
+    );
+
+    expect(container.querySelector(".session-progress-card")?.textContent).toContain("Release");
+    expect(container.querySelector(".session-hovercard__excerpt")).toBeNull();
+    expect(container.textContent).not.toContain("This must not appear.");
+  });
+
+  it("renders nothing when no session facts are known", () => {
+    const container = document.createElement("div");
+    render(renderSessionHovercard({}), container);
+
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -1,0 +1,180 @@
+import type { ProgressCard } from "@openclaw/gateway-protocol";
+import { html, nothing } from "lit";
+import type {
+  ControlUiSessionPullRequest,
+  ControlUiSessionPullRequestSnapshot,
+} from "../../../src/gateway/control-ui-contract.js";
+import { t } from "../i18n/index.ts";
+import { formatRelativeTimestamp } from "../lib/format.ts";
+import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
+import { sessionOwnerInitials } from "./session-owner-chip.ts";
+import { renderSessionProgressCard } from "./session-progress-card.ts";
+
+const MAX_VISIBLE_PULL_REQUESTS = 3;
+
+function pullRequestStateLabel(state: ControlUiSessionPullRequest["state"]): string {
+  return t(`sessionHovercard.states.${state}`);
+}
+
+function checksPresentation(checks: NonNullable<ControlUiSessionPullRequest["checks"]>): {
+  glyph: string;
+  label: string;
+} {
+  switch (checks.state) {
+    case "passing":
+      return { glyph: "✓", label: t("sessionHovercard.checks.passing") };
+    case "failing":
+      return { glyph: "✗", label: t("sessionHovercard.checks.failing") };
+    case "pending":
+      return { glyph: "○", label: t("sessionHovercard.checks.pending") };
+    default:
+      return checks.state satisfies never;
+  }
+}
+
+function changedFilesLabel(changedFiles: number): string {
+  return t(changedFiles === 1 ? "sessionHovercard.changedFile" : "sessionHovercard.changedFiles", {
+    count: String(changedFiles),
+  });
+}
+
+function renderDiffStats(item: { additions?: number; deletions?: number; changedFiles?: number }) {
+  if (
+    item.additions === undefined &&
+    item.deletions === undefined &&
+    item.changedFiles === undefined
+  ) {
+    return nothing;
+  }
+  return html`<span class="session-hovercard__diff">
+    ${item.changedFiles === undefined
+      ? nothing
+      : html`<span class="session-hovercard__files">${changedFilesLabel(item.changedFiles)}</span>`}
+    ${item.additions === undefined
+      ? nothing
+      : html`<span class="session-hovercard__additions">+${item.additions.toLocaleString()}</span>`}
+    ${item.deletions === undefined
+      ? nothing
+      : html`<span class="session-hovercard__deletions">−${item.deletions.toLocaleString()}</span>`}
+  </span>`;
+}
+
+function renderHeader(row: SidebarRecentSession | undefined) {
+  if (!row) {
+    return nothing;
+  }
+  const owner = row.owner?.actor ?? row.createdActor;
+  const ownerLabel = owner?.label?.trim() || owner?.id?.trim();
+  const initials = owner ? sessionOwnerInitials(owner) : "";
+  const created = formatRelativeTimestamp(row.startedAt, { fallback: "" });
+  const updated = formatRelativeTimestamp(row.updatedAt, { fallback: "" });
+  const metadata = [
+    ownerLabel,
+    created ? t("sessionHovercard.created", { time: created }) : undefined,
+    updated ? t("sessionHovercard.updated", { time: updated }) : undefined,
+  ].filter((value): value is string => Boolean(value));
+  return html`<header class="session-hovercard__header">
+    ${initials
+      ? html`<span class="session-hovercard__avatar" aria-hidden="true">${initials}</span>`
+      : nothing}
+    <span class="session-hovercard__heading">
+      <span class="session-hovercard__title">${row.label}</span>
+      ${metadata.length > 0
+        ? html`<span class="session-hovercard__meta">${metadata.join(" · ")}</span>`
+        : nothing}
+    </span>
+  </header>`;
+}
+
+function renderPullRequestChip(pullRequest: ControlUiSessionPullRequest) {
+  const state = pullRequestStateLabel(pullRequest.state);
+  const checks = pullRequest.checks ? checksPresentation(pullRequest.checks) : null;
+  return html`<a
+    class="session-hovercard__chip session-hovercard__pr-chip"
+    data-state=${pullRequest.state}
+    href=${pullRequest.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label=${t("sessionHovercard.pullRequestLabel", {
+      number: String(pullRequest.number),
+      state,
+    })}
+  >
+    <span class="session-hovercard__pr-number">#${pullRequest.number}</span>
+    <span class="session-hovercard__pr-state">${state}</span>
+    ${checks
+      ? html`<span
+          class="session-hovercard__checks"
+          data-checks=${pullRequest.checks?.state}
+          aria-label=${checks.label}
+          title=${checks.label}
+          >${checks.glyph}</span
+        >`
+      : nothing}
+    ${renderDiffStats(pullRequest)}
+  </a>`;
+}
+
+function renderPullRequestDetails(snapshot: ControlUiSessionPullRequestSnapshot | undefined) {
+  if (!snapshot) {
+    return nothing;
+  }
+  if (snapshot.pullRequests.length > 0) {
+    const visible = snapshot.pullRequests.slice(0, MAX_VISIBLE_PULL_REQUESTS);
+    const hiddenCount = snapshot.pullRequests.length - visible.length;
+    return html`<div class="session-hovercard__chips">
+      ${visible.map(renderPullRequestChip)}
+      ${hiddenCount > 0
+        ? html`<span class="session-hovercard__more"
+            >${t("sessionHovercard.more", { count: String(hiddenCount) })}</span
+          >`
+        : nothing}
+    </div>`;
+  }
+  const branch = snapshot.branch;
+  if (!branch) {
+    return nothing;
+  }
+  const noPullRequest = t("sessionHovercard.noPrYet");
+  return html`
+    <div class="session-hovercard__chips">
+      <span class="session-hovercard__chip session-hovercard__branch-chip"
+        >${branch.owner}/${branch.repo} · ${branch.branch}</span
+      >
+      ${renderDiffStats(branch)}
+    </div>
+    <div class="session-hovercard__no-pr">
+      ${branch.createUrl
+        ? html`<a href=${branch.createUrl} target="_blank" rel="noopener noreferrer"
+            >${noPullRequest}</a
+          >`
+        : noPullRequest}
+    </div>
+  `;
+}
+
+export function renderSessionHovercard(input: {
+  row?: SidebarRecentSession;
+  pullRequests?: ControlUiSessionPullRequestSnapshot;
+  progressCard?: ProgressCard | null;
+}) {
+  const hasPullRequestDetails = Boolean(
+    input.pullRequests && (input.pullRequests.pullRequests.length > 0 || input.pullRequests.branch),
+  );
+  const lastMessagePreview = input.progressCard
+    ? undefined
+    : input.row?.lastMessagePreview?.trim() || undefined;
+  if (!input.row && !hasPullRequestDetails && !input.progressCard) {
+    return nothing;
+  }
+  return html`<div class="session-hovercard">
+    ${renderHeader(input.row)} ${renderPullRequestDetails(input.pullRequests)}
+    ${input.progressCard
+      ? html`<div class="session-hovercard__divider" role="presentation"></div>
+          ${renderSessionProgressCard(input.progressCard, "hovercard")}`
+      : lastMessagePreview
+        ? html`<div class="session-hovercard__divider" role="presentation"></div>
+            <div class="session-hovercard__excerpt">${lastMessagePreview}</div>`
+        : nothing}
+  </div>`;
+}

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -60,7 +60,7 @@ export function renderSessionOwnerChip(
     : nothing;
 }
 
-function sessionOwnerInitials(owner: SessionCreatedActor): string {
+export function sessionOwnerInitials(owner: SessionCreatedActor): string {
   const source = owner.label?.trim() || owner.id?.trim() || "";
   if (!source) {
     return "";

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -8,9 +8,16 @@ import {
   sessionProgressCardsForGateway,
   type SessionProgressCardStore,
 } from "../lib/session-progress-cards.ts";
+import {
+  scopedSessionPullRequestKey,
+  sessionPullRequestsForGateway,
+  type SessionPullRequestSnapshotStore,
+} from "../lib/session-pull-requests.ts";
+import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import type { AppSidebarSessionNavigationElement } from "./app-sidebar-session-navigation.ts";
 import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
+import { renderSessionHovercard } from "./session-hovercard.ts";
 import { SessionLinkTitler } from "./session-link-titling.ts";
-import { renderSessionProgressCard } from "./session-progress-card.ts";
 import { sessionProgressHoverAnchorFromEvent } from "./session-progress-hovercard-target.ts";
 
 const OPEN_DELAY_MS = 350;
@@ -22,8 +29,13 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private applicationGateway: ApplicationGateway | null = null;
   private progressCards: SessionProgressCardStore | null = null;
   private stopProgressCardUpdates: (() => void) | null = null;
+  private pullRequests: SessionPullRequestSnapshotStore | null = null;
+  private stopPullRequestUpdates: (() => void) | null = null;
   private activeAnchor: HTMLAnchorElement | null = null;
   private activeSessionKey: string | null = null;
+  private activePullRequestKey: string | null = null;
+  private open = false;
+  private lastProgressCard: ProgressCard | null = null;
   private readonly hovercard = new PortaledHovercardController(() => this.close());
   private readonly sessionLinkTitler = new SessionLinkTitler(this);
   private loadGeneration = 0;
@@ -111,22 +123,24 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.stopProgressCardUpdates?.();
     this.stopProgressCardUpdates = null;
     this.progressCards = null;
+    this.releasePullRequestStore();
   }
 
   private readonly handleProgressCardUpdate = () => {
     const sessionKey = this.activeSessionKey;
-    if (!sessionKey || !this.hovercard.held) {
+    if (!sessionKey || !this.open || !this.hovercard.held) {
       return;
     }
     const card = this.progressCards?.get(sessionKey);
-    if (card) {
-      this.show(card);
-    } else if (card === null) {
-      this.close();
-    } else {
-      this.hovercard.clearCard();
-      this.hovercard.pointerOverCard = false;
-      this.hovercard.cardFocusInside = false;
+    if (card !== undefined) {
+      this.lastProgressCard = card;
+    }
+    this.showCurrent();
+  };
+
+  private readonly handlePullRequestUpdate = () => {
+    if (this.open && this.hovercard.held) {
+      this.showCurrent();
     }
   };
 
@@ -197,6 +211,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.close();
     this.activeAnchor = anchor;
     this.activeSessionKey = sessionKey;
+    this.open = false;
+    this.lastProgressCard = null;
     this.progressCards?.watch(this, [sessionKey]);
     this.hovercard.markTrigger(anchor);
     this.activeAnchorObserver.observe(this, { childList: true, subtree: true });
@@ -209,28 +225,84 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (anchor?.dataset.sessionKey === sessionKey) {
       void this.sessionLinkTitler.decorate(anchor, true);
     }
+    if (
+      generation !== this.loadGeneration ||
+      this.activeSessionKey !== sessionKey ||
+      !this.hovercard.held
+    ) {
+      return;
+    }
+    this.open = true;
+    this.watchPullRequests(sessionKey);
+    this.showCurrent();
     try {
-      const card = await this.progressCards?.load(sessionKey);
-      if (
-        generation !== this.loadGeneration ||
-        this.activeSessionKey !== sessionKey ||
-        !card ||
-        !this.hovercard.held
-      ) {
-        return;
-      }
-      this.show(card);
+      await this.progressCards?.load(sessionKey);
     } catch {
-      // A missing or unavailable card has no hover surface by design.
+      // Session facts and the last successful card remain useful when refresh fails.
+    }
+    if (
+      generation === this.loadGeneration &&
+      this.activeSessionKey === sessionKey &&
+      this.hovercard.held
+    ) {
+      this.showCurrent();
     }
   }
 
-  private show(progressCard: ProgressCard): void {
-    const anchor = this.activeAnchor;
-    if (!anchor) {
+  private watchPullRequests(sessionKey: string): void {
+    const gateway = this.applicationGateway;
+    if (!gateway) {
       return;
     }
-    if (this.hovercard.card?.dataset.revision === String(progressCard.revision)) {
+    this.releasePullRequestStore();
+    const agentId = parseAgentSessionKey(sessionKey)?.agentId ?? gateway.snapshot.assistantAgentId;
+    this.activePullRequestKey = scopedSessionPullRequestKey(sessionKey, agentId ?? undefined);
+    this.pullRequests = sessionPullRequestsForGateway(gateway);
+    this.stopPullRequestUpdates = this.pullRequests.subscribe(this.handlePullRequestUpdate);
+    this.pullRequests.watch(this, [this.activePullRequestKey], { foreground: true });
+  }
+
+  private releasePullRequestStore(): void {
+    this.pullRequests?.unwatch(this);
+    this.stopPullRequestUpdates?.();
+    this.stopPullRequestUpdates = null;
+    this.pullRequests = null;
+    this.activePullRequestKey = null;
+  }
+
+  private showCurrent(): void {
+    const anchor = this.activeAnchor;
+    const sessionKey = this.activeSessionKey;
+    if (!anchor || !sessionKey || !this.open) {
+      return;
+    }
+    const sidebarRow =
+      this.querySelector<AppSidebarSessionNavigationElement>(
+        "openclaw-app-sidebar",
+      )?.findSidebarSessionByKey(sessionKey);
+    const pullRequests = this.activePullRequestKey
+      ? this.pullRequests?.get(this.activePullRequestKey)
+      : undefined;
+    const currentProgressCard = this.progressCards?.get(sessionKey);
+    if (currentProgressCard !== undefined) {
+      this.lastProgressCard = currentProgressCard;
+    }
+    const revision = JSON.stringify({
+      progress: this.lastProgressCard?.revision ?? null,
+      pullRequests: pullRequests
+        ? { branch: pullRequests.branch, pullRequests: pullRequests.pullRequests }
+        : null,
+      row: sidebarRow
+        ? {
+            label: sidebarRow.label,
+            lastMessagePreview: sidebarRow.lastMessagePreview,
+            owner: sidebarRow.owner?.actor ?? sidebarRow.createdActor,
+            startedAt: sidebarRow.startedAt,
+            updatedAt: sidebarRow.updatedAt,
+          }
+        : null,
+    });
+    if (this.hovercard.card?.dataset.revision === revision) {
       return;
     }
     nextHovercardId += 1;
@@ -238,9 +310,22 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       `openclaw-session-progress-hovercard-${nextHovercardId}`,
       "session-progress-hovercard",
     );
-    card.dataset.revision = String(progressCard.revision);
-    card.setAttribute("aria-label", t("sessionProgressCard.ariaLabel"));
-    render(renderSessionProgressCard(progressCard, "hovercard"), card);
+    card.dataset.revision = revision;
+    card.setAttribute("aria-label", t("sessionHovercard.ariaLabel"));
+    render(
+      renderSessionHovercard({
+        row: sidebarRow,
+        pullRequests,
+        progressCard: this.lastProgressCard,
+      }),
+      card,
+    );
+    if (!card.firstElementChild) {
+      this.hovercard.clearCard();
+      this.hovercard.pointerOverCard = false;
+      this.hovercard.cardFocusInside = false;
+      return;
+    }
     card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
     card.addEventListener("focusin", this.handleCardFocusIn);
@@ -294,8 +379,11 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private close(): void {
     this.hovercard.reset();
     this.loadGeneration += 1;
+    this.open = false;
+    this.lastProgressCard = null;
     this.activeAnchorObserver.disconnect();
     this.progressCards?.unwatch(this);
+    this.releasePullRequestStore();
     this.activeAnchor = null;
     this.activeSessionKey = null;
   }

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
+import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
   captureUiProofEnabled,
   chatSessionListResponse,
@@ -30,10 +32,26 @@ async function captureProof(page: Page, fileName: string): Promise<void> {
   });
 }
 
+async function waitForPullRequestSubscription(
+  gateway: Awaited<ReturnType<typeof installMockGateway>>,
+  sessionKey: string,
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const requests = await gateway.getRequests(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+      return requests.some((request) => {
+        const sessionKeys = isRecord(request.params) ? request.params.sessionKeys : undefined;
+        return Array.isArray(sessionKeys) && sessionKeys.includes(sessionKey);
+      });
+    })
+    .toBe(true);
+}
+
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("renders safe progress markdown and refreshes the hovered card after a change event", async () => {
+    const now = Date.now();
     const selectedSessionKey = "agent:main:selected";
     const sessionKey = "agent:main:other-session";
     const initialMarkdown = [
@@ -59,15 +77,21 @@ suite.define(() => {
       },
       async ({ page }) => {
         const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "progressCard.get",
+            SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+          ],
           historyMessages: [
             {
               role: "assistant",
-              timestamp: 1,
+              timestamp: now - 30 * 60_000,
               content: [{ type: "text", text: `Follow progress in ${sessionKey}.` }],
             },
           ],
           methodResponses: {
+            [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
             "progressCard.get": {
               cases: [
                 {
@@ -86,7 +110,7 @@ suite.define(() => {
                         { step: "Package", status: "in_progress" },
                         { step: "Publish", status: "pending" },
                       ],
-                      updatedAt: 1,
+                      updatedAt: now - 15 * 60_000,
                     },
                   },
                 },
@@ -97,14 +121,16 @@ suite.define(() => {
                 key: selectedSessionKey,
                 kind: "direct",
                 label: "Selected session",
-                updatedAt: 3,
+                updatedAt: now - 5 * 60_000,
               },
               {
+                createdActor: { type: "human", id: "profile-ada", label: "Ada King" },
                 key: sessionKey,
                 kind: "direct",
                 label: "Other session",
                 displayName: "Other session",
-                updatedAt: 2,
+                startedAt: now - 2 * 60 * 60_000,
+                updatedAt: now - 15 * 60_000,
               },
             ]),
           },
@@ -133,8 +159,53 @@ suite.define(() => {
         expect(await link.getAttribute("href")).toBe("/chat/main/other-session");
         await link.hover();
 
+        await waitForPullRequestSubscription(gateway, sessionKey);
+        await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+          sessions: {
+            [sessionKey]: {
+              pullRequests: [
+                {
+                  additions: 128,
+                  branch: "steipete/session-hovercard-unify",
+                  changedFiles: 7,
+                  checks: { state: "passing", passed: 24, failed: 0, skipped: 2, running: 0 },
+                  deletions: 34,
+                  number: 417,
+                  owner: "openclaw",
+                  repo: "openclaw",
+                  state: "open",
+                  title: "Restore the session hovercard",
+                  url: "https://github.com/openclaw/openclaw/pull/417",
+                },
+              ],
+              rateLimited: false,
+              status: "ready",
+            },
+          },
+        });
+
         await card.waitFor({ state: "visible" });
         expect(["bottom", "top"]).toContain(await card.getAttribute("data-side"));
+        await expect
+          .poll(() => card.locator(".session-hovercard__title").textContent())
+          .toBe("Other session");
+        await expect
+          .poll(() => card.locator(".session-hovercard__meta").textContent())
+          .toContain("Ada King");
+        const pullRequest = card.locator(".session-hovercard__pr-chip");
+        await expect
+          .poll(() => pullRequest.locator(".session-hovercard__pr-number").textContent())
+          .toBe("#417");
+        expect(await pullRequest.locator(".session-hovercard__checks").textContent()).toBe("✓");
+        expect(await pullRequest.locator(".session-hovercard__files").textContent()).toBe(
+          "7 files",
+        );
+        expect(await pullRequest.locator(".session-hovercard__additions").textContent()).toBe(
+          "+128",
+        );
+        expect(await pullRequest.locator(".session-hovercard__deletions").textContent()).toBe(
+          "−34",
+        );
         await expect.poll(() => card.locator("strong").textContent()).toContain("Building");
 
         const progress = card.locator("progress");
@@ -159,7 +230,25 @@ suite.define(() => {
           .poll(() => card.locator(".session-progress-card__step--pending").textContent())
           .toContain("Publish");
         expect(await page.evaluate(() => "__progressCardPwned" in window)).toBe(false);
-        await captureProof(page, "chat-link-hovercard-open.png");
+        await captureProof(page, "chat-link-hovercard-progress.png");
+
+        await gateway.deferNext("progressCard.get", { sessionKey });
+        await gateway.emitGatewayEvent("progressCard.changed", { revision: 2, sessionKey });
+        await expect
+          .poll(
+            async () =>
+              (await gateway.getRequests("progressCard.get")).filter(
+                (request) => isRecord(request.params) && request.params.sessionKey === sessionKey,
+              ).length,
+          )
+          .toBe(2);
+        await gateway.rejectDeferred("progressCard.get", {
+          code: "UNAVAILABLE",
+          message: "temporary refresh failure",
+          retryable: true,
+        });
+        await expect.poll(() => card.locator("strong").textContent()).toContain("Building");
+        await expect.poll(() => card.locator("progress").getAttribute("value")).toBe("3");
 
         await gateway.setMethodResponse("progressCard.get", {
           cases: [
@@ -176,7 +265,7 @@ suite.define(() => {
                     { step: "Package", status: "completed" },
                     { step: "Publish", status: "in_progress" },
                   ],
-                  updatedAt: 2,
+                  updatedAt: now,
                 },
               },
             },
@@ -196,7 +285,7 @@ suite.define(() => {
                 (request) => isRecord(request.params) && request.params.sessionKey === sessionKey,
               ).length,
           )
-          .toBe(2);
+          .toBe(3);
         await captureProof(page, "hovercard-updated.png");
       },
     );
@@ -296,8 +385,11 @@ suite.define(() => {
     );
   });
 
-  it("quietly leaves a titled link when the session has no progress card", async () => {
+  it("shows the latest turn when the session has no progress card", async () => {
+    const now = Date.now();
     const sessionKey = "agent:main:no-progress-card";
+    const lastMessagePreview =
+      "The final release notes are ready for review, including <strong>plain text</strong>, rollout details, verification notes, compatibility guidance, and a concise operator checklist.";
 
     await suite.withPage(
       {
@@ -312,7 +404,7 @@ suite.define(() => {
           historyMessages: [
             {
               role: "assistant",
-              timestamp: 1,
+              timestamp: now - 10 * 60_000,
               content: [{ type: "text", text: `No card yet for ${sessionKey}.` }],
             },
           ],
@@ -324,7 +416,8 @@ suite.define(() => {
                 kind: "direct",
                 label: "No progress card",
                 displayName: "No progress card",
-                updatedAt: 1,
+                lastMessagePreview,
+                updatedAt: now - 5 * 60_000,
               },
             ]),
           },
@@ -348,7 +441,19 @@ suite.define(() => {
         expect(await link.getAttribute("title")).toBe(sessionKey);
         await link.hover();
         await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);
-        await expect.poll(() => page.locator(".session-progress-hovercard").count()).toBe(0);
+        const card = page.locator(".session-progress-hovercard");
+        await card.waitFor({ state: "visible" });
+        await expect
+          .poll(() => card.locator(".session-hovercard__excerpt").textContent())
+          .toBe(lastMessagePreview);
+        expect(await card.locator(".session-hovercard__excerpt strong").count()).toBe(0);
+        expect(await card.locator(".session-progress-card").count()).toBe(0);
+        expect(
+          await card
+            .locator(".session-hovercard__excerpt")
+            .evaluate((element) => getComputedStyle(element).webkitLineClamp),
+        ).toBe("2");
+        await captureProof(page, "chat-link-hovercard-last-turn.png");
       },
     );
   });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -164,6 +164,27 @@ export const en: TranslationMap = {
     issue: "issue",
     ariaLabel: "{state} {kind} {repo} #{number}: {title}, by {author}",
   },
+  sessionHovercard: {
+    ariaLabel: "Session information",
+    created: "created {time}",
+    updated: "updated {time}",
+    noPrYet: "No PR yet",
+    more: "+{count} more",
+    changedFile: "{count} file",
+    changedFiles: "{count} files",
+    pullRequestLabel: "Pull request #{number}, {state}",
+    states: {
+      open: "Open",
+      draft: "Draft",
+      merged: "Merged",
+      closed: "Closed",
+    },
+    checks: {
+      passing: "CI checks passing",
+      failing: "CI checks failing",
+      pending: "CI checks running",
+    },
+  },
   sessionProgressCard: {
     ariaLabel: "Session progress",
     title: "Progress",

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -4,6 +4,148 @@
   color: var(--text);
 }
 
+.session-hovercard {
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.session-hovercard__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.session-hovercard__avatar {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--accent-subtle) 70%, var(--panel-strong));
+  color: var(--text);
+  flex: 0 0 34px;
+  font-size: var(--control-ui-text-xs);
+  font-weight: 700;
+  place-items: center;
+}
+
+.session-hovercard__heading {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.session-hovercard__title {
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--control-ui-text-sm);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-hovercard__meta,
+.session-hovercard__no-pr,
+.session-hovercard__more {
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1.35;
+}
+
+.session-hovercard__chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.session-hovercard__chip,
+.session-hovercard__diff {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  border: 1px solid color-mix(in srgb, currentColor 24%, var(--border));
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1.4;
+}
+
+.session-hovercard__chip {
+  padding: 3px 8px;
+  text-decoration: none;
+}
+
+.session-hovercard__diff {
+  padding: 3px 7px;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.session-hovercard__pr-chip[data-state="open"] {
+  color: var(--ok);
+}
+
+.session-hovercard__pr-chip[data-state="draft"] {
+  color: var(--muted);
+}
+
+.session-hovercard__pr-chip[data-state="merged"] {
+  color: var(--pr-merged);
+}
+
+.session-hovercard__pr-chip[data-state="closed"] {
+  color: var(--danger);
+}
+
+.session-hovercard__pr-number,
+.session-hovercard__pr-state,
+.session-hovercard__files {
+  color: currentColor;
+}
+
+.session-hovercard__checks[data-checks="passing"],
+.session-hovercard__additions {
+  color: var(--ok);
+}
+
+.session-hovercard__checks[data-checks="failing"],
+.session-hovercard__deletions {
+  color: var(--danger);
+}
+
+.session-hovercard__checks[data-checks="pending"] {
+  color: var(--warn);
+}
+
+.session-hovercard__no-pr a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.session-hovercard__divider {
+  height: 1px;
+  background: var(--border);
+}
+
+.session-hovercard__excerpt {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--control-ui-text-sm);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .session-progress-card--composer {
   flex: 1 1 100%;
   overflow: hidden;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users hovering a chat session link would see only its progress card, or nothing at all when the session had no progress card.

#125733 regressed #125678's composite session-info hovercard while moving the trigger from sidebar rows to chat session links. That removed the owner/timestamp header and detailed pull-request checks/diff presentation, leaving the Gateway's session PR snapshot broadcast without its hovercard renderer.

## Why This Change Was Made

This restores the composite renderer inside the existing chat-link hovercard runtime and keeps the current `a.markdown-session-link[data-session-key]` trigger unchanged, so sidebar rows remain hover-inert. The card now renders session information and PR facts first, then either progress or a bounded plain-text excerpt of the same latest-turn preview used by the sidebar. A failed progress refresh retains the last successful card.

## User Impact

Chat session links once again reveal owner, created/updated timing, pull-request checks, and diff facts. Sessions without a progress card still show something useful—their latest turn—while known sessions without either body render a header-only card and genuinely unknown sessions remain silent.

## Evidence

Before — #125733 left only the progress section:

![Before: progress-only session hovercard](https://github.com/user-attachments/assets/096cf2d4-0b58-4e88-98f1-7c16f3893ca2)

After — one composite card restores session and PR information above progress:

![After: composite session hovercard with progress](https://github.com/user-attachments/assets/976c2744-7de6-4d60-9e6b-9f732b5b79b4)

After — a session without progress shows a literal, two-line latest-turn excerpt:

![After: session hovercard latest-turn fallback](https://github.com/user-attachments/assets/15e82daf-aee4-4125-8c11-1b955d46ee19)

Validated with:

- `pnpm tsgo:ui`
- `pnpm lint:ui:styles`
- `pnpm check:assertion-safety`
- `pnpm deadcode:exports`
- `pnpm ui:i18n:baseline`
- focused renderer/target Vitest: 10 tests passed
- focused mocked-Gateway Playwright E2E: 3 tests passed, including sidebar inertness, PR snapshot rendering, plain-text fallback, keyboard/viewport behavior, revision refresh, and failed-refresh retention
- `pnpm ui:build`
- `pnpm format`
- branch autoreview: no accepted/actionable findings
