### PR TITLE
fix: Claude live sessions lose prompt cache on every captured turn

### DIFF
--- a/src/agents/cli-runner/claude-live-process-approval.test.ts
+++ b/src/agents/cli-runner/claude-live-process-approval.test.ts
@@ -523,6 +523,6 @@ describe("Claude live process approvals", () => {
         deniedReason: "plugin-approval",
       },
     ]);
-    expect(liveRunLifecycle.cancel).toHaveBeenCalledWith("manual-cancel");
+    expect(liveRunLifecycle.cancel).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/cli-runner/claude-live-process-capture.test.ts
+++ b/src/agents/cli-runner/claude-live-process-capture.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { markMcpLoopbackRequestStarted } from "../../gateway/mcp-http.loopback-runtime.js";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import {
+  buildClaudeLiveRunContext,
+  buildPreparedCliRunContext,
+  createCancelableLiveRunLifecycle,
+  createClaudeInputStartedEvent,
+  mockClaudeLiveRun,
+} from "../cli-runner.test-helpers.js";
+import {
+  restoreCliRunnerPrepareTestDeps,
+  supervisorSpawnMock,
+} from "../cli-runner.test-support.js";
+import { runClaudeTurn } from "./claude-live-session.js";
+import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
+import { executePreparedCliRun } from "./execute.js";
+import { cliBackendLog } from "./log.js";
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+function emitClaudeInputStarted(stdout: ((chunk: string) => void) | undefined, data: string): void {
+  const event = createClaudeInputStartedEvent(data);
+  if (event) {
+    stdout?.(`${JSON.stringify(event)}\n`);
+  }
+}
+
+function createCapturedLiveTurnRunner(options: {
+  results: string[];
+  cleanup?: (runId: string) => Promise<void>;
+}) {
+  const cancels: Array<ReturnType<typeof vi.fn>> = [];
+  const captureKeys: string[] = [];
+  let turnIndex = 0;
+  supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+    const spawnIndex = supervisorSpawnMock.mock.calls.length;
+    const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+    const lifecycle = createCancelableLiveRunLifecycle();
+    cancels.push(lifecycle.cancel);
+    return {
+      runId: `live-run-${spawnIndex}`,
+      pid: 2345 + spawnIndex,
+      startedAtMs: Date.now(),
+      stdin: {
+        write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+          emitClaudeInputStarted(input.onStdout, dataValue);
+          const result = options.results[turnIndex] ?? "ok";
+          turnIndex += 1;
+          input.onStdout?.(
+            [
+              JSON.stringify({ type: "system", subtype: "init", session_id: "live-session" }),
+              JSON.stringify({ type: "result", session_id: "live-session", result }),
+            ].join("\n") + "\n",
+          );
+          cb?.();
+        }),
+        end: vi.fn(),
+      },
+      ...lifecycle,
+    };
+  });
+  const runTurn = async (runId: string, args: string[], env: Record<string, string>) => {
+    const context = buildClaudeLiveRunContext({
+      runId,
+      backend: {
+        resumeArgs: ["-p", "--output-format", "stream-json", "--resume", "{sessionId}"],
+      },
+      mcpDeliveryCapture: true,
+    });
+    const result = await runClaudeTurn({
+      context,
+      args,
+      env,
+      prompt: "hi",
+      useResume: args.some((entry) => entry.startsWith("--resume")),
+      noOutputTimeoutMs: 1_000,
+      getProcessSupervisor: () => ({
+        spawn: (spawnArgs: Parameters<SupervisorSpawnFn>[0]) =>
+          supervisorSpawnMock(spawnArgs) as ReturnType<SupervisorSpawnFn>,
+        cancel: vi.fn(),
+        cancelScope: vi.fn(),
+        getRecord: vi.fn(),
+      }),
+      onAssistantDelta: () => {},
+      onMcpCaptureReady: (captureKey) => captureKeys.push(captureKey),
+      cleanup: async () => {
+        await options.cleanup?.(runId);
+      },
+    });
+    return result.output.text;
+  };
+  return { cancels, captureKeys, runTurn };
+}
+
+beforeEach(() => {
+  resetClaudeLiveSessionsForTest();
+  restoreCliRunnerPrepareTestDeps();
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  resetClaudeLiveSessionsForTest();
+});
+
+describe("Claude live MCP capture lifetime", () => {
+  it("reuses a captured Claude live process and capture key across resume turns", async () => {
+    const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
+    const { cancels, captureKeys, runTurn } = createCapturedLiveTurnRunner({
+      results: ["first-ok", "resume-ok"],
+    });
+    const env = { ANTHROPIC_BASE_URL: "https://one.example" };
+    const freshArgs = ["-p", "--output-format", "stream-json"];
+    const resumeArgs = ["-p", "--output-format", "stream-json", "--resume", "live-session"];
+
+    await expect(runTurn("run-live-fresh", freshArgs, env)).resolves.toBe("first-ok");
+    await expect(runTurn("run-live-resume", resumeArgs, env)).resolves.toBe("resume-ok");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledOnce();
+    expect(cancels[0]).not.toHaveBeenCalled();
+    expect(captureKeys[0]).toEqual(expect.any(String));
+    expect(captureKeys).toEqual([captureKeys[0], captureKeys[0]]);
+    expect(
+      logInfoSpy.mock.calls
+        .map(([message]) => message)
+        .filter((message) => typeof message === "string" && message.includes("reason=restart")),
+    ).toEqual([]);
+  });
+
+  it("still restarts a captured Claude live process when resume identity changes", async () => {
+    const logWarnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    const { cancels, captureKeys, runTurn } = createCapturedLiveTurnRunner({
+      results: ["first-ok", "env-ok", "fresh-ok"],
+      cleanup: async (runId) => {
+        if (runId === "run-live-fresh") {
+          throw new Error("captured cleanup failed");
+        }
+      },
+    });
+    const freshArgs = ["-p", "--output-format", "stream-json"];
+    const resumeArgs = ["-p", "--output-format", "stream-json", "--resume", "live-session"];
+
+    await expect(
+      runTurn("run-live-fresh", freshArgs, { ANTHROPIC_BASE_URL: "https://one.example" }),
+    ).resolves.toBe("first-ok");
+    await expect(
+      runTurn("run-live-env-change", resumeArgs, { ANTHROPIC_BASE_URL: "https://two.example" }),
+    ).resolves.toBe("env-ok");
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+    expect(cancels[0]).toHaveBeenCalledWith("manual-cancel");
+    expect(captureKeys[1]).not.toBe(captureKeys[0]);
+
+    await expect(
+      runTurn("run-live-fresh-retry", freshArgs, { ANTHROPIC_BASE_URL: "https://two.example" }),
+    ).resolves.toBe("fresh-ok");
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(3);
+    expect(cancels[1]).toHaveBeenCalledWith("manual-cancel");
+    expect(captureKeys[2]).not.toBe(captureKeys[1]);
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Claude live session cleanup failed: captured cleanup failed"),
+    );
+  });
+
+  it("fences a reused Claude live capture key between execute turns", async () => {
+    const live = mockClaudeLiveRun(supervisorSpawnMock, {
+      cancelable: true,
+      onWrite: ({ data, emit, writeIndex }) => {
+        if ((JSON.parse(data) as { type?: string }).type !== "user") {
+          return;
+        }
+        emit([
+          { type: "system", subtype: "init", session_id: "captured-live" },
+          {
+            type: "result",
+            session_id: "captured-live",
+            result: writeIndex === 0 ? "one" : "two",
+          },
+        ]);
+      },
+    });
+    const activateCapture = vi.fn<(captureKey: string) => void>();
+    const deactivateCapture = vi.fn<(captureKey: string) => void>();
+    const backend = {
+      resumeArgs: ["-p", "--output-format", "stream-json", "--resume={sessionId}"],
+      liveSession: "claude-stdio" as const,
+    };
+    const buildContext = (prompt: string) => {
+      const context = buildPreparedCliRunContext({
+        backend,
+        prompt,
+        mcpDeliveryCapture: true,
+      });
+      context.preparedBackend.mcpClientGrantCapture = {
+        activate: activateCapture,
+        deactivate: deactivateCapture,
+      };
+      return context;
+    };
+
+    const first = await executePreparedCliRun(buildContext("first"));
+    const second = await executePreparedCliRun(buildContext("second"), "captured-live");
+
+    expect(first.text).toBe("one");
+    expect(second.text).toBe("two");
+    expect(supervisorSpawnMock).toHaveBeenCalledOnce();
+    expect(live.lifecycle.cancel).not.toHaveBeenCalled();
+    const captureKey = activateCapture.mock.calls[0]?.[0];
+    expect(typeof captureKey).toBe("string");
+    expect(captureKey?.length).toBeGreaterThan(0);
+    expect(activateCapture.mock.calls.map(([key]) => key)).toEqual([captureKey, captureKey]);
+    expect(deactivateCapture.mock.calls.map(([key]) => key)).toEqual([captureKey, captureKey]);
+    expect(deactivateCapture.mock.invocationCallOrder[0]).toBeLessThan(
+      activateCapture.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  it("closes a captured Claude live process when MCP delivery capture cannot drain", async () => {
+    const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
+    const live = mockClaudeLiveRun(supervisorSpawnMock, {
+      cancelable: true,
+      onWrite: ({ data, emit }) => {
+        if ((JSON.parse(data) as { type?: string }).type !== "user") {
+          return;
+        }
+        markMcpLoopbackRequestStarted(live.spawnInput.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY);
+        emit([
+          { type: "system", subtype: "init", session_id: "captured-drain" },
+          { type: "result", session_id: "captured-drain", result: "ok" },
+        ]);
+      },
+    });
+    const context = buildClaudeLiveRunContext({
+      backend: {
+        resumeArgs: ["-p", "--output-format", "stream-json", "--resume={sessionId}"],
+      },
+      mcpDeliveryCapture: true,
+    });
+
+    await expect(executePreparedCliRun(context)).rejects.toThrow(
+      "CLI message tool call remained in flight after exit",
+    );
+    expect(live.lifecycle.cancel).toHaveBeenCalledWith("manual-cancel");
+    expect(
+      logInfoSpy.mock.calls
+        .map(([message]) => message)
+        .some(
+          (message) =>
+            typeof message === "string" && message.includes("reason=mcp-capture-rotation"),
+        ),
+    ).toBe(true);
+  }, 15_000);
+});

--- a/src/agents/cli-runner/claude-live-process.test.ts
+++ b/src/agents/cli-runner/claude-live-process.test.ts
@@ -28,7 +28,6 @@ import { callGatewayTool } from "../tools/gateway.js";
 import { runClaudeTurn } from "./claude-live-session.js";
 import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
 import { executePreparedCliRun } from "./execute.js";
-import { cliBackendLog } from "./log.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 vi.mock("../tools/gateway.js", () => ({
@@ -637,131 +636,6 @@ describe("Claude live process", () => {
 
     expect(cleanup).toHaveBeenCalledOnce();
     expect(supervisorSpawnMock).not.toHaveBeenCalled();
-  });
-
-  it("uses a fresh Claude live process and capture key for every captured turn", async () => {
-    const logWarnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    const cancels: Array<ReturnType<typeof vi.fn>> = [];
-    const captureKeys: string[] = [];
-    const turnResults = ["first-ok", "resume-ok", "env-ok", "fresh-ok"];
-    let turnIndex = 0;
-    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
-      const spawnIndex = supervisorSpawnMock.mock.calls.length;
-      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
-      const cancel = vi.fn();
-      cancels.push(cancel);
-      let resolveExit: (() => void) | undefined;
-      const exited = new Promise<{
-        reason: "manual-cancel";
-        exitCode: null;
-        exitSignal: null;
-        durationMs: number;
-        stdout: string;
-        stderr: string;
-        timedOut: false;
-        noOutputTimedOut: false;
-      }>((resolve) => {
-        resolveExit = () =>
-          resolve({
-            reason: "manual-cancel",
-            exitCode: null,
-            exitSignal: null,
-            durationMs: 1,
-            stdout: "",
-            stderr: "",
-            timedOut: false,
-            noOutputTimedOut: false,
-          });
-      });
-      cancel.mockImplementation(() => resolveExit?.());
-      return {
-        runId: `live-run-${spawnIndex}`,
-        pid: 2345 + spawnIndex,
-        startedAtMs: Date.now(),
-        stdin: {
-          write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
-            emitClaudeInputStarted(input.onStdout, dataValue);
-            const result = turnResults[turnIndex] ?? "ok";
-            turnIndex += 1;
-            input.onStdout?.(
-              [
-                JSON.stringify({ type: "system", subtype: "init", session_id: "live-session" }),
-                JSON.stringify({ type: "result", session_id: "live-session", result }),
-              ].join("\n") + "\n",
-            );
-            cb?.();
-          }),
-          end: vi.fn(),
-        },
-        wait: vi.fn(() => exited),
-        cancel,
-      };
-    });
-    const runTurn = async (runId: string, args: string[], env: Record<string, string>) => {
-      const context = buildClaudeLiveRunContext({
-        runId,
-        backend: {
-          resumeArgs: ["-p", "--output-format", "stream-json", "--resume", "{sessionId}"],
-        },
-        mcpDeliveryCapture: true,
-      });
-      const result = await runClaudeTurn({
-        context,
-        args,
-        env,
-        prompt: "hi",
-        useResume: args.some((entry) => entry.startsWith("--resume")),
-        noOutputTimeoutMs: 1_000,
-        getProcessSupervisor: () => ({
-          spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
-            supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
-          cancel: vi.fn(),
-          cancelScope: vi.fn(),
-          getRecord: vi.fn(),
-        }),
-        onAssistantDelta: () => {},
-        onMcpCaptureReady: (captureKey) => captureKeys.push(captureKey),
-        cleanup: async () => {
-          if (runId === "run-live-resume") {
-            throw new Error("captured cleanup failed");
-          }
-        },
-      });
-      return result.output.text;
-    };
-    const freshArgs = ["-p", "--output-format", "stream-json"];
-    const resumeArgs = ["-p", "--output-format", "stream-json", "--resume", "live-session"];
-
-    await expect(
-      runTurn("run-live-fresh", freshArgs, { ANTHROPIC_BASE_URL: "https://one.example" }),
-    ).resolves.toBe("first-ok");
-    await expect(
-      runTurn("run-live-resume", resumeArgs, { ANTHROPIC_BASE_URL: "https://one.example" }),
-    ).resolves.toBe("resume-ok");
-    expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
-    expect(cancels[0]).toHaveBeenCalledWith("manual-cancel");
-    expect(cancels[1]).toHaveBeenCalledWith("manual-cancel");
-    expect(captureKeys[1]).not.toBe(captureKeys[0]);
-
-    await expect(
-      runTurn("run-live-env-change", resumeArgs, { ANTHROPIC_BASE_URL: "https://two.example" }),
-    ).resolves.toBe("env-ok");
-    expect(supervisorSpawnMock).toHaveBeenCalledTimes(3);
-    expect(cancels[2]).toHaveBeenCalledWith("manual-cancel");
-    expect(captureKeys[2]).not.toBe(captureKeys[1]);
-
-    await expect(
-      runTurn("run-live-fresh-retry", freshArgs, {
-        ANTHROPIC_BASE_URL: "https://two.example",
-      }),
-    ).resolves.toBe("fresh-ok");
-
-    expect(supervisorSpawnMock).toHaveBeenCalledTimes(4);
-    expect(cancels[3]).toHaveBeenCalledWith("manual-cancel");
-    expect(captureKeys[3]).not.toBe(captureKeys[2]);
-    expect(logWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Claude live session cleanup failed: captured cleanup failed"),
-    );
   });
 
   it.each([

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -452,6 +452,9 @@ async function runSerializedClaudeTurn(
       });
     }
     const generation = crypto.randomUUID();
+    // Capture keys are child env/MCP-header state and cannot rotate without a
+    // new process. Bind one key to this process; grant activate/deactivate is
+    // the per-turn admission fence. Drain timeout still kills the child.
     const mcpCaptureKey = params.context.mcpDeliveryCapture ? crypto.randomUUID() : undefined;
     if (mcpCaptureKey) {
       try {
@@ -562,16 +565,8 @@ async function runSerializedClaudeTurn(
     return { output: await outputPromise };
   } finally {
     params.context.params.abortSignal?.removeEventListener("abort", abort);
-    try {
-      if (replyBackendHandle) {
-        params.context.params.replyOperation?.detachBackend(replyBackendHandle);
-      }
-    } finally {
-      if (session.mcpCaptureKey) {
-        session.close("restart");
-        await session.waitForExit();
-        await session.cleanupResources();
-      }
+    if (replyBackendHandle) {
+      params.context.params.replyOperation?.detachBackend(replyBackendHandle);
     }
   }
 }

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -573,6 +573,8 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         return;
       }
       if (params.useManagedClaudeLiveSession) {
+        // The child still holds the process-env capture key. If drain cannot
+        // prove idle, kill it so a stale key cannot admit later sends.
         await closeClaudeSession(context, "mcp-capture-rotation");
       }
       const internalStates = await Promise.all(
@@ -599,7 +601,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   };
 
   const finalizeCapture = (finalizeParsedTools: () => void) => {
-    // Captured MCP calls may settle after the CLI process exits. Drain first so
+    // Captured MCP calls may settle after the attempt returns. Drain first so
     // finalization can use their trusted terminal outcomes.
     try {
       finalizeParsedTools();

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -357,7 +357,7 @@ export async function waitForMcpLoopbackToolCallCaptureIdle(
   return true;
 }
 
-/** Clear an unfinished invocation capture. Attempt keys are unique per CLI execution. */
+/** Clear observers for this capture key. Grant admission is fenced separately. */
 export function clearMcpLoopbackToolCallCapture(captureKey: string): void {
   deleteMcpLoopbackToolCallCapture(captureKey.trim());
 }


### PR DESCRIPTION
Related: #124300

## What Problem This Solves

Fixes an issue where users running OpenClaw through the Claude CLI live backend with MCP delivery capture (the default Gateway message-tool path, including Telegram) would lose prompt-cache continuity after **every** completed turn. Each message spawned a fresh `claude` process that resumed from disk, so the first resume of a process could rewrite the entire prompt prefix.

Measured today on one Telegram Fable session (09:28–10:48 UTC, 2026-08-18): 42 API iterations, 7,237,084 cache-read tokens, and 1,174,177 one-hour cache-write tokens (billed 2x input). The final iteration read 0 cached tokens and rewrote 215,064. Gateway journals showed every completed Claude turn logging `claude live session close: ... reason=restart`.

This is the remaining steady-state cost after #124300 (`7f93011562d`), which already restored cache reuse **within** a live process. Per-turn process death made that worst case the normal path.

## Why This Change Was Made

The capture key must ride child process environment and MCP headers (`OPENCLAW_MCP_CLI_CAPTURE_KEY`, `x-openclaw-cli-capture-key`). Claude materializes those at spawn; there is no stdio control to rotate them without a new process. Commit `0ea08076c3b5` therefore killed the warm process after every captured turn so the attempt could release the key without leaving it usable for later sends (`f5aba544373` later moved that `finally` block).

This change keeps that security invariant without the kill:

- Mint **one capture key per live process** at spawn.
- Each turn activates the MCP loopback grant for that key before writing the user prompt, then deactivates it after drain/finalize. Late or cross-turn requests fail grant resolution because `activeCaptureKey` is cleared.
- If MCP delivery drain cannot prove idle (`CLI_MCP_DELIVERY_DRAIN_GRACE_MS`, plus 250ms admission grace), close the session with `mcp-capture-rotation` so the env key dies with the child.
- Genuine restarts stay: fingerprint/env change, non-resume vs resume-capable, `forceNewSession`, fork (`closeClaudeSession(..., "restart")`), idle timeout, abort, and run-end live-session cleanup.

Non-live one-shot CLI still gets a unique per-attempt key. Unchanged.

Accepted remaining window: a delayed HTTP packet from turn N that arrives after turn N+1 reactivates the same process-stable key would be attributed to N+1. Drain + admission grace + deactivate-between-turns is the mitigation. Fully closing that window requires killing the process (the old behavior). The one-time cold-resume prefix rewrite after a genuine process death (gateway reboot, model switch) remains an accepted cost from #124300.

## User Impact

Claude CLI live sessions with MCP delivery capture keep the warm process across messages, so API-side prompt cache can stay hot instead of rewriting the prefix on every turn. Operators should see `reason=restart` only for real session identity changes, not after every captured message. Message-tool sends after a captured turn still cannot use a stale capture key.

## Evidence

**Pre-fix reproduction** (regression test captured before the production edit): `reuses a captured Claude live process and capture key across resume turns` failed on `main` with `expected "vi.fn()" to be called once, but got 2 times` — the `finally` block killed the child, so the second resume turn spawned again.

**Post-fix:**

- Same test: one spawn, same capture key, no `reason=restart`.
- Identity-change path still restarts and still logs cleanup failures.
- Grant fence: same process-stable key, deactivate of turn 1 before activate of turn 2, process not cancelled.
- Drain timeout still closes with `reason=mcp-capture-rotation` and fails closed (`CLI message tool call remained in flight after exit`).
- Plugin-approval block path no longer kills the live process.

Commands (worktree, Node 25.9 via `/usr/bin/node`):

```
/usr/bin/node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-process.test.ts src/agents/cli-runner/claude-live-process-capture.test.ts src/agents/cli-runner/claude-live-process-approval.test.ts src/agents/cli-runner/claude-live-registry.test.ts src/agents/cli-runner/claude-live-session.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-runner.spawn.test.ts
# 182 tests passed (66 + 116)

PATH="/usr/bin:$PATH" /usr/bin/node scripts/check-changed.mjs -- src/agents/cli-runner/claude-live-session.ts src/agents/cli-runner/execute-tool-tracking.ts src/agents/cli-runner/claude-live-process.test.ts src/agents/cli-runner/claude-live-process-capture.test.ts src/agents/cli-runner/claude-live-process-approval.test.ts src/gateway/mcp-http.loopback-runtime.ts
# passed
```

Autoreview: `python3 .agents/skills/autoreview/scripts/autoreview --engine claude --mode local --thinking max` (`claude-fable-5`). Result: `autoreview clean: no accepted/actionable findings reported`.

Production LOC (`git diff --numstat origin/main...HEAD`): `claude-live-session.ts` +5/−10, `execute-tool-tracking.ts` +3/−1 comments, `mcp-http.loopback-runtime.ts` comment rewrite. Net production ≈ −3. Tests: new `claude-live-process-capture.test.ts` (+255) after splitting off the capture lifetime cases so `claude-live-process.test.ts` stays under the 1000-line cap.

Live Telegram/Gateway proof was not run: this worktree must not touch the operator gateway, `~/.openclaw`, or the main checkout. Owner-boundary tests inject spawn, grant activate/deactivate, and in-flight MCP drain in the original execution order.

Head: `565510b98bd553e18cb40a8a8455edabeed004ac`.
