### PR TITLE
refactor(slack): remove cache test reset seams

### DIFF
--- a/extensions/slack/src/channel-type.test.ts
+++ b/extensions/slack/src/channel-type.test.ts
@@ -1,10 +1,6 @@
 // Slack tests cover channel type plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  resetSlackChannelTypeCacheForTest,
-  resolveSlackChannelType,
-  resolveSlackConversationInfo,
-} from "./channel-type.js";
+import { resolveSlackChannelType, resolveSlackConversationInfo } from "./channel-type.js";
 import { registerSlackInstallationState } from "./installation-identity-state.js";
 
 const slackClientMocks = vi.hoisted(() => {
@@ -47,7 +43,6 @@ describe("resolveSlackChannelType", () => {
     createSlackWebClientMock.mockClear();
     vi.stubEnv("SLACK_BOT_TOKEN", "");
     vi.stubEnv("SLACK_USER_TOKEN", "");
-    resetSlackChannelTypeCacheForTest();
   });
 
   afterEach(() => {
@@ -55,7 +50,7 @@ describe("resolveSlackChannelType", () => {
   });
 
   it("uses configured defaultAccount for omitted-account cache keys", async () => {
-    const channelId = "C123";
+    const channelId = "CDEFAULTACCOUNT1";
 
     await expect(
       resolveSlackChannelType({
@@ -97,7 +92,7 @@ describe("resolveSlackChannelType", () => {
   it("returns Slack IM peer user metadata from conversations.info", async () => {
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {
-        id: "D0AEWSDHAQH",
+        id: "DINFOMETADATA1",
         is_im: true,
         user: "U09G2DJ0275",
       },
@@ -112,7 +107,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DINFOMETADATA1",
       }),
     ).resolves.toEqual({
       type: "dm",
@@ -120,7 +115,7 @@ describe("resolveSlackChannelType", () => {
     });
     expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test", { teamId: undefined });
     expect(createSlackWebClientMock).not.toHaveBeenCalled();
-    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "D0AEWSDHAQH" });
+    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "DINFOMETADATA1" });
     expect(conversationsOpenMock).not.toHaveBeenCalled();
   });
 
@@ -130,7 +125,7 @@ describe("resolveSlackChannelType", () => {
       await expect(
         resolveSlackConversationInfo({
           cfg: { channels: { slack: { botToken: "xoxb-test" } } } as never,
-          channelId: "C123",
+          channelId: "CENTERPRISELOOKUP1",
         }),
       ).rejects.toThrow("unsupported_enterprise_slack_delivery");
       expect(createSlackReadClientMock).not.toHaveBeenCalled();
@@ -142,7 +137,7 @@ describe("resolveSlackChannelType", () => {
   it("uses conversations.open only for explicit native IM writes", async () => {
     conversationsOpenMock.mockResolvedValueOnce({
       channel: {
-        id: "D0AEWSDHAQH",
+        id: "DEXPLICITWRITE1",
         is_im: true,
         user: "U09G2DJ0275",
       },
@@ -158,7 +153,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DEXPLICITWRITE1",
         operation: "write",
       }),
     ).resolves.toEqual({
@@ -168,7 +163,7 @@ describe("resolveSlackChannelType", () => {
     expect(createSlackWebClientMock).toHaveBeenCalledWith("botB", { teamId: undefined });
     expect(createSlackReadClientMock).not.toHaveBeenCalled();
     expect(conversationsOpenMock).toHaveBeenCalledWith({
-      channel: "D0AEWSDHAQH",
+      channel: "DEXPLICITWRITE1",
       prevent_creation: true,
       return_im: true,
     });
@@ -178,7 +173,7 @@ describe("resolveSlackChannelType", () => {
   it("uses the user token to open native IMs for user identity", async () => {
     conversationsOpenMock.mockResolvedValueOnce({
       channel: {
-        id: "D0AEWSDHAQH",
+        id: "DUSERIDENTITY1",
         is_im: true,
         user: "U09G2DJ0275",
       },
@@ -194,7 +189,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DUSERIDENTITY1",
         operation: "write",
       }),
     ).resolves.toEqual({
@@ -206,7 +201,7 @@ describe("resolveSlackChannelType", () => {
     });
     expect(createSlackReadClientMock).not.toHaveBeenCalled();
     expect(conversationsOpenMock).toHaveBeenCalledWith({
-      channel: "D0AEWSDHAQH",
+      channel: "DUSERIDENTITY1",
       prevent_creation: true,
       return_im: true,
     });
@@ -217,7 +212,7 @@ describe("resolveSlackChannelType", () => {
     vi.stubEnv("SLACK_USER_TOKEN", "envUsr");
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {
-        id: "D0AEWSDHAQH",
+        id: "DENVUSERREAD1",
         is_im: true,
         user: "U09G2DJ0275",
       },
@@ -232,7 +227,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DENVUSERREAD1",
         operation: "read",
       }),
     ).resolves.toEqual({
@@ -241,7 +236,7 @@ describe("resolveSlackChannelType", () => {
     });
     expect(createSlackReadClientMock).toHaveBeenCalledWith("envUsr", { teamId: undefined });
     expect(createSlackWebClientMock).not.toHaveBeenCalled();
-    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "D0AEWSDHAQH" });
+    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "DENVUSERREAD1" });
     expect(conversationsOpenMock).not.toHaveBeenCalled();
   });
 
@@ -249,7 +244,7 @@ describe("resolveSlackChannelType", () => {
     vi.stubEnv("SLACK_BOT_TOKEN", "envBot");
     conversationsOpenMock.mockResolvedValueOnce({
       channel: {
-        id: "D0AEWSDHAQH",
+        id: "DENVBOTWRITE1",
         is_im: true,
         user: "U09G2DJ0275",
       },
@@ -264,7 +259,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DENVBOTWRITE1",
         operation: "write",
       }),
     ).resolves.toEqual({
@@ -274,7 +269,7 @@ describe("resolveSlackChannelType", () => {
     expect(createSlackWebClientMock).toHaveBeenCalledWith("envBot", { teamId: undefined });
     expect(createSlackReadClientMock).not.toHaveBeenCalled();
     expect(conversationsOpenMock).toHaveBeenCalledWith({
-      channel: "D0AEWSDHAQH",
+      channel: "DENVBOTWRITE1",
       prevent_creation: true,
       return_im: true,
     });
@@ -284,7 +279,7 @@ describe("resolveSlackChannelType", () => {
   it("uses the read credential to classify C-prefixed MPIMs and returns their name", async () => {
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {
-        id: "C0MPIM",
+        id: "CREADCREDENTIAL1",
         is_mpim: true,
         name: "mpdm-alice--bob-1",
       },
@@ -300,7 +295,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "C0MPIM",
+        channelId: "CREADCREDENTIAL1",
         operation: "read",
       }),
     ).resolves.toEqual({
@@ -311,20 +306,20 @@ describe("resolveSlackChannelType", () => {
       teamId: undefined,
     });
     expect(createSlackWebClientMock).not.toHaveBeenCalled();
-    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "C0MPIM" });
+    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "CREADCREDENTIAL1" });
   });
 
   it("does not reuse cached metadata across Slack credential rotation", async () => {
     conversationsInfoMock
       .mockResolvedValueOnce({
         channel: {
-          id: "C0CHANNEL",
+          id: "CCREDENTIALROTATION1",
           name: "before-rotation",
         },
       })
       .mockResolvedValueOnce({
         channel: {
-          id: "C0CHANNEL",
+          id: "CCREDENTIALROTATION1",
           name: "after-rotation",
         },
       });
@@ -338,7 +333,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "C0CHANNEL",
+        channelId: "CCREDENTIALROTATION1",
       }),
     ).resolves.toMatchObject({ name: "before-rotation" });
     await expect(
@@ -350,7 +345,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "C0CHANNEL",
+        channelId: "CCREDENTIALROTATION1",
       }),
     ).resolves.toMatchObject({ name: "after-rotation" });
 
@@ -367,13 +362,13 @@ describe("resolveSlackChannelType", () => {
     conversationsInfoMock
       .mockResolvedValueOnce({
         channel: {
-          id: "C0CHANNEL",
+          id: "CFRESHNAME1",
           name: "old-name",
         },
       })
       .mockResolvedValueOnce({
         channel: {
-          id: "C0CHANNEL",
+          id: "CFRESHNAME1",
           name: "new-name",
         },
       });
@@ -388,14 +383,14 @@ describe("resolveSlackChannelType", () => {
     await expect(
       resolveSlackConversationInfo({
         cfg,
-        channelId: "C0CHANNEL",
+        channelId: "CFRESHNAME1",
         requireFreshName: true,
       }),
     ).resolves.toMatchObject({ name: "old-name" });
     await expect(
       resolveSlackConversationInfo({
         cfg,
-        channelId: "C0CHANNEL",
+        channelId: "CFRESHNAME1",
         requireFreshName: true,
       }),
     ).resolves.toMatchObject({ name: "new-name" });
@@ -415,7 +410,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DLOOKUPFAILURE1",
       }),
     ).resolves.toEqual({
       type: "dm",
@@ -425,19 +420,19 @@ describe("resolveSlackChannelType", () => {
   it.each([
     {
       name: "group DM",
-      channelId: "C0MPIM",
+      channelId: "CCONFIGGROUP1",
       slackConfig: {
         dm: {
-          groupChannels: ["C0MPIM"],
+          groupChannels: ["CCONFIGGROUP1"],
         },
       },
     },
     {
       name: "channel",
-      channelId: "C0CHANNEL",
+      channelId: "CCONFIGCHANNEL1",
       slackConfig: {
         channels: {
-          C0CHANNEL: {},
+          CCONFIGCHANNEL1: {},
         },
       },
     },
@@ -468,7 +463,7 @@ describe("resolveSlackChannelType", () => {
   it("keeps successful Slack metadata authoritative over configured fallback", async () => {
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {
-        id: "C0CHANNEL",
+        id: "CAUTHORITATIVE1",
         is_mpim: false,
       },
     });
@@ -480,12 +475,12 @@ describe("resolveSlackChannelType", () => {
             slack: {
               botToken: "xoxb-test",
               dm: {
-                groupChannels: ["C0CHANNEL"],
+                groupChannels: ["CAUTHORITATIVE1"],
               },
             },
           },
         } as never,
-        channelId: "C0CHANNEL",
+        channelId: "CAUTHORITATIVE1",
       }),
     ).resolves.toEqual({
       type: "channel",
@@ -497,7 +492,7 @@ describe("resolveSlackChannelType", () => {
       .mockRejectedValueOnce(new Error("temporary_failure"))
       .mockResolvedValueOnce({
         channel: {
-          id: "D0AEWSDHAQH",
+          id: "DRETRYLOOKUP1",
           is_im: true,
           user: "U09G2DJ0275",
         },
@@ -514,7 +509,7 @@ describe("resolveSlackChannelType", () => {
     await expect(
       resolveSlackConversationInfo({
         cfg,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DRETRYLOOKUP1",
       }),
     ).resolves.toEqual({
       type: "dm",
@@ -522,7 +517,7 @@ describe("resolveSlackChannelType", () => {
     await expect(
       resolveSlackConversationInfo({
         cfg,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DRETRYLOOKUP1",
       }),
     ).resolves.toEqual({
       type: "dm",
@@ -539,12 +534,12 @@ describe("resolveSlackChannelType", () => {
           channels: {
             slack: {
               dm: {
-                groupChannels: ["D0AEWSDHAQH"],
+                groupChannels: ["DNATIVEOVERRIDE1"],
               },
             },
           },
         } as never,
-        channelId: "D0AEWSDHAQH",
+        channelId: "DNATIVEOVERRIDE1",
       }),
     ).resolves.toEqual({
       type: "dm",
@@ -572,32 +567,32 @@ describe("resolveSlackChannelType", () => {
     for (let index = 0; index < cacheMaxEntries; index++) {
       await resolveSlackConversationInfo({
         cfg,
-        channelId: `C${index.toString().padStart(8, "0")}`,
+        channelId: `C${index.toString().padStart(10, "0")}`,
       });
     }
     expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries);
 
     await resolveSlackConversationInfo({
       cfg,
-      channelId: "C00000000",
+      channelId: "C0000000000",
     });
     expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries);
 
     await resolveSlackConversationInfo({
       cfg,
-      channelId: `C${cacheMaxEntries.toString().padStart(8, "0")}`,
+      channelId: `C${cacheMaxEntries.toString().padStart(10, "0")}`,
     });
     expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries + 1);
 
     await resolveSlackConversationInfo({
       cfg,
-      channelId: "C00000001",
+      channelId: "C0000000001",
     });
     expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries + 2);
 
     await resolveSlackConversationInfo({
       cfg,
-      channelId: "C00000000",
+      channelId: "C0000000000",
     });
     expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries + 2);
   });
@@ -605,7 +600,7 @@ describe("resolveSlackChannelType", () => {
   it("preserves the channel-type wrapper contract", async () => {
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {
-        id: "G123",
+        id: "GWRAPPERCONTRACT1",
         is_mpim: true,
       },
     });
@@ -619,7 +614,7 @@ describe("resolveSlackChannelType", () => {
             },
           },
         } as never,
-        channelId: "G123",
+        channelId: "GWRAPPERCONTRACT1",
       }),
     ).resolves.toBe("group");
   });

--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -159,7 +159,3 @@ export async function resolveSlackChannelType(params: {
 }): Promise<"channel" | "group" | "dm" | "unknown"> {
   return (await resolveSlackConversationInfo(params)).type;
 }
-
-export function resetSlackChannelTypeCacheForTest(): void {
-  SLACK_CONVERSATION_INFO_CACHE.clear();
-}

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -12,11 +12,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveSlackAttachmentContent,
   resolveSlackMedia,
-  resolveSlackThreadHistory,
-  resolveSlackThreadStarter,
-  resetSlackThreadStarterCacheForTest,
   SLACK_MEDIA_READ_IDLE_TIMEOUT_MS,
 } from "./media.js";
+import { resolveSlackThreadHistory, resolveSlackThreadStarter } from "./thread.js";
 import { logVerbose } from "./thread.runtime.js";
 
 type FetchMock = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -29,13 +27,19 @@ type SaveMediaBufferMock = (
 ) => Promise<SavedMedia>;
 type SlackMediaResult = NonNullable<Awaited<ReturnType<typeof resolveSlackMedia>>>;
 type ResolveSlackThreadStarterParams = Parameters<typeof resolveSlackThreadStarter>[0];
+let threadStarterIdentitySequence = 0;
+let threadStarterIdentity = {
+  channelId: "CMEDIA0",
+  threadTs: "0.000",
+  workspaceScope: { accountId: "media-test-0", teamId: "TM0" },
+};
 
 function resolveTestSlackThreadStarter(
-  params: Omit<ResolveSlackThreadStarterParams, "workspaceScope">,
+  params: Omit<ResolveSlackThreadStarterParams, "channelId" | "threadTs" | "workspaceScope">,
 ) {
   return resolveSlackThreadStarter({
     ...params,
-    workspaceScope: { accountId: "test", teamId: "T1" },
+    ...threadStarterIdentity,
   });
 }
 
@@ -143,6 +147,15 @@ const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof vi.fn<FetchMock>>;
 
 beforeEach(() => {
+  threadStarterIdentitySequence += 1;
+  threadStarterIdentity = {
+    channelId: `CMEDIA${threadStarterIdentitySequence}`,
+    threadTs: `${threadStarterIdentitySequence}.000`,
+    workspaceScope: {
+      accountId: `media-test-${threadStarterIdentitySequence}`,
+      teamId: `TM${threadStarterIdentitySequence}`,
+    },
+  };
   readRemoteMediaBufferMock.mockClear();
   fetchWithRuntimeDispatcherMock.mockClear();
   logVerboseMock.mockClear();
@@ -1649,7 +1662,6 @@ describe("resolveSlackThreadHistory", () => {
 
 describe("resolveSlackThreadStarter", () => {
   beforeEach(() => {
-    resetSlackThreadStarterCacheForTest();
     vi.mocked(logVerbose).mockClear();
   });
 
@@ -1662,8 +1674,6 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1.000",
       client,
     });
 
@@ -1684,8 +1694,6 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1.000",
       client,
     });
 
@@ -1715,8 +1723,6 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1.000",
       client,
     });
 
@@ -1756,8 +1762,6 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1.000",
       client,
     });
 
@@ -1780,8 +1784,6 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1.000",
       client,
     });
 
@@ -1802,16 +1804,14 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C42",
-      threadTs: "9.999",
       client,
     });
 
     expect(result).toBeNull();
     expectVerboseLogContains("slack thread starter fetch failed");
     expectVerboseLogContains("not_in_channel");
-    expectVerboseLogContains("channel=C42");
-    expectVerboseLogContains("ts=9.999");
+    expectVerboseLogContains(`channel=${threadStarterIdentity.channelId}`);
+    expectVerboseLogContains(`ts=${threadStarterIdentity.threadTs}`);
   });
 
   it("surfaces non-Error thrown values via logVerbose", async () => {
@@ -1821,8 +1821,6 @@ describe("resolveSlackThreadStarter", () => {
     } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
 
     const result = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1.000",
       client,
     });
 

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -16,11 +16,6 @@ import { type FetchLike, fetchWithRuntimeDispatcher, saveRemoteMedia } from "./m
 import { isGovSlackClient } from "./slack-client-kind.js";
 import { logVerbose } from "./thread.runtime.js";
 export type { SlackMediaResult } from "./media-types.js";
-export {
-  resetSlackThreadStarterCacheForTest,
-  resolveSlackThreadHistory,
-  resolveSlackThreadStarter,
-} from "./thread.js";
 
 function isSlackHostname(hostname: string, govSlack: boolean): boolean {
   const normalized = normalizeHostname(hostname);

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -23,7 +23,6 @@ import {
 import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackEventScope } from "../event-scope.js";
-import { resetSlackThreadStarterCacheForTest } from "../thread.js";
 import { resolveSlackMessageContent } from "./prepare-content.js";
 import { prepareSlackMessage } from "./prepare.js";
 import {
@@ -101,7 +100,6 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   beforeEach(() => {
-    resetSlackThreadStarterCacheForTest();
     clearSlackThreadParticipationCache();
     enqueueSystemEventMock.mockClear();
     logVerboseMock.mockClear();
@@ -1313,11 +1311,16 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expectFollowUpMentioned?: boolean;
   };
 
+  let threadRouteScenarioSequence = 0;
+
   async function runThreadRouteScenario(scenario: ThreadRouteScenario) {
     const implicit = scenario.mentionType === "implicit";
     const channelId = implicit ? "C0AGG76CP1S" : "C0AHZFCAS1K";
     const userId = implicit ? "U_TRAJCHE" : "U_BEK";
-    const rootTs = implicit ? "1778073105.769279" : "1777244692.409919";
+    threadRouteScenarioSequence += 1;
+    const rootTs = `${implicit ? "1778073105" : "1777244692"}.${String(
+      700_000 + threadRouteScenarioSequence,
+    ).padStart(6, "0")}`;
     const replyToMode = implicit ? "first" : "all";
     const rootText = implicit
       ? "What day is it?"
@@ -3082,6 +3085,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
 
     const prepared = await prepareThreadMessage(slackCtx, {
+      channel: "CFIRSTTHREADTURN1",
       text: "current message",
       ts: "101.000",
     });
@@ -3212,7 +3216,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
   it("uses room users allowlist for thread context filtering", async () => {
     const { prepared, replies } = await prepareThreadContextAllowlistCase({
-      channel: "C123",
+      channel: "CROOMALLOWLIST1",
       channelType: "channel",
       user: "U1",
       userName: "Alice",
@@ -3223,7 +3227,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       followUpTs: "100.800",
       currentTs: "101.000",
       channelsConfig: {
-        C123: {
+        CROOMALLOWLIST1: {
           users: ["U1"],
           requireMention: false,
         },
@@ -3915,6 +3919,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
 
       const prepared = await prepareThreadMessage(slackCtx, {
+        channel: "C123",
         text: "bound reply",
         ts: "101.000",
         thread_ts: "100.000",
@@ -3969,6 +3974,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       slackCtx,
       createThreadAccount("foundation"),
       createThreadReplyMessage({
+        channel: "CFOUNDATIONTHREAD1",
         text: "bound thread reply",
         ts: "101.000",
         thread_ts: "100.000",

--- a/extensions/slack/src/monitor/monitor.media.test.ts
+++ b/extensions/slack/src/monitor/monitor.media.test.ts
@@ -1,11 +1,12 @@
 // Slack tests cover monitor.media plugin behavior.
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { resetSlackThreadStarterCacheForTest, resolveSlackThreadStarter } from "./thread.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSlackThreadStarter } from "./thread.js";
 
 type ResolveSlackThreadStarterParams = Parameters<typeof resolveSlackThreadStarter>[0];
 type ThreadStarterClient = ResolveSlackThreadStarterParams["client"];
 
-const TEST_WORKSPACE_SCOPE = { accountId: "test", teamId: "T1" };
+let testWorkspaceSequence = 0;
+let testWorkspaceScope = { accountId: "test-0", teamId: "T0" };
 
 function resolveTestSlackThreadStarter(
   params: Omit<ResolveSlackThreadStarterParams, "workspaceScope"> & {
@@ -14,7 +15,7 @@ function resolveTestSlackThreadStarter(
 ) {
   return resolveSlackThreadStarter({
     ...params,
-    workspaceScope: params.workspaceScope ?? TEST_WORKSPACE_SCOPE,
+    workspaceScope: params.workspaceScope ?? testWorkspaceScope,
   });
 }
 
@@ -31,8 +32,15 @@ function createThreadStarterRepliesClient(
 }
 
 describe("resolveSlackThreadStarter cache", () => {
+  beforeEach(() => {
+    testWorkspaceSequence += 1;
+    testWorkspaceScope = {
+      accountId: `test-${testWorkspaceSequence}`,
+      teamId: `T${testWorkspaceSequence}`,
+    };
+  });
+
   afterEach(() => {
-    resetSlackThreadStarterCacheForTest();
     vi.useRealTimers();
   });
 
@@ -107,45 +115,6 @@ describe("resolveSlackThreadStarter cache", () => {
       client,
     });
 
-    expect(replies).toHaveBeenCalledTimes(2);
-  });
-
-  it("drops cached thread starters when the current clock is not a valid date timestamp", async () => {
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
-    const { replies, client } = createThreadStarterRepliesClient();
-
-    const first = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1000.1",
-      client,
-    });
-    nowSpy.mockReturnValue(Number.NaN);
-    const second = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1000.1",
-      client,
-    });
-
-    expect(first).toEqual(second);
-    expect(replies).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not cache thread starters when the expiry timestamp would exceed the valid date range", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_000);
-    const { replies, client } = createThreadStarterRepliesClient();
-
-    const first = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1000.1",
-      client,
-    });
-    const second = await resolveTestSlackThreadStarter({
-      channelId: "C1",
-      threadTs: "1000.1",
-      client,
-    });
-
-    expect(first).toEqual(second);
     expect(replies).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -193,10 +193,6 @@ export async function resolveSlackThreadStarter(params: {
   }
 }
 
-export function resetSlackThreadStarterCacheForTest(): void {
-  THREAD_STARTER_CACHE.clear();
-}
-
 type SlackThreadMessage = {
   text: string;
   userId?: string;


### PR DESCRIPTION
## What Problem This Solves

Slack cache tests depended on production-only reset exports and a historical media-module resolver barrel. That made behavior tests clear internal module state instead of isolating through the cache identities production actually uses.

## Why This Change Was Made

Tests now isolate conversation-info caching through distinct Slack-shaped channel IDs and thread-starter caching through distinct account/team/channel/thread identities. Cache reuse, credential rotation, fresh-name authorization, failed-DM retry, TTL refetch, account/team isolation, and the exact 1024-entry and 2000-entry capacity boundaries remain covered. Two impossible-clock thread-cache cases were removed because they replay the shared normalization-core timestamp contract.

Production behavior is unchanged. This removes the two test-only reset exports and the obsolete thread-resolver re-exports from `media.ts`; runtime callers already import from `thread.ts`.

## User Impact

No user-visible behavior changes. No docs, changelog, schema, protocol, config, dependency, operator-state, release, or publish changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/slack/src/channel-type.test.ts` — 18 passed
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/monitor.media.test.ts extensions/slack/src/monitor/media.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor.tool-result.test.ts` — 259 passed
- `node scripts/run-vitest.mjs extensions/slack` — 135 files, 2,417 tests passed
- `node scripts/check-changed.mjs -- extensions/slack/src/channel-type.test.ts extensions/slack/src/channel-type.ts extensions/slack/src/monitor/media.test.ts extensions/slack/src/monitor/media.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/monitor.media.test.ts extensions/slack/src/monitor/thread.ts` — passed
- `git diff --check` — passed
- Codex-backed autoreview — clean, no accepted/actionable findings

Production LOC: +0/-13 (net -13). Tests: +93/-125 (net -32). Total: +93/-138 across seven files.

AI-assisted: implemented and validated with Codex; the final diff was reviewed by the repository autoreview workflow.
