### PR TITLE
feat(ui): activity feed automation grouping, live status, deep-link inspector

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -401,10 +401,11 @@ The page redacts credential-bearing URL-like values before rendering and quotes 
 
 ## Activity tab
 
-The Activity tab lives in **Settings › System**, next to Logs and Debug. It has two views with different durability:
+The Activity tab lives in **Settings › System**, next to Logs and Debug. It has two tabs plus a deep-link inspector:
 
+- **Sessions** shows recent session activity grouped by day, with search, time, and people filters. Active rows offer **Inspect run** when the Gateway has recorded a run reference.
 - **Live activity** is the existing ephemeral browser-local observer for tool activity. It is derived from the same Gateway `session.tool` and tool event stream that powers Chat tool cards. It does not add another Gateway event family, endpoint, durable activity store, metrics feed, or external observer stream.
-- **Run inspector** reads the Gateway's durable, immutable `audit.run.inspect` projection. Open a run directly with `/activity?view=run&run=<percent-encoded-run-id>`. Reloading or revisiting the link queries the Gateway again; it never reconstructs identity from Live activity.
+- **Run inspector** is deep-link only and reads the Gateway's durable, immutable `audit.run.inspect` projection. Use **Inspect run** on an active session or the run ID link in Live activity, or open `/activity?view=run&run=<percent-encoded-run-id>` directly. Reloading or revisiting the link queries the Gateway again; it never reconstructs identity from Live activity.
 
 Live activity entries keep only sanitized summaries and redacted, truncated output previews. Tool argument values are not stored in Activity state; the UI shows that arguments are hidden and records only the argument field count. The in-memory list follows the current browser tab, survives navigation within the Control UI, and resets on page reload, session switch, Gateway switch, or **Clear**.
 

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -324,9 +324,11 @@ function buildActivitySessionRows(baseTime: number) {
     ["fixture-polish", "Mock fixture polish", owners.colin, 6 * day],
     ["weekly-summary", "Weekly activity summary", owners.patricia, 6.5 * day],
   ] as const;
+  const automationKeys = new Set(["release-check", "api-notes", "design-review"]);
   return fixtures.map(([key, label, owner, age]) =>
     sessionRow(`agent:activity:${key}`, label, baseTime - age, {
       createdActor: owner,
+      hasAutomation: automationKeys.has(key),
       owner: { actor: owner },
     }),
   );

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -327,6 +327,20 @@ function buildActivitySessionRows(baseTime: number) {
   const automationKeys = new Set(["release-check", "api-notes", "design-review"]);
   return fixtures.map(([key, label, owner, age]) =>
     sessionRow(`agent:activity:${key}`, label, baseTime - age, {
+      ...(key === "archive-audit"
+        ? {
+            activeRunIds: ["mock-activity-live-run"],
+            hasActiveRun: true,
+            observerDigest: {
+              headline: "Waiting on a fictional mock approval",
+              health: "waiting-on-user",
+              revision: 1,
+              runId: "mock-activity-live-run",
+              updatedAt: baseTime - age,
+            },
+            status: "running",
+          }
+        : {}),
       createdActor: owner,
       hasAutomation: automationKeys.has(key),
       owner: { actor: owner },

--- a/ui/src/e2e/activity-run-inspector.e2e.test.ts
+++ b/ui/src/e2e/activity-run-inspector.e2e.test.ts
@@ -230,12 +230,13 @@ describeControlUiE2e("Control UI durable Activity run inspector", () => {
       });
       expect((await gateway.getRequests("audit.run.inspect")).length).toBe(1);
 
-      const runTab = page.getByRole("tab", { name: "Run inspector" });
-      await expect.poll(() => runTab.getAttribute("aria-selected")).toBe("true");
-      const modePanel = page.getByRole("tabpanel");
-      await expect
-        .poll(() => modePanel.getAttribute("aria-labelledby"))
-        .toBe("activity-mode-tab-run");
+      expect(await page.getByRole("tab", { name: "Run inspector" }).count()).toBe(0);
+      const modePanel = page.locator("#activity-mode-panel");
+      expect(await modePanel.getAttribute("role")).toBeNull();
+      expect(await modePanel.getAttribute("aria-labelledby")).toBeNull();
+      const backToSessions = page.getByRole("link", { name: "Back to sessions" });
+      await backToSessions.waitFor();
+      expect(await backToSessions.getAttribute("href")).toBe("/activity");
       await page.getByRole("status", { name: "Inspection coverage: Unattributed" }).waitFor();
       for (const state of ["Present", "Absent", "Unknown", "Unsupported"]) {
         await page.locator(`[aria-label="Evidence state: ${state}"]`).first().waitFor();
@@ -271,6 +272,10 @@ describeControlUiE2e("Control UI durable Activity run inspector", () => {
       });
       expect((await gateway.getRequests("audit.run.inspect")).length).toBe(1);
 
+      await backToSessions.click();
+      await page.getByRole("tab", { name: "Sessions" }).waitFor();
+      expect(await page.getByRole("tab").count()).toBe(2);
+      expect(await page.getByRole("tab", { name: "Run inspector" }).count()).toBe(0);
       const liveTab = page.getByRole("tab", { name: "Live activity" });
       await liveTab.focus();
       await expect
@@ -282,6 +287,10 @@ describeControlUiE2e("Control UI durable Activity run inspector", () => {
         .poll(() => modePanel.getAttribute("aria-labelledby"))
         .toBe("activity-mode-tab-live");
       expect(new URL(page.url()).search).toBe("?view=live");
+      await page.goBack();
+      await expect
+        .poll(() => page.getByRole("tab", { name: "Sessions" }).getAttribute("aria-selected"))
+        .toBe("true");
       await page.goBack();
       await page.getByRole("heading", { name: "Identity and authority" }).waitFor();
     } finally {

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -54,7 +54,7 @@ suite.define(() => {
           ],
           methodResponses: {
             "sessions.list": {
-              count: 4,
+              count: 5,
               creators: [
                 { id: "profile-alice", label: "Alice Chen" },
                 { id: "profile-bob", label: "Bob Rivera" },
@@ -74,6 +74,16 @@ suite.define(() => {
                     actor: { type: "human", id: "profile-alice", label: "Alice Chen" },
                   },
                   participants: [{ type: "human", id: "profile-bob", label: "Bob Rivera" }],
+                  activeRunIds: ["mock run:a/b"],
+                  hasActiveRun: true,
+                  observerDigest: {
+                    headline: "Waiting on a fictional mock approval",
+                    health: "waiting-on-user",
+                    revision: 1,
+                    runId: "mock run:a/b",
+                    updatedAt: now - 4 * 60_000,
+                  },
+                  status: "running",
                   updatedAt: now - 4 * 60_000,
                 },
                 {
@@ -86,6 +96,7 @@ suite.define(() => {
                     actor: { type: "human", id: "profile-bob", label: "Bob Rivera" },
                   },
                   participants: [{ type: "human", id: "profile-alice", label: "Alice Chen" }],
+                  hasAutomation: true,
                   updatedAt: now - 42 * 60_000,
                 },
                 {
@@ -97,7 +108,20 @@ suite.define(() => {
                   owner: {
                     actor: { type: "human", id: "profile-carol", label: "Carol Singh" },
                   },
-                  updatedAt: now - 26 * 60 * 60_000,
+                  hasAutomation: true,
+                  updatedAt: now - 2 * 60 * 60_000,
+                },
+                {
+                  key: "agent:main:nightly-maintenance",
+                  kind: "direct",
+                  displayName: "Nightly mock maintenance",
+                  agentId: "main",
+                  createdActor: { type: "human", id: "profile-carol", label: "Carol Singh" },
+                  owner: {
+                    actor: { type: "human", id: "profile-carol", label: "Carol Singh" },
+                  },
+                  hasAutomation: true,
+                  updatedAt: now - 3 * 60 * 60_000,
                 },
                 {
                   key: "agent:main:incident-notes",
@@ -147,9 +171,32 @@ suite.define(() => {
           )
           .toBe(3);
         await page.keyboard.press("Escape");
+        const automationGroup = page.locator("[data-activity-automation-group]");
+        await expect.poll(() => automationGroup.count()).toBe(1);
+        await expect.poll(() => automationGroup.getAttribute("aria-expanded")).toBe("false");
+        await expect.poll(() => page.locator("[data-activity-session]").count()).toBe(2);
+        await automationGroup.click();
+        await expect.poll(() => page.locator("[data-activity-session]").count()).toBe(5);
+        await automationGroup.click();
+        await expect.poll(() => page.locator("[data-activity-session]").count()).toBe(2);
+
+        const liveRow = page.locator(`[data-activity-session="${releaseKey}"]`);
+        await expect.poll(() => liveRow.locator(".activity-feed__run-dot").count()).toBe(1);
         await expect
-          .poll(() => page.locator(".activity-feed__sessions > .activity-feed__session").count())
-          .toBe(4);
+          .poll(() => liveRow.locator(".activity-feed__session-headline").textContent())
+          .toContain("Waiting on a fictional mock approval");
+        const inspectRun = liveRow.locator("xpath=following-sibling::a");
+        await liveRow.hover();
+        await expect
+          .poll(() => inspectRun.evaluate((element) => getComputedStyle(element).opacity))
+          .toBe("1");
+        await inspectRun.focus();
+        await expect
+          .poll(() => inspectRun.evaluate((element) => document.activeElement === element))
+          .toBe(true);
+        expect(await inspectRun.getAttribute("href")).toBe(
+          "/activity?view=run&run=mock%20run%3Aa%2Fb",
+        );
         await page.screenshot({
           animations: "disabled",
           path: path.join(outputDir, "02-global-activity.png"),

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3376,6 +3376,8 @@ export const en: TranslationMap = {
     unknownDate: "Unknown date",
     noSessions: "No sessions match these filters.",
     automationGroup: "{count} automation sessions",
+    inspectRun: "Inspect run",
+    backToSessions: "Back to sessions",
     channelLabel: "Channel: {value}",
     agentLabel: "Agent: {value}",
     online: "Online",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3375,6 +3375,7 @@ export const en: TranslationMap = {
     yesterday: "Yesterday",
     unknownDate: "Unknown date",
     noSessions: "No sessions match these filters.",
+    automationGroup: "{count} automation sessions",
     channelLabel: "Channel: {value}",
     agentLabel: "Agent: {value}",
     online: "Online",

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -74,6 +74,7 @@ class ActivityPage extends OpenClawLightDomElement {
   };
   @state() private toolFilter = "";
   @state() private expandedIds = new Set<string>();
+  @state() private expandedAutomationDays = new Set<string>();
   @state() private autoFollow = true;
   @state() private runInspector: RunInspectorState = { status: "empty" };
   @state() private presencePayload: PresencePayload | undefined;
@@ -517,10 +518,20 @@ class ActivityPage extends OpenClawLightDomElement {
         ${mode === "sessions"
           ? renderSessionActivityView({
               context: this.context,
+              expandedAutomationDays: this.expandedAutomationDays,
               filters,
               presenceViewers,
               retainedIdentity,
               rows: sessionRows,
+              onAutomationDayToggle: (dayKey) => {
+                const next = new Set(this.expandedAutomationDays);
+                if (next.has(dayKey)) {
+                  next.delete(dayKey);
+                } else {
+                  next.add(dayKey);
+                }
+                this.expandedAutomationDays = next;
+              },
               onFiltersChange: (next) =>
                 this.context.navigate("activity", { search: sessionActivitySearch(next) }),
             })

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { html, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/schema/audit-run.js";
 import type { EventLogEntry } from "../../api/event-log.ts";
@@ -9,6 +9,7 @@ import {
   type GatewayEventFrame,
 } from "../../api/gateway.ts";
 import { titleForRoute } from "../../app-navigation.ts";
+import { pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -17,6 +18,7 @@ import {
 import { loadSettings } from "../../app/settings.ts";
 import { readPresenceEntries, type PresencePayload } from "../../app/user-profile.ts";
 import { renderHubTabs } from "../../components/hub-tabs.ts";
+import { icons } from "../../components/icons.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
@@ -338,20 +340,14 @@ class ActivityPage extends OpenClawLightDomElement {
     );
   }
 
-  private selectMode(mode: "sessions" | "live" | "run") {
+  private selectMode(mode: "sessions" | "live") {
     if (mode === "sessions") {
       this.context.navigate("activity", { search: "" });
       return;
     }
     if (mode === "live") {
       this.context.navigate("activity", { search: "?view=live" });
-      return;
     }
-    const search = new URLSearchParams({ view: "run" });
-    if (this.routeData?.mode === "run" && this.routeData.selector) {
-      search.set(this.routeData.selector.kind, this.routeData.selector.id);
-    }
-    this.context.navigate("activity", { search: `?${search.toString()}` });
   }
 
   private rebuildEntries(
@@ -438,6 +434,7 @@ class ActivityPage extends OpenClawLightDomElement {
 
   override render() {
     const liveActivity = renderActivity({
+      basePath: this.context.basePath,
       entries: this.entries,
       filterText: this.filterText,
       statusFilters: this.statusFilters,
@@ -500,21 +497,26 @@ class ActivityPage extends OpenClawLightDomElement {
       this.retainedIdentities.set(retainedIdentity.id, retainedIdentity);
     }
     const body = html`
-      ${renderHubTabs({
-        id: "activity-mode",
-        active: mode,
-        tabs: [
-          { value: "sessions", label: t("activityFeed.sessionsMode") },
-          { value: "live", label: t("activity.runInspector.liveMode") },
-          { value: "run", label: t("activity.runInspector.mode") },
-        ],
-        ariaLabel: t("activity.runInspector.activityView"),
-        panelId: "activity-mode-panel",
-        className: "activity-mode-tabs",
-        variant: "sub",
-        onSelect: (selected) => this.selectMode(selected),
-      })}
-      <div id="activity-mode-panel" role="tabpanel" aria-labelledby=${`activity-mode-tab-${mode}`}>
+      ${mode === "run"
+        ? nothing
+        : renderHubTabs({
+            id: "activity-mode",
+            active: mode,
+            tabs: [
+              { value: "sessions", label: t("activityFeed.sessionsMode") },
+              { value: "live", label: t("activity.runInspector.liveMode") },
+            ],
+            ariaLabel: t("activity.runInspector.activityView"),
+            panelId: "activity-mode-panel",
+            className: "activity-mode-tabs",
+            variant: "sub",
+            onSelect: (selected) => this.selectMode(selected),
+          })}
+      <div
+        id="activity-mode-panel"
+        role=${mode === "run" ? nothing : "tabpanel"}
+        aria-labelledby=${mode === "run" ? nothing : `activity-mode-tab-${mode}`}
+      >
         ${mode === "sessions"
           ? renderSessionActivityView({
               context: this.context,
@@ -536,13 +538,22 @@ class ActivityPage extends OpenClawLightDomElement {
                 this.context.navigate("activity", { search: sessionActivitySearch(next) }),
             })
           : mode === "run"
-            ? renderRunInspector({
-                basePath: this.context.basePath,
-                state: this.runInspector,
-                onLoadMoreExecutions: () => this.loadMoreExecutions(),
-                onRetry: () =>
-                  this.syncRunInspector(this.context.gateway, this.context.gateway.snapshot, true),
-              })
+            ? html`<a
+                  class="activity-run-inspector-back"
+                  href=${pathForRoute("activity", this.context.basePath)}
+                  >${icons.arrowLeft}${t("activityFeed.backToSessions")}</a
+                >
+                ${renderRunInspector({
+                  basePath: this.context.basePath,
+                  state: this.runInspector,
+                  onLoadMoreExecutions: () => this.loadMoreExecutions(),
+                  onRetry: () =>
+                    this.syncRunInspector(
+                      this.context.gateway,
+                      this.context.gateway.snapshot,
+                      true,
+                    ),
+                })}`
             : html`<div id="activity-live-panel">${liveActivity}</div>`}
       </div>
     `;

--- a/ui/src/pages/activity/run-inspector-model.ts
+++ b/ui/src/pages/activity/run-inspector-model.ts
@@ -1,4 +1,5 @@
 import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/schema/audit-run.js";
+import { pathForRoute } from "../../app-route-paths.ts";
 import { parseSessionActivityFilters, type SessionActivityFilters } from "./session-activity.ts";
 
 export type RunInspectorSelector = { kind: "run" | "execution"; id: string };
@@ -7,6 +8,10 @@ export type ActivityRouteData =
   | { mode: "sessions"; filters: SessionActivityFilters; selector: null }
   | { mode: "live"; selector: null }
   | { mode: "run"; selector: RunInspectorSelector | null };
+
+export function activityRunInspectorHref(runId: string, basePath: string): string {
+  return `${pathForRoute("activity", basePath)}?view=run&run=${encodeURIComponent(runId)}`;
+}
 
 export function resolveActivityRouteData(search: string): ActivityRouteData {
   const params = new URLSearchParams(search);

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -251,13 +251,24 @@ describe("session activity live status", () => {
           context,
           rows: [
             row("Digest run", owner, now, {
-              activeRunIds: ["fallback-run"],
+              activeRunIds: ["fallback-run", "digest run:a/b"],
               hasActiveRun: true,
               observerDigest: {
                 headline: "Running",
                 health: "on-track",
                 revision: 1,
                 runId: "digest run:a/b",
+                updatedAt: now,
+              },
+            }),
+            row("Stale digest", owner, now - 500, {
+              activeRunIds: ["current-run"],
+              hasActiveRun: true,
+              observerDigest: {
+                headline: "Running",
+                health: "on-track",
+                revision: 1,
+                runId: "ended-run",
                 updatedAt: now,
               },
             }),
@@ -280,6 +291,7 @@ describe("session activity live status", () => {
       ),
     ).toEqual([
       "/control/activity?view=run&run=digest%20run%3Aa%2Fb",
+      "/control/activity?view=run&run=current-run",
       "/control/activity?view=run&run=fallback%20run%3Aa%2Fb",
     ]);
   });

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -189,3 +189,51 @@ describe("session activity automation grouping", () => {
     }
   });
 });
+
+describe("session activity live status", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("uses the recorded active run and observer digest for the row status", () => {
+    const now = Date.now();
+    const owner = { id: "owner", label: "Owner" };
+    const observerDigest = {
+      headline: "  Waiting on a fake approval  ",
+      health: "waiting-on-user" as const,
+      revision: 1,
+      runId: "fake-run",
+      updatedAt: now,
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderSessionActivityView(
+        props({
+          rows: [
+            row("Active session", owner, now, { hasActiveRun: true, observerDigest }),
+            row("Inactive session", owner, now - 1_000, {
+              observerDigest,
+              status: "running",
+            }),
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const active = container.querySelector('[data-activity-session="Active session"]');
+    const inactive = container.querySelector('[data-activity-session="Inactive session"]');
+    expect(active?.querySelector(".activity-feed__run-dot")).not.toBeNull();
+    expect(active?.querySelector(".activity-feed__session-headline")?.textContent?.trim()).toBe(
+      "Waiting on a fake approval",
+    );
+    expect(
+      active?.querySelector(".activity-feed__session-headline")?.getAttribute("data-health"),
+    ).toBe("waiting-on-user");
+    expect(active?.textContent).toContain("Owner");
+    expect(inactive?.querySelector(".activity-feed__run-dot")).toBeNull();
+    expect(inactive?.querySelector(".activity-feed__session-headline")).toBeNull();
+  });
+});

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -236,4 +236,51 @@ describe("session activity live status", () => {
     expect(inactive?.querySelector(".activity-feed__run-dot")).toBeNull();
     expect(inactive?.querySelector(".activity-feed__session-headline")).toBeNull();
   });
+
+  it("links active rows to their recorded run ids", () => {
+    const now = Date.now();
+    const owner = { id: "owner", label: "Owner" };
+    const base = props();
+    const context = { ...base.context, basePath: "/control" } as ApplicationContext;
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderSessionActivityView(
+        props({
+          context,
+          rows: [
+            row("Digest run", owner, now, {
+              activeRunIds: ["fallback-run"],
+              hasActiveRun: true,
+              observerDigest: {
+                headline: "Running",
+                health: "on-track",
+                revision: 1,
+                runId: "digest run:a/b",
+                updatedAt: now,
+              },
+            }),
+            row("Active run fallback", owner, now - 1_000, {
+              activeRunIds: ["fallback run:a/b"],
+              hasActiveRun: true,
+            }),
+            row("Inactive run", owner, now - 2_000, {
+              activeRunIds: ["inactive-run"],
+            }),
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(
+      [...container.querySelectorAll<HTMLAnchorElement>(".activity-feed__inspect-run")].map(
+        (link) => link.getAttribute("href"),
+      ),
+    ).toEqual([
+      "/control/activity?view=run&run=digest%20run%3Aa%2Fb",
+      "/control/activity?view=run&run=fallback%20run%3Aa%2Fb",
+    ]);
+  });
 });

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -7,7 +7,12 @@ import type { ApplicationContext } from "../../app/context.ts";
 import type { PresenceViewer } from "../../lib/presence-users.ts";
 import { renderSessionActivityView } from "./session-activity-view.ts";
 
-function row(key: string, owner: { id: string; label?: string }, updatedAt: number) {
+function row(
+  key: string,
+  owner: { id: string; label?: string },
+  updatedAt: number,
+  overrides: Partial<GatewaySessionRow> = {},
+) {
   const actor = { type: "human" as const, ...owner };
   return {
     key,
@@ -16,6 +21,7 @@ function row(key: string, owner: { id: string; label?: string }, updatedAt: numb
     updatedAt,
     createdActor: actor,
     owner: { actor },
+    ...overrides,
   } satisfies GatewaySessionRow;
 }
 
@@ -33,6 +39,8 @@ function props(overrides: Partial<Parameters<typeof renderSessionActivityView>[0
     presenceViewers: [] as PresenceViewer[],
     retainedIdentity: null,
     rows: [] as GatewaySessionRow[],
+    expandedAutomationDays: new Set<string>(),
+    onAutomationDayToggle: vi.fn(),
     onFiltersChange: vi.fn(),
     ...overrides,
   };
@@ -108,5 +116,76 @@ describe("session activity people filter", () => {
       query: "release",
       time: "30d",
     });
+  });
+});
+
+describe("session activity automation grouping", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("collapses two automation sessions, keeps one inline, and bypasses grouping for filters", () => {
+    const current = new Date();
+    const now = new Date(
+      current.getFullYear(),
+      current.getMonth(),
+      current.getDate(),
+      12,
+    ).getTime();
+    const owner = { id: "owner", label: "Owner" };
+    const regular = row("Regular session", owner, now);
+    const automationOne = row("Automation one", owner, now - 1_000, { hasAutomation: true });
+    const automationTwo = row("Automation two", owner, now - 2_000, { hasAutomation: true });
+    const onAutomationDayToggle = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderSessionActivityView(
+        props({ rows: [regular, automationOne, automationTwo], onAutomationDayToggle }),
+      ),
+      container,
+    );
+
+    const group = container.querySelector<HTMLButtonElement>("[data-activity-automation-group]");
+    expect(group?.textContent).toContain("2 automation sessions");
+    expect(group?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelectorAll("[data-activity-session]")).toHaveLength(1);
+    const dayKey = group?.dataset.activityAutomationGroup;
+    expect(dayKey).toBeTruthy();
+    group?.click();
+    expect(onAutomationDayToggle).toHaveBeenCalledWith(dayKey);
+
+    render(
+      renderSessionActivityView(
+        props({
+          rows: [regular, automationOne, automationTwo],
+          expandedAutomationDays: new Set([dayKey!]),
+        }),
+      ),
+      container,
+    );
+    expect(container.querySelectorAll("[data-activity-session]")).toHaveLength(3);
+
+    render(renderSessionActivityView(props({ rows: [regular, automationOne] })), container);
+    expect(container.querySelector("[data-activity-automation-group]")).toBeNull();
+    expect(container.querySelectorAll("[data-activity-session]")).toHaveLength(2);
+
+    for (const filteredProps of [
+      { filters: { personId: null, query: "Automation", time: "7d" as const } },
+      {
+        filters: { personId: "owner", query: "", time: "7d" as const },
+        retainedIdentity: { id: "owner", name: "Owner", watchedSessions: [] },
+      },
+    ]) {
+      render(
+        renderSessionActivityView(
+          props({ rows: [automationOne, automationTwo], ...filteredProps }),
+        ),
+        container,
+      );
+      expect(container.querySelector("[data-activity-automation-group]")).toBeNull();
+      expect(container.querySelectorAll("[data-activity-session]")).toHaveLength(2);
+    }
   });
 });

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -30,10 +30,12 @@ import {
 
 type SessionActivityViewProps = {
   context: ApplicationContext;
+  expandedAutomationDays: ReadonlySet<string>;
   filters: SessionActivityFilters;
   presenceViewers: readonly PresenceViewer[];
   retainedIdentity: PresenceViewer | null;
   rows: readonly GatewaySessionRow[];
+  onAutomationDayToggle: (dayKey: string) => void;
   onFiltersChange: (filters: SessionActivityFilters) => void;
 };
 
@@ -277,6 +279,41 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
   </a>`;
 }
 
+function renderDaySessions(
+  props: SessionActivityViewProps,
+  day: ReturnType<typeof projectSessionActivity>["days"][number],
+) {
+  if (props.filters.query || props.filters.personId) {
+    return day.sessions.map((row) => renderSessionLink(props.context, row));
+  }
+  // GatewaySessionRow.hasAutomation records that an enabled cron job is bound to the session;
+  // grouping must consume that fact directly rather than infer automation from titles or keys.
+  const automation = day.sessions.filter((row) => row.hasAutomation === true);
+  if (automation.length < 2) {
+    return day.sessions.map((row) => renderSessionLink(props.context, row));
+  }
+  const expanded = props.expandedAutomationDays.has(day.key);
+  return html`
+    ${day.sessions
+      .filter((row) => row.hasAutomation !== true)
+      .map((row) => renderSessionLink(props.context, row))}
+    <button
+      type="button"
+      class="activity-feed__session activity-feed__automation-group"
+      data-activity-automation-group=${day.key}
+      aria-expanded=${String(expanded)}
+      @click=${() => props.onAutomationDayToggle(day.key)}
+    >
+      <span class="activity-feed__automation-group-icon" aria-hidden="true">${icons.clock}</span>
+      <span>${t("activityFeed.automationGroup", { count: String(automation.length) })}</span>
+      <span class="activity-feed__automation-group-chevron" aria-hidden="true"
+        >${icons.chevronRight}</span
+      >
+    </button>
+    ${expanded ? automation.map((row) => renderSessionLink(props.context, row)) : nothing}
+  `;
+}
+
 function renderIdentityHeader(
   context: ApplicationContext,
   identity: PresenceViewer,
@@ -410,9 +447,7 @@ export function renderSessionActivityView(props: SessionActivityViewProps) {
                 ? projection.days.map(
                     (day) => html`<section class="activity-feed__day">
                       <h3>${dayLabel(day.timestamp)}</h3>
-                      <div class="activity-feed__sessions">
-                        ${day.sessions.map((row) => renderSessionLink(props.context, row))}
-                      </div>
+                      <div class="activity-feed__sessions">${renderDaySessions(props, day)}</div>
                     </section>`,
                   )
                 : html`<section class="activity-feed__empty" role="status">

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -249,6 +249,7 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
   const owner = sessionActivityOwner(row);
   const ownerName = presenceViewerLabel(owner);
   const activityAt = sessionActivityTimestamp(row);
+  const headline = row.hasActiveRun === true ? row.observerDigest?.headline.trim() : "";
   const scope = row.channel
     ? t("activityFeed.channelLabel", { value: row.channel })
     : row.agentId
@@ -260,21 +261,38 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
     href=${sessionHref(context, row)}
     @click=${(event: MouseEvent) => navigateToSession(event, context, row)}
   >
-    <openclaw-viewer-avatar
-      .user=${owner}
-      .markAsViewer=${false}
-      variant="footer"
-    ></openclaw-viewer-avatar>
+    <span class="activity-feed__session-avatar">
+      ${row.hasActiveRun === true
+        ? html`<span
+            class="activity-feed__presence-dot activity-feed__run-dot"
+            aria-hidden="true"
+          ></span>`
+        : nothing}
+      <openclaw-viewer-avatar
+        .user=${owner}
+        .markAsViewer=${false}
+        variant="footer"
+      ></openclaw-viewer-avatar>
+    </span>
     <span class="activity-feed__session-main">
       <span class="activity-feed__session-title">${resolveSessionDisplayName(row.key, row)}</span>
       <span class="activity-feed__session-meta">
-        <span>${ownerName}</span>${scope
+        ${headline
+          ? html`<span
+              class="activity-feed__session-headline"
+              data-health=${row.observerDigest?.health ?? nothing}
+              >${headline}</span
+            >`
+          : html`<span>${ownerName}</span>`}${scope
           ? html`<span class="activity-feed__session-scope">${scope}</span>`
           : nothing}
       </span>
     </span>
     <span class="activity-feed__session-time">
-      ${activityAt > 0 ? formatRelativeTimestamp(activityAt, { fallback: "" }) : nothing}
+      ${headline ? html`<span class="activity-feed__session-owner">${ownerName}</span>` : nothing}
+      ${activityAt > 0
+        ? html`<span>${formatRelativeTimestamp(activityAt, { fallback: "" })}</span>`
+        : nothing}
     </span>
   </a>`;
 }

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -251,8 +251,16 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
   const ownerName = presenceViewerLabel(owner);
   const activityAt = sessionActivityTimestamp(row);
   const headline = row.hasActiveRun === true ? row.observerDigest?.headline.trim() : "";
+  // The observer digest can outlive the run it described (restart/overlap), so its
+  // runId may reference an obsolete audit record; trust it only when it is still an
+  // active run, otherwise fall back to the row's own active-run list.
+  const digestRunId = row.observerDigest?.runId;
   const activeRunId =
-    row.hasActiveRun === true ? (row.observerDigest?.runId ?? row.activeRunIds?.[0]) : undefined;
+    row.hasActiveRun === true
+      ? digestRunId && row.activeRunIds?.includes(digestRunId)
+        ? digestRunId
+        : row.activeRunIds?.[0]
+      : undefined;
   const scope = row.channel
     ? t("activityFeed.channelLabel", { value: row.channel })
     : row.agentId

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -18,6 +18,7 @@ import {
   resolveSessionPreferredFace,
   sessionNavigationTarget,
 } from "../../lib/sessions/route-navigation.ts";
+import { activityRunInspectorHref } from "./run-inspector-model.ts";
 import {
   ACTIVITY_TIME_FILTERS,
   projectSessionActivity,
@@ -250,51 +251,62 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
   const ownerName = presenceViewerLabel(owner);
   const activityAt = sessionActivityTimestamp(row);
   const headline = row.hasActiveRun === true ? row.observerDigest?.headline.trim() : "";
+  const activeRunId =
+    row.hasActiveRun === true ? (row.observerDigest?.runId ?? row.activeRunIds?.[0]) : undefined;
   const scope = row.channel
     ? t("activityFeed.channelLabel", { value: row.channel })
     : row.agentId
       ? t("activityFeed.agentLabel", { value: row.agentId })
       : null;
-  return html`<a
-    class="activity-feed__session"
-    data-activity-session=${row.key}
-    href=${sessionHref(context, row)}
-    @click=${(event: MouseEvent) => navigateToSession(event, context, row)}
-  >
-    <span class="activity-feed__session-avatar">
-      ${row.hasActiveRun === true
-        ? html`<span
-            class="activity-feed__presence-dot activity-feed__run-dot"
-            aria-hidden="true"
-          ></span>`
-        : nothing}
-      <openclaw-viewer-avatar
-        .user=${owner}
-        .markAsViewer=${false}
-        variant="footer"
-      ></openclaw-viewer-avatar>
-    </span>
-    <span class="activity-feed__session-main">
-      <span class="activity-feed__session-title">${resolveSessionDisplayName(row.key, row)}</span>
-      <span class="activity-feed__session-meta">
-        ${headline
+  return html`<div class="activity-feed__session-row">
+    <a
+      class="activity-feed__session"
+      data-activity-session=${row.key}
+      href=${sessionHref(context, row)}
+      @click=${(event: MouseEvent) => navigateToSession(event, context, row)}
+    >
+      <span class="activity-feed__session-avatar">
+        ${row.hasActiveRun === true
           ? html`<span
-              class="activity-feed__session-headline"
-              data-health=${row.observerDigest?.health ?? nothing}
-              >${headline}</span
-            >`
-          : html`<span>${ownerName}</span>`}${scope
-          ? html`<span class="activity-feed__session-scope">${scope}</span>`
+              class="activity-feed__presence-dot activity-feed__run-dot"
+              aria-hidden="true"
+            ></span>`
+          : nothing}
+        <openclaw-viewer-avatar
+          .user=${owner}
+          .markAsViewer=${false}
+          variant="footer"
+        ></openclaw-viewer-avatar>
+      </span>
+      <span class="activity-feed__session-main">
+        <span class="activity-feed__session-title">${resolveSessionDisplayName(row.key, row)}</span>
+        <span class="activity-feed__session-meta">
+          ${headline
+            ? html`<span
+                class="activity-feed__session-headline"
+                data-health=${row.observerDigest?.health ?? nothing}
+                >${headline}</span
+              >`
+            : html`<span>${ownerName}</span>`}${scope
+            ? html`<span class="activity-feed__session-scope">${scope}</span>`
+            : nothing}
+        </span>
+      </span>
+      <span class="activity-feed__session-time">
+        ${headline ? html`<span class="activity-feed__session-owner">${ownerName}</span>` : nothing}
+        ${activityAt > 0
+          ? html`<span>${formatRelativeTimestamp(activityAt, { fallback: "" })}</span>`
           : nothing}
       </span>
-    </span>
-    <span class="activity-feed__session-time">
-      ${headline ? html`<span class="activity-feed__session-owner">${ownerName}</span>` : nothing}
-      ${activityAt > 0
-        ? html`<span>${formatRelativeTimestamp(activityAt, { fallback: "" })}</span>`
-        : nothing}
-    </span>
-  </a>`;
+    </a>
+    ${activeRunId
+      ? html`<a
+          class="activity-feed__inspect-run"
+          href=${activityRunInspectorHref(activeRunId, context.basePath)}
+          >${t("activityFeed.inspectRun")}</a
+        >`
+      : nothing}
+  </div>`;
 }
 
 function renderDaySessions(

--- a/ui/src/pages/activity/view.test.ts
+++ b/ui/src/pages/activity/view.test.ts
@@ -35,6 +35,7 @@ function createProps(overrides: Partial<ActivityProps> = {}): ActivityProps {
     error: true,
   };
   return {
+    basePath: "/control",
     entries: [createEntry()],
     filterText: "",
     statusFilters,
@@ -146,5 +147,20 @@ describe("renderActivity", () => {
       (element) => element.textContent?.trim(),
     );
     expect(meta).toContain("2m");
+  });
+
+  it("links the displayed run id to the deep-link inspector", async () => {
+    await i18n.setLocale("en");
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderActivity(createProps({ entries: [createEntry({ runId: "live run:a/b" })] })),
+      container,
+    );
+
+    expect(
+      container.querySelector<HTMLAnchorElement>(".activity-entry__run-link")?.getAttribute("href"),
+    ).toBe("/control/activity?view=run&run=live%20run%3Aa%2Fb");
   });
 });

--- a/ui/src/pages/activity/view.ts
+++ b/ui/src/pages/activity/view.ts
@@ -12,6 +12,7 @@ import { t } from "../../i18n/index.ts";
 import { registerActivityEnglish } from "../../i18n/locales/en-activity.ts";
 import { formatDurationCompact, formatTimeMs } from "../../lib/format.ts";
 import "../../styles/activity.css";
+import { activityRunInspectorHref } from "./run-inspector-model.ts";
 import type { ActivityEntry, ActivityStatus } from "./tool-activity.ts";
 
 registerActivityEnglish();
@@ -19,6 +20,7 @@ registerActivityEnglish();
 const STATUS_ORDER: ActivityStatus[] = ["running", "done", "error"];
 
 type ActivityProps = {
+  basePath: string;
   entries: ActivityEntry[];
   filterText: string;
   statusFilters: Record<ActivityStatus, boolean>;
@@ -180,7 +182,11 @@ function renderEntry(props: ActivityProps, entry: ActivityEntry) {
                 <span>${hiddenArgumentsLabel(entry.hiddenArgumentCount)}</span>
                 <span class="mono">${t("activity.toolCallId")}: ${entry.toolCallId}</span>
               `}
-          <span class="mono">${t("activity.runId")}: ${entry.runId}</span>
+          <a
+            class="activity-entry__run-link mono"
+            href=${activityRunInspectorHref(entry.runId, props.basePath)}
+            >${t("activity.runId")}: ${entry.runId}</a
+          >
           ${entry.sessionKey
             ? html`<span class="mono">${t("activity.session")}: ${entry.sessionKey}</span>`
             : nothing}

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -316,6 +316,47 @@ openclaw-activity-page {
   border-top: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
 }
 
+.activity-feed__automation-group {
+  width: 100%;
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: var(--cursor-action);
+}
+
+.activity-feed__session + .activity-feed__automation-group {
+  border-top: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+}
+
+.activity-feed__automation-group:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.activity-feed__automation-group-icon,
+.activity-feed__automation-group-chevron {
+  display: inline-flex;
+}
+
+.activity-feed__automation-group-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.activity-feed__automation-group-chevron svg {
+  width: 18px;
+  height: 18px;
+  transition: transform var(--duration-fast) ease;
+}
+
+.activity-feed__automation-group[aria-expanded="true"]
+  .activity-feed__automation-group-chevron
+  svg {
+  transform: rotate(90deg);
+}
+
 .activity-feed__session:hover,
 .activity-feed__session:focus-visible {
   background: var(--bg-hover);

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -370,6 +370,21 @@ openclaw-activity-page {
   font-size: 9px;
 }
 
+.activity-feed__session-avatar {
+  position: relative;
+  display: inline-flex;
+}
+
+.activity-feed__run-dot {
+  top: -2px;
+  right: auto;
+  bottom: auto;
+  left: -2px;
+  border-color: var(--card);
+  background: var(--accent);
+  animation: pulse-subtle 1.8s ease-in-out infinite;
+}
+
 .activity-feed__session-main {
   display: grid;
   gap: 3px;
@@ -399,10 +414,40 @@ openclaw-activity-page {
   white-space: nowrap;
 }
 
+.activity-feed__session-headline,
+.activity-feed__session-owner {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-feed__session-headline[data-health="grinding"] {
+  color: var(--accent);
+}
+
+.activity-feed__session-headline[data-health="stuck"],
+.activity-feed__session-headline[data-health="waiting-on-user"] {
+  color: var(--warn);
+}
+
+.activity-feed__session-headline[data-health="failed"] {
+  color: var(--danger);
+}
+
 .activity-feed__session-time {
+  display: flex;
+  max-width: 260px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
   color: var(--muted);
   font-size: var(--control-ui-text-sm);
   white-space: nowrap;
+}
+
+.activity-feed__session-owner {
+  max-width: 140px;
 }
 
 .activity-feed__identity {

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -312,7 +312,13 @@ openclaw-activity-page {
   text-decoration: none;
 }
 
-.activity-feed__session + .activity-feed__session {
+.activity-feed__session-row {
+  position: relative;
+}
+
+.activity-feed__session-row + .activity-feed__session-row,
+.activity-feed__automation-group + .activity-feed__session-row,
+.activity-feed__session-row + .activity-feed__automation-group {
   border-top: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
 }
 
@@ -324,10 +330,6 @@ openclaw-activity-page {
   font: inherit;
   text-align: left;
   cursor: var(--cursor-action);
-}
-
-.activity-feed__session + .activity-feed__automation-group {
-  border-top: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
 }
 
 .activity-feed__automation-group:focus-visible {
@@ -358,8 +360,46 @@ openclaw-activity-page {
 }
 
 .activity-feed__session:hover,
-.activity-feed__session:focus-visible {
+.activity-feed__session:focus-visible,
+.activity-feed__session-row:hover .activity-feed__session,
+.activity-feed__session-row:focus-within .activity-feed__session {
   background: var(--bg-hover);
+  text-decoration: none;
+}
+
+.activity-feed__session-row:has(.activity-feed__inspect-run) .activity-feed__session {
+  padding-right: 118px;
+}
+
+.activity-feed__inspect-run {
+  position: absolute;
+  top: 50%;
+  right: var(--space-4);
+  z-index: 1;
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  color: var(--muted);
+  background: var(--bg-elevated);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1;
+  text-decoration: none;
+  pointer-events: none;
+  translate: 0 -50%;
+  transition: opacity var(--duration-fast) ease;
+}
+
+.activity-feed__session-row:hover .activity-feed__inspect-run,
+.activity-feed__session-row:focus-within .activity-feed__inspect-run {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.activity-feed__inspect-run:hover,
+.activity-feed__inspect-run:focus-visible {
+  border-color: var(--border-strong);
+  color: var(--text);
   text-decoration: none;
 }
 
@@ -653,9 +693,36 @@ openclaw-activity-page {
 
 .activity-entry__tool,
 .activity-entry__text,
-.activity-entry__facts span {
+.activity-entry__facts span,
+.activity-entry__facts a {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.activity-entry__run-link {
+  color: inherit;
+}
+
+.activity-run-inspector-back {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+  text-decoration: none;
+}
+
+.activity-run-inspector-back:hover,
+.activity-run-inspector-back:focus-visible {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.activity-run-inspector-back svg {
+  width: 16px;
+  height: 16px;
 }
 
 .activity-entry__text {
@@ -747,6 +814,13 @@ openclaw-activity-page {
 
   .activity-stream {
     max-height: calc(100vh - 360px);
+  }
+}
+
+@media (pointer: coarse) {
+  .activity-feed__inspect-run {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Three follow-ups from the Activity toolbar redesign (#125917):

1. **Automation noise.** Cron-driven sessions (heartbeats, scheduled check-ins) interleave with human work in the Sessions feed, burying the activity the page exists to show.
2. **No live signal.** A session actively running right now looked identical to one finished hours ago; seeing what a session is doing required opening it.
3. **Run inspector as a browse tab.** The identity-evidence inspector is a forensic diagnostic you arrive at with a run reference in hand — nobody discovers audit evidence by clicking a nav tab, and the tab implied otherwise.

## Why This Change Was Made

All three use facts the Gateway already records at the owning boundary — no string heuristics, no new inference:

- `GatewaySessionRow.hasAutomation` (an enabled cron job is bound to the session) drives grouping.
- `hasActiveRun` + `observerDigest` (headline, health, runId) drive the live row treatment.
- The inspector's documented URL contract (`/activity?view=run&run=<id>`) already made it deep-linkable; the tab was redundant chrome.

## User Impact

- **Automation grouping:** within each day, ≥2 cron-bound sessions collapse into one "N automation sessions" row that expands inline on click. Grouping is presentation-only (counts unchanged) and bypassed while a search query or person filter is active, so filtering always shows exact matches.
- **Live rows:** sessions with an active run get a pulse dot and show the observer digest headline as their status line (tinted by run health), with the owner moved beside the timestamp.
- **Run inspector:** the tab strip now has two tabs (Sessions, Live activity). The inspector remains fully reachable via its documented deep link, a hover/focus-revealed "Inspect run" action on rows with an active run, and the run ID link in Live activity entries; the inspector view gained a "Back to sessions" affordance. Docs updated to match (`docs/web/control-ui.md`).

### Before (current main)

![before](https://github.com/user-attachments/assets/2b769586-abc9-4b44-b1ef-ce39772db83e)

### After — automation sessions collapsed, live row with status headline

![collapsed](https://github.com/user-attachments/assets/df59a2ee-1d5f-43d1-9c37-1809ec400d69)

### After — automation group expanded

![expanded](https://github.com/user-attachments/assets/0930bbc9-7284-4ebf-b513-9e65996e747d)

### After — hover reveals Inspect run on an active row

![inspect-run](https://github.com/user-attachments/assets/1ab90871-6f29-4ed7-862f-a0e4243f05fe)

### After — deep-linked run inspector with back affordance

![deep-link](https://github.com/user-attachments/assets/89f049d4-f01c-4566-8231-3b280543122e)

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/activity ui/src/e2e/activity-session-feed.capture.e2e.test.ts ui/src/e2e/activity-run-inspector.e2e.test.ts` — all green (activity unit suite 45 tests; feed capture e2e exercises collapse→expand→collapse and the Inspect run href; run-inspector e2e covers the deep link with the tab removed).
- `node scripts/check-changed.mjs` — green (tsgo, stylelint, oxlint, i18n verify, docs formatting, guards); `pnpm ui:i18n:baseline` committed with source.
- Screenshots captured on the mocked dev server with seeded automation/active-run fixtures; every capture inspected.
- Autoreview (Codex, gpt-5.6-sol, high): clean on the full branch diff.
- Touch targets: "Inspect run" is keyboard-reachable (`:focus-within` reveal) and always visible on coarse pointers.
