### PR TITLE
fix(gateway): apply configured edge auth to session-URL targets

### DIFF
--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -110,6 +110,7 @@ application token from an operator-installed `cloudflared` binary:
         command: "/usr/local/bin/cloudflared",
         args: ["access", "token", "-app=https://gateway.example"],
         jsonOnly: false,
+        passEnv: ["HOME"],
         trustedDirs: ["/usr/local/bin"],
       },
     },
@@ -132,7 +133,14 @@ application token from an operator-installed `cloudflared` binary:
 
 `secrets.providers.*.command` must be an absolute path; replace
 `/usr/local/bin/cloudflared` with the real, non-symlink install location on your
-host, such as the resolved executable under a Homebrew prefix.
+host, such as the resolved executable under a Homebrew prefix, and keep
+`trustedDirs` pointing at the directory that actually holds it.
+
+Exec providers run with a scrubbed environment. `cloudflared` reads its cached
+application token from the user's home directory, so `passEnv: ["HOME"]` is
+required; without it the provider exits non-zero and no header is produced.
+Run `cloudflared access login <gateway-url>` once first so a token exists to
+read.
 
 For a Cloudflare Access service token, provide the two fixed headers from any
 supported secret provider. This example reads them from environment-backed

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -538,6 +538,25 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.token).toBe("test-token");
   });
 
+  it("still connects to an explicit secure url when config cannot be loaded", async () => {
+    // A secure target reads config only for gateway.remote.edgeAuth, so an invalid
+    // config must not block a connection the flags already fully describe.
+    getRuntimeConfig.mockImplementation(() => {
+      throw new Error("invalid config");
+    });
+
+    await callGatewayCli({
+      method: "health",
+      url: "wss://override.example/ws",
+      token: "test-token",
+    });
+
+    expect(getRuntimeConfig).toHaveBeenCalled();
+    expect(lastClientOptions?.url).toBe("wss://override.example/ws");
+    expect(lastClientOptions?.token).toBe("test-token");
+    expect(lastClientOptions?.edgeAuthHeaders).toBeUndefined();
+  });
+
   it("reconnects with admin only after sessions.create cwd returns structured escalation", async () => {
     const scopeAttempts: Array<readonly string[] | undefined> = [];
     gatewayClientRequest = async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -82,7 +82,10 @@ import {
   resolveEdgeAuthHeaders,
   type EdgeAuthHeadersConfig,
 } from "./edge-auth.js";
-import { canSkipGatewayConfigLoad } from "./explicit-connection-policy.js";
+import {
+  canSkipGatewayConfigLoad,
+  isExplicitGatewayConnection,
+} from "./explicit-connection-policy.js";
 import { resolvePreauthHandshakeTimeoutMs } from "./handshake-timeouts.js";
 import {
   CLI_DEFAULT_OPERATOR_SCOPES,
@@ -407,6 +410,19 @@ async function loadGatewayConfig(): Promise<OpenClawConfig> {
   return await defaultGetRuntimeConfig();
 }
 
+/**
+ * Load config for a fully flag-addressed connection. Config only supplies
+ * gateway.remote.edgeAuth here, so an unreadable or invalid config degrades to
+ * empty rather than blocking a connection the flags already describe.
+ */
+async function loadGatewayConfigForExplicitConnection(): Promise<OpenClawConfig> {
+  try {
+    return await loadGatewayConfig();
+  } catch {
+    return {};
+  }
+}
+
 function loadGatewayConfigForConnectionDetails(): OpenClawConfig {
   return readGatewayDispatchConfig();
 }
@@ -624,8 +640,18 @@ async function resolveGatewayCallContext(
     urlOverride,
     explicitAuth,
   });
+  const explicitConnection = isExplicitGatewayConnection({
+    config: opts.config,
+    urlOverride,
+    explicitAuth,
+  });
   const config =
-    opts.config ?? (canSkipConfigLoad ? ({} as OpenClawConfig) : await loadGatewayConfig());
+    opts.config ??
+    (canSkipConfigLoad
+      ? ({} as OpenClawConfig)
+      : explicitConnection
+        ? await loadGatewayConfigForExplicitConnection()
+        : await loadGatewayConfig());
   const configPath = opts.configPath ?? resolveGatewayConfigPath(process.env);
   const isRemoteMode = opts.localPortOverride === undefined && config.gateway?.mode === "remote";
   return {

--- a/src/gateway/explicit-connection-policy.test.ts
+++ b/src/gateway/explicit-connection-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { canSkipGatewayConfigLoad } from "./explicit-connection-policy.js";
+import {
+  canSkipGatewayConfigLoad,
+  isExplicitGatewayConnection,
+} from "./explicit-connection-policy.js";
 
 describe("canSkipGatewayConfigLoad", () => {
   const explicitAuth = { token: "t" };
@@ -30,6 +33,26 @@ describe("canSkipGatewayConfigLoad", () => {
   it("never skips when a config was already supplied", () => {
     expect(
       canSkipGatewayConfigLoad({ config: {}, urlOverride: "ws://127.0.0.1:18789", explicitAuth }),
+    ).toBe(false);
+  });
+});
+
+describe("isExplicitGatewayConnection", () => {
+  it("is true only when url and explicit auth fully address the gateway", () => {
+    expect(
+      isExplicitGatewayConnection({
+        urlOverride: "wss://gateway.example",
+        explicitAuth: { token: "t" },
+      }),
+    ).toBe(true);
+    expect(isExplicitGatewayConnection({ urlOverride: "wss://gateway.example" })).toBe(false);
+    expect(isExplicitGatewayConnection({ explicitAuth: { token: "t" } })).toBe(false);
+    expect(
+      isExplicitGatewayConnection({
+        config: {},
+        urlOverride: "wss://gateway.example",
+        explicitAuth: { token: "t" },
+      }),
     ).toBe(false);
   });
 });

--- a/src/gateway/explicit-connection-policy.test.ts
+++ b/src/gateway/explicit-connection-policy.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { canSkipGatewayConfigLoad } from "./explicit-connection-policy.js";
+
+describe("canSkipGatewayConfigLoad", () => {
+  const explicitAuth = { token: "t" };
+
+  it("skips config IO for a plaintext loopback target with explicit auth", () => {
+    expect(canSkipGatewayConfigLoad({ urlOverride: "ws://127.0.0.1:18789", explicitAuth })).toBe(
+      true,
+    );
+  });
+
+  it("loads config for a wss target so configured edge auth is not dropped", () => {
+    expect(canSkipGatewayConfigLoad({ urlOverride: "wss://gateway.example", explicitAuth })).toBe(
+      false,
+    );
+  });
+
+  it("loads config for an https session URL target", () => {
+    expect(
+      canSkipGatewayConfigLoad({ urlOverride: "https://gateway.example/chat/main", explicitAuth }),
+    ).toBe(false);
+  });
+
+  it("never skips without a url or without explicit auth", () => {
+    expect(canSkipGatewayConfigLoad({ explicitAuth })).toBe(false);
+    expect(canSkipGatewayConfigLoad({ urlOverride: "ws://127.0.0.1:18789" })).toBe(false);
+  });
+
+  it("never skips when a config was already supplied", () => {
+    expect(
+      canSkipGatewayConfigLoad({ config: {}, urlOverride: "ws://127.0.0.1:18789", explicitAuth }),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/explicit-connection-policy.ts
+++ b/src/gateway/explicit-connection-policy.ts
@@ -10,15 +10,27 @@ function hasExplicitGatewayConnectionAuth(auth?: ExplicitGatewayAuth): boolean {
   return Boolean(trimToUndefined(auth?.token) || trimToUndefined(auth?.password));
 }
 
+// gateway.remote.edgeAuth lives in config and only ever applies to secure remote
+// targets. Skipping the config load for one would silently drop the edge
+// credential and surface as an identity-proxy rejection the flags cannot explain.
+function targetMayRequireConfiguredEdgeAuth(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "wss:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /** Returns true when url/auth flags are sufficient and loading OpenClaw config is unnecessary. */
 export function canSkipGatewayConfigLoad(params: {
   config?: OpenClawConfig;
   urlOverride?: string;
   explicitAuth?: ExplicitGatewayAuth;
 }): boolean {
-  return (
-    !params.config &&
-    Boolean(trimToUndefined(params.urlOverride)) &&
-    hasExplicitGatewayConnectionAuth(params.explicitAuth)
-  );
+  const urlOverride = trimToUndefined(params.urlOverride);
+  if (!urlOverride || params.config || !hasExplicitGatewayConnectionAuth(params.explicitAuth)) {
+    return false;
+  }
+  return !targetMayRequireConfiguredEdgeAuth(urlOverride);
 }

--- a/src/gateway/explicit-connection-policy.ts
+++ b/src/gateway/explicit-connection-policy.ts
@@ -22,6 +22,23 @@ function targetMayRequireConfiguredEdgeAuth(url: string): boolean {
   }
 }
 
+/**
+ * True when the caller fully addressed the Gateway with flags. Config is then
+ * consulted only for gateway.remote.edgeAuth, so a broken config must not block
+ * the connection: this is the historical recovery path for an invalid config.
+ */
+export function isExplicitGatewayConnection(params: {
+  config?: OpenClawConfig;
+  urlOverride?: string;
+  explicitAuth?: ExplicitGatewayAuth;
+}): boolean {
+  return (
+    !params.config &&
+    Boolean(trimToUndefined(params.urlOverride)) &&
+    hasExplicitGatewayConnectionAuth(params.explicitAuth)
+  );
+}
+
 /** Returns true when url/auth flags are sufficient and loading OpenClaw config is unnecessary. */
 export function canSkipGatewayConfigLoad(params: {
   config?: OpenClawConfig;


### PR DESCRIPTION
Follow-up to #125700.

## What Problem This Solves

Two defects in the edge-auth feature, both found by driving it against a real
Cloudflare Access-fronted Gateway rather than by reading the diff.

**1. A session-URL target silently ignored `gateway.remote.edgeAuth`.** Pasting a Control UI
link — the documented way to continue a web session in the terminal — still failed:

```
openclaw tui https://gateway.example/chat/main --token <token>
gateway rejected websocket upgrade (HTTP 302)
```

while the configured form (`openclaw tui`, using `gateway.remote.url`) connected fine. The
headline use case of #125700 was broken.

**2. The documented Cloudflare example could not work as written.** Following it produced only:

```
Exec provider "cloudflare-access" exited with code 1.
```

with nothing pointing at the cause.

## Why This Change Was Made

**Defect 1** is `canSkipGatewayConfigLoad` (`src/gateway/explicit-connection-policy.ts`): when a
caller supplies both a URL and explicit auth, it skips reading config entirely, on the assumption
that flags fully describe the connection. `edgeAuth` broke that assumption — the edge credential
lives in config, so skipping the load dropped it and surfaced as an identity-proxy rejection the
flags could not explain.

The fix is narrow and follows the invariant already enforced elsewhere: `edgeAuth` only ever applies
to a secure target (`wss://` is required before any secret resolves). So config IO is skipped only
for plaintext loopback targets, and always performed for `wss://`/`https://` ones. Explicit
credentials still win; this only restores the config *read*.

**Defect 2** is environmental. Exec secret providers run with a scrubbed environment, and
`cloudflared` reads its cached application token from the user's home directory — so
`passEnv: ["HOME"]` is mandatory. Without it the provider exits non-zero and no header is produced.
The docs now include it, explain the scrubbed environment, note that `trustedDirs` must point at the
directory actually holding the binary, and tell readers to run `cloudflared access login` first.

## User Impact

Operators behind an identity-aware proxy can now paste a Control UI session URL into `openclaw tui`
and `openclaw attach`, not just rely on the configured-gateway form. Operators following the
Cloudflare docs get a working example instead of an unexplained exit code. No config migration; no
behavior change for anyone not using `edgeAuth`.

## Evidence

**Live, against the real Cloudflare Access edge (this is the proof gap #125700 declared).**

Configured path — attached to a real session and round-tripped a model reply:

```
openclaw tui - wss://team.openclaw.ai - agent main - session main
<message sent>
EDGE-OK
connected | idle
```

URL-target path — the case this PR fixes. Before, the identical command returned the Cloudflare 302
above. After:

```
openclaw tui - wss://team.openclaw.ai - agent main - session main
gateway connected
```

(The subsequent `Unknown agent id "main"` is unrelated: that Gateway uses different agent ids than
the one guessed in the URL path. The upgrade, Access traversal, and Gateway handshake all succeeded.)

**Gates.** `node scripts/check-changed.mjs` exit 0. Focused suites: 162 tests passed across
`explicit-connection-policy`, `edge-auth`, and `call`. Codex autoreview clean (no accepted or
actionable findings).

**Regression coverage.** Five cases in `src/gateway/explicit-connection-policy.test.ts`: `ws://`
loopback still skips config IO; `wss://` and `https://` session URLs do not; and no-url, no-auth,
and config-already-supplied all behave as before.
