### PR TITLE
refactor(telegram): remove forum cache test reset

### DIFF
--- a/extensions/telegram/api.ts
+++ b/extensions/telegram/api.ts
@@ -50,7 +50,6 @@ export {
   hasBotMention,
   isBinaryContent,
   normalizeForwardedContext,
-  resetTelegramForumFlagCacheForTest,
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,

--- a/extensions/telegram/src/bot-native-command-login.test.ts
+++ b/extensions/telegram/src/bot-native-command-login.test.ts
@@ -19,7 +19,6 @@ import {
   resetNativeCommandMenuMocks,
 } from "./bot-native-commands.menu-test-support.js";
 import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
-import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
 
 const loginSessionMocks = vi.hoisted(() => ({
   getSessionEntry: vi.fn(),
@@ -119,7 +118,6 @@ function registerLoginCommand(params: {
 
 describe("registerTelegramNativeCommands /login", () => {
   beforeEach(() => {
-    resetTelegramForumFlagCacheForTest();
     resetNativeCommandMenuMocks();
     loginSessionMocks.loadSessionStore.mockReset().mockReturnValue({});
     loginSessionMocks.getSessionEntry

--- a/extensions/telegram/src/bot-native-command-plugins.test.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.test.ts
@@ -18,7 +18,11 @@ import {
   emitTelegramMessageSentHooks,
   resetNativeCommandMenuMocks,
 } from "./bot-native-commands.menu-test-support.js";
-import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
+
+const UNMATCHED_FORUM_CHAT_ID = -1_001_234_567_891;
+const BOUND_FORUM_CHAT_ID = -1_001_234_567_892;
+const GENERAL_FORUM_CHAT_ID = -1_001_234_567_893;
+const PERSISTED_FORUM_CHAT_ID = -1_001_234_567_894;
 
 const pluginSessionMocks = vi.hoisted(() => ({
   getSessionEntry: vi.fn(),
@@ -143,7 +147,6 @@ registerTelegramNativeCommands(createNativeCommandTestParams({}));
 
 describe("registerTelegramNativeCommands", () => {
   beforeEach(() => {
-    resetTelegramForumFlagCacheForTest();
     resetNativeCommandMenuMocks();
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());
@@ -253,7 +256,7 @@ describe("registerTelegramNativeCommands", () => {
         message_id: 2,
         date: Math.floor(Date.now() / 1000),
         chat: {
-          id: -1001234567890,
+          id: UNMATCHED_FORUM_CHAT_ID,
           type: "supergroup",
           title: "Forum Group",
           is_forum: true,
@@ -264,7 +267,7 @@ describe("registerTelegramNativeCommands", () => {
     });
 
     const sendMessageCall = firstCall(sendMessage);
-    expect(sendMessageCall[0]).toBe(-1001234567890);
+    expect(sendMessageCall[0]).toBe(UNMATCHED_FORUM_CHAT_ID);
     expect(sendMessageCall[1]).toBe("Command not found.");
     expect(
       (sendMessageCall[2] as { message_thread_id?: number } | undefined)?.message_thread_id,
@@ -536,7 +539,7 @@ describe("registerTelegramNativeCommands", () => {
         message_id: 2,
         date: Math.floor(Date.now() / 1000),
         chat: {
-          id: -1001234567890,
+          id: BOUND_FORUM_CHAT_ID,
           type: "supergroup",
           title: "Forum Group",
           is_forum: true,
@@ -549,13 +552,17 @@ describe("registerTelegramNativeCommands", () => {
     const commandParams = firstExecutePluginCommandParams();
     expect(commandParams.channel).toBe("telegram");
     expect(commandParams.accountId).toBe("default");
-    expect(commandParams.from).toBe("telegram:group:-1001234567890:topic:77");
-    expect(commandParams.to).toBe("telegram:-1001234567890");
+    expect(commandParams.from).toBe(`telegram:group:${BOUND_FORUM_CHAT_ID}:topic:77`);
+    expect(commandParams.to).toBe(`telegram:${BOUND_FORUM_CHAT_ID}`);
     expect(commandParams.messageThreadId).toBe(77);
   });
 
   it("treats Telegram forum #General commands as topic 1 when Telegram omits topic metadata", async () => {
-    const getChat = vi.fn(async () => ({ id: -1001234567890, type: "supergroup", is_forum: true }));
+    const getChat = vi.fn(async () => ({
+      id: GENERAL_FORUM_CHAT_ID,
+      type: "supergroup",
+      is_forum: true,
+    }));
     const { handler } = registerPlugCommand({
       botHarness: createCommandBot({ api: { getChat } }),
     });
@@ -566,7 +573,7 @@ describe("registerTelegramNativeCommands", () => {
         message_id: 2,
         date: Math.floor(Date.now() / 1000),
         chat: {
-          id: -1001234567890,
+          id: GENERAL_FORUM_CHAT_ID,
           type: "supergroup",
           title: "Forum Group",
         },
@@ -574,11 +581,11 @@ describe("registerTelegramNativeCommands", () => {
       },
     });
 
-    expect(getChat).toHaveBeenCalledWith(-1001234567890);
+    expect(getChat).toHaveBeenCalledWith(GENERAL_FORUM_CHAT_ID);
     const commandParams = firstExecutePluginCommandParams();
     expect(commandParams.accountId).toBe("default");
-    expect(commandParams.from).toBe("telegram:group:-1001234567890:topic:1");
-    expect(commandParams.to).toBe("telegram:-1001234567890");
+    expect(commandParams.from).toBe(`telegram:group:${GENERAL_FORUM_CHAT_ID}:topic:1`);
+    expect(commandParams.to).toBe(`telegram:${GENERAL_FORUM_CHAT_ID}`);
     expect(commandParams.messageThreadId).toBe(1);
   });
 
@@ -631,12 +638,16 @@ describe("registerTelegramNativeCommands", () => {
     });
 
     await handler(
-      createTelegramTopicCommandContext({ match: "bind --cwd /tmp/work", threadId: 42 }),
+      createTelegramTopicCommandContext({
+        match: "bind --cwd /tmp/work",
+        chatId: PERSISTED_FORUM_CHAT_ID,
+        threadId: 42,
+      }),
     );
 
     expect(firstExecutePluginCommandParams()).toEqual(
       expect.objectContaining({
-        sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+        sessionKey: `agent:main:telegram:group:${PERSISTED_FORUM_CHAT_ID}:topic:42`,
         sessionId: "sess-topic",
         messageThreadId: 42,
       }),

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -17,7 +17,6 @@ import {
   resetNativeCommandMenuMocks,
   waitForRegisteredCommands,
 } from "./bot-native-commands.menu-test-support.js";
-import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
 import { normalizeTelegramCommandName, TELEGRAM_COMMAND_NAME_PATTERN } from "./command-config.js";
 
 type TelegramInlineKeyboardReplyMarkup = {
@@ -76,7 +75,6 @@ registerTelegramNativeCommands(createNativeCommandTestParams({}));
 
 describe("registerTelegramNativeCommands", () => {
   beforeEach(() => {
-    resetTelegramForumFlagCacheForTest();
     resetNativeCommandMenuMocks();
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -14,7 +14,6 @@ import {
   type TelegramMentionCaseForTest,
   type TelegramMentionPolicyForTest,
 } from "./bot.create-telegram-bot.test-support.js";
-import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
 import { setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 
@@ -271,7 +270,7 @@ async function dispatchTelegramGroupPhoto(params: {
         id: -100456,
         type: "supergroup",
         title: "Ops Chat",
-        ...(params.topicId ? { is_forum: true } : {}),
+        is_forum: params.topicId !== undefined,
       },
       message_id: params.messageId,
       date: 1736380800,
@@ -397,7 +396,6 @@ describe("createTelegramBot channel_post media", () => {
   });
 
   beforeEach(() => {
-    resetTelegramForumFlagCacheForTest();
     setTelegramRuntime({
       state: {
         openKeyedStore: ((options) =>

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -105,7 +105,6 @@ const {
   buildTelegramGroupFrom,
   buildTypingThreadParams,
   resolveTelegramForumFlag,
-  resetTelegramForumFlagCacheForTest,
   resolveTelegramThreadSpec,
 } = await import("./bot/helpers.js");
 const { resolveTelegramGroupPromptSettings, resolveTelegramScopedGroupConfig } =
@@ -132,6 +131,12 @@ const TELEGRAM_TEST_TIMINGS = {
   textFragmentGapMs: 30,
 } as const;
 const INBOUND_DEBOUNCE_MS = 4321;
+let forumCacheChatId = -1_008_000_000_000;
+
+function nextForumCacheChatId(): number {
+  forumCacheChatId += 1;
+  return forumCacheChatId;
+}
 
 type TelegramMessageHandler = (ctx: TelegramMiddlewareTestContext) => Promise<void>;
 type MessagePolicyCase = {
@@ -432,7 +437,6 @@ describe("createTelegramBot", () => {
   beforeEach(async () => {
     previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = createTelegramBotTestStateDir();
-    resetTelegramForumFlagCacheForTest();
     clearPluginInteractiveHandlers();
     resetTelegramAccountThrottlersForTest();
     throttlerSpy.mockReset();
@@ -1710,6 +1714,7 @@ describe("createTelegramBot", () => {
   });
 
   it("does not let unauthorized group stop cancel pending same-sender inbound debounce", async () => {
+    const chatId = nextForumCacheChatId();
     loadConfig.mockReturnValue({
       agents: {
         defaults: {
@@ -1749,7 +1754,7 @@ describe("createTelegramBot", () => {
         ctx: {
           update: { update_id: 104 },
           message: {
-            chat: { id: -1007, type: "supergroup", title: "OpenClaw Ops" },
+            chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
             text: "first",
             date: 1736380804,
             message_id: 104,
@@ -1767,7 +1772,7 @@ describe("createTelegramBot", () => {
         ctx: {
           update: { update_id: 105 },
           message: {
-            chat: { id: -1007, type: "supergroup", title: "OpenClaw Ops" },
+            chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
             text: "stop",
             date: 1736380805,
             message_id: 105,
@@ -2846,6 +2851,7 @@ describe("createTelegramBot", () => {
   });
 
   it("ignores group self-authored message updates instead of re-processing bot output", async () => {
+    const chatId = nextForumCacheChatId();
     loadConfig.mockReturnValue({
       channels: { telegram: { dmPolicy: "pairing" } },
     });
@@ -2859,7 +2865,7 @@ describe("createTelegramBot", () => {
 
     await handler({
       message: {
-        chat: { id: -1001234, type: "supergroup", title: "OpenClaw Ops" },
+        chat: { id: chatId, type: "supergroup", title: "OpenClaw Ops" },
         message_id: 1884,
         date: 1736380800,
         from: { id: 7, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
@@ -4687,14 +4693,9 @@ describe("createTelegramBot", () => {
       authorized: true,
     });
   });
-  it.each([
-    { name: "resolves topic-scoped forum metadata", messageThreadId: 99, expectedTopicId: 99 },
-    {
-      name: "resolves General topic forum metadata and typing fallback",
-      messageThreadId: undefined,
-      expectedTopicId: 1,
-    },
-  ] as const)("$name", ({ messageThreadId, expectedTopicId }) => {
+  it("resolves topic-scoped forum metadata", () => {
+    const messageThreadId = 99;
+    const expectedTopicId = 99;
     const threadSpec = resolveTelegramThreadSpec({
       isGroup: true,
       isForum: true,
@@ -4718,14 +4719,15 @@ describe("createTelegramBot", () => {
   });
 
   it("routes General-topic forum metadata via getChat when Telegram omits forum metadata", async () => {
+    const chatId = nextForumCacheChatId();
     getChatSpy.mockResolvedValue({
-      id: -1001234567890,
+      id: chatId,
       type: "supergroup",
       is_forum: true,
       title: "Forum Group",
     });
     const isForum = await resolveTelegramForumFlag({
-      chatId: -1001234567890,
+      chatId,
       chatType: "supergroup",
       isGroup: true,
       isForum: undefined,
@@ -4740,16 +4742,16 @@ describe("createTelegramBot", () => {
     const route = resolveTelegramConversationRoute({
       cfg: {},
       accountId: "default",
-      chatId: -1001234567890,
+      chatId,
       isGroup: true,
       resolvedThreadId,
     });
 
     expect(getChatSpy).toHaveBeenCalledOnce();
-    expect(getChatSpy).toHaveBeenCalledWith(-1001234567890);
-    expect(route.route.sessionKey).toContain("telegram:group:-1001234567890:topic:1");
-    expect(buildTelegramGroupFrom(-1001234567890, resolvedThreadId)).toBe(
-      "telegram:group:-1001234567890:topic:1",
+    expect(getChatSpy).toHaveBeenCalledWith(chatId);
+    expect(route.route.sessionKey).toContain(`telegram:group:${chatId}:topic:1`);
+    expect(buildTelegramGroupFrom(chatId, resolvedThreadId)).toBe(
+      `telegram:group:${chatId}:topic:1`,
     );
     expect(buildTypingThreadParams(resolvedThreadId)).toEqual({ message_thread_id: 1 });
   });
@@ -5059,6 +5061,7 @@ describe("createTelegramBot", () => {
   });
 
   it("threads native command replies inside topics", async () => {
+    const chatId = nextForumCacheChatId();
     commandSpy.mockClear();
     sendMessageSpy.mockClear();
     replySpy.mockResolvedValue({ text: "response" });
@@ -5082,12 +5085,12 @@ describe("createTelegramBot", () => {
     ) => Promise<void>;
 
     await handler({
-      ...makeForumGroupMessageCtx({ threadId: 99, text: "/status" }),
+      ...makeForumGroupMessageCtx({ chatId, threadId: 99, text: "/status" }),
       match: "",
     });
 
     const statusCall = requireValue(sendMessageSpy.mock.calls.at(0), "status reply call");
-    expect(statusCall[0]).toBe("-1001234567890");
+    expect(statusCall[0]).toBe(String(chatId));
     expect(statusCall[1]).toBeTypeOf("string");
     expectRecordFields(
       statusCall[2],

--- a/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
+++ b/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
@@ -16,7 +16,6 @@ import {
 } from "./bot-handlers.message-pipeline.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
-import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
 import { asTelegramClientFetch, createTelegramClientFetch } from "./client-fetch.js";
 import { createTelegramIngressResolver, createTelegramIngressSubject } from "./ingress.js";
 import * as telegramRequestTimeouts from "./request-timeouts.js";
@@ -56,7 +55,6 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
 
   afterAll(async () => {
     vi.restoreAllMocks();
-    resetTelegramForumFlagCacheForTest();
     for (const socket of liveSockets) {
       socket.destroy();
     }
@@ -71,7 +69,6 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
       (method, configuredTimeoutSeconds) =>
         method === "getchat" ? 100 : canonicalRequestTimeout(method, configuredTimeoutSeconds),
     );
-    resetTelegramForumFlagCacheForTest();
 
     const clientFetch = createTelegramClientFetch({
       fetchImpl: asTelegramClientFetch(globalThis.fetch),

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -1,6 +1,6 @@
 // Telegram tests cover helpers plugin behavior.
 import type { MessageEntity } from "grammy/types";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   describeReplyTarget,
   getTelegramTextParts,
@@ -10,7 +10,6 @@ import {
   resolveTelegramBotHasTopicsEnabled,
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
-  resetTelegramForumFlagCacheForTest,
   shouldUseTelegramDmThreadSession,
 } from "./helpers.js";
 import { renderTelegramTextEntities } from "./inbound-text-entities.js";
@@ -19,6 +18,13 @@ type TelegramMessage = Parameters<typeof normalizeForwardedContext>[0];
 
 function asMalformedTelegramMessage(message: unknown): TelegramMessage {
   return message as TelegramMessage;
+}
+
+let forumChatId = -1_009_000_000_000;
+
+function nextForumChatId(): number {
+  forumChatId += 1;
+  return forumChatId;
 }
 
 describe("resolveTelegramForumThreadId", () => {
@@ -41,19 +47,16 @@ describe("resolveTelegramForumThreadId", () => {
 });
 
 describe("resolveTelegramForumFlag", () => {
-  beforeEach(() => {
-    resetTelegramForumFlagCacheForTest();
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("keeps explicit forum metadata when Telegram already provides it", async () => {
+    const chatId = nextForumChatId();
     const getChat = vi.fn(async () => ({ is_forum: false }));
     await expect(
       resolveTelegramForumFlag({
-        chatId: -100123,
+        chatId,
         chatType: "supergroup",
         isGroup: true,
         isForum: true,
@@ -64,25 +67,27 @@ describe("resolveTelegramForumFlag", () => {
   });
 
   it("falls back to getChat for supergroups when is_forum is omitted", async () => {
+    const chatId = nextForumChatId();
     const getChat = vi.fn(async () => ({ is_forum: true }));
     await expect(
       resolveTelegramForumFlag({
-        chatId: -100789,
+        chatId,
         chatType: "supergroup",
         isGroup: true,
         getChat,
       }),
     ).resolves.toBe(true);
-    expect(getChat).toHaveBeenCalledWith(-100789);
+    expect(getChat).toHaveBeenCalledWith(chatId);
   });
 
   it("uses supergroup topic-message metadata before getChat lookup", async () => {
+    const chatId = nextForumChatId();
     const getChat = vi.fn(async () => {
       throw new Error("lookup should not run");
     });
     await expect(
       resolveTelegramForumFlag({
-        chatId: -100987,
+        chatId,
         chatType: "supergroup",
         isGroup: true,
         isTopicMessage: true,
@@ -107,9 +112,10 @@ describe("resolveTelegramForumFlag", () => {
   });
 
   it("reuses resolved forum metadata for later supergroup updates", async () => {
+    const chatId = nextForumChatId();
     const getChat = vi.fn(async () => ({ is_forum: true }));
     const params = {
-      chatId: -100456,
+      chatId,
       chatType: "supergroup" as const,
       isGroup: true,
       getChat,
@@ -120,9 +126,10 @@ describe("resolveTelegramForumFlag", () => {
   });
 
   it("refreshes cached forum metadata from explicit Telegram updates", async () => {
+    const chatId = nextForumChatId();
     const getChat = vi.fn(async () => ({ is_forum: true }));
     const params = {
-      chatId: -100654,
+      chatId,
       chatType: "supergroup" as const,
       isGroup: true,
       getChat,
@@ -134,10 +141,11 @@ describe("resolveTelegramForumFlag", () => {
   });
 
   it("drops cached forum metadata when the current clock is not a valid date timestamp", async () => {
+    const chatId = nextForumChatId();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     const getChat = vi.fn(async () => ({ is_forum: true }));
     const params = {
-      chatId: -100655,
+      chatId,
       chatType: "supergroup" as const,
       isGroup: true,
       getChat,
@@ -149,10 +157,11 @@ describe("resolveTelegramForumFlag", () => {
   });
 
   it("does not cache forum metadata when the expiry timestamp would exceed the valid date range", async () => {
+    const chatId = nextForumChatId();
     vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_000);
     const getChat = vi.fn(async () => ({ is_forum: true }));
     const params = {
-      chatId: -100656,
+      chatId,
       chatType: "supergroup" as const,
       isGroup: true,
       getChat,
@@ -163,17 +172,20 @@ describe("resolveTelegramForumFlag", () => {
   });
 
   it("returns false when forum lookup is unavailable", async () => {
+    const chatId = nextForumChatId();
     const getChat = vi.fn(async () => {
       throw new Error("lookup failed");
     });
     await expect(
       resolveTelegramForumFlag({
-        chatId: -100999,
+        chatId,
         chatType: "supergroup",
         isGroup: true,
         getChat,
       }),
     ).resolves.toBe(false);
+    expect(getChat).toHaveBeenCalledOnce();
+    expect(getChat).toHaveBeenCalledWith(chatId);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -69,10 +69,6 @@ const TELEGRAM_FORUM_FLAG_CACHE_MAX_CHATS = 1024;
 const TELEGRAM_FORUM_FLAG_CACHE_TTL_MS = 10 * 60_000;
 const telegramForumFlagByChatId = new Map<string, { expiresAtMs: number; isForum: boolean }>();
 
-export function resetTelegramForumFlagCacheForTest(): void {
-  telegramForumFlagByChatId.clear();
-}
-
 function cacheTelegramForumFlag(chatId: string | number, isForum: boolean, nowMs = Date.now()) {
   const cacheKey = String(chatId);
   const expiresAtMs = resolveExpiresAtMsFromDurationMs(TELEGRAM_FORUM_FLAG_CACHE_TTL_MS, {


### PR DESCRIPTION
## What Problem This Solves

Telegram tests currently clear the production forum-metadata cache through a test-only exported reset. That couples otherwise behavioral suites to process-global implementation state and exposes an undocumented `ForTest` symbol through the plugin API.

## Why This Change Was Made

Cache-sensitive tests now isolate through Telegram facts: unique valid chat IDs within and across cases, or explicit `is_forum` metadata for fixed fixtures. The production 1024-entry cache, TTL, explicit refresh, `getChat` fallback, and unsafe-clock behavior are unchanged. One General-topic helper-composition pseudo-test was deleted; the real helper owner tests and handler boundaries remain.

Retained coverage includes the helpers cache owner cases, plugin-command General-topic routing, message-context General-topic routing, group-login security, the grammY/HTTP response-body cancellation integration, and channel media-policy matrices.

## User Impact

No user-visible behavior changes. This is behavior-neutral test-seam cleanup: Telegram runtime routing, transport, topic handling, and cache semantics are unchanged.

Production LOC: +0/-5 (net -5) | Tests: +78/-61 (net +17)

No docs, changelog, schema, protocol, config, dependency, lockfile, release, or operator-state changes.

## Evidence

Rebased exact head: `b69d49854b3cd5dbafccf450485032b8b2357b46` on current `origin/main` `8d6cbee1b527cd8df313db401a40fbbd4e0c0ee8`.

- Focused owner/boundary set: `node scripts/run-vitest.mjs extensions/telegram/api.test.ts extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot-native-command-plugins.test.ts extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts extensions/telegram/src/bot-native-command-login.test.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts` — 8 files, 305 tests passed.
- Dedicated Telegram project: `node scripts/run-vitest.mjs extensions/telegram` — 211 Vitest shards passed.
- Build: `pnpm build` — passed.
- Package boundary: `pnpm test:extensions:package-boundary:compile` — 122 plugins compiled; Telegram passed.
- Changed gate: `node scripts/check-changed.mjs -- <the 9 changed files>` — passed extension production/test typecheck, lint, format, dead-export, boundary, database-first, and import-cycle checks.
- `git diff --check origin/main...HEAD` — passed.
- Codex-backed autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Repository-wide search confirms `resetTelegramForumFlagCacheForTest` has no remaining declaration, export, or consumer.
- Codex CLI review-runner contract checked directly in `codex-rs/exec/src/cli.rs:26-40` and `codex-rs/exec/src/lib.rs:330-335,527-536,798-803`.

The previous exact-head `openclaw/ci-gate` was red only because the unrelated QA Smoke `subagent-completion-direct-fallback` scenario timed out. Its root causes are now repaired on main by #126062 (`2cd87d3d27c1ac78e268680aef4f70d2e8f0d425`) and #125946 (`fe816d69ef5dcea1620f44dcb256f0d5eb98ea14`). Neither repair was replayed into this branch; both are inherited from the rebased base.

No live Telegram proof was run because the change is behavior-neutral and production routing, transport, topic, and cache behavior is byte-unchanged apart from deleting the unreachable test reset. The mock/unit owner and boundary suites are the intended gate.

AI-assisted change; implementation and evidence were reviewed by the maintainer workflow.
